### PR TITLE
node:net: emit 'close' on a server TLS wrap whose handshake fails on the stream-level engine

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -242,12 +242,8 @@ function emitCloseNT(self, hasError) {
 // Shared-fd TLS pair teardown: mirrors node's close ordering, where the
 // close-callbacks phase runs after the check phase (lib/net.js close path in
 // node v26.3.0), so destroy()-time setImmediates still see the pair alive.
-function closeAdoptedTLSRawNT(handle, self, isException) {
-  setImmediate(closeAdoptedTLSRawNowNT, handle, self, isException);
-}
-function closeAdoptedTLSRawNowNT(handle, self, isException) {
-  handle.close(onSocketHandleClosed);
-  setImmediate(emitCloseNT, self, isException);
+function closeAdoptedTLSRawNT(self, handle, isException) {
+  setImmediate(closeSocketHandle, self, handle, isException);
 }
 function detachSocket(self) {
   if (!self) self = this;
@@ -2198,16 +2194,17 @@ Socket.prototype._destroy = function _destroy(err, callback) {
       // Enqueue closing the socket as a microtask, so that the socket can be
       // accessible when an `error` event is handled in the `next tick queue`.
       // Close the handle captured above rather than re-reading _handle: when
-      // the TLS engine runs over a stream (upgradeDuplexToTLS) its close
-      // callback fires right after the failed handshake that brought us here
-      // and detaches _handle before this microtask runs. Nothing else emits
-      // 'close' once _destroy has run, so the deferred close must not bail.
+      // the failed handshake was dispatched with JS already on the stack (the
+      // stream-level TLS engine fed from a 'data' listener, resumeSNI from an
+      // asynchronous SNICallback completion), the native close callback runs
+      // right behind it, before any microtask, and detaches _handle. Nothing
+      // else emits 'close' once _destroy has run, so this must not bail.
       queueMicrotask(() => closeSocketHandle(this, currentHandle, isException, true));
     } else if (currentHandle[kAdoptedTLSRaw]) {
       // Shared-fd TLS pair: defer the close two check-phase turns
       // (test-tls-socket-close); see closeAdoptedTLSRawNT.
       currentHandle.pause?.();
-      setImmediate(closeAdoptedTLSRawNT, currentHandle, this, isException);
+      setImmediate(closeAdoptedTLSRawNT, this, currentHandle, isException);
     } else {
       closeSocketHandle(this, currentHandle, isException);
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2197,14 +2197,19 @@ Socket.prototype._destroy = function _destroy(err, callback) {
     } else if (this._closeAfterHandlingError) {
       // Enqueue closing the socket as a microtask, so that the socket can be
       // accessible when an `error` event is handled in the `next tick queue`.
-      queueMicrotask(() => closeSocketHandle(this, isException, true));
+      // Close the handle captured above rather than re-reading _handle: when
+      // the TLS engine runs over a stream (upgradeDuplexToTLS) its close
+      // callback fires right after the failed handshake that brought us here
+      // and detaches _handle before this microtask runs. Nothing else emits
+      // 'close' once _destroy has run, so the deferred close must not bail.
+      queueMicrotask(() => closeSocketHandle(this, currentHandle, isException, true));
     } else if (currentHandle[kAdoptedTLSRaw]) {
       // Shared-fd TLS pair: defer the close two check-phase turns
       // (test-tls-socket-close); see closeAdoptedTLSRawNT.
       currentHandle.pause?.();
       setImmediate(closeAdoptedTLSRawNT, currentHandle, this, isException);
     } else {
-      closeSocketHandle(this, isException);
+      closeSocketHandle(this, currentHandle, isException);
     }
 
     if (!this._closeAfterHandlingError) {
@@ -4272,25 +4277,25 @@ function initSocketHandle(self) {
 // intercepts close on `socket._handle` and invokes it, so always pass one.
 function onSocketHandleClosed() {}
 
-function closeSocketHandle(self, isException, isCleanupPending = false) {
-  const handle = self._handle;
-  $debug("closeSocketHandle", isException, isCleanupPending, !!handle);
-  if (handle) {
-    handle.close(onSocketHandleClosed);
-    setImmediate(() => {
-      $debug("emit close", isCleanupPending);
-      self.emit("close", isException);
-      if (isCleanupPending) {
-        // A second destroy() before this runs clears self._handle, and a
-        // re-attach replaces it - only tear down the handle captured here.
-        handle.onread = noop;
-        if (self._handle === handle) {
-          self._handle = null;
-          self._sockname = null;
-        }
+// Closes the handle _destroy found on the socket and emits 'close' for it. The
+// handle may have closed natively and detached itself (self._handle is null by
+// now) in the meantime; closing it again is a no-op and 'close' is still owed.
+function closeSocketHandle(self, handle, isException, isCleanupPending = false) {
+  $debug("closeSocketHandle", isException, isCleanupPending);
+  handle.close(onSocketHandleClosed);
+  setImmediate(() => {
+    $debug("emit close", isCleanupPending);
+    self.emit("close", isException);
+    if (isCleanupPending) {
+      // A second destroy() before this runs clears self._handle, and a
+      // re-attach replaces it - only tear down the handle captured here.
+      handle.onread = noop;
+      if (self._handle === handle) {
+        self._handle = null;
+        self._sockname = null;
       }
-    });
-  }
+    }
+  });
 }
 
 // Reformat a native listen error to Node's "listen <CODE>: <description> <addr>"

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4271,8 +4271,6 @@ function initSocketHandle(self) {
 // intercepts close on `socket._handle` and invokes it, so always pass one.
 function onSocketHandleClosed() {}
 
-// `handle` is the one _destroy found; close() on one the native side already
-// closed is a no-op, and 'close' is emitted either way.
 function closeSocketHandle(self, handle, isException, isCleanupPending = false) {
   $debug("closeSocketHandle", isException, isCleanupPending);
   handle.close(onSocketHandleClosed);
@@ -4280,8 +4278,7 @@ function closeSocketHandle(self, handle, isException, isCleanupPending = false) 
     $debug("emit close", isCleanupPending);
     self.emit("close", isException);
     if (isCleanupPending) {
-      // The native close may have detached self._handle by now, or a re-attach
-      // replaced it; only tear down the handle captured here.
+      // self._handle may have been detached or replaced since.
       handle.onread = noop;
       if (self._handle === handle) {
         self._handle = null;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2193,12 +2193,9 @@ Socket.prototype._destroy = function _destroy(err, callback) {
     } else if (this._closeAfterHandlingError) {
       // Enqueue closing the socket as a microtask, so that the socket can be
       // accessible when an `error` event is handled in the `next tick queue`.
-      // Close the handle captured above rather than re-reading _handle: when
-      // the failed handshake was dispatched with JS already on the stack (the
-      // stream-level TLS engine fed from a 'data' listener, resumeSNI from an
-      // asynchronous SNICallback completion), the native close callback runs
-      // right behind it, before any microtask, and detaches _handle. Nothing
-      // else emits 'close' once _destroy has run, so this must not bail.
+      // A handshake failure dispatched from inside a JS-initiated native call
+      // (stream-level TLS engine, resumeSNI) is followed by the native close,
+      // which detaches _handle, before this microtask runs; pass the handle.
       queueMicrotask(() => closeSocketHandle(this, currentHandle, isException, true));
     } else if (currentHandle[kAdoptedTLSRaw]) {
       // Shared-fd TLS pair: defer the close two check-phase turns
@@ -4274,9 +4271,8 @@ function initSocketHandle(self) {
 // intercepts close on `socket._handle` and invokes it, so always pass one.
 function onSocketHandleClosed() {}
 
-// Closes the handle _destroy found on the socket and emits 'close' for it. The
-// handle may have closed natively and detached itself (self._handle is null by
-// now) in the meantime; closing it again is a no-op and 'close' is still owed.
+// `handle` is the one _destroy found; close() on one the native side already
+// closed is a no-op, and 'close' is emitted either way.
 function closeSocketHandle(self, handle, isException, isCleanupPending = false) {
   $debug("closeSocketHandle", isException, isCleanupPending);
   handle.close(onSocketHandleClosed);
@@ -4284,8 +4280,8 @@ function closeSocketHandle(self, handle, isException, isCleanupPending = false) 
     $debug("emit close", isCleanupPending);
     self.emit("close", isException);
     if (isCleanupPending) {
-      // A second destroy() before this runs clears self._handle, and a
-      // re-attach replaces it - only tear down the handle captured here.
+      // The native close may have detached self._handle by now, or a re-attach
+      // replaced it; only tear down the handle captured here.
       handle.onread = noop;
       if (self._handle === handle) {
         self._handle = null;

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2020,15 +2020,18 @@ it("destroys a server wrap whose socket was destroyed before the deferred upgrad
   }
 });
 
-// A server wrap adopts the connection's fd unless the connection still has
-// unflushed plain writes or is not a net.Socket at all; then the TLS engine runs
-// over the stream itself. Whichever way the wrap is driven, node destroys it
-// with the handshake error, so 'error' is followed by 'close' reporting
-// hadError: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L480-L488
-// The stream-level engine reports the failed handshake and its own close back
-// to back from inside one stream event; the wrap's deferred teardown used to
-// find its handle already gone by the time it ran and never emitted 'close'.
-describe("server-side TLSSocket wrap handshake failure", () => {
+// A failed server-side handshake destroys the socket with the error, so after
+// 'error' (tlsClientError on a tls.Server) node emits 'close' reporting hadError:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L480-L488
+// That destroy defers closing the handle to a microtask. Whenever the failure is
+// dispatched with JS already on the stack, the native close callback follows it
+// before that microtask runs: the stream-level TLS engine (a wrapped connection
+// with unflushed writes, or a generic Duplex) is fed from a 'data' listener, and
+// an asynchronous SNICallback rejection resumes the handshake from the user's
+// callback. The deferred teardown used to find the handle already detached and
+// never emitted 'close'. A failure dispatched straight from the event loop (the
+// fd-adopting wrap fed bad bytes) never had the problem and pins that ordering.
+describe("server-side handshake failure emits 'close'", () => {
   // Accepts one plain connection, hands it to `wrap` (which must write a plain
   // banner so the peer knows the wrap is in place), lets `peer` drive the
   // client once that banner arrives, and resolves with the wrap's 'error' /
@@ -2070,15 +2073,17 @@ describe("server-side TLSSocket wrap handshake failure", () => {
     }
   }
 
-  const adoptingWrap = (conn: net.Socket) => {
+  const serverOptions = (extra: tls.TlsOptions = {}) => ({ isServer: true, ...COMMON_CERT, ...extra });
+
+  const adoptingWrap = (conn: net.Socket, extra?: tls.TlsOptions) => {
     conn.write("220 banner\r\n");
-    return new TLSSocket(conn, { isServer: true, ...COMMON_CERT });
+    return new TLSSocket(conn, serverOptions(extra));
   };
 
   const unflushedWriteWrap = (conn: net.Socket) => {
     conn.cork();
     conn.write("220 banner\r\n");
-    const wrapped = new TLSSocket(conn, { isServer: true, ...COMMON_CERT });
+    const wrapped = new TLSSocket(conn, serverOptions());
     conn.uncork();
     return wrapped;
   };
@@ -2096,11 +2101,23 @@ describe("server-side TLSSocket wrap handshake failure", () => {
     });
     conn.on("data", chunk => transport.push(chunk));
     conn.on("end", () => transport.push(null));
-    return new TLSSocket(transport, { isServer: true, ...COMMON_CERT });
+    return new TLSSocket(transport, serverOptions());
   };
 
   const sendPlaintext = (client: net.Socket) => {
     client.write("this is not a ClientHello\r\n");
+  };
+
+  // Rejects from a later turn, so the handshake is suspended and then resumed
+  // (and failed) from inside this callback rather than from the event loop.
+  const rejectingSNI: tls.TlsOptions = {
+    SNICallback: (_servername, cb) => {
+      setImmediate(cb, new Error("unknown servername"));
+    },
+  };
+
+  const startTLSClient = (client: net.Socket) => {
+    connect({ socket: client, servername: "rejected.example.com", rejectUnauthorized: false }).on("error", () => {});
   };
 
   it("emits 'error' then 'close' with hadError when the wrap adopted the connection's fd", async () => {
@@ -2121,6 +2138,39 @@ describe("server-side TLSSocket wrap handshake failure", () => {
     // ends the wrap without one); either way 'close' must follow, and its
     // hadError flag must agree with whether an 'error' was emitted.
     expect(events.at(-1)).toBe(`close:${events.includes("error")}`);
+  });
+
+  it("emits 'error' then 'close' with hadError when an asynchronous SNICallback rejects an fd-adopting wrap", async () => {
+    const events = await failHandshake(conn => adoptingWrap(conn, rejectingSNI), startTLSClient);
+    expect(events).toEqual(["error", "close:true"]);
+  });
+
+  it("tls.Server emits 'close' with hadError on the socket it reported through tlsClientError when an asynchronous SNICallback rejects", async () => {
+    const server = createServer({ ...COMMON_CERT, ...rejectingSNI });
+    const closed = Promise.withResolvers<{ message: string; hadError: boolean }>();
+    server.on("tlsClientError", (err, socket) => {
+      socket.on("close", hadError => closed.resolve({ message: err.message, hadError }));
+    });
+    server.on("secureConnection", () => closed.reject(new Error("secureConnection must not fire")));
+    let client: TLSSocket | undefined;
+    try {
+      const listening = Promise.withResolvers<void>();
+      server.once("listening", listening.resolve);
+      server.once("error", listening.reject);
+      server.listen(0, "127.0.0.1");
+      await listening.promise;
+      client = connect({
+        port: (server.address() as AddressInfo).port,
+        host: "127.0.0.1",
+        servername: "rejected.example.com",
+        rejectUnauthorized: false,
+      });
+      client.on("error", () => {});
+      expect(await closed.promise).toEqual({ message: "unknown servername", hadError: true });
+    } finally {
+      client?.destroy();
+      server.close();
+    }
   });
 });
 

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -5,6 +5,7 @@ import https from "https";
 import net, { AddressInfo } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
+import { Duplex } from "node:stream";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { PeerCertificate } from "tls";
@@ -2017,6 +2018,110 @@ it("destroys a server wrap whose socket was destroyed before the deferred upgrad
     conn?.destroy();
     rawServer.close();
   }
+});
+
+// A server wrap adopts the connection's fd unless the connection still has
+// unflushed plain writes or is not a net.Socket at all; then the TLS engine runs
+// over the stream itself. Whichever way the wrap is driven, node destroys it
+// with the handshake error, so 'error' is followed by 'close' reporting
+// hadError: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L480-L488
+// The stream-level engine reports the failed handshake and its own close back
+// to back from inside one stream event; the wrap's deferred teardown used to
+// find its handle already gone by the time it ran and never emitted 'close'.
+describe("server-side TLSSocket wrap handshake failure", () => {
+  // Accepts one plain connection, hands it to `wrap` (which must write a plain
+  // banner so the peer knows the wrap is in place), lets `peer` drive the
+  // client once that banner arrives, and resolves with the wrap's 'error' /
+  // 'close' events once 'close' has fired.
+  async function failHandshake(
+    wrap: (conn: net.Socket) => TLSSocket,
+    peer: (client: net.Socket) => void,
+  ): Promise<string[]> {
+    const events: string[] = [];
+    const closed = Promise.withResolvers<string[]>();
+    let conn: net.Socket | undefined;
+    const rawServer = net.createServer(socket => {
+      conn = socket;
+      // Only the wrap's lifecycle is under test; the plain connection's own
+      // fate after the peer goes away is not.
+      conn.on("error", () => {});
+      const wrapped = wrap(conn);
+      wrapped.on("error", () => events.push("error"));
+      wrapped.on("close", hadError => {
+        events.push(`close:${hadError}`);
+        closed.resolve(events);
+      });
+    });
+    let client: net.Socket | undefined;
+    try {
+      const listening = Promise.withResolvers<void>();
+      rawServer.once("listening", listening.resolve);
+      rawServer.once("error", listening.reject);
+      rawServer.listen(0, "127.0.0.1");
+      await listening.promise;
+      client = net.connect((rawServer.address() as AddressInfo).port, "127.0.0.1");
+      client.on("error", () => {});
+      client.once("data", () => peer(client!));
+      return await closed.promise;
+    } finally {
+      client?.destroy();
+      conn?.destroy();
+      rawServer.close();
+    }
+  }
+
+  const adoptingWrap = (conn: net.Socket) => {
+    conn.write("220 banner\r\n");
+    return new TLSSocket(conn, { isServer: true, ...COMMON_CERT });
+  };
+
+  const unflushedWriteWrap = (conn: net.Socket) => {
+    conn.cork();
+    conn.write("220 banner\r\n");
+    const wrapped = new TLSSocket(conn, { isServer: true, ...COMMON_CERT });
+    conn.uncork();
+    return wrapped;
+  };
+
+  const duplexWrap = (conn: net.Socket) => {
+    conn.write("220 banner\r\n");
+    const transport = new Duplex({
+      read() {},
+      write(chunk, encoding, callback) {
+        conn.write(chunk, encoding, callback);
+      },
+      final(callback) {
+        conn.end(callback);
+      },
+    });
+    conn.on("data", chunk => transport.push(chunk));
+    conn.on("end", () => transport.push(null));
+    return new TLSSocket(transport, { isServer: true, ...COMMON_CERT });
+  };
+
+  const sendPlaintext = (client: net.Socket) => {
+    client.write("this is not a ClientHello\r\n");
+  };
+
+  it("emits 'error' then 'close' with hadError when the wrap adopted the connection's fd", async () => {
+    expect(await failHandshake(adoptingWrap, sendPlaintext)).toEqual(["error", "close:true"]);
+  });
+
+  it("emits 'error' then 'close' with hadError when the connection had unflushed writes", async () => {
+    expect(await failHandshake(unflushedWriteWrap, sendPlaintext)).toEqual(["error", "close:true"]);
+  });
+
+  it("emits 'error' then 'close' with hadError when wrapping a generic Duplex", async () => {
+    expect(await failHandshake(duplexWrap, sendPlaintext)).toEqual(["error", "close:true"]);
+  });
+
+  it("emits 'close' when the peer disconnects mid-handshake and the connection had unflushed writes", async () => {
+    const events = await failHandshake(unflushedWriteWrap, client => client.destroy());
+    // Both wrap flavors currently report the disconnect through 'error' (node
+    // ends the wrap without one); either way 'close' must follow, and its
+    // hadError flag must agree with whether an 'error' was emitted.
+    expect(events.at(-1)).toBe(`close:${events.includes("error")}`);
+  });
 });
 
 it("exposes the server-side peer verification result via socket.ssl.verifyError()", async () => {


### PR DESCRIPTION
### Problem
- A server-side TLS socket whose handshake fails emits `'error'` (or `'tlsClientError'` on a `tls.Server`) but never `'close'`, although `socket.destroyed` becomes `true`. Node emits `'error'` followed by `'close'` with `hadError === true`.
- It happens whenever the failure is reported while JS is already on the stack. Two ways users hit that:
  - `new tls.TLSSocket(conn, { isServer: true })` running on the stream-level TLS engine (taken when `conn` still has unflushed plain writes, or is a generic `Duplex`), and the peer then sends non-TLS bytes or disconnects: the engine is fed from a `'data'` listener.
  - a `tls.Server` (or an fd-adopting wrap) whose asynchronous `SNICallback` rejects the connection, the usual shape of an SNI-routing server turning away unknown hostnames: `resumeSNI` fails the handshake from inside the user's callback.
- Cause: the handshake-failure destroy (`_closeAfterHandlingError`) makes `Socket.prototype._destroy` (`src/js/node/net.ts:2193`) defer `closeSocketHandle` to a microtask so the `'error'` listeners can still see the connection, and `closeSocketHandle` re-read `self._handle` when it finally ran. Bun's native close callback (`ServerHandlers.close` -> `detachSocket`) nulls `_handle`, and on the dispatches above it runs synchronously right after the handshake callback, inside the same native call, before any microtask checkpoint (microtasks drain only when the outermost event-loop entry unwinds, `src/jsc/event_loop.rs` `exit()`). The deferred close then found no handle and returned without emitting. A failure dispatched straight from the event loop (for example an fd-adopting wrap fed bad bytes) drains the microtask first, which is why that ordering worked.
- The error code reported on the engine path (`UNABLE_TO_GET_ISSUER_CERT` instead of `ERR_SSL_WRONG_VERSION_NUMBER`) is a separate bug fixed by #32929; this PR leaves it alone and the tests do not assert the code.

### Fix
- `_destroy` passes the handle it found (`currentHandle`) into `closeSocketHandle`, which closes and reports that handle instead of re-reading `_handle`. `closeAdoptedTLSRawNowNT` was the same close-then-report sequence, so the adopted raw-socket branch now calls `closeSocketHandle` too.
- Why this is correct: a `net.Socket` emits `'close'` exactly once, from whichever teardown branch its `_destroy` takes. The native close callback deliberately does not emit it (it only detaches the handle and pushes EOF, relying on `_destroy`), so once `_destroy` has run the deferred branch is the only emitter left and must not depend on `_handle` still being attached. The synchronous branch already tolerates the detach (`_destroy` re-checks `this._handle` after `closeSocketHandle` returns, because `handle.close()` dispatches the native close re-entrantly); this gives the deferred branch the same tolerance. It is also what Node's `closeSocketHandle` effectively does: nothing in Node detaches `_handle` behind the stream's back, so it always closes the handle `destroy()` found.
- Closing the captured handle after the native side closed it is a no-op: the close dispatch puts the wrapper into the detached state before calling into JS (`src/runtime/socket/socket_body.rs:2057`), `close()` on a detached wrapper does nothing (`src/uws_sys/socket.rs:343`), and the event-loop unref it performs is idempotent (`src/io/keep_alive.rs:43`). When nothing detached the handle in between, `currentHandle === this._handle` and the behaviour is byte-for-byte the old one.
- Verified with `test/js/node/tls/node-tls-server.test.ts`, describe "server-side handshake failure emits 'close'": six cases (fd-adopting wrap fed bad bytes; unflushed-write wrap fed bad bytes; generic `Duplex` wrap fed bad bytes; unflushed-write wrap whose peer disconnects; fd-adopting wrap rejected by an asynchronous `SNICallback`; `tls.Server` rejected by an asynchronous `SNICallback`, asserting `'close'` on the socket handed to `tlsClientError`). Five wait forever for `'close'` on the unfixed build; all six pass with the fix; the expected sequences were checked against Node v26.3.0 with the probes below.
- Also run with the fix: the rest of `node-tls-server.test.ts`, `node-tls-connect.test.ts`, `node-tls-upgrade.test.ts`, the `test/js/node/net` suites, and 89 vendored Node `test-tls-*` / `test-net-*` / `test-https-*` close, destroy, SNI and handshake-failure tests (including `test-tls-socket-close` for the adopted raw-socket branch and `test-tls-sni-option` for asynchronous SNI), all passing. The only failures seen were pre-existing in this container and reproduce without the diff (tests binding `localhost` while connecting to `127.0.0.1`, and one 60s leak test).

### Background
- `_closeAfterHandlingError`: Node's server-side handshake failure path destroys the socket with the error but keeps `_handle` attached until the next microtask so `'error'` / `'tlsClientError'` listeners can still inspect the connection; `closeSocketHandle` then closes the handle and emits `'close'`. Bun mirrors this.
- `detachSocket`: Bun's native close callbacks null `socket._handle` because the native object is gone. It is the one way `_handle` can disappear between `destroy()` and the deferred close, and it never emits `'close'` itself.
- Nested dispatch: Bun drains microtasks when the outermost native-to-JS entry returns. A socket callback invoked straight from the I/O loop gets a microtask checkpoint as soon as it returns; one invoked from inside a JS-initiated native call (the stream engine's listener thunks, `resumeSNI`, `_handle.close()`) does not get one until the outer JS frame finishes, so anything native does right after that callback, such as dispatching the close, runs before the microtask.
- Server wrap paths: `new TLSSocket(conn, { isServer: true })` normally adopts the connection's fd into a native TLS socket driven by the C TLS code. When the fd cannot be adopted (pending plain bytes must go out first, or there is no fd), `upgradeDuplexToTLS` runs a BoringSSL engine over the stream instead, fed by the stream's `'data'` events.

<details>
<summary>Event logs from the probes (events on the server-side socket)</summary>

```
case                                            Bun before                              Bun after                                  Node v26.3.0
unflushed-write wrap, non-TLS bytes             error                                   error, close:true                          error, close:true
unflushed-write wrap, peer disconnects          end, error(ECONNRESET)                  end, error(ECONNRESET), close:true         end, close:false
generic Duplex wrap, non-TLS bytes              error                                   error, close:true                          error, close:true
fd-adopting wrap, async SNICallback rejects     error                                   error, close:true                          error, close:true
tls.Server, async SNICallback rejects           tlsClientError                          tlsClientError, close:true                 tlsClientError, close:true
fd-adopting wrap, non-TLS bytes                 error, close:true                       unchanged                                  error, close:true
```

The `'error'` on a mid-handshake disconnect is pre-existing behaviour on both wrap flavours and out of scope; that test only asserts that `'close'` arrives and that its `hadError` agrees with whether an `'error'` was emitted.

net.ts debug trace of an unfixed failing case (`BUN_DEBUG_JS=net`), showing the native close detaching the handle before the deferred close runs:

```
[net] Socket.prototype._destroy          <- ServerHandlers.handshake(false): destroy(err), close deferred to a microtask
[net] Bun.Server close                   <- native close callback, detachSocket() nulls _handle
[events] TLSSocket.emit error
[net] closeSocketHandle true true false  <- _handle already null: nothing closed, no 'close'
```

The first revision of this PR described the problem as specific to the stream-level engine; review of the dispatch path showed the condition is the nested dispatch above, which the asynchronous `SNICallback` cases also reach on the plain fd path. The code change is the same; the description, comments and test matrix were widened to match.
</details>
