### PR TITLE
node:module: throw instead of crashing when _resolveFilename is set to a non-callable

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -231,32 +231,33 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
     if (!isESM) {
         if (globalObject) [[likely]] {
             if (globalObject->hasOverriddenModuleResolveFilenameFunction) [[unlikely]] {
-                auto overrideHandler = uncheckedDowncast<JSObject>(globalObject->m_moduleResolveFilenameFunction.getInitializedOnMainThread(globalObject));
-                if (overrideHandler) [[likely]] {
-                    ASSERT(overrideHandler->isCallable());
-
-                    MarkedArgumentBuffer args;
-                    args.append(moduleName);
-                    args.append(parentModule);
-                    args.append(jsBoolean(false));
-                    args.append(resolveFilenameOptions);
-
-                    JSValue thisValue = globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
-                    JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, overrideHandler, JSC::getCallData(overrideHandler), thisValue, args);
-                    RETURN_IF_EXCEPTION(scope, {});
-                    if (!isRequireDotResolve) {
-                        JSString* string = result.toString(globalObject);
-                        RETURN_IF_EXCEPTION(scope, {});
-                        auto str = string->value(globalObject);
-                        RETURN_IF_EXCEPTION(scope, {});
-                        WTF::String prefixed = Bun::isUnprefixedNodeBuiltin(str);
-                        if (!prefixed.isNull()) {
-                            return JSValue::encode(jsString(vm, prefixed));
-                        }
-                        return JSC::JSValue::encode(string);
-                    }
-                    return JSC::JSValue::encode(result);
+                JSValue overrideHandler = globalObject->m_moduleResolveFilenameOverride.get();
+                JSC::CallData overrideCallData = JSC::getCallData(overrideHandler);
+                if (overrideCallData.type == JSC::CallData::Type::None) [[unlikely]] {
+                    return JSC::throwVMTypeError(lexicalGlobalObject, scope, "Module._resolveFilename is not a function"_s);
                 }
+
+                MarkedArgumentBuffer args;
+                args.append(moduleName);
+                args.append(parentModule);
+                args.append(jsBoolean(false));
+                args.append(resolveFilenameOptions);
+
+                JSValue thisValue = globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
+                JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, overrideHandler, overrideCallData, thisValue, args);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (!isRequireDotResolve) {
+                    JSString* string = result.toString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    auto str = string->value(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    WTF::String prefixed = Bun::isUnprefixedNodeBuiltin(str);
+                    if (!prefixed.isNull()) {
+                        return JSValue::encode(jsString(vm, prefixed));
+                    }
+                    return JSC::JSValue::encode(string);
+                }
+                return JSC::JSValue::encode(result);
             }
         }
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -486,9 +486,7 @@ public:
     /* TODO: these should use LazyProperty */                                                                \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_moduleResolveFilenameFunction)                       \
-    /* Whatever user code assigned to require("module")._resolveFilename. Like Node's plain data */          \
-    /* property it holds any value; require() throws if it is not callable. Only meaningful while */         \
-    /* hasOverriddenModuleResolveFilenameFunction is set. */                                                 \
+    /* The user-assigned Module._resolveFilename value; require() throws if it is not callable. */           \
     V(public, WriteBarrier<JSC::Unknown>, m_moduleResolveFilenameOverride)                                   \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -485,7 +485,11 @@ public:
                                                                                                              \
     /* TODO: these should use LazyProperty */                                                                \
                                                                                                              \
-    V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleResolveFilenameFunction)                           \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_moduleResolveFilenameFunction)                       \
+    /* Whatever user code assigned to require("module")._resolveFilename. Like Node's plain data */          \
+    /* property it holds any value; require() throws if it is not callable. Only meaningful while */         \
+    /* hasOverriddenModuleResolveFilenameFunction is set. */                                                 \
+    V(public, WriteBarrier<JSC::Unknown>, m_moduleResolveFilenameOverride)                                   \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -418,6 +418,9 @@ JSC_DEFINE_CUSTOM_GETTER(nodeModuleResolveFilename,
         PropertyName propertyName))
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    if (globalObject->hasOverriddenModuleResolveFilenameFunction) [[unlikely]] {
+        return JSValue::encode(globalObject->m_moduleResolveFilenameOverride.get());
+    }
     return JSValue::encode(
         globalObject->m_moduleResolveFilenameFunction.getInitializedOnMainThread(
             globalObject));
@@ -430,20 +433,26 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleResolveFilename,
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto value = JSValue::decode(encodedValue);
-    if (value.isCell()) {
-        bool isOriginal = false;
-        if (value.isCallable()) {
-            JSC::CallData callData = JSC::getCallData(value);
+    bool isOriginal = false;
+    if (value.isCallable()) {
+        JSC::CallData callData = JSC::getCallData(value);
 
-            if (callData.type == JSC::CallData::Type::Native) {
-                if (callData.native.function.untaggedPtr() == &jsFunctionResolveFileName) {
-                    isOriginal = true;
-                }
+        if (callData.type == JSC::CallData::Type::Native) {
+            if (callData.native.function.untaggedPtr() == &jsFunctionResolveFileName) {
+                isOriginal = true;
             }
         }
-        globalObject->hasOverriddenModuleResolveFilenameFunction = !isOriginal;
-        globalObject->m_moduleResolveFilenameFunction.set(
-            lexicalGlobalObject->vm(), globalObject, value.asCell());
+    }
+
+    if (isOriginal) {
+        globalObject->hasOverriddenModuleResolveFilenameFunction = false;
+        globalObject->m_moduleResolveFilenameOverride.clear();
+    } else {
+        // Any value is accepted, as with Node's plain data property; whether it
+        // is callable is checked when require() goes to call it.
+        globalObject->m_moduleResolveFilenameOverride.set(
+            lexicalGlobalObject->vm(), globalObject, value);
+        globalObject->hasOverriddenModuleResolveFilenameFunction = true;
     }
 
     return true;
@@ -1144,7 +1153,7 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
         });
 
     globalObject->m_moduleResolveFilenameFunction.initLater(
-        [](const Zig::GlobalObject::Initializer<JSCell>& init) {
+        [](const Zig::GlobalObject::Initializer<JSFunction>& init) {
             JSFunction* resolveFilenameFunction = JSFunction::create(
                 init.vm, init.owner, 2, "_resolveFilename"_s,
                 jsFunctionResolveFileName, JSC::ImplementationVisibility::Public,

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -448,8 +448,6 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleResolveFilename,
         globalObject->hasOverriddenModuleResolveFilenameFunction = false;
         globalObject->m_moduleResolveFilenameOverride.clear();
     } else {
-        // Any value is accepted, as with Node's plain data property; whether it
-        // is callable is checked when require() goes to call it.
         globalObject->m_moduleResolveFilenameOverride.set(
             lexicalGlobalObject->vm(), globalObject, value);
         globalObject->hasOverriddenModuleResolveFilenameFunction = true;

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -790,7 +790,7 @@ console.log("survived", require("./late.js"));`,
       `,
     });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.cjs"],
+      cmd: [bunExe(), path.join(String(dir), "main.cjs")],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -746,6 +746,76 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  test("Overwriting _resolveFilename with a non-callable makes require() throw like Node", async () => {
+    // Node keeps _resolveFilename as a plain data property: any value can be
+    // assigned and reads back, and require() throws when it goes to call it.
+    using dir = tempDir("resolve-filename-non-callable", {
+      "dep.cjs": `module.exports = "dep";`,
+      "main.cjs": `
+        const Module = require("module");
+        const original = Module._resolveFilename;
+        const attempt = fn => {
+          try {
+            return "returned " + String(fn());
+          } catch (e) {
+            return e.constructor.name + ": " + e.message;
+          }
+        };
+        const results = {};
+        for (const [label, value] of [
+          ["object", {}],
+          ["string", "not a function"],
+          ["undefined", undefined],
+          ["null", null],
+          ["number", 42],
+          ["symbol", Symbol("s")],
+        ]) {
+          Module._resolveFilename = value;
+          results[label] = {
+            readsBack: Object.is(Module._resolveFilename, value),
+            require: attempt(() => require("./dep.cjs")),
+            requireResolve: attempt(() => require.resolve("./dep.cjs")),
+            createRequire: attempt(() => Module.createRequire(__filename)("./dep.cjs")),
+          };
+        }
+        // Callable objects other than plain functions are still honored.
+        Module._resolveFilename = new Proxy(original, {});
+        results.callableProxy = attempt(() => require("./dep.cjs"));
+        Module._resolveFilename = original;
+        results.restored = {
+          readsBack: Module._resolveFilename === original,
+          require: attempt(() => require("./dep.cjs")),
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const notAFunction = {
+      readsBack: true,
+      require: "TypeError: Module._resolveFilename is not a function",
+      requireResolve: "TypeError: Module._resolveFilename is not a function",
+      createRequire: "TypeError: Module._resolveFilename is not a function",
+    };
+    expect(JSON.parse(stdout)).toEqual({
+      object: notAFunction,
+      string: notAFunction,
+      undefined: notAFunction,
+      null: notAFunction,
+      number: notAFunction,
+      symbol: notAFunction,
+      callableProxy: "returned dep",
+      restored: { readsBack: true, require: "returned dep" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("Overwriting Module.prototype.require", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", path.join(import.meta.dir, "modulePrototypeOverwrite.cjs")],


### PR DESCRIPTION
### Problem
- `require("module")._resolveFilename = {}` (or a string, or any other non-callable object) followed by `require("./x")` or `require.resolve("./x")` crashes the process: `panic(main thread): Segmentation fault at address 0x5` in release builds, `ASSERTION FAILED: overrideHandler->isCallable()` at `ImportMetaObject.cpp:231` (`functionImportMeta__resolveSyncPrivate`) in debug builds.
- Node throws `TypeError: Module._resolveFilename is not a function` from the `require()` call instead; the assignment itself is allowed and the property reads back as whatever was assigned.
- Cause: the custom setter `setNodeModuleResolveFilename` (`src/jsc/modules/NodeModuleModule.cpp:439`) stores any cell into `m_moduleResolveFilenameFunction`, the `LazyProperty` that otherwise holds the builtin, and sets `hasOverriddenModuleResolveFilenameFunction`. The `require()` path (`src/jsc/bindings/ImportMetaObject.cpp:228`) then downcasts the stored cell to a `JSObject` and calls it, trusting the assertion that it is callable. The same setter silently dropped non-cell values (`undefined`, `null`, numbers), so `Module._resolveFilename = undefined` left the builtin in place, unlike Node.

### Fix
- Adds a `WriteBarrier<JSC::Unknown>` slot (`m_moduleResolveFilenameOverride`) on the global object for the user-assigned value. The setter stores whatever was assigned there (any value, as a plain data property would) and flags the override; assigning the builtin back clears both. `m_moduleResolveFilenameFunction` now only ever holds the builtin and is typed `LazyProperty<JSFunction>` accordingly. The getter returns the override while one is set.
- The slot lives on `Zig::GlobalObject` because the rest of this feature's per-realm state (the builtin's slot and `hasOverriddenModuleResolveFilenameFunction`) already does, and it sits next to them; the `Module` constructor object itself is a plain `InternalFunction` with no fields of its own, so holding the value there would mean splitting the state across two objects. `hasOverriddenModuleResolveFilenameFunction` is kept as the fast-path check (it is also what `bun:internal-for-testing` exposes and what #36871 snapshots).
- `functionImportMeta__resolveSyncPrivate` looks up the override's `CallData` once; when there is none it throws `TypeError: Module._resolveFilename is not a function`, otherwise it calls through as before. Callable non-functions (e.g. a `Proxy` around a function) keep working because the check is `getCallData`, not a `JSFunction` type check.
- Why this is correct: it matches Node. `_resolveFilename` there is a plain data property, so assignment always succeeds and reads back, and only `Module._load` calling it throws; `require()`, `require.resolve()` and `createRequire()` requires all reach that one call, and in Bun all three reach this one native function, so a single check covers them. ESM resolution does not consult `_resolveFilename` in either runtime and is unchanged (the check is inside the existing `!isESM` branch).
- Verified with `test/js/node/module/node-module-module.test.js` ("Overwriting _resolveFilename with a non-callable makes require() throw like Node"), which runs a child that assigns `{}`, a string, `undefined`, `null`, a number and a symbol and checks that each reads back and that `require`, `require.resolve` and a `createRequire` require throw Node's message, that a callable `Proxy` override is honored, and that restoring the original makes `require` work again. The child's expected output was generated by running the same script under Node v26.3.0. The test crashes the child on the released binary and passes with this change.
- Also ran `test/js/bun/resolve/import-meta.test.js` (covers the slow-path flag toggling), `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` (reads the getter when building the `node:module` namespace) and `test/js/node/module/module-resolve-filename-paths.test.js` with the debug build; all pass.
- Rebased onto main after #34102 landed. That change passes Node-compatible arguments to the override and kept the assertion. The callability check now sits in front of that call, and the arguments are the ones #34102 introduced.
- Intentionally excluded: `Module.runMain` (`setModuleRunMain` / `NodeModuleModule__callOverriddenRunMain`, same file) has the same setter and call-site pattern, reachable only when a preload assigns it. It is left out of this PR because the Rust entry-point loader currently reports any exception from a runMain override as a bare `Error occurred loading entry point: JSError`, so a TypeError thrown there would be swallowed; the crash and that reporting need to be fixed together and are tracked as a separate change.

### Background
- `Module._resolveFilename` in Bun is a custom accessor on the `node:module` constructor rather than a data property. Assigning it runs `setNodeModuleResolveFilename`; reading it runs the matching getter. The native `require()` fast path skips the JS-visible property entirely and only consults the override when `hasOverriddenModuleResolveFilenameFunction` is set, which is why the setter has to record the override somewhere native code can see it.
- `LazyProperty<T>` is JSC's "create on first access" slot; it can only hold a `T*` cell, which is why the old setter could not store primitives. `WriteBarrier<Unknown>` is a GC-visited slot that holds any `JSValue`. Members of `Zig::GlobalObject` declared through `FOR_EACH_GLOBALOBJECT_GC_MEMBER` are visited by the garbage collector automatically, so the new slot keeps the assigned value alive. `Error.prepareStackTrace` already uses this same two-slot arrangement (builtin in a `LazyProperty`, user value in a `WriteBarrier<Unknown>`).
- `JSC::getCallData(value)` returns `CallData::Type::None` for anything that cannot be called (primitives, plain objects, strings) and a usable `CallData` for functions, bound functions and callable proxies; `profiledCall` takes that `CallData`, so computing it once serves both the check and the call.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
