### PR TITLE
build: track the files generate-classes and bindgen read besides their sources

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -29,6 +29,18 @@
  * eval/ dir, JSSink.lut.txt consumed within its own step). The remaining
  * #included exception is BunBuiltinNames+extras.h from bundle-functions.ts,
  * reached through the PCH.
+ *
+ * ## Inputs
+ *
+ * A step's inputs are everything whose content reaches its output, not just
+ * the script named on the command line: the modules the script (or its
+ * sources) import that take part in generating (class-definitions.ts,
+ * bindgen-lib*.ts), and whatever it reads on its own (the bun_runtime .rs
+ * tree for generate-classes, src/runtime + src/jsc for host-exports,
+ * ErrorCode.ts for bundle-modules). Ninja only re-runs a step for files
+ * listed on its edge, so a file missing here means a stale output until some
+ * listed file happens to change. helpers.ts (writeIfNotChanged, argParse)
+ * does not shape any output and is not listed.
  */
 
 import { spawnSync } from "node:child_process";
@@ -380,6 +392,11 @@ function shJoin(cfg: Config, args: string[]): string {
   return quoteArgs(args, cfg.host.os === "windows");
 }
 
+/** Forward slashes, so globbed paths can be compared against a prefix on every host. */
+function slashed(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // Individual step emitters
 // ───────────────────────────────────────────────────────────────────────────
@@ -575,8 +592,35 @@ function emitErrorCode({ n, cfg, o, dirStamp }: Ctx): void {
   o.cppHeaders.push(...cppOutputs);
 }
 
-function emitGeneratedClasses({ n, cfg, sources, o, dirStamp }: Ctx): void {
+/**
+ * Files of the bun_runtime crate that live outside src/runtime/: lib.rs mounts
+ * them with `#[path]`, so generate-classes.ts's walk of the crate reads them
+ * like any other module. test/internal/source-lints/build-codegen-script-inputs.test.ts
+ * checks this list against the `#[path]` attributes in the tree.
+ */
+const runtimeCrateFilesOutsideSrcRuntime = ["src/bun.js.rs", "src/jsc/generated_classes_list.rs"];
+
+/** Exported for test/internal/source-lints/build-codegen-script-inputs.test.ts. */
+export function emitGeneratedClasses({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "generate-classes.ts");
+  // Imported by the script and, for define(), by every .classes.ts it loads.
+  const classDefinitions = resolve(cfg.cwd, "src", "codegen", "class-definitions.ts");
+
+  // generated_classes.rs refers to each class's Rust type by a `crate::…` path
+  // the script resolves by walking the bun_runtime `pub mod` tree from
+  // src/runtime/lib.rs, so the crate's sources are inputs: moving a struct or
+  // adding a re-export changes the output without any .classes.ts changing.
+  // Every one of these is already an input of the cargo edge, and restat +
+  // writeIfNotChanged keep an edit that leaves the resolved paths alone from
+  // reaching cargo or the C++ compiles (same shape as emitHostExports).
+  const runtimeDir = slashed(resolve(cfg.cwd, "src", "runtime")) + "/";
+  const rsInputs = [
+    ...sources.rust.filter(p => {
+      const q = slashed(p);
+      return q.endsWith(".rs") && q.startsWith(runtimeDir);
+    }),
+    ...runtimeCrateFilesOutsideSrcRuntime.map(p => resolve(cfg.cwd, p)),
+  ];
 
   const outputs = [
     resolve(cfg.codegenDir, "ZigGeneratedClasses.h"),
@@ -596,7 +640,8 @@ function emitGeneratedClasses({ n, cfg, sources, o, dirStamp }: Ctx): void {
   n.build({
     outputs,
     rule: "codegen",
-    inputs: [script, ...sources.zigGeneratedClasses],
+    inputs: [script, classDefinitions, ...sources.zigGeneratedClasses],
+    implicitInputs: rsInputs,
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,
@@ -621,7 +666,6 @@ function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
   // the two crates so unrelated edits (e.g. src/bundler) don't re-run the
   // scrape. restat=1 + writeIfNotChanged means a no-marker-change edit
   // produces identical output and the cargo step is pruned.
-  const slashed = (p: string) => p.replace(/\\/g, "/");
   const scrapeDirs = [slashed(`${cfg.cwd}/src/runtime/`), slashed(`${cfg.cwd}/src/jsc/`)];
   const rsInputs = sources.rust.filter(p => {
     const q = slashed(p);
@@ -855,6 +899,9 @@ export function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
 export function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
+  // The generator proper: bindgen.ts and every .bind.ts (`import ... from
+  // "bindgen"`, a tsconfig path for bindgen-lib.ts) import these.
+  const lib = ["bindgen-lib.ts", "bindgen-lib-internal.ts"].map(f => resolve(cfg.cwd, "src", "codegen", f));
 
   const cppOut = resolve(cfg.codegenDir, "GeneratedBindings.cpp");
   // Plus one header per .bind.ts (node_os.bind.ts → GeneratedNodeOs.h), which
@@ -869,7 +916,7 @@ export function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   n.build({
     outputs: [cppOut, ...headers],
     rule: "codegen",
-    inputs: [script, ...sources.bindgen],
+    inputs: [script, ...lib, ...sources.bindgen],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,

--- a/test/internal/source-lints/build-codegen-script-inputs.test.ts
+++ b/test/internal/source-lints/build-codegen-script-inputs.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Two codegen steps in scripts/build/codegen.ts read more than the entry script
+ * and the globbed sources their ninja edges used to list, so editing one of the
+ * other files left the generated output stale until some listed file changed:
+ *
+ * - generate-classes: class-definitions.ts (imported by the script and, for
+ *   define(), by every .classes.ts), and the .rs files of the bun_runtime crate,
+ *   which the script walks to resolve each class to the `crate::...` path it
+ *   writes into generated_classes.rs. The crate is src/runtime/ plus the files
+ *   lib.rs mounts from outside that directory with `#[path]`; codegen.ts names
+ *   those explicitly, so the last test checks its list against the tree.
+ * - bindgen: bindgen-lib.ts and bindgen-lib-internal.ts, imported by bindgen.ts
+ *   and (as "bindgen") by every .bind.ts.
+ *
+ * Everything here is configure-time emission into a scratch build dir; nothing
+ * is run or written.
+ */
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve, sep } from "node:path";
+
+import {
+  emitBindgen,
+  emitGeneratedClasses,
+  registerCodegenRules,
+  type CodegenOutputs,
+} from "../../../scripts/build/codegen.ts";
+import { registerDirStamps } from "../../../scripts/build/compile.ts";
+import { resolveConfig, type Config, type Toolchain } from "../../../scripts/build/config.ts";
+import { Ninja } from "../../../scripts/build/ninja.ts";
+import type { Sources } from "../../../scripts/glob-sources.ts";
+
+/** A fully-populated fake toolchain; neither emitter under test runs any of it. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+interface Configured {
+  cfg: Config;
+  n: Ninja;
+  o: CodegenOutputs;
+  dirStamp: string;
+  /** Absolute path of a file in the repo. */
+  src: (repoRelative: string) => string;
+}
+
+/**
+ * A linux-x64 debug target in `buildDir` (resolves on every host once told
+ * where its sysroot is; the path is only recorded), with the rules the emitters
+ * reference registered and the empty output groups emitCodegen hands them.
+ */
+function configure(buildDir: string): Configured {
+  const cfg = resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildType: "Debug", buildDir, linuxSysroot: buildDir },
+    mockToolchain(),
+  );
+  const n = new Ninja({ buildDir });
+  registerDirStamps(n, cfg);
+  registerCodegenRules(n, cfg);
+  const o: CodegenOutputs = {
+    all: [],
+    rustInputs: [],
+    rustOrderOnly: [],
+    cppSources: [],
+    cppHeaders: [],
+    cppAll: [],
+    bindgenV2Cpp: [],
+    internalModulesAsm: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.S"),
+    internalModulesBin: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.bin"),
+    rootInstall: resolve(buildDir, "stamps", "install.stamp"),
+  };
+  return { cfg, n, o, dirStamp: resolve(cfg.codegenDir, ".dir"), src: p => resolve(cfg.cwd, p) };
+}
+
+/** Just the lists the emitter under test reads; it never looks at the rest of `Sources`. */
+function sourceLists(lists: Partial<Sources>): Sources {
+  return lists as Sources;
+}
+
+/** Splits one side of a build line on unescaped spaces and undoes ninja's path escaping. */
+function paths(n: Ninja, s: string): string[] {
+  return s
+    .split(/(?<!\$) /)
+    .filter(token => token.length > 0)
+    .map(token => resolve(n.buildDir, token.replace(/\$([ :$])/g, "$1")));
+}
+
+/**
+ * The inputs ninja compares mtimes against for the `build` statement in `n`
+ * that produces `output`: its explicit and `|` implicit inputs, as absolute
+ * paths. `||` order-only inputs are left out; a file listed there would not
+ * re-run the step when it changes.
+ */
+function trackedInputs(n: Ninja, output: string): string[] {
+  for (const line of n
+    .toString()
+    .replace(/ \$\n +/g, " ")
+    .split("\n")) {
+    if (!line.startsWith("build ")) continue;
+    const colon = line.search(/(?<!\$): /);
+    const outputs = paths(n, line.slice("build ".length, colon).replace(/(?<!\$) \| /, " "));
+    if (!outputs.includes(output)) continue;
+
+    const [tracked = ""] = line.slice(colon + 2).split(/(?<!\$) \|\| /);
+    const [explicit = "", implicit = ""] = tracked.split(/(?<!\$) \| /);
+    // The first explicit token is the rule name.
+    return [...paths(n, explicit).slice(1), ...paths(n, implicit)];
+  }
+  throw new Error(`no build edge produces ${output}`);
+}
+
+function inSrcRuntime(cfg: Config, file: string): boolean {
+  return file.startsWith(resolve(cfg.cwd, "src", "runtime") + sep);
+}
+
+/**
+ * Every existing file outside src/runtime/ that a `#[path = "..."]` attribute
+ * in the crate points at, resolved the way generate-classes.ts resolves them
+ * (against the declaring file's directory; for an attribute inside an inline
+ * `mod { }` block, which the walk skips, that can name a file that is not
+ * there, hence the existence check). Whether the mount is `pub` is not checked:
+ * a private one only makes the edge list a file the walk skips.
+ */
+function filesMountedFromOutsideSrcRuntime(cfg: Config): string[] {
+  const mounted = new Set<string>();
+  for (const file of new Bun.Glob("src/runtime/**/*.rs").scanSync({ cwd: cfg.cwd, absolute: true })) {
+    for (const [, target] of readFileSync(file, "utf8").matchAll(/#\[path\s*=\s*"([^"]+)"\]/g)) {
+      const abs = resolve(dirname(file), target!);
+      if (!inSrcRuntime(cfg, abs) && existsSync(abs)) mounted.add(abs);
+    }
+  }
+  return [...mounted].sort();
+}
+
+/** Emits the generate-classes step for the given source lists and returns the inputs its edge tracks. */
+function generatedClassesInputs(c: Configured, rust: string[], zigGeneratedClasses: string[]): string[] {
+  const { n, cfg, o, dirStamp } = c;
+  emitGeneratedClasses({ n, cfg, sources: sourceLists({ zigGeneratedClasses, rust }), o, dirStamp });
+  return trackedInputs(n, resolve(cfg.codegenDir, "generated_classes.rs"));
+}
+
+describe("emitGeneratedClasses", () => {
+  test("tracks class-definitions.ts along with the script and the .classes.ts files", () => {
+    using dir = tempDir("build-codegen-classes-inputs", {});
+    const c = configure(String(dir));
+    const classesFiles = [c.src("src/runtime/api/Archive.classes.ts"), c.src("src/jsc/resolve_message.classes.ts")];
+
+    expect(generatedClassesInputs(c, [], classesFiles)).toEqual(
+      expect.arrayContaining([
+        c.src("src/codegen/generate-classes.ts"),
+        c.src("src/codegen/class-definitions.ts"),
+        ...classesFiles,
+      ]),
+    );
+  });
+
+  test("tracks the .rs files under src/runtime/ from the rust glob and nothing else from it", () => {
+    using dir = tempDir("build-codegen-classes-rs", {});
+    const c = configure(String(dir));
+    const crate = [c.src("src/runtime/lib.rs"), c.src("src/runtime/api.rs"), c.src("src/runtime/api/Archive.rs")];
+    // The rest of what glob-sources' `rust` pattern matches: the crate's
+    // non-.rs entries, other crates (one with a directory name that shares the
+    // prefix), and the workspace manifests.
+    const otherRustSources = [
+      c.src("src/runtime/Cargo.toml"),
+      c.src("src/runtime/server/dev-error-page.html"),
+      c.src("src/runtime_probe/lib.rs"),
+      c.src("src/jsc/lib.rs"),
+      c.src("src/install/lib.rs"),
+      c.src("Cargo.toml"),
+      c.src("Cargo.lock"),
+      c.src("rust-toolchain.toml"),
+    ];
+
+    const tracked = generatedClassesInputs(
+      c,
+      [...otherRustSources, ...crate],
+      [c.src("src/runtime/api/Archive.classes.ts")],
+    );
+
+    expect(tracked).toEqual(expect.arrayContaining(crate));
+    for (const p of otherRustSources) expect(tracked).not.toContain(p);
+  });
+
+  test("the .rs files it tracks outside src/runtime/ are the ones the crate mounts from there with #[path]", () => {
+    using dir = tempDir("build-codegen-classes-mounts", {});
+    const c = configure(String(dir));
+
+    const tracked = generatedClassesInputs(
+      c,
+      [c.src("src/runtime/lib.rs")],
+      [c.src("src/runtime/api/Archive.classes.ts")],
+    );
+
+    const mounted = filesMountedFromOutsideSrcRuntime(c.cfg);
+    // lib.rs mounts src/bun.js.rs and src/jsc/generated_classes_list.rs today;
+    // what matters is that codegen.ts's list and the tree's attributes move together.
+    expect(mounted).not.toBeEmpty();
+    expect(tracked.filter(p => p.endsWith(".rs") && !inSrcRuntime(c.cfg, p)).sort()).toEqual(mounted);
+  });
+});
+
+describe("emitBindgen", () => {
+  test("tracks bindgen-lib.ts and bindgen-lib-internal.ts along with the script and the .bind.ts files", () => {
+    using dir = tempDir("build-codegen-bindgen-inputs", {});
+    const c = configure(String(dir));
+    const { n, cfg, o, dirStamp } = c;
+    const bindgen = [c.src("src/runtime/node/node_os.bind.ts"), c.src("src/runtime/api/BunObject.bind.ts")];
+
+    emitBindgen({ n, cfg, sources: sourceLists({ bindgen }), o, dirStamp });
+
+    expect(trackedInputs(n, resolve(cfg.codegenDir, "GeneratedBindings.cpp"))).toEqual(
+      expect.arrayContaining([
+        c.src("src/codegen/bindgen.ts"),
+        c.src("src/codegen/bindgen-lib.ts"),
+        c.src("src/codegen/bindgen-lib-internal.ts"),
+        ...bindgen,
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
### Problem

- The generate-classes edge in `scripts/build/codegen.ts` (`emitGeneratedClasses`) lists `generate-classes.ts` and the `*.classes.ts` files, but the script reads two more kinds of input whose content ends up in its outputs, so an edit to either leaves `ZigGeneratedClasses.*` / `generated_classes.rs` stale until some `.classes.ts` happens to change:
  - `src/codegen/class-definitions.ts`: imported by the script (`generate-classes.ts:5`) and by every `.classes.ts` for `define()`, which shapes the definitions the generator sees (it adds the `inspectCustom` prototype entry, sorts members, fills in defaults).
  - The bun_runtime crate's `.rs` files: `rustModuleResolver` (`generate-classes.ts:1980`) walks the `pub mod` tree from `src/runtime/lib.rs`, reading each file, and writes the resolved `crate::...` path of every class into `generated_classes.rs` (`pub use crate::api::archive::Archive as Archive;`). Moving a type or adding/removing a re-export changes that output with no `.classes.ts` edit; when the stale path no longer exists, the next incremental `bun bd` fails in cargo until a `.classes.ts` is touched. The walk reads 299 of the 420 files under `src/runtime/` plus two files `lib.rs` mounts from outside the directory with `#[path]` (`src/bun.js.rs`, `src/jsc/generated_classes_list.rs`). No `.rs` file was on the edge.
- Reproduced on a warm linux-x64 debug tree: with the target up to date, `touch src/codegen/class-definitions.ts` or `touch src/runtime/lib.rs` followed by `ninja -n codegen/ZigGeneratedClasses.cpp` prints `no work to do`; appending `pub use crate::api::archive::Archive;` to `src/runtime/api.rs` and running ninja leaves `generated_classes.rs` at `crate::api::archive::Archive`, and touching a `.classes.ts` afterwards regenerates it as `crate::api::Archive`. Transcript below.
- The bindgen edge (`emitBindgen`) has the same gap: it lists `bindgen.ts` and the `.bind.ts` files, but `bindgen.ts` imports `bindgen-lib-internal.ts` (the type model and emitters) and every `.bind.ts` imports `bindgen-lib.ts` (as `"bindgen"`, a path in `src/tsconfig.json`). `touch src/codegen/bindgen-lib-internal.ts; ninja -n codegen/GeneratedBindings.cpp` prints `no work to do`.

### Fix

- `emitGeneratedClasses`: `class-definitions.ts` joins the inputs; the `.rs` files under `src/runtime/` (filtered out of the `rust` glob the cargo edge already uses) plus the two `#[path]`-mounted files become implicit inputs. 422 files on this tree.
- `emitBindgen`: `bindgen-lib.ts` and `bindgen-lib-internal.ts` join the inputs.
- Why this is correct: ninja re-runs a step only for files listed on its edge, and these are the files whose content reaches the outputs. `src/runtime/` is the right boundary for the walk because the walk is the crate's module tree; the two files that tree reaches outside the directory are named explicitly (the only way out of the directory is a `#[path]` attribute), and the new test fails if the attributes in the tree and that list ever disagree. The directory over-approximates the walk by the files it skips (private modules); an edit to one of them costs a re-run of the step (under a second) and nothing more, because the codegen rule has `restat = 1` and the script writes with `writeIfNotChanged`, so unchanged outputs do not dirty cargo or the C++ compiles (after a touch of `class-definitions.ts`, ninja planned 2 steps and ran 1; the `.lut.h` step was pruned). Edits to other crates still do not re-run it, and every file added here is already an input of the cargo edge, so ninja stats nothing new; `emitHostExports` already re-runs on the same `src/runtime/` edits, so no edit that went straight to cargo before waits on a codegen step now.
- Not a depfile: the script would have to emit one, the shared `codegen` rule would need a variant, and the build's minimum ninja is 1.9 (`ninja.ts`), all of that to track two files that the test now pins instead.
- Left as is: `helpers.ts` (`writeIfNotChanged`, `argParse`), which no edge lists because it does not shape any output; `js_classes.ts`, which #38049 adds to this edge together with the bundle-modules inputs (that PR and this one touch the same `inputs:` line in `emitGeneratedClasses`, both additively). The codegen.ts header gets a paragraph stating the rule the edges follow.
- Verified:
  - `test/internal/source-lints/build-codegen-script-inputs.test.ts` (a build-script unit test per that directory's README; it runs the emitters into a scratch build dir and parses the build lines): passes with `bun bd test`; with `codegen.ts` at main the file fails to load (the emitter is not exported there); with the exports kept and only the new inputs removed all four tests fail on their assertions.
  - Real ninja on the debug tree after reconfiguring: touching `class-definitions.ts`, `src/runtime/lib.rs`, `src/bun.js.rs` or `bindgen-lib-internal.ts` each plans the step (`-d explain` names the file); touching `src/install/lib.rs` does not; a second run is `no work to do`.
  - `bunx tsc --noEmit -p scripts/build/tsconfig.json` reports nothing in `codegen.ts`; `test/internal/source-lints/` and `test/internal/build-codegen-declared-outputs.test.ts` still pass.

### Background

- A ninja edge lists explicit inputs, implicit inputs (`| file`) and order-only inputs (`|| file`). Ninja re-runs the edge when an explicit or implicit input is newer than its outputs; order-only inputs only have to exist; a file in none of the lists is invisible. The `codegen` rule does not use `$in` (each script gets its arguments via `$args`), so explicit versus implicit is only a matter of spelling here; this change follows the file's habit of putting bulk lists in `implicitInputs`.
- `restat = 1` makes ninja re-stat an edge's outputs after the command; outputs whose mtime did not move do not dirty anything downstream. The codegen scripts only rewrite a file when its content changed, so a re-run with the same result stops at the step itself.
- `generate-classes.ts` turns the `*.classes.ts` definitions into the C++ wrapper classes (`ZigGeneratedClasses.*`) and into `generated_classes.rs`, the Rust side of the same bindings. For the latter it has to know where each class's Rust type lives, which it works out by following `pub mod` declarations from the crate root, honouring `#[path = "..."]`, the Rust attribute that mounts a file from an arbitrary location as a module. `src/runtime/lib.rs` uses it for `src/bun.js.rs` and for `src/jsc/generated_classes_list.rs` (kept under `src/jsc` to avoid a crate cycle, per the comment there).
- `emitHostExports`, a few lines below, is the existing example of a codegen step whose inputs are a filtered slice of the `rust` glob.
- bindgen is the `.bind.ts`-driven binding generator: `bindgen-lib.ts` is the API the `.bind.ts` files import, `bindgen-lib-internal.ts` holds the type model that `bindgen.ts` generates from.

<details>
<summary>ninja transcript (linux-x64, build/debug)</summary>

Before, target up to date:

```
$ ninja -C build/debug -n codegen/ZigGeneratedClasses.cpp
ninja: no work to do.
$ touch src/codegen/class-definitions.ts; ninja -C build/debug -n codegen/ZigGeneratedClasses.cpp
ninja: no work to do.
$ touch src/runtime/lib.rs; ninja -C build/debug -n codegen/ZigGeneratedClasses.cpp
ninja: no work to do.
$ touch src/runtime/api/Archive.classes.ts; ninja -C build/debug -n codegen/ZigGeneratedClasses.cpp   # control
[1/1] gen ZigGeneratedClasses.{cpp,h,rs}

$ grep -n "Archive as Archive" build/debug/codegen/generated_classes.rs
42:pub use crate::api::archive::Archive as Archive;
$ echo 'pub use crate::api::archive::Archive;' >> src/runtime/api.rs
$ ninja -C build/debug codegen/generated_classes.rs
ninja: no work to do.
$ touch src/runtime/api/Archive.classes.ts; ninja -C build/debug codegen/generated_classes.rs
[1/1] gen ZigGeneratedClasses.{cpp,h,rs}
$ grep -n "Archive as Archive" build/debug/codegen/generated_classes.rs
42:pub use crate::api::Archive as Archive;

$ touch src/codegen/bindgen-lib-internal.ts; ninja -C build/debug -n codegen/GeneratedBindings.cpp
ninja: no work to do.
$ touch src/codegen/bindgen.ts; ninja -C build/debug -n codegen/GeneratedBindings.cpp   # control
[1/1] gen .bind.ts → GeneratedBindings.cpp
```

After (`bun scripts/build.ts --configure-only`, targets brought up to date, one touch at a time, each followed by a real run):

```
$ touch src/codegen/class-definitions.ts; ninja -C build/debug -n -d explain codegen/ZigGeneratedClasses.cpp
ninja explain: recorded mtime of codegen/ZigGeneratedClasses.h older than most recent input ../../src/codegen/class-definitions.ts (...)
[1/1] gen ZigGeneratedClasses.{cpp,h,rs}
$ touch src/runtime/lib.rs; ...
ninja explain: ... older than most recent input ../../src/runtime/lib.rs (...)
[1/1] gen ZigGeneratedClasses.{cpp,h,rs}
$ touch src/bun.js.rs; ...
ninja explain: ... older than most recent input ../../src/bun.js.rs (...)
[1/1] gen ZigGeneratedClasses.{cpp,h,rs}
$ touch src/install/lib.rs; ninja -C build/debug -n codegen/ZigGeneratedClasses.cpp
ninja: no work to do.
$ touch src/codegen/bindgen-lib-internal.ts; ninja -C build/debug -n -d explain codegen/GeneratedBindings.cpp
ninja explain: recorded mtime of codegen/GeneratedBindings.cpp older than most recent input ../../src/codegen/bindgen-lib-internal.ts (...)
[1/1] gen .bind.ts → GeneratedBindings.cpp

$ touch src/codegen/class-definitions.ts; ninja -C build/debug codegen/ZigGeneratedClasses.lut.h
[1/2] gen ZigGeneratedClasses.{cpp,h,rs}
(the second step, the .lut.h, was pruned by restat: the .lut.txt did not change)
```

The edge now carries 422 `.rs` implicit inputs (420 under `src/runtime/` plus the two mounts); `build.ninja` grows from 1.96 MB to 2.01 MB.

</details>

Related, all separate: #38049 (js_classes.ts on this edge plus the bundle-modules inputs), #38038 (deleted glob inputs), #38035 (bindgen declared outputs), #37992 (PCH). The bake-codegen edge has a gap of its own (the bundles pull in `src/runtime.bun.js` and `src/runtime/bake/package.json`) and is filed separately as well.
