### PR TITLE
test(terminal): run the Ctrl+C platform-gap test on Windows too

### DIFF
--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -189,8 +189,8 @@ describe("Bun.Terminal platform behaviour", () => {
   // tests observe ConPTY, not the agent's process tree.
   const enableCtrlC = isWindows
     ? `import { dlopen } from 'bun:ffi';
-       dlopen('kernel32.dll', { SetConsoleCtrlHandler: { args: ['ptr', 'bool'], returns: 'bool' } })
-         .symbols.SetConsoleCtrlHandler(null, false);`
+       const k32 = dlopen('kernel32.dll', { SetConsoleCtrlHandler: { args: ['ptr', 'bool'], returns: 'bool' } });
+       if (!k32.symbols.SetConsoleCtrlHandler(null, false)) throw new Error('SetConsoleCtrlHandler(NULL, FALSE) failed');`
     : "";
 
   test("SAME: Ctrl+C input interrupts the child", async () => {

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -181,8 +181,12 @@ describe("Bun.Terminal platform behaviour", () => {
     }
   });
 
-  // System conhost's ConPTY does not translate \x03 input to CTRL_C_EVENT.
-  test.todoIf(isWindows)("SAME: Ctrl+C input interrupts the child", async () => {
+  test("SAME: Ctrl+C input interrupts the child", async () => {
+    // POSIX: the line discipline (ISIG) turns ^C into SIGINT. ConPTY: conhost
+    // turns ^C into a CTRL_C_EVENT for the attached child as long as the
+    // child's input mode still has ENABLE_PROCESSED_INPUT (the default), and
+    // libuv reports that event as SIGINT. Holds for the inbox conhost of both
+    // Server 2019 (17763) and Windows 11 24H2 (26100).
     const { output } = await runInTerminal(
       `process.on('SIGINT', () => { process.stdout.write('SIGINT'); process.exit(0); });
        setInterval(() => {}, 1000);
@@ -193,6 +197,23 @@ describe("Bun.Terminal platform behaviour", () => {
       },
     );
     expect(output).toContain("SIGINT");
+  });
+
+  test("SAME: in raw mode Ctrl+C reaches the child as a byte", async () => {
+    // setRawMode(true) clears ISIG (POSIX) / ENABLE_PROCESSED_INPUT (Windows),
+    // so the same ^C is delivered as 0x03 on stdin instead of interrupting.
+    const { output } = await runInTerminal(
+      `process.stdin.setRawMode(true);
+       process.stdin.on('data', d => process.stdout.write('HEX:' + Buffer.from(d).toString('hex')));
+       process.on('SIGINT', () => { process.stdout.write('SIGINT'); process.exit(1); });
+       process.stdout.write('READY');`,
+      {
+        done: o => o.includes("HEX:") || o.includes("SIGINT"),
+        afterReady: t => void t.write("\x03"),
+      },
+    );
+    expect(output).toContain("HEX:03");
+    expect(output).not.toContain("SIGINT");
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -181,6 +181,18 @@ describe("Bun.Terminal platform behaviour", () => {
     }
   });
 
+  // Windows keeps a per-process "ignore Ctrl+C" flag (set by
+  // CREATE_NEW_PROCESS_GROUP or SetConsoleCtrlHandler(NULL, TRUE)) and copies
+  // it into every child, including one attached to a fresh ConPTY. CI agents
+  // start their jobs that way, so on CI the children below would discard the
+  // CTRL_C_EVENT conhost generates for them. Clear the inherited flag so these
+  // tests observe ConPTY, not the agent's process tree.
+  const enableCtrlC = isWindows
+    ? `import { dlopen } from 'bun:ffi';
+       dlopen('kernel32.dll', { SetConsoleCtrlHandler: { args: ['ptr', 'bool'], returns: 'bool' } })
+         .symbols.SetConsoleCtrlHandler(null, false);`
+    : "";
+
   test("SAME: Ctrl+C input interrupts the child", async () => {
     // POSIX: the line discipline (ISIG) turns ^C into SIGINT. ConPTY: conhost
     // turns ^C into a CTRL_C_EVENT for the attached child as long as the
@@ -188,7 +200,8 @@ describe("Bun.Terminal platform behaviour", () => {
     // libuv reports that event as SIGINT. Holds for the inbox conhost of both
     // Server 2019 (17763) and Windows 11 24H2 (26100).
     const { output } = await runInTerminal(
-      `process.on('SIGINT', () => { process.stdout.write('SIGINT'); process.exit(0); });
+      `${enableCtrlC}
+       process.on('SIGINT', () => { process.stdout.write('SIGINT'); process.exit(0); });
        setInterval(() => {}, 1000);
        process.stdout.write('READY');`,
       {
@@ -203,7 +216,8 @@ describe("Bun.Terminal platform behaviour", () => {
     // setRawMode(true) clears ISIG (POSIX) / ENABLE_PROCESSED_INPUT (Windows),
     // so the same ^C is delivered as 0x03 on stdin instead of interrupting.
     const { output } = await runInTerminal(
-      `process.stdin.setRawMode(true);
+      `${enableCtrlC}
+       process.stdin.setRawMode(true);
        process.stdin.on('data', d => process.stdout.write('HEX:' + Buffer.from(d).toString('hex')));
        process.on('SIGINT', () => { process.stdout.write('SIGINT'); process.exit(1); });
        process.stdout.write('READY');`,


### PR DESCRIPTION
### Problem
- `test/js/bun/terminal/terminal-platform-gaps.test.ts:184` marks `SAME: Ctrl+C input interrupts the child` as `test.todoIf(isWindows)` with the comment "System conhost's ConPTY does not translate \x03 input to CTRL_C_EVENT" (added in #29522). The Windows half of the assertion has therefore never run (todo bodies only execute under `--todo`).
- The stated reason is wrong: `bun test --todo` on the unmodified file reports the test as "marked as todo but passes" on both Windows CI images (Server 2019 x64, conhost 17763; Windows 11 24H2 arm64, conhost 26100). conhost does turn the `^C` into a `CTRL_C_EVENT` for the child.
- What actually makes the test fail on CI (first push of this PR, timed out on both Windows lanes) is the process tree, not ConPTY: Windows keeps a per-process "ignore Ctrl+C" flag and copies it into every child, including one attached to a fresh ConPTY. The CI agent starts its job with that flag set, so the child discarded the event. Reproduced locally on both images by setting the flag in an ancestor (`SetConsoleCtrlHandler(NULL, TRUE)`) and running the file: the SIGINT test times out exactly as on CI; clearing the flag makes it pass again.
- The other two Windows todos in the file were checked the same way and are still genuine: `resize ... fires SIGWINCH` times out on both images; `closing an inline terminal ... terminates the child` times out on Server 2019 (it passes on 24H2, which is what its comment already says). Both are left alone.

### Fix
- Drop the `todoIf` and replace the comment with what happens: conhost turns the `^C` into a `CTRL_C_EVENT` while the child's input mode still has `ENABLE_PROCESSED_INPUT` (the default), and libuv surfaces that as `SIGINT`. That is the ConPTY counterpart of the line discipline's `ISIG`, so the test belongs in the SAME group on every platform.
- On Windows the child scripts first call `SetConsoleCtrlHandler(NULL, FALSE)` through `bun:ffi` (same kernel32 pattern as `test/js/bun/spawn/spawn.test.ts`) to clear the inherited flag, so the tests observe ConPTY rather than however the test runner happened to be launched. The comment above the helper explains the flag.
- Add `SAME: in raw mode Ctrl+C reaches the child as a byte`: after `process.stdin.setRawMode(true)` (clears `ISIG` on POSIX, `ENABLE_PROCESSED_INPUT` on Windows) the same `^C` arrives as `0x03` on stdin and no `SIGINT` fires. This is the other half of the mechanism described in the corrected comment and was not covered anywhere in `test/js/bun/terminal/`. It passed on both Windows lanes in the first CI run, before the flag fix, since the byte path does not depend on the flag.
- Verified:
  - Windows Server 2019 x64, debug build: whole file 18 pass / 2 todo both normally and with the ignore flag inherited from an ancestor; the two Ctrl+C tests 15/15 runs with the flag inherited, 10/10 without; release canary 10/10 with the flag inherited.
  - Windows 11 24H2 arm64, debug build: same matrix, 18 pass / 2 todo, 15/15 with the flag inherited, 10/10 without.
  - Linux x64, debug build: whole file 20/20 pass.
  - Latency of the new test matches the existing stdin tests in this file on Server 2019 (about 100 ms from READY to the echoed byte, versus about 150 ms for `terminal.write reaches child stdin`), so it adds no new flake exposure on that lane.

### Background
- ConPTY (`CreatePseudoConsole`) gives the child a real console hosted by conhost. Bytes written to `Bun.Terminal` go to conhost's input pipe and are processed as keyboard input, exactly as typing into a console window would be.
- `ENABLE_PROCESSED_INPUT` is a flag of a console input handle's mode. While it is set, a Ctrl+C keystroke is not placed in the input buffer; the console delivers `CTRL_C_EVENT` to the processes attached to it instead. Clearing it (what raw mode does) puts the `0x03` byte in the input buffer. It is the console equivalent of the termios `ISIG` flag.
- Separately from the console mode, each process has an "ignore Ctrl+C" flag: `SetConsoleCtrlHandler(NULL, TRUE)` sets it, `CREATE_NEW_PROCESS_GROUP` sets it for the new process, and `SetConsoleCtrlHandler(NULL, FALSE)` clears it. A process with the flag set drops `CTRL_C_EVENT` before any handler runs, and the flag is inherited by child processes even when they get a new console. Agents set it on the jobs they run so they can interrupt them with Ctrl+Break instead.
- `process.on('SIGINT')` on Windows is implemented with libuv's `uv_signal_t`, whose console control handler maps `CTRL_C_EVENT` to `SIGINT`; it does not touch the ignore flag (Node behaves the same way).
- `bun test --todo` executes todo bodies and reports one that passes as a failure, which is how the stale todo was found.
