### PR TITLE
types: declare crl on Bun.TLSOptions

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -711,6 +711,9 @@ interface TLSOptions {
   /** Server certificate */
   cert?: string | Buffer | BunFile | Array<string | Buffer | BunFile>;
 
+  /** PEM formatted certificate revocation lists */
+  crl?: string | Buffer | BunFile | Array<string | Buffer | BunFile>;
+
   /** Path to DH parameters file */
   dhParamsFile?: string;
 

--- a/docs/runtime/http/tls.mdx
+++ b/docs/runtime/http/tls.mdx
@@ -55,6 +55,22 @@ Bun.serve({
 });
 ```
 
+### Certificate revocation lists
+
+Pass `crl` to reject peer certificates that a CA has revoked. It accepts the same value types as `ca`: the PEM contents of one or more CRLs as a string, `BunFile`, `TypedArray`, `Buffer`, or an array of those. On a server this applies to client certificates, so it is used together with `requestCert`.
+
+```ts
+Bun.serve({
+  tls: {
+    key: Bun.file("./key.pem"),
+    cert: Bun.file("./cert.pem"),
+    ca: Bun.file("./client-ca.pem"), // CA that issues the client certificates
+    requestCert: true, // ask clients for a certificate
+    crl: Bun.file("./client-ca.crl.pem"), // reject the ones this CA has revoked // [!code ++]
+  },
+});
+```
+
 ### Diffie-Hellman
 
 To override Diffie-Hellman parameters:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4223,6 +4223,12 @@ declare module "bun" {
      */
     ca?: string | BufferSource | BunFile | Array<string | BufferSource | BunFile> | undefined;
     /**
+     * PEM formatted CRLs (Certificate Revocation Lists). A peer certificate
+     * listed in one of them fails verification: a client certificate when a
+     * server sets `requestCert`, or the server certificate when connecting.
+     */
+    crl?: string | BufferSource | BunFile | Array<string | BufferSource | BunFile> | undefined;
+    /**
      *  Cert chains in PEM format. One cert chain should be provided per
      *  private key. Each cert chain should consist of the PEM formatted
      *  certificate for a provided private key, followed by the PEM

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -367,36 +367,87 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
+  // The tests below run on debug builds too: spawning tsc over a single file
+  // is cheap, unlike the in-process LanguageService runs above.
+  async function expectSingleFileToTypeCheck(name: string, source: string) {
+    const checkDir = join(TEMP_DIR, `${name}-check`);
+    const fileName = `${name}.ts`;
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.include = [fileName];
+    tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, {
+      "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      [fileName]: source,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
-           view satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
-      });
+      await expectSingleFileToTypeCheck(
+        "mmap-options",
+        `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+         view satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+      );
+    });
+  });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+  describe("Bun.TLSOptions", () => {
+    test("crl accepts the same value types as ca on every API that takes a tls object", async () => {
+      await expectSingleFileToTypeCheck(
+        "tls-options-crl",
+        `const crlFile = Bun.file("./crl.pem");
+         ({ crl: "pem" }) satisfies Bun.TLSOptions;
+         ({ crl: Buffer.from("pem") }) satisfies Bun.TLSOptions;
+         ({ crl: new Uint8Array(1) }) satisfies Bun.TLSOptions;
+         ({ crl: crlFile }) satisfies Bun.TLSOptions;
+         ({ crl: ["pem", Buffer.from("pem"), new Uint8Array(1), crlFile] }) satisfies Bun.TLSOptions;
+         ({ crl: undefined }) satisfies Bun.TLSOptions;
+         // @ts-expect-error crl takes PEM contents, not a number
+         ({ crl: 1 }) satisfies Bun.TLSOptions;
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+         Bun.serve({
+           fetch: () => new Response(),
+           tls: { key: "key", cert: "cert", ca: "ca", requestCert: true, crl: crlFile },
+         });
+         Bun.serve({
+           fetch: () => new Response(),
+           tls: [
+             { key: "key", cert: "cert", crl: "pem" },
+             { serverName: "a.example.com", key: "key", cert: "cert", crl: [crlFile] },
+           ],
+         });
+         Bun.listen({
+           hostname: "localhost",
+           port: 0,
+           socket: { data() {} },
+           tls: { key: "key", cert: "cert", ca: "ca", requestCert: true, crl: [crlFile] },
+         });
+         Bun.connect({
+           hostname: "localhost",
+           port: 0,
+           socket: { data() {} },
+           tls: { ca: "ca", crl: "pem" },
+         });
+         fetch("https://localhost", { tls: { ca: "ca", crl: Buffer.from("pem") } });
+         new WebSocket("wss://localhost", { tls: { ca: "ca", crl: crlFile } });`,
+      );
     });
   });
 

--- a/test/integration/bun-types/fixture/fetch.ts
+++ b/test/integration/bun-types/fixture/fetch.ts
@@ -332,3 +332,16 @@ if (typeof process !== "undefined") {
   // @ts-expect-error - Proxy must be string or object, not array
   fetch("https://example.com", { proxy: ["http://proxy.example.com"] });
 }
+
+{
+  // crl takes the same value types as ca
+  fetch("https://example.com", { tls: { ca: "ca", crl: "crl" } });
+  fetch("https://example.com", { tls: { ca: Buffer.from("ca"), crl: Buffer.from("crl") } });
+  fetch("https://example.com", { tls: { ca: Bun.file("ca.pem"), crl: Bun.file("crl.pem") } });
+  fetch("https://example.com", { tls: { crl: ["crl", new Uint8Array(1), Bun.file("crl.pem")] } });
+}
+
+{
+  // @ts-expect-error - crl takes PEM contents, not a number
+  fetch("https://example.com", { tls: { crl: 1 } });
+}

--- a/test/integration/bun-types/fixture/serve.ts
+++ b/test/integration/bun-types/fixture/serve.ts
@@ -84,3 +84,27 @@ const s4 = Bun.serve({
     },
   },
 });
+
+Bun.serve({
+  fetch: () => new Response("hello"),
+  tls: {
+    key: Bun.file("key.pem"),
+    cert: Bun.file("cert.pem"),
+    ca: Bun.file("client-ca.pem"),
+    requestCert: true,
+    crl: Bun.file("client-ca.crl.pem"),
+  },
+});
+
+Bun.serve({
+  fetch: () => new Response("hello"),
+  tls: [
+    { key: "key", cert: "cert", crl: "crl" },
+    {
+      serverName: "revoking.example.com",
+      key: "key",
+      cert: "cert",
+      crl: ["crl", Buffer.from("crl"), Bun.file("crl.pem")],
+    },
+  ],
+});

--- a/test/integration/bun-types/fixture/tcp.ts
+++ b/test/integration/bun-types/fixture/tcp.ts
@@ -115,6 +115,42 @@ Bun.listen({
       console.log("asdf");
     },
   },
+  hostname: "adsf",
+  port: 324,
+  tls: {
+    cert: "asdf",
+    key: Bun.file("adsf"),
+    ca: Buffer.from("asdf"),
+    requestCert: true,
+    crl: ["asdf", Buffer.from("asdf"), new Uint8Array(1), Bun.file("asdf")],
+  },
+});
+
+await Bun.connect({
+  data: { arg: "asdf" },
+  socket: {
+    data(socket) {
+      socket.data.arg.toLowerCase();
+    },
+  },
+  hostname: "adsf",
+  port: 324,
+  tls: {
+    ca: Bun.file("asdf"),
+    crl: Bun.file("asdf"),
+  },
+});
+
+Bun.listen({
+  data: { arg: "asdf" },
+  socket: {
+    data(socket) {
+      socket.data.arg.toLowerCase();
+    },
+    open() {
+      console.log("asdf");
+    },
+  },
   unix: "asdf",
 });
 


### PR DESCRIPTION
### Problem
- Passing `crl` in a `tls` object to `Bun.serve`, `Bun.listen`, `Bun.connect`, `fetch` or `new WebSocket` fails to type-check: `error TS2353: Object literal may only specify known properties, and 'crl' does not exist in type 'TLSOptions'`.
- The runtime has accepted the option since #32630: `src/runtime/socket/SSLConfig.bindv2.ts:99` declares `crl` with the same shape as `ca`/`cert`/`key`, `src/runtime/socket/SSLConfig.rs:208` reads it through the same `handle_file_for_field` helper, and `packages/bun-usockets/src/crypto/openssl.c:1289` loads the CRLs into the context's cert store and turns on CRL checking.
- Every API above builds its TLS context through that one converter (`SSLConfig::from_js`), so they all honor `crl`. Only the declaration in `packages/bun-types/bun.d.ts` (`interface TLSOptions`) never gained the member; `docs/` did not mention it either.

### Fix
- `packages/bun-types/bun.d.ts`: add `crl` to `Bun.TLSOptions` with the same value type as `ca` (`string | BufferSource | BunFile | Array<...>`), which is the shape the converter accepts. `BunFetchRequestInitTLS` (fetch) extends `Bun.TLSOptions`, and the serve/listen/connect/WebSocket option types reference it directly, so one member covers every API.
- Correct because it only declares behavior the runtime already has: with the released binary, `Bun.serve({ tls: { ca, requestCert: true, crl } })` rejects a client certificate listed in the CRL and accepts one that is not, `fetch`/`Bun.connect` with `tls: { ca, crl }` fail verification of a revoked server certificate with `CERT_REVOKED`, and all four value shapes (string, Buffer, BunFile, array) are accepted while an unparseable value throws (transcript in the details below).
- `docs/runtime/http/tls.mdx` gains a short CRL section and `docs/runtime/http/server.mdx` lists the option; the snippet shape in `tls.mdx` is the one executed below.
- Deliberately scoped to `crl`. The same sync also left `allowPartialTrustChain`, `sessionTimeout`, `sigalgs` (and later `ecdhCurve`) undeclared; those are tracked separately so this stays a one-member change.
- Verification:
  - `test/integration/bun-types/bun-types.test.ts`, new `Bun.TLSOptions` case: type-checks `crl` in every value shape and on serve (single and per-serverName array), listen, connect, fetch and WebSocket, plus a `@ts-expect-error` for a non-PEM value. It runs on debug builds too (spawns `tsc` over one file, the pattern the existing `Bun.mmap` case uses; that case now shares the helper). Without the `bun.d.ts` hunk it fails with 13 `crl does not exist` diagnostics; with it, `bun bd test test/integration/bun-types/bun-types.test.ts` passes.
  - `test/integration/bun-types/fixture/{serve,tcp,fetch}.ts`: usage lines so the release-lane checks (with and without `lib.dom`, and tsgo) cover the member as well; the full file passes on a release build (16/16) and the `checks without lib.dom.d.ts` case fails without the `bun.d.ts` hunk.

### Background
- `Bun.TLSOptions` is the single TypeScript interface behind the `tls` option of `Bun.serve`, `Bun.listen`, `Bun.connect`, `fetch` and the WebSocket client. At runtime all of them convert that object with `SSLConfig::from_js`, generated from `SSLConfig.bindv2.ts`, so the option set is identical across the APIs and the interface is meant to mirror that file.
- A CRL (certificate revocation list) is a CA-signed list of certificates the CA has revoked. When a TLS context has CRLs configured, a peer certificate on the list fails verification: for a server that is the client certificate it asked for with `requestCert`; for a client it is the server's certificate.
- `test/integration/bun-types` packs `packages/bun-types` and type-checks the `fixture/` directory against it. Its whole-fixture cases only run on release builds (the in-process TypeScript service is too slow under a debug build), which is why the new coverage also includes a single-file `tsc` case that runs everywhere.

<details>
<summary>Runtime probes against the released binary (1.4.0-canary), using the Node key fixtures: agent3 and agent4 are both issued by ca2, ca2-crl.pem revokes agent4</summary>

`Bun.serve` with `ca: ca2, requestCert: true` (the docs snippet shape), client certificates presented via `fetch`:

```
without crl: {"agent3":"HTTP 200 ok","agent4":"HTTP 200 ok"}
with crl:    {"agent3":"HTTP 200 ok","agent4":"rejected: ECONNRESET"}
```

Server presenting agent4, client passing `tls: { ca: ca2, crl: ca2-crl }` (agent4 is a client-auth fixture, hence `INVALID_PURPOSE` as the baseline error):

```
fetch        without crl: INVALID_PURPOSE    with crl: CERT_REVOKED
Bun.connect  without crl: INVALID_PURPOSE    with crl: CERT_REVOKED   (handshake callback)
```

Value shapes and rejection of an unparseable value:

```
serve crl as string / Buffer / BunFile / array: accepted
serve   crl: "garbage"  -> ERR_OSSL_PEM_NO_START_LINE
listen  crl: "garbage"  -> ERR_CRYPTO_OPERATION_FAILED (Failed to parse CRL)
connect crl: "garbage"  -> ERR_CRYPTO_OPERATION_FAILED (Failed to parse CRL)
```

Type-check failure on main (the new test's `tsc` output, trimmed):

```
tls-options-crl.ts(2,13): error TS2353: Object literal may only specify known properties, and 'crl' does not exist in type 'TLSOptions'.
tls-options-crl.ts(13,74): error TS2353: ... 'crl' does not exist in type 'TLSOptions[] | TLSOptions'.
tls-options-crl.ts(34,56): error TS2769: ... 'crl' does not exist in type 'BunFetchRequestInitTLS'.
(13 diagnostics in total)
```

</details>
