### PR TITLE
publish, pm whoami, audit: honor NODE_TLS_REJECT_UNAUTHORIZED=0 like bun install

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -163,6 +163,7 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
         None,
         http::FetchRedirect::Follow,
     );
+    req.client.flags.reject_unauthorized = manager.tls_reject_unauthorized();
 
     let res = match req.send_sync(&mut response_buf) {
         Ok(res) => res,

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -490,6 +490,7 @@ fn send_audit_request(
         None,
         http::FetchRedirect::Follow,
     );
+    req.client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
     let res = match req.send_sync(&mut response_buf) {
         Ok(r) => r,
         Err(err) => {

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -761,6 +761,7 @@ impl PublishCommand {
     }
 
     fn check_package_version_exists(
+        manager: &PackageManager,
         package_name: &[u8],
         version: &[u8],
         registry: &Npm::Registry::Scope,
@@ -835,6 +836,7 @@ impl PublishCommand {
             None,
             http::FetchRedirect::Follow,
         );
+        req.client.flags.reject_unauthorized = manager.tls_reject_unauthorized();
 
         let Ok(res) = req.send_sync(&mut response_buf) else {
             return false;
@@ -877,6 +879,7 @@ impl PublishCommand {
         if tolerate_republish {
             let version_without_build_tag = dependency::without_build_tag(&ctx.package_version);
             let package_exists = Self::check_package_version_exists(
+                ctx.manager,
                 &ctx.package_name,
                 version_without_build_tag,
                 registry,
@@ -949,6 +952,7 @@ impl PublishCommand {
         // arena so the URL outlives `print_buf.clear()` below.
         let publish_url = URL::parse(crate::cli::cli_dupe(&print_buf));
         print_buf.clear();
+        let reject_unauthorized = ctx.manager.tls_reject_unauthorized();
 
         let mut req = http::AsyncHTTP::init_sync(
             http::Method::PUT,
@@ -960,6 +964,7 @@ impl PublishCommand {
             None,
             http::FetchRedirect::Follow,
         );
+        req.client.flags.reject_unauthorized = reject_unauthorized;
 
         let res = match req.send_sync(&mut response_buf) {
             Ok(r) => r,
@@ -1054,6 +1059,7 @@ impl PublishCommand {
                     None,
                     http::FetchRedirect::Follow,
                 );
+                otp_req.client.flags.reject_unauthorized = reject_unauthorized;
 
                 let otp_res = match otp_req.send_sync(&mut response_buf) {
                     Ok(r) => r,
@@ -1268,6 +1274,7 @@ impl PublishCommand {
                     ctx.uses_workspaces,
                     ctx.manager.options.publish_config.auth_type,
                 )?;
+                let reject_unauthorized = ctx.manager.tls_reject_unauthorized();
 
                 loop {
                     response_buf.reset();
@@ -1284,6 +1291,7 @@ impl PublishCommand {
                         None,
                         http::FetchRedirect::Follow,
                     );
+                    req.client.flags.reject_unauthorized = reject_unauthorized;
 
                     let res = match req.send_sync(response_buf) {
                         Ok(r) => r,

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, DirectoryTree, gunzipJsonRequest, lazyPromiseLike, tempDir } from "harness";
+import { bunEnv, bunExe, DirectoryTree, gunzipJsonRequest, lazyPromiseLike, tempDir, tls } from "harness";
 import { join } from "node:path";
 import { resolveBulkAdvisoryFixture } from "./registry/fixtures/audit/audit-fixtures";
 
@@ -397,5 +397,50 @@ describe("`bun audit`", () => {
     expect(JSON.parse(receivedBody)).toEqual({ [packageName]: ["1.0.0"] });
     expect(stdout).toBe("No vulnerabilities found\n");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("`bun audit` against a registry with a self-signed certificate", () => {
+  async function audit(env: NodeJS.Dict<string>) {
+    const requests: string[] = [];
+    using auditServer = Bun.serve({
+      port: 0,
+      tls,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname}`);
+        return Response.json({});
+      },
+    });
+    using dir = tempDir("bun-test-audit-self-signed", fixture("safe-is-number@7"));
+
+    await using proc = spawn({
+      cmd: [bunExe(), "audit"],
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: String(dir),
+      env: {
+        ...env,
+        NPM_CONFIG_REGISTRY: `https://localhost:${auditServer.port}`,
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, requests };
+  }
+
+  test("NODE_TLS_REJECT_UNAUTHORIZED=0 turns verification off", async () => {
+    const { stdout, stderr, exitCode, requests } = await audit({ ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" });
+
+    expect(stderr).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(stdout).toBe("No vulnerabilities found\n");
+    expect(requests).toEqual(["POST /-/npm/v1/security/advisories/bulk"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("verification stays on when the variable is unset", async () => {
+    const { stderr, exitCode, requests } = await audit({ ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: undefined });
+
+    expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(requests).toEqual([]);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tls, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
 import {
@@ -716,6 +716,55 @@ test("bun pm whoami still works", async () => {
 
   // Exit code will be non-zero due to missing auth
   expect(exitCode).toBe(1);
+});
+
+describe.concurrent("bun pm whoami against a registry with a self-signed certificate", () => {
+  async function whoami(env: NodeJS.Dict<string>) {
+    const requests: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      tls,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname}`);
+        return Response.json({ username: "self-signed-user" });
+      },
+    });
+    using dir = tempDir("pm-whoami-self-signed", {
+      "package.json": JSON.stringify({ name: "whoami-self-signed", version: "1.0.0" }),
+      "bunfig.toml": Bun.TOML.stringify({
+        install: {
+          cache: false,
+          registry: { url: `https://localhost:${server.port}`, token: "self-signed-token" },
+        },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "whoami"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, requests };
+  }
+
+  test("NODE_TLS_REJECT_UNAUTHORIZED=0 turns verification off", async () => {
+    const { stdout, stderr, exitCode, requests } = await whoami({ ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" });
+
+    expect(stderr).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(stdout).toBe("self-signed-user\n");
+    expect(requests).toEqual(["GET /-/whoami"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("verification stays on when the variable is unset", async () => {
+    const { stderr, exitCode, requests } = await whoami({ ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: undefined });
+
+    expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
 });
 
 test.each([

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -11,6 +11,7 @@ import {
   pack,
   runBunInstall,
   tempDir,
+  tls,
   tmpdirSync,
 } from "harness";
 import { delimiter, join } from "path";
@@ -1315,5 +1316,98 @@ describe("--tolerate-republish", async () => {
     expect(exitCode).toBe(0);
     expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n");
     expect(err).not.toContain("error:");
+  });
+});
+
+describe.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0", () => {
+  const rejectUnauthorizedOff = { ...env, NODE_TLS_REJECT_UNAUTHORIZED: "0" };
+  const rejectUnauthorizedOn = { ...env, NODE_TLS_REJECT_UNAUTHORIZED: undefined };
+
+  // The harness certificate is self-signed, so every request to this registry
+  // fails verification unless the client has turned it off.
+  function selfSignedRegistry(name: string, opts: { otp?: string } = {}) {
+    const requests: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      tls,
+      fetch(req) {
+        const { pathname } = new URL(req.url);
+        requests.push(`${req.method} ${pathname}`);
+        if (req.method === "PUT") {
+          if (opts.otp !== undefined && req.headers.get("npm-otp") !== opts.otp) {
+            return Response.json(
+              { authUrl: "customapp://login", doneUrl: `https://localhost:${server.port}/-/done` },
+              { status: 401, headers: { "www-authenticate": "OTP" } },
+            );
+          }
+          return new Response("OK");
+        }
+        if (pathname === "/-/done") {
+          return Response.json({ token: opts.otp });
+        }
+        // the --tolerate-republish manifest GET
+        return Response.json({ name, versions: { "1.0.0": {} } });
+      },
+    });
+    const dir = tempDir(`publish-self-signed-${name}`, {
+      "package.json": JSON.stringify({ name, version: "1.0.0" }),
+      "bunfig.toml": Bun.TOML.stringify({
+        install: {
+          cache: false,
+          registry: { url: `https://localhost:${server.port}`, token: "self-signed-token" },
+        },
+      }),
+    });
+    return {
+      requests,
+      packageDir: String(dir),
+      [Symbol.dispose]() {
+        server.stop(true);
+        dir[Symbol.dispose]();
+      },
+    };
+  }
+
+  test("publishes to a registry with a self-signed certificate", async () => {
+    using registry = selfSignedRegistry("tls-publish");
+
+    const { out, err, exitCode } = await publish(rejectUnauthorizedOff, registry.packageDir);
+
+    expect(err).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(out).toContain(" + tls-publish@1.0.0");
+    expect(registry.requests).toEqual(["PUT /tls-publish"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("--tolerate-republish reads the manifest from a registry with a self-signed certificate", async () => {
+    using registry = selfSignedRegistry("tls-republish");
+
+    const { err, exitCode } = await publish(rejectUnauthorizedOff, registry.packageDir, "--tolerate-republish");
+
+    expect(err).toBe("warn: Registry already knows about version 1.0.0; skipping.\n");
+    expect(registry.requests).toEqual(["GET /tls-republish"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("web login polls the done url and retries with the OTP on a registry with a self-signed certificate", async () => {
+    using registry = selfSignedRegistry("tls-web-login", { otp: "123456" });
+
+    const { out, err, exitCode } = await publish(rejectUnauthorizedOff, registry.packageDir);
+
+    expect(err).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(out).toContain("Authenticate your account at:");
+    expect(out).toContain(" + tls-web-login@1.0.0");
+    expect(registry.requests).toEqual(["PUT /tls-web-login", "GET /-/done", "PUT /tls-web-login"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("certificate verification stays on when the variable is unset", async () => {
+    using registry = selfSignedRegistry("tls-verified");
+
+    const { err, exitCode } = await publish(rejectUnauthorizedOn, registry.packageDir);
+
+    expect(err).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(registry.requests).toEqual([]);
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- Against a registry that serves a self-signed or private-CA certificate, `NODE_TLS_REJECT_UNAUTHORIZED=0 bun install` works, but in the same environment `bun publish`, `bun pm whoami` (and its `bun whoami` alias) and `bun audit` fail without ever reaching the registry:
  - `DEPTH_ZERO_SELF_SIGNED_CERT: failed to publish package`
  - `DEPTH_ZERO_SELF_SIGNED_CERT: whoami request failed to send`
  - `DEPTH_ZERO_SELF_SIGNED_CERT: audit request failed`
- Cause: `HTTPClient`'s flags default to `reject_unauthorized: true` (`src/http/lib.rs`), and `AsyncHTTP::init_sync` has no parameter for it, so each caller has to set the flag on the request itself. `bun install` (`src/install/NetworkTask.rs`) and `bun pm view` (`src/runtime/cli/pm_view_command.rs:135`) do; these requests never did:
  - `src/runtime/cli/publish_command.rs`: the `--tolerate-republish` manifest GET in `check_package_version_exists`, the publish PUT, the OTP retry PUT, and the web login `doneUrl` poll in `get_otp`
  - `src/install/npm.rs` `whoami()`
  - `src/runtime/cli/audit_command.rs` `send_audit_request()`
- There is no `strict-ssl` support yet, so this variable (or `ca`/`cafile`) is the only way to use such a registry, and only some commands honored it.

### Fix
- After each of the six `init_sync` calls, set `req.client.flags.reject_unauthorized = manager.tls_reject_unauthorized()`, the same line `pm_view_command.rs` has. `check_package_version_exists` gains a `&PackageManager` parameter to reach it.
- Why this is right:
  - It applies the policy `bun install` already implements to the rest of the registry traffic. Under Node/npm the variable is process wide, so `npm publish`, `npm whoami` and `npm audit` all accept the same registry that `npm install` does; Bun's runtime (`fetch`, `node:tls`, S3) reads it process wide as well. Only these CLI requests were left out.
  - Going through `PackageManager::tls_reject_unauthorized()` rather than reading the environment directly keeps a single definition of "verify registry certificates" for all registry commands (the open `strict-ssl` work in #31775 plugs into that same accessor).
  - Behaviour with the variable unset is unchanged: the accessor returns `true` unless the value is exactly `"0"`, which is what the flag already defaulted to. The new tests check that verification still fails closed by default for all three commands.
  - The `doneUrl` poll is restricted to the registry's own origin (`get_otp` compares protocol, host and port), so it is registry traffic like the others.
- Verified with the tests added next to each command (all spawn the command against a `Bun.serve` registry using the harness self-signed certificate and record the requests it receives):
  - `test/cli/install/bun-publish.test.ts`, `NODE_TLS_REJECT_UNAUTHORIZED=0` block: the publish PUT; the `--tolerate-republish` GET (the registry reports the version as existing, so publish must print the skip warning and send nothing else); the 401 -> `doneUrl` GET -> OTP PUT sequence; and the default-on control.
  - `test/cli/install/bun-pm.test.ts`: `bun pm whoami` prints the username from the registry, plus the default-on control.
  - `test/cli/install/bun-audit.test.ts`: `bun audit` reports against the registry's response, plus the default-on control.
  - `USE_SYSTEM_BUN=1 bun test` on the three files (released 1.4.0): the 5 opt-in tests fail with `DEPTH_ZERO_SELF_SIGNED_CERT` and an empty request log, the 3 controls pass.
  - `bun bd test` on the three files: publish 43 pass, pm 20 pass, audit 19 pass.
  - `bun bd test test/cli/install/bun-install-registry.test.ts -t "whoami|certificate authority"`: 14 pass (the existing `whoami` and CA coverage on the touched `whoami()` path).

### Background
- `AsyncHTTP::init_sync` (`src/http/AsyncHTTP.rs`) builds the blocking request the CLI commands use. TLS verification is controlled per request by `client.flags.reject_unauthorized`; when it is true the client fails the connection on an unverifiable certificate (`DEPTH_ZERO_SELF_SIGNED_CERT` is the error for a self-signed leaf), when false it connects anyway. Configured CAs (`--ca`, `cafile`) are separate: they are loaded once into the HTTP thread in `PackageManager::init` and so already apply to every command.
- `PackageManager::tls_reject_unauthorized()` (`src/install/PackageManager.rs`) reads the package manager's env loader, which `PackageManager::init` fills for every install-family command; `Loader::get_tls_reject_unauthorized` (`src/dotenv/env_loader.rs`) returns `false` only when `NODE_TLS_REJECT_UNAUTHORIZED` is exactly `"0"`.
- `bun publish` can make up to four requests: with `--tolerate-republish` it first GETs the package manifest and skips the upload if the version is already there; the PUT may come back `401` with `www-authenticate: OTP` and a JSON body carrying `authUrl`/`doneUrl`, after which publish polls `doneUrl` until it returns a token and repeats the PUT with an `npm-otp` header.

<details>
<summary>Probe against the released binary (bun 1.4.0), before the fix</summary>

`Bun.serve({ tls })` registry on `https://localhost:<port>`, bunfig `install.registry = { url, token }`, every command run with `NODE_TLS_REJECT_UNAUTHORIZED=0`; `seen` is what the registry received:

```
== pm view (control, already honors env) (exit 0)
   seen: ["GET /tls-pkg"]
== pm whoami (exit 1)
   seen: []
   stderr: DEPTH_ZERO_SELF_SIGNED_CERT: whoami request failed to send
== audit (exit 1)
   seen: []
   stderr: DEPTH_ZERO_SELF_SIGNED_CERT: audit request failed
== publish (exit 1)
   seen: []
   stderr: DEPTH_ZERO_SELF_SIGNED_CERT: failed to publish package
== publish --tolerate-republish (exit 1)
   seen: []
   stderr: DEPTH_ZERO_SELF_SIGNED_CERT: failed to publish package
```
</details>

Related: #38075 fixes the `http_proxy` half of the same call sites (publish and whoami); the two changes are independent, this one only adds a line after each request is built.
