### PR TITLE
error: give errors created with no JS frames a .stack property

### DIFF
--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -4,6 +4,7 @@
 
 #include "BunClientData.h"
 #include "ErrorStackFrame.h"
+#include "FormatStackTraceForJS.h"
 
 #include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/ErrorInstance.h>
@@ -166,13 +167,16 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
         return;
 
     size_t limit = globalObject->stackTraceLimit().value_or(10);
-    if (!limit)
-        return;
+    if (limit) {
+        WTF::Vector<JSC::StackFrame> frames;
+        collectAsyncStackFramesFromPromise(vm, instance, promise, frames, limit);
+        if (!frames.isEmpty()) {
+            instance->setStackFrames(vm, WTF::move(frames));
+            return;
+        }
+    }
 
-    WTF::Vector<JSC::StackFrame> frames;
-    collectAsyncStackFramesFromPromise(vm, instance, promise, frames, limit);
-    if (frames.isEmpty())
-        return;
-
-    instance->setStackFrames(vm, WTF::move(frames));
+    // Nothing was awaiting the promise (consumed via .then()/.catch(), a combinator, or
+    // top-level await), so the error keeps its empty trace; still give it a .stack.
+    Bun::installLazyStackIfFrameless(vm, globalObject, instance);
 }

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -163,10 +163,12 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
     // would desync m_stackTrace from the cached property.
     if (instance->hasMaterializedErrorInfo())
         return;
-    if (auto* existing = instance->stackTrace(); existing && !existing->isEmpty())
+    // Null: no capture at all (Error.stackTraceLimit deleted) or a stack string is already set (structuredClone, GC finalizer).
+    auto* existing = instance->stackTrace();
+    if (!existing || !existing->isEmpty())
         return;
 
-    size_t limit = globalObject->stackTraceLimit().value_or(10);
+    size_t limit = globalObject->stackTraceLimit().value_or(Bun::DEFAULT_ERROR_STACK_TRACE_LIMIT);
     if (limit) {
         WTF::Vector<JSC::StackFrame> frames;
         collectAsyncStackFramesFromPromise(vm, instance, promise, frames, limit);

--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -176,7 +176,5 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
         }
     }
 
-    // Nothing was awaiting the promise (consumed via .then()/.catch(), a combinator, or
-    // top-level await), so the error keeps its empty trace; still give it a .stack.
     Bun::installLazyStackIfFrameless(vm, globalObject, instance);
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -29,6 +29,7 @@
 #include <openssl/err.h>
 #include "ErrorCode.h"
 #include "ErrorStackTrace.h"
+#include "FormatStackTraceForJS.h"
 #include "KeyObject.h"
 
 namespace WTF {
@@ -216,6 +217,9 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
         // exception were thrown by ErrorInstance::create)
         return uncheckedDowncast<JSObject>(thrown_exception->value());
     }
+    // Native code also builds these while no JS is running (e.g. the redis client reporting
+    // a dropped connection), which would otherwise leave them with no .stack at all.
+    Bun::installLazyStackIfFrameless(vm, globalObject, created_error);
     return created_error;
 }
 

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -217,8 +217,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
         // exception were thrown by ErrorInstance::create)
         return uncheckedDowncast<JSObject>(thrown_exception->value());
     }
-    // Native code also builds these while no JS is running (e.g. the redis client reporting
-    // a dropped connection), which would otherwise leave them with no .stack at all.
+    // Native code also builds these from I/O callbacks (e.g. the redis client), with no JS on the stack.
     Bun::installLazyStackIfFrameless(vm, globalObject, created_error);
     return created_error;
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -217,7 +217,6 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
         // exception were thrown by ErrorInstance::create)
         return uncheckedDowncast<JSObject>(thrown_exception->value());
     }
-    // Native code also builds these from I/O callbacks (e.g. the redis client), with no JS on the stack.
     Bun::installLazyStackIfFrameless(vm, globalObject, created_error);
     return created_error;
 }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -756,6 +756,24 @@ JSC_DEFINE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter, (JSGlobalObject * g
     return true;
 }
 
+void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::ErrorInstance* error)
+{
+    // ErrorInstance::materializeErrorInfoIfNeeded only defines .stack when the captured
+    // trace has at least one frame; an error created from native code while no JS is
+    // running captures none. V8 still gives such an error its "Name: message" line. A null
+    // trace means Error.stackTraceLimit was deleted, which leaves .stack undefined in V8 too.
+    auto* stackTrace = error->stackTrace();
+    if (!stackTrace || !stackTrace->isEmpty())
+        return;
+
+    // Already installed, or .stack was assigned explicitly.
+    if (error->getDirect(vm, vm.propertyNames->stack))
+        return;
+
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    error->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::CustomAccessor | 0);
+}
+
 JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(lexicalGlobalObject);

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -758,9 +758,8 @@ JSC_DEFINE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter, (JSGlobalObject * g
 
 void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::ErrorInstance* error)
 {
-    // ErrorInstance::materializeErrorInfoIfNeeded does nothing for an empty trace. A null trace
-    // means Error.stackTraceLimit was deleted, which leaves .stack undefined in V8 as well.
     auto* stackTrace = error->stackTrace();
+    // Null means Error.stackTraceLimit was deleted; V8 leaves .stack undefined for that too.
     if (!stackTrace || !stackTrace->isEmpty())
         return;
 
@@ -770,6 +769,13 @@ void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobal
 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     error->putDirectCustomAccessor(vm, vm.propertyNames->stack, globalObject->m_lazyStackCustomGetterSetter.get(globalObject), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::CustomAccessor | 0);
+}
+
+JSC::JSValue installLazyStackIfFrameless(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
+{
+    if (auto* error = dynamicDowncast<JSC::ErrorInstance>(value))
+        installLazyStackIfFrameless(JSC::getVM(globalObject), globalObject, error);
+    return value;
 }
 
 JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -758,15 +758,13 @@ JSC_DEFINE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter, (JSGlobalObject * g
 
 void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::ErrorInstance* error)
 {
-    // ErrorInstance::materializeErrorInfoIfNeeded only defines .stack when the captured
-    // trace has at least one frame; an error created from native code while no JS is
-    // running captures none. V8 still gives such an error its "Name: message" line. A null
-    // trace means Error.stackTraceLimit was deleted, which leaves .stack undefined in V8 too.
+    // ErrorInstance::materializeErrorInfoIfNeeded does nothing for an empty trace. A null trace
+    // means Error.stackTraceLimit was deleted, which leaves .stack undefined in V8 as well.
     auto* stackTrace = error->stackTrace();
     if (!stackTrace || !stackTrace->isEmpty())
         return;
 
-    // Already installed, or .stack was assigned explicitly.
+    // Already installed, or assigned explicitly.
     if (error->getDirect(vm, vm.propertyNames->stack))
         return;
 

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -79,6 +79,10 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace);
 JSC_DECLARE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter);
 JSC_DECLARE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter);
 
+// Gives an error whose captured trace has no frames (created from native code with no JS
+// on the stack) an own .stack that formats to "Name: message" on first access, as V8 does.
+void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::ErrorInstance* error);
+
 // Internal wrapper functions for JSC error info callbacks
 WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, WTF::Vector<JSC::StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, WTF::String& sourceURL, void* bunErrorData);
 JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, WTF::Vector<JSC::StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, WTF::String& sourceURL, JSC::JSObject* errorInstance, void* bunErrorData);

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -79,8 +79,8 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace);
 JSC_DECLARE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter);
 JSC_DECLARE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter);
 
-// Gives an error whose captured trace has no frames (created from native code with no JS
-// on the stack) an own .stack that formats to "Name: message" on first access, as V8 does.
+// An error created while no JS is running captures no frames; like V8, still give it a
+// .stack that formats to "Name: message" on first access.
 void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::ErrorInstance* error);
 
 // Internal wrapper functions for JSC error info callbacks

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -79,9 +79,10 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionDefaultErrorPrepareStackTrace);
 JSC_DECLARE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter);
 JSC_DECLARE_CUSTOM_SETTER(errorInstanceLazyStackCustomSetter);
 
-// An error created while no JS is running captures no frames; like V8, still give it a
-// .stack that formats to "Name: message" on first access.
+// JSC defines no .stack at all for an error that captured zero frames; V8 still gives it "Name: message".
 void installLazyStackIfFrameless(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::ErrorInstance* error);
+// Same, for constructors that hand back a JSValue; anything that is not an ErrorInstance passes through.
+JSC::JSValue installLazyStackIfFrameless(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
 
 // Internal wrapper functions for JSC error info callbacks
 WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, WTF::Vector<JSC::StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, WTF::String& sourceURL, void* bunErrorData);

--- a/src/jsc/bindings/S3Error.cpp
+++ b/src/jsc/bindings/S3Error.cpp
@@ -6,6 +6,7 @@
 #include <wtf/Compiler.h>
 #include "ZigGeneratedClasses.h"
 #include "S3Error.h"
+#include "FormatStackTraceForJS.h"
 
 namespace Bun {
 
@@ -38,6 +39,7 @@ SYSV_ABI JSC::EncodedJSValue S3Error__toErrorInstance(const S3Error* arg0,
 
     auto prototype = defaultGlobalObject(globalObject)->m_S3ErrorStructure.getInitializedOnMainThread(globalObject);
     JSC::JSObject* result = JSC::ErrorInstance::create(vm, prototype, message, {});
+    installLazyStackIfFrameless(globalObject, result);
     result->putDirect(vm, vm.propertyNames->name, defaultGlobalObject(globalObject)->commonStrings().s3ErrorString(globalObject), JSC::PropertyAttribute::DontEnum | 0);
     if (err.code.tag != BunStringTag::Empty) {
         JSC::JSValue code = Bun::toJS(globalObject, err.code);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -171,6 +171,7 @@
 #include "ErrorStackFrame.h"
 #include "AsyncStackTrace.h"
 #include "ErrorStackTrace.h"
+#include "FormatStackTraceForJS.h"
 #include "ObjectBindings.h"
 
 #include <JavaScriptCore/VMInlines.h>
@@ -2583,6 +2584,9 @@ static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, J
     auto& names = WebCore::builtinNames(vm);
 
     JSC::JSObject* result = createError(globalObject, errorType, message);
+    // Most of these are created once an fs/dns/socket/fetch operation completes, while no JS
+    // is running, which would otherwise leave them with no .stack at all.
+    Bun::installLazyStackIfFrameless(vm, globalObject, uncheckedDowncast<JSC::ErrorInstance>(result));
 
     auto clientData = WebCore::clientData(vm);
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2584,8 +2584,7 @@ static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, J
     auto& names = WebCore::builtinNames(vm);
 
     JSC::JSObject* result = createError(globalObject, errorType, message);
-    // Most of these are created once an fs/dns/socket/fetch operation completes, while no JS
-    // is running, which would otherwise leave them with no .stack at all.
+    // Usually created from an I/O completion callback, with no JS on the stack.
     Bun::installLazyStackIfFrameless(vm, globalObject, uncheckedDowncast<JSC::ErrorInstance>(result));
 
     auto clientData = WebCore::clientData(vm);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2584,8 +2584,7 @@ static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, J
     auto& names = WebCore::builtinNames(vm);
 
     JSC::JSObject* result = createError(globalObject, errorType, message);
-    // Usually created from an I/O completion callback, with no JS on the stack.
-    Bun::installLazyStackIfFrameless(vm, globalObject, uncheckedDowncast<JSC::ErrorInstance>(result));
+    Bun::installLazyStackIfFrameless(globalObject, result);
 
     auto clientData = WebCore::clientData(vm);
 
@@ -2667,6 +2666,7 @@ JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError
     auto message = makeString("A system error occurred: "_s, syscallString, " returned "_s, codeString, " ("_s, messageString, ")"_s);
 
     JSC::JSObject* result = JSC::ErrorInstance::create(vm, JSC::ErrorInstance::createStructure(vm, globalObject, globalObject->errorPrototype()), message, {});
+    Bun::installLazyStackIfFrameless(globalObject, result);
     JSC::JSObject* info = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
 
     auto clientData = WebCore::clientData(vm);
@@ -3634,14 +3634,18 @@ JSC::EncodedJSValue JSC__JSGlobalObject__createAggregateError(JSC::JSGlobalObjec
 
     JSC::Structure* errorStructure = globalObject->errorStructure(JSC::ErrorType::AggregateError);
 
-    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::createAggregateError(vm, errorStructure, array, message, cause, nullptr, JSC::TypeNothing, false)));
+    auto* error = JSC::createAggregateError(vm, errorStructure, array, message, cause, nullptr, JSC::TypeNothing, false);
+    Bun::installLazyStackIfFrameless(vm, globalObject, error);
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(error));
 }
 JSC::EncodedJSValue JSC__JSGlobalObject__createAggregateErrorWithArray(JSC::JSGlobalObject* global, JSC::JSArray* array, BunString message, JSValue cause)
 {
     auto& vm = JSC::getVM(global);
     JSC::Structure* errorStructure = global->errorStructure(JSC::ErrorType::AggregateError);
     WTF::String messageString = message.toWTFString();
-    return JSC::JSValue::encode(JSC::createAggregateError(vm, errorStructure, array, messageString, cause, nullptr, JSC::TypeNothing, false));
+    auto* error = JSC::createAggregateError(vm, errorStructure, array, messageString, cause, nullptr, JSC::TypeNothing, false);
+    Bun::installLazyStackIfFrameless(vm, global, error);
+    return JSC::JSValue::encode(error);
 }
 
 JSC::EncodedJSValue ZigString__toAtomicValue(const ZigString* arg0, JSC::JSGlobalObject* arg1)
@@ -3760,27 +3764,27 @@ JSC::EncodedJSValue ZigString__toExternalValueWithCallback(const ZigString* arg0
 
 JSC::EncodedJSValue ZigString__toErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    return JSC::JSValue::encode(Zig::getErrorInstance(str, globalObject));
+    return JSC::JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, Zig::getErrorInstance(str, globalObject)));
 }
 
 JSC::EncodedJSValue ZigString__toTypeErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    return JSC::JSValue::encode(Zig::getTypeErrorInstance(str, globalObject));
+    return JSC::JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, Zig::getTypeErrorInstance(str, globalObject)));
 }
 
 JSC::EncodedJSValue ZigString__toDOMExceptionInstance(const ZigString* str, JSC::JSGlobalObject* globalObject, WebCore::ExceptionCode code)
 {
-    return JSValue::encode(createDOMException(globalObject, code, toStringCopy(*str)));
+    return JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, createDOMException(globalObject, code, toStringCopy(*str))));
 }
 
 JSC::EncodedJSValue ZigString__toSyntaxErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    return JSC::JSValue::encode(Zig::getSyntaxErrorInstance(str, globalObject));
+    return JSC::JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, Zig::getSyntaxErrorInstance(str, globalObject)));
 }
 
 JSC::EncodedJSValue ZigString__toRangeErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    return JSC::JSValue::encode(Zig::getRangeErrorInstance(str, globalObject));
+    return JSC::JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, Zig::getRangeErrorInstance(str, globalObject)));
 }
 
 JSC::JSPromise*
@@ -6338,17 +6342,17 @@ CPP_DECL void JSC__VM__performOpportunisticallyScheduledTasks(JSC::VM* vm, doubl
 
 extern "C" EncodedJSValue JSC__createError(JSC::JSGlobalObject* globalObject, const BunString* str)
 {
-    return JSValue::encode(JSC::createError(globalObject, str->toWTFString(BunString::ZeroCopy)));
+    return JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, JSC::createError(globalObject, str->toWTFString(BunString::ZeroCopy))));
 }
 
 extern "C" EncodedJSValue JSC__createTypeError(JSC::JSGlobalObject* globalObject, const BunString* str)
 {
-    return JSValue::encode(JSC::createTypeError(globalObject, str->toWTFString(BunString::ZeroCopy)));
+    return JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, JSC::createTypeError(globalObject, str->toWTFString(BunString::ZeroCopy))));
 }
 
 extern "C" EncodedJSValue JSC__createRangeError(JSC::JSGlobalObject* globalObject, const BunString* str)
 {
-    return JSValue::encode(JSC::createRangeError(globalObject, str->toWTFString(BunString::ZeroCopy)));
+    return JSValue::encode(Bun::installLazyStackIfFrameless(globalObject, JSC::createRangeError(globalObject, str->toWTFString(BunString::ZeroCopy))));
 }
 
 extern "C" EncodedJSValue ExpectMatcherUtils__getSingleton(JSC::JSGlobalObject* globalObject_)

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -13,6 +13,7 @@
 #include <JavaScriptCore/ArrayBuffer.h>
 #include "CryptoKeyRaw.h"
 #include "JSKeyObject.h"
+#include "FormatStackTraceForJS.h"
 
 namespace Bun {
 
@@ -382,6 +383,7 @@ JSValue createCryptoError(JSC::JSGlobalObject* globalObject, ThrowScope& scope, 
     // Create error object with the message
     JSC::JSObject* errorObject = createError(globalObject, errorMessage);
     RETURN_IF_EXCEPTION(scope, {});
+    installLazyStackIfFrameless(globalObject, errorObject);
 
     PutPropertySlot messageSlot(errorObject, false);
     errorObject->put(errorObject, globalObject, Identifier::fromString(vm, "message"_s), jsString(vm, errorMessage), messageSlot);

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -57,6 +57,7 @@
 #include "JSBuffer.h"
 #include "BunClientData.h"
 #include "ErrorEvent.h"
+#include "FormatStackTraceForJS.h"
 #include "WebSocketDeflate.h"
 
 namespace WebCore {
@@ -76,7 +77,7 @@ static ErrorEvent::Init createErrorEventInit(WebSocket& webSocket, const String&
     eventInit.bubbles = false;
     eventInit.cancelable = false;
     eventInit.colno = 0;
-    eventInit.error = JSC::createError(globalObject, eventInit.message);
+    eventInit.error = Bun::installLazyStackIfFrameless(globalObject, JSC::createError(globalObject, eventInit.message));
     return eventInit;
 }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -279,7 +279,7 @@ impl JSBundleCompletionTask {
                     global_this,
                     BunString::static_(b"Bundle failed"),
                 );
-                return promise.reject(global_this, aggregate_error);
+                return promise.reject_with_async_stack(global_this, aggregate_error);
             } else {
                 return promise.resolve(global_this, build_result);
             }

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -504,6 +504,27 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
   await expect(password.verify("correct horse", junkMemory)).rejects.toThrow("InvalidEncoding");
 });
 
+test("verify's rejection has a .stack even when nothing awaits it", async () => {
+  // The error is created once the thread pool job completes, with no JS on the stack, and
+  // .then() leaves no await chain to recover frames from.
+  const err = await new Promise<any>(resolve => password.verify("correct horse", "not a hash").then(resolve, resolve));
+
+  expect(err.code).toBe("PASSWORD_UNSUPPORTED_ALGORITHM");
+  expect(err.stack).toBe(`${err.name}: ${err.message}`);
+});
+
+test("verify's rejection lists the async frame when awaited inside an async function", async () => {
+  async function check() {
+    await password.verify("correct horse", "not a hash");
+  }
+  const err = await check().then(
+    () => new Error("unexpected resolve"),
+    e => e,
+  );
+
+  expect(err.stack).toStartWith(`${err.name}: ${err.message}\n    at async check `);
+});
+
 test("verifySync reads the password buffer only after every argument has been coerced", () => {
   const hashed = password.hashSync("correct horse", { algorithm: "argon2id", memoryCost: 8, timeCost: 1 });
   const passwordBytes = new TextEncoder().encode("correct horse");

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -504,27 +504,6 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
   await expect(password.verify("correct horse", junkMemory)).rejects.toThrow("InvalidEncoding");
 });
 
-test("verify's rejection has a .stack even when nothing awaits it", async () => {
-  // The error is created once the thread pool job completes, with no JS on the stack, and
-  // .then() leaves no await chain to recover frames from.
-  const err = await new Promise<any>(resolve => password.verify("correct horse", "not a hash").then(resolve, resolve));
-
-  expect(err.code).toBe("PASSWORD_UNSUPPORTED_ALGORITHM");
-  expect(err.stack).toBe(`${err.name}: ${err.message}`);
-});
-
-test("verify's rejection lists the async frame when awaited inside an async function", async () => {
-  async function check() {
-    await password.verify("correct horse", "not a hash");
-  }
-  const err = await check().then(
-    () => new Error("unexpected resolve"),
-    e => e,
-  );
-
-  expect(err.stack).toStartWith(`${err.name}: ${err.message}\n    at async check `);
-});
-
 test("verifySync reads the password buffer only after every argument has been coerced", () => {
   const hashed = password.hashSync("correct horse", { algorithm: "argon2id", memoryCost: 8, timeCost: 1 });
   const passwordBytes = new TextEncoder().encode("correct horse");

--- a/test/js/node/crypto/crypto-sign-regression.test.ts
+++ b/test/js/node/crypto/crypto-sign-regression.test.ts
@@ -43,3 +43,20 @@ test("crypto.sign() supports all RSA digest variants", () => {
     expect(signature.length).toBeGreaterThan(0);
   }
 });
+
+test("an error from the sign job is passed to the callback with a .stack", async () => {
+  // A PSS salt longer than the modulus makes the signing itself fail, so the error is
+  // created when the thread pool job completes, with no JS on the stack (as in node).
+  const { promise, resolve } = Promise.withResolvers<Error | null>();
+  sign(
+    "sha256",
+    Buffer.from("test message"),
+    { key: DUMMY_PRIVATE_KEY, padding: constants.RSA_PKCS1_PSS_PADDING, saltLength: 4000 },
+    resolve,
+  );
+  const err = (await promise)!;
+
+  expect(err).toBeInstanceOf(Error);
+  expect(Object.prototype.hasOwnProperty.call(err, "stack")).toBe(true);
+  expect(err.stack).toBe(`Error: ${err.message}`);
+});

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -259,8 +259,8 @@ test("fs.promises async stack through Promise subclass", async () => {
 
   expect(caught).toBeDefined();
   expect(caught.code).toBe("ENOENT");
-  // Subclass .then() may not preserve the reaction chain — must not crash.
-  expect(typeof caught.stack === "string" || caught.stack === undefined).toBe(true);
+  // Subclass .then() may not preserve the reaction chain; the error still gets a .stack.
+  expect(caught.stack).toStartWith(`Error: ${caught.message}`);
 });
 
 test("fs.promises async stack through custom thenable", async () => {
@@ -282,8 +282,8 @@ test("fs.promises async stack through custom thenable", async () => {
 
   expect(caught).toBeDefined();
   expect(caught.code).toBe("ENOENT");
-  // Custom thenables break the direct reaction chain — must not crash.
-  expect(typeof caught.stack === "string" || caught.stack === undefined).toBe(true);
+  // Custom thenables break the direct reaction chain; the error still gets a .stack.
+  expect(caught.stack).toStartWith(`Error: ${caught.message}`);
 });
 
 test("fs.promises async stack with Promise.all", async () => {
@@ -300,8 +300,20 @@ test("fs.promises async stack with Promise.all", async () => {
 
   expect(caught).toBeDefined();
   expect(caught.code).toBe("ENOENT");
-  // Promise.all uses combinator context — must not crash.
-  expect(typeof caught.stack === "string" || caught.stack === undefined).toBe(true);
+  // Promise.all uses combinator context, so no async frames are recovered; the error
+  // still gets a .stack.
+  expect(caught.stack).toStartWith(`Error: ${caught.message}`);
+});
+
+test("fs.promises errors that nothing awaits still have a .stack", async () => {
+  // .catch() attaches a handler but nothing awaits the derived promise, so there is no
+  // async chain to recover frames from: the error keeps an empty trace.
+  const caught = await new Promise(resolve => readFile("/nonexistent-path/x.txt").catch(resolve));
+
+  expect(caught.code).toBe("ENOENT");
+  expect(caught.stack).toBe(`Error: ${caught.message}`);
+  expect(Object.prototype.hasOwnProperty.call(caught, "stack")).toBe(true);
+  expect(Object.keys(caught)).not.toContain("stack");
 });
 
 it("an unused FileHandle.writer() does not prevent close()", async () => {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1201,6 +1201,24 @@ describe("errors created by native code while no JS is running", () => {
     expect(err.stack).toStartWith(`${err.name}: ${err.message}\n    at async requestIt `);
   });
 
+  test("the AggregateError from a failed Bun.build() behaves the same way", async () => {
+    using dir = tempDir("frameless-error", { "entry.ts": `import "./does-not-exist";` });
+    const options = { entrypoints: [join(String(dir), "entry.ts")] };
+    const nothingAwaits = await new Promise(resolve => Bun.build(options).then(resolve, resolve));
+    async function buildIt() {
+      await Bun.build(options);
+    }
+    const awaited = await buildIt().then(
+      () => new Error("unexpected success"),
+      e => e,
+    );
+
+    expect(nothingAwaits).toBeInstanceOf(AggregateError);
+    expect(nothingAwaits.stack).toBe(`AggregateError: ${nothingAwaits.message}`);
+    expect(awaited).toBeInstanceOf(AggregateError);
+    expect(awaited.stack).toStartWith(`AggregateError: ${awaited.message}\n    at async buildIt `);
+  });
+
   test("Error.stackTraceLimit = 0 leaves the 'name: message' line, as in V8", () => {
     using dir = tempDir("frameless-error", {});
     const originalLimit = Error.stackTraceLimit;
@@ -1244,6 +1262,46 @@ describe("errors created by native code while no JS is running", () => {
       Error.stackTraceLimit = originalLimit;
     }
     expect({ code: systemError.code, stack: systemError.stack }).toEqual({ code: "ENOENT", stack: undefined });
+  });
+
+  // Bun.password.verify builds a plain Error once its thread pool job finishes and rejects
+  // through the async stack attach, so these exercise that path by itself.
+  function verifyNothingAwaits() {
+    return new Promise(resolve => Bun.password.verify("pw", "not a hash").then(resolve, resolve));
+  }
+  async function verifyAwaited() {
+    try {
+      await Bun.password.verify("pw", "not a hash");
+    } catch (e) {
+      return e;
+    }
+  }
+  function describeStack(err) {
+    const header = `${err.name}: ${err.message}`;
+    if (err.stack === undefined) return "undefined";
+    if (err.stack === header) return "header";
+    if (err.stack.startsWith(`${header}\n    at async verifyAwaited `)) return "header + async frame";
+    return err.stack;
+  }
+
+  test("Error.stackTraceLimit applies the same way whether or not something awaits a native rejection", async () => {
+    const originalLimit = Error.stackTraceLimit;
+    const results = {};
+    try {
+      Error.stackTraceLimit = 10;
+      results.limit10 = [describeStack(await verifyNothingAwaits()), describeStack(await verifyAwaited())];
+      Error.stackTraceLimit = 0;
+      results.limit0 = [describeStack(await verifyNothingAwaits()), describeStack(await verifyAwaited())];
+      delete Error.stackTraceLimit;
+      results.deleted = [describeStack(await verifyNothingAwaits()), describeStack(await verifyAwaited())];
+    } finally {
+      Error.stackTraceLimit = originalLimit;
+    }
+    expect(results).toEqual({
+      limit10: ["header", "header + async frame"],
+      limit0: ["header", "header"],
+      deleted: ["undefined", "undefined"],
+    });
   });
 
   // node's unhandled rejection warning only prints the rejection value's .stack when the

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,7 +1,10 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
-import { afterEach, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { once } from "node:events";
+import fs from "node:fs";
+import net from "node:net";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -1120,4 +1123,147 @@ test("lazy error-info materialization does not store an empty stack value when t
     signalCode: null,
   });
   expect(exitCode).toBe(0);
+});
+
+describe("errors created by native code while no JS is running", () => {
+  // fs callbacks run from the event loop, so the ENOENT error is built with no JS frames
+  // on the stack and JSC captures an empty trace for it.
+  async function framelessError() {
+    using dir = tempDir("frameless-error", {});
+    const { promise, resolve } = Promise.withResolvers();
+    fs.readFile(join(String(dir), "missing.txt"), resolve);
+    const err = await promise;
+    expect(err.code).toBe("ENOENT");
+    return err;
+  }
+
+  test("have an own, non-enumerable .stack holding the 'name: message' line", async () => {
+    const err = await framelessError();
+    expect(Object.getOwnPropertyDescriptor(err, "stack")).toMatchObject({ enumerable: false, configurable: true });
+    expect(Object.keys(err)).not.toContain("stack");
+    expect(err.stack).toBe(`Error: ${err.message}`);
+    expect(Object.getOwnPropertyDescriptor(err, "stack")).toMatchObject({
+      value: `Error: ${err.message}`,
+      writable: true,
+      enumerable: false,
+    });
+  });
+
+  test(".stack is formatted on first read, like an error with frames", async () => {
+    const err = await framelessError();
+    err.name = "Renamed";
+    err.message = "changed";
+    expect(err.stack).toBe("Renamed: changed");
+  });
+
+  test("Error.prepareStackTrace runs on first read and receives no call sites", async () => {
+    const err = await framelessError();
+    Error.prepareStackTrace = mock((error, callSites) => `prepared ${error.code} with ${callSites.length} call sites`);
+    expect(err.stack).toBe("prepared ENOENT with 0 call sites");
+    expect(err.stack).toBe("prepared ENOENT with 0 call sites");
+    expect(Error.prepareStackTrace).toHaveBeenCalledTimes(1);
+  });
+
+  test("assigning .stack before it is read replaces it", async () => {
+    const err = await framelessError();
+    err.stack = "mine";
+    expect(Object.getOwnPropertyDescriptor(err, "stack")).toMatchObject({ value: "mine", enumerable: false });
+  });
+
+  // fetch() builds its error when the connection attempt fails and recovers frames, if any,
+  // from the async functions awaiting the promise it is about to reject.
+  async function closedPortURL() {
+    const listener = net.createServer();
+    await once(listener.listen(0, "127.0.0.1"), "listening");
+    const { port } = listener.address();
+    await new Promise(resolve => listener.close(resolve));
+    return `http://127.0.0.1:${port}/`;
+  }
+
+  test("a rejection nothing awaits gets the 'name: message' line", async () => {
+    const url = await closedPortURL();
+    const err = await new Promise(resolve => fetch(url).then(resolve, resolve));
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.stack).toBe(`${err.name}: ${err.message}`);
+  });
+
+  test("a rejection awaited inside an async function still lists the async frame", async () => {
+    const url = await closedPortURL();
+    async function requestIt() {
+      await fetch(url);
+    }
+    const err = await requestIt().then(
+      () => new Error("unexpected response"),
+      e => e,
+    );
+
+    expect(err.stack).toStartWith(`${err.name}: ${err.message}\n    at async requestIt `);
+  });
+
+  test("Error.stackTraceLimit = 0 leaves the 'name: message' line, as in V8", () => {
+    using dir = tempDir("frameless-error", {});
+    const originalLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 0;
+    let systemError, codeError;
+    try {
+      try {
+        fs.readFileSync(join(String(dir), "missing.txt"));
+      } catch (e) {
+        systemError = e;
+      }
+      try {
+        Buffer.alloc(-1);
+      } catch (e) {
+        codeError = e;
+      }
+    } finally {
+      Error.stackTraceLimit = originalLimit;
+    }
+    expect({ code: systemError.code, stack: systemError.stack }).toEqual({
+      code: "ENOENT",
+      stack: `Error: ${systemError.message}`,
+    });
+    expect(codeError.code).toBe("ERR_OUT_OF_RANGE");
+    expect(codeError.stack).toStartWith("RangeError");
+    expect(codeError.stack).toEndWith(`: ${codeError.message}`);
+  });
+
+  test("deleting Error.stackTraceLimit still disables .stack entirely, as in V8", () => {
+    using dir = tempDir("frameless-error", {});
+    const originalLimit = Error.stackTraceLimit;
+    delete Error.stackTraceLimit;
+    let systemError;
+    try {
+      try {
+        fs.readFileSync(join(String(dir), "missing.txt"));
+      } catch (e) {
+        systemError = e;
+      }
+    } finally {
+      Error.stackTraceLimit = originalLimit;
+    }
+    expect({ code: systemError.code, stack: systemError.stack }).toEqual({ code: "ENOENT", stack: undefined });
+  });
+
+  // node's unhandled rejection warning only prints the rejection value's .stack when the
+  // value has an own .stack property; without one it falls back to a generic rendering.
+  test("--unhandled-rejections=warn prints the error for a native rejection", async () => {
+    using dir = tempDir("frameless-error", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--unhandled-rejections=warn",
+        "-e",
+        `require("node:fs/promises").readFile(${JSON.stringify(join(String(dir), "missing.txt"))})`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory");
+    expect(stderr).not.toContain("[object Object]");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1261,9 +1261,9 @@ describe("errors created by native code while no JS is running", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory");
     expect(stderr).not.toContain("[object Object]");
-    expect(exitCode).toBe(0);
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
   });
 });

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -441,3 +441,25 @@ describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
     }
   });
 });
+
+describe("Valkey: Connection Error Shape", () => {
+  test("a command rejected because the connection failed has a .stack", async () => {
+    const listener = net.createServer();
+    await new Promise<void>(resolve => listener.listen(0, "127.0.0.1", resolve));
+    const { port } = listener.address() as net.AddressInfo;
+    await new Promise(resolve => listener.close(resolve));
+
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      // The error is created by the socket's failure callback, with no JS on the stack, and
+      // .then() leaves no await chain to recover frames from.
+      const err = await new Promise<any>(resolve => client.get("key").then(resolve, resolve));
+
+      expect(err.code).toBe("ERR_REDIS_CONNECTION_CLOSED");
+      expect(err.stack).toStartWith(err.name);
+      expect(err.stack).toEndWith(`: ${err.message}`);
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/test/js/web/websocket/error-event.test.ts
+++ b/test/js/web/websocket/error-event.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { once } from "node:events";
+import net from "node:net";
 
 test("WebSocket error event snapshot", async () => {
   const ws = new WebSocket("ws://127.0.0.1:8080");
@@ -37,4 +39,20 @@ test("ErrorEvent with no message", async () => {
   message: "", 
   error: null
 }`);
+});
+
+test("event.error of a failed connection has a .stack", async () => {
+  const listener = net.createServer();
+  await once(listener.listen(0, "127.0.0.1"), "listening");
+  const { port } = listener.address() as net.AddressInfo;
+  await new Promise(resolve => listener.close(resolve));
+
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  const { promise, resolve } = Promise.withResolvers<ErrorEvent>();
+  ws.onerror = resolve;
+  const { error } = await promise;
+
+  // The error is created when the connection attempt fails, with no JS on the stack.
+  expect(Object.prototype.hasOwnProperty.call(error, "stack")).toBe(true);
+  expect(error.stack).toBe(`Error: ${error.message}`);
 });


### PR DESCRIPTION
### Problem

- Any error Bun builds while no JS is running has no `stack` property at all: `typeof err.stack === "undefined"`, `Object.hasOwn(err, "stack") === false`. Node always gives an error a `.stack` string, at minimum the `Name: message` line. Code doing `err.stack.split("\n")` throws, and `--unhandled-rejections=warn` prints `UnhandledPromiseRejectionWarning: [object Object]` for these rejections because node's error-like check is "has an own `stack`".
- Affected (all reproduced on 1.4.0 and main, probe below): every `fs` callback and `fs.promises` error, `Bun.file().text()`, `Bun.connect()` (the rejection and the `connectError` argument), `fetch()` network failures, `node:dns`, `RedisClient` connection errors, `Bun.password.verify()`, the `AggregateError` from `Bun.build()` / `Bun.Transpiler`, the `WebSocket` error event's `.error`, `node:crypto` job errors passed to callbacks. The one exception was an error `await`ed directly inside an async function, which got a string because an `at async f` frame was attached.
- Cause: JSC's `ErrorInstance::materializeErrorInfoIfNeeded` (vendored `ErrorInstance.cpp:410`) only defines `.stack` when the captured frame vector is non-empty. An error created from an event loop callback captures an empty vector, so nothing ever defines the property. `Bun__attachAsyncStackFromPromise` (`src/jsc/bindings/AsyncStackTrace.cpp`) fills the vector when an async function is awaiting the promise, but returned without touching the error for `.then()` / `.catch()`, combinators, top-level await, and callback or event delivery.

### Fix

- `Bun::installLazyStackIfFrameless` (`FormatStackTraceForJS.cpp`): if an error's frame vector exists but is empty and it has no own `stack` yet, install the lazy `stack` accessor `Error.captureStackTrace` already uses. The first read formats the empty vector the normal way (so `Error.prepareStackTrace` runs, with an empty call-site array) and replaces the accessor with a non-enumerable data property holding `Name: message`.
- Called from every function native code constructs an `ErrorInstance` through: `systemErrorToErrorInstance` and `SystemError__toErrorInstanceWithInfoObject`, `ErrorCodeCache::createError` (all `ERR_*` errors), the `ZigString__to*ErrorInstance` / `JSC__create*Error` string-to-error family (and `ZigString__toDOMExceptionInstance`, for the codes that yield a real Error), both `createAggregateError` bindings, `S3Error__toErrorInstance`, `createCryptoError` (node:crypto jobs), and `WebSocket.cpp`'s error event. Constructors called during JS execution see a non-empty vector and return after one check, so synchronous errors are untouched. `createOutOfMemoryError` is deliberately left out.
- `Bun__attachAsyncStackFromPromise` also calls it when the await walk recovers nothing (covers any constructor not listed above). It now returns early for a null vector too, which is what the helper does: a null vector means the error was created with `Error.stackTraceLimit` deleted (V8 leaves `.stack` undefined in that case) or already holds a stack string; previously it attached frames to those, so a deleted limit behaved differently depending on whether something awaited the promise.
- `Bun.build()` rejects through `reject_with_async_stack` like the other native promise APIs (`js_bundle_completion_task.rs`), so an awaited failure lists the awaiting function.
- Why this is the right shape:
  - Matches node: own, non-enumerable `.stack`; V8 also exposes it as an accessor until first read; formatted lazily, so later `name` / `message` changes and `Error.prepareStackTrace` are honored; `Error.stackTraceLimit = 0` yields the header line, a deleted `Error.stackTraceLimit` yields undefined, in both the `.then()` and `await` consumption modes (test matrix below).
  - No stack capture on the success path of any API (the approach #35998 took for fetch, dropped because it allocates an Error per call). Frameless errors pay one property add; output of `console.log` / uncaught printing for them is byte-identical because the printer reads the frame vector, not the property.
  - Idempotent: the own-property check makes the constructor-time and attach-time calls compose and leaves a user-assigned `.stack` alone.
- The uniform fix is one condition in the Bun-owned `USE(BUN_JSC_ADDITIONS)` block of `ErrorInstance::materializeErrorInfoIfNeeded` (`fn && m_stackTrace && !m_stackTrace->isEmpty()` -> `fn && m_stackTrace`; Bun's hook already formats an empty vector). That needs an oven-sh/WebKit change plus a pin bump, and its fail-before cannot be demonstrated from this repo alone, so this PR does it at Bun's constructors; once the engine change lands, the helper and its call sites can be deleted. Until then the only remaining gap is `Error.stackTraceLimit = 0; new Error()`, which is constructed inside JSC.
- Replaces #35515 (SystemError site only) and #35989 (attach site only), both closed.
- Verified (every new assertion fails on the released binary with `USE_SYSTEM_BUN=1` and passes with `bun bd test`; the two tests below that pin unchanged behavior are marked):
  - `test/js/node/v8/capture-stack-trace.test.js`, new `describe`: fs callback error (callback delivery): own + non-enumerable, lazy formatting, `prepareStackTrace` with zero call sites, assignment; `fetch()` via `.then()` gets the header, via `await` still gets the async frame (unchanged behavior); `Bun.build()` via `.then()` and via `await`; `Error.stackTraceLimit = 0` for a SystemError and an `ERR_*` error; deleted limit on a sync error (unchanged behavior); the `{10, 0, deleted} x {.then(), await}` matrix on `Bun.password.verify()` (plain constructor + attach); `--unhandled-rejections=warn` prints the error.
  - `test/js/node/fs/promises.test.js`: the Promise-subclass / thenable / `Promise.all` tests used to accept `undefined`, now require the header; new `.catch()` test.
  - `test/js/valkey/reliability/connection-failures.test.ts`: `ERR_REDIS_CONNECTION_CLOSED` via the error-code constructor (plain reject, no attach); needs no server.
  - `test/js/web/websocket/error-event.test.ts`: `event.error` of a refused connection.
  - `test/js/node/crypto/crypto-sign-regression.test.ts`: `crypto.sign()` callback error from a failing job.
  - Also green with the change: bun-file, streams, s3 (local error paths), transpiler error tests, domexception, error-code-mirror, websocket close/handshake, fs promises, and node's crypto sign/keygen, prepare-stack-trace and unhandled-rejection-warning tests. `inspect-error.test.js` has two failures in a debug build that reproduce without this change.

### Background

- Frame vector and materialization: a JSC `ErrorInstance` stores the frames captured at construction in `m_stackTrace` and only defines the `stack` / `line` / `column` properties on the first access to one of them (`materializeErrorInfoIfNeeded`), formatting through Bun's hook. With zero frames that code is skipped entirely, which is the bug. `getStackTrace` returns an empty vector when there was nothing to capture and a null one when `Error.stackTraceLimit` is deleted or not a number; errors rebuilt by `structuredClone` also have a null vector and carry a stack string instead.
- Lazy stack accessor: `errorInstanceLazyStackCustomGetter` (`FormatStackTraceForJS.cpp`) is a `CustomGetterSetter` Bun installs as an own `stack` property; reading it formats whatever frames the error holds at that moment and `putDirect`s the result over itself. Until now only `Error.captureStackTrace` installed it.
- Async stack attach: errors created by event loop tasks are passed to `Bun__attachAsyncStackFromPromise`, which walks the promise's reaction chain looking for async functions awaiting it and stores those as `at async f` frames. Consumers that are not a direct `await` (`.then()`, `Promise.all`, top-level await, callbacks) give it nothing to find.
- SystemError: the Rust-side struct for errno-style errors (`code` / `syscall` / `path` / `errno`); `systemErrorToErrorInstance` turns it into a JS Error. `ERR_*` errors are node-style coded errors, all built by `ErrorCodeCache::createError`. Message-only errors from Rust go through the `ZigString__to*ErrorInstance` / `JSC__create*Error` bindings.

<details>
<summary>Probe: native errors with and without .stack (main before / after)</summary>

`typeof e.stack` before, on main: fs.promises `await` / `.then()` / `.catch()`, `fs.readFile` / `open` / `stat` callbacks, `createReadStream` error event, `Bun.file().text()` / `.arrayBuffer()`, `Bun.connect` (`await`, `.then()`, `connectError` argument, rejection after `connectError`), `fetch` (`await`, `.catch()`), `dns.lookup` callback, `dns.promises.lookup`, `dns.resolve4` callback, `RedisClient`, `Bun.password.verify` via `.then()`, `Bun.build` (`.then()` and awaited), `Bun.Transpiler.transform`, `WebSocket` error event, `crypto.sign` callback: all `undefined`. zlib callbacks, `Bun.spawn` ENOENT, `Bun.SQL`, `Bun.file().stream()`, aborted `fs.promises.readFile`: `string` (created with JS on the stack).

After: every row above is a `string`; the awaited `Bun.build` row additionally has the `at async` frame.

`Bun.password.verify()` rejection, `.stack` by `Error.stackTraceLimit` and consumer:

| limit   | `.then()` before | `await` before  | `.then()` after | `await` after   |
| ------- | ---------------- | --------------- | --------------- | --------------- |
| 10      | undefined        | header + frame  | header          | header + frame  |
| 0       | undefined        | undefined       | header          | header          |
| deleted | undefined        | header + frame  | undefined       | undefined       |

```
$ bun --unhandled-rejections=warn -e 'require("fs/promises").readFile("/nonexistent")'
before: (node:1) UnhandledPromiseRejectionWarning: [object Object]
after:  (node:1) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/nonexistent'
```
</details>

<details>
<summary>Earlier revision</summary>

The first revision of this PR called the helper from three sites only (SystemError constructor, `ErrorCodeCache::createError`, the attach fallback) and described `Bun.build`'s AggregateError and the WebSocket error event as needing an engine change; both are built by Bun's own C++, so review of that revision led to hooking every constructor, the null-vector consistency fix in the attach, and the `Bun.build` / `WebSocket` / `crypto` / matrix tests. The `Bun.password` tests moved from `password.test.ts` into the matrix.
</details>
