### PR TITLE
js_parser: fix panic on decorated declare/abstract fields in class expressions with experimentalDecorators

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2639,6 +2639,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return;
         }
 
+        // Legacy TS decorators are only lowered for class statements (`lower_class`); on a
+        // class expression they are dropped, matching tsc's output. Decorated `declare` and
+        // `abstract` fields only survive parsing so that lowering can emit their decorator
+        // calls, so without lowering they go too: they have no JS form of their own.
+        if TYPESCRIPT && e_.has_decorators {
+            let properties = e_.properties.slice_mut();
+            let mut end: usize = 0;
+            for i in 0..properties.len() {
+                if matches!(
+                    properties[i].kind,
+                    G::PropertyKind::Declare | G::PropertyKind::Abstract
+                ) {
+                    continue;
+                }
+                properties.swap(end, i);
+                end += 1;
+            }
+            e_.properties.truncate(end);
+        }
+
         // Remove unused class names when minifying (only when bundling is enabled)
         // unless --keep-names is specified
         if p.options.features.minify_syntax

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import DecoratedClass from "./decorator-export-default-class-fixture";
 import DecoratedAnonClass from "./decorator-export-default-class-fixture-anon";
 
@@ -1054,6 +1054,112 @@ test("decorator and declare", () => {
 
   new A();
   expect(counter).toBe(1);
+});
+
+describe("decorated declare/abstract fields in a class expression", () => {
+  // tsc rejects experimental decorators inside class expressions (TS1206) and its output just
+  // drops them, and a `declare`/`abstract` field has nothing else to emit. These run in a
+  // child process because the bug was a transpiler crash.
+  const source = `
+    const A = class {
+      @dec declare a: number;
+      @dec static declare b: number;
+      @dec abstract c: string;
+      @dec declare [key]: number;
+      @dec declare private d: number;
+      e = 1;
+      @dec f = 2;
+      @dec m() {}
+    };
+  `;
+
+  test.concurrent("are removed from the transpiled output", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const transpiler = new Bun.Transpiler({
+            loader: "ts",
+            tsconfig: { compilerOptions: { experimentalDecorators: true } },
+          });
+          process.stdout.write(transpiler.transformSync(${JSON.stringify(source)}));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "const A = class {
+        e = 1;
+        f = 2;
+        m() {}
+      };"
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("do not define a property or run the decorator", async () => {
+    using dir = tempDir("legacy-decorators-class-expr", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+      "index.ts": `
+        const calls: string[] = [];
+        const dec = (_target: unknown, name: PropertyKey) => { calls.push(String(name)); };
+        const key = "computed";
+        ${source}
+        class Outer {
+          Inner = class {
+            @dec declare a: number;
+            e = 1;
+          };
+        }
+        export default (class {
+          @dec declare a: number;
+          e = 1;
+        });
+        const a = new A();
+        console.log(JSON.stringify({
+          calls,
+          a: { ...a },
+          aHasStatic: "b" in A,
+          inner: { ...new (new Outer().Inner)() },
+          m: typeof a.m,
+        }));
+      `,
+      "main.ts": `
+        import Anon from "./index.ts";
+        console.log(JSON.stringify({ ...new Anon() }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(
+      stdout
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line)),
+    ).toEqual([
+      {
+        calls: [],
+        a: { e: 1, f: 2 },
+        aHasStatic: false,
+        inner: { e: 1 },
+        m: "function",
+      },
+      { e: 1 },
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });
 
 test("lowering many decorated instance fields into a large constructor body stays linear", async () => {


### PR DESCRIPTION
### Problem
- With `experimentalDecorators: true`, a class *expression* containing a decorated `declare` field crashes the transpiler: `panic: infallible: prop has value` / `Crashed while printing <file>` (`src/js_printer/lib.rs:4742`, in `print_property`). Hit by `bun file.ts`, `bun build`, and `Bun.Transpiler`.
  ```ts
  const dec: any = () => {};
  const A = class { @dec declare x: number; y = 1 };
  ```
- Same panic for `@dec abstract x: T` and `@dec static declare x: T`. A decorated `declare [computedKey]: T` does not panic but is printed as a real `[computedKey];` field, so the instance gets an own property it should not have.
- Cause: `parse_property` (`src/js_parser/parse/parse_property.rs:431`, `:457`) keeps a decorated `declare`/`abstract` field as a `PropertyKind::Declare`/`Abstract` marker with no value, purely so `lower_class` (`src/js_parser/p.rs:6632`) can emit its `__legacyDecorateClassTS` call and then drop it. `lower_class` only runs for class statements. For class expressions, `e_class` (`src/js_parser/visit/visit_expr.rs`) only lowers standard decorators, so in legacy mode the marker survives to the printer, which requires a value for every kind other than `Normal`/`AutoAccessor`.

### Fix
- `e_class`: after visiting, when the class is not being lowered for standard decorators and has decorators, compact `properties` to drop `Declare`/`Abstract` entries (same swap + `truncate` compaction used elsewhere in the visitor). Gated on the `TYPESCRIPT` const generic since these kinds only come from TS syntax; JS and decorator-free TS classes do no extra work.
- Why dropping is correct: legacy decorators on class expression members are already dropped by Bun (fields and methods keep their member, lose the decorator), and tsc does the same: it reports TS1206 "Decorators are not valid here" for each such member and its emitted output for the snippet above is `const A = class { y = 1 }`. A `declare`/`abstract` field has no runtime form of its own, so once its decorator is dropped nothing remains to print. Class statements (`lower_class`) and standard decorator mode are not touched; their output is byte-identical before and after.
- Verified: `test/bundler/transpiler/decorators.test.ts` (new `describe` covering instance/static `declare`, `abstract`, computed key, `declare` with an access modifier, in a variable initializer, a class field initializer, and a parenthesized `export default`; both tests fail with the panic on the current release and pass with this change)
  - `bun bd test test/bundler/transpiler/decorators.test.ts` (26 pass)
  - `bun bd test` on `es-decorators`, `es-decorators-esbuild`, `decorator-metadata`, `bundler_decorator_metadata`, `ts-use-define-for-class-fields`, `esbuild/ts`, `transpiler.test.js`, regression 27526/27575 (all pass)
  - diffed `bun build --no-bundle` output of class statement and standard-decorator variants against the release binary: identical

### Background
- *Legacy (experimental) decorators*: the TypeScript `experimentalDecorators` flavour. Bun lowers them in `lower_class` by emitting `__legacyDecorateClassTS(...)` statements after the class statement; this needs a statement position, so it is only wired up for class declarations (`s_class` and `export default class`). *Standard decorators* (TC39) are lowered by `lower_decorators.rs` for both statements and expressions and are unaffected here.
- *`PropertyKind::Declare` / `Abstract`*: a `declare x: T` or `abstract x: T` field normally emits nothing and is discarded at parse time. When it carries decorators, tsc still emits the decorator call for it (`__decorate([...], A.prototype, "x", void 0)`), so the parser keeps a marker property of this kind (no value, no initializer) for `lower_class` to consume. The printer has no way to print such a marker.
- *`StoreSlice::truncate`*: class properties are an arena slice; removing entries is done by swapping kept entries to the front and shortening the slice view, with the arena still owning the tail.
