### PR TITLE
fs(windows): copy reparse points that are not links as files and directories in cp

### DIFF
--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -58,6 +58,11 @@ impl IteratorResultWName {
 pub struct IteratorResultW {
     pub name: IteratorResultWName,
     pub(crate) kind: EntryKind,
+    /// `kind` is `SymLink` for every entry with `FILE_ATTRIBUTE_REPARSE_POINT`;
+    /// these say what the entry actually is. `reparse_tag` is 0 for anything
+    /// but a reparse point, and for one whose filesystem does not report tags.
+    pub(crate) file_attributes: u32,
+    pub(crate) reparse_tag: u32,
 }
 #[cfg(windows)]
 pub(crate) type ResultW = sys::Result<Option<IteratorResultW>>;
@@ -438,7 +443,7 @@ mod platform {
     use bun_sys::windows::ntdll;
     use bun_sys::windows::{
         BOOLEAN, FALSE, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
-        FILE_DIRECTORY_INFORMATION, IO_STATUS_BLOCK, TRUE, UNICODE_STRING, Win32ErrorExt as _,
+        FILE_FULL_DIR_INFORMATION, IO_STATUS_BLOCK, TRUE, UNICODE_STRING, Win32ErrorExt as _,
     };
 
     // While the official api docs guarantee FILE_BOTH_DIR_INFORMATION to be aligned properly
@@ -462,6 +467,8 @@ mod platform {
             name_data: &mut Self::NameData,
             dir_info_name: &[u16],
             kind: EntryKind,
+            file_attributes: u32,
+            reparse_tag: u32,
         ) -> Self::Entry;
     }
     pub struct OsPathFalse;
@@ -478,6 +485,8 @@ mod platform {
             name_data: &mut [u8; 513],
             dir_info_name: &[u16],
             kind: EntryKind,
+            _file_attributes: u32,
+            _reparse_tag: u32,
         ) -> IteratorResult {
             // Trust that Windows gives us valid UTF-16LE
             let name_utf8 = strings::paths::from_w_path(&mut name_data[..], dir_info_name);
@@ -499,6 +508,8 @@ mod platform {
             name_data: &mut [u16; 257],
             dir_info_name: &[u16],
             kind: EntryKind,
+            file_attributes: u32,
+            reparse_tag: u32,
         ) -> IteratorResultW {
             let len = dir_info_name.len();
             name_data[..len].copy_from_slice(dir_info_name);
@@ -508,6 +519,8 @@ mod platform {
                     data: RawSlice::new(&name_data[..len]),
                 },
                 kind,
+                file_attributes,
+                reparse_tag,
             }
         }
     }
@@ -534,7 +547,7 @@ mod platform {
         // If a buffer contains two or more of these structures, the
         // NextEntryOffset value in each entry, except the last, falls on an
         // 8-byte boundary.
-        // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_directory_information
+        // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_full_dir_information
         pub(crate) buf: [u8; 8192],
         pub(crate) index: usize,
         pub(crate) end_index: usize,
@@ -599,7 +612,7 @@ mod platform {
                             &mut io,
                             self.buf.as_mut_ptr().cast(),
                             self.buf.len() as u32,
-                            w::FILE_INFORMATION_CLASS::FileDirectoryInformation,
+                            w::FILE_INFORMATION_CLASS::FileFullDirectoryInformation,
                             FALSE as BOOLEAN,
                             filter_ptr,
                             if self.first {
@@ -654,30 +667,41 @@ mod platform {
 
                 let entry_offset = self.index;
                 let p = self.buf.as_ptr();
-                // While the official api docs guarantee FILE_DIRECTORY_INFORMATION to
+                // While the official api docs guarantee FILE_FULL_DIR_INFORMATION to
                 // be aligned properly this may not always be the case (e.g. due to
                 // faulty VM/Sandboxing tools) — read fields via unaligned loads.
                 // SAFETY: entry_offset < end_index ≤ buf.len(); the header up through
                 // FileName lies within `buf` per the kernel contract.
-                let next_entry_offset =
-                    unsafe {
-                        core::ptr::read_unaligned(p.add(
-                            entry_offset + offset_of!(FILE_DIRECTORY_INFORMATION, NextEntryOffset),
-                        ) as *const u32)
-                    };
+                let next_entry_offset = unsafe {
+                    core::ptr::read_unaligned(
+                        p.add(entry_offset + offset_of!(FILE_FULL_DIR_INFORMATION, NextEntryOffset))
+                            as *const u32,
+                    )
+                };
                 // SAFETY: see above.
                 let file_name_length = unsafe {
                     core::ptr::read_unaligned(
-                        p.add(entry_offset + offset_of!(FILE_DIRECTORY_INFORMATION, FileNameLength))
+                        p.add(entry_offset + offset_of!(FILE_FULL_DIR_INFORMATION, FileNameLength))
                             as *const u32,
                     )
                 } as usize;
                 // SAFETY: see above.
                 let file_attributes = unsafe {
                     core::ptr::read_unaligned(
-                        p.add(entry_offset + offset_of!(FILE_DIRECTORY_INFORMATION, FileAttributes))
+                        p.add(entry_offset + offset_of!(FILE_FULL_DIR_INFORMATION, FileAttributes))
                             as *const u32,
                     )
+                };
+                let reparse_tag = if file_attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                    // SAFETY: see above.
+                    unsafe {
+                        core::ptr::read_unaligned(
+                            p.add(entry_offset + offset_of!(FILE_FULL_DIR_INFORMATION, EaSize))
+                                as *const u32,
+                        )
+                    }
+                } else {
+                    0
                 };
 
                 if next_entry_offset != 0 {
@@ -687,14 +711,14 @@ mod platform {
                 }
 
                 // Some filesystem / filter drivers have been observed returning
-                // FILE_DIRECTORY_INFORMATION entries with an out-of-range
+                // FILE_FULL_DIR_INFORMATION entries with an out-of-range
                 // FileNameLength (well beyond the 255-WCHAR NTFS component
                 // limit). Clamp to what fits in name_data (destination) and to
                 // what remains in buf (source) so a misbehaving driver cannot
                 // walk us past the end of either buffer.
                 let max_name_u16 = <Select<USE_WINDOWS_OSPATH> as WindowsOsPath>::max_name_u16();
                 let name_byte_offset =
-                    entry_offset + offset_of!(FILE_DIRECTORY_INFORMATION, FileName);
+                    entry_offset + offset_of!(FILE_FULL_DIR_INFORMATION, FileName);
                 let buf_remaining_u16 =
                     self.buf.len().saturating_sub(name_byte_offset) / size_of::<u16>();
                 let name_len_u16 = (file_name_length / 2)
@@ -702,8 +726,8 @@ mod platform {
                     .min(buf_remaining_u16);
                 // name_byte_offset + name_len_u16*2 ≤ buf.len() by clamp above.
                 // `buf` follows the 8-byte `Fd` in a `repr(C, align(8))` struct so
-                // it is itself 8-byte aligned, and per MS docs each record (and
-                // thus its FileName at offset 64) lands on an 8-byte boundary —
+                // it is itself 8-byte aligned, and per MS docs each record lands on
+                // an 8-byte boundary, so its FileName (offset 68) is u16-aligned —
                 // bytemuck checks the u8→u16 alignment at runtime.
                 let dir_info_name: &[u16] = bytemuck::cast_slice(
                     &self.buf[name_byte_offset..name_byte_offset + name_len_u16 * 2],
@@ -734,6 +758,8 @@ mod platform {
                         &mut self.name_data,
                         dir_info_name,
                         kind,
+                        file_attributes,
+                        reparse_tag,
                     ),
                 ));
             }

--- a/src/runtime/node/dir_iterator.rs
+++ b/src/runtime/node/dir_iterator.rs
@@ -58,9 +58,8 @@ impl IteratorResultWName {
 pub struct IteratorResultW {
     pub name: IteratorResultWName,
     pub(crate) kind: EntryKind,
-    /// `kind` is `SymLink` for every entry with `FILE_ATTRIBUTE_REPARSE_POINT`;
-    /// these say what the entry actually is. `reparse_tag` is 0 for anything
-    /// but a reparse point, and for one whose filesystem does not report tags.
+    /// `kind` is `SymLink` for any reparse point; these say which. The tag is 0
+    /// for non-reparse entries and on filesystems that do not report it.
     pub(crate) file_attributes: u32,
     pub(crate) reparse_tag: u32,
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1411,6 +1411,10 @@ mod _async_tasks {
         path_buf: Box<[OSPathChar]>,
         src_len: usize,
         dest_len: usize,
+        /// Classification the directory scan already made for a reparse entry;
+        /// `None` makes `copy_single_file_sync` look at the entry itself.
+        #[cfg(windows)]
+        kind: Option<CpEntryKind>,
         pub task: WorkPoolTask,
     }
 
@@ -1423,6 +1427,7 @@ mod _async_tasks {
             path_buf: Box<[OSPathChar]>,
             src_len: usize,
             dest_len: usize,
+            #[cfg(windows)] kind: Option<CpEntryKind>,
         ) {
             debug_assert_eq!(path_buf.len(), src_len + 1 + dest_len + 1);
             debug_assert_eq!(path_buf[src_len], 0);
@@ -1436,6 +1441,8 @@ mod _async_tasks {
                 path_buf,
                 src_len,
                 dest_len,
+                #[cfg(windows)]
+                kind,
                 task: WorkPoolTask::default(),
             });
         }
@@ -1467,6 +1474,10 @@ mod _async_tasks {
             let mut node_fs = NodeFS::default();
 
             let args = &parent.args;
+            #[cfg(windows)]
+            let reuse_stat = self.kind;
+            #[cfg(not(windows))]
+            let reuse_stat = None;
             let result = node_fs.copy_single_file_sync(
                 self.src(),
                 self.dest(),
@@ -1475,7 +1486,7 @@ mod _async_tasks {
                 } else {
                     0i32
                 }),
-                None,
+                reuse_stat,
                 &parent.args,
             );
 
@@ -2064,22 +2075,23 @@ mod _async_tasks {
                     return false;
                 }
 
-                // Non-link reparse directories come back as `SymLink` too.
+                // Every reparse point is reported as `SymLink`; work out here,
+                // once, which of them are really directories to walk or files.
                 #[cfg(windows)]
-                let kind = match current.kind {
-                    crate::node::dirent::Kind::SymLink => {
+                let reparse_kind =
+                    (current.kind == crate::node::dirent::Kind::SymLink).then(|| {
                         let sd = src_dir_len as usize;
                         src_buf[sd + 1..sd + 1 + cname.len()].copy_from_slice(cname);
                         src_buf[sd] = paths::SEP as OSPathChar;
                         src_buf[sd + 1 + cname.len()] = 0;
                         let child = OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + cname.len());
-                        if CpEntryKind::reparse_entry_is_directory(child) {
-                            crate::node::dirent::Kind::Directory
-                        } else {
-                            current.kind
-                        }
-                    }
-                    kind => kind,
+                        CpEntryKind::of_reparse_entry(&current, child)
+                    });
+                #[cfg(windows)]
+                let kind = if reparse_kind == Some(CpEntryKind::Directory) {
+                    crate::node::dirent::Kind::Directory
+                } else {
+                    current.kind
                 };
                 #[cfg(not(windows))]
                 let kind = current.kind;
@@ -2133,6 +2145,8 @@ mod _async_tasks {
                             path_buf,
                             sd + 1 + cname.len(),
                             dd + 1 + cname.len(),
+                            #[cfg(windows)]
+                            reparse_kind,
                         );
                     }
                 }
@@ -4636,12 +4650,17 @@ impl CpEntryKind {
         }
     }
 
-    /// Whether an entry the iterator reported as `SymLink` (on Windows: "has
-    /// the reparse attribute") is really a directory to descend into.
-    pub(crate) fn reparse_entry_is_directory(src: &OSPathSliceZ) -> bool {
-        windows::query_attribute_tag(src).is_some_and(|info| {
-            Self::from_attribute_tag(info.FileAttributes, info.ReparseTag) == Self::Directory
-        })
+    /// A walked entry that has the reparse attribute. The listing normally
+    /// carries its tag; only on a filesystem that leaves it out is `child`,
+    /// the entry's path, looked at.
+    pub(crate) fn of_reparse_entry(
+        entry: &DirIterator::IteratorResultW,
+        child: &OSPathSliceZ,
+    ) -> Self {
+        if entry.reparse_tag != 0 {
+            return Self::from_attribute_tag(entry.file_attributes, entry.reparse_tag);
+        }
+        Self::classify(child, entry.file_attributes)
     }
 }
 
@@ -8484,13 +8503,17 @@ impl NodeFS {
             dest_buf[dd] = paths::SEP as OSPathChar;
             dest_buf[dd + 1 + name_slice.len()] = 0;
 
-            // Non-link reparse directories come back as `SymLink` too.
+            // Every reparse point is reported as `SymLink`; work out here, once,
+            // which of them are really directories to walk or files.
             #[cfg(windows)]
-            let kind = if current.kind == sys::FileKind::SymLink
-                && CpEntryKind::reparse_entry_is_directory(OSPathSliceZ::from_buf(
-                    &src_buf[..],
-                    sd + 1 + name_slice.len(),
-                )) {
+            let reparse_kind = (current.kind == sys::FileKind::SymLink).then(|| {
+                CpEntryKind::of_reparse_entry(
+                    &current,
+                    OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + name_slice.len()),
+                )
+            });
+            #[cfg(windows)]
+            let kind = if reparse_kind == Some(CpEntryKind::Directory) {
                 sys::FileKind::Directory
             } else {
                 current.kind
@@ -8513,6 +8536,10 @@ impl NodeFS {
                     // NUL written at [len] above; `from_buf` debug-asserts it.
                     let src_z = OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + name_slice.len());
                     let dest_z = OSPathSliceZ::from_buf(&dest_buf[..], dd + 1 + name_slice.len());
+                    #[cfg(windows)]
+                    let reuse_stat = reparse_kind;
+                    #[cfg(not(windows))]
+                    let reuse_stat = None;
                     let r = self.copy_single_file_sync(
                         src_z,
                         dest_z,
@@ -8523,7 +8550,7 @@ impl NodeFS {
                                 0i32
                             },
                         ),
-                        None,
+                        reuse_stat,
                         args,
                     );
                     if let Err(ref e) = r {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2064,8 +2064,7 @@ mod _async_tasks {
                     return false;
                 }
 
-                // The iterator reports every reparse point as `SymLink`; a
-                // non-link reparse directory (see `CpEntryKind`) is walked.
+                // Non-link reparse directories come back as `SymLink` too.
                 #[cfg(windows)]
                 let kind = match current.kind {
                     crate::node::dirent::Kind::SymLink => {
@@ -4595,14 +4594,10 @@ pub mod ret {
     pub(crate) type Writev = Write;
 }
 
-/// What the Windows `cp` paths (`cp_sync_inner`, `NewAsyncCpTask`,
-/// `copy_single_file_sync`) are copying. `FILE_ATTRIBUTE_REPARSE_POINT` alone
-/// does not make an entry a link: an entry is a link when `lstat` would report
-/// one, i.e. its reparse tag is a name surrogate (symlink, junction) or an
-/// app-exec link. Every other reparse point (cloud-file placeholder,
-/// deduplicated or projected file, ...) is an ordinary file or directory whose
-/// filter driver serves its contents through a normal open, so `CopyFileW`
-/// copies it and a directory walk descends into it.
+/// What the Windows `cp` paths are copying. Only the reparse points `lstat`
+/// reports as links (name surrogates such as symlinks and junctions, plus
+/// app-exec links) are `Link`; cloud placeholders, dedup stubs and other
+/// reparse points read like plain entries, so they are `File` or `Directory`.
 #[cfg(windows)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CpEntryKind {
@@ -4627,9 +4622,8 @@ impl CpEntryKind {
         }
     }
 
-    /// `attributes` is the `GetFileAttributesW` result for `src`. Only a
-    /// reparse point needs the extra lookup of its tag; one that cannot even be
-    /// opened for that stays a link, so the link branch reports the error.
+    /// `attributes` comes from `GetFileAttributesW`; only a reparse point needs
+    /// its tag looked up. One that cannot be opened for that stays a `Link`.
     pub(crate) fn classify(src: &OSPathSliceZ, attributes: windows::DWORD) -> Self {
         if attributes & sys::c::FILE_ATTRIBUTE_REPARSE_POINT == 0 {
             return Self::from_attribute_tag(attributes, 0);
@@ -4642,9 +4636,8 @@ impl CpEntryKind {
         }
     }
 
-    /// For an entry the directory iterator reported as `SymLink`, which on
-    /// Windows only means the reparse-point attribute is set: does the copy
-    /// have to descend into it instead of copying it as a single entry?
+    /// Whether an entry the iterator reported as `SymLink` (on Windows: "has
+    /// the reparse attribute") is really a directory to descend into.
     pub(crate) fn reparse_entry_is_directory(src: &OSPathSliceZ) -> bool {
         windows::query_attribute_tag(src).is_some_and(|info| {
             Self::from_attribute_tag(info.FileAttributes, info.ReparseTag) == Self::Directory
@@ -8491,8 +8484,7 @@ impl NodeFS {
             dest_buf[dd] = paths::SEP as OSPathChar;
             dest_buf[dd + 1 + name_slice.len()] = 0;
 
-            // The iterator reports every reparse point as `SymLink`; a non-link
-            // reparse directory (see `CpEntryKind`) is walked.
+            // Non-link reparse directories come back as `SymLink` too.
             #[cfg(windows)]
             let kind = if current.kind == sys::FileKind::SymLink
                 && CpEntryKind::reparse_entry_is_directory(OSPathSliceZ::from_buf(

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1411,8 +1411,7 @@ mod _async_tasks {
         path_buf: Box<[OSPathChar]>,
         src_len: usize,
         dest_len: usize,
-        /// Classification the directory scan already made for a reparse entry;
-        /// `None` makes `copy_single_file_sync` look at the entry itself.
+        /// Set when the directory scan already classified a reparse entry.
         #[cfg(windows)]
         kind: Option<CpEntryKind>,
         pub task: WorkPoolTask,
@@ -2075,8 +2074,7 @@ mod _async_tasks {
                     return false;
                 }
 
-                // Every reparse point is reported as `SymLink`; work out here,
-                // once, which of them are really directories to walk or files.
+                // Reparse points all come back as `SymLink`; classify them here, once.
                 #[cfg(windows)]
                 let reparse_kind =
                     (current.kind == crate::node::dirent::Kind::SymLink).then(|| {
@@ -4650,9 +4648,8 @@ impl CpEntryKind {
         }
     }
 
-    /// A walked entry that has the reparse attribute. The listing normally
-    /// carries its tag; only on a filesystem that leaves it out is `child`,
-    /// the entry's path, looked at.
+    /// A walked reparse entry. `child`, its path, is only consulted when the
+    /// listing did not include the tag.
     pub(crate) fn of_reparse_entry(
         entry: &DirIterator::IteratorResultW,
         child: &OSPathSliceZ,
@@ -8503,8 +8500,7 @@ impl NodeFS {
             dest_buf[dd] = paths::SEP as OSPathChar;
             dest_buf[dd + 1 + name_slice.len()] = 0;
 
-            // Every reparse point is reported as `SymLink`; work out here, once,
-            // which of them are really directories to walk or files.
+            // Reparse points all come back as `SymLink`; classify them here, once.
             #[cfg(windows)]
             let reparse_kind = (current.kind == sys::FileKind::SymLink).then(|| {
                 CpEntryKind::of_reparse_entry(

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1823,9 +1823,8 @@ mod _async_tasks {
                     }));
                     return;
                 }
-                let file_or_symlink = (attributes & bun_sys::c::FILE_ATTRIBUTE_DIRECTORY) == 0
-                    || (attributes & bun_sys::c::FILE_ATTRIBUTE_REPARSE_POINT) != 0;
-                if file_or_symlink {
+                let kind = CpEntryKind::classify(src, attributes);
+                if kind != CpEntryKind::Directory {
                     let r = nodefs.copy_single_file_sync(
                         src,
                         dest,
@@ -1849,7 +1848,7 @@ mod _async_tasks {
                                 },
                             )
                         },
-                        Some(attributes),
+                        Some(kind),
                         &this.args,
                     );
                     if let Err(e) = &r {
@@ -2065,7 +2064,28 @@ mod _async_tasks {
                     return false;
                 }
 
-                match current.kind {
+                // The iterator reports every reparse point as `SymLink`; a
+                // non-link reparse directory (see `CpEntryKind`) is walked.
+                #[cfg(windows)]
+                let kind = match current.kind {
+                    crate::node::dirent::Kind::SymLink => {
+                        let sd = src_dir_len as usize;
+                        src_buf[sd + 1..sd + 1 + cname.len()].copy_from_slice(cname);
+                        src_buf[sd] = paths::SEP as OSPathChar;
+                        src_buf[sd + 1 + cname.len()] = 0;
+                        let child = OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + cname.len());
+                        if CpEntryKind::reparse_entry_is_directory(child) {
+                            crate::node::dirent::Kind::Directory
+                        } else {
+                            current.kind
+                        }
+                    }
+                    kind => kind,
+                };
+                #[cfg(not(windows))]
+                let kind = current.kind;
+
+                match kind {
                     crate::node::dirent::Kind::Directory => {
                         let sd = src_dir_len as usize;
                         let dd = dest_dir_len as usize;
@@ -4573,6 +4593,63 @@ pub mod ret {
     pub(crate) type Chown = ();
     pub(crate) type Lutimes = ();
     pub(crate) type Writev = Write;
+}
+
+/// What the Windows `cp` paths (`cp_sync_inner`, `NewAsyncCpTask`,
+/// `copy_single_file_sync`) are copying. `FILE_ATTRIBUTE_REPARSE_POINT` alone
+/// does not make an entry a link: an entry is a link when `lstat` would report
+/// one, i.e. its reparse tag is a name surrogate (symlink, junction) or an
+/// app-exec link. Every other reparse point (cloud-file placeholder,
+/// deduplicated or projected file, ...) is an ordinary file or directory whose
+/// filter driver serves its contents through a normal open, so `CopyFileW`
+/// copies it and a directory walk descends into it.
+#[cfg(windows)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CpEntryKind {
+    File,
+    Directory,
+    Link { is_dir: bool },
+}
+
+#[cfg(windows)]
+impl CpEntryKind {
+    fn from_attribute_tag(attributes: windows::DWORD, reparse_tag: windows::DWORD) -> Self {
+        let is_dir = attributes & sys::c::FILE_ATTRIBUTE_DIRECTORY != 0;
+        if attributes & sys::c::FILE_ATTRIBUTE_REPARSE_POINT != 0
+            && (windows::is_reparse_tag_name_surrogate(reparse_tag)
+                || reparse_tag == windows::IO_REPARSE_TAG_APPEXECLINK)
+        {
+            Self::Link { is_dir }
+        } else if is_dir {
+            Self::Directory
+        } else {
+            Self::File
+        }
+    }
+
+    /// `attributes` is the `GetFileAttributesW` result for `src`. Only a
+    /// reparse point needs the extra lookup of its tag; one that cannot even be
+    /// opened for that stays a link, so the link branch reports the error.
+    pub(crate) fn classify(src: &OSPathSliceZ, attributes: windows::DWORD) -> Self {
+        if attributes & sys::c::FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+            return Self::from_attribute_tag(attributes, 0);
+        }
+        match windows::query_attribute_tag(src) {
+            Some(info) => Self::from_attribute_tag(info.FileAttributes, info.ReparseTag),
+            None => Self::Link {
+                is_dir: attributes & sys::c::FILE_ATTRIBUTE_DIRECTORY != 0,
+            },
+        }
+    }
+
+    /// For an entry the directory iterator reported as `SymLink`, which on
+    /// Windows only means the reparse-point attribute is set: does the copy
+    /// have to descend into it instead of copying it as a single entry?
+    pub(crate) fn reparse_entry_is_directory(src: &OSPathSliceZ) -> bool {
+        windows::query_attribute_tag(src).is_some_and(|info| {
+            Self::from_attribute_tag(info.FileAttributes, info.ReparseTag) == Self::Directory
+        })
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -8272,9 +8349,8 @@ impl NodeFS {
                     ..Default::default()
                 });
             }
-            if attributes & sys::c::FILE_ATTRIBUTE_DIRECTORY == 0
-                || attributes & sys::c::FILE_ATTRIBUTE_REPARSE_POINT != 0
-            {
+            let kind = CpEntryKind::classify(src, attributes);
+            if kind != CpEntryKind::Directory {
                 let r = self.copy_single_file_sync(
                     src,
                     dest,
@@ -8283,7 +8359,7 @@ impl NodeFS {
                     } else {
                         0i32
                     }),
-                    Some(attributes),
+                    Some(kind),
                     args,
                 );
                 if let Err(ref e) = r {
@@ -8415,7 +8491,22 @@ impl NodeFS {
             dest_buf[dd] = paths::SEP as OSPathChar;
             dest_buf[dd + 1 + name_slice.len()] = 0;
 
-            match current.kind {
+            // The iterator reports every reparse point as `SymLink`; a non-link
+            // reparse directory (see `CpEntryKind`) is walked.
+            #[cfg(windows)]
+            let kind = if current.kind == sys::FileKind::SymLink
+                && CpEntryKind::reparse_entry_is_directory(OSPathSliceZ::from_buf(
+                    &src_buf[..],
+                    sd + 1 + name_slice.len(),
+                )) {
+                sys::FileKind::Directory
+            } else {
+                current.kind
+            };
+            #[cfg(not(windows))]
+            let kind = current.kind;
+
+            match kind {
                 sys::FileKind::Directory => {
                     let r = self.cp_sync_inner(
                         src_buf,
@@ -8545,8 +8636,8 @@ impl NodeFS {
         src: &OSPathSliceZ,
         dest: &OSPathSliceZ,
         mode: constants::Copyfile,
-        // Stat on posix, file attributes on windows
-        #[cfg(windows)] reuse_stat: Option<windows::DWORD>,
+        // Stat on posix, the already classified entry on windows
+        #[cfg(windows)] reuse_stat: Option<CpEntryKind>,
         #[cfg(not(windows))] reuse_stat: Option<&sys::Stat>,
         args: &args::Cp,
     ) -> Maybe<ret::CopyFile> {
@@ -9008,8 +9099,8 @@ impl NodeFS {
                 sys::Tag::copyfile,
                 self.os_path_into_sync_error_buf(dest.as_slice()),
             );
-            let stat_ = match reuse_stat {
-                Some(a) => a,
+            let kind = match reuse_stat {
+                Some(kind) => kind,
                 None => {
                     let a = unsafe { sys::c::GetFileAttributesW(src.as_ptr()) };
                     if a == sys::c::INVALID_FILE_ATTRIBUTES {
@@ -9022,10 +9113,10 @@ impl NodeFS {
                         return Maybe::<ret::CopyFile>::errno_sys_p(0, sys::Tag::copyfile, p)
                             .unwrap_or(src_enoent_maybe);
                     }
-                    a
+                    CpEntryKind::classify(src, a)
                 }
             };
-            if stat_ & sys::c::FILE_ATTRIBUTE_REPARSE_POINT == 0 {
+            if !matches!(kind, CpEntryKind::Link { .. }) {
                 if unsafe {
                     sys::c::CopyFileW(
                         src.as_ptr(),
@@ -9098,7 +9189,7 @@ impl NodeFS {
                 } else {
                     bun_core::WStr::from_buf(&wbuf[..], len)
                 };
-                let is_dir = stat_ & windows::FILE_ATTRIBUTE_DIRECTORY != 0;
+                let is_dir = matches!(kind, CpEntryKind::Link { is_dir: true });
                 // `symlink_w`/`symlink_or_junction` (not raw `CreateSymbolicLinkW`)
                 // so unprivileged creation is requested. UNC targets skip the junction
                 // fallback: libuv's `fs__create_junction` only accepts drive-letter targets.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -159,6 +159,7 @@ pub use bun_windows_sys::FILE_DIRECTORY_FILE;
 pub use bun_windows_sys::FILE_DIRECTORY_INFORMATION;
 pub use bun_windows_sys::FILE_FS_DEVICE_INFORMATION;
 pub use bun_windows_sys::FILE_FS_VOLUME_INFORMATION;
+pub use bun_windows_sys::FILE_FULL_DIR_INFORMATION;
 pub use bun_windows_sys::FILE_INFO_BY_HANDLE_CLASS;
 pub use bun_windows_sys::FILE_INFORMATION_CLASS;
 pub use bun_windows_sys::FILE_NON_DIRECTORY_FILE;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -393,6 +393,7 @@ pub fn CreateIoCompletionPort(
 pub use bun_windows_sys::externs::BY_HANDLE_FILE_INFORMATION;
 pub use bun_windows_sys::externs::CreateFileW;
 pub use bun_windows_sys::externs::FILE_FLAG_BACKUP_SEMANTICS;
+pub use bun_windows_sys::externs::FILE_FLAG_OPEN_REPARSE_POINT;
 /// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
 pub use bun_windows_sys::externs::GetFileInformationByHandle;
 pub use bun_windows_sys::externs::OPEN_EXISTING;
@@ -551,6 +552,57 @@ pub fn CreateHardLinkW(
 }
 
 pub use bun_windows_sys::externs::CopyFileW;
+
+pub use bun_windows_sys::externs::{
+    FILE_ATTRIBUTE_TAG_INFORMATION, IO_REPARSE_TAG_APPEXECLINK, is_reparse_tag_name_surrogate,
+};
+
+/// Attributes and reparse tag of the entry at `path` itself. A reparse point is
+/// opened rather than followed, so this works whatever its tag is, and the
+/// path goes through the same Win32 parsing as `GetFileAttributesW` /
+/// `CopyFileW` (a trailing separator is fine, unlike with `FindFirstFileW`).
+/// `None` when the entry cannot be opened.
+pub fn query_attribute_tag(path: &bun_core::WStr) -> Option<FILE_ATTRIBUTE_TAG_INFORMATION> {
+    // Zero access: attribute queries need none, and a handle without access
+    // bits is exempt from other openers' share modes.
+    // SAFETY: `path` is NUL-terminated (`WStr` invariant); null security
+    // attributes and template handle are allowed.
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+    // SAFETY: `handle` was just returned by `CreateFileW` and is closed once.
+    let _close = scopeguard::guard(handle, |h| unsafe {
+        let _ = externs::CloseHandle(h);
+    });
+    let mut io: IO_STATUS_BLOCK = bun_core::ffi::zeroed();
+    let mut info = FILE_ATTRIBUTE_TAG_INFORMATION {
+        FileAttributes: 0,
+        ReparseTag: 0,
+    };
+    // SAFETY: `handle` is open; `io` and `info` are valid for writes of the
+    // sizes passed for the duration of the call.
+    let rc = unsafe {
+        ntdll::NtQueryInformationFile(
+            handle,
+            &mut io,
+            ptr::from_mut(&mut info).cast::<c_void>(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFORMATION>() as ULONG,
+            windows::FileInformationClass::FileAttributeTagInformation,
+        )
+    };
+    NT_SUCCESS(rc).then_some(info)
+}
 
 pub use bun_windows_sys::externs::SetFileInformationByHandle;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -557,14 +557,11 @@ pub use bun_windows_sys::externs::{
     FILE_ATTRIBUTE_TAG_INFORMATION, IO_REPARSE_TAG_APPEXECLINK, is_reparse_tag_name_surrogate,
 };
 
-/// Attributes and reparse tag of the entry at `path` itself. A reparse point is
-/// opened rather than followed, so this works whatever its tag is, and the
-/// path goes through the same Win32 parsing as `GetFileAttributesW` /
-/// `CopyFileW` (a trailing separator is fine, unlike with `FindFirstFileW`).
-/// `None` when the entry cannot be opened.
+/// Attributes and reparse tag of the entry at `path` itself (not followed), or
+/// `None` if it cannot be opened. Unlike `FindFirstFileW`, this accepts every
+/// path `GetFileAttributesW` does, trailing separator included.
 pub fn query_attribute_tag(path: &bun_core::WStr) -> Option<FILE_ATTRIBUTE_TAG_INFORMATION> {
-    // Zero access: attribute queries need none, and a handle without access
-    // bits is exempt from other openers' share modes.
+    // Zero access: enough for attribute queries, and immune to share modes.
     // SAFETY: `path` is NUL-terminated (`WStr` invariant); null security
     // attributes and template handle are allowed.
     let handle = unsafe {

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -395,6 +395,24 @@ pub struct FILE_DIRECTORY_INFORMATION {
     pub FileName: [WCHAR; 1],
 }
 
+/// `FILE_FULL_DIR_INFORMATION` (`ntifs.h`): `FILE_DIRECTORY_INFORMATION` plus
+/// `EaSize`, which for a reparse point holds the reparse tag instead.
+#[repr(C)]
+pub struct FILE_FULL_DIR_INFORMATION {
+    pub NextEntryOffset: ULONG,
+    pub FileIndex: ULONG,
+    pub CreationTime: LARGE_INTEGER,
+    pub LastAccessTime: LARGE_INTEGER,
+    pub LastWriteTime: LARGE_INTEGER,
+    pub ChangeTime: LARGE_INTEGER,
+    pub EndOfFile: LARGE_INTEGER,
+    pub AllocationSize: LARGE_INTEGER,
+    pub FileAttributes: ULONG,
+    pub FileNameLength: ULONG,
+    pub EaSize: ULONG,
+    pub FileName: [WCHAR; 1],
+}
+
 /// `FILE_INFORMATION_CLASS` (`wdm.h`) — selector for `NtQuery*` /
 /// `NtSetInformationFile`. Newtype-over-u32 so unmapped values round-trip.
 #[repr(transparent)]
@@ -402,6 +420,7 @@ pub struct FILE_DIRECTORY_INFORMATION {
 pub struct FILE_INFORMATION_CLASS(pub u32);
 impl FILE_INFORMATION_CLASS {
     pub const FileDirectoryInformation: Self = Self(1);
+    pub const FileFullDirectoryInformation: Self = Self(2);
     pub const FileBasicInformation: Self = Self(4);
     pub const FileDispositionInformation: Self = Self(13);
     pub const FileAllInformation: Self = Self(18);

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -332,6 +332,7 @@ pub const OPEN_EXISTING: DWORD = 3;
 
 // `CreateFileW` dwFlagsAndAttributes (`winbase.h`).
 pub const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x0200_0000;
+pub const FILE_FLAG_OPEN_REPARSE_POINT: DWORD = 0x0020_0000;
 pub const FILE_FLAG_OVERLAPPED: DWORD = 0x4000_0000;
 
 // Reparse tags (`winnt.h`). `IsReparseTagNameSurrogate` == bit 29: the reparse
@@ -341,6 +342,9 @@ pub const FILE_FLAG_OVERLAPPED: DWORD = 0x4000_0000;
 pub const fn is_reparse_tag_name_surrogate(tag: DWORD) -> bool {
     (tag & 0x2000_0000) != 0
 }
+/// Store app execution alias (`%LOCALAPPDATA%\Microsoft\WindowsApps\*.exe`):
+/// not a name surrogate, but libuv's `readlink`/`lstat` decode it as a link.
+pub const IO_REPARSE_TAG_APPEXECLINK: DWORD = 0x8000_001B;
 
 // `CreateNamedPipeW` dwOpenMode / dwPipeMode (`winbase.h`).
 pub const PIPE_ACCESS_INBOUND: DWORD = 0x0000_0001;
@@ -362,6 +366,16 @@ pub struct FILE_BASIC_INFORMATION {
     pub LastWriteTime: LARGE_INTEGER,
     pub ChangeTime: LARGE_INTEGER,
     pub FileAttributes: ULONG,
+}
+
+/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`) — output of
+/// `NtQueryInformationFile(FileAttributeTagInformation)`. `ReparseTag` is 0
+/// unless `FileAttributes` has `FILE_ATTRIBUTE_REPARSE_POINT`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FILE_ATTRIBUTE_TAG_INFORMATION {
+    pub FileAttributes: ULONG,
+    pub ReparseTag: ULONG,
 }
 
 /// `FILE_DIRECTORY_INFORMATION` (`ntifs.h`) — `NtQueryDirectoryFile` record.
@@ -393,6 +407,7 @@ impl FILE_INFORMATION_CLASS {
     pub const FileDispositionInformation: Self = Self(13);
     pub const FileAllInformation: Self = Self(18);
     pub const FileEndOfFileInformation: Self = Self(20);
+    pub const FileAttributeTagInformation: Self = Self(35);
     pub const FileDispositionInformationEx: Self = Self(64);
 }
 

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -342,8 +342,8 @@ pub const FILE_FLAG_OVERLAPPED: DWORD = 0x4000_0000;
 pub const fn is_reparse_tag_name_surrogate(tag: DWORD) -> bool {
     (tag & 0x2000_0000) != 0
 }
-/// Store app execution alias (`%LOCALAPPDATA%\Microsoft\WindowsApps\*.exe`):
-/// not a name surrogate, but libuv's `readlink`/`lstat` decode it as a link.
+/// Store app execution alias; not a name surrogate, but libuv's `readlink`
+/// and `lstat` treat it as a link.
 pub const IO_REPARSE_TAG_APPEXECLINK: DWORD = 0x8000_001B;
 
 // `CreateNamedPipeW` dwOpenMode / dwPipeMode (`winbase.h`).
@@ -368,9 +368,8 @@ pub struct FILE_BASIC_INFORMATION {
     pub FileAttributes: ULONG,
 }
 
-/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`), the output of
-/// `NtQueryInformationFile(FileAttributeTagInformation)`. `ReparseTag` is 0
-/// unless `FileAttributes` has `FILE_ATTRIBUTE_REPARSE_POINT`.
+/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`), output of
+/// `NtQueryInformationFile(FileAttributeTagInformation)`.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct FILE_ATTRIBUTE_TAG_INFORMATION {

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -368,7 +368,7 @@ pub struct FILE_BASIC_INFORMATION {
     pub FileAttributes: ULONG,
 }
 
-/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`) — output of
+/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`), the output of
 /// `NtQueryInformationFile(FileAttributeTagInformation)`. `ReparseTag` is 0
 /// unless `FileAttributes` has `FILE_ATTRIBUTE_REPARSE_POINT`.
 #[repr(C)]

--- a/test/_util/windows-reparse-points.ts
+++ b/test/_util/windows-reparse-points.ts
@@ -22,8 +22,7 @@
  * the Windows directory count as aware); `exposePlaceholders()` opts the
  * current process in so the code under test sees the placeholders.
  *
- * Everything here goes through bun:ffi, which is unavailable on Windows
- * arm64: gate callers with `isWindows && !isArm64`.
+ * Windows only: gate callers with `isWindows`.
  */
 import { dlopen, ptr } from "bun:ffi";
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
@@ -111,6 +110,11 @@ export function isReparsePoint(path: string): boolean {
   return (fileAttributes(path) & FILE_ATTRIBUTE_REPARSE_POINT) !== 0;
 }
 
+/** Set on directories and on directory-flavored links (directory symlinks, junctions). */
+export function hasDirectoryAttribute(path: string): boolean {
+  return (fileAttributes(path) & FILE_ATTRIBUTE_DIRECTORY) !== 0;
+}
+
 /**
  * Stamps an existing file or directory with a non-Microsoft reparse tag that
  * is not a name surrogate. A directory gets the tag's "directory" bit (bit 28),
@@ -169,7 +173,7 @@ export function registerSyncRoot(root: string): Disposable {
   const rootW = wide(root);
   const providerName = wide("bun test");
   const providerVersion = wide("1.0");
-  // CF_SYNC_REGISTRATION (x64 layout): StructSize, ProviderName, ProviderVersion,
+  // CF_SYNC_REGISTRATION (64-bit layout): StructSize, ProviderName, ProviderVersion,
   // SyncRootIdentity, SyncRootIdentityLength, FileIdentity, FileIdentityLength, ProviderId.
   const registration = Buffer.alloc(72);
   registration.writeUInt32LE(registration.length, 0);

--- a/test/_util/windows-reparse-points.ts
+++ b/test/_util/windows-reparse-points.ts
@@ -10,9 +10,12 @@
  *
  * - `setNonLinkReparsePoint()` stamps a file or directory with a custom tag
  *   (FSCTL_SET_REPARSE_POINT needs nothing but write access to the entry).
+ *   Works on any NTFS volume; the data of a tagged file is unreadable, though,
+ *   since no driver owns the tag, so only tagged directories are copyable.
  * - `registerSyncRoot()` + `convertToPlaceholder()` create real cloud-file
  *   placeholders through the Cloud Files API (cldapi.dll), hydrated and in
- *   sync, so they stay readable without a sync provider running.
+ *   sync, so they stay readable without a sync provider running. Gate their
+ *   use on `cloudFilesAvailable()`.
  *
  * Windows hides the reparse attribute of cloud placeholders from processes
  * that have not declared themselves placeholder-aware (executables run from
@@ -23,6 +26,9 @@
  * arm64: gate callers with `isWindows && !isArm64`.
  */
 import { dlopen, ptr } from "bun:ffi";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const INVALID_HANDLE_VALUE = 0xffffffffffffffffn;
 const GENERIC_READ = 0x80000000;
@@ -41,53 +47,62 @@ const CF_HYDRATION_POLICY_FULL = 2;
 const CF_POPULATION_POLICY_ALWAYS_FULL = 3;
 const CF_CONVERT_FLAG_MARK_IN_SYNC = 1;
 
-function loadLibraries() {
-  return {
-    kernel32: dlopen("kernel32.dll", {
+function memoize<T>(load: () => T): () => T {
+  let value: T | undefined;
+  return () => (value ??= load());
+}
+
+const kernel32 = memoize(
+  () =>
+    dlopen("kernel32.dll", {
       CreateFileW: { args: ["ptr", "u32", "u32", "ptr", "u32", "u32", "ptr"], returns: "u64" },
       CloseHandle: { args: ["u64"], returns: "i32" },
       DeviceIoControl: { args: ["u64", "u32", "ptr", "u32", "ptr", "u32", "ptr", "ptr"], returns: "i32" },
       GetFileAttributesW: { args: ["ptr"], returns: "u32" },
       GetLastError: { args: [], returns: "u32" },
     }).symbols,
-    ntdll: dlopen("ntdll.dll", {
+);
+
+const ntdll = memoize(
+  () =>
+    dlopen("ntdll.dll", {
       RtlSetProcessPlaceholderCompatibilityMode: { args: ["i8"], returns: "i8" },
     }).symbols,
-    cldapi: dlopen("cldapi.dll", {
+);
+
+const cldapi = memoize(
+  () =>
+    dlopen("cldapi.dll", {
       CfRegisterSyncRoot: { args: ["ptr", "ptr", "ptr", "u32"], returns: "i32" },
       CfUnregisterSyncRoot: { args: ["ptr"], returns: "i32" },
       CfConvertToPlaceholder: { args: ["u64", "ptr", "u32", "u32", "ptr", "ptr"], returns: "i32" },
     }).symbols,
-  };
-}
-
-let libraries: ReturnType<typeof loadLibraries> | undefined;
-const lib = () => (libraries ??= loadLibraries());
+);
 
 const wide = (s: string) => Buffer.from(s + "\0", "utf16le");
 const hresult = (hr: number) => "0x" + (hr >>> 0).toString(16);
 
 function withHandle<T>(path: string, access: number, flags: number, fn: (handle: number | bigint) => T): T {
-  const { kernel32 } = lib();
+  const k32 = kernel32();
   const pathW = wide(path);
-  const handle = kernel32.CreateFileW(ptr(pathW), access >>> 0, FILE_SHARE_ALL, null, OPEN_EXISTING, flags, null);
+  const handle = k32.CreateFileW(ptr(pathW), access >>> 0, FILE_SHARE_ALL, null, OPEN_EXISTING, flags, null);
   if (handle === INVALID_HANDLE_VALUE) {
-    throw new Error(`CreateFileW(${path}) failed: Win32 error ${kernel32.GetLastError()}`);
+    throw new Error(`CreateFileW(${path}) failed: Win32 error ${k32.GetLastError()}`);
   }
   try {
     return fn(handle);
   } finally {
-    kernel32.CloseHandle(handle);
+    k32.CloseHandle(handle);
   }
 }
 
 /** `GetFileAttributesW` of the entry itself; a reparse point is not followed. */
 export function fileAttributes(path: string): number {
-  const { kernel32 } = lib();
+  const k32 = kernel32();
   const pathW = wide(path);
-  const attributes = kernel32.GetFileAttributesW(ptr(pathW));
+  const attributes = k32.GetFileAttributesW(ptr(pathW));
   if (attributes === INVALID_FILE_ATTRIBUTES) {
-    throw new Error(`GetFileAttributesW(${path}) failed: Win32 error ${kernel32.GetLastError()}`);
+    throw new Error(`GetFileAttributesW(${path}) failed: Win32 error ${k32.GetLastError()}`);
   }
   return attributes;
 }
@@ -103,7 +118,7 @@ export function isReparsePoint(path: string): boolean {
  * cloud and projected-file-system directories have.
  */
 export function setNonLinkReparsePoint(path: string): void {
-  const { kernel32 } = lib();
+  const k32 = kernel32();
   const isDirectory = (fileAttributes(path) & FILE_ATTRIBUTE_DIRECTORY) !== 0;
   const payload = Buffer.from("bun test reparse point");
   // REPARSE_GUID_DATA_BUFFER: tag, data length, reserved, GUID, data.
@@ -114,7 +129,7 @@ export function setNonLinkReparsePoint(path: string): void {
   payload.copy(buffer, 24);
   const bytesReturned = Buffer.alloc(4);
   withHandle(path, GENERIC_WRITE, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, handle => {
-    const ok = kernel32.DeviceIoControl(
+    const ok = k32.DeviceIoControl(
       handle,
       FSCTL_SET_REPARSE_POINT,
       ptr(buffer),
@@ -124,7 +139,7 @@ export function setNonLinkReparsePoint(path: string): void {
       ptr(bytesReturned),
       null,
     );
-    if (!ok) throw new Error(`FSCTL_SET_REPARSE_POINT(${path}) failed: Win32 error ${kernel32.GetLastError()}`);
+    if (!ok) throw new Error(`FSCTL_SET_REPARSE_POINT(${path}) failed: Win32 error ${k32.GetLastError()}`);
   });
 }
 
@@ -133,23 +148,24 @@ export function setNonLinkReparsePoint(path: string): void {
  * Disposing restores the previous mode.
  */
 export function exposePlaceholders(): Disposable {
-  const { ntdll } = lib();
-  const previous = ntdll.RtlSetProcessPlaceholderCompatibilityMode(PHCM_EXPOSE_PLACEHOLDERS);
+  const nt = ntdll();
+  const previous = nt.RtlSetProcessPlaceholderCompatibilityMode(PHCM_EXPOSE_PLACEHOLDERS);
   if (previous < 0) throw new Error(`RtlSetProcessPlaceholderCompatibilityMode failed: ${previous}`);
   return {
     [Symbol.dispose]() {
-      ntdll.RtlSetProcessPlaceholderCompatibilityMode(previous);
+      nt.RtlSetProcessPlaceholderCompatibilityMode(previous);
     },
   };
 }
 
 /**
  * Registers the existing directory `root` as a Cloud Files sync root so that
- * entries below it can become placeholders. Dispose before deleting `root`:
- * unregistering needs the directory to still exist.
+ * entries below it can become placeholders; the directory itself gets a cloud
+ * reparse tag too. Dispose before deleting `root`: unregistering needs the
+ * directory to still exist.
  */
 export function registerSyncRoot(root: string): Disposable {
-  const { cldapi } = lib();
+  const cf = cldapi();
   const rootW = wide(root);
   const providerName = wide("bun test");
   const providerVersion = wide("1.0");
@@ -164,7 +180,7 @@ export function registerSyncRoot(root: string): Disposable {
   policies.writeUInt32LE(policies.length, 0);
   policies.writeUInt16LE(CF_HYDRATION_POLICY_FULL, 4);
   policies.writeUInt16LE(CF_POPULATION_POLICY_ALWAYS_FULL, 8);
-  const hr = cldapi.CfRegisterSyncRoot(
+  const hr = cf.CfRegisterSyncRoot(
     ptr(rootW),
     ptr(registration),
     ptr(policies),
@@ -173,7 +189,7 @@ export function registerSyncRoot(root: string): Disposable {
   if (hr !== 0) throw new Error(`CfRegisterSyncRoot(${root}) failed: ${hresult(hr)}`);
   return {
     [Symbol.dispose]() {
-      const hr = cldapi.CfUnregisterSyncRoot(ptr(rootW));
+      const hr = cf.CfUnregisterSyncRoot(ptr(rootW));
       if (hr !== 0) throw new Error(`CfUnregisterSyncRoot(${root}) failed: ${hresult(hr)}`);
     },
   };
@@ -185,10 +201,10 @@ export function registerSyncRoot(root: string): Disposable {
  * contents (or children) stay on disk.
  */
 export function convertToPlaceholder(path: string): void {
-  const { cldapi } = lib();
+  const cf = cldapi();
   const identity = Buffer.from(path);
   withHandle(path, GENERIC_READ | GENERIC_WRITE, FILE_FLAG_BACKUP_SEMANTICS, handle => {
-    const hr = cldapi.CfConvertToPlaceholder(
+    const hr = cf.CfConvertToPlaceholder(
       handle,
       ptr(identity),
       identity.length,
@@ -199,3 +215,21 @@ export function convertToPlaceholder(path: string): void {
     if (hr !== 0) throw new Error(`CfConvertToPlaceholder(${path}) failed: ${hresult(hr)}`);
   });
 }
+
+/**
+ * Whether this machine lets us create placeholders: cldapi.dll is present, the
+ * cloud filter is running and the current user may register a sync root. Found
+ * out by registering (and unregistering) one on a scratch directory, once.
+ * Only call on Windows x64, where the ffi fixtures work at all.
+ */
+export const cloudFilesAvailable = memoize((): boolean => {
+  const scratch = mkdtempSync(join(realpathSync.native(tmpdir()), "cloud-files-probe-"));
+  try {
+    registerSyncRoot(scratch)[Symbol.dispose]();
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});

--- a/test/_util/windows-reparse-points.ts
+++ b/test/_util/windows-reparse-points.ts
@@ -1,0 +1,201 @@
+/**
+ * Fixtures for Windows reparse points that are not links.
+ *
+ * A symlink or junction is a reparse point whose tag is a "name surrogate".
+ * Cloud-file placeholders (OneDrive Files On-Demand), deduplicated files,
+ * projected files and third-party sync clients also mark their entries with
+ * FILE_ATTRIBUTE_REPARSE_POINT, but those entries are ordinary files and
+ * directories: a normal open reads their contents and a directory keeps its
+ * children. Two ways to make such entries without a sync client installed:
+ *
+ * - `setNonLinkReparsePoint()` stamps a file or directory with a custom tag
+ *   (FSCTL_SET_REPARSE_POINT needs nothing but write access to the entry).
+ * - `registerSyncRoot()` + `convertToPlaceholder()` create real cloud-file
+ *   placeholders through the Cloud Files API (cldapi.dll), hydrated and in
+ *   sync, so they stay readable without a sync provider running.
+ *
+ * Windows hides the reparse attribute of cloud placeholders from processes
+ * that have not declared themselves placeholder-aware (executables run from
+ * the Windows directory count as aware); `exposePlaceholders()` opts the
+ * current process in so the code under test sees the placeholders.
+ *
+ * Everything here goes through bun:ffi, which is unavailable on Windows
+ * arm64: gate callers with `isWindows && !isArm64`.
+ */
+import { dlopen, ptr } from "bun:ffi";
+
+const INVALID_HANDLE_VALUE = 0xffffffffffffffffn;
+const GENERIC_READ = 0x80000000;
+const GENERIC_WRITE = 0x40000000;
+const FILE_SHARE_ALL = 0x7;
+const OPEN_EXISTING = 3;
+const FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+const FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+const FILE_ATTRIBUTE_DIRECTORY = 0x10;
+const FILE_ATTRIBUTE_REPARSE_POINT = 0x400;
+const INVALID_FILE_ATTRIBUTES = 0xffffffff;
+const FSCTL_SET_REPARSE_POINT = 0x000900a4;
+const PHCM_EXPOSE_PLACEHOLDERS = 2;
+const CF_REGISTER_FLAG_DISABLE_ON_DEMAND_POPULATION_ON_ROOT = 2;
+const CF_HYDRATION_POLICY_FULL = 2;
+const CF_POPULATION_POLICY_ALWAYS_FULL = 3;
+const CF_CONVERT_FLAG_MARK_IN_SYNC = 1;
+
+function loadLibraries() {
+  return {
+    kernel32: dlopen("kernel32.dll", {
+      CreateFileW: { args: ["ptr", "u32", "u32", "ptr", "u32", "u32", "ptr"], returns: "u64" },
+      CloseHandle: { args: ["u64"], returns: "i32" },
+      DeviceIoControl: { args: ["u64", "u32", "ptr", "u32", "ptr", "u32", "ptr", "ptr"], returns: "i32" },
+      GetFileAttributesW: { args: ["ptr"], returns: "u32" },
+      GetLastError: { args: [], returns: "u32" },
+    }).symbols,
+    ntdll: dlopen("ntdll.dll", {
+      RtlSetProcessPlaceholderCompatibilityMode: { args: ["i8"], returns: "i8" },
+    }).symbols,
+    cldapi: dlopen("cldapi.dll", {
+      CfRegisterSyncRoot: { args: ["ptr", "ptr", "ptr", "u32"], returns: "i32" },
+      CfUnregisterSyncRoot: { args: ["ptr"], returns: "i32" },
+      CfConvertToPlaceholder: { args: ["u64", "ptr", "u32", "u32", "ptr", "ptr"], returns: "i32" },
+    }).symbols,
+  };
+}
+
+let libraries: ReturnType<typeof loadLibraries> | undefined;
+const lib = () => (libraries ??= loadLibraries());
+
+const wide = (s: string) => Buffer.from(s + "\0", "utf16le");
+const hresult = (hr: number) => "0x" + (hr >>> 0).toString(16);
+
+function withHandle<T>(path: string, access: number, flags: number, fn: (handle: number | bigint) => T): T {
+  const { kernel32 } = lib();
+  const pathW = wide(path);
+  const handle = kernel32.CreateFileW(ptr(pathW), access >>> 0, FILE_SHARE_ALL, null, OPEN_EXISTING, flags, null);
+  if (handle === INVALID_HANDLE_VALUE) {
+    throw new Error(`CreateFileW(${path}) failed: Win32 error ${kernel32.GetLastError()}`);
+  }
+  try {
+    return fn(handle);
+  } finally {
+    kernel32.CloseHandle(handle);
+  }
+}
+
+/** `GetFileAttributesW` of the entry itself; a reparse point is not followed. */
+export function fileAttributes(path: string): number {
+  const { kernel32 } = lib();
+  const pathW = wide(path);
+  const attributes = kernel32.GetFileAttributesW(ptr(pathW));
+  if (attributes === INVALID_FILE_ATTRIBUTES) {
+    throw new Error(`GetFileAttributesW(${path}) failed: Win32 error ${kernel32.GetLastError()}`);
+  }
+  return attributes;
+}
+
+export function isReparsePoint(path: string): boolean {
+  return (fileAttributes(path) & FILE_ATTRIBUTE_REPARSE_POINT) !== 0;
+}
+
+/**
+ * Stamps an existing file or directory with a non-Microsoft reparse tag that
+ * is not a name surrogate. A directory gets the tag's "directory" bit (bit 28),
+ * which tells NTFS the directory still holds real children; that is the shape
+ * cloud and projected-file-system directories have.
+ */
+export function setNonLinkReparsePoint(path: string): void {
+  const { kernel32 } = lib();
+  const isDirectory = (fileAttributes(path) & FILE_ATTRIBUTE_DIRECTORY) !== 0;
+  const payload = Buffer.from("bun test reparse point");
+  // REPARSE_GUID_DATA_BUFFER: tag, data length, reserved, GUID, data.
+  const buffer = Buffer.alloc(8 + 16 + payload.length);
+  buffer.writeUInt32LE(isDirectory ? 0x10000bad : 0x00000bad, 0);
+  buffer.writeUInt16LE(payload.length, 4);
+  Buffer.from("0b7e5d1e2f3a4b5c8d9e0f1a2b3c4d5e", "hex").copy(buffer, 8);
+  payload.copy(buffer, 24);
+  const bytesReturned = Buffer.alloc(4);
+  withHandle(path, GENERIC_WRITE, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, handle => {
+    const ok = kernel32.DeviceIoControl(
+      handle,
+      FSCTL_SET_REPARSE_POINT,
+      ptr(buffer),
+      buffer.length,
+      null,
+      0,
+      ptr(bytesReturned),
+      null,
+    );
+    if (!ok) throw new Error(`FSCTL_SET_REPARSE_POINT(${path}) failed: Win32 error ${kernel32.GetLastError()}`);
+  });
+}
+
+/**
+ * Makes cloud-file placeholders show their reparse attribute to this process.
+ * Disposing restores the previous mode.
+ */
+export function exposePlaceholders(): Disposable {
+  const { ntdll } = lib();
+  const previous = ntdll.RtlSetProcessPlaceholderCompatibilityMode(PHCM_EXPOSE_PLACEHOLDERS);
+  if (previous < 0) throw new Error(`RtlSetProcessPlaceholderCompatibilityMode failed: ${previous}`);
+  return {
+    [Symbol.dispose]() {
+      ntdll.RtlSetProcessPlaceholderCompatibilityMode(previous);
+    },
+  };
+}
+
+/**
+ * Registers the existing directory `root` as a Cloud Files sync root so that
+ * entries below it can become placeholders. Dispose before deleting `root`:
+ * unregistering needs the directory to still exist.
+ */
+export function registerSyncRoot(root: string): Disposable {
+  const { cldapi } = lib();
+  const rootW = wide(root);
+  const providerName = wide("bun test");
+  const providerVersion = wide("1.0");
+  // CF_SYNC_REGISTRATION (x64 layout): StructSize, ProviderName, ProviderVersion,
+  // SyncRootIdentity, SyncRootIdentityLength, FileIdentity, FileIdentityLength, ProviderId.
+  const registration = Buffer.alloc(72);
+  registration.writeUInt32LE(registration.length, 0);
+  registration.writeBigUInt64LE(BigInt(ptr(providerName)), 8);
+  registration.writeBigUInt64LE(BigInt(ptr(providerVersion)), 16);
+  // CF_SYNC_POLICIES: StructSize, Hydration, Population, InSync, HardLink, PlaceholderManagement.
+  const policies = Buffer.alloc(24);
+  policies.writeUInt32LE(policies.length, 0);
+  policies.writeUInt16LE(CF_HYDRATION_POLICY_FULL, 4);
+  policies.writeUInt16LE(CF_POPULATION_POLICY_ALWAYS_FULL, 8);
+  const hr = cldapi.CfRegisterSyncRoot(
+    ptr(rootW),
+    ptr(registration),
+    ptr(policies),
+    CF_REGISTER_FLAG_DISABLE_ON_DEMAND_POPULATION_ON_ROOT,
+  );
+  if (hr !== 0) throw new Error(`CfRegisterSyncRoot(${root}) failed: ${hresult(hr)}`);
+  return {
+    [Symbol.dispose]() {
+      const hr = cldapi.CfUnregisterSyncRoot(ptr(rootW));
+      if (hr !== 0) throw new Error(`CfUnregisterSyncRoot(${root}) failed: ${hresult(hr)}`);
+    },
+  };
+}
+
+/**
+ * Turns an existing file or directory under a registered sync root into a
+ * hydrated, in-sync placeholder: it gains a cloud reparse tag while its
+ * contents (or children) stay on disk.
+ */
+export function convertToPlaceholder(path: string): void {
+  const { cldapi } = lib();
+  const identity = Buffer.from(path);
+  withHandle(path, GENERIC_READ | GENERIC_WRITE, FILE_FLAG_BACKUP_SEMANTICS, handle => {
+    const hr = cldapi.CfConvertToPlaceholder(
+      handle,
+      ptr(identity),
+      identity.length,
+      CF_CONVERT_FLAG_MARK_IN_SYNC,
+      null,
+      null,
+    );
+    if (hr !== 0) throw new Error(`CfConvertToPlaceholder(${path}) failed: ${hresult(hr)}`);
+  });
+}

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -2,6 +2,7 @@ import {
   cloudFilesAvailable,
   convertToPlaceholder,
   exposePlaceholders,
+  hasDirectoryAttribute,
   isReparsePoint,
   registerSyncRoot,
   setNonLinkReparsePoint,
@@ -9,8 +10,8 @@ import {
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { isArm64, isWindows, tempDir, tempDirWithFiles } from "harness";
-import { lstatSync, readdirSync, readFileSync, symlinkSync } from "node:fs";
+import { isWindows, tempDir, tempDirWithFiles } from "harness";
+import { lstatSync, readdirSync, readFileSync, readlinkSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
@@ -187,13 +188,15 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
   // deduplicated files and similar entries also carry
   // FILE_ATTRIBUTE_REPARSE_POINT but are plain files and directories; cp used
   // to recreate every one of them as a symlink pointing back at the source.
-  // The fixtures are built with bun:ffi, which is unavailable on Windows arm64.
-  describe.if(isWindows && !isArm64)("reparse points that are not links", () => {
-    // What cp produced at `path`: a link, or the entry's kind, its contents and
-    // whether the copy is itself a reparse point.
+  describe.if(isWindows)("reparse points that are not links", () => {
+    // What cp produced at `path`: for a link its flavor and target, otherwise
+    // the entry's kind, its contents and whether the copy is itself a reparse
+    // point.
     function copied(path: string) {
       const stat = lstatSync(path);
-      if (stat.isSymbolicLink()) return "link";
+      if (stat.isSymbolicLink()) {
+        return { link: hasDirectoryAttribute(path) ? "directory" : "file", target: readlinkSync(path) };
+      }
       return {
         kind: stat.isDirectory() ? "directory" : "file",
         reparsePoint: isReparsePoint(path),
@@ -221,8 +224,10 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       });
       using outDir = tempDir("cp-reparse-out", {});
       const src = String(srcDir);
-      symlinkSync(join(src, "plain.txt"), join(src, "file_link.txt"), "file");
-      symlinkSync(join(src, "plain_dir"), join(src, "junction"), "junction");
+      const fileTarget = join(src, "plain.txt");
+      const dirTarget = join(src, "plain_dir");
+      symlinkSync(fileTarget, join(src, "file_link.txt"), "file");
+      symlinkSync(dirTarget, join(src, "junction"), "junction");
       setNonLinkReparsePoint(join(src, "tagged_dir"));
       const entries = ["tagged_dir", "file_link.txt", "junction", "plain.txt", "plain_dir"];
       expect(entries.map(name => isReparsePoint(join(src, name)))).toEqual([true, true, true, false, false]);
@@ -239,8 +244,8 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
         "tagged_dir": taggedDirectory,
         "tagged_dir/inner.txt": innerFile,
         "plain.txt": { kind: "file", reparsePoint: false, contents: "plain" },
-        "file_link.txt": "link",
-        "junction": "link",
+        "file_link.txt": { link: "file", target: fileTarget },
+        "junction": { link: "directory", target: dirTarget },
       });
     });
 
@@ -268,7 +273,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
     // make, so they are what exercises the file copy. Needs the Cloud Files
     // platform (cldapi.dll, its filter driver, and permission to register a
     // sync root); skipped where that is missing.
-    describe.if(isWindows && !isArm64 && cloudFilesAvailable())("cloud-file placeholders", () => {
+    describe.if(isWindows && cloudFilesAvailable())("cloud-file placeholders", () => {
       const placeholderFile = { kind: "file", reparsePoint: false, contents: "placeholder contents" };
 
       test("cp -R copies a placeholder file and its folder inside a directory", async () => {

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,16 @@
+import {
+  convertToPlaceholder,
+  exposePlaceholders,
+  isReparsePoint,
+  registerSyncRoot,
+  setNonLinkReparsePoint,
+} from "_util/windows-reparse-points.ts";
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { isArm64, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { lstatSync, readdirSync, readFileSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +179,128 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+
+  // Only a reparse point whose tag is a name surrogate (symlink, junction) is a
+  // link. Cloud-file placeholders (including the sync root directory itself),
+  // deduplicated files and similar entries also carry
+  // FILE_ATTRIBUTE_REPARSE_POINT but are plain files and directories; cp used
+  // to recreate every one of them as a symlink pointing back at the source.
+  // The fixtures are built with bun:ffi, which is unavailable on Windows arm64.
+  describe.if(isWindows && !isArm64)("reparse points that are not links", () => {
+    // What cp produced at `path`: a link, or the entry's kind, its contents and
+    // whether the copy is itself a reparse point.
+    function copied(path: string) {
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) return "link";
+      return {
+        kind: stat.isDirectory() ? "directory" : "file",
+        reparsePoint: isReparsePoint(path),
+        contents: stat.isDirectory() ? readdirSync(path).sort() : readFileSync(path, "utf8"),
+      };
+    }
+
+    test("cp -R copies the ones inside a directory as what they are", async () => {
+      using srcDir = tempDir("cp-reparse-src", {
+        "plain.txt": "plain",
+        "plain_dir/x.txt": "x",
+        "cloud/placeholder.txt": "placeholder contents",
+        "tagged_dir/inner.txt": "tagged inner",
+      });
+      using outDir = tempDir("cp-reparse-out", {});
+      const src = String(srcDir);
+      symlinkSync(join(src, "plain.txt"), join(src, "file_link.txt"), "file");
+      symlinkSync(join(src, "plain_dir"), join(src, "junction"), "junction");
+      setNonLinkReparsePoint(join(src, "tagged_dir"));
+      // Registering tags the `cloud` directory itself as well.
+      using _syncRoot = registerSyncRoot(join(src, "cloud"));
+      convertToPlaceholder(join(src, "cloud", "placeholder.txt"));
+      using _exposed = exposePlaceholders();
+      const entries = ["file_link.txt", "junction", "tagged_dir", "cloud", "cloud/placeholder.txt", "plain.txt"];
+      expect(entries.map(name => isReparsePoint(join(src, name)))).toEqual([true, true, true, true, true, false]);
+
+      const copy = join(String(outDir), "copy");
+      const { stderr, exitCode } = await $`cp -R ${src} ${copy}`.quiet();
+      expect(stderr.toString()).toBe("");
+      expect(exitCode).toBe(0);
+
+      expect({
+        "cloud": copied(join(copy, "cloud")),
+        "cloud/placeholder.txt": copied(join(copy, "cloud", "placeholder.txt")),
+        "tagged_dir": copied(join(copy, "tagged_dir")),
+        "tagged_dir/inner.txt": copied(join(copy, "tagged_dir", "inner.txt")),
+        "plain.txt": copied(join(copy, "plain.txt")),
+        "file_link.txt": copied(join(copy, "file_link.txt")),
+        "junction": copied(join(copy, "junction")),
+      }).toEqual({
+        "cloud": { kind: "directory", reparsePoint: false, contents: ["placeholder.txt"] },
+        "cloud/placeholder.txt": { kind: "file", reparsePoint: false, contents: "placeholder contents" },
+        "tagged_dir": { kind: "directory", reparsePoint: false, contents: ["inner.txt"] },
+        "tagged_dir/inner.txt": { kind: "file", reparsePoint: false, contents: "tagged inner" },
+        "plain.txt": { kind: "file", reparsePoint: false, contents: "plain" },
+        "file_link.txt": "link",
+        "junction": "link",
+      });
+    });
+
+    test("cp copies the one given as the operand", async () => {
+      using srcDir = tempDir("cp-reparse-operand-src", {
+        "placeholder.txt": "placeholder contents",
+        "tagged_dir/inner.txt": "tagged inner",
+      });
+      using outDir = tempDir("cp-reparse-operand-out", {});
+      const src = String(srcDir);
+      const out = String(outDir);
+      setNonLinkReparsePoint(join(src, "tagged_dir"));
+      // Registering tags `src` itself as well.
+      using _syncRoot = registerSyncRoot(src);
+      convertToPlaceholder(join(src, "placeholder.txt"));
+      using _exposed = exposePlaceholders();
+      expect([src, join(src, "placeholder.txt"), join(src, "tagged_dir")].map(isReparsePoint)).toEqual([
+        true,
+        true,
+        true,
+      ]);
+
+      const commands: Record<string, string[]> = {
+        "placeholder file": [join(src, "placeholder.txt"), join(out, "file.txt")],
+        "tagged directory": ["-R", join(src, "tagged_dir"), join(out, "dir")],
+        "tagged directory with a trailing separator": ["-R", join(src, "tagged_dir") + "\\", join(out, "dir2")],
+        "sync root directory": ["-R", src, join(out, "root")],
+      };
+      const results: Record<string, { stderr: string; exitCode: number }> = {};
+      for (const [name, args] of Object.entries(commands)) {
+        const { stderr, exitCode } = await $`cp ${args}`.quiet();
+        results[name] = { stderr: stderr.toString(), exitCode };
+      }
+      const ok = { stderr: "", exitCode: 0 };
+      expect(results).toEqual({
+        "placeholder file": ok,
+        "tagged directory": ok,
+        "tagged directory with a trailing separator": ok,
+        "sync root directory": ok,
+      });
+
+      const taggedDirectory = { kind: "directory", reparsePoint: false, contents: ["inner.txt"] };
+      const placeholderFile = { kind: "file", reparsePoint: false, contents: "placeholder contents" };
+      expect({
+        "file.txt": copied(join(out, "file.txt")),
+        "dir": copied(join(out, "dir")),
+        "dir/inner.txt": copied(join(out, "dir", "inner.txt")),
+        "dir2": copied(join(out, "dir2")),
+        "root": copied(join(out, "root")),
+        "root/placeholder.txt": copied(join(out, "root", "placeholder.txt")),
+        "root/tagged_dir": copied(join(out, "root", "tagged_dir")),
+      }).toEqual({
+        "file.txt": placeholderFile,
+        "dir": taggedDirectory,
+        "dir/inner.txt": { kind: "file", reparsePoint: false, contents: "tagged inner" },
+        "dir2": taggedDirectory,
+        "root": { kind: "directory", reparsePoint: false, contents: ["placeholder.txt", "tagged_dir"] },
+        "root/placeholder.txt": placeholderFile,
+        "root/tagged_dir": taggedDirectory,
+      });
+    });
   });
 });
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,4 +1,5 @@
 import {
+  cloudFilesAvailable,
   convertToPlaceholder,
   exposePlaceholders,
   isReparsePoint,
@@ -199,12 +200,23 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
         contents: stat.isDirectory() ? readdirSync(path).sort() : readFileSync(path, "utf8"),
       };
     }
+    const taggedDirectory = { kind: "directory", reparsePoint: false, contents: ["inner.txt"] };
+    const innerFile = { kind: "file", reparsePoint: false, contents: "tagged inner" };
+    const ok = { stderr: "", exitCode: 0 };
 
-    test("cp -R copies the ones inside a directory as what they are", async () => {
+    async function cp(commands: Record<string, string[]>) {
+      const results: Record<string, { stderr: string; exitCode: number }> = {};
+      for (const [name, args] of Object.entries(commands)) {
+        const { stderr, exitCode } = await $`cp ${args}`.quiet();
+        results[name] = { stderr: stderr.toString(), exitCode };
+      }
+      return results;
+    }
+
+    test("cp -R walks a tagged directory and still copies links as links", async () => {
       using srcDir = tempDir("cp-reparse-src", {
         "plain.txt": "plain",
         "plain_dir/x.txt": "x",
-        "cloud/placeholder.txt": "placeholder contents",
         "tagged_dir/inner.txt": "tagged inner",
       });
       using outDir = tempDir("cp-reparse-out", {});
@@ -212,93 +224,108 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       symlinkSync(join(src, "plain.txt"), join(src, "file_link.txt"), "file");
       symlinkSync(join(src, "plain_dir"), join(src, "junction"), "junction");
       setNonLinkReparsePoint(join(src, "tagged_dir"));
-      // Registering tags the `cloud` directory itself as well.
-      using _syncRoot = registerSyncRoot(join(src, "cloud"));
-      convertToPlaceholder(join(src, "cloud", "placeholder.txt"));
-      using _exposed = exposePlaceholders();
-      const entries = ["file_link.txt", "junction", "tagged_dir", "cloud", "cloud/placeholder.txt", "plain.txt"];
-      expect(entries.map(name => isReparsePoint(join(src, name)))).toEqual([true, true, true, true, true, false]);
+      const entries = ["tagged_dir", "file_link.txt", "junction", "plain.txt", "plain_dir"];
+      expect(entries.map(name => isReparsePoint(join(src, name)))).toEqual([true, true, true, false, false]);
 
       const copy = join(String(outDir), "copy");
-      const { stderr, exitCode } = await $`cp -R ${src} ${copy}`.quiet();
-      expect(stderr.toString()).toBe("");
-      expect(exitCode).toBe(0);
-
+      expect(await cp({ tree: ["-R", src, copy] })).toEqual({ tree: ok });
       expect({
-        "cloud": copied(join(copy, "cloud")),
-        "cloud/placeholder.txt": copied(join(copy, "cloud", "placeholder.txt")),
         "tagged_dir": copied(join(copy, "tagged_dir")),
         "tagged_dir/inner.txt": copied(join(copy, "tagged_dir", "inner.txt")),
         "plain.txt": copied(join(copy, "plain.txt")),
         "file_link.txt": copied(join(copy, "file_link.txt")),
         "junction": copied(join(copy, "junction")),
       }).toEqual({
-        "cloud": { kind: "directory", reparsePoint: false, contents: ["placeholder.txt"] },
-        "cloud/placeholder.txt": { kind: "file", reparsePoint: false, contents: "placeholder contents" },
-        "tagged_dir": { kind: "directory", reparsePoint: false, contents: ["inner.txt"] },
-        "tagged_dir/inner.txt": { kind: "file", reparsePoint: false, contents: "tagged inner" },
+        "tagged_dir": taggedDirectory,
+        "tagged_dir/inner.txt": innerFile,
         "plain.txt": { kind: "file", reparsePoint: false, contents: "plain" },
         "file_link.txt": "link",
         "junction": "link",
       });
     });
 
-    test("cp copies the one given as the operand", async () => {
-      using srcDir = tempDir("cp-reparse-operand-src", {
-        "placeholder.txt": "placeholder contents",
-        "tagged_dir/inner.txt": "tagged inner",
-      });
+    test("cp -R copies a tagged directory given as the operand", async () => {
+      using srcDir = tempDir("cp-reparse-operand-src", { "tagged_dir/inner.txt": "tagged inner" });
       using outDir = tempDir("cp-reparse-operand-out", {});
       const src = String(srcDir);
       const out = String(outDir);
       setNonLinkReparsePoint(join(src, "tagged_dir"));
-      // Registering tags `src` itself as well.
-      using _syncRoot = registerSyncRoot(src);
-      convertToPlaceholder(join(src, "placeholder.txt"));
-      using _exposed = exposePlaceholders();
-      expect([src, join(src, "placeholder.txt"), join(src, "tagged_dir")].map(isReparsePoint)).toEqual([
-        true,
-        true,
-        true,
-      ]);
 
-      const commands: Record<string, string[]> = {
-        "placeholder file": [join(src, "placeholder.txt"), join(out, "file.txt")],
-        "tagged directory": ["-R", join(src, "tagged_dir"), join(out, "dir")],
-        "tagged directory with a trailing separator": ["-R", join(src, "tagged_dir") + "\\", join(out, "dir2")],
-        "sync root directory": ["-R", src, join(out, "root")],
-      };
-      const results: Record<string, { stderr: string; exitCode: number }> = {};
-      for (const [name, args] of Object.entries(commands)) {
-        const { stderr, exitCode } = await $`cp ${args}`.quiet();
-        results[name] = { stderr: stderr.toString(), exitCode };
-      }
-      const ok = { stderr: "", exitCode: 0 };
-      expect(results).toEqual({
-        "placeholder file": ok,
-        "tagged directory": ok,
-        "tagged directory with a trailing separator": ok,
-        "sync root directory": ok,
-      });
-
-      const taggedDirectory = { kind: "directory", reparsePoint: false, contents: ["inner.txt"] };
-      const placeholderFile = { kind: "file", reparsePoint: false, contents: "placeholder contents" };
+      expect(
+        await cp({
+          "directory": ["-R", join(src, "tagged_dir"), join(out, "dir")],
+          "directory with a trailing separator": ["-R", join(src, "tagged_dir") + "\\", join(out, "dir2")],
+        }),
+      ).toEqual({ "directory": ok, "directory with a trailing separator": ok });
       expect({
-        "file.txt": copied(join(out, "file.txt")),
         "dir": copied(join(out, "dir")),
         "dir/inner.txt": copied(join(out, "dir", "inner.txt")),
         "dir2": copied(join(out, "dir2")),
-        "root": copied(join(out, "root")),
-        "root/placeholder.txt": copied(join(out, "root", "placeholder.txt")),
-        "root/tagged_dir": copied(join(out, "root", "tagged_dir")),
-      }).toEqual({
-        "file.txt": placeholderFile,
-        "dir": taggedDirectory,
-        "dir/inner.txt": { kind: "file", reparsePoint: false, contents: "tagged inner" },
-        "dir2": taggedDirectory,
-        "root": { kind: "directory", reparsePoint: false, contents: ["placeholder.txt", "tagged_dir"] },
-        "root/placeholder.txt": placeholderFile,
-        "root/tagged_dir": taggedDirectory,
+      }).toEqual({ "dir": taggedDirectory, "dir/inner.txt": innerFile, "dir2": taggedDirectory });
+    });
+
+    // Placeholder files are the only readable non-link reparse files we can
+    // make, so they are what exercises the file copy. Needs the Cloud Files
+    // platform (cldapi.dll, its filter driver, and permission to register a
+    // sync root); skipped where that is missing.
+    describe.if(isWindows && !isArm64 && cloudFilesAvailable())("cloud-file placeholders", () => {
+      const placeholderFile = { kind: "file", reparsePoint: false, contents: "placeholder contents" };
+
+      test("cp -R copies a placeholder file and its folder inside a directory", async () => {
+        using srcDir = tempDir("cp-placeholder-src", {
+          "cloud/placeholder.txt": "placeholder contents",
+          "cloud/folder/inner.txt": "inner",
+        });
+        using outDir = tempDir("cp-placeholder-out", {});
+        const src = String(srcDir);
+        // Registering tags the `cloud` directory itself as well.
+        using _syncRoot = registerSyncRoot(join(src, "cloud"));
+        convertToPlaceholder(join(src, "cloud", "placeholder.txt"));
+        convertToPlaceholder(join(src, "cloud", "folder"));
+        using _exposed = exposePlaceholders();
+        const entries = ["cloud", "cloud/placeholder.txt", "cloud/folder", "cloud/folder/inner.txt"];
+        expect(entries.map(name => isReparsePoint(join(src, name)))).toEqual([true, true, true, false]);
+
+        const copy = join(String(outDir), "copy");
+        expect(await cp({ tree: ["-R", src, copy] })).toEqual({ tree: ok });
+        expect({
+          "cloud": copied(join(copy, "cloud")),
+          "cloud/placeholder.txt": copied(join(copy, "cloud", "placeholder.txt")),
+          "cloud/folder": copied(join(copy, "cloud", "folder")),
+          "cloud/folder/inner.txt": copied(join(copy, "cloud", "folder", "inner.txt")),
+        }).toEqual({
+          "cloud": { kind: "directory", reparsePoint: false, contents: ["folder", "placeholder.txt"] },
+          "cloud/placeholder.txt": placeholderFile,
+          "cloud/folder": { kind: "directory", reparsePoint: false, contents: ["inner.txt"] },
+          "cloud/folder/inner.txt": { kind: "file", reparsePoint: false, contents: "inner" },
+        });
+      });
+
+      test("cp copies a placeholder file or the sync root given as the operand", async () => {
+        using srcDir = tempDir("cp-placeholder-operand-src", { "placeholder.txt": "placeholder contents" });
+        using outDir = tempDir("cp-placeholder-operand-out", {});
+        const src = String(srcDir);
+        const out = String(outDir);
+        using _syncRoot = registerSyncRoot(src);
+        convertToPlaceholder(join(src, "placeholder.txt"));
+        using _exposed = exposePlaceholders();
+        expect([src, join(src, "placeholder.txt")].map(isReparsePoint)).toEqual([true, true]);
+
+        expect(
+          await cp({
+            "file": [join(src, "placeholder.txt"), join(out, "file.txt")],
+            "sync root": ["-R", src, join(out, "root")],
+          }),
+        ).toEqual({ "file": ok, "sync root": ok });
+        expect({
+          "file.txt": copied(join(out, "file.txt")),
+          "root": copied(join(out, "root")),
+          "root/placeholder.txt": copied(join(out, "root", "placeholder.txt")),
+        }).toEqual({
+          "file.txt": placeholderFile,
+          "root": { kind: "directory", reparsePoint: false, contents: ["placeholder.txt"] },
+          "root/placeholder.txt": placeholderFile,
+        });
       });
     });
   });

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -7,7 +7,7 @@ import {
 } from "_util/windows-reparse-points.ts";
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isArm64, isLinux, isPosix, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isPosix, isWindows, tempDir } from "harness";
 import { mkfifo } from "mkfifo";
 import { isAbsolute, join } from "path";
 
@@ -47,30 +47,26 @@ for (const [name, copy] of impls) {
     // A cloud-file placeholder carries FILE_ATTRIBUTE_REPARSE_POINT but is a
     // regular file (lstat says so, which is why the native single-file copy is
     // used for it); node copies its contents, while this used to produce a
-    // symlink pointing back at the source. The fixture needs bun:ffi (absent
-    // on Windows arm64) and the Cloud Files platform.
-    test.if(isWindows && !isArm64 && cloudFilesAvailable())(
-      "single file that is a reparse point but not a link",
-      async () => {
-        await using basename = tempDir("cp", {
-          "from/a.txt": "a",
-        });
-        using _syncRoot = registerSyncRoot(basename + "\\from");
-        convertToPlaceholder(basename + "\\from\\a.txt");
-        using _exposed = exposePlaceholders();
-        expect(isReparsePoint(basename + "\\from\\a.txt")).toBe(true);
+    // symlink pointing back at the source.
+    test.if(isWindows && cloudFilesAvailable())("single file that is a reparse point but not a link", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+      });
+      using _syncRoot = registerSyncRoot(basename + "\\from");
+      convertToPlaceholder(basename + "\\from\\a.txt");
+      using _exposed = exposePlaceholders();
+      expect(isReparsePoint(basename + "\\from\\a.txt")).toBe(true);
 
-        await copy(basename + "/from/a.txt", basename + "/to.txt");
+      await copy(basename + "/from/a.txt", basename + "/to.txt");
 
-        const stat = fs.lstatSync(basename + "/to.txt");
-        expect({
-          isFile: stat.isFile(),
-          isSymbolicLink: stat.isSymbolicLink(),
-          reparsePoint: isReparsePoint(basename + "\\to.txt"),
-          content: fs.readFileSync(basename + "/to.txt", "utf8"),
-        }).toEqual({ isFile: true, isSymbolicLink: false, reparsePoint: false, content: "a" });
-      },
-    );
+      const stat = fs.lstatSync(basename + "/to.txt");
+      expect({
+        isFile: stat.isFile(),
+        isSymbolicLink: stat.isSymbolicLink(),
+        reparsePoint: isReparsePoint(basename + "\\to.txt"),
+        content: fs.readFileSync(basename + "/to.txt", "utf8"),
+      }).toEqual({ isFile: true, isSymbolicLink: false, reparsePoint: false, content: "a" });
+    });
 
     test("refuse to copy directory with 'recursive: false'", async () => {
       await using basename = tempDir("cp", {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,4 +1,5 @@
 import {
+  cloudFilesAvailable,
   convertToPlaceholder,
   exposePlaceholders,
   isReparsePoint,
@@ -46,27 +47,30 @@ for (const [name, copy] of impls) {
     // A cloud-file placeholder carries FILE_ATTRIBUTE_REPARSE_POINT but is a
     // regular file (lstat says so, which is why the native single-file copy is
     // used for it); node copies its contents, while this used to produce a
-    // symlink pointing back at the source. The fixture needs bun:ffi, which is
-    // unavailable on Windows arm64.
-    test.if(isWindows && !isArm64)("single file that is a reparse point but not a link", async () => {
-      await using basename = tempDir("cp", {
-        "from/a.txt": "a",
-      });
-      using _syncRoot = registerSyncRoot(basename + "\\from");
-      convertToPlaceholder(basename + "\\from\\a.txt");
-      using _exposed = exposePlaceholders();
-      expect(isReparsePoint(basename + "\\from\\a.txt")).toBe(true);
+    // symlink pointing back at the source. The fixture needs bun:ffi (absent
+    // on Windows arm64) and the Cloud Files platform.
+    test.if(isWindows && !isArm64 && cloudFilesAvailable())(
+      "single file that is a reparse point but not a link",
+      async () => {
+        await using basename = tempDir("cp", {
+          "from/a.txt": "a",
+        });
+        using _syncRoot = registerSyncRoot(basename + "\\from");
+        convertToPlaceholder(basename + "\\from\\a.txt");
+        using _exposed = exposePlaceholders();
+        expect(isReparsePoint(basename + "\\from\\a.txt")).toBe(true);
 
-      await copy(basename + "/from/a.txt", basename + "/to.txt");
+        await copy(basename + "/from/a.txt", basename + "/to.txt");
 
-      const stat = fs.lstatSync(basename + "/to.txt");
-      expect({
-        isFile: stat.isFile(),
-        isSymbolicLink: stat.isSymbolicLink(),
-        reparsePoint: isReparsePoint(basename + "\\to.txt"),
-        content: fs.readFileSync(basename + "/to.txt", "utf8"),
-      }).toEqual({ isFile: true, isSymbolicLink: false, reparsePoint: false, content: "a" });
-    });
+        const stat = fs.lstatSync(basename + "/to.txt");
+        expect({
+          isFile: stat.isFile(),
+          isSymbolicLink: stat.isSymbolicLink(),
+          reparsePoint: isReparsePoint(basename + "\\to.txt"),
+          content: fs.readFileSync(basename + "/to.txt", "utf8"),
+        }).toEqual({ isFile: true, isSymbolicLink: false, reparsePoint: false, content: "a" });
+      },
+    );
 
     test("refuse to copy directory with 'recursive: false'", async () => {
       await using basename = tempDir("cp", {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,12 @@
+import {
+  convertToPlaceholder,
+  exposePlaceholders,
+  isReparsePoint,
+  registerSyncRoot,
+} from "_util/windows-reparse-points.ts";
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isArm64, isLinux, isPosix, isWindows, tempDir } from "harness";
 import { mkfifo } from "mkfifo";
 import { isAbsolute, join } from "path";
 
@@ -35,6 +41,31 @@ for (const [name, copy] of impls) {
       await copy(basename + "/from/a.txt", basename + "/to.txt");
 
       expect(fs.readFileSync(basename + "/to.txt", "utf8")).toBe("a");
+    });
+
+    // A cloud-file placeholder carries FILE_ATTRIBUTE_REPARSE_POINT but is a
+    // regular file (lstat says so, which is why the native single-file copy is
+    // used for it); node copies its contents, while this used to produce a
+    // symlink pointing back at the source. The fixture needs bun:ffi, which is
+    // unavailable on Windows arm64.
+    test.if(isWindows && !isArm64)("single file that is a reparse point but not a link", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+      });
+      using _syncRoot = registerSyncRoot(basename + "\\from");
+      convertToPlaceholder(basename + "\\from\\a.txt");
+      using _exposed = exposePlaceholders();
+      expect(isReparsePoint(basename + "\\from\\a.txt")).toBe(true);
+
+      await copy(basename + "/from/a.txt", basename + "/to.txt");
+
+      const stat = fs.lstatSync(basename + "/to.txt");
+      expect({
+        isFile: stat.isFile(),
+        isSymbolicLink: stat.isSymbolicLink(),
+        reparsePoint: isReparsePoint(basename + "\\to.txt"),
+        content: fs.readFileSync(basename + "/to.txt", "utf8"),
+      }).toEqual({ isFile: true, isSymbolicLink: false, reparsePoint: false, content: "a" });
     });
 
     test("refuse to copy directory with 'recursive: false'", async () => {


### PR DESCRIPTION
### Problem
- On Windows, the native copy used by the shell `cp` builtin (the default `cp` there) and by the single-file fast path of `fs.cp` / `fs.cpSync` treats every entry that has `FILE_ATTRIBUTE_REPARSE_POINT` as a link: it opens the entry, asks where the open landed, and creates a symlink to that. A reparse point that is not a link lands on itself, so the "copy" is a symlink pointing back into the source:
  ```
  cp -R src out          # src holds a cloud-file placeholder and a placeholder folder
  out\placeholder.txt -> src\placeholder.txt      (symlink, should be a file)
  out\placeholder_dir -> src\placeholder_dir      (symlink, should be a directory)
  fs.cpSync("src\\placeholder.txt", "a.txt")      # a.txt is a symlink as well
  ```
  Copying a sync root folder itself (`cp -R OneDrive backup`) makes `backup` a single symlink to the source, because the root folder carries a reparse point too. Node copies all of these as files and directories (checked with node 26 on the same fixture).
- Affected entries: cloud-file placeholders (OneDrive / Files On-Demand and other sync clients built on the Cloud Files API), deduplicated files on servers with Data Deduplication, projected-file-system and container (WCI) files, and anything else tagged by a filter driver. Symlinks and junctions were and still are handled by the link branch.
- Cause: the classification looks at the attribute bit only, in `src/runtime/node/node_fs.rs`: the single-operand checks in `NewAsyncCpTask::cp_async` and `NodeFS::cp_sync_inner`, the `FILE_ATTRIBUTE_REPARSE_POINT` test in `copy_single_file_sync` that picks the link branch over `CopyFileW`, and both directory walkers, which take the iterator's `SymLink` kind (on Windows that kind means nothing more than "has the attribute") as "not a directory" and never descend into such a directory.

### Fix
- `CpEntryKind` (node_fs.rs) classifies a source as `File`, `Directory` or `Link` from its attributes and reparse tag. An entry is a link when its tag is a name surrogate (the symlink and junction tags, plus whatever else Windows flags as standing in for a path) or an app-exec link, the one non-surrogate tag libuv's `readlink`, and so Bun's `fs.lstat`, decodes as a link. Everything `fs.lstat` calls a link therefore stays a link here; the entries that change are the ones `lstat` reports as files and directories, which is also how node's lstat-driven `fs.cp` walker treats them.
- Links take the unchanged link branch, so symlink and junction copies come out as before (app-exec links too: they failed to copy before and still do). Only non-link reparse points change behavior: files go to `CopyFileW`, which reads them the way every other program does (the owning filter serves the contents through a normal open), and directories are walked; the walk already opens directories with `FILE_OPEN_REPARSE_POINT`, so that works regardless of tag.
- Where the tag comes from:
  - Walked entries: the node directory iterator (`src/runtime/node/dir_iterator.rs`) now asks `NtQueryDirectoryFile` for `FileFullDirectoryInformation` instead of `FileDirectoryInformation`. The two records differ by one field, `EaSize`, which for a reparse point holds its tag (checked on NTFS here: symlink `0xA000000C`, junction `0xA0000003`, custom tag as stamped, 0 for plain entries). The Windows-only `IteratorResultW` carries attributes and tag; the walkers classify reparse entries from that and hand the result to the `CpSingleTask` (`copy_single_file_sync`'s existing `reuse_stat` slot), so a walked reparse entry costs no syscall to classify and no longer gets re-stat'ed by the copy. `readdir` ignores the new field, so its output is unchanged; the record grows by 4 bytes, which is below what #36201 measured as noise for a 16-byte growth.
  - The top-level operand, and a listing that does not report tags: the new `bun_sys::windows::query_attribute_tag`, an attribute-only `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` plus `NtQueryInformationFile(FileAttributeTagInformation)`. `exists()` reads tags with `FindFirstFileW` (#34765), but that rejects a trailing separator, which shell directory operands routinely have (`cp -R dir\ out`), and needs list access on the parent; the open goes through the same path handling as the surrounding `GetFileAttributesW`/`CopyFileW` calls. It runs once per reparse-point operand; plain operands and plain entries cost nothing extra. An operand that cannot even be opened for attributes stays a link, so the existing branch reports the error as before.
- `cp_sync_inner` gets the same walker change as the async task for parity; on Windows `fs.cpSync` only takes the native path for single files, so that walker is not reachable from JS there.
- Verified:
  - `test/js/bun/shell/commands/cp.test.ts`, new block "reparse points that are not links": a tree holding a directory stamped with a custom non-surrogate tag, a file symlink and a junction (the links are checked for flavor and target, not just for being links), that directory as the operand with and without a trailing separator, and, gated on `cloudFilesAvailable()`, a cloud sync root with a placeholder file and folder inside a walked tree plus the placeholder file and the sync root as operands. On the unfixed build every non-link reparse entry comes out as a link to the source (output below); with the fix they are plain files and directories with the right contents and the symlink and junction are unchanged.
  - `test/js/node/fs/cp.test.ts`, "single file that is a reparse point but not a link", for `fs.cpSync` and `fs.promises.cp`: a symlink before, a regular file after.
  - Fixtures are in `test/_util/windows-reparse-points.ts`: a custom tag via `FSCTL_SET_REPARSE_POINT`, real placeholders via the Cloud Files API, and `cloudFilesAvailable()`, which registers and unregisters a scratch sync root once and skips the placeholder tests where that fails. bun:ffi works on Windows arm64 since #33696, so the tests run on both Windows lanes; CI build 94311 ran them on Server 2019 x64 with 0 skips, and the arm64 fail-before below is from Windows 11 arm64.
  - On Windows x64 with `bun bd test`: both cp files, `cp-symlink-target`, `util/which`, `fs/dir`, `readdir-windows-ntstatus` (111 pass, 0 fail), the readdir/opendir/Dirent tests of `fs.test.ts` (31 pass) and node's `test-fs-readdir*.js` / `test-fs-opendir.js` all pass on the new directory record. The six new tests fail on the unfixed canary of the base commit on Windows x64 and on Windows 11 arm64. The modified files load and skip on Linux.

### Background
- A reparse point is an NTFS entry with a driver-defined blob attached; the blob starts with a 32-bit tag saying which driver owns it. Symlinks and junctions are two such tags, but so are cloud placeholders, dedup stubs, projected files and so on. Bit 29 of the tag (`IsReparseTagNameSurrogate`) marks the tags that stand in for another path; app-exec links (`IO_REPARSE_TAG_APPEXECLINK`, Store app aliases) lack that bit but are decoded as links by libuv's `readlink`, which is why they count as links here.
- A non-surrogate reparse point is still a real file or directory: opening it normally hands it to its filter driver, which serves the data (for a cloud placeholder, downloading it if needed), and a directory one (tags with the "directory" bit, 28) keeps real children. `CopyFileW`, and with it node's `fs.copyFile`, copies such entries this way.
- Windows hides the reparse attribute of cloud placeholders from processes that have not declared themselves placeholder-aware (`RtlSetProcessPlaceholderCompatibilityMode`); executables under the Windows directory, like the `bun.exe` on the CI image, are treated as aware. The tests opt the test process in (`exposePlaceholders()`) so the copy code sees the placeholders; the other affected reparse types are visible to every process.
- The native copy: `ShellCpTask` and `fs.promises.cp` run `NewAsyncCpTask`, which scans directories on the thread pool, recurses into entries the iterator reports as directories and spawns a `CpSingleTask` per other entry; each task calls `copy_single_file_sync`, which decides between `CopyFileW` and recreating a link. `fs.cpSync` calls `NodeFS::cp` -> `cp_sync_inner`, the synchronous equivalent. `src/js/internal/fs/cp*.ts` only hands regular files (and, on macOS, link-free trees) to this native code, which is why `fs.cp` is affected for single files only while the shell builtin is affected for whole trees.
- `NtQueryDirectoryFile` fills a buffer with fixed-layout records, one per entry, in the information class the caller picks; the iterator reads the fields it needs at their offsets. `readdir` (node and bun alike) reports any entry with the reparse attribute as a symlink and keeps doing so; the tag is consumed by cp, the code that has to act on the difference.

<details>
<summary>New tests against the unfixed build (canary at the base commit, Windows x64; same result on Windows 11 arm64)</summary>

```
test\js\bun\shell\commands\cp.test.ts
  cp -R walks a tagged directory and still copies links as links
-   "tagged_dir": { kind: "directory", reparsePoint: false, contents: ["inner.txt"] },
+   "tagged_dir": { link: "directory", target: "...\\src\\tagged_dir" },
    "file_link.txt": { link: "file", target: "...\\src\\plain.txt" },        (unchanged)
    "junction": { link: "directory", target: "...\\src\\plain_dir" },      (unchanged)
  cp -R copies a tagged directory given as the operand
+   "dir": { link: "directory", ... },   "dir2": { link: "directory", ... }
  cloud-file placeholders > cp -R copies a placeholder file and its folder inside a directory
+   "cloud": { link: "directory", ... }
  cloud-file placeholders > cp copies a placeholder file or the sync root given as the operand
+   "file.txt": { link: "file", ... },   "root": { link: "directory", ... }

test\js\node\fs\cp.test.ts (fs.cpSync and fs.cp)
-   { isFile: true,  isSymbolicLink: false, reparsePoint: false, content: "a" }
+   { isFile: false, isSymbolicLink: true,  reparsePoint: true,  content: "a" }
```
</details>

<details>
<summary>Earlier revision</summary>

Up to fe504c5 the walkers classified each reparse entry with `query_attribute_tag` on the scan thread and the copy task then looked the entry up again; the tests were also skipped on Windows arm64 on the outdated premise that bun:ffi was unavailable there. 8e0d6bb moved the classification onto the directory listing as described above, removed the arm64 skip, and made the link assertions check flavor and target.
</details>
