### PR TITLE
build: list the files the bake and runtime.out.js bundles read outside their globs

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -419,14 +419,16 @@ function emitBunError({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.rustInputs.push(...outputs);
 }
 
-function emitRuntimeJs({ n, cfg, o, dirStamp }: Ctx): void {
+/** Exported (with emitBakeCodegen) for test/internal/source-lints/build-codegen-bundle-inputs.test.ts. */
+export function emitRuntimeJs({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const src = resolve(cfg.cwd, "src", "runtime.bun.js");
   const out = resolve(cfg.codegenDir, "runtime.out.js");
 
   n.build({
     outputs: [out],
     rule: "esbuild",
-    inputs: [src],
+    // The entry plus runtime.js, which it re-exports; esbuild has no depfile.
+    inputs: sources.bundlerRuntime,
     implicitInputs: [o.rootInstall],
     orderOnlyInputs: [dirStamp],
     vars: {
@@ -752,7 +754,7 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.cppHeaders.push(...outputs.filter(p => p.endsWith(".h")));
 }
 
-function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bake-codegen.ts");
 
   // InternalModuleRegistry.cpp is listed as a dep in CMake for this step too.
@@ -774,7 +776,9 @@ function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   n.build({
     outputs,
     rule: "codegen",
-    inputs: [script, ...sources.bakeRuntime],
+    // hmr-module.ts imports ../../runtime.bun, so the bundler runtime is
+    // inlined into bake.client.js and bake.server.js as well.
+    inputs: [script, ...sources.bakeRuntime, ...sources.bundlerRuntime],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,

--- a/scripts/glob-sources.ts
+++ b/scripts/glob-sources.ts
@@ -56,11 +56,37 @@ const patterns = {
   jsCodegen: {
     paths: ["src/codegen/*.ts"],
   },
-  /** server-rendering runtime bundled into binary */
+  /**
+   * the bundler's runtime helpers (`__reExport`, `__name`, `__using`, ...).
+   * runtime.bun.js re-exports runtime.js, so both are bundled wherever it is
+   * the entry or an import: runtime.out.js, and the bake runtimes via
+   * hmr-module.ts (emitBakeCodegen adds this list to its edge).
+   */
+  bundlerRuntime: {
+    paths: ["src/runtime.js", "src/runtime.bun.js"],
+  },
+  /**
+   * server-rendering runtime bundled into binary. Next to the modules, the
+   * other files whose contents reach bake-codegen.ts's output:
+   * - dev_server/mod.rs: the MessageId/IncomingMessageId enums it turns
+   *   into generated.ts
+   * - package.json: the `#stack-trace` imports map (picked per bundle
+   *   condition) and `sideEffects`
+   * - tsconfig.json + the tsconfig.base.json it extends: how the modules
+   *   are transpiled (class fields, decorators, jsx)
+   * - client/icons/*: inlined as data: URLs when the script bundles
+   *   overlay.css into the client and error runtimes
+   */
   bakeRuntime: {
-    // dev_server/mod.rs is read by bake-codegen.ts to derive the
-    // MessageId/IncomingMessageId const-enums in generated.ts.
-    paths: ["src/runtime/bake/*.ts", "src/runtime/bake/*/*.{ts,css}", "src/runtime/bake/dev_server/mod.rs"],
+    paths: [
+      "src/runtime/bake/*.ts",
+      "src/runtime/bake/*/*.{ts,css}",
+      "src/runtime/bake/client/icons/*",
+      "src/runtime/bake/dev_server/mod.rs",
+      "src/runtime/bake/package.json",
+      "src/runtime/bake/tsconfig.json",
+      "tsconfig.base.json",
+    ],
     exclude: ["src/runtime/bake/generated.ts"],
   },
   /** legacy bindgen input */
@@ -142,35 +168,43 @@ export type Sources = { [K in keyof typeof patterns]: string[] };
  */
 export function globAllSources(): Sources {
   const result = {} as Sources;
+  for (const field of Object.keys(patterns) as (keyof Sources)[]) {
+    result[field] = globSourceList(field);
+  }
+  return result;
+}
 
-  for (const [field, spec] of Object.entries(patterns) as [keyof Sources, SourcePattern][]) {
-    const excludeExact = new Set<string>();
-    const excludePrefix: string[] = [];
-    for (const ex of (spec.exclude ?? []).map(normalize)) {
-      if (ex.endsWith("/**"))
-        excludePrefix.push(ex.slice(0, -2)); // keep trailing '/'
-      else excludeExact.add(ex);
+/**
+ * Glob one source list. Absolute paths, sorted. For callers (tests) that
+ * need a single list: the `src/**` lists take seconds to expand under a
+ * debug build.
+ */
+export function globSourceList(field: keyof Sources): string[] {
+  const spec: SourcePattern = patterns[field];
+  const excludeExact = new Set<string>();
+  const excludePrefix: string[] = [];
+  for (const ex of (spec.exclude ?? []).map(normalize)) {
+    if (ex.endsWith("/**"))
+      excludePrefix.push(ex.slice(0, -2)); // keep trailing '/'
+    else excludeExact.add(ex);
+  }
+  const files: string[] = [];
+  for (const pattern of spec.paths) {
+    for (const rel of globSync(pattern, { cwd: root })) {
+      const normalized = normalize(rel);
+      if (excludeExact.has(normalized)) continue;
+      if (excludePrefix.some(p => normalized.startsWith(p))) continue;
+      files.push(resolve(root, normalized));
     }
-    const files: string[] = [];
-    for (const pattern of spec.paths) {
-      for (const rel of globSync(pattern, { cwd: root })) {
-        const normalized = normalize(rel);
-        if (excludeExact.has(normalized)) continue;
-        if (excludePrefix.some(p => normalized.startsWith(p))) continue;
-        files.push(resolve(root, normalized));
-      }
-    }
-
-    files.sort((a, b) => a.localeCompare(b));
-    assert(files.length > 0, `Source list '${field}' matched nothing`, {
-      file: import.meta.url,
-      hint: `Patterns: ${spec.paths.join(", ")}`,
-    });
-
-    result[field] = files;
   }
 
-  return result;
+  files.sort((a, b) => a.localeCompare(b));
+  assert(files.length > 0, `Source list '${field}' matched nothing`, {
+    file: import.meta.url,
+    hint: `Patterns: ${spec.paths.join(", ")}`,
+  });
+
+  return files;
 }
 
 /** Forward slashes, no leading ./ — for exclude-set comparisons. */

--- a/test/internal/source-lints/build-codegen-bundle-inputs.test.ts
+++ b/test/internal/source-lints/build-codegen-bundle-inputs.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Two codegen steps in scripts/build/codegen.ts run a bundler, so what they
+ * read is decided by imports rather than by their source globs, and neither
+ * writes a depfile. Every file a bundle pulls in therefore has to be listed on
+ * the step's ninja edge by hand (the lists in scripts/glob-sources.ts), or an
+ * edit to it leaves the output stale until some listed file happens to change:
+ *
+ *   runtime.out.js (esbuild on src/runtime.bun.js)
+ *     src/runtime.js                     re-exported by runtime.bun.js; most of the helpers live here
+ *   bake.{client,server,error}.js (bake-codegen.ts on src/runtime/bake)
+ *     src/runtime.bun.js, src/runtime.js imported by hmr-module.ts
+ *     src/runtime/bake/package.json      the `#stack-trace` imports map and `sideEffects`
+ *     src/runtime/bake/tsconfig.json     class field / decorator / jsx lowering of the modules,
+ *     tsconfig.base.json                 which it extends
+ *     src/runtime/bake/client/icons/*    inlined as data: URLs when overlay.css is bundled
+ *     src/runtime/bake/dev_server/mod.rs the enums the script converts into generated.ts
+ *
+ * The two steps are emitted with the real source lists for a scratch build
+ * dir, and the edges are captured as the emitters hand them to the Ninja
+ * writer; nothing is run or written.
+ */
+import { describe, expect, spyOn, test } from "bun:test";
+import { tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+import {
+  emitBakeCodegen,
+  emitRuntimeJs,
+  registerCodegenRules,
+  type CodegenOutputs,
+} from "../../../scripts/build/codegen.ts";
+import { registerDirStamps } from "../../../scripts/build/compile.ts";
+import { resolveConfig, type Config, type Toolchain } from "../../../scripts/build/config.ts";
+import { Ninja, type BuildNode } from "../../../scripts/build/ninja.ts";
+import { quote } from "../../../scripts/build/shell.ts";
+import { globSourceList, type Sources } from "../../../scripts/glob-sources.ts";
+
+/** A fully-populated fake toolchain; emitting these two steps runs none of it. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+interface Emitted {
+  cfg: Config;
+  /** Every edge the step emitted, with the absolute paths the emitter passed in. */
+  edges: BuildNode[];
+}
+
+/**
+ * Emits `step` for a linux-x64 debug target in `buildDir` (resolves on every
+ * host once told where its sysroot is; the path is only recorded), fed the
+ * two source lists these steps read, expanded from the repo as configure
+ * would. Nothing is written to `buildDir`.
+ */
+function emit(buildDir: string, step: typeof emitBakeCodegen): Emitted {
+  const cfg = resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildType: "Debug", buildDir, linuxSysroot: buildDir },
+    mockToolchain(),
+  );
+  const n = new Ninja({ buildDir });
+  registerDirStamps(n, cfg);
+  registerCodegenRules(n, cfg);
+  const sources = {
+    bakeRuntime: globSourceList("bakeRuntime"),
+    bundlerRuntime: globSourceList("bundlerRuntime"),
+  } as Sources;
+  const o: CodegenOutputs = {
+    all: [],
+    rustInputs: [],
+    rustOrderOnly: [],
+    cppSources: [],
+    cppHeaders: [],
+    cppAll: [],
+    bindgenV2Cpp: [],
+    internalModulesAsm: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.S"),
+    internalModulesBin: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.bin"),
+    rootInstall: resolve(buildDir, "stamps", "install.stamp"),
+  };
+
+  const build = spyOn(n, "build");
+  step({ n, cfg, sources, o, dirStamp: resolve(cfg.codegenDir, ".dir") });
+  return { cfg, edges: build.mock.calls.map(([node]) => node) };
+}
+
+/** The edge that produces `<codegen dir>/${output}`. */
+function edgeProducing({ cfg, edges }: Emitted, output: string): BuildNode {
+  const abs = resolve(cfg.codegenDir, output);
+  const edge = edges.find(e => e.outputs.includes(abs));
+  if (edge === undefined) throw new Error(`no build edge produces ${output}`);
+  return edge;
+}
+
+/**
+ * The files whose mtime re-runs `edge` (explicit and implicit inputs alike),
+ * repo-relative with forward slashes.
+ */
+function dependencies(cfg: Config, edge: BuildNode): string[] {
+  return [...edge.inputs, ...(edge.implicitInputs ?? [])].map(p => relative(cfg.cwd, p).replaceAll("\\", "/"));
+}
+
+interface Tracked {
+  /** The file is where the edge is expected to point (a move has to update the list too). */
+  exists: boolean;
+  /** The edge lists it. */
+  listed: boolean;
+}
+
+/** One entry per repo-relative path in `files`, as the edge sees them. */
+function tracking(cfg: Config, edge: BuildNode, files: string[]): Record<string, Tracked> {
+  const deps = dependencies(cfg, edge);
+  return Object.fromEntries(
+    files.map(file => [file, { exists: existsSync(resolve(cfg.cwd, file)), listed: deps.includes(file) }]),
+  );
+}
+
+function tracked(files: string[]): Record<string, Tracked> {
+  return Object.fromEntries(files.map(file => [file, { exists: true, listed: true }]));
+}
+
+describe("bundling codegen steps list everything their bundles read", () => {
+  test("bake.{client,server,error}.js: the bundler runtime, package.json, the tsconfigs, the icons", () => {
+    using dir = tempDir("build-codegen-bundle-inputs", {});
+    const emitted = emit(String(dir), emitBakeCodegen);
+    const { cfg } = emitted;
+    const edge = edgeProducing(emitted, "bake.client.js");
+
+    const reads = [
+      "src/codegen/bake-codegen.ts",
+      "src/runtime.bun.js",
+      "src/runtime.js",
+      "src/runtime/bake/package.json",
+      "src/runtime/bake/tsconfig.json",
+      "tsconfig.base.json",
+      "src/runtime/bake/client/icons/dismiss.svg",
+      "src/runtime/bake/client/icons/next.svg",
+      "src/runtime/bake/client/icons/prev.svg",
+      "src/runtime/bake/dev_server/mod.rs",
+      // The globbed modules themselves: one per pattern.
+      "src/runtime/bake/hmr-module.ts",
+      "src/runtime/bake/client/overlay.css",
+      "src/runtime/bake/server/stack-trace-stub.ts",
+    ];
+    expect(tracking(cfg, edge, reads)).toEqual(tracked(reads));
+    // One edge writes all three bundles, so the inputs above cover each of them.
+    expect(edge.outputs.map(p => relative(cfg.codegenDir, p))).toEqual([
+      "bake.client.js",
+      "bake.server.js",
+      "bake.error.js",
+    ]);
+    // Written by the step itself (from dev_server/mod.rs above), so it must
+    // not be an input of it.
+    expect(dependencies(cfg, edge)).not.toContain("src/runtime/bake/generated.ts");
+  });
+
+  test("runtime.out.js: runtime.js next to the runtime.bun.js entry", () => {
+    using dir = tempDir("build-codegen-bundle-inputs", {});
+    const emitted = emit(String(dir), emitRuntimeJs);
+    const { cfg } = emitted;
+    const edge = edgeProducing(emitted, "runtime.out.js");
+
+    const reads = ["src/runtime.bun.js", "src/runtime.js"];
+    expect(tracking(cfg, edge, reads)).toEqual(tracked(reads));
+    // The esbuild rule takes its entry point from $args, not $in: listing
+    // runtime.js only tracks it, runtime.bun.js stays the one entry.
+    const entry = quote(resolve(cfg.cwd, "src", "runtime.bun.js"), cfg.host.os === "windows");
+    expect(edge.vars?.args).toStartWith(`${entry} `);
+  });
+});


### PR DESCRIPTION
### Problem
- On a warm tree, editing any of the files below and running `bun bd` leaves `codegen/bake.{client,server,error}.js` stale: `touch <file>; ninja -C build/debug -n codegen/bake.client.js` prints `no work to do` for each of them (touching `hmr-module.ts` plans the step). Debug builds read those files at runtime and release builds embed them, so the stale bundle is what runs either way.
  - `src/runtime.bun.js` and `src/runtime.js`: `hmr-module.ts:18` imports `../../runtime.bun`, which re-exports `runtime.js`; `__name`, `__legacyDecorateClassTS`, `__using`, ... are inlined into `bake.client.js` and `bake.server.js`.
  - `src/runtime/bake/package.json`: its `imports` map resolves `#stack-trace` (`hmr-module.ts:21`) to the client or the server implementation depending on the bundle's condition; it also sets `sideEffects`.
  - `src/runtime/bake/tsconfig.json` and the root `tsconfig.base.json` it extends: setting `useDefineForClassFields: false` in either changes all three bundles (50 / 24 / 22 lines).
  - `src/runtime/bake/client/icons/*.svg`: `overlay.css` references them with `url()`; the script's `bun build overlay.css` inlines them as base64 `data:` URLs into `bake.client.js` and `bake.error.js` (the three data URLs decode to exactly the three files).
- `codegen/runtime.out.js` has the first gap as well: its edge (`emitRuntimeJs` in `scripts/build/codegen.ts`) lists `src/runtime.bun.js` only, so an edit to `src/runtime.js`, where most of that bundle's helpers live, does not re-run esbuild. It mostly went unnoticed because the edge also depends on the root `bun install` stamp, which moves whenever `package.json` or `bun.lock` changes.
- Cause: the bake edge's inputs are the `bakeRuntime` list in `scripts/glob-sources.ts` (`src/runtime/bake/*.ts`, `src/runtime/bake/*/*.{ts,css}`, `dev_server/mod.rs`) and the runtime.out.js edge's input is its entry file. Both steps are bundlers, so their real input set is decided by imports, and neither writes a depfile: a file the globs do not cover is invisible to ninja. The CMake build used the same lists; none of these files were ever tracked.

### Fix
- `scripts/glob-sources.ts`: a `bundlerRuntime` list (`src/runtime.js`, `src/runtime.bun.js`); `bakeRuntime` also lists `client/icons/*`, `package.json`, `tsconfig.json` and `tsconfig.base.json`, with a line per file saying what of it reaches the output. `globAllSources()` is split so one list can be expanded by itself (`globSourceList`): the test needs two small lists, and expanding all of them takes ~18s under a debug build.
- `scripts/build/codegen.ts`: the runtime.out.js edge's inputs become `sources.bundlerRuntime` (the entry on the esbuild command line is unchanged; that rule does not use `$in`), and the bake edge's inputs become `bakeRuntime` plus `bundlerRuntime`. The two emitters are exported for the test.
- Why this is correct: with no depfile, the edge's input list is the only way ninja learns what a step read, which is how `dev_server/mod.rs` (this edge) and `ErrorCode.ts` (bundle-modules) are already tracked. The two runtime files are defined once and both edges consume the list, so a change to what the bundler runtime consists of has one place to go. Over-triggering is cheap: the bake step runs in well under a second, its rule has `restat = 1` and the script uses `writeIfNotChanged`, so a touch that leaves the bundles unchanged re-runs only the step; `runtime.js` edits now relink exactly as `runtime.bun.js` edits already did. Existing trees re-run nothing: the new inputs are ordinary source files, older than the outputs unless actually edited since the last build.
- Verified:
  - `test/internal/source-lints/build-codegen-bundle-inputs.test.ts` emits the two steps with the real lists and checks that each file above exists and is on its edge (plus one globbed module per pattern as a control, and that the script's own `generated.ts` output is still excluded), and that `runtime.bun.js` is still the entry of runtime.out.js. With main's lists and wiring it fails with `listed: false` for each of the eight files on the bake edge and for `runtime.js` on the runtime.out.js edge; with `scripts/` stashed outright it fails on the missing exports. It lives in `source-lints/` because it only imports the build scripts and runs nothing (`bun bd test` passes as well).
  - Real ninja on a linux-x64 debug tree: after reconfiguring, touching each file plans `gen bake.{client,server,error}.js` (the two runtime files also plan `esbuild runtime.out.js`), and an untouched tree is still `no work to do`. Transcript below.
  - `bunx tsc --noEmit -p scripts/build/tsconfig.json` reports nothing new; `test/internal/build-codegen-declared-outputs.test.ts` still passes; `bun bd` builds and the smoke test passes with the regenerated graph.

### Background
- `scripts/build/codegen.ts` writes one ninja `build` edge per generator script, and `scripts/glob-sources.ts` holds the source lists those edges are built from, expanded on every configure (every `bun bd` reconfigures). ninja re-runs an edge when an input written on the edge is newer than its outputs, and for nothing else. Compiles get their exact input set from the compiler's depfile; the `codegen` and `esbuild` rules have none, so their edges carry the whole list by hand.
- bake-codegen (`src/codegen/bake-codegen.ts`) bundles the dev server's hot-reloading runtime (`src/runtime/bake/hmr-runtime-{client,server,error}.ts`) with `Bun.build()` into `bake.*.js`. As for any bundle, the inputs are whatever the entries import, wherever that lives, plus the files that steer resolution and transpilation: the nearest `package.json` (its `imports` field maps `#`-prefixed specifiers, per condition) and the `tsconfig.json` chain.
- `src/runtime.js` holds the helpers the bundler injects into its output (`__reExport`, `__toESM`, `__name`, ...); `src/runtime.bun.js` adds the `using` helpers and re-exports the rest. esbuild bundles it into `codegen/runtime.out.js` for the bundler to use (read at runtime in debug builds, embedded in release), and hmr-module.ts imports it directly, so the bake runtimes carry their own copy.

<details>
<summary>ninja transcript (linux-x64, build/debug)</summary>

Before, with both targets up to date, one touch at a time:

```
touch src/runtime.bun.js;                     ninja -n codegen/bake.client.js   -> no work to do
touch src/runtime/bake/package.json;          ninja -n codegen/bake.client.js   -> no work to do
touch src/runtime/bake/tsconfig.json;         ninja -n codegen/bake.client.js   -> no work to do
touch src/runtime/bake/client/icons/next.svg; ninja -n codegen/bake.client.js   -> no work to do
touch src/runtime/bake/hmr-module.ts;         ninja -n codegen/bake.client.js   -> [1/1] gen bake.{client,server,error}.js   (control)
touch src/runtime.js;                         ninja -n codegen/runtime.out.js   -> no work to do
touch src/runtime.bun.js;                     ninja -n codegen/runtime.out.js   -> [1/1] esbuild runtime.out.js            (control)
```

After `bun scripts/build.ts --configure-only`, with both targets rebuilt between touches (T = `codegen/bake.client.js codegen/runtime.out.js`):

```
ninja -n T                                    -> no work to do
touch src/runtime.js;                         -> [1/2] esbuild runtime.out.js  [2/2] gen bake.{client,server,error}.js
touch src/runtime.bun.js;                     -> [1/2] esbuild runtime.out.js  [2/2] gen bake.{client,server,error}.js
touch src/runtime/bake/package.json;          -> [1/1] gen bake.{client,server,error}.js
touch src/runtime/bake/tsconfig.json;         -> [1/1] gen bake.{client,server,error}.js
touch tsconfig.base.json;                     -> [1/1] gen bake.{client,server,error}.js
touch src/runtime/bake/client/icons/next.svg; -> [1/1] gen bake.{client,server,error}.js
ninja -n T                                    -> no work to do
```

The regenerated bake edge lists the three icons, `package.json`, `tsconfig.json`, `tsconfig.base.json`, `runtime.bun.js` and `runtime.js` after the globbed modules (30 files, up from 24); the runtime.out.js edge reads `esbuild ../../src/runtime.bun.js ../../src/runtime.js | stamps/install_....stamp`.

The module set of the three bundles, from `Bun.build({ metafile: true })` with the script's options, is the globbed `src/runtime/bake` files plus `../../runtime.bun.js` and `../../runtime.js`, nothing else. The metafile does not cover the CSS build or the config files; those were checked as described under Problem.

</details>

Related: #38049 does the same for the files bundle-modules and generate-classes read outside their globs; #38038 adds input-set manifests to these edges and touches the same `n.build()` call in `emitBakeCodegen`, so whichever lands second needs a one-line rebase.
