### PR TITLE
run: honor http_proxy and NODE_TLS_REJECT_UNAUTHORIZED when prefetching markdown images

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3078,7 +3078,8 @@ struct RemoteImageDownload {
     // prefetchRemoteImages (can't be set in the literal because
     // AsyncHTTP.init needs a pointer to response_buffer, which only
     // has a stable address once the owning struct is live).
-    // Self-referential: borrows from `url: Box<[u8]>` below.
+    // Self-referential: borrows from `url: Box<[u8]>` below (and its proxy
+    // URL, if any, from the arena-backed env loader in prefetch_remote_images).
     async_http: bun_http::AsyncHTTP<'static>,
     response_buffer: bun_core::MutableString,
     url: Box<[u8]>,
@@ -3200,6 +3201,16 @@ impl RunCommand {
 
         bun_http::http_thread::init(&Default::default());
 
+        // Lives in the process-lifetime CLI arena (the caller exits right
+        // after rendering) so the proxy URLs borrowed from it below satisfy
+        // the `AsyncHTTP<'static>` stored in each download.
+        let env: &'static DotEnv::Loader = {
+            let env = runner_arena().alloc(DotEnv::Loader::init());
+            env.load_process().unwrap_or_oom();
+            env
+        };
+        let reject_unauthorized = Some(env.get_tls_reject_unauthorized());
+
         // Heap-allocate each Download so AsyncHTTP.task has a stable
         // address (see RemoteImageDownload doc comment).
         let mut downloads: Vec<Box<RemoteImageDownload>> = Vec::new();
@@ -3238,9 +3249,11 @@ impl RunCommand {
                 ::core::slice::from_raw_parts(url.as_ptr(), url.len())
             };
             let d_ptr: *mut RemoteImageDownload = slot;
+            let url = bun_url::URL::parse(url_static);
+            let http_proxy = env.get_http_proxy_for(&url);
             let async_http = bun_http::AsyncHTTP::init(
                 bun_http::Method::GET,
-                bun_url::URL::parse(url_static),
+                url,
                 Default::default(),
                 b"",
                 b"",
@@ -3249,7 +3262,11 @@ impl RunCommand {
                     RemoteImageDownload::on_done,
                 ),
                 bun_http::FetchRedirect::Follow,
-                Default::default(),
+                bun_http::async_http::Options {
+                    http_proxy,
+                    reject_unauthorized,
+                    ..Default::default()
+                },
             );
             // SAFETY: last field — all four fields are now initialized.
             unsafe { ::core::ptr::addr_of_mut!((*slot).async_http).write(async_http) };

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3078,8 +3078,9 @@ struct RemoteImageDownload {
     // prefetchRemoteImages (can't be set in the literal because
     // AsyncHTTP.init needs a pointer to response_buffer, which only
     // has a stable address once the owning struct is live).
-    // Self-referential: borrows from `url: Box<[u8]>` below (and its proxy
-    // URL, if any, from the arena-backed env loader in prefetch_remote_images).
+    // Self-referential: borrows from `url: Box<[u8]>` below. Its proxy URL,
+    // if any, borrows the env loader on prefetch_remote_images' stack, which
+    // outlives every download.
     async_http: bun_http::AsyncHTTP<'static>,
     response_buffer: bun_core::MutableString,
     url: Box<[u8]>,
@@ -3201,11 +3202,10 @@ impl RunCommand {
 
         bun_http::http_thread::init(&Default::default());
 
-        // Lives in the process-lifetime CLI arena (the caller exits right
-        // after rendering) so the proxy URLs borrowed from it below satisfy
-        // the `AsyncHTTP<'static>` stored in each download.
-        let env: &'static DotEnv::Loader = {
-            let env = runner_arena().alloc(DotEnv::Loader::init());
+        // Declared before `downloads`: the proxy URLs handed to the downloads
+        // below are views into this map, so it must be dropped after them.
+        let env = {
+            let mut env = DotEnv::Loader::init();
             env.load_process().unwrap_or_oom();
             env
         };
@@ -3250,7 +3250,13 @@ impl RunCommand {
             };
             let d_ptr: *mut RemoteImageDownload = slot;
             let url = bun_url::URL::parse(url_static);
-            let http_proxy = env.get_http_proxy_for(&url);
+            // SAFETY: the proxy URL is a view into `env`, which is immutable
+            // from here on and declared before `downloads`, so it is dropped
+            // after every AsyncHTTP holding the view; none of them is still
+            // in flight by then because the channel loop below waits for all.
+            let http_proxy = env
+                .get_http_proxy_for(&url)
+                .map(|proxy| unsafe { proxy.erase_lifetime() });
             let async_http = bun_http::AsyncHTTP::init(
                 bun_http::Method::GET,
                 url,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3078,12 +3078,12 @@ struct RemoteImageDownload {
     // prefetchRemoteImages (can't be set in the literal because
     // AsyncHTTP.init needs a pointer to response_buffer, which only
     // has a stable address once the owning struct is live).
-    // Self-referential: borrows from `url: Box<[u8]>` below. Its proxy URL,
-    // if any, borrows the env loader on prefetch_remote_images' stack, which
-    // outlives every download.
+    // Self-referential: borrows from `url` and `proxy` below.
     async_http: bun_http::AsyncHTTP<'static>,
     response_buffer: bun_core::MutableString,
     url: Box<[u8]>,
+    /// Proxy href the env selects for `url`, if any.
+    proxy: Option<Box<[u8]>>,
     done: *const DoneChannel,
 }
 
@@ -3202,13 +3202,8 @@ impl RunCommand {
 
         bun_http::http_thread::init(&Default::default());
 
-        // Declared before `downloads`: the proxy URLs handed to the downloads
-        // below are views into this map, so it must be dropped after them.
-        let env = {
-            let mut env = DotEnv::Loader::init();
-            env.load_process().unwrap_or_oom();
-            env
-        };
+        let mut env = DotEnv::Loader::init();
+        env.load_process().unwrap_or_oom();
         let reject_unauthorized = Some(env.get_tls_reject_unauthorized());
 
         // Heap-allocate each Download so AsyncHTTP.task has a stable
@@ -3227,11 +3222,14 @@ impl RunCommand {
             let Ok(response_buffer) = bun_core::MutableString::init(8 * 1024) else {
                 continue;
             };
+            let proxy: Option<Box<[u8]>> = env
+                .get_http_proxy_for(&bun_url::URL::parse(&raw_url))
+                .map(|proxy| Box::from(proxy.href));
             // `AsyncHTTP` holds non-nullable `fn()` pointers (result_callback,
             // task.callback), so `mem::zeroed()` would be instant UB. Allocate
             // an uninit `Box`, write the cheap fields first to obtain stable
-            // heap addresses for `url`/`response_buffer`, then `ptr::write`
-            // the fully-formed `AsyncHTTP` last.
+            // heap addresses for `url`/`proxy`/`response_buffer`, then
+            // `ptr::write` the fully-formed `AsyncHTTP` last.
             let mut d: Box<::core::mem::MaybeUninit<RemoteImageDownload>> =
                 Box::new(::core::mem::MaybeUninit::uninit());
             let slot = d.as_mut_ptr();
@@ -3240,23 +3238,21 @@ impl RunCommand {
             unsafe {
                 ::core::ptr::addr_of_mut!((*slot).response_buffer).write(response_buffer);
                 ::core::ptr::addr_of_mut!((*slot).url).write(raw_url);
+                ::core::ptr::addr_of_mut!((*slot).proxy).write(proxy);
                 ::core::ptr::addr_of_mut!((*slot).done).write(&raw const done_channel);
             }
-            // SAFETY: `(*slot).url` is heap-owned and outlives the AsyncHTTP
-            // (freed only when `downloads` drops after the channel drains).
-            let url_static: &'static [u8] = unsafe {
-                let url = &*::core::ptr::addr_of!((*slot).url);
-                ::core::slice::from_raw_parts(url.as_ptr(), url.len())
+            // SAFETY: `(*slot).url` and `(*slot).proxy` are heap-owned and outlive
+            // the AsyncHTTP (freed only when `downloads` drops after the channel
+            // drains).
+            let (url, http_proxy): (bun_url::URL<'static>, Option<bun_url::URL<'static>>) = unsafe {
+                let url: &[u8] = &*::core::ptr::addr_of!((*slot).url);
+                let proxy: Option<&[u8]> = (*::core::ptr::addr_of!((*slot).proxy)).as_deref();
+                (
+                    bun_url::URL::parse(bun_ptr::detach_lifetime(url)),
+                    proxy.map(|href| bun_url::URL::parse(bun_ptr::detach_lifetime(href))),
+                )
             };
             let d_ptr: *mut RemoteImageDownload = slot;
-            let url = bun_url::URL::parse(url_static);
-            // SAFETY: the proxy URL is a view into `env`, which is immutable
-            // from here on and declared before `downloads`, so it is dropped
-            // after every AsyncHTTP holding the view; none of them is still
-            // in flight by then because the channel loop below waits for all.
-            let http_proxy = env
-                .get_http_proxy_for(&url)
-                .map(|proxy| unsafe { proxy.erase_lifetime() });
             let async_http = bun_http::AsyncHTTP::init(
                 bun_http::Method::GET,
                 url,
@@ -3274,7 +3270,7 @@ impl RunCommand {
                     ..Default::default()
                 },
             );
-            // SAFETY: last field — all four fields are now initialized.
+            // SAFETY: last field — all five fields are now initialized.
             unsafe { ::core::ptr::addr_of_mut!((*slot).async_http).write(async_http) };
             // SAFETY: every field of `RemoteImageDownload` was `ptr::write`n above.
             let mut d: Box<RemoteImageDownload> = unsafe {

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -417,12 +417,12 @@ describe("bun <file.md>", () => {
   );
 });
 
-// The prefetch only runs when stdout is a TTY (hence the pty, which is
-// POSIX-only) and the terminal looks like Kitty. It stages whatever bytes it
-// receives without inspecting them, so each server below answers with its own
+// The prefetch only runs when stdout is a TTY (hence the `terminal` option)
+// and the terminal looks like Kitty. It stages whatever bytes it receives
+// without inspecting them, so each server below answers with its own
 // recognizable body and the tests assert which one got staged, next to what
 // each server saw.
-describe.concurrent.skipIf(!isPosix)("bun <file.md> remote image prefetch honors the proxy and TLS env", () => {
+describe.concurrent("bun <file.md> remote image prefetch honors the proxy and TLS env", () => {
   const ORIGIN_BODY = "image bytes served by the origin";
   const PROXY_BODY = "image bytes served by the proxy";
 

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, rmSync, symlinkSync } from "fs";
 import { bunEnv, bunExe, isASAN, isDebug, isPosix, tempDir, tls } from "harness";
-import { once } from "node:events";
-import net from "node:net";
 import { join } from "path";
 
 // The remote-image prefetch reads the proxy and TLS variables from the
@@ -428,9 +426,12 @@ describe.concurrent.skipIf(!isPosix)("bun <file.md> remote image prefetch honors
   const ORIGIN_BODY = "image bytes served by the origin";
   const PROXY_BODY = "image bytes served by the proxy";
 
-  // An HTTP proxy receives the target as an absolute URL, so `req.url` here is
-  // the image URL the child asked for. Answering in the origin's place (rather
-  // than forwarding) lets the staged bytes show whose answer was used.
+  // Serves as the origin or as the proxy. A proxy is asked for an http target
+  // as `GET <absolute image URL>` and for an https target as `CONNECT
+  // host:port`; `req.url` carries that target either way. Answering in the
+  // origin's place (rather than forwarding) lets the staged bytes show whose
+  // answer was used, and refusing the tunnel is enough since these tests are
+  // only about where the request went.
   function recordingServer(body: string, options: { tls?: typeof tls } = {}) {
     const log: string[] = [];
     const server = Bun.serve({
@@ -439,6 +440,7 @@ describe.concurrent.skipIf(!isPosix)("bun <file.md> remote image prefetch honors
       tls: options.tls,
       fetch(req) {
         log.push(`${req.method} ${req.url}`);
+        if (req.method === "CONNECT") return new Response(null, { status: 403 });
         return new Response(body, { headers: { "content-type": "image/png" } });
       },
     });
@@ -447,39 +449,6 @@ describe.concurrent.skipIf(!isPosix)("bun <file.md> remote image prefetch honors
       port: server.port,
       [Symbol.dispose]() {
         server.stop(true);
-      },
-    };
-  }
-
-  // https targets reach a proxy as `CONNECT host:port`. Bun.serve does not
-  // take CONNECT, so record the request line on a raw socket and refuse the
-  // tunnel: routing is all these tests are about.
-  async function connectRecorder() {
-    const log: string[] = [];
-    const sockets = new Set<net.Socket>();
-    const server = net.createServer(socket => {
-      sockets.add(socket);
-      socket.on("error", () => {});
-      socket.on("close", () => sockets.delete(socket));
-      let head = "";
-      socket.on("data", chunk => {
-        if (head.includes("\r\n")) return;
-        head += chunk.toString("latin1");
-        const eol = head.indexOf("\r\n");
-        if (eol === -1) return;
-        log.push(head.slice(0, eol));
-        socket.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n");
-      });
-    });
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    return {
-      log,
-      port: (server.address() as net.AddressInfo).port,
-      async [Symbol.asyncDispose]() {
-        for (const socket of sockets) socket.destroy();
-        server.close();
-        await once(server, "close");
       },
     };
   }
@@ -533,13 +502,13 @@ describe.concurrent.skipIf(!isPosix)("bun <file.md> remote image prefetch honors
 
   test("https image asks https_proxy for a CONNECT tunnel", async () => {
     using origin = recordingServer(ORIGIN_BODY, { tls });
-    await using proxy = await connectRecorder();
+    using proxy = recordingServer(PROXY_BODY);
     const imageUrl = `https://127.0.0.1:${origin.port}/img.png`;
 
     const { exitCode, staged } = await prefetch(imageUrl, { https_proxy: `http://127.0.0.1:${proxy.port}` });
 
     expect({ proxy: proxy.log, origin: origin.log, staged }).toEqual({
-      proxy: [`CONNECT 127.0.0.1:${origin.port} HTTP/1.1`],
+      proxy: [`CONNECT 127.0.0.1:${origin.port}`],
       origin: [],
       staged: [],
     });

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -1,7 +1,22 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, rmSync, symlinkSync } from "fs";
-import { bunEnv, bunExe, isASAN, isDebug, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isPosix, tempDir, tls } from "harness";
+import { once } from "node:events";
+import net from "node:net";
 import { join } from "path";
+
+// The remote-image prefetch reads the proxy and TLS variables from the
+// process env, and `bunEnv` carries whatever the host has set in them. Spread
+// this after `bunEnv` so a test only sees the variables it sets itself.
+const withoutProxyEnv = {
+  http_proxy: undefined,
+  HTTP_PROXY: undefined,
+  https_proxy: undefined,
+  HTTPS_PROXY: undefined,
+  no_proxy: undefined,
+  NO_PROXY: undefined,
+  NODE_TLS_REJECT_UNAUTHORIZED: undefined,
+};
 
 // Tracks exit code from the last runMd() call so individual tests can
 // assert it after snapshotting stdout (giving a readable diff on failure).
@@ -365,6 +380,7 @@ describe("bun <file.md>", () => {
       const decoy = join(tmp, "decoy");
       const env = {
         ...bunEnv,
+        ...withoutProxyEnv,
         FORCE_COLOR: "1",
         TERM: "xterm-kitty",
         KITTY_WINDOW_ID: "1",
@@ -401,4 +417,170 @@ describe("bun <file.md>", () => {
       expect(secondExit).toBe(0);
     },
   );
+});
+
+// The prefetch only runs when stdout is a TTY (hence the pty, which is
+// POSIX-only) and the terminal looks like Kitty. It stages whatever bytes it
+// receives without inspecting them, so each server below answers with its own
+// recognizable body and the tests assert which one got staged, next to what
+// each server saw.
+describe.concurrent.skipIf(!isPosix)("bun <file.md> remote image prefetch honors the proxy and TLS env", () => {
+  const ORIGIN_BODY = "image bytes served by the origin";
+  const PROXY_BODY = "image bytes served by the proxy";
+
+  // An HTTP proxy receives the target as an absolute URL, so `req.url` here is
+  // the image URL the child asked for. Answering in the origin's place (rather
+  // than forwarding) lets the staged bytes show whose answer was used.
+  function recordingServer(body: string, options: { tls?: typeof tls } = {}) {
+    const log: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: options.tls,
+      fetch(req) {
+        log.push(`${req.method} ${req.url}`);
+        return new Response(body, { headers: { "content-type": "image/png" } });
+      },
+    });
+    return {
+      log,
+      port: server.port,
+      [Symbol.dispose]() {
+        server.stop(true);
+      },
+    };
+  }
+
+  // https targets reach a proxy as `CONNECT host:port`. Bun.serve does not
+  // take CONNECT, so record the request line on a raw socket and refuse the
+  // tunnel: routing is all these tests are about.
+  async function connectRecorder() {
+    const log: string[] = [];
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer(socket => {
+      sockets.add(socket);
+      socket.on("error", () => {});
+      socket.on("close", () => sockets.delete(socket));
+      let head = "";
+      socket.on("data", chunk => {
+        if (head.includes("\r\n")) return;
+        head += chunk.toString("latin1");
+        const eol = head.indexOf("\r\n");
+        if (eol === -1) return;
+        log.push(head.slice(0, eol));
+        socket.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    return {
+      log,
+      port: (server.address() as net.AddressInfo).port,
+      async [Symbol.asyncDispose]() {
+        for (const socket of sockets) socket.destroy();
+        server.close();
+        await once(server, "close");
+      },
+    };
+  }
+
+  // Renders a document with one remote image and resolves once the child has
+  // exited; the prefetch blocks on every download before rendering, so by then
+  // the servers have seen everything they are going to see. Returns the bodies
+  // the prefetch staged into BUN_TMPDIR.
+  async function prefetch(imageUrl: string, env: Record<string, string>) {
+    using dir = tempDir("md-remote-img-env-", {
+      "doc.md": `![img](${imageUrl})\n`,
+      "tmp/.keep": "",
+    });
+    const tmp = join(String(dir), "tmp");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./doc.md"],
+      env: {
+        ...bunEnv,
+        ...withoutProxyEnv,
+        FORCE_COLOR: "1",
+        TERM: "xterm-kitty",
+        KITTY_WINDOW_ID: "1",
+        BUN_TMPDIR: tmp,
+        ...env,
+      },
+      cwd: String(dir),
+      terminal: { cols: 80, rows: 24, data() {} },
+    });
+    const exitCode = await proc.exited;
+    proc.terminal?.close();
+    const staged = readdirSync(tmp)
+      .filter(name => name.startsWith("bun-md-"))
+      .map(name => readFileSync(join(tmp, name), "utf8"));
+    return { exitCode, staged };
+  }
+
+  test("http image is requested through http_proxy", async () => {
+    using origin = recordingServer(ORIGIN_BODY);
+    using proxy = recordingServer(PROXY_BODY);
+    const imageUrl = `http://127.0.0.1:${origin.port}/img.png`;
+
+    const { exitCode, staged } = await prefetch(imageUrl, { http_proxy: `http://127.0.0.1:${proxy.port}` });
+
+    expect({ proxy: proxy.log, origin: origin.log, staged }).toEqual({
+      proxy: [`GET ${imageUrl}`],
+      origin: [],
+      staged: [PROXY_BODY],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("https image asks https_proxy for a CONNECT tunnel", async () => {
+    using origin = recordingServer(ORIGIN_BODY, { tls });
+    await using proxy = await connectRecorder();
+    const imageUrl = `https://127.0.0.1:${origin.port}/img.png`;
+
+    const { exitCode, staged } = await prefetch(imageUrl, { https_proxy: `http://127.0.0.1:${proxy.port}` });
+
+    expect({ proxy: proxy.log, origin: origin.log, staged }).toEqual({
+      proxy: [`CONNECT 127.0.0.1:${origin.port} HTTP/1.1`],
+      origin: [],
+      staged: [],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("image host listed in NO_PROXY is requested directly", async () => {
+    using origin = recordingServer(ORIGIN_BODY);
+    using proxy = recordingServer(PROXY_BODY);
+    const imageUrl = `http://127.0.0.1:${origin.port}/img.png`;
+
+    const { exitCode, staged } = await prefetch(imageUrl, {
+      http_proxy: `http://127.0.0.1:${proxy.port}`,
+      NO_PROXY: "127.0.0.1",
+    });
+
+    expect({ proxy: proxy.log, origin: origin.log, staged }).toEqual({
+      proxy: [],
+      origin: [`GET ${imageUrl}`],
+      staged: [ORIGIN_BODY],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("NODE_TLS_REJECT_UNAUTHORIZED=0 accepts a self-signed https image", async () => {
+    using origin = recordingServer(ORIGIN_BODY, { tls });
+    const imageUrl = `https://127.0.0.1:${origin.port}/img.png`;
+
+    const { exitCode, staged } = await prefetch(imageUrl, { NODE_TLS_REJECT_UNAUTHORIZED: "0" });
+
+    expect({ origin: origin.log, staged }).toEqual({ origin: [`GET ${imageUrl}`], staged: [ORIGIN_BODY] });
+    expect(exitCode).toBe(0);
+  });
+
+  test("self-signed https image is still rejected by default", async () => {
+    using origin = recordingServer(ORIGIN_BODY, { tls });
+    const imageUrl = `https://127.0.0.1:${origin.port}/img.png`;
+
+    const { exitCode, staged } = await prefetch(imageUrl, {});
+
+    expect({ origin: origin.log, staged }).toEqual({ origin: [], staged: [] });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun README.md` in a Kitty-compatible terminal downloads the document's `http(s)` images so they can be drawn inline. With `http_proxy` / `https_proxy` set (a network that is only reachable through the proxy), every one of those downloads connects to the image host directly and fails. The prefetch is silent by design (the image falls back to its alt text), so the user just never sees images and nothing says the proxy env was ignored.
- The same downloads always verify certificates, so `NODE_TLS_REJECT_UNAUTHORIZED=0` is ignored here as well, unlike `bun install`, `bun pm view`, `bun upgrade`, `bun create` and `bun build --compile`.
- Cause: `prefetch_remote_images` (`src/runtime/cli/run_command.rs`) builds each download with `AsyncHTTP::init(..., Options::default())`, so `http_proxy` is `None` and `reject_unauthorized` stays at its default. No env loader is available to it (it is reached from `boot_and_handle_error`, before the VM and its env loading exist), so nothing was reading the variables. `bun install`, `bun audit`, `bun pm view`, `bun upgrade`, `bun create` and the `bun build --compile` target download all resolve the proxy through `Loader::get_http_proxy_for`.
- Not covered here: `bun publish` / `bun pm whoami` get the same proxy treatment in #38075, and `bun audit`, `bun publish` and `bun pm whoami` also never set `reject_unauthorized` (`audit_command.rs`, `publish_command.rs`, `install/npm.rs`); that is left for a follow-up, since each of those sites reads its settings from a `PackageManager` rather than from a loader of its own.
- Probe with the released `bun` 1.4.0 (details below): with `http_proxy` pointing at a local recording proxy and `NO_PROXY` unset, the origin logs `GET /img.png` and the proxy logs nothing.

### Fix
- `prefetch_remote_images` loads the process environment into a local `bun_dotenv::Loader` (only once it knows there is at least one remote image, next to the existing `http_thread::init`). For each image it copies the href returned by `env.get_http_proxy_for(&url)` into a new `proxy: Option<Box<[u8]>>` field on that image's `RemoteImageDownload`, and builds the request with `http_proxy` parsed from that field and `reject_unauthorized: Some(env.get_tls_reject_unauthorized())`.
- The request already borrows its URL from the `url` buffer owned by the same download (the struct is documented as self-referential for that reason); the proxy href gets the same owner, so the one existing invariant (the buffers are freed when the download is, after the channel loop has waited for every request) covers both, and nothing borrows the loader. An earlier revision parked the loader in the CLI arena instead; LeakSanitizer does not scan the arena, so the asan lane reported the loader's map as leaked and aborted every prefetching run (build 94315).
- Why this is right: `get_http_proxy_for` is the one definition of how the proxy env applies to a CLI download (`http_proxy` for `http://` targets, `https_proxy` for `https://`, nothing for hosts matching `NO_PROXY`), and it is resolved per image URL because a document can reference several hosts. Process env is the right source: the markdown renderer never loads `.env` files and should not start to because of images. With no proxy variables set, `get_http_proxy_for` returns `None` and `get_tls_reject_unauthorized` returns `true`, so behaviour is unchanged from before.
- Tests, in `test/cli/run/markdown-entrypoint.test.ts` (a new `describe`; the prefetch only runs when stdout is a TTY, so the child is spawned with `Bun.spawn`'s `terminal` option, which is a pty on POSIX and ConPTY on Windows, so the tests run on every lane): an `http` image is requested from the `http_proxy` as `GET http://127.0.0.1:<origin>/img.png` and the proxy's body is what gets staged; an `https` image reaches the `https_proxy` as `CONNECT 127.0.0.1:<origin>`; a host listed in `NO_PROXY` is fetched directly; a self-signed `https` image is fetched with `NODE_TLS_REJECT_UNAUTHORIZED=0` and still rejected without it. Each test also asserts what the other server did not see. The existing staging test now clears the ambient proxy variables, since the prefetch reads them from this change on.
  - `USE_SYSTEM_BUN=1 bun test test/cli/run/markdown-entrypoint.test.ts`: the `http_proxy`, `https_proxy` and `NODE_TLS_REJECT_UNAUTHORIZED=0` tests fail (origin gets the request, proxy sees nothing, nothing fetched from the self-signed server), the two negative tests pass.
  - `bun bd test test/cli/run/markdown-entrypoint.test.ts`: 35 pass on Linux, also with the asan lane's `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1` and `LSAN_OPTIONS` exported the way `scripts/runner.node.mjs` sets them.
  - Same two runs on Windows x64 (ConPTY): the same 3 tests fail on the released binary and the file passes with the debug build (34 pass, 1 skip: the pre-existing POSIX-only staging test).

### Background
- The Kitty graphics protocol lets a terminal draw an image from a file on disk. When `bun <file>.md` renders to a terminal that supports it (`KITTY_WINDOW_ID` set, a Kitty-like `TERM`, or a probe answers), `prefetch_remote_images` downloads every `http(s)` image in the document into temp files before rendering; every failure is silent and the image is rendered as its alt text instead. This is why the symptom is simply "no images".
- `AsyncHTTP` (`src/http/AsyncHTTP.rs`) is the request object behind `fetch()` and the CLI's downloads. Its `Options::http_proxy` is the only way a request learns about a proxy: for an `http://` target the client connects to the proxy and sends the request with an absolute URL (`GET http://host:port/path`), for an `https://` target it asks the proxy for a `CONNECT host:port` tunnel. `Options::reject_unauthorized` is the certificate verification switch, `true` by default. `bun_url::URL<'a>` is a borrowed view (every component is a slice of the bytes it was parsed from, and `href` is the whole input), which is why the prefetch keeps the bytes of both URLs alive on the download for as long as the request runs.
- `bun_dotenv::Loader` is Bun's env map. `load_process()` copies the process environment into it; `get_http_proxy_for(&url)` reads `http_proxy`/`HTTP_PROXY` or `https_proxy`/`HTTPS_PROXY` depending on the URL's scheme and returns `None` if the URL's host matches `no_proxy`/`NO_PROXY`; `get_tls_reject_unauthorized()` is `NODE_TLS_REJECT_UNAUTHORIZED != "0"`. `bun upgrade`, `bun create` and `bun pm cache rm` create a loader this same way for their own one-shot commands.

<details>
<summary>Probe against the released binary (bun 1.4.0)</summary>

Recording proxy in `http_proxy`, origin on `127.0.0.1` counting direct hits, `NO_PROXY` unset, `bun ./doc.md` spawned under a pty with `KITTY_WINDOW_ID=1` where `doc.md` contains one image pointing at the origin:

```
released bun 1.4.0:
  proxyLog:   []
  directHits: ["GET /img.png"]

with this change:
  proxyLog:   ["GET http://127.0.0.1:42459/img.png"]
  directHits: []
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/markdown-entrypoint.test.ts
bun test v1.4.0 (422f8fc7b)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [189.04ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [135.13ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [129.31ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [128.73ms]
(pass) bun <file.md> > renders horizontal rules [125.00ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [131.77ms]
(pass) bun <file.md> > renders fenced code block without language [139.61ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [204.07ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [1137.64ms]
(pass) bun <file.md> > renders link with text + url pair fallback [121.45ms]
(pass) bun <file.md> > renders images as alt text with link [114.43ms]
(pass) bun <file.md> > renders wikilinks [122.82ms]
(pass) bun <file.md> > falls back to 
... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [12.14ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [5.61ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [3.22ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [6.25ms]
(pass) bun <file.md> > renders horizontal rules [4.32ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [3.36ms]
(pass) bun <file.md> > renders fenced code block without language [5.96ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [11.41ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [22.41ms]
(pass) bun <file.md> > renders link with text + url pair fallback [4.47ms]
(pass) bun <file.md> > renders images as alt text with link [3.85ms]
(pass) bun <file.md> > renders wikilinks [14.03ms]
(pass) bun <file.md> > falls back to literal text when `[[` never closes [3.90ms]
(pass) bun <file.md> > renders simple table with alignment [3.94ms]
(pass) bun <file.md> > renders table with CJK multi-width graphemes [6.22
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/markdown-entrypoint.test.ts
bun test v1.4.0 (422f8fc7b)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [168.35ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [117.25ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [119.69ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [117.82ms]
(pass) bun <file.md> > renders horizontal rules [121.68ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [126.10ms]
(pass) bun <file.md> > renders fenced code block without language [117.47ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [127.97ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [1157.23ms]
(pass) bun <file.md> > renders link with text + url pair fallback [125.96ms]
(pass) bun <file.md> > renders images as alt text with link [113.60ms]
(pass) bun <file.md> > renders wikilinks [118.95ms]
(pass) bun <file.md> > falls back to 
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     422f8fc7b2
  features     baseline

22 deps, 123 codegen, 1176 objects in 716ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [14.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [9.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] gen .bind.ts → GeneratedBindings.cpp
[7/1238] fetch zlib
[zlib] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [28.00ms]
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/run_command.rs           |  41 ++++++---
 test/cli/run/markdown-entrypoint.test.ts | 153 ++++++++++++++++++++++++++++++-
 2 files changed, 182 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/cli/run_command.rs               10     11      0
test/cli/run/markdown-entrypoint.test.ts      5     10      0
```

</details>

<!-- robobun:evidence:end -->