### PR TITLE
node:fs: accessSync() returns undefined, promises.access() resolves to undefined, symlink callback gets null

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -63,7 +63,7 @@ var access = function access(path, mode, callback) {
     }
 
     callback = ensureCallback(callback);
-    fs.access(path, mode).then(callOnceWithNull.bind(null, callback), callback);
+    fs.access(path, mode).then(FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback), callback);
   },
   appendFile = function appendFile(path, data, options, callback) {
     if (!$isCallable(callback)) {
@@ -426,7 +426,10 @@ var access = function access(path, mode, callback) {
       callback = wrapFsCallback(callback);
     }
 
-    fs.symlink(target, path, type).then(callback, callback);
+    fs.symlink(target, path, type).then(
+      $isCallable(callback) ? FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback) : callback,
+      callback,
+    );
   },
   truncate = function truncate(path, len, callback) {
     if (typeof path === "number") {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -63,7 +63,7 @@ var access = function access(path, mode, callback) {
     }
 
     callback = ensureCallback(callback);
-    fs.access(path, mode).then(callback, callback);
+    fs.access(path, mode).then(callOnceWithNull.bind(null, callback), callback);
   },
   appendFile = function appendFile(path, data, options, callback) {
     if (!$isCallable(callback)) {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1146,12 +1146,6 @@ mod _async_tasks {
             Ok(JSValue::js_boolean(*self))
         }
     }
-    impl FsReturn for Null {
-        #[inline]
-        fn fs_to_js(&mut self, _global: &JSGlobalObject) -> JsResult<JSValue> {
-            Ok(JSValue::NULL)
-        }
-    }
     impl FsReturn for Stats {
         #[inline]
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -4445,18 +4439,10 @@ impl StringOrUndefined {
     }
 }
 
-/// For use in `Return`'s definitions to act as `void` while returning `null` to JavaScript
-pub struct Null;
-impl Null {
-    pub fn to_js(&self, _: &JSGlobalObject) -> JSValue {
-        JSValue::NULL
-    }
-}
-
 pub mod ret {
     use super::*;
 
-    pub(crate) type Access = Null;
+    pub(crate) type Access = ();
     pub(crate) type AppendFile = ();
     pub type Close = ();
     pub(crate) type CopyFile = ();
@@ -4636,7 +4622,7 @@ impl NodeFS {
                 if (mode & sys::posix::W_OK) != 0 || ((mode & sys::posix::X_OK) != 0 && !is_dir) {
                     return Err(sys::Error::from_code(E::EACCES, sys::Tag::access).with_path(p));
                 }
-                return Ok(Null);
+                return Ok(());
             }
         }
         // The `bun_sys::access` Windows
@@ -4650,7 +4636,7 @@ impl NodeFS {
         };
         match Syscall::access(path, args.mode.as_int()) {
             Err(err) => Err(err.with_path(args.path.slice())),
-            Ok(_) => Ok(Null),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -60,6 +60,9 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           dirStatIsDir: fs.statSync(assetDir).isDirectory(),
           dirLstatIsDir: fs.lstatSync(assetDir).isDirectory(),
           accessOk: errcode(() => fs.accessSync(assetDir)) === "",
+          // JSON.stringify drops undefined values, so compare here and ship a boolean
+          accessReturnsUndefined: fs.accessSync(asset) === undefined,
+          accessPromiseResolvesUndefined: (await fs.promises.access(asset)) === undefined,
           accessWriteErr: errcode(() => fs.accessSync(asset, fs.constants.W_OK)),
           readdir: fs.readdirSync(assetDir).sort(),
           readdirHasAsset: fs.readdirSync(assetDir).includes(path.basename(asset)),
@@ -139,6 +142,8 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           dirStatIsDir: true,
           dirLstatIsDir: true,
           accessOk: true,
+          accessReturnsUndefined: true,
+          accessPromiseResolvesUndefined: true,
           accessWriteErr: "EACCES",
           // the hashed file-loader name is covered by readdirHasAsset
           readdir: expect.arrayContaining(["client", "config.json"]),

--- a/test/js/bun/bun-object/write.spec.ts
+++ b/test/js/bun/bun-object/write.spec.ts
@@ -127,9 +127,8 @@ describe("Bun.write() on file paths", () => {
           await Bun.write(filepath, content);
         });
         it("Recursively creates the directory", async () => {
-          // FIXME: should be undefined, not null
-          expect(await fs.access(rootdir, constants.F_OK)).toBeFalsy();
-          expect(await fs.access(path.dirname(filepath), constants.F_OK)).toBeFalsy();
+          expect(await fs.access(rootdir, constants.F_OK)).toBeUndefined();
+          expect(await fs.access(path.dirname(filepath), constants.F_OK)).toBeUndefined();
         });
 
         it("Creates a file with the provided content", async () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -123,7 +123,7 @@ it.skipIf(isWindows)("fs.chmodSync applies mode bits above 0o777", () => {
   expect(statSync(dirPath).mode & 0o7777).toBe(0o1755);
 });
 
-describe("fs.access success values match node", () => {
+describe("fs.access and fs.symlink success values match node", () => {
   it("accessSync returns undefined", () => {
     using dir = tempDir("fs-access-success", { "file.txt": "" });
     const file = join(String(dir), "file.txt");
@@ -160,6 +160,30 @@ describe("fs.access success values match node", () => {
     const args = await promise;
     expect(args).toHaveLength(1);
     expect(args[0]).toMatchObject({ code: "ENOENT", syscall: "access" });
+  });
+
+  // symlink was the other wrapper that handed the native promise's resolution
+  // value straight to the callback.
+  it("symlink callback is called with exactly (null) in both overloads", async () => {
+    using dir = tempDir("fs-symlink-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+
+    const threeArgs = Promise.withResolvers<unknown[]>();
+    fs.symlink(file, join(String(dir), "link-3"), (...args) => threeArgs.resolve(args));
+    expect(await threeArgs.promise).toStrictEqual([null]);
+
+    const fourArgs = Promise.withResolvers<unknown[]>();
+    fs.symlink(file, join(String(dir), "link-4"), "file", (...args) => fourArgs.resolve(args));
+    expect(await fourArgs.promise).toStrictEqual([null]);
+  });
+
+  it("symlink callback receives the error on failure", async () => {
+    using dir = tempDir("fs-symlink-failure", { "file.txt": "", "taken": "" });
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    fs.symlink(join(String(dir), "file.txt"), join(String(dir), "taken"), (...args) => resolve(args));
+    const args = await promise;
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({ code: "EEXIST", syscall: "symlink" });
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -123,6 +123,46 @@ it.skipIf(isWindows)("fs.chmodSync applies mode bits above 0o777", () => {
   expect(statSync(dirPath).mode & 0o7777).toBe(0o1755);
 });
 
+describe("fs.access success values match node", () => {
+  it("accessSync returns undefined", () => {
+    using dir = tempDir("fs-access-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+    expect(fs.accessSync(file)).toBeUndefined();
+    expect(fs.accessSync(file, constants.R_OK)).toBeUndefined();
+    expect(fs.accessSync(String(dir))).toBeUndefined();
+  });
+
+  it("promises.access resolves to undefined", async () => {
+    using dir = tempDir("fs-access-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+    expect(await promises.access(file)).toBeUndefined();
+    expect(await promises.access(file, constants.R_OK)).toBeUndefined();
+    expect(await promises.access(String(dir))).toBeUndefined();
+  });
+
+  it("access callback is called with exactly (null)", async () => {
+    using dir = tempDir("fs-access-success", { "file.txt": "" });
+    const file = join(String(dir), "file.txt");
+
+    const withoutMode = Promise.withResolvers<unknown[]>();
+    fs.access(file, (...args) => withoutMode.resolve(args));
+    expect(await withoutMode.promise).toStrictEqual([null]);
+
+    const withMode = Promise.withResolvers<unknown[]>();
+    fs.access(file, constants.R_OK, (...args) => withMode.resolve(args));
+    expect(await withMode.promise).toStrictEqual([null]);
+  });
+
+  it("access callback receives the error on failure", async () => {
+    using dir = tempDir("fs-access-success", {});
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    fs.access(join(String(dir), "missing.txt"), (...args) => resolve(args));
+    const args = await promise;
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatchObject({ code: "ENOENT", syscall: "access" });
+  });
+});
+
 it.concurrent("fs.writeFile(1, data) should work when its inherited", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), "1"],
@@ -5709,7 +5749,7 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
   ];
   const existTests = [
     ["existsSync", 'assert.strictEqual(fs.existsSync("../../config"), true)'],
-    ["accessSync", 'assert.strictEqual(fs.accessSync("../../config"), null)'],
+    ["accessSync", 'assert.strictEqual(fs.accessSync("../../config"), undefined)'],
   ];
 
   for (const [name, code] of nonExistTests) {


### PR DESCRIPTION
### Problem
- `fs.accessSync(existingPath)` returns `null`, and `fs.promises.access(existingPath)` resolves to `null`. Node returns and resolves `undefined` for both; every other void `node:fs` operation in bun (`chmodSync`, `utimesSync`, `unlinkSync`, ...) already returns `undefined`.
- Cause: `ret::Access` in `src/runtime/node/node_fs.rs` was the `Null` marker type, whose `FsReturn::fs_to_js` yields `JSValue::NULL`. Both the sync binding (`run_sync`) and the async task resolve through that same `fs_to_js`, so both entry points produced `null`. `access` was the only user of `Null`.
- Same class, found while fixing the callback wrapper: `fs.symlink(target, path, cb)` calls `cb(undefined)` on success (both overloads) because its wrapper in `src/js/node/fs.ts` hands the native promise's resolution value straight to the callback. Node calls `cb(null)`. `access` and `symlink` were the only two wrappers written as `.then(callback, callback)`.
- Two in-tree tests had been written around the old value: `test/js/node/fs/fs.test.ts` asserted `accessSync(...) === null` in the kernel32 long-path case, and `test/js/bun/bun-object/write.spec.ts` had loosened `await fs.promises.access(...)` to `toBeFalsy()` under a FIXME. Both now assert `undefined`.

Repro (`/tmp/repro.cjs`; the three `cb(...)` lines complete concurrently, so their order varies):

```js
const fs = require("fs"), path = require("path");
const dir = fs.mkdtempSync(path.join(require("os").tmpdir(), "access-"));
const file = path.join(dir, "f"); fs.writeFileSync(file, "");
const cb = name => (...args) => console.log(name + " cb:", args);
console.log("accessSync:", fs.accessSync(file));
fs.promises.access(file).then(v => {
  console.log("promises.access:", v);
  fs.access(file, cb("access"));
  fs.symlink(file, path.join(dir, "l3"), cb("symlink 3-arg"));
  fs.symlink(file, path.join(dir, "l4"), "file", cb("symlink 4-arg"));
});
```

```
== node v26.3.0                 == bun 1.4.0 (released)          == this branch
accessSync: undefined           accessSync: null                 accessSync: undefined
promises.access: undefined      promises.access: null            promises.access: undefined
access cb: [ null ]             access cb: [ null ]              access cb: [ null ]
symlink 3-arg cb: [ null ]      symlink 3-arg cb: [ undefined ]  symlink 3-arg cb: [ null ]
symlink 4-arg cb: [ null ]      symlink 4-arg cb: [ undefined ]  symlink 4-arg cb: [ null ]
```

### Fix
- `ret::Access` becomes `()`, which is what the other void ops use and converts to `undefined`; the `Null` marker and its `FsReturn` impl are deleted. Both the real `access(2)` path and the compiled-executable (`/$bunfs/`) branch of `NodeFS::access` now return `Ok(())`.
- The `access` and `symlink` callback wrappers in `fs.ts` now supply the `null` themselves: the success handler is `callOnceWithNull` (the helper `fs.cp` and `Dir#close` already use) bound to the callback with the module's `FunctionPrototypeBind`, the same form `nullcallback` uses a few lines up. For `access` this keeps the callback at exactly `(null)` once the native promise resolves with `undefined`; for `symlink` it changes `(undefined)` to `(null)`. `symlink`'s non-callable 4-argument case is left as it was (handler ignored, gated on `$isCallable`).
- Why this is correct: the return values and callback arguments of every touched entry point (`accessSync`, `promises.access`, callback `access`, callback `symlink`) now match node's, as shown above. The only JS consumers of the native `access` resolution value were the wrappers in `fs.ts` and `fs.promises.ts`; `fs.promises.access` is a thin `asyncWrap` that forwards the value, so it picks up `undefined` with no further change.
- Known remainder, out of scope here and being fixed separately: the 22 wrappers built on `nullcallback` (`chmod`, `unlink`, `utimes`, `rename`, ...) still invoke `cb(null, undefined)`, because the bound callback also receives the promise's resolution value, where node invokes `cb(null)`. The `null` they pass is already correct, which is why they are not touched by this PR.
- Also intentionally untouched: the pre-existing `.bind(null, ...)` handler sites elsewhere in `fs.ts` (`cp`, `Dir#close`, `Dir#read`, `opendir`, `glob`); switching them to `FunctionPrototypeBind` would be a file-wide style pass unrelated to this fix.
- Verified:
  - `test/js/node/fs/fs.test.ts`: new `fs.access and fs.symlink success values match node` block covers `accessSync` (with and without mode, on a file and a directory), `promises.access`, the `access` callback receiving exactly `[null]` (`toStrictEqual`, since `toEqual` accepts a trailing `undefined`), both `symlink` overloads receiving exactly `[null]`, and the error path of each callback. On the released bun the two `undefined` tests, the `symlink` test and the updated kernel32 case fail; all pass with this branch. The `access` callback test fails if only the Rust half is applied. The existing non-callable `symlink` callback test and the callback-throw dispatch tests for both `symlink` overloads still pass.
  - `test/js/bun/bun-object/write.spec.ts`: the tightened `toBeUndefined()` fails on the released bun (`Received: null`) and passes here.
  - `test/bundler/compile-asset-bunfs.test.ts`: the existing compiled binary now also reports the `accessSync`/`promises.access` return values for an embedded asset, covering the `/$bunfs/` branch. Fails before (both `false`), passes after.
  - Node's `test/js/node/test/parallel/test-fs-access.js` (run as a non-root user, since it skips under root) and all six `test-fs-symlink*.js` pass, as do `test-fs-null-bytes.js`, the two `test-trace-events-fs-*.js` tests, `async-context-fs-access.js`, `fs/promises.test.js`, and the rest of `fs.test.ts`.

### Background
- `ret::*` (in `node_fs.rs`) are the per-operation result types that `NodeFS::<op>` returns. Each implements `FsReturn::fs_to_js`, and both the synchronous binding and the thread-pool task (`AsyncFSTask`) convert the result to a JS value through that single trait method, so the result type decides what `xSync()` returns and what the `fs.promises.x()` promise resolves with. `()` converts to `undefined`.
- The callback API in `fs.ts` is built on the same native promises: each wrapper calls the native function and attaches handlers to the returned promise. A fulfillment handler receives the promise's resolution value as its argument. Node calls a void operation's callback with a single `null` (the error slot), so these wrappers have to supply the `null` themselves rather than pass the user callback in as the fulfillment handler.
- `FunctionPrototypeBind` is the copy of `Function.prototype.bind` that `fs.ts` takes when the module is first loaded; `nullcallback` already builds its handlers with it, and the two new sites follow that existing form.
