### PR TITLE
sys(windows): give mkdirat, renameat and unlinkat errors the POSIX arms' path and syscall

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4050,7 +4050,11 @@ mod windows_impl {
         let mut wt = WPathBuffer::default();
         let from_w = bun_paths::string_paths::to_nt_path(&mut wf, from.as_bytes());
         let to_w = bun_paths::string_paths::to_nt_path(&mut wt, to.as_bytes());
+        // `rename_at_w` reports the NT step that failed (`open` of the source
+        // or `NtSetInformationFile`) with no path; report the same shape as
+        // the POSIX arm, which callers such as shell `mv` print.
         super::windows::rename_at_w(from_dir, from_w, to_dir, to_w, true)
+            .map_err(|e| e.with_path_and_syscall(from.as_bytes(), Tag::rename))
     }
     pub(crate) fn renameat2(
         from_dir: Fd,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4024,11 +4024,7 @@ mod windows_impl {
         let utf8 = bun_paths::string_paths::from_w_path(buf, &wbuf[..len as usize]);
         Ok(utf8.len())
     }
-    // The NT-backed `mkdirat`, `renameat` and `unlinkat_with_flags` get their
-    // errors from helpers that report the NT step that failed (`open`,
-    // `NtSetInformationFile`) with no path. Re-tag them into the shape the
-    // POSIX arms return, the operation's own `Tag` plus the caller's path,
-    // which is what callers such as the shell builtins and `bun patch` print.
+    // The NT helpers tag errors with the failing step and no path; report the POSIX arms' shape.
     pub fn mkdirat(dir: impl AsFd, path: &ZStr, _mode: Mode) -> Maybe<()> {
         let dir = dir.as_fd();
         // Open with `op = OnlyCreate`, then close the resulting handle on

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4024,6 +4024,11 @@ mod windows_impl {
         let utf8 = bun_paths::string_paths::from_w_path(buf, &wbuf[..len as usize]);
         Ok(utf8.len())
     }
+    // The NT-backed `mkdirat`, `renameat` and `unlinkat_with_flags` get their
+    // errors from helpers that report the NT step that failed (`open`,
+    // `NtSetInformationFile`) with no path. Re-tag them into the shape the
+    // POSIX arms return, the operation's own `Tag` plus the caller's path,
+    // which is what callers such as the shell builtins and `bun patch` print.
     pub fn mkdirat(dir: impl AsFd, path: &ZStr, _mode: Mode) -> Maybe<()> {
         let dir = dir.as_fd();
         // Open with `op = OnlyCreate`, then close the resulting handle on
@@ -4039,7 +4044,8 @@ mod windows_impl {
                 op: super::WindowsOpenDirOp::OnlyCreate,
                 ..Default::default()
             },
-        )?;
+        )
+        .map_err(|e| e.with_path_and_syscall(path.as_bytes(), Tag::mkdir))?;
         made.close();
         Ok(())
     }
@@ -4050,9 +4056,6 @@ mod windows_impl {
         let mut wt = WPathBuffer::default();
         let from_w = bun_paths::string_paths::to_nt_path(&mut wf, from.as_bytes());
         let to_w = bun_paths::string_paths::to_nt_path(&mut wt, to.as_bytes());
-        // `rename_at_w` reports the NT step that failed (`open` of the source
-        // or `NtSetInformationFile`) with no path; report the same shape as
-        // the POSIX arm, which callers such as shell `mv` print.
         super::windows::rename_at_w(from_dir, from_w, to_dir, to_w, true)
             .map_err(|e| e.with_path_and_syscall(from.as_bytes(), Tag::rename))
     }
@@ -4086,6 +4089,7 @@ mod windows_impl {
                 remove_dir: (flags & AT_REMOVEDIR) != 0,
             },
         )
+        .map_err(|e| e.with_path_and_syscall(path.as_bytes(), Tag::unlink))
     }
     /// 2-arg form (`flags = 0`).
     #[inline]

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -2,9 +2,23 @@ import { $ } from "bun";
 import { patchInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import fs from "fs/promises";
-import { tempDirWithFiles as __tempDirWithFiles, bunEnv, bunExe, tempDir } from "harness";
+import { tempDirWithFiles as __tempDirWithFiles, bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join as __join } from "node:path";
 const { parse, apply, makeDiff } = patchInternals;
+
+/**
+ * Applies a patch that is expected to fail and returns the error it threw.
+ * The `syscall` assertions on it cover the Windows `*at` wrappers, which used to
+ * report the NT step that failed (`open`) instead of the operation.
+ */
+function applyError(patchfile: string, dir: string): any {
+  try {
+    apply(patchfile, dir);
+  } catch (e) {
+    return e;
+  }
+  return undefined;
+}
 
 const makeDiffJs = async (aFolder: string, bFolder: string, cwd: string): Promise<string> => {
   const { stdout, stderr } =
@@ -143,6 +157,20 @@ describe("apply", () => {
         await $`if ls -d ${join(afolder, "byebye.txt")}; then echo oops; else echo okay!; fi;`.cwd(tempdir).text(),
       ).toBe("okay!\n");
     });
+
+    test("of a missing file reports the unlink syscall", async () => {
+      await using tempdir = tempDir("patch-test", {});
+
+      const patchfile = [
+        "diff --git a/missing.txt b/missing.txt",
+        "deleted file mode 100644",
+        "--- a/missing.txt",
+        "+++ /dev/null",
+        "",
+      ].join("\n");
+
+      expect(applyError(patchfile, String(tempdir))).toMatchObject({ code: "ENOENT", syscall: "unlink" });
+    });
   });
 
   describe("creation", () => {
@@ -179,6 +207,24 @@ describe("apply", () => {
 
       expect(await $`cat ${join(afolder, "newfile.txt")}`.cwd(tempdir).text()).toBe(files["b/newfile.txt"]);
     });
+
+    // `?` is a legal file name character on POSIX, so a patch made there can
+    // name a directory that Windows refuses to create.
+    test.skipIf(!isWindows)("in a directory Windows cannot create reports the mkdir syscall", async () => {
+      await using tempdir = tempDir("patch-test", {});
+
+      const patchfile = [
+        "diff --git a/bad?dir/new.txt b/bad?dir/new.txt",
+        "new file mode 100644",
+        "--- /dev/null",
+        "+++ b/bad?dir/new.txt",
+        "@@ -0,0 +1 @@",
+        "+hi",
+        "",
+      ].join("\n");
+
+      expect(applyError(patchfile, String(tempdir))).toMatchObject({ code: "ENOENT", syscall: "mkdir" });
+    });
   });
 
   describe("rename", () => {
@@ -205,15 +251,9 @@ describe("apply", () => {
     test("of a missing source reports the rename syscall", async () => {
       await using tempdir = tempDir("patch-test", {});
 
-      let err: any;
-      try {
-        apply("rename from missing.txt\nrename to renamed.txt\n", String(tempdir));
-      } catch (e) {
-        err = e;
-      }
+      const patchfile = "rename from missing.txt\nrename to renamed.txt\n";
 
-      // Windows used to report the NT step that failed (`open`) instead of the operation.
-      expect(err).toMatchObject({ code: "ENOENT", syscall: "rename" });
+      expect(applyError(patchfile, String(tempdir))).toMatchObject({ code: "ENOENT", syscall: "rename" });
     });
 
     test("to a destination dir longer than the path buffer throws instead of crashing", async () => {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -202,6 +202,20 @@ describe("apply", () => {
       ).toBe("okay!\n");
     });
 
+    test("of a missing source reports the rename syscall", async () => {
+      await using tempdir = tempDir("patch-test", {});
+
+      let err: any;
+      try {
+        apply("rename from missing.txt\nrename to renamed.txt\n", String(tempdir));
+      } catch (e) {
+        err = e;
+      }
+
+      // Windows used to report the NT step that failed (`open`) instead of the operation.
+      expect(err).toMatchObject({ code: "ENOENT", syscall: "rename" });
+    });
+
     test("to a destination dir longer than the path buffer throws instead of crashing", async () => {
       await using tempdir = tempDir("patch-test", { "from.txt": "hello!" });
 

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -52,6 +52,25 @@ describe("mv", async () => {
     .file("file1.txt", "hello")
     .runAsTest("fails if destination folder does not exist");
 
+  // Both messages name the source because renameat() attaches it to the error.
+  // The Windows wrapper did not, so these printed "mv: No such file or
+  // directory" there. The first fails opening the source, the second fails the
+  // rename itself, which are separate error paths in the Windows wrapper.
+  TestBuilder.command`mv missing b`
+    .ensureTempDir()
+    .exitCode(2 /* ENOENT */)
+    .stderr("mv: missing: No such file or directory\n")
+    .doesNotExist("b")
+    .runAsTest("names the source when it does not exist");
+
+  TestBuilder.command`mv a missing_dir/b`
+    .ensureTempDir()
+    .file("a", "file")
+    .exitCode(2 /* ENOENT */)
+    .stderr("mv: a: No such file or directory\n")
+    .fileEquals("a", "file")
+    .runAsTest("names the source when the destination's parent does not exist");
+
   TestBuilder.command`mkdir -p foo; mkdir -p bar; echo hi > foo/inside_foo; echo hi > bar/inside_bar; mv foo bar; ls -R bar`
     .ensureTempDir()
     .stdout(str =>


### PR DESCRIPTION
### Problem

- On Windows, shell `mv missing b` prints `mv: No such file or directory` (exit 2). Linux and macOS print `mv: missing: No such file or directory`. `mv a missing_dir/b` drops the operand the same way (`mv: a: No such file or directory` on POSIX). Reproduced on Windows Server 2019 with Bun 1.4.0 and with a release build of main (05dd45ea43).
- On Windows, a failed rename, file deletion or directory creation inside `bun patch` is reported as the syscall `open` (or `NtSetInformationFile`) instead of `rename`, `unlink` or `mkdir`: `patchInternals.apply` throws `ENOENT: no such file or directory, open` for all three, and the `failed applying patch file: ...` message from `bun install` carries the same suffix. POSIX reports the operation.
- Cause: three `*at` wrappers in `bun_sys` decorate their errors differently per platform. The POSIX arms go through `check_p!` / `check_fp!` (`src/sys/lib.rs:2450` `mkdirat`, `:2506` `renameat`, `:2593` `unlinkat_with_flags`), so every error carries the operation's tag and the caller's path. The Windows arms (`src/sys/lib.rs:4027`, `:4046`, `:4071`) return the error from the NT helper unchanged (`open_dir_at_windows_nt_path`, `rename_at_w`, `DeleteFileBun`): tagged `open` or `NtSetInformationFile`, whichever NT step failed, and with no path. Shell `mv` (`src/runtime/shell/builtin/mv.rs:470`, printed by `Builtin::task_error_to_string`) only names the operand when the error carries a path, and relies on the wrapper having attached it.

### Fix

- Each of the three Windows arms maps its error through `with_path_and_syscall(path, Tag::{mkdir, rename, unlink})`, so both arms of each function return the same error shape. (`renameat` attaches `from`; `unlinkat_with_flags` uses `unlink` for the `AT_REMOVEDIR` form too, because the POSIX arm does.)
- The NT helpers have no other callers that want this (`rename_at_w` has one caller; `extract_tarball` calls `move_opened_file_at` directly and prints its own from/to lines; `DeleteFileBun` is also used with the empty name to delete a directory through its own handle) and only hold UTF-16 copies of the paths, so the arms in `lib.rs`, which still have the caller's path, are where it is attached. `access`, `chdir` and `utimens` in the same module attach their path the same way.
- Why this is right: the POSIX shape is the contract callers were written against, and the operation is what the caller asked for; which NT step failed is an implementation detail of the emulation. `with_path_and_syscall` keeps the errno and resets `fd` and `from_libuv`; none of the error sources behind these arms (`open_dir_at_windows_nt_path`, `normalize_path_windows`, `open_file_at_windows_nt_path`, `move_opened_file_at`, `DeleteFileBun`) set either, so nothing is dropped.
- Blast radius (audited every caller on Windows, including `renameat2`, `renameat_concurrently*`, `move_file_z*`, `mkdir_recursive_at*`, `rmdirat`, `Dir::delete_tree` and the recursive `fs.rm` walk, which all funnel through these arms): nothing branches on `syscall`, and the only `path` consumers are shell message formatting. What changes is display: shell `mv` names the operand, as on POSIX; `rm -r` names the directory when removing the emptied top directory fails (the one `rm` branch that does not attach its own path; POSIX already prints it); `bun patch` reports the operation; and a handful of `Output::err` sites in the installer, `bun test --timings` and lcov writing change their `(open)` / `(NtSetInformationFile)` suffix to the operation (`Output::err` does not print the path). Everything else branches on `get_errno()`, prints `err.name()`, or discards the error. `node:fs` `mkdir`, `rename`, `unlink` and `rmdir` use the non-`at` wrappers (libuv / `CreateDirectoryW`) and are unaffected; its recursive `rm` only reads the errno. The `snapshot.rs` code that compares tags is fed by `bun_sys::mkdir` / `open`, not these arms. No existing test expectation changes.
- Tests:
  - `test/js/bun/shell/commands/mv.test.ts`: `mv missing b` (the source open fails) and `mv a missing_dir/b` (the rename itself fails), the two error paths of the Windows rename helper, both asserting that the message names the source.
  - `test/js/bun/patch/patch.test.ts`: a `rename from` of a missing file reports `rename`, a deletion of a missing file reports `unlink`, and (Windows only, since the name is legal elsewhere) creating a file under `bad?dir/` reports `mkdir`. These are the user-visible surface of the `bun patch` apply path; `ENOENT` is what Windows already reported in all three cases.
- Verification:
  - Windows Server 2019 x64, release build of main (05dd45ea43): the two `mv` tests fail with `mv: No such file or directory`; the three patch tests fail with `ENOENT: no such file or directory, open`. Debug build of this branch: `mv.test.ts` 8 pass, 7 skip (the EXDEV cases are POSIX-only); `patch.test.ts` 29 pass, 1 skip; `rm.test.ts`, `rm-windows-ntstatus.test.ts` and `bunshell.test.ts` unchanged (the latter's 5 `tilde_expansion` failures on this VM come from an unset `HOME` and are identical with the release binary).
  - Linux debug build: both files pass. The source change is inside `#[cfg(windows)]`, so on Linux the new tests pass with or without it; the failing run is Windows-only.
- #38052 (empty path operands) asserts the `mv a ""` message per platform because of this gap. Whichever of the two lands second should collapse that expectation to the POSIX string.

### Background

- `bun_sys::Error` is the syscall error type: an errno, a `Tag` naming the syscall, and an optional `path`. The `with_path*` helpers return a copy with the path attached; `with_path_and_syscall` also replaces the tag, which `node_fs` uses for the same purpose (reporting `utime` or `truncate` rather than the call they were implemented with). `Display` renders it as `CODE: path: message (syscall())`, and the JS `SystemError` built from it exposes `code`, `syscall` and `path`.
- Shell builtins print a `bun_sys::Error` through `Builtin::task_error_to_string`: `mv: <path>: <message>` when the error carries a path, `mv: <message>` otherwise. The builtin does not know which operand failed, so the wrapper has to say.
- Windows has none of the `*at` syscalls. `bun_sys` emulates them with NT calls relative to a directory handle: `mkdirat` is an `NtCreateFile` of a directory, `unlinkat` opens the entry and marks it for deletion with `NtSetInformationFile`, and `renameat` opens the source with `DELETE` access and renames it through the handle with `NtSetInformationFile`. That is why the raw errors are tagged with one of those two steps.

<details>
<summary>Earlier version of this PR</summary>

The first revision only changed `renameat`, which is what the `mv` report pointed at. Review pointed out that `mkdirat` and `unlinkat_with_flags`, a few lines away in the same module, have the identical divergence and reach the same `bun patch` surface, so they were brought in line in the same way, with the two extra patch tests.

</details>

<details>
<summary>Before/after on Windows</summary>

Bun 1.4.0 release (same output from a release build of main at 05dd45ea43):

```
mv missing b                        {"exitCode":2,"stderr":"mv: No such file or directory\n"}
mv a nodir/b                        {"exitCode":2,"stderr":"mv: No such file or directory\n"}
patch: rename from missing.txt      {"code":"ENOENT","syscall":"open"}
patch: delete missing.txt           {"code":"ENOENT","syscall":"open"}
patch: create bad?dir/new.txt       {"code":"ENOENT","syscall":"open"}
```

Debug build of this branch (the `mv` and patch rename/delete lines are identical to Linux; the `bad?dir` case succeeds on Linux):

```
mv missing b                        {"exitCode":2,"stderr":"mv: missing: No such file or directory\n"}
mv a nodir/b                        {"exitCode":2,"stderr":"mv: a: No such file or directory\n"}
patch: rename from missing.txt      {"code":"ENOENT","syscall":"rename"}
patch: delete missing.txt           {"code":"ENOENT","syscall":"unlink"}
patch: create bad?dir/new.txt       {"code":"ENOENT","syscall":"mkdir"}
```

The debug log for the second `mv` shows the rename step failing (`moveOpenedFileAt(...) = NTSTATUS(0xC000003A)`, `STATUS_OBJECT_PATH_NOT_FOUND`), i.e. the `NtSetInformationFile` error path; the first fails while opening the source.

`USE_SYSTEM_BUN=1 bun test` on Windows without the fix:

```
- "mv: missing: No such file or directory
+ "mv: No such file or directory
(fail) mv > names the source when it does not exist
- "mv: a: No such file or directory
+ "mv: No such file or directory
(fail) mv > names the source when the destination's parent does not exist

+ [Error: ENOENT: no such file or directory, open]
(fail) apply > deletion > of a missing file reports the unlink syscall
+ [Error: ENOENT: no such file or directory, open]
(fail) apply > creation > in a directory Windows cannot create reports the mkdir syscall
+ [Error: ENOENT: no such file or directory, open]
(fail) apply > rename > of a missing source reports the rename syscall
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/patch/patch.test.ts

<!-- robobun:evidence:end -->