### PR TITLE
ci(verify-baseline): build the static scanner in build-bun and download it instead of cargo-building it per job

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -482,6 +482,13 @@ function getBuildArgs(target, options, mode) {
   if (baseline) args.push("--baseline=on");
   if (profile === "asan") args.push("--asan=on");
 
+  // Targets that get a verify-baseline step also build the static scanner
+  // that step runs and upload it as an artifact (scripts/build/
+  // verify-baseline-static.ts): the step's test-fleet host has neither the
+  // pinned rust toolchain nor the scanner's crates, and building it there
+  // downloaded both on every job. getVerifyBaselineStep() downloads it.
+  if (needsBaselineVerification(target)) args.push("--verify-baseline-static=on");
+
   // canary: options.canary can be number (revision count) or undefined
   // (default on). Old system used CANARY_REVISION as a counter; build.ts
   // has only on/off — disabled only when explicitly 0.
@@ -511,7 +518,8 @@ function getBuildCommand(target, options, mode) {
 }
 
 /**
- * deps + C++ + cargo + link on one agent; also uploads libbun-*.a, libbun_rust.a and the dep libs.
+ * deps + C++ + cargo + link on one agent; also uploads libbun-*.a, libbun_rust.a and the dep libs
+ * (and, for targets with a verify-baseline step, that step's verify-baseline-static scanner).
  *
  * @param {Platform} platform
  * @param {PipelineOptions} options
@@ -666,6 +674,13 @@ function getVerifyBaselineStep(platform, options) {
   const profileDir = `${triplet}-profile`;
   const profileExe = os === "windows" ? "bun-profile.exe" : "bun-profile";
 
+  // The static scanner, built for this step's host by the build-bun step
+  // (getBuildArgs passes --verify-baseline-static=on; the artifact name is
+  // verifyBaselineStaticArtifact() in scripts/build/ci.ts). Downloading it
+  // is what keeps this step off static.rust-lang.org and crates.io: the
+  // image it runs on has neither the pinned nightly nor the scanner's crates.
+  const staticChecker = os === "windows" ? "verify-baseline-static.exe" : "verify-baseline-static";
+
   const setupCommands =
     os === "windows"
       ? [
@@ -674,13 +689,15 @@ function getVerifyBaselineStep(platform, options) {
           // becomes the step result.
           `echo Downloading build artifacts...`,
           `buildkite-agent artifact download ${profileDir}.zip . --step ${targetKey}-build-bun || exit /b 1`,
+          `buildkite-agent artifact download ${staticChecker} . --step ${targetKey}-build-bun || exit /b 1`,
           `echo Extracting ${profileDir}.zip...`,
           `tar -xf ${profileDir}.zip || exit /b 1`,
         ]
       : [
           `buildkite-agent artifact download '${profileDir}.zip' . --step ${targetKey}-build-bun`,
+          `buildkite-agent artifact download '${staticChecker}' . --step ${targetKey}-build-bun`,
           `unzip -o '${profileDir}.zip'`,
-          `chmod +x ${profileDir}/${profileExe}`,
+          `chmod +x ${profileDir}/${profileExe} ${staticChecker}`,
           // Linux lanes pin a known-good qemu (see PINNED_QEMU). sha256 check makes a
           // truncated/hijacked download a hard failure before anything runs under it.
           ...(abi === "android"
@@ -713,8 +730,7 @@ function getVerifyBaselineStep(platform, options) {
     timeout_in_minutes: hasWebKitChanges(options) ? 30 : 10,
     command: [
       ...setupCommands,
-      `cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml${os === "windows" ? " || exit /b 1" : ""}`,
-      `bun scripts/verify-baseline.ts --binary ${profileDir}/${profileExe} --arch ${platform.arch} --emulator ${emulator}${skipEmulationFlag}${jitStressFlag}`,
+      `bun scripts/verify-baseline.ts --binary ${profileDir}/${profileExe} --static-checker ${staticChecker} --arch ${platform.arch} --emulator ${emulator}${skipEmulationFlag}${jitStressFlag}`,
     ],
   };
 }

--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -16,6 +16,8 @@ on:
       - "src/jsc/bindings/**"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
+      # verify-baseline-static-build.test.ts checks the artifact contract between scripts/build/ci.ts and this file.
+      - ".buildkite/ci.mjs"
       - "test/harness.ts"
       - "test/tsconfig.json"
       - "test/_util/**"
@@ -28,6 +30,8 @@ on:
       - "src/jsc/bindings/**"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
+      # verify-baseline-static-build.test.ts checks the artifact contract between scripts/build/ci.ts and this file.
+      - ".buildkite/ci.mjs"
       - "test/harness.ts"
       - "test/tsconfig.json"
       - "test/_util/**"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -445,6 +445,7 @@ function parseArgs(argv: string[]): CliArgs {
     "valgrind",
     "fuzzilli",
     "socketFaultInjection",
+    "verifyBaselineStatic",
     "unifiedSources",
     "archiveDeps",
     "timeTrace",

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -204,6 +204,7 @@ Split CI modes: `rust-only` (lolhtml+codegen+cargo → libbun_rust.a), `cpp-only
 | `error.ts`                     | `BuildError` with hint/file/cause, `assert()`                                                                           |
 | `download.ts`                  | `downloadWithRetry()`, archive extraction                                                                               |
 | `winsysroot.ts`                | Windows MSVC CRT + SDK sysroot (xwin): validates, adds case aliases, CI fetch                                           |
+| `verify-baseline-static.ts`    | `--verify-baseline-static=on`: cargo edge building the static ISA scanner for the CI verify-baseline step's host        |
 | `fetch-cli.ts`                 | Build-time CLI ninja invokes for downloads                                                                              |
 | `ci.ts`                        | CI integration — annotations, artifacts, log groups                                                                     |
 | `clean.ts`                     | `bun run clean` preset-based cleanup                                                                                    |

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -45,6 +45,7 @@ import { emitShims, machoPostlinkCommand, machoPostlinkImplicitInputs } from "./
 import { computeDepLibs, resolveDep, type ResolvedDep } from "./source.ts";
 import { streamPath } from "./stream.ts";
 import { generateUnifiedSources } from "./unified.ts";
+import { emitVerifyBaselineStatic } from "./verify-baseline-static.ts";
 
 // ───────────────────────────────────────────────────────────────────────────
 // Executable naming
@@ -152,6 +153,13 @@ export interface BunOutput {
   objects: string[];
   /** Stamps of the buildkite artifact-upload edges; archive-link adds them to the default targets. */
   uploadStamps?: string[];
+  /**
+   * The static ISA scanner built for the CI verify-baseline step (see
+   * verify-baseline-static.ts). Only when `cfg.verifyBaselineStatic` is on and
+   * the mode builds from source (full / archive-link); configure.ts adds it to
+   * the default targets and ci.ts uploads it.
+   */
+  verifyBaselineStatic?: string | undefined;
 }
 
 /**
@@ -511,7 +519,24 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // ─── Step 7: post-link (strip, dsymutil, smoke test) ───
   const { strippedExe, dsym } = emitPostLink(n, cfg, exe, exeName, flags.stripflags);
 
-  return { exe, strippedExe, dsym, deps, codegen, rustObjects, objects: allObjects, uploadStamps };
+  // ─── Step 8: the verify-baseline step's scanner (CI lanes that get one) ───
+  // Nothing links against it; it is sequenced behind the cargo step (see
+  // emitVerifyBaselineStatic) and otherwise runs whenever a slot is free.
+  const verifyBaselineStatic = cfg.verifyBaselineStatic
+    ? emitVerifyBaselineStatic(n, cfg, sources, rustObjects)
+    : undefined;
+
+  return {
+    exe,
+    strippedExe,
+    dsym,
+    deps,
+    codegen,
+    rustObjects,
+    objects: allObjects,
+    uploadStamps,
+    verifyBaselineStatic,
+  };
 }
 
 function registerBkUploadRules(n: Ninja, cfg: Config): void {

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -30,6 +30,7 @@ import { webkitTestFFIPath } from "./deps/webkit.ts";
 import { BuildError } from "./error.ts";
 import { crossFeaturesJson } from "./features-json.ts";
 import { orderFilePath, usesOrderFile } from "./flags.ts";
+import { VERIFY_BASELINE_STATIC_NAME } from "./verify-baseline-static.ts";
 
 /** True if running under any CI (env: CI, BUILDKITE, or GITHUB_ACTIONS). */
 export const isCI: boolean = utils.isCI;
@@ -355,11 +356,17 @@ function upload(paths: string[], cwd: string): void {
 //           ├── bun-asan
 //           └── features.json
 //
+//   verify-baseline-static[.exe] (only with --verify-baseline-static=on)
+//     The static ISA scanner, built for the verify-baseline step's host
+//     (verify-baseline-static.ts). Deliberately not a zip: test shards
+//     download '*.zip' and must not pick it up.
+//
 // bunTriplet = bun-${os}-${arch}[-musl][-baseline]
 //
-// Test steps (runner.node.mjs) download '**' from build-bun and pick any
-// bun*.zip; baseline-verification step downloads ${triplet}.zip specifically
-// and expects ${triplet}/bun inside.
+// Test steps (runner.node.mjs) download '*.zip' from build-bun and pick any
+// bun*.zip; the verify-baseline step (getVerifyBaselineStep in ci.mjs)
+// downloads ${bunTriplet}-profile.zip and verify-baseline-static[.exe] by
+// exact name and expects ${bunTriplet}-profile/bun-profile inside the zip.
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
@@ -466,9 +473,27 @@ export function packageAndUpload(cfg: Config, output: BunOutput): void {
     run(["buildkite-agent", "meta-data", "set", `binary-size:${bunTriplet}`, String(bytes)], buildDir);
   }
 
+  // ─── verify-baseline-static ───
+  // Copied to the top of buildDir so the artifact is the bare name the
+  // verify-baseline step downloads (artifact names are buildDir-relative
+  // paths); cargo's own output sits under deps/<name>/<triple>/release/.
+  if (output.verifyBaselineStatic !== undefined) {
+    const artifact = verifyBaselineStaticArtifact(cfg);
+    cpSync(output.verifyBaselineStatic, resolve(buildDir, artifact));
+    zipPaths.push(artifact);
+  }
+
   // ─── Upload ───
-  console.log(`Uploading ${zipPaths.length} zips...`);
+  console.log(`Uploading ${zipPaths.length} artifacts...`);
   upload(zipPaths, buildDir);
+}
+
+/**
+ * Artifact name of the scanner built by verify-baseline-static.ts. Must match
+ * the name getVerifyBaselineStep() in .buildkite/ci.mjs downloads.
+ */
+export function verifyBaselineStaticArtifact(cfg: Config): string {
+  return `${VERIFY_BASELINE_STATIC_NAME}${cfg.exeSuffix}`;
 }
 
 /**

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -157,6 +157,14 @@ export interface Config {
    * acquire atomic load per syscall, zero when compiled out.
    */
   socketFaultInjection: boolean;
+  /**
+   * Also build `scripts/verify-baseline-static` (the static ISA scanner) for
+   * the host the CI `verify-baseline` step runs on, so that step downloads it
+   * from `build-bun` instead of installing a rust toolchain and fetching
+   * crates itself. See verify-baseline-static.ts. Off unless the pipeline
+   * asks for it (`.buildkite/ci.mjs` passes it for the targets it verifies).
+   */
+  verifyBaselineStatic: boolean;
   /** Bundle small .cpp files into unified TUs (WebKit-style). See unified.ts. */
   unifiedSources: boolean;
   /**
@@ -350,6 +358,7 @@ export interface PartialConfig {
   valgrind?: boolean;
   fuzzilli?: boolean;
   socketFaultInjection?: boolean;
+  verifyBaselineStatic?: boolean;
   unifiedSources?: boolean;
   archiveDeps?: boolean;
   timeTrace?: boolean;
@@ -1204,6 +1213,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     valgrind,
     fuzzilli,
     socketFaultInjection,
+    verifyBaselineStatic: partial.verifyBaselineStatic ?? false,
     unifiedSources: partial.unifiedSources ?? true,
     archiveDeps: partial.archiveDeps ?? false,
     timeTrace: partial.timeTrace ?? false,

--- a/scripts/build/configure.ts
+++ b/scripts/build/configure.ts
@@ -331,6 +331,8 @@ export async function configure(input: ConfigureInput): Promise<ConfigureResult>
     const targets = [defaultTarget, "check"];
     if (output.dsym !== undefined) targets.push(n.rel(output.dsym));
     for (const stamp of output.uploadStamps ?? []) targets.push(n.rel(stamp));
+    // Same situation as dsym: nothing links against it, so it has to be a default.
+    if (output.verifyBaselineStatic !== undefined) targets.push(n.rel(output.verifyBaselineStatic));
     n.default(targets);
   }
 

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -113,9 +113,11 @@ function windowsShimDestPath(cfg: Config): string {
  * Path to the `rustup` binary that owns `cfg.cargo`, or `undefined` if
  * `cfg.cargo` isn't a rustup proxy (a distro/Homebrew cargo, say).
  * `rustup target add` is only meaningful when rustup is the toolchain
- * manager — `rust_build_cross` requires it; everyone else gets `rust_build`.
+ * manager — `rust_build_cross` (and `dep_cargo_cross`, which
+ * verify-baseline-static.ts picks the same way) require it; everyone else
+ * gets the plain rule.
  */
-function findRustup(cfg: Config): string | undefined {
+export function findRustup(cfg: Config): string | undefined {
   if (cfg.cargo === undefined) return undefined;
   const rustup = join(dirname(cfg.cargo), `rustup${cfg.host.exeSuffix}`);
   return existsSync(rustup) ? rustup : undefined;

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -578,6 +578,7 @@ export function registerDepRules(n: Ninja, cfg: Config): void {
   // Cargo build: runs `cargo build` in the manifest dir. Only registered
   // if cargo is available — a missing rust toolchain makes ninja fail with
   // a clear "unknown build rule 'dep_cargo'" instead of a cryptic sh error.
+  // Shared with verify-baseline-static.ts (no dep uses it at the moment).
   //
   // Env is passed via stream.ts --env (ninja has no native env support).
   // restat: cargo's incremental build doesn't touch unchanged outputs.

--- a/scripts/build/verify-baseline-static.ts
+++ b/scripts/build/verify-baseline-static.ts
@@ -1,0 +1,211 @@
+/**
+ * `verify-baseline-static` — the static ISA scanner in
+ * `scripts/verify-baseline-static/` (its own cargo workspace), built as one
+ * more edge of a CI build and uploaded next to the bun zips (ci.ts), so the
+ * pipeline's `verify-baseline` step (.buildkite/ci.mjs) downloads it instead
+ * of building it.
+ *
+ * That step runs on a test-fleet image (debian / alpine / win-2019), which
+ * carries neither the nightly pinned in `rust-toolchain.toml` nor the
+ * scanner's crates: building it there re-downloaded both on every job and
+ * failed the step whenever static.rust-lang.org or crates.io did. The build
+ * host has already installed the pinned toolchain and fetched bun's own
+ * crate graph from crates.io by the time this edge runs, so building it here
+ * adds no download source the build didn't already depend on.
+ *
+ * The scanner only *reads* the binary it checks, so it is built for the host
+ * the verify step runs on (`getVerifyBaselineHost()` in ci.mjs), not for
+ * bun's own target — see `verifyBaselineStaticTriple()`. Enabled by
+ * `cfg.verifyBaselineStatic`; ci.mjs turns it on for exactly the targets it
+ * emits a verify-baseline step for.
+ */
+
+import { resolve } from "node:path";
+import type { Sources } from "../glob-sources.ts";
+import type { Config } from "./config.ts";
+import { assert } from "./error.ts";
+import type { Ninja } from "./ninja.ts";
+import { findRustup } from "./rust.ts";
+import { quote, quoteArgs } from "./shell.ts";
+import { depBuildDir } from "./source.ts";
+import { ucrtServicingLibDir } from "./winsysroot.ts";
+
+export const VERIFY_BASELINE_STATIC_NAME = "verify-baseline-static";
+
+/** `scripts/verify-baseline-static/` — the directory holding the scanner's Cargo.toml. */
+export function verifyBaselineStaticManifestDir(cfg: Config): string {
+  return resolve(cfg.cwd, "scripts", VERIFY_BASELINE_STATIC_NAME);
+}
+
+/**
+ * Rust triple the scanner is built for: the verify step's host, which
+ * ci.mjs keeps on the target's os + arch (the emulated run needs that; the
+ * scan itself would work from anywhere).
+ *
+ * Linux is always `*-unknown-linux-musl`, whatever libc bun itself targets:
+ * with `+crt-static` that is one fully static executable that runs on the
+ * glibc (debian) host, the alpine host, and the glibc host that scans the
+ * android build, and rustc links it from the crt objects + libc.a bundled in
+ * its own `rust-std`, so no sysroot is involved — only a linker. The price is
+ * that the glibc and android lanes' build hosts install one more `rust-std`
+ * (the musl one; the musl and windows lanes already have theirs, the triple
+ * being bun's own). Using bun's triple instead would need the glibc sysroot
+ * link set up for the gnu lanes and still an exception for android, whose
+ * scanner has to run on a debian host.
+ */
+export function verifyBaselineStaticTriple(cfg: Config): string {
+  assert(
+    cfg.linux || cfg.windows,
+    `--verify-baseline-static=on: the verify-baseline step only exists for linux and windows targets (got os=${cfg.os})`,
+    { hint: "needsBaselineVerification() in .buildkite/ci.mjs decides which targets get one." },
+  );
+  const arch = cfg.x64 ? "x86_64" : "aarch64";
+  return cfg.windows ? `${arch}-pc-windows-msvc` : `${arch}-unknown-linux-musl`;
+}
+
+/**
+ * Where cargo leaves the executable: `<buildDir>/deps/verify-baseline-static/
+ * <triple>/release/verify-baseline-static[.exe]`. The scanner runs on the
+ * target's OS, so the target's exe suffix is the right one.
+ */
+export function verifyBaselineStaticExe(cfg: Config): string {
+  return resolve(
+    depBuildDir(cfg, VERIFY_BASELINE_STATIC_NAME),
+    verifyBaselineStaticTriple(cfg),
+    "release",
+    `${VERIFY_BASELINE_STATIC_NAME}${cfg.exeSuffix}`,
+  );
+}
+
+export interface VerifyBaselineStaticInvocation {
+  /** `cargo build <args>`. */
+  args: string[];
+  /** Environment the cargo process runs under. */
+  env: Record<string, string>;
+  triple: string;
+  exe: string;
+}
+
+/**
+ * The cargo command line + environment for the scanner. Pure function of
+ * `cfg` (no I/O) so it can be unit-tested; `emitVerifyBaselineStatic()` is
+ * the only build-graph caller.
+ */
+export function verifyBaselineStaticInvocation(cfg: Config): VerifyBaselineStaticInvocation {
+  const triple = verifyBaselineStaticTriple(cfg);
+  const exe = verifyBaselineStaticExe(cfg);
+
+  // Its own target dir, not bun's `rust-target/`: cargo holds a lock on the
+  // target dir for the whole of a build, so sharing one would serialize this
+  // behind the minutes-long bun_bin build for no reason.
+  const args = [
+    "--locked",
+    "--release",
+    "--target-dir",
+    depBuildDir(cfg, VERIFY_BASELINE_STATIC_NAME),
+    "--target",
+    triple,
+  ];
+
+  const env: Record<string, string> = { CARGO_TERM_COLOR: "always" };
+  if (cfg.cargoHome !== undefined) env.CARGO_HOME = cfg.cargoHome;
+  if (cfg.rustupHome !== undefined) env.RUSTUP_HOME = cfg.rustupHome;
+  // Same pin as every other cargo invocation in this build (see rust.ts);
+  // this is also the toolchain `dep_cargo_cross` installs the triple's
+  // rust-std into.
+  if (cfg.rustToolchain !== undefined) env.RUSTUP_TOOLCHAIN = cfg.rustToolchain;
+
+  // The linker is invoked by rustc directly, in the linker's own dialect, so
+  // the host's C compiler driver (which the aarch64 build host only has for
+  // aarch64) never enters into a foreign-arch link:
+  //   - linux: lld in `ld.lld` guise — rustc infers the ld flavor from the
+  //     name and hands it its self-contained musl crt objects. `cfg.ld` is
+  //     whichever ld.lld the bun link itself uses (clang's, or rustc's
+  //     gcc-ld/ wrapper under cross-language LTO); both take the same args.
+  //   - windows: `msvcLinker ?? ld`, exactly as rust.ts does for
+  //     bun_shim_impl.exe — the gcc-ld/lld-link wrapper `ld` may have been
+  //     swapped to cannot be driven by rustc (see `msvcLinker` in config.ts).
+  // The env var also overrides the `linker = "clang++"` that the generated
+  // repo-root `.cargo/config.toml` (cargo-config.ts) declares for this
+  // triple; cargo finds that file from the manifest dir.
+  const linker = cfg.windows ? (cfg.msvcLinker ?? cfg.ld) : cfg.ld;
+  assert(linker !== "", `--verify-baseline-static=on: no lld was resolved for a ${cfg.os} target on this host`);
+  env[`CARGO_TARGET_${triple.toUpperCase().replace(/-/g, "_")}_LINKER`] = linker;
+
+  const rustflags = [
+    // Static CRT on both targets: musl's libc.a (its default, made explicit)
+    // and libcmt/libucrt on windows (bun itself links /MT), so the artifact
+    // runs on the verify host with no vcruntime redistributable or libc
+    // version in the picture.
+    "-Ctarget-feature=+crt-static",
+  ];
+  if (cfg.windows) {
+    // Same library search setup as the bun.exe link (linkFlags in flags.ts):
+    // the serviced UCRT overlay ahead of the xwin splat. Both are undefined
+    // on a native windows host, where the VS dev shell's LIB env applies.
+    const ucrt = ucrtServicingLibDir(cfg);
+    if (ucrt !== undefined) rustflags.push(`-Clink-arg=/libpath:${ucrt}`);
+    if (cfg.winsysroot !== undefined) rustflags.push(`-Clink-arg=/winsysroot:${cfg.winsysroot}`);
+  }
+  if (cfg.ci) rustflags.push(`--remap-path-prefix=${cfg.cwd}=.`);
+  // Always set, even though the flags above would be enough reason: setting
+  // CARGO_ENCODED_RUSTFLAGS is what stops cargo from applying the
+  // `rustflags` of the generated `.cargo/config.toml` — those are
+  // `-Clink-arg=-fuse-ld=lld`-style clang driver flags, which lld rejects
+  // when it is invoked directly as it is here.
+  env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
+
+  return { args, env, triple, exe };
+}
+
+/**
+ * Emit the cargo edge. Returns the executable path; the caller adds it to the
+ * default targets (configure.ts) and ci.ts uploads it after the build.
+ *
+ * `rustObjects` is bun's own cargo output (`emitRust()`), and this edge is
+ * sequenced behind it: both edges begin with `rustup toolchain install` of
+ * the same toolchain into the same RUSTUP_HOME, and by the time bun's has
+ * finished, this one has at most a `rust-std` to add. It also puts the
+ * scanner's ~20s of rustc into the link phase, where cores are idle, rather
+ * than on top of the C++ compile. Order-only: the scanner does not depend on
+ * bun's contents, so a bun rebuild must not rebuild it.
+ */
+export function emitVerifyBaselineStatic(n: Ninja, cfg: Config, sources: Sources, rustObjects: string[]): string {
+  assert(cfg.cargo !== undefined, "--verify-baseline-static=on requires cargo but no rust toolchain was found", {
+    hint: "Install rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+  });
+  const { args, env, triple, exe } = verifyBaselineStaticInvocation(cfg);
+  const hostWin = cfg.host.os === "windows";
+
+  n.comment(`─── ${VERIFY_BASELINE_STATIC_NAME} (${triple}, for the verify-baseline CI step) ───`);
+  n.blank();
+  // `dep_cargo_cross` (source.ts) first runs `rustup toolchain install
+  // --target <triple>`: the pinned toolchain on a CI build host only has the
+  // rust-std of bun's own triple installed (rust.ts's rust_build_cross), and
+  // this triple differs from it on the glibc and android lanes. Without
+  // rustup there is nothing to install with; the plain rule then trusts the
+  // toolchain to have the target already.
+  n.build({
+    outputs: [exe],
+    rule: findRustup(cfg) !== undefined ? "dep_cargo_cross" : "dep_cargo",
+    inputs: [],
+    // Cargo fingerprints the sources itself; these only decide when ninja
+    // re-invokes it. The toolchain pin is an input because a channel bump
+    // changes the output without touching any scanner source.
+    implicitInputs: [...sources.verifyBaselineStatic, cfg.cargo, resolve(cfg.cwd, "rust-toolchain.toml")],
+    orderOnlyInputs: rustObjects,
+    vars: {
+      name: VERIFY_BASELINE_STATIC_NAME,
+      manifestdir: verifyBaselineStaticManifestDir(cfg),
+      args: quoteArgs(args, hostWin),
+      rust_target: triple,
+      env: Object.entries(env)
+        .map(([k, v]) => `--env=${k}=${quote(v, hostWin)}`)
+        .join(" "),
+    },
+  });
+  n.phony(VERIFY_BASELINE_STATIC_NAME, [exe]);
+  n.blank();
+
+  return exe;
+}

--- a/scripts/build/verify-baseline-static.ts
+++ b/scripts/build/verify-baseline-static.ts
@@ -146,13 +146,18 @@ export function verifyBaselineStaticInvocation(cfg: Config): VerifyBaselineStati
     const ucrt = ucrtServicingLibDir(cfg);
     if (ucrt !== undefined) rustflags.push(`-Clink-arg=/libpath:${ucrt}`);
     if (cfg.winsysroot !== undefined) rustflags.push(`-Clink-arg=/winsysroot:${cfg.winsysroot}`);
+    // rustc passes /DEBUG to the msvc linker regardless of the crate's
+    // `strip = true`, and lld-link then warns LNK4099 for every libcmt
+    // member whose PDB the splat does not carry (~60 lines per build) and
+    // writes a .pdb nobody uploads. Link args come after rustc's own, and
+    // the last /DEBUG option wins.
+    rustflags.push("-Clink-arg=/DEBUG:NONE");
   }
   if (cfg.ci) rustflags.push(`--remap-path-prefix=${cfg.cwd}=.`);
-  // Always set, even though the flags above would be enough reason: setting
-  // CARGO_ENCODED_RUSTFLAGS is what stops cargo from applying the
-  // `rustflags` of the generated `.cargo/config.toml` — those are
-  // `-Clink-arg=-fuse-ld=lld`-style clang driver flags, which lld rejects
-  // when it is invoked directly as it is here.
+  // Setting CARGO_ENCODED_RUSTFLAGS (never empty here) is also what stops
+  // cargo from applying the `rustflags` of the generated `.cargo/config.toml`:
+  // those are `-Clink-arg=-fuse-ld=lld`-style clang driver flags, which lld
+  // rejects when invoked directly as it is here.
   env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
 
   return { args, env, triple, exe };

--- a/scripts/glob-sources.ts
+++ b/scripts/glob-sources.ts
@@ -92,6 +92,18 @@ const patterns = {
       "rust-toolchain.toml",
     ],
   },
+  /**
+   * `scripts/verify-baseline-static` — its own cargo workspace, built by the
+   * edge in build/verify-baseline-static.ts (implicit inputs, so an edit
+   * re-invokes cargo). Not part of the workspace `rust` list above.
+   */
+  verifyBaselineStatic: {
+    paths: [
+      "scripts/verify-baseline-static/Cargo.toml",
+      "scripts/verify-baseline-static/Cargo.lock",
+      "scripts/verify-baseline-static/src/**/*.rs",
+    ],
+  },
   /** all `*.cpp` compiled into bun (bindings, webcore, v8 shim, usockets) */
   cxx: {
     paths: [

--- a/scripts/verify-baseline-static/README.md
+++ b/scripts/verify-baseline-static/README.md
@@ -30,6 +30,12 @@ base one without editing it.
 
 Exit `0` = clean, `1` = violations, `2` = tool error.
 
+In CI the `build-bun` step builds this crate (`scripts/build/verify-baseline-static.ts`,
+cross-compiled for the host the `verify-baseline` step runs on) and uploads it as the
+`verify-baseline-static[.exe]` artifact; the `verify-baseline` step downloads that and
+passes it to `scripts/verify-baseline.ts --static-checker`, so the test-fleet images need
+neither a rust toolchain nor the crates. The `cargo build` above is for local use.
+
 Use the `-profile` artifact. The stripped release binary has no `.symtab`
 (ELF) and no companion `.pdb` (PE) — every violation becomes `<no-symbol@addr>`
 and nothing in the allowlist matches. Windows auto-discovers `<binary>.pdb`

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -8,6 +8,12 @@
 // Usage:
 //   bun scripts/verify-baseline.ts --binary ./bun --arch x64 --emulator /usr/bin/qemu-x86_64
 //   bun scripts/verify-baseline.ts --binary ./bun.exe --arch x64 --emulator ./sde.exe
+//
+// The static scan (phase 0) runs scripts/verify-baseline-static. CI passes
+// --static-checker with the executable the build-bun step uploaded (see
+// getVerifyBaselineStep in .buildkite/ci.mjs); without the flag, a locally
+// `cargo build --release`-built one is used if present and the scan is
+// skipped otherwise.
 
 import { readdirSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -25,6 +31,7 @@ const { values } = parseArgs({
     // fallback for local dev.
     arch: { type: "string" },
     emulator: { type: "string" },
+    "static-checker": { type: "string" },
     "jit-stress": { type: "boolean", default: false },
     "skip-emulation": { type: "boolean", default: false },
   },
@@ -184,9 +191,19 @@ async function runTest(label: string, binaryArgs: string[], options?: RunTestOpt
 
 // Phase 0: Static instruction scan (no emulation — disassembles the binary).
 // Catches instructions in code paths the emulator test below never executes.
-// Soft-skipped if the checker isn't built (dev without cargo).
+// An explicit --static-checker must exist: in CI a missing one means the
+// build-bun artifact is gone, and silently skipping the scan would turn that
+// into a green step. The implicit local path is soft-skipped if it isn't built
+// (dev without cargo).
 const staticCheckerExe = isWindows ? "verify-baseline-static.exe" : "verify-baseline-static";
-const staticChecker = join(scriptDir, "verify-baseline-static", "target", "release", staticCheckerExe);
+const explicitStaticChecker = values["static-checker"];
+const staticChecker =
+  explicitStaticChecker !== undefined
+    ? resolve(explicitStaticChecker)
+    : join(scriptDir, "verify-baseline-static", "target", "release", staticCheckerExe);
+if (explicitStaticChecker !== undefined && !(await Bun.file(staticChecker).exists())) {
+  throw new Error(`--static-checker not found: ${staticChecker}`);
+}
 const staticAllowlistName = isWindows
   ? "allowlist-x64-windows.txt"
   : isAarch64

--- a/test/internal/source-lints/verify-baseline-static-build.test.ts
+++ b/test/internal/source-lints/verify-baseline-static-build.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Configure-time tests for scripts/build/verify-baseline-static.ts: the CI
+ * build (`--verify-baseline-static=on`, passed by .buildkite/ci.mjs for every
+ * target that gets a verify-baseline step) cross-builds the static ISA scanner
+ * for the host that step runs on and uploads it, so the step no longer installs
+ * a rust toolchain and fetches the scanner's crates on a test-fleet image.
+ *
+ * Nothing here runs cargo; these pin down the cargo invocation the edge is
+ * emitted with (target triple, linker, rustflags) and the artifact contract
+ * with ci.mjs. The windows cases describe a windows target built on a linux
+ * host, which is the only way CI builds windows; on a windows host the same
+ * inputs resolve to the native toolchain, so they are skipped there.
+ */
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { join, relative, resolve } from "node:path";
+
+import { verifyBaselineStaticArtifact } from "../../../scripts/build/ci.ts";
+import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../../scripts/build/config.ts";
+import { Ninja } from "../../../scripts/build/ninja.ts";
+import { rustLibPath, rustTarget } from "../../../scripts/build/rust.ts";
+import { registerDepRules } from "../../../scripts/build/source.ts";
+import {
+  emitVerifyBaselineStatic,
+  verifyBaselineStaticExe,
+  verifyBaselineStaticInvocation,
+  verifyBaselineStaticTriple,
+} from "../../../scripts/build/verify-baseline-static.ts";
+import { globAllSources, type Sources } from "../../../scripts/glob-sources.ts";
+
+const repoRoot = resolve(import.meta.dir, "..", "..", "..");
+const checkerDir = resolve(repoRoot, "scripts", "verify-baseline-static");
+
+/** A fully-populated fake toolchain; resolveConfig records these paths without spawning them. */
+function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: undefined,
+    rustLld: undefined,
+    rustLlvmVersion: "21.1.0",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: undefined,
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: "/fake/rust/bin/cargo",
+    cargoHome: "/fake/rust/cargo-home",
+    rustupHome: "/fake/rust/rustup-home",
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+    ...overrides,
+  };
+}
+
+/** What `--profile=ci-build --os=linux --arch=<arch> --abi=gnu` resolves to (the sysroot path is only recorded). */
+function linuxCi(partial: PartialConfig = {}, toolchain = mockToolchain()): Config {
+  return resolveConfig(
+    {
+      os: "linux",
+      arch: "x64",
+      abi: "gnu",
+      buildType: "Release",
+      ci: true,
+      buildkite: false,
+      linuxSysroot: "/fake/linux-sysroot",
+      verifyBaselineStatic: true,
+      ...partial,
+    },
+    toolchain,
+  );
+}
+
+/** The windows lane: a windows target cross-built on the linux build host, with an xwin splat. */
+function windowsCi(partial: PartialConfig = {}, toolchain?: Toolchain): Config {
+  return resolveConfig(
+    {
+      os: "windows",
+      arch: "x64",
+      buildType: "Release",
+      ci: true,
+      buildkite: false,
+      winsysroot: "/fake/winsysroot",
+      verifyBaselineStatic: true,
+      ...partial,
+    },
+    toolchain ??
+      mockToolchain({
+        cc: "/fake/llvm/bin/clang-cl",
+        cxx: "/fake/llvm/bin/clang-cl",
+        ar: "/fake/llvm/bin/llvm-lib",
+        ld: "/fake/llvm/bin/lld-link",
+        rc: "/fake/llvm/bin/llvm-rc",
+      }),
+  );
+}
+
+function rustflagsOf(cfg: Config): string[] {
+  return verifyBaselineStaticInvocation(cfg).env.CARGO_ENCODED_RUSTFLAGS!.split("\x1f");
+}
+
+describe("verifyBaselineStatic config flag", () => {
+  test("off unless asked for; ci.mjs turns it on per target", () => {
+    expect(linuxCi({ verifyBaselineStatic: undefined }).verifyBaselineStatic).toBe(false);
+    expect(linuxCi().verifyBaselineStatic).toBe(true);
+  });
+});
+
+describe("target triple: the verify-baseline step's host, not bun's own target", () => {
+  test("every linux lane gets a musl-static scanner for its arch, whatever libc bun targets", () => {
+    // getVerifyBaselineHost() in ci.mjs puts glibc and android builds on a
+    // debian host and musl builds on an alpine host; one static musl binary
+    // per arch runs on both, so the abi never enters into it (android resolves
+    // through the same `cfg.linux` branch; it needs an NDK to configure, so
+    // gnu stands in for it here).
+    const x64 = linuxCi();
+    expect(rustTarget(x64)).toBe("x86_64-unknown-linux-gnu");
+    expect(verifyBaselineStaticTriple(x64)).toBe("x86_64-unknown-linux-musl");
+
+    const aarch64 = linuxCi({ arch: "aarch64" });
+    expect(rustTarget(aarch64)).toBe("aarch64-unknown-linux-gnu");
+    expect(verifyBaselineStaticTriple(aarch64)).toBe("aarch64-unknown-linux-musl");
+  });
+
+  test("the musl lanes' scanner triple is bun's own triple", () => {
+    // Configuring a musl target on a glibc host requires a musl sysroot; a
+    // stub with the one file detectLinuxMuslSysroot() looks for is enough,
+    // the path is only recorded.
+    using sysroot = tempDir("vbs-musl-sysroot", { "usr/lib/libc.so": "" });
+    const previous = process.env.LINUX_MUSL_SYSROOT;
+    process.env.LINUX_MUSL_SYSROOT = String(sysroot);
+    try {
+      const musl = linuxCi({ arch: "aarch64", abi: "musl", linuxSysroot: undefined });
+      expect(rustTarget(musl)).toBe("aarch64-unknown-linux-musl");
+      expect(verifyBaselineStaticTriple(musl)).toBe("aarch64-unknown-linux-musl");
+    } finally {
+      if (previous === undefined) delete process.env.LINUX_MUSL_SYSROOT;
+      else process.env.LINUX_MUSL_SYSROOT = previous;
+    }
+  });
+
+  test.skipIf(isWindows)("windows builds get a pc-windows-msvc scanner", () => {
+    expect(verifyBaselineStaticTriple(windowsCi())).toBe("x86_64-pc-windows-msvc");
+    expect(verifyBaselineStaticTriple(windowsCi({ arch: "aarch64" }))).toBe("aarch64-pc-windows-msvc");
+  });
+
+  test("targets without a verify-baseline step are rejected at configure time", () => {
+    const freebsd = resolveConfig(
+      {
+        os: "freebsd",
+        arch: "x64",
+        buildType: "Release",
+        ci: true,
+        buildkite: false,
+        freebsdSysroot: "/fake/freebsd-sysroot",
+        verifyBaselineStatic: true,
+      },
+      mockToolchain(),
+    );
+    expect(() => verifyBaselineStaticTriple(freebsd)).toThrow(/verify-baseline step only exists for linux and windows/);
+  });
+});
+
+describe("cargo invocation", () => {
+  test("builds the locked release binary into its own target dir under deps/", () => {
+    const cfg = linuxCi();
+    const { args, exe, triple } = verifyBaselineStaticInvocation(cfg);
+    const targetDir = resolve(cfg.buildDir, "deps", "verify-baseline-static");
+    expect(args).toEqual(["--locked", "--release", "--target-dir", targetDir, "--target", triple]);
+    expect(exe).toBe(resolve(targetDir, "x86_64-unknown-linux-musl", "release", "verify-baseline-static"));
+    expect(exe).toBe(verifyBaselineStaticExe(cfg));
+  });
+
+  test("pins the same rustup toolchain as the rest of the build", () => {
+    const cfg = linuxCi();
+    const { env } = verifyBaselineStaticInvocation(cfg);
+    expect(cfg.rustToolchain).toBeDefined();
+    expect(env).toMatchObject({
+      RUSTUP_TOOLCHAIN: cfg.rustToolchain!,
+      CARGO_HOME: "/fake/rust/cargo-home",
+      RUSTUP_HOME: "/fake/rust/rustup-home",
+    });
+  });
+
+  test("linux links with the build's own lld, invoked directly, as a static executable", () => {
+    const cfg = linuxCi();
+    expect(verifyBaselineStaticInvocation(cfg).env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER).toBe(cfg.ld);
+    expect(cfg.ld).toBe("/fake/llvm/bin/ld.lld");
+    expect(rustflagsOf(cfg)).toEqual(["-Ctarget-feature=+crt-static", `--remap-path-prefix=${cfg.cwd}=.`]);
+
+    const aarch64 = verifyBaselineStaticInvocation(linuxCi({ arch: "aarch64" })).env;
+    expect(aarch64.CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER).toBe("/fake/llvm/bin/ld.lld");
+    expect(aarch64.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER).toBeUndefined();
+  });
+
+  test("linux follows the cross-language-LTO swap to rustc's gcc-ld/ld.lld", () => {
+    // The release lanes link with rustc's bundled lld when rustc's LLVM is
+    // newer than clang's (config.ts). rustc drives its own ld.lld wrapper
+    // fine (unlike the lld-link one below), so the scanner links with it too.
+    using dir = tempDir("vbs-rust-lld", { "gcc-ld/ld.lld": "", "gcc-ld/lld-link": "" });
+    const rustLld = join(String(dir), "gcc-ld", "ld.lld");
+    const cfg = linuxCi({}, mockToolchain({ rustLld, rustLlvmVersion: "22.1.4" }));
+    expect(cfg.crossLangLto).toBe(true);
+    expect(cfg.ld).toBe(rustLld);
+    expect(verifyBaselineStaticInvocation(cfg).env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER).toBe(rustLld);
+  });
+
+  test("rustflags are always set, so the generated .cargo/config.toml's clang-driver link args never apply", () => {
+    // cargo-config.ts writes `-Clink-arg=-fuse-ld=lld` for every triple into
+    // the repo-root config, which cargo finds from the scanner's manifest
+    // dir; lld invoked directly rejects it. CARGO_ENCODED_RUSTFLAGS replaces
+    // config rustflags, so it has to be present even with nothing CI-specific
+    // to say.
+    expect(rustflagsOf(linuxCi({ ci: false }))).toEqual(["-Ctarget-feature=+crt-static"]);
+  });
+
+  test.skipIf(isWindows)("windows links like bun.exe does: static CRT against the UCRT overlay + xwin splat", () => {
+    const cfg = windowsCi();
+    const { env } = verifyBaselineStaticInvocation(cfg);
+    expect(env.CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER).toBe("/fake/llvm/bin/lld-link");
+    const flags = rustflagsOf(cfg);
+    expect(flags[0]).toBe("-Ctarget-feature=+crt-static");
+    // Overlay first: an explicit /libpath: is searched before the
+    // /winsysroot-derived directories (same ordering as linkFlags in flags.ts).
+    const libpath = flags.findIndex(f => f.startsWith("-Clink-arg=/libpath:"));
+    const winsysroot = flags.indexOf("-Clink-arg=/winsysroot:/fake/winsysroot");
+    expect(libpath).toBeGreaterThan(0);
+    expect(winsysroot).toBeGreaterThan(libpath);
+    expect(flags[libpath]).toContain("ucrt-servicing-");
+    expect(flags).toContain(`--remap-path-prefix=${cfg.cwd}=.`);
+  });
+
+  test.skipIf(isWindows)("windows keeps the host lld-link when cfg.ld was swapped to rustc's gcc-ld/lld-link", () => {
+    // rustc prepends `-flavor link` to a linker inside its own gcc-ld/, which
+    // that wrapper then passes on as an input file; config.ts exposes the
+    // host lld-link as msvcLinker for cargo-driven links for exactly this
+    // reason, and the scanner is one of those links.
+    using dir = tempDir("vbs-rust-lld-link", { "gcc-ld/ld.lld": "", "gcc-ld/lld-link": "" });
+    const cfg = windowsCi(
+      {},
+      mockToolchain({
+        cc: "/fake/llvm/bin/clang-cl",
+        cxx: "/fake/llvm/bin/clang-cl",
+        ar: "/fake/llvm/bin/llvm-lib",
+        ld: "/fake/llvm/bin/lld-link",
+        rc: "/fake/llvm/bin/llvm-rc",
+        rustLld: join(String(dir), "gcc-ld", "ld.lld"),
+        rustLlvmVersion: "22.1.4",
+      }),
+    );
+    expect(cfg.ld).toBe(join(String(dir), "gcc-ld", "lld-link"));
+    expect(cfg.msvcLinker).toBe("/fake/llvm/bin/lld-link");
+    expect(verifyBaselineStaticInvocation(cfg).env.CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER).toBe(
+      "/fake/llvm/bin/lld-link",
+    );
+  });
+});
+
+describe("artifact contract with .buildkite/ci.mjs", () => {
+  test("the uploaded name is the bare executable name getVerifyBaselineStep() downloads", () => {
+    expect(verifyBaselineStaticArtifact(linuxCi())).toBe("verify-baseline-static");
+    if (!isWindows) expect(verifyBaselineStaticArtifact(windowsCi())).toBe("verify-baseline-static.exe");
+    // Test shards download every *.zip from build-bun; this must not be one.
+    expect(verifyBaselineStaticArtifact(linuxCi())).not.toEndWith(".zip");
+  });
+
+  test("ci.mjs builds the scanner for, and downloads it in, the same set of targets", async () => {
+    const ciMjs = await Bun.file(resolve(repoRoot, ".buildkite", "ci.mjs")).text();
+    expect(ciMjs).toContain("--verify-baseline-static=on");
+    for (const artifact of ["verify-baseline-static", "verify-baseline-static.exe"]) {
+      expect(ciMjs).toContain(`"${artifact}"`);
+    }
+    // The step runs the downloaded binary; building one there is what this
+    // artifact exists to avoid.
+    expect(ciMjs).toContain("--static-checker");
+    expect(ciMjs).not.toMatch(/cargo build/);
+  });
+});
+
+describe("ninja edge", () => {
+  const sources = globAllSources();
+
+  test("the scanner's sources are globbed separately from the workspace's", () => {
+    const rel = (paths: string[]) => paths.map(p => relative(repoRoot, p).replaceAll("\\", "/")).sort();
+    expect(rel(sources.verifyBaselineStatic)).toEqual(
+      expect.arrayContaining([
+        "scripts/verify-baseline-static/Cargo.lock",
+        "scripts/verify-baseline-static/Cargo.toml",
+        "scripts/verify-baseline-static/src/main.rs",
+      ]),
+    );
+    expect(sources.verifyBaselineStatic.every(p => p.startsWith(checkerDir))).toBe(true);
+    // The source lints iterate `rust`; the scanner is not part of the port.
+    expect(sources.rust.some(p => p.startsWith(checkerDir))).toBe(false);
+  });
+
+  /**
+   * Emit the edge with cargo living in `binDir`. Returns the `build` line that
+   * produces the scanner (continuations joined) plus the whole file, and a
+   * spelling helper for paths as the build line carries them (buildDir-relative,
+   * ninja-escaped, as Ninja.build() writes them).
+   */
+  function emit(binDir: string): { cfg: Config; edge: string; ninja: string; ninjaPath: (p: string) => string } {
+    const cfg = linuxCi({ buildDir: join(binDir, "build") }, mockToolchain({ cargo: join(binDir, "cargo") }));
+    const n = new Ninja({ buildDir: cfg.buildDir });
+    registerDepRules(n, cfg);
+    const exe = emitVerifyBaselineStatic(n, cfg, { verifyBaselineStatic: sources.verifyBaselineStatic } as Sources, [
+      rustLibPath(cfg),
+    ]);
+    expect(exe).toBe(verifyBaselineStaticExe(cfg));
+    const ninja = n.toString().replace(/ \$\n +/g, " ");
+    const ninjaPath = (p: string) =>
+      relative(cfg.buildDir, p).replace(/\$/g, "$$$$").replace(/ /g, "$ ").replace(/:/g, "$:");
+    const edge = ninja.split("\n").find(line => line.startsWith(`build ${ninjaPath(exe)}:`));
+    expect(edge).toBeDefined();
+    return { cfg, edge: edge!, ninja, ninjaPath };
+  }
+
+  test("with rustup next to cargo, the edge installs the triple's rust-std before building", () => {
+    // `rustup` is looked up next to cargo with the host's exe suffix
+    // (findRustup in rust.ts); create both spellings so this holds on every host.
+    using dir = tempDir("vbs-edge-rustup", { cargo: "", rustup: "", "rustup.exe": "" });
+    const { cfg, edge, ninja, ninjaPath } = emit(String(dir));
+    expect(edge).toContain(": dep_cargo_cross |");
+    // `build <out>: <rule> | <implicit inputs> || <order-only inputs>`. The
+    // implicit inputs are what re-invoke cargo: every scanner source, cargo
+    // itself, and the toolchain pin. libbun_rust.a is order-only: the edge
+    // waits for bun's own cargo step (shared rustup/cargo state) but a bun
+    // rebuild does not rebuild the scanner.
+    const [implicit, orderOnly] = edge.slice(edge.indexOf("|") + 1).split("||");
+    expect(implicit!.trim().split(" ").sort()).toEqual(
+      [...sources.verifyBaselineStatic, cfg.cargo!, resolve(cfg.cwd, "rust-toolchain.toml")].map(ninjaPath).sort(),
+    );
+    expect(orderOnly!.trim()).toBe(ninjaPath(rustLibPath(cfg)));
+    expect(ninja).toContain("rust_target = x86_64-unknown-linux-musl");
+    expect(ninja).toContain(`manifestdir = ${checkerDir}`);
+    expect(ninja).toContain("CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/fake/llvm/bin/ld.lld");
+    expect(ninja).toContain(`build verify-baseline-static: phony ${ninjaPath(verifyBaselineStaticExe(cfg))}`);
+  });
+
+  test("without rustup, the plain cargo rule is used", () => {
+    using dir = tempDir("vbs-edge-plain", { cargo: "" });
+    expect(emit(String(dir)).edge).toContain(": dep_cargo |");
+  });
+});

--- a/test/internal/source-lints/verify-baseline-static-build.test.ts
+++ b/test/internal/source-lints/verify-baseline-static-build.test.ts
@@ -26,6 +26,7 @@ import {
   verifyBaselineStaticInvocation,
   verifyBaselineStaticTriple,
 } from "../../../scripts/build/verify-baseline-static.ts";
+import { ucrtServicingLibDir } from "../../../scripts/build/winsysroot.ts";
 import { globAllSources, type Sources } from "../../../scripts/glob-sources.ts";
 
 const repoRoot = resolve(import.meta.dir, "..", "..", "..");
@@ -232,16 +233,19 @@ describe("cargo invocation", () => {
     const cfg = windowsCi();
     const { env } = verifyBaselineStaticInvocation(cfg);
     expect(env.CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER).toBe("/fake/llvm/bin/lld-link");
-    const flags = rustflagsOf(cfg);
-    expect(flags[0]).toBe("-Ctarget-feature=+crt-static");
-    // Overlay first: an explicit /libpath: is searched before the
-    // /winsysroot-derived directories (same ordering as linkFlags in flags.ts).
-    const libpath = flags.findIndex(f => f.startsWith("-Clink-arg=/libpath:"));
-    const winsysroot = flags.indexOf("-Clink-arg=/winsysroot:/fake/winsysroot");
-    expect(libpath).toBeGreaterThan(0);
-    expect(winsysroot).toBeGreaterThan(libpath);
-    expect(flags[libpath]).toContain("ucrt-servicing-");
-    expect(flags).toContain(`--remap-path-prefix=${cfg.cwd}=.`);
+    const ucrtOverlay = ucrtServicingLibDir(cfg)!;
+    expect(ucrtOverlay).toContain("ucrt-servicing-");
+    // The overlay's explicit /libpath: is searched before the directories
+    // /winsysroot: derives (same ordering as linkFlags in flags.ts), and
+    // /DEBUG:NONE has to come after the /DEBUG rustc itself passes, which
+    // it does because rustc appends link args after its own.
+    expect(rustflagsOf(cfg)).toEqual([
+      "-Ctarget-feature=+crt-static",
+      `-Clink-arg=/libpath:${ucrtOverlay}`,
+      "-Clink-arg=/winsysroot:/fake/winsysroot",
+      "-Clink-arg=/DEBUG:NONE",
+      `--remap-path-prefix=${cfg.cwd}=.`,
+    ]);
   });
 
   test.skipIf(isWindows)("windows keeps the host lld-link when cfg.ld was swapped to rustc's gcc-ld/lld-link", () => {


### PR DESCRIPTION
### Problem

- Every `<target> - verify-baseline` step (linux x64, aarch64, x64-musl, aarch64-musl, aarch64-android, windows x64) runs `cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml` on its test-fleet host (`.buildkite/ci.mjs`, `getVerifyBaselineStep`).
- Those images have rustup with a stable toolchain (`scripts/bootstrap.sh` `install_rust`, `bootstrap.ps1`), not the nightly pinned by the repo-root `rust-toolchain.toml`, and none of the scanner's crates. So each job first downloads the toolchain and the crates: build 93705, `:linux: x64 - verify-baseline`, shows `syncing channel updates for nightly-2026-07-20` -> `downloading 19 components` (35 s) -> `Updating crates.io index` -> 8 more seconds of compiling, in a step whose actual work takes about 3 s.
- That makes six jobs per build depend on static.rust-lang.org and crates.io being up, the same failure class as the qemu download #37955 removes from the same step (that PR leaves the cargo build alone).

### Fix

- `build-bun` builds the scanner and uploads it; `verify-baseline` downloads it.
  - `.buildkite/ci.mjs`: `getBuildArgs` passes `--verify-baseline-static=on` for exactly the targets `needsBaselineVerification()` gives a verify step; the verify step downloads `verify-baseline-static[.exe]` next to the profile zip and runs `verify-baseline.ts --static-checker <it>` instead of `cargo build`. The generated pipeline diff is below.
  - `scripts/build/verify-baseline-static.ts` (new): one cargo edge (reusing the unused `dep_cargo_cross` rule, which first `rustup toolchain install --target`s the triple) that builds `scripts/verify-baseline-static` for the host the verify step runs on, into `deps/verify-baseline-static/`. `bun.ts` emits it, `configure.ts` adds it to the defaults, `ci.ts` `packageAndUpload()` copies it to the bare artifact name and uploads it with the zips. Its sources are a new `glob-sources.ts` list so edits re-invoke cargo and the Rust source lints keep ignoring it.
  - `scripts/verify-baseline.ts`: `--static-checker <path>`. An explicitly given checker that is missing is an error, so a lost artifact cannot turn into a green step; the old implicit local path and its soft-skip are unchanged.
- Why building it on the build host is the right place: by the time this edge runs, that host has already installed the pinned toolchain and fetched bun's own ~180 crates from crates.io for `libbun_rust.a`, so the build gains no new download source. The edge is order-only sequenced behind the `libbun_rust.a` edge for that reason (one rustup at a time in the toolchain dir; it then runs during the link, on idle cores). The scanner only reads the binary it checks, so it does not have to be built for bun's own target.
- Which triple, and how it links without a sysroot:
  - linux lanes: `<arch>-unknown-linux-musl` + `-Ctarget-feature=+crt-static`, whatever libc bun targets. One static executable runs on the debian hosts (glibc and android lanes) and the alpine hosts alike, and rustc links it from the crt objects and `libc.a` inside its own `rust-std`, so the only tool involved is a linker. The cost is that the two glibc lanes and the android lane install one extra `rust-std` on the build host; the musl and windows lanes' scanner triple is bun's own, already installed.
  - windows: `<arch>-pc-windows-msvc` + `+crt-static` (bun itself links `/MT`), with the same `/libpath:<UCRT overlay>` + `/winsysroot:<xwin splat>` search setup as the `bun.exe` link in `flags.ts`, plus `/DEBUG:NONE`: rustc passes `/DEBUG` regardless of the crate's `strip = true`, which made lld-link warn LNK4099 for every libcmt member whose PDB the splat lacks (~60 log lines on the first CI run) and write an unused .pdb. Link args come after rustc's own and the last `/DEBUG` option wins (checked against lld-link locally).
  - The linker is `CARGO_TARGET_<triple>_LINKER` = `cfg.ld` on linux (rustc infers the ld flavor from the `ld.lld` name and invokes it directly; this works for clang's ld.lld, rust-lld, and the `gcc-ld/ld.lld` wrapper the LTO lanes swap in, all tried below) and `cfg.msvcLinker ?? cfg.ld` on windows, the same choice `rust.ts` makes for `bun_shim_impl.exe`: rustc prepends `-flavor link` to a linker inside its own `gcc-ld/`, which the `lld-link` wrapper mis-forwards (the reason `msvcLinker` exists in `config.ts`; reproduced below). `CARGO_ENCODED_RUSTFLAGS` is always set because that is what stops cargo from applying the generated `.cargo/config.toml`'s `-Clink-arg=-fuse-ld=lld`, which lld invoked directly rejects (the first thing that failed when prototyping).
- Verified:
  - `test/internal/source-lints/verify-baseline-static-build.test.ts` (17 tests): triple per target, the linker and rustflags for both OSes including both LTO-swap cases, the `--locked --release --target` args, the artifact name and its use in `ci.mjs`, the glob list, and the emitted edge (rule choice with and without rustup, implicit vs order-only inputs). Fails on main (the module does not exist); `bun test test/internal/source-lints/` passes (98).
  - `bun scripts/build.ts --configure-only --profile=ci-build --os=linux --arch=x64 --abi=gnu --verify-baseline-static=on`, then `ninja verify-baseline-static`: the edge links a `static-pie`, stripped x86_64 musl executable through the `gcc-ld/ld.lld` wrapper that `cfg.ld` resolves to under LTO (rustc's LLVM 22 vs clang 21, as in CI), with no checkout path embedded; it scans a local `bun-profile` and reports `PASS`; a second ninja run is a no-op.
  - The same cargo invocation cross-arch (`aarch64-unknown-linux-musl` from this x64 box, i.e. the mirror image of the arm64 build host building the x64 lanes) with clang's ld.lld, rust-lld, and `gcc-ld/ld.lld` each produce a statically linked aarch64 executable.
  - `verify-baseline.ts --static-checker <built binary> --skip-emulation` runs the scan and exits 0; with a missing path it exits 1 with `--static-checker not found`.
  - `node .buildkite/ci.mjs`: the only changes are on the 6 verified targets (diff below).
  - CI on this PR (build 94270): all six `build-bun` steps built and uploaded the scanner in 6 to 8 s each at the tail of the build (the glibc and android lanes log the one extra `rust-std` install, the musl and windows lanes log `unchanged`), and all six `verify-baseline` steps downloaded it and passed with no rustup or cargo output; this includes the windows-msvc link, which could not be tried locally (Microsoft's CDN, the xwin source, is unreachable from the development container) and the resulting `verify-baseline-static.exe` running on the Windows 2019 host.

### Background

- `verify-baseline` is a per-target CI step that checks a release `bun-profile` contains no instructions beyond the baseline CPU (x64 Nehalem, aarch64 armv8-a+crc): `scripts/verify-baseline-static` (a small Rust program using `object`/`iced-x86`/`pdb`) disassembles `.text` and diffs against an allowlist, then `scripts/verify-baseline.ts` runs tests under qemu or Intel SDE. It runs on a host matching the target's OS and arch because of the emulated part; the scanner itself reads the file and would work anywhere.
- All build lanes run on one debian-13 arm64 build host and cross-compile (`buildHostPlatform` in `ci.mjs`), so a binary that must run on an x64 verify host has to be cross-linked from arm64. Rust's `*-linux-musl` targets ship their own crt objects and libc and link statically by default, which is why they need only a linker; its `*-linux-gnu` targets would need a glibc sysroot.
- `rust-toolchain.toml` pins a nightly; the build passes it as `RUSTUP_TOOLCHAIN` to every cargo invocation, and `rust_build_cross` / `dep_cargo_cross` run `rustup toolchain install --target <triple>` first so the needed `rust-std` is present (CI images only preinstall targets for their default stable toolchain).
- Under cross-language LTO, `config.ts` swaps `cfg.ld` to rustc's bundled lld (shipped as thin wrappers in `gcc-ld/`, one per flavor) when rustc's LLVM is newer than clang's; `cfg.msvcLinker` is the un-swapped host `lld-link` kept for links that rustc itself drives.
- Buildkite artifact names are the paths given to `buildkite-agent artifact upload` relative to its cwd; test shards fetch `*.zip` from `build-bun`, so this artifact is deliberately not a zip.

<details>
<summary>Generated pipeline diff (node .buildkite/ci.mjs, linux-x64 shown; the other five targets change identically)</summary>

```diff
-          - node --experimental-strip-types scripts/build.ts --profile=ci-build --os=linux --arch=x64 --abi=gnu
+          - node --experimental-strip-types scripts/build.ts --profile=ci-build --os=linux --arch=x64 --abi=gnu --verify-baseline-static=on
...
           - buildkite-agent artifact download 'bun-linux-x64-profile.zip' . --step linux-x64-build-bun
+          - buildkite-agent artifact download 'verify-baseline-static' . --step linux-x64-build-bun
           - unzip -o 'bun-linux-x64-profile.zip'
-          - chmod +x bun-linux-x64-profile/bun-profile
+          - chmod +x bun-linux-x64-profile/bun-profile verify-baseline-static
...
-          - cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml
-          - bun scripts/verify-baseline.ts --binary bun-linux-x64-profile/bun-profile --arch x64 --emulator ./qemu-linux-x86_64-9.1.0/bin/qemu-x86_64
+          - bun scripts/verify-baseline.ts --binary bun-linux-x64-profile/bun-profile --static-checker verify-baseline-static --arch x64 --emulator ./qemu-linux-x86_64-9.1.0/bin/qemu-x86_64
```

Windows: `buildkite-agent artifact download verify-baseline-static.exe . --step windows-x64-build-bun || exit /b 1` and `--static-checker verify-baseline-static.exe`. No other step changes.

</details>

<details>
<summary>Emitted edge in the ci-build configuration</summary>

```ninja
build deps/verify-baseline-static/x86_64-unknown-linux-musl/release/verify-baseline-static: dep_cargo_cross | $
    ../../scripts/verify-baseline-static/Cargo.lock ../../scripts/verify-baseline-static/Cargo.toml $
    ../../scripts/verify-baseline-static/src/aarch64.rs ../../scripts/verify-baseline-static/src/main.rs $
    .../cargo ../../rust-toolchain.toml || rust-target/x86_64-unknown-linux-gnu/release/libbun_rust.a
  name = verify-baseline-static
  manifestdir = .../scripts/verify-baseline-static
  args = --locked --release --target-dir .../deps/verify-baseline-static --target x86_64-unknown-linux-musl
  rust_target = x86_64-unknown-linux-musl
  env = ... --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=.../lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld/ld.lld --env=CARGO_ENCODED_RUSTFLAGS='-Ctarget-feature=+crt-static<US>--remap-path-prefix=<checkout>=.'
```

`ninja verify-baseline-static` on it: `Finished release profile in 17s`; `file` reports `ELF 64-bit LSB pie executable, x86-64, static-pie linked, stripped`.

</details>

<details>
<summary>Why the windows linker is msvcLinker and not cfg.ld</summary>

```
$ rustc --target x86_64-pc-windows-msvc -Clinker=<sysroot>/bin/gcc-ld/lld-link m.rs
rust-lld: warning: ignoring unknown argument '-flavor'
rust-lld: error: could not open 'link': No such file or directory
```

The `gcc-ld/ld.lld` wrapper is invoked by rustc without `-flavor` and links the musl targets fine (checked with the pinned nightly), so linux can follow `cfg.ld` directly.

</details>

