### PR TITLE
test(http2): give the detached-payload subprocess cases a debug-scaled timeout

### DIFF
--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3417,10 +3417,17 @@ describe.concurrent(
       return JSON.parse(stdout.trim());
     }
 
+    // Each case takes ~60 ms on a release build, but a debug build spends ~2 s per subprocess just
+    // loading node:http2 (and node:tls), and with the cases running concurrently they land at
+    // 2.5-6 s there, past the 5 s default.
+    const timeout = 15_000 * ASAN_MULTIPLIER;
+
     // A single-frame write (<= 16374 bytes) corked behind HEADERS straddles the 16 KiB cork;
     // the mid-write cork flush is what runs the Duplex.
-    it.each(["transfer", "resize0"])("single DATA frame straddling the cork flush (%s)", async mode => {
-      const result = await run(/* js */ `
+    it.each(["transfer", "resize0"])(
+      "single DATA frame straddling the cork flush (%s)",
+      async mode => {
+        const result = await run(/* js */ `
       const holder = { src: payload(16374, ${mode === "resize0"}) };
       const snap = Buffer.from(holder.src);
       let armed = false, fired = 0;
@@ -3437,15 +3444,19 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplex.data(), snap) }));
       process.exit(0);
     `);
-      expect(result).toEqual({ fired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ fired: true, foreign: 0 });
+      },
+      timeout,
+    );
 
     // HEADERS sized so the cork sits within 8 bytes of full: the 9-byte DATA frame header is
     // what straddles, so the Duplex runs before the payload itself is written at all. The
     // header value uses a character HPACK will not huffman-encode, so the block length tracks
     // N byte for byte; the sweep keeps the case on target if the fixed overhead ever shifts.
-    it("DATA frame header straddling the cork flush", async () => {
-      const result = await run(/* js */ `
+    it(
+      "DATA frame header straddling the cork flush",
+      async () => {
+        const result = await run(/* js */ `
       const results = [];
       for (let n = 16344; n <= 16352; n++) {
         const holder = { src: payload(8000, false) };
@@ -3471,13 +3482,17 @@ describe.concurrent(
       }));
       process.exit(0);
     `);
-      expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
+      },
+      timeout,
+    );
 
     // A write larger than the peer's window: the in-window part is batched and flushed (running
     // the Duplex) and only then is the remainder queued until WINDOW_UPDATE arrives.
-    it("flow-control-limited tail queued after a flush", async () => {
-      const result = await run(/* js */ `
+    it(
+      "flow-control-limited tail queued after a flush",
+      async () => {
+        const result = await run(/* js */ `
       const SZ = 65535 + 32768;
       const holder = { src: payload(SZ, false) };
       const snap = Buffer.from(holder.src);
@@ -3498,13 +3513,17 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplex.data(), snap) }));
       process.exit(0);
     `);
-      expect(result).toEqual({ fired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ fired: true, foreign: 0 });
+      },
+      timeout,
+    );
 
     // Two sessions share the thread's cork slot. B's write first flushes A's corked HEADERS
     // through A's Duplex, and it is A's transport JS that detaches B's payload.
-    it("another session's transport JS running on cork handover", async () => {
-      const result = await run(/* js */ `
+    it(
+      "another session's transport JS running on cork handover",
+      async () => {
+        const result = await run(/* js */ `
       const holder = { src: payload(8000, false) };
       const snap = Buffer.from(holder.src);
       let armed = false, fired = 0;
@@ -3523,8 +3542,10 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplexB.data(), snap) }));
       process.exit(0);
     `);
-      expect(result).toEqual({ fired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ fired: true, foreign: 0 });
+      },
+      timeout,
+    );
 
     // Same handover, but B is a native TCP connection to a local h2c server: B's own writes
     // never run JS, so the only JS that can touch B's payload mid-send is A's Duplex being
@@ -3573,14 +3594,17 @@ describe.concurrent(
     `);
         expect(result).toEqual({ native: true, firedDuringWrite: true, foreign: 0 });
       },
+      timeout,
     );
 
     // The session's socket is a native TLSSocket, but one upgraded from a JS Duplex
     // (tls.connect({ socket })), so every TLS record is written through that Duplex's JS.
     // Oracle: the request body a real secure server receives.
-    it.each(["straddle", "tail"])("TLSSocket over a JS Duplex against a real server (%s)", async face => {
-      const result = await run(
-        /* js */ `
+    it.each(["straddle", "tail"])(
+      "TLSSocket over a JS Duplex against a real server (%s)",
+      async face => {
+        const result = await run(
+          /* js */ `
       const net = require("node:net");
       const tls = require("node:tls");
       const SZ = ${face === "tail" ? 65535 + 32768 : 16374};
@@ -3630,10 +3654,12 @@ describe.concurrent(
       console.log(JSON.stringify({ native: !!socket._handle, fired: fired > 0, foreign: foreign(got, snap) }));
       process.exit(0);
     `,
-        { ...bunEnv, TLS_CERT_JSON: JSON.stringify(TLS_CERT) },
-      );
-      expect(result).toEqual({ native: true, fired: true, foreign: 0 });
-    });
+          { ...bunEnv, TLS_CERT_JSON: JSON.stringify(TLS_CERT) },
+        );
+        expect(result).toEqual({ native: true, fired: true, foreign: 0 });
+      },
+      timeout,
+    );
   },
 );
 


### PR DESCRIPTION
### Problem
- `bun bd test test/js/node/http2/node-http2.test.js` intermittently fails in the `describe.concurrent` block "http2 DATA payload survives its ArrayBuffer being detached/resized by transport JS mid-send" with `this test timed out after 5000ms`. Reported independently from four debug-build runs (1 to 4 cases per run); here, 10 runs of the block on a debug build had a timeout in 6 of them, 12 timeouts across 5 of the 9 cases.
- Each of the 9 cases spawns a bun subprocess (`run()` in the block, `node-http2.test.js:3407`) and none of the 7 `it()` / `it.each()` calls passes a timeout, so they get the 5 s default.
- On a debug build a subprocess spends ~2 s before the scenario starts (`bun-debug -e 'require("node:http2")'` takes 1.9 s here, 2.8 s on the reporting machine, against 0.3 s for an empty `-e`), and the 9 subprocesses start at once, so the cases complete in 2.5 to 6.8 s. On a release build the same cases take 47 to 81 ms each.

### Fix
- Define `timeout = 15_000 * ASAN_MULTIPLIER` in the block and pass it to its 7 `it()` / `it.each()` calls (9 cases). `ASAN_MULTIPLIER` is the file's existing constant (`isDebug ? 15 : isASAN ? 3 : 1`), and `15_000 * ASAN_MULTIPLIER` is the value the file already uses for its other debug-slow test (`node-http2.test.js:2339`); the sibling `node-http2-streams-rehash.test.ts` uses the same pattern. The remaining lines in the diff are prettier moving the callbacks out of the hugged form once a third argument is present (`git diff -w` is 36 lines).
- Raising a timeout is the right fix here rather than shrinking the workload: the time is debug-build process start plus loading `node:http2`, which every subprocess pays before the test's own code runs, and the subprocesses exist so that a crash or a stale read in the native send path fails one case instead of the runner. Running the cases serially would not help either: the TLS cases take ~4 s on their own under debug, and the block would take ~30 s instead of ~6 s.
- Values per build: 225 s debug, 45 s ASAN, 15 s release. These are ceilings for a hung case, not durations; the cases still finish in the times above. In CI the explicit value replaces the runner's `--timeout` (90 s, 270 s on the ASAN lane) for these 9 cases; the whole file takes 6.8 s on the release lane and 21 s on the ASAN lane, so they stay far inside it.
- #37832 replaces the pad-length sweep in one of the failing cases ("DATA frame header straddling the cork flush") and deliberately leaves the others' timeouts alone; the other four cases that timed out here have nothing to shrink. The two PRs are complementary; whichever lands second has a few-line conflict on that one case.
- Left alone on purpose: the file's standalone subprocess tests (`padded DATA write`, `setNextStreamID at the edges`, `header names longer than 4096 bytes`, `session teardown from a socket write`, `socket chunk transferred by a frame event handler`). They take 2.7 to 3.7 s under debug, run one at a time, and have not been seen timing out in any of the runs above.
- Verification (debug build, 16 vCPU container with a 12 CPU quota):
  - 10 runs of the block without the change: 6 runs with at least one timeout, 12 in total (`DATA frame header` x4, `TLSSocket ... (straddle)` x3, `TLSSocket ... (tail)` x2, `flow-control-limited tail` x2, `native writer (transfer)` x1).
  - 10 runs of the block with the change: 90 of 90 cases pass; the slowest completions were 6.8 s, 6.1 s, 5.4 s and 5.2 s, i.e. four cases that would have timed out.
  - `bun bd test test/js/node/http2/node-http2.test.js -t "DATA payload survives" --timeout 1`: 9 pass with the change (a per-test timeout overrides the CLI default, so this shows the value reaches all 9 cases, the `it.each` ones included); 9 time out without it.
  - Whole file with the change on the debug build: 357 pass, 6 skip, 0 fail. The block under the release binary: 9 pass in 0.4 s.

### Background
- `bun:test` resolves a test's timeout as: the test's own argument, else `setDefaultTimeout()`, else the `--timeout` flag, whose default is 5000 ms (`src/runtime/test_runner/ScopeFunctions.rs:746`, `src/options_types/context.rs:483`). Bun's CI runner always passes `--timeout` (half the per-file budget, 3x that on ASAN; `scripts/runner.node.mjs:1964`), so the 5 s default only applies to plain `bun test` / `bun bd test` runs, which is why the failure shows up locally and not in CI.
- `ASAN_MULTIPLIER` at the top of the file scales timeouts for builds that are slower than release: 15x for a debug build, 3x for the release+ASAN build CI uses. Those ratios match this file's measured runtimes (~105 s debug and 21 s ASAN against 6.8 s release).
- The block's cases run in subprocesses because they detach or shrink an `ArrayBuffer` while the native http2 code is still sending from it; if that ever reads freed memory or crashes, the subprocess dies and the case fails, instead of taking the test runner down with it.

<details>
<summary>Per-case durations, debug build, unfixed, max over 10 runs of the block</summary>

```
5013 ms  TLSSocket over a JS Duplex against a real server (straddle)      (timed out 3/10)
5011 ms  TLSSocket over a JS Duplex against a real server (tail)          (timed out 2/10)
5006 ms  flow-control-limited tail queued after a flush                   (timed out 2/10)
5001 ms  DATA frame header straddling the cork flush                      (timed out 4/10)
5000 ms  another session's transport JS ... native writer (transfer)      (timed out 1/10)
4721 ms  another session's transport JS ... native writer (resize0)
4368 ms  single DATA frame straddling the cork flush (transfer)
3915 ms  another session's transport JS running on cork handover
3743 ms  single DATA frame straddling the cork flush (resize0)
```

Same block with the change, max over 10 runs (all pass):

```
6816 ms  DATA frame header straddling the cork flush
6107 ms  TLSSocket over a JS Duplex against a real server (straddle)
5443 ms  TLSSocket over a JS Duplex against a real server (tail)
5186 ms  flow-control-limited tail queued after a flush
4811 ms  another session's transport JS ... native writer (transfer)
4652 ms  single DATA frame straddling the cork flush (transfer)
4644 ms  another session's transport JS ... native writer (resize0)
4471 ms  another session's transport JS running on cork handover
4042 ms  single DATA frame straddling the cork flush (resize0)
```

Release binary, one run of the block: 47 to 81 ms per case, 0.3 s for the block.

</details>
