### PR TITLE
node:fs: drop the error of fs.symlink() when its 4-argument callback is not callable

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -425,9 +425,7 @@ var access = function access(path, mode, callback) {
     } else if ($isCallable(callback)) {
       callback = wrapFsCallback(callback);
     } else {
-      // node does not validate the 4-argument overload's callback; a
-      // non-callable one is skipped on completion, on failure as well as on
-      // success.
+      // node does not validate this overload's callback: it skips a non-function one, on failure too
       callback = discardResult;
     }
 

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -52,6 +52,8 @@ function nullcallback(callback) {
 }
 const FunctionPrototypeBind = nullcallback.bind;
 
+function discardResult() {}
+
 function openAsBlob(path, options) {
   return Promise.$resolve(Bun.file(path, options));
 }
@@ -421,9 +423,12 @@ var access = function access(path, mode, callback) {
       callback = ensureCallback(type);
       type = undefined;
     } else if ($isCallable(callback)) {
-      // Not ensureCallback: node does not validate the 4-argument overload's
-      // callback, and a non-callable one must stay an ignored `.then` handler.
       callback = wrapFsCallback(callback);
+    } else {
+      // node does not validate the 4-argument overload's callback; a
+      // non-callable one is skipped on completion, on failure as well as on
+      // success.
+      callback = discardResult;
     }
 
     fs.symlink(target, path, type).then(callback, callback);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6330,13 +6330,36 @@ describe("a throw from a node-style callback is an uncaughtException", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("leaves a non-callable symlink callback as an ignored handler, like node", async () => {
-    const { stdout, exitCode } = await runScript(`
-      require("fs").symlink(${file}, ${dirLit} + "/lnc", "file", "notafunc");
-      setTimeout(() => console.log("quiet"), 50);
-    `);
-    expect(stdout).toBe("quiet");
-    expect(exitCode).toBe(0);
+  // node does not validate the 4-argument overload's callback: it is stored on
+  // the request as-is and a non-function one is skipped when the operation
+  // completes, whether the link was created or the operation failed. The
+  // pending operation keeps the process alive, so "exited" is printed after
+  // it completed and anything it reported would precede it.
+  describe("ignores a non-callable 4-argument symlink callback, like node", () => {
+    function symlinkIgnoringCallback(link: string, callbackLiteral: string) {
+      return runScript(`
+        process.on("uncaughtException", e => console.log("UNCAUGHT:" + e.code));
+        process.on("unhandledRejection", e => console.log("REJECTED:" + e.code));
+        process.on("exit", () => console.log("exited"));
+        require("fs").symlink(${file}, ${JSON.stringify(link)}, "file", ${callbackLiteral});
+      `);
+    }
+
+    it("still creates the link", async () => {
+      const link = join(dir, "lnc-created");
+      const { stdout, exitCode } = await symlinkIgnoringCallback(link, `"notafunc"`);
+      expect(stdout).toBe("exited");
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+      expect(exitCode).toBe(0);
+    });
+
+    it.each([`"notafunc"`, "null"])("drops the error of a failed operation (callback: %s)", async callbackLiteral => {
+      const link = join(dir, "missing-dir", "lnc");
+      const { stdout, exitCode } = await symlinkIgnoringCallback(link, callbackLiteral);
+      expect(stdout).toBe("exited");
+      expect(existsSync(link)).toBe(false);
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6335,7 +6335,7 @@ describe("a throw from a node-style callback is an uncaughtException", () => {
   // completes, whether the link was created or the operation failed. The
   // pending operation keeps the process alive, so "exited" is printed after
   // it completed and anything it reported would precede it.
-  describe("ignores a non-callable 4-argument symlink callback, like node", () => {
+  describe.concurrent("ignores a non-callable 4-argument symlink callback, like node", () => {
     function symlinkIgnoringCallback(link: string, callbackLiteral: string) {
       return runScript(`
         process.on("uncaughtException", e => console.log("UNCAUGHT:" + e.code));
@@ -6359,6 +6359,17 @@ describe("a throw from a node-style callback is an uncaughtException", () => {
       expect(stdout).toBe("exited");
       expect(existsSync(link)).toBe(false);
       expect(exitCode).toBe(0);
+    });
+
+    // An undefined callback selects the 3-argument overload, whose callback
+    // (here the string "file") node does validate.
+    it("still throws when the callback is undefined", () => {
+      const link = join(dir, "lnc-undefined");
+      expect(() => fs.symlink(join(dir, "file.txt"), link, "file", undefined as any)).toThrowWithCode(
+        TypeError,
+        "ERR_INVALID_ARG_TYPE",
+      );
+      expect(existsSync(link)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### Problem
- `fs.symlink(target, path, type, callback)` with a non-callable `callback` (`"notafunc"`, `null`, `123`, ...) turns a failed operation into an unhandled rejection, and the process exits with 1:
  ```
  $ bun -e "require('fs').symlink('t', '/missing-dir/x', 'file', 123); setTimeout(() => console.log('alive'), 50)"
  ENOENT: no such file or directory, symlink 't' -> '/missing-dir/x'
  ...
  $ echo $?
  1
  ```
- Node v26.3.0 prints `alive` and exits 0. Its `symlink` only validates the callback in the 3-argument overload; in the 4-argument overload the value is stored on the request as-is, and a non-function `oncomplete` is skipped when the operation completes, on failure as well as on success. Bun already matched the success half (there was a test for it), only the failure half diverged.
- Cause: `src/js/node/fs.ts` `symlink` kept the non-callable value and did `fs.symlink(target, path, type).then(callback, callback)`. `then` ignores non-callable handlers, so the derived promise rejected with the operation's error and nothing handled it.

### Fix
- The non-callable branch now installs a no-op (`discardResult`) as the callback, so both `then` handlers are real functions and the operation's outcome is dropped either way. The callable branch and the 3-argument overload (which still throws `ERR_INVALID_ARG_TYPE`) are unchanged, as is the synchronous validation of `target`, `path` and `type`, which happens inside the native call before any promise exists.
- Why this is correct: matches node. Node's `req.oncomplete = callback` plus the non-function skip in `MakeCallback` is exactly "run the operation, drop its outcome"; a no-op on both promise handlers is the same thing in this wrapper. Every other `node:fs` callback function validates its callback (`makeCallback`), so `symlink`'s 4-argument overload is the only place this applies.
- Verified:
  - `test/js/node/fs/fs.test.ts`: the former "leaves a non-callable symlink callback as an ignored handler" test becomes a `describe.concurrent` with four cases: the link is still created (the old success case, now also asserting the link exists); a failing operation (link inside a missing directory) stays silent with a `"notafunc"` and with a `null` callback; and an explicit `undefined` callback still selects the 3-argument overload and throws `ERR_INVALID_ARG_TYPE`, pinning the boundary the new branch sits behind. The spawned cases log any `unhandledRejection`/`uncaughtException` and print `exited` from the `exit` event, so the expected stdout is exactly `exited` and no timer is involved: the pending operation keeps the process alive until it completes. The two failure cases print `REJECTED:ENOENT` before `exited` on the released bun; all four pass with this build.
  - A probe matrix (bad `type`, bad `target`/`path`, the 3-argument overloads, `null`/object/number/falsy callbacks) produces identical output under node v26.3.0 and this build; before the change every defined non-callable printed a rejection.
  - Node's `test-fs-symlink.js`, `-buffer-path`, `-dir`, `-longpath`, `-dir-junction`, `-dir-junction-relative` pass; the rest of `fs.test.ts` passes apart from the pre-existing debug-build timeout of `readdirSync(path, {recursive: true} should work x 100`, which #37828 addresses.
- Related, not covered here: the callable success path still calls `cb(undefined)` where node passes `null`; #38065 fixes that and touches the same `.then` line. With this change `callback` is always callable after the branch, so #38065's `$isCallable` ternary collapses to its bound helper; whichever lands second is a one-line rebase.

### Background
- The callback form of `node:fs` in bun is a thin layer over the promise-returning native binding: each wrapper calls `binding.op(...).then(onSuccess, onError)`, normally after `ensureCallback` has validated and wrapped the user callback.
- `Promise.prototype.then` treats a non-callable handler as absent, so the promise it returns settles the same way as the original. A rejection that reaches such a promise with no further handlers is reported as an unhandled rejection, which exits the process with 1 by default.
- In node, an async fs operation completes through `FSReqCallback`, whose `oncomplete` property holds the user callback. `AsyncWrap::MakeCallback` looks the property up at completion time and returns without calling anything if it is not a function, which is why a non-callable 4-argument `symlink` callback silently drops both results and errors there.
