### PR TITLE
node:module: apply Module.wrapper to CommonJS loaded through the ESM loader without double-wrapping it

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1396,6 +1396,65 @@ void RequireResolveFunctionPrototype::finishCreation(JSC::VM& vm)
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
+// CommonJS source reaches this file already wrapped by the transpiler
+// (js_parser, WrapMode::BunCommonjs), or by `bun build --format=cjs` behind a
+// `// @bun @bun-cjs` pragma line:
+//
+//   (function(exports, require, module, __filename, __dirname) {
+//     ...
+//   });
+//
+// Returns the text between the wrapper's braces (for transpiler output that
+// begins with the newline after `{`, so line numbers survive re-wrapping), or a
+// null String when the source is not in this shape.
+static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
+{
+    unsigned headerStart = 0;
+    while (source.hasInfixStartingAt("//"_s, headerStart) || source.hasInfixStartingAt("#!"_s, headerStart)) {
+        auto lineEnd = source.find('\n', headerStart);
+        if (lineEnd == WTF::notFound)
+            return String();
+        headerStart = lineEnd + 1;
+    }
+    if (!source.hasInfixStartingAt("(function("_s, headerStart))
+        return String();
+
+    auto bodyStart = source.find('{', headerStart);
+    auto bodyEnd = source.reverseFind("})"_s);
+    if (bodyStart == WTF::notFound || bodyEnd == WTF::notFound || bodyEnd <= bodyStart)
+        return String();
+    bodyStart += 1;
+    return source.substring(bodyStart, bodyEnd - bodyStart);
+}
+
+// Swaps the transpiler's wrapper for the one assigned to
+// `require("node:module").wrapper`. Every path that turns a CommonJS
+// ResolvedSource into a SourceProvider must go through here, otherwise the
+// user's wrapper ends up enclosing the transpiler's function expression, which
+// is then never called.
+static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, ResolvedSource& source, bool isBuiltIn)
+{
+    if (!globalObject->hasOverriddenModuleWrapper) [[likely]]
+        return;
+
+    auto transpiled = source.source_code.toWTFString(BunString::ZeroCopy);
+    auto body = commonJSModuleBodyWithoutWrapper(transpiled);
+    if (body.isNull())
+        return;
+
+    // Same ownership rule as Zig::SourceProvider::create, which consumes the
+    // +1 on the replacement string below.
+    if (source.needsDeref && !isBuiltIn) {
+        source.needsDeref = false;
+        source.source_code.deref();
+    }
+    source.source_code = Bun::toStringRef(makeString(
+        globalObject->m_moduleWrapperStart,
+        body,
+        globalObject->m_moduleWrapperEnd));
+    source.needsDeref = true;
+}
+
 void JSCommonJSModule::evaluate(
     Zig::GlobalObject* globalObject,
     const WTF::String& key,
@@ -1404,23 +1463,7 @@ void JSCommonJSModule::evaluate(
 {
     auto& vm = JSC::getVM(globalObject);
 
-    if (globalObject->hasOverriddenModuleWrapper) [[unlikely]] {
-        auto string = source.source_code.toWTFString(BunString::ZeroCopy);
-        auto trimStart = string.find('\n');
-        if (trimStart != WTF::notFound) {
-            if (source.needsDeref && !isBuiltIn) {
-                source.needsDeref = false;
-                source.source_code.deref();
-            }
-            auto wrapperStart = globalObject->m_moduleWrapperStart;
-            auto wrapperEnd = globalObject->m_moduleWrapperEnd;
-            source.source_code = Bun::toStringRef(makeString(
-                wrapperStart,
-                string.substring(trimStart, string.length() - trimStart - 4),
-                wrapperEnd));
-            source.needsDeref = true;
-        }
-    }
+    applyOverriddenModuleWrapper(globalObject, source, isBuiltIn);
 
     auto sourceProvider = Zig::SourceProvider::create(globalObject, source, JSC::SourceProviderSourceType::Program, isBuiltIn);
     this->ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
@@ -1472,17 +1515,9 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
             source.needsDeref = false;
             source.source_code.deref();
         }
-        // Remove the wrapper from the source string, since the transpiler has added it.
-        auto trimStart = sourceString.find('\n');
-        WTF::String sourceStringWithoutWrapper;
-        if (trimStart != WTF::notFound) {
-            auto wrapperStart = globalObject->m_moduleWrapperStart;
-            auto wrapperEnd = globalObject->m_moduleWrapperEnd;
-            sourceStringWithoutWrapper = sourceString.substring(trimStart, sourceString.length() - trimStart - 4);
-        } else {
+        WTF::String sourceStringWithoutWrapper = commonJSModuleBodyWithoutWrapper(sourceString);
+        if (sourceStringWithoutWrapper.isNull())
             sourceStringWithoutWrapper = sourceString;
-        }
-        RETURN_IF_EXCEPTION(scope, );
 
         // _compile(source, filename)
         MarkedArgumentBuffer arguments;
@@ -1532,14 +1567,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             requireMapKey = JSC::jsString(vm, WTF::String("."_s));
         }
 
-        if (globalObject->hasOverriddenModuleWrapper) [[unlikely]] {
-            auto concat = makeString(
-                globalObject->m_moduleWrapperStart,
-                source.source_code.toWTFString(BunString::ZeroCopy),
-                globalObject->m_moduleWrapperEnd);
-            source.source_code.deref();
-            source.source_code = Bun::toStringRef(concat);
-        }
+        applyOverriddenModuleWrapper(globalObject, source, isBuiltIn);
 
         auto sourceProvider = Zig::SourceProvider::create(globalObject, source, JSC::SourceProviderSourceType::Program, isBuiltIn);
         if (!isBuiltIn && !globalObject->hasOverriddenModuleWrapper && Bun::IsolatedModuleCache::canUse(vm, globalObject->bunVM())) {

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1404,9 +1404,12 @@ void RequireResolveFunctionPrototype::finishCreation(JSC::VM& vm)
 //     ...
 //   });
 //
-// Returns the text between the wrapper's braces (for transpiler output that
-// begins with the newline after `{`, so line numbers survive re-wrapping), or a
-// null String when the source is not in this shape.
+// Both put the closing `})` on a line of its own (or directly after `{` for an
+// empty module) and only ever follow it with `;` and `//` comment lines, such as
+// the inline source map the inspector appends. Returns the text between the
+// wrapper's braces (for transpiler output that begins with the newline after
+// `{`, so line numbers survive re-wrapping), or a null String when the source is
+// not in this shape, in which case callers leave the transpiler's wrapper alone.
 static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
 {
     unsigned headerStart = 0;
@@ -1424,6 +1427,23 @@ static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
     if (bodyStart == WTF::notFound || bodyEnd == WTF::notFound || bodyEnd <= bodyStart)
         return String();
     bodyStart += 1;
+    if (bodyEnd != bodyStart && source[bodyEnd - 1] != '\n')
+        return String();
+
+    for (unsigned i = bodyEnd + 2; i < source.length();) {
+        if (source.hasInfixStartingAt("//"_s, i)) {
+            auto lineEnd = source.find('\n', i);
+            if (lineEnd == WTF::notFound)
+                break;
+            i = lineEnd + 1;
+            continue;
+        }
+        auto c = source[i];
+        if (c != ';' && !isASCIIWhitespace(c))
+            return String();
+        i++;
+    }
+
     return source.substring(bodyStart, bodyEnd - bodyStart);
 }
 
@@ -1432,9 +1452,16 @@ static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
 // ResolvedSource into a SourceProvider must go through here, otherwise the
 // user's wrapper ends up enclosing the transpiler's function expression, which
 // is then never called.
-static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, ResolvedSource& source, bool isBuiltIn)
+static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, JSValue filename, ResolvedSource& source, bool isBuiltIn)
 {
     if (!globalObject->hasOverriddenModuleWrapper) [[likely]]
+        return;
+
+    // `bun -e` / stdin code is transpiled without the wrapper and evaluated as
+    // a script by evaluateCommonJSModuleOnce (Node runs it as a script too,
+    // outside Module.wrapper), so there is nothing to swap out. Wrapping it
+    // would turn the whole program into a function expression nothing calls.
+    if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename)))
         return;
 
     auto transpiled = source.source_code.toWTFString(BunString::ZeroCopy);
@@ -1463,7 +1490,7 @@ void JSCommonJSModule::evaluate(
 {
     auto& vm = JSC::getVM(globalObject);
 
-    applyOverriddenModuleWrapper(globalObject, source, isBuiltIn);
+    applyOverriddenModuleWrapper(globalObject, this->m_filename.get(), source, isBuiltIn);
 
     auto sourceProvider = Zig::SourceProvider::create(globalObject, source, JSC::SourceProviderSourceType::Program, isBuiltIn);
     this->ignoreESModuleAnnotation = source.tag == ResolvedSourceTagPackageJSONTypeModule;
@@ -1567,7 +1594,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
             requireMapKey = JSC::jsString(vm, WTF::String("."_s));
         }
 
-        applyOverriddenModuleWrapper(globalObject, source, isBuiltIn);
+        applyOverriddenModuleWrapper(globalObject, filename, source, isBuiltIn);
 
         auto sourceProvider = Zig::SourceProvider::create(globalObject, source, JSC::SourceProviderSourceType::Program, isBuiltIn);
         if (!isBuiltIn && !globalObject->hasOverriddenModuleWrapper && Bun::IsolatedModuleCache::canUse(vm, globalObject->bunVM())) {

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1396,14 +1396,7 @@ void RequireResolveFunctionPrototype::finishCreation(JSC::VM& vm)
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
-// The transpiler (and `bun build --format=cjs`, behind `#!` / `// @bun` lines) emits
-//
-//   (function(exports, require, module, __filename, __dirname) {
-//     ...
-//   });
-//
-// possibly followed by `//` comments. Returns the body, or a null String if the
-// source does not look like this.
+// Matches the wrapper emitted by js_parser (WrapMode::BunCommonjs) and by `bun build --format=cjs --target=bun`; null String when the source is not shaped like that.
 static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
 {
     unsigned headerStart = 0;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1396,20 +1396,14 @@ void RequireResolveFunctionPrototype::finishCreation(JSC::VM& vm)
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
-// CommonJS source reaches this file already wrapped by the transpiler
-// (js_parser, WrapMode::BunCommonjs), or by `bun build --format=cjs` behind a
-// `// @bun @bun-cjs` pragma line:
+// The transpiler (and `bun build --format=cjs`, behind `#!` / `// @bun` lines) emits
 //
 //   (function(exports, require, module, __filename, __dirname) {
 //     ...
 //   });
 //
-// Both put the closing `})` on a line of its own (or directly after `{` for an
-// empty module) and only ever follow it with `;` and `//` comment lines, such as
-// the inline source map the inspector appends. Returns the text between the
-// wrapper's braces (for transpiler output that begins with the newline after
-// `{`, so line numbers survive re-wrapping), or a null String when the source is
-// not in this shape, in which case callers leave the transpiler's wrapper alone.
+// possibly followed by `//` comments. Returns the body, or a null String if the
+// source does not look like this.
 static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
 {
     unsigned headerStart = 0;
@@ -1447,20 +1441,13 @@ static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
     return source.substring(bodyStart, bodyEnd - bodyStart);
 }
 
-// Swaps the transpiler's wrapper for the one assigned to
-// `require("node:module").wrapper`. Every path that turns a CommonJS
-// ResolvedSource into a SourceProvider must go through here, otherwise the
-// user's wrapper ends up enclosing the transpiler's function expression, which
-// is then never called.
+// Replaces the transpiler's wrapper with the one assigned to require("node:module").wrapper.
 static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, JSValue filename, ResolvedSource& source, bool isBuiltIn)
 {
     if (!globalObject->hasOverriddenModuleWrapper) [[likely]]
         return;
 
-    // `bun -e` / stdin code is transpiled without the wrapper and evaluated as
-    // a script by evaluateCommonJSModuleOnce (Node runs it as a script too,
-    // outside Module.wrapper), so there is nothing to swap out. Wrapping it
-    // would turn the whole program into a function expression nothing calls.
+    // -e / stdin code is transpiled without a wrapper and run as a script.
     if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename)))
         return;
 
@@ -1469,8 +1456,7 @@ static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, JSValu
     if (body.isNull())
         return;
 
-    // Same ownership rule as Zig::SourceProvider::create, which consumes the
-    // +1 on the replacement string below.
+    // Zig::SourceProvider::create derefs the replacement under the same condition.
     if (source.needsDeref && !isBuiltIn) {
         source.needsDeref = false;
         source.source_code.deref();

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1396,28 +1396,36 @@ void RequireResolveFunctionPrototype::finishCreation(JSC::VM& vm)
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 
-// Matches the wrapper emitted by js_parser (WrapMode::BunCommonjs) and by `bun build --format=cjs --target=bun`; null String when the source is not shaped like that.
-static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
+struct UnwrappedCommonJSModule {
+    // One "\n" per line the wrapper header occupied, then the text between the wrapper's braces, so line numbers survive re-wrapping.
+    WTF::String body;
+    // What followed the closing "})": ";", newlines and "//" comments such as sourceMappingURL.
+    WTF::String trailer;
+};
+
+// Undoes the wrapper emitted by js_parser (WrapMode::BunCommonjs) and by `bun build --format=cjs --target=bun`; nullopt when the source is not shaped like that.
+static std::optional<UnwrappedCommonJSModule> unwrapCommonJSModule(const WTF::String& source)
 {
     unsigned headerStart = 0;
     while (source.hasInfixStartingAt("//"_s, headerStart) || source.hasInfixStartingAt("#!"_s, headerStart)) {
         auto lineEnd = source.find('\n', headerStart);
         if (lineEnd == WTF::notFound)
-            return String();
+            return std::nullopt;
         headerStart = lineEnd + 1;
     }
     if (!source.hasInfixStartingAt("(function("_s, headerStart))
-        return String();
+        return std::nullopt;
 
     auto bodyStart = source.find('{', headerStart);
     auto bodyEnd = source.reverseFind("})"_s);
     if (bodyStart == WTF::notFound || bodyEnd == WTF::notFound || bodyEnd <= bodyStart)
-        return String();
+        return std::nullopt;
     bodyStart += 1;
     if (bodyEnd != bodyStart && source[bodyEnd - 1] != '\n')
-        return String();
+        return std::nullopt;
 
-    for (unsigned i = bodyEnd + 2; i < source.length();) {
+    auto trailerStart = bodyEnd + 2;
+    for (unsigned i = trailerStart; i < source.length();) {
         if (source.hasInfixStartingAt("//"_s, i)) {
             auto lineEnd = source.find('\n', i);
             if (lineEnd == WTF::notFound)
@@ -1427,11 +1435,20 @@ static WTF::String commonJSModuleBodyWithoutWrapper(const WTF::String& source)
         }
         auto c = source[i];
         if (c != ';' && !isASCIIWhitespace(c))
-            return String();
+            return std::nullopt;
         i++;
     }
 
-    return source.substring(bodyStart, bodyEnd - bodyStart);
+    unsigned headerLines = 0;
+    for (unsigned i = 0; i < bodyStart; i++) {
+        if (source[i] == '\n')
+            headerLines++;
+    }
+
+    return UnwrappedCommonJSModule {
+        makeString(pad('\n', headerLines, ""_s), StringView(source).substring(bodyStart, bodyEnd - bodyStart)),
+        source.substring(trailerStart),
+    };
 }
 
 // Replaces the transpiler's wrapper with the one assigned to require("node:module").wrapper.
@@ -1444,9 +1461,8 @@ static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, JSValu
     if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(filename)))
         return;
 
-    auto transpiled = source.source_code.toWTFString(BunString::ZeroCopy);
-    auto body = commonJSModuleBodyWithoutWrapper(transpiled);
-    if (body.isNull())
+    auto unwrapped = unwrapCommonJSModule(source.source_code.toWTFString(BunString::ZeroCopy));
+    if (!unwrapped)
         return;
 
     // Zig::SourceProvider::create derefs the replacement under the same condition.
@@ -1456,8 +1472,9 @@ static void applyOverriddenModuleWrapper(Zig::GlobalObject* globalObject, JSValu
     }
     source.source_code = Bun::toStringRef(makeString(
         globalObject->m_moduleWrapperStart,
-        body,
-        globalObject->m_moduleWrapperEnd));
+        unwrapped->body,
+        globalObject->m_moduleWrapperEnd,
+        unwrapped->trailer));
     source.needsDeref = true;
 }
 
@@ -1517,17 +1534,21 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
         }
         WTF::String sourceString = source.source_code.toWTFString(BunString::ZeroCopy);
         RETURN_IF_EXCEPTION(scope, );
+        auto unwrapped = unwrapCommonJSModule(sourceString);
+        if (!unwrapped) {
+            // _compile would wrap the wrapper; run the source as it is instead.
+            scope.release();
+            this->evaluate(globalObject, key, source, false);
+            return;
+        }
         if (source.needsDeref) {
             source.needsDeref = false;
             source.source_code.deref();
         }
-        WTF::String sourceStringWithoutWrapper = commonJSModuleBodyWithoutWrapper(sourceString);
-        if (sourceStringWithoutWrapper.isNull())
-            sourceStringWithoutWrapper = sourceString;
 
         // _compile(source, filename)
         MarkedArgumentBuffer arguments;
-        arguments.append(jsString(vm, sourceStringWithoutWrapper));
+        arguments.append(jsString(vm, unwrapped->body));
         arguments.append(keyJSString);
         JSC::profiledCall(globalObject, ProfilingReason::API, compileFunction, callData, this, arguments);
         RETURN_IF_EXCEPTION(scope, );

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -533,11 +533,42 @@ console.log("survived", require("./late.js"));`,
       using dir = tempDir("module-wrapper-eval", {
         "set-wrapper.cjs": setWrapper,
       });
-      // -e code is evaluated as a script, not through the wrapper. The IIFE
-      // makes the source look like wrapped output, so the eval entry point has
-      // to be recognized by identity rather than by shape.
+      // module.exports makes this CommonJS; -e code is evaluated as a script
+      // and used to be wrapped into a function expression that never ran.
       const code = `(function () { module.exports = 1; console.log(JSON.stringify({ ran: true })); })();`;
       expect(await runFixture(dir, ["-r", "./set-wrapper.cjs", "-e", code])).toEqual({ ran: true });
+    });
+
+    test("does not wrap -e code that is shaped like wrapped output", async () => {
+      using dir = tempDir("module-wrapper-eval-shape", {
+        "preload.cjs": /* js */ `
+          globalThis.wrapCount = 0;
+          require("node:module").wrapper = [
+            "globalThis.wrapCount++; (function (exports, require, module, __filename, __dirname) {",
+            "\\n})",
+          ];
+          const dep = require("./dep.cjs");
+          process.on("exit", () =>
+            console.log(JSON.stringify({ dep, wrapCount: globalThis.wrapCount, evalRan: globalThis.evalRan })),
+          );
+        `,
+        "dep.cjs": `module.exports = "dep";`,
+      });
+      // Starts with a function expression and ends with a callback's "});", so
+      // textually it passes for a wrapped module, but -e code is never wrapped
+      // by the transpiler. Swapping wrappers here would run wrapper[0] again and
+      // splice the IIFE body into the user's wrapper function.
+      const code = [
+        "(function () { globalThis.evalRan = true; })();",
+        "process.nextTick(function () {",
+        "  module.exports = 1;",
+        "});",
+      ].join("\n");
+      expect(await runFixture(dir, ["-r", "./preload.cjs", "-e", code])).toEqual({
+        dep: "dep",
+        wrapCount: 1,
+        evalRan: true,
+      });
     });
 
     test("mutating Module.wrapper in place applies to imported CommonJS", async () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -465,6 +465,119 @@ console.log("survived", require("./late.js"));`,
     expect(wrap()).toBe("(function (exports, require, module, __filename, __dirname) { undefined\n});");
   });
 
+  describe("Module.wrapper override", () => {
+    // Every fixture records the modules that ran through the custom wrapper in
+    // globalThis.wrapped, then prints one JSON object for the test to compare.
+    async function runFixture(dir, cmd) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...cmd],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    const setWrapper = /* js */ `
+      globalThis.wrapped = [];
+      globalThis.note = filename => globalThis.wrapped.push(require("node:path").basename(filename));
+      require("node:module").wrapper = [
+        "(function (exports, require, module, __filename, __dirname) { globalThis.note(__filename); ",
+        "\\n});",
+      ];
+    `;
+
+    test("applies to CommonJS loaded through import() and import, like require()", async () => {
+      using dir = tempDir("module-wrapper-import", {
+        "set-wrapper.cjs": setWrapper,
+        "main.mjs": /* js */ `
+          import { createRequire } from "node:module";
+          const require = createRequire(import.meta.url);
+          require("./set-wrapper.cjs");
+          const viaImport = (await import("./dep-import.cjs")).default;
+          const viaStaticImport = (await import("./reexport.mjs")).default;
+          const viaRequire = require("./dep-require.cjs");
+          const viaRequireEmpty = require("./empty.cjs");
+          console.log(JSON.stringify({ viaImport, viaStaticImport, viaRequire, viaRequireEmpty, wrapped: globalThis.wrapped }));
+        `,
+        "dep-import.cjs": `module.exports = { loadedBy: "import()" };`,
+        "reexport.mjs": `export { default } from "./dep-static.cjs";`,
+        "dep-static.cjs": `module.exports = { loadedBy: "import" };`,
+        "dep-require.cjs": `module.exports = { loadedBy: "require" };`,
+        "empty.cjs": "",
+      });
+      expect(await runFixture(dir, ["main.mjs"])).toEqual({
+        viaImport: { loadedBy: "import()" },
+        viaStaticImport: { loadedBy: "import" },
+        viaRequire: { loadedBy: "require" },
+        viaRequireEmpty: {},
+        wrapped: ["dep-import.cjs", "dep-static.cjs", "dep-require.cjs", "empty.cjs"],
+      });
+    });
+
+    test("assigning the wrapper in a preload keeps a CommonJS entry point running", async () => {
+      using dir = tempDir("module-wrapper-preload", {
+        // jest-runtime style: copies the property back onto Module, which
+        // makes the setter run even though nothing changed.
+        "preload.cjs": `const Module = require("node:module"); Module.wrapper = Module.wrapper;`,
+        "main.cjs": `console.log(JSON.stringify({ ran: true, filename: require("node:path").basename(__filename) }));`,
+      });
+      expect(await runFixture(dir, ["-r", "./preload.cjs", "./main.cjs"])).toEqual({ ran: true, filename: "main.cjs" });
+    });
+
+    test("mutating Module.wrapper in place applies to imported CommonJS", async () => {
+      using dir = tempDir("module-wrapper-mutate", {
+        "main.mjs": /* js */ `
+          import Module from "node:module";
+          globalThis.wrapped = [];
+          Module.wrapper[0] += "globalThis.wrapped.push(require('node:path').basename(__filename));";
+          const dep = (await import("./dep.cjs")).default;
+          console.log(JSON.stringify({ dep, wrapped: globalThis.wrapped }));
+        `,
+        "dep.cjs": `module.exports = { answer: 42 };`,
+      });
+      expect(await runFixture(dir, ["main.mjs"])).toEqual({ dep: { answer: 42 }, wrapped: ["dep.cjs"] });
+    });
+
+    test("applies to bun build --format=cjs output (pragma line before the wrapper)", async () => {
+      using dir = tempDir("module-wrapper-prebundled", {
+        "set-wrapper.cjs": setWrapper,
+        "src/dep.cjs": `#!/usr/bin/env bun\nmodule.exports = { bundled: true };`,
+        "main.mjs": /* js */ `
+          import { createRequire } from "node:module";
+          const require = createRequire(import.meta.url);
+          const { success, logs } = await Bun.build({
+            entrypoints: ["./src/dep.cjs"],
+            outdir: "./out",
+            target: "bun",
+            format: "cjs",
+          });
+          if (!success) throw new AggregateError(logs);
+          const header = (await Bun.file("./out/dep.js").text()).split("\\n", 3);
+          require("./set-wrapper.cjs");
+          const viaRequire = require("./out/dep.js");
+          delete require.cache[require.resolve("./out/dep.js")];
+          const viaImport = (await import("./out/dep.js")).default;
+          console.log(JSON.stringify({ header, viaRequire, viaImport, wrapped: globalThis.wrapped }));
+        `,
+      });
+      expect(await runFixture(dir, ["main.mjs"])).toEqual({
+        header: [
+          "#!/usr/bin/env bun",
+          "// @bun @bun-cjs",
+          expect.stringContaining("(function(exports, require, module, __filename, __dirname) {"),
+        ],
+        viaRequire: { bundled: true },
+        viaImport: { bundled: true },
+        wrapped: ["dep.js", "dep.js"],
+      });
+    });
+  });
+
   test("Overwriting _resolveFilename", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", path.join(import.meta.dir, "resolveFilenameOverwrite.cjs")],

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -529,6 +529,17 @@ console.log("survived", require("./late.js"));`,
       expect(await runFixture(dir, ["-r", "./preload.cjs", "./main.cjs"])).toEqual({ ran: true, filename: "main.cjs" });
     });
 
+    test("assigning the wrapper in a preload keeps -e code running", async () => {
+      using dir = tempDir("module-wrapper-eval", {
+        "set-wrapper.cjs": setWrapper,
+      });
+      // -e code is evaluated as a script, not through the wrapper. The IIFE
+      // makes the source look like wrapped output, so the eval entry point has
+      // to be recognized by identity rather than by shape.
+      const code = `(function () { module.exports = 1; console.log(JSON.stringify({ ran: true })); })();`;
+      expect(await runFixture(dir, ["-r", "./set-wrapper.cjs", "-e", code])).toEqual({ ran: true });
+    });
+
     test("mutating Module.wrapper in place applies to imported CommonJS", async () => {
       using dir = tempDir("module-wrapper-mutate", {
         "main.mjs": /* js */ `
@@ -550,30 +561,45 @@ console.log("survived", require("./late.js"));`,
         "main.mjs": /* js */ `
           import { createRequire } from "node:module";
           const require = createRequire(import.meta.url);
-          const { success, logs } = await Bun.build({
-            entrypoints: ["./src/dep.cjs"],
-            outdir: "./out",
-            target: "bun",
-            format: "cjs",
-          });
-          if (!success) throw new AggregateError(logs);
-          const header = (await Bun.file("./out/dep.js").text()).split("\\n", 3);
+          async function build(outdir, footer) {
+            const { success, logs } = await Bun.build({
+              entrypoints: ["./src/dep.cjs"],
+              outdir,
+              target: "bun",
+              format: "cjs",
+              footer,
+            });
+            if (!success) throw new AggregateError(logs);
+            return outdir + "/dep.js";
+          }
+          const plain = await build("./out/plain");
+          const commentFooter = await build("./out/comment-footer", "// comment after the wrapper");
+          const codeFooter = await build("./out/code-footer", "var afterTheWrapper = 1;");
+          const header = (await Bun.file(plain).text()).split("\\n", 3);
+
           require("./set-wrapper.cjs");
-          const viaRequire = require("./out/dep.js");
-          delete require.cache[require.resolve("./out/dep.js")];
-          const viaImport = (await import("./out/dep.js")).default;
-          console.log(JSON.stringify({ header, viaRequire, viaImport, wrapped: globalThis.wrapped }));
+          const results = {};
+          for (const [name, file] of Object.entries({ plain, commentFooter, codeFooter })) {
+            const viaRequire = require(file);
+            delete require.cache[require.resolve(file)];
+            const viaImport = (await import(file)).default;
+            results[name] = { viaRequire, viaImport, wrapped: globalThis.wrapped.splice(0) };
+          }
+          console.log(JSON.stringify({ header, ...results }));
         `,
       });
+      const loaded = { viaRequire: { bundled: true }, viaImport: { bundled: true } };
       expect(await runFixture(dir, ["main.mjs"])).toEqual({
         header: [
           "#!/usr/bin/env bun",
           "// @bun @bun-cjs",
           expect.stringContaining("(function(exports, require, module, __filename, __dirname) {"),
         ],
-        viaRequire: { bundled: true },
-        viaImport: { bundled: true },
-        wrapped: ["dep.js", "dep.js"],
+        plain: { ...loaded, wrapped: ["dep.js", "dep.js"] },
+        commentFooter: { ...loaded, wrapped: ["dep.js", "dep.js"] },
+        // Code after the wrapper is not something the wrapper swap can
+        // understand, so the file keeps its own wrapper instead of breaking.
+        codeFooter: { ...loaded, wrapped: [] },
       });
     });
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -588,49 +588,73 @@ console.log("survived", require("./late.js"));`,
     test("applies to bun build --format=cjs output (pragma line before the wrapper)", async () => {
       using dir = tempDir("module-wrapper-prebundled", {
         "set-wrapper.cjs": setWrapper,
-        "src/dep.cjs": `#!/usr/bin/env bun\nmodule.exports = { bundled: true };`,
+        // fail() throws on line 2 of this file; the bundle's header takes up
+        // three lines in front of it.
+        "src/dep.cjs": `#!/usr/bin/env bun\nmodule.exports = { bundled: true, fail: () => { throw new Error("boom"); } };`,
         "main.mjs": /* js */ `
           import { createRequire } from "node:module";
           const require = createRequire(import.meta.url);
-          async function build(outdir, footer) {
+          async function build(outdir, options) {
             const { success, logs } = await Bun.build({
               entrypoints: ["./src/dep.cjs"],
               outdir,
               target: "bun",
               format: "cjs",
-              footer,
+              ...options,
             });
             if (!success) throw new AggregateError(logs);
             return outdir + "/dep.js";
           }
-          const plain = await build("./out/plain");
-          const commentFooter = await build("./out/comment-footer", "// comment after the wrapper");
-          const codeFooter = await build("./out/code-footer", "var afterTheWrapper = 1;");
-          const header = (await Bun.file(plain).text()).split("\\n", 3);
+          const files = {
+            plain: await build("./out/plain"),
+            commentFooter: await build("./out/comment-footer", { footer: "// comment after the wrapper" }),
+            codeFooter: await build("./out/code-footer", { footer: "var afterTheWrapper = 1;" }),
+            inlineSourceMap: await build("./out/inline", { sourcemap: "inline" }),
+            linkedSourceMap: await build("./out/linked", { sourcemap: "linked" }),
+          };
+          const header = (await Bun.file(files.plain).text()).split("\\n", 3);
+          function throwsAt(exports) {
+            try {
+              exports.fail();
+            } catch (error) {
+              const [, file, line] = /dep\\.(c?js):(\\d+):/.exec(error.stack);
+              return "dep." + file + ":" + line;
+            }
+          }
 
           require("./set-wrapper.cjs");
           const results = {};
-          for (const [name, file] of Object.entries({ plain, commentFooter, codeFooter })) {
+          for (const [name, file] of Object.entries(files)) {
             const viaRequire = require(file);
             delete require.cache[require.resolve(file)];
             const viaImport = (await import(file)).default;
-            results[name] = { viaRequire, viaImport, wrapped: globalThis.wrapped.splice(0) };
+            results[name] = {
+              viaRequire,
+              viaImport,
+              throwsAt: [throwsAt(viaRequire), throwsAt(viaImport)],
+              wrapped: globalThis.wrapped.splice(0),
+            };
           }
           console.log(JSON.stringify({ header, ...results }));
         `,
       });
       const loaded = { viaRequire: { bundled: true }, viaImport: { bundled: true } };
+      const bundledLine = expect.stringMatching(/^dep\.js:\d+$/);
       expect(await runFixture(dir, ["main.mjs"])).toEqual({
         header: [
           "#!/usr/bin/env bun",
           "// @bun @bun-cjs",
           expect.stringContaining("(function(exports, require, module, __filename, __dirname) {"),
         ],
-        plain: { ...loaded, wrapped: ["dep.js", "dep.js"] },
-        commentFooter: { ...loaded, wrapped: ["dep.js", "dep.js"] },
+        plain: { ...loaded, throwsAt: [bundledLine, bundledLine], wrapped: ["dep.js", "dep.js"] },
+        commentFooter: { ...loaded, throwsAt: [bundledLine, bundledLine], wrapped: ["dep.js", "dep.js"] },
         // Code after the wrapper is not something the wrapper swap can
         // understand, so the file keeps its own wrapper instead of breaking.
-        codeFooter: { ...loaded, wrapped: [] },
+        codeFooter: { ...loaded, throwsAt: [bundledLine, bundledLine], wrapped: [] },
+        // Re-wrapping keeps every line where it was and keeps the
+        // sourceMappingURL comment, so stack traces still map back to the source.
+        inlineSourceMap: { ...loaded, throwsAt: ["dep.cjs:2", "dep.cjs:2"], wrapped: ["dep.js", "dep.js"] },
+        linkedSourceMap: { ...loaded, throwsAt: ["dep.cjs:2", "dep.cjs:2"], wrapped: ["dep.js", "dep.js"] },
       });
     });
   });

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -191,3 +191,32 @@ test("mutating extensions is banned by some files", () => {
     expect(globalThis.pass).toBe(n);
   }
 });
+test("already wrapped files reach a mutated compile function unwrapped, or are evaluated as they are", () => {
+  // The shape `bun build --target=bun --format=cjs` emits. footer.js has code
+  // after the wrapper, so it cannot be unwrapped; it is evaluated as it is,
+  // bypassing _compile, instead of being wrapped a second time.
+  const wrapped =
+    '// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {\nmodule.exports = "%s";\n})\n';
+  using dir = tempDir("require-extensions-wrapped", {
+    "wrapped.js": wrapped.replace("%s", "wrapped"),
+    "footer.js": wrapped.replace("%s", "footer") + "var footer = 1;\n",
+  });
+  const original = require.extensions[".js"]!;
+  const compiled: string[] = [];
+  try {
+    require.extensions[".js"] = function (module: any, filename: string) {
+      const originalCompile = module._compile;
+      module._compile = function (code: string, compiledFilename: string) {
+        compiled.push(code);
+        return originalCompile.call(this, code, compiledFilename);
+      };
+      original(module, filename);
+    };
+    expect(require(path.join(String(dir), "wrapped.js"))).toBe("wrapped");
+    expect(require(path.join(String(dir), "footer.js"))).toBe("footer");
+  } finally {
+    require.extensions[".js"] = original;
+  }
+  // The pragma line is replaced by a newline so that line numbers are unchanged.
+  expect(compiled).toEqual(['\n\nmodule.exports = "wrapped";\n']);
+});


### PR DESCRIPTION
### Problem

- After any assignment to `require("node:module").wrapper` (a custom wrapper, Node's default strings, or even `Module.wrapper = Module.wrapper`, which is what a jest-runtime style property copy does), a CommonJS file loaded through the ESM loader evaluates to `module.exports === {}` and its body never runs. This covers `import x from "./dep.cjs"`, `await import("./dep.cjs")`, and a CommonJS entry point after a `-r` preload: `bun -r ./sets-wrapper.cjs ./main.cjs` silently does nothing. `require()` of the same file works. Node runs the body in all of these cases.
- Cause: the transpiler hands over CommonJS source already wrapped in `(function(exports, require, module, __filename, __dirname) { ... });`. `JSCommonJSModule::evaluate` (the `require()` path, `src/jsc/bindings/JSCommonJSModule.cpp`) strips that wrapper before concatenating the user's `m_moduleWrapperStart` / `m_moduleWrapperEnd`. `createCommonJSModule` (the ESM loader path, same file, previously around line 1535) concatenated without stripping, so the user's function body consisted of the transpiler's function expression, which nothing ever called.
- The strip in `evaluate()` was also a guess ("drop the first line and the last four characters") that breaks on `bun build --target=bun --format=cjs` output, which puts a `// @bun @bun-cjs` pragma line (and optionally a hashbang) before the wrapper and ends in `})` without a semicolon: `require()` of such a file under an overridden wrapper threw `SyntaxError: Unexpected end of script`. An empty `.cjs` file (synthetic `(function(){})` source, no newline) skipped the override entirely.

### Fix

- One helper, `unwrapCommonJSModule`, takes the wrapper apart: it skips leading `#!` / `//` lines, requires `(function(`, takes everything after the first `{` up to the last `})`, requires that `})` to sit on its own line (or directly after `{` for an empty module) and to be followed only by `;`, whitespace and `//` comment lines, and returns nullopt for anything else (for example a `bun build` `footer` containing code). It returns two strings: the body, preceded by one newline per line the header occupied, and the trailer that followed `})`. `applyOverriddenModuleWrapper` emits `wrapper[0] + body + wrapper[1] + trailer`, so the result is the original program with only the wrapper text replaced: every line keeps its number and `//# sourceMappingURL` / `//# debugId` comments (from `bun build`, or appended to runtime output by the inspector) survive, which `already_bundled` source map lookup depends on since it scans the provider text for that comment. It is called from both `evaluate()` (require) and `createCommonJSModule()` (ESM loader); when the source is not recognized the transpiler's wrapper is left in place, so the module still runs, without the override, instead of producing broken code.
- For the transpiler's own output the header holds no newline and the trailer is `;\n`, so the body is byte for byte what the old `evaluate()` code produced (`require-extensions.test.ts` pins that text) and `require()` behaviour is unchanged apart from the trailing `;`.
- The `module._compile` override path (`evaluateWithPotentiallyOverriddenCompile`) uses the same helper for the text it hands to `_compile`, replacing its private copy of the old guess. When the source cannot be unwrapped it now evaluates the module as it is instead of passing the still wrapped text to `_compile`, which wrapped it a second time and yielded `{}`.
- The `-e` / stdin entry point is transpiled without a wrapper (`remove_cjs_module_wrapper`) and evaluated as a script by `evaluateCommonJSModuleOnce`, so `applyOverriddenModuleWrapper` skips it (`Bun__VM__specifierIsEvalEntryPoint`, the same check `evaluateCommonJSModuleOnce` makes) rather than relying on the shape check, which a program that starts with a function expression and ends with a callback's `});` passes. Before this change `bun -r ./sets-wrapper.cjs -e 'module.exports = 1; ...'` silently ran nothing for the same double-wrapping reason. Node also runs `-e` code as a script, outside `Module.wrapper`.
- Why this is correct: Node evaluates `wrapper[0] + source + wrapper[1]` for every CommonJS module regardless of whether it was reached via `require()` or an ESM import; Bun's equivalent of `source` is the body the transpiler produced, so every place that turns transpiled CommonJS into a `SourceProvider` has to take the transpiler's wrapper off the same way, and there were two such places disagreeing.
- Ownership: the replacement string follows the rule `evaluate()` already used (deref the incoming `source_code` only when `needsDeref && !isBuiltIn`, then hand over a +1 that `Zig::SourceProvider::create` consumes). The removed `createCommonJSModule` code deref'd unconditionally and never set `needsDeref`, so it was also wrong for sources that arrive with `needsDeref == false`.
- Verified with `test/js/node/module/node-module-module.test.js` ("Module.wrapper override", six tests: import()/static import/require()/empty file with a custom wrapper; `-r` preload with a no-op assignment followed by a CommonJS entry point; `-r` preload followed by `-e` code; `-e` code shaped so that the helper would accept it, observed through a wrapper whose first element increments a counter; in-place `Module.wrapper[0] +=` mutation followed by import(); and `Bun.build({ format: "cjs", target: "bun" })` output loaded via require() and import(), built plain, with a comment `footer`, with a code `footer` (keeps its own wrapper), and with inline and linked source maps, where the stack of an error thrown on line 2 of the source must still say `dep.cjs:2` after re-wrapping), plus one test in `require-extensions.test.ts` for what a mutated `_compile` receives for an already wrapped file and for the fallback when it cannot be unwrapped. All fail on the current release and pass with this change. The counter test also fails with the entry point check alone removed (rebuilt without it: wrapCount 2), the source map variants fail without the newline padding or without the trailer, and the code-footer variant fails without the trailing-content rule.
- Also run: `test/js/node/module/`, `test/regression/issue/require-extensions-override.test.ts`, `test/js/node/test/parallel/test-module-wrap.js` and `test-module-wrapper.js`, and `require-extensions.test.ts` under `BUN_JSC_validateExceptionChecks=1`. With and without the override, an error thrown from `bun build --format=cjs --sourcemap=inline|linked` output reports the same `src/dep.cjs:2:11` frame.

### Background

- `Module.wrapper` is Node's two-element array of strings placed around a CommonJS file's text before it is evaluated; assigning it (or mutating it through the array proxy) makes Node use the assigned strings for every module loaded afterwards. Bun stores the strings on the global object (`m_moduleWrapperStart` / `m_moduleWrapperEnd`) and sets `hasOverriddenModuleWrapper`; both the setter in `NodeModuleModule.cpp` and the proxy's mutation callback set the flag, so the two paths share the consumers changed here.
- Bun's transpiler (`js_parser`, `WrapMode::BunCommonjs`) emits each CommonJS module as a complete function expression; `evaluateCommonJSModuleOnce` evaluates that text as a program and calls the resulting function with `(exports, require, module, __filename, __dirname)`. Honouring a user wrapper therefore means swapping the transpiler's function header and footer for the user's strings, not adding a second layer.
- `require()` evaluates through `JSCommonJSModule::evaluate`. Anything that goes through the ESM loader (static imports, `import()`, and the entry point, which Bun always loads as an ES module) goes through `createCommonJSModule`, which builds the `JSCommonJSModule` and a synthetic ES module record around it; the two functions were the two consumers that disagreed.
- `ResolvedSource` is the struct the Rust transpiler returns; `needsDeref` records whether the C++ side owns a reference on `source_code` that it must release, and `Zig::SourceProvider::create` releases it after copying the string into the provider.

<details>
<summary>Repro</summary>

```js
// u.mjs
import Module from "node:module";
Module.wrapper = ["(function (exports, require, module, __filename, __dirname) { ", "\n});"];
const ns = await import("./dep.cjs");
console.log(JSON.stringify(ns.default));
// dep.cjs
console.log("dep body ran");
module.exports = { answer: 6 };
```

```
$ node u.mjs
dep body ran
{"answer":6}
$ bun u.mjs          # 1.4.0
{}
$ bun-debug u.mjs    # this branch
dep body ran
{"answer":6}
```

```
$ cat patch.cjs
require("node:module").wrapper = require("node:module").wrapper;
$ bun -r ./patch.cjs ./main.cjs      # 1.4.0: prints nothing, exit 0
$ bun-debug -r ./patch.cjs ./main.cjs
main.cjs body ran
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->