### PR TITLE
publish, pm whoami: route registry requests through http_proxy

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -146,6 +146,7 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
     // returns. `init_sync` borrows the URL/header buffers for the duration of
     // the synchronous request only.
     let url = URL::parse(&print_buf);
+    let http_proxy = manager.http_proxy(&url);
 
     // `headers.allocate()` set `content.ptr` to a valid `content.len`-byte
     // allocation; `headers` outlives `req`. `written_slice()` is the safe
@@ -159,7 +160,7 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
         headers.entries,
         header_buf,
         b"",
-        None,
+        http_proxy,
         None,
         http::FetchRedirect::Follow,
     );

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -761,6 +761,7 @@ impl PublishCommand {
     }
 
     fn check_package_version_exists(
+        manager: &PackageManager,
         package_name: &[u8],
         version: &[u8],
         registry: &Npm::Registry::Scope,
@@ -825,13 +826,14 @@ impl PublishCommand {
             headers.append(b"authorization", &auth_buf);
         }
 
+        let http_proxy = manager.http_proxy(&package_url);
         let mut req = http::AsyncHTTP::init_sync(
             http::Method::GET,
             package_url,
             headers.entries,
             headers.content.written_slice(),
             b"",
-            None,
+            http_proxy,
             None,
             http::FetchRedirect::Follow,
         );
@@ -877,6 +879,7 @@ impl PublishCommand {
         if tolerate_republish {
             let version_without_build_tag = dependency::without_build_tag(&ctx.package_version);
             let package_exists = Self::check_package_version_exists(
+                ctx.manager,
                 &ctx.package_name,
                 version_without_build_tag,
                 registry,
@@ -949,6 +952,7 @@ impl PublishCommand {
         // arena so the URL outlives `print_buf.clear()` below.
         let publish_url = URL::parse(crate::cli::cli_dupe(&print_buf));
         print_buf.clear();
+        let http_proxy = ctx.manager.http_proxy(&publish_url);
 
         let mut req = http::AsyncHTTP::init_sync(
             http::Method::PUT,
@@ -956,7 +960,7 @@ impl PublishCommand {
             publish_headers.entries,
             publish_headers.content.written_slice(),
             publish_req_body,
-            None,
+            http_proxy.clone(),
             None,
             http::FetchRedirect::Follow,
         );
@@ -1050,7 +1054,7 @@ impl PublishCommand {
                     otp_headers.entries,
                     otp_headers.content.written_slice(),
                     publish_req_body,
-                    None,
+                    http_proxy,
                     None,
                     http::FetchRedirect::Follow,
                 );
@@ -1269,18 +1273,20 @@ impl PublishCommand {
                     ctx.manager.options.publish_config.auth_type,
                 )?;
 
+                let http_proxy = ctx.manager.http_proxy(&done_url);
+
                 loop {
                     response_buf.reset();
 
-                    // Note: `done_url`/`auth_headers.entries` move into
-                    // `init_sync`, so re-clone per iteration.
+                    // Note: `done_url`/`auth_headers.entries`/`http_proxy` move
+                    // into `init_sync`, so re-clone per iteration.
                     let mut req = http::AsyncHTTP::init_sync(
                         http::Method::GET,
                         done_url.clone(),
                         auth_headers.entries.clone()?,
                         auth_headers.content.written_slice(),
                         b"",
-                        None,
+                        http_proxy.clone(),
                         None,
                         http::FetchRedirect::Follow,
                     );

--- a/test/cli/install/bun-install-proxy.test.ts
+++ b/test/cli/install/bun-install-proxy.test.ts
@@ -8,130 +8,131 @@ const execAsync = promisify(exec);
 const dockerCLI = dockerExe() as string;
 const SQUID_URL = "http://127.0.0.1:3128";
 if (isDockerEnabled()) {
-  beforeAll(async () => {
-    async function isSquidRunning() {
-      const text = await fetch(SQUID_URL)
-        .then(res => res.text())
-        .catch(() => {});
-      return text?.includes("squid") ?? false;
-    }
-    if (!(await isSquidRunning())) {
-      // try to create or error if is already created
-      await execAsync(
-        `${dockerCLI} run -d --name squid-container -e TZ=UTC -p 3128:3128 ubuntu/squid:5.2-22.04_beta`,
-      ).catch(() => {});
-
-      async function waitForSquid(max_wait = 60_000) {
-        const start = Date.now();
-        while (true) {
-          if (await isSquidRunning()) {
-            return;
-          }
-          if (Date.now() - start > max_wait) {
-            throw new Error("Squid did not start in time");
-          }
-
-          await Bun.sleep(1000);
-        }
+  describe("squid", () => {
+    beforeAll(async () => {
+      async function isSquidRunning() {
+        const text = await fetch(SQUID_URL)
+          .then(res => res.text())
+          .catch(() => {});
+        return text?.includes("squid") ?? false;
       }
-      // wait for squid to start
-      await waitForSquid();
-    }
-  });
+      if (!(await isSquidRunning())) {
+        // try to create or error if is already created
+        await execAsync(
+          `${dockerCLI} run -d --name squid-container -e TZ=UTC -p 3128:3128 ubuntu/squid:5.2-22.04_beta`,
+        ).catch(() => {});
 
-  it("bun install with proxy with big packages", async () => {
-    const files = {
-      "package.json": JSON.stringify({
-        "name": "test-install",
-        "module": "index.ts",
-        "type": "module",
-        "private": true,
-        "dependencies": {
-          "gastby": "1.0.1",
-          "mitata": "1.0.34",
-          "next.js": "1.0.3",
-          "react": "19.1.0",
-          "react-dom": "19.1.0",
-          "@types/react": "18.3.3",
-          "esbuild": "0.21.4",
-          "peechy": "0.4.34",
-          "prettier": "3.5.3",
-          "prettier-plugin-organize-imports": "4.0.0",
-          "source-map-js": "1.2.0",
-          "typescript": "5.7.2",
-        },
-      }),
-    };
-    const promises = new Array(5);
-    // this repro a hang when using a proxy, we run multiple times to make sure it's not a flaky test
-    for (let i = 0; i < 5; i++) {
-      const package_dir = tempDirWithFiles("codex-" + i, files);
+        async function waitForSquid(max_wait = 60_000) {
+          const start = Date.now();
+          while (true) {
+            if (await isSquidRunning()) {
+              return;
+            }
+            if (Date.now() - start > max_wait) {
+              throw new Error("Squid did not start in time");
+            }
 
-      const { exited } = Bun.spawn([bunExe(), "install", "--ignore-scripts"], {
-        cwd: package_dir,
-        // @ts-ignore
-        env: {
-          ...bunEnv,
-          BUN_INSTALL_CACHE_DIR: join(package_dir, ".bun-install-cache"),
-          TMPDIR: join(package_dir, ".tmp"),
-          BUN_TMPDIR: join(package_dir, ".tmp"),
-          HTTPS_PROXY: SQUID_URL,
-          HTTP_PROXY: SQUID_URL,
-        },
-        stdio: ["inherit", "inherit", "inherit"],
-        timeout: 20_000,
-      });
-      promises[i] = exited
-        .then(r => {
-          if (r !== 0) {
-            throw new Error("failed to install with exit code " + r);
+            await Bun.sleep(1000);
           }
-        })
-        .finally(() => {
-          return rm(package_dir, { recursive: true, force: true });
-        });
-    }
+        }
+        // wait for squid to start
+        await waitForSquid();
+      }
+    });
 
-    await Promise.all(promises);
-  }, 60_000);
+    it("bun install with proxy with big packages", async () => {
+      const files = {
+        "package.json": JSON.stringify({
+          "name": "test-install",
+          "module": "index.ts",
+          "type": "module",
+          "private": true,
+          "dependencies": {
+            "gastby": "1.0.1",
+            "mitata": "1.0.34",
+            "next.js": "1.0.3",
+            "react": "19.1.0",
+            "react-dom": "19.1.0",
+            "@types/react": "18.3.3",
+            "esbuild": "0.21.4",
+            "peechy": "0.4.34",
+            "prettier": "3.5.3",
+            "prettier-plugin-organize-imports": "4.0.0",
+            "source-map-js": "1.2.0",
+            "typescript": "5.7.2",
+          },
+        }),
+      };
+      const promises = new Array(5);
+      // this repro a hang when using a proxy, we run multiple times to make sure it's not a flaky test
+      for (let i = 0; i < 5; i++) {
+        const package_dir = tempDirWithFiles("codex-" + i, files);
+
+        const { exited } = Bun.spawn([bunExe(), "install", "--ignore-scripts"], {
+          cwd: package_dir,
+          // @ts-ignore
+          env: {
+            ...bunEnv,
+            BUN_INSTALL_CACHE_DIR: join(package_dir, ".bun-install-cache"),
+            TMPDIR: join(package_dir, ".tmp"),
+            BUN_TMPDIR: join(package_dir, ".tmp"),
+            HTTPS_PROXY: SQUID_URL,
+            HTTP_PROXY: SQUID_URL,
+          },
+          stdio: ["inherit", "inherit", "inherit"],
+          timeout: 20_000,
+        });
+        promises[i] = exited
+          .then(r => {
+            if (r !== 0) {
+              throw new Error("failed to install with exit code " + r);
+            }
+          })
+          .finally(() => {
+            return rm(package_dir, { recursive: true, force: true });
+          });
+      }
+
+      await Promise.all(promises);
+    }, 60_000);
+  });
 }
 
+// Each command builds its registry requests separately, and `bun audit`
+// (#20295), `bun publish` and `bun pm whoami` have each shipped without the
+// proxy, so every command that talks to the registry gets a case here.
 describe("registry commands honor http_proxy", () => {
-  type ProxiedRequest = { method: string; url: string; otp: string | null };
+  type RegistryRequest = { via: "proxy" | "registry"; method: string; url: string; otp?: string };
 
-  // The registry named in bunfig.toml only records the requests that reach it
-  // directly; http_proxy points at `proxy`, which answers in the registry's
-  // place. A request sent through an HTTP proxy names the full registry URL as
-  // its target, which is what `req.url` holds at the proxy.
-  function proxiedRegistry(respond: (req: ProxiedRequest, registryUrl: string) => Response) {
-    const direct: string[] = [];
-    const proxied: ProxiedRequest[] = [];
-    const registry = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch(req) {
-        direct.push(`${req.method} ${new URL(req.url).pathname}`);
-        return new Response(null, { status: 500 });
-      },
-    });
+  // The registry from bunfig.toml and the proxy from http_proxy both answer
+  // with `respond`, and every request records which of the two received it.
+  // A request sent through an HTTP proxy names the full registry URL as its
+  // target, so `req.url` is the registry URL at either server.
+  function registryBehindProxy(respond: (req: RegistryRequest) => Response) {
+    const requests: RegistryRequest[] = [];
+    const serve = (via: RegistryRequest["via"]) =>
+      Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch(req) {
+          await req.arrayBuffer();
+          const request: RegistryRequest = { via, method: req.method, url: req.url };
+          const otp = req.headers.get("npm-otp");
+          if (otp !== null) request.otp = otp;
+          requests.push(request);
+          return respond(request);
+        },
+      });
+    const registry = serve("registry");
+    const proxy = serve("proxy");
     const registryUrl = `http://127.0.0.1:${registry.port}/`;
-    const proxy = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      async fetch(req) {
-        await req.arrayBuffer();
-        const request = { method: req.method, url: req.url, otp: req.headers.get("npm-otp") };
-        proxied.push(request);
-        return respond(request, registryUrl);
-      },
-    });
     return {
       registryUrl,
-      direct,
-      proxied,
-      async run(packageName: string, ...args: string[]) {
-        using dir = tempDir(`proxy-${packageName}`, {
-          "package.json": JSON.stringify({ name: packageName, version: "1.0.0" }),
+      requests,
+      async run(args: string[], opts: { files?: Record<string, string>; env?: Record<string, string> } = {}) {
+        using dir = tempDir("registry-behind-proxy", {
+          "package.json": JSON.stringify({ name: "app", version: "1.0.0" }),
+          ...opts.files,
           "bunfig.toml": Bun.TOML.stringify({
             install: { cache: false, registry: { url: registryUrl, token: "unused" } },
           }),
@@ -141,12 +142,14 @@ describe("registry commands honor http_proxy", () => {
           cwd: String(dir),
           env: {
             ...bunEnv,
+            BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
             NO_PROXY: undefined,
             no_proxy: undefined,
             HTTPS_PROXY: undefined,
             https_proxy: undefined,
             HTTP_PROXY: undefined,
             http_proxy: `http://127.0.0.1:${proxy.port}`,
+            ...opts.env,
           },
           stdout: "pipe",
           stderr: "pipe",
@@ -161,13 +164,19 @@ describe("registry commands honor http_proxy", () => {
     };
   }
 
-  it.concurrent("bun pm whoami", async () => {
-    using setup = proxiedRegistry(() => Response.json({ username: "user-behind-the-proxy" }));
+  const manifest = (name: string) =>
+    Response.json({
+      name,
+      "dist-tags": { latest: "1.0.0" },
+      versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball: `http://127.0.0.1:1/${name}-1.0.0.tgz` } } },
+    });
 
-    const { stdout, stderr, exitCode } = await setup.run("whoami-pkg", "pm", "whoami");
-    expect({ proxied: setup.proxied, direct: setup.direct, stdout, stderr, exitCode }).toEqual({
-      proxied: [{ method: "GET", url: `${setup.registryUrl}-/whoami`, otp: null }],
-      direct: [],
+  it.concurrent("bun pm whoami", async () => {
+    using setup = registryBehindProxy(() => Response.json({ username: "user-behind-the-proxy" }));
+
+    const { stdout, stderr, exitCode } = await setup.run(["pm", "whoami"]);
+    expect({ requests: setup.requests, stdout, stderr, exitCode }).toEqual({
+      requests: [{ via: "proxy", method: "GET", url: `${setup.registryUrl}-/whoami` }],
       stdout: "user-behind-the-proxy\n",
       stderr: "",
       exitCode: 0,
@@ -175,53 +184,110 @@ describe("registry commands honor http_proxy", () => {
   });
 
   it.concurrent("bun publish", async () => {
-    using setup = proxiedRegistry(() => Response.json({ ok: true }));
+    using setup = registryBehindProxy(() => Response.json({ ok: true }));
 
-    const { stdout, stderr, exitCode } = await setup.run("publish-pkg", "publish");
-    expect({ proxied: setup.proxied, direct: setup.direct, stderr, exitCode }).toEqual({
-      proxied: [{ method: "PUT", url: `${setup.registryUrl}publish-pkg`, otp: null }],
-      direct: [],
+    const { stdout, stderr, exitCode } = await setup.run(["publish"]);
+    expect({ requests: setup.requests, stderr, exitCode }).toEqual({
+      requests: [{ via: "proxy", method: "PUT", url: `${setup.registryUrl}app` }],
       stderr: "",
       exitCode: 0,
     });
-    expect(stdout).toContain(" + publish-pkg@1.0.0");
+    expect(stdout).toContain(" + app@1.0.0");
   });
 
   it.concurrent("bun publish --tolerate-republish version lookup", async () => {
-    using setup = proxiedRegistry(({ method }) =>
-      method === "GET" ? Response.json({ versions: { "1.0.0": {} } }) : new Response(null, { status: 500 }),
+    using setup = registryBehindProxy(({ method }) =>
+      method === "GET" ? manifest("app") : new Response(null, { status: 500 }),
     );
 
-    const { stderr, exitCode } = await setup.run("republish-pkg", "publish", "--tolerate-republish");
-    expect({ proxied: setup.proxied, direct: setup.direct, stderr, exitCode }).toEqual({
-      proxied: [{ method: "GET", url: `${setup.registryUrl}republish-pkg`, otp: null }],
-      direct: [],
+    const { stderr, exitCode } = await setup.run(["publish", "--tolerate-republish"]);
+    expect({ requests: setup.requests, stderr, exitCode }).toEqual({
+      requests: [{ via: "proxy", method: "GET", url: `${setup.registryUrl}app` }],
       stderr: "warn: Registry already knows about version 1.0.0; skipping.\n",
       exitCode: 0,
     });
   });
 
   it.concurrent("bun publish web login poll and OTP retry", async () => {
-    using setup = proxiedRegistry(({ url, otp }, registryUrl) => {
+    using setup = registryBehindProxy(({ url, otp }) => {
       if (url.endsWith("/-/done")) return Response.json({ token: "otp-from-web-login" });
       if (otp === "otp-from-web-login") return Response.json({ ok: true });
       return Response.json(
-        { authUrl: `${registryUrl}-/auth`, doneUrl: `${registryUrl}-/done` },
+        { authUrl: new URL("/-/auth", url).href, doneUrl: new URL("/-/done", url).href },
         { status: 401, headers: { "www-authenticate": "OTP" } },
       );
     });
 
-    const { stdout, stderr, exitCode } = await setup.run("otp-pkg", "publish");
-    expect({ proxied: setup.proxied, direct: setup.direct, stderr, exitCode }).toEqual({
-      proxied: [
-        { method: "PUT", url: `${setup.registryUrl}otp-pkg`, otp: null },
-        { method: "GET", url: `${setup.registryUrl}-/done`, otp: null },
-        { method: "PUT", url: `${setup.registryUrl}otp-pkg`, otp: "otp-from-web-login" },
+    const { stdout, stderr, exitCode } = await setup.run(["publish"]);
+    expect({ requests: setup.requests, stderr, exitCode }).toEqual({
+      requests: [
+        { via: "proxy", method: "PUT", url: `${setup.registryUrl}app` },
+        { via: "proxy", method: "GET", url: `${setup.registryUrl}-/done` },
+        { via: "proxy", method: "PUT", url: `${setup.registryUrl}app`, otp: "otp-from-web-login" },
       ],
-      direct: [],
       stderr: "",
       exitCode: 0,
     });
-    expect(stdout).toContain(" + otp-pkg@1.0.0");
+    expect(stdout).toContain(" + app@1.0.0");
+  });
+
+  it.concurrent("bun publish to a registry listed in no_proxy goes direct", async () => {
+    using setup = registryBehindProxy(() => Response.json({ ok: true }));
+
+    const { stdout, stderr, exitCode } = await setup.run(["publish"], { env: { no_proxy: "127.0.0.1" } });
+    expect({ requests: setup.requests, stderr, exitCode }).toEqual({
+      requests: [{ via: "registry", method: "PUT", url: `${setup.registryUrl}app` }],
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(stdout).toContain(" + app@1.0.0");
+  });
+
+  it.concurrent("bun info", async () => {
+    using setup = registryBehindProxy(() => manifest("some-dep"));
+
+    const { stdout, stderr, exitCode } = await setup.run(["info", "some-dep", "name"]);
+    expect({ requests: setup.requests, stdout, stderr, exitCode }).toEqual({
+      requests: [{ via: "proxy", method: "GET", url: `${setup.registryUrl}some-dep` }],
+      stdout: "some-dep\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("bun audit", async () => {
+    using setup = registryBehindProxy(() => Response.json({}));
+
+    const { stdout, stderr, exitCode } = await setup.run(["audit"], {
+      files: {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "some-dep": "1.0.0" } }),
+        "bun.lock": JSON.stringify({
+          lockfileVersion: 1,
+          workspaces: { "": { name: "app", dependencies: { "some-dep": "1.0.0" } } },
+          packages: { "some-dep": ["some-dep@1.0.0", "", {}, "sha512-AAAA"] },
+        }),
+      },
+    });
+    expect({ requests: setup.requests, stdout, stderr, exitCode }).toEqual({
+      requests: [{ via: "proxy", method: "POST", url: `${setup.registryUrl}-/npm/v1/security/advisories/bulk` }],
+      stdout: "No vulnerabilities found\n",
+      stderr: expect.stringMatching(/^bun audit v.*\n$/),
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("bun install", async () => {
+    using setup = registryBehindProxy(() => new Response(null, { status: 404 }));
+
+    const { stderr, exitCode } = await setup.run(["install"], {
+      files: {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "some-dep": "1.0.0" } }),
+      },
+    });
+    expect({ requests: setup.requests, stderr, exitCode }).toEqual({
+      requests: [{ via: "proxy", method: "GET", url: `${setup.registryUrl}some-dep` }],
+      stderr: expect.stringContaining(`error: GET ${setup.registryUrl}some-dep - 404`),
+      exitCode: 1,
+    });
   });
 });

--- a/test/cli/install/bun-install-proxy.test.ts
+++ b/test/cli/install/bun-install-proxy.test.ts
@@ -1,7 +1,7 @@
-import { beforeAll, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { exec } from "child_process";
 import { rm } from "fs/promises";
-import { bunEnv, bunExe, dockerExe, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, dockerExe, isDockerEnabled, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 import { promisify } from "util";
 const execAsync = promisify(exec);
@@ -95,3 +95,133 @@ if (isDockerEnabled()) {
     await Promise.all(promises);
   }, 60_000);
 }
+
+describe("registry commands honor http_proxy", () => {
+  type ProxiedRequest = { method: string; url: string; otp: string | null };
+
+  // The registry named in bunfig.toml only records the requests that reach it
+  // directly; http_proxy points at `proxy`, which answers in the registry's
+  // place. A request sent through an HTTP proxy names the full registry URL as
+  // its target, which is what `req.url` holds at the proxy.
+  function proxiedRegistry(respond: (req: ProxiedRequest, registryUrl: string) => Response) {
+    const direct: string[] = [];
+    const proxied: ProxiedRequest[] = [];
+    const registry = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        direct.push(`${req.method} ${new URL(req.url).pathname}`);
+        return new Response(null, { status: 500 });
+      },
+    });
+    const registryUrl = `http://127.0.0.1:${registry.port}/`;
+    const proxy = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        await req.arrayBuffer();
+        const request = { method: req.method, url: req.url, otp: req.headers.get("npm-otp") };
+        proxied.push(request);
+        return respond(request, registryUrl);
+      },
+    });
+    return {
+      registryUrl,
+      direct,
+      proxied,
+      async run(packageName: string, ...args: string[]) {
+        using dir = tempDir(`proxy-${packageName}`, {
+          "package.json": JSON.stringify({ name: packageName, version: "1.0.0" }),
+          "bunfig.toml": Bun.TOML.stringify({
+            install: { cache: false, registry: { url: registryUrl, token: "unused" } },
+          }),
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), ...args],
+          cwd: String(dir),
+          env: {
+            ...bunEnv,
+            NO_PROXY: undefined,
+            no_proxy: undefined,
+            HTTPS_PROXY: undefined,
+            https_proxy: undefined,
+            HTTP_PROXY: undefined,
+            http_proxy: `http://127.0.0.1:${proxy.port}`,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { stdout, stderr, exitCode };
+      },
+      [Symbol.dispose]() {
+        registry.stop(true);
+        proxy.stop(true);
+      },
+    };
+  }
+
+  it.concurrent("bun pm whoami", async () => {
+    using setup = proxiedRegistry(() => Response.json({ username: "user-behind-the-proxy" }));
+
+    const { stdout, stderr, exitCode } = await setup.run("whoami-pkg", "pm", "whoami");
+    expect({ proxied: setup.proxied, direct: setup.direct, stdout, stderr, exitCode }).toEqual({
+      proxied: [{ method: "GET", url: `${setup.registryUrl}-/whoami`, otp: null }],
+      direct: [],
+      stdout: "user-behind-the-proxy\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("bun publish", async () => {
+    using setup = proxiedRegistry(() => Response.json({ ok: true }));
+
+    const { stdout, stderr, exitCode } = await setup.run("publish-pkg", "publish");
+    expect({ proxied: setup.proxied, direct: setup.direct, stderr, exitCode }).toEqual({
+      proxied: [{ method: "PUT", url: `${setup.registryUrl}publish-pkg`, otp: null }],
+      direct: [],
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(stdout).toContain(" + publish-pkg@1.0.0");
+  });
+
+  it.concurrent("bun publish --tolerate-republish version lookup", async () => {
+    using setup = proxiedRegistry(({ method }) =>
+      method === "GET" ? Response.json({ versions: { "1.0.0": {} } }) : new Response(null, { status: 500 }),
+    );
+
+    const { stderr, exitCode } = await setup.run("republish-pkg", "publish", "--tolerate-republish");
+    expect({ proxied: setup.proxied, direct: setup.direct, stderr, exitCode }).toEqual({
+      proxied: [{ method: "GET", url: `${setup.registryUrl}republish-pkg`, otp: null }],
+      direct: [],
+      stderr: "warn: Registry already knows about version 1.0.0; skipping.\n",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("bun publish web login poll and OTP retry", async () => {
+    using setup = proxiedRegistry(({ url, otp }, registryUrl) => {
+      if (url.endsWith("/-/done")) return Response.json({ token: "otp-from-web-login" });
+      if (otp === "otp-from-web-login") return Response.json({ ok: true });
+      return Response.json(
+        { authUrl: `${registryUrl}-/auth`, doneUrl: `${registryUrl}-/done` },
+        { status: 401, headers: { "www-authenticate": "OTP" } },
+      );
+    });
+
+    const { stdout, stderr, exitCode } = await setup.run("otp-pkg", "publish");
+    expect({ proxied: setup.proxied, direct: setup.direct, stderr, exitCode }).toEqual({
+      proxied: [
+        { method: "PUT", url: `${setup.registryUrl}otp-pkg`, otp: null },
+        { method: "GET", url: `${setup.registryUrl}-/done`, otp: null },
+        { method: "PUT", url: `${setup.registryUrl}otp-pkg`, otp: "otp-from-web-login" },
+      ],
+      direct: [],
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(stdout).toContain(" + otp-pkg@1.0.0");
+  });
+});

--- a/test/internal/source-lints/init-sync-http-proxy.test.ts
+++ b/test/internal/source-lints/init-sync-http-proxy.test.ts
@@ -1,0 +1,146 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `AsyncHTTP::init_sync` is how CLI commands (install, publish, audit, pm view,
+// upgrade, create, ...) make a blocking request, and its `http_proxy` argument
+// is the only way the request learns about http_proxy / https_proxy /
+// NO_PROXY. A literal `None` there is a command that silently ignores the
+// proxy environment every other command honours: `bun audit` shipped that way
+// (#20295), and so did `bun publish` and `bun pm whoami`. Resolve it from the
+// environment instead, for the URL being requested:
+//
+//   let http_proxy = pm.http_proxy(&url);                   // with a PackageManager
+//   let http_proxy = env_loader.get_http_proxy_for(&url);   // with a dotenv Loader
+//
+// Both return `None` when no proxy applies, so there is never a reason to
+// write the literal. The argument is found by position, so the lint also
+// fails if the signature changes shape; update INIT_SYNC_ARGS along with it.
+
+const INIT_SYNC_ARGS = [
+  "method",
+  "url",
+  "headers",
+  "headers_buf",
+  "request_body",
+  "http_proxy",
+  "hostname",
+  "redirect_type",
+];
+const HTTP_PROXY_ARG = INIT_SYNC_ARGS.indexOf("http_proxy");
+const CALL = "AsyncHTTP::init_sync(";
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// A string or char literal (`"..."`, `b"..."`, `'x'`, `b'\n'`) starting at
+// lastIndex; a lifetime (`'a`) has no closing quote after its first character
+// and does not match.
+const LITERAL = /b?"(?:\\[\s\S]|[^\\"])*"|b?'(?:\\[\s\S]|[^\\'])'/y;
+const COMMENT = /\/\/[^\n]*|\/\*[\s\S]*?\*\//y;
+
+function matchAt(re: RegExp, source: string, at: number): string | null {
+  re.lastIndex = at;
+  return re.exec(source)?.[0] ?? null;
+}
+
+/** Replaces comments with spaces (line count preserved); literals are kept as-is. */
+function stripComments(source: string): string {
+  let out = "";
+  for (let i = 0; i < source.length; ) {
+    const literal = matchAt(LITERAL, source, i);
+    if (literal !== null) {
+      out += literal;
+      i += literal.length;
+      continue;
+    }
+    const comment = matchAt(COMMENT, source, i);
+    if (comment !== null) {
+      out += comment.replace(/[^\n]/g, " ");
+      i += comment.length;
+      continue;
+    }
+    out += source[i++];
+  }
+  return out;
+}
+
+/**
+ * The arguments of the call whose `(` is at `source[open]`, split on the
+ * commas at nesting depth 0, or `null` if the call is never closed.
+ */
+function callArguments(source: string, open: number): string[] | null {
+  const args: string[] = [];
+  let current = "";
+  let depth = 0;
+  for (let i = open + 1; i < source.length; ) {
+    const literal = matchAt(LITERAL, source, i);
+    if (literal !== null) {
+      current += literal;
+      i += literal.length;
+      continue;
+    }
+    const c = source[i++]!;
+    if (c === "(" || c === "[" || c === "{") depth++;
+    if (c === ")" || c === "]" || c === "}") {
+      if (depth === 0) {
+        if (current.trim() !== "") args.push(current.trim());
+        return args;
+      }
+      depth--;
+    }
+    if (c === "," && depth === 0) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += c;
+  }
+  return null;
+}
+
+const offenders: string[] = [];
+let calls = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  const content = await file(abs).text();
+  if (!content.includes(CALL)) continue;
+  const code = stripComments(content);
+  for (let at = code.indexOf(CALL); at !== -1; at = code.indexOf(CALL, at + CALL.length)) {
+    calls++;
+    const where = `${source}:${code.slice(0, at).split("\n").length}`;
+    const args = callArguments(code, at + CALL.length - 1);
+    if (args === null || args.length !== INIT_SYNC_ARGS.length) {
+      offenders.push(
+        `${where}: expected the ${INIT_SYNC_ARGS.length} arguments (${INIT_SYNC_ARGS.join(", ")}), found ${args?.length ?? "an unterminated call"}; update this lint if init_sync changed`,
+      );
+    } else if (args[HTTP_PROXY_ARG] === "None") {
+      offenders.push(`${where}: AsyncHTTP::init_sync with http_proxy: None; resolve it from the environment`);
+    }
+  }
+}
+
+test("scans the AsyncHTTP::init_sync call sites", () => {
+  expect(calls).toBeGreaterThan(0);
+});
+
+test("every AsyncHTTP::init_sync call resolves http_proxy from the environment", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- With `HTTP_PROXY` / `HTTPS_PROXY` set (a network where the registry is only reachable through the proxy), `bun install`, `bun audit` and `bun pm view` go through the proxy, but `bun publish` and `bun pm whoami` connect to the registry directly and fail (`ConnectionRefused` / timeout, or a `500`/`4xx` from whatever answers), with nothing saying the proxy env was ignored.
- Cause: these requests are built with `None` in the `http_proxy` slot of `AsyncHTTP::init_sync`, so the client never looks at the proxy env:
  - `src/runtime/cli/publish_command.rs`: the `--tolerate-republish` manifest GET (`check_package_version_exists`), the publish PUT, the OTP retry PUT, and the web login `doneUrl` poll in `get_otp` (four sites).
  - `src/install/npm.rs` `whoami()` (`bun pm whoami` / `bun whoami`).
- Probe against a local recording proxy with the released `bun` 1.4.0 (details below): `bun install` sends `GET http://127.0.0.1:<registry>/<pkg>` to the proxy; `bun pm whoami`, `bun publish` and `bun publish --tolerate-republish` hit the registry directly and the proxy sees nothing.

### Fix
- Each of the five requests resolves its proxy with `PackageManager::http_proxy(&url)` for the URL it is about to fetch and passes it to `init_sync`, which is exactly what `audit_command.rs` and `pm_view_command.rs` already do. `check_package_version_exists` gains a `&PackageManager` parameter to reach it.
- Why this is right: `bun install` and the other registry commands already define how the proxy env applies to registry traffic (and npm applies its proxy config to `publish` and `whoami` too); publish and whoami were simply left out. Resolving per request URL rather than once per command is what the helper is designed for: it picks `http_proxy` vs `https_proxy` from the URL's scheme and applies `NO_PROXY` to the URL's host, and the `doneUrl` is supplied by the registry, so it has to be resolved on its own. Behaviour with no proxy env is unchanged (`http_proxy()` returns `None`, as before), and hosts listed in `NO_PROXY` still go direct.
- Verified with `test/cli/install/bun-install-proxy.test.ts` (new `describe`, no docker needed): a `Bun.serve` registry that records direct hits plus a `Bun.serve` proxy that answers in its place. An HTTP proxy receives the target as the full registry URL, so `req.url` at the proxy pins down exactly which request was routed through it. The four tests cover `bun pm whoami`, the publish PUT, the `--tolerate-republish` GET (the proxied answer is honoured: publish prints the skip warning and sends nothing else), and the 401 -> `doneUrl` GET -> OTP PUT sequence, asserting the full request list each time and zero direct hits.
  - `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-install-proxy.test.ts`: 4 fail (every request lands on the registry directly, the proxy log is empty).
  - `bun bd test test/cli/install/bun-install-proxy.test.ts`: 4 pass.
  - `bun bd test test/cli/install/bun-publish.test.ts --timeout 60000`: 39 pass; `bun-pm.test.ts`: 19 pass; `bun-install-registry.test.ts -t whoami`: 6 pass. This container has `HTTP_PROXY` set with `NO_PROXY=localhost,...`, so those suites also exercise the `NO_PROXY` exemption on the changed paths.

### Background
- `AsyncHTTP::init_sync` (`src/http/AsyncHTTP.rs`) is the blocking request used by CLI commands; its `http_proxy: Option<URL>` argument is the only way a request learns about a proxy. When it is set and the target is `http://`, the client connects to the proxy and sends the request in absolute form (`PUT http://registry:port/pkg HTTP/1.1`, see `write_proxy_request` in `src/http/lib.rs`); for `https://` targets it opens a `CONNECT` tunnel. When it is `None`, the client connects to the target host directly.
- `PackageManager::http_proxy(&url)` wraps `Loader::get_http_proxy_for` (`src/dotenv/env_loader.rs`): it reads `http_proxy`/`HTTP_PROXY` or `https_proxy`/`HTTPS_PROXY` depending on the URL's scheme and returns `None` when the URL's host matches `NO_PROXY`. `bun install` (`NetworkTask`), `bun audit` and `bun pm view` all call it right before building their request.
- `--tolerate-republish` makes publish GET the package manifest first and skip the upload when the version already exists. The web login flow is: the PUT gets a `401` with `www-authenticate: OTP` and a JSON body carrying `authUrl`/`doneUrl`; publish polls `doneUrl` until it returns a token, then repeats the PUT with an `npm-otp` header. All of those are separate requests, which is why there are four sites in `publish_command.rs`.

<details>
<summary>Probe against the released binary (bun 1.4.0-canary, before the fix)</summary>

Recording proxy on `http_proxy`, registry stub on `127.0.0.1:38195` counting direct hits, `NO_PROXY` unset:

```
== bun install (control) (exit 1)
   proxyLog: ["GET http://127.0.0.1:38195/dep-behind-proxy"]
   directHits: []
== bun pm whoami (exit 1)
   proxyLog: []
   directHits: ["GET /-/whoami"]
   stderr: 500 Internal Server Error: http://127.0.0.1:38195/-/whoami
== bun publish (exit 1)
   proxyLog: []
   directHits: ["PUT /proxy-pkg"]
   stderr: 500 Internal Server Error: http://127.0.0.1:38195/proxy-pkg
== bun publish --tolerate-republish (exit 1)
   proxyLog: []
   directHits: ["GET /proxy-pkg","PUT /proxy-pkg"]
```
</details>
