### PR TITLE
require(esm): return the namespace when the module is evicted from require.cache during evaluation

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -385,6 +385,7 @@ declare function $redirect(): TODO;
 declare function $relative(): TODO;
 declare function $require(): TODO;
 declare function $requireESM(path: string): any;
+declare function $requireESMIntoModule(this: JSCommonJSModule, id: string): void;
 declare const $requireMap: Map<string, JSCommonJSModule>;
 declare const $internalModuleRegistry: InternalFieldObject<any[]>;
 declare function $resolve(name: string, from: string): Promise<string>;

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -167,6 +167,7 @@ using namespace JSC;
     macro(removeAbortAlgorithmFromSignal) \
     macro(require) \
     macro(requireESM) \
+    macro(requireESMIntoModule) \
     macro(requireMap) \
     macro(requireNativeModule) \
     macro(resolveSync) \

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -106,34 +106,33 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
 
   // -1 means we need to lookup the module from the ESM registry.
   if (out === -1) {
+    // Keep the namespace $requireESM returns instead of looking the registry up
+    // again: the module may have deleted itself from require.cache while evaluating.
+    let namespace: any;
     try {
-      out = $requireESM(id);
+      namespace = $requireESM(id);
     } catch (exception) {
       // Since the ESM code is mostly JS, we need to handle exceptions here.
       $requireMap.$delete(id);
       throw exception;
     }
 
-    // If we can pull out a ModuleNamespaceObject, let's do it.
-    const namespace = $esmNamespaceForCjs(id);
-    if (namespace !== undefined) {
-      // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-      // Various libraries expect __esModule to be set when using ESM from require().
-      // We don't want to always inject the __esModule export into every module,
-      // And creating an Object wrapper causes the actual exports to not be own properties.
-      // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-      // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-      // https://github.com/oven-sh/bun/issues/14411
-      if (namespace.__esModule === undefined) {
-        try {
-          namespace.__esModule = true;
-        } catch {
-          // https://github.com/oven-sh/bun/issues/17816
-        }
+    // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
+    // Various libraries expect __esModule to be set when using ESM from require().
+    // We don't want to always inject the __esModule export into every module,
+    // And creating an Object wrapper causes the actual exports to not be own properties.
+    // So instead of either of those, we make it so that the __esModule property can be set at runtime.
+    // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
+    // https://github.com/oven-sh/bun/issues/14411
+    if (namespace.__esModule === undefined) {
+      try {
+        namespace.__esModule = true;
+      } catch {
+        // https://github.com/oven-sh/bun/issues/17816
       }
-
-      return (mod.exports = namespace["module.exports"] ?? namespace);
     }
+
+    return (mod.exports = namespace["module.exports"] ?? namespace);
   }
 
   const c = $evaluateCommonJSModule(mod, this);
@@ -320,42 +319,40 @@ export function requireESM(this, resolved: string) {
     exports = $loadEsmIntoCjs(resolved);
   }
   if (exports === undefined) {
-    throw new TypeError(`require() failed to evaluate module "${resolved}". This is an internal consistentency error.`);
+    throw new TypeError(`require() failed to evaluate module "${resolved}". This is an internal consistency error.`);
   }
   return exports;
 }
 
 export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: string) {
   $assert(this);
+  // As in overridableRequire, the module may have deleted itself from
+  // require.cache while evaluating, so don't look the namespace up again.
+  let namespace: any;
   try {
-    $requireESM(id);
+    namespace = $requireESM(id);
   } catch (exception) {
     // Since the ESM code is mostly JS, we need to handle exceptions here.
     $requireMap.$delete(id);
     throw exception;
   }
 
-  // If we can pull out a ModuleNamespaceObject, let's do it.
-  const namespace = $esmNamespaceForCjs(id);
-  if (namespace !== undefined) {
-    // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-    // Various libraries expect __esModule to be set when using ESM from require().
-    // We don't want to always inject the __esModule export into every module,
-    // And creating an Object wrapper causes the actual exports to not be own properties.
-    // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-    // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-    // https://github.com/oven-sh/bun/issues/14411
-    if (namespace.__esModule === undefined) {
-      try {
-        namespace.__esModule = true;
-      } catch {
-        // https://github.com/oven-sh/bun/issues/17816
-      }
+  // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
+  // Various libraries expect __esModule to be set when using ESM from require().
+  // We don't want to always inject the __esModule export into every module,
+  // And creating an Object wrapper causes the actual exports to not be own properties.
+  // So instead of either of those, we make it so that the __esModule property can be set at runtime.
+  // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
+  // https://github.com/oven-sh/bun/issues/14411
+  if (namespace.__esModule === undefined) {
+    try {
+      namespace.__esModule = true;
+    } catch {
+      // https://github.com/oven-sh/bun/issues/17816
     }
-
-    this.exports = namespace["module.exports"] ?? namespace;
-    return;
   }
+
+  this.exports = namespace["module.exports"] ?? namespace;
 }
 
 $visibility = "Private";

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -287,8 +287,7 @@ function loadEsmIntoCjs__dead(resolvedSpecifier: string) {
 }
 */
 
-// Returns the raw namespace (this is also import.meta.bakeBuiltin); the
-// require()-specific shaping of it lives in requireESMIntoModule.
+// Also bound as import.meta.bakeBuiltin, so this returns the namespace unshaped.
 $visibility = "Private";
 export function requireESM(this, resolved: string) {
   var exports = $esmNamespaceForCjs(resolved);
@@ -298,15 +297,12 @@ export function requireESM(this, resolved: string) {
   return exports;
 }
 
-// `this` is the CommonJS module object standing in for the ES module `id`.
-// Called by require() and, through C++, by the builtin Module._extensions loaders.
+// Also called from C++ by the builtin Module._extensions loaders (JSCommonJSExtensions.cpp).
 $visibility = "Private";
 export function requireESMIntoModule(this: JSCommonJSModule, id: string) {
   $assert(this);
   let namespace: any;
   try {
-    // Use the namespace this call returns rather than looking the registry up
-    // again: the module may have deleted itself from require.cache while evaluating.
     namespace = $requireESM(id);
   } catch (exception) {
     // Since the ESM code is mostly JS, we need to handle exceptions here.

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -106,33 +106,8 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
 
   // -1 means we need to lookup the module from the ESM registry.
   if (out === -1) {
-    // Keep the namespace $requireESM returns instead of looking the registry up
-    // again: the module may have deleted itself from require.cache while evaluating.
-    let namespace: any;
-    try {
-      namespace = $requireESM(id);
-    } catch (exception) {
-      // Since the ESM code is mostly JS, we need to handle exceptions here.
-      $requireMap.$delete(id);
-      throw exception;
-    }
-
-    // In Bun, when __esModule is not defined, it's a CustomAccessor on the prototype.
-    // Various libraries expect __esModule to be set when using ESM from require().
-    // We don't want to always inject the __esModule export into every module,
-    // And creating an Object wrapper causes the actual exports to not be own properties.
-    // So instead of either of those, we make it so that the __esModule property can be set at runtime.
-    // It only supports "true" and undefined. Anything non-truthy is treated as undefined.
-    // https://github.com/oven-sh/bun/issues/14411
-    if (namespace.__esModule === undefined) {
-      try {
-        namespace.__esModule = true;
-      } catch {
-        // https://github.com/oven-sh/bun/issues/17816
-      }
-    }
-
-    return (mod.exports = namespace["module.exports"] ?? namespace);
+    $requireESMIntoModule.$call(mod, id);
+    return mod.exports;
   }
 
   const c = $evaluateCommonJSModule(mod, this);
@@ -312,24 +287,26 @@ function loadEsmIntoCjs__dead(resolvedSpecifier: string) {
 }
 */
 
+// Returns the raw namespace (this is also import.meta.bakeBuiltin); the
+// require()-specific shaping of it lives in requireESMIntoModule.
 $visibility = "Private";
 export function requireESM(this, resolved: string) {
   var exports = $esmNamespaceForCjs(resolved);
   if (exports === undefined) {
     exports = $loadEsmIntoCjs(resolved);
   }
-  if (exports === undefined) {
-    throw new TypeError(`require() failed to evaluate module "${resolved}". This is an internal consistency error.`);
-  }
   return exports;
 }
 
-export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: string) {
+// `this` is the CommonJS module object standing in for the ES module `id`.
+// Called by require() and, through C++, by the builtin Module._extensions loaders.
+$visibility = "Private";
+export function requireESMIntoModule(this: JSCommonJSModule, id: string) {
   $assert(this);
-  // As in overridableRequire, the module may have deleted itself from
-  // require.cache while evaluating, so don't look the namespace up again.
   let namespace: any;
   try {
+    // Use the namespace this call returns rather than looking the registry up
+    // again: the module may have deleted itself from require.cache while evaluating.
     namespace = $requireESM(id);
   } catch (exception) {
     // Since the ESM code is mostly JS, we need to handle exceptions here.

--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -280,13 +280,13 @@ JSC::EncodedJSValue builtinLoader(JSC::JSGlobalObject* globalObject, JSC::CallFr
     RETURN_IF_EXCEPTION(scope, {});
     if (result == jsNumber(-1)) {
         // ESM
-        JSC::JSFunction* requireESM = global->requireESMFromHijackedExtension();
+        JSC::JSFunction* requireESMIntoModule = global->requireESMIntoModuleFunction();
         JSC::MarkedArgumentBuffer args;
         args.append(specifier);
-        JSC::CallData callData = JSC::getCallData(requireESM);
+        JSC::CallData callData = JSC::getCallData(requireESMIntoModule);
         ASSERT(callData.type == JSC::CallData::Type::JS);
         NakedPtr<JSC::Exception> returnedException = nullptr;
-        JSC::profiledCall(global, JSC::ProfilingReason::API, requireESM, callData, mod, args, returnedException);
+        JSC::profiledCall(global, JSC::ProfilingReason::API, requireESMIntoModule, callData, mod, args, returnedException);
         if (returnedException) [[unlikely]] {
             throwException(globalObject, scope, returnedException->value());
             return {};

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -761,6 +761,15 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
+// loadModuleSync() without fetch parameters loads the (key, JavaScript) entry.
+// registryEntry() would also match the JSON/HostDefined entry that an
+// `import ... with { type }` of the same file registers, which that load
+// leaves untouched.
+static JSC::ModuleRegistryEntry* javaScriptRegistryEntry(JSC::JSModuleLoader* loader, const JSC::Identifier& key)
+{
+    return loader->moduleMap().get({ key.impl(), JSC::ScriptFetchParameters::Type::JavaScript }).get();
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -825,32 +834,29 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
 
     auto* loader = globalObject->moduleLoader();
     bool entryExistedBefore = false;
-    // fetchCommonJSModule() already parsed the file into the registry, so the
-    // record to evaluate is normally known now. Keep it rather than re-reading
-    // the registry after the load: the module's top level (or a dependency's)
-    // may `delete require.cache[...]` while it runs, and like a static import
-    // this load still returns the instance it evaluated. The eviction only
-    // affects the next load.
-    JSC::AbstractModuleRecord* record = nullptr;
-    if (auto* entry = loader->registryEntry(key)) {
+    if (auto* existing = loader->registryEntry(key)) {
         entryExistedBefore = true;
-        record = entry->record();
-        if (isModuleEvaluated(record)) {
-            auto* ns = record->getModuleNamespace(globalObject, false);
+        if (isModuleEvaluated(existing->record())) {
+            auto* ns = existing->record()->getModuleNamespace(globalObject, false);
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
     }
 
+    // Hold the entry the load below evaluates instead of looking it up again
+    // afterwards: the module's own top level may `delete require.cache[key]`,
+    // which removes the entry from the registry while its record is still
+    // being evaluated. The entry cell itself keeps pointing at that record.
+    JSC::ModuleRegistryEntry* entry = javaScriptRegistryEntry(loader, key);
+
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Builtin ES modules and module mocks arrive without a parsed entry; the
-    // load itself creates it.
-    if (!record) {
-        if (auto* entry = loader->registryEntry(key))
-            record = entry->record();
-    }
+    // Builtin ES modules and module mocks reach this point before any entry
+    // exists; the load creates it.
+    if (!entry)
+        entry = javaScriptRegistryEntry(loader, key);
+    JSC::AbstractModuleRecord* record = entry ? entry->record() : nullptr;
 
     switch (promise->status()) {
     case JSPromise::Status::Fulfilled:
@@ -2969,8 +2975,8 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleStderr, (JSGlobalObject * globalObject, Encod
     return JSValue::encode(stderrValue);
 }
 
-// The CommonJS `require()` machinery (`@requireESM`, `@loadEsmIntoCjs`,
-// `@internalRequire`) is only ever reached from inside CommonJS modules. A
+// The CommonJS `require()` machinery (`@requireESM`, `@requireESMIntoModule`,
+// `@loadEsmIntoCjs`, `@internalRequire`) is only ever reached from inside CommonJS modules. A
 // process whose entry point is ESM (the common case for short scripts) never
 // touches it, so parsing/compiling these builtins during global object setup is
 // pure startup overhead. Register lazy custom-value getters instead: the first
@@ -2978,8 +2984,8 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleStderr, (JSGlobalObject * globalObject, Encod
 // accessor with the plain builtin function for subsequent fast access.
 //
 // Note: these private names are only consumed via `op_get_from_scope` from
-// builtin JS (`$requireESM`, `$loadEsmIntoCjs`, `$internalRequire`), never via
-// `getDirect`, so a custom accessor is a transparent substitute. (`@create*ReadableStream`
+// builtin JS (`$requireESM`, `$requireESMIntoModule`, `$loadEsmIntoCjs`, `$internalRequire`),
+// never via `getDirect`, so a custom accessor is a transparent substitute. (`@create*ReadableStream`
 // next to these *do* have `getDirect` callers and must stay eager.)
 #define BUN_DEFINE_LAZY_GLOBAL_BUILTIN_GETTER(getterName, codeGenerator, attributes)                                           \
     JSC_DEFINE_CUSTOM_GETTER(getterName, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue, PropertyName name))            \
@@ -2990,6 +2996,7 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleStderr, (JSGlobalObject * globalObject, Encod
         return JSValue::encode(fn);                                                                                            \
     }
 BUN_DEFINE_LAZY_GLOBAL_BUILTIN_GETTER(getRequireESMBuiltin, commonJSRequireESMCodeGenerator, PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly)
+BUN_DEFINE_LAZY_GLOBAL_BUILTIN_GETTER(getRequireESMIntoModuleBuiltin, commonJSRequireESMIntoModuleCodeGenerator, PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly)
 BUN_DEFINE_LAZY_GLOBAL_BUILTIN_GETTER(getLoadEsmIntoCjsBuiltin, commonJSLoadEsmIntoCjsCodeGenerator, PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly)
 BUN_DEFINE_LAZY_GLOBAL_BUILTIN_GETTER(getInternalRequireBuiltin, commonJSInternalRequireCodeGenerator, PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly)
 #undef BUN_DEFINE_LAZY_GLOBAL_BUILTIN_GETTER
@@ -3171,10 +3178,11 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     // i've noticed doing it as is will work somewhat but getDirect() wont be able to find them
 
     putDirectBuiltinFunction(vm, this, builtinNames.createFIFOPrivateName(), fifoCreateFIFOCodeGenerator(vm), PropertyAttribute::Builtin | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-    // These three are CommonJS-only and never reached on an ESM startup path; install
+    // These four are CommonJS-only and never reached on an ESM startup path; install
     // lazy getters so their source isn't parsed during global object construction.
-    // (See getRequireESMBuiltin / getLoadEsmIntoCjsBuiltin / getInternalRequireBuiltin above.)
+    // (See getRequireESMBuiltin / getRequireESMIntoModuleBuiltin / getLoadEsmIntoCjsBuiltin / getInternalRequireBuiltin above.)
     putDirectCustomAccessor(vm, builtinNames.requireESMPrivateName(), JSC::CustomGetterSetter::create(vm, getRequireESMBuiltin, nullptr), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::CustomValue);
+    putDirectCustomAccessor(vm, builtinNames.requireESMIntoModulePrivateName(), JSC::CustomGetterSetter::create(vm, getRequireESMIntoModuleBuiltin, nullptr), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::CustomValue);
     putDirectCustomAccessor(vm, builtinNames.loadEsmIntoCjsPrivateName(), JSC::CustomGetterSetter::create(vm, getLoadEsmIntoCjsBuiltin, nullptr), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::CustomValue);
     putDirectCustomAccessor(vm, builtinNames.internalRequirePrivateName(), JSC::CustomGetterSetter::create(vm, getInternalRequireBuiltin, nullptr), PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | PropertyAttribute::CustomValue);
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -761,8 +761,7 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
-// The entry loadModuleSync() loads. registryEntry() would also match the entry an
-// `import ... with { type }` of the same file registers, which that load does not touch.
+// The entry loadModuleSync() loads; registryEntry() would also match one registered by an import with a type attribute.
 static JSC::ModuleRegistryEntry* javaScriptRegistryEntry(JSC::JSModuleLoader* loader, const JSC::Identifier& key)
 {
     return loader->moduleMap().get({ key.impl(), JSC::ScriptFetchParameters::Type::JavaScript }).get();
@@ -841,8 +840,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
         }
     }
 
-    // Held across the load: the module's top level may `delete require.cache[key]`,
-    // which unlinks the entry from the registry but not from its record.
+    // Held across the load: the module's top level may `delete require.cache[key]`, which only unlinks the entry from the registry.
     JSC::ModuleRegistryEntry* entry = javaScriptRegistryEntry(loader, key);
 
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -761,10 +761,8 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
-// loadModuleSync() without fetch parameters loads the (key, JavaScript) entry.
-// registryEntry() would also match the JSON/HostDefined entry that an
-// `import ... with { type }` of the same file registers, which that load
-// leaves untouched.
+// The entry loadModuleSync() loads. registryEntry() would also match the entry an
+// `import ... with { type }` of the same file registers, which that load does not touch.
 static JSC::ModuleRegistryEntry* javaScriptRegistryEntry(JSC::JSModuleLoader* loader, const JSC::Identifier& key)
 {
     return loader->moduleMap().get({ key.impl(), JSC::ScriptFetchParameters::Type::JavaScript }).get();
@@ -843,17 +841,14 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
         }
     }
 
-    // Hold the entry the load below evaluates instead of looking it up again
-    // afterwards: the module's own top level may `delete require.cache[key]`,
-    // which removes the entry from the registry while its record is still
-    // being evaluated. The entry cell itself keeps pointing at that record.
+    // Held across the load: the module's top level may `delete require.cache[key]`,
+    // which unlinks the entry from the registry but not from its record.
     JSC::ModuleRegistryEntry* entry = javaScriptRegistryEntry(loader, key);
 
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Builtin ES modules and module mocks reach this point before any entry
-    // exists; the load creates it.
+    // Builtin ES modules and module mocks have no entry until the load creates it.
     if (!entry)
         entry = javaScriptRegistryEntry(loader, key);
     JSC::AbstractModuleRecord* record = entry ? entry->record() : nullptr;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -825,10 +825,18 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
 
     auto* loader = globalObject->moduleLoader();
     bool entryExistedBefore = false;
+    // fetchCommonJSModule() already parsed the file into the registry, so the
+    // record to evaluate is normally known now. Keep it rather than re-reading
+    // the registry after the load: the module's top level (or a dependency's)
+    // may `delete require.cache[...]` while it runs, and like a static import
+    // this load still returns the instance it evaluated. The eviction only
+    // affects the next load.
+    JSC::AbstractModuleRecord* record = nullptr;
     if (auto* entry = loader->registryEntry(key)) {
         entryExistedBefore = true;
-        if (isModuleEvaluated(entry->record())) {
-            auto* ns = entry->record()->getModuleNamespace(globalObject, false);
+        record = entry->record();
+        if (isModuleEvaluated(record)) {
+            auto* ns = record->getModuleNamespace(globalObject, false);
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
@@ -836,6 +844,13 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
 
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);
     RETURN_IF_EXCEPTION(scope, {});
+
+    // Builtin ES modules and module mocks arrive without a parsed entry; the
+    // load itself creates it.
+    if (!record) {
+        if (auto* entry = loader->registryEntry(key))
+            record = entry->record();
+    }
 
     switch (promise->status()) {
     case JSPromise::Status::Fulfilled:
@@ -859,12 +874,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
         // it OR any dependency has top-level await, in which case bindings can
         // still be in TDZ and we must throw the "async module" error instead
         // of returning a half-initialized namespace.
-        if (auto* entry = loader->registryEntry(key)) {
-            if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(entry->record())) {
-                auto status = cyclic->status();
-                if ((status == JSC::CyclicModuleRecord::Status::Evaluating || status == JSC::CyclicModuleRecord::Status::Evaluated) && !cyclic->hasTLA() && !cyclic->evaluationError())
-                    break;
-            }
+        if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record)) {
+            auto status = cyclic->status();
+            if ((status == JSC::CyclicModuleRecord::Status::Evaluating || status == JSC::CyclicModuleRecord::Status::Evaluated) && !cyclic->hasTLA() && !cyclic->evaluationError())
+                break;
         }
         // Only drop the entry we created. If the entry already existed (an
         // outer import() is mid-load, or the module is EvaluatingAsync from a
@@ -878,9 +891,8 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     }
 
-    auto* entry = loader->registryEntry(key);
-    if (!entry || !entry->record()) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, makeString("require() failed to evaluate module \""_s, keyString, "\". This is an internal consistentency error."_s));
+    if (!record) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, makeString("require() failed to evaluate module \""_s, keyString, "\". This is an internal consistency error."_s));
 
     // The loadModule promise resolved, so the entire graph linked + evaluated
     // synchronously. We deliberately do NOT gate on CyclicModuleRecord::status()
@@ -891,7 +903,6 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     // the namespace in that state matches the old loader's behaviour and Node's
     // require(esm) cycle semantics. evaluationError() still surfaces a real
     // throw from the module body.
-    auto* record = entry->record();
     if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record)) {
         if (JSValue err = cyclic->evaluationError()) {
             scope.throwException(globalObject, err);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -314,7 +314,7 @@ public:
     JSObject* lazyRequireCacheObject() const { return m_lazyRequireCacheObject.getInitializedOnMainThread(this); }
     Bun::JSCommonJSExtensions* lazyRequireExtensionsObject() const { return m_lazyRequireExtensionsObject.getInitializedOnMainThread(this); }
     JSC::JSFunction* modulePrototypeUnderscoreCompileFunction() const { return m_modulePrototypeUnderscoreCompileFunction.getInitializedOnMainThread(this); }
-    JSC::JSFunction* requireESMFromHijackedExtension() const { return m_commonJSRequireESMFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
+    JSC::JSFunction* requireESMIntoModuleFunction() const { return m_commonJSRequireESMIntoModuleFunction.getInitializedOnMainThread(this); }
 
     Structure* NodeVMGlobalObjectStructure() const { return m_cachedNodeVMGlobalObjectStructure.getInitializedOnMainThread(this); }
     Structure* globalProxyStructure() const { return m_cachedGlobalProxyStructure.getInitializedOnMainThread(this); }
@@ -519,7 +519,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleResolveFilenameFunction)                           \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
-    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMIntoModuleFunction)                \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_nodeModuleConstructor)                                 \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapEntryStructure)                    \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapOriginStructure)                   \

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1169,10 +1169,10 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
             init.set(resolveFilenameFunction);
         });
 
-    globalObject->m_commonJSRequireESMFromHijackedExtensionFunction.initLater(
+    globalObject->m_commonJSRequireESMIntoModuleFunction.initLater(
         [](const Zig::GlobalObject::Initializer<JSFunction>& init) {
-            JSC::JSFunction* requireESM = JSC::JSFunction::create(init.vm, init.owner, commonJSRequireESMFromHijackedExtensionCodeGenerator(init.vm), init.owner);
-            init.set(requireESM);
+            JSC::JSFunction* requireESMIntoModule = JSC::JSFunction::create(init.vm, init.owner, commonJSRequireESMIntoModuleCodeGenerator(init.vm), init.owner);
+            init.set(requireESMIntoModule);
         });
 
     globalObject->m_lazyRequireCacheObject.initLater(

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -161,8 +161,8 @@ describe.concurrent("require(esm) of a module evicted from require.cache during 
     expect(exitCode).toBe(0);
   });
 
-  // A user-wrapped require.extensions loader reaches the ESM namespace through
-  // Module._extensions (requireESMFromHijackedExtension) rather than require().
+  // A user-wrapped require.extensions loader goes through the builtin
+  // Module._extensions loader, which assigns module.exports itself.
   it("sets module.exports when loaded through a wrapped require.extensions loader", async () => {
     using dir = tempDir("require-esm-self-evict-extensions", {
       "self-evict.mjs": selfEvicting,
@@ -178,7 +178,7 @@ describe.concurrent("require(esm) of a module evicted from require.cache during 
         const second = require("./self-evict.mjs");
         console.log(JSON.stringify({
           wrapperCalls,
-          first: { x: first.x, evaluation: first.evaluation },
+          first: { x: first.x, evaluation: first.evaluation, __esModule: first.__esModule },
           cachedAfterFirst,
           second: { x: second.x, evaluation: second.evaluation },
         }));
@@ -188,9 +188,115 @@ describe.concurrent("require(esm) of a module evicted from require.cache during 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
       wrapperCalls: 2,
-      first: { x: 1, evaluation: 1 },
+      first: { x: 1, evaluation: 1, __esModule: true },
       cachedAfterFirst: false,
       second: { x: 1, evaluation: 2 },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // Here the registry entry exists before require() is called but has no
+  // module record yet: an import() graph asked a plugin for the file and the
+  // plugin has not answered. require() has to finish that entry (record created
+  // during the load) and still return it after the module removes the entry.
+  it("returns the namespace when the entry was still being fetched by an import() graph", async () => {
+    using dir = tempDir("require-esm-self-evict-while-fetching", {
+      "side.mjs": selfEvicting,
+      "outer.mjs": /* js */ `
+        export { x as sideX } from "./side.mjs";
+      `,
+      "entry.cjs": /* js */ `
+        const { readFileSync } = require("node:fs");
+        const importAskedForSide = Promise.withResolvers();
+        let releaseImportFetch;
+        Bun.plugin({
+          name: "hold the import() graph's fetch of side.mjs",
+          setup(build) {
+            build.onLoad({ filter: /side\\.mjs$/ }, args => {
+              const source = { contents: readFileSync(args.path, "utf8"), loader: "js" };
+              // Only the first load (the import() graph) is held back; require() gets its source synchronously.
+              if (releaseImportFetch) return source;
+              const { promise, resolve } = Promise.withResolvers();
+              releaseImportFetch = () => resolve(source);
+              importAskedForSide.resolve();
+              return promise;
+            });
+          },
+        });
+
+        (async () => {
+          const outerImport = import("./outer.mjs");
+          await importAskedForSide.promise;
+          releaseImportFetch();
+          // The loader turns the released source into a module record a few
+          // microtasks later; require() on every hop until then covers the hop
+          // on which require() itself has to finish the entry.
+          let required;
+          const errors = [];
+          while (required === undefined && errors.length < 32) {
+            await null;
+            try {
+              required = require("./side.mjs");
+            } catch (error) {
+              errors.push(error.message);
+              if (!error.message.includes("async module")) break;
+            }
+          }
+          const outer = await outerImport;
+          console.log(JSON.stringify({
+            required: required && { x: required.x },
+            outerSideX: outer.sideX,
+            unexpectedErrors: errors.filter(message => !message.includes("async module")),
+          }));
+        })();
+      `,
+    });
+    const { stdout, stderr, exitCode } = await bunRun(path.join(dir, "entry.cjs"));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      required: { x: 1 },
+      outerSideX: 1,
+      unexpectedErrors: [],
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
+// `import "./dep.js" with { type: "js" }` registers dep.js under a separate,
+// attribute-typed registry entry. require() of the same file loads and
+// evaluates the plain entry, and must report that one: not the attribute-typed
+// instance, whose evaluation failed here.
+describe.concurrent("require(esm) of a file that an import with a type attribute already registered", () => {
+  it("returns the instance require() evaluated", async () => {
+    using dir = tempDir("require-esm-attribute-typed-entry", {
+      "dep.js": /* js */ `
+        if (!globalThis.depThrewOnce) {
+          globalThis.depThrewOnce = true;
+          throw new Error("dep.js failed on purpose");
+        }
+        export const v = "second evaluation";
+      `,
+      "graph.mjs": /* js */ `
+        import { v } from "./dep.js" with { type: "js" };
+        export { v };
+      `,
+      "entry.cjs": /* js */ `
+        import("./graph.mjs").then(
+          () => {
+            throw new Error("graph.mjs was expected to fail");
+          },
+          importError => {
+            const required = require("./dep.js");
+            console.log(JSON.stringify({ importError: importError.message, required: required.v }));
+          },
+        );
+      `,
+    });
+    const { stdout, stderr, exitCode } = await bunRun(path.join(dir, "entry.cjs"));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      importError: "dep.js failed on purpose",
+      required: "second evaluation",
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -1,4 +1,4 @@
-import { bunRun, tempDirWithFiles } from "harness";
+import { bunRun, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 const fixture = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", "require", ...segs);
@@ -81,5 +81,117 @@ describe("require(specifier)", () => {
       });
       expect(main.filename).toContain(main.path);
     });
+  });
+});
+
+// The ESM registry entry is removed while the module's own top level is still
+// running. require() must still return the namespace of the instance it just
+// evaluated; the eviction applies to the next require(), which evaluates the
+// file again.
+describe.concurrent("require(esm) of a module evicted from require.cache during its own evaluation", () => {
+  const selfEvicting = /* js */ `
+    globalThis.evaluations = (globalThis.evaluations ?? 0) + 1;
+    delete require.cache[import.meta.path];
+    export const x = 1;
+    export const evaluation = globalThis.evaluations;
+  `;
+
+  it("returns the namespace when the module deletes itself from require.cache", async () => {
+    using dir = tempDir("require-esm-self-evict", {
+      "self-evict.mjs": selfEvicting,
+      "entry.cjs": /* js */ `
+        const first = require("./self-evict.mjs");
+        const cachedAfterFirst = require.resolve("./self-evict.mjs") in require.cache;
+        const second = require("./self-evict.mjs");
+        console.log(JSON.stringify({
+          first: { x: first.x, evaluation: first.evaluation },
+          cachedAfterFirst,
+          second: { x: second.x, evaluation: second.evaluation },
+          sameNamespace: first === second,
+        }));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await bunRun(path.join(dir, "entry.cjs"));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      first: { x: 1, evaluation: 1 },
+      cachedAfterFirst: false,
+      second: { x: 1, evaluation: 2 },
+      sameNamespace: false,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("returns the namespace when a dependency clears require.cache", async () => {
+    using dir = tempDir("require-esm-dep-clears-cache", {
+      "clear-cache.mjs": /* js */ `
+        for (const key of Object.keys(require.cache)) delete require.cache[key];
+        export const cleared = true;
+      `,
+      "leaf.mjs": /* js */ `
+        export const leaf = "leaf";
+      `,
+      "root.mjs": /* js */ `
+        import { cleared } from "./clear-cache.mjs";
+        export * from "./leaf.mjs";
+        export { cleared };
+        globalThis.evaluations = (globalThis.evaluations ?? 0) + 1;
+        export const evaluation = globalThis.evaluations;
+      `,
+      "entry.cjs": /* js */ `
+        const first = require("./root.mjs");
+        const cachedAfterFirst = require.resolve("./root.mjs") in require.cache;
+        const second = require("./root.mjs");
+        console.log(JSON.stringify({
+          first: { cleared: first.cleared, leaf: first.leaf, evaluation: first.evaluation },
+          cachedAfterFirst,
+          second: { cleared: second.cleared, leaf: second.leaf, evaluation: second.evaluation },
+          sameNamespace: first === second,
+        }));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await bunRun(path.join(dir, "entry.cjs"));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      first: { cleared: true, leaf: "leaf", evaluation: 1 },
+      cachedAfterFirst: false,
+      second: { cleared: true, leaf: "leaf", evaluation: 2 },
+      sameNamespace: false,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // A user-wrapped require.extensions loader reaches the ESM namespace through
+  // Module._extensions (requireESMFromHijackedExtension) rather than require().
+  it("sets module.exports when loaded through a wrapped require.extensions loader", async () => {
+    using dir = tempDir("require-esm-self-evict-extensions", {
+      "self-evict.mjs": selfEvicting,
+      "entry.cjs": /* js */ `
+        const builtinLoader = require.extensions[".mjs"];
+        let wrapperCalls = 0;
+        require.extensions[".mjs"] = function (module, filename) {
+          wrapperCalls++;
+          builtinLoader(module, filename);
+        };
+        const first = require("./self-evict.mjs");
+        const cachedAfterFirst = require.resolve("./self-evict.mjs") in require.cache;
+        const second = require("./self-evict.mjs");
+        console.log(JSON.stringify({
+          wrapperCalls,
+          first: { x: first.x, evaluation: first.evaluation },
+          cachedAfterFirst,
+          second: { x: second.x, evaluation: second.evaluation },
+        }));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await bunRun(path.join(dir, "entry.cjs"));
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      wrapperCalls: 2,
+      first: { x: 1, evaluation: 1 },
+      cachedAfterFirst: false,
+      second: { x: 1, evaluation: 2 },
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `require()` of an ES module that removes itself from `require.cache` while its top level is still running (directly, or through a dependency that clears the cache) throws instead of returning the namespace:
  `TypeError: require() failed to evaluate module "/abs/self-evict.mjs". This is an internal consistentency error.`
- Static `import` and `import()` of the same file work; only the require() path is affected. Reproduces on the released 1.4.x binaries and on main.
- Cause, two stale lookups after evaluation:
  - `functionEsmLoadSync` (`src/jsc/bindings/ZigGlobalObject.cpp`, the `registryEntry(key)` after the `loadModuleSync()` switch) re-reads the registry to find the record it just evaluated. The eviction removed the entry during evaluation, so it falls into the internal-error branch.
  - `overridableRequire` and `requireESMFromHijackedExtension` (`src/js/builtins/CommonJS.ts`) discard what `$requireESM` returns and call `$esmNamespaceForCjs(id)` again. With the entry gone that is `undefined`, and require() would return the empty placeholder `module.exports` (`{}`); that is what the tests get when only the C++ half is applied.
- Reported by @alii while reviewing #35453 (`jest.resetModules()` called at the top level of a module that is itself being require()d hits the same path), to be handled separately from that PR.

### Fix
- `functionEsmLoadSync`: read the record off the registry entry before calling `loadModuleSync()` and use that record afterwards (Pending/SCC check, `evaluationError()` check, namespace). The post-load registry lookup is kept only for the case where no entry existed before the call (builtin ES modules, module mocks), because there the load itself creates the entry.
- `overridableRequire` / `requireESMFromHijackedExtension`: use the namespace `$requireESM` returns. `$requireESM` returns a namespace or throws, so the `namespace !== undefined` fallthrough (which returned `{}`) is removed.
- Why the held record is the right one: require() only reaches `functionEsmLoadSync` after `fetchCommonJSModule()` parsed the file into the registry, and `loadModuleSync()` links and evaluates the record stored in that entry. An entry's record is written in only two places in JSC (`ModuleRegistryEntry::fetchComplete`, which runs once when the entry goes Fetching -> Fetched, and `moduleLoadStep`'s `setRecord`, which stores the value the same entry's module promise resolved with, i.e. that same record), so an entry that already has a record never switches to a different one, and the record read before the load is the instance whose top level ran. Its namespace does not depend on the registry either: export resolution, including `export *`, walks each record's own loaded-modules map.
- Resulting behavior matches what a static import of the same file already did: the caller gets the instance that was just evaluated, and the eviction applies to the next require(), which evaluates the file again (asserted by the tests: the second require() sees evaluation 2 and a different namespace object). Node also returns the namespace here (its `require.cache` has no ESM entries, so the delete is a no-op there).
- Unchanged: the already-evaluated fast path, the TLA/Pending handling (when an entry pre-exists the held record is the one the registry had), and the `require.cache` proxy, which still answers from the registry via `$esmNamespaceForCjs`.
- Both messages now spell "consistency" correctly.
- Verified with `bun bd test test/js/bun/resolve/require.test.ts`: 3 new tests (module deletes itself; a dependency clears the whole cache while the root is mid-load, with an `export *` resolved after the eviction; the `require.extensions` wrapper path). All 3 fail on the released binary with the TypeError above, fail with `{}` exports when only the C++ change is applied, and fail with the TypeError when only the JS change is applied.
- Also ran: the rest of `test/js/bun/resolve` (the `require-esm-*`, `esModule*` files included), `test/regression/issue/24387.test.ts`, `test/js/node/module/require-extensions.test.ts`, `node-module-module.test.js`, `test/js/bun/test/mock/mock-module*.test.ts`, `test/cli/run/require-cache.test.ts`. The only failures were timeouts of the RSS leak loops and the 2000x `import()` loops under the debug+ASAN build, on fixtures that never enter the require(esm) path, plus two `enableCompileCache` ownership tests that also fail on the released binary when run as root.

### Background
- ESM registry: JSC's `JSModuleLoader` maps a resolved path to a `ModuleRegistryEntry`, which holds the module record (the parsed module: its bindings, environment, and the records it imports). `delete require.cache[key]` for an ESM key calls `$esmRegistryDelete`, which removes the entry. The record itself stays alive while something references it, here the C++ local and then the namespace object handed back to the caller.
- require(esm) flow: `overridableRequire` (CommonJS.ts) calls the native `$require`; `fetchCommonJSModule` transpiles the file, sees it is ESM, stores the source in the registry (which parses it into a record) and returns -1; `overridableRequire` then calls `$requireESM`, which tries `$esmNamespaceForCjs` (registry lookup, undefined unless already evaluated) and otherwise `functionEsmLoadSync`, whose `loadModuleSync()` (a Bun addition to JSC that drains the loader's promise reactions synchronously) links and evaluates the graph. The module's top level runs inside that call, which is when the eviction happens.
- Module namespace object: built from a record by `getModuleNamespace()`. Resolving its exports, including `export *` re-exports, uses the loaded-modules map each record filled in while its graph was loading, not the registry.
- `requireESMFromHijackedExtension`: the variant used when user code installs a function in `require.extensions` that calls the builtin loader (`Module._extensions['.js']`); it assigns the namespace to `module.exports` itself, so it had the same second lookup.
