### PR TITLE
bundler: copy file/wasm/napi/sqlite assets byte-for-byte when they start with a BOM

### DIFF
--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -126,6 +126,37 @@ impl Loader {
         )
     }
 
+    /// Loaders that pass the file's bytes through as-is (copied to the output
+    /// directory, content-hashed, base64/data-URL encoded) instead of parsing
+    /// them as text. Reading a file for one of these must not rewrite a
+    /// BOM-shaped prefix; see `bun_resolver::fs::BomHandling`.
+    pub fn is_binary(self) -> bool {
+        match self {
+            Loader::File
+            | Loader::Wasm
+            | Loader::Napi
+            | Loader::Sqlite
+            | Loader::SqliteEmbedded
+            | Loader::Base64
+            | Loader::Dataurl => true,
+            Loader::Jsx
+            | Loader::Js
+            | Loader::Ts
+            | Loader::Tsx
+            | Loader::Css
+            | Loader::Json
+            | Loader::Jsonc
+            | Loader::Toml
+            | Loader::Yaml
+            | Loader::Json5
+            | Loader::Xml
+            | Loader::Html
+            | Loader::Md
+            | Loader::Text
+            | Loader::Bunsh => false,
+        }
+    }
+
     pub fn handles_empty_file(self) -> bool {
         matches!(self, Loader::Wasm | Loader::File | Loader::Text)
     }

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1378,7 +1378,7 @@ pub mod parse_worker {
         resolver: *mut Resolver,
         bump: &Bump,
         file_path: &mut Fs::Path,
-        _loader: Loader,
+        loader: Loader,
     ) -> core::result::Result<CacheEntry, AnyError> {
         match &task.contents_or_fd {
             ContentsOrFd::Fd { dir, file } => 'brk: {
@@ -1458,6 +1458,7 @@ pub mod parse_worker {
                     false,
                     contents_file.unwrap_valid(),
                     read_arena,
+                    Fs::BomHandling::for_loader(loader),
                 ) {
                     Ok(e) => {
                         // `bun_resolver::cache::Entry` ↔ `crate::cache::Entry`

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1448,6 +1448,7 @@ impl<'a> Transpiler<'a> {
                 USE_SHARED_BUFFER,
                 file_descriptor,
                 if USE_SHARED_BUFFER { None } else { Some(arena) },
+                Fs::BomHandling::for_loader(loader),
             ) {
                 Ok(e) => e,
                 Err(err) => {
@@ -3027,6 +3028,7 @@ impl<'a> Transpiler<'a> {
             false,
             None,
             None,
+            Fs::BomHandling::Convert,
         ) {
             Ok(e) => e,
             Err(err) => {

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -24,6 +24,37 @@ bun_core::define_scoped_log!(debug, Fs, hidden);
 // `bun_core::strings`; `bun_resolver::fs_full::BOM` re-exports it.
 pub use bun_core::strings::BOM;
 
+/// What a file read does with a leading byte-order mark.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BomHandling {
+    /// Strip a UTF-8 BOM and transcode UTF-16LE input to UTF-8: the bytes
+    /// are about to be parsed as text.
+    Convert,
+    /// Return the bytes exactly as they are on disk: the file is emitted
+    /// (or hashed / encoded) byte-for-byte, so a prefix that merely looks
+    /// like a BOM must survive.
+    Keep,
+}
+
+impl BomHandling {
+    pub fn for_loader(loader: bun_ast::Loader) -> Self {
+        if loader.is_binary() {
+            Self::Keep
+        } else {
+            Self::Convert
+        }
+    }
+
+    /// The BOM `bytes` start with, if there is one and it is to be converted.
+    #[inline]
+    fn detect(self, bytes: &[u8]) -> Option<BOM> {
+        match self {
+            BomHandling::Convert => BOM::detect(bytes),
+            BomHandling::Keep => None,
+        }
+    }
+}
+
 mod preallocate {
     pub(crate) mod counts {
         pub(crate) const FILES: usize = 4096;
@@ -736,12 +767,19 @@ pub fn read_file_contents<'buf>(
     use_shared_buffer: bool,
     shared: &'buf mut MutableString,
     stream: bool,
+    bom_handling: BomHandling,
 ) -> crate::CrateResult<Cow<'buf, [u8]>> {
     match (use_shared_buffer, stream) {
-        (true, true) => read_file_with_handle_impl::<true, true>(None, file, shared),
-        (true, false) => read_file_with_handle_impl::<true, false>(None, file, shared),
-        (false, true) => read_file_with_handle_impl::<false, true>(None, file, shared),
-        (false, false) => read_file_with_handle_impl::<false, false>(None, file, shared),
+        (true, true) => read_file_with_handle_impl::<true, true>(None, file, shared, bom_handling),
+        (true, false) => {
+            read_file_with_handle_impl::<true, false>(None, file, shared, bom_handling)
+        }
+        (false, true) => {
+            read_file_with_handle_impl::<false, true>(None, file, shared, bom_handling)
+        }
+        (false, false) => {
+            read_file_with_handle_impl::<false, false>(None, file, shared, bom_handling)
+        }
     }
     .map(|p| p.contents)
 }
@@ -759,6 +797,7 @@ pub fn read_file_contents_in_arena(
     file: &bun_sys::File,
     path: &[u8],
     arena: &bun_alloc::Arena,
+    bom_handling: BomHandling,
 ) -> crate::CrateResult<(core::ptr::NonNull<u8>, usize)> {
     let _ = path;
     crate::fs::FileSystem::set_max_fd(file.handle().native());
@@ -775,7 +814,7 @@ pub fn read_file_contents_in_arena(
         // `finish_arena_contents` writes the trailing NUL at `[read_count]`.
         let buf = arena_alloc_uninit_bytes(arena, read_count + 1);
         buf[..read_count].copy_from_slice(&initial_buf[..read_count]);
-        return Ok(finish_arena_contents(arena, buf, read_count));
+        return Ok(finish_arena_contents(arena, buf, read_count, bom_handling));
     }
     let initial_len = read_count;
 
@@ -810,7 +849,7 @@ pub fn read_file_contents_in_arena(
     let total = read_count + initial_len;
     debug!("read({}, {}) = {}", file.handle(), size, read_count);
 
-    Ok(finish_arena_contents(arena, buf, total))
+    Ok(finish_arena_contents(arena, buf, total, bom_handling))
 }
 
 /// Allocate `len` bytes from `arena` left **uninitialized** (no zero-fill),
@@ -833,15 +872,17 @@ fn arena_alloc_uninit_bytes(arena: &bun_alloc::Arena, len: usize) -> &mut [u8] {
     unsafe { core::slice::from_raw_parts_mut(slot.as_mut_ptr().cast::<u8>(), len) }
 }
 
-/// Strip BOM in-place (UTF-8) or via a fresh arena copy (UTF-16), write the
-/// trailing NUL, and return `(ptr, len)`. `buf.len() >= total + 1`.
+/// Strip BOM in-place (UTF-8) or via a fresh arena copy (UTF-16) when
+/// `bom_handling` asks for it, write the trailing NUL, and return
+/// `(ptr, len)`. `buf.len() >= total + 1`.
 #[inline]
 fn finish_arena_contents(
     arena: &bun_alloc::Arena,
     buf: &mut [u8],
     mut total: usize,
+    bom_handling: BomHandling,
 ) -> (core::ptr::NonNull<u8>, usize) {
-    if let Some(bom) = BOM::detect(&buf[..total]) {
+    if let Some(bom) = bom_handling.detect(&buf[..total]) {
         debug!("Convert {} BOM", bom.tag_name());
         match bom {
             BOM::Utf8 => {
@@ -874,6 +915,7 @@ pub fn read_file_with_handle_impl<'buf, const USE_SHARED_BUFFER: bool, const STR
     size_hint: Option<usize>,
     file: &bun_sys::File,
     shared_buffer: &'buf mut MutableString,
+    bom_handling: BomHandling,
 ) -> crate::CrateResult<PathContentsPair<'buf>> {
     // allocator param dropped (global mimalloc)
     crate::fs::FileSystem::set_max_fd(file.handle().native());
@@ -969,7 +1011,7 @@ pub fn read_file_with_handle_impl<'buf, const USE_SHARED_BUFFER: bool, const STR
         // `file_contents_len == shared_buffer.list.len()` here (set by `truncate` in
         // the read loop above); borrow the Vec directly so the slice ends before the
         // `&mut shared_buffer.list` reborrow inside the BOM branch.
-        if let Some(bom) = BOM::detect(&shared_buffer.list[..file_contents_len]) {
+        if let Some(bom) = bom_handling.detect(&shared_buffer.list[..file_contents_len]) {
             debug!("Convert {} BOM", bom.tag_name());
             // We pre-set `list.len` to the un-BOM'd payload length so the helper sees the
             // correct logical size (the read loop above truncated to `file_contents_len`).
@@ -998,7 +1040,7 @@ pub fn read_file_with_handle_impl<'buf, const USE_SHARED_BUFFER: bool, const STR
                 allocation.push(0);
                 allocation.truncate(read_count);
 
-                if let Some(bom) = BOM::detect(&allocation) {
+                if let Some(bom) = bom_handling.detect(&allocation) {
                     debug!("Convert {} BOM", bom.tag_name());
                     allocation = bom.remove_and_convert_to_utf8_and_free(allocation);
                 }
@@ -1050,7 +1092,7 @@ pub fn read_file_with_handle_impl<'buf, const USE_SHARED_BUFFER: bool, const STR
         // `read_all` above.
         unsafe { buf.set_len(total) };
 
-        if let Some(bom) = BOM::detect(&buf) {
+        if let Some(bom) = bom_handling.detect(&buf) {
             debug!("Convert {} BOM", bom.tag_name());
             buf = bom.remove_and_convert_to_utf8_and_free(buf);
         }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1733,7 +1733,7 @@ pub mod fs {
     /// `bun_bundler::cache`) routes through ONE body instead of inlining a
     /// subset of `readFileWithHandleAndAllocator`.
     pub use super::fs_full::{
-        BOM, PathContentsPair, read_file_contents, read_file_contents_in_arena,
+        BOM, BomHandling, PathContentsPair, read_file_contents, read_file_contents_in_arena,
         read_file_with_handle_impl,
     };
 
@@ -2318,6 +2318,10 @@ pub mod cache {
         /// drops instead of landing in the worker thread's default mimalloc
         /// heap (which is never destroyed). `None` keeps the global-heap
         /// `Contents::Owned(Vec<u8>)` path.
+        ///
+        /// `bom_handling`: text that is about to be parsed wants
+        /// [`fs_mod::BomHandling::Convert`]; files emitted byte-for-byte (the
+        /// bundler's binary loaders) must pass [`fs_mod::BomHandling::Keep`].
         pub fn read_file_with_allocator(
             &mut self,
             _fs: &mut fs_mod::FileSystem,
@@ -2326,6 +2330,7 @@ pub mod cache {
             use_shared_buffer: bool,
             _file_handle: Option<Fd>,
             arena: Option<&bun_alloc::Arena>,
+            bom_handling: fs_mod::BomHandling,
         ) -> crate::CrateResult<Entry> {
             let rfs = &_fs.fs;
 
@@ -2389,7 +2394,12 @@ pub mod cache {
                 // are reclaimed by `mi_heap_destroy` instead of pinning a
                 // segment in the worker thread's default heap.
                 (false, Some(arena)) => {
-                    match fs_mod::read_file_contents_in_arena(file_handle, path, arena) {
+                    match fs_mod::read_file_contents_in_arena(
+                        file_handle,
+                        path,
+                        arena,
+                        bom_handling,
+                    ) {
                         Ok((_, 0)) => Contents::Empty,
                         Ok((ptr, len)) => Contents::Arena { ptr, len },
                         Err(err) => {
@@ -2406,8 +2416,14 @@ pub mod cache {
                 }
                 _ => {
                     let shared = self.shared_buffer();
-                    match fs_mod::read_file_contents(file_handle, use_shared_buffer, shared, stream)
-                        .map(Contents::from)
+                    match fs_mod::read_file_contents(
+                        file_handle,
+                        use_shared_buffer,
+                        shared,
+                        stream,
+                        bom_handling,
+                    )
+                    .map(Contents::from)
                     {
                         Ok(c) => c,
                         Err(err) => {

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -412,6 +412,7 @@ impl PackageJSON {
             false,
             None,
             None,
+            fs::BomHandling::Convert,
         ) {
             Ok(e) => e,
             Err(err) => {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4087,6 +4087,7 @@ impl<'a> Resolver<'a> {
             false,
             None,
             None,
+            Fs::BomHandling::Convert,
         )?;
         // NOTE: reshaped for borrowck — `mem::take` the contents (leaving
         // `Contents::Empty` behind) so `entry` stays whole for the close-guard.

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -454,6 +454,82 @@ describe("bundler", async () => {
     }
   });
 
+  // Inputs are read through the same reader as JS/TS sources, which strips a
+  // UTF-8 BOM and transcodes UTF-16LE. Loaders that emit the file itself must
+  // copy it byte-for-byte even when its first bytes look like a BOM.
+  describe("BOM-prefixed inputs", () => {
+    const bomPayloads = {
+      utf8: Buffer.from([0xef, 0xbb, 0xbf, ...Buffer.from("hello")]),
+      utf16le: Buffer.from([0xff, 0xfe, ...Buffer.from("hi", "utf16le")]),
+    };
+    // Every loader whose output is the input file copied into outdir.
+    const copyLoaders = [
+      { loader: "file", ext: ".bin", attributes: "" },
+      { loader: "wasm", ext: ".wasm", attributes: "" },
+      { loader: "napi", ext: ".node", attributes: "" },
+      { loader: "sqlite_embedded", ext: ".sqlite", attributes: ' with { type: "sqlite", embed: "true" }' },
+    ];
+    const assets = copyLoaders.flatMap(({ loader, ext, attributes }) =>
+      Object.entries(bomPayloads).map(([encoding, bytes]) => ({
+        name: `${loader}_${encoding}`,
+        ext,
+        attributes,
+        bytes,
+      })),
+    );
+    const files = Object.fromEntries(assets.map(asset => [`/${asset.name}${asset.ext}`, asset.bytes]));
+    const entry = assets
+      .map(asset => `import ${asset.name} from "./${asset.name}${asset.ext}"${asset.attributes};`)
+      .join("\n");
+    const expectedHex = Object.fromEntries(assets.map(asset => [asset.name, asset.bytes.toString("hex")]));
+
+    for (const backend of ["api", "cli"] as const) {
+      itBundled(`bun/loader-copy-keeps-bom-bytes-${backend}`, {
+        backend,
+        target: "bun",
+        outdir: "/out",
+        loader: { ".bin": "file" },
+        files: {
+          "/entry.ts": `${entry}\nexport { ${assets.map(asset => asset.name).join(", ")} };`,
+          ...files,
+        },
+        onAfterBundle(api) {
+          // Assets are emitted as `[name]-[hash].[ext]`.
+          const emitted = readdirSync(api.outdir);
+          const emittedHex = Object.fromEntries(
+            assets.map(asset => {
+              const output = emitted.filter(out => out.startsWith(`${asset.name}-`) && out.endsWith(asset.ext));
+              expect(output).toHaveLength(1);
+              return [asset.name, fs.readFileSync(join(api.outdir, output[0])).toString("hex")];
+            }),
+          );
+          expect(emittedHex).toEqual(expectedHex);
+        },
+      });
+    }
+
+    // Text loaders still get the BOM stripped and UTF-16LE transcoded.
+    itBundled("bun/loader-text-converts-bom", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import utf8 from "./utf8.txt";
+          import utf16le from "./utf16le.txt";
+          import { utf8 as utf8Module } from "./utf8.js";
+          import { utf16le as utf16leModule } from "./utf16le.js";
+          console.write(JSON.stringify({ utf8, utf16le, utf8Module, utf16leModule }));
+        `,
+        "/utf8.txt": bomPayloads.utf8,
+        "/utf16le.txt": bomPayloads.utf16le,
+        "/utf8.js": Buffer.from([0xef, 0xbb, 0xbf, ...Buffer.from('export const utf8 = "utf8 module";')]),
+        "/utf16le.js": Buffer.from([0xff, 0xfe, ...Buffer.from('export const utf16le = "utf16le module";', "utf16le")]),
+      },
+      run: {
+        stdout: '{"utf8":"hello","utf16le":"hi","utf8Module":"utf8 module","utf16leModule":"utf16le module"}',
+      },
+    });
+  });
+
   // Lazy-export modules (JSON, TOML, CSS modules, ...) used to crash the
   // printer when bundled with the dev server's module format.
   // https://github.com/oven-sh/bun/issues/31943


### PR DESCRIPTION
### Problem
- `bun build` / `Bun.build` rewrite assets whose first bytes look like a byte-order mark: an asset starting with `EF BB BF` is emitted without those three bytes, and one starting with `FF FE` (a UTF-16LE text file, e.g. a `.reg` or an Excel "Unicode text" export imported through the `file` loader) is emitted re-encoded as UTF-8. The content hash in the asset name is computed from the rewritten bytes too.
- Affects every loader that emits the input file itself: `file`, `wasm`, `napi`, `sqlite` (`embed: "true"`). Repro on bun 1.4.0: `printf '\xef\xbb\xbfhello' > a.bin` bundled with `--loader .bin:file` produces a 5-byte `a-*.bin` (`68 65 6c 6c 6f`); `printf '\xff\xfeh\0i\0' > b.bin` produces a 2-byte `b-*.bin` (`68 69`).
- Cause: `ParseTask::get_code_for_parse_task_without_plugins` (`src/bundler/ParseTask.rs:1454`) reads every input through `cache::Fs::read_file_with_allocator`, and the readers behind it (`finish_arena_contents` and the three arms of `read_file_with_handle_impl` in `src/resolver/fs.rs`) unconditionally run `BOM::detect` + strip/transcode. That is right for text that is about to be parsed and wrong for bytes that are copied into the output: `process_files_to_copy` (`src/bundler/bundle_v2.rs:4285`) writes `source.contents` as the asset, so the rewritten buffer is what lands on disk.

### Fix
- `read_file_with_allocator` (and the `read_file_contents*` helpers under it) take a new `bun_resolver::fs::BomHandling { Convert, Keep }`; the four BOM sites in `fs.rs` go through `BomHandling::detect`, which returns `None` for `Keep`. The fixing line is the `Fs::BomHandling::for_loader(loader)` argument in `ParseTask.rs`; the previously unused `_loader` parameter already carried the loader there.
- `Loader::is_binary()` (`src/ast/loader.rs`) is the classification: `file`, `wasm`, `napi`, `sqlite`, `sqlite_embedded`, `base64`, `dataurl` read verbatim; everything else keeps the current stripping/transcoding. It is an exhaustive `match` so a new loader has to be classified. `base64`/`dataurl` are listed because they encode the raw bytes once implemented (#36327, #36334; the latter currently re-reads the file itself to get around this reader); in the bundler today they ignore the contents, so listing them changes nothing yet.
- Why this is correct: the BOM conversion exists so parsers see UTF-8 text; a copied asset has no parser, and the bytes on disk are the output contract. esbuild's `file` loader emits all three repro inputs unchanged (8, 6 and 6 bytes with esbuild 0.18.6; output in the details block). Text reads are unchanged: `package.json`, `tsconfig.json`, `bun build` CSS entry points, and the runtime `Transpiler::parse` path all pass `Convert` (the runtime path derives it from its loader like the bundler does; only text loaders, plus `wasm`, whose magic `\0asm` cannot collide with a BOM, reach it).
- Not changed: `bun build --no-bundle` copies assets with a file copy (`build_copied_file_output`, see #35644) and the runtime `file` loader only exports the path, so neither went through this reader. Plugin-provided contents (`onLoad`, in-memory `files`) never did either.
- Verified: `test/bundler/bundler_loader.test.ts` ("BOM-prefixed inputs"): `loader-copy-keeps-bom-bytes-{api,cli}` bundle all four copying loaders with a UTF-8-BOM and a UTF-16LE-BOM payload and compare the emitted bytes with the input; all 8 assets come out rewritten on `USE_SYSTEM_BUN=1` (1.4.0) and byte-exact with this build. `loader-text-converts-bom` pins the unchanged side: `.txt` and `.js` inputs with either BOM still come through stripped/transcoded.
- Also ran with this build: the rest of `bundler_loader.test.ts` (53 pass), `bundler_bun.test.ts` (sqlite embed), `bundler_files.test.ts`, `native-plugin.test.ts` (the `fetchSourceCode` path goes through the same function; 19 pass, 1 pre-existing skip), and the repro above (`a-*.bin` is 8 bytes, `b-*.bin` is 6).

### Background
- BOM (byte-order mark): the optional bytes `EF BB BF` (UTF-8) or `FF FE` (UTF-16LE) at the start of a text file that declare its encoding. Bun's file reader (`bun_core::strings::BOM`) detects these two and either drops the UTF-8 marker or transcodes the UTF-16LE body to UTF-8 so the JS/JSON/CSS/... parsers only ever see UTF-8. Nothing distinguishes a BOM from arbitrary binary data that happens to start with the same bytes; only the loader knows whether the file is text.
- `cache::Fs::read_file_with_allocator` (`src/resolver/lib.rs`): the one file reader shared by the resolver (`package.json`, `tsconfig.json`), the runtime transpiler, and the bundler's parse tasks. It handles fd reuse and the per-worker arena, which is why the fix is a parameter on it rather than a separate raw read in the bundler.
- `ParseTask` (`src/bundler/ParseTask.rs`): the per-input-file unit of work in the bundler. For copying loaders its "AST" is just a placeholder string for the asset URL; the file bytes are kept as `source.contents` and later written out by `process_files_to_copy` under a content-hashed name.

<details>
<summary>Repro before/after</summary>

```
$ printf '\xef\xbb\xbfhello' > a.bin; printf '\xff\xfeh\x00i\x00' > b.bin
$ printf 'import a from "./a.bin"; import b from "./b.bin"; console.log(a, b);' > e.js
$ bun build ./e.js --loader .bin:file --outdir=dist

# bun 1.4.0
a-hvs6h2nf.bin  5 bytes    68 65 6c 6c 6f
b-tezyx107.bin  2 bytes    68 69

# this branch
a-rs58fy5c.bin  8 bytes    ef bb bf 68 65 6c 6c 6f
b-z0j5q0bj.bin  6 bytes    ff fe 68 00 69 00

# esbuild 0.18.6: esbuild e.js --bundle --loader:.bin=file --outdir=esb
a-WQADS3YA.bin  8b         ef bb bf 68 65 6c 6c 6f
b-G5LK74FN.bin  6b         ff fe 68 00 69 00
```

A third input starting with `FE FF` (UTF-16BE) was already copied unchanged by bun because `BOM::detect` does not recognize that marker.
</details>
