### PR TITLE
node:tls: use the stream engine for server-side wraps the native upgrade cannot adopt

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2408,8 +2408,7 @@ function adoptServerTLS(self, connection, tls) {
     try {
       attachServerTLSEngine(self, connection, tls);
     } catch (err) {
-      // Here there is no caller to throw to (unlike the synchronous engine
-      // branch, which throws from the constructor); report on the wrap.
+      // No caller to throw to here, unlike the synchronous engine branch.
       self.destroy(err);
       return;
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2393,9 +2393,7 @@ function attachServerTLSEngine(self, connection, tls) {
 // Deferred a tick so plain writes made by later 'connection' listeners are seen below.
 function adoptServerTLS(self, connection, tls) {
   if (self.destroyed || connection.destroyed) {
-    // A wrap destroyed before adoption (e.g. while the connection was still
-    // connecting) releases the connection it would have owned, like the
-    // client-side 'connect' path above.
+    // A destroyed wrap releases the connection it would have owned (mirrors the client 'connect' path).
     connection.destroy();
     self.destroy();
     return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2405,7 +2405,14 @@ function adoptServerTLS(self, connection, tls) {
     return;
   }
   if (isNamedPipeSocket(handle) || hasUnflushedWrites(connection)) {
-    attachServerTLSEngine(self, connection, tls);
+    try {
+      attachServerTLSEngine(self, connection, tls);
+    } catch (err) {
+      // Here there is no caller to throw to (unlike the synchronous engine
+      // branch, which throws from the constructor); report on the wrap.
+      self.destroy(err);
+      return;
+    }
     self.emit(kUpgradeAttached);
     return;
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2390,9 +2390,7 @@ function attachServerTLSEngine(self, connection, tls) {
   self._handle = result;
 }
 
-// A failed adoption owns both sockets: the wrap reports the failure, and the
-// connection dies with it (mirrors the client 'connect' path; nothing else
-// holds a connection wrapped inline).
+// The wrap reports the error and the connection dies with it: an inline-wrapped connection has no other owner.
 function failServerAdoption(self, connection, err) {
   self._handle = null;
   connection.destroy();

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2353,19 +2353,14 @@ Socket.prototype.pause = function pause() {
 Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, tls) {
   const socket = connection._handle;
   if (!socket || isNamedPipeSocket(socket) || connection.encrypted || hasUnflushedWrites(connection)) {
-    // Nothing to adopt (generic Duplex, or a Windows named pipe, which has no
-    // us_socket_t; the client path routes pipes the same way), TLS over TLS
-    // (the fd belongs to the outer SSL layer), or pending plain writes that
-    // must flush first: run the TLS engine over the stream itself.
+    // No fd to adopt (Duplex, named pipe), TLS over TLS, or plain writes still queued: TLS engine over the stream.
     attachServerTLSEngine(this, connection, tls);
     this[kupgraded] = connection;
     return;
   }
   this[kupgraded] = connection;
   if (connection.connecting) {
-    // Adoption needs the established socket, so wait for it the way the
-    // client path does; a connection that fails first takes the wrap down
-    // with it, as adoptServerTLS does for one destroyed in the meantime.
+    // upgradeTLS needs an established socket: adopt once connected; a failed connect closes the wrap instead.
     const onConnect = () => {
       connection.removeListener("close", onClose);
       process.nextTick(adoptServerTLS, this, connection, tls);
@@ -2395,32 +2390,24 @@ function attachServerTLSEngine(self, connection, tls) {
   self._handle = result;
 }
 
-// The deferred half of the server-side wrap. Runs a tick after the wrap (or
-// after the connection's 'connect'), so that writes the user queued on the
-// plain connection in between are seen below.
+// Deferred a tick so plain writes made by later 'connection' listeners are seen below.
 function adoptServerTLS(self, connection, tls) {
   if (self.destroyed || connection.destroyed) {
     self.destroy();
     return;
   }
-  // Re-read: a connection that was still connecting when wrapped may have
-  // swapped handles (family autoselection) or turned out to be a named pipe.
+  // Re-read: family autoselection swaps handles while connecting, and the result may be a pipe.
   const handle = connection._handle;
   if (!handle) {
     self.destroy();
     return;
   }
-  // Queued plain writes (a user 'connection' listener runs after the
-  // server's) must flush before any TLS output, so they, like a pipe, take
-  // the stream-level engine.
   if (isNamedPipeSocket(handle) || hasUnflushedWrites(connection)) {
     attachServerTLSEngine(self, connection, tls);
     self.emit(kUpgradeAttached);
     return;
   }
-  // Bytes that already arrived before the wrap were pulled off the fd into
-  // the connection's readable buffer; hand them to the TLS engine so the
-  // handshake doesn't stall.
+  // Bytes already pulled off the fd (the ClientHello) go to the TLS engine.
   const pending = connection.read();
   let result;
   try {
@@ -2432,10 +2419,7 @@ function adoptServerTLS(self, connection, tls) {
       initialData: pending || undefined,
     });
   } catch (err) {
-    // The constructor already returned, so a throw here would be an uncaught
-    // exception. Reachable when the native socket closed under a connection
-    // that is not destroyed yet (peer reset with unread bytes still buffered):
-    // the handle object survives but has nothing left to adopt.
+    // e.g. the peer reset a connection that still had unread bytes: the handle outlives the native socket.
     self._handle = null;
     self.destroy(err);
     return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2390,18 +2390,25 @@ function attachServerTLSEngine(self, connection, tls) {
   self._handle = result;
 }
 
+// A failed adoption owns both sockets: the wrap reports the failure, and the
+// connection dies with it (mirrors the client 'connect' path; nothing else
+// holds a connection wrapped inline).
+function failServerAdoption(self, connection, err) {
+  self._handle = null;
+  connection.destroy();
+  self.destroy(err);
+}
+
 // Deferred a tick so plain writes made by later 'connection' listeners are seen below.
 function adoptServerTLS(self, connection, tls) {
   if (self.destroyed || connection.destroyed) {
-    // A destroyed wrap releases the connection it would have owned (mirrors the client 'connect' path).
-    connection.destroy();
-    self.destroy();
+    failServerAdoption(self, connection);
     return;
   }
   // Re-read: family autoselection swaps handles while connecting, and the result may be a pipe.
   const handle = connection._handle;
   if (!handle) {
-    self.destroy();
+    failServerAdoption(self, connection);
     return;
   }
   if (isNamedPipeSocket(handle) || hasUnflushedWrites(connection)) {
@@ -2409,7 +2416,7 @@ function adoptServerTLS(self, connection, tls) {
       attachServerTLSEngine(self, connection, tls);
     } catch (err) {
       // No caller to throw to here, unlike the synchronous engine branch.
-      self.destroy(err);
+      failServerAdoption(self, connection, err);
       return;
     }
     self.emit(kUpgradeAttached);
@@ -2428,13 +2435,11 @@ function adoptServerTLS(self, connection, tls) {
     });
   } catch (err) {
     // e.g. the peer reset a connection that still had unread bytes: the handle outlives the native socket.
-    self._handle = null;
-    self.destroy(err);
+    failServerAdoption(self, connection, err);
     return;
   }
   if (!result) {
-    self._handle = null;
-    self.destroy(new Error("Invalid socket"));
+    failServerAdoption(self, connection, new Error("Invalid socket"));
     return;
   }
   const [raw, tlsHandle] = result;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2352,97 +2352,107 @@ Socket.prototype.pause = function pause() {
 // state carried via `data` (mirrors tls.createServer's one-handler-for-all model).
 Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, tls) {
   const socket = connection._handle;
-  if (
-    !socket ||
-    connection.connecting ||
-    isNamedPipeSocket(socket) ||
-    connection.encrypted ||
-    hasUnflushedWrites(connection)
-  ) {
-    // No adoptable fd (generic Duplex, still connecting, or a Windows named
-    // pipe, which upgradeTLS rejects just like the client path's
-    // isNamedPipeSocket check in connect()), TLS over TLS (the fd belongs to
-    // the outer SSL layer), or pending plain writes that must flush first:
-    // run the TLS engine over the stream itself.
-    const [result, events] = upgradeDuplexToTLS(connection, {
-      data: this,
-      tls,
-      socket: serverHandlersFor(this),
-      isServer: true,
-    });
-    connection.on("data", events[0]);
-    connection.on("end", events[1]);
-    connection.on("drain", events[2]);
-    connection.on("close", events[3]);
+  if (!socket || isNamedPipeSocket(socket) || connection.encrypted || hasUnflushedWrites(connection)) {
+    // Nothing to adopt (generic Duplex, or a Windows named pipe, which has no
+    // us_socket_t; the client path routes pipes the same way), TLS over TLS
+    // (the fd belongs to the outer SSL layer), or pending plain writes that
+    // must flush first: run the TLS engine over the stream itself.
+    attachServerTLSEngine(this, connection, tls);
     this[kupgraded] = connection;
-    this._handle = result;
     return;
   }
   this[kupgraded] = connection;
-  process.nextTick(() => {
-    if (this.destroyed || connection.destroyed) {
+  if (connection.connecting) {
+    // Adoption needs the established socket, so wait for it the way the
+    // client path does; a connection that fails first takes the wrap down
+    // with it, as adoptServerTLS does for one destroyed in the meantime.
+    const onConnect = () => {
+      connection.removeListener("close", onClose);
+      process.nextTick(adoptServerTLS, this, connection, tls);
+    };
+    const onClose = () => {
+      connection.removeListener("connect", onConnect);
       this.destroy();
-      return;
-    }
-    const handle = connection._handle;
-    if (!handle) {
-      this.destroy();
-      return;
-    }
-    // Writes may have been queued between the wrap and this tick (a user
-    // 'connection' listener runs after the server's): those bytes must flush
-    // before any TLS output, so fall back to the stream-level engine.
-    if (hasUnflushedWrites(connection)) {
-      const [result, events] = upgradeDuplexToTLS(connection, {
-        data: this,
-        tls,
-        socket: serverHandlersFor(this),
-        isServer: true,
-      });
-      connection.on("data", events[0]);
-      connection.on("end", events[1]);
-      connection.on("drain", events[2]);
-      connection.on("close", events[3]);
-      this._handle = result;
-      this.emit(kUpgradeAttached);
-      return;
-    }
-    // Bytes that already arrived before the wrap were pulled off the fd into
-    // the connection's readable buffer; hand them to the TLS engine so the
-    // handshake doesn't stall.
-    const pending = connection.read();
-    let result;
-    try {
-      result = handle.upgradeTLS({
-        data: this,
-        tls,
-        socket: serverHandlersFor(this),
-        isServer: true,
-        initialData: pending || undefined,
-      });
-    } catch (err) {
-      // The constructor already returned, so a throw here would be an uncaught
-      // exception. Reachable when the native socket closed under a connection
-      // that is not destroyed yet (peer reset with unread bytes still buffered):
-      // the handle object survives but has nothing left to adopt.
-      this._handle = null;
-      this.destroy(err);
-      return;
-    }
-    if (!result) {
-      this._handle = null;
-      this.destroy(new Error("Invalid socket"));
-      return;
-    }
-    const [raw, tlsHandle] = result;
-    connection._handle = raw;
-    raw[kAdoptedTLSRaw] = true;
-    this.once("end", this[kCloseRawConnection]);
-    raw.connecting = false;
-    this._handle = tlsHandle;
-    this.emit(kUpgradeAttached);
-  });
+    };
+    connection.once("connect", onConnect);
+    connection.once("close", onClose);
+    return;
+  }
+  process.nextTick(adoptServerTLS, this, connection, tls);
 };
+
+function attachServerTLSEngine(self, connection, tls) {
+  const [result, events] = upgradeDuplexToTLS(connection, {
+    data: self,
+    tls,
+    socket: serverHandlersFor(self),
+    isServer: true,
+  });
+  connection.on("data", events[0]);
+  connection.on("end", events[1]);
+  connection.on("drain", events[2]);
+  connection.on("close", events[3]);
+  self._handle = result;
+}
+
+// The deferred half of the server-side wrap. Runs a tick after the wrap (or
+// after the connection's 'connect'), so that writes the user queued on the
+// plain connection in between are seen below.
+function adoptServerTLS(self, connection, tls) {
+  if (self.destroyed || connection.destroyed) {
+    self.destroy();
+    return;
+  }
+  // Re-read: a connection that was still connecting when wrapped may have
+  // swapped handles (family autoselection) or turned out to be a named pipe.
+  const handle = connection._handle;
+  if (!handle) {
+    self.destroy();
+    return;
+  }
+  // Queued plain writes (a user 'connection' listener runs after the
+  // server's) must flush before any TLS output, so they, like a pipe, take
+  // the stream-level engine.
+  if (isNamedPipeSocket(handle) || hasUnflushedWrites(connection)) {
+    attachServerTLSEngine(self, connection, tls);
+    self.emit(kUpgradeAttached);
+    return;
+  }
+  // Bytes that already arrived before the wrap were pulled off the fd into
+  // the connection's readable buffer; hand them to the TLS engine so the
+  // handshake doesn't stall.
+  const pending = connection.read();
+  let result;
+  try {
+    result = handle.upgradeTLS({
+      data: self,
+      tls,
+      socket: serverHandlersFor(self),
+      isServer: true,
+      initialData: pending || undefined,
+    });
+  } catch (err) {
+    // The constructor already returned, so a throw here would be an uncaught
+    // exception. Reachable when the native socket closed under a connection
+    // that is not destroyed yet (peer reset with unread bytes still buffered):
+    // the handle object survives but has nothing left to adopt.
+    self._handle = null;
+    self.destroy(err);
+    return;
+  }
+  if (!result) {
+    self._handle = null;
+    self.destroy(new Error("Invalid socket"));
+    return;
+  }
+  const [raw, tlsHandle] = result;
+  connection._handle = raw;
+  raw[kAdoptedTLSRaw] = true;
+  self.once("end", self[kCloseRawConnection]);
+  raw.connecting = false;
+  self._handle = tlsHandle;
+  self.emit(kUpgradeAttached);
+}
 
 Socket.prototype.read = function read(size) {
   if (!this.connecting && !drainOnreadTail(this, true)) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2393,6 +2393,10 @@ function attachServerTLSEngine(self, connection, tls) {
 // Deferred a tick so plain writes made by later 'connection' listeners are seen below.
 function adoptServerTLS(self, connection, tls) {
   if (self.destroyed || connection.destroyed) {
+    // A wrap destroyed before adoption (e.g. while the connection was still
+    // connecting) releases the connection it would have owned, like the
+    // client-side 'connect' path above.
+    connection.destroy();
     self.destroy();
     return;
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2352,10 +2352,18 @@ Socket.prototype.pause = function pause() {
 // state carried via `data` (mirrors tls.createServer's one-handler-for-all model).
 Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, tls) {
   const socket = connection._handle;
-  if (!socket || connection.encrypted || hasUnflushedWrites(connection)) {
-    // No adoptable fd (generic Duplex / not yet connected), TLS over TLS (the
-    // fd belongs to the outer SSL layer), or pending plain writes that must
-    // flush first: run the TLS engine over the stream itself.
+  if (
+    !socket ||
+    connection.connecting ||
+    isNamedPipeSocket(socket) ||
+    connection.encrypted ||
+    hasUnflushedWrites(connection)
+  ) {
+    // No adoptable fd (generic Duplex, still connecting, or a Windows named
+    // pipe, which upgradeTLS rejects just like the client path's
+    // isNamedPipeSocket check in connect()), TLS over TLS (the fd belongs to
+    // the outer SSL layer), or pending plain writes that must flush first:
+    // run the TLS engine over the stream itself.
     const [result, events] = upgradeDuplexToTLS(connection, {
       data: this,
       tls,
@@ -2403,13 +2411,24 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     // the connection's readable buffer; hand them to the TLS engine so the
     // handshake doesn't stall.
     const pending = connection.read();
-    const result = handle.upgradeTLS({
-      data: this,
-      tls,
-      socket: serverHandlersFor(this),
-      isServer: true,
-      initialData: pending || undefined,
-    });
+    let result;
+    try {
+      result = handle.upgradeTLS({
+        data: this,
+        tls,
+        socket: serverHandlersFor(this),
+        isServer: true,
+        initialData: pending || undefined,
+      });
+    } catch (err) {
+      // The constructor already returned, so a throw here would be an uncaught
+      // exception. Reachable when the native socket closed under a connection
+      // that is not destroyed yet (peer reset with unread bytes still buffered):
+      // the handle object survives but has nothing left to adopt.
+      this._handle = null;
+      this.destroy(err);
+      return;
+    }
     if (!result) {
       this._handle = null;
       this.destroy(new Error("Invalid socket"));

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -105,6 +105,7 @@ async function serverWrapRoundTrip(wrap: ServerWrap) {
   const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
   const echoed = Promise.withResolvers<string>();
   const server = net.createServer(accepted => {
+    accepted.on("error", echoed.reject);
     wrap(
       accepted,
       secure => {
@@ -120,7 +121,13 @@ async function serverWrapRoundTrip(wrap: ServerWrap) {
     await once(server, "listening");
     client = connect({ socket: net.connect(pipeName), rejectUnauthorized: false }, () => client!.write("ping"));
     client.on("error", echoed.reject);
-    client.once("data", chunk => echoed.resolve(chunk.toString()));
+    // Read through to the server's close_notify before tearing down: a pipe
+    // write is only complete once the peer has read it, so closing on the
+    // first data chunk would fail the server's still-pending close_notify
+    // write with EPIPE.
+    let received = "";
+    client.on("data", chunk => (received += chunk));
+    client.on("end", () => echoed.resolve(received));
     expect(await echoed.promise).toBe("echo:ping");
   } finally {
     client?.destroy();

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -3,7 +3,7 @@ import { expectMaxObjectTypeCount, isWindows, tls } from "harness";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import net from "node:net";
-import { connect, createServer } from "node:tls";
+import { connect, createServer, TLSSocket } from "node:tls";
 
 it.if(isWindows)("should work with named pipes and tls", async () => {
   await expectMaxObjectTypeCount(expect, "TLSSocket", 0);
@@ -93,4 +93,54 @@ it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", asy
   }
   await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
+});
+
+// Server-side wraps of an accepted named-pipe connection. A pipe has no fd for
+// the native upgrade to adopt; the wrap has to run the TLS engine over the
+// stream, the way tls.connect({ socket }) already does for pipes. It used to
+// throw "upgradeTLS requires an established socket" from nextTick, uncaught.
+type ServerWrap = (accepted: net.Socket, echo: (secure: TLSSocket) => void, fail: (err: Error) => void) => void;
+
+async function serverWrapRoundTrip(wrap: ServerWrap) {
+  const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+  const echoed = Promise.withResolvers<string>();
+  const server = net.createServer(accepted => {
+    wrap(
+      accepted,
+      secure => {
+        secure.on("error", echoed.reject);
+        secure.on("data", chunk => secure.end(`echo:${chunk}`));
+      },
+      echoed.reject,
+    );
+  });
+  let client: TLSSocket | undefined;
+  try {
+    server.listen(pipeName);
+    await once(server, "listening");
+    client = connect({ socket: net.connect(pipeName), rejectUnauthorized: false }, () => client!.write("ping"));
+    client.on("error", echoed.reject);
+    client.once("data", chunk => echoed.resolve(chunk.toString()));
+    expect(await echoed.promise).toBe("echo:ping");
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+}
+
+it.if(isWindows)("new TLSSocket(pipeSocket, { isServer: true }) completes a handshake over a named pipe", async () => {
+  await serverWrapRoundTrip((accepted, echo) => echo(new TLSSocket(accepted, { isServer: true, ...tls })));
+});
+
+it.if(isWindows)("tls.Server wraps a named-pipe connection handed in via emit('connection')", async () => {
+  const tlsServer = createServer(tls);
+  try {
+    await serverWrapRoundTrip((accepted, echo, fail) => {
+      tlsServer.once("secureConnection", echo);
+      tlsServer.once("tlsClientError", fail);
+      tlsServer.emit("connection", accepted);
+    });
+  } finally {
+    tlsServer.close();
+  }
 });

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2192,6 +2192,8 @@ it("fails a server wrap on the wrap's 'error' when the deferred stream engine re
     await listening.promise;
     outgoing = net.connect((rawServer.address() as AddressInfo).port, "127.0.0.1");
     const conn = await accepted.promise;
+    const connClosed = Promise.withResolvers<void>();
+    conn.on("close", connClosed.resolve);
     wrapped = new TLSSocket(conn, { isServer: true, secureContext: { context: {} } as any });
     const failed = Promise.withResolvers<Error>();
     const closed = Promise.withResolvers<void>();
@@ -2203,6 +2205,39 @@ it("fails a server wrap on the wrap's 'error' when the deferred stream engine re
     conn.write("banner");
     expect((await failed.promise).message).toContain("SecureContext");
     await closed.promise;
+    // The refusal releases the connection along with the wrap.
+    await connClosed.promise;
+    expect(conn.destroyed).toBe(true);
+  } finally {
+    wrapped?.destroy();
+    outgoing?.destroy();
+    rawServer.close();
+  }
+});
+
+it("releases the connection when the deferred adoption refuses the options", async () => {
+  // Same refusal through the native adoption branch (no queued writes): the
+  // wrap reports the error and the connection must not stay open and refed
+  // with no owner.
+  const accepted = Promise.withResolvers<net.Socket>();
+  const rawServer = net.createServer(accepted.resolve);
+  let outgoing: net.Socket | undefined;
+  let wrapped: TLSSocket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    rawServer.once("error", listening.reject);
+    rawServer.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+    outgoing = net.connect((rawServer.address() as AddressInfo).port, "127.0.0.1");
+    const conn = await accepted.promise;
+    const connClosed = Promise.withResolvers<void>();
+    conn.on("close", connClosed.resolve);
+    wrapped = new TLSSocket(conn, { isServer: true, secureContext: { context: {} } as any });
+    const failed = Promise.withResolvers<Error>();
+    wrapped.on("error", failed.resolve);
+    expect((await failed.promise).message).toContain("SecureContext");
+    await connClosed.promise;
+    expect(conn.destroyed).toBe(true);
   } finally {
     wrapped?.destroy();
     outgoing?.destroy();

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2019,12 +2019,30 @@ it("destroys a server wrap whose socket was destroyed before the deferred upgrad
   }
 });
 
-it("completes a server wrap of a socket that is still connecting", async () => {
-  // Node wraps the handle synchronously whatever state it is in. The deferred
-  // native adoption needs an established socket, so a socket whose lookup is
-  // still in flight has to take the stream-level engine; it used to throw
-  // "upgradeTLS requires an established socket" from nextTick, uncaught.
+// Node wraps the handle synchronously whatever state it is in. Bun's deferred
+// native adoption needs an established socket, so a socket wrapped while its
+// lookup is still in flight is adopted once it connects (or the wrap closes
+// with it if it never does); it used to throw "upgradeTLS requires an
+// established socket" from nextTick, uncaught. The lookup settles on a later
+// turn, so the wrap and the tick after it both run before the socket has a
+// handle to adopt.
+function connectLater(port: number, lookupError: Error | null = null) {
+  const outgoing = net.connect({
+    port,
+    host: "localhost",
+    family: 4,
+    lookup: (_host, _options, callback) => setImmediate(callback, lookupError, "127.0.0.1", 4),
+  });
+  expect(outgoing.connecting).toBe(true);
+  return outgoing;
+}
+
+it("adopts a socket that was still connecting when wrapped as the server side", async () => {
   const echoed = Promise.withResolvers<string>();
+  // The wrap must end up on the fd like a wrap of a connected socket does,
+  // which is observable as the peer's address; the stream-level engine has no
+  // fd and reports none.
+  const peer = Promise.withResolvers<{ remoteAddress: string | undefined; remotePort: number | undefined }>();
   // The listener plays the TLS client over the connection it accepts; the
   // outgoing socket below is the side wrapped as the TLS server.
   const rawServer = net.createServer(accepted => {
@@ -2042,23 +2060,47 @@ it("completes a server wrap of a socket that is still connecting", async () => {
     rawServer.once("error", listening.reject);
     rawServer.listen(0, "127.0.0.1", listening.resolve);
     await listening.promise;
-    outgoing = net.connect({
-      port: (rawServer.address() as AddressInfo).port,
-      host: "localhost",
-      family: 4,
-      // Resolves on a later turn, so both the wrap and its deferred step run
-      // while the socket has no established handle yet.
-      lookup: (_host, _options, callback) => setImmediate(callback, null, "127.0.0.1", 4),
-    });
-    expect(outgoing.connecting).toBe(true);
+    const port = (rawServer.address() as AddressInfo).port;
+    outgoing = connectLater(port);
+    const outgoingClosed = once(outgoing, "close");
     wrapped = new TLSSocket(outgoing, { isServer: true, ...COMMON_CERT });
     wrapped.on("error", echoed.reject);
-    wrapped.on("data", chunk => wrapped!.end(`echo:${chunk}`));
+    wrapped.on("data", chunk => {
+      peer.resolve({ remoteAddress: wrapped!.remoteAddress, remotePort: wrapped!.remotePort });
+      wrapped!.end(`echo:${chunk}`);
+    });
     expect(await echoed.promise).toBe("echo:ping");
+    expect(await peer.promise).toEqual({ remoteAddress: "127.0.0.1", remotePort: port });
+    // Ending the exchange releases the wrapped connection as well.
+    await outgoingClosed;
   } finally {
     wrapped?.destroy();
     outgoing?.destroy();
     rawServer.close();
+  }
+});
+
+it("closes a server wrap whose connecting socket fails to connect", async () => {
+  // Node closes the wrap, without an error of its own, when the wrapped
+  // socket fails; the failure itself is reported on that socket.
+  const outgoing = connectLater(1, Object.assign(new Error("getaddrinfo ENOTFOUND localhost"), { code: "ENOTFOUND" }));
+  const outgoingFailed = Promise.withResolvers<string>();
+  outgoing.on("error", err => outgoingFailed.resolve((err as NodeJS.ErrnoException).code!));
+  const wrapped = new TLSSocket(outgoing, { isServer: true, ...COMMON_CERT });
+  try {
+    const events: string[] = [];
+    const wrapClosed = Promise.withResolvers<void>();
+    wrapped.on("error", err => events.push(`error: ${err.message}`));
+    wrapped.on("close", hadError => {
+      events.push(`close: hadError=${hadError}`);
+      wrapClosed.resolve();
+    });
+    expect(await outgoingFailed.promise).toBe("ENOTFOUND");
+    await wrapClosed.promise;
+    expect(events).toEqual(["close: hadError=false"]);
+  } finally {
+    wrapped.destroy();
+    outgoing.destroy();
   }
 });
 

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2234,8 +2234,11 @@ it("releases the connection when the deferred adoption refuses the options", asy
     conn.on("close", connClosed.resolve);
     wrapped = new TLSSocket(conn, { isServer: true, secureContext: { context: {} } as any });
     const failed = Promise.withResolvers<Error>();
+    const closed = Promise.withResolvers<void>();
     wrapped.on("error", failed.resolve);
+    wrapped.on("close", closed.resolve);
     expect((await failed.promise).message).toContain("SecureContext");
+    await closed.promise;
     await connClosed.promise;
     expect(conn.destroyed).toBe(true);
   } finally {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2080,6 +2080,28 @@ it("adopts a socket that was still connecting when wrapped as the server side", 
   }
 });
 
+it("releases a connecting socket whose server wrap was destroyed before it connected", async () => {
+  // Destroying the wrap mid-connect must tear the connection down once it
+  // connects; otherwise it stays open and refed with no owner.
+  const rawServer = net.createServer(() => {});
+  let outgoing: net.Socket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    rawServer.once("error", listening.reject);
+    rawServer.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+    outgoing = connectLater((rawServer.address() as AddressInfo).port);
+    const outgoingClosed = once(outgoing, "close");
+    const wrapped = new TLSSocket(outgoing, { isServer: true, ...COMMON_CERT });
+    wrapped.destroy();
+    await outgoingClosed;
+    expect(outgoing.destroyed).toBe(true);
+  } finally {
+    outgoing?.destroy();
+    rawServer.close();
+  }
+});
+
 it("closes a server wrap whose connecting socket fails to connect", async () => {
   // Node closes the wrap, without an error of its own, when the wrapped
   // socket fails; the failure itself is reported on that socket.

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2019,6 +2019,99 @@ it("destroys a server wrap whose socket was destroyed before the deferred upgrad
   }
 });
 
+it("completes a server wrap of a socket that is still connecting", async () => {
+  // Node wraps the handle synchronously whatever state it is in. The deferred
+  // native adoption needs an established socket, so a socket whose lookup is
+  // still in flight has to take the stream-level engine; it used to throw
+  // "upgradeTLS requires an established socket" from nextTick, uncaught.
+  const echoed = Promise.withResolvers<string>();
+  // The listener plays the TLS client over the connection it accepts; the
+  // outgoing socket below is the side wrapped as the TLS server.
+  const rawServer = net.createServer(accepted => {
+    const client = connect({ socket: accepted, rejectUnauthorized: false }, () => client.write("ping"));
+    client.on("error", echoed.reject);
+    client.once("data", chunk => {
+      echoed.resolve(chunk.toString());
+      client.end();
+    });
+  });
+  let outgoing: net.Socket | undefined;
+  let wrapped: TLSSocket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    rawServer.once("error", listening.reject);
+    rawServer.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+    outgoing = net.connect({
+      port: (rawServer.address() as AddressInfo).port,
+      host: "localhost",
+      family: 4,
+      // Resolves on a later turn, so both the wrap and its deferred step run
+      // while the socket has no established handle yet.
+      lookup: (_host, _options, callback) => setImmediate(callback, null, "127.0.0.1", 4),
+    });
+    expect(outgoing.connecting).toBe(true);
+    wrapped = new TLSSocket(outgoing, { isServer: true, ...COMMON_CERT });
+    wrapped.on("error", echoed.reject);
+    wrapped.on("data", chunk => wrapped!.end(`echo:${chunk}`));
+    expect(await echoed.promise).toBe("echo:ping");
+  } finally {
+    wrapped?.destroy();
+    outgoing?.destroy();
+    rawServer.close();
+  }
+});
+
+it("fails a server wrap on the wrap's 'error' when the connection's handle is already gone", async () => {
+  // A peer reset behind an unread byte closes the native socket without
+  // ending the net.Socket (the byte is still buffered), so the connection
+  // still carries a handle, but one with nothing left to adopt. The deferred
+  // adoption's refusal belongs to the wrap (Node surfaces every failure of a
+  // wrapped socket on the TLSSocket); it used to escape nextTick as an
+  // uncaught exception.
+  const accepted = Promise.withResolvers<net.Socket>();
+  const rawServer = net.createServer(socket => {
+    socket.write("x");
+    accepted.resolve(socket);
+  });
+  let outgoing: net.Socket | undefined;
+  let wrapped: TLSSocket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    rawServer.once("error", listening.reject);
+    rawServer.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+    outgoing = net.connect((rawServer.address() as AddressInfo).port, "127.0.0.1");
+    // No 'error' listener on purpose: with one, the reset would destroy the
+    // socket and the wrap would take the handle-less path instead.
+    const byteBuffered = Promise.withResolvers<void>();
+    const eofBuffered = Promise.withResolvers<void>();
+    let readableEvents = 0;
+    outgoing.on("readable", () => (++readableEvents === 1 ? byteBuffered : eofBuffered).resolve());
+    // Nothing reads the byte, so it stays buffered; the 'readable' that
+    // follows the reset is the EOF the close pushed in behind it.
+    await byteBuffered.promise;
+    (await accepted.promise).resetAndDestroy();
+    await eofBuffered.promise;
+    expect({ destroyed: outgoing.destroyed, pending: outgoing.pending }).toEqual({ destroyed: false, pending: false });
+
+    wrapped = new TLSSocket(outgoing, { isServer: true, ...COMMON_CERT });
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    wrapped.on("error", err => events.push(`error: ${err.message}`));
+    wrapped.on("close", () => {
+      events.push("close");
+      closed.resolve();
+    });
+    await closed.promise;
+    expect(events).toEqual(["error: upgradeTLS requires an established socket", "close"]);
+  } finally {
+    wrapped?.destroy();
+    outgoing?.destroy();
+    rawServer.close();
+  }
+});
+
 it("exposes the server-side peer verification result via socket.ssl.verifyError()", async () => {
   // Node's server path consults the same TLSWrap.verifyError() that clients
   // use, so the shim must be populated for server sockets too:

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2176,6 +2176,40 @@ it("fails a server wrap on the wrap's 'error' when the connection's handle is al
   }
 });
 
+it("fails a server wrap on the wrap's 'error' when the deferred stream engine refuses the options", async () => {
+  // A fake secureContext passes the constructor (it never validates the
+  // object) but the engine rejects it. With writes still queued at the
+  // deferred tick that rejection happens in the stream-engine branch, where
+  // it used to escape nextTick as an uncaught exception.
+  const accepted = Promise.withResolvers<net.Socket>();
+  const rawServer = net.createServer(accepted.resolve);
+  let outgoing: net.Socket | undefined;
+  let wrapped: TLSSocket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    rawServer.once("error", listening.reject);
+    rawServer.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+    outgoing = net.connect((rawServer.address() as AddressInfo).port, "127.0.0.1");
+    const conn = await accepted.promise;
+    wrapped = new TLSSocket(conn, { isServer: true, secureContext: { context: {} } as any });
+    const failed = Promise.withResolvers<Error>();
+    const closed = Promise.withResolvers<void>();
+    wrapped.on("error", failed.resolve);
+    wrapped.on("close", closed.resolve);
+    // Corked, the write stays in the writable buffer into the deferred tick,
+    // which routes the wrap to the stream engine.
+    conn.cork();
+    conn.write("banner");
+    expect((await failed.promise).message).toContain("SecureContext");
+    await closed.promise;
+  } finally {
+    wrapped?.destroy();
+    outgoing?.destroy();
+    rawServer.close();
+  }
+});
+
 it("exposes the server-side peer verification result via socket.ssl.verifyError()", async () => {
   // Node's server path consults the same TLSWrap.verifyError() that clients
   // use, so the shim must be populated for server sockets too:


### PR DESCRIPTION
### Problem
- `new tls.TLSSocket(socket, { isServer: true })` (also what `tlsServer.emit("connection", socket)` does) crashes the process with an uncaught `TypeError: upgradeTLS requires an established socket` when the wrapped `net.Socket` holds a handle the native upgrade cannot adopt:
  - Windows: a named-pipe connection accepted by `net.createServer().listen("\\\\.\\pipe\\...")` (the STARTTLS-over-pipe pattern). The client side, `tls.connect({ socket: pipeSocket })`, already works.
  - Every platform: a socket that is still looking up or connecting when it is wrapped, which includes `new TLSSocket(net.connect(...), { isServer: true })` written in one tick.
  - Every platform: an outgoing socket the peer reset while a byte was still unread. The native socket is gone, but the `net.Socket` is not destroyed yet and still carries the dead handle.
- Cause: `Socket.prototype[bunUpgradeServerTLS]` (`src/js/node/net.ts:2353` before this change) picks fd adoption unless `!socket || connection.encrypted || hasUnflushedWrites(connection)`, so all three cases take the adoption branch, which calls `handle.upgradeTLS()` from `process.nextTick`. `upgrade_tls_impl` (`src/runtime/socket/socket_body.rs:3375`) accepts only `InternalSocket::Connected` and throws; inside `nextTick` there is no caller, so the throw is an uncaught exception.
- The client path (`Socket.prototype.connect`, `net.ts:1990`) checks `isNamedPipeSocket` and waits for a connecting socket before adopting; the server path never got the equivalent.

### Fix
- Named pipes take the stream-level engine branch that already serves handle-less Duplexes, TLS over TLS and pending plain writes. A pipe has no `us_socket_t` to adopt, and this is the branch the client path already uses for pipes.
- A connecting socket waits for `'connect'` and then runs the same deferred adoption a connected socket gets; if the connection closes first, the wrap is destroyed (Node closes the wrap, without an error of its own, when the wrapped socket fails; the failure itself stays on that socket). Adopting after connect rather than switching such sockets to the stream engine keeps them identical to a wrap made one event later: peer address, `setNoDelay`/`setKeepAlive`, native read backpressure and `destroy()` propagation all come from the adopted fd, which the stream engine has none of. A wrap destroyed while the connection was still connecting destroys the connection once it connects, like the client-side `'connect'` path; otherwise it would stay open and refed with no owner.
- The deferred step (now `adoptServerTLS`) re-reads `connection._handle`, because family autoselection swaps handles while connecting and a connecting socket can turn out to be a pipe, and checks for a pipe alongside the existing queued-writes check, mirroring the client path's post-connect check.
- `handle.upgradeTLS()` is wrapped so a refused adoption destroys the wrap with the error, next to the existing `Invalid socket` branch; the deferred stream-engine attach is guarded the same way (the synchronous one keeps throwing to the constructor's caller). Every failure exit of the deferred step goes through one helper that destroys the connection along with the wrap: with the inline `new TLSSocket(net.connect(...), { isServer: true })` idiom nothing else holds the connection, so leaving it would pin the event loop with an unowned open socket. By then the constructor has returned, so the wrap's `'error'` (which `tls.Server` turns into `'tlsClientError'`) is the only surface left, and it is where Node reports failures of a wrapped socket.
- The change is in JS because that layer owns the choice between the two engines and is the only one that sees the stream state (`connecting`, queued writes) the choice depends on. The native `Connected` check is the right invariant for adoption and is unchanged.
- Verified:
  - `test/js/node/tls/node-tls-server.test.ts`: six new tests. A wrap of a still-connecting socket completes a round trip and reports the peer's address (which pins adoption; the stream engine reports none) and releases the wrapped socket afterwards; a wrap destroyed mid-connect releases the connection once it connects; a wrap of a connecting socket whose connect fails emits `'close'` and nothing else; a wrap of a connection whose handle is gone emits `'error'` then `'close'`; a deferred refusal (a fake `secureContext` object, which the constructor never validates) lands on the wrap's `'error'` instead of escaping `nextTick` uncaught and releases the connection, covered through both the adoption branch and the stream-engine branch (queued corked write). All six fail on the current release and pass with this change: 10/10 runs on Linux (ASAN debug), 5/5 on a Windows x64 debug build for the first three.
  - `test/js/node/tls/node-tls-namedpipes.test.ts` (Windows only): direct wrap and `tls.Server` `emit('connection')` of an accepted named-pipe connection complete a handshake and a round trip. Both fail on the current Windows canary with the same TypeError and pass on a Windows x64 debug build of this branch, 10/10 runs.
  - The verbatim repro from the report prints `client got: echo:hi` on Windows with this change.
  - A probe wrapping a connecting socket in the same-tick IP-literal shape, the hostname + `autoSelectFamily` shape, and destroying the wrap against a silent peer produces the same event sequence as Node 26 on all three (peer address present, `setNoDelay` honored, wrapped socket destroyed). On the current release the IP-literal shape adopts the half-connected socket and then keeps the process alive after the exchange; waiting for `'connect'` removes that as well.
  - Existing wrap coverage still passes (list in the details below).
- Reported separately, not changed here: once a wrap runs over a pipe, an error on the underlying plain socket (for example EPIPE from a close_notify the peer never read) still surfaces on the plain socket instead of the TLSSocket. That is pre-existing stream-engine behavior, reproducible today with the client-side pipe upgrade; the new pipe test reads through to close_notify so it does not depend on it.

### Background
- A `net.Socket` keeps its native connection in `_handle`. For TCP and Unix sockets that is a uSockets `us_socket_t` (`InternalSocket::Connected`). A Windows named pipe is a libuv pipe (`InternalSocket::Pipe`) with no `us_socket_t`, and a socket that is still resolving or connecting is `Detached` or `Connecting`. `net.connect()` creates the handle object up front and connects it in place (or replaces it per attempt under family autoselection), so `connection._handle` is non-null for the whole connecting phase.
- node:tls has two ways to put TLS on an existing connection. Adoption (`handle.upgradeTLS`) moves the `us_socket_t` into the TLS socket group so the native read path drives the handshake; it needs a `Connected` socket and gives the TLSSocket everything the fd offers (addresses, socket options, read backpressure via pause/resume). The stream-level engine (`upgradeDuplexToTLS`) runs BoringSSL over the JS stream's `'data'`/`'end'`/`'drain'`/`'close'` events and its `write()`, so it works over anything Duplex-shaped but exposes none of the fd-level features; it is the fallback for generic Duplexes, TLS over TLS and pending plain writes.
- The server-side wrap defers adoption by one tick on purpose: the user's `'connection'` listener runs after `tls.Server`'s own and may still write a plain banner that has to leave before any TLS bytes. That deferral is what turns a throwing `upgradeTLS` into an uncaught exception rather than an exception from the constructor, and it is why the connecting case can reuse the deferred step as-is after `'connect'`.
- Node's `_wrapHandle` (`lib/_tls_wrap.js`) wraps whatever handle the socket has, connecting or pipe included, and reports what happens to the wrapped socket on the TLSSocket.

<details>
<summary>Other suites run against this change</summary>

All with the Linux ASAN debug build unless noted.

- `test/js/node/tls/node-tls-server.test.ts`: 72 pass; the one remaining failure in this container (`listen("localhost")` binding a different address than `connect` dials) reproduces without this change and does not touch the wrap path.
- `test/js/node/tls/node-tls-upgrade.test.ts`, `node-tls-connect.test.ts`, `node-tls-duplex-close-throw-uaf.test.ts`: pass.
- Vendored Node tests that wrap sockets server-side or inject connections: `test-tls-starttls-server`, `test-tls-delayed-attach`, `test-tls-delayed-attach-error`, `test-tls-socket-destroy`, `test-tls-retain-handle-no-abort`, `test-tls-socket-failed-handshake-emits-error`, `test-tls-exportkeyingmaterial`, `test-tls-snicallback-error`, `test-tls-error-servername`, `test-tls-socket-constructor-alpn-options-parsing`, `test-tls-transport-destroy-after-own-gc`, `test-tls-ticket`, `test-double-tls-server`, `test-tls-socket-close`, `test-tls-handshake-exception`, `test-tls-destroy-stream`, `test-http2-client-connection-tunnelling`, `test-http2-client-proxy-over-http2`, `test-http2-autoselect-protocol`, `test-http2-socket-close`: all pass.
- Windows x64 debug build: the new `node-tls-namedpipes.test.ts` tests 10/10 runs, the three new `node-tls-server.test.ts` tests 5/5 runs, all green. (The pre-existing 400-connection named-pipe test in that file exceeds 5 s on a debug build there; it does not use the wrap path and CI runs it on release builds, where it takes well under a second.)

Earlier revision of this PR: connecting sockets were sent to the stream engine as well. Review pointed out that this would have permanently cost them the fd-level behavior listed under Background, and that a failed connect then produced a spurious `'error'` and no `'close'` on the wrap; the current revision adopts after `'connect'` instead and the new tests pin the address and close behavior.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/tls/node-tls-namedpipes.test.ts

<!-- robobun:evidence:end -->