### PR TITLE
shell(cp): replace an existing destination when copying a symlink

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8493,7 +8493,27 @@ impl NodeFS {
     /// so an overwriting copy removes the entry first. unlink (`uv_fs_unlink`
     /// on Windows) also removes directory links and junctions; a directory is
     /// left in place and its EISDIR/EPERM becomes the copy's error, as with `cp`.
-    fn cp_unlink_dest_for_link(dest: &ZStr) -> Maybe<()> {
+    /// When the entry is the link being copied (`cp -R link .`), removing it
+    /// would lose the link, so that is refused like the same-inode check in the
+    /// FreeBSD arm of `copy_single_file_sync`.
+    fn cp_unlink_dest_for_link(src: &ZStr, dest: &ZStr) -> Maybe<()> {
+        let dest_stat = match Syscall::lstat(dest) {
+            Ok(stat) => stat,
+            Err(err) if err.get_errno() == E::ENOENT => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        // Filesystems without stable file ids report 0, which identifies nothing.
+        let is_src = dest_stat.st_ino != 0
+            && Syscall::lstat(src)
+                .is_ok_and(|s| s.st_dev == dest_stat.st_dev && s.st_ino == dest_stat.st_ino);
+        if is_src {
+            return Err(sys::Error {
+                errno: E::EINVAL as _,
+                syscall: sys::Tag::copyfile,
+                path: dest.as_bytes().into(),
+                ..Default::default()
+            });
+        }
         match Syscall::unlink(dest) {
             Err(err) if err.get_errno() != E::ENOENT => Err(err),
             _ => Ok(()),
@@ -8556,7 +8576,7 @@ impl NodeFS {
             ZStr::from_buf(&resolved_buf[..], resolved_len)
         };
         if !mode.shouldnt_overwrite() {
-            Self::cp_unlink_dest_for_link(dest)?;
+            Self::cp_unlink_dest_for_link(src, dest)?;
         }
         Syscall::symlink(target, dest)
     }
@@ -8608,7 +8628,7 @@ impl NodeFS {
                         // Without COPYFILE_EXCL, copyfile(3) ignores the EEXIST
                         // from recreating the link and reports success with the
                         // old destination still in place.
-                        Self::cp_unlink_dest_for_link(dest)?;
+                        Self::cp_unlink_dest_for_link(src, dest)?;
                     }
                     return Maybe::<ret::CopyFile>::errno_sys_p(
                         bun_sys::c::copyfile_rc(src, dest, mode_),
@@ -9127,11 +9147,12 @@ impl NodeFS {
                 };
                 let is_dir = stat_ & windows::FILE_ATTRIBUTE_DIRECTORY != 0;
                 if !mode.shouldnt_overwrite() {
+                    let mut src8 = paths::path_buffer_pool::get();
                     let mut dest8 = paths::path_buffer_pool::get();
-                    Self::cp_unlink_dest_for_link(strings::from_wpath(
-                        &mut dest8[..],
-                        dest.as_slice(),
-                    ))?;
+                    Self::cp_unlink_dest_for_link(
+                        strings::from_wpath(&mut src8[..], src.as_slice()),
+                        strings::from_wpath(&mut dest8[..], dest.as_slice()),
+                    )?;
                 }
                 // `symlink_w`/`symlink_or_junction` (not raw `CreateSymbolicLinkW`)
                 // so unprivileged creation is requested. UNC targets skip the junction

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8489,20 +8489,17 @@ impl NodeFS {
         result
     }
 
-    /// A link, unlike a regular file, cannot be copied over an existing entry,
-    /// so an overwriting copy removes the entry first. unlink (`uv_fs_unlink`
-    /// on Windows) also removes directory links and junctions; a directory is
-    /// left in place and its EISDIR/EPERM becomes the copy's error, as with `cp`.
-    /// When the entry is the link being copied (`cp -R link .`), removing it
-    /// would lose the link, so that is refused like the same-inode check in the
-    /// FreeBSD arm of `copy_single_file_sync`.
+    /// A link cannot be created over an existing entry, so an overwriting copy
+    /// removes the entry first. A directory is left alone: unlink's error is the
+    /// copy's error, as with `cp` (`uv_fs_unlink` does remove directory links).
     fn cp_unlink_dest_for_link(src: &ZStr, dest: &ZStr) -> Maybe<()> {
         let dest_stat = match Syscall::lstat(dest) {
             Ok(stat) => stat,
             Err(err) if err.get_errno() == E::ENOENT => return Ok(()),
             Err(err) => return Err(err),
         };
-        // Filesystems without stable file ids report 0, which identifies nothing.
+        // `cp -R link .`: the entry is the link being copied. Inode 0 means the
+        // filesystem has no file ids.
         let is_src = dest_stat.st_ino != 0
             && Syscall::lstat(src)
                 .is_ok_and(|s| s.st_dev == dest_stat.st_dev && s.st_ino == dest_stat.st_ino);
@@ -8625,9 +8622,8 @@ impl NodeFS {
                     if mode.shouldnt_overwrite() {
                         mode_ |= bun_sys::c::COPYFILE_EXCL;
                     } else {
-                        // Without COPYFILE_EXCL, copyfile(3) ignores the EEXIST
-                        // from recreating the link and reports success with the
-                        // old destination still in place.
+                        // copyfile(3) without COPYFILE_EXCL keeps an existing dest
+                        // when the source is a link (its EEXIST is ignored).
                         Self::cp_unlink_dest_for_link(src, dest)?;
                     }
                     return Maybe::<ret::CopyFile>::errno_sys_p(

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8489,8 +8489,24 @@ impl NodeFS {
         result
     }
 
+    /// A link, unlike a regular file, cannot be copied over an existing entry,
+    /// so an overwriting copy removes the entry first. unlink (`uv_fs_unlink`
+    /// on Windows) also removes directory links and junctions; a directory is
+    /// left in place and its EISDIR/EPERM becomes the copy's error, as with `cp`.
+    fn cp_unlink_dest_for_link(dest: &ZStr) -> Maybe<()> {
+        match Syscall::unlink(dest) {
+            Err(err) if err.get_errno() != E::ENOENT => Err(err),
+            _ => Ok(()),
+        }
+    }
+
     #[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
-    fn cp_symlink(&mut self, src: &ZStr, dest: &ZStr) -> Maybe<ret::CopyFile> {
+    fn cp_symlink(
+        &mut self,
+        src: &ZStr,
+        dest: &ZStr,
+        mode: constants::Copyfile,
+    ) -> Maybe<ret::CopyFile> {
         let mut target_buf = PathBuffer::uninit();
         // `bun_sys::readlink` returns the byte length on every
         // platform (the `Syscall` alias = `sys_uv` on Windows would return the
@@ -8505,38 +8521,44 @@ impl NodeFS {
         target_buf[link_len] = 0;
         // SAFETY: NUL written at `target_buf[link_len]`.
         let link_target = ZStr::from_buf(&target_buf[..], link_len);
-        if paths::is_absolute(link_target.as_bytes()) {
-            return Syscall::symlink(link_target, dest);
-        }
-        let mut cwd_buf = PathBuffer::uninit();
         let mut resolved_buf = PathBuffer::uninit();
-        let src_dir = paths::resolve_path::dirname::<paths::platform::Posix>(src.as_bytes());
-        let Ok(cwd_len) = sys::getcwd(&mut cwd_buf[..]) else {
-            // If we can't resolve cwd, preserve the link target as-is rather
-            // than pointing the copied link back at the source path.
-            return Syscall::symlink(link_target, dest);
+        let target: &ZStr = 'resolve: {
+            if paths::is_absolute(link_target.as_bytes()) {
+                break 'resolve link_target;
+            }
+            let mut cwd_buf = PathBuffer::uninit();
+            let src_dir = paths::resolve_path::dirname::<paths::platform::Posix>(src.as_bytes());
+            let Ok(cwd_len) = sys::getcwd(&mut cwd_buf[..]) else {
+                // If we can't resolve cwd, preserve the link target as-is rather
+                // than pointing the copied link back at the source path.
+                break 'resolve link_target;
+            };
+            let cwd = &cwd_buf[..cwd_len];
+            let resolved_buf_len = resolved_buf.len();
+            let Some(resolved) =
+                paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Posix>(
+                    cwd,
+                    &mut resolved_buf[..resolved_buf_len - 1],
+                    &[src_dir, link_target.as_bytes()],
+                )
+            else {
+                self.sync_error_buf[..src.len()].copy_from_slice(src.as_bytes());
+                return Err(sys::Error {
+                    errno: E::ENAMETOOLONG as _,
+                    syscall: sys::Tag::symlink,
+                    path: self.sync_error_buf[..src.len()].into(),
+                    ..Default::default()
+                });
+            };
+            let resolved_len = resolved.len();
+            resolved_buf[resolved_len] = 0;
+            // SAFETY: NUL written at `resolved_buf[resolved_len]`.
+            ZStr::from_buf(&resolved_buf[..], resolved_len)
         };
-        let cwd = &cwd_buf[..cwd_len];
-        let resolved_buf_len = resolved_buf.len();
-        let Some(resolved) =
-            paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Posix>(
-                cwd,
-                &mut resolved_buf[..resolved_buf_len - 1],
-                &[src_dir, link_target.as_bytes()],
-            )
-        else {
-            self.sync_error_buf[..src.len()].copy_from_slice(src.as_bytes());
-            return Err(sys::Error {
-                errno: E::ENAMETOOLONG as _,
-                syscall: sys::Tag::symlink,
-                path: self.sync_error_buf[..src.len()].into(),
-                ..Default::default()
-            });
-        };
-        let resolved_len = resolved.len();
-        resolved_buf[resolved_len] = 0;
-        // SAFETY: NUL written at `resolved_buf[resolved_len]`.
-        Syscall::symlink(ZStr::from_buf(&resolved_buf[..], resolved_len), dest)
+        if !mode.shouldnt_overwrite() {
+            Self::cp_unlink_dest_for_link(dest)?;
+        }
+        Syscall::symlink(target, dest)
     }
 
     /// This is `copyFile`, but it copies symlinks as-is
@@ -8582,6 +8604,11 @@ impl NodeFS {
                         | bun_sys::c::COPYFILE_NOFOLLOW_SRC;
                     if mode.shouldnt_overwrite() {
                         mode_ |= bun_sys::c::COPYFILE_EXCL;
+                    } else {
+                        // Without COPYFILE_EXCL, copyfile(3) ignores the EEXIST
+                        // from recreating the link and reports success with the
+                        // old destination still in place.
+                        Self::cp_unlink_dest_for_link(dest)?;
                     }
                     return Maybe::<ret::CopyFile>::errno_sys_p(
                         bun_sys::c::copyfile_rc(src, dest, mode_),
@@ -8700,7 +8727,7 @@ impl NodeFS {
                     if err.get_errno() == E::ELOOP {
                         // ELOOP is returned when you open a symlink with NOFOLLOW.
                         // as in, it does not actually let you open it.
-                        return self.cp_symlink(src, dest);
+                        return self.cp_symlink(src, dest, mode);
                     }
                     return Err(err);
                 }
@@ -8872,7 +8899,7 @@ impl NodeFS {
                     // open(2) returns EMLINK for this case, though POSIX
                     // specifies ELOOP; accept either.
                     if matches!(err.get_errno(), E::EMLINK | E::ELOOP) {
-                        return self.cp_symlink(src, dest);
+                        return self.cp_symlink(src, dest, mode);
                     }
                     return Err(err);
                 }
@@ -9099,6 +9126,13 @@ impl NodeFS {
                     bun_core::WStr::from_buf(&wbuf[..], len)
                 };
                 let is_dir = stat_ & windows::FILE_ATTRIBUTE_DIRECTORY != 0;
+                if !mode.shouldnt_overwrite() {
+                    let mut dest8 = paths::path_buffer_pool::get();
+                    Self::cp_unlink_dest_for_link(strings::from_wpath(
+                        &mut dest8[..],
+                        dest.as_slice(),
+                    ))?;
+                }
                 // `symlink_w`/`symlink_or_junction` (not raw `CreateSymbolicLinkW`)
                 // so unprivileged creation is requested. UNC targets skip the junction
                 // fallback: libuv's `fs__create_junction` only accepts drive-letter targets.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8498,11 +8498,12 @@ impl NodeFS {
             Err(err) if err.get_errno() == E::ENOENT => return Ok(()),
             Err(err) => return Err(err),
         };
-        // `cp -R link .`: the entry is the link being copied. Inode 0 means the
-        // filesystem has no file ids.
+        // cp's same-file rule for a link source: the entry may be neither the link
+        // itself (`cp -R link .`) nor what it points at (`cp -R link target`).
+        // Inode 0 means the filesystem has no file ids.
+        let same = |s: sys::Stat| s.st_dev == dest_stat.st_dev && s.st_ino == dest_stat.st_ino;
         let is_src = dest_stat.st_ino != 0
-            && Syscall::lstat(src)
-                .is_ok_and(|s| s.st_dev == dest_stat.st_dev && s.st_ino == dest_stat.st_ino);
+            && (Syscall::lstat(src).is_ok_and(same) || Syscall::stat(src).is_ok_and(same));
         if is_src {
             return Err(sys::Error {
                 errno: E::EINVAL as _,

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isLinux, tempDir, tempDirWithFiles } from "harness";
+import { lstatSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,121 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is only the default on Windows; on POSIX it is switched on by an
+// env var that is read once per process, so each cp runs in a child bun.
+describe.concurrent("bunshell cp -R replaces an existing destination with the copied link", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+  const copied = { exitCode: 0, stderr: "" };
+
+  const at = (dir: String, ...parts: string[]) => join(String(dir), ...parts);
+
+  /**
+   * The sources: `link` and `src/link` point at `new.txt`, `dirlink` at `newdir/`.
+   * `old.txt` and `olddir/` are what each test's stale destination entry points at,
+   * and `dest/` is the directory the sources get copied into.
+   */
+  function setup(name: string) {
+    const dir = tempDir(`shell-cp-replace-link-${name}`, {
+      "new.txt": "new",
+      "old.txt": "old",
+      "newdir/marker.txt": "new",
+      "olddir/marker.txt": "old",
+      "src/file.txt": "file",
+      dest: {},
+    });
+    symlinkSync(at(dir, "new.txt"), at(dir, "link"));
+    symlinkSync(at(dir, "new.txt"), at(dir, "src", "link"));
+    symlinkSync(at(dir, "newdir"), at(dir, "dirlink"));
+    return dir;
+  }
+
+  /** Runs `command` through the shell builtin inside `dir`; returns cp's exit code and stderr. */
+  async function cp(dir: String, command: string): Promise<{ exitCode: number; stderr: string }> {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const r = await Bun.$`${{ raw: process.argv[1] }}`.nothrow().quiet();" +
+          "console.log(JSON.stringify({ exitCode: r.exitCode, stderr: r.stderr.toString() }));",
+        command,
+      ],
+      cwd: String(dir),
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  /** Whether `path` is a link now, and what reading through it gives. */
+  function entry(path: string) {
+    return { isLink: lstatSync(path).isSymbolicLink(), reads: readFileSync(path, "utf8") };
+  }
+
+  test("a stale link at the destination is replaced", async () => {
+    using dir = setup("link");
+    symlinkSync(at(dir, "old.txt"), at(dir, "dest", "link"));
+
+    expect(await cp(dir, "cp -R link dest")).toEqual(copied);
+    expect(entry(at(dir, "dest", "link"))).toEqual({ isLink: true, reads: "new" });
+    // The stale link was removed, not written through.
+    expect(readFileSync(at(dir, "old.txt"), "utf8")).toBe("old");
+  });
+
+  test("a stale directory link at the destination is replaced", async () => {
+    using dir = setup("dirlink");
+    symlinkSync(at(dir, "olddir"), at(dir, "dest", "dirlink"));
+
+    expect(await cp(dir, "cp -R dirlink dest")).toEqual(copied);
+    expect(lstatSync(at(dir, "dest", "dirlink")).isSymbolicLink()).toBe(true);
+    expect(readFileSync(at(dir, "dest", "dirlink", "marker.txt"), "utf8")).toBe("new");
+    // Removing the stale link left the directory it pointed at alone.
+    expect(readFileSync(at(dir, "olddir", "marker.txt"), "utf8")).toBe("old");
+  });
+
+  test("a regular file at the destination is replaced by the link", async () => {
+    using dir = setup("file");
+    writeFileSync(at(dir, "dest", "link"), "stale");
+
+    expect(await cp(dir, "cp -R link dest")).toEqual(copied);
+    expect(entry(at(dir, "dest", "link"))).toEqual({ isLink: true, reads: "new" });
+  });
+
+  test("a stale link named as the target operand is replaced", async () => {
+    using dir = setup("operand");
+    symlinkSync(at(dir, "old.txt"), at(dir, "target"));
+
+    expect(await cp(dir, "cp -R link target")).toEqual(copied);
+    expect(entry(at(dir, "target"))).toEqual({ isLink: true, reads: "new" });
+    expect(readFileSync(at(dir, "old.txt"), "utf8")).toBe("old");
+  });
+
+  test("a stale link inside an already existing destination tree is replaced", async () => {
+    using dir = setup("tree");
+    mkdirSync(at(dir, "dest", "src"));
+    symlinkSync(at(dir, "old.txt"), at(dir, "dest", "src", "link"));
+
+    expect(await cp(dir, "cp -R src dest")).toEqual(copied);
+    expect(entry(at(dir, "dest", "src", "link"))).toEqual({ isLink: true, reads: "new" });
+    expect(entry(at(dir, "dest", "src", "file.txt"))).toEqual({ isLink: false, reads: "file" });
+  });
+
+  test("a directory at the destination is kept and the copy fails", async () => {
+    using dir = setup("dir");
+    mkdirSync(at(dir, "dest", "link"));
+    writeFileSync(at(dir, "dest", "link", "keep.txt"), "keep");
+
+    expect(await cp(dir, "cp -R link dest")).toEqual({
+      exitCode: 1,
+      // unlink refuses a directory with EISDIR on Linux and EPERM elsewhere (libuv's on Windows included).
+      stderr: `cp: ${isLinux ? "Is a directory" : "Operation not permitted"}: ${at(dir, "dest", "link")}\n`,
+    });
+    expect(readFileSync(at(dir, "dest", "link", "keep.txt"), "utf8")).toBe("keep");
   });
 });
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -228,6 +228,16 @@ describe.concurrent("bunshell cp -R replaces an existing destination with the co
     return { isLink: lstatSync(path).isSymbolicLink(), reads: readFileSync(path, "utf8") };
   }
 
+  test("links are still created where nothing exists yet", async () => {
+    using dir = setup("fresh");
+
+    expect(await cp(dir, "cp -R link dirlink src dest")).toEqual(copied);
+    expect(entry(at(dir, "dest", "link"))).toEqual({ isLink: true, reads: "new" });
+    expect(entry(at(dir, "dest", "dirlink", "marker.txt"))).toEqual({ isLink: false, reads: "new" });
+    expect(lstatSync(at(dir, "dest", "dirlink")).isSymbolicLink()).toBe(true);
+    expect(entry(at(dir, "dest", "src", "link"))).toEqual({ isLink: true, reads: "new" });
+  });
+
   test("a stale link at the destination is replaced", async () => {
     using dir = setup("link");
     symlinkSync(at(dir, "old.txt"), at(dir, "dest", "link"));

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -296,6 +296,17 @@ describe.concurrent("bunshell cp -R replaces an existing destination with the co
     expect(entry(at(dir, "link"))).toEqual({ isLink: true, reads: "new" });
   });
 
+  test("a link copied onto the file it points at keeps the file and the copy fails", async () => {
+    using dir = setup("target");
+
+    expect(await cp(dir, "cp -R link new.txt")).toEqual({
+      exitCode: 1,
+      stderr: `cp: Invalid argument: ${at(dir, "new.txt")}\n`,
+    });
+    expect(entry(at(dir, "new.txt"))).toEqual({ isLink: false, reads: "new" });
+    expect(entry(at(dir, "link"))).toEqual({ isLink: true, reads: "new" });
+  });
+
   test("a directory at the destination is kept and the copy fails", async () => {
     using dir = setup("dir");
     mkdirSync(at(dir, "dest", "link"));

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, isLinux, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, isLinux, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { lstatSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
@@ -290,7 +290,9 @@ describe.concurrent("bunshell cp -R replaces an existing destination with the co
     using dir = setup("self");
 
     expect(await cp(dir, "cp -R link .")).toEqual({
-      exitCode: 1,
+      // The error names the source path, which the builtin on Windows holds back as
+      // a possible EBUSY and then reports without failing the command (#37943).
+      exitCode: isWindows ? 0 : 1,
       stderr: `cp: Invalid argument: ${at(dir, "link")}\n`,
     });
     expect(entry(at(dir, "link"))).toEqual({ isLink: true, reads: "new" });

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -286,6 +286,16 @@ describe.concurrent("bunshell cp -R replaces an existing destination with the co
     expect(entry(at(dir, "dest", "src", "file.txt"))).toEqual({ isLink: false, reads: "file" });
   });
 
+  test("a link copied onto itself is kept and the copy fails", async () => {
+    using dir = setup("self");
+
+    expect(await cp(dir, "cp -R link .")).toEqual({
+      exitCode: 1,
+      stderr: `cp: Invalid argument: ${at(dir, "link")}\n`,
+    });
+    expect(entry(at(dir, "link"))).toEqual({ isLink: true, reads: "new" });
+  });
+
   test("a directory at the destination is kept and the copy fails", async () => {
     using dir = setup("dir");
     mkdirSync(at(dir, "dest", "link"));


### PR DESCRIPTION
### Problem
- Bun Shell `cp -R` of a symlink onto an existing entry exits 0 with no message and leaves the old entry in place. coreutils and BSD `cp` replace it.
  ```sh
  mkdir -p dest rdir other && ln -s rdir link && ln -s other dest/link
  BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'console.log((await Bun.$`cp -R link dest`.nothrow().quiet()).exitCode)'
  # bun 1.4.0: 0, and dest/link still points at other      cp -R: exit 0, dest/link -> rdir
  ```
- The same happens for a link inside a tree copied over an existing tree (`cp -R d dest` with a stale `dest/d/l`), for a link named as the target operand, and for a regular file at the destination, on Linux, macOS and Windows. The builtin is the default `cp` on Windows and opt-in on POSIX.
- Cause: the builtin asks the native copy (`NodeFS::copy_single_file_sync`, `src/runtime/node/node_fs.rs`) to overwrite (`CpFlags { force: true }`), but the symlink arm of each platform tries to create the new link on top of whatever is at the destination: `cp_symlink` calls `symlink(2)` on Linux/FreeBSD, the macOS arm calls `copyfile(3)`, and the Windows arm calls `symlink_w`/`symlink_or_junction`. That fails with EEXIST, and the callers of `copy_single_file_sync` (the single-file branches of `cp_async`/`cp_sync_inner` and `CpSingleTask::run_owned` for tree entries) treat EEXIST as "already there, fine", which is the skip semantics meant for `force: false`. On macOS `copyfile(3)` itself ignores the EEXIST from its internal `symlink()` when `COPYFILE_EXCL` is not set and returns success. A regular file never hits this because its arm opens the destination and truncates it.

### Fix
- New `cp_unlink_dest_for_link(src, dest)`: if something is at `dest`, unlink it. Each symlink arm calls it right before creating the link, only when the copy is in overwrite mode (`!mode.shouldnt_overwrite()`, i.e. `force` and not `errorOnExist`): `cp_symlink` (Linux/FreeBSD; it now takes the copy mode), the `S_ISLNK` branch of the macOS arm, and the reparse point branch of the Windows arm. `cp_symlink` resolves the link target before the unlink so a resolution failure (ENAMETOOLONG) leaves the destination untouched; that reordering is the rest of its diff.
- This is what `cp` does: in `-R` mode coreutils unlinks the destination before recreating any non-regular source (`copy_internal`: `dereference == DEREF_NEVER && !S_ISREG (src)` leads to `unlinkat`, ENOENT ignored), and BSD `cp`'s `copy_link` is readlink, unlink, symlink. It is also what node's `fs.cp` does for a link over an existing link (`copyLink`: unlink, then symlink), which Bun's JS port in `src/js/internal/fs/cp*.ts` already follows.
- A directory at the destination is not replaced: unlink fails on it (EISDIR on Linux, EPERM on macOS and from libuv on Windows) and that error, carrying the path, is the copy's result, so `cp` now exits 1 with `cp: Is a directory: <dest>` instead of 0. coreutils refuses this case too ("cannot overwrite directory with non-directory"). On Windows it already failed this way because `CreateSymbolicLinkW` over a directory is denied; the new test pins that it keeps failing and keeps the directory's contents.
- The helper refuses (EINVAL, the errno the FreeBSD arm already uses for a same-inode copy) when the entry at `dest` is the source: either the link itself (`lstat` dev/ino of both match; `cp -R link .`, where the builtin appends the basename and hands the native copy `dest == src`) or the file the link points at (`stat(src)` matches; `cp -R link target`). Without this the unlink would delete the user's link in the first case (on macOS `copyfile` then fails with ENOENT and nothing is recreated) and the user's file in the second, replaced by a link to itself. Both were a silent exit 0 before, and both are the cases cp(1)'s `same_file_ok` refuses for a link source in `-R` mode; two different links to one file still replace each other, as in cp. The comparison is skipped when the filesystem reports inode 0. #37962 adds the general same-file check with cp's wording in the builtin; this one only protects the unlink this PR introduces.
- On Windows the self-copy case prints the error but still exits 0, because the builtin holds back any error reported against the source path as a possible EBUSY and does not fail the command when it turns out to be real (pre-existing, fixed by #37943); the test pins that exit code per platform and the link's survival everywhere.
- Windows uses `Syscall::unlink` = `sys_uv::unlink` (`uv_fs_unlink`), which removes file links, directory links and junctions but refuses a real directory, unlike `DeleteFileW` (cannot remove directory links) or `RemoveDirectoryW` (would remove a real directory). `uv_fs_lstat`/`uv_fs_stat` fill dev/ino from the volume serial number and file index, so the same-file comparison works there as well (verified by the Windows runs below).
- The callers' EEXIST handling is unchanged: with the arms removing the destination first, an EEXIST can no longer come out of an overwriting copy, so that code only runs for the `force: false` skip it was written for. In skip mode (`COPYFILE_EXCL`) nothing is unlinked and the arms fail with EEXIST as before.
- `fs.cp`/`fs.cpSync` do not change: `tryNativeFastPath` in `src/js/internal/fs/cp*.ts` only sends regular files (and, on macOS, link-free trees into a missing destination) to the native copy, so these arms are reached from the shell builtin. (The one exception is a Windows reparse point that is not a link, which the Windows arm currently misclassifies as one; #38083 fixes that classification. With `force`, replacing the destination is also what node does for such a file.)
- Tests: `test/js/bun/shell/commands/cp.test.ts`, new block "bunshell cp -R replaces an existing destination with the copied link", each case running `cp` in a child bun with the builtin enabled: stale link, stale directory link (the report's case), regular file, link named as the target operand, stale link inside an existing tree (the `CpSingleTask` path), a link copied onto itself, a link copied onto the file it points at, a directory at the destination, plus the previously untested plain case of copying links to a fresh destination (the nothing-to-unlink branch). On bun 1.4.0, 8 of the 9 fail on Linux and 7 on the Windows canary (the fresh-destination case is a regression guard that passes both ways; the directory case already errored on Windows); all 9 pass with this branch on Linux and on a Windows debug build. The tests also check that the unlink removed the stale link and not what it pointed at, and that the two refused copies leave the link and the file intact. Each clause of the same-file check has a test that fails without it (self-copy for the `lstat` half, link-onto-target for the `stat` half).
- Also run: `test/js/node/fs/cp.test.ts` and `cp-symlink-target.test.ts` on Linux and Windows, and the 77 `test/js/node/test/parallel/test-fs-cp-*` files on Linux; `cargo check -p bun_runtime` for `aarch64-apple-darwin` and `x86_64-unknown-freebsd` is clean; the macOS arm cannot be run here, and the new block passed on the darwin 14 CI lane (9 pass), as well as on the Linux and Windows lanes.

### Background
- Shell `cp` builtin: `ShellCpTask` (`src/runtime/shell/builtin/cp.rs`) resolves the operands and hands each source/destination pair to `ShellAsyncCpTask`, the same `NewAsyncCpTask` type behind `fs.promises.cp`, with `force: true, error_on_exist: false`. It copies a single non-directory source directly, and each non-directory entry of a tree through a `CpSingleTask`; both end in `copy_single_file_sync`. The builtin never follows links (it `lstat`s and opens with `O_NOFOLLOW`), so a symlink source is recreated as a link.
- `constants::Copyfile` is the mode `copy_single_file_sync` receives: the callers turn `force`/`errorOnExist` into `COPYFILE_EXCL` or 0, and `shouldnt_overwrite()` reads that bit. The shell always ends up with 0 (overwrite).
- `copy_single_file_sync` has one arm per platform. It detects a symlink source via `open(O_NOFOLLOW)` failing with ELOOP (EMLINK on FreeBSD), via `lstat` on macOS, and via `FILE_ATTRIBUTE_REPARSE_POINT` on Windows, where a link to a directory is itself a directory entry and must be removed as one.
- `st_dev`/`st_ino`: the device and inode numbers a stat call reports; two names with the same pair are the same entry. `lstat` reports them for a link itself rather than for what it points at.
