### PR TITLE
worker_threads: pass the close Event to MessagePort 'close' listeners

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -124,8 +124,14 @@ function injectFakeEmitter(Class) {
     return event.error;
   }
 
-  function customEventHandler(event) {
-    return event.detail;
+  // node hands a node-style listener emit()'s argument when the event came from
+  // emit(), and otherwise the Event itself: its native 'close' is
+  // dispatchEvent(new MessagePortCloseEvent()). emit() below stashes its argument
+  // on the event it synthesizes; every other event (bun's native 'close' Event,
+  // anything passed to dispatchEvent()) is delivered as-is.
+  const kEmitArg = Symbol("emitArg");
+  function eventOrEmitArgHandler(event: Event) {
+    return kEmitArg in event ? event[kEmitArg] : event;
   }
 
   function wrapped(run, listener) {
@@ -146,7 +152,7 @@ function injectFakeEmitter(Class) {
       }
 
       default: {
-        return wrapped(customEventHandler, listener);
+        return wrapped(eventOrEmitArgHandler, listener);
       }
     }
   }
@@ -210,11 +216,14 @@ function injectFakeEmitter(Class) {
       case "message":
         this.dispatchEvent(new (EventClass(event))(event, ...args));
         break;
-      default:
+      default: {
         // Non-standard events surface as CustomEvent (detail = first arg) to
         // addEventListener and as the raw argument to .on(), matching node.
-        this.dispatchEvent(new CustomEvent(event, { detail: args[0] }));
+        const customEvent = new CustomEvent(event, { detail: args[0] });
+        customEvent[kEmitArg] = args[0];
+        this.dispatchEvent(customEvent);
         break;
+      }
     }
     return this;
   }

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -124,8 +124,7 @@ function injectFakeEmitter(Class) {
     return event.error;
   }
 
-  // node: .on() listeners get emit()'s argument, or the Event itself for anything
-  // dispatched as an event (its 'close' is a dispatched MessagePortCloseEvent).
+  // node hands .on() listeners emit()'s argument, and any dispatched event (e.g. its 'close') as the event itself.
   const kEmitArg = Symbol("emitArg");
   function eventOrEmitArgHandler(event: Event) {
     return kEmitArg in event ? event[kEmitArg] : event;

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -124,11 +124,8 @@ function injectFakeEmitter(Class) {
     return event.error;
   }
 
-  // node hands a node-style listener emit()'s argument when the event came from
-  // emit(), and otherwise the Event itself: its native 'close' is
-  // dispatchEvent(new MessagePortCloseEvent()). emit() below stashes its argument
-  // on the event it synthesizes; every other event (bun's native 'close' Event,
-  // anything passed to dispatchEvent()) is delivered as-is.
+  // node: .on() listeners get emit()'s argument, or the Event itself for anything
+  // dispatched as an event (its 'close' is a dispatched MessagePortCloseEvent).
   const kEmitArg = Symbol("emitArg");
   function eventOrEmitArgHandler(event: Event) {
     return kEmitArg in event ? event[kEmitArg] : event;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1439,6 +1439,88 @@ test("close(cb) interleaves with other close listeners in registration order", a
   expect(order2).toEqual(["B", "C"]);
 });
 
+// node's 'close' is dispatchEvent(new MessagePortCloseEvent()), and node-style
+// listeners receive a dispatched event as-is. The .on() shim used to hand every
+// non-message listener event.detail, which a plain Event does not have.
+function recordCloseArgs(port: MessagePort, seen: unknown[], via: string) {
+  return (...args: unknown[]) => {
+    const event = args[0] as Event | undefined;
+    seen.push({
+      via,
+      argc: args.length,
+      isEvent: event instanceof Event,
+      type: event?.type,
+      target: event?.target === port,
+    });
+  };
+}
+
+test("'close' listeners receive the close Event when the port itself is closed", async () => {
+  const { port1, port2 } = new MessageChannel();
+  const seen: unknown[] = [];
+  port1.on("close", recordCloseArgs(port1, seen, "on"));
+  port1.once("close", recordCloseArgs(port1, seen, "once"));
+  const resolved = once(port1, "close");
+  port1.close(recordCloseArgs(port1, seen, "close(cb)"));
+  const [arg] = await resolved;
+  expect(seen).toEqual([
+    { via: "on", argc: 1, isEvent: true, type: "close", target: true },
+    { via: "once", argc: 1, isEvent: true, type: "close", target: true },
+    { via: "close(cb)", argc: 1, isEvent: true, type: "close", target: true },
+  ]);
+  expect(arg).toBeInstanceOf(Event);
+  port2.close();
+});
+
+test("'close' listeners receive the close Event when the peer is closed", async () => {
+  const { port1, port2 } = new MessageChannel();
+  const seen: unknown[] = [];
+  port1.on("close", recordCloseArgs(port1, seen, "on"));
+  const resolved = once(port1, "close");
+  port2.close();
+  const [arg] = await resolved;
+  expect(seen).toEqual([{ via: "on", argc: 1, isEvent: true, type: "close", target: true }]);
+  expect(arg).toBeInstanceOf(Event);
+  port1.close();
+});
+
+// The two other sources of non-message events, as node delivers them: emit()'s
+// argument exactly as passed (undefined when omitted), and an event handed to
+// dispatchEvent() as that very event. addEventListener() still sees a CustomEvent.
+test("non-message .on() listeners get emit()'s argument or the dispatched event itself", () => {
+  const { port1, port2 } = new MessageChannel();
+  const received: unknown[] = [];
+  const details: unknown[] = [];
+  port1.on("custom", arg => received.push(arg));
+  port1.addEventListener("custom", event => details.push((event as CustomEvent).detail));
+
+  const payload = { id: 1 };
+  const plain = new Event("custom");
+  const custom = new CustomEvent("custom", { detail: 7 });
+  port1.emit("custom", payload);
+  port1.emit("custom");
+  port1.dispatchEvent(plain);
+  port1.dispatchEvent(custom);
+
+  expect({
+    argc: received.length,
+    emitPayloadByIdentity: received[0] === payload,
+    omittedEmitArgIsUndefined: received[1] === undefined,
+    plainEventByIdentity: received[2] === plain,
+    customEventByIdentity: received[3] === custom,
+    details,
+  }).toEqual({
+    argc: 4,
+    emitPayloadByIdentity: true,
+    omittedEmitArgIsUndefined: true,
+    plainEventByIdentity: true,
+    customEventByIdentity: true,
+    details: [payload, null, undefined, 7],
+  });
+  port1.close();
+  port2.close();
+});
+
 test("getHeapStatistics settles when terminated mid-request", async () => {
   const w = new Worker("setInterval(() => {}, 1e6)", { eval: true });
   await once(w, "online");


### PR DESCRIPTION
### Problem
- `port.on("close", fn)` on a `node:worker_threads` `MessagePort` calls `fn(undefined)`. Node calls it with the close event (an `Event` subclass named `MessagePortCloseEvent`, `type === "close"`, `target === port`). Same for `port.once("close")`, `port.close(cb)` and `events.once(port, "close")`, which resolves to `[undefined]` in Bun and `[Event]` in Node.
- Cause: `injectFakeEmitter()` in `src/js/node/worker_threads.ts` wraps every non-`message`/`error` listener in `customEventHandler`, which returns `event.detail`. The native close event dispatched by `MessagePort::dispatchCloseEvent()` (`src/jsc/bindings/webcore/MessagePort.cpp`) is a plain `Event`, so `.detail` is `undefined`.
- The same wrapper also turns `port.emit("x")` (no argument) into `null` (the `CustomEvent` default for `detail`) and hands a listener `event.detail` instead of the event for `port.dispatchEvent(new Event("x"))`; Node gives `undefined` and the event respectively.

### Fix
- `emit()` stores its argument on the `CustomEvent` it synthesizes under a module-private symbol. The `.on()`/`.once()` wrapper for non-message events returns that stored value when it is present and otherwise passes the event object through unchanged. `addEventListener()` listeners are unaffected: they still receive the `CustomEvent` with `.detail`.
- This matches Node's dispatch rule for node-style listeners: `emit(type, arg)` delivers `arg`, and anything that goes through `dispatchEvent(event)` delivers `event`. Node's own `'close'` is `this.dispatchEvent(new MessagePortCloseEvent())`, so the close listener gets the event. Bun's native close already dispatches an `Event` of type `close` with `bubbles`/`cancelable` false, the same shape as Node's, so passing it through is all that is needed. The constructor name stays `Event` (Node's `MessagePortCloseEvent` class is not exported, so nothing can `instanceof` it).
- `message`/`messageerror`/`error` listeners are untouched; those still unwrap `.data`/`.error` because Bun's native delivery creates a `MessageEvent` for them.
- Verified with three new tests in `test/js/node/worker_threads/worker_threads.test.ts`: close of the port itself (`on`, `once`, `close(cb)`, `events.once`), close of the peer, and the emit()/dispatchEvent() paths (payload identity, omitted argument is `undefined`, a dispatched `Event`/`CustomEvent` arrives by identity, `addEventListener` still sees `.detail`). All three fail on `main` (`isEvent: false`, `type: undefined`; `omittedEmitArgIsUndefined: false`, `plainEventByIdentity: false`) and pass with the fix.
- Also run: the full `worker_threads.test.ts` (125 pass), `test/js/web/workers/message-channel.test.ts` / `message-event.test.ts`, and the 24 upstream `test-worker-message-port*`, `test-messagechannel`, `test-event-target`, `test-eventtarget*`, `test-worker-workerdata-messageport` tests, all passing on the debug build. The repro from the report prints `1 Event` (Node: `1 MessagePortCloseEvent`).

### Background
- Node's `MessagePort` is a `NodeEventTarget`: one `EventTarget` listener list, where listeners added with `.on()`/`.once()` are flagged node-style. Its dispatch (`kHybridDispatch` in `lib/internal/event_target.js`) takes a "node value" and hands it to node-style listeners as-is, while `EventTarget`-style listeners get an `Event`. `emit(type, arg)` dispatches with `arg` as the node value; `dispatchEvent(event)` dispatches with `event` itself as the node value; native message delivery dispatches with the message data.
- Bun's `MessagePort` is WebCore's `EventTarget`. `node:worker_threads` grafts the node-style methods onto its prototype (`injectFakeEmitter`): `.on(type, fn)` registers a wrapper via `addEventListener` that extracts the node value from the event it receives, so the extractor is the only place where this rule can be applied. This PR makes that extractor follow the rule above for non-message events.
- Related open PRs #35796, #35799, #33856 and #35811 change other parts of this shim (emit payload for `message`/`error`, listener registry, install timing, a native rewrite); none of them changes what a `'close'` listener receives, and the native rewrite in #35811 would need the same pass-through (its node-style argument helper returns `undefined` for a plain `Event`). The tests here cover that case for whichever lands later.

<details>
<summary>Repro output</summary>

```js
const { MessageChannel } = require("worker_threads");
const { port1, port2 } = new MessageChannel();
port1.on("close", (...args) => { console.log(args.length, args[0] && args[0].constructor.name); port2.close(); });
port1.close();
```

```
node v26.3.0:  1 MessagePortCloseEvent
bun 1.4.0:     1 undefined
this branch:   1 Event
```

Node also passes the event for a peer-initiated close, for `close(cb)`, and resolves `events.once(port, "close")` to `[MessagePortCloseEvent]`; `port.emit("foo")` delivers `undefined`; `port.dispatchEvent(ev)` delivers `ev` itself (also for a `CustomEvent`). This branch matches all of those.
</details>
