### PR TITLE
node:module: check exceptions from the parent lookup in the native require resolver

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -215,7 +215,10 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (moduleName.isString()) {
             auto moduleString = moduleName.toWTFString(globalObject);
-            if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(moduleString, from.toWTFString(globalObject))) {
+            RETURN_IF_EXCEPTION(scope, {});
+            auto fromString = from.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(moduleString, fromString)) {
                 if (moduleString == resolvedString.value())
                     return JSC::JSValue::encode(moduleName);
                 return JSC::JSValue::encode(jsString(vm, resolvedString.value()));
@@ -230,6 +233,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                 if (overrideHandler) [[likely]] {
                     ASSERT(overrideHandler->isCallable());
                     JSValue parentModuleObject = globalObject->requireMap()->get(globalObject, from);
+                    RETURN_IF_EXCEPTION(scope, {});
 
                     JSValue parentID = jsUndefined();
                     if (auto* parent = dynamicDowncast<Bun::JSCommonJSModule>(parentModuleObject)) {
@@ -242,6 +246,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                     args.append(moduleName);
                     args.append(parentModuleObject);
                     auto parentIdStr = parentID.toWTFString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
                     auto bunStr = Bun::toString(parentIdStr);
                     args.append(jsBoolean(Bun__isBunMain(lexicalGlobalObject, &bunStr)));
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -478,6 +478,86 @@ console.log("survived", require("./late.js"));`,
     expect(await proc.exited).toBe(0);
   });
 
+  // Before calling an overridden _resolveFilename (or matching Bun.plugin virtual modules), the
+  // native resolver looks `this.filename` up in the require cache and coerces it to a string. A
+  // parent whose filename is not a string makes that coercion throw; BUN_JSC_validateExceptionChecks
+  // additionally aborts (debug builds only) if any of those calls is left without an exception check.
+  test("_resolveFilename override and virtual modules propagate parent lookup exceptions", async () => {
+    using dir = tempDir("resolve-filename-exception-checks", {
+      "target.cjs": `module.exports = "target";`,
+      "main.cjs": `
+        const Module = require("module");
+        const path = require("path");
+        const target = path.join(__dirname, "target.cjs");
+        const original = Module._resolveFilename;
+        let overrideCalls = 0;
+        Module._resolveFilename = () => {
+          overrideCalls++;
+          return target;
+        };
+
+        console.log("require via override =", require("not-a-real-module"));
+        console.log("require.resolve({ paths }) via override =", require.resolve("not-a-real-module", { paths: [__dirname] }) === target);
+
+        // Not in the require cache, and its filename cannot be converted to a string.
+        const throwingParent = { filename: { toString() { throw new Error("boom"); } } };
+        overrideCalls = 0;
+        try {
+          Module.prototype.require.call(throwingParent, "not-a-real-module");
+          console.log("throwing parent via override = returned");
+        } catch (e) {
+          console.log("throwing parent via override =", String(e), "| override calls:", overrideCalls);
+        }
+
+        // Registered only now: once a virtual module exists, every require() coerces the parent in
+        // the virtual-module branch first, which would hide the override branch from the case above.
+        Module._resolveFilename = original;
+        Bun.plugin({
+          name: "virtual",
+          setup(build) {
+            build.module("virtual-module", () => ({ exports: { ok: true }, loader: "object" }));
+          },
+        });
+        for (const specifier of ["virtual-module", "not-a-real-module"]) {
+          try {
+            Module.prototype.require.call(throwingParent, specifier);
+            console.log("throwing parent with virtual modules, " + specifier + " = returned");
+          } catch (e) {
+            console.log("throwing parent with virtual modules, " + specifier + " =", String(e));
+          }
+        }
+        console.log("virtual module still loads =", require("virtual-module").ok);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      cwd: String(dir),
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The validator's report names the unchecked call site; surfacing those lines makes a
+    // failure point at the offending scope instead of just showing a truncated transcript.
+    const uncheckedScopes = stderr
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+    expect({ transcript: stdout.trimEnd().split("\n"), uncheckedScopes, exitCode }).toEqual({
+      transcript: [
+        "require via override = target",
+        "require.resolve({ paths }) via override = true",
+        "throwing parent via override = Error: boom | override calls: 0",
+        "throwing parent with virtual modules, virtual-module = Error: boom",
+        "throwing parent with virtual modules, not-a-real-module = Error: boom",
+        "virtual module still loads = true",
+      ],
+      uncheckedScopes: [],
+      exitCode: 0,
+    });
+  });
+
   test("Overwriting Module.prototype.require", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", path.join(import.meta.dir, "modulePrototypeOverwrite.cjs")],


### PR DESCRIPTION
### Problem
- Any program that overrides `require("module")._resolveFilename` and then calls `require()` aborts under JSC's exception-check validator:
  ```
  BUN_JSC_validateExceptionChecks=1 bun-debug test/js/node/module/resolveFilenameOverwrite.cjs
  ERROR: Unchecked JS exception:
      This scope can throw a JS exception: getImpl @ JavaScriptCore/JSOrderedHashTable.h:180
      But the exception was unchecked as of this scope: executeCallImpl @ JavaScriptCore/interpreter/Interpreter.cpp:1294
  vendor/WebKit/Source/JavaScriptCore/runtime/VM.cpp(1590) : void JSC::VM::verifyExceptionCheckNeedIsSatisfied(...)
  ```
- Cause: `functionImportMeta__resolveSyncPrivate` (src/jsc/bindings/ImportMetaObject.cpp) is the native resolver behind `require()` and `require.resolve()`. In its `_resolveFilename` override branch it calls `globalObject->requireMap()->get(globalObject, from)` (line 232) and `parentID.toWTFString(globalObject)` (line 244) with no `RETURN_IF_EXCEPTION` after either. Every other `requireMap()->get()` call site in the tree checks (JSCommonJSModule.cpp:1511, :1582, :1632, BunPlugin.cpp:689).
- `from` is `this.filename` of whatever `require` was invoked on, so the `toWTFString` genuinely throws when the parent's filename is an object with a throwing `toString` (for example `Module.prototype.require.call(fakeModule, id)`). A plain debug build then calls the override with that exception already pending and asserts:
  ```
  ASSERTION FAILED: Unexpected exception observed on thread ...
  !exception()
  JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
  ```
  In release builds the error happens to propagate only because JSC's own `executeCallImpl` bails out on the pending exception before entering the override.
- The virtual-module branch a few lines above (line 217-218) coerces the same `from` (and the specifier) with `toWTFString` and is unchecked in the same way; with a virtual module registered (`Bun.plugin` `build.module()` or `mock.module()`) the same throwing parent trips the validator there instead (`toWTFStringSlowCase` unchecked as of the next scope in `Bun__resolveSync`).
- CI does not catch any of this because `test/js/node/module/node-module-module.test.js`, which spawns the `_resolveFilename` fixture, is listed in `test/no-validate-exceptions.txt`.

### Fix
- Add `RETURN_IF_EXCEPTION(scope, {})` after the four exception-capable calls in `functionImportMeta__resolveSyncPrivate`: the specifier and parent coercions in the virtual-module branch, and `requireMap()->get()` and the parent-id coercion in the override branch. `scope` is the function's `DECLARE_THROW_SCOPE`; the rest of the function (`profiledCall`, `result.toString`, the `paths` loop) already follows this pattern.
- Why this is correct: each of these calls can leave an exception pending (`JSMap::get` hashes the key under a throw scope; `toWTFString` on a non-string runs user `toString`), and the only sensible outcome is to propagate that exception to the `require()` caller. The checks do exactly that and change nothing on the non-throwing path; the eager coercion order is kept as it was.
- `functionImportMeta__resolveSync` (the public `import.meta.resolveSync`) has a similar-looking virtual-module branch but is not touched: it only ever passes a string or `undefined` as `from` and checks `moduleName.isString()` first, so neither coercion there can run user code.
- Verification (`test/js/node/module/node-module-module.test.js`, new test `_resolveFilename override and virtual modules propagate parent lookup exceptions`): it spawns a fixture under `BUN_JSC_validateExceptionChecks=1` that exercises the override with a cached parent, `require.resolve(..., { paths })` through the override, a throwing parent against the override (asserting the override is never called), and the same parent against the virtual-module branch for both a matching and a non-matching specifier, and asserts the transcript plus the validator's report lines plus exit code in one `toEqual`.
  - Unfixed debug build: fails with exit 134 and `uncheckedScopes` naming `getImpl @ JSOrderedHashTable.h:180`.
  - Fixed debug build: passes. `resolveFilenameOverwrite.cjs` and the brief's one-liner repro also run clean under the validator; the throwing-parent repro no longer asserts.
  - `test/js/node/module/module-resolve-filename-paths.test.js` and `test/js/bun/plugin/plugins.test.ts` (virtual modules via `require()`) pass on the fixed build.
  - On release builds the env var is a no-op and the test passes before and after; the debug and ASAN lanes are the ones that exercise it.
- `node-module-module.test.js` stays in `test/no-validate-exceptions.txt` for now: with this change applied, the file's remaining validator failures are the ones owned by #34745 (`Module.wrap`) and the `Module.runMain` override path (reported separately), so the entry can be dropped once those land too.
- Overlaps textually with #38089 (non-callable `_resolveFilename`), which re-indents this block without adding these checks, and with #34102, which replaces the parent lookup in the override branch with arguments passed from JS (the virtual-module hunk is unaffected by it); whichever lands second needs a trivial rebase.

### Background
- **Throw scope / `RETURN_IF_EXCEPTION`**: JSC host code declares a `ThrowScope` and must check for a pending exception after every call that may throw (`RETURN_IF_EXCEPTION`), instead of continuing to run with the exception set. Calling back into JS with an exception pending is a debug assertion (`assertNoException`), and in release it makes later throws silently replace or reorder the original error.
- **`BUN_JSC_validateExceptionChecks=1`**: debug-only JSC mode in which every scope that could have thrown records that the caller owes a check; creating the next scope (or destroying the current one) without that check aborts the process and prints the two locations shown above. Bun's ASAN CI lanes run tests with it enabled except for files listed in `test/no-validate-exceptions.txt`.
- **`functionImportMeta__resolveSyncPrivate`**: the `$resolveSync` builtin used by the CommonJS `require`/`require.resolve` implementation in `src/js/builtins/CommonJS.ts`. It receives the specifier and the parent's `filename`, first consults runtime virtual modules (`Bun.plugin` `build.module()` / `mock.module()`), then an overridden `Module._resolveFilename` if one was installed, then the native resolver.
