### PR TITLE
bun:ffi: make cc() reject non-numeric i64/u64 arguments instead of passing garbage

### DIFF
--- a/src/jsc/bindings/JSCFFIBridge.cpp
+++ b/src/jsc/bindings/JSCFFIBridge.cpp
@@ -125,23 +125,22 @@ extern "C" void Bun__JSCFFICallbackClose(JSC::EncodedJSValue callbackValue)
         callback->close();
 }
 
-// JSVALUE_TO_INT64_SLOW for the wrappers cc() compiles (src/runtime/ffi/FFI.h). The wrapper decodes
-// numbers inline; everything else (a BigInt, or a value that is not a number at all) gets the same
-// conversion a dlopen()'d symbol's i64/u64/i64_fast/u64_fast argument gets, TypeError included.
-// Both signednesses come back as the raw 64 bits of the argument slot; the wrapper casts.
-extern "C" int64_t Bun__FFI__jsValueToInt64Slow(JSC::JSGlobalObject* globalObject, int32_t abiType, bool* threw, JSC::EncodedJSValue encodedValue)
+// JSVALUE_TO_SLOT_SLOW for the wrappers cc() compiles (src/runtime/ffi/FFI.h): the conversion a
+// dlopen()'d symbol's argument of the same type gets, for the values the wrapper does not decode
+// inline. `abiType` is an ABIType discriminant, which is also the engine's tag (static_asserts
+// above). A rejected value leaves the engine's TypeError pending and reports it through `threw`.
+// No string arena is passed: nothing would free a transcoded string once the native call is over,
+// so a type that would need one (`cstring` given a JS string) throws instead.
+extern "C" uint64_t Bun__FFI__jsValueToSlotSlow(JSC::JSGlobalObject* globalObject, int32_t abiType, bool* threw, JSC::EncodedJSValue encodedValue)
 {
-    auto type = static_cast<JSC::FFI::Type>(abiType);
-    ASSERT(type == JSC::FFI::Type::Int64 || type == JSC::FFI::Type::Uint64 || type == JSC::FFI::Type::Int64Fast || type == JSC::FFI::Type::Uint64Fast);
-
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     uint64_t slot = 0;
-    JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), type, JSC::JSValue::decode(encodedValue), slot, nullptr);
+    JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), static_cast<JSC::FFI::Type>(abiType), JSC::JSValue::decode(encodedValue), slot, nullptr);
     if (scope.exception()) [[unlikely]] {
         *threw = true;
         return 0;
     }
-    return static_cast<int64_t>(slot);
+    return slot;
 }

--- a/src/jsc/bindings/JSCFFIBridge.cpp
+++ b/src/jsc/bindings/JSCFFIBridge.cpp
@@ -2,6 +2,7 @@
 #include "root.h"
 
 #include <JavaScriptCore/BunFFI.h>
+#include <JavaScriptCore/FFIConversions.h>
 #include <JavaScriptCore/FFISignature.h>
 #include <JavaScriptCore/FFIType.h>
 #include <JavaScriptCore/FFIContext.h>
@@ -16,7 +17,11 @@
 #include "headers-handwritten.h"
 
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::Char) == 0, "FFI::Type tag drift");
+static_assert(static_cast<uint8_t>(JSC::FFI::Type::Int64) == 7, "FFI::Type tag drift");
+static_assert(static_cast<uint8_t>(JSC::FFI::Type::Uint64) == 8, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::Pointer) == 12, "FFI::Type tag drift");
+static_assert(static_cast<uint8_t>(JSC::FFI::Type::Int64Fast) == 15, "FFI::Type tag drift");
+static_assert(static_cast<uint8_t>(JSC::FFI::Type::Uint64Fast) == 16, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::JSValue) == 19, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::Buffer) == 20, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::BufferLength) == 21, "FFI::Type tag drift");
@@ -118,4 +123,25 @@ extern "C" void Bun__JSCFFICallbackClose(JSC::EncodedJSValue callbackValue)
 {
     if (auto* callback = dynamicDowncast<JSC::JSFFICallback>(JSC::JSValue::decode(callbackValue)))
         callback->close();
+}
+
+// JSVALUE_TO_INT64_SLOW for the wrappers cc() compiles (src/runtime/ffi/FFI.h). The wrapper decodes
+// numbers inline; everything else (a BigInt, or a value that is not a number at all) gets the same
+// conversion a dlopen()'d symbol's i64/u64/i64_fast/u64_fast argument gets, TypeError included.
+// Both signednesses come back as the raw 64 bits of the argument slot; the wrapper casts.
+extern "C" int64_t Bun__FFI__jsValueToInt64Slow(JSC::JSGlobalObject* globalObject, int32_t abiType, bool* threw, JSC::EncodedJSValue encodedValue)
+{
+    auto type = static_cast<JSC::FFI::Type>(abiType);
+    ASSERT(type == JSC::FFI::Type::Int64 || type == JSC::FFI::Type::Uint64 || type == JSC::FFI::Type::Int64Fast || type == JSC::FFI::Type::Uint64Fast);
+
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    uint64_t slot = 0;
+    JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), type, JSC::JSValue::decode(encodedValue), slot, nullptr);
+    if (scope.exception()) [[unlikely]] {
+        *threw = true;
+        return 0;
+    }
+    return static_cast<int64_t>(slot);
 }

--- a/src/jsc/bindings/JSCFFIBridge.cpp
+++ b/src/jsc/bindings/JSCFFIBridge.cpp
@@ -125,18 +125,14 @@ extern "C" void Bun__JSCFFICallbackClose(JSC::EncodedJSValue callbackValue)
         callback->close();
 }
 
-// JSVALUE_TO_SLOT_SLOW for the wrappers cc() compiles (src/runtime/ffi/FFI.h): the conversion a
-// dlopen()'d symbol's argument of the same type gets, for the values the wrapper does not decode
-// inline. `abiType` is an ABIType discriminant, which is also the engine's tag (static_asserts
-// above). A rejected value leaves the engine's TypeError pending and reports it through `threw`.
-// No string arena is passed: nothing would free a transcoded string once the native call is over,
-// so a type that would need one (`cstring` given a JS string) throws instead.
+// JSVALUE_TO_SLOT_SLOW in src/runtime/ffi/FFI.h: the dlopen() argument conversion for cc() wrappers.
 extern "C" uint64_t Bun__FFI__jsValueToSlotSlow(JSC::JSGlobalObject* globalObject, int32_t abiType, bool* threw, JSC::EncodedJSValue encodedValue)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     uint64_t slot = 0;
+    // No string arena: nothing could free a transcoded `cstring` after the call, so JS strings throw.
     JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), static_cast<JSC::FFI::Type>(abiType), JSC::JSValue::decode(encodedValue), slot, nullptr);
     if (scope.exception()) [[unlikely]] {
         *threw = true;

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -144,12 +144,13 @@ static bool JSVALUE_IS_CELL(EncodedJSValue val) __attribute__((__always_inline__
 static bool JSVALUE_IS_INT32(EncodedJSValue val) __attribute__((__always_inline__)); 
 static bool JSVALUE_IS_NUMBER(EncodedJSValue val) __attribute__((__always_inline__));
 
-// The engine's 64-bit integer argument conversion, shared with dlopen()'d symbols; it serves both
-// signednesses (an unsigned result is the same 64 bits). `abiType` is one of the ABI_TYPE_* tags
-// the runtime defines when it compiles this file. Throws a TypeError for values that are neither a
-// number nor a BigInt and sets `*threw`, in which case the generated wrapper returns without
-// calling the native function.
-int64_t JSVALUE_TO_INT64_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
+// The engine's argument conversion for the type tagged `abiType` (one of the ABI_TYPE_* tags the
+// runtime defines when it compiles this file), i.e. what dlopen()'d symbols run for every argument.
+// The conversions below decode the common encodings inline and come here for the rest. Returns the
+// 64-bit argument slot, which the caller casts to the C type. A value the type does not accept
+// throws a TypeError and sets `*threw`; the generated wrapper then returns without calling the
+// native function.
+uint64_t JSVALUE_TO_SLOT_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
 static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 static int64_t  JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 
@@ -332,7 +333,7 @@ static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* t
 
   // BigInt, or not a number at all (undefined, null, a boolean, an object, ...): the slow path
   // converts the former and throws for the latter.
-  return (uint64_t)JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
+  return JSVALUE_TO_SLOT_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
@@ -343,7 +344,7 @@ static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* thr
     return (int64_t)JSVALUE_TO_DOUBLE(value);
   }
 
-  return JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
+  return (int64_t)JSVALUE_TO_SLOT_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -125,6 +125,8 @@ napi_value asNapiValue;
 
 EncodedJSValue ValueUndefined = { TagValueUndefined };
 EncodedJSValue ValueTrue = { TagValueTrue };
+// What a host function returns after throwing; JSC unwinds to the pending exception and ignores it.
+EncodedJSValue ValueEmpty = { 0 };
 
 typedef void* JSContext;
 
@@ -142,10 +144,14 @@ static bool JSVALUE_IS_CELL(EncodedJSValue val) __attribute__((__always_inline__
 static bool JSVALUE_IS_INT32(EncodedJSValue val) __attribute__((__always_inline__)); 
 static bool JSVALUE_IS_NUMBER(EncodedJSValue val) __attribute__((__always_inline__));
 
-static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) __attribute__((__always_inline__));
-static int64_t  JSVALUE_TO_INT64(EncodedJSValue value) __attribute__((__always_inline__));
-uint64_t JSVALUE_TO_UINT64_SLOW(EncodedJSValue value);
-int64_t  JSVALUE_TO_INT64_SLOW(EncodedJSValue value);
+// The engine's 64-bit integer argument conversion, shared with dlopen()'d symbols; it serves both
+// signednesses (an unsigned result is the same 64 bits). `abiType` is one of the ABI_TYPE_* tags
+// the runtime defines when it compiles this file. Throws a TypeError for values that are neither a
+// number nor a BigInt and sets `*threw`, in which case the generated wrapper returns without
+// calling the native function.
+int64_t JSVALUE_TO_INT64_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
+static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
+static int64_t  JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 
 EncodedJSValue UINT64_TO_JSVALUE_SLOW(void* jsGlobalObject, uint64_t val);
 EncodedJSValue INT64_TO_JSVALUE_SLOW(void* jsGlobalObject, int64_t val);
@@ -311,7 +317,7 @@ static bool JSVALUE_TO_BOOL(EncodedJSValue val) {
 }
 
 
-static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) {
+static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
     return (uint64_t)JSVALUE_TO_INT32(value);
   }
@@ -324,9 +330,11 @@ static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) {
     return (uint64_t)JSVALUE_TO_TYPED_ARRAY_LENGTH(value);
   }
 
-  return JSVALUE_TO_UINT64_SLOW(value);
+  // BigInt, or not a number at all (undefined, null, a boolean, an object, ...): the slow path
+  // converts the former and throws for the latter.
+  return (uint64_t)JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
-static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
+static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
     return (int64_t)JSVALUE_TO_INT32(value);
   }
@@ -335,7 +343,7 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
     return (int64_t)JSVALUE_TO_DOUBLE(value);
   }
 
-  return JSVALUE_TO_INT64_SLOW(value);
+  return JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -144,12 +144,7 @@ static bool JSVALUE_IS_CELL(EncodedJSValue val) __attribute__((__always_inline__
 static bool JSVALUE_IS_INT32(EncodedJSValue val) __attribute__((__always_inline__)); 
 static bool JSVALUE_IS_NUMBER(EncodedJSValue val) __attribute__((__always_inline__));
 
-// The engine's argument conversion for the type tagged `abiType` (one of the ABI_TYPE_* tags the
-// runtime defines when it compiles this file), i.e. what dlopen()'d symbols run for every argument.
-// The conversions below decode the common encodings inline and come here for the rest. Returns the
-// 64-bit argument slot, which the caller casts to the C type. A value the type does not accept
-// throws a TypeError and sets `*threw`; the generated wrapper then returns without calling the
-// native function.
+// The dlopen() argument conversion for the ABI_TYPE_* type `abiType`; when it throws, `*threw` is set and the wrapper must return.
 uint64_t JSVALUE_TO_SLOT_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
 static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 static int64_t  JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
@@ -331,8 +326,7 @@ static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* t
     return (uint64_t)JSVALUE_TO_TYPED_ARRAY_LENGTH(value);
   }
 
-  // BigInt, or not a number at all (undefined, null, a boolean, an object, ...): the slow path
-  // converts the former and throws for the latter.
+  // A BigInt, or not a number at all (the slow path throws for those).
   return JSVALUE_TO_SLOT_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -107,25 +107,19 @@ bun_core::comptime_string_map! {
 // ToCFormatter / ToJSFormatter. Indexed by `self as usize`.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// How a generated wrapper turns an argument's JSValue into the C parameter; the functions named
-/// here are defined in `FFI.h`.
+/// The `FFI.h` function a generated wrapper converts an argument with.
 enum ToC {
     /// Written out by [`ToCFormatter`] itself, or not an argument type.
     Special,
-    /// `f(arg)`: decodes the JSValue's bits and cannot fail.
+    /// `f(arg)`; cannot fail.
     Infallible(&'static str),
-    /// `f(JS_GLOBAL_OBJECT, ABI_TYPE_*, &threw, arg)`: decodes the common encodings inline and
-    /// hands everything else to the engine's converter (`JSVALUE_TO_SLOT_SLOW`), which throws for
-    /// values the type does not accept. The wrapper runs these conversions before the native call
-    /// and returns as soon as one of them threw.
+    /// `f(JS_GLOBAL_OBJECT, ABI_TYPE_*, &threw, arg)`; may throw via `JSVALUE_TO_SLOT_SLOW`.
     Fallible(&'static str),
 }
 
 struct AbiRow {
     c_type: &'static [u8],
-    /// `#define`d to the variant's discriminant, which is also the engine's tag for the type, when
-    /// a wrapper is compiled (`Function::compile`), so `FFI.h` and the generated code can name the
-    /// type they ask the engine's converter for.
+    /// `#define`d to the discriminant (also the engine's type tag) by `Function::compile`.
     tag_define: &'static str,
     to_c: ToC,
     to_js: Option<(&'static str, &'static str)>,
@@ -183,8 +177,7 @@ impl ABIType {
     /// See [`ABI_TYPE_LABEL`].
     pub(crate) const LABEL: &'static __ComptimeStringMap_ABI_TYPE_LABEL = &ABI_TYPE_LABEL;
 
-    /// The `ABI_TYPE_*` preprocessor definitions every generated wrapper is compiled with, one per
-    /// variant; see [`AbiRow::tag_define`].
+    /// One [`AbiRow::tag_define`] per variant, for `define_symbols`.
     pub(crate) fn tag_defines() -> [(&'static str, i64); ABI_TYPE_COUNT] {
         core::array::from_fn(|i| (ABI_TABLE[i].tag_define, i as i64))
     }

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -123,28 +123,28 @@ static ABI_TABLE: [AbiRow; 22] = {
         AbiRow { c_type, to_c_macro, to_js }
     }
     [
-    /* Char      */ r(b"char",       Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int8T     */ r(b"int8_t",     Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint8T    */ r(b"uint8_t",    Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int16T    */ r(b"int16_t",    Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint16T   */ r(b"uint16_t",   Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int32T    */ r(b"int32_t",    Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint32T   */ r(b"uint32_t",   Some("JSVALUE_TO_INT32("),               Some(("UINT32_TO_JSVALUE(", ")"))),
-    /* Int64T    */ r(b"int64_t",    Some("JSVALUE_TO_INT64("),               Some(("INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Uint64T   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),              Some(("UINT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Double    */ r(b"double",     Some("JSVALUE_TO_DOUBLE("),              Some(("DOUBLE_TO_JSVALUE(", ")"))),
-    /* Float     */ r(b"float",      Some("JSVALUE_TO_FLOAT("),               Some(("FLOAT_TO_JSVALUE(", ")"))),
-    /* Bool      */ r(b"bool",       Some("JSVALUE_TO_BOOL("),                Some(("BOOLEAN_TO_JSVALUE(", ")"))),
-    /* Ptr       */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
-    /* Void      */ r(b"void",       None,                                    None),
-    /* CString   */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
-    /* I64Fast   */ r(b"int64_t",    Some("JSVALUE_TO_INT64("),               Some(("INT64_TO_JSVALUE(JS_GLOBAL_OBJECT, (int64_t)", ")"))),
-    /* U64Fast   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),              Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
-    /* NapiEnv   */ r(b"napi_env",   None,                                    None),
-    /* NapiValue */ r(b"napi_value", None,                                    Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
-    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_TYPED_ARRAY_VECTOR("),  None),
-    /* BufferLen */ r(b"uint64_t",   None,                                    None),
+    /* Char      */ r(b"char",       Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int8T     */ r(b"int8_t",     Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint8T    */ r(b"uint8_t",    Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int16T    */ r(b"int16_t",    Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint16T   */ r(b"uint16_t",   Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int32T    */ r(b"int32_t",    Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint32T   */ r(b"uint32_t",   Some("JSVALUE_TO_INT32("),                                                   Some(("UINT32_TO_JSVALUE(", ")"))),
+    /* Int64T    */ r(b"int64_t",    Some("JSVALUE_TO_INT64(JS_GLOBAL_OBJECT, ABI_TYPE_INT64, &threw, "),         Some(("INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Uint64T   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64(JS_GLOBAL_OBJECT, ABI_TYPE_UINT64, &threw, "),       Some(("UINT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Double    */ r(b"double",     Some("JSVALUE_TO_DOUBLE("),                                                  Some(("DOUBLE_TO_JSVALUE(", ")"))),
+    /* Float     */ r(b"float",      Some("JSVALUE_TO_FLOAT("),                                                   Some(("FLOAT_TO_JSVALUE(", ")"))),
+    /* Bool      */ r(b"bool",       Some("JSVALUE_TO_BOOL("),                                                    Some(("BOOLEAN_TO_JSVALUE(", ")"))),
+    /* Ptr       */ r(b"void*",      Some("JSVALUE_TO_PTR("),                                                     Some(("PTR_TO_JSVALUE(", ")"))),
+    /* Void      */ r(b"void",       None,                                                                        None),
+    /* CString   */ r(b"void*",      Some("JSVALUE_TO_PTR("),                                                     Some(("PTR_TO_JSVALUE(", ")"))),
+    /* I64Fast   */ r(b"int64_t",    Some("JSVALUE_TO_INT64(JS_GLOBAL_OBJECT, ABI_TYPE_INT64_FAST, &threw, "),    Some(("INT64_TO_JSVALUE(JS_GLOBAL_OBJECT, (int64_t)", ")"))),
+    /* U64Fast   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64(JS_GLOBAL_OBJECT, ABI_TYPE_UINT64_FAST, &threw, "),  Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR("),                                                     Some(("PTR_TO_JSVALUE(", ")"))),
+    /* NapiEnv   */ r(b"napi_env",   None,                                                                        None),
+    /* NapiValue */ r(b"napi_value", None,                                                                        Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
+    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_TYPED_ARRAY_VECTOR("),                                      None),
+    /* BufferLen */ r(b"uint64_t",   None,                                                                        None),
     ]
 };
 
@@ -160,6 +160,17 @@ impl ABIType {
 
     /// See [`ABI_TYPE_LABEL`].
     pub(crate) const LABEL: &'static __ComptimeStringMap_ABI_TYPE_LABEL = &ABI_TYPE_LABEL;
+
+    /// Preprocessor definitions the generated wrappers (`Function::compile`) are compiled with:
+    /// the tags the `to_c` conversions in [`ABI_TABLE`] hand to `JSVALUE_TO_INT64_SLOW` (see
+    /// `FFI.h`), which passes them on to the engine's converter; the engine's type tags are these
+    /// same discriminants.
+    pub(crate) const TAG_DEFINES: &'static [(&'static str, i64)] = &[
+        ("ABI_TYPE_INT64", ABIType::Int64T as i64),
+        ("ABI_TYPE_UINT64", ABIType::Uint64T as i64),
+        ("ABI_TYPE_INT64_FAST", ABIType::I64Fast as i64),
+        ("ABI_TYPE_UINT64_FAST", ABIType::U64Fast as i64),
+    ];
 
     /// Returns `None` for out-of-range discriminants.
     #[inline]
@@ -207,6 +218,16 @@ impl ABIType {
 
     pub(crate) fn is_floating_point(self) -> bool {
         matches!(self, ABIType::Double | ABIType::Float)
+    }
+
+    /// Argument conversions that may throw (see `JSVALUE_TO_INT64_SLOW` in `FFI.h`). The
+    /// generated wrapper converts these into locals first and returns before the native call if
+    /// one of them threw.
+    pub(crate) fn arg_conversion_can_throw(self) -> bool {
+        matches!(
+            self,
+            ABIType::Int64T | ABIType::Uint64T | ABIType::I64Fast | ABIType::U64Fast
+        )
     }
 
     pub(crate) fn to_c(self, symbol: &[u8]) -> ToCFormatter<'_> {

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -107,44 +107,66 @@ bun_core::comptime_string_map! {
 // ToCFormatter / ToJSFormatter. Indexed by `self as usize`.
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// How a generated wrapper turns an argument's JSValue into the C parameter; the functions named
+/// here are defined in `FFI.h`.
+enum ToC {
+    /// Written out by [`ToCFormatter`] itself, or not an argument type.
+    Special,
+    /// `f(arg)`: decodes the JSValue's bits and cannot fail.
+    Infallible(&'static str),
+    /// `f(JS_GLOBAL_OBJECT, ABI_TYPE_*, &threw, arg)`: decodes the common encodings inline and
+    /// hands everything else to the engine's converter (`JSVALUE_TO_SLOT_SLOW`), which throws for
+    /// values the type does not accept. The wrapper runs these conversions before the native call
+    /// and returns as soon as one of them threw.
+    Fallible(&'static str),
+}
+
 struct AbiRow {
     c_type: &'static [u8],
-    to_c_macro: Option<&'static str>,
+    /// `#define`d to the variant's discriminant, which is also the engine's tag for the type, when
+    /// a wrapper is compiled (`Function::compile`), so `FFI.h` and the generated code can name the
+    /// type they ask the engine's converter for.
+    tag_define: &'static str,
+    to_c: ToC,
     to_js: Option<(&'static str, &'static str)>,
 }
 
+const ABI_TYPE_COUNT: usize = 22;
+
 #[rustfmt::skip]
-static ABI_TABLE: [AbiRow; 22] = {
+static ABI_TABLE: [AbiRow; ABI_TYPE_COUNT] = {
+    use ToC::*;
     const fn r(
         c_type: &'static [u8],
-        to_c_macro: Option<&'static str>,
+        tag_define: &'static str,
+        to_c: ToC,
         to_js: Option<(&'static str, &'static str)>,
     ) -> AbiRow {
-        AbiRow { c_type, to_c_macro, to_js }
+        AbiRow { c_type, tag_define, to_c, to_js }
     }
     [
-    /* Char      */ r(b"char",       Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int8T     */ r(b"int8_t",     Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint8T    */ r(b"uint8_t",    Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int16T    */ r(b"int16_t",    Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint16T   */ r(b"uint16_t",   Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int32T    */ r(b"int32_t",    Some("JSVALUE_TO_INT32("),                                                   Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint32T   */ r(b"uint32_t",   Some("JSVALUE_TO_INT32("),                                                   Some(("UINT32_TO_JSVALUE(", ")"))),
-    /* Int64T    */ r(b"int64_t",    Some("JSVALUE_TO_INT64(JS_GLOBAL_OBJECT, ABI_TYPE_INT64, &threw, "),         Some(("INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Uint64T   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64(JS_GLOBAL_OBJECT, ABI_TYPE_UINT64, &threw, "),       Some(("UINT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Double    */ r(b"double",     Some("JSVALUE_TO_DOUBLE("),                                                  Some(("DOUBLE_TO_JSVALUE(", ")"))),
-    /* Float     */ r(b"float",      Some("JSVALUE_TO_FLOAT("),                                                   Some(("FLOAT_TO_JSVALUE(", ")"))),
-    /* Bool      */ r(b"bool",       Some("JSVALUE_TO_BOOL("),                                                    Some(("BOOLEAN_TO_JSVALUE(", ")"))),
-    /* Ptr       */ r(b"void*",      Some("JSVALUE_TO_PTR("),                                                     Some(("PTR_TO_JSVALUE(", ")"))),
-    /* Void      */ r(b"void",       None,                                                                        None),
-    /* CString   */ r(b"void*",      Some("JSVALUE_TO_PTR("),                                                     Some(("PTR_TO_JSVALUE(", ")"))),
-    /* I64Fast   */ r(b"int64_t",    Some("JSVALUE_TO_INT64(JS_GLOBAL_OBJECT, ABI_TYPE_INT64_FAST, &threw, "),    Some(("INT64_TO_JSVALUE(JS_GLOBAL_OBJECT, (int64_t)", ")"))),
-    /* U64Fast   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64(JS_GLOBAL_OBJECT, ABI_TYPE_UINT64_FAST, &threw, "),  Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR("),                                                     Some(("PTR_TO_JSVALUE(", ")"))),
-    /* NapiEnv   */ r(b"napi_env",   None,                                                                        None),
-    /* NapiValue */ r(b"napi_value", None,                                                                        Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
-    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_TYPED_ARRAY_VECTOR("),                                      None),
-    /* BufferLen */ r(b"uint64_t",   None,                                                                        None),
+    /* Char      */ r(b"char",       "ABI_TYPE_CHAR",          Infallible("JSVALUE_TO_INT32"),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int8T     */ r(b"int8_t",     "ABI_TYPE_I8",            Infallible("JSVALUE_TO_INT32"),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint8T    */ r(b"uint8_t",    "ABI_TYPE_U8",            Infallible("JSVALUE_TO_INT32"),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int16T    */ r(b"int16_t",    "ABI_TYPE_I16",           Infallible("JSVALUE_TO_INT32"),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint16T   */ r(b"uint16_t",   "ABI_TYPE_U16",           Infallible("JSVALUE_TO_INT32"),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int32T    */ r(b"int32_t",    "ABI_TYPE_I32",           Infallible("JSVALUE_TO_INT32"),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint32T   */ r(b"uint32_t",   "ABI_TYPE_U32",           Infallible("JSVALUE_TO_INT32"),               Some(("UINT32_TO_JSVALUE(", ")"))),
+    /* Int64T    */ r(b"int64_t",    "ABI_TYPE_I64",           Fallible("JSVALUE_TO_INT64"),                 Some(("INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Uint64T   */ r(b"uint64_t",   "ABI_TYPE_U64",           Fallible("JSVALUE_TO_UINT64"),                Some(("UINT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Double    */ r(b"double",     "ABI_TYPE_F64",           Infallible("JSVALUE_TO_DOUBLE"),              Some(("DOUBLE_TO_JSVALUE(", ")"))),
+    /* Float     */ r(b"float",      "ABI_TYPE_F32",           Infallible("JSVALUE_TO_FLOAT"),               Some(("FLOAT_TO_JSVALUE(", ")"))),
+    /* Bool      */ r(b"bool",       "ABI_TYPE_BOOL",          Infallible("JSVALUE_TO_BOOL"),                Some(("BOOLEAN_TO_JSVALUE(", ")"))),
+    /* Ptr       */ r(b"void*",      "ABI_TYPE_PTR",           Infallible("JSVALUE_TO_PTR"),                 Some(("PTR_TO_JSVALUE(", ")"))),
+    /* Void      */ r(b"void",       "ABI_TYPE_VOID",          Special,                                      None),
+    /* CString   */ r(b"void*",      "ABI_TYPE_CSTRING",       Infallible("JSVALUE_TO_PTR"),                 Some(("PTR_TO_JSVALUE(", ")"))),
+    /* I64Fast   */ r(b"int64_t",    "ABI_TYPE_I64_FAST",      Fallible("JSVALUE_TO_INT64"),                 Some(("INT64_TO_JSVALUE(JS_GLOBAL_OBJECT, (int64_t)", ")"))),
+    /* U64Fast   */ r(b"uint64_t",   "ABI_TYPE_U64_FAST",      Fallible("JSVALUE_TO_UINT64"),                Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Function  */ r(b"void*",      "ABI_TYPE_FUNCTION",      Infallible("JSVALUE_TO_PTR"),                 Some(("PTR_TO_JSVALUE(", ")"))),
+    /* NapiEnv   */ r(b"napi_env",   "ABI_TYPE_NAPI_ENV",      Special,                                      None),
+    /* NapiValue */ r(b"napi_value", "ABI_TYPE_NAPI_VALUE",    Special,                                      Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
+    /* Buffer    */ r(b"void*",      "ABI_TYPE_BUFFER",        Infallible("JSVALUE_TO_TYPED_ARRAY_VECTOR"),  None),
+    /* BufferLen */ r(b"uint64_t",   "ABI_TYPE_BUFFER_LENGTH", Special,                                      None),
     ]
 };
 
@@ -161,16 +183,11 @@ impl ABIType {
     /// See [`ABI_TYPE_LABEL`].
     pub(crate) const LABEL: &'static __ComptimeStringMap_ABI_TYPE_LABEL = &ABI_TYPE_LABEL;
 
-    /// Preprocessor definitions the generated wrappers (`Function::compile`) are compiled with:
-    /// the tags the `to_c` conversions in [`ABI_TABLE`] hand to `JSVALUE_TO_INT64_SLOW` (see
-    /// `FFI.h`), which passes them on to the engine's converter; the engine's type tags are these
-    /// same discriminants.
-    pub(crate) const TAG_DEFINES: &'static [(&'static str, i64)] = &[
-        ("ABI_TYPE_INT64", ABIType::Int64T as i64),
-        ("ABI_TYPE_UINT64", ABIType::Uint64T as i64),
-        ("ABI_TYPE_INT64_FAST", ABIType::I64Fast as i64),
-        ("ABI_TYPE_UINT64_FAST", ABIType::U64Fast as i64),
-    ];
+    /// The `ABI_TYPE_*` preprocessor definitions every generated wrapper is compiled with, one per
+    /// variant; see [`AbiRow::tag_define`].
+    pub(crate) fn tag_defines() -> [(&'static str, i64); ABI_TYPE_COUNT] {
+        core::array::from_fn(|i| (ABI_TABLE[i].tag_define, i as i64))
+    }
 
     /// Returns `None` for out-of-range discriminants.
     #[inline]
@@ -220,14 +237,9 @@ impl ABIType {
         matches!(self, ABIType::Double | ABIType::Float)
     }
 
-    /// Argument conversions that may throw (see `JSVALUE_TO_INT64_SLOW` in `FFI.h`). The
-    /// generated wrapper converts these into locals first and returns before the native call if
-    /// one of them threw.
+    /// See [`ToC::Fallible`].
     pub(crate) fn arg_conversion_can_throw(self) -> bool {
-        matches!(
-            self,
-            ABIType::Int64T | ABIType::Uint64T | ABIType::I64Fast | ABIType::U64Fast
-        )
+        matches!(self.row().to_c, ToC::Fallible(_))
     }
 
     pub(crate) fn to_c(self, symbol: &[u8]) -> ToCFormatter<'_> {
@@ -264,17 +276,21 @@ pub struct ToCFormatter<'a> {
 impl fmt::Display for ToCFormatter<'_> {
     fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
         let row = self.tag.row();
-        let Some(macro_) = row.to_c_macro else {
-            return match self.tag {
+        let symbol = BStr::new(self.symbol);
+        match row.to_c {
+            ToC::Infallible(function) => write!(writer, "{function}({symbol})"),
+            ToC::Fallible(function) => write!(
+                writer,
+                "{function}(JS_GLOBAL_OBJECT, {}, &threw, {symbol})",
+                row.tag_define
+            ),
+            ToC::Special => match self.tag {
                 ABIType::Void => Ok(()),
                 ABIType::NapiEnv => writer.write_str("((napi_env)&Bun__thisFFIModuleNapiEnv)"),
-                ABIType::NapiValue => write!(writer, "{}.asNapiValue", BStr::new(self.symbol)),
+                ABIType::NapiValue => write!(writer, "{symbol}.asNapiValue"),
                 _ => unreachable!(),
-            };
-        };
-        writer.write_str(macro_)?;
-        fmt::Display::fmt(BStr::new(self.symbol), writer)?;
-        writer.write_str(")")
+            },
+        }
     }
 }
 

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -153,16 +153,16 @@ fn create_jsc_ffi_function(
 mod exposed_to_ffi {
     use super::{JSGlobalObject, JSValue};
     unsafe extern "C" {
-        /// `JSCFFIBridge.cpp`: converts an `i64`/`u64`/`i64_fast`/`u64_fast` argument the inline
-        /// paths in `FFI.h` don't handle (BigInts, and non-numbers, which throw) with the same
-        /// conversion dlopen()'d symbols use.
-        #[link_name = "Bun__FFI__jsValueToInt64Slow"]
-        pub(super) fn JSVALUE_TO_INT64_SLOW(
+        /// `JSCFFIBridge.cpp`: the engine's conversion (the one dlopen()'d symbols use) for an
+        /// argument of type `abi_type`; the `ToC::Fallible` conversions in `FFI.h` call it for the
+        /// values they don't decode inline.
+        #[link_name = "Bun__FFI__jsValueToSlotSlow"]
+        pub(super) fn JSVALUE_TO_SLOT_SLOW(
             global: *mut JSGlobalObject,
             abi_type: i32,
             threw: *mut bool,
             value: JSValue,
-        ) -> i64;
+        ) -> u64;
         #[link_name = "JSC__JSValue__fromInt64NoTruncate"]
         pub(super) fn INT64_TO_JSVALUE(global: *mut JSGlobalObject, i: i64) -> JSValue;
         #[link_name = "JSC__JSValue__fromUInt64NoTruncate"]
@@ -2070,7 +2070,7 @@ impl Function {
         CompilerRT::define(state);
         // Only the wrapper is compiled with these; the user's own C (`CompileC::compile`) must not
         // see them.
-        state.define_symbols(ABIType::TAG_DEFINES);
+        state.define_symbols(&ABIType::tag_defines());
 
         // SAFETY: source_code was NUL-terminated above
         if state
@@ -2633,8 +2633,8 @@ impl CompilerRT {
 
         state
             .add_symbol(
-                zstr!("JSVALUE_TO_INT64_SLOW"),
-                exposed_to_ffi::JSVALUE_TO_INT64_SLOW as *const c_void,
+                zstr!("JSVALUE_TO_SLOT_SLOW"),
+                exposed_to_ffi::JSVALUE_TO_SLOT_SLOW as *const c_void,
             )
             .expect("unreachable");
         state

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -153,9 +153,7 @@ fn create_jsc_ffi_function(
 mod exposed_to_ffi {
     use super::{JSGlobalObject, JSValue};
     unsafe extern "C" {
-        /// `JSCFFIBridge.cpp`: the engine's conversion (the one dlopen()'d symbols use) for an
-        /// argument of type `abi_type`; the `ToC::Fallible` conversions in `FFI.h` call it for the
-        /// values they don't decode inline.
+        /// `JSCFFIBridge.cpp`; what the `ToC::Fallible` conversions in `FFI.h` fall back to.
         #[link_name = "Bun__FFI__jsValueToSlotSlow"]
         pub(super) fn JSVALUE_TO_SLOT_SLOW(
             global: *mut JSGlobalObject,
@@ -2068,8 +2066,7 @@ impl Function {
         }
 
         CompilerRT::define(state);
-        // Only the wrapper is compiled with these; the user's own C (`CompileC::compile`) must not
-        // see them.
+        // Wrapper-only: the user's C (`CompileC::compile`) is compiled without these.
         state.define_symbols(&ABIType::tag_defines());
 
         // SAFETY: source_code was NUL-terminated above
@@ -2200,8 +2197,7 @@ impl Function {
         let mut arg_buf = [0u8; 512];
         arg_buf[0..3].copy_from_slice(b"arg");
 
-        // Conversions that can throw come first: once one of them has thrown, the native function
-        // must not be entered and no handle scope may have been opened.
+        // Converted first: a throw has to return before the native call and the handle scope.
         let mut declared_threw = false;
         for (i, arg) in self.arg_types.iter().enumerate() {
             if !arg.arg_conversion_can_throw() {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -153,10 +153,16 @@ fn create_jsc_ffi_function(
 mod exposed_to_ffi {
     use super::{JSGlobalObject, JSValue};
     unsafe extern "C" {
-        #[link_name = "JSC__JSValue__toInt64"]
-        pub(super) fn JSVALUE_TO_INT64(value: JSValue) -> i64;
-        #[link_name = "JSC__JSValue__toUInt64NoTruncate"]
-        pub(super) fn JSVALUE_TO_UINT64(value: JSValue) -> u64;
+        /// `JSCFFIBridge.cpp`: converts an `i64`/`u64`/`i64_fast`/`u64_fast` argument the inline
+        /// paths in `FFI.h` don't handle (BigInts, and non-numbers, which throw) with the same
+        /// conversion dlopen()'d symbols use.
+        #[link_name = "Bun__FFI__jsValueToInt64Slow"]
+        pub(super) fn JSVALUE_TO_INT64_SLOW(
+            global: *mut JSGlobalObject,
+            abi_type: i32,
+            threw: *mut bool,
+            value: JSValue,
+        ) -> i64;
         #[link_name = "JSC__JSValue__fromInt64NoTruncate"]
         pub(super) fn INT64_TO_JSVALUE(global: *mut JSGlobalObject, i: i64) -> JSValue;
         #[link_name = "JSC__JSValue__fromUInt64NoTruncate"]
@@ -2062,6 +2068,9 @@ impl Function {
         }
 
         CompilerRT::define(state);
+        // Only the wrapper is compiled with these; the user's own C (`CompileC::compile`) must not
+        // see them.
+        state.define_symbols(ABIType::TAG_DEFINES);
 
         // SAFETY: source_code was NUL-terminated above
         if state
@@ -2145,12 +2154,6 @@ impl Function {
               ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {\n",
         )?;
 
-        if self.needs_handle_scope() {
-            writer.write_all(
-                b"  void* handleScope = NapiHandleScope__open(&Bun__thisFFIModuleNapiEnv, false);\n",
-            )?;
-        }
-
         if !self.arg_types.is_empty() {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {
@@ -2195,6 +2198,36 @@ impl Function {
         // );
 
         let mut arg_buf = [0u8; 512];
+        arg_buf[0..3].copy_from_slice(b"arg");
+
+        // Conversions that can throw come first: once one of them has thrown, the native function
+        // must not be entered and no handle scope may have been opened.
+        let mut declared_threw = false;
+        for (i, arg) in self.arg_types.iter().enumerate() {
+            if !arg.arg_conversion_can_throw() {
+                continue;
+            }
+            if !declared_threw {
+                declared_threw = true;
+                writer.write_all(b"  bool threw = false;\n")?;
+            }
+            let length_buf = bun_core::fmt::print_int(&mut arg_buf[3..], i);
+            let arg_name = &arg_buf[0..3 + length_buf];
+            writer.write_all(b"  ")?;
+            arg.param_typename(writer)?;
+            write!(
+                writer,
+                " converted{} = {};\n  if (threw) return ValueEmpty.asZigRepr;\n",
+                i,
+                arg.to_c(arg_name)
+            )?;
+        }
+
+        if self.needs_handle_scope() {
+            writer.write_all(
+                b"  void* handleScope = NapiHandleScope__open(&Bun__thisFFIModuleNapiEnv, false);\n",
+            )?;
+        }
 
         writer.write_all(b"    ")?;
         if self.return_type != ABIType::Void {
@@ -2203,7 +2236,6 @@ impl Function {
         }
         write!(writer, "{}(", BStr::new(self.base_name.as_bytes()))?;
         first = true;
-        arg_buf[0..3].copy_from_slice(b"arg");
         for (i, arg) in self.arg_types.iter().enumerate() {
             if !first {
                 writer.write_all(b", ")?;
@@ -2213,7 +2245,9 @@ impl Function {
 
             let length_buf = bun_core::fmt::print_int(&mut arg_buf[3..], i);
             let arg_name = &arg_buf[0..3 + length_buf];
-            if arg.needs_a_cast_in_c() {
+            if arg.arg_conversion_can_throw() {
+                write!(writer, "converted{}", i)?;
+            } else if arg.needs_a_cast_in_c() {
                 write!(writer, "{}", arg.to_c(arg_name))?;
             } else {
                 writer.write_all(arg_name)?;
@@ -2600,13 +2634,7 @@ impl CompilerRT {
         state
             .add_symbol(
                 zstr!("JSVALUE_TO_INT64_SLOW"),
-                WORKAROUND.jsvalue_to_int64 as *const c_void,
-            )
-            .expect("unreachable");
-        state
-            .add_symbol(
-                zstr!("JSVALUE_TO_UINT64_SLOW"),
-                WORKAROUND.jsvalue_to_uint64 as *const c_void,
+                exposed_to_ffi::JSVALUE_TO_INT64_SLOW as *const c_void,
             )
             .expect("unreachable");
         state
@@ -2625,15 +2653,11 @@ impl CompilerRT {
 }
 
 struct MyFunctionSStructWorkAround {
-    jsvalue_to_int64: unsafe extern "C" fn(JSValue) -> i64,
-    jsvalue_to_uint64: unsafe extern "C" fn(JSValue) -> u64,
     int64_to_jsvalue: unsafe extern "C" fn(*mut JSGlobalObject, i64) -> JSValue,
     uint64_to_jsvalue: unsafe extern "C" fn(*mut JSGlobalObject, u64) -> JSValue,
 }
 
 static WORKAROUND: MyFunctionSStructWorkAround = MyFunctionSStructWorkAround {
-    jsvalue_to_int64: exposed_to_ffi::JSVALUE_TO_INT64,
-    jsvalue_to_uint64: exposed_to_ffi::JSVALUE_TO_UINT64,
     int64_to_jsvalue: exposed_to_ffi::INT64_TO_JSVALUE,
     uint64_to_jsvalue: exposed_to_ffi::UINT64_TO_JSVALUE,
 };

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1090,12 +1090,17 @@ describe("double <-> JSValue conversions", () => {
 describe.concurrent("64-bit integer arguments (i64, u64, i64_fast, u64_fast)", () => {
   const cannotConvert = (type: string) => `TypeError: bun:ffi cannot convert argument to '${type}'`;
 
-  // The wrapper cc() compiles decodes numbers inline and hands everything else to a slow path that
-  // used to assume it was given a BigInt: any other value (undefined, null, an object, ...) hit an
-  // assertion in debug builds and reached C as INT64_MIN / 0 in release builds. The slow path is
-  // now the engine's conversion, the one dlopen()/CFunction symbols use, so the fixture runs one
-  // input matrix through a cc() wrapper and through a CFunction over the very same C functions and
-  // the two tables must agree. Runs in a subprocess because the unfixed debug build aborts.
+  // The wrapper cc() compiles decodes int32-tagged and double-encoded numbers inline and hands
+  // everything else to a slow path that used to assume it was given a BigInt: any other value
+  // (undefined, null, an object, ...) hit an assertion in debug builds and reached C as INT64_MIN
+  // or 0 in release builds. The slow path is now the engine's conversion, the one dlopen() and
+  // CFunction symbols use for every argument, so the fixture runs one input matrix through a cc()
+  // wrapper and through a CFunction over the very same C functions and the two tables must agree.
+  // The matrix covers what reaches the slow path (BigInts and non-numbers) plus one input per
+  // inline branch; the inline branches themselves are not under test here, and for u64 the
+  // double-encoded branch is known to differ from the engine for negative and non-finite numbers
+  // (tracked separately), which is why no such input is in the matrix. Runs in a subprocess
+  // because the unfixed debug build aborts.
   it("accepts what dlopen accepts and throws a TypeError for the rest", async () => {
     using dir = tempDir("bun-ffi-cc-int64-args", {
       "int64.c": /* c */ `
@@ -1105,14 +1110,18 @@ describe.concurrent("64-bit integer arguments (i64, u64, i64_fast, u64_fast)", (
         unsigned long long echo_u64_fast(unsigned long long x) { return x; }
 
         static int native_calls = 0;
-        long long add_i64(long long a, long long b) { native_calls++; return a + b; }
+        /* Two 64-bit parameters of different types: the TypeError names the one that was rejected. */
+        long long add_i64_u64(long long a, unsigned long long b) { native_calls++; return a + (long long)b; }
+        /* A 64-bit parameter between two parameters that are converted inline. */
+        double mixed(int a, long long b, double c) { native_calls++; return a * 1000000 + b * 1000 + c; }
         int take_native_calls(void) { int calls = native_calls; native_calls = 0; return calls; }
 
         void* address_of_echo_i64(void) { return (void*)&echo_i64; }
         void* address_of_echo_u64(void) { return (void*)&echo_u64; }
         void* address_of_echo_i64_fast(void) { return (void*)&echo_i64_fast; }
         void* address_of_echo_u64_fast(void) { return (void*)&echo_u64_fast; }
-        void* address_of_add_i64(void) { return (void*)&add_i64; }
+        void* address_of_add_i64_u64(void) { return (void*)&add_i64_u64; }
+        void* address_of_mixed(void) { return (void*)&mixed; }
       `,
       "fixture.js": /* js */ `
         import { cc, CFunction } from "bun:ffi";
@@ -1125,7 +1134,8 @@ describe.concurrent("64-bit integer arguments (i64, u64, i64_fast, u64_fast)", (
           echo_u64: { args: ["u64"], returns: "u64" },
           echo_i64_fast: { args: ["i64_fast"], returns: "i64" },
           echo_u64_fast: { args: ["u64_fast"], returns: "u64" },
-          add_i64: { args: ["i64", "i64"], returns: "i64" },
+          add_i64_u64: { args: ["i64", "u64"], returns: "i64" },
+          mixed: { args: ["i32", "i64", "f64"], returns: "f64" },
         };
         const { symbols: compiled } = cc({
           source: path.join(import.meta.dir, "int64.c"),
@@ -1175,13 +1185,19 @@ describe.concurrent("64-bit integer arguments (i64, u64, i64_fast, u64_fast)", (
             for (const label in inputs) table[name][label] = outcome(symbols[name], inputs[label]);
           }
           compiled.take_native_calls();
-          table.add_i64 = {
-            both_valid: outcome(symbols.add_i64, 1, 2),
-            second_invalid: outcome(symbols.add_i64, 1, undefined),
-            first_invalid: outcome(symbols.add_i64, {}, 2),
-            valid_after_invalid: outcome(symbols.add_i64, 3, 4n),
-            native_calls: compiled.take_native_calls(),
+          table.add_i64_u64 = {
+            both_valid: outcome(symbols.add_i64_u64, 1, 2),
+            first_invalid: outcome(symbols.add_i64_u64, {}, 2),
+            second_invalid: outcome(symbols.add_i64_u64, 1, undefined),
+            both_invalid: outcome(symbols.add_i64_u64, undefined, undefined),
+            valid_after_invalid: outcome(symbols.add_i64_u64, 3, 4n),
           };
+          table.mixed = {
+            valid: outcome(symbols.mixed, 1, 2, 0.5),
+            bigint: outcome(symbols.mixed, 1, -2n, 0.5),
+            invalid: outcome(symbols.mixed, 1, null, 0.5),
+          };
+          table.native_calls = compiled.take_native_calls();
           return table;
         }
 
@@ -1219,14 +1235,22 @@ describe.concurrent("64-bit integer arguments (i64, u64, i64_fast, u64_fast)", (
       echo_u64: echo("u64", false),
       echo_i64_fast: echo("i64_fast", true),
       echo_u64_fast: echo("u64_fast", false),
-      add_i64: {
+      add_i64_u64: {
         both_valid: "3",
-        second_invalid: cannotConvert("i64"),
         first_invalid: cannotConvert("i64"),
+        second_invalid: cannotConvert("u64"),
+        // Arguments are converted left to right, so the first rejected one is the one reported.
+        both_invalid: cannotConvert("i64"),
         valid_after_invalid: "7",
-        // A rejected argument stops the call before C is entered: only the two valid calls ran.
-        native_calls: 2,
       },
+      mixed: {
+        valid: "1002000.5",
+        bigint: "998000.5",
+        invalid: cannotConvert("i64"),
+      },
+      // A rejected argument stops the call before C is entered: only the four valid multi-argument
+      // calls above reached the native functions.
+      native_calls: 4,
     };
 
     // On a crash there is no JSON; report the process output instead so the failure shows it.

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1087,6 +1087,231 @@ describe("double <-> JSValue conversions", () => {
   });
 });
 
+describe.concurrent("64-bit integer arguments (i64, u64, i64_fast, u64_fast)", () => {
+  const cannotConvert = (type: string) => `TypeError: bun:ffi cannot convert argument to '${type}'`;
+
+  // The wrapper cc() compiles decodes numbers inline and hands everything else to a slow path that
+  // used to assume it was given a BigInt: any other value (undefined, null, an object, ...) hit an
+  // assertion in debug builds and reached C as INT64_MIN / 0 in release builds. The slow path is
+  // now the engine's conversion, the one dlopen()/CFunction symbols use, so the fixture runs one
+  // input matrix through a cc() wrapper and through a CFunction over the very same C functions and
+  // the two tables must agree. Runs in a subprocess because the unfixed debug build aborts.
+  it("accepts what dlopen accepts and throws a TypeError for the rest", async () => {
+    using dir = tempDir("bun-ffi-cc-int64-args", {
+      "int64.c": /* c */ `
+        long long echo_i64(long long x) { return x; }
+        unsigned long long echo_u64(unsigned long long x) { return x; }
+        long long echo_i64_fast(long long x) { return x; }
+        unsigned long long echo_u64_fast(unsigned long long x) { return x; }
+
+        static int native_calls = 0;
+        long long add_i64(long long a, long long b) { native_calls++; return a + b; }
+        int take_native_calls(void) { int calls = native_calls; native_calls = 0; return calls; }
+
+        void* address_of_echo_i64(void) { return (void*)&echo_i64; }
+        void* address_of_echo_u64(void) { return (void*)&echo_u64; }
+        void* address_of_echo_i64_fast(void) { return (void*)&echo_i64_fast; }
+        void* address_of_echo_u64_fast(void) { return (void*)&echo_u64_fast; }
+        void* address_of_add_i64(void) { return (void*)&add_i64; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, CFunction } from "bun:ffi";
+        import path from "path";
+
+        // Returns are declared as i64/u64 throughout (exact BigInts), so only the argument
+        // conversion under test differs between the four echo functions.
+        const signatures = {
+          echo_i64: { args: ["i64"], returns: "i64" },
+          echo_u64: { args: ["u64"], returns: "u64" },
+          echo_i64_fast: { args: ["i64_fast"], returns: "i64" },
+          echo_u64_fast: { args: ["u64_fast"], returns: "u64" },
+          add_i64: { args: ["i64", "i64"], returns: "i64" },
+        };
+        const { symbols: compiled } = cc({
+          source: path.join(import.meta.dir, "int64.c"),
+          symbols: {
+            ...signatures,
+            take_native_calls: { args: [], returns: "i32" },
+            ...Object.fromEntries(Object.keys(signatures).map(name => ["address_of_" + name, { args: [], returns: "ptr" }])),
+          },
+        });
+        // The same C functions behind the engine's (dlopen-style) argument conversion.
+        const engine = Object.fromEntries(
+          Object.entries(signatures).map(([name, signature]) => [
+            name,
+            new CFunction({ ...signature, ptr: compiled["address_of_" + name]() }),
+          ]),
+        );
+
+        const inputs = {
+          int32: 7,
+          negative_int32: -7,
+          double: 2 ** 40,
+          bigint: 5n,
+          negative_bigint: -5n,
+          bigint_2_pow_63: 2n ** 63n,
+          undefined: undefined,
+          null: null,
+          boolean: true,
+          plain_object: {},
+          object_with_valueOf: { valueOf: () => 7 },
+          string: "7",
+          array: [7],
+          view: new Uint8Array(3),
+        };
+
+        function outcome(fn, ...args) {
+          try {
+            return String(fn(...args));
+          } catch (error) {
+            return error.name + ": " + error.message;
+          }
+        }
+
+        function run(symbols) {
+          const table = {};
+          for (const name of ["echo_i64", "echo_u64", "echo_i64_fast", "echo_u64_fast"]) {
+            table[name] = {};
+            for (const label in inputs) table[name][label] = outcome(symbols[name], inputs[label]);
+          }
+          compiled.take_native_calls();
+          table.add_i64 = {
+            both_valid: outcome(symbols.add_i64, 1, 2),
+            second_invalid: outcome(symbols.add_i64, 1, undefined),
+            first_invalid: outcome(symbols.add_i64, {}, 2),
+            valid_after_invalid: outcome(symbols.add_i64, 3, 4n),
+            native_calls: compiled.take_native_calls(),
+          };
+          return table;
+        }
+
+        console.log(JSON.stringify({ cc: run(compiled), engine: run(engine) }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const echo = (type: string, signed: boolean) => ({
+      int32: "7",
+      negative_int32: signed ? "-7" : "18446744073709551609",
+      double: "1099511627776",
+      bigint: "5",
+      negative_bigint: signed ? "-5" : "18446744073709551611",
+      bigint_2_pow_63: signed ? "-9223372036854775808" : "9223372036854775808",
+      undefined: cannotConvert(type),
+      null: cannotConvert(type),
+      boolean: cannotConvert(type),
+      plain_object: cannotConvert(type),
+      object_with_valueOf: cannotConvert(type),
+      string: cannotConvert(type),
+      array: cannotConvert(type),
+      view: cannotConvert(type),
+    });
+    const expected = {
+      echo_i64: echo("i64", true),
+      echo_u64: echo("u64", false),
+      echo_i64_fast: echo("i64_fast", true),
+      echo_u64_fast: echo("u64_fast", false),
+      add_i64: {
+        both_valid: "3",
+        second_invalid: cannotConvert("i64"),
+        first_invalid: cannotConvert("i64"),
+        valid_after_invalid: "7",
+        // A rejected argument stops the call before C is entered: only the two valid calls ran.
+        native_calls: 2,
+      },
+    };
+
+    // On a crash there is no JSON; report the process output instead so the failure shows it.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : { stdout, stderr };
+    expect({ results, exitCode }).toEqual({
+      results: {
+        cc: {
+          ...expected,
+          // Pre-existing cc()-only shortcut, unrelated to the slow path: a TypedArray given to an
+          // unsigned 64-bit parameter is converted inline to its length.
+          echo_u64: { ...expected.echo_u64, view: "3" },
+          echo_u64_fast: { ...expected.echo_u64_fast, view: "3" },
+        },
+        engine: expected,
+      },
+      exitCode: 0,
+    });
+  });
+
+  // napi_env wrappers open a handle scope around the native call; a rejected argument has to bail
+  // out before that happens and leave later calls working. cc()-compiled C only exercises napi on
+  // POSIX today (see the napi_create_double test above).
+  it.skipIf(isWindows)("a rejected argument bails out of a napi_env wrapper too", async () => {
+    using dir = tempDir("bun-ffi-cc-int64-args-napi", {
+      "napi_int64.c": /* c */ `
+        typedef struct napi_env_fake* napi_env_t;
+        static int native_calls = 0;
+        long long with_env(napi_env_t env, long long x) { native_calls++; return env != 0 ? x : -1; }
+        int get_native_calls(void) { return native_calls; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "napi_int64.c"),
+          symbols: {
+            with_env: { args: ["napi_env", "i64"], returns: "i64" },
+            get_native_calls: { args: [], returns: "i32" },
+          },
+        });
+
+        function outcome(fn, ...args) {
+          try {
+            return String(fn(...args));
+          } catch (error) {
+            return error.name + ": " + error.message;
+          }
+        }
+
+        // The napi_env position is filled in by the wrapper; the JS argument there is ignored.
+        const results = {
+          rejected: outcome(symbols.with_env, null, {}),
+          calls_after_rejection: symbols.get_native_calls(),
+          number: outcome(symbols.with_env, null, 42),
+          bigint: outcome(symbols.with_env, null, -2n),
+          calls_at_end: symbols.get_native_calls(),
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : { stdout, stderr };
+    expect({ results, exitCode }).toEqual({
+      results: {
+        rejected: cannotConvert("i64"),
+        calls_after_rejection: 0,
+        number: "42",
+        bigint: "-2",
+        calls_at_end: 2,
+      },
+      exitCode: 0,
+    });
+  });
+});
+
 describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", () => {
   const plantedHeader = "#define bool int\n#define true 100\n#define false 0\n";
   const files = {

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -146,12 +146,13 @@ static bool JSVALUE_IS_CELL(EncodedJSValue val) __attribute__((__always_inline__
 static bool JSVALUE_IS_INT32(EncodedJSValue val) __attribute__((__always_inline__)); 
 static bool JSVALUE_IS_NUMBER(EncodedJSValue val) __attribute__((__always_inline__));
 
-// The engine's 64-bit integer argument conversion, shared with dlopen()'d symbols; it serves both
-// signednesses (an unsigned result is the same 64 bits). `abiType` is one of the ABI_TYPE_* tags
-// the runtime defines when it compiles this file. Throws a TypeError for values that are neither a
-// number nor a BigInt and sets `*threw`, in which case the generated wrapper returns without
-// calling the native function.
-int64_t JSVALUE_TO_INT64_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
+// The engine's argument conversion for the type tagged `abiType` (one of the ABI_TYPE_* tags the
+// runtime defines when it compiles this file), i.e. what dlopen()'d symbols run for every argument.
+// The conversions below decode the common encodings inline and come here for the rest. Returns the
+// 64-bit argument slot, which the caller casts to the C type. A value the type does not accept
+// throws a TypeError and sets `*threw`; the generated wrapper then returns without calling the
+// native function.
+uint64_t JSVALUE_TO_SLOT_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
 static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 static int64_t  JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 
@@ -334,7 +335,7 @@ static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* t
 
   // BigInt, or not a number at all (undefined, null, a boolean, an object, ...): the slow path
   // converts the former and throws for the latter.
-  return (uint64_t)JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
+  return JSVALUE_TO_SLOT_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
@@ -345,7 +346,7 @@ static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* thr
     return (int64_t)JSVALUE_TO_DOUBLE(value);
   }
 
-  return JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
+  return (int64_t)JSVALUE_TO_SLOT_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -146,12 +146,7 @@ static bool JSVALUE_IS_CELL(EncodedJSValue val) __attribute__((__always_inline__
 static bool JSVALUE_IS_INT32(EncodedJSValue val) __attribute__((__always_inline__)); 
 static bool JSVALUE_IS_NUMBER(EncodedJSValue val) __attribute__((__always_inline__));
 
-// The engine's argument conversion for the type tagged `abiType` (one of the ABI_TYPE_* tags the
-// runtime defines when it compiles this file), i.e. what dlopen()'d symbols run for every argument.
-// The conversions below decode the common encodings inline and come here for the rest. Returns the
-// 64-bit argument slot, which the caller casts to the C type. A value the type does not accept
-// throws a TypeError and sets `*threw`; the generated wrapper then returns without calling the
-// native function.
+// The dlopen() argument conversion for the ABI_TYPE_* type `abiType`; when it throws, `*threw` is set and the wrapper must return.
 uint64_t JSVALUE_TO_SLOT_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
 static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 static int64_t  JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
@@ -333,8 +328,7 @@ static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* t
     return (uint64_t)JSVALUE_TO_TYPED_ARRAY_LENGTH(value);
   }
 
-  // BigInt, or not a number at all (undefined, null, a boolean, an object, ...): the slow path
-  // converts the former and throws for the latter.
+  // A BigInt, or not a number at all (the slow path throws for those).
   return JSVALUE_TO_SLOT_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -127,6 +127,8 @@ napi_value asNapiValue;
 
 EncodedJSValue ValueUndefined = { TagValueUndefined };
 EncodedJSValue ValueTrue = { TagValueTrue };
+// What a host function returns after throwing; JSC unwinds to the pending exception and ignores it.
+EncodedJSValue ValueEmpty = { 0 };
 
 typedef void* JSContext;
 
@@ -144,10 +146,14 @@ static bool JSVALUE_IS_CELL(EncodedJSValue val) __attribute__((__always_inline__
 static bool JSVALUE_IS_INT32(EncodedJSValue val) __attribute__((__always_inline__)); 
 static bool JSVALUE_IS_NUMBER(EncodedJSValue val) __attribute__((__always_inline__));
 
-static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) __attribute__((__always_inline__));
-static int64_t  JSVALUE_TO_INT64(EncodedJSValue value) __attribute__((__always_inline__));
-uint64_t JSVALUE_TO_UINT64_SLOW(EncodedJSValue value);
-int64_t  JSVALUE_TO_INT64_SLOW(EncodedJSValue value);
+// The engine's 64-bit integer argument conversion, shared with dlopen()'d symbols; it serves both
+// signednesses (an unsigned result is the same 64 bits). `abiType` is one of the ABI_TYPE_* tags
+// the runtime defines when it compiles this file. Throws a TypeError for values that are neither a
+// number nor a BigInt and sets `*threw`, in which case the generated wrapper returns without
+// calling the native function.
+int64_t JSVALUE_TO_INT64_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t value);
+static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
+static int64_t  JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) __attribute__((__always_inline__));
 
 EncodedJSValue UINT64_TO_JSVALUE_SLOW(void* jsGlobalObject, uint64_t val);
 EncodedJSValue INT64_TO_JSVALUE_SLOW(void* jsGlobalObject, int64_t val);
@@ -313,7 +319,7 @@ static bool JSVALUE_TO_BOOL(EncodedJSValue val) {
 }
 
 
-static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) {
+static uint64_t JSVALUE_TO_UINT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
     return (uint64_t)JSVALUE_TO_INT32(value);
   }
@@ -326,9 +332,11 @@ static uint64_t JSVALUE_TO_UINT64(EncodedJSValue value) {
     return (uint64_t)JSVALUE_TO_TYPED_ARRAY_LENGTH(value);
   }
 
-  return JSVALUE_TO_UINT64_SLOW(value);
+  // BigInt, or not a number at all (undefined, null, a boolean, an object, ...): the slow path
+  // converts the former and throws for the latter.
+  return (uint64_t)JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
-static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
+static int64_t JSVALUE_TO_INT64(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue value) {
   if (JSVALUE_IS_INT32(value)) {
     return (int64_t)JSVALUE_TO_INT32(value);
   }
@@ -337,7 +345,7 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
     return (int64_t)JSVALUE_TO_DOUBLE(value);
   }
 
-  return JSVALUE_TO_INT64_SLOW(value);
+  return JSVALUE_TO_INT64_SLOW(jsGlobalObject, abiType, threw, value.asInt64);
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {


### PR DESCRIPTION
### Problem

- A symbol compiled with `cc()` that declares an `i64`, `u64`, `i64_fast` or `u64_fast` argument and is given something that is neither a number nor a BigInt (`undefined`, `null`, a boolean, an object, a string) aborts debug builds with `ASSERTION FAILED: value.isHeapBigInt() || value.isNumber()` in `JSC__JSValue__toInt64` (`src/jsc/bindings/bindings.cpp:4366`); release builds hand the C function `INT64_MIN` (signed types) or `0` (unsigned types).
- Cause: the wrapper `cc()` compiles converts these arguments with `JSVALUE_TO_INT64` / `JSVALUE_TO_UINT64` (`src/runtime/ffi/FFI.h:314` and `:329` on main). Both decode int32-tagged and double-encoded numbers inline and tail-call a slow path for everything else; the slow paths were `JSC__JSValue__toInt64` and `JSC__JSValue__toUInt64NoTruncate` (`bindings.cpp:4363`, `:4468`), which only accept numbers and BigInts and read anything else as a double. The wrapper also had no way to report a failed conversion: it always went on to call the C function.
- Only `cc()` is affected. Since #35246, `dlopen()`/`linkSymbols()`/`CFunction` convert arguments in the engine (`JSC::FFI::writeInt64Slot`), which converts int32/double/BigInt and throws `TypeError: bun:ffi cannot convert argument to 'i64'` (the type's name) for anything else. `cc()` still calls through the TinyCC-compiled wrapper built from `FFI.h`.
- Distinct from the other open `FFI.h` fixes: #37978 (int32-family arguments and the int32 box boundary), #37989 (pointer-typed arguments) and #38014 (missing arguments). #38014 makes a missing `i64` argument behave like an explicit `undefined`, i.e. it lands on this path.

### Fix

- `FFI.h`: the int32 and double branches of `JSVALUE_TO_INT64` / `JSVALUE_TO_UINT64` are unchanged; their slow path is now `JSVALUE_TO_SLOT_SLOW(globalObject, abiType, &threw, value)`, bound to the new `Bun__FFI__jsValueToSlotSlow` (`JSCFFIBridge.cpp`), which runs the engine's `writeSlotFromJSValue` for the argument's type, returns the 64-bit argument slot and sets `*threw` when the engine threw. The two `bindings.cpp` functions keep their other callers and are no longer handed to TinyCC.
- `abi_type.rs`: each row of the ABI table now carries its `ABI_TYPE_*` define name and says whether its conversion is `Infallible` (`f(arg)`, as before) or `Fallible` (`f(JS_GLOBAL_OBJECT, ABI_TYPE_X, &threw, arg)`); the four 64-bit integer rows are `Fallible`. `Function::compile` defines every tag for the wrapper's compilation only (the user's C, compiled by `CompileC::compile`, does not see them), and `print_source_code` converts every `Fallible` argument into a local before the call, returning the empty JSValue (the host-function convention after a throw) as soon as one threw, so the C function is never entered with an exception pending; the napi handle scope, when there is one, is opened after these conversions. Another argument type that wants the same treatment only needs its row flipped to `Fallible` plus its own `FFI.h` inline function; #37989 (pointer types) is that case, and this is the mechanism both fixes share.
- Why this is correct: the engine converter is the definition of what a bun:ffi 64-bit integer argument accepts (it is what `dlopen()` has run since #35246), so the values this change routes to it, BigInts and non-numbers, now get exactly `dlopen()`'s results and `dlopen()`'s TypeErrors; BigInts produce the same bits as before (`toBigInt64`/`toBigUInt64` either way), so the only observable change is that inputs which previously aborted or produced garbage now throw. Numbers are not routed and their inline branches are untouched. That is deliberate: `u64`'s double branch already differs from the engine for negative and non-finite numbers (TinyCC's unsigned conversion drops the sign), and the engine's own `doubleToUInt64` mis-converts `[2^63, 2^64)` where `cc()` is right, so the two need one decision made together; that is tracked as a separate bug and this PR does not claim parity for them. The other pre-existing `cc()`-only extra, a TypedArray given to `u64`/`u64_fast` converting to its length, is likewise untouched and pinned by the test so the difference from `dlopen()` stays visible.
- Generated code: wrappers without 64-bit integer arguments produce the same C as before, except that napi wrappers now open their handle scope after loading the argument slots (reading slots creates no handles). `test/js/bun/ffi/ffi.test.fixture.receiver.c` is the checked-in `viewSource()` output regenerated by the `ffi print` test, as in #34653 and #32787.
- Overlaps textually with #37978, #37989 and #38014 in `print_source_code` and the ABI table; whichever lands later rebases (#37978 and #38014 delete `needs_a_cast_in_c()`, which the call-site branch here still consults; #37989 becomes four `Fallible` rows plus its `FFI.h` and test changes on top of this).
- Verified with `test/js/bun/ffi/cc.test.ts`, new `64-bit integer arguments` block. The matrix test runs the same inputs (numbers, BigInts, eight kinds of non-numbers) through a `cc()` wrapper and through a `CFunction` over the same C functions for all four types and requires the tables to match; an `(i64, u64)` function shows which argument is reported when several are bad (left to right, like the engine) and, via a call counter, that a rejected argument stops the call before C; an `(i32, i64, f64)` function covers a fallible conversion between inline ones. A second test covers the bail-out in a `napi_env` wrapper. Both fail on the unfixed binary (release: garbage values and 8 native calls instead of 4 in the `cc` table while the `engine` table already matches; debug: the assertion abort above) and pass under the debug ASAN build, also with `BUN_JSC_validateExceptionChecks=1`.
  - `bun bd test test/js/bun/ffi/`: everything else passes except the pre-existing 5s timeouts of the `dlopen()` "integer identities" tests and the two worker-terminate tests, which take about 5s each under debug ASAN in this container and do not use `cc()`.
  - `test/js/bun/ffi/cc-fixture.js` (`uint64_t` argument plus `napi_env`) still passes on the debug build.

### Background

- `cc()` compiles the user's C with TinyCC and, per symbol, compiles a second small C file: `FFI.h` followed by a wrapper generated by `Function::print_source_code` (`viewSource()` prints it). JSC installs that wrapper directly as the host function for `symbols.name`; it reads the raw NaN-boxed argument slots from the call frame, converts them, calls the user's function and boxes the result. `FFI.h` is therefore C compiled at runtime, and anything it calls (`add_symbol`) or any constant it uses (`define_symbols`) has to be handed to TinyCC by `CompilerRT::inject` / `Function::compile` in `ffi_body.rs`.
- A JSValue is 64 bits that encode either an int32, a double, a few immediates (`undefined`, `null`, booleans) or a pointer to a heap cell (objects, strings, BigInts). `FFI.h` can tell numbers apart by their tag bits; a BigInt and a plain object are both just cells to it, which is why everything that is not a number goes to a slow path in the runtime.
- `JSC::FFI::writeSlotFromJSValue` (engine, `FFIConversions.cpp`) converts one JS argument into the 64-bit slot the native call thunk reads, given the argument's `FFI::Type`. `ABIType` in `abi_type.rs` uses the same numbering as `FFI::Type` (pinned by the `static_assert`s in `JSCFFIBridge.cpp`), so the tag the wrapper passes can be handed to the engine as is.
- A host function signals a throw in JSC by leaving the exception on the VM and returning; by convention it returns the empty JSValue (encoded as 0, `ValueEmpty` here), and the caller checks the VM's exception slot after the call. Running native code or further conversions with an exception pending is not allowed, hence the check after each conversion.

<details>
<summary>Repro from the report</summary>

```c
// i64.c
long long echo_i64(long long x) { return x; }
unsigned long long echo_u64(unsigned long long x) { return x; }
```

```ts
import { cc } from "bun:ffi";
const { symbols } = cc({ source: "./i64.c", symbols: {
  echo_i64: { args: ["i64"], returns: "i64" },
  echo_u64: { args: ["u64"], returns: "u64" },
} });
console.log(symbols.echo_i64(undefined)); // 1.4.0: -9223372036854775808n   now: TypeError: bun:ffi cannot convert argument to 'i64'
console.log(symbols.echo_u64(undefined)); // 1.4.0: 0n                       now: TypeError: bun:ffi cannot convert argument to 'u64'
```

Debug build before the fix:

```
ASSERTION FAILED: value.isHeapBigInt() || value.isNumber()
../../src/jsc/bindings/bindings.cpp(4366) : int64_t JSC__JSValue__toInt64(JSC::EncodedJSValue)
```

`null`, `true`, `{}`, `"12"`, `() => 1` and a TypedArray (for `i64`) behave the same way as `undefined` before and after; numbers and BigInts are unchanged. The same definitions through `CFunction` over the compiled function's address throw the TypeErrors shown above both before and after.

</details>

<details>
<summary>Earlier revision</summary>

The first revision (8cb84c39) had the same fix but wired it specifically to the 64-bit integer types: an int64-only bridge function, a hand-written list of four tag defines, and a hard-coded list of throwing types. Self-review pointed out that #37989 needs the identical plumbing for pointer types, that the two-argument test could not tell which argument had thrown (both were `i64`), and that the body over-claimed parity for `u64` doubles. 66691e32 made the mechanism table-driven as described above, changed the multi-argument tests, and scoped the parity claim; da480007 shortened comments.

</details>
