### PR TITLE
fs.cp: fail with ENOENT when the destination's parent is a dangling symlink

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9140,14 +9140,15 @@ impl NodeFS {
 
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of
     /// `copy_single_file_sync`. Tries `open(dest, flags, mode)`; on ENOENT
-    /// creates the parent directory and retries once. An EEXIST from here
-    /// always means `dest` itself exists (the `cp` callers skip the file on it).
+    /// creates the parent directory and retries once, reporting the last
+    /// `open` attempt's error. An EEXIST from here always means `dest` itself
+    /// exists (the `cp` callers skip the file on it).
     #[cfg_attr(windows, allow(dead_code))]
     fn cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
         // PORT: extracted from the mac/linux/freebsd arms of `copy_single_file_sync`
         // only — there `OSPathSliceZ == ZStr`. Taking `&ZStr` keeps the body
         // monomorphic (and lets it type-check on Windows where it's dead code).
-        let err = match Syscall::open(dest, flags, mode) {
+        let mut err = match Syscall::open(dest, flags, mode) {
             Ok(result) => return Ok(result),
             Err(err) => err,
         };
@@ -9164,11 +9165,10 @@ impl NodeFS {
                 ..Default::default()
             });
             match mkdir_result {
-                Ok(_) => {
-                    if let Ok(result) = Syscall::open(dest, flags, mode) {
-                        return Ok(result);
-                    }
-                }
+                Ok(_) => match Syscall::open(dest, flags, mode) {
+                    Ok(result) => return Ok(result),
+                    Err(retry_err) => err = retry_err,
+                },
                 // A dangling symlink holds the parent's name: this EEXIST is not
                 // about `dest`, which callers would take it for.
                 Err(mkdir_err) if mkdir_err.get_errno() == E::EEXIST => {}

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9157,7 +9157,12 @@ impl NodeFS {
             // No trailing separator on the parent: with one, mkdir(2) on the BSD
             // kernels follows a symlink at that name (Linux says EEXIST either
             // way), so a dangling link there would get its target created.
-            let parent = paths::resolve_path::dirname::<paths::platform::Auto>(dest.as_bytes());
+            // `dirname` leaves one behind when `dest` has a run of them
+            // (`a//x` -> `a/`); a lone root separator stays.
+            let mut parent = paths::resolve_path::dirname::<paths::platform::Auto>(dest.as_bytes());
+            while parent.len() > 1 && parent[parent.len() - 1] == paths::SEP {
+                parent = &parent[..parent.len() - 1];
+            }
             let mkdir_result = self.mkdir_recursive(&args::Mkdir {
                 path: PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(parent, false)),
                 recursive: true,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9139,11 +9139,9 @@ impl NodeFS {
     }
 
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of
-    /// `copy_single_file_sync`.
-    /// Tries `open(dest, flags, mode)`; on ENOENT creates the
-    /// parent directory and retries once. Errors about `dest` are annotated
-    /// with `dest` copied into `sync_error_buf`. An EEXIST from here always
-    /// means `dest` itself exists: the `cp` callers skip the file on it.
+    /// `copy_single_file_sync`. Tries `open(dest, flags, mode)`; on ENOENT
+    /// creates the parent directory and retries once. An EEXIST from here
+    /// always means `dest` itself exists (the `cp` callers skip the file on it).
     #[cfg_attr(windows, allow(dead_code))]
     fn cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
         // PORT: extracted from the mac/linux/freebsd arms of `copy_single_file_sync`
@@ -9154,11 +9152,8 @@ impl NodeFS {
             Err(err) => err,
         };
         if err.get_errno() == E::ENOENT {
-            // No trailing separator on the parent: with one, mkdir(2) on the BSD
-            // kernels follows a symlink at that name (Linux says EEXIST either
-            // way), so a dangling link there would get its target created.
-            // `dirname` leaves one behind when `dest` has a run of them
-            // (`a//x` -> `a/`); a lone root separator stays.
+            // Given a trailing separator, mkdir(2) on the BSD kernels follows a
+            // symlink at the parent's name and creates its target.
             let mut parent = paths::resolve_path::dirname::<paths::platform::Auto>(dest.as_bytes());
             while parent.len() > 1 && parent[parent.len() - 1] == paths::SEP {
                 parent = &parent[..parent.len() - 1];
@@ -9174,9 +9169,8 @@ impl NodeFS {
                         return Ok(result);
                     }
                 }
-                // The parent's name is held by a non-directory (a dangling
-                // symlink, as open() found nothing there). This EEXIST is about
-                // the parent, not `dest`, so report the open() failure instead.
+                // A dangling symlink holds the parent's name: this EEXIST is not
+                // about `dest`, which callers would take it for.
                 Err(mkdir_err) if mkdir_err.get_errno() == E::EEXIST => {}
                 Err(mkdir_err) => return Err(mkdir_err),
             }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9141,40 +9141,43 @@ impl NodeFS {
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of
     /// `copy_single_file_sync`.
     /// Tries `open(dest, flags, mode)`; on ENOENT creates the
-    /// parent directory and retries once. Any other error is annotated with
-    /// `dest` copied into `sync_error_buf`.
+    /// parent directory and retries once. Errors about `dest` are annotated
+    /// with `dest` copied into `sync_error_buf`. An EEXIST from here always
+    /// means `dest` itself exists: the `cp` callers skip the file on it.
     #[cfg_attr(windows, allow(dead_code))]
     fn cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
         // PORT: extracted from the mac/linux/freebsd arms of `copy_single_file_sync`
         // only — there `OSPathSliceZ == ZStr`. Taking `&ZStr` keeps the body
         // monomorphic (and lets it type-check on Windows where it's dead code).
-        match Syscall::open(dest, flags, mode) {
-            Ok(result) => Ok(result),
-            Err(err) => {
-                if err.get_errno() == E::ENOENT {
-                    // Create the parent directory if it doesn't exist
-                    let bytes = dest.as_bytes();
-                    let mut len = bytes.len();
-                    while len > 0 && bytes[len - 1] != paths::SEP {
-                        len -= 1;
-                    }
-                    let mkdir_result = self.mkdir_recursive(&args::Mkdir {
-                        path: PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
-                            &bytes[..len],
-                            false,
-                        )),
-                        recursive: true,
-                        ..Default::default()
-                    });
-                    mkdir_result?;
+        let err = match Syscall::open(dest, flags, mode) {
+            Ok(result) => return Ok(result),
+            Err(err) => err,
+        };
+        if err.get_errno() == E::ENOENT {
+            // No trailing separator on the parent: with one, mkdir(2) on the BSD
+            // kernels follows a symlink at that name (Linux says EEXIST either
+            // way), so a dangling link there would get its target created.
+            let parent = paths::resolve_path::dirname::<paths::platform::Auto>(dest.as_bytes());
+            let mkdir_result = self.mkdir_recursive(&args::Mkdir {
+                path: PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(parent, false)),
+                recursive: true,
+                ..Default::default()
+            });
+            match mkdir_result {
+                Ok(_) => {
                     if let Ok(result) = Syscall::open(dest, flags, mode) {
                         return Ok(result);
                     }
                 }
-                self.sync_error_buf[..dest.len()].copy_from_slice(dest.as_bytes());
-                Err(err.with_path(&self.sync_error_buf[..dest.len()]))
+                // The parent's name is held by a non-directory (a dangling
+                // symlink, as open() found nothing there). This EEXIST is about
+                // the parent, not `dest`, so report the open() failure instead.
+                Err(mkdir_err) if mkdir_err.get_errno() == E::EEXIST => {}
+                Err(mkdir_err) => return Err(mkdir_err),
             }
         }
+        self.sync_error_buf[..dest.len()].copy_from_slice(dest.as_bytes());
+        Err(err.with_path(&self.sync_error_buf[..dest.len()]))
     }
 
     /// Const-generic dispatch from `NodeFSFunctionEnum` to the matching

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir, tempDirWithFiles } from "harness";
+import { readdirSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +173,37 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+// The builtin copies through the node:fs cp engine, which used to report a copy
+// whose destination parent is a dangling symlink as done without copying
+// anything (the engine's mkdir of the parent fails with EEXIST, which was taken
+// for "destination exists"). On POSIX the builtin is enabled by an env var read
+// once at startup, so the command runs in a child bun.
+test("bunshell cp into a dangling symlink parent fails", async () => {
+  using dir = tempDir("shell-cp-dangling-parent", { "a.txt": "A\n" });
+  symlinkSync("missing", join(String(dir), "dangling"));
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const r = await Bun.$\`cp a.txt dangling/out.txt\`.nothrow().quiet();
+       console.log(JSON.stringify({ exitCode: r.exitCode, stderr: r.stderr.toString() }));`,
+    ],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    exitCode: 1,
+    stderr: `cp: No such file or directory: ${join(String(dir), "dangling", "out.txt")}\n`,
+  });
+  expect(exitCode).toBe(0);
+  // Neither the link's target nor anything else was created.
+  expect(readdirSync(String(dir)).sort()).toEqual(["a.txt", "dangling"]);
 });
 
 function expectSortedOutput(expected: string) {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -146,6 +146,29 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/result/a.txt", "win");
     });
 
+    // The destination's missing parent is created on demand. When the parent's
+    // name is held by a dangling symlink that mkdir fails with EEXIST, which
+    // used to be taken for "dest already exists" and reported as success with
+    // nothing copied. node reports ENOENT. Over 128 KB macOS copies with
+    // copyfile() instead of open()+write(), which creates the parent separately.
+    for (const [size, content] of [
+      ["small", "a"],
+      ["over 128 KB", Buffer.alloc(256 * 1024, "x").toString()],
+    ] as const) {
+      test(`${size} file into a dangling symlink parent fails with ENOENT`, async () => {
+        await using basename = tempDir("cp", {
+          "from/a.txt": content,
+        });
+        fs.symlinkSync("missing", basename + "/dangling");
+
+        const e = await copyShouldThrow(basename + "/from/a.txt", basename + "/dangling/a.txt");
+        expect(e.code).toBe("ENOENT");
+
+        // Neither the link's target nor anything else was created.
+        expect(fs.readdirSync(String(basename)).sort()).toEqual(["dangling", "from"]);
+      });
+    }
+
     test("symlinks - single file", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -173,6 +173,23 @@ for (const [name, copy] of impls) {
       }
     }
 
+    // A directory tree goes through the JS port on Linux and Windows, whose
+    // parent mkdir reports EEXIST (as node's cpSync does; node's promises.cp
+    // reports ENOENT), and through the native copy on macOS, which reports
+    // ENOENT. Either way nothing may be created.
+    test("directory into a dangling symlink parent fails", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+        "from/sub/b.txt": "b",
+      });
+      fs.symlinkSync("missing", basename + "/dangling");
+
+      const e = await copyShouldThrow(basename + "/from", basename + "/dangling/out", { recursive: true });
+      expect(["ENOENT", "EEXIST"]).toContain(e.code);
+
+      expect(fs.readdirSync(String(basename)).sort()).toEqual(["dangling", "from"]);
+    });
+
     test("single file into missing nested directories creates them", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",
@@ -181,6 +198,22 @@ for (const [name, copy] of impls) {
       await copy(basename + "/from/a.txt", basename + "/to/deeper/a.txt");
 
       assertContent(basename + "/to/deeper/a.txt", "a");
+    });
+
+    // Once the parent has been created the destination is opened again, and
+    // that attempt's error is the one to report: with a trailing slash Linux
+    // fails it with EISDIR, which is also what node reports. It used to report
+    // the first attempt's ENOENT, and created a directory named x as well.
+    test.skipIf(!isLinux)("single file to a path with a trailing slash reports the retried open's error", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+      });
+
+      const e = await copyShouldThrow(basename + "/from/a.txt", basename + "/newdir/x/");
+      expect(e.code).toBe("EISDIR");
+
+      // The parent was created, as for any destination, but nothing inside it.
+      expect(fs.readdirSync(basename + "/newdir")).toEqual([]);
     });
 
     test("symlinks - single file", async () => {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -173,6 +173,16 @@ for (const [name, copy] of impls) {
       }
     }
 
+    test("single file into missing nested directories creates them", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+      });
+
+      await copy(basename + "/from/a.txt", basename + "/to/deeper/a.txt");
+
+      assertContent(basename + "/to/deeper/a.txt", "a");
+    });
+
     test("symlinks - single file", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -151,22 +151,26 @@ for (const [name, copy] of impls) {
     // used to be taken for "dest already exists" and reported as success with
     // nothing copied. node reports ENOENT. Over 128 KB macOS copies with
     // copyfile() instead of open()+write(), which creates the parent separately.
+    // With a doubled separator the parent is derived as "dangling/", and a
+    // trailing separator makes mkdir follow the link on macOS and FreeBSD.
     for (const [size, content] of [
       ["small", "a"],
       ["over 128 KB", Buffer.alloc(256 * 1024, "x").toString()],
     ] as const) {
-      test(`${size} file into a dangling symlink parent fails with ENOENT`, async () => {
-        await using basename = tempDir("cp", {
-          "from/a.txt": content,
+      for (const dest of ["dangling/a.txt", "dangling//a.txt"]) {
+        test(`${size} file into a dangling symlink parent (${dest}) fails with ENOENT`, async () => {
+          await using basename = tempDir("cp", {
+            "from/a.txt": content,
+          });
+          fs.symlinkSync("missing", basename + "/dangling");
+
+          const e = await copyShouldThrow(basename + "/from/a.txt", basename + "/" + dest);
+          expect(e.code).toBe("ENOENT");
+
+          // Neither the link's target nor anything else was created.
+          expect(fs.readdirSync(String(basename)).sort()).toEqual(["dangling", "from"]);
         });
-        fs.symlinkSync("missing", basename + "/dangling");
-
-        const e = await copyShouldThrow(basename + "/from/a.txt", basename + "/dangling/a.txt");
-        expect(e.code).toBe("ENOENT");
-
-        // Neither the link's target nor anything else was created.
-        expect(fs.readdirSync(String(basename)).sort()).toEqual(["dangling", "from"]);
-      });
+      }
     }
 
     test("symlinks - single file", async () => {


### PR DESCRIPTION
### Problem
- `fs.cpSync("a.txt", "dangling/x")`, `fs.promises.cp(...)` and `fs.cp(...)` return successfully and copy nothing when `dangling` is a symlink to a path that does not exist. Node throws ENOENT. The shell `cp` builtin (`cp a.txt dangling/x`) exits 0 the same way; cp(1) fails with "No such file or directory".
- Reproduces with bun 1.4.0 and main on Linux. With a regular file in place of the link (`cp a.txt file/x`) bun already fails correctly (ENOTDIR), so this is specific to the path below.
- Cause: `NodeFS::cp_open_dest_with_mkdir` (`src/runtime/node/node_fs.rs`, the Linux, FreeBSD and macOS-under-128 KB file copy) gets ENOENT opening `dangling/x`, runs a recursive mkdir of the parent, and `mkdir("dangling")` fails with EEXIST because the link occupies the name. That EEXIST was returned as the copy's result, and every caller (`cp_sync_inner`, `NewAsyncCpTask::cp_async`, `CpSingleTask`) treats EEXIST as "the destination already exists", which is a success unless `errorOnExist` is set. The EEXIST those arms are written for is the one from opening the destination itself with `O_EXCL`.

### Fix
- When the parent mkdir fails with EEXIST, `cp_open_dest_with_mkdir` reports the ENOENT it got from opening the destination instead. Other mkdir failures (EACCES, EROFS, ...) are still returned as before, since they describe why the copy failed and are what node reports for them too.
- Why this is right: after `open()` said ENOENT, an EEXIST from creating the parent can only mean the parent's name is held by something that does not resolve to a directory, so the copy did not happen and the destination does not exist. ENOENT is the error the open already produced and the code node throws (`cpSync` from `copyfile`, `promises.cp` from its parent `mkdir`). It keeps EEXIST meaning one thing for the callers, which is what their skip logic depends on.
- The parent passed to the recursive mkdir is now `dirname(dest)` with any trailing separators stripped (a lone root stays), instead of the prefix up to and including the separator. On Linux `mkdir("dangling/")` and `mkdir("dangling")` both fail with EEXIST, but on the BSD-derived kernels a trailing separator makes mkdir follow a symlink at that name, which would have created the dangling link's target and copied through it. Naming the parent without the separator gives the same result on every platform. The explicit strip is there because `dirname("dangling//x")` is `"dangling/"`; the sys-level `make_path` used by the macOS `copyfile()` arm walks components and never passes a trailing separator, so that arm did not need it.
- Once the parent has been created, the error of the second `open()` is the one reported; it used to report the first attempt's ENOENT whatever the retry said. The retry is the attempt that describes the state after the parent exists: for a destination spelled with a trailing slash (`newdir/x/`) it is EISDIR, which is also what node reports, and an EEXIST from a concurrent creation under `O_EXCL` now reaches the callers' skip logic as it should. The EEXIST arm still reports the first attempt's ENOENT, since there is no retry in that case.
- macOS files over 128 KB and Windows were already correct (their parent-creating retries ignore the mkdir result and report the second copy attempt's error); the tests below cover them so the behaviour is pinned across arms. The shell builtin shares the fixed path through `NewAsyncCpTask`, so it now prints `cp: No such file or directory: <dest>` and exits 1.
- Verified with `test/js/node/fs/cp.test.ts`, each for `cpSync` and `promises.cp`: a small and an over-128 KB file copied to `dangling/a.txt` and to `dangling//a.txt` (8 tests; they fail on the unfixed build because nothing is thrown, and the `//` spelling is what exercises the separator strip on the macOS lane), a file copied to `newdir/x/` expecting EISDIR with `newdir` left empty (Linux only; unfixed builds report ENOENT and create a directory `x`), a directory tree copied into the dangling parent (it must throw and create nothing; see the next bullet for the code), and a file copied into two missing directory levels, pinning the parent creation this PR recomputes. The whole file passes on Linux and Windows, and the darwin 14 lane passed it at the previous head (this head adds the Linux-only test and the directory test).
- `test/js/bun/shell/commands/cp.test.ts` ("bunshell cp into a dangling symlink parent fails", runs `cp` in a child bun with the builtin enabled): exits 0 with no output before, `1` + the ENOENT line after; passes on Windows as well, where the builtin is the default.
- All 77 `test/js/node/test/parallel/test-fs-cp-*` tests pass with this branch; `cargo fmt` is clean.
- Directory trees: on Linux and Windows they go through the JS port, whose own parent `mkdir` reports EEXIST for a dangling parent because bun's recursive mkdir reports EEXIST where node reports ENOENT (node's `cpSync` happens to report EEXIST here too, its `promises.cp` ENOENT); #38146 fixes that mkdir gap separately, after which the directory test's accepted set (`ENOENT` or `EEXIST`) narrows naturally. On macOS a plain tree with default options takes the native directory copy instead, whose `mkdir` of the destination reports ENOENT and creates nothing; the directory test is what exercises that arm in CI. The same native walk hands `mkdir(2)` a `dangling/` prefix for a `dangling//out` spelling, which on the BSD kernels would follow the link; that lives in the recursive mkdir walk rather than in the code this PR touches and is reported separately, so that spelling is deliberately not in the directory test.

### Background
- `fs.cp` / `fs.cpSync` hand regular-file copies with default options to the native implementation in `node_fs.rs` (`NodeFS::cp` for sync, `NewAsyncCpTask` for `fs.promises.cp`, `fs.cp` and, as `ShellAsyncCpTask`, the shell builtin); on macOS a directory tree made only of files and directories, with default options and no existing destination, is handed to it as well (one `clonefile()`, with a per-entry fallback). Everything else goes through the JS port of node's implementation in `src/js/internal/fs/cp*.ts`. Both native entry points copy one file with `copy_single_file_sync`.
- Node's `fs.cp` creates the destination's missing parent directories. The native implementation does this lazily: it tries to open the destination and, on ENOENT, creates the parent and retries; `cp_open_dest_with_mkdir` is that step for the platforms that copy with `open()` + write loop.
- `force: false` is implemented by opening the destination with `O_EXCL` (or `COPYFILE_EXCL` / `CopyFileW(failIfExists)`) and treating the resulting EEXIST as "skip this file", which is why the callers swallow EEXIST.
- A dangling symlink is a symlink whose target does not exist. Opening a path through it fails with ENOENT, while creating something with its name fails with EEXIST, which is how one operation's "missing" turns into another's "exists".

<details>
<summary>Repro before and after (Linux)</summary>

```
$ mkdir t && cd t && echo A > a.txt && ln -s missing dangling
$ cat r.mjs
import fs from "node:fs";
const run = async (label, f) => { try { await f(); console.log(label, "no error"); } catch (e) { console.log(label, e.code); } };
await run("cpSync      ", () => fs.cpSync("a.txt", "dangling/x"));
await run("promises.cp ", () => fs.promises.cp("a.txt", "dangling/y"));
await run("cp          ", () => new Promise((res, rej) => fs.cp("a.txt", "dangling/z", e => e ? rej(e) : res())));
console.log(fs.readdirSync(".").join(" "));

# bun 1.4.0
cpSync       no error
promises.cp  no error
cp           no error
r.mjs a.txt dangling

# this branch
cpSync       ENOENT
promises.cp  ENOENT
cp           ENOENT
r.mjs a.txt dangling

# node v26.3.0
cpSync       ENOENT
promises.cp  ENOENT
cp           ENOENT
a.txt dangling r.mjs

# shell builtin
$ BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'const r = await Bun.$`cp a.txt dangling/x`.nothrow().quiet(); console.log(r.exitCode, JSON.stringify(r.stderr.toString()))'
0 ""                                                                  # bun 1.4.0
1 "cp: No such file or directory: /tmp/t/dangling/x\n"                # this branch
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->