### PR TITLE
node:fs: call void operation callbacks with (null) alone, as node does

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -47,8 +47,17 @@ function ensureCallback(callback) {
 //
 // function () { callback(null); }
 //
+// The resolved value must not reach the callback: node's void operations call
+// back with `null` alone (FSReqCallback::Resolve drops an undefined result),
+// https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L736-L741
 function nullcallback(callback) {
-  return FunctionPrototypeBind.$call(callback, undefined, null);
+  return FunctionPrototypeBind.$call(callOnceWithNull, undefined, callback);
+}
+function callOnceWithNull(callback) {
+  callback(null);
+}
+function callOnceWithNullThen(callback, value) {
+  callback(null, value);
 }
 const FunctionPrototypeBind = nullcallback.bind;
 
@@ -207,7 +216,12 @@ var access = function access(path, mode, callback) {
 
     callback = ensureCallback(callback);
 
-    fs.mkdir(path, options).then(nullcallback(callback), callback);
+    fs.mkdir(path, options).then(function (firstDirCreated) {
+      // Only a recursive mkdir that created something resolves with a path;
+      // node passes it along and otherwise calls back with `null` alone.
+      if (firstDirCreated === undefined) callback(null);
+      else callback(null, firstDirCreated);
+    }, callback);
   },
   mkdtemp = function mkdtemp(prefix, options, callback) {
     if ($isCallable(options)) {
@@ -1003,7 +1017,10 @@ function cp(src, dest, options, callback) {
   dest = getValidatedFsPath(dest, "dest");
   callback = guardCallback(callback);
 
-  promises.cp(src, dest, options).then(callOnceWithNull.bind(null, callback), callback);
+  // Unlike the other void operations, node's fs.cp is util.callbackify(cpFn),
+  // so a successful copy calls back with (null, undefined):
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1098
+  promises.cp(src, dest, options).then(callOnceWithNullThen.bind(null, callback), callback);
 }
 
 function _toUnixTimestamp(time: any, name = "time") {
@@ -1034,12 +1051,6 @@ function onOpendirStatFulfilled(callback, path, result, stats) {
 }
 function onOpendirStatRejected(callback, path, err) {
   process.nextTick(callback, typeof err?.errno === "number" ? opendirStatError(err, path) : err);
-}
-function callOnceWithNull(callback) {
-  callback(null);
-}
-function callOnceWithNullThen(callback, value) {
-  callback(null, value);
 }
 
 function opendirSync(path, options) {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1020,7 +1020,9 @@ function cp(src, dest, options, callback) {
   // Unlike the other void operations, node's fs.cp is util.callbackify(cpFn),
   // so a successful copy calls back with (null, undefined):
   // https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1098
-  promises.cp(src, dest, options).then(callOnceWithNullThen.bind(null, callback), callback);
+  promises
+    .cp(src, dest, options)
+    .then(FunctionPrototypeBind.$call(callOnceWithNullThen, undefined, callback), callback);
 }
 
 function _toUnixTimestamp(time: any, name = "time") {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6340,6 +6340,81 @@ describe("a throw from a node-style callback is an uncaughtException", () => {
   });
 });
 
+// On success node calls a void operation's callback with exactly one argument,
+// `null`. Visible through arguments.length, e.g. multi-argument promisify
+// wrappers. toStrictEqual is what tells [null] apart from [null, undefined].
+describe("a void operation's callback receives the same arguments as in node", () => {
+  type Callback = (...args: unknown[]) => void;
+  function argumentsPassedTo(run: (cb: Callback) => void): Promise<unknown[]> {
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    run((...args) => resolve(args));
+    return promise;
+  }
+  async function withFd(dir: string, run: (fd: number, cb: Callback) => void): Promise<unknown[]> {
+    const fd = openSync(join(dir, "file.txt"), "r+");
+    try {
+      return await argumentsPassedTo(cb => run(fd, cb));
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  // Every case runs in a fresh directory holding file.txt and an empty subdir/.
+  const voidOps: Record<string, (dir: string) => Promise<unknown[]>> = {
+    access: dir => argumentsPassedTo(cb => fs.access(join(dir, "file.txt"), cb)),
+    appendFile: dir => argumentsPassedTo(cb => fs.appendFile(join(dir, "file.txt"), "more", cb)),
+    writeFile: dir => argumentsPassedTo(cb => fs.writeFile(join(dir, "written.txt"), "data", cb)),
+    copyFile: dir => argumentsPassedTo(cb => fs.copyFile(join(dir, "file.txt"), join(dir, "copy.txt"), cb)),
+    rename: dir => argumentsPassedTo(cb => fs.rename(join(dir, "file.txt"), join(dir, "renamed.txt"), cb)),
+    link: dir => argumentsPassedTo(cb => fs.link(join(dir, "file.txt"), join(dir, "hardlink.txt"), cb)),
+    unlink: dir => argumentsPassedTo(cb => fs.unlink(join(dir, "file.txt"), cb)),
+    rm: dir => argumentsPassedTo(cb => fs.rm(join(dir, "file.txt"), cb)),
+    "rm (recursive)": dir => argumentsPassedTo(cb => fs.rm(join(dir, "subdir"), { recursive: true }, cb)),
+    rmdir: dir => argumentsPassedTo(cb => fs.rmdir(join(dir, "subdir"), cb)),
+    mkdir: dir => argumentsPassedTo(cb => fs.mkdir(join(dir, "created"), cb)),
+    "mkdir (recursive, directory already exists)": dir =>
+      argumentsPassedTo(cb => fs.mkdir(join(dir, "subdir"), { recursive: true }, cb)),
+    truncate: dir => argumentsPassedTo(cb => fs.truncate(join(dir, "file.txt"), cb)),
+    chmod: dir => argumentsPassedTo(cb => fs.chmod(join(dir, "file.txt"), 0o644, cb)),
+    // uid/gid -1 leaves ownership unchanged, so these succeed unprivileged.
+    chown: dir => argumentsPassedTo(cb => fs.chown(join(dir, "file.txt"), -1, -1, cb)),
+    lchown: dir => argumentsPassedTo(cb => fs.lchown(join(dir, "file.txt"), -1, -1, cb)),
+    utimes: dir => argumentsPassedTo(cb => fs.utimes(join(dir, "file.txt"), 1, 1, cb)),
+    lutimes: dir => argumentsPassedTo(cb => fs.lutimes(join(dir, "file.txt"), 1, 1, cb)),
+    fchmod: dir => withFd(dir, (fd, cb) => fs.fchmod(fd, 0o644, cb)),
+    fchown: dir => withFd(dir, (fd, cb) => fs.fchown(fd, -1, -1, cb)),
+    fsync: dir => withFd(dir, (fd, cb) => fs.fsync(fd, cb)),
+    fdatasync: dir => withFd(dir, (fd, cb) => fs.fdatasync(fd, cb)),
+    ftruncate: dir => withFd(dir, (fd, cb) => fs.ftruncate(fd, cb)),
+    futimes: dir => withFd(dir, (fd, cb) => fs.futimes(fd, 1, 1, cb)),
+    close: dir => argumentsPassedTo(cb => fs.close(openSync(join(dir, "file.txt"), "r"), cb)),
+  };
+  if (fs.lchmod) {
+    voidOps.lchmod = dir => argumentsPassedTo(cb => fs.lchmod(join(dir, "file.txt"), 0o644, cb));
+  }
+
+  it.each(Object.entries(voidOps))("%s calls back with [null]", async (_name, run) => {
+    using dir = tempDir("fs-callback-arguments", { "file.txt": "data" });
+    mkdirSync(join(String(dir), "subdir"));
+    expect(await run(String(dir))).toStrictEqual([null]);
+  });
+
+  it("mkdir (recursive) still passes the first directory it created", async () => {
+    using dir = tempDir("fs-callback-arguments-mkdir", {});
+    const first = join(String(dir), "a");
+    const args = await argumentsPassedTo(cb => fs.mkdir(join(first, "b", "c"), { recursive: true }, cb));
+    expect(args).toStrictEqual([null, path.toNamespacedPath(first)]);
+  });
+
+  // node implements fs.cp with util.callbackify, so it is the one operation
+  // whose callback gets the (undefined) result as a second argument.
+  it("cp calls back with [null, undefined]", async () => {
+    using dir = tempDir("fs-callback-arguments-cp", { "file.txt": "data" });
+    const args = await argumentsPassedTo(cb => fs.cp(join(String(dir), "file.txt"), join(String(dir), "copy.txt"), cb));
+    expect(args).toStrictEqual([null, undefined]);
+  });
+});
+
 describe("fs.Utf8Stream", () => {
   // A write started from the reopen 'ready' listener is still in flight when the
   // reopen path announces 'drain'; the write's own completion is what must emit it.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6277,6 +6277,11 @@ describe("a throw from a node-style callback is an uncaughtException", () => {
       "fs.read",
       `const fs = require("fs"); fs.open(${file}, "r", (e, fd) => fs.read(fd, Buffer.alloc(4), 0, 4, 0, () => { throw new Error("boom"); }))`,
     ],
+    // The three ways a void operation reaches its callback on success:
+    // nullcallback (chmod and most others), mkdir's own handler, and cp's.
+    ["fs.chmod", `require("fs").chmod(${file}, 0o644, () => { throw new Error("boom"); })`],
+    ["fs.mkdir", `require("fs").mkdir(${dirLit} + "/mk", () => { throw new Error("boom"); })`],
+    ["fs.cp", `require("fs").cp(${file}, ${dirLit} + "/cp.txt", () => { throw new Error("boom"); })`],
     // Both symlink overloads: the 4-argument form takes a different path.
     ["fs.symlink (3-arg)", `require("fs").symlink(${file}, ${dirLit} + "/l3", () => { throw new Error("boom"); })`],
     [


### PR DESCRIPTION
### Problem
- The callback form of every void `node:fs` operation calls back with two arguments on success, `(null, undefined)`; node calls back with one, `(null)`:
  ```
  $ bun  -e "require('fs').chmod('f', 0o644, function(){ console.log(arguments.length, Array.from(arguments)) })"
  2 [ null, undefined ]
  $ node -e "require('fs').chmod('f', 0o644, function(){ console.log(arguments.length, Array.from(arguments)) })"
  1 [ null ]
  ```
- Affects the 22 operations wired through `nullcallback()`: appendFile, chmod, chown, copyFile, fchmod, fchown, fdatasync, fsync, ftruncate, futimes, lchmod, lchown, link, lutimes, mkdir, rename, rm, rmdir, truncate, unlink, utimes, writeFile.
- Cause: `nullcallback()` (`src/js/node/fs.ts:50`) returns `callback.bind(undefined, null)`, and callers pass that straight to `.then()`, e.g. `fs.chmod(path, mode).then(nullcallback(callback), callback)` (`fs.ts:141`). The promise machinery invokes the bound function with the resolved value, so the user callback receives `(null, undefined)`.
- `fs.cp` has the opposite mismatch: bun calls back with `(null)`, node with `(null, undefined)`.
- Observable through `arguments.length` and rest parameters, e.g. multi-argument promisify wrappers (`pify`'s `multiArgs`) resolve to `[undefined]` in bun and `[]` in node.

### Fix
- `nullcallback()` now binds `callOnceWithNull` (the existing helper used by `Dir.prototype.close`) with the callback, so the fulfillment value is dropped and the callback receives exactly `(null)`. This is what the comment above `nullcallback` always claimed it was equivalent to; the `callOnceWithNull`/`callOnceWithNullThen` declarations move up next to it.
- `mkdir` gets its own fulfillment handler: a recursive mkdir resolves with the first directory it created, and node passes that along as a second argument, so it is forwarded when defined and dropped otherwise. That is the same rule as node's `FSReqCallback::Resolve` (see Background); the other 21 operations always resolve with `undefined`, so they only need `callOnceWithNull`.
- `cp` switches to `callOnceWithNullThen`, so it calls back with `(null, undefined)` like node, whose `fs.cp` is `util.callbackify(cpFn)` (lib/fs.js#L1098 in v26.3.0). Matching the observable behavior rather than the other operations' shape is deliberate; a code comment says why.
- Why this is correct: it matches node. For every operation touched here, node v26.3.0 and this branch now produce identical callback argument lists (probe output in the details below).
- `fs.access` and `fs.symlink` hand the native promise's value to the callback directly and are handled in #38065; they are left alone here. `access` appears in the new table only because it already matches.
- Verified:
  - `test/js/node/fs/fs.test.ts`, new `describe("a void operation's callback receives the same arguments as in node")`: one row per operation asserting `toStrictEqual([null])` (`toEqual` would accept the extra `undefined`), plus recursive mkdir still passing `[null, firstDirCreated]` and cp passing `[null, undefined]`. 24 of the 27 cases fail on the released binary (1.4.0), all pass with the fix.
  - Full `test/js/node/fs/fs.test.ts`: 537 pass, 0 fail.
  - `test/js/node/fs/{cp,cp-symlink-target,dir,fs-mkdir}.test.ts`, `promises.test.js`: 123 pass, 0 fail.
  - Ported node tests for the affected operations (test-fs-mkdir*, rm, rmdir*, chmod*, utimes*, lchown*, lchmod, link, cp-async-*, append-file*, write-file*, truncate*, copyfile*, rename*, unlink*, fsync*, chown*, futimes*, opendir*) and test-trace-events-fs-{async,sync}: all pass.

### Background
- The callback form of `node:fs` in bun is a thin layer over the native promise-returning binding: `binding.op(...).then(onSuccess, callback)`. `onSuccess` is always invoked with the promise's resolved value, so whatever function is passed there decides what the user callback sees.
- `Function.prototype.bind` prepends the bound arguments and still forwards the call-time arguments. `callback.bind(undefined, null)` therefore calls `callback(null, resolvedValue)`; binding a helper that takes the callback as its bound argument and ignores the rest is what yields `callback(null)`.
- In node, async fs operations complete through `FSReqCallback::Resolve` (src/node_file.cc#L736-L741 in v26.3.0): it calls the callback with just `null` when the result is `undefined`, and with `(null, result)` otherwise. Recursive `mkdir` is the only operation touched here whose result can be defined.
- `fs.cp` is the exception because node implements it in JS via `util.callbackify`, which always calls `cb(null, ret)`, even when `ret` is `undefined`.
- #33366 replaces this promise layer with native callbacks and would subsume this change; this PR is the narrow fix for the argument shape on the current code.

<details>
<summary>Probe: callback argument lists, node v26.3.0 vs this branch</summary>

Each operation is run on a fresh file/directory and the callback's `arguments` are printed. The two runtimes now print identical output for all of these; the `bun 1.4.0` column is what the released binary prints.

```
op                           node v26.3.0 / this branch        bun 1.4.0
access                       1 [null]                          1 [null]
appendFile                   1 [null]                          2 [null, undefined]
chmod                        1 [null]                          2 [null, undefined]
chown                        1 [null]                          2 [null, undefined]
close                        1 [null]                          1 [null]
copyFile                     1 [null]                          2 [null, undefined]
cp                           2 [null, undefined]               1 [null]
fchmod                       1 [null]                          2 [null, undefined]
fchown                       1 [null]                          2 [null, undefined]
fdatasync                    1 [null]                          2 [null, undefined]
fsync                        1 [null]                          2 [null, undefined]
ftruncate                    1 [null]                          2 [null, undefined]
futimes                      1 [null]                          2 [null, undefined]
lchown                       1 [null]                          2 [null, undefined]
link                         1 [null]                          2 [null, undefined]
lutimes                      1 [null]                          2 [null, undefined]
mkdir                        1 [null]                          2 [null, undefined]
mkdir (recursive, created)   2 [null, "<first dir created>"]   2 [null, "<first dir created>"]
mkdir (recursive, existing)  1 [null]                          2 [null, undefined]
rename                       1 [null]                          2 [null, undefined]
rm                           1 [null]                          2 [null, undefined]
rm (recursive)               1 [null]                          2 [null, undefined]
rmdir                        1 [null]                          2 [null, undefined]
truncate                     1 [null]                          2 [null, undefined]
unlink                       1 [null]                          2 [null, undefined]
utimes                       1 [null]                          2 [null, undefined]
writeFile                    1 [null]                          2 [null, undefined]
```

Unchanged and already matching node: `dir.read` (`(null, dirent)` / `(null, null)`), `dir.close` (`(null)`), and the value-returning operations (`(null, value)`).
</details>
