### PR TITLE
worker_threads: bind this to the port in MessagePort on()/once() listeners

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -128,9 +128,10 @@ function injectFakeEmitter(Class) {
     return event.detail;
   }
 
+  // EventTarget calls the wrapper with `this` = the port; node's listeners see the port as `this` too.
   function wrapped(run, listener) {
     return function (event) {
-      return listener(run(event));
+      return listener.$call(this, run(event));
     };
   }
 
@@ -197,7 +198,7 @@ function injectFakeEmitter(Class) {
     // a listener that already fired.
     function onceWrapper(ev) {
       registryFor(target, false)?.get(event)?.delete(listener);
-      return wrapper(ev);
+      return wrapper.$call(this, ev);
     }
     register(this, event, listener, onceWrapper, { once: true });
     return this;

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -128,9 +128,7 @@ function injectFakeEmitter(Class) {
     return event.detail;
   }
 
-  // node calls the listener with `this` = the port it was registered on. Bound
-  // here rather than taken from the wrapper's own `this`: fakeParentPort()
-  // registers on the global scope, so EventTarget would pass that instead.
+  // node-style listeners run with `this` = the object on()/once() was called on.
   function wrapped(target, run, listener) {
     return function (event) {
       return listener.$call(target, run(event));

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -128,26 +128,28 @@ function injectFakeEmitter(Class) {
     return event.detail;
   }
 
-  // EventTarget calls the wrapper with `this` = the port; node's listeners see the port as `this` too.
-  function wrapped(run, listener) {
+  // node calls the listener with `this` = the port it was registered on. Bound
+  // here rather than taken from the wrapper's own `this`: fakeParentPort()
+  // registers on the global scope, so EventTarget would pass that instead.
+  function wrapped(target, run, listener) {
     return function (event) {
-      return listener.$call(this, run(event));
+      return listener.$call(target, run(event));
     };
   }
 
-  function functionForEventType(event, listener) {
+  function functionForEventType(target, event, listener) {
     switch (event) {
       case "error":
       case "messageerror": {
-        return wrapped(errorEventHandler, listener);
+        return wrapped(target, errorEventHandler, listener);
       }
 
       case "message": {
-        return wrapped(messageEventHandler, listener);
+        return wrapped(target, messageEventHandler, listener);
       }
 
       default: {
-        return wrapped(customEventHandler, listener);
+        return wrapped(target, customEventHandler, listener);
       }
     }
   }
@@ -174,7 +176,7 @@ function injectFakeEmitter(Class) {
   }
 
   function on(event, listener) {
-    register(this, event, listener, functionForEventType(event, listener), undefined);
+    register(this, event, listener, functionForEventType(this, event, listener), undefined);
     return this;
   }
 
@@ -191,14 +193,14 @@ function injectFakeEmitter(Class) {
   }
 
   function once(event, listener) {
-    const wrapper = functionForEventType(event, listener);
     const target = this;
+    const wrapper = functionForEventType(target, event, listener);
     // EventTarget drops a {once:true} listener natively, without telling the
     // registry — so purge it here or listenerCount()/eventNames() keep counting
     // a listener that already fired.
     function onceWrapper(ev) {
       registryFor(target, false)?.get(event)?.delete(listener);
-      return wrapper.$call(this, ev);
+      return wrapper(ev);
     }
     register(this, event, listener, onceWrapper, { once: true });
     return this;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1418,6 +1418,68 @@ test("off() removes a pending once() listener", () => {
   port2.close();
 });
 
+// node invokes node-style listeners with `this` bound to the port (the same
+// `this` EventTarget hands the on()/once() wrappers). The wrappers used to call
+// the user's function bare, so `this` was undefined. Covers the three ways a
+// wrapper gets invoked: a native MessageEvent, a native close Event, and emit().
+test("on()/once() listeners are called with `this` bound to the port", async () => {
+  const { port1, port2 } = new MessageChannel();
+  const calls: unknown[] = [];
+  const { promise: messaged, resolve: onMessaged } = Promise.withResolvers<void>();
+  const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+
+  port1.on("message", function (this: unknown, data) {
+    calls.push(["on message", this === port1, data]);
+  });
+  port1.once("message", function (this: unknown, data) {
+    calls.push(["once message", this === port1, data]);
+    onMessaged();
+  });
+  port1.on("close", function (this: unknown) {
+    calls.push(["on close", this === port1]);
+  });
+  port1.once("close", function (this: unknown) {
+    calls.push(["once close", this === port1]);
+    onClosed();
+  });
+  port1.on("custom", function (this: unknown, arg) {
+    calls.push(["on custom", this === port1, arg]);
+  });
+  port1.once("custom", function (this: unknown, arg) {
+    calls.push(["once custom", this === port1, arg]);
+  });
+
+  port1.emit("custom", 42);
+  port2.postMessage("hi");
+  await messaged;
+  port1.close();
+  await closed;
+  port2.close();
+
+  expect(calls).toEqual([
+    ["on custom", true, 42],
+    ["once custom", true, 42],
+    ["on message", true, "hi"],
+    ["once message", true, "hi"],
+    ["on close", true],
+    ["once close", true],
+  ]);
+});
+
+test("parentPort.on() listeners are called with `this` bound to parentPort", async () => {
+  const w = new Worker(
+    `const { parentPort } = require("node:worker_threads");
+     parentPort.once("message", function (data) {
+       this.postMessage({ data, thisIsParentPort: this === parentPort });
+     });`,
+    { eval: true },
+  );
+  w.postMessage("ping");
+  const [reply] = await once(w, "message");
+  await w.terminate();
+  expect(reply).toEqual({ data: "ping", thisIsParentPort: true });
+});
+
 test("close(cb) interleaves with other close listeners in registration order", async () => {
   // node's mechanism is `this.once('close', cb)`, so cb interleaves with other
   // close listeners in the order they were registered (verified against node).

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1418,10 +1418,12 @@ test("off() removes a pending once() listener", () => {
   port2.close();
 });
 
-// node invokes node-style listeners with `this` bound to the port (the same
-// `this` EventTarget hands the on()/once() wrappers). The wrappers used to call
-// the user's function bare, so `this` was undefined. Covers the three ways a
-// wrapper gets invoked: a native MessageEvent, a native close Event, and emit().
+// node invokes node-style listeners with `this` bound to the port. The on()/once()
+// wrappers used to call the user's function bare, so `this` was undefined. Covers
+// every way a wrapper gets invoked: a native MessageEvent, a native close Event
+// (on, once and close(cb), which is once("close", cb)), and emit(). The last
+// listener registered for each event is the one that resolves, so every earlier
+// one has already run by the time the promise settles.
 test("on()/once() listeners are called with `this` bound to the port", async () => {
   const { port1, port2 } = new MessageChannel();
   const calls: unknown[] = [];
@@ -1440,7 +1442,6 @@ test("on()/once() listeners are called with `this` bound to the port", async () 
   });
   port1.once("close", function (this: unknown) {
     calls.push(["once close", this === port1]);
-    onClosed();
   });
   port1.on("custom", function (this: unknown, arg) {
     calls.push(["on custom", this === port1, arg]);
@@ -1452,7 +1453,10 @@ test("on()/once() listeners are called with `this` bound to the port", async () 
   port1.emit("custom", 42);
   port2.postMessage("hi");
   await messaged;
-  port1.close();
+  port1.close(function (this: unknown) {
+    calls.push(["close(cb)", this === port1]);
+    onClosed();
+  });
   await closed;
   port2.close();
 
@@ -1463,6 +1467,7 @@ test("on()/once() listeners are called with `this` bound to the port", async () 
     ["once message", true, "hi"],
     ["on close", true],
     ["once close", true],
+    ["close(cb)", true],
   ]);
 });
 
@@ -1478,6 +1483,65 @@ test("parentPort.on() listeners are called with `this` bound to parentPort", asy
   const [reply] = await once(w, "message");
   await w.terminate();
   expect(reply).toEqual({ data: "ping", thisIsParentPort: true });
+});
+
+// In a plain globalThis.Worker, parentPort is a stand-in object whose
+// addEventListener forwards to the worker's global scope, so EventTarget invokes
+// the wrapper with the global scope as `this`. The listener must still see the
+// object it was registered on.
+test("the stand-in parentPort of a non-node Worker also binds `this` to parentPort", async () => {
+  const url = URL.createObjectURL(
+    new Blob([
+      `const { parentPort } = require("worker_threads");
+       parentPort.on("message", function (data) {
+         self.postMessage({ data, thisIsParentPort: this === parentPort, thisIsGlobal: this === self });
+       });`,
+    ]),
+  );
+  const w = new globalThis.Worker(url);
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    w.onmessage = e => resolve(e.data);
+    w.onerror = e => reject(new Error(e.message));
+    w.postMessage("ping");
+    expect(await promise).toEqual({ data: "ping", thisIsParentPort: true, thisIsGlobal: false });
+  } finally {
+    w.terminate();
+    URL.revokeObjectURL(url);
+  }
+});
+
+// The wrappers hand the listener's return value back to EventTarget, which is
+// how a rejecting async on()/once() listener becomes an uncaughtException, as in
+// node. Spawned because the test runner would otherwise see the exceptions itself.
+test("a rejecting async on()/once() listener is reported as an uncaughtException", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { MessageChannel } = require("worker_threads");
+       const { port1, port2 } = new MessageChannel();
+       const seen = [];
+       process.on("uncaughtException", err => {
+         seen.push(err.message);
+         if (seen.length === 2) {
+           console.log(JSON.stringify(seen));
+           port1.close();
+         }
+       });
+       port1.on("message", async () => { throw new Error("from on"); });
+       port1.once("message", async () => { throw new Error("from once"); });
+       port2.postMessage(1);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(["from on", "from once"]),
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test("close(cb) interleaves with other close listeners in registration order", async () => {


### PR DESCRIPTION
### Problem
- A listener registered on a `node:worker_threads` `MessagePort` with `port.on(...)` or `port.once(...)` runs with `this === undefined` (`globalThis` in sloppy-mode code). Node calls it with `this` bound to the port, so `port.on("message", function () { this.postMessage(...) })` works in node and in bun either throws (strict code) or hits the global object (sloppy code).
- The same applies to `'close'` listeners, to the callback of `close(cb)` (which is `once('close', cb)`), to listeners fired through `port.emit()`, and to `parentPort` (a `MessagePort` in a `node:worker_threads` worker).
- Cause: the node-style emitter shim in `src/js/node/worker_threads.ts` (`injectFakeEmitter`) registers a wrapper through `addEventListener`. `wrapped()` unwraps the Event and then calls the user's listener bare, `listener(run(event))`, so the listener gets no `this` at all.
- Repro and node v26.3.0 output are in the details block below.

### Fix
- `on()` and `once()` pass the object they were called on into `wrapped()`, and the wrapper calls `listener.$call(target, run(event))`. `functionForEventType()` only threads the extra argument through.
- Matches node: `NodeEventTarget` dispatch (`lib/internal/event_target.js`, `kHybridDispatch`) invokes a node-style listener as `FunctionPrototypeCall(callback, this, arg)` where `this` is the target whose `on()` registered it. Node's `EventTarget` has no propagation, so that is always the object `.on()` was called on, which is what this binds.
- The target is bound at registration instead of forwarding the `this` bun's `EventTarget` hands the wrapper because the two differ in one case: the stand-in `parentPort` that `fakeParentPort()` builds for a plain `globalThis.Worker` that loads `node:worker_threads`. Its `addEventListener` forwards to the worker's global scope, so `EventTarget` would invoke the listener with the global scope as `this`; binding gives `this === parentPort` there as well. For a real port both are the same object.
- One binding covers every entry point: native `'message'`, native `'close'`, `close(cb)`, and `emit()` all end up in the same wrapper. The wrapper still returns the listener's result, so a rejecting async listener is still turned into an `uncaughtException` by `JSEventListener` (same as node).
- `$call` is the tamper-proof call used throughout `src/js`.
- Verified (`test/js/node/worker_threads/worker_threads.test.ts`, four new tests):
  - `on()/once() listeners are called with \`this\` bound to the port`: `on` + `once` for a native `MessageEvent`, a native close `Event`, `close(cb)`, and `emit()`. Fails before the fix (every `true` is `false`).
  - `parentPort.on() listeners are called with \`this\` bound to parentPort`: real worker; fails before the fix.
  - `the stand-in parentPort of a non-node Worker also binds \`this\` to parentPort`: the `fakeParentPort()` path; fails before the fix and also fails if the wrapper forwards `EventTarget`'s `this` instead of binding (`this` is the global scope there).
  - `a rejecting async on()/once() listener is reported as an uncaughtException`: pins the return-value forwarding the rewritten lines are responsible for. Passes before and after, and node prints the same output.
  - Whole file: 126 pass with the debug build. Upstream `test/js/node/test/parallel/test-worker-message-port*.js`, `test-worker-message-channel.js`, `test-worker-message-event.js`, `test-worker-messaging.js`, `test-worker-onmessage.js`, `test-worker-parent-port-ref.js`, `test-worker-workerdata-messageport.js` all exit 0; `test/js/web/workers/message-channel.test.ts` passes.
- Related: #38060 changes what a `'close'` listener receives as its argument in this same function and is independent of this change (the new tests do not assert the close listener's argument). #35811 rewrites the shim natively and would bind `this` as a side effect; this PR is the small fix for the shim as it exists today.

### Background
- `MessagePort` in bun is WebCore's `EventTarget`-based port. `node:worker_threads` adds node's emitter-style surface (`on`, `once`, `off`, `emit`, `listenerCount`, ...) to its prototype in `injectFakeEmitter`. `.on(type, fn)` does not store `fn` itself; it registers a small wrapper via `addEventListener` that converts the Event into the value a node listener expects (`MessageEvent.data` for `'message'`, and so on) and then calls `fn`.
- Node's `MessagePort` is a `NodeEventTarget`: an `EventTarget` with node-style methods on top. A node-style listener receives the unwrapped value instead of an Event and is called with `this` bound to the target.
- `fakeParentPort()` (same file): in a plain web `Worker` there is no parent `MessagePort`, so `parentPort` is an object created from `MessagePort.prototype` whose `addEventListener`/`postMessage` forward to the worker's global scope. It inherits the shim's `on()`/`once()`.

<details>
<summary>Repro</summary>

```js
const { MessageChannel } = require("worker_threads");
const { port1, port2 } = new MessageChannel();
port1.on("message", function (data) { console.log("on message this===port1:", this === port1); });
port1.once("message", function () { console.log("once message this===port1:", this === port1); port1.close(); });
port1.addEventListener("message", function () { console.log("addEventListener this===port1:", this === port1); });
port1.on("close", function () { console.log("on close this===port1:", this === port1); });
port1.on("custom", function (d) { console.log("emit custom this===port1:", this === port1); });
port1.emit("custom", 42);
port2.postMessage(1);
```

node v26.3.0: every line prints `true`.

bun before this change: `addEventListener` prints `true`, every `on`/`once`/`emit` line prints `false`.

bun with this change: every line prints `true`.

</details>

<details>
<summary>First version of this PR</summary>

The first push forwarded the `this` that `EventTarget` invokes the wrapper with (`listener.$call(this, ...)`). That is the port for a real `MessagePort`, but for the stand-in `parentPort` of a plain `globalThis.Worker` it is the worker's global scope, since that object registers its listeners there. Binding the registration target covers both, at the same size; the stand-in test was added to pin it.

</details>
