### PR TITLE
Bun.openInEditor: use the [debug] editor setting from bunfig.toml

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -154,7 +154,7 @@ Higher values show more nested properties but may produce verbose output for com
 
 #### `debug.editor`
 
-The editor that [`Bun.openInEditor()`](/runtime/utils#bun-openineditor) opens files with when it is called without an `editor` option. This takes precedence over the `$EDITOR` and `$VISUAL` environment variables. Accepts an absolute path to an editor, or the name of a known editor (for example `"code"` or `"subl"`), which is looked up on `PATH`. When a named editor cannot be found, Bun falls back to `$EDITOR` and `$VISUAL`.
+The editor that [`Bun.openInEditor()`](/runtime/utils#bun-openineditor) opens files with when it is called without an `editor` option. Accepts an absolute path to an editor, or the name of an editor Bun knows (for example `"code"` or `"subl"`), which is looked up on `PATH` (and in `/Applications` on macOS). This setting is consulted before the `$EDITOR` and `$VISUAL` environment variables. If the configured editor is not installed, Bun continues with the detection it performs without this setting: `$EDITOR` or `$VISUAL`, then a built-in list of common editors.
 
 ```toml title="bunfig.toml" icon="settings"
 [debug]

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -150,6 +150,17 @@ depth = 3
 
 Higher values show more nested properties but may produce verbose output for complex objects. The `--console-depth` CLI flag overrides this setting.
 
+### `debug`
+
+#### `debug.editor`
+
+The editor that [`Bun.openInEditor()`](/runtime/utils#bun-openineditor) opens files with when it is called without an `editor` option. This takes precedence over the `$EDITOR` and `$VISUAL` environment variables. Accepts an absolute path to an editor, or the name of a known editor (for example `"code"` or `"subl"`), which is looked up on `PATH`. When a named editor cannot be found, Bun falls back to `$EDITOR` and `$VISUAL`.
+
+```toml title="bunfig.toml" icon="settings"
+[debug]
+editor = "code"
+```
+
 ## Serve
 
 The `[serve]` section configures `Bun.serve` and `bun run` when serving HTTP.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5042,7 +5042,8 @@ declare module "bun" {
   function shrink(): void;
 
   /**
-   * Open a file in your local editor. The editor is detected from `$VISUAL` or `$EDITOR`
+   * Open a file in your local editor. The editor is taken from the `[debug] editor`
+   * setting in `bunfig.toml`, otherwise detected from `$VISUAL` or `$EDITOR`
    *
    * @param path Path of the file to open
    * @param options Editor, line, and column overrides

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -981,8 +981,7 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
         let mut editor_choice: Option<Editor> = None;
 
         if let Some(sliced) = &editor_name {
-            // Reuse the cached editor only if this same name resolved to one;
-            // `name` may also hold a bunfig editor that auto-detection did not find.
+            // `name` may be a bunfig editor that auto-detection failed to find.
             if edit.found().is_none() || !strings::eql_long(edit.name, sliced.slice(), true) {
                 let prev = core::mem::take(edit);
                 // Own the bytes in `name_storage` and

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -981,9 +981,9 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
         let mut editor_choice: Option<Editor> = None;
 
         if let Some(sliced) = &editor_name {
-            let prev_name = edit.name;
-
-            if !strings::eql_long(prev_name, sliced.slice(), true) {
+            // Reuse the cached editor only if this same name resolved to one;
+            // `name` may also hold a bunfig editor that auto-detection did not find.
+            if edit.found().is_none() || !strings::eql_long(edit.name, sliced.slice(), true) {
                 let prev = core::mem::take(edit);
                 // Own the bytes in `name_storage` and
                 // hand back a thread-lifetime borrow.
@@ -1002,17 +1002,6 @@ fn open_in_editor(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
                         "Could not find editor \"{}\"",
                         bstr::BStr::new(sliced.slice()),
                     )));
-                } else if edit.name.as_ptr() == edit.path.as_ptr() {
-                    // `detect_editor` aliased `path` to `name` (absolute
-                    // editor path). `name` is backed by `slot.name_storage`,
-                    // which a later call may drop while the detached editor
-                    // thread is still reading argv[0]. Give `path`
-                    // process-lifetime storage, matching every other
-                    // `detect_editor` branch.
-                    edit.path = bun_resolver::fs::FileSystem::instance()
-                        .dirname_store
-                        .append_slice(edit.path)
-                        .expect("unreachable");
                 }
             }
         }

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -434,13 +434,9 @@ fn auto_close(spawned: *mut SpawnedEditorContext) {
 
 pub struct EditorContext {
     pub(crate) editor: Option<Editor>,
-    /// Editor name or absolute path that `detect_editor` tries first: bunfig's
-    /// `[debug] editor`, or the `editor` option of `Bun.openInEditor` (whose
-    /// storage `open_in_editor` manages). Empty means environment only.
+    /// Name or absolute path tried first by `detect_editor`; empty means environment only.
     pub name: &'static [u8],
-    /// Resolved binary, stored in `Fs.FileSystem.instance.dirname_store`
-    /// (process-lifetime) because the thread `Editor::open` spawns reads it
-    /// after this context may have been replaced.
+    /// Always a `dirname_store` copy: the thread spawned by `Editor::open` outlives this context.
     pub path: &'static [u8],
 }
 
@@ -464,8 +460,7 @@ impl EditorContext {
     pub(crate) fn auto_detect_editor(&mut self, env: &mut dot_env::Loader) {
         if self.editor.is_none() {
             if self.name.is_empty() {
-                // `[debug] editor` from bunfig.toml. The CLI context is
-                // process-lifetime, so the slice satisfies `name: &'static`.
+                // bunfig `[debug] editor`; the CLI context is process-lifetime.
                 if let Some(ctx) = bun_options_types::context::try_get() {
                     self.name = &ctx.debug.editor;
                 }
@@ -482,8 +477,7 @@ impl EditorContext {
             .expect("unreachable");
     }
 
-    /// Every tier only accepts a binary that exists, so an editor that is
-    /// configured but not installed falls through to the next tier.
+    /// Each tier only accepts a binary that exists; otherwise the next tier is tried.
     pub(crate) fn detect_editor(&mut self, env: &mut dot_env::Loader) {
         let mut buf = PathBuffer::uninit();
         // Note: borrowck — `by_path_for_editor`/`by_fallback` tie `out`'s lifetime

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -459,6 +459,13 @@ impl EditorContext {
 
     pub(crate) fn auto_detect_editor(&mut self, env: &mut dot_env::Loader) {
         if self.editor.is_none() {
+            if self.name.is_empty() {
+                // `[debug] editor` from bunfig.toml. The CLI context is
+                // process-lifetime, so the slice satisfies `name: &'static`.
+                if let Some(ctx) = bun_options_types::context::try_get() {
+                    self.name = &ctx.debug.editor;
+                }
+            }
             self.detect_editor(env);
         }
     }

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -434,9 +434,13 @@ fn auto_close(spawned: *mut SpawnedEditorContext) {
 
 pub struct EditorContext {
     pub(crate) editor: Option<Editor>,
-    // Note: `name`/`path` are never freed; `path` is backed by
-    // `Fs.FileSystem.instance.dirname_store` (process-lifetime arena) or aliases `name`.
+    /// Editor name or absolute path that `detect_editor` tries first: bunfig's
+    /// `[debug] editor`, or the `editor` option of `Bun.openInEditor` (whose
+    /// storage `open_in_editor` manages). Empty means environment only.
     pub name: &'static [u8],
+    /// Resolved binary, stored in `Fs.FileSystem.instance.dirname_store`
+    /// (process-lifetime) because the thread `Editor::open` spawns reads it
+    /// after this context may have been replaced.
     pub path: &'static [u8],
 }
 
@@ -470,6 +474,16 @@ impl EditorContext {
         }
     }
 
+    fn resolve(&mut self, editor: Editor, path: &[u8]) {
+        self.editor = Some(editor);
+        self.path = Fs::FileSystem::instance()
+            .dirname_store
+            .append_slice(path)
+            .expect("unreachable");
+    }
+
+    /// Every tier only accepts a binary that exists, so an editor that is
+    /// configured but not installed falls through to the next tier.
     pub(crate) fn detect_editor(&mut self, env: &mut dot_env::Loader) {
         let mut buf = PathBuffer::uninit();
         // Note: borrowck — `by_path_for_editor`/`by_fallback` tie `out`'s lifetime
@@ -481,12 +495,15 @@ impl EditorContext {
 
         // first: choose from user preference
         if !self.name.is_empty() {
-            // /usr/bin/vim
+            // /usr/bin/vim (`which` does not consult PATH for an absolute path)
             if bun_paths::is_absolute(self.name) {
-                self.editor =
-                    Some(Editor::by_name(bun_paths::basename(self.name)).unwrap_or(Editor::Other));
-                self.path = self.name;
-                return;
+                // SAFETY: see note above — exclusive per-call reborrow.
+                if let Some(bin) = which(unsafe { &mut *buf_ptr }, b"", b"", self.name) {
+                    let editor_ =
+                        Editor::by_name(bun_paths::basename(self.name)).unwrap_or(Editor::Other);
+                    self.resolve(editor_, bin.as_bytes());
+                    return;
+                }
             }
 
             // "vscode"
@@ -499,22 +516,14 @@ impl EditorContext {
                     Fs::FileSystem::instance().top_level_dir,
                     &mut out,
                 ) {
-                    self.editor = Some(editor_);
-                    self.path = Fs::FileSystem::instance()
-                        .dirname_store
-                        .append_slice(out)
-                        .expect("unreachable");
+                    self.resolve(editor_, out);
                     return;
                 }
 
                 // not in path, try common ones
                 let mut static_out: &'static [u8] = b"";
                 if Editor::by_fallback_path_for_editor(editor_, Some(&mut static_out)) {
-                    self.editor = Some(editor_);
-                    self.path = Fs::FileSystem::instance()
-                        .dirname_store
-                        .append_slice(static_out)
-                        .expect("unreachable");
+                    self.resolve(editor_, static_out);
                     return;
                 }
             }
@@ -530,22 +539,14 @@ impl EditorContext {
                 Fs::FileSystem::instance().top_level_dir,
                 &mut out,
             ) {
-                self.editor = Some(editor_);
-                self.path = Fs::FileSystem::instance()
-                    .dirname_store
-                    .append_slice(out)
-                    .expect("unreachable");
+                self.resolve(editor_, out);
                 return;
             }
 
             // not in path, try common ones
             let mut static_out: &'static [u8] = b"";
             if Editor::by_fallback_path_for_editor(editor_, Some(&mut static_out)) {
-                self.editor = Some(editor_);
-                self.path = Fs::FileSystem::instance()
-                    .dirname_store
-                    .append_slice(static_out)
-                    .expect("unreachable");
+                self.resolve(editor_, static_out);
                 return;
             }
         }
@@ -558,11 +559,7 @@ impl EditorContext {
             Fs::FileSystem::instance().top_level_dir,
             &mut out,
         ) {
-            self.editor = Some(editor_);
-            self.path = Fs::FileSystem::instance()
-                .dirname_store
-                .append_slice(out)
-                .expect("unreachable");
+            self.resolve(editor_, out);
             return;
         }
 

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { existsSync, symlinkSync } from "node:fs";
+import { chmodSync, existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // Option getters and toString run user JS that may call Bun.openInEditor
@@ -105,4 +105,86 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
   });
 
   await Promise.all(runs);
+});
+
+// `[debug] editor` in bunfig.toml is the documented way to pick the editor
+// Bun.openInEditor() uses when no `editor` option is passed. It was parsed
+// but never read, so only $EDITOR/$VISUAL and the built-in list applied.
+// Linux-only like the tests above: PATH holds only the fake editors, so
+// nothing real can be detected (macOS would also probe /Applications).
+describe.skipIf(!isLinux)("Bun.openInEditor reads [debug] editor from bunfig.toml", () => {
+  // Records its own name and its arguments. Shell builtins only, since PATH
+  // has nothing else on it; the trailing "done" line marks the record complete.
+  const fakeEditor = ({ root }: { root: string }) => `#!/bin/sh
+printf '%s\\n' "\${0##*/}" "$@" done > "${join(root, "argv.txt")}"
+`;
+
+  const fixture = `
+    import { existsSync, readFileSync } from "node:fs";
+    const [file, editor] = process.argv.slice(2);
+    if (editor) Bun.openInEditor(file, { editor });
+    else Bun.openInEditor(file);
+    let text = "";
+    while (!text.endsWith("\\ndone\\n")) {
+      await Bun.sleep(5);
+      if (existsSync("argv.txt")) text = readFileSync("argv.txt", "utf8");
+    }
+    process.stdout.write(text);
+  `;
+
+  const absoluteMyEditor = ({ root }: { root: string }) => `[debug]\neditor = "${join(root, "my-editor")}"\n`;
+
+  test.concurrent.each([
+    {
+      name: "an absolute path is used as the editor",
+      bunfig: absoluteMyEditor,
+      editors: ["my-editor"],
+      opens: "my-editor",
+    },
+    {
+      name: "an editor name is looked up on PATH and beats $EDITOR",
+      bunfig: `[debug]\neditor = "code"\n`,
+      editors: ["code", "subl"],
+      EDITOR: "subl",
+      opens: "code",
+    },
+    {
+      name: "an editor name that is not installed falls back to $EDITOR",
+      bunfig: `[debug]\neditor = "code"\n`,
+      editors: ["subl"],
+      EDITOR: "subl",
+      opens: "subl",
+    },
+    {
+      name: "the editor option beats bunfig",
+      bunfig: absoluteMyEditor,
+      editors: ["my-editor", "other-editor"],
+      option: "other-editor",
+      opens: "other-editor",
+    },
+  ])("$name", async ({ bunfig, editors, EDITOR, option, opens }) => {
+    using dir = tempDir("open-in-editor-bunfig", {
+      "bunfig.toml": bunfig,
+      "run.js": fixture,
+      ...Object.fromEntries(editors.map(name => [name, fakeEditor])),
+    });
+    for (const name of editors) chmodSync(join(String(dir), name), 0o755);
+    const file = join(String(dir), "opened.ts");
+
+    const cmd = [bunExe(), "run.js", file];
+    if (option) cmd.push(join(String(dir), option));
+
+    await using proc = Bun.spawn({
+      cmd,
+      env: { ...bunEnv, PATH: String(dir), EDITOR, VISUAL: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.split("\n")).toEqual([opens, file, "done", ""]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -107,11 +107,11 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
   await Promise.all(runs);
 });
 
-// `[debug] editor` in bunfig.toml is the documented way to pick the editor
-// Bun.openInEditor() uses when no `editor` option is passed. It was parsed
-// but never read, so only $EDITOR/$VISUAL and the built-in list applied.
-// Linux-only like the tests above: PATH holds only the fake editors, so
-// nothing real can be detected (macOS would also probe /Applications).
+// `[debug] editor` in bunfig.toml picks the editor Bun.openInEditor() uses when
+// no `editor` option is passed. It used to be parsed but never read, and an
+// absolute path used to be spawned without checking that it exists, which
+// silently did nothing. Linux-only like the tests above: PATH holds only the
+// fake editors, so nothing real can be detected (macOS also probes /Applications).
 describe.skipIf(!isLinux)("Bun.openInEditor reads [debug] editor from bunfig.toml", () => {
   // Records its own name and its arguments. Shell builtins only, since PATH
   // has nothing else on it; the trailing "done" line marks the record complete.
@@ -119,25 +119,48 @@ describe.skipIf(!isLinux)("Bun.openInEditor reads [debug] editor from bunfig.tom
 printf '%s\\n' "\${0##*/}" "$@" done > "${join(root, "argv.txt")}"
 `;
 
-  const fixture = `
-    import { existsSync, readFileSync } from "node:fs";
-    const [file, editor] = process.argv.slice(2);
-    if (editor) Bun.openInEditor(file, { editor });
-    else Bun.openInEditor(file);
-    let text = "";
-    while (!text.endsWith("\\ndone\\n")) {
+  // Polls with a fresh BunFile each time, since a BunFile keeps the size it
+  // first saw. Bun.file and console.write are used instead of node:fs and
+  // process.stdout because those are noticeably slower to load in a debug build.
+  const readRecord = `
+    let record = "";
+    while (!record.endsWith("\\ndone\\n")) {
       await Bun.sleep(5);
-      if (existsSync("argv.txt")) text = readFileSync("argv.txt", "utf8");
+      const argv = Bun.file("argv.txt");
+      if (await argv.exists()) record = await argv.text();
     }
-    process.stdout.write(text);
   `;
 
-  const absoluteMyEditor = ({ root }: { root: string }) => `[debug]\neditor = "${join(root, "my-editor")}"\n`;
+  // Prints the editor's record when a call is expected to open something, and
+  // otherwise just how the call ended, so a call that wrongly opens nothing
+  // fails instead of waiting for a record that never comes.
+  const fixture = `
+    const [file, expectation, editor] = process.argv.slice(2);
+    let outcome = "returned";
+    try {
+      if (editor) Bun.openInEditor(file, { editor });
+      else Bun.openInEditor(file);
+    } catch (e) {
+      outcome = "threw: " + e.message;
+    }
+    if (outcome !== "returned" || expectation !== "opens") {
+      console.log(outcome);
+    } else {
+      ${readRecord}
+      console.write(record);
+    }
+  `;
 
+  const bunfigMyEditor = ({ root }: { root: string }) => `[debug]\neditor = "${join(root, "my-editor")}"\n`;
+  const bunfigMovedCode = ({ root }: { root: string }) => `[debug]\neditor = "${join(root, "gone", "code")}"\n`;
+
+  // `code` is first on the built-in preference list, so a case that installs
+  // both `code` and `subl` and sets EDITOR=subl can tell the three sources apart:
+  // the bunfig entry, $EDITOR, and the built-in list would each pick differently.
   test.concurrent.each([
     {
       name: "an absolute path is used as the editor",
-      bunfig: absoluteMyEditor,
+      bunfig: bunfigMyEditor,
       editors: ["my-editor"],
       opens: "my-editor",
     },
@@ -150,19 +173,46 @@ printf '%s\\n' "\${0##*/}" "$@" done > "${join(root, "argv.txt")}"
     },
     {
       name: "an editor name that is not installed falls back to $EDITOR",
-      bunfig: `[debug]\neditor = "code"\n`,
-      editors: ["subl"],
+      bunfig: `[debug]\neditor = "webstorm"\n`,
+      editors: ["code", "subl"],
       EDITOR: "subl",
       opens: "subl",
     },
     {
+      name: "an absolute path that does not exist falls back to $EDITOR",
+      bunfig: bunfigMyEditor,
+      editors: ["code", "subl"],
+      EDITOR: "subl",
+      opens: "subl",
+    },
+    {
+      name: "an absolute path that does not exist is looked up on PATH by name first",
+      bunfig: bunfigMovedCode,
+      editors: ["code", "subl"],
+      EDITOR: "subl",
+      opens: "code",
+    },
+    {
+      name: "an absolute path that does not exist throws when nothing else is found",
+      bunfig: bunfigMyEditor,
+      editors: [],
+      throws: () => "Failed to auto-detect editor",
+    },
+    {
       name: "the editor option beats bunfig",
-      bunfig: absoluteMyEditor,
+      bunfig: bunfigMyEditor,
       editors: ["my-editor", "other-editor"],
       option: "other-editor",
       opens: "other-editor",
     },
-  ])("$name", async ({ bunfig, editors, EDITOR, option, opens }) => {
+    {
+      name: "an editor option whose path does not exist throws instead of opening nothing",
+      bunfig: bunfigMyEditor,
+      editors: ["my-editor"],
+      option: "missing-editor",
+      throws: (dir: string) => `Could not find editor "${join(dir, "missing-editor")}"`,
+    },
+  ])("$name", async ({ bunfig, editors, EDITOR, option, opens, throws }) => {
     using dir = tempDir("open-in-editor-bunfig", {
       "bunfig.toml": bunfig,
       "run.js": fixture,
@@ -171,7 +221,7 @@ printf '%s\\n' "\${0##*/}" "$@" done > "${join(root, "argv.txt")}"
     for (const name of editors) chmodSync(join(String(dir), name), 0o755);
     const file = join(String(dir), "opened.ts");
 
-    const cmd = [bunExe(), "run.js", file];
+    const cmd = [bunExe(), "run.js", file, opens ? "opens" : "throws"];
     if (option) cmd.push(join(String(dir), option));
 
     await using proc = Bun.spawn({
@@ -184,7 +234,59 @@ printf '%s\\n' "\${0##*/}" "$@" done > "${join(root, "argv.txt")}"
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
-    expect(stdout.split("\n")).toEqual([opens, file, "done", ""]);
+    expect(stdout.split("\n")).toEqual(throws ? [`threw: ${throws(String(dir))}`, ""] : [opens, file, "done", ""]);
+    expect(exitCode).toBe(0);
+  });
+
+  // An `editor` option equal to the current name reuses the cached editor. A
+  // bunfig editor that auto-detection failed to find must not be reused that
+  // way: the explicit request gets its own lookup, and succeeds once the editor
+  // is installed.
+  test.concurrent("an editor option is looked up again after the bunfig editor was not found", async () => {
+    using dir = tempDir("open-in-editor-bunfig-retry", {
+      "bunfig.toml": `[debug]\neditor = "code"\n`,
+      "bin/.keep": "",
+      "code": fakeEditor,
+      "run.js": `
+        import { renameSync } from "node:fs";
+        const file = process.argv[2];
+        const attempt = options => {
+          try {
+            Bun.openInEditor(file, options);
+            return "opened";
+          } catch (e) {
+            return e.message;
+          }
+        };
+        const outcomes = [attempt(), attempt({ editor: "code" })];
+        renameSync("code", "bin/code");
+        outcomes.push(attempt({ editor: "code" }));
+        ${readRecord}
+        console.write(outcomes.join("\\n") + "\\n" + record);
+      `,
+    });
+    chmodSync(join(String(dir), "code"), 0o755);
+    const file = join(String(dir), "opened.ts");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.js", file],
+      env: { ...bunEnv, PATH: join(String(dir), "bin"), EDITOR: undefined, VISUAL: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.split("\n")).toEqual([
+      "Failed to auto-detect editor",
+      'Could not find editor "code"',
+      "opened",
+      "code",
+      file,
+      "done",
+      "",
+    ]);
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `[debug] editor = "..."` in `bunfig.toml` has no effect on `Bun.openInEditor()`. With it set, no `$EDITOR`/`$VISUAL` and nothing on `PATH`, `Bun.openInEditor("x.txt")` throws `Failed to auto-detect editor` and the configured editor is never run. `docs/runtime/utils.mdx` documents the setting as overriding the auto-detected editor.
- The bunfig parser stores the value (`src/bunfig/bunfig.rs:1013-1018` writes `ctx.debug.editor`), but nothing reads `DebugOptions.editor`. `Bun.openInEditor` (`open_in_editor` in `src/runtime/api/BunObject.rs`) starts from an `EditorContext` whose `name` is empty, so `EditorContext::detect_editor` (`src/runtime/cli/open.rs`) skips its preference branch and goes straight to `$EDITOR`/`$VISUAL` and the built-in list.
- Not a port regression: the only reader was the old `bun dev` server (`http_editor_context.name = debug.editor`), removed in #7283; the Zig `Bun.openInEditor` never read it either.
- Related, and what makes wiring the setting up safely need one more change: `detect_editor`'s absolute-path branch accepted the path without checking it exists. The spawn then fails on a detached thread (`let _ = sync::spawn(..)` in `auto_close`) and the result is cached, so `{ editor: "/path/that/moved" }` makes `Bun.openInEditor()` silently do nothing for the rest of the process, while `{ editor: "name-that-is-missing" }` falls through to `$EDITOR`. A bunfig value is persistent config, and this key has been dead since 2023, so stale absolute paths are exactly what reading it again would hit.

### Fix
- `EditorContext::auto_detect_editor` seeds `name` from the CLI context's `debug.editor` (via `bun_options_types::context::try_get()`, the same lookup `console.depth` uses at runtime) when no preference has been set, then runs the existing `detect_editor`. This is the line that makes the setting work.
- `detect_editor`'s absolute-path branch now resolves the path with `bun_which::which` (which checks that an absolute path is an executable file, and on Windows also tries `.exe`/`.cmd`/`.bat`) and only commits when that succeeds; otherwise detection continues with the basename, `$EDITOR`/`$VISUAL` and the built-in list, exactly as it already did for a name that is not installed. With that, every tier verifies before committing, so the setting behaves like the `editor` option does today: an editor that is not installed is skipped rather than failing calls, and a path that is missing when nothing else is found produces the existing `Could not find editor` / `Failed to auto-detect editor` errors instead of a silent no-op. The four `editor = Some(..); path = dirname_store.append(..)` blocks in that function are folded into `resolve()` so the new branch commits the same way as the others.
- `open_in_editor` reuses the cached editor for an `editor` option only if the same name actually resolved to one (`found().is_some()`). `name` can now hold a bunfig value that auto-detection failed to find; without this guard an explicit `{ editor }` equal to that value would hit the name-equality shortcut, report `Failed to auto-detect editor` instead of `Could not find editor`, and never retry once the editor is installed.
- The block in `open_in_editor` that copied `path` into `dirname_store` when `detect_editor` had aliased it to the option's `name_storage` is removed: `detect_editor` no longer aliases `path` to `name` in any branch, so it was dead.
- Precedence, all covered by the tests: an explicit `{ editor }` option, then `[debug] editor`, then `$EDITOR`/`$VISUAL`, then the built-in list. The option still wins because its path writes `name` itself and `auto_detect_editor` only runs when nothing has been resolved.
- Borrowing `ctx.debug.editor` as the `&'static` name is sound because the CLI context is process-lifetime and the field is only written while bunfig is loaded at startup (`load_config`/`load_config_path` callers in `run_command.rs`, `repl_command.rs`, `PackageManager.rs`); `path` is always a `dirname_store` copy, so the detached editor thread never reads either `name` storage.
- Docs: `docs/runtime/bunfig.mdx` gains a `debug.editor` entry describing the full fallback chain (the utils page already linked to the bunfig reference for it), and the `openInEditor` JSDoc mentions the setting.
- Verified with `bun bd test test/js/bun/util/open-in-editor-gc.test.ts` (11 pass). The new cases put fake editors that record their argv into a temp dir, set `PATH` to just that dir and run a script next to a `bunfig.toml`; where both `code` and `subl` are installed with `EDITOR=subl`, the bunfig entry, `$EDITOR` and the built-in list (which starts with `code`) would each pick a different editor, so the cases can tell the sources apart. On the unfixed binary (`USE_SYSTEM_BUN=1`) 4 of the 9 fail, each quickly, with the failure named in parentheses:
  - absolute path in bunfig opens that editor (`Failed to auto-detect editor`)
  - `editor = "code"` beats `EDITOR=subl` (`subl` opens)
  - `editor = "webstorm"`, not installed, falls back to `$EDITOR` (pin)
  - absolute path that does not exist falls back to `$EDITOR` (pin; fails on the seed-only version of this change, where nothing opens)
  - absolute path that does not exist but whose basename is `code` opens `code` from `PATH` (`subl` opens)
  - absolute path that does not exist with nothing else installed throws `Failed to auto-detect editor` (pin; silent no-op on the seed-only version)
  - `{ editor }` option beats bunfig (pin)
  - `{ editor: "/abs/missing" }` throws `Could not find editor "..."` (returns without opening anything)
  - bunfig `code` not installed: plain call fails, `{ editor: "code" }` reports `Could not find editor "code"`, and succeeds once `code` is put on `PATH` (pin; on the seed-only version both explicit calls report `Failed to auto-detect editor`)
- Linux-only like the other tests in the file: with `PATH` limited to the fake editors nothing real can be detected there, while macOS detection also probes `/Applications`.

### Background
- `EditorContext` (`src/runtime/cli/open.rs`) is the per-thread cache behind `Bun.openInEditor`: `name` is the editor the user asked for, `editor` the resolved kind and `path` the binary to spawn. `detect_editor` tries `name` first (absolute path, or a known name looked up on `PATH`), then `$EDITOR`/`$VISUAL`, then a built-in preference list, and records `Editor::None` when nothing was found so the search is not repeated; `auto_detect_editor` runs it once when nothing has been resolved yet. `open_in_editor` in `BunObject.rs` sets `name` itself when an `editor` option is passed and otherwise calls `auto_detect_editor`.
- `Editor::open` builds the argv and hands it to a detached thread that spawns the editor and waits for it, so `path` has to outlive the call; `dirname_store` is a process-lifetime arena used for that.
- `ContextData` (`src/options_types/context.rs`) is the process-global CLI context that argument parsing and bunfig loading fill in during startup; `bun_options_types::context::try_get()` is the read-only handle runtime code uses to consult it, and `debug.editor` is where the `[debug] editor` value lands.

<details>
<summary>Earlier version of this PR</summary>

The first push only seeded `name` from bunfig. Self-review found that this made a stale absolute path in an existing bunfig silently disable `Bun.openInEditor()` (the path was committed without being checked, and the failed spawn was cached), and that an explicit `{ editor }` equal to a bunfig value auto-detection had failed on hit the name-equality shortcut and was never looked up. The absolute-path probe, the `found()` guard and the corresponding test cases were added in response; the docs entry was also corrected to describe the full fallback chain.
</details>
