### PR TITLE
MessagePort: close a port whose peer closed, so it is rejected as a transferable

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -285,10 +285,6 @@ void MessagePort::peerClosed()
     // A handler in that flush closed or transferred this port.
     if (m_isDetached || m_isClosing)
         return;
-    // Not receiving, messages still queued: node's close notification waits behind them.
-    // attach() notifies again once the port starts; tryTakeMessage() closes on the empty read.
-    if (MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0)
-        return;
     if (!m_pipe->isOtherSideClosedByRequest(m_side)) {
         // Peer collected, not closed: node never closes a channel over that (see jsRef()), so
         // only release the loop refs of a port that is started or listening for 'close'. An
@@ -299,6 +295,10 @@ void MessagePort::peerClosed()
         }
         return;
     }
+    // Not receiving, messages still queued: node's close notification waits behind them.
+    // attach() notifies again once the port starts; tryTakeMessage() closes on the empty read.
+    if (MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0)
+        return;
     close();
 }
 
@@ -394,7 +394,9 @@ JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject, bool& h
     auto message = m_pipe->takeOne(m_side);
     if (!message) {
         // This read reached the peer's close: node closes the port here (see peerClosed()).
-        if (m_pipe->isOtherSideClosedByRequest(m_side))
+        // Peer state before our queue, as in virtualHasPendingActivity(): a message the peer
+        // sent between takeOne() and its close() is then visible and must not be dropped.
+        if (m_pipe->isOtherSideClosedByRequest(m_side) && !MessagePortPipe::queuedCount(m_pipe->state(m_side)))
             close();
         return jsUndefined();
     }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -107,14 +107,11 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     }
     RETURN_IF_EXCEPTION(warnScope, {});
 
-    if (!isEntangled())
-        return {};
-
     Vector<TransferredMessagePort> transferredPorts;
+    // Posting a port's own entangled peer targets the message at itself.
+    // (The source port itself was rejected before serialization above.)
+    bool targetsEntangledPeer = false;
     if (!ports.isEmpty()) {
-        // Posting a port's own entangled peer targets the message at itself.
-        // (The source port itself was rejected before serialization above.)
-        bool targetsEntangledPeer = false;
         for (auto& port : ports) {
             if (port->pipe() == m_pipe.ptr()) {
                 targetsEntangledPeer = true;
@@ -127,20 +124,25 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
         if (disentangled.hasException())
             return disentangled.releaseException();
         transferredPorts = disentangled.releaseReturnValue();
+    }
 
-        if (targetsEntangledPeer) {
-            // Posting the port's own entangled peer: node warns and loses the channel
-            // rather than throwing. Transferables were already detached above; drop the
-            // message and close so the dead channel stops reffing the loop.
-            Bun__Process__emitWarning(defaultGlobalObject(&state),
-                JSC::JSValue::encode(JSC::jsString(vm, String("The target port was posted to itself, and the communication channel was lost"_s))),
-                JSC::JSValue::encode(JSC::jsString(vm, String("Warning"_s))),
-                JSC::JSValue::encode(JSC::jsUndefined()),
-                JSC::JSValue::encode(JSC::jsUndefined()));
-            CLEAR_IF_EXCEPTION(warnScope);
-            close();
-            return {};
-        }
+    // A closed port drops the message; the ports taken out of the transfer list go down with it
+    // (~TransferredMessagePort closes their sides, so their peers see a close), as in node.
+    if (!isEntangled())
+        return {};
+
+    if (targetsEntangledPeer) {
+        // Posting the port's own entangled peer: node warns and loses the channel
+        // rather than throwing. Transferables were already detached above; drop the
+        // message and close so the dead channel stops reffing the loop.
+        Bun__Process__emitWarning(defaultGlobalObject(&state),
+            JSC::JSValue::encode(JSC::jsString(vm, String("The target port was posted to itself, and the communication channel was lost"_s))),
+            JSC::JSValue::encode(JSC::jsString(vm, String("Warning"_s))),
+            JSC::JSValue::encode(JSC::jsUndefined()),
+            JSC::JSValue::encode(JSC::jsUndefined()));
+        CLEAR_IF_EXCEPTION(warnScope);
+        close();
+        return {};
     }
 
     m_pipe->send(m_side, MessageWithMessagePorts { messageData.releaseReturnValue(), WTF::move(transferredPorts) });
@@ -170,6 +172,7 @@ void MessagePort::start()
         }
     }
     m_started = true;
+    m_receiving = true;
 
     auto* context = scriptExecutionContext();
     ASSERT(context);
@@ -193,10 +196,11 @@ void MessagePort::flushQueuedMessagesBeforeClose()
     // re-injecting into this closing port (via its entangled peer) can't starve the loop.
     size_t limit = std::max<size_t>(MessagePortPipe::queuedCount(m_pipe->state(m_side)), 1000);
     for (size_t i = 0; i < limit; ++i) {
-        // A handler (or a microtask it queued) may have transferred this port; the
-        // remaining inbox now belongs to the new owner. drainAndDispatch()'s
-        // per-iteration ctxId/port re-check guards the same case.
-        if (m_isDetached)
+        // A handler (or a microtask it queued) may have transferred this port (the remaining
+        // inbox now belongs to the new owner) or removed the last listener, e.g. once(): like
+        // drainAndDispatch(), stop and leave the rest queued. peerClosed() then keeps the port
+        // open for a later listener; close() drops it.
+        if (m_isDetached || !hasMessageEventListener())
             break;
         auto message = m_pipe->takeOne(m_side);
         if (!message)
@@ -288,16 +292,18 @@ void MessagePort::peerClosed()
     if (!m_pipe->isOtherSideClosedByRequest(m_side)) {
         // Peer collected, not closed: node never closes a channel over that (see jsRef()), so
         // only release the loop refs of a port that is started or listening for 'close'. An
-        // idle port keeps its one 'close' event for its own close(cb).
+        // idle port keeps its one 'close' event for its own close(cb); it is notified again
+        // if it ever gets a 'close' listener (addEventListener) or starts (attach()).
         if (m_started || m_hasCloseEventListener.load(std::memory_order_relaxed)) {
             dispatchCloseEvent();
             jsUnref(defaultGlobalObject(context->globalObject()));
         }
         return;
     }
-    // Not receiving, messages still queued: node's close notification waits behind them.
-    // attach() notifies again once the port starts; tryTakeMessage() closes on the empty read.
-    if (MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0)
+    // Not receiving with messages queued: node's close notification waits behind them. The
+    // next 'message' listener (attach()) or the receiveMessageOnPort() that empties the queue
+    // (tryTakeMessage()) completes the close.
+    if (!m_receiving && MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0)
         return;
     close();
 }
@@ -535,13 +541,19 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
         start();
         m_hasMessageEventListener = true;
         // start() no-ops after the first call; re-attach so a listener re-added after a
-        // pause re-schedules the drain for messages buffered meanwhile.
+        // pause resumes receiving and re-schedules the drain for messages buffered meanwhile.
         if (m_started && isEntangled()) {
+            m_receiving = true;
             if (auto* context = scriptExecutionContext())
                 m_pipe->attach(m_side, context->identifier(), ThreadSafeWeakPtr<MessagePort> { *this });
         }
     } else if (eventType == eventNames().closeEvent) {
         m_hasCloseEventListener.store(true, std::memory_order_release);
+        // Reports a peer that went away while this port had no listener (see peerClosed()).
+        if (isEntangled()) {
+            if (auto* context = scriptExecutionContext())
+                m_pipe->registerCloseContext(m_side, context->identifier(), ThreadSafeWeakPtr<MessagePort> { *this });
+        }
     }
     return EventTarget::addEventListener(eventType, WTF::move(listener), options);
 }
@@ -549,8 +561,12 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
 bool MessagePort::removeEventListener(const AtomString& eventType, EventListener& listener, const EventListenerOptions& options)
 {
     auto result = EventTarget::removeEventListener(eventType, listener, options);
-    if (!hasEventListeners(eventNames().messageEvent))
+    if (!hasEventListeners(eventNames().messageEvent)) {
         m_hasMessageEventListener = false;
+        // Node stops the port when its last 'message' listener goes.
+        if (eventType == eventNames().messageEvent)
+            m_receiving = false;
+    }
     if (!hasEventListeners(eventNames().closeEvent))
         m_hasCloseEventListener.store(false, std::memory_order_release);
     return result;

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -50,6 +50,9 @@ Ref<MessagePort> MessagePort::create(ScriptExecutionContext& context, Ref<Messag
 {
     auto messagePort = adoptRef(*new MessagePort(context, WTF::move(pipe), side));
     messagePort->suspendIfNeeded();
+    // The peer's close() closes this port too (peerClosed()), whether or not it ever
+    // gets a listener, so the pipe has to know where to deliver that from the start.
+    messagePort->m_pipe->registerCloseContext(side, context.identifier(), ThreadSafeWeakPtr<MessagePort> { messagePort.get() });
     return messagePort;
 }
 
@@ -271,24 +274,45 @@ void MessagePort::dispatchCloseEvent()
 
 void MessagePort::peerClosed()
 {
-    if (m_isDetached)
+    if (m_isDetached || m_isClosing)
         return;
     auto* context = scriptExecutionContext();
     if (!context || !context->globalObject())
         return;
     Ref protectedThis { *this };
-    // Deliver whatever the peer sent before it closed, then fire 'close'. Node orders
-    // them that way, and registerCloseContext()'s retroactive notify can land before any
-    // drain is scheduled -- e.g. on('close') registered before on('message').
+    // Deliver whatever the peer sent before it closed first: node orders them that way, and
+    // this task can run before the drain (the peer closed before this port got a listener).
     if (m_started && hasMessageEventListener())
         flushQueuedMessagesBeforeClose();
-    // Fire 'close' (guarded against a double dispatch) and release this side's loop refs
-    // so the loop can idle, matching node.
-    dispatchCloseEvent();
-    // jsUnref() clears both the listener loop-ref (m_isRefd) and the onmessage/ref()
-    // keepalive (m_hasRef), so a listening transferred port stops pinning the loop.
-    auto* globalObject = defaultGlobalObject(context->globalObject());
-    jsUnref(globalObject);
+    // A 'message' handler in that flush closed or transferred this port itself.
+    if (m_isDetached || m_isClosing)
+        return;
+
+    // In node the peer's close is an entry at the tail of this port's queue: a port that is
+    // not receiving stays open, and transferable, until everything queued ahead of it has
+    // been consumed. attach() notifies again once the port starts and its drain has run, and
+    // tryTakeMessage() closes on the receiveMessageOnPort() call that finds the queue empty.
+    if (MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0)
+        return;
+
+    if (!m_pipe->isOtherSideClosedByRequest(m_side)) {
+        // The peer's wrapper was garbage collected rather than closed. Node never closes a
+        // channel over that, so this port stays open (closing it here would make a later
+        // transfer fail at GC timing; jsRef() draws the same line). A port that is started
+        // or listening for 'close' is still told, so the listening peer of a collected port
+        // releases its loop refs instead of pinning the process. An idle port is left alone:
+        // its 'close' belongs to whoever eventually closes it (close(cb) relies on that),
+        // and attach() notifies again if it starts later.
+        if (m_started || m_hasCloseEventListener.load(std::memory_order_relaxed)) {
+            dispatchCloseEvent();
+            jsUnref(defaultGlobalObject(context->globalObject()));
+        }
+        return;
+    }
+
+    // Closed exactly as if close() had been called on it: rejected as a transferable,
+    // postMessage() drops the message, loop refs released, 'close' from close()'s task.
+    close();
 }
 
 TransferredMessagePort MessagePort::disentangle()
@@ -381,8 +405,13 @@ JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject, bool& h
         return jsUndefined();
 
     auto message = m_pipe->takeOne(m_side);
-    if (!message)
+    if (!message) {
+        // The queue is drained down to the peer's close (see peerClosed()): node closes
+        // the port on this call and reports no message.
+        if (m_pipe->isOtherSideClosedByRequest(m_side))
+            close();
         return jsUndefined();
+    }
 
     hadMessage = true;
     auto ports = MessagePort::entanglePorts(*context, WTF::move(message->transferredPorts));
@@ -525,12 +554,6 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
         }
     } else if (eventType == eventNames().closeEvent) {
         m_hasCloseEventListener.store(true, std::memory_order_release);
-        if (isEntangled()) {
-            // Record our context with the pipe so the peer's close() can deliver a
-            // 'close' event even if we never started (no 'message' listener).
-            if (auto* context = scriptExecutionContext())
-                m_pipe->registerCloseContext(m_side, context->identifier(), ThreadSafeWeakPtr<MessagePort> { *this });
-        }
     }
     return EventTarget::addEventListener(eventType, WTF::move(listener), options);
 }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -50,8 +50,7 @@ Ref<MessagePort> MessagePort::create(ScriptExecutionContext& context, Ref<Messag
 {
     auto messagePort = adoptRef(*new MessagePort(context, WTF::move(pipe), side));
     messagePort->suspendIfNeeded();
-    // The peer's close() closes this port too (peerClosed()), whether or not it ever
-    // gets a listener, so the pipe has to know where to deliver that from the start.
+    // So the peer's close() reaches this port (peerClosed()) even if it never gets a listener.
     messagePort->m_pipe->registerCloseContext(side, context.identifier(), ThreadSafeWeakPtr<MessagePort> { messagePort.get() });
     return messagePort;
 }
@@ -280,38 +279,26 @@ void MessagePort::peerClosed()
     if (!context || !context->globalObject())
         return;
     Ref protectedThis { *this };
-    // Deliver whatever the peer sent before it closed first: node orders them that way, and
-    // this task can run before the drain (the peer closed before this port got a listener).
+    // Node delivers what the peer sent before closing first; this task can run before the drain.
     if (m_started && hasMessageEventListener())
         flushQueuedMessagesBeforeClose();
-    // A 'message' handler in that flush closed or transferred this port itself.
+    // A handler in that flush closed or transferred this port.
     if (m_isDetached || m_isClosing)
         return;
-
-    // In node the peer's close is an entry at the tail of this port's queue: a port that is
-    // not receiving stays open, and transferable, until everything queued ahead of it has
-    // been consumed. attach() notifies again once the port starts and its drain has run, and
-    // tryTakeMessage() closes on the receiveMessageOnPort() call that finds the queue empty.
+    // Not receiving, messages still queued: node's close notification waits behind them.
+    // attach() notifies again once the port starts; tryTakeMessage() closes on the empty read.
     if (MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0)
         return;
-
     if (!m_pipe->isOtherSideClosedByRequest(m_side)) {
-        // The peer's wrapper was garbage collected rather than closed. Node never closes a
-        // channel over that, so this port stays open (closing it here would make a later
-        // transfer fail at GC timing; jsRef() draws the same line). A port that is started
-        // or listening for 'close' is still told, so the listening peer of a collected port
-        // releases its loop refs instead of pinning the process. An idle port is left alone:
-        // its 'close' belongs to whoever eventually closes it (close(cb) relies on that),
-        // and attach() notifies again if it starts later.
+        // Peer collected, not closed: node never closes a channel over that (see jsRef()), so
+        // only release the loop refs of a port that is started or listening for 'close'. An
+        // idle port keeps its one 'close' event for its own close(cb).
         if (m_started || m_hasCloseEventListener.load(std::memory_order_relaxed)) {
             dispatchCloseEvent();
             jsUnref(defaultGlobalObject(context->globalObject()));
         }
         return;
     }
-
-    // Closed exactly as if close() had been called on it: rejected as a transferable,
-    // postMessage() drops the message, loop refs released, 'close' from close()'s task.
     close();
 }
 
@@ -406,8 +393,7 @@ JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject, bool& h
 
     auto message = m_pipe->takeOne(m_side);
     if (!message) {
-        // The queue is drained down to the peer's close (see peerClosed()): node closes
-        // the port on this call and reports no message.
+        // This read reached the peer's close: node closes the port here (see peerClosed()).
         if (m_pipe->isOtherSideClosedByRequest(m_side))
             close();
         return jsUndefined();

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -158,20 +158,24 @@ void MessagePort::entrySettled()
 
 void MessagePort::start()
 {
-    if (m_started || !isEntangled())
+    if (!isEntangled())
         return;
-    // A node worker's parentPort delivers nothing until the entry module has evaluated; keep the
-    // request and let entrySettled() perform it. Messages stay buffered in the pipe meanwhile.
-    if (auto* context = scriptExecutionContext()) {
-        if (auto* jsGlobal = context->globalObject()) {
-            auto* globalObject = defaultGlobalObject(jsGlobal);
-            if (globalObject->nodeParentPort() == this && !globalObject->nodeWorkerEntrySettled()) {
-                m_startDeferredUntilEntrySettled = true;
-                return;
+    if (!m_started) {
+        // A node worker's parentPort delivers nothing until the entry module has evaluated; keep the
+        // request and let entrySettled() perform it. Messages stay buffered in the pipe meanwhile.
+        if (auto* context = scriptExecutionContext()) {
+            if (auto* jsGlobal = context->globalObject()) {
+                auto* globalObject = defaultGlobalObject(jsGlobal);
+                if (globalObject->nodeParentPort() == this && !globalObject->nodeWorkerEntrySettled()) {
+                    m_startDeferredUntilEntrySettled = true;
+                    return;
+                }
             }
         }
+        m_started = true;
     }
-    m_started = true;
+    // Every call turns delivery (back) on, as node's Start() does for a port whose last 'message'
+    // listener was removed. attach() re-schedules the drain and re-reports a peer that has closed.
     m_receiving = true;
 
     auto* context = scriptExecutionContext();
@@ -538,15 +542,9 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
 bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
 {
     if (eventType == eventNames().messageEvent) {
+        // Also resumes a port paused by removing its listeners (see start()).
         start();
         m_hasMessageEventListener = true;
-        // start() no-ops after the first call; re-attach so a listener re-added after a
-        // pause resumes receiving and re-schedules the drain for messages buffered meanwhile.
-        if (m_started && isEntangled()) {
-            m_receiving = true;
-            if (auto* context = scriptExecutionContext())
-                m_pipe->attach(m_side, context->identifier(), ThreadSafeWeakPtr<MessagePort> { *this });
-        }
     } else if (eventType == eventNames().closeEvent) {
         m_hasCloseEventListener.store(true, std::memory_order_release);
         // Reports a peer that went away while this port had no listener (see peerClosed()).

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -146,6 +146,10 @@ private:
     const uint8_t m_side { 0 };
 
     bool m_started { false };
+    // Node's receiving_messages_: set by start() (explicitly or through a 'message' listener),
+    // cleared when the last 'message' listener is removed. While clear, a peer's close waits
+    // behind the queued messages (peerClosed()); m_started itself is never cleared.
+    bool m_receiving { false };
     bool m_isDetached { false };
     bool m_isClosing { false };
     // True while a 'message' handler is on the stack. close() called from inside one

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -79,9 +79,7 @@ public:
     // The worker's entry module finished evaluating: a start() requested before that takes effect now.
     void entrySettled();
     void close();
-    // Called (via the pipe, as a task) on the entangled peer of a side that closed.
-    // Delivers what is still queued if this port is receiving, then closes this port
-    // too, as node does; see the body for the not-receiving and collected-peer cases.
+    // Posted by the pipe to the peer of a side that closed: closes this port too once its queue is drained.
     void peerClosed();
     void dispatchCloseEvent();
 

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -79,8 +79,9 @@ public:
     // The worker's entry module finished evaluating: a start() requested before that takes effect now.
     void entrySettled();
     void close();
-    // Called on the entangled peer when this side closes: dispatches a
-    // 'close' event and releases the event-loop ref so the loop can idle.
+    // Called (via the pipe, as a task) on the entangled peer of a side that closed.
+    // Delivers what is still queued if this port is receiving, then closes this port
+    // too, as node does; see the body for the not-receiving and collected-peer cases.
     void peerClosed();
     void dispatchCloseEvent();
 

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -247,15 +247,17 @@ void MessagePortPipe::registerCloseContext(uint8_t side, ScriptExecutionContextI
     {
         Locker locker { s.lock };
         uint64_t st = s.state.load(std::memory_order_relaxed);
-        // Already closed, or context already known (started or previously registered).
-        if ((st & Closed) || (st & (Attached | ContextKnown)))
+        if (st & Closed)
             return;
-        s.ctxId = ctxId;
-        s.port = WTF::move(port);
-        s.state.store(st | ContextKnown, std::memory_order_release);
+        // Already known (started, or registered at creation): keep that, only re-check the peer.
+        if (!(st & (Attached | ContextKnown))) {
+            s.ctxId = ctxId;
+            s.port = WTF::move(port);
+            s.state.store(st | ContextKnown, std::memory_order_release);
+        }
     }
-    // See attach(): re-deliver a peer-close that fired while this side had no
-    // context (in transit or never registered).
+    // See attach(). Also how a port that ignored a collected peer while it had no listener
+    // (MessagePort::peerClosed) hears about it again once it gets a 'close' listener.
     if (m_sides[1 - side].state.load(std::memory_order_acquire) & Closed)
         notifyPeerClosed(side);
 }

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -234,10 +234,8 @@ void MessagePortPipe::attach(uint8_t side, ScriptExecutionContextIdentifier ctxI
     }
     if (wakeCtx)
         scheduleDrain(side, wakeCtx);
-    // Peer already closed: notify again now that this side is receiving. The task runs
-    // after the drain scheduled above, so a peerClosed() that earlier left the port
-    // open because messages were still queued (see MessagePort::peerClosed) now
-    // delivers whatever is left and completes the close.
+    // Peer already closed: notify again now that this side is receiving. The task runs after the
+    // drain scheduled above, so a close that peerClosed() deferred behind queued messages completes.
     if (m_sides[1 - side].state.load(std::memory_order_acquire) & Closed)
         notifyPeerClosed(side);
 }

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -234,9 +234,10 @@ void MessagePortPipe::attach(uint8_t side, ScriptExecutionContextIdentifier ctxI
     }
     if (wakeCtx)
         scheduleDrain(side, wakeCtx);
-    // Peer already closed while this side was in transit (detach() cleared
-    // ContextKnown so notifyPeerClosed() early-returned): re-deliver to the new
-    // owner, or the receiving context's listener loop-ref is never released.
+    // Peer already closed: notify again now that this side is receiving. The task runs
+    // after the drain scheduled above, so a peerClosed() that earlier left the port
+    // open because messages were still queued (see MessagePort::peerClosed) now
+    // delivers whatever is left and completes the close.
     if (m_sides[1 - side].state.load(std::memory_order_acquire) & Closed)
         notifyPeerClosed(side);
 }

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -64,8 +64,9 @@ public:
     // already queued (e.g. after transfer). Passing a null port is allowed and
     // means "just buffer, don't dispatch" (used before start()).
     void attach(uint8_t side, ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>);
-    // Called when a MessagePort is created for this side: records ctxId/port so the peer's close()
-    // reaches a port that never started, without enabling drains. No-op once attached/registered/closed.
+    // Records ctxId/port (unless already attached/registered) so the peer's close() reaches a port
+    // that never started, without enabling drains, and reports a peer that is already closed. Called
+    // when a MessagePort is created for this side and when it gains a 'close' listener.
     void registerCloseContext(uint8_t side, ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>);
     void detach(uint8_t side);
     // Explicit == a real, permanent close: close(), context teardown, or an orphaned

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -64,9 +64,9 @@ public:
     // already queued (e.g. after transfer). Passing a null port is allowed and
     // means "just buffer, don't dispatch" (used before start()).
     void attach(uint8_t side, ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>);
-    // Like attach() but only records ctxId/port so the peer's close() can deliver
-    // a 'close' event to a port that never started (no 'message' listener). Does
-    // NOT enable drains. No-op if already attached/registered/closed.
+    // Like attach() but only records ctxId/port so the peer's close() reaches a port
+    // that never started (no 'message' listener). Called when a MessagePort is created
+    // for this side. Does NOT enable drains. No-op if already attached/registered/closed.
     void registerCloseContext(uint8_t side, ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>);
     void detach(uint8_t side);
     // Explicit == a real, permanent close: close(), context teardown, or an orphaned

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -64,9 +64,8 @@ public:
     // already queued (e.g. after transfer). Passing a null port is allowed and
     // means "just buffer, don't dispatch" (used before start()).
     void attach(uint8_t side, ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>);
-    // Like attach() but only records ctxId/port so the peer's close() reaches a port
-    // that never started (no 'message' listener). Called when a MessagePort is created
-    // for this side. Does NOT enable drains. No-op if already attached/registered/closed.
+    // Called when a MessagePort is created for this side: records ctxId/port so the peer's close()
+    // reaches a port that never started, without enabling drains. No-op once attached/registered/closed.
     void registerCloseContext(uint8_t side, ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<MessagePort>);
     void detach(uint8_t side);
     // Explicit == a real, permanent close: close(), context teardown, or an orphaned

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1977,6 +1977,23 @@ describe("a port whose peer closed is closed too", () => {
     carrier.port2.close();
   });
 
+  // The wait-for-the-queue-to-drain rule is for an explicit close only: nothing would ever
+  // re-notify a 'close'-listening port that never starts, and until 'close' has been dispatched
+  // such a port is pinned in the heap. This is what main did before the change, kept as is.
+  test("a 'close'-listening port with an unread message is still told when its peer is garbage collected", async () => {
+    let closes = 0;
+    const port1 = await survivorOfCollectedPeer((survivor, doomed) => {
+      survivor.on("close", () => closes++);
+      doomed.postMessage("unread");
+    });
+    for (let i = 0; i < 20 && closes === 0; i++) await tick();
+    expect({ closes, unread: receiveMessageOnPort(port1), rejected: isRejectedAsDetached(port1) }).toEqual({
+      closes: 1,
+      unread: { message: "unread" },
+      rejected: false,
+    });
+  });
+
   // ...and an idle port is not even told: its one 'close' event has to stay available for
   // the close() that eventually happens (node's test-worker-message-port.js relies on this).
   test("a port whose peer was garbage collected still delivers close(cb) when it is closed later", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1785,6 +1785,248 @@ test("MessagePort: peer closing while a port is in transit still delivers 'close
   });
 });
 
+// When one port of a channel is close()d, node closes the other one as well (once the
+// close has propagated): it fires 'close', drops its loop refs, and from then on it is
+// rejected as a transferable like any closed port. Bun fired 'close' on the peer but
+// left it open, so a dead endpoint could be transferred; a peer with no listeners was
+// not told at all.
+describe("a port whose peer closed is closed too", () => {
+  const detached = expect.objectContaining({
+    name: "DataCloneError",
+    message: "MessagePort in transfer list is already detached",
+  });
+  const tick = () => new Promise(r => setImmediate(r));
+
+  // Probe without transferring anything: the trailing plain object is itself invalid, so the
+  // post always throws, and the message says whether `port` (checked first, in list order)
+  // was rejected as detached.
+  function isRejectedAsDetached(port: MessagePort): boolean {
+    const carrier = new MessageChannel();
+    let message: string | undefined;
+    try {
+      carrier.port1.postMessage(null, [port, {} as any]);
+    } catch (e: any) {
+      message = e.message;
+    } finally {
+      carrier.port1.close();
+      carrier.port2.close();
+    }
+    if (message === undefined) throw new Error("the probe post must throw");
+    return message === "MessagePort in transfer list is already detached";
+  }
+
+  test("with a 'close' listener: rejected by postMessage and structuredClone, transfer stays atomic", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const carrier = new MessageChannel();
+    const closed = once(port1, "close");
+    port2.close();
+    await closed;
+
+    const ab = new ArrayBuffer(8);
+    expect(() => carrier.port1.postMessage(null, [ab, port1])).toThrow(detached);
+    // Same as node: a bad port later in the list means nothing earlier in it is transferred.
+    expect(ab.byteLength).toBe(8);
+    expect(() => structuredClone(port1, { transfer: [port1] })).toThrow(detached);
+    expect(port1.hasRef()).toBe(false);
+    carrier.port1.close();
+    carrier.port2.close();
+  });
+
+  test("with a 'message' listener: what the peer sent first is delivered, then the port closes", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const events: string[] = [];
+    port1.on("message", m => events.push(m));
+    const closed = once(port1, "close");
+    port2.postMessage("m1");
+    port2.close();
+    await closed;
+    events.push("close");
+
+    expect(events).toEqual(["m1", "close"]);
+    expect(isRejectedAsDetached(port1)).toBe(true);
+    expect(port1.hasRef()).toBe(false);
+  });
+
+  test("the port is already closed when its own 'close' listener runs", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+    port1.on("close", () => resolve(isRejectedAsDetached(port1)));
+    port2.close();
+    expect(await promise).toBe(true);
+  });
+
+  test("with no listeners at all", async () => {
+    const { port1, port2 } = new MessageChannel();
+    port2.close();
+    // The close reaches port1 as a task; poll for it rather than assume how many turns it takes.
+    let rejected = false;
+    for (let i = 0; i < 100 && !rejected; i++) {
+      await tick();
+      rejected = isRejectedAsDetached(port1);
+    }
+    expect(rejected).toBe(true);
+  });
+
+  test("Worker.postMessage() and the Worker constructor's transferList reject it as well", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const closed = once(port1, "close");
+    port2.close();
+    await closed;
+
+    const worker = new Worker("", { eval: true });
+    try {
+      expect(() => worker.postMessage(port1, [port1])).toThrow(detached);
+      expect(() => new Worker("", { eval: true, workerData: port1, transferList: [port1] })).toThrow(detached);
+    } finally {
+      await worker.terminate();
+    }
+  });
+
+  // node's close notification sits behind whatever the peer posted before closing: a port
+  // that is not receiving keeps those messages and stays open until they are consumed.
+  test("a port that is not receiving stays open until a 'message' listener drains the queue", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const events: string[] = [];
+    const closed = once(port1, "close");
+    port2.postMessage("m1");
+    port2.postMessage("m2");
+    port2.close();
+    for (let i = 0; i < 4; i++) await tick();
+    expect({ events, rejected: isRejectedAsDetached(port1) }).toEqual({ events: [], rejected: false });
+
+    port1.on("message", m => events.push(m));
+    await closed;
+    events.push("close");
+    expect(events).toEqual(["m1", "m2", "close"]);
+    expect(isRejectedAsDetached(port1)).toBe(true);
+  });
+
+  test("a port that is not receiving stays open until receiveMessageOnPort() drains the queue", async () => {
+    const { port1, port2 } = new MessageChannel();
+    let closes = 0;
+    const closed = once(port1, "close");
+    port1.on("close", () => closes++);
+    port2.postMessage("m1");
+    port2.close();
+    for (let i = 0; i < 4; i++) await tick();
+    expect({ closes, rejected: isRejectedAsDetached(port1) }).toEqual({ closes: 0, rejected: false });
+
+    expect(receiveMessageOnPort(port1)).toEqual({ message: "m1" });
+    // Taking the last message does not close it yet (node closes on reaching the notification).
+    expect({ closes, rejected: isRejectedAsDetached(port1) }).toEqual({ closes: 0, rejected: false });
+
+    // This call reaches the peer's close: no message, and the port is closed on the spot.
+    expect(receiveMessageOnPort(port1)).toBeUndefined();
+    expect({ closes, rejected: isRejectedAsDetached(port1) }).toEqual({ closes: 0, rejected: true });
+    await closed;
+    expect(closes).toBe(1);
+  });
+
+  test("a port left open that way is still a valid transferable; the receiver gets the queue and the close", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const carrier = new MessageChannel();
+    let senderCloses = 0;
+    port1.on("close", () => senderCloses++);
+    port2.postMessage("m1");
+    port2.close();
+    for (let i = 0; i < 4; i++) await tick();
+    expect(senderCloses).toBe(0);
+
+    carrier.port1.postMessage(port1, [port1]);
+    const [received] = (await once(carrier.port2, "message")) as [MessagePort];
+    const events: string[] = [];
+    const closed = once(received, "close");
+    received.on("message", m => events.push(m));
+    await closed;
+    events.push("close");
+    expect(events).toEqual(["m1", "close"]);
+    carrier.port1.close();
+    carrier.port2.close();
+  });
+
+  // Only an explicit close counts. Bun collects an entangled port whose wrapper is unreachable
+  // (node never does) and notifies the peer so it releases its loop refs; closing the peer on
+  // top of that would make its transfer fail or not depending on when GC ran.
+  test("a peer that was garbage collected rather than closed leaves the port transferable", async () => {
+    const carrier = new MessageChannel();
+    let port1!: MessagePort;
+    (() => {
+      const channel = new MessageChannel();
+      port1 = channel.port1;
+      port1.on("close", () => {});
+    })();
+    for (let i = 0; i < 5; i++) {
+      Bun.gc(true);
+      await tick();
+    }
+    expect(isRejectedAsDetached(port1)).toBe(false);
+    carrier.port1.postMessage(port1, [port1]);
+    carrier.port1.close();
+    carrier.port2.close();
+  });
+
+  // ...and an idle port is not even told: its one 'close' event has to stay available for
+  // the close() that eventually happens (node's test-worker-message-port.js relies on this).
+  test("a port whose peer was garbage collected still delivers close(cb) when it is closed later", async () => {
+    let idle!: MessagePort;
+    let unread!: MessagePort;
+    (() => {
+      idle = new MessageChannel().port2;
+      const channel = new MessageChannel();
+      unread = channel.port2;
+      channel.port1.postMessage("queued");
+    })();
+    for (let i = 0; i < 5; i++) {
+      Bun.gc(true);
+      await tick();
+    }
+
+    // 'close' is dispatched from a task queued by close(); give it a few turns, then give up.
+    function closeCallbackFires(port: MessagePort): Promise<string> {
+      return Promise.race([
+        new Promise<string>(resolve => port.close(() => resolve("called"))),
+        (async () => {
+          for (let i = 0; i < 20; i++) await tick();
+          return "not called";
+        })(),
+      ]);
+    }
+
+    expect(await closeCallbackFires(idle)).toBe("called");
+    // close() from inside the 'message' handler, as node's test does.
+    const unreadResult = await new Promise<string>(resolve => {
+      unread.on("message", m => closeCallbackFires(unread).then(cb => resolve(`${m}, close(cb) ${cb}`)));
+    });
+    expect(unreadResult).toBe("queued, close(cb) called");
+  });
+
+  // The same missing notification left a ref()'d port with no listeners pinning the loop
+  // forever after its peer closed; node's port closes and the process exits.
+  test("a ref()'d port with no listeners lets the process exit once its peer closes", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { MessageChannel } = require("worker_threads");
+         const { port1, port2 } = new MessageChannel();
+         port1.ref();
+         port2.close();
+         // unref'd, so it only ever fires if something else (the port) is still holding the loop open.
+         setTimeout(() => { console.log("still running, hasRef=" + port1.hasRef()); process.exit(1); }, 3000).unref();
+         process.on("exit", code => console.log("exit " + code + ", hasRef=" + port1.hasRef()));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "exit 0, hasRef=false",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 test("workerData is not unwrapped for a non-node globalThis.Worker", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1944,21 +1944,33 @@ describe("a port whose peer closed is closed too", () => {
     carrier.port2.close();
   });
 
+  // Makes a channel, drops one port and collects it (its WeakRef clearing is the proof; the
+  // collection runs ~MessagePort, which posts the peer notification), then gives the surviving
+  // port a turn to process that notification and returns it.
+  async function survivorOfCollectedPeer(prepare: (survivor: MessagePort, doomed: MessagePort) => void) {
+    const { survivor, doomed } = (() => {
+      const { port1, port2 } = new MessageChannel();
+      prepare(port1, port2);
+      return { survivor: port1, doomed: new WeakRef(port2) };
+    })();
+    let collected = false;
+    for (let i = 0; i < 20 && !collected; i++) {
+      // new WeakRef() / deref() keep the target alive for the rest of the current turn.
+      await tick();
+      Bun.gc(true);
+      collected = doomed.deref() === undefined;
+    }
+    expect(collected).toBe(true);
+    await tick();
+    return survivor;
+  }
+
   // Only an explicit close counts. Bun collects an entangled port whose wrapper is unreachable
   // (node never does) and notifies the peer so it releases its loop refs; closing the peer on
   // top of that would make its transfer fail or not depending on when GC ran.
   test("a peer that was garbage collected rather than closed leaves the port transferable", async () => {
     const carrier = new MessageChannel();
-    let port1!: MessagePort;
-    (() => {
-      const channel = new MessageChannel();
-      port1 = channel.port1;
-      port1.on("close", () => {});
-    })();
-    for (let i = 0; i < 5; i++) {
-      Bun.gc(true);
-      await tick();
-    }
+    const port1 = await survivorOfCollectedPeer(survivor => survivor.on("close", () => {}));
     expect(isRejectedAsDetached(port1)).toBe(false);
     carrier.port1.postMessage(port1, [port1]);
     carrier.port1.close();
@@ -1968,18 +1980,8 @@ describe("a port whose peer closed is closed too", () => {
   // ...and an idle port is not even told: its one 'close' event has to stay available for
   // the close() that eventually happens (node's test-worker-message-port.js relies on this).
   test("a port whose peer was garbage collected still delivers close(cb) when it is closed later", async () => {
-    let idle!: MessagePort;
-    let unread!: MessagePort;
-    (() => {
-      idle = new MessageChannel().port2;
-      const channel = new MessageChannel();
-      unread = channel.port2;
-      channel.port1.postMessage("queued");
-    })();
-    for (let i = 0; i < 5; i++) {
-      Bun.gc(true);
-      await tick();
-    }
+    const idle = await survivorOfCollectedPeer(() => {});
+    const unread = await survivorOfCollectedPeer((_survivor, doomed) => doomed.postMessage("queued"));
 
     // 'close' is dispatched from a task queued by close(); give it a few turns, then give up.
     function closeCallbackFires(port: MessagePort): Promise<string> {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2025,6 +2025,35 @@ describe("a port whose peer closed is closed too", () => {
     });
   });
 
+  // start() turns a paused port back on as well (node's Start() always sets receiving), whether
+  // it is called before the peer closes or only after the close was already put on hold.
+  test.each([
+    ["before the peer closes", true],
+    ["after the peer closed", false],
+  ])("start() on a paused port resumes it (%s), so the port is closed", async (_name, startFirst) => {
+    const { port1, port2 } = new MessageChannel();
+    port1.ref();
+    const handler = () => {};
+    port1.on("message", handler);
+    port1.off("message", handler);
+    let closes = 0;
+    port1.on("close", () => closes++);
+    if (startFirst) port1.start();
+    port2.postMessage("dropped");
+    port2.close();
+    if (!startFirst) {
+      for (let i = 0; i < 4; i++) await tick();
+      expect({ closes, rejected: isRejectedAsDetached(port1) }).toEqual({ closes: 0, rejected: false });
+      port1.start();
+    }
+    for (let i = 0; i < 20 && closes === 0; i++) await tick();
+    expect({ closes, rejected: isRejectedAsDetached(port1), hasRef: port1.hasRef() }).toEqual({
+      closes: 1,
+      rejected: true,
+      hasRef: false,
+    });
+  });
+
   test("a port left open that way is still a valid transferable; the receiver gets the queue and the close", async () => {
     const { port1, port2 } = new MessageChannel();
     const carrier = new MessageChannel();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1867,6 +1867,44 @@ describe("a port whose peer closed is closed too", () => {
     expect(rejected).toBe(true);
   });
 
+  test("a 'close' listener added once the port has closed is not called (the event has passed)", async () => {
+    const { port1, port2 } = new MessageChannel();
+    port2.close();
+    let rejected = false;
+    for (let i = 0; i < 100 && !rejected; i++) {
+      await tick();
+      rejected = isRejectedAsDetached(port1);
+    }
+    expect(rejected).toBe(true);
+
+    let closes = 0;
+    port1.on("close", () => closes++);
+    for (let i = 0; i < 4; i++) await tick();
+    expect(closes).toBe(0);
+  });
+
+  // postMessage() on a closed port still serializes (node does, so transfers keep their side
+  // effects): the ArrayBuffer is detached and a port in the list is consumed, and since the
+  // message goes nowhere that port's own peer sees it close.
+  test("postMessage() on the closed port is dropped but still consumes its transfer list", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const closed = once(port1, "close");
+    port2.close();
+    await closed;
+
+    const third = new MessageChannel();
+    let thirdPeerCloses = 0;
+    third.port2.on("close", () => thirdPeerCloses++);
+    const ab = new ArrayBuffer(8);
+    expect(() => port1.postMessage({ ab, port: third.port1 }, [ab, third.port1])).not.toThrow();
+    for (let i = 0; i < 20 && thirdPeerCloses === 0; i++) await tick();
+    expect({ byteLength: ab.byteLength, consumed: isRejectedAsDetached(third.port1), thirdPeerCloses }).toEqual({
+      byteLength: 0,
+      consumed: true,
+      thirdPeerCloses: 1,
+    });
+  });
+
   test("Worker.postMessage() and the Worker constructor's transferList reject it as well", async () => {
     const { port1, port2 } = new MessageChannel();
     const closed = once(port1, "close");
@@ -1922,6 +1960,71 @@ describe("a port whose peer closed is closed too", () => {
     expect(closes).toBe(1);
   });
 
+  // Removing the last 'message' listener stops a port in node (setupPortReferencing calls
+  // stopMessagePort), so a port paused that way is "not receiving" as well: what the peer sent
+  // before closing waits for the next listener, and only then does the port close.
+  test.each([
+    [
+      "on() then off()",
+      async (port: MessagePort) => {
+        const handler = () => {};
+        port.on("message", handler);
+        port.off("message", handler);
+      },
+    ],
+    [
+      "a once() listener that has fired",
+      async (port: MessagePort, peer: MessagePort) => {
+        const fired = once(port, "message");
+        peer.postMessage("consumed by once()");
+        await fired;
+      },
+    ],
+    [
+      "onmessage set, then cleared",
+      async (port: MessagePort) => {
+        port.onmessage = () => {};
+        port.onmessage = null;
+      },
+    ],
+  ])("a port paused by %s stays open until the next 'message' listener drains the queue", async (_name, pause) => {
+    const { port1, port2 } = new MessageChannel();
+    await pause(port1, port2);
+    let closes = 0;
+    port1.on("close", () => closes++);
+    port2.postMessage("while paused");
+    port2.close();
+    for (let i = 0; i < 4; i++) await tick();
+    expect({ closes, rejected: isRejectedAsDetached(port1) }).toEqual({ closes: 0, rejected: false });
+
+    const [message] = await once(port1, "message");
+    for (let i = 0; i < 20 && closes === 0; i++) await tick();
+    expect({ message, closes, rejected: isRejectedAsDetached(port1) }).toEqual({
+      message: "while paused",
+      closes: 1,
+      rejected: true,
+    });
+  });
+
+  // Whereas a port that was start()ed and never given a listener is receiving: node emits its
+  // messages into the void and reaches the close. Bun keeps them buffered instead, so nothing
+  // would ever drain it; the close must not wait for that, or a ref()'d one pins the loop forever.
+  test("a start()ed port without a 'message' listener is closed even with a message queued", async () => {
+    const { port1, port2 } = new MessageChannel();
+    port1.ref();
+    port1.start();
+    let closes = 0;
+    port1.on("close", () => closes++);
+    port2.postMessage("dropped");
+    port2.close();
+    for (let i = 0; i < 20 && closes === 0; i++) await tick();
+    expect({ closes, rejected: isRejectedAsDetached(port1), hasRef: port1.hasRef() }).toEqual({
+      closes: 1,
+      rejected: true,
+      hasRef: false,
+    });
+  });
+
   test("a port left open that way is still a valid transferable; the receiver gets the queue and the close", async () => {
     const { port1, port2 } = new MessageChannel();
     const carrier = new MessageChannel();
@@ -1940,6 +2043,43 @@ describe("a port whose peer closed is closed too", () => {
     await closed;
     events.push("close");
     expect(events).toEqual(["m1", "close"]);
+    carrier.port1.close();
+    carrier.port2.close();
+  });
+
+  // For a received port whose peer is already gone, the close notification is processed before
+  // the first drain, so peerClosed() itself delivers the queue. A once() handler stops the port
+  // after one message; the delivery must stop there too and leave the rest for the next listener.
+  test("a once() handler on a received port stops the delivery; the next listener gets the rest", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const carrier = new MessageChannel();
+    port2.postMessage("m1");
+    port2.postMessage("m2");
+    port2.close();
+    carrier.port1.postMessage(port1, [port1]);
+
+    const { promise, resolve } = Promise.withResolvers<{ received: MessagePort; first: unknown }>();
+    carrier.port2.on("message", (received: MessagePort) => {
+      // Registered synchronously on receipt, like a handler that sets up the port it was handed.
+      received.once("message", first => resolve({ received, first }));
+    });
+    const { received, first } = await promise;
+    let closes = 0;
+    received.on("close", () => closes++);
+    for (let i = 0; i < 4; i++) await tick();
+    expect({ first, closes, rejected: isRejectedAsDetached(received) }).toEqual({
+      first: "m1",
+      closes: 0,
+      rejected: false,
+    });
+
+    const [second] = await once(received, "message");
+    for (let i = 0; i < 20 && closes === 0; i++) await tick();
+    expect({ second, closes, rejected: isRejectedAsDetached(received) }).toEqual({
+      second: "m2",
+      closes: 1,
+      rejected: true,
+    });
     carrier.port1.close();
     carrier.port2.close();
   });
@@ -2017,6 +2157,17 @@ describe("a port whose peer closed is closed too", () => {
       unread.on("message", m => closeCallbackFires(unread).then(cb => resolve(`${m}, close(cb) ${cb}`)));
     });
     expect(unreadResult).toBe("queued, close(cb) called");
+  });
+
+  // ...but once it does start listening for 'close' it is told after all (as on main): unlike the
+  // explicitly closed case above, the port is still open, and until that event has been delivered
+  // a 'close'-listening port is kept alive in the heap.
+  test("a 'close' listener added after the peer was garbage collected is still told", async () => {
+    const port1 = await survivorOfCollectedPeer(() => {});
+    let closes = 0;
+    port1.on("close", () => closes++);
+    for (let i = 0; i < 20 && closes === 0; i++) await tick();
+    expect({ closes, rejected: isRejectedAsDetached(port1) }).toEqual({ closes: 1, rejected: false });
   });
 
   // The same missing notification left a ref()'d port with no listeners pinning the loop


### PR DESCRIPTION
### Problem

- After one side of a `MessageChannel` is `close()`d, the other port can still be put in a transfer list: `carrier.postMessage(port, [port])`, `structuredClone(x, { transfer: [port] })`, `worker.postMessage(port, [port])` and `new Worker(f, { transferList: [port] })` all accept it and ship a dead endpoint. Node throws `DataCloneError: MessagePort in transfer list is already detached` once the peer's close has been processed (by the time the port's own `'close'` has fired), because in node the peer's close closes this port too.
- A port with no listeners is not told about the peer's close at all. Besides staying transferable forever, a `ref()`'d one keeps the process alive forever (`port1.ref(); port2.close();` hangs; node exits).
- Cause: `MessagePort::peerClosed()` (src/jsc/bindings/webcore/MessagePort.cpp) dispatched `'close'` and released the loop refs but left the port entangled (`m_isDetached` / `m_isClosing` stayed false), which is the state every transfer path checks: the pre-check in `MessagePort::postMessage`, `SerializedScriptValue::create` (src/jsc/bindings/webcore/SerializedScriptValue.cpp, shared by all the entry points above) and `MessagePort::disentanglePorts`. And the pipe only learned which context to notify from `addEventListener('close')` or `start()`, so a listenerless port was never notified.

### Fix

- `peerClosed()` closes the port through `close()` once nothing the peer sent is left to deliver, so it ends up in the same state as an explicitly closed port: rejected by every transfer path, `postMessage()` on it dropped, loop refs released, `'close'` dispatched from `close()`'s task (so inside the `'close'` handler the port is already closed, as in node).
- What "left to deliver" means follows node, where the peer's close is an entry at the tail of the port's queue:
  - A receiving port gets the queued messages first (the existing flush). The flush now stops if a handler removes the last listener (a `once()` handler), exactly as the regular drain does, and leaves the rest queued.
  - A port that is not receiving keeps the queued messages and stays open (and transferable) until it is drained. Not receiving is node's `receiving_messages_` (new `m_receiving`): never started, or the last `'message'` listener was removed (node stops the port then, so `off()`, a fired `once()` and `onmessage = null` all defer); `start()` or a new `'message'` listener turns it back on (every `start()` call re-attaches, which also re-reports a peer that closed while the port was paused). A port that was `start()`ed and never given a listener is receiving: node emits its messages into the void and closes, and bun has no drain for it at all, so it closes right away too (otherwise a `ref()`'d one would pin the loop forever). The deferred close is completed by the next `'message'` listener (`MessagePortPipe::attach()` already re-notifies once its drain has run) or by the `receiveMessageOnPort()` call that finds the queue empty (`tryTakeMessage()` closes on it, which is node's behaviour for that call). `tryTakeMessage()` reads the peer's state before re-reading its own queue, the ordering `virtualHasPendingActivity()` already documents, so a message a worker sent right before closing cannot be dropped.
- `MessagePort::create()` registers the port's context with the pipe, so the notification reaches a port whether or not it ever gets a listener. `registerCloseContext()` also re-reports a peer that is already closed, and `addEventListener('close')` still calls it (see the next bullet).
- A peer that was garbage collected rather than closed (bun collects entangled ports, node never does) still does not close the port: that would turn a transfer into a GC-timing-dependent `DataCloneError`, the line `jsRef()` and the existing "hasRef() survives collection of the unreferenced peer" test already draw. As on main, such a port fires `'close'` and releases its loop refs if it is started or listening for `'close'` (a listening peer must not pin the process), with no queue deferral. Since the notification now also reaches idle ports, those are left untouched (firing their one `'close'` early would swallow a later `close(cb)`; node's test-worker-message-port.js caught that) and are told once they add a `'close'` listener, as on main, so they are not kept alive waiting for an event that would never come.
- `postMessage()` on a closed port still disentangles the ports in its transfer list before dropping the message, as node does and as main did for a peer-closed port (which was still open); otherwise closing the port here would have left such a port usable and its peer uninformed. This also covers a port closed by its own `close()`.
- Behavioural differences from main other than the fix itself: a `'close'` listener added after an explicitly closed peer's notification was processed no longer fires (the port is closed by then; node fires nothing either), and a port paused by removing its listener now closes, and is rejected, once a later listener has drained it (main left it open forever).
- Verified:
  - `describe("a port whose peer closed is closed too")` in test/js/node/worker_threads/worker_threads.test.ts, 22 tests: the report (with the transfer staying atomic and `structuredClone`), a receiving port, rejection inside the port's own `'close'` handler, no listeners at all, a late `'close'` listener, `postMessage()` on the closed port consuming its transfer list, `Worker.postMessage()` and the `Worker` constructor, the deferred cases (never started with a late listener or `receiveMessageOnPort()`, the three paused variants, `start()` without a listener, `start()` on a paused port before and after the peer's close, transferring the port left open, a `once()` handler on a received port), the collected-peer cases (transferable, unread message, `close(cb)` later, late `'close'` listener) and the `ref()` hang as a spawned process. 17 fail on the release build; the four collected-peer tests and the `postMessage()` one pass there and exist to pin the behaviour kept from main (each failed on the intermediate revision whose mistake it guards against).
  - The node v26.3.0 comparison in the details below: identical output for all five not-receiving / receiving variants, and a 22-scenario probe of the report's shapes matches except for bun processing the notification one turn earlier in two of them.
  - worker_threads.test.ts (142 tests), message-channel, message-port-pipe, message-port-closed-leak, message-port-context-destroy-leak, message-event, worker-postmessage-transfer, worker-refused-completion, worker-shutdown-post-leak, worker-transfer-terminate-stress, worker-transfer-list, structured-clone, and the 28 upstream `test-messagechannel` / `test-worker-message-*` / `test-worker-workerdata-messageport` / `test-worker-messaging` files pass on the debug+ASAN build.
- Related open PRs touch neighbouring lines but fix other things: #38019 (when `hasRef()` flips relative to `'close'`; it reorders the tail of `peerClosed()`, which now goes through `close()` for an explicit peer close, so they compose after a textual rebase), #37966 (re-checking the transfer list after serializing; same `isDetached() || isClosing()` predicate this PR makes true for a peer-closed port), #34011 (`postMessage()` return value), #34912 (draining a started port without listeners; with it, the `start()`-only case drains instead of being dropped at close, same outcome), #32564 / #36434 (what a collected peer should do; this PR keeps main's behaviour there).

### Background

- A `MessageChannel` in bun is one `MessagePortPipe` with two sides; each JS `MessagePort` owns one side. Closing a side marks it `Closed` in the pipe and posts a task to the other side's context, which calls `peerClosed()` on the port owning that side. The pipe can only post that task if it knows the side's context (`registerCloseContext()` / `attach()`).
- `CloseKind::Explicit` (`close()`, context teardown, a transferred port that was never received) additionally sets `ClosedByRequest`; `CloseKind::Collected` (the owning wrapper was garbage collected while entangled) does not. `isOtherSideClosedByRequest()` tells them apart.
- Messages for a port buffer in the pipe until a drain delivers them; a drain only runs for a port that has a `'message'` listener, and `receiveMessageOnPort()` pops one synchronously. `start()` is the Web API that turns delivery on; adding a `'message'` listener calls it implicitly.
- `close()` marks the port detached synchronously and dispatches `'close'` from a queued task, so listeners added right after (and `close(cb)`) still see it; the event is dispatched at most once per port.
- `virtualHasPendingActivity()` keeps a port's wrapper alive while it is listening for `'close'` and that event has not been dispatched; this is why an idle port that will never get a peer-side `'close'` has to be notified once it starts listening.
- Every transfer entry point serializes through `SerializedScriptValue::create`, which rejects a port with `isDetached() || isClosing()` set; closing the port is what makes all of them reject it.

<details>
<summary>node v26.3.0 vs this branch vs bun 1.4.0: a port whose peer posts "x" and then closes</summary>

Each line: the port's state a few turns after the peer closed, what a listener added afterwards receives, and the final state (`REJECTED` = rejected as a transferable).

node v26.3.0 and this branch print the same thing:

```
on+off         | after peer close: closes=0 open | late listener got: x | end: closes=1 REJECTED
once fired     | after peer close: closes=0 open | late listener got: x | end: closes=1 REJECTED
onmessage=null | after peer close: closes=0 open | late listener got: x | end: closes=1 REJECTED
start() only   | after peer close: closes=1 REJECTED | late listener got: n/a | end: closes=1 REJECTED
never started  | after peer close: closes=0 open | late listener got: x | end: closes=1 REJECTED
```

bun 1.4.0:

```
on+off         | after peer close: closes=1 open | late listener got: x | end: closes=1 open
once fired     | after peer close: closes=1 open | late listener got: x | end: closes=1 open
onmessage=null | after peer close: closes=1 open | late listener got: x | end: closes=1 open
start() only   | after peer close: closes=1 open | late listener got: n/a | end: closes=1 open
never started  | after peer close: closes=1 open | late listener got: x | end: closes=1 open
```

</details>

<details>
<summary>Repro from the report</summary>

```js
import { MessageChannel } from "node:worker_threads";
const a = new MessageChannel();
const carrier = new MessageChannel();
let closes = 0;
a.port1.on("close", () => closes++);
a.port2.close();
setTimeout(() => {
  console.log("closes after peer close:", closes);
  try { carrier.port1.postMessage(a.port1, [a.port1]); console.log("transfer accepted"); }
  catch (e) { console.log("transfer threw:", e.name); }
  setTimeout(() => { console.log("closes at end:", closes); process.exit(0); }, 100);
}, 100);
```

node v26.3.0 and this branch:

```
closes after peer close: 1
transfer threw: DataCloneError
closes at end: 1
```

bun 1.4.0:

```
closes after peer close: 1
transfer accepted
closes at end: 1
```

Listenerless variant (hangs on 1.4.0; exits with `hasRef=false` on node and this branch):

```js
const { port1, port2 } = new MessageChannel();
port1.ref();
port2.close();
process.on("exit", () => console.log("hasRef=" + port1.hasRef()));
```

</details>

<details>
<summary>Earlier revisions of this PR</summary>

- 6e339fb: `peerClosed()` deferred behind the queue for collected peers too, which left a `'close'`-listening port with an unread message pinned forever, and `tryTakeMessage()` read its own queue before the peer's state (a worker's `postMessage(); close()` landing in between dropped the message). Both fixed in f0af4bc.
- f0af4bc: the deferral still applied to a `start()`ed port without a listener (a `ref()`'d one hung), an idle port whose peer was collected was never told even after it added a `'close'` listener (pinned), `peerClosed()`'s flush dispatched past a `once()` handler, and `postMessage()` on the now-closed port no longer consumed the ports in its transfer list. All fixed in d2851de, each with a test that fails on f0af4bc.
- d2851de: `start()` only turned receiving on the first time it ran, so `start()` on a paused port left the close on hold (a `ref()`'d one hung). Fixed in 5db54a9, with a test for both orders relative to the peer's close.

</details>
