### PR TITLE
build(windows): mark the rust_shim edge restat so the build after a shim rebuild is a no-op

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -239,6 +239,17 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
   // overwriting the exe makes this dir's stamp stale → the shim is rebuilt
   // for the right arch on the next build here.
   //
+  // So the edge rewrites one of its own inputs, and that is what `restat` is
+  // for here (not pruning: the stamp is touched unconditionally, so nothing
+  // downstream is ever pruned). For a non-restat edge, ninja 1.11+ logs the
+  // time the command *started* as the output's mtime; the exe copied during
+  // the command is newer than that, so the stamp is dirty again on the build
+  // right after every real shim rebuild: one more cargo round for the shim,
+  // then one for bun_bin, whose edge has the stamp as an input. With restat,
+  // ninja logs the stamp's mtime as re-stat'ed after the command, and the
+  // touch runs after the copy, so the next build is a no-op. A sibling build
+  // dir's overwrite lands later than that, so it still invalidates the stamp.
+  //
   // Registered for windows *targets* only; the shell dialect follows the
   // HOST (cmd.exe natively, sh when cross-compiling from linux/macOS).
   if (cfg.windows) {
@@ -250,9 +261,7 @@ export function registerRustRules(n: Ninja, cfg: Config): void {
           `( cmp -s $shim_src $shim_dest 2>/dev/null || cp $shim_src $shim_dest ) && touch $out`,
       description: "cargo bun_shim_impl → $shim_dest",
       pool: "console",
-      // No restat: the stamp ($out) is touched unconditionally, so there's
-      // nothing for ninja to prune on; the content-conditional copy above
-      // exists for cargo's dep-info on $shim_dest, not for restat.
+      restat: true,
     });
   }
 

--- a/test/internal/build-rust-shim-edge.test.ts
+++ b/test/internal/build-rust-shim-edge.test.ts
@@ -17,8 +17,12 @@
  * The graph under test is what registerRustRules() + emitRust() emit, pointed
  * at a scratch repo and at a cargo stand-in that writes the PE where cargo
  * would. Driving it takes ninja itself and a non-windows host: the stand-in is
- * a shell script, and the rule's shell dialect follows the host. The emission
- * test at the end runs everywhere.
+ * a shell script, and the rule's shell dialect follows the host. The `ninja`
+ * on PATH may also be samurai (Alpine), which logs every edge's post-command
+ * mtime and so never had the extra rebuild; there the build test only checks
+ * that the restat rule still converges and still notices the sibling's
+ * overwrite, and the driver's messages are not parsed beyond what the two
+ * implementations share. The emission test at the end runs everywhere.
  */
 import { which } from "bun";
 import { describe, expect, test } from "bun:test";
@@ -174,27 +178,44 @@ function edge(
   };
 }
 
-function buildShim(buildDir: string, ...flags: string[]): { stdout: string; stderr: string; exitCode: number } {
-  const { stdout, stderr, exitCode } = Bun.spawnSync({
-    cmd: [ninjaExe!, "-C", buildDir, ...flags, "bun-shim"],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
-}
-
 /**
- * What the next build would do, per a dry run with `-d explain`: a failing
- * assertion then shows ninja's own reason, e.g. "recorded mtime of
- * .../bun_shim_impl.stamp older than most recent input .../bun_shim_impl.exe".
+ * Drives the stamp edge with the `ninja` on PATH. It is run from the build dir
+ * and asked for the stamp itself rather than via `-C` and the `bun-shim`
+ * phony: `-C` makes samurai announce the directory on stderr, and samurai 1.2
+ * crashes on a dry run that reaches a pending edge through a phony.
  */
-function nextBuild(buildDir: string): { noWorkToDo: boolean; explain: string[] } {
-  const { stdout, stderr, exitCode } = buildShim(buildDir, "-n", "-d", "explain");
-  const explain = stderr.split("\n").filter(line => line.startsWith("ninja explain: "));
-  expect(stderr.replace(/^ninja explain: .*\n?/gm, "")).toBe("");
-  expect(exitCode).toBe(0);
-  return { noWorkToDo: stdout.includes("ninja: no work to do."), explain };
+function shimDriver(buildDir: string, shimStamp: string) {
+  const target = slash(relative(buildDir, shimStamp));
+  const run = (...flags: string[]) => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [ninjaExe!, ...flags, target],
+      cwd: buildDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+  };
+  return {
+    build: () => run(),
+    /**
+     * What the next build would do, per a dry run with `-d explain`. Both
+     * implementations print a `[N/M] <description>` line per edge they would
+     * run and one `explain` line per reason on stderr (ninja: "ninja explain:
+     * recorded mtime of .../bun_shim_impl.stamp older than most recent input
+     * .../bun_shim_impl.exe"), so a failing assertion shows the reason; a
+     * clean graph yields neither (ninja's "no work to do" / samurai's
+     * "nothing to do" notes are the only other output).
+     */
+    nextBuild: () => {
+      const { stdout, stderr, exitCode } = run("-n", "-d", "explain");
+      expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
+      return {
+        runsEdge: /^\[\d+\/\d+\] /m.test(stdout),
+        explain: stderr.split("\n").filter(line => line.includes("explain")),
+      };
+    },
+  };
 }
 
 describe("rust_shim edge", () => {
@@ -218,16 +239,17 @@ describe("rust_shim edge", () => {
       expect(stampEdge.bindings).toMatchObject({ shim_src: quote(shimSrc, false), shim_dest: quote(shimDest, false) });
       // emitRust() pre-creates the 0-byte placeholder so the input exists.
       expect(readFileSync(shimDest, "utf8")).toBe("");
+      const driver = shimDriver(buildDir, shimStamp);
 
       // Fresh build dir: builds the PE and copies it over the placeholder.
-      expect(buildShim(buildDir)).toMatchObject({ stderr: "", exitCode: 0 });
+      expect(driver.build()).toMatchObject({ stderr: "", exitCode: 0 });
       expect(readFileSync(shimDest, "utf8")).toBe(pe);
       expect(existsSync(shimStamp)).toBe(true);
 
       // Nothing has changed since, so the next build has nothing to do. Without
       // restat, ninja recorded the command's start time for the stamp, the
       // copy above postdates it, and the edge (then bun_bin's) runs once more.
-      expect(nextBuild(buildDir)).toEqual({ noWorkToDo: true, explain: [] });
+      expect(driver.nextBuild()).toEqual({ runsEdge: false, explain: [] });
 
       // A build dir for another arch/profile copies its own PE over the shared
       // exe, after this dir's stamp. This dir has to notice and put its PE
@@ -235,15 +257,15 @@ describe("rust_shim edge", () => {
       writeFileSync(shimDest, "MZ shim copied by a sibling build dir\n");
       const afterStamp = new Date(statSync(shimStamp).mtimeMs + 1_000);
       utimesSync(shimDest, afterStamp, afterStamp);
-      const overwritten = nextBuild(buildDir);
-      expect(overwritten.noWorkToDo).toBe(false);
-      expect(overwritten.explain.join("\n")).toContain("bun_shim_impl.stamp is dirty");
+      const overwritten = driver.nextBuild();
+      expect(overwritten.runsEdge).toBe(true);
+      expect(overwritten.explain.join("\n")).toContain("bun_shim_impl.stamp");
 
-      expect(buildShim(buildDir)).toMatchObject({ stderr: "", exitCode: 0 });
+      expect(driver.build()).toMatchObject({ stderr: "", exitCode: 0 });
       expect(readFileSync(shimDest, "utf8")).toBe(pe);
       // That rebuild rewrote the exe during the command just like the fresh
       // build did, and has to converge the same way.
-      expect(nextBuild(buildDir)).toEqual({ noWorkToDo: true, explain: [] });
+      expect(driver.nextBuild()).toEqual({ runsEdge: false, explain: [] });
     },
     // Each of the two real builds starts bunExe() once, to run stream.ts;
     // that alone is ~2.5s per build in a debug build (~50ms in a release one).

--- a/test/internal/build-rust-shim-edge.test.ts
+++ b/test/internal/build-rust-shim-edge.test.ts
@@ -16,8 +16,9 @@
  *
  * The graph under test is what registerRustRules() + emitRust() emit, pointed
  * at a scratch repo and at a cargo stand-in that writes the PE where cargo
- * would. Driving it takes ninja itself and a non-windows host: the stand-in is
- * a shell script, and the rule's shell dialect follows the host. The `ninja`
+ * would. Driving it takes ninja itself, node (the build's own wrapper runtime,
+ * see the build test) and a non-windows host: the stand-in is a shell script,
+ * and the rule's shell dialect follows the host. The `ninja`
  * on PATH may also be samurai (Alpine), which logs every edge's post-command
  * mtime and so never had the extra rebuild; there the build test only checks
  * that the restat rule still converges and still notices the sibling's
@@ -26,7 +27,7 @@
  */
 import { which } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, isWindows, nodeExe, tempDir } from "harness";
 import { chmodSync, existsSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 
@@ -37,8 +38,9 @@ import { quote } from "../../scripts/build/shell.ts";
 
 // Test-only CI lanes may run without a build toolchain; the build test skips there.
 const ninjaExe = which("ninja");
+const node = nodeExe();
 
-/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
+/** A fully-populated fake toolchain; resolveConfig never spawns any of these (the build test overrides jsRuntime). */
 function mockToolchain(overrides: Partial<Toolchain>): Toolchain {
   return {
     cc: "/fake/llvm/bin/clang-cl",
@@ -59,9 +61,7 @@ function mockToolchain(overrides: Partial<Toolchain>): Toolchain {
     llvmStrip: "/fake/llvm/bin/llvm-strip",
     dsymutil: undefined,
     bun: "/fake/bin/bun",
-    // The rule command runs scripts/build/stream.ts through this, so it is the
-    // one real tool here: ninja has to be able to run the edge.
-    jsRuntime: quote(bunExe(), isWindows),
+    jsRuntime: "/fake/bin/node",
     esbuild: "/fake/bin/esbuild",
     ccache: undefined,
     cmake: "/fake/bin/cmake",
@@ -102,7 +102,7 @@ interface ShimGraph {
  * with `<dir>/repo` (from `fixtureTree`) standing in for the source tree, so
  * the exe the edge writes lands in the scratch dir and not in this checkout.
  */
-function emitShimGraph(dir: string): ShimGraph {
+function emitShimGraph(dir: string, toolchain: Partial<Toolchain> = {}): ShimGraph {
   const repo = join(dir, "repo");
   const cargo = join(dir, "toolchain", "cargo");
   const buildDir = join(dir, "build");
@@ -111,7 +111,7 @@ function emitShimGraph(dir: string): ShimGraph {
       // winsysroot is only consulted when cross-compiling, and then only
       // spliced into flags; nothing probes it.
       { os: "windows", buildType: "Debug", buildDir, winsysroot: join(dir, "winsysroot") },
-      mockToolchain({ cargo }),
+      mockToolchain({ cargo, ...toolchain }),
     ),
     cwd: repo,
   };
@@ -219,11 +219,17 @@ function shimDriver(buildDir: string, shimStamp: string) {
 }
 
 describe("rust_shim edge", () => {
-  test.skipIf(isWindows || ninjaExe === null)(
+  test.skipIf(isWindows || ninjaExe === null || node === null)(
     "the build after a shim build is a no-op, and a sibling build dir overwriting the exe still re-runs it",
     async () => {
       using dir = tempDir("build-rust-shim-edge", fixtureTree);
-      const { cfg, ninja, cargo, shimSrc, shimDest, shimStamp } = emitShimGraph(String(dir));
+      // The rule command runs scripts/build/stream.ts through cfg.jsRuntime,
+      // i.e. whatever configured the build. This is the form configure.ts
+      // produces under node, which is what CI builds run with; bunExe() works
+      // too, but a debug build takes seconds to start stream.ts, and this
+      // test starts it twice.
+      const jsRuntime = `${quote(node!, false)} --experimental-strip-types`;
+      const { cfg, ninja, cargo, shimSrc, shimDest, shimStamp } = emitShimGraph(String(dir), { jsRuntime });
       const { buildDir } = cfg;
 
       // `cargo build -p bun_shim_impl ...` stand-in: links the PE on the first
@@ -242,7 +248,7 @@ describe("rust_shim edge", () => {
       const driver = shimDriver(buildDir, shimStamp);
 
       // Fresh build dir: builds the PE and copies it over the placeholder.
-      expect(driver.build()).toMatchObject({ stderr: "", exitCode: 0 });
+      expect(driver.build()).toMatchObject({ exitCode: 0 });
       expect(readFileSync(shimDest, "utf8")).toBe(pe);
       expect(existsSync(shimStamp)).toBe(true);
 
@@ -261,15 +267,12 @@ describe("rust_shim edge", () => {
       expect(overwritten.runsEdge).toBe(true);
       expect(overwritten.explain.join("\n")).toContain("bun_shim_impl.stamp");
 
-      expect(driver.build()).toMatchObject({ stderr: "", exitCode: 0 });
+      expect(driver.build()).toMatchObject({ exitCode: 0 });
       expect(readFileSync(shimDest, "utf8")).toBe(pe);
       // That rebuild rewrote the exe during the command just like the fresh
       // build did, and has to converge the same way.
       expect(driver.nextBuild()).toEqual({ runsEdge: false, explain: [] });
     },
-    // Each of the two real builds starts bunExe() once, to run stream.ts;
-    // that alone is ~2.5s per build in a debug build (~50ms in a release one).
-    60_000,
   );
 
   test("the rule is restat, and the exe it rewrites stays an input of the stamp", () => {

--- a/test/internal/build-rust-shim-edge.test.ts
+++ b/test/internal/build-rust-shim-edge.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Incremental behaviour of the Windows .bin/ shim edge in scripts/build/rust.ts
+ * (rule `rust_shim`, emitted for windows targets).
+ *
+ * The edge's declared output is a per-build-dir stamp; the source-tree exe it
+ * copies the freshly built PE over (src/install/windows-shim/bun_shim_impl.exe,
+ * one path shared by every windows build dir) is one of its implicit inputs,
+ * so a sibling build dir overwriting the exe re-runs it. It is therefore an
+ * edge that rewrites one of its own inputs, and ninja (1.11+) records a
+ * non-restat edge's mtime as the time its command started: the exe copied
+ * during the command is newer than that, so the stamp is dirty again on the
+ * build right after every real shim rebuild, which re-runs cargo for the shim
+ * and then for bun_bin (whose edge has the stamp as an input). The rule has to
+ * be `restat` so that the recorded mtime is the stamp's own, taken after the
+ * copy.
+ *
+ * The graph under test is what registerRustRules() + emitRust() emit, pointed
+ * at a scratch repo and at a cargo stand-in that writes the PE where cargo
+ * would. Driving it takes ninja itself and a non-windows host: the stand-in is
+ * a shell script, and the rule's shell dialect follows the host. The emission
+ * test at the end runs everywhere.
+ */
+import { which } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { chmodSync, existsSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
+import { Ninja } from "../../scripts/build/ninja.ts";
+import { emitRust, registerRustRules, rustTarget } from "../../scripts/build/rust.ts";
+import { quote } from "../../scripts/build/shell.ts";
+
+// Test-only CI lanes may run without a build toolchain; the build test skips there.
+const ninjaExe = which("ninja");
+
+/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
+function mockToolchain(overrides: Partial<Toolchain>): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang-cl",
+    cxx: "/fake/llvm/bin/clang-cl",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-lib",
+    ranlib: undefined,
+    ld: "/fake/llvm/bin/lld-link",
+    ld64Lld: undefined,
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/llvm/bin/llvm-strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: undefined,
+    bun: "/fake/bin/bun",
+    // The rule command runs scripts/build/stream.ts through this, so it is the
+    // one real tool here: ninja has to be able to run the edge.
+    jsRuntime: quote(bunExe(), isWindows),
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: "/fake/llvm/bin/llvm-rc",
+    mt: undefined,
+    nasm: undefined,
+    ...overrides,
+  };
+}
+
+/** The shim edge's inputs, minus the exe (emitRust() pre-creates it). The build test fills in the cargo script. */
+const fixtureTree = {
+  "repo/Cargo.toml": "[workspace]\n",
+  "repo/src/install/windows-shim/bun_shim_impl.rs": "// stands in for the shim crate\n",
+  "vendor/lolhtml/.ref": "",
+  "toolchain/cargo": "",
+};
+
+interface ShimGraph {
+  cfg: Config;
+  ninja: Ninja;
+  /** The cargo stand-in's path (resolveConfig only stores it; it is also one of the edge's inputs). */
+  cargo: string;
+  /** Where the stand-in writes the PE: cargo's output path for `--profile shim`. */
+  shimSrc: string;
+  /** The source-tree exe the edge copies the PE over, and one of its inputs. */
+  shimDest: string;
+  /** The edge's declared output. */
+  shimStamp: string;
+}
+
+/**
+ * Emit the rust edges for a windows target (host arch) into `<dir>/build`,
+ * with `<dir>/repo` (from `fixtureTree`) standing in for the source tree, so
+ * the exe the edge writes lands in the scratch dir and not in this checkout.
+ */
+function emitShimGraph(dir: string): ShimGraph {
+  const repo = join(dir, "repo");
+  const cargo = join(dir, "toolchain", "cargo");
+  const buildDir = join(dir, "build");
+  const cfg: Config = {
+    ...resolveConfig(
+      // winsysroot is only consulted when cross-compiling, and then only
+      // spliced into flags; nothing probes it.
+      { os: "windows", buildType: "Debug", buildDir, winsysroot: join(dir, "winsysroot") },
+      mockToolchain({ cargo }),
+    ),
+    cwd: repo,
+  };
+  expect(cfg.windows).toBe(true);
+
+  const ninja = new Ninja({ buildDir });
+  registerRustRules(ninja, cfg);
+  emitRust(ninja, cfg, {
+    codegenInputs: [],
+    codegenOrderOnly: [],
+    rustSources: [join(repo, "src", "install", "windows-shim", "bun_shim_impl.rs"), join(repo, "Cargo.toml")],
+    vendorStamps: [join(dir, "vendor", "lolhtml", ".ref")],
+  });
+
+  const shimOutDir = join(buildDir, "rust-target", rustTarget(cfg), "shim");
+  return {
+    cfg,
+    ninja,
+    cargo,
+    shimSrc: join(shimOutDir, "bun_shim_impl.exe"),
+    shimDest: join(repo, "src", "install", "windows-shim", "bun_shim_impl.exe"),
+    shimStamp: join(shimOutDir, "bun_shim_impl.stamp"),
+  };
+}
+
+const slash = (p: string) => p.replaceAll("\\", "/");
+
+/** Unwrap `$\n` continuations so each rule / build statement is one line followed by its bindings. */
+const ninjaLines = (text: string) => text.replace(/ \$\n +/g, " ").split("\n");
+
+/** The indented `key = value` bindings following line `start`, up to the blank line ninja.ts emits after every block. */
+function bindingsAfter(lines: string[], start: number): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  for (let i = start + 1; i < lines.length && lines[i] !== ""; i++) {
+    const m = /^ {2}(\w+) = (.*)$/.exec(lines[i]!);
+    if (m !== null) bindings[m[1]!] = m[2]!;
+  }
+  return bindings;
+}
+
+/** Bindings of `rule <name>`. */
+function rule(text: string, name: string): Record<string, string> {
+  const lines = ninjaLines(text);
+  const start = lines.indexOf(`rule ${name}`);
+  if (start === -1) throw new Error(`no rule ${name} in:\n${text}`);
+  return bindingsAfter(lines, start);
+}
+
+/** The edge producing `output` (buildDir-relative, `/`-separated), which has no explicit inputs. */
+function edge(
+  text: string,
+  output: string,
+): { rule: string; implicitInputs: string[]; bindings: Record<string, string> } {
+  const lines = ninjaLines(text);
+  const prefix = `build ${output}: `;
+  const start = lines.findIndex(line => slash(line).startsWith(prefix));
+  if (start === -1) throw new Error(`no edge producing ${output} in:\n${text}`);
+  // `<rule> | <implicit inputs...>` (`|| <order-only>` never follows on this edge)
+  const [ruleName = "", implicit = ""] = slash(lines[start]!).slice(prefix.length).split(" | ");
+  return {
+    rule: ruleName,
+    implicitInputs: implicit.split(" ").filter(p => p.length > 0),
+    bindings: bindingsAfter(lines, start),
+  };
+}
+
+function buildShim(buildDir: string, ...flags: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [ninjaExe!, "-C", buildDir, ...flags, "bun-shim"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+}
+
+/**
+ * What the next build would do, per a dry run with `-d explain`: a failing
+ * assertion then shows ninja's own reason, e.g. "recorded mtime of
+ * .../bun_shim_impl.stamp older than most recent input .../bun_shim_impl.exe".
+ */
+function nextBuild(buildDir: string): { noWorkToDo: boolean; explain: string[] } {
+  const { stdout, stderr, exitCode } = buildShim(buildDir, "-n", "-d", "explain");
+  const explain = stderr.split("\n").filter(line => line.startsWith("ninja explain: "));
+  expect(stderr.replace(/^ninja explain: .*\n?/gm, "")).toBe("");
+  expect(exitCode).toBe(0);
+  return { noWorkToDo: stdout.includes("ninja: no work to do."), explain };
+}
+
+describe("rust_shim edge", () => {
+  test.skipIf(isWindows || ninjaExe === null)(
+    "the build after a shim build is a no-op, and a sibling build dir overwriting the exe still re-runs it",
+    async () => {
+      using dir = tempDir("build-rust-shim-edge", fixtureTree);
+      const { cfg, ninja, cargo, shimSrc, shimDest, shimStamp } = emitShimGraph(String(dir));
+      const { buildDir } = cfg;
+
+      // `cargo build -p bun_shim_impl ...` stand-in: links the PE on the first
+      // call and, like cargo's fingerprinting would, does nothing after that.
+      const pe = `MZ shim for ${rustTarget(cfg)}\n`;
+      writeFileSync(
+        cargo,
+        `#!/bin/sh\nout=${quote(shimSrc, false)}\n[ -e "$out" ] || { mkdir -p "$(dirname "$out")" && printf '%s\\n' ${quote(pe.trimEnd(), false)} > "$out"; }\n`,
+      );
+      chmodSync(cargo, 0o755);
+      await ninja.write();
+      const stampEdge = edge(ninja.toString(), slash(relative(buildDir, shimStamp)));
+      expect(stampEdge.bindings).toMatchObject({ shim_src: quote(shimSrc, false), shim_dest: quote(shimDest, false) });
+      // emitRust() pre-creates the 0-byte placeholder so the input exists.
+      expect(readFileSync(shimDest, "utf8")).toBe("");
+
+      // Fresh build dir: builds the PE and copies it over the placeholder.
+      expect(buildShim(buildDir)).toMatchObject({ stderr: "", exitCode: 0 });
+      expect(readFileSync(shimDest, "utf8")).toBe(pe);
+      expect(existsSync(shimStamp)).toBe(true);
+
+      // Nothing has changed since, so the next build has nothing to do. Without
+      // restat, ninja recorded the command's start time for the stamp, the
+      // copy above postdates it, and the edge (then bun_bin's) runs once more.
+      expect(nextBuild(buildDir)).toEqual({ noWorkToDo: true, explain: [] });
+
+      // A build dir for another arch/profile copies its own PE over the shared
+      // exe, after this dir's stamp. This dir has to notice and put its PE
+      // back, or its bun would embed the other arch's shim.
+      writeFileSync(shimDest, "MZ shim copied by a sibling build dir\n");
+      const afterStamp = new Date(statSync(shimStamp).mtimeMs + 1_000);
+      utimesSync(shimDest, afterStamp, afterStamp);
+      const overwritten = nextBuild(buildDir);
+      expect(overwritten.noWorkToDo).toBe(false);
+      expect(overwritten.explain.join("\n")).toContain("bun_shim_impl.stamp is dirty");
+
+      expect(buildShim(buildDir)).toMatchObject({ stderr: "", exitCode: 0 });
+      expect(readFileSync(shimDest, "utf8")).toBe(pe);
+      // That rebuild rewrote the exe during the command just like the fresh
+      // build did, and has to converge the same way.
+      expect(nextBuild(buildDir)).toEqual({ noWorkToDo: true, explain: [] });
+    },
+    // Each of the two real builds starts bunExe() once, to run stream.ts;
+    // that alone is ~2.5s per build in a debug build (~50ms in a release one).
+    60_000,
+  );
+
+  test("the rule is restat, and the exe it rewrites stays an input of the stamp", () => {
+    using dir = tempDir("build-rust-shim-edge", fixtureTree);
+    const { cfg, ninja, shimDest, shimStamp } = emitShimGraph(String(dir));
+    const text = ninja.toString();
+
+    // restat is what makes ninja record the stamp's post-copy mtime. The exe
+    // staying an input is the sibling-build-dir invalidation described in the
+    // rule's comment; dropping it would also make the next build a no-op,
+    // at the cost of embedding a stale exe.
+    expect(rule(text, "rust_shim").restat).toBe("1");
+    const stamp = edge(text, slash(relative(cfg.buildDir, shimStamp)));
+    expect(stamp.rule).toBe("rust_shim");
+    expect(stamp.implicitInputs).toContain(slash(relative(cfg.buildDir, shimDest)));
+  });
+});

--- a/test/internal/build-rust-shim-edge.test.ts
+++ b/test/internal/build-rust-shim-edge.test.ts
@@ -18,12 +18,16 @@
  * at a scratch repo and at a cargo stand-in that writes the PE where cargo
  * would. Driving it takes ninja itself, node (the build's own wrapper runtime,
  * see the build test) and a non-windows host: the stand-in is a shell script,
- * and the rule's shell dialect follows the host. The `ninja`
- * on PATH may also be samurai (Alpine), which logs every edge's post-command
- * mtime and so never had the extra rebuild; there the build test only checks
- * that the restat rule still converges and still notices the sibling's
- * overwrite, and the driver's messages are not parsed beyond what the two
- * implementations share. The emission test at the end runs everywhere.
+ * and the rule's shell dialect follows the host.
+ *
+ * The build test fails without the restat only under ninja 1.11+, the driver
+ * on the debian, ubuntu and macOS lanes and on developer machines. Alpine's
+ * `ninja` is samurai, which logs every edge's post-command mtime and so never
+ * had the extra rebuild, but it is a driver bun's build runs under, so the
+ * test runs there too and checks that the restat rule still converges and
+ * still notices the sibling's overwrite under it. Accordingly, nothing is read
+ * from the driver beyond what both implementations print. The emission test
+ * at the end runs everywhere.
  */
 import { which } from "bun";
 import { describe, expect, test } from "bun:test";
@@ -36,7 +40,8 @@ import { Ninja } from "../../scripts/build/ninja.ts";
 import { emitRust, registerRustRules, rustTarget } from "../../scripts/build/rust.ts";
 import { quote } from "../../scripts/build/shell.ts";
 
-// Test-only CI lanes may run without a build toolchain; the build test skips there.
+// The build test skips where either is missing (test-only lanes without a
+// build toolchain); it also skips on Windows hosts, see the header.
 const ninjaExe = which("ninja");
 const node = nodeExe();
 
@@ -200,18 +205,19 @@ function shimDriver(buildDir: string, shimStamp: string) {
     build: () => run(),
     /**
      * What the next build would do, per a dry run with `-d explain`. Both
-     * implementations print a `[N/M] <description>` line per edge they would
-     * run and one `explain` line per reason on stderr (ninja: "ninja explain:
-     * recorded mtime of .../bun_shim_impl.stamp older than most recent input
-     * .../bun_shim_impl.exe"), so a failing assertion shows the reason; a
-     * clean graph yields neither (ninja's "no work to do" / samurai's
-     * "nothing to do" notes are the only other output).
+     * implementations print each edge they would run as its description
+     * behind a NINJA_STATUS-dependent prefix (the rust_shim rule's is "cargo
+     * bun_shim_impl → <exe>"), and one `explain` line per reason on stderr
+     * (ninja: "ninja explain: recorded mtime of .../bun_shim_impl.stamp older
+     * than most recent input .../bun_shim_impl.exe"), so a failing assertion
+     * shows the reason. A clean graph yields neither; ninja's "no work to do"
+     * and samurai's "nothing to do" notes are the only other output.
      */
     nextBuild: () => {
       const { stdout, stderr, exitCode } = run("-n", "-d", "explain");
       expect({ stderr, exitCode }).toMatchObject({ exitCode: 0 });
       return {
-        runsEdge: /^\[\d+\/\d+\] /m.test(stdout),
+        runsEdge: stdout.includes("cargo bun_shim_impl"),
         explain: stderr.split("\n").filter(line => line.includes("explain")),
       };
     },


### PR DESCRIPTION
### Problem
- On Windows targets, the build right after a successful `bun bd` is not a no-op whenever the shim was really rebuilt (fresh build dir, or any change under `src/install/windows-shim/`). `ninja -n -d explain bun-rust` reports: `recorded mtime of rust-target/x86_64-pc-windows-msvc/shim/bun_shim_impl.stamp older than most recent input ../../src/install/windows-shim/bun_shim_impl.exe`, and cargo runs again for the shim and then for `bun_bin` (the shim stamp is an input of that edge). The third build converges.
- Cause: the `rust_shim` rule in `scripts/build/rust.ts` (`registerRustRules`) copies the freshly linked PE over `src/install/windows-shim/bun_shim_impl.exe`, and that exe is an implicit input of the same edge (`emitRust`, by design: see Background). The rule was not `restat`, and for a non-restat edge ninja 1.11+ logs the time the command started as the output's mtime. The exe written during the command is always newer than that, so the stamp comes out dirty again after every run that actually copied.
- The comment on the rule said restat was unnecessary because the stamp is touched unconditionally. That is true for pruning, but restat also changes which mtime ninja logs, which is what matters here.

### Fix
- `restat: true` on the `rust_shim` rule, and the rule comment now says why. No change to the command, the stamp, or the edge's inputs.
- Correct because with restat ninja logs the stamp's mtime as re-stat'ed after the command, and the stamp is touched after the copy, so the logged mtime is never older than the exe and the next build has nothing to do. The stamp is still touched on every run, so its mtime always changes and `bun_bin`'s edge is never pruned (same downstream behaviour as before); the exe stays an input, and a sibling build dir's overwrite lands after the logged mtime, so it still invalidates this dir's stamp. Verified on the real graph that `type nul > $out` on the existing 0-byte stamp does bump its mtime.
- Test: `test/internal/build-rust-shim-edge.test.ts`. It emits the real rust edges (`registerRustRules` + `emitRust`) for a windows target into a scratch dir, with a cargo stand-in that writes the PE and the rule's `stream.ts` wrapper running under node as it does in CI builds, and drives them with ninja: the build after a build must be a no-op, a sibling overwrite of the exe must still re-run the edge and restore it, and that rebuild must converge too. Without the `rust.ts` change it fails with the explain line above (10/10 runs) wherever the driver is ninja 1.11+, which is the debian, ubuntu and macOS lanes and developer machines; a second test asserts the emitted rule/edge shape and runs on every host, including hosts without ninja. The ninja-driven test skips on Windows hosts (the stand-in is a shell script) and on test-only lanes without ninja or node. On Alpine the `ninja` on PATH is samurai, which logs post-command mtimes for every edge and so never had the extra rebuild, but bun's build does run under it, so the test runs there as well and checks that the restat rule still converges and still notices the overwrite under it (checked locally against samurai 1.2 too). It reads nothing from the driver beyond what both print, the pending edge's description and the `-d explain` lines, so it is also independent of `NINJA_STATUS`; samurai reports on stderr and crashes on a dry run through a phony, hence the stamp is requested directly.
- The fix is in `scripts/`, not in the binary, so the before/after is `scripts/build/rust.ts` from `main` versus from this branch, not a different bun build; both `bun bd test` and `USE_SYSTEM_BUN=1 bun test` fail without the change and pass with it.
- Also verified with the real build on windows-x64 (ninja 1.13.2): unfixed, `bun bd --target=bun-shim` followed by `ninja -n -d explain bun-shim` reproduces the explain line above; with this change, after a forced shim relink (shim output dir removed, PE rebuilt and copied) the same check prints `ninja: no work to do.` Logs below.

### Background
- `rust_shim` builds the `node_modules/.bin` launcher PE (`bun_shim_impl.exe`) with cargo and copies it into the source tree, where `bun_install` embeds it with `include_bytes!`. The copy is content-conditional so a no-op cargo run does not bump the exe's mtime and recompile `bun_install`.
- The edge's declared output is a per-build-dir stamp rather than the exe, because the exe path is shared by every windows arch/profile build dir. The exe is instead an implicit input of the edge, so when a sibling build dir (other arch) overwrites it, this dir's stamp becomes stale and the edge copies the right PE back. This PR keeps that design; it is what makes the edge rewrite one of its own inputs.
- ninja records an mtime per output in `.ninja_log` and, on later builds, considers the edge dirty if any input is newer than that logged mtime. Since ninja 1.11 a non-restat edge logs its command's start time; a `restat` edge re-stats its outputs after the command and logs what it finds (and additionally prunes dependents whose outputs did not change, which never applies here because the stamp is always touched).

<details>
<summary>windows-x64 runs, real build graph</summary>

Unfixed, right after `bun bd --target=bun-shim` succeeded:

```
> ninja -C build\debug -n -d explain bun-shim
ninja explain: recorded mtime of rust-target/x86_64-pc-windows-msvc/shim/bun_shim_impl.stamp older than most recent input ../../src/install/windows-shim/bun_shim_impl.exe (8083024360024091 vs 8083024686882634)
[0/1] cargo bun_shim_impl → C:\workspace\bun\src\install\windows-shim\bun_shim_impl.exe
```

With this change, after removing `build/debug/rust-target/x86_64-pc-windows-msvc/shim/` so cargo relinks the PE and the edge copies it (exe mtime 05:35:36.579, stamp mtime 05:35:37.564):

```
> ninja -C build\debug -n -d explain bun-shim
ninja: no work to do.
```

Standalone graph with the rule's exact cmd.exe command (stand-in for cargo), both variants: without restat, build 2 is dirty with the same explain line; with restat, build 2 is `no work to do`, overwriting the exe afterwards makes the stamp dirty, the rebuild restores the exe and bumps the existing stamp (`type nul >` moved its mtime from .3497050 to .5059167), and build 4 is `no work to do` again. `copy` preserves the source PE's mtime, which is why the unfixed exe is newer than the logged start time by exactly the shim's link time.
</details>

<details>
<summary>linux, new test without the fix</summary>

```
expect(nextBuild(buildDir)).toEqual({ noWorkToDo: true, explain: [] });
+   "explain": [
+     "ninja explain: recorded mtime of rust-target/x86_64-pc-windows-msvc/shim/bun_shim_impl.stamp older than most recent input ../repo/src/install/windows-shim/bun_shim_impl.exe (1786597022236145463 vs 1786597022331317113)",
+     "ninja explain: rust-target/x86_64-pc-windows-msvc/shim/bun_shim_impl.stamp is dirty",
+   "noWorkToDo": false,
(fail) rust_shim edge > the build after a shim build is a no-op, and a sibling build dir overwriting the exe still re-runs it
(fail) rust_shim edge > the rule is restat, and the exe it rewrites stays an input of the stamp
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->