### PR TITLE
run --filter/--parallel: set npm_package_* and npm_lifecycle_* per script

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -30,9 +30,7 @@ struct ScriptConfig {
     // parsed `PackageJSON` (which owns the file bytes) drops.
     deps: Vec<Box<[u8]>>,
 
-    /// This package's `$PATH` (its own `node_modules/.bin` chain) plus the
-    /// `npm_package_*` / `npm_lifecycle_*` vars for this package and script;
-    /// everything else comes from the env shared by the whole run.
+    /// This package's `$PATH` and this script's `npm_*` vars, layered over the run's shared env.
     env: ScriptEnv,
     elide_count: Option<usize>,
 }
@@ -310,11 +308,8 @@ struct State<'a> {
     pretty_output: bool,
     shell_bin: &'static ZStr, // intentionally leaked (process exits)
     aborted: bool,
-    // Raw `*mut` — process-lifetime singleton owned
-    // by Transpiler; ProcessHandle::start mutates `env.map` (per-script
-    // `ScriptEnv` overlay) so a shared borrow won't do, and `&'a mut` would
-    // conflict with the Transpiler's own raw-ptr field. Reborrow `&mut *env`
-    // at use sites.
+    // Process-lifetime loader owned by the Transpiler; `ProcessHandle::start` mutates it per
+    // spawn, so it is reborrowed `&mut` at use sites rather than held as `&'a`/`&'a mut`.
     env: *mut bun_dotenv::Loader,
 }
 
@@ -749,7 +744,7 @@ pub(crate) fn run_scripts_with_filter(
 ) -> crate::Result<core::convert::Infallible> {
     // Never returns normally; Result<Infallible, _> keeps `?` support.
     // Own the slice — `ctx` is reborrowed `&mut` for
-    // `configure_env_for_run` below while `script_name` is still live.
+    // `configure_env_for_multi_script_run` below while `script_name` is still live.
     let script_name_owned: Box<[u8]> = if ctx.positionals.len() > 1 {
         ctx.positionals[1].clone()
     } else if ctx.positionals.len() > 0 {
@@ -801,14 +796,9 @@ pub(crate) fn run_scripts_with_filter(
     // `RunCommand::configure_env_for_run(...) -> Result<Transpiler, _>`; until then
     // pass `&mut MaybeUninit<Transpiler>` (zeroed() is invalid: Transpiler is not #[repr(C)] POD).
     let mut this_transpiler = core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(&mut *ctx, &mut this_transpiler, None, true, false)?;
-    // SAFETY: configure_env_for_run fully initializes the out-param on Ok.
+    RunCommand::configure_env_for_multi_script_run(&mut *ctx, &mut this_transpiler)?;
+    // SAFETY: configure_env_for_multi_script_run fully initializes the out-param on Ok.
     let mut this_transpiler = unsafe { this_transpiler.assume_init() };
-    // Same value `bun run <script>` exports (see `RunCommand::exec`).
-    this_transpiler
-        .env_mut()
-        .map
-        .put(b"npm_command", b"run-script")?;
 
     let mut package_json_iter = FilterArg::PackageFilterIterator::init(&patterns, resolve_root)?;
     // defer package_json_iter.deinit() — handled by Drop

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -8,7 +8,7 @@ use crate::api::bun::process::SpawnResultExt as _;
 use crate::api::bun::process::{self as spawn, Process, Rusage, SpawnOptions, Status};
 use crate::cli::Command;
 use crate::cli::filter_arg as FilterArg;
-use crate::cli::run_command::RunCommand;
+use crate::cli::run_command::{RunCommand, ScriptEnv};
 use bun_collections::StringHashMap;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -30,13 +30,10 @@ struct ScriptConfig {
     // parsed `PackageJSON` (which owns the file bytes) drops.
     deps: Vec<Box<[u8]>>,
 
-    // $PATH must be set per script because it contains
-    // node_modules/.bin
-    // ../node_modules/.bin
-    // ../../node_modules/.bin
-    // and so forth, in addition to the user's $PATH.
-    #[allow(non_snake_case)]
-    PATH: Box<[u8]>,
+    /// This package's `$PATH` (its own `node_modules/.bin` chain) plus the
+    /// `npm_package_*` / `npm_lifecycle_*` vars for this package and script;
+    /// everything else comes from the env shared by the whole run.
+    env: ScriptEnv,
     elide_count: Option<usize>,
 }
 
@@ -103,36 +100,22 @@ impl<'a> ProcessHandle<'a> {
             core::ptr::null(),
         ];
         handle.start_time = Some(Instant::now());
-        let spawned: spawn::SpawnProcessResult = 'brk: {
-            // Get the envp with the PATH configured
-            // There's probably a more optimal way to do this where you have a Vec shared
-            // instead of creating a new one for each process
-            let env_ptr = state.env;
-            // SAFETY: state.env is the process-lifetime DotEnv loader (Transpiler::env).
-            let env = unsafe { &mut *env_ptr };
-            // Copy to owned — `original_path` borrows env.map which is
-            // mutated by put() below.
-            let original_path: Box<[u8]> = env.map.get(b"PATH").unwrap_or(b"").into();
-            let _ = env.map.put(b"PATH", &handle.config.PATH);
-            // Restores PATH unconditionally at block exit (success OR error).
-            // Keep the guard armed for the whole block so `?` early-returns also
-            // restore.
-            scopeguard::defer! {
-                // SAFETY: env_ptr valid for the run loop lifetime (see above).
-                let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
-            }
-            // SAFETY: see above; reborrow through raw ptr to avoid overlapping &mut with guard.
-            let envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
+        let spawned: spawn::SpawnProcessResult = {
+            // SAFETY: state.env is the process-lifetime DotEnv loader (Transpiler::env);
+            // this is the only borrow of it while `create_envp` runs.
+            let envp = handle
+                .config
+                .env
+                .create_envp(unsafe { &mut (*state.env).map })?;
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
-            break 'brk unsafe {
+            unsafe {
                 spawn::spawn_process(
                     &handle.options,
                     argv.as_ptr(),
                     envp.as_ptr().cast::<*const c_char>(),
                 )
-            }??;
-            // `_guard` drops here (or on `?` above), restoring PATH.
+            }??
         };
         #[cfg(unix)]
         let (stdout_fd, stderr_fd) = (spawned.stdout, spawned.stderr);
@@ -328,9 +311,10 @@ struct State<'a> {
     shell_bin: &'static ZStr, // intentionally leaked (process exits)
     aborted: bool,
     // Raw `*mut` — process-lifetime singleton owned
-    // by Transpiler; ProcessHandle::start mutates `env.map` (PATH swap) so a
-    // shared borrow won't do, and `&'a mut` would conflict with the Transpiler's
-    // own raw-ptr field. Reborrow `&mut *env` at use sites.
+    // by Transpiler; ProcessHandle::start mutates `env.map` (per-script
+    // `ScriptEnv` overlay) so a shared borrow won't do, and `&'a mut` would
+    // conflict with the Transpiler's own raw-ptr field. Reborrow `&mut *env`
+    // at use sites.
     env: *mut bun_dotenv::Loader,
 }
 
@@ -820,6 +804,11 @@ pub(crate) fn run_scripts_with_filter(
     let _ = RunCommand::configure_env_for_run(&mut *ctx, &mut this_transpiler, None, true, false)?;
     // SAFETY: configure_env_for_run fully initializes the out-param on Ok.
     let mut this_transpiler = unsafe { this_transpiler.assume_init() };
+    // Same value `bun run <script>` exports (see `RunCommand::exec`).
+    this_transpiler
+        .env_mut()
+        .map
+        .put(b"npm_command", b"run-script")?;
 
     let mut package_json_iter = FilterArg::PackageFilterIterator::init(&patterns, resolve_root)?;
     // defer package_json_iter.deinit() — handled by Drop
@@ -867,6 +856,7 @@ pub(crate) fn run_scripts_with_filter(
             dirpath,
             run_in_bun,
         )?;
+        let package_env = ScriptEnv::new(&path_var, Some(&pkgjson));
 
         for (i, name) in [&pre_script_name[..], script_name, &post_script_name[..]]
             .iter()
@@ -926,7 +916,7 @@ pub(crate) fn run_scripts_with_filter(
                 script_content: Box::<[u8]>::from(&interned[0..len_command_only]),
                 combined,
                 deps,
-                PATH: Box::<[u8]>::from(&path_var[..]),
+                env: package_env.with_script(name, original_content),
                 elide_count: ctx.bundler_options.elide_lines,
             });
         }

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -41,8 +41,7 @@ struct ScriptConfig {
     label: Box<[u8]>,
     command: Box<[u8]>,
     cwd: Box<[u8]>,
-    /// `$PATH` and the `npm_*` vars specific to this script's package and
-    /// (for package.json scripts) to the script itself.
+    /// This package's `$PATH` and this script's `npm_*` vars, layered over the run's shared env.
     env: ScriptEnv,
 }
 
@@ -873,14 +872,9 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     // Out-param init pattern.
     let mut this_transpiler_slot =
         ::core::mem::MaybeUninit::<bun_bundler::Transpiler<'static>>::uninit();
-    let _ = RunCommand::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, false)?;
-    // SAFETY: `configure_env_for_run` fully writes the slot on the success path.
+    RunCommand::configure_env_for_multi_script_run(ctx, &mut this_transpiler_slot)?;
+    // SAFETY: `configure_env_for_multi_script_run` fully writes the slot on the success path.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };
-    // Same value `bun run <script>` exports (see `RunCommand::exec`).
-    this_transpiler
-        .env_mut()
-        .map
-        .put(b"npm_command", b"run-script")?;
     let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
 
     // SAFETY: transpiler.env is a process-lifetime *mut Loader set in init.

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -15,7 +15,7 @@ use bun_resolver::package_json::{IncludeDependencies, IncludeScripts};
 
 use crate::Command;
 use crate::filter_arg as FilterArg;
-use crate::run_command::RunCommand;
+use crate::run_command::{RunCommand, ScriptEnv};
 
 // `bun.spawn` (Process/Status/SpawnOptions/Rusage/spawnProcess) —
 // lives under crate::api::bun::process.
@@ -41,8 +41,9 @@ struct ScriptConfig {
     label: Box<[u8]>,
     command: Box<[u8]>,
     cwd: Box<[u8]>,
-    /// PATH env var value for this script
-    path: Box<[u8]>,
+    /// `$PATH` and the `npm_*` vars specific to this script's package and
+    /// (for package.json scripts) to the script itself.
+    env: ScriptEnv,
 }
 
 /// Wraps a BufferedReader and tracks whether it represents stdout or stderr,
@@ -156,19 +157,13 @@ impl<'a> ProcessHandle<'a> {
         ];
 
         self.start_time = Instant::now().into();
-        let envp;
-        let env_ptr = state.env;
         let spawned: SpawnProcessResult = {
-            // SAFETY: state.env points at the process-lifetime DotEnv loader.
-            let env = unsafe { &mut *env_ptr };
-            let original_path: Box<[u8]> = env.map.get(b"PATH").map(Box::from).unwrap_or_default();
-            let _ = env.map.put(b"PATH", &self.config.path);
-            let _restore = scopeguard::guard(original_path, move |original_path| {
-                // SAFETY: env_ptr is the process-lifetime loader; outlives this scope.
-                let _ = unsafe { (*env_ptr).map.put(b"PATH", &original_path) };
-            });
-            // SAFETY: same loader; the `_restore` guard's closure has not fired yet.
-            envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
+            // SAFETY: state.env points at the process-lifetime DotEnv loader; this
+            // is the only borrow of it while `create_envp` runs.
+            let envp = self
+                .config
+                .env
+                .create_envp(unsafe { &mut (*state.env).map })?;
             // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
             // with argv[0] non-null; valid for this call.
             unsafe {
@@ -723,7 +718,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
     raw_name: &[u8],
     scripts_map: Option<&StringArrayHashMap<V>>,
     cwd: &[u8],
-    path: &[u8],
+    package_env: &ScriptEnv,
     label_prefix: Option<&[u8]>,
 ) -> Result<(), Error> {
     let group_start = configs.len();
@@ -766,7 +761,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
                 label: label.clone(),
                 command: cmd_buf.into_boxed_slice(),
                 cwd: Box::from(cwd),
-                path: Box::from(path),
+                env: package_env.with_script(&pre_name, pc),
             });
         }
 
@@ -779,7 +774,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
                 label: label.clone(),
                 command: cmd_buf.into_boxed_slice(),
                 cwd: Box::from(cwd),
-                path: Box::from(path),
+                env: package_env.with_script(raw_name, content),
             });
         }
 
@@ -791,7 +786,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
                 label,
                 command: cmd_buf.into_boxed_slice(),
                 cwd: Box::from(cwd),
-                path: Box::from(path),
+                env: package_env.with_script(&post_name, pc),
             });
         }
     } else {
@@ -824,7 +819,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
             label,
             command: command_z,
             cwd: Box::from(cwd),
-            path: Box::from(path),
+            env: package_env.clone(),
         });
     }
 
@@ -881,6 +876,11 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     let _ = RunCommand::configure_env_for_run(ctx, &mut this_transpiler_slot, None, true, false)?;
     // SAFETY: `configure_env_for_run` fully writes the slot on the success path.
     let this_transpiler = unsafe { this_transpiler_slot.assume_init_mut() };
+    // Same value `bun run <script>` exports (see `RunCommand::exec`).
+    this_transpiler
+        .env_mut()
+        .map
+        .put(b"npm_command", b"run-script")?;
     let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
 
     // SAFETY: transpiler.env is a process-lifetime *mut Loader set in init.
@@ -958,7 +958,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             name: Box<[u8]>,
             dirpath: Box<[u8]>,
             scripts: OwnedScriptsMap,
-            path: Box<[u8]>,
+            env: ScriptEnv,
         }
         let mut matched_packages: Vec<MatchedPackage> = Vec::new();
 
@@ -1021,7 +1021,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                 name: pkg_name,
                 dirpath,
                 scripts: owned_scripts,
-                path: pkg_path_env.into(),
+                env: ScriptEnv::new(&pkg_path_env, Some(&pkgjson)),
             });
         }
 
@@ -1053,7 +1053,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             matched_name,
                             Some(&pkg.scripts),
                             &pkg.dirpath,
-                            &pkg.path,
+                            &pkg.env,
                             Some(&pkg.name),
                         )?;
                     }
@@ -1065,7 +1065,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             raw_name,
                             Some(&pkg.scripts),
                             &pkg.dirpath,
-                            &pkg.path,
+                            &pkg.env,
                             Some(&pkg.name),
                         )?;
                     } else if ctx.workspaces && !ctx.if_present {
@@ -1116,6 +1116,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
 
         let package_json = (*root_dir_info).enclosing_package_json;
         let scripts_map: Option<&ScriptsMap> = package_json.and_then(|pkg| pkg.scripts.as_deref());
+        let package_env = ScriptEnv::new(&path_env, package_json);
 
         for raw_name in &script_names {
             // Check if this is a glob pattern
@@ -1147,7 +1148,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             matched_name,
                             scripts_map,
                             cwd,
-                            &path_env,
+                            &package_env,
                             None,
                         )?;
                     }
@@ -1165,7 +1166,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                     raw_name,
                     scripts_map,
                     cwd,
-                    &path_env,
+                    &package_env,
                     None,
                 )?;
             }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -71,27 +71,19 @@ impl NpmArgs {
     const PACKAGE_VERSION: &'static [u8] = b"npm_package_version";
 }
 
-/// The env vars that differ between the scripts one `bun run` spawns
-/// (`--filter`, `--parallel`, `--sequential`): the package's `$PATH` and the
-/// `npm_package_*` / `npm_lifecycle_*` vars `bun run <script>` sets when run
-/// inside that package. Those runners share one env loader, which
-/// `configure_env_for_run` seeded from the cwd package, so [`Self::create_envp`]
-/// overlays these vars on it only while building each script's envp.
+/// Vars `--filter` / `--parallel` set per script on top of the env map the whole run shares.
 #[derive(Clone)]
 pub(crate) struct ScriptEnv {
     vars: Vec<(Box<[u8]>, Box<[u8]>)>,
 }
 
 impl ScriptEnv {
-    /// `path` is the `$PATH` built for the package directory by
-    /// `configure_path_for_run_with_package_json_dir`.
     pub(crate) fn new(path: &[u8], package_json: Option<&PackageJSON>) -> Self {
         let mut env = Self { vars: Vec::new() };
         env.set(b"PATH", path);
         if let Some(package_json) = package_json {
             env.set(b"npm_package_json", package_json.source.path.text);
-            // Like `configure_env_for_run` (and npm), a package.json without a
-            // name or version leaves the inherited values alone.
+            // A missing name/version stays inherited, as in `configure_env_for_run` and npm.
             if !package_json.name.is_empty() {
                 env.set(NpmArgs::PACKAGE_NAME, &package_json.name);
             }
@@ -110,9 +102,7 @@ impl ScriptEnv {
         env
     }
 
-    /// The env for one package.json script of this package. `script` is the
-    /// body as written in package.json: `npm_lifecycle_script` carries it
-    /// verbatim, not the rewritten command that actually runs.
+    /// `script` is the package.json body verbatim: that is what `npm_lifecycle_script` carries.
     pub(crate) fn with_script(&self, name: &[u8], script: &[u8]) -> Self {
         let mut env = self.clone();
         env.set(b"npm_lifecycle_event", name);
@@ -124,9 +114,7 @@ impl ScriptEnv {
         self.vars.push((Box::from(key), Box::from(value)));
     }
 
-    /// Builds the script's envp from the shared `map` with these vars applied.
-    /// `map` is put back the way it was found, so nothing set for this script
-    /// is seen by the next script spawned from the same map.
+    /// Envp of `map` plus these vars; `map` is restored so they do not reach the next spawn.
     pub(crate) fn create_envp(
         &self,
         map: &mut DotEnv::Map,
@@ -624,7 +612,15 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         log_errors: bool,
         store_root_fd: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
-        Self::configure_env_for_run_impl(ctx, this_transpiler, env, log_errors, store_root_fd, true)
+        Self::configure_env_for_run_impl(
+            ctx,
+            this_transpiler,
+            env,
+            log_errors,
+            store_root_fd,
+            true,
+            true,
+        )
     }
 
     /// Like [`Self::configure_env_for_run`] but does **not** construct the
@@ -645,7 +641,25 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             log_errors,
             store_root_fd,
             false,
+            true,
         )
+    }
+
+    /// [`Self::configure_env_for_run`] for `--filter` / `--parallel`, whose scripts span packages:
+    /// the cwd package's `npm_package_*` vars are not seeded; each [`ScriptEnv`] brings its own.
+    pub(crate) fn configure_env_for_multi_script_run(
+        ctx: &mut ContextData,
+        this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
+    ) -> crate::Result<()> {
+        Self::configure_env_for_run_impl(ctx, this_transpiler, None, true, false, true, false)?;
+        // SAFETY: `configure_env_for_run_impl` returned `Ok`, so the slot is initialized.
+        let this_transpiler = unsafe { this_transpiler.assume_init_mut() };
+        // Same value `exec` exports for `bun run <script>`.
+        this_transpiler
+            .env_mut()
+            .map
+            .put(b"npm_command", b"run-script")?;
+        Ok(())
     }
 
     /// `configure_linker()` + `load_tsconfig_json` setup, factored into a
@@ -670,6 +684,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         log_errors: bool,
         store_root_fd: bool,
         with_linker: bool,
+        seed_cwd_package: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
         let args = ctx.args.clone();
         let env_is_none = env.is_none();
@@ -812,7 +827,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             }
         }
 
-        if let Some(package_json) = root_dir_info.enclosing_package_json {
+        if seed_cwd_package && let Some(package_json) = root_dir_info.enclosing_package_json {
             if !package_json.name.is_empty() {
                 if env_loader.map.get(NpmArgs::PACKAGE_NAME).is_none() {
                     env_loader

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -71,6 +71,76 @@ impl NpmArgs {
     const PACKAGE_VERSION: &'static [u8] = b"npm_package_version";
 }
 
+/// The env vars that differ between the scripts one `bun run` spawns
+/// (`--filter`, `--parallel`, `--sequential`): the package's `$PATH` and the
+/// `npm_package_*` / `npm_lifecycle_*` vars `bun run <script>` sets when run
+/// inside that package. Those runners share one env loader, which
+/// `configure_env_for_run` seeded from the cwd package, so [`Self::create_envp`]
+/// overlays these vars on it only while building each script's envp.
+#[derive(Clone)]
+pub(crate) struct ScriptEnv {
+    vars: Vec<(&'static [u8], Box<[u8]>)>,
+}
+
+impl ScriptEnv {
+    /// `path` is the `$PATH` built for the package directory by
+    /// `configure_path_for_run_with_package_json_dir`.
+    pub(crate) fn new(path: &[u8], package_json: Option<&PackageJSON>) -> Self {
+        let mut vars: Vec<(&'static [u8], Box<[u8]>)> = vec![(b"PATH", Box::from(path))];
+        if let Some(package_json) = package_json {
+            vars.push((
+                b"npm_package_json",
+                Box::from(package_json.source.path.text),
+            ));
+            // Like `configure_env_for_run` (and npm), a package.json without a
+            // name or version leaves the inherited values alone.
+            if !package_json.name.is_empty() {
+                vars.push((NpmArgs::PACKAGE_NAME, package_json.name.clone()));
+            }
+            if !package_json.version.is_empty() {
+                vars.push((NpmArgs::PACKAGE_VERSION, package_json.version.clone()));
+            }
+        }
+        Self { vars }
+    }
+
+    /// The env for one package.json script of this package. `script` is the
+    /// body as written in package.json: `npm_lifecycle_script` carries it
+    /// verbatim, not the rewritten command that actually runs.
+    pub(crate) fn with_script(&self, name: &[u8], script: &[u8]) -> Self {
+        let mut env = self.clone();
+        env.vars.push((b"npm_lifecycle_event", Box::from(name)));
+        env.vars.push((b"npm_lifecycle_script", Box::from(script)));
+        env
+    }
+
+    /// Builds the script's envp from the shared `map` with these vars applied.
+    /// `map` is put back the way it was found, so nothing set for this script
+    /// is seen by the next script spawned from the same map.
+    pub(crate) fn create_envp(
+        &self,
+        map: &mut DotEnv::Map,
+    ) -> Result<DotEnv::NullDelimitedEnvMap, bun_alloc::AllocError> {
+        let previous: Vec<(&'static [u8], Option<Box<[u8]>>)> = self
+            .vars
+            .iter()
+            .map(|(key, _)| (*key, map.get(key).map(Box::from)))
+            .collect();
+        let envp = self
+            .vars
+            .iter()
+            .try_for_each(|(key, value)| map.put(key, value))
+            .and_then(|()| map.create_null_delimited_env_map());
+        for (key, value) in &previous {
+            match value {
+                Some(value) => map.put(key, value)?,
+                None => map.remove(key),
+            }
+        }
+        envp
+    }
+}
+
 /// Runtime knobs `Command::start` passes through to select the per-tag exec
 /// behavior.
 #[derive(Clone, Copy)]

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -79,29 +79,35 @@ impl NpmArgs {
 /// overlays these vars on it only while building each script's envp.
 #[derive(Clone)]
 pub(crate) struct ScriptEnv {
-    vars: Vec<(&'static [u8], Box<[u8]>)>,
+    vars: Vec<(Box<[u8]>, Box<[u8]>)>,
 }
 
 impl ScriptEnv {
     /// `path` is the `$PATH` built for the package directory by
     /// `configure_path_for_run_with_package_json_dir`.
     pub(crate) fn new(path: &[u8], package_json: Option<&PackageJSON>) -> Self {
-        let mut vars: Vec<(&'static [u8], Box<[u8]>)> = vec![(b"PATH", Box::from(path))];
+        let mut env = Self { vars: Vec::new() };
+        env.set(b"PATH", path);
         if let Some(package_json) = package_json {
-            vars.push((
-                b"npm_package_json",
-                Box::from(package_json.source.path.text),
-            ));
+            env.set(b"npm_package_json", package_json.source.path.text);
             // Like `configure_env_for_run` (and npm), a package.json without a
             // name or version leaves the inherited values alone.
             if !package_json.name.is_empty() {
-                vars.push((NpmArgs::PACKAGE_NAME, package_json.name.clone()));
+                env.set(NpmArgs::PACKAGE_NAME, &package_json.name);
             }
             if !package_json.version.is_empty() {
-                vars.push((NpmArgs::PACKAGE_VERSION, package_json.version.clone()));
+                env.set(NpmArgs::PACKAGE_VERSION, &package_json.version);
+            }
+            if let Some(config) = package_json.config.as_deref() {
+                for (key, value) in config.iter() {
+                    env.vars.push((
+                        strings::concat(&[b"npm_package_config_", &key[..]]),
+                        Box::from(*value),
+                    ));
+                }
             }
         }
-        Self { vars }
+        env
     }
 
     /// The env for one package.json script of this package. `script` is the
@@ -109,9 +115,13 @@ impl ScriptEnv {
     /// verbatim, not the rewritten command that actually runs.
     pub(crate) fn with_script(&self, name: &[u8], script: &[u8]) -> Self {
         let mut env = self.clone();
-        env.vars.push((b"npm_lifecycle_event", Box::from(name)));
-        env.vars.push((b"npm_lifecycle_script", Box::from(script)));
+        env.set(b"npm_lifecycle_event", name);
+        env.set(b"npm_lifecycle_script", script);
         env
+    }
+
+    fn set(&mut self, key: &[u8], value: &[u8]) {
+        self.vars.push((Box::from(key), Box::from(value)));
     }
 
     /// Builds the script's envp from the shared `map` with these vars applied.
@@ -121,10 +131,10 @@ impl ScriptEnv {
         &self,
         map: &mut DotEnv::Map,
     ) -> Result<DotEnv::NullDelimitedEnvMap, bun_alloc::AllocError> {
-        let previous: Vec<(&'static [u8], Option<Box<[u8]>>)> = self
+        let previous: Vec<(&[u8], Option<Box<[u8]>>)> = self
             .vars
             .iter()
-            .map(|(key, _)| (*key, map.get(key).map(Box::from)))
+            .map(|(key, _)| (&key[..], map.get(key).map(Box::from)))
             .collect();
         let envp = self
             .vars

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -685,7 +685,13 @@ describe("bun", () => {
           "package.json": JSON.stringify({ name: "pkg-b", version: "2.0.0", scripts: { present: printEnv } }),
         },
       },
-      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      // None of the root's values may show up in the packages' scripts.
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "0.0.1",
+        config: { port: "3000" },
+        workspaces: ["packages/*"],
+      }),
     });
 
     await using proc = Bun.spawn({
@@ -705,7 +711,7 @@ describe("bun", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Output lines look like `pkg-a present: {...}`; the packages run concurrently.
     const envs = stdout
@@ -726,7 +732,7 @@ describe("bun", () => {
       npm_lifecycle_script: printEnv,
       npm_command: "run-script",
     };
-    expect({ envs, exitCode }).toEqual({
+    expect({ envs, stderr, exitCode }).toEqual({
       envs: [
         { ...pkgA, npm_lifecycle_event: "prepresent" },
         { ...pkgA, npm_lifecycle_event: "present" },
@@ -734,12 +740,13 @@ describe("bun", () => {
           npm_package_name: "pkg-b",
           npm_package_version: "2.0.0",
           npm_package_json: packageJson("b"),
-          // pkg-b has no "config", so pkg-a's npm_package_config_port must not reach it.
+          // No "config" here, so neither the root's nor pkg-a's npm_package_config_port may show up.
           npm_lifecycle_event: "present",
           npm_lifecycle_script: printEnv,
           npm_command: "run-script",
         },
       ],
+      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -662,6 +662,91 @@ describe("bun", () => {
     expect(stderr).toContain("skipping this workspace package");
     expect(exitCode).toBe(0);
   });
+
+  test("each script gets the npm_* env of its own package and script", async () => {
+    const printEnv = `${bunExe()} print-env.js`;
+    const printEnvJs = `
+      const { npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command } = process.env;
+      console.log(JSON.stringify({ npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command }));
+    `;
+    using dir = tempDir("filter-npm-env", {
+      packages: {
+        a: {
+          "print-env.js": printEnvJs,
+          "package.json": JSON.stringify({
+            name: "pkg-a",
+            version: "1.0.0",
+            scripts: { prepresent: printEnv, present: printEnv },
+          }),
+        },
+        b: {
+          "print-env.js": printEnvJs,
+          "package.json": JSON.stringify({ name: "pkg-b", version: "2.0.0", scripts: { present: printEnv } }),
+        },
+      },
+      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "*", "present"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        // What the environment looks like when a root package.json script
+        // invokes `bun run --filter`. Every value must be replaced per package.
+        npm_package_name: "outer",
+        npm_package_version: "0.0.0-outer",
+        npm_package_json: "outer/package.json",
+        npm_lifecycle_event: "outer",
+        npm_lifecycle_script: "outer",
+        npm_command: "outer",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Output lines look like `pkg-a present: {...}`; the packages run concurrently.
+    const envs = stdout
+      .split("\n")
+      .map(line => line.match(/\{.*\}/)?.[0])
+      .filter(json => json !== undefined)
+      .map(json => JSON.parse(json))
+      .map(env => ({ ...env, npm_package_json: env.npm_package_json.replaceAll("\\", "/") }))
+      .sort((x, y) =>
+        `${x.npm_package_name} ${x.npm_lifecycle_event}` < `${y.npm_package_name} ${y.npm_lifecycle_event}` ? -1 : 1,
+      );
+    const packageJson = (pkg: string) => join(String(dir), "packages", pkg, "package.json").replaceAll("\\", "/");
+    expect({ envs, exitCode }).toEqual({
+      envs: [
+        {
+          npm_package_name: "pkg-a",
+          npm_package_version: "1.0.0",
+          npm_package_json: packageJson("a"),
+          npm_lifecycle_event: "prepresent",
+          npm_lifecycle_script: printEnv,
+          npm_command: "run-script",
+        },
+        {
+          npm_package_name: "pkg-a",
+          npm_package_version: "1.0.0",
+          npm_package_json: packageJson("a"),
+          npm_lifecycle_event: "present",
+          npm_lifecycle_script: printEnv,
+          npm_command: "run-script",
+        },
+        {
+          npm_package_name: "pkg-b",
+          npm_package_version: "2.0.0",
+          npm_package_json: packageJson("b"),
+          npm_lifecycle_event: "present",
+          npm_lifecycle_script: printEnv,
+          npm_command: "run-script",
+        },
+      ],
+      exitCode: 0,
+    });
+  });
 });
 
 // #20319: on Windows, `bun --filter` / `bun run --parallel` spawn each script

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -666,8 +666,8 @@ describe("bun", () => {
   test("each script gets the npm_* env of its own package and script", async () => {
     const printEnv = `${bunExe()} print-env.js`;
     const printEnvJs = `
-      const { npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command } = process.env;
-      console.log(JSON.stringify({ npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command }));
+      const { npm_package_name, npm_package_version, npm_package_json, npm_package_config_port, npm_lifecycle_event, npm_lifecycle_script, npm_command } = process.env;
+      console.log(JSON.stringify({ npm_package_name, npm_package_version, npm_package_json, npm_package_config_port, npm_lifecycle_event, npm_lifecycle_script, npm_command }));
     `;
     using dir = tempDir("filter-npm-env", {
       packages: {
@@ -676,6 +676,7 @@ describe("bun", () => {
           "package.json": JSON.stringify({
             name: "pkg-a",
             version: "1.0.0",
+            config: { port: "8080" },
             scripts: { prepresent: printEnv, present: printEnv },
           }),
         },
@@ -717,28 +718,23 @@ describe("bun", () => {
         `${x.npm_package_name} ${x.npm_lifecycle_event}` < `${y.npm_package_name} ${y.npm_lifecycle_event}` ? -1 : 1,
       );
     const packageJson = (pkg: string) => join(String(dir), "packages", pkg, "package.json").replaceAll("\\", "/");
+    const pkgA = {
+      npm_package_name: "pkg-a",
+      npm_package_version: "1.0.0",
+      npm_package_json: packageJson("a"),
+      npm_package_config_port: "8080",
+      npm_lifecycle_script: printEnv,
+      npm_command: "run-script",
+    };
     expect({ envs, exitCode }).toEqual({
       envs: [
-        {
-          npm_package_name: "pkg-a",
-          npm_package_version: "1.0.0",
-          npm_package_json: packageJson("a"),
-          npm_lifecycle_event: "prepresent",
-          npm_lifecycle_script: printEnv,
-          npm_command: "run-script",
-        },
-        {
-          npm_package_name: "pkg-a",
-          npm_package_version: "1.0.0",
-          npm_package_json: packageJson("a"),
-          npm_lifecycle_event: "present",
-          npm_lifecycle_script: printEnv,
-          npm_command: "run-script",
-        },
+        { ...pkgA, npm_lifecycle_event: "prepresent" },
+        { ...pkgA, npm_lifecycle_event: "present" },
         {
           npm_package_name: "pkg-b",
           npm_package_version: "2.0.0",
           npm_package_json: packageJson("b"),
+          // pkg-b has no "config", so pkg-a's npm_package_config_port must not reach it.
           npm_lifecycle_event: "present",
           npm_lifecycle_script: printEnv,
           npm_command: "run-script",

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2143,3 +2143,112 @@ describe("workspace integration", () => {
     expect(r.exitCode).toBe(0);
   });
 });
+
+// ─── npm_* ENV PER SCRIPT ───────────────────────────────────────────────────
+
+describe.concurrent("npm_* env per script", () => {
+  const printEnv = `${bunExe()} print-env.js`;
+  const printEnvJs = `
+    const { npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command } = process.env;
+    console.log(JSON.stringify({ npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command }));
+  `;
+  // What the environment looks like when a package.json script invokes
+  // `bun run --parallel`; values a script's own package does not define are
+  // inherited from here.
+  const inherited = {
+    npm_package_name: "outer",
+    npm_package_version: "0.0.0-outer",
+    npm_package_json: "outer/package.json",
+    npm_lifecycle_event: "outer",
+    npm_lifecycle_script: "outer",
+    npm_command: "outer",
+  };
+  const posix = (p: string) => p.replaceAll("\\", "/");
+  /** The JSON objects printed by `print-env.js`, one per `label | {...}` line, in output order. */
+  const printedEnvs = (stdout: string) =>
+    stdout
+      .split("\n")
+      .map(line => line.match(/\{.*\}/)?.[0])
+      .filter(json => json !== undefined)
+      .map(json => JSON.parse(json))
+      .map(env => ({ ...env, npm_package_json: posix(env.npm_package_json) }));
+
+  test("package.json scripts get npm_lifecycle_*; a raw command run after them does not", async () => {
+    using dir = tempDir("mr-npm-env", {
+      "print-env.js": printEnvJs,
+      "package.json": JSON.stringify({ name: "solo", version: "3.0.0", scripts: { a: printEnv } }),
+    });
+    const r = await runMulti(["run", "--sequential", "a", "./print-env.js"], String(dir), inherited);
+    const pkg = {
+      npm_package_name: "solo",
+      npm_package_version: "3.0.0",
+      npm_package_json: posix(path.join(String(dir), "package.json")),
+      npm_command: "run-script",
+    };
+    expect({ envs: printedEnvs(r.stdout), exitCode: r.exitCode }).toEqual({
+      envs: [
+        { ...pkg, npm_lifecycle_event: "a", npm_lifecycle_script: printEnv },
+        { ...pkg, npm_lifecycle_event: "outer", npm_lifecycle_script: "outer" },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("workspace packages each get their own npm_package_* and pre/post npm_lifecycle_event", async () => {
+    using dir = tempDir("mr-ws-npm-env", {
+      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      "packages/a/print-env.js": printEnvJs,
+      "packages/a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        scripts: { prebuild: printEnv, build: printEnv, postbuild: printEnv },
+      }),
+      "packages/b/print-env.js": printEnvJs,
+      "packages/b/package.json": JSON.stringify({ name: "pkg-b", version: "2.0.0", scripts: { build: printEnv } }),
+      // No name or version: those stay inherited (the "packages/noname" label
+      // is only for output), but the script still gets its own package.json.
+      "packages/noname/print-env.js": printEnvJs,
+      "packages/noname/package.json": JSON.stringify({ scripts: { build: printEnv } }),
+    });
+    const r = await runMulti(
+      ["run", "--parallel", "--filter", "*", "--filter", "./packages/noname", "build"],
+      String(dir),
+      inherited,
+    );
+    const packageJson = (pkg: string) => posix(path.join(String(dir), "packages", pkg, "package.json"));
+    const envs = printedEnvs(r.stdout).sort((x, y) =>
+      `${x.npm_package_json} ${x.npm_lifecycle_event}` < `${y.npm_package_json} ${y.npm_lifecycle_event}` ? -1 : 1,
+    );
+    const a = {
+      npm_package_name: "pkg-a",
+      npm_package_version: "1.0.0",
+      npm_package_json: packageJson("a"),
+      npm_lifecycle_script: printEnv,
+      npm_command: "run-script",
+    };
+    expect({ envs, exitCode: r.exitCode }).toEqual({
+      envs: [
+        { ...a, npm_lifecycle_event: "build" },
+        { ...a, npm_lifecycle_event: "postbuild" },
+        { ...a, npm_lifecycle_event: "prebuild" },
+        {
+          npm_package_name: "pkg-b",
+          npm_package_version: "2.0.0",
+          npm_package_json: packageJson("b"),
+          npm_lifecycle_event: "build",
+          npm_lifecycle_script: printEnv,
+          npm_command: "run-script",
+        },
+        {
+          npm_package_name: "outer",
+          npm_package_version: "0.0.0-outer",
+          npm_package_json: packageJson("noname"),
+          npm_lifecycle_event: "build",
+          npm_lifecycle_script: printEnv,
+          npm_command: "run-script",
+        },
+      ],
+      exitCode: 0,
+    });
+  });
+});

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -2149,8 +2149,8 @@ describe("workspace integration", () => {
 describe.concurrent("npm_* env per script", () => {
   const printEnv = `${bunExe()} print-env.js`;
   const printEnvJs = `
-    const { npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command } = process.env;
-    console.log(JSON.stringify({ npm_package_name, npm_package_version, npm_package_json, npm_lifecycle_event, npm_lifecycle_script, npm_command }));
+    const { npm_package_name, npm_package_version, npm_package_json, npm_package_config_port, npm_lifecycle_event, npm_lifecycle_script, npm_command } = process.env;
+    console.log(JSON.stringify({ npm_package_name, npm_package_version, npm_package_json, npm_package_config_port, npm_lifecycle_event, npm_lifecycle_script, npm_command }));
   `;
   // What the environment looks like when a package.json script invokes
   // `bun run --parallel`; values a script's own package does not define are
@@ -2196,7 +2196,13 @@ describe.concurrent("npm_* env per script", () => {
 
   test("workspace packages each get their own npm_package_* and pre/post npm_lifecycle_event", async () => {
     using dir = tempDir("mr-ws-npm-env", {
-      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      // None of the root's values may show up in the packages' scripts.
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "0.0.1",
+        config: { port: "3000" },
+        workspaces: ["packages/*"],
+      }),
       "packages/a/print-env.js": printEnvJs,
       "packages/a/package.json": JSON.stringify({
         name: "pkg-a",
@@ -2205,8 +2211,8 @@ describe.concurrent("npm_* env per script", () => {
       }),
       "packages/b/print-env.js": printEnvJs,
       "packages/b/package.json": JSON.stringify({ name: "pkg-b", version: "2.0.0", scripts: { build: printEnv } }),
-      // No name or version: those stay inherited (the "packages/noname" label
-      // is only for output), but the script still gets its own package.json.
+      // No name or version: those stay what the run inherited (not the root's, and the
+      // "packages/noname" label is only for output), but the script still gets its own package.json.
       "packages/noname/print-env.js": printEnvJs,
       "packages/noname/package.json": JSON.stringify({ scripts: { build: printEnv } }),
     });


### PR DESCRIPTION
Related: #11713 (the `--filter` case raised in its comments; the nested `bun run` case itself is #38071, which changes a different part of `run_command.rs`).

### Problem
- `bun run --filter '*' <script>` spawns every workspace package's script with the root package's `npm_package_name`, `npm_package_version` and `npm_package_json`, and without `npm_lifecycle_event`, `npm_lifecycle_script` or `npm_command`. A plain `bun run <script>` inside the package sets all six; `npm run <script> -ws` sets them per package as well.
- `bun run --parallel` / `--sequential` (with or without `--filter`) behave the same way, including for pre/post scripts.
- Cause: both runners call `configure_env_for_run` once, which seeds the `npm_*` vars from the cwd package into the single env map shared by the whole run, and then build each script's envp from that map after swapping in only the per-package `PATH` (`src/runtime/cli/filter_run.rs` `ProcessHandle::start`, `src/runtime/cli/multi_run.rs` `ProcessHandle::start`). Nothing else in the map varied per script.
- Reproduces with the 1.4.0 release binary (output below).

### Fix
- Adds `ScriptEnv` (`src/runtime/cli/run_command.rs`, next to the existing `npm_*` seeding): the vars that differ per script, i.e. the package's `PATH`, `npm_package_json`, `npm_package_name` / `npm_package_version` (only when package.json defines them) and, for package.json scripts, `npm_lifecycle_event` / `npm_lifecycle_script`. `create_envp` puts them into the shared map, builds the envp, and restores the previous entries, so the PATH-only swap both runners had becomes one call and the values of one script never leak into the next spawn (a raw `--parallel` command spawned after a script, or a name-less package spawned after a named one).
- `filter_run.rs` builds one `ScriptEnv` per matched package and derives the pre/main/post entries from it; `multi_run.rs` does the same for each matched workspace package and for the cwd package in single-package mode. Both runners also export `npm_command=run-script`, the value `RunCommand::exec` exports for `bun run <script>`.
- Values match what `bun run <script>` run inside the package produces: `npm_package_json` is the same `PackageJSON.source.path` the single-script path uses, `npm_lifecycle_script` is the script body as written in package.json (not the rewritten command that is executed), and a package.json without `name` / `version` leaves the inherited values alone, as the single-script path and npm both do.
- Verified with `test/cli/run/filter-workspace.test.ts` ("each script gets the npm_* env of its own package and script") and the two tests in the new `npm_* env per script` block of `test/cli/run/multi-run.test.ts` (single package plus a raw command run after a script; workspace with pre/post scripts and a name-less package). All three fail on the release binary (every value is still the inherited one) and pass with the change.
- `bun bd test` on the full `filter-workspace.test.ts` (59 pass), `multi-run.test.ts` (123 pass), `run-process-env.test.ts` and the `$npm_*` tests in `test/cli/install/bun-run.test.ts` pass.

### Background
- `bun run` spawns package.json scripts with an environment built from an env map (`bun_dotenv::Map`): the parent process environment plus the `npm_*` variables npm defines for lifecycle scripts. `configure_env_for_run` fills that map from the package.json of the directory `bun run` was invoked in.
- `--filter`, `--parallel` and `--sequential` are implemented by separate runners (`filter_run.rs`, `multi_run.rs`) that spawn many scripts, possibly from different packages, out of that one map. `PATH` already had to differ per package (each package's own `node_modules/.bin` chain), which is the swap this change generalizes.
- `npm_lifecycle_event` is the name of the script being run (`prebuild`, `build`, `postbuild`), `npm_lifecycle_script` its body, and `npm_command` the command that triggered it; bun uses `run-script` for the latter.

<details>
<summary>Repro (bun 1.4.0, then this branch)</summary>

```
/tmp/ws/package.json             {"name":"root-ws","version":"0.0.1","workspaces":["packages/*"]}
/tmp/ws/packages/a/package.json  {"name":"pkg-a","version":"1.1.1","scripts":{"p":"echo name=$npm_package_name ver=$npm_package_version json=$npm_package_json ev=[$npm_lifecycle_event] cmd=[$npm_command]"}}
/tmp/ws/packages/b/package.json  same with pkg-b / 2.2.2
```

`bun run --filter '*' p` with 1.4.0:

```
pkg-a p: name=root-ws ver=0.0.1 json=/tmp/ws/package.json ev=[] cmd=[]
pkg-b p: name=root-ws ver=0.0.1 json=/tmp/ws/package.json ev=[] cmd=[]
```

`bun run --parallel --filter '*' p` with 1.4.0 prints the same values; `bun run --parallel p` inside a single package prints `ev=[] cmd=[]`.

With this change:

```
pkg-a p: name=pkg-a ver=1.1.1 json=/tmp/ws/packages/a/package.json ev=[p] cmd=[run-script]
pkg-b p: name=pkg-b ver=2.2.2 json=/tmp/ws/packages/b/package.json ev=[p] cmd=[run-script]
```

`npm run p -ws` (npm 11) prints the per-package values as well, with `npm_command=run`.
</details>
