### PR TITLE
bun:ffi: copy the TinyCC diagnostic into the error cc() throws

### DIFF
--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -465,7 +465,7 @@ impl CompileC {
         if this_.is_null() {
             return;
         }
-        let mut msg: &[u8] = if message.is_null() {
+        let msg: &[u8] = if message.is_null() {
             b""
         } else {
             // SAFETY: TCC guarantees `message` is a valid NUL-terminated string when non-null.
@@ -474,17 +474,6 @@ impl CompileC {
         if msg.is_empty() {
             return;
         }
-
-        let mut offset: usize = 0;
-        // the message we get from TCC sometimes has garbage in it
-        // i think because we're doing in-memory compilation
-        while offset < msg.len() {
-            if msg[offset] > 0x20 && msg[offset] < 0x7f {
-                break;
-            }
-            offset += 1;
-        }
-        msg = &msg[offset..];
 
         // SAFETY: TinyCC threads our own `&mut CompileC` back as `ctx`; the
         // caller is suspended in the TCC call, so this access is exclusive.
@@ -1232,7 +1221,10 @@ impl FFI {
             }
             match &function.step {
                 Step::Failed { msg, .. } => {
-                    let res = ZigString::init(msg).to_error_instance(global_this);
+                    // `to_error_instance` wraps an untagged `ZigString` without
+                    // copying, and `msg` is freed with `compile_c` when this
+                    // returns; the UTF-8 tag makes it copy.
+                    let res = ZigString::init_utf8(msg).to_error_instance(global_this);
                     return Err(global_this.throw_value(res));
                 }
                 Step::Pending => {
@@ -1988,19 +1980,7 @@ impl Function {
     pub(crate) unsafe extern "C" fn handle_tcc_error(ctx: *mut Function, message: *const c_char) {
         debug_assert!(!ctx.is_null());
         // SAFETY: TCC passes a valid NUL-terminated string
-        let mut msg: &[u8] = unsafe { bun_core::ffi::cstr(message) }.to_bytes();
-        if !msg.is_empty() {
-            let mut offset: usize = 0;
-            // the message we get from TCC sometimes has garbage in it
-            // i think because we're doing in-memory compilation
-            while offset < msg.len() {
-                if msg[offset] > 0x20 && msg[offset] < 0x7f {
-                    break;
-                }
-                offset += 1;
-            }
-            msg = &msg[offset..];
-        }
+        let msg: &[u8] = unsafe { bun_core::ffi::cstr(message) }.to_bytes();
 
         // SAFETY: TinyCC threads our own `&mut Function` back as `ctx`; the
         // caller is suspended in the TCC call, so this access is exclusive.

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1221,9 +1221,7 @@ impl FFI {
             }
             match &function.step {
                 Step::Failed { msg, .. } => {
-                    // `to_error_instance` wraps an untagged `ZigString` without
-                    // copying, and `msg` is freed with `compile_c` when this
-                    // returns; the UTF-8 tag makes it copy.
+                    // UTF-8-tagged so it is copied: `msg` dies with `compile_c` below.
                     let res = ZigString::init_utf8(msg).to_error_instance(global_this);
                     return Err(global_this.throw_value(res));
                 }

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -139,6 +139,76 @@ describe("given a source file with syntax errors", () => {
   });
 });
 
+// TinyCC reports a diagnostic through a callback; cc() stores the text and
+// throws it later. The wrapper path used to build the Error around the stored
+// bytes without copying them, and cc() freed them on return, so the message
+// reached JS with its first bytes replaced by allocator metadata (a use after
+// free under ASan).
+describe("TinyCC diagnostics thrown by cc()", () => {
+  // One spawned fixture covers both places cc() can fail:
+  // - unresolved.c compiles but does not link, so the diagnostic is collected
+  //   and thrown under a "N errors while compiling" header;
+  // - clash.c defines JSFunctionCall, the entry point of the wrapper cc()
+  //   compiles around every symbol, so the user's C compiles and the wrapper
+  //   does not, and that diagnostic is thrown on its own.
+  it("reach JS byte for byte", async () => {
+    using dir = tempDir("bun-ffi-cc-diagnostics", {
+      "unresolved.c": /* c */ `
+        int bun_test_missing_symbol(int);
+        int add(int a, int b) { return bun_test_missing_symbol(a) + b; }
+      `,
+      "clash.c": /* c */ `
+        int JSFunctionCall(int a) { return a + 1; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        function messageOf(options) {
+          try {
+            cc(options);
+          } catch (error) {
+            return error.message;
+          }
+          return "cc() did not throw";
+        }
+
+        const source = path.join(import.meta.dir, "unresolved.c");
+        const unresolved = messageOf({ source, symbols: { add: { args: ["int", "int"], returns: "int" } } });
+        const clash = messageOf({
+          source: path.join(import.meta.dir, "clash.c"),
+          symbols: { JSFunctionCall: { args: ["int"], returns: "int" } },
+        });
+        console.log(JSON.stringify({ source, unresolved, clash }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let messages: any = stdout;
+    try {
+      messages = JSON.parse(stdout);
+    } catch {}
+
+    // stderr is part of the received object so a crashed fixture shows why,
+    // but it is not asserted empty: debug builds print benign warnings.
+    expect({ messages, stderr, exitCode }).toMatchObject({
+      messages: {
+        unresolved: `1 errors while compiling ${messages.source}\ntcc: error: unresolved reference to 'bun_test_missing_symbol'\n`,
+        clash: expect.stringMatching(/^<string>:\d+: error: .*'JSFunctionCall'$/),
+      },
+      exitCode: 0,
+    });
+  });
+});
+
 describe.skip("given a ping(cstr) function", () => {
   const library = makeValidCase(
     "ping",

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -10,7 +10,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "fs";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isMacOS, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 // TODO: we need to install build-essential and Apple SDK in CI.
@@ -145,16 +145,19 @@ describe("given a source file with syntax errors", () => {
 // JS with its first bytes replaced by allocator metadata, a use after free
 // under ASan) and read them as Latin-1 although TinyCC echoes UTF-8 source.
 describe("TinyCC diagnostics thrown by cc()", () => {
+  // On Mach-O, TinyCC prefixes C symbols with "_" and reports them that way;
+  // asm labels are taken verbatim, so the one below supplies the prefix itself.
+  const symbolPrefix = isMacOS ? "_" : "";
+
   // One spawned fixture covers both places cc() can fail:
   // - unresolved.c compiles but does not link, so the diagnostic is collected
   //   and thrown under a "N errors while compiling" header;
   // - clash.c defines JSFunctionCall, the entry point of the wrapper cc()
   //   compiles around every symbol, so the user's C compiles and the wrapper
   //   does not, and that diagnostic is thrown on its own;
-  // - nonascii.c exports its function under the asm label "y ñ" (TinyCC keeps
-  //   asm labels verbatim, hence the underscore macOS symbols otherwise get),
-  //   so the wrapper's declaration of it is a syntax error whose diagnostic
-  //   quotes the non-ASCII token.
+  // - nonascii.c exports its function under the asm label "y ñ", so the
+  //   wrapper's declaration of it is a syntax error whose diagnostic quotes
+  //   the non-ASCII token.
   it("reach JS byte for byte", async () => {
     using dir = tempDir("bun-ffi-cc-diagnostics", {
       "unresolved.c": /* c */ `
@@ -165,11 +168,7 @@ describe("TinyCC diagnostics thrown by cc()", () => {
         int JSFunctionCall(int a) { return a + 1; }
       `,
       "nonascii.c": /* c */ `
-        #ifdef __APPLE__
-        int add(int a, int b) __asm__("_y ñ");
-        #else
-        int add(int a, int b) __asm__("y ñ");
-        #endif
+        int add(int a, int b) __asm__("${symbolPrefix}y ñ");
         int add(int a, int b) { return a + b; }
       `,
       "fixture.js": /* js */ `
@@ -214,7 +213,7 @@ describe("TinyCC diagnostics thrown by cc()", () => {
     // but it is not asserted empty: debug builds print benign warnings.
     expect({ messages, stderr, exitCode }).toMatchObject({
       messages: {
-        unresolved: `1 errors while compiling ${messages.source}\ntcc: error: unresolved reference to 'bun_test_missing_symbol'\n`,
+        unresolved: `1 errors while compiling ${messages.source}\ntcc: error: unresolved reference to '${symbolPrefix}bun_test_missing_symbol'\n`,
         clash: expect.stringMatching(/^<string>:\d+: error: .*'JSFunctionCall'$/),
         nonascii: expect.stringMatching(/^<string>:\d+: error: .*'ñ'/),
       },

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -139,11 +139,13 @@ describe("given a source file with syntax errors", () => {
   });
 });
 
-// TinyCC reports a diagnostic through a callback; cc() stores the text and
-// throws it later. The wrapper path used to build the Error around the stored
-// bytes without copying them (cc() freed them on return, so the message reached
-// JS with its first bytes replaced by allocator metadata, a use after free
-// under ASan) and read them as Latin-1 although TinyCC echoes UTF-8 source.
+// TinyCC reports each diagnostic through a callback; cc() stores the text and
+// throws it later. Two things used to mangle it on the way to JS: the callbacks
+// dropped leading bytes outside 0x21..0x7e (a diagnostic starts with the source
+// path exactly as it was passed in), and the wrapper path built the Error around
+// the stored bytes without copying them (cc() freed them on return, so the
+// message arrived with its first bytes replaced by allocator metadata, a use
+// after free under ASan) and read them as Latin-1 although TinyCC echoes UTF-8.
 describe("TinyCC diagnostics thrown by cc()", () => {
   // On Mach-O, TinyCC prefixes C symbols with "_" and reports them that way;
   // asm labels are taken verbatim, so the one below supplies the prefix itself.
@@ -152,6 +154,9 @@ describe("TinyCC diagnostics thrown by cc()", () => {
   // One spawned fixture covers both places cc() can fail:
   // - unresolved.c compiles but does not link, so the diagnostic is collected
   //   and thrown under a "N errors while compiling" header;
+  // - " relative.c" has a syntax error and is passed by its relative name, so
+  //   its diagnostic starts with a space (a non-ASCII name would do as well,
+  //   but TinyCC's narrow open() cannot find one on Windows);
   // - clash.c defines JSFunctionCall, the entry point of the wrapper cc()
   //   compiles around every symbol, so the user's C compiles and the wrapper
   //   does not, and that diagnostic is thrown on its own;
@@ -164,6 +169,7 @@ describe("TinyCC diagnostics thrown by cc()", () => {
         int bun_test_missing_symbol(int);
         int add(int a, int b) { return bun_test_missing_symbol(a) + b; }
       `,
+      " relative.c": "int add(int a, int b) { return a  b; }\n",
       "clash.c": /* c */ `
         int JSFunctionCall(int a) { return a + 1; }
       `,
@@ -175,21 +181,25 @@ describe("TinyCC diagnostics thrown by cc()", () => {
         import { cc } from "bun:ffi";
         import path from "path";
 
-        function messageOf(file, symbols) {
+        const add = { add: { args: ["int", "int"], returns: "int" } };
+
+        function messageOf(source, symbols) {
           try {
-            cc({ source: path.join(import.meta.dir, file), symbols });
+            cc({ source, symbols });
           } catch (error) {
             return error.message;
           }
           return "cc() did not throw";
         }
 
+        const unresolvedSource = path.join(import.meta.dir, "unresolved.c");
         console.log(
           JSON.stringify({
-            source: path.join(import.meta.dir, "unresolved.c"),
-            unresolved: messageOf("unresolved.c", { add: { args: ["int", "int"], returns: "int" } }),
-            clash: messageOf("clash.c", { JSFunctionCall: { args: ["int"], returns: "int" } }),
-            nonascii: messageOf("nonascii.c", { "y ñ": { args: ["int", "int"], returns: "int" } }),
+            unresolvedSource,
+            unresolved: messageOf(unresolvedSource, add),
+            relative: messageOf(" relative.c", add),
+            clash: messageOf(path.join(import.meta.dir, "clash.c"), { JSFunctionCall: { args: ["int"], returns: "int" } }),
+            nonascii: messageOf(path.join(import.meta.dir, "nonascii.c"), { "y ñ": { args: ["int", "int"], returns: "int" } }),
           }),
         );
       `,
@@ -213,7 +223,8 @@ describe("TinyCC diagnostics thrown by cc()", () => {
     // but it is not asserted empty: debug builds print benign warnings.
     expect({ messages, stderr, exitCode }).toMatchObject({
       messages: {
-        unresolved: `1 errors while compiling ${messages.source}\ntcc: error: unresolved reference to '${symbolPrefix}bun_test_missing_symbol'\n`,
+        unresolved: `1 errors while compiling ${messages.unresolvedSource}\ntcc: error: unresolved reference to '${symbolPrefix}bun_test_missing_symbol'\n`,
+        relative: "1 errors while compiling  relative.c\n relative.c:1: error: ';' expected (got 'b')\n",
         clash: expect.stringMatching(/^<string>:\d+: error: .*'JSFunctionCall'$/),
         nonascii: expect.stringMatching(/^<string>:\d+: error: .*'ñ'/),
       },

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -141,16 +141,20 @@ describe("given a source file with syntax errors", () => {
 
 // TinyCC reports a diagnostic through a callback; cc() stores the text and
 // throws it later. The wrapper path used to build the Error around the stored
-// bytes without copying them, and cc() freed them on return, so the message
-// reached JS with its first bytes replaced by allocator metadata (a use after
-// free under ASan).
+// bytes without copying them (cc() freed them on return, so the message reached
+// JS with its first bytes replaced by allocator metadata, a use after free
+// under ASan) and read them as Latin-1 although TinyCC echoes UTF-8 source.
 describe("TinyCC diagnostics thrown by cc()", () => {
   // One spawned fixture covers both places cc() can fail:
   // - unresolved.c compiles but does not link, so the diagnostic is collected
   //   and thrown under a "N errors while compiling" header;
   // - clash.c defines JSFunctionCall, the entry point of the wrapper cc()
   //   compiles around every symbol, so the user's C compiles and the wrapper
-  //   does not, and that diagnostic is thrown on its own.
+  //   does not, and that diagnostic is thrown on its own;
+  // - nonascii.c exports its function under the asm label "y ñ" (TinyCC keeps
+  //   asm labels verbatim, hence the underscore macOS symbols otherwise get),
+  //   so the wrapper's declaration of it is a syntax error whose diagnostic
+  //   quotes the non-ASCII token.
   it("reach JS byte for byte", async () => {
     using dir = tempDir("bun-ffi-cc-diagnostics", {
       "unresolved.c": /* c */ `
@@ -160,26 +164,35 @@ describe("TinyCC diagnostics thrown by cc()", () => {
       "clash.c": /* c */ `
         int JSFunctionCall(int a) { return a + 1; }
       `,
+      "nonascii.c": /* c */ `
+        #ifdef __APPLE__
+        int add(int a, int b) __asm__("_y ñ");
+        #else
+        int add(int a, int b) __asm__("y ñ");
+        #endif
+        int add(int a, int b) { return a + b; }
+      `,
       "fixture.js": /* js */ `
         import { cc } from "bun:ffi";
         import path from "path";
 
-        function messageOf(options) {
+        function messageOf(file, symbols) {
           try {
-            cc(options);
+            cc({ source: path.join(import.meta.dir, file), symbols });
           } catch (error) {
             return error.message;
           }
           return "cc() did not throw";
         }
 
-        const source = path.join(import.meta.dir, "unresolved.c");
-        const unresolved = messageOf({ source, symbols: { add: { args: ["int", "int"], returns: "int" } } });
-        const clash = messageOf({
-          source: path.join(import.meta.dir, "clash.c"),
-          symbols: { JSFunctionCall: { args: ["int"], returns: "int" } },
-        });
-        console.log(JSON.stringify({ source, unresolved, clash }));
+        console.log(
+          JSON.stringify({
+            source: path.join(import.meta.dir, "unresolved.c"),
+            unresolved: messageOf("unresolved.c", { add: { args: ["int", "int"], returns: "int" } }),
+            clash: messageOf("clash.c", { JSFunctionCall: { args: ["int"], returns: "int" } }),
+            nonascii: messageOf("nonascii.c", { "y ñ": { args: ["int", "int"], returns: "int" } }),
+          }),
+        );
       `,
     });
 
@@ -203,6 +216,7 @@ describe("TinyCC diagnostics thrown by cc()", () => {
       messages: {
         unresolved: `1 errors while compiling ${messages.source}\ntcc: error: unresolved reference to 'bun_test_missing_symbol'\n`,
         clash: expect.stringMatching(/^<string>:\d+: error: .*'JSFunctionCall'$/),
+        nonascii: expect.stringMatching(/^<string>:\d+: error: .*'ñ'/),
       },
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- When the wrapper that `cc()` compiles around a symbol fails in TinyCC, the Error thrown to JS has the first 8 bytes of its message replaced by garbage, e.g. `error: @nÁÈ[or: unresolved reference to 'memmove'` for TinyCC's `tcc: error: unresolved reference to 'memmove'` (seen on the Linux aarch64 lanes of #38014; any wrapper diagnostic does it, on every platform).
- Under an ASan build the same case is `AddressSanitizer: heap-use-after-free` reading the message (`JSC::stringCopySameType` <- `JSON.stringify`), freed in `FFI::bun_ffi_cc` at the end of `cc()`.
- Cause: `src/runtime/ffi/ffi_body.rs:1235` (before this change) threw `ZigString::init(msg).to_error_instance(...)`. For an untagged `ZigString`, `toErrorInstance` builds the message with the non-copying `Zig::toString` (`src/jsc/bindings/helpers.h`, `getErrorInstance`), so the Error's `.message` points straight at the `Step::Failed` buffer. That buffer is owned by the `Function` inside the `CompileC` local, which is dropped when `cc()` returns the exception, before JS can read it. The 8 garbage bytes are the allocator's free-list link written at the start of the freed block; the rest of the message survives, which is why the text after the first 8 bytes was intact in every sample.
- Same call, second defect: `init` reads the bytes as Latin-1, but TinyCC's text is UTF-8 (it quotes source tokens), so a diagnostic mentioning a non-ASCII name comes out as mojibake (`(got 'Ã±')` for `(got 'ñ')`).
- Both TinyCC error callbacks (`Function::handle_tcc_error`, `CompileC::handle_compilation_error`) also skipped leading bytes outside `0x21..0x7e`. The loop dates from 5e270f9d77 (2022), where the callback had been storing TinyCC's own buffer (freed by TinyCC right after the callback) and the same commit fixed that by copying; the loop runs on the freshly delivered text, so it never had garbage to remove. Wrapper diagnostics always start with `<string>:` or `tcc:`, so there it does nothing; a `CompileC` diagnostic starts with the source path exactly as the user passed it, so there it eats the first byte of a relative path that starts with a space or a non-ASCII character (`ñsyntax.c:1: error: ...` arrives as `syntax.c:1: error: ...`).

### Fix
- Throw `ZigString::init_utf8(msg).to_error_instance(...)`. A UTF-8-tagged `ZigString` is decoded as UTF-8 and copied by `toErrorInstance`, so the Error owns a correctly decoded message. This is the tree's idiom for a message in a transient buffer (`JSGlobalObject::create_error_instance`, "Ensure we clone it"). Every `Step::Failed` message goes through this one site, so the static `fail()` messages are covered too.
- Remove the leading-byte loop from both callbacks; they store the message exactly as TinyCC produced it.
- #31451 (open) makes `getErrorInstance` copy for every caller; that removes the use after free for this site too, but not the Latin-1 decoding or the loops, and it has no test for this path. The two changes are independent (different files) and both stand with the other applied.
- Intentionally not changed here: the three `ZigString::init(function_name...)` sites that name the JS functions and keys in the success paths of `cc()`, `dlopen()` and `linkSymbols()` (`ffi_body.rs` ~1234, ~1577, ~1663, plus the `put` calls next to them). They share the Latin-1 half of the defect (a non-ASCII symbol name comes back as `aÃ±adir`) but not the lifetime half, and need their own tests across the three entry points; filed separately.
- Test: `test/js/bun/ffi/cc.test.ts`, "TinyCC diagnostics thrown by cc()". One spawned fixture exercises the paths and prints the messages:
  - an unresolved reference in the user's C (`CompileC` path), expected exactly `1 errors while compiling <file>\ntcc: error: unresolved reference to 'bun_test_missing_symbol'\n` (on macOS TinyCC stores and reports C symbols with a `_` prefix, so the expected name carries it there); this one passes before and after and pins the format of the untouched formatting path;
  - a syntax error in a file passed by the relative name ` relative.c` (`CompileC` path), expected exactly `1 errors while compiling  relative.c\n relative.c:1: error: ';' expected (got 'b')\n`; before the change the second line loses its leading space (a non-ASCII name shows the same thing but cannot be opened through TinyCC's narrow `open()` on Windows, hence the space);
  - a C function named `JSFunctionCall`, which collides with the wrapper's entry point so the user's C compiles and the wrapper does not (`Function` path), expected `<string>:<line>: error: ... 'JSFunctionCall'`;
  - a function exported under the asm label `y ñ` (asm labels are taken verbatim, so on macOS the label itself carries the `_`), so the wrapper's declaration of it is a syntax error quoting the non-ASCII token (`Function` path), expected `<string>:<line>: error: ... 'ñ'`; this still distinguishes `init_utf8` from `init` once #31451 copies untagged strings, since that copy is Latin-1.
  - Without the fix, release build: the wrapper messages come back as `AMM:371: error: incompatible types for redefinition of 'JSFunctionCall'` and `Pm.M:371: error: ';' expected (got 'Ã±')` (the 8-byte `<string>` prefix is exactly what gets overwritten), and the relative case loses its leading space, so the test fails on all three.
  - Without the fix, `bun bd` (ASan): the fixture dies with `heap-use-after-free`, freed at `FFI::bun_ffi_cc` (`ffi_body.rs:1271`, the drop of `compile_c`), so the test fails.
  - With the fix, `bun bd test test/js/bun/ffi/cc.test.ts` passes, including under ASan (the syntax-error cases go through TinyCC's longjmp and are clean there); the rest of `test/js/bun/ffi/` is unchanged.

### Background
- `cc()` compiles the user's C into one TinyCC state (`CompileC::compile`), then, for each requested symbol, generates a small C wrapper (`Function::print_source_code`, which declares the user's function by name and defines `JSFunctionCall`) and compiles it from a string in a second TinyCC state (`Function::compile`). TinyCC delivers diagnostics through the error callback registered on each state. The user-source state's callback collects them and `cc()` formats them into a fresh string under a `N errors while compiling <file>` header (that path copies, and was only affected by the loop); the wrapper state's callback stores the text in `Step::Failed { msg }`, which `cc()` throws as-is (the path fixed here).
- `ZigString` is a borrowed pointer+length with flag bits in the pointer. `toErrorInstance` decodes and copies the bytes when the UTF-8 flag is set; an untagged string is treated as Latin-1 and wrapped with `StringImpl::createWithoutCopying`, which is meant for static text. `init` leaves the string untagged; `init_utf8` sets the flag.
- The "first 8 bytes are garbage" shape is what a freed block looks like with mimalloc (the allocator in release builds): freeing writes the free-list `next` pointer into the first 8 bytes of the block and leaves the rest alone. The values seen in CI (for example `90 4b 7c 4e 0d 05 00 00`, a pointer in the address range mimalloc reserves) are such pointers.

<details>
<summary>Related sites (not changed here)</summary>

- `src/jsc/AsyncModule.rs` builds two errors from a local `Vec` through the same untagged `to_error_instance`; #31451 is the fix for those.
- The success-path symbol names in `ffi_body.rs` described under Fix; filed separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->