### PR TITLE
shell(cp): copy the contents of a dir/. or dir/.. source into the target

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -592,7 +592,7 @@ impl ShellCpTask {
         let mut buf3 = bun_paths::PathBuffer::uninit();
         // We have to give an absolute path to our cp implementation for it to
         // work with cwd.
-        let src: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.src) {
+        let mut src: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.src) {
             // `self.src` is the bare argv bytes (no NUL); re-terminate via
             // the thread-local join buffer.
             resolve_path::join_z::<platform::Auto>(&[&self.src])
@@ -607,6 +607,11 @@ impl ShellCpTask {
                 &[&self.cwd_path, &self.tgt],
             )
         };
+        // From the operand as written: the joins above normalized a trailing
+        // `.` or `..` away, and cp(1) copies `dir/.` (the directory itself)
+        // into the target rather than into `target/dir`.
+        let basename = resolve_path::basename(&self.src);
+        let dot_operand = basename == b"." || basename == b"..";
 
         // Cases:
         //   SRC       DEST
@@ -616,10 +621,31 @@ impl ShellCpTask {
         //   folder -> folder
         // We need to check dest to see what it is; if it doesn't exist we
         // need to create it.
-        let src_is_dir = match Self::is_dir(src) {
+        let mut src_is_dir = match Self::is_dir(src) {
             Ok(x) => x,
             Err(e) => return Some(ShellErr::new_sys(&e)),
         };
+
+        // `x/.` is the directory `x` leads to, through a symlink at `x`, and
+        // ENOTDIR for anything else; `src` is `x` itself, which `is_dir` does
+        // not follow.
+        if dot_operand && !src_is_dir {
+            let mut real_buf = bun_paths::path_buffer_pool::get();
+            src = match bun_sys::realpath(src, &mut real_buf) {
+                Ok(real) => resolve_path::join_z::<platform::Auto>(&[real]),
+                Err(e) => return Some(ShellErr::new_sys(&e.with_path(&self.src))),
+            };
+            src_is_dir = match Self::is_dir(src) {
+                Ok(x) => x,
+                Err(e) => return Some(ShellErr::new_sys(&e)),
+            };
+            if !src_is_dir {
+                return Some(ShellErr::new_sys(
+                    &bun_sys::Error::from_code(bun_sys::E::ENOTDIR, bun_sys::Tag::lstat)
+                        .with_path(&self.src),
+                ));
+            }
+        }
 
         // Any source directory without -R is an error.
         if src_is_dir && !self.opts.recursive {
@@ -658,11 +684,12 @@ impl ShellCpTask {
         } else if self.opts.recursive {
             // 2nd synopsis: -R source_files... -> target.
             if tgt_exists {
-                let basename = resolve_path::basename(src.as_bytes());
-                tgt = resolve_path::join_z_buf::<platform::Auto>(
-                    buf3.as_mut_slice(),
-                    &[tgt.as_bytes(), basename],
-                );
+                if !dot_operand {
+                    tgt = resolve_path::join_z_buf::<platform::Auto>(
+                        buf3.as_mut_slice(),
+                        &[tgt.as_bytes(), basename],
+                    );
+                }
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -689,7 +716,6 @@ impl ShellCpTask {
                         .into_boxed_slice(),
                 ));
             }
-            let basename = resolve_path::basename(src.as_bytes());
             tgt = resolve_path::join_z_buf::<platform::Auto>(
                 buf3.as_mut_slice(),
                 &[tgt.as_bytes(), basename],

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { lstatSync, readdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,144 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is the default only on Windows; on POSIX it is enabled by an env
+// var that is read once per process, so each of these runs cp in a child bun.
+describe.concurrent("bunshell cp -R of a source written as dir/. or dir/..", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  /** `d` is the directory being copied, `e` the existing (empty) target directory. */
+  function setup() {
+    return tempDir("shell-cp-dot-source", {
+      "d": { "f": "F\n", "sub": { "g": "G\n" } },
+      "e": {},
+      "other": "other\n",
+    });
+  }
+
+  /** Runs `command` through the shell in `cwd` and returns cp's exit code followed by its stderr. */
+  async function cp(cwd: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const result = await Bun.$\`${command}\`.nothrow().quiet();
+         process.stdout.write(result.exitCode + "\\n" + result.stderr.toString());`,
+      ],
+      cwd,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+  const copied = { stdout: "0\n", stderr: "", exitCode: 0 };
+  function failed(message: string) {
+    return { stdout: `1\ncp: ${message}\n`, stderr: "", exitCode: 0 };
+  }
+
+  /** Every path under `dir`, relative to it, with `/` separators. */
+  function tree(dir: string) {
+    return readdirSync(dir, { recursive: true })
+      .map(entry => String(entry).replaceAll("\\", "/"))
+      .sort();
+  }
+  const contentsOfD = ["f", "sub", "sub/g"];
+  const dItself = ["d", "d/f", "d/sub", "d/sub/g"];
+
+  test.each(["d/.", "d/./", "./d/.", "d/sub/.."])("cp -R %s e copies the contents of d into e", async operand => {
+    using dir = setup();
+    expect(await cp(String(dir), `cp -R ${operand} e`)).toEqual(copied);
+    expect(tree(join(String(dir), "e"))).toEqual(contentsOfD);
+    expect(readFileSync(join(String(dir), "e/sub/g"), "utf8")).toBe("G\n");
+  });
+
+  test("cp -R . ../e run inside d copies the contents of d into e", async () => {
+    using dir = setup();
+    expect(await cp(join(String(dir), "d"), "cp -R . ../e")).toEqual(copied);
+    expect(tree(join(String(dir), "e"))).toEqual(contentsOfD);
+  });
+
+  test("cp -R d/. other e applies to that operand only", async () => {
+    using dir = setup();
+    expect(await cp(String(dir), "cp -R d/. other e")).toEqual(copied);
+    expect(tree(join(String(dir), "e"))).toEqual(["f", "other", "sub", "sub/g"]);
+  });
+
+  test("cp -R d/. e keeps what e already holds", async () => {
+    using dir = setup();
+    writeFileSync(join(String(dir), "e/kept"), "kept\n");
+    expect(await cp(String(dir), "cp -R d/. e")).toEqual(copied);
+    expect(tree(join(String(dir), "e"))).toEqual(["f", "kept", "sub", "sub/g"]);
+  });
+
+  test.each(["d", "d/", "./d"])("cp -R %s e copies d itself into e", async operand => {
+    using dir = setup();
+    expect(await cp(String(dir), `cp -R ${operand} e`)).toEqual(copied);
+    expect(tree(join(String(dir), "e"))).toEqual(dItself);
+  });
+
+  test("cp -R d/. new creates new holding the contents of d", async () => {
+    using dir = setup();
+    expect(await cp(String(dir), "cp -R d/. new")).toEqual(copied);
+    expect(tree(join(String(dir), "new"))).toEqual(contentsOfD);
+  });
+
+  test("cp d/. e without -R is refused", async () => {
+    using dir = setup();
+    expect(await cp(String(dir), "cp d/. e")).toEqual(failed("d/. is a directory (not copied)"));
+    expect(tree(join(String(dir), "e"))).toEqual([]);
+  });
+
+  test.each(["cp -R other/. e", "cp other/. e"])("%s fails because other is a file", async command => {
+    using dir = setup();
+    expect(await cp(String(dir), command)).toEqual(failed("Not a directory: other/."));
+    expect(tree(join(String(dir), "e"))).toEqual([]);
+  });
+
+  // Creating symlinks needs extra privileges on Windows.
+  describe.concurrent.skipIf(isWindows)("through a symlink", () => {
+    /** Adds `dirlink -> d`, `filelink -> other` and `dangling -> nowhere` to the fixture. */
+    function setupWithLinks() {
+      const dir = setup();
+      symlinkSync("d", join(String(dir), "dirlink"));
+      symlinkSync("other", join(String(dir), "filelink"));
+      symlinkSync("nowhere", join(String(dir), "dangling"));
+      return dir;
+    }
+
+    test("cp -R dirlink/. e copies the contents of the directory the link points to", async () => {
+      using dir = setupWithLinks();
+      expect(await cp(String(dir), "cp -R dirlink/. e")).toEqual(copied);
+      expect(tree(join(String(dir), "e"))).toEqual(contentsOfD);
+    });
+
+    test("cp -R dirlink e still copies the link itself", async () => {
+      using dir = setupWithLinks();
+      expect(await cp(String(dir), "cp -R dirlink e")).toEqual(copied);
+      expect(readdirSync(join(String(dir), "e"))).toEqual(["dirlink"]);
+      expect(lstatSync(join(String(dir), "e/dirlink")).isSymbolicLink()).toBeTrue();
+    });
+
+    test("cp dirlink/. e without -R is refused", async () => {
+      using dir = setupWithLinks();
+      expect(await cp(String(dir), "cp dirlink/. e")).toEqual(failed("dirlink/. is a directory (not copied)"));
+      expect(tree(join(String(dir), "e"))).toEqual([]);
+    });
+
+    test("cp -R filelink/. e fails because the link points to a file", async () => {
+      using dir = setupWithLinks();
+      expect(await cp(String(dir), "cp -R filelink/. e")).toEqual(failed("Not a directory: filelink/."));
+      expect(tree(join(String(dir), "e"))).toEqual([]);
+    });
+
+    test("cp -R dangling/. e fails because the link points nowhere", async () => {
+      using dir = setupWithLinks();
+      expect(await cp(String(dir), "cp -R dangling/. e")).toEqual(failed("No such file or directory: dangling/."));
+      expect(tree(join(String(dir), "e"))).toEqual([]);
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (the default `cp` on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) copies `cp -R src/. dest` to `dest/src/...` instead of putting the contents of `src` into `dest`. Same for `cp -R . dest` and `cp -R a/b/.. dest`. coreutils and BSD cp copy the contents (this is the usual "copy a directory's contents" idiom); bun 1.4.0 and main behave as described.
  ```
  mkdir -p rdir dest && echo inner > rdir/inner.txt
  BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'await Bun.$`cp -R rdir/. dest`'
  # bun: dest/rdir/inner.txt        cp -R: dest/inner.txt
  ```
- Cause: `ShellCpTask::run_from_thread_pool_impl` (`src/runtime/shell/builtin/cp.rs`) joins the operand onto the cwd, which normalizes `rdir/.` to `.../rdir`, and then takes the name to append to the target from that normalized path, so the trailing `.` that carries the meaning is gone by the time the destination is chosen.
- A second effect of the same normalization: in `link/.` the `.` makes the kernel follow a symlink at `link`, but the builtin classifies the normalized `.../link` with `lstat`, so it saw a symlink rather than the directory behind it and handed the link to the copy (with the first fix alone, `cp -R link/. dest` would exit 0 without copying anything). Likewise `file/.`, which `stat` rejects with ENOTDIR, was silently accepted and copied the file.

### Fix
- The appended name is taken from the operand as written (`resolve_path::basename(&self.src)`), and when it is `.` or `..` the target is used as is, so the contents of the resolved directory land in the target. This is what coreutils does in `do_copy`: the destination is `target/last_component(arg)`, with `..` special-cased to the target itself (and `target/.` is the target). The 3rd synopsis (files into a directory) uses the same basename; for a non-directory operand it is identical to the one computed before, since a `.`/`..`/trailing-slash last component never reaches it.
- A `.`/`..` operand whose normalized path is not a directory is resolved with `realpath`, and if the result is still not a directory the copy fails with `cp: Not a directory: <operand>` (a dangling link fails with realpath's ENOENT). This is the outcome `stat("x/.")` gives for the same operands, which is what cp(1) reports. Only this rare case pays the extra syscalls; a plain `dir/.` goes through the same single `lstat` as before.
- `..` is still resolved lexically like everywhere else in the shell (`cp -R missing/.. dest` copies the cwd's contents where coreutils fails with ENOENT); unchanged by this PR.
- Verified with `test/js/bun/shell/commands/cp.test.ts`, new block "bunshell cp -R of a source written as dir/. or dir/.." (each test runs cp in a child bun with the builtin enabled, since the in-process suite is skipped on POSIX): 13 of the 19 tests fail on bun 1.4.0 (`d/.`, `d/./`, `./d/.`, `d/sub/..`, `.` from inside the directory, mixed with a plain operand, merging into a non-empty target, `file/.` with and without `-R`, `dirlink/.` with `-R` and without, `filelink/.`, `dangling/.`), all 19 pass with the fix; the other 6 pin behavior that must not change (`d`, `d/`, `./d` still land in `e/d`, a link operand without `/.` is still copied as a link, `dir/.` without `-R` is still refused, `d/.` to a new directory).
- Also compared against coreutils by hand for the shapes above plus two `.` operands on one command line, an absolute `.../dir/.` operand, and a file as target: every case ends in the same tree or the same success/failure.
- Overlap with open PRs in the same function: #37927 (copy into itself, compared by inode) and #37962 record the appended basename in the block this PR wraps in `if !dot_operand`, a one-line textual conflict either way. Note for #37927: `cp -R d/. d` now resolves to the same pair as the already-reachable `cp -R d <parent of d>`, which copies the directory onto itself (bun 1.4.0 exits 0 on that today); #37927's check covers both spellings. An empty operand (`cp -R "" dest`) resolves to the cwd today and is copied into `dest/<cwd name>`; with this PR its empty basename puts the cwd's contents into `dest` instead. Both are wrong, and #38002 rejects the empty operand with ENOENT before this code runs.
- For every other operand the destination is unchanged: `resolve_path::basename` only looks at separators and normalization keeps a last component that is not `.`/`..`, so the basename of the operand as written and of the normalized path are the same bytes (`a/../d`, `d/`, `C:d`, `\\server\share\dir` included).

### Background
- The builtin resolves each source and the target to absolute, normalized paths because the node:fs copy it delegates to (`ShellAsyncCpTask`) needs them that way, then applies the POSIX `cp` synopses: file to file; `-R` sources into a target, appending each source's basename when the target exists; files into an existing directory, appending the basename. Normalization is what turns `rdir/.` into `rdir`.
- In cp(1), `dir/.` and `dir` are different operands: both name the same directory, but the copy is placed at `target/<last component of the operand>`, so `dir` becomes `target/dir` while `dir/.` becomes `target/.`, the target itself. `dir/..` is special-cased by coreutils to the target as well.
- `lstat` reports a symlink as a symlink; `stat` and any path with a component after the link (such as `link/.`) report what it points to. `realpath` returns the link-free absolute path of what a path resolves to, which is the form the rest of the builtin and the native copy expect.
