### PR TITLE
run: set npm_package_name/version/json and npm_config_local_prefix per run

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2041,7 +2041,18 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         // not repeated.
         unsafe { (*transpiler_for_deinit).deinit() };
     }
-    ctx.manager.env_mut().map.put(b"npm_command", b"pack")?;
+    let script_env = ctx.manager.env_mut();
+    script_env.map.put(b"npm_command", b"pack")?;
+    // `configure_env_for_run` described the package.json of the directory the
+    // package manager chdir'd to, which for a workspace member is the
+    // workspace root; the lifecycle scripts belong to the manifest being packed.
+    script_env
+        .map
+        .put(b"npm_package_json", abs_package_json_path.as_bytes())?;
+    script_env.map.put(b"npm_package_name", package_name)?;
+    script_env
+        .map
+        .put(b"npm_package_version", package_version)?;
 
     let (postpack_script, publish_script, postpublish_script, ran_scripts): (
         Option<Box<[u8]>>,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -682,9 +682,14 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // remaining env-var seeding.
         let env_loader = this_transpiler.env_mut();
 
+        // Like npm, `npm_config_local_prefix` and the `npm_package_*` vars below
+        // describe this run and overwrite what an outer `bun run` exported
+        // (`cd pkg && bun run x` must see `pkg`'s values); name/version are left
+        // alone only when package.json lacks them. `npm_config_user_agent` /
+        // `npm_execpath` are deliberately inherited.
         env_loader
             .map
-            .put_default(b"npm_config_local_prefix", top_level_dir)
+            .put(b"npm_config_local_prefix", top_level_dir)
             .expect("unreachable");
 
         // Propagate --no-orphans / [run] noOrphans to the script's env so any
@@ -734,26 +739,22 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
         if let Some(package_json) = root_dir_info.enclosing_package_json {
             if !package_json.name.is_empty() {
-                if env_loader.map.get(NpmArgs::PACKAGE_NAME).is_none() {
-                    env_loader
-                        .map
-                        .put(NpmArgs::PACKAGE_NAME, &package_json.name)
-                        .expect("unreachable");
-                }
+                env_loader
+                    .map
+                    .put(NpmArgs::PACKAGE_NAME, &package_json.name)
+                    .expect("unreachable");
             }
 
             env_loader
                 .map
-                .put_default(b"npm_package_json", package_json.source.path.text)
+                .put(b"npm_package_json", package_json.source.path.text)
                 .expect("unreachable");
 
             if !package_json.version.is_empty() {
-                if env_loader.map.get(NpmArgs::PACKAGE_VERSION).is_none() {
-                    env_loader
-                        .map
-                        .put(NpmArgs::PACKAGE_VERSION, &package_json.version)
-                        .expect("unreachable");
-                }
+                env_loader
+                    .map
+                    .put(NpmArgs::PACKAGE_VERSION, &package_json.version)
+                    .expect("unreachable");
             }
 
             if let Some(config) = package_json.config.as_deref() {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -609,6 +609,61 @@ describe("workspaces", () => {
     const tarball = readTarball(join(packageDir, "pkgs", "pkg1", "pkg1-1.1.1.tgz"));
     expect(tarball.entries).toMatchObject([{ "pathname": "package/package.json" }, { "pathname": "package/index.js" }]);
   });
+
+  describe("lifecycle scripts describe the workspace member being packed", () => {
+    const echoPackageEnv = "$npm_package_name $npm_package_version $npm_package_json $npm_config_local_prefix";
+    let pkg1Dir: string;
+    let expectedLines: string[];
+
+    beforeEach(async () => {
+      pkg1Dir = join(packageDir, "pkgs", "pkg1");
+      // npm_config_local_prefix is the workspace root, as with npm.
+      const memberEnv = `pkg1 1.1.1 ${join(pkg1Dir, "package.json")} ${packageDir}`;
+      expectedLines = [`prepack ${memberEnv}`, `postpack ${memberEnv}`];
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({ name: "pack-workspace", version: "2.2.2", workspaces: ["pkgs/*"] }),
+        ),
+        write(
+          join(pkg1Dir, "package.json"),
+          JSON.stringify({
+            name: "pkg1",
+            version: "1.1.1",
+            scripts: {
+              prepack: `echo prepack ${echoPackageEnv}`,
+              postpack: `echo postpack ${echoPackageEnv}`,
+              release: `'${bunExe()}' pm pack --dry-run`,
+            },
+          }),
+        ),
+      ]);
+    });
+
+    function lifecycleLines(out: string) {
+      return out.split("\n").filter(line => line.startsWith("prepack ") || line.startsWith("postpack "));
+    }
+
+    test("bun pm pack in the member", async () => {
+      const { out } = await pack(pkg1Dir, bunEnv, "--dry-run");
+      expect(lifecycleLines(out)).toEqual(expectedLines);
+    });
+
+    test("bun pm pack from a member script", async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "run", "--silent", "release"],
+        cwd: pkg1Dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(lifecycleLines(out)).toEqual(expectedLines);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   test("replaces workspace: protocol without lockfile", async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1127,6 +1127,34 @@ it("$npm_lifecycle_event is accurate during publish", async () => {
   expect(exitCode).toBe(0);
 });
 
+it("lifecycle scripts get the workspace member's npm_package_* when publishing a member", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const memberDir = join(packageDir, "packages", "publish-pkg-12");
+  const echoPackageEnv = "$npm_package_name $npm_package_version $npm_package_json $npm_config_local_prefix";
+  const events = ["prepublishOnly", "prepack", "postpack", "publish", "postpublish"];
+  await Promise.all([
+    write(join(packageDir, "bunfig.toml"), await registry.authBunfig("npm_package_env")),
+    write(packageJson, JSON.stringify({ name: "root", version: "0.0.1", workspaces: ["packages/*"] })),
+    write(
+      join(memberDir, "package.json"),
+      JSON.stringify({
+        name: "publish-pkg-12",
+        version: "12.0.0",
+        scripts: Object.fromEntries(events.map(event => [event, `echo ${event} ${echoPackageEnv}`])),
+      }),
+    ),
+  ]);
+
+  const { out, err, exitCode } = await publish(env, memberDir, "--dry-run");
+  // npm_config_local_prefix is the workspace root, as with npm.
+  const memberEnv = `publish-pkg-12 12.0.0 ${join(memberDir, "package.json")} ${packageDir}`;
+  expect(out.split("\n").filter(line => events.some(event => line.startsWith(`${event} `)))).toEqual(
+    events.map(event => `${event} ${memberEnv}`),
+  );
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+});
+
 describe("readme", () => {
   // Regression for https://github.com/oven-sh/bun/issues/30255 — `bun publish`
   // packed the README into the tarball but never populated the version-level

--- a/test/cli/run/run-process-env.test.ts
+++ b/test/cli/run/run-process-env.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, test } from "bun:test";
-import { bunExe, bunRunAsScript, tempDir } from "harness";
+import { bunEnv, bunExe, bunRunAsScript, tempDir } from "harness";
+import { join } from "node:path";
+
+// Run with `bun <file>` (not `bun run`), so it prints exactly what the
+// `bun run <script>` under test exported instead of re-deriving the values.
+const printNpmPackageEnv = `process.stdout.write(JSON.stringify({
+  npm_package_name: process.env.npm_package_name,
+  npm_package_version: process.env.npm_package_version,
+  npm_package_json: process.env.npm_package_json,
+  npm_config_local_prefix: process.env.npm_config_local_prefix,
+}));`;
+
+async function runScript(cwd: string, script: string, env: Record<string, string | undefined> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--silent", script],
+    cwd,
+    env: { ...bunEnv, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
 
 describe("process.env", () => {
   test("npm_lifecycle_event", () => {
@@ -24,5 +48,79 @@ describe("process.env", () => {
     });
     const { stdout } = bunRunAsScript(dir, "first");
     expect(stdout).toBe("second");
+  });
+
+  // https://github.com/oven-sh/bun/issues/11713
+  test.concurrent("nested bun run exports the inner package's npm_package_* and npm_config_local_prefix", async () => {
+    using dir = tempDir("processenv_nested_pkg", {
+      "package.json": JSON.stringify({
+        name: "outer-pkg",
+        version: "1.0.0",
+        scripts: { outer: `cd inner && '${bunExe()}' run --silent inner` },
+      }),
+      "print-env.js": printNpmPackageEnv,
+      "inner": {
+        "package.json": JSON.stringify({
+          name: "inner-pkg",
+          version: "2.0.0",
+          scripts: { inner: `'${bunExe()}' ../print-env.js` },
+        }),
+      },
+    });
+
+    expect(await runScript(String(dir), "outer")).toEqual({
+      npm_package_name: "inner-pkg",
+      npm_package_version: "2.0.0",
+      npm_package_json: join(String(dir), "inner", "package.json"),
+      npm_config_local_prefix: join(String(dir), "inner"),
+    });
+  });
+
+  // npm only exports name/version when the package.json has them, so the outer run's values stay visible.
+  test.concurrent("unnamed inner package.json keeps the inherited npm_package_name/version", async () => {
+    using dir = tempDir("processenv_nested_unnamed", {
+      "package.json": JSON.stringify({
+        name: "outer-pkg",
+        version: "1.0.0",
+        scripts: { outer: `'${bunExe()}' run --silent --cwd inner inner` },
+      }),
+      "print-env.js": printNpmPackageEnv,
+      "inner": {
+        "package.json": JSON.stringify({
+          scripts: { inner: `'${bunExe()}' ../print-env.js` },
+        }),
+      },
+    });
+
+    expect(await runScript(String(dir), "outer")).toEqual({
+      npm_package_name: "outer-pkg",
+      npm_package_version: "1.0.0",
+      npm_package_json: join(String(dir), "inner", "package.json"),
+      npm_config_local_prefix: join(String(dir), "inner"),
+    });
+  });
+
+  test.concurrent("npm_package_* and npm_config_local_prefix overwrite inherited environment values", async () => {
+    using dir = tempDir("processenv_stale_pkg", {
+      "package.json": JSON.stringify({
+        name: "my-pkg",
+        version: "3.0.0",
+        scripts: { print: `'${bunExe()}' print-env.js` },
+      }),
+      "print-env.js": printNpmPackageEnv,
+    });
+
+    const stale = {
+      npm_package_name: "stale-name",
+      npm_package_version: "0.0.0-stale",
+      npm_package_json: "/stale/package.json",
+      npm_config_local_prefix: "/stale",
+    };
+    expect(await runScript(String(dir), "print", stale)).toEqual({
+      npm_package_name: "my-pkg",
+      npm_package_version: "3.0.0",
+      npm_package_json: join(String(dir), "package.json"),
+      npm_config_local_prefix: String(dir),
+    });
   });
 });


### PR DESCRIPTION
Fixes #11713

### Problem
- A package.json script that runs `bun run` in a different package (`cd inner && bun run x`, or `bun run --cwd inner x`) leaves the inner script looking at the outer package: `npm_package_name`, `npm_package_version`, `npm_package_json` and `npm_config_local_prefix` all still carry the outer package's values. npm gives the inner package's values for all four.
- The same thing happens for a single `bun run` when any of the four is already present in the environment: the inherited value wins over the package.json being run. npm overwrites them (checked with npm 11 and a pre-set `npm_package_name=BOGUS`, and `npx -c` behaves the same).
- Cause: `configure_env_for_run_impl` in `src/runtime/cli/run_command.rs` seeds `npm_config_local_prefix` and `npm_package_json` with `put_default`, and `npm_package_name` / `npm_package_version` behind an `is_none()` check on the map, so anything the outer `bun run` exported is kept. `npm_lifecycle_event` in the same file already uses a plain `put` for exactly this nested case (#3589).
- Present in 1.3.14 as well, so not a regression; the test lives next to the existing nested `npm_lifecycle_event` test.

### Fix
- Write the four variables with `put` for every run. The values are unchanged (`npm_config_local_prefix` is still the invocation directory; making it the package root is a separate discrepancy, tracked in #21088). `npm_config_user_agent` and `npm_execpath` keep their inherit-if-set behavior, which is intentional.
- `npm_package_name` / `npm_package_version` are still only written when the package.json defines them. npm does the same (it only exports the fields the manifest has), so with a name-less inner package.json the outer run's name stays visible under both tools; the test pins that down so the inherited value is not mistaken for a leak.
- This is the one place the `bun run`, `bunx`, `bun run <file>` fallback and `bun pm pack` paths seed these variables, so all of them now describe the package they are actually running in. `bun run --filter` still builds one env for every workspace package; that is a separate gap in `filter_run.rs` and is not changed here.
- Verified: `test/cli/run/run-process-env.test.ts` gains three tests (nested run via `cd`, nested run via `--cwd` with a name-less inner package, single run with stale values pre-set in the environment). All three fail on the release binary with the outer/stale values and pass with this change; the two existing tests in the file still pass.
- `test/cli/install/bun-run.test.ts` (292 pass), `test/cli/run/env.test.ts` (96 pass) and the `$npm_*` tests in `test/cli/install/bun-pack.test.ts` pass with the change.
- The issue's repro (outer `parent-script: cd child && npm run child-script`, child script prints `npm_package_name`) prints `child` with this change; it printed `parent` before.

### Background
- `bun run <script>` builds the script's environment by loading the parent process environment into an env map and then seeding the `npm_*` variables npm defines for lifecycle scripts (`npm_lifecycle_event`, `npm_package_*`, `npm_config_*`). The map is what the script is spawned with, so anything the outer `bun run` exported is already in it when a nested `bun run` seeds its own values.
- `put` overwrites an existing key in that map; `put_default` only inserts when the key is missing. `put_default` is right for values that a parent process is allowed to pin (the user agent, `npm_execpath`) and wrong for values that describe the current run.
- `npm_config_local_prefix` is npm's name for the project directory of the current run; `npm_package_json` is the path of the package.json whose script is running.

<details>
<summary>Repro and npm comparison</summary>

```
/tmp/nested/package.json
  {"name":"outer-pkg","version":"1.0.0","scripts":{"via-bun":"cd inner && bun run --silent p","via-npm":"cd inner && npm run --silent p"}}
/tmp/nested/inner/package.json
  {"name":"inner-pkg","version":"2.0.0","scripts":{"p":"env | grep -E '^npm_(package_name|package_version|package_json|config_local_prefix)=' | sort"}}
```

`bun run --silent via-bun` before (bun 1.4.0 and 1.3.14):

```
npm_config_local_prefix=/tmp/nested
npm_package_json=/tmp/nested/package.json
npm_package_name=outer-pkg
npm_package_version=1.0.0
```

`npm run --silent via-npm` (npm 11.16.0), and `bun run --silent via-bun` with this change:

```
npm_config_local_prefix=/tmp/nested/inner
npm_package_json=/tmp/nested/inner/package.json
npm_package_name=inner-pkg
npm_package_version=2.0.0
```

Name-less inner package.json, `cd inner && npm run p` from the outer script: npm prints `name=[outer-pkg] version=[1.0.0] json=[/tmp/noname/inner/package.json] prefix=[/tmp/noname/inner]`, which is what bun prints with this change.
</details>
