### PR TITLE
bun build --no-bundle: apply force_node_env to the per-file JSX pragma

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2882,7 +2882,14 @@ impl<'a> Transpiler<'a> {
             | options::Loader::Md => {
                 // borrowck — `parse` consumes `&mut self`, so capture
                 // the option fields needed for `ParseOptions` first.
-                let jsx = jsx_pragma_from_resolver(&resolve_result.jsx);
+                let mut jsx = jsx_pragma_from_resolver(&resolve_result.jsx);
+                // `resolve_result.jsx` is the tsconfig-merged value; an explicit
+                // NODE_ENV / `--production` outranks tsconfig, as in bundle_v2.
+                match self.options.force_node_env {
+                    options::ForceNodeEnv::Development => jsx.development = true,
+                    options::ForceNodeEnv::Production => jsx.development = false,
+                    options::ForceNodeEnv::Unspecified => {}
+                }
                 let dirname_fd = resolve_result.dirname_fd;
                 let emit_decorator_metadata = resolve_result.flags.emit_decorator_metadata();
                 let experimental_decorators = resolve_result.flags.experimental_decorators();

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -467,9 +467,13 @@ impl BuildCommand {
         this_transpiler.resolver.env_loader = core::ptr::NonNull::new(this_transpiler.env);
 
         // Allow tsconfig.json overriding, but always set it to false if --production is passed.
+        // `force_node_env` is what the per-file parse paths consult, so set it too;
+        // `configure_defines` may have set it to `Development` from an ambient NODE_ENV.
         if ctx.bundler_options.production {
             this_transpiler.options.jsx.development = false;
             this_transpiler.resolver.opts.jsx.development = false;
+            this_transpiler.options.force_node_env = options::ForceNodeEnv::Production;
+            this_transpiler.resolver.opts.force_node_env = options::ForceNodeEnv::Production;
         }
 
         match &ctx.debug.macros {

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -69,3 +69,92 @@ describe("tsconfig compilerOptions.jsx", () => {
     }
   });
 });
+
+// An explicit NODE_ENV (environment or --define) and --production outrank the
+// tsconfig's dev/prod choice. `bun build --no-bundle` transpiles each entry
+// point from the resolver's per-file (tsconfig-merged) jsx settings, so it has
+// to apply that override the same way the bundled path does.
+describe("bun build: NODE_ENV / --production outrank tsconfig jsx in --no-bundle and bundled mode alike", () => {
+  const DEV = "react/jsx-dev-runtime";
+  const PROD = "react/jsx-runtime";
+  const tsconfig = (jsx: string) => JSON.stringify({ compilerOptions: { jsx } });
+  const entry = `export const el = <div>hi</div>;\n`;
+
+  type Case = {
+    files: Record<string, string>;
+    entry?: string;
+    env?: Record<string, string>;
+    args?: string[];
+    expected: string;
+  };
+
+  const cases: [name: string, c: Case][] = [
+    // Controls: tsconfig decides when nothing outranks it.
+    ['"react-jsx", NODE_ENV unset', { files: { "tsconfig.json": tsconfig("react-jsx") }, expected: PROD }],
+    ['"react-jsxdev", NODE_ENV unset', { files: { "tsconfig.json": tsconfig("react-jsxdev") }, expected: DEV }],
+    [
+      '"react-jsx" + NODE_ENV=development',
+      { files: { "tsconfig.json": tsconfig("react-jsx") }, env: { NODE_ENV: "development" }, expected: DEV },
+    ],
+    [
+      '"react-jsx" + BUN_ENV=development',
+      { files: { "tsconfig.json": tsconfig("react-jsx") }, env: { BUN_ENV: "development" }, expected: DEV },
+    ],
+    [
+      '"react-jsx" + --define process.env.NODE_ENV=\'"development"\'',
+      {
+        files: { "tsconfig.json": tsconfig("react-jsx") },
+        args: ["--define", 'process.env.NODE_ENV="development"'],
+        expected: DEV,
+      },
+    ],
+    [
+      'nested "react-jsx" tsconfig next to the entry point + NODE_ENV=development',
+      {
+        files: { "src/tsconfig.json": tsconfig("react-jsx") },
+        entry: "src/m.tsx",
+        env: { NODE_ENV: "development" },
+        expected: DEV,
+      },
+    ],
+    [
+      '"react-jsxdev" + --production',
+      { files: { "tsconfig.json": tsconfig("react-jsxdev") }, args: ["--production"], expected: PROD },
+    ],
+    [
+      '"react-jsx" + --production with NODE_ENV=development in the environment',
+      {
+        files: { "tsconfig.json": tsconfig("react-jsx") },
+        env: { NODE_ENV: "development" },
+        args: ["--production"],
+        expected: PROD,
+      },
+    ],
+  ];
+
+  async function build(cwd: string, args: string[], env: Record<string, string> | undefined) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, ...env },
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      stderr,
+      exitCode,
+      runtimes: [...new Set(stdout.match(/react\/jsx(?:-dev)?-runtime/g))].sort(),
+    };
+  }
+
+  test.concurrent.each(cases)("%s", async (_name, { files, entry: entryPath = "m.tsx", env, args = [], expected }) => {
+    using dir = tempDir("jsx-tsconfig-node-env", { ...files, [entryPath]: entry });
+
+    const noBundle = await build(String(dir), ["--no-bundle", ...args, entryPath], env);
+    const bundled = await build(String(dir), ["--external", "react*", ...args, entryPath], env);
+
+    const want = { stderr: "", exitCode: 0, runtimes: [expected] };
+    expect({ noBundle, bundled }).toEqual({ noBundle: want, bundled: want });
+  });
+});


### PR DESCRIPTION
### Problem

- With `tsconfig.json` `{"compilerOptions":{"jsx":"react-jsx"}}`, `NODE_ENV=development bun build --no-bundle m.tsx` emits `import { jsx } from "react/jsx-runtime"` (production), while `NODE_ENV=development bun build m.tsx` emits `jsxDEV` from `react/jsx-dev-runtime`. Same with `BUN_ENV=development` and `--define process.env.NODE_ENV='"development"'`. Reproduces on bun 1.4.0 and main.
- The split also exists for `--production`: with `"jsx": "react-jsxdev"`, `bun build --production --no-bundle` emits the development runtime, bundled mode emits production. And with `NODE_ENV=development` in the environment, `bun build --production` (bundled) emits the development runtime.
- Cause, first half: `configure_defines` (`src/bundler/transpiler.rs:598`) records an explicit `NODE_ENV=development` as `options.force_node_env = Development`. The bundled path applies it to every parse task (`bundle_v2.rs:2663`, `:2773`, `:6221`, `:6594`). The `--no-bundle` path, `build_with_resolve_result_eager` (`src/bundler/transpiler.rs:2885`), copies `resolve_result.jsx` into `ParseOptions` and never looks at `force_node_env`, so the tsconfig's `development: false` (what `"react-jsx"` means since #34422) is what gets parsed.
- Cause, second half: `--production` only wrote `options.jsx.development = false` (`src/runtime/cli/build_command.rs:470`), a transpiler-wide value. The per-file parse paths take their dev/prod choice from the per-file tsconfig result plus `force_node_env`, and `--production` set neither, so a tsconfig `"react-jsxdev"` won in `--no-bundle`, and an ambient `NODE_ENV=development` (turned into `force_node_env = Development` by `configure_defines`) won in bundled mode.

### Fix

- `build_with_resolve_result_eager`: after copying the resolver's pragma, override `jsx.development` from `force_node_env`, the same three-way match the bundled path uses. `Unspecified` leaves the per-file tsconfig value alone, which is the existing `--no-bundle` behavior.
- `build_command`: `--production` also sets `force_node_env = Production` (on `options` and `resolver.opts`, next to the existing `jsx.development = false`), so both parse paths see it and it outranks an ambient `NODE_ENV`.
- Why this is right: `force_node_env` is documented (`bundler/options.rs:1319`, `Pragma::development` in `options_types/jsx.rs`) as the thing that overrides tsconfig's dev/prod choice, with tsconfig only deciding when it is `Unspecified`; the bundled path already implements exactly that, and `--no-bundle` and bundled mode transpile the same file from the same resolver result, so they have to agree. For `--production`, the existing block's stated intent ("always set it to false if --production is passed") now holds for the per-file values too.
- Behavior change: with `--production`, the JSX runtime is now production in both modes regardless of tsconfig or `NODE_ENV`. Without `--production`, an explicit `NODE_ENV=production` vs a tsconfig `"react-jsxdev"` is unchanged (tsconfig still wins in both modes); #36269 is what makes that direction set `force_node_env`, and the override added here will honor it in `--no-bundle` once it lands.
- Verified with `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`: a new block runs each case through `bun build --no-bundle` and `bun build --external 'react*'` and asserts both emit the same runtime. Cases: `NODE_ENV=development`, `BUN_ENV=development`, `--define`, a nested tsconfig next to the entry point (all vs `"react-jsx"`), `--production` vs `"react-jsxdev"`, `--production` with `NODE_ENV=development` in the environment, plus two controls with `NODE_ENV` unset. 6 of 8 fail on the released binary (the first five in `--no-bundle`, the last one in bundled mode); all pass with this change.
- Also passing locally: `bundler_jsx`, `bundler_minify`, `bundler_minify_symbol_for`, `bundler_string`, `bundler_html`, `esbuild/tsconfig`, `regression/issue/19652`, and the `--no-bundle` regression tests (29242, 31401, 23569).

### Background

- Automatic JSX runtime: `jsx.development` selects `jsxDEV` from `<pkg>/jsx-dev-runtime` versus `jsx`/`jsxs` from `<pkg>/jsx-runtime`. tsconfig `"jsx": "react-jsx"` maps to `development: false`, `"react-jsxdev"` to `true` (`RUNTIME_MAP` in `options_types/jsx.rs`).
- Per-file JSX pragma: the resolver starts from the transpiler-wide `options.jsx` and merges the nearest enclosing tsconfig's `jsx*` fields over it (`resolver.rs` `merge_jsx`), returning the result as `resolve_result.jsx`. Both build modes parse from this value; the bundled path copies it in `ParseTask::init` and then applies `force_node_env`.
- `force_node_env` (`ForceNodeEnv::{Unspecified, Development, Production}`): set when the user states a NODE_ENV explicitly (`configure_defines`), or by callers such as the HTML dev bundle; consumers override `jsx.development` with it and fall back to the tsconfig-derived value when it is `Unspecified`.
- `bun build --no-bundle` (`Transpiler::transform` -> `build_with_resolve_result_eager`) transpiles each entry point on its own without linking; it is the only user of that function. `Bun.build()` has no equivalent mode and is not affected by this change.

### Related

- #36269 (bundled mode, `--jsx-*` flags): adds the same two `--production` lines in `build_command.rs` and makes explicit `NODE_ENV=production` set `force_node_env`; independent of this change otherwise.
- #33855 (`--production` vs ambient `NODE_ENV` for the `process.env.NODE_ENV` define): sets `force_node_env = Production` before `configure_defines`; if it lands, the two lines added here become redundant and can be dropped.
- #36469 (`bun run`) and #38050 (tsconfig without a `"jsx"` key) fix different entry points of the same precedence and compose with this.

<details>
<summary>Repro on bun 1.4.0</summary>

```sh
mkdir /tmp/x && cd /tmp/x
printf 'export const el = <div>hi</div>;\n' > m.tsx
echo '{"compilerOptions":{"jsx":"react-jsx"}}' > tsconfig.json
NODE_ENV=development bun build --external 'react*' ./m.tsx | grep -o 'react/jsx[a-z-]*'   # react/jsx-dev-runtime
NODE_ENV=development bun build --no-bundle ./m.tsx | head -1                               # import { jsx ... } from "react/jsx-runtime"

echo '{"compilerOptions":{"jsx":"react-jsxdev"}}' > tsconfig.json
bun build --production --external 'react*' ./m.tsx | grep -o 'react/jsx[a-z-]*'            # react/jsx-runtime
bun build --production --no-bundle ./m.tsx | grep -o 'react/jsx[a-z-]*'                    # react/jsx-dev-runtime

echo '{"compilerOptions":{"jsx":"react-jsx"}}' > tsconfig.json
NODE_ENV=development bun build --production --external 'react*' ./m.tsx | grep -o 'react/jsx[a-z-]*'   # react/jsx-dev-runtime
```

</details>
