### PR TITLE
sys(windows): resolve . and .. components in the existence probe (recursive mkdir of "." threw EEXIST)

### DIFF
--- a/src/paths/classify.rs
+++ b/src/paths/classify.rs
@@ -12,6 +12,9 @@ pub struct RelPathFacts {
     pub has_sep: bool,
     /// Any `.` anywhere (including inside names like `a.b`).
     pub has_dot: bool,
+    /// Some component is exactly `.` or `..`; names like `a.b` or `...` don't
+    /// count.
+    pub has_dot_component: bool,
     /// `..` resolution climbs above the segment's own start: the running
     /// component depth (name +1, `..` −1, `.`/empty 0) ever goes negative.
     pub climbs_above_start: bool,
@@ -24,19 +27,27 @@ pub fn classify_rel_t<T: PathChar>(rel: &[T], fmt: PathFormat) -> RelPathFacts {
     let mut facts = RelPathFacts {
         has_sep: false,
         has_dot: false,
+        has_dot_component: false,
         climbs_above_start: false,
     };
     let mut depth = 0isize; // net component depth so far
     let mut dots = 0usize; // `.` count in the current component
     let mut other = false; // non-dot chars in the current component
+    fn close_component(dots: usize, other: bool, facts: &mut RelPathFacts, depth: &mut isize) {
+        match (other, dots) {
+            (false, 0) => {}
+            (false, 1) => facts.has_dot_component = true,
+            (false, 2) => {
+                facts.has_dot_component = true;
+                *depth -= 1;
+            }
+            _ => *depth += 1,
+        }
+    }
     for &c in rel {
         if fmt.is_sep(c) {
             facts.has_sep = true;
-            if other || dots > 2 {
-                depth += 1;
-            } else if dots == 2 {
-                depth -= 1;
-            }
+            close_component(dots, other, &mut facts, &mut depth);
             dots = 0;
             other = false;
             if depth < 0 {
@@ -49,9 +60,7 @@ pub fn classify_rel_t<T: PathChar>(rel: &[T], fmt: PathFormat) -> RelPathFacts {
             other = true;
         }
     }
-    if dots == 2 && !other {
-        depth -= 1; // trailing `..` component applies its −1 too
-    }
+    close_component(dots, other, &mut facts, &mut depth);
     facts.climbs_above_start = depth < 0;
     facts
 }
@@ -122,5 +131,64 @@ mod tests {
         check("..", P, (false, true, true));
         check("a/../b", P, (true, true, false));
         check("a/..", P, (true, true, false));
+    }
+
+    #[track_caller]
+    fn check_dot_component(rel: &str, fmt: PathFormat, want: bool) {
+        assert_eq!(
+            classify_rel_t(rel.as_bytes(), fmt).has_dot_component,
+            want,
+            "{rel:?} {fmt:?}"
+        );
+        let wide: Vec<u16> = rel.encode_utf16().collect();
+        assert_eq!(
+            classify_rel_t(&wide, fmt).has_dot_component,
+            want,
+            "{rel:?} {fmt:?} (u16)"
+        );
+    }
+
+    #[test]
+    fn dot_components() {
+        use PathFormat::Windows as W;
+        for rel in [
+            ".",
+            "..",
+            ".\\",
+            "..\\",
+            ".\\a",
+            "../a",
+            "a\\.",
+            "a/..",
+            "a\\.\\b",
+            "a\\..\\b",
+            "a\\\\..",
+            "C:\\a\\..\\b",
+            "\\\\?\\C:\\a\\.",
+        ] {
+            check_dot_component(rel, W, true);
+        }
+        // Dots inside a name, and three or more dots, are ordinary names.
+        for rel in [
+            "",
+            "a",
+            "a\\",
+            "a.b",
+            ".a",
+            "a.",
+            "..a",
+            "a..",
+            "...",
+            "a\\...\\b",
+            ".hidden\\x",
+            "a.b\\c.d",
+            "C:\\a.b\\c",
+        ] {
+            check_dot_component(rel, W, false);
+        }
+        // Under the posix format a backslash is part of the name.
+        check_dot_component("a/./b", PathFormat::Posix, true);
+        check_dot_component("a\\.", PathFormat::Posix, false);
+        check_dot_component(".\\a", PathFormat::Posix, false);
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7332,19 +7332,15 @@ pub enum ExistsAtType {
     File,
     Directory,
 }
-/// Windows tail — `NtQueryAttributesFile` against an
-/// OBJECT_ATTRIBUTES built from an already NT-prefixed wide path. Shared by the
-/// UTF-8 (`exists_at_type`) and UTF-16 (`exists_at_type_w`) entry points so the
-/// width dispatch does not
+/// Windows tail: `NtQueryAttributesFile` against an OBJECT_ATTRIBUTES built
+/// from an NT object name, either absolute (`\??\…`, `\Device\…`) or relative
+/// to `dir`; a relative one must not contain `.`/`..` components (see
+/// [`exists_at_type_resolved`]). Shared by the UTF-8 (`exists_at_type`) and
+/// UTF-16 (`exists_at_type_w`) entry points so the width dispatch does not
 /// duplicate the syscall body.
 #[cfg(windows)]
-fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
+fn exists_at_type_nt(dir: Fd, path: &[u16]) -> Maybe<ExistsAtType> {
     use bun_windows_sys::externs as w;
-    // Trim leading `.\` — NtQueryAttributesFile expects relative paths
-    // without it.
-    if path.len() > 2 && path[0] == b'.' as u16 && path[1] == b'\\' as u16 {
-        path = &path[2..];
-    }
     let path_len_bytes = (path.len() * 2) as u16;
     let mut nt_name = w::UNICODE_STRING {
         Length: path_len_bytes,
@@ -7390,6 +7386,22 @@ fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
         },
     )
 }
+/// `exists_at_type` for a path with a `.` or `..` component. Those are Win32
+/// syntax: an NT object name cannot carry them (`NtQueryAttributesFile` fails
+/// with `OBJECT_NAME_INVALID`, which `directory_exists_at` cannot tell apart
+/// from a real failure), so build the name the way `openat` does: absolute
+/// paths collapse lexically, relative ones resolve against `dir`. Paths
+/// without such a component skip this and its directory-handle query.
+#[cfg(windows)]
+fn exists_at_type_resolved(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
+    let mut wbuf = bun_paths::w_path_buffer_pool::get();
+    let path = normalize_path_windows(dir, sub, &mut wbuf.0[..])?;
+    exists_at_type_nt(dir, path.as_slice())
+}
+#[cfg(windows)]
+fn has_dot_component<T: bun_paths::PathChar>(path: &[T]) -> bool {
+    bun_paths::classify_rel_t(path, bun_paths::PathFormat::Windows).has_dot_component
+}
 /// `fstatat` then `S_ISDIR`.
 pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
     #[cfg(unix)]
@@ -7403,10 +7415,16 @@ pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
     }
     #[cfg(windows)]
     {
+        let sub = sub.as_bytes();
+        if has_dot_component(sub) {
+            let mut wide_buf = bun_paths::w_path_buffer_pool::get();
+            let wide = convert_path_u8_to_u16(&mut wide_buf.0[..], sub)?;
+            return exists_at_type_resolved(dir, wide);
+        }
         // `NtQueryAttributesFile` against an OBJECT_ATTRIBUTES
         // built from the (optionally NT-prefixed) wide path.
         let mut wbuf = bun_paths::w_path_buffer_pool::get();
-        let path = bun_paths::string_paths::to_nt_path(&mut wbuf.0[..], sub.as_bytes()).as_slice();
+        let path = bun_paths::string_paths::to_nt_path(&mut wbuf.0[..], sub).as_slice();
         exists_at_type_nt(dir, path)
     }
 }
@@ -7415,6 +7433,9 @@ pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
 /// `toNTPath16` instead of re-widening from UTF-8.
 #[cfg(windows)]
 pub(crate) fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
+    if has_dot_component(sub) {
+        return exists_at_type_resolved(dir, sub);
+    }
     let mut wbuf = bun_paths::w_path_buffer_pool::get();
     let path = bun_paths::string_paths::to_nt_path16(&mut wbuf.0[..], sub).as_slice();
     exists_at_type_nt(dir, path)

--- a/test/bundler/compile-windows-metadata.test.ts
+++ b/test/bundler/compile-windows-metadata.test.ts
@@ -75,6 +75,32 @@ async function readVersionInfo(outfile: string) {
 
 const windowsTarget = process.arch === "arm64" ? "bun-windows-aarch64" : "bun-windows-x64";
 
+// A minimal valid ICO header (one 16x16 32bpp image entry).
+const icoHeader = Buffer.from([
+  0x00,
+  0x00, // Reserved
+  0x01,
+  0x00, // Type (1 = ICO)
+  0x01,
+  0x00, // Count (1 image)
+  0x10, // Width (16)
+  0x10, // Height (16)
+  0x00, // Color count
+  0x00, // Reserved
+  0x01,
+  0x00, // Color planes
+  0x20,
+  0x00, // Bits per pixel
+  0x68,
+  0x01,
+  0x00,
+  0x00, // Size
+  0x16,
+  0x00,
+  0x00,
+  0x00, // Offset
+]);
+
 // https://github.com/oven-sh/bun/issues/19916
 describe.skipIf(!isWindows).concurrent("--windows-hide-console", () => {
   // The default-target console-subsystem baseline is asserted inside
@@ -373,6 +399,44 @@ describe.skipIf(!isWindows).concurrent("Windows compile metadata", () => {
         OriginalFilename: "",
       });
     });
+
+    test("windows.icon spelled relative to the cwd through ..", async () => {
+      // The option is validated with an existence check that used to reject
+      // any spelling containing a "." or ".." component ("windows.icon must be
+      // a valid path to an ico file") although the file exists. The build runs
+      // in a child so the relative path has a known cwd.
+      using dir = tempDir("windows-metadata-relative-icon", {
+        "icon.ico": icoHeader,
+        proj: {
+          "app.js": `console.log("Relative icon test");`,
+          "build.js": `
+            const result = await Bun.build({
+              entrypoints: ["./app.js"],
+              outdir: "./out",
+              compile: {
+                target: ${JSON.stringify(windowsTarget)},
+                outfile: "relative-icon.exe",
+                windows: { icon: "../icon.ico" },
+              },
+            });
+            console.log(JSON.stringify({
+              success: result.success,
+              outputs: result.outputs.map(output => require("path").basename(output.path)),
+            }));
+          `,
+        },
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.js"],
+        cwd: join(String(dir), "proj"),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const { stdout } = await expectBuildOk(proc);
+      expect(JSON.parse(stdout)).toEqual({ success: true, outputs: ["relative-icon.exe"] });
+    });
   });
 
   describe("Version string formats", () => {
@@ -611,32 +675,6 @@ describe.skipIf(!isWindows).concurrent("Windows compile metadata", () => {
     });
 
     test("metadata with --windows-icon", async () => {
-      // Create a simple .ico file (minimal valid ICO header)
-      const icoHeader = Buffer.from([
-        0x00,
-        0x00, // Reserved
-        0x01,
-        0x00, // Type (1 = ICO)
-        0x01,
-        0x00, // Count (1 image)
-        0x10, // Width (16)
-        0x10, // Height (16)
-        0x00, // Color count
-        0x00, // Reserved
-        0x01,
-        0x00, // Color planes
-        0x20,
-        0x00, // Bits per pixel
-        0x68,
-        0x01,
-        0x00,
-        0x00, // Size
-        0x16,
-        0x00,
-        0x00,
-        0x00, // Offset
-      ]);
-
       using dir = tempDir("windows-metadata-icon", {
         "app.js": `console.log("Icon test");`,
         "icon.ico": icoHeader,

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { isLinux, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -397,5 +397,73 @@ describe("fs.promises.mkdir", () => {
     expect(fs.existsSync(pathname)).toBe(true);
     expect(fs.statSync(pathname).isDirectory()).toBe(true);
     expect(result).toBeUndefined();
+  });
+});
+
+describe("fs.mkdir - recursive on an existing directory spelled with . or ..", () => {
+  // The paths are relative, so the calls run in a child process whose cwd is
+  // <root>/cwd. On Windows, bun used to throw EEXIST for every directory case
+  // here that is spelled with a "." or ".." component: the probe that checks
+  // whether the EEXIST came from a directory handed that spelling to NT, which
+  // rejects it. Node returns undefined for all of them on every platform.
+  const cases = [".", "..", "../cwd", "../cwd/sub", "./sub", "../cwd/file.txt"];
+  const expected = {
+    ".": "undefined",
+    "..": "undefined",
+    "../cwd": "undefined",
+    "../cwd/sub": "undefined",
+    "./sub": "undefined",
+    "../cwd/file.txt": { code: "EEXIST", syscall: "mkdir" },
+  };
+
+  it("returns undefined from mkdirSync, mkdir and promises.mkdir", async () => {
+    using root = tempDir("mkdir-dot-components", {
+      "fixture.js": `
+        const fs = require("fs");
+        const { promisify } = require("util");
+        const cases = ${JSON.stringify(cases)};
+        const apis = {
+          mkdirSync: async p => fs.mkdirSync(p, { recursive: true }),
+          mkdir: p => promisify(fs.mkdir)(p, { recursive: true }),
+          "promises.mkdir": p => fs.promises.mkdir(p, { recursive: true }),
+        };
+        (async () => {
+          const results = {};
+          for (const [api, mkdir] of Object.entries(apis)) {
+            results[api] = {};
+            for (const p of cases) {
+              results[api][p] = await mkdir(p).then(
+                returned => (returned === undefined ? "undefined" : { created: returned }),
+                err => ({ code: err.code, syscall: err.syscall }),
+              );
+            }
+          }
+          process.stdout.write(JSON.stringify(results));
+        })();
+      `,
+      cwd: {
+        sub: {},
+        "file.txt": "",
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(String(root), "fixture.js")],
+      cwd: path.join(String(root), "cwd"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      mkdirSync: expected,
+      mkdir: expected,
+      "promises.mkdir": expected,
+    });
+    expect(exitCode).toBe(0);
+    // The entries the cases name were there all along, and none of the calls created anything.
+    expect(fs.readdirSync(path.join(String(root), "cwd")).sort()).toEqual(["file.txt", "sub"]);
+    expect(fs.readdirSync(String(root)).sort()).toEqual(["cwd", "fixture.js"]);
   });
 });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -458,6 +458,73 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   }, 20_000);
 
+  test("Module._stat() resolves paths spelled with . or .. components", async () => {
+    // Relative paths, so the calls run in a child whose cwd is <root>/cwd. On
+    // Windows every case with a "." or ".." component used to come back
+    // negative (bun handed the spelling to NT, which rejects it), while node
+    // answers from the resolved path.
+    using root = tempDir("module-stat-dot-components", {
+      cwd: {
+        sub: {},
+        "file.txt": "",
+      },
+    });
+    const cases = [
+      ".",
+      "..",
+      "../cwd",
+      "../cwd/sub",
+      "./sub",
+      "sub/.",
+      "sub/..",
+      "./file.txt",
+      "../cwd/file.txt",
+      "sub/../file.txt",
+      "<cwd>/sub/..",
+      "<cwd>/sub/../file.txt",
+      "../cwd/missing",
+      "missing/..",
+    ];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { _stat } = require("module");
+         const results = {};
+         for (const c of ${JSON.stringify(cases)}) {
+           const rc = _stat(c.replace("<cwd>", process.cwd()));
+           results[c] = rc < 0 ? "negative" : rc;
+         }
+         process.stdout.write(JSON.stringify(results));`,
+      ],
+      cwd: path.join(String(root), "cwd"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      ".": 1,
+      "..": 1,
+      "../cwd": 1,
+      "../cwd/sub": 1,
+      "./sub": 1,
+      "sub/.": 1,
+      "sub/..": 1,
+      "./file.txt": 0,
+      "../cwd/file.txt": 0,
+      "sub/../file.txt": 0,
+      "<cwd>/sub/..": 1,
+      "<cwd>/sub/../file.txt": 0,
+      "../cwd/missing": "negative",
+      // Windows resolves ".." lexically, so the missing directory is never
+      // looked up there; POSIX has to walk through it. Node answers the same way.
+      "missing/..": isWindows ? 1 : "negative",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("Module.wrap", () => {
     var mod = { exports: {} };
     expect(eval(wrap("exports.foo = 1; return 42"))(mod.exports, mod)).toBe(42);


### PR DESCRIPTION
### Problem
- On Windows, `fs.mkdirSync(".", { recursive: true })` throws `EEXIST: file already exists, mkdir '.'`. Same for `".."` and for any existing directory reached through a `..` component (`"../pkg"`), and for the callback and `fs.promises` forms. Node v26.3.0 returns `undefined` for all of them, as does bun on POSIX.
- `require("module")._stat(p)` on Windows returns a negative value (missing) for every `p` with a `.` or `..` component that names an existing entry: `"."`, `".."`, `"sub/.."`, `"sub/../file.txt"`, and `C:\...\sub\..` spelled absolutely. Node returns 1 / 0.
- `Bun.build({ compile: { windows: { icon: "../icon.ico" } } })` on Windows throws `TypeError: windows.icon must be a valid path to an ico file` although the file exists; `compile.executablePath` spelled the same way throws its equivalent (`src/runtime/api/JSBundler.rs:324` and `:353`, same probe).
- Cause: `bun_sys::exists_at_type` (`src/sys/lib.rs:7394`, wide arm `exists_at_type_w` at `:7417`) converts the path with `to_nt_path`, which only normalizes slashes, and `exists_at_type_nt` (`:7341`) hands the result to `NtQueryAttributesFile` relative to the directory handle. A relative NT object name cannot contain `.` or `..` components (those are Win32 syntax, see Background), so NT fails with `STATUS_OBJECT_NAME_INVALID`; the only thing handled was a leading `.\`, which `:7345` trimmed off. That status maps to an errno other than `ENOENT`, so `directory_exists_at` returns `Err`.
- Recursive mkdir (`src/runtime/node/node_fs.rs:5670`) calls that probe after `CreateDirectoryW` reports `EEXIST`, to decide whether the existing entry is a directory; on `Err` it rethrows the `EEXIST`. `Module._stat` (`src/jsc/NodeModuleModule.rs:121`) is the same probe exposed directly, and the two `Bun.build` options pass the user's string to it as is. The remaining `directory_exists_at` / `exists_at` callers (install, `bun create`, `bun pm version`, static routes) pass resolved paths or bare names, so they were not observably affected.

### Fix
- `exists_at_type` / `exists_at_type_w`: a path with a `.` or `..` component is converted with `normalize_path_windows` instead (new `exists_at_type_resolved`). That is the builder every Windows `openat` already uses: an absolute path has its components collapsed lexically (no syscall), a relative one is resolved against the directory handle (the cwd handle when none is given) into an absolute `\Device\...` name. `exists_at_type_nt` then queries it with no `RootDirectory`, exactly as it already does for `\??\` names.
- The `.\` trim in `exists_at_type_nt` is deleted: every path with a dot component now takes the route above, so nothing starting with `.\` reaches it any more.
- `RelPathFacts` (`src/paths/classify.rs`, the classifier `normalize_path_windows` itself uses) gains `has_dot_component`, computed in the same pass; the component bookkeeping it needs was already there, so the existing depth logic is folded into one `close_component` helper. The routing uses this rather than the existing `has_dot` so that names that merely contain a dot (`lodash@4.17.21`, the install cache probes) keep today's syscall-free conversion and do not pay the directory-handle query (#33874 measured that route at 12 to 15 us per call). Paths without a dot component run byte-for-byte the same code as before.
- Why this is right: on Windows the probe's job is to answer for the same file the preceding Win32 call (`CreateDirectoryW`, or node's `uv_fs_stat`) acted on, and Win32 resolves `.` / `..` lexically before reaching NT; `normalize_path_windows` does the same lexical collapse, so the answers now match node for every spelling, including `missing/..` (a directory on Windows, `ENOENT` on POSIX, in node as well as here). Putting it in `exists_at_type` fixes every caller of the probe rather than the one mkdir call site, and reuses the one NT name builder instead of adding a second.
- Out of scope, unchanged: relative mkdir arguments that normalize to nothing (`mkdirSync("sub/..", { recursive: true })`) still fail with `ENOENT` because `os_path_kernel32` in `src/runtime/node/types.rs` turns them into an empty string before any syscall; #33034 joins relative arguments onto the cwd in that slicer, which covers it. `..` from a volume root keeps `normalize_path_windows`'s existing refusal to climb above the volume, like `readdir("..")` there.
- Verified:
  - `test/js/node/fs/fs-mkdir.test.ts` ("recursive on an existing directory spelled with . or .."): runs `mkdirSync`, `fs.mkdir` and `fs.promises.mkdir` from a child whose cwd is `<root>/cwd` on `.`, `..`, `../cwd`, `../cwd/sub`, `./sub` and an existing file. On Windows with bun 1.4.0 it fails (`EEXIST` for the four dotted directory spellings in all three APIs); it passes with this build. The expectations are the output of node v26.3.0 on both Windows and Linux (transcript below).
  - `test/js/node/module/node-module-module.test.js` ("Module._stat() resolves paths spelled with . or .. components"): 14 spellings covering relative and absolute paths, directories, files and missing entries. Fails on Windows with bun 1.4.0 (11 of 14 come back negative), passes with this build; expectations again equal node's output on both platforms.
  - `test/bundler/compile-windows-metadata.test.ts` ("windows.icon spelled relative to the cwd through .."): a child process builds with `windows: { icon: "../icon.ico" }`. On Windows with bun 1.4.0 it fails with the `TypeError` above; with this build the compile succeeds. (The `.ico` bytes the existing `--windows-icon` test defined inline moved to module scope so both tests share them.) Windows-only like the rest of that file.
  - The first two tests already passed on Linux before the change (the bug is Windows-only); they still pass under the Linux debug/ASAN build.
  - `cargo test -p bun_paths` covers `has_dot_component` (`a.b`, `.a`, `...`, `..a`, posix format) and the unchanged `climbs_above_start` cases.
  - On Windows with this build: the whole `fs-mkdir`, `node-module-module`, `cp`, `cp-symlink-target`, `dir`, `promises`, `fs-path-length` suites, the upstream `test-module-stat.js`, and `public-hoist-pattern`, `overrides`, `bun-create`, `bun-link` (install and `bun create` callers of the probe) all pass. `fs.test.ts`: 500 pass, the one failure is the pre-existing debug-build timeout of "readSync works on large files". In `compile-windows-metadata.test.ts` the concurrent compiles of a 200 MB debug executable hit the 5 s timeout on the box with or without this change; every test in it passes when run on its own.
  - `cargo check -p bun_sys --target x86_64-pc-windows-msvc` is clean (the workspace denies warnings).

### Background
- Win32 paths vs NT object names: Win32 file APIs (`CreateDirectoryW`, what node's libuv calls) take paths like `..\x` or `C:\a\..\b` and resolve `.` / `..` lexically (without looking at the disk) before asking the kernel. The NT layer underneath (`NtCreateFile`, `NtQueryAttributesFile`) takes object names: either absolute (`\??\C:\a\b`, or a device form such as `\Device\HarddiskVolume3\a\b`) or a name relative to a directory handle passed as `OBJECT_ATTRIBUTES.RootDirectory`. Neither form may contain `.` or `..` components; NT rejects them instead of resolving them.
- `normalize_path_windows` (`src/sys/lib.rs`): bun's converter from a possibly relative path plus directory handle into an NT object name. Bare names pass through untouched (they are valid relative names); absolute paths are normalized lexically and prefixed with `\??\`; anything else asks the directory handle for its own NT name and joins the relative part onto it. `openat`, `open_dir_at` and friends all go through it; the existence probe did not.
- `exists_at_type` / `directory_exists_at`: bun_sys's "is there a file or directory at (dir, path)?" helper (`fstatat` on POSIX). Recursive mkdir uses it because on Windows `CreateDirectoryW` reports `EEXIST` for an existing file and an existing directory alike; `Module._stat` is node's undocumented `internalModuleStat` (0 file, 1 directory, negative otherwise), which bun implements with this helper.
- `RelPathFacts` / `classify_rel_t` (`src/paths/classify.rs`): one-pass scan of a path that reports the facts path routing needs (any separator, any dot, whether `..` climbs above the start). `normalize_path_windows` routes on it; this PR adds a fourth, more precise fact and routes the probe on that.

<details>
<summary>node v26.3.0 vs bun 1.4.0 vs this branch on Windows Server (cwd is &lt;root&gt;/cwd, containing sub/ and file.txt)</summary>

```
mkdirSync / mkdir / promises.mkdir, { recursive: true }   node        bun 1.4.0   this branch
  "."                                                    undefined   EEXIST      undefined
  ".."                                                   undefined   EEXIST      undefined
  "../cwd"                                               undefined   EEXIST      undefined
  "../cwd/sub"                                           undefined   EEXIST      undefined
  "./sub"                                                undefined   undefined   undefined
  "../cwd/file.txt"                                      EEXIST      EEXIST      EEXIST

Module._stat                                             node        bun 1.4.0   this branch
  "." ".." "../cwd" "../cwd/sub" "sub/." "sub/.."        1           <0          1
  "./sub"                                                1           1           1
  "./file.txt"                                           0           0           0
  "../cwd/file.txt" "sub/../file.txt"                    0           <0          0
  <cwd>/sub/..                                           1           <0          1
  <cwd>/sub/../file.txt                                  0           <0          0
  "../cwd/missing"                                       <0          <0          <0
  "missing/.."                                           1           <0          1
```

The same fixture under node v26.3.0 on Linux gives identical results except `"missing/.."`, which is `<0` there (POSIX walks through the missing directory); bun on Linux agrees both before and after, and the test branches on `isWindows` for that one entry.
</details>
