### PR TITLE
node:http2: end a pushed response on its HEADERS frame when the stream was ended before respond()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3810,7 +3810,13 @@ class ServerHttp2Stream extends Http2Stream {
       statusCode === HTTP_STATUS_NO_CONTENT ||
       statusCode === HTTP_STATUS_RESET_CONTENT ||
       statusCode === HTTP_STATUS_NOT_MODIFIED ||
-      this.headRequest === true
+      this.headRequest === true ||
+      // The writable side was ended before respond() (pushStream({ endStream }) or an explicit
+      // end() on a pushed stream) and _final parked its callback waiting for this call: no body
+      // can follow, so END_STREAM has to ride on the HEADERS frame, as node's SubmitResponse
+      // does once the stream's writable half is shut. The onStreamEnd dispatched by the native
+      // request() below is what completes the parked callback.
+      typeof this[bunHTTP2StreamFinal] === "function"
     ) {
       // When endStream is true the HEADERS frame itself carries END_STREAM
       // and the stream moves to HALF_CLOSED_LOCAL inside native request().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3984,6 +3984,130 @@ it("http2 pushStream reports an unsendable array element through the callback", 
   expect(blocks).toEqual([]);
 });
 
+// A pushed stream whose writable side is ended before respond() has no body to send, so its
+// response HEADERS frame has to carry END_STREAM itself (node submits such a response without a
+// body). Without that flag nothing ever ends the pushed response: the client's pushed stream never
+// emits 'end'/'close' and the server push stream's writable never finishes.
+describe("http2 pushStream: response ended before respond()", () => {
+  const END_STREAM = 0x1;
+  // Serves one request that pushes /pushed and hands the pushed stream to `respond`. Checks which
+  // frame of the pushed response carried END_STREAM (the flags argument of the client's 'push'
+  // event is the flags byte of the pushed response's HEADERS frame), then reports how the pushed
+  // response ended on both sides.
+  async function observePushedResponse({ pushHeaders, pushOptions, respond, headersCarryEndStream }) {
+    // Every failure on either side rejects this one promise; it is raced against each wait below.
+    const { promise: failure, reject } = Promise.withResolvers();
+    const { promise: pushedResponseFlags, resolve: onPushedResponse } = Promise.withResolvers();
+    const { promise: parentEnded, resolve: onParentEnd } = Promise.withResolvers();
+    const { promise: pushedClosed, resolve: onPushedClose } = Promise.withResolvers();
+    const { promise: serverPushFinished, resolve: onServerPushFinish } = Promise.withResolvers();
+    let wantTrailersEvents = 0;
+    const server = http2.createServer();
+    server.on("error", reject);
+    server.on("sessionError", reject);
+    server.on("stream", stream => {
+      stream.on("error", reject);
+      stream.pushStream({ ":path": "/pushed", ...pushHeaders }, pushOptions, (err, push) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        push.on("error", reject);
+        push.on("wantTrailers", () => wantTrailersEvents++);
+        // node finishes an endStream/HEAD push's writable before the callback even runs.
+        if (push.writableFinished) onServerPushFinish();
+        else push.once("finish", onServerPushFinish);
+        try {
+          respond(push);
+        } catch (e) {
+          reject(e);
+          return;
+        }
+        // Written after the pushed response, so once the client has received this response it has
+        // also received every frame the pushed response consisted of.
+        stream.respond({ ":status": 200 });
+        stream.end("parent");
+      });
+    });
+    let client;
+    try {
+      await Promise.race([failure, new Promise(listening => server.listen(0, "127.0.0.1", listening))]);
+      client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      client.on("error", reject);
+      client.on("stream", pushed => {
+        pushed.on("error", reject);
+        const chunks = [];
+        let ended = false;
+        pushed.on("push", (_headers, flags) => onPushedResponse(flags));
+        pushed.on("data", chunk => chunks.push(chunk));
+        pushed.on("end", () => (ended = true));
+        pushed.on("close", () =>
+          onPushedClose({ ended, rstCode: pushed.rstCode, body: Buffer.concat(chunks).toString() }),
+        );
+      });
+      const req = client.request({ ":path": "/" });
+      req.on("error", reject);
+      req.on("end", onParentEnd);
+      req.resume();
+      await Promise.race([failure, parentEnded]);
+      const flags = await Promise.race([failure, pushedResponseFlags]);
+      // Asserted before waiting for the pushed response to end: a pushed response that was never
+      // ended would otherwise keep the waits below pending forever.
+      expect((flags & END_STREAM) !== 0).toBe(headersCarryEndStream);
+      const pushedResponse = await Promise.race([failure, pushedClosed]);
+      await Promise.race([failure, serverPushFinished]);
+      return { ...pushedResponse, wantTrailersEvents };
+    } finally {
+      client?.close();
+      server.close();
+    }
+  }
+
+  it.each([
+    ["pushStream({ endStream: true })", { pushOptions: { endStream: true }, respond: push => push.respond() }],
+    [
+      "push.end() before push.respond()",
+      {
+        respond: push => {
+          push.end();
+          push.respond({ ":status": 200 });
+        },
+      },
+    ],
+    [
+      // A response without a body never asks for trailers (node: no body, no trailers callback).
+      "push.end() before push.respond({ waitForTrailers: true })",
+      {
+        respond: push => {
+          push.end();
+          push.respond({ ":status": 200 }, { waitForTrailers: true });
+        },
+      },
+    ],
+    [
+      // pushStream() ends a HEAD push's writable side itself; respond() has always ended these
+      // through headRequest, so this one documents that the two paths agree.
+      "a :method HEAD push",
+      { pushHeaders: { ":method": "HEAD" }, respond: push => push.respond({ ":status": 200 }) },
+    ],
+  ])(
+    "%s puts END_STREAM on the pushed response's HEADERS frame",
+    async (_name, { pushHeaders, pushOptions, respond }) => {
+      const observed = await observePushedResponse({ pushHeaders, pushOptions, respond, headersCarryEndStream: true });
+      expect(observed).toEqual({ ended: true, rstCode: 0, body: "", wantTrailersEvents: 0 });
+    },
+  );
+
+  it("a pushed stream that is still writable at respond() time ends with its body", async () => {
+    const respond = push => {
+      push.respond({ ":status": 200 });
+      push.end("pushed body");
+    };
+    const observed = await observePushedResponse({ respond, headersCarryEndStream: false });
+    expect(observed).toEqual({ ended: true, rstCode: 0, body: "pushed body", wantTrailersEvents: 0 });
+  });
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;


### PR DESCRIPTION
### Problem

- On a `node:http2` server, a pushed stream whose writable side is ended before `respond()` never gets its response ended on the wire. Two ways to get there:
  - `stream.pushStream(headers, { endStream: true }, (err, push) => push.respond(...))`
  - `stream.pushStream(headers, (err, push) => { push.end(); push.respond(...); })`
- Frames the server sends for the pushed stream, against node v26.3.0 (HEADERS flags `0x4` = END_HEADERS, `0x5` = END_HEADERS | END_STREAM):
  ```
  node: PUSH_PROMISE(1)  HEADERS sid=2 flags=0x5
  bun:  PUSH_PROMISE(1)  HEADERS sid=2 flags=0x4   (nothing follows on stream 2)
  ```
- Consequences: the client's pushed stream never emits `'end'`/`'close'`, the server push stream's writable never finishes (`'finish'` never fires, `writableFinished` stays false), and a `client.close()` waiting on the pushed stream never completes. The `:method HEAD` variant of the same thing works.
- Cause: `Http2Stream#_final` (`src/js/node/http2.ts:2887`) handles an ended-but-unresponded push stream by parking its callback in `bunHTTP2StreamFinal` instead of writing an empty `DATA` frame ahead of the response `HEADERS`, and relies on `respond()` to put END_STREAM on the `HEADERS` frame. `ServerHttp2Stream#respond()` (`:3807`) only did that for `options.endStream`, status 204/205/304 and `headRequest`, so for a plain push it sent `HEADERS` without END_STREAM and the parked callback was never completed.

### Fix

- `respond()` also forces `endStream` when `_final` has parked its callback. The `HEADERS` frame then carries END_STREAM, the native `request()` dispatches `onStreamEnd`, and the existing handler completes the parked callback through `markWritableDone` (the path HEAD pushes already take today).
- Matches node: `Http2Stream::SubmitResponse` submits the response without a data provider whenever the stream's writable half has been shut (`!is_writable()`), which is the state `pushStream({ endStream })` and `push.end()` leave the stream in, so nghttp2 sets END_STREAM on the `HEADERS` frame.
- The parked callback is the right signal for this (rather than `writableEnded`): it is set from `_final`, i.e. only once `end()` was called *and* every buffered chunk has been written. `writableEnded` is already true during the implicit `respond()` that `_write`/`_writev` issue for data buffered behind a `cork()` when `end()` was called before uncorking, and forcing END_STREAM there would put the body on a half-closed stream.
- `respond(headers, { waitForTrailers: true })` on such a stream goes through the same branch, which already strips `waitForTrailers`, so no `'wantTrailers'` is emitted; node also never asks for trailers on a response that has no body.
- Related, independent: #38082 makes the native side treat an even-id server stream as `HALF_CLOSED_REMOTE` so a completed push is released and emits `'close'`. It keeps the parked-callback branch in `_final` and does not touch `respond()`, so this bug is present with or without it; with both, an `endStream` push closes exactly like node's. #33380 covers the neighbouring `close()`/`destroy()`-before-`respond()` paths.
- Tests: `test/js/node/http2/node-http2.test.js`, `describe("http2 pushStream: response ended before respond()")`. One real client/server session per case; the flags argument of the client's `'push'` event is the flags byte of the pushed response's `HEADERS` frame, so END_STREAM placement is asserted directly, then the pushed stream's `'end'`/`'close'` (`rstCode` 0) and the server push stream's `'finish'`. Cases: `pushStream({ endStream: true })`, `push.end()` before `respond()`, the same with `waitForTrailers`, a HEAD push (passes before too; pins that the two paths agree), and a push that is still writable at `respond()` time (END_STREAM must stay on its DATA frame). The first three fail on main at the flags assertion and pass with the fix.
- Also run with the fix: the whole of `node-http2.test.js` (362 pass), `h2-conformance.test.ts` (61 pass), and all 261 upstream `test-http2-*` tests under `test/js/node/test` (all pass).

### Background

- Server push: the server announces a request it is going to answer unasked with a `PUSH_PROMISE` frame on the client's stream, reserving a new even-numbered stream id, and then sends the response on that stream. In `node:http2` that is `stream.pushStream()`, whose callback receives a `ServerHttp2Stream` for the reserved id; the response is sent with the normal `respond()`/`end()` API.
- END_STREAM: the HTTP/2 flag that closes the sender's side of a stream. It rides on the last frame the sender emits for the stream, either a `DATA` frame or, for a response with no body, the `HEADERS` frame itself. A response whose `HEADERS` lacks it is, as far as the peer is concerned, still in progress until a frame carrying it arrives.
- `_final` and the parked callback: `_final` is the `stream.Writable` hook that runs once `end()` was called and every buffered write has been flushed; the writable emits `'finish'` when its callback is invoked. For a push stream that was ended before `respond()`, bun's `_final` cannot send anything yet (a response has to start with `HEADERS`), so it stores the callback in the `bunHTTP2StreamFinal` slot; `markWritableDone`, run from the `onStreamEnd` dispatch, invokes it once the END_STREAM has gone out.
