### PR TITLE
Test that compiled worker_threads run split ESM chunks from bytecode

### DIFF
--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -2,6 +2,40 @@ import { describe, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 
+// With BUN_JSC_verboseDiskCache=1 JSC prints a "[Disk Cache] Cache hit/miss" line
+// for every top-level code block it compiles, and with
+// BUN_JSC_reportBytecodeCacheDecodeTimes=1 a "BytecodeCache: decoded <path>" line
+// for every module whose embedded bytecode was used. Every thread prints its own
+// lines, so the counts show which modules each worker ran from bytecode. The one
+// expected miss per thread is the synthetic bun:main wrapper, which is not part
+// of the binary.
+const bytecodeCacheEnv = {
+  BUN_JSC_verboseDiskCache: "1",
+  BUN_JSC_reportBytecodeCacheDecodeTimes: "1",
+};
+
+function bytecodeCacheStats(stderr: string) {
+  let hits = 0;
+  let misses = 0;
+  const decoded: Record<string, number> = {};
+  for (const line of stderr.split("\n")) {
+    if (line.includes("[Disk Cache] Cache hit for sourceCode")) {
+      hits++;
+    } else if (line.includes("[Disk Cache] Cache miss for sourceCode")) {
+      misses++;
+    } else {
+      const match = /^BytecodeCache: decoded (.+) \(\d+ bytes\)/.exec(line.trim());
+      if (match) {
+        const name = match[1].split(/[\\/]/).pop()!;
+        decoded[name] = (decoded[name] ?? 0) + 1;
+      }
+    }
+  }
+  return { hits, misses, decoded };
+}
+
+const workerCount = 4;
+
 describe("bundler", () => {
   describe("compile with splitting", () => {
     // The embedded module graph is laid out in load order: the entry point's
@@ -169,6 +203,161 @@ describe("bundler", () => {
         for (const name of chunks) {
           expect(name).toMatch(/^(\/\$bunfs|B:\/~BUN)\/root\/chunk-[0-9a-z]+\.js$/);
         }
+      },
+    });
+
+    // Every thread wraps the same embedded bytecode in its own CachedBytecode, so
+    // worker_threads loading the entry point and the split chunks it imports must
+    // run all of them from bytecode, exactly like the main thread does.
+    // Both worker tests use the CLI: it names split chunks [name]-[hash].js, which
+    // the chunk assertions rely on (Bun.build names them chunk-[hash].js).
+    itBundled("compile/splitting/WorkerThreadsSameEntryBytecode+minify", {
+      backend: "cli",
+      compile: true,
+      splitting: true,
+      bytecode: true,
+      format: "esm",
+      minifySyntax: true,
+      minifyIdentifiers: true,
+      minifyWhitespace: true,
+      files: {
+        "/entry.ts": /* js */ `
+          import { Worker, isMainThread, parentPort } from "node:worker_threads";
+
+          async function run() {
+            const [{ task }, { other }] = await Promise.all([import("./task.ts"), import("./other.ts")]);
+            return task(10) + other(5);
+          }
+
+          if (isMainThread) {
+            const main = await run();
+            const workers = await Promise.all(
+              Array.from({ length: ${workerCount} }, () => new Promise((resolve, reject) => {
+                const worker = new Worker(new URL(import.meta.url));
+                let result;
+                worker.on("message", value => { result = value; });
+                worker.on("error", reject);
+                worker.on("exit", code => {
+                  if (code === 0) resolve(result);
+                  else reject(new Error("worker exited with " + code));
+                });
+              })),
+            );
+            console.log(JSON.stringify({ main, workers }));
+          } else {
+            parentPort.postMessage(await run());
+          }
+        `,
+        "/task.ts": /* js */ `
+          import { shared } from "./shared.ts";
+          export function task(n) {
+            return shared("task", n) * 2;
+          }
+        `,
+        "/other.ts": /* js */ `
+          import { shared } from "./shared.ts";
+          export function other(n) {
+            return shared("other", n) + 1;
+          }
+        `,
+        "/shared.ts": /* js */ `
+          export function shared(label, n) {
+            let total = 0;
+            for (let i = 0; i < n; i++) total += i;
+            return total + label.length;
+          }
+        `,
+      },
+      run: {
+        stdout: JSON.stringify({ main: 114, workers: Array(workerCount).fill(114) }),
+        env: bytecodeCacheEnv,
+        validate({ stderr }) {
+          const threads = 1 + workerCount;
+          const { hits, misses, decoded } = bytecodeCacheStats(stderr);
+          expect(misses).toBe(threads);
+          expect(Object.keys(decoded)).toEqual(
+            expect.arrayContaining([expect.stringMatching(/^task-\w+\.js$/), expect.stringMatching(/^other-\w+\.js$/)]),
+          );
+          // The entry and every split chunk are decoded once per thread.
+          expect(decoded).toEqual(Object.fromEntries(Object.keys(decoded).map(name => [name, threads])));
+          expect(hits).toBe(threads * Object.keys(decoded).length);
+        },
+      },
+    });
+
+    // Here the worker entry and the chunks only it imports are loaded for the
+    // first time by several threads at once, not by the main thread first.
+    itBundled("compile/splitting/WorkerThreadsSeparateEntryBytecode+minify", {
+      backend: "cli",
+      compile: true,
+      splitting: true,
+      bytecode: true,
+      format: "esm",
+      minifySyntax: true,
+      minifyIdentifiers: true,
+      minifyWhitespace: true,
+      files: {
+        "/entry.ts": /* js */ `
+          import { Worker } from "node:worker_threads";
+
+          const workers = await Promise.all(
+            Array.from({ length: ${workerCount} }, () => new Promise((resolve, reject) => {
+              const worker = new Worker("./worker.ts");
+              let result;
+              worker.on("message", value => { result = value; });
+              worker.on("error", reject);
+              worker.on("exit", code => {
+                if (code === 0) resolve(result);
+                else reject(new Error("worker exited with " + code));
+              });
+            })),
+          );
+          console.log(JSON.stringify(workers));
+        `,
+        "/worker.ts": /* js */ `
+          import { parentPort } from "node:worker_threads";
+          import { shared } from "./shared.ts";
+          const { lazy } = await import("./lazy.ts");
+          parentPort.postMessage(shared(10) + lazy());
+        `,
+        "/lazy.ts": /* js */ `
+          import { shared } from "./shared.ts";
+          export function lazy() {
+            return shared(4) + 1000;
+          }
+        `,
+        "/shared.ts": /* js */ `
+          export function shared(n) {
+            let total = 0;
+            for (let i = 0; i < n; i++) total += i;
+            return total;
+          }
+        `,
+      },
+      entryPointsRaw: ["./entry.ts", "./worker.ts"],
+      outfile: "dist/out",
+      run: {
+        file: "dist/out",
+        setCwd: true,
+        stdout: JSON.stringify(Array(workerCount).fill(1051)),
+        env: bytecodeCacheEnv,
+        validate({ stderr }) {
+          const { hits, misses, decoded } = bytecodeCacheStats(stderr);
+          expect(misses).toBe(1 + workerCount);
+          const lazyChunk = Object.keys(decoded).find(name => /^lazy-\w+\.js$/.test(name));
+          expect(lazyChunk).toBeDefined();
+          expect(decoded).toEqual(expect.objectContaining({ "worker.js": workerCount, [lazyChunk!]: workerCount }));
+          expect(hits).toBe(Object.values(decoded).reduce((sum, count) => sum + count, 0));
+          // Main entry once, then worker.js, the chunk holding shared.ts and the
+          // lazy.ts chunk once per worker.
+          expect(hits).toBeGreaterThanOrEqual(1 + 3 * workerCount);
+          // A module is decoded by the main thread, by every worker, or by both;
+          // never by only some of the workers.
+          const partiallyDecoded = Object.entries(decoded).filter(
+            ([, count]) => count !== 1 && count !== workerCount && count !== workerCount + 1,
+          );
+          expect(partiallyDecoded).toEqual([]);
+        },
       },
     });
 


### PR DESCRIPTION
### Problem
- Question that came up: in a `bun build --compile --minify --bytecode --splitting --format=esm` binary, do `worker_threads` workers still run from the embedded bytecode when several of them load the same entry point?
- They do, on both the current canary and main, but nothing in the test suite pinned it: `compile/WorkerBytecodeESM` only checks stdout, and the one worker test that does count cache hits (`compile/WorkerRelativePathTSExtensionBytecode`) is CJS, one worker, no splitting. A regression here would be silent: JSC just falls back to parsing and the program still works.

### Fix
- Adds two tests to `test/bundler/bundler_compile_splitting.test.ts`, both `esm + splitting + minify + bytecode`:
  - `WorkerThreadsSameEntryBytecode`: the entry spawns 4 workers of `import.meta.url`; main and every worker dynamically import two modules that share a split chunk. Asserts every embedded module (entry and each chunk) is decoded exactly 5 times (main + 4 workers), hits equal `5 x modules`, and misses equal 5 (one synthetic `bun:main` per thread).
  - `WorkerThreadsSeparateEntryBytecode`: two entry points, the main one never loads the worker's modules, so `worker.js`, its shared chunk and its dynamically imported chunk are first loaded by 4 threads at the same time. Asserts `worker.js` and the lazy chunk are decoded exactly 4 times, misses equal 5, and no module is decoded by only some of the workers.
- The counts come from two existing JSC options: `BUN_JSC_verboseDiskCache=1` (one hit/miss line per top-level code block, already used by the other bytecode tests) and `BUN_JSC_reportBytecodeCacheDecodeTimes=1` (one `BytecodeCache: decoded <path>` line per successfully decoded module, which is what makes the per-module, per-thread counting possible).
- Verified: `bun bd test test/bundler/bundler_compile_splitting.test.ts -t WorkerThreads` passes (about 11s per test in a debug ASAN build, in line with the other compile tests in the file; about 1s in release). Flipping `bytecode: true` to `false` in the first test fails it with 30 misses instead of 5. Outside the test suite, the same binaries were run 200 times with 16 workers (release) and 25 times with 8 workers (debug ASAN) with identical counts every time.

### Background
- `--bytecode` with `--compile` stores JSC's serialized unlinked code blocks for each output chunk in the executable next to the chunk's source. At load time `fetch_builtin_module` (`src/runtime/jsc_hooks.rs`) hands JSC a pointer straight into that embedded section, and `Zig::SourceProvider::create` (`src/jsc/bindings/ZigSourceProvider.cpp`) wraps it in a `JSC::CachedBytecode` with a no-op destructor.
- A worker is a separate JSC VM on its own thread, with its own `CodeCache`, so every thread performs its own lookup and decode. That works from one shared buffer because each thread creates its own `CachedBytecode` object, decoding only reads the buffer, and the module record (`module_info`) is copied out before it is parsed (`ModuleInfoDeserialized::create` in `src/bundler/analyze_transpiled_module.rs`). The tests exercise exactly this: the same bytes decoded by five threads, including concurrently on first load.
- A lookup is a hit when JSC's `SourceCodeKey` matches: source hash and length, strictness, script mode, and code generation flags. `bun:main` is a wrapper module generated in memory for every thread's entry, so it is never in the binary and always misses; that is the one miss per thread the tests expect, same as the existing bytecode tests.

<details>
<summary>Related finding, handled separately</summary>

While checking this I found that any non-ASCII byte in the output (for example `--banner '// ✓'`) makes `--bytecode` miss for every module, because the bytecode is generated from the output treated as Latin-1 while the runtime decodes the embedded file as UTF-8. That is independent of workers and has been filed separately; these tests only use ASCII output.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/bundler_compile_splitting.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/bundler_compile_splitting.test.ts
bun test v1.4.1 (861e9ae04)

test/bundler/bundler_compile_splitting.test.ts:
(pass) bundler > compile with splitting > compile/splitting/ModulesLaidOutInLoadOrder [24860.66ms]
(pass) bundler > compile with splitting > compile/splitting/StartupModulesPrecedeLazyChunks [4862.50ms]
(pass) bundler > compile with splitting > compile/splitting/ChunkNamesAreHashed [4562.58ms]
(pass) bundler > compile with splitting > compile/splitting/WorkerThreadsSameEntryBytecode+minify [5279.79ms]
(pass) bundler > compile with splitting > compile/splitting/WorkerThreadsSeparateEntryBytecode+minify [4969.48ms]
(pass) bundler > compile with splitting > compile/splitting/RelativePathsAcrossChunks [3098.35ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk [2981.45ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk+minify [3283.84ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule [3495.69ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+minify [3273.05ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode [3641.00ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode+minify [3336.00ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting [2453.54ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+minify [2734.65ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+bytecode [2994.93ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+bytecode+minify [3282.00ms]
(pass) bundler > compile with splitting > compile/splitting/ReExportExternalFromSplitChunk [2922.45
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/bundler_compile_splitting.test.ts | 189 +++++++++++++++++++++++++
 1 file changed, 189 insertions(+)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
test/bundler/bundler_compile_splitting.test.ts      8      7      0
```

</details>

<!-- robobun:evidence:end -->