### PR TITLE
node:http2: release server push streams once their response ends

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2268,16 +2268,6 @@ function isFinalWrite(stream: Http2Stream, pendingLength: number) {
   );
 }
 
-// writeStream settled the stream to HALF_CLOSED_LOCAL synchronously with the dispatch
-// suppressed: the JS side runs the bookkeeping the onStreamEnd(5) handler would have.
-function onEndStreamSettled(stream: Http2Stream) {
-  markWritableDone(stream);
-  if ((stream.id & 1) === 0 && stream[bunHTTP2Session]?.type === constants.NGHTTP2_SESSION_SERVER) {
-    if (!stream.rstCode) stream.rstCode = 0;
-    markStreamClosed(stream);
-  }
-}
-
 function markWritableDone(stream: Http2Stream) {
   const _final = stream[bunHTTP2StreamFinal];
   if (typeof _final === "function") {
@@ -2887,8 +2877,9 @@ class Http2Stream extends Duplex {
         if (this instanceof ServerHttp2Stream && !this.headersSent && (this.id & 1) === 0) {
           // A locally-pushed (even-id) stream ended before respond() (HEAD/endStream pushes): an
           // empty DATA frame would precede the response HEADERS on the wire. respond() forces
-          // endStream for these streams, so END_STREAM rides on the HEADERS frame and the
-          // onStreamEnd(5) dispatch completes this callback through markWritableDone.
+          // endStream for these streams, so END_STREAM rides on the HEADERS frame; that closes
+          // the stream (a push has no client half) and the streamEnd(7) handler completes this
+          // callback through markStreamClosed -> markWritableDone.
           this[bunHTTP2StreamFinal] = callback;
           return;
         }
@@ -2946,16 +2937,10 @@ class Http2Stream extends Duplex {
         // program's last live turn.
         native.flush();
         if (settled === 5) {
-          // HALF_CLOSED_LOCAL settled synchronously; the dispatch was suppressed.
+          // HALF_CLOSED_LOCAL settled synchronously; the dispatch was suppressed. A full close
+          // (the peer's half was already closed, which is always the case for a server push) was
+          // dispatched as streamEnd(7) from inside writeStream instead.
           markWritableDone(this);
-          // A server-initiated push (even id) has no client→server half, so HALF_CLOSED_LOCAL is
-          // its CLOSED state — mark it closed here so the diagnostics close-channel observes
-          // destroyed === false and rstCode === NGHTTP2_NO_ERROR, like node's nghttp2
-          // onStreamClose path.
-          if ((this.#id & 1) === 0 && this[bunHTTP2Session]?.type === constants.NGHTTP2_SESSION_SERVER) {
-            if (!this.rstCode) this.rstCode = 0;
-            markStreamClosed(this);
-          }
         }
         return;
       }
@@ -3068,7 +3053,9 @@ class Http2Stream extends Duplex {
         if (status & kWriteFlushedWithoutCallback) session[kDeferWriteCallback](callback);
         if (endStream) {
           this[bunHTTP2StreamStatus] |= StreamState.EndStreamSent;
-          if ((status & ~kWriteFlushedWithoutCallback) === 5) onEndStreamSettled(this);
+          // 5 = HALF_CLOSED_LOCAL settled synchronously with its onStreamEnd dispatch suppressed;
+          // a full close (7) was already dispatched as streamEnd from inside writeStream.
+          if ((status & ~kWriteFlushedWithoutCallback) === 5) markWritableDone(this);
         }
         if (onClientStreamBodyChunkSentChannel.hasSubscribers && this instanceof ClientHttp2Stream) {
           onClientStreamBodyChunkSentChannel.publish({ stream: this, writev: true, data, encoding: "" });
@@ -3109,7 +3096,8 @@ class Http2Stream extends Duplex {
         if (status & kWriteFlushedWithoutCallback) session[kDeferWriteCallback](callback);
         if (endStream) {
           this[bunHTTP2StreamStatus] |= StreamState.EndStreamSent;
-          if ((status & ~kWriteFlushedWithoutCallback) === 5) onEndStreamSettled(this);
+          // See _writev.
+          if ((status & ~kWriteFlushedWithoutCallback) === 5) markWritableDone(this);
         }
         if (onClientStreamBodyChunkSentChannel.hasSubscribers && this instanceof ClientHttp2Stream) {
           onClientStreamBodyChunkSentChannel.publish({ stream: this, writev: false, data: chunk, encoding });

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5325,7 +5325,7 @@ impl H2FrameParser {
         } else {
             self.local_settings.get().initial_window_size
         };
-        let stream = bun_core::heap::into_raw(Box::new(Stream::init(
+        let mut new_stream = Stream::init(
             stream_identifier,
             local_window_size,
             self.remote_settings
@@ -5333,7 +5333,14 @@ impl H2FrameParser {
                 .map(|s| s.initial_window_size)
                 .unwrap_or(DEFAULT_WINDOW_SIZE as u32),
             self.padding_strategy.get(),
-        )));
+        );
+        // A server-initiated (even) stream is a push: the peer never has a half to close on it
+        // (RFC 9113 §5.1, reserved (local) -> half-closed (remote)), so our END_STREAM must take
+        // it straight to CLOSED. Left OPEN it would settle at HALF_CLOSED_LOCAL and never be freed.
+        if self.is_server.get() && stream_identifier.is_multiple_of(2) {
+            new_stream.state = StreamState::HALF_CLOSED_REMOTE;
+        }
+        let stream = bun_core::heap::into_raw(Box::new(new_stream));
         self.streams
             .with_mut(|s| s.insert(stream_identifier, stream));
 

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -761,6 +761,223 @@ describe("push stream states (checklist §5.1, RFC 9113 §6.4/§8.4)", () => {
   });
 });
 
+// Server side of a push (RFC 9113 §5.1 / §8.4): a promised stream has no client half, so it is
+// complete as soon as the server's response on it ends. Node then closes it right away (rstCode 0)
+// and lets it be collected while the session lives on. These streams used to be modelled like a
+// request stream, so ending the response only half-closed them: they never emitted 'close', stayed
+// rooted until the session died, still counted as open for session.close(), and a session torn
+// down later errored every one of them.
+describe("server push stream lifecycle (RFC 9113 §5.1 / §8.4)", () => {
+  const PUSHES = 8;
+
+  type PushLog = {
+    refs: WeakRef<object>[];
+    closes: number[]; // rstCode seen by each push's 'close'
+    errors: string[];
+    remoteClose: number[]; // stream.state.remoteClose as handed to the pushStream callback
+  };
+
+  /** An h2c server that answers every request with one push, finished by `finish`, then the response. */
+  async function listenPushServer(
+    pushHeaders: http2.OutgoingHttpHeaders,
+    finish: (push: http2.ServerHttp2Stream) => void,
+  ) {
+    const log: PushLog = { refs: [], closes: [], errors: [], remoteClose: [] };
+    let session: http2.ServerHttp2Session | undefined;
+    const pushServer = http2.createServer();
+    pushServer.on("session", s => (session = s));
+    pushServer.on("stream", stream => {
+      stream.pushStream(pushHeaders, (err, push) => {
+        if (err) throw err;
+        log.refs.push(new WeakRef(push));
+        log.remoteClose.push(push.state.remoteClose!);
+        push.on("error", (e: any) => log.errors.push(e.code));
+        push.on("close", () => log.closes.push(push.rstCode));
+        finish(push);
+        stream.respond({ ":status": 200 });
+        stream.end("main");
+      });
+    });
+    pushServer.listen(0);
+    await once(pushServer, "listening");
+    return {
+      server: pushServer,
+      port: (pushServer.address() as net.AddressInfo).port,
+      log,
+      session: () => session!,
+    };
+  }
+
+  /** Gives deferred teardown work (immediates) and the GC a bounded number of turns to reach `done`. */
+  async function settle(done: () => boolean) {
+    for (let i = 0; i < 50 && !done(); i++) {
+      await new Promise(resolve => setImmediate(resolve));
+      await gcTick();
+    }
+  }
+
+  const live = (refs: WeakRef<object>[]) => refs.filter(ref => ref.deref() !== undefined).length;
+
+  // One case per native path that sends the server's END_STREAM: a DATA frame (end(body)), the
+  // response HEADERS (respond({ endStream }), and a HEAD push whose end() precedes respond()), and
+  // a trailers HEADERS frame.
+  const endings: Array<[string, http2.OutgoingHttpHeaders, (push: http2.ServerHttp2Stream) => void]> = [
+    [
+      "end(body)",
+      { ":path": "/pushed" },
+      push => {
+        push.respond({ ":status": 200 });
+        push.end("pushed");
+      },
+    ],
+    [
+      "respond({ endStream: true })",
+      { ":path": "/pushed" },
+      push => push.respond({ ":status": 200 }, { endStream: true }),
+    ],
+    [
+      "a HEAD push (ended before respond())",
+      { ":path": "/pushed", ":method": "HEAD" },
+      push => push.respond({ ":status": 200 }),
+    ],
+    [
+      "trailers",
+      { ":path": "/pushed" },
+      push => {
+        push.respond({ ":status": 200 }, { waitForTrailers: true });
+        push.on("wantTrailers", () => push.sendTrailers({ "x-pushed": "done" }));
+        push.end("pushed");
+      },
+    ],
+  ];
+
+  test.each(endings)(
+    "pushes finished with %s close with rstCode 0 and are released",
+    async (_, pushHeaders, finish) => {
+      const { server: pushServer, port: pushPort, log, session } = await listenPushServer(pushHeaders, finish);
+      const client = http2.connect(`http://127.0.0.1:${pushPort}`);
+      let pushedClosed = 0;
+      client.on("stream", pushed => {
+        pushed.on("error", () => {});
+        pushed.on("close", () => pushedClosed++);
+        pushed.resume();
+      });
+      try {
+        for (let i = 0; i < PUSHES; i++) {
+          const { promise, resolve, reject } = Promise.withResolvers<void>();
+          const req = client.request({ ":path": "/" });
+          req.on("error", reject);
+          req.on("close", resolve);
+          req.resume();
+          req.end();
+          await promise;
+        }
+        // The pushed responses precede each main response on the wire, so once the client has
+        // closed every pushed stream the server has long sent each push's END_STREAM.
+        await settle(() => pushedClosed === PUSHES);
+        expect(pushedClosed).toBe(PUSHES);
+
+        await settle(() => log.closes.length === PUSHES && live(log.refs) === 0);
+        expect(log.closes).toEqual(Array(PUSHES).fill(0));
+        expect(live(log.refs)).toBe(0);
+        // The peer's half is closed from the moment the stream exists (node reports the same).
+        expect(log.remoteClose).toEqual(Array(PUSHES).fill(1));
+
+        // The pushes are gone from the session: its teardown must not touch them again.
+        const serverSessionClosed = once(session(), "close");
+        client.destroy();
+        await serverSessionClosed;
+        await new Promise(resolve => setImmediate(resolve));
+        expect(log.errors).toEqual([]);
+        expect(log.closes).toHaveLength(PUSHES);
+      } finally {
+        client.destroy();
+        pushServer.close();
+      }
+    },
+  );
+
+  /** Connects a raw client, sends one GET on stream 1, and waits for the push (stream 2) and the response to end. */
+  async function pushOverRawClient(pushPort: number) {
+    const c = await RawH2.connect(pushPort);
+    c.sendPreface();
+    c.sendEmptySettings(); // SETTINGS_ENABLE_PUSH stays at its default of 1
+    await c.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+    c.sendSettingsAck();
+    c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM | END_HEADERS */, 1, requestHeaderBlock("GET"));
+    const endStreamOn = (id: number) => (f: Frame) =>
+      f.type === FrameType.DATA && f.streamId === id && (f.flags & 0x1) !== 0;
+    await c.waitFor(endStreamOn(2));
+    await c.waitFor(endStreamOn(1));
+    return c;
+  }
+
+  const finishWithBody = (push: http2.ServerHttp2Stream) => {
+    push.respond({ ":status": 200 });
+    push.end("pushed");
+  };
+
+  test("a completed push is closed by its END_STREAM alone and no longer holds session.close() open", async () => {
+    const {
+      server: pushServer,
+      port: pushPort,
+      log,
+      session,
+    } = await listenPushServer({ ":path": "/pushed" }, finishWithBody);
+    let c: RawH2 | undefined;
+    try {
+      c = await pushOverRawClient(pushPort);
+      const promise = c.frames.find(f => f.type === FrameType.PUSH_PROMISE)!;
+      expect([promise.streamId, promise.payload.readUInt32BE(0) & 0x7fffffff]).toEqual([1, 2]);
+
+      await settle(() => log.closes.length === 1);
+      expect(log.closes).toEqual([0]);
+      expect(c.frames.filter(f => f.type === FrameType.RST_STREAM)).toEqual([]);
+
+      // Both streams are done, so a graceful close has nothing to wait for. This raw client never
+      // reacts to the GOAWAY, so the session can only end through its own stream accounting.
+      const serverSession = session();
+      const closed = once(serverSession, "close");
+      serverSession.close();
+      await c.waitForGoaway();
+      await closed;
+      expect(log.errors).toEqual([]);
+    } finally {
+      c?.destroy();
+      pushServer.close();
+    }
+  });
+
+  test("a client's RST_STREAM arriving after the push completed is ignored", async () => {
+    const { server: pushServer, port: pushPort, log } = await listenPushServer({ ":path": "/pushed" }, finishWithBody);
+    let c: RawH2 | undefined;
+    try {
+      c = await pushOverRawClient(pushPort);
+      await settle(() => log.closes.length === 1);
+      expect(log.closes).toEqual([0]);
+
+      // A client typically cancels a push it does not want as soon as it sees the PUSH_PROMISE; a
+      // small push has often completed on the server by the time that reset arrives (§5.1: frames
+      // for a closed stream are tolerated). The server stream is gone, so nothing may be reported
+      // on it, and the connection stays usable.
+      const cancel = Buffer.alloc(4);
+      cancel.writeUInt32BE(ErrorCode.CANCEL, 0);
+      c.sendFrame(FrameType.RST_STREAM, 0, 2, cancel);
+      const ping = Buffer.from("late-rst");
+      c.sendFrame(FrameType.PING, 0, 0, ping);
+      const ack = await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(ack.payload.equals(ping)).toBe(true);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(c.frames.filter(f => f.type === FrameType.GOAWAY || f.type === FrameType.RST_STREAM)).toEqual([]);
+      expect(log.closes).toEqual([0]);
+      expect(log.errors).toEqual([]);
+    } finally {
+      c?.destroy();
+      pushServer.close();
+    }
+  });
+});
+
 describe("inbound flow control after local end-stream (RFC 9113 §6.9)", () => {
   // Regression coverage for the test-http2-pipe failure mode: the server responds and ends its
   // side before the request body arrives, the request body is piped into a backpressured


### PR DESCRIPTION
### Problem

- On a `node:http2` server, every stream created by `stream.pushStream()` stays alive after its response has completed, until the whole session is torn down. Node releases a push as soon as its response ends.
- User-visible consequences of the same thing, all measured against node v26.3.0 (which does none of them):
  - a completed push never emits `'close'` (node: `'close'` with `rstCode === 0` right after the response ends);
  - a `WeakRef` to it never clears, so a long-lived session accumulates one `ServerHttp2Stream` (plus its native `Stream` box, its two `Strong` roots and anything the user attached to it) per push;
  - it still counts as an open stream, so a server-side `session.close()` never completes on its own after a push was served;
  - when the client later disconnects, every long-finished push gets `'error'` (`ECONNRESET`) and closes with `rstCode` 2, which is an uncaught exception for code that stopped listening to a stream it had finished with;
  - a client `RST_STREAM` arriving after the push completed (common: clients cancel unwanted pushes as soon as they see the `PUSH_PROMISE`, small pushes are often already complete) was delivered to the finished stream and closed it with `rstCode` 8.
- Cause: `pushStream()` reserves the promised stream through `getNextStream()`, and `handle_received_stream_id` (`src/runtime/api/bun/h2_frame_parser.rs:5301`) creates every stream in state `OPEN`. A pushed stream has no client half (RFC 9113 5.1: reserved (local), then half-closed (remote) once the response `HEADERS` goes out), but modelled as `OPEN` our own `END_STREAM` only moves it to `HALF_CLOSED_LOCAL` in each close tail (`send_data` `:7673`, `send_trailers` `:8166`, `request()` `:9609`, `Stream::flush_queue` `:1890`). Only the `CLOSED` branch of those tails calls `free_resources`, which is what drops the stream's JS roots and queues its native eviction, so nothing ever releases it.
- The JS layer papered over this for the events it could see: `onEndStreamSettled` and `_final` treated a state-5 settle as "closed" for even-id server streams (`src/js/node/http2.ts`), which is why `'finish'` and the diagnostics close channel looked right while the stream stayed rooted and counted.
- Not the same as #38044 (the `CLOSED` arm of `flush_queue` does not call `free_resources`) nor #34675 (pushes whose `PUSH_PROMISE` was rejected before reaching the wire). The two overlap for one shape only: a push whose body is larger than the peer's window sends its last frame through `flush_queue`. With this PR alone such a push now closes correctly in JS (`'close'` with `rstCode` 0, session count released, measured with a 200 KB body) but its objects stay rooted until #38044's release lands; the two changes are independent lines and compose.

### Fix

- `handle_received_stream_id`: a stream the server creates itself (even id on a server session) starts in `HALF_CLOSED_REMOTE`. From then on a push takes exactly the path a request stream takes after its request body ended: the response's `END_STREAM` (DATA, response `HEADERS`, or trailers) moves it to `CLOSED`, `free_resources` runs, and JS receives `streamEnd(7)`, whose existing handler closes the stream, decrements the session's open-stream count and destroys it with `rstCode` 0.
- Correct because the peer's half of a pushed stream is closed by definition: the only frames a client may send on it are `RST_STREAM`, `WINDOW_UPDATE` and `PRIORITY`, and `HALF_CLOSED_REMOTE` is exactly the state this encoder uses for "we may still send, the peer has nothing more to send" (`can_send_data` true, `can_receive_data` false). The reserved (local) / half-closed (remote) distinction only concerns which frames we may send before the response `HEADERS`, which the JS layer already enforces (`respond()` always precedes writes), and how the inbound engine would classify peer frames, which this outbound state machine does not take part in. `stream.state` on a push now reports `remoteClose: 1, localClose: 0` from the pushStream callback on, as node does; its numeric `state` reads 6 where node reads 3 (reserved (local)) until node's queued response `HEADERS` is actually written, then 6 as well. A separate reserved state in this enum would only change that number before `respond()`, so it is not added.
- Inbound frames on a released push are handled by existing code: a late `RST_STREAM` on an id at or below the highest started id is tolerated by the engine (`h2/connection.rs`, `handle_rst_stream`), matching node, which ignores resets of closed streams. Before, the still-registered stream made the engine deliver it.
- The JS state-5 special cases for even-id server streams (`onEndStreamSettled`'s second half and the block in `_final`) are removed: a push can no longer settle at 5, and leaving them would have hidden a regression of this fix. The two `_write`/`_writev` call sites now call `markWritableDone` directly, which is what remained of `onEndStreamSettled`.
- Tests: `test/js/node/http2/h2-conformance.test.ts`, `describe("server push stream lifecycle")`:
  - one case per native close tail (`end(body)`, `respond({ endStream: true })`, a HEAD push whose `end()` precedes `respond()`, trailers): 8 pushes over one client session must all emit `'close'` with `rstCode` 0, their `WeakRef`s must clear while the session is alive, `state.remoteClose` is 1, and tearing the client down afterwards must not error any of them. Before the fix: no `'close'` at all, 8/8 alive, `remoteClose` 0;
  - over a raw client that ignores `GOAWAY`: the push closes with `rstCode` 0 without any `RST_STREAM` on the wire, and a `session.close()` afterwards completes (the session has no open streams left). Before the fix the push never closed;
  - over a raw client: a `RST_STREAM(CANCEL)` sent after the push completed is ignored (PING still answered, no `GOAWAY`, no `RST_STREAM`, the push's `rstCode` stays 0, no `'error'`). Before the fix the push closed with `rstCode` 8 on that reset.
- Also run on the debug (ASAN) build: the rest of `h2-conformance.test.ts` and `h2-push-refusal-staged.test.ts` (68 pass); `node-http2.test.js` (357 pass, 6 skip); all 274 upstream `test-http2-*` and `test-diagnostics-channel-http2-*` files under `test/js/node/test/parallel` (274 pass; these include `test-diagnostics-channel-http2-server-stream-close`, which pins the close-channel shape the removed JS special cases were added for, and the `*push*` tests).
- The client side of a push (a `PUSH_PROMISE` received by a `node:http2` client) is tracked by the inbound engine, which already walks reserved (remote) to closed and releases the stream; 10 received pushes are collected both before and after this change, so nothing changes there.
- Found along the way and handed off separately: `pushStream(headers, { endStream: true })` and `push.end()` before `respond()` (non-HEAD) never send `END_STREAM` on the pushed response. That is a `respond()` bug and is unchanged here; this PR's HEAD case uses the path that does work.

### Background

- `node:http2` in Bun has two native layers per session. The inbound engine (`src/runtime/api/bun/h2/`) parses received frames and keeps its own RFC state per stream it has seen. The outbound encoder (`h2_frame_parser.rs`) keeps a `Stream` per stream in `streams` with a small state enum (`OPEN`, `HALF_CLOSED_LOCAL`, `HALF_CLOSED_REMOTE`, `CLOSED`) that only exists to decide, when we send `END_STREAM`, whether the stream is now fully closed. It also holds the stream's JS object rooted (a `Strong` handle the GC cannot collect) in `Stream.js_context` and in the session-level `sctx` map.
- `Stream::free_resources` is the release point: it drops those roots, drops the abort-signal listener and queues the id so the next inbound batch evicts the engine entry and frees the `Stream` box. It is called from the `CLOSED` branch of each close tail and from reset/error paths; a stream that ends up in `HALF_CLOSED_LOCAL` waits for the peer's `END_STREAM` (`on_stream_end`) to be released, which for a push never comes.
- Server push (RFC 9113 8.4): the server sends `PUSH_PROMISE` on a request stream, reserving an even stream id, then sends a normal response on that id. The client never sends a request body on it; it can only reset it, update its window or set its priority.
- `streamEnd(state)` is the dispatch JS receives when a stream's local or full close is recorded natively: 5 means our half closed (JS completes the writable), 7 means fully closed (JS closes and destroys the stream and updates the session's open-stream count). `writeStream` returns the settled state instead of dispatching for the 5 case, to avoid re-entering JS from inside the host call; 7 is always dispatched.

<details>
<summary>Standalone repro (10 sequential requests, each served with one push, then GC)</summary>

```js
const http2 = require("node:http2");
const total = 10, refs = [];
let closes = 0;
const gc = typeof Bun !== "undefined" ? () => Bun.gc(true) : globalThis.gc;
const server = http2.createServer();
server.on("stream", s => {
  s.pushStream({ ":path": "/pushed" }, (err, push) => {
    refs.push(new WeakRef(push));
    push.on("close", () => closes++);
    push.respond({ ":status": 200 });
    push.end("pushed");
    s.respond({ ":status": 200 });
    s.end("main");
  });
});
server.listen(0, async () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("stream", p => { p.resume(); p.on("error", () => {}); });
  for (let i = 0; i < total; i++)
    await new Promise((res, rej) => { const r = client.request({ ":path": "/" }); r.on("error", rej); r.resume(); r.on("close", res); r.end(); });
  let alive = total;
  for (let i = 0; i < 50 && alive > 0; i++) { await new Promise(r => setImmediate(r)); gc(); await new Promise(r => setTimeout(r, 10)); alive = refs.filter(w => w.deref()).length; }
  console.log(`push streams alive ${alive}/${total}, 'close' events ${closes}/${total}`);
  client.close(); server.close();
});
```

```
bun 1.4.0:             push streams alive 10/10, 'close' events 0/10
this branch (debug):   push streams alive 0/10,  'close' events 10/10
node v26.3.0 (--expose-gc): push streams alive 0/10, 'close' events 10/10
```

Teardown variant (complete one push, then `client.socket.resetAndDestroy()`), events seen on the server's push stream:

```
bun 1.4.0:    finish, then at teardown: error ECONNRESET, close rstCode=2
node v26.3.0: finish, close rstCode=0 (nothing at teardown)
```

</details>
