### PR TITLE
repl: handle Ctrl+C at the prompt on Windows instead of exiting

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -944,17 +944,39 @@ impl<'a> Repl<'a> {
         }
         #[cfg(windows)]
         {
+            // With ENABLE_PROCESSED_INPUT the console turns Ctrl+C into a
+            // CTRL_C_EVENT, whose default handler exits the process, instead of
+            // the 0x03 byte that read_key maps to Key::CtrlC. libuv's raw mode
+            // (setRawMode, which node's REPL uses) leaves it off as well;
+            // processed_input_while_evaluating() turns it back on while
+            // JavaScript runs.
             self.original_windows_mode = bun_sys::windows::update_stdio_mode_flags(
                 bun_sys::Stdio::StdIn,
                 bun_sys::windows::UpdateStdioModeFlagsOpts {
-                    set: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT
-                        | bun_sys::windows::ENABLE_PROCESSED_INPUT,
+                    set: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
                     unset: bun_sys::windows::ENABLE_LINE_INPUT
-                        | bun_sys::windows::ENABLE_ECHO_INPUT,
+                        | bun_sys::windows::ENABLE_ECHO_INPUT
+                        | bun_sys::windows::ENABLE_PROCESSED_INPUT,
                 },
             )
             .ok();
         }
+    }
+
+    /// Nothing reads stdin while JavaScript runs, so a Ctrl+C typed during an
+    /// evaluation would sit in the console input buffer until the next prompt.
+    /// With ENABLE_PROCESSED_INPUT back on it raises CTRL_C_EVENT instead and
+    /// ends the process, which is the only way out of a hung evaluation. The
+    /// guard restores the line editor's mode on drop. `None` when
+    /// setup_terminal() left the console alone (stdin or stdout is not a tty).
+    #[cfg(windows)]
+    fn processed_input_while_evaluating(&self) -> Option<bun_sys::windows::StdinModeGuard> {
+        self.original_windows_mode.is_some().then(|| {
+            bun_sys::windows::StdinModeGuard::set(bun_sys::windows::UpdateStdioModeFlagsOpts {
+                set: bun_sys::windows::ENABLE_PROCESSED_INPUT,
+                ..Default::default()
+            })
+        })
     }
 
     fn restore_terminal(&mut self) {
@@ -1001,7 +1023,8 @@ impl<'a> Repl<'a> {
                 bun_sys::posix::sigaction(libc::SIGINT, &raw const act, core::ptr::null_mut());
             }
         }
-        // On Windows, ENABLE_PROCESSED_INPUT is already set so Ctrl+C works
+        // On Windows, processed_input_while_evaluating() already has Ctrl+C
+        // raising CTRL_C_EVENT for the whole evaluation, this wait included.
     }
 
     /// Restore raw terminal mode after promise wait
@@ -1293,6 +1316,8 @@ impl<'a> Repl<'a> {
         let Some(vm) = self.vm else {
             return;
         };
+        #[cfg(windows)]
+        let _processed_input = self.processed_input_while_evaluating();
 
         // Transform the code using REPL mode (hoists declarations, wraps result in { value: expr })
         let Some(transformed_code) = self.transform_for_repl(code) else {
@@ -1607,6 +1632,8 @@ impl<'a> Repl<'a> {
         let Some(vm) = self.vm else {
             return;
         };
+        #[cfg(windows)]
+        let _processed_input = self.processed_input_while_evaluating();
 
         let Some(transformed_code) = self.transform_for_repl(code) else {
             self.evaluate_raw(code);

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -944,12 +944,8 @@ impl<'a> Repl<'a> {
         }
         #[cfg(windows)]
         {
-            // With ENABLE_PROCESSED_INPUT the console turns Ctrl+C into a
-            // CTRL_C_EVENT, whose default handler exits the process, instead of
-            // the 0x03 byte that read_key maps to Key::CtrlC. libuv's raw mode
-            // (setRawMode, which node's REPL uses) leaves it off as well;
-            // processed_input_while_evaluating() turns it back on while
-            // JavaScript runs.
+            // ENABLE_PROCESSED_INPUT would turn Ctrl+C into a CTRL_C_EVENT (which
+            // exits the process) instead of the 0x03 byte behind Key::CtrlC.
             self.original_windows_mode = bun_sys::windows::update_stdio_mode_flags(
                 bun_sys::Stdio::StdIn,
                 bun_sys::windows::UpdateStdioModeFlagsOpts {
@@ -963,12 +959,9 @@ impl<'a> Repl<'a> {
         }
     }
 
-    /// Nothing reads stdin while JavaScript runs, so a Ctrl+C typed during an
-    /// evaluation would sit in the console input buffer until the next prompt.
-    /// With ENABLE_PROCESSED_INPUT back on it raises CTRL_C_EVENT instead and
-    /// ends the process, which is the only way out of a hung evaluation. The
-    /// guard restores the line editor's mode on drop. `None` when
-    /// setup_terminal() left the console alone (stdin or stdout is not a tty).
+    /// Nothing reads stdin while JavaScript runs, so Ctrl+C has to raise
+    /// CTRL_C_EVENT (ending the process) to get out of a hung evaluation.
+    /// Dropping the guard restores the line editor's mode.
     #[cfg(windows)]
     fn processed_input_while_evaluating(&self) -> Option<bun_sys::windows::StdinModeGuard> {
         self.original_windows_mode.is_some().then(|| {
@@ -1023,8 +1016,7 @@ impl<'a> Repl<'a> {
                 bun_sys::posix::sigaction(libc::SIGINT, &raw const act, core::ptr::null_mut());
             }
         }
-        // On Windows, processed_input_while_evaluating() already has Ctrl+C
-        // raising CTRL_C_EVENT for the whole evaluation, this wait included.
+        // Windows: covered by processed_input_while_evaluating().
     }
 
     /// Restore raw terminal mode after promise wait

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1225,6 +1225,19 @@ describe("Bun REPL (Terminal) Ctrl+C", () => {
     });
   });
 
+  test("input typed while an evaluation is running is evaluated afterwards", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      // The first line reports that it is running, then keeps the REPL away
+      // from stdin long enough for the second line to be queued by the
+      // terminal (on Windows: while the evaluation-time console mode is set).
+      send('console.log("BU" + "SY"); for (const t = Date.now(); Date.now() - t < 200; ); "first" + "-done"\n');
+      await waitFor("BUSY");
+      send('"second" + "-done"\n');
+      await waitFor('"second-done"');
+      expect(allOutput()).toMatch(/"first-done"[\s\S]*"second-done"/);
+    });
+  });
+
   // The REPL does not read stdin while JavaScript runs, so a Ctrl+C typed then
   // would sit in the console input buffer until the next prompt. On Windows the
   // REPL sets ENABLE_PROCESSED_INPUT for the duration of an evaluation, so
@@ -1232,7 +1245,7 @@ describe("Bun REPL (Terminal) Ctrl+C", () => {
   // The flag is observed from inside the evaluation rather than by sending
   // Ctrl+C during one: CI job trees run with Ctrl+C ignored (an inherited
   // per-process flag), and a process that ignores Ctrl+C never sees the event.
-  test.skipIf(!isWindows)("evaluation runs with ENABLE_PROCESSED_INPUT set, the prompt without", async () => {
+  test.skipIf(!isWindows)("evaluations run with ENABLE_PROCESSED_INPUT set, the prompt without", async () => {
     const ENABLE_PROCESSED_INPUT = 0x1;
     using dir = tempDir("repl-console-mode", {
       "mode.js": `
@@ -1241,17 +1254,30 @@ describe("Bun REPL (Terminal) Ctrl+C", () => {
           GetStdHandle: { args: ["i32"], returns: "ptr" },
           GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
         });
-        const mode = new Uint32Array(1);
-        const STD_INPUT_HANDLE = -10;
-        kernel32.symbols.GetConsoleMode(kernel32.symbols.GetStdHandle(STD_INPUT_HANDLE), ffi.ptr(mode));
-        "conmode=" + mode[0].toString(16);
+        function stdinMode() {
+          const mode = new Uint32Array(1);
+          const STD_INPUT_HANDLE = -10;
+          kernel32.symbols.GetConsoleMode(kernel32.symbols.GetStdHandle(STD_INPUT_HANDLE), ffi.ptr(mode));
+          return mode[0].toString(16);
+        }
+        "loadmode=" + stdinMode();
       `,
     });
+    const modeIn = (output: string, label: string) =>
+      parseInt(output.match(new RegExp(`${label}=([0-9a-f]+)`))![1], 16);
     await withTerminalRepl(async ({ send, waitFor }) => {
+      // Each wait also requires the prompt that follows the output: the REPL
+      // prints it only after the evaluation (and the mode guard) is gone, so
+      // the Ctrl+C below is sent once the line editor's mode is back.
+      // `.load` evaluates through evaluate_and_print, `.copy <code>` through
+      // evaluate_and_copy; the typed `.copy` line echoes `copymode="`, which
+      // the patterns' hex digits exclude.
       send(`.load ${path.join(String(dir), "mode.js")}\n`);
-      const output = await waitFor(/conmode=[0-9a-f]+/);
-      const mode = parseInt(output.match(/conmode=([0-9a-f]+)/)![1], 16);
-      expect(mode & ENABLE_PROCESSED_INPUT).toBe(ENABLE_PROCESSED_INPUT);
+      const loaded = await waitFor(/loadmode=[0-9a-f]+[\s\S]*>/);
+      expect(modeIn(loaded, "loadmode") & ENABLE_PROCESSED_INPUT).toBe(ENABLE_PROCESSED_INPUT);
+      send('.copy console.log("copymode=" + stdinMode())\n');
+      const copied = await waitFor(/copymode=[0-9a-f]+[\s\S]*>/);
+      expect(modeIn(copied, "copymode") & ENABLE_PROCESSED_INPUT).toBe(ENABLE_PROCESSED_INPUT);
       // Back at the prompt the flag is off again, so Ctrl+C arrives as a key.
       send("\x03");
       await waitFor("press Ctrl+C again to exit");

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -78,31 +78,35 @@ async function withTerminalRepl(
   const waitFor = async (pattern: string | RegExp, timeoutMs = 5000): Promise<string> => {
     const deadline = Date.now() + timeoutMs;
     while (true) {
-      const all = received.join("");
+      // Match on text only: ConPTY re-renders the REPL's output from its screen
+      // buffer (the trailing space of the "> " prompt comes back as an erase
+      // sequence, for instance), so the escape sequences are not the REPL's own.
+      const all = stripAnsi(received.join(""));
       const recent = all.slice(cursor);
       const matched = typeof pattern === "string" ? recent.includes(pattern) : pattern.test(recent);
       if (matched) {
         cursor = all.length;
         return recent;
       }
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) {
+      if (proc.exitCode !== null || proc.signalCode !== null) {
         throw new Error(
-          `Timed out waiting for pattern: ${pattern}\nReceived so far:\n${stripAnsi(received.join("").slice(cursor))}`,
+          `REPL exited (code ${proc.exitCode}, signal ${proc.signalCode}) before printing ${pattern}\nReceived so far:\n${recent}`,
         );
       }
-      // Wait for the next chunk of terminal data (or time out).
-
-      await new Promise<void>(resolve => {
-        resolveWaiter = resolve;
-      });
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for pattern: ${pattern}\nReceived so far:\n${recent}`);
+      }
+      // Wait for the next chunk of terminal data, or for the REPL to exit.
+      const { promise, resolve } = Promise.withResolvers<void>();
+      resolveWaiter = resolve;
+      await Promise.race([promise, proc.exited]);
       resolveWaiter = null;
     }
   };
 
   const allOutput = () => stripAnsi(received.join(""));
 
-  await waitFor(/\u276f|> /); // Wait for prompt
+  await waitFor(/\u276f|>/); // Wait for prompt
 
   await fn({ terminal, proc, send, waitFor, allOutput });
 
@@ -973,18 +977,6 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
     });
   });
 
-  test("Ctrl+C cancels current input", async () => {
-    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
-      send("some partial input");
-      await waitFor("some partial input");
-      send("\x03"); // Ctrl+C
-      await waitFor(/\u276f|> /);
-      // Should be back at a clean prompt
-      send("1 + 1\n");
-      await waitFor("2");
-    });
-  });
-
   test("Ctrl+D exits on empty line", async () => {
     await withTerminalRepl(async ({ terminal, proc }) => {
       terminal.write("\x04"); // Ctrl+D
@@ -1189,6 +1181,64 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       terminal.write(new Uint8Array([0xc2, 0x62])); // stray lead + 'b'
       send('".length\n');
       await waitFor(/\n\s*2\b/);
+    });
+  });
+});
+
+// Ctrl+C is a keystroke (0x03) the line editor handles itself. These run on
+// Windows too: the REPL used to leave ENABLE_PROCESSED_INPUT set on the console
+// while line editing, so conhost turned Ctrl+C into a CTRL_C_EVENT and the
+// process exited with STATUS_CONTROL_C_EXIT instead of reaching handle_ctrl_c.
+describe("Bun REPL (Terminal) Ctrl+C", () => {
+  test("Ctrl+C with pending input clears the line", async () => {
+    await withTerminalRepl(async ({ send, waitFor, proc }) => {
+      send("some partial input");
+      await waitFor("some partial input");
+      send("\x03");
+      await waitFor("^C");
+      // The next evaluation must not see the cancelled text. The operands are
+      // split so the echoed input does not contain the expected result.
+      send('"still" + "-alive"\n');
+      await waitFor('"still-alive"');
+      expect(proc.exitCode).toBeNull();
+    });
+  });
+
+  test("Ctrl+C on an empty line shows the exit hint; a second one exits", async () => {
+    await withTerminalRepl(async ({ send, waitFor, proc }) => {
+      send("\x03");
+      await waitFor("press Ctrl+C again to exit");
+      expect(proc.exitCode).toBeNull();
+      send("\x03");
+      expect(await proc.exited).toBe(0);
+    });
+  });
+
+  test("Ctrl+C while a multiline input is pending discards it", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      send("function __abandoned() {\n");
+      await waitFor("...");
+      send("\x03");
+      // Evaluates as a fresh line only if Ctrl+C dropped the open function body.
+      send('typeof __abandoned + "-" + "checked"\n');
+      await waitFor('"undefined-checked"');
+    });
+  });
+
+  // The REPL does not read stdin while JavaScript runs, so a Ctrl+C typed then
+  // would sit in the console input buffer until the next prompt. On Windows the
+  // REPL turns ENABLE_PROCESSED_INPUT back on for the duration of an evaluation,
+  // so conhost raises CTRL_C_EVENT and the process ends instead of hanging.
+  // (POSIX re-enables ISIG only around the promise wait and interrupts the wait
+  // rather than exiting, so this assertion is Windows-specific.)
+  test.skipIf(!isWindows)("Ctrl+C during an evaluation still ends the process", async () => {
+    await withTerminalRepl(async ({ send, waitFor, proc }) => {
+      // The marker is printed from inside the evaluation; it is split so the
+      // echoed input does not match it.
+      send('console.log("EVAL" + "UATING"); await new Promise(() => {})\n');
+      await waitFor("EVALUATING");
+      send("\x03");
+      expect(await proc.exited).not.toBe(0);
     });
   });
 });

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1227,18 +1227,34 @@ describe("Bun REPL (Terminal) Ctrl+C", () => {
 
   // The REPL does not read stdin while JavaScript runs, so a Ctrl+C typed then
   // would sit in the console input buffer until the next prompt. On Windows the
-  // REPL turns ENABLE_PROCESSED_INPUT back on for the duration of an evaluation,
-  // so conhost raises CTRL_C_EVENT and the process ends instead of hanging.
-  // (POSIX re-enables ISIG only around the promise wait and interrupts the wait
-  // rather than exiting, so this assertion is Windows-specific.)
-  test.skipIf(!isWindows)("Ctrl+C during an evaluation still ends the process", async () => {
-    await withTerminalRepl(async ({ send, waitFor, proc }) => {
-      // The marker is printed from inside the evaluation; it is split so the
-      // echoed input does not match it.
-      send('console.log("EVAL" + "UATING"); await new Promise(() => {})\n');
-      await waitFor("EVALUATING");
+  // REPL sets ENABLE_PROCESSED_INPUT for the duration of an evaluation, so
+  // conhost raises CTRL_C_EVENT instead, and clears it again for the prompt.
+  // The flag is observed from inside the evaluation rather than by sending
+  // Ctrl+C during one: CI job trees run with Ctrl+C ignored (an inherited
+  // per-process flag), and a process that ignores Ctrl+C never sees the event.
+  test.skipIf(!isWindows)("evaluation runs with ENABLE_PROCESSED_INPUT set, the prompt without", async () => {
+    const ENABLE_PROCESSED_INPUT = 0x1;
+    using dir = tempDir("repl-console-mode", {
+      "mode.js": `
+        const ffi = require("bun:ffi");
+        const kernel32 = ffi.dlopen("kernel32.dll", {
+          GetStdHandle: { args: ["i32"], returns: "ptr" },
+          GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
+        });
+        const mode = new Uint32Array(1);
+        const STD_INPUT_HANDLE = -10;
+        kernel32.symbols.GetConsoleMode(kernel32.symbols.GetStdHandle(STD_INPUT_HANDLE), ffi.ptr(mode));
+        "conmode=" + mode[0].toString(16);
+      `,
+    });
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      send(`.load ${path.join(String(dir), "mode.js")}\n`);
+      const output = await waitFor(/conmode=[0-9a-f]+/);
+      const mode = parseInt(output.match(/conmode=([0-9a-f]+)/)![1], 16);
+      expect(mode & ENABLE_PROCESSED_INPUT).toBe(ENABLE_PROCESSED_INPUT);
+      // Back at the prompt the flag is off again, so Ctrl+C arrives as a key.
       send("\x03");
-      expect(await proc.exited).not.toBe(0);
+      await waitFor("press Ctrl+C again to exit");
     });
   });
 });


### PR DESCRIPTION
### Problem
- On Windows, pressing Ctrl+C in `bun repl` while sitting at the prompt ends the process with `STATUS_CONTROL_C_EXIT` (0xC000013A). On POSIX the same keystroke clears the line, or prints `(press Ctrl+C again to exit, or Ctrl+D)` on an empty line.
- Cause: `setup_terminal()` in `src/runtime/cli/repl.rs` sets `ENABLE_PROCESSED_INPUT` on the console input mode. With that flag conhost consumes Ctrl+C and raises a `CTRL_C_EVENT` instead of queueing the `0x03` byte, so `read_key()` never produces `Key::CtrlC` and `handle_ctrl_c()` is dead code on Windows. The REPL installs no console control handler, so the default one exits the process.
- This is the "ctrl+c just quits bun repl" half of #27558. The other half, breaking out of a running `while (1) {}`, is #33411 and is not changed here, so this PR does not close that issue.
- The flag combination was copied from the `bun init` / `bun update -i` prompts, where exiting on Ctrl+C is the intended behaviour (`init_command.rs` says so in a comment). The REPL wants the keystroke.

### Fix
- `setup_terminal()` clears `ENABLE_PROCESSED_INPUT` together with line input and echo, so Ctrl+C arrives as `0x03` and goes through the existing `Key::CtrlC` path, the same path POSIX raw mode (no `ISIG`) uses. This is also what libuv's raw mode does on Windows (`uv_tty_set_mode` only puts `ENABLE_PROCESSED_INPUT` in the normal mode word), so node's REPL and `process.stdin.setRawMode(true)` already run with it off.
- `evaluate_and_print()` and `evaluate_and_copy()` hold a `StdinModeGuard` that sets the flag back for the duration of the evaluation (`evaluate_raw` is only reached from inside these two). Nothing reads stdin while JavaScript runs, so a Ctrl+C typed then would otherwise sit in the input buffer until the next prompt; with the flag set it still raises `CTRL_C_EVENT` and ends the process, which is what happens today and is the only way out of a hung evaluation on Windows. The guard restores the line editor's mode on every return path, and is skipped when `setup_terminal()` did not touch the console (stdin or stdout not a tty), so piped `bun repl` is unchanged.
- POSIX code is untouched; the SIGINT handling around the promise wait is the same as before. #33411 (interrupting a running evaluation) builds on `CTRL_C_EVENT` being raised during evaluation, which this change keeps.
- Tests: `test/js/bun/repl/repl.test.ts`, new `Bun REPL (Terminal) Ctrl+C` block that runs on Windows too (the existing terminal block is still `todoIf(isWindows)`). Ctrl+C with pending input, on an empty line (hint, then exit 0 on the second press), and with a multiline input pending, which fail on an unfixed bun on both Windows configurations. A Windows-only test reads stdin's console mode through `bun:ffi` from inside an evaluation, once via `.load` (`evaluate_and_print`) and once via `.copy <code>` (`evaluate_and_copy`), asserting `ENABLE_PROCESSED_INPUT` is set each time; removing only the `evaluate_and_copy` guard makes its second assertion fail. Each of those waits also requires the prompt printed after the evaluation, which the REPL writes only after the guard has been dropped, and the test then sends Ctrl+C and expects the hint (the mode was restored; this step fails on an unfixed bun). A cross-platform test types a second line while the first is still evaluating and expects both results: input queued while the evaluation-time mode is in effect is delivered (`SetConsoleMode` does not discard queued input). The `withTerminalRepl` helper now matches on ANSI-stripped output, because ConPTY re-renders the REPL's output (the trailing space of `> ` comes back as an erase sequence), and fails immediately with the exit code when the REPL exits while a test is waiting for output.
- The evaluation test observes the mode flag instead of sending Ctrl+C during an evaluation: CI job trees run with Ctrl+C ignored (the per-process flag set by `CREATE_NEW_PROCESS_GROUP` / `SetConsoleCtrlHandler(NULL, TRUE)` is inherited by children), and a process that ignores Ctrl+C never receives `CTRL_C_EVENT`, so a test expecting the REPL to die during an evaluation hangs there. Reproduced locally by setting that flag in the process that runs `bun test`: the keystroke tests are unaffected, a kill-based test hangs, the mode-based test passes.
- Verified on Windows Server 2019 x64 (build 17763) and Windows 11 24H2 arm64 (build 26100), the two Windows CI configurations: with `USE_SYSTEM_BUN=1` (bun 1.4.0) the four Ctrl+C tests fail with `REPL exited (code 58, signal null) before printing ...` (58 is the low byte of 0xC000013A) and the type-ahead test passes; with the debug build all five pass, both normally and with Ctrl+C ignored in the test runner as in CI, across repeated runs. The full file passes on Windows x64 and Linux; CI on the previous revision was green on both Windows lanes.

### Background
- Windows console input mode: every console input buffer has a flag word set with `SetConsoleMode`. `ENABLE_LINE_INPUT` / `ENABLE_ECHO_INPUT` are the equivalent of termios `ICANON` / `ECHO`; `ENABLE_PROCESSED_INPUT` is the equivalent of `ISIG`: while set, Ctrl+C is not delivered as input but turned into a `CTRL_C_EVENT`. `ENABLE_VIRTUAL_TERMINAL_INPUT` makes arrow keys and friends arrive as escape sequences, which is how the REPL decodes them.
- `CTRL_C_EVENT`: conhost runs the process's console control handlers (`SetConsoleCtrlHandler`) on a new thread; if none claims the event, the default handler calls `ExitProcess(STATUS_CONTROL_C_EXIT)`. The mode flag only affects keyboard Ctrl+C; `GenerateConsoleCtrlEvent` from another process still ends the REPL, just as `kill -INT` ends it on POSIX.
- `bun_sys::windows::StdinModeGuard`: existing RAII helper that applies a set/unset pair to stdin's console mode and restores the previous mode on drop; inert when stdin is not a console. Already used by `prompt()`, `bun init` and `bun update -i`.
- Bun.Terminal on Windows is a ConPTY. Writing `\x03` to it goes through conhost's input path, so it is converted to `CTRL_C_EVENT` or delivered as a byte depending on the client's mode, exactly like a keypress; the unfixed REPL dies under it on both Windows versions above, which is what makes the tests fail before the fix.

<details>
<summary>Test runs</summary>

Windows Server 2019 x64, `USE_SYSTEM_BUN=1 bun test test/js/bun/repl/repl.test.ts -t "Terminal\) Ctrl"` (bun 1.4.0):

```
error: REPL exited (code 58, signal null) before printing ^C
(fail) Bun REPL (Terminal) Ctrl+C > Ctrl+C with pending input clears the line [41.89ms]
error: REPL exited (code 58, signal null) before printing press Ctrl+C again to exit
(fail) Bun REPL (Terminal) Ctrl+C > Ctrl+C on an empty line shows the exit hint; a second one exits [31.06ms]
error: REPL exited (code 58, signal null) before printing "undefined-checked"
(fail) Bun REPL (Terminal) Ctrl+C > Ctrl+C while a multiline input is pending discards it [45.53ms]
(pass) Bun REPL (Terminal) Ctrl+C > input typed while an evaluation is running is evaluated afterwards [267.10ms]
error: REPL exited (code 58, signal null) before printing press Ctrl+C again to exit
(fail) Bun REPL (Terminal) Ctrl+C > evaluations run with ENABLE_PROCESSED_INPUT set, the prompt without [76.85ms]
 1 pass
 4 fail
```

Same machine, debug build with this change, run from a parent that called `SetConsoleCtrlHandler(NULL, TRUE)` first (what a CI job tree looks like; the plain run is identical):

```
(pass) Bun REPL (Terminal) Ctrl+C > Ctrl+C with pending input clears the line [272.51ms]
(pass) Bun REPL (Terminal) Ctrl+C > Ctrl+C on an empty line shows the exit hint; a second one exits [231.80ms]
(pass) Bun REPL (Terminal) Ctrl+C > Ctrl+C while a multiline input is pending discards it [251.23ms]
(pass) Bun REPL (Terminal) Ctrl+C > input typed while an evaluation is running is evaluated afterwards [460.30ms]
(pass) Bun REPL (Terminal) Ctrl+C > evaluations run with ENABLE_PROCESSED_INPUT set, the prompt without [306.83ms]
 5 pass
 0 fail
```

Same machine, debug build with the `evaluate_and_copy` guard deleted (everything else unchanged): the mode test fails at its `.copy` assertion (`Expected: 1, Received: 0`), the `.load` assertion before it passes.

Windows 11 24H2 arm64: identical results in all configurations. Repeated runs of the whole block with the debug build under the Ctrl+C-ignored parent: 5/5 on Server 2019, 3/3 on Windows 11.

Full file: Windows x64 debug build 129 pass / 2 skip / 20 todo / 0 fail (previous revision); Linux debug build 150 pass / 1 skip / 0 fail (previous revision), the block itself re-run on Linux after the last change. `cargo fmt --check` and prettier clean. The `cfg(windows)` code was compiled by the x64 and arm64 Windows builds, the `cfg(unix)` side by the Linux build.

The exit code 58 in the messages above is Bun truncating the child's 32-bit status to one byte on Windows (node reports 3221225786); reported separately.
</details>

