### PR TITLE
bun build: pad the summary size column from the printed output name

### DIFF
--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -41,8 +41,7 @@ fn splat_byte_all(
     Ok(())
 }
 
-/// The name an output file gets in the per-file summary. The size column is
-/// padded from this same string, so the two cannot drift apart.
+/// Name printed in the per-file summary; the size column is padded from the same string.
 #[inline]
 fn summary_path(f: &options::OutputFile) -> &[u8] {
     strings::trim_prefix(&f.dest_path, b"./")

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -41,6 +41,13 @@ fn splat_byte_all(
     Ok(())
 }
 
+/// The name an output file gets in the per-file summary. The size column is
+/// padded from this same string, so the two cannot drift apart.
+#[inline]
+fn summary_path(f: &options::OutputFile) -> &[u8] {
+    strings::trim_prefix(&f.dest_path, b"./")
+}
+
 pub(crate) struct BuildCommand;
 
 impl BuildCommand {
@@ -835,8 +842,7 @@ impl BuildCommand {
             let mut size_padding: usize = 0;
 
             for f in output_files.iter() {
-                max_path_len =
-                    max_path_len.max(from_path.len().max(f.dest_path.len()) + 2 - from_path.len());
+                max_path_len = max_path_len.max(summary_path(f).len());
                 size_padding = size_padding.max(bun_fmt::count(format_args!(
                     "{}",
                     bun_fmt::size(f.size, Default::default())
@@ -1077,10 +1083,10 @@ impl BuildCommand {
 
                 debug_assert!(!bun_paths::is_absolute(&f.dest_path));
 
-                let rel_path = strings::trim_prefix(&f.dest_path, b"./");
+                let rel_path = summary_path(f);
 
                 // Print summary
-                let padding_count = 2usize.max(rel_path.len().max(max_path_len) - rel_path.len());
+                let padding_count = max_path_len.saturating_sub(rel_path.len()) + 2;
                 splat_byte_all(writer, b' ', 2)?;
 
                 if Output::enable_ansi_colors_stdout() {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -451,7 +451,7 @@ describe.concurrent("summary size column alignment", () => {
     `);
   });
 
-  test("outputs that share a directory", async () => {
+  test("outputs that share a directory under --root", async () => {
     using dir = tempDir("build-summary-shared-dir", {
       "sub/a.js": `console.log(1);`,
       "sub/bbb.js": `console.log(2);`,
@@ -462,6 +462,23 @@ describe.concurrent("summary size column alignment", () => {
 
         sub/a.js    28 bytes  (entry point)
         sub/bbb.js  30 bytes  (entry point)
+
+      "
+    `);
+  });
+
+  test("outputs that share a directory from --entry-naming", async () => {
+    using dir = tempDir("build-summary-entry-naming-dir", {
+      "a.js": `console.log(1);`,
+      "bbb.js": `console.log(2);`,
+    });
+
+    expect(await buildSummary(String(dir), ["--entry-naming=js/[name].[ext]", "./a.js", "./bbb.js"]))
+      .toMatchInlineSnapshot(`
+      "Bundled 2 modules in {time}ms
+
+        js/a.js    24 bytes  (entry point)
+        js/bbb.js  26 bytes  (entry point)
 
       "
     `);

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -420,6 +420,54 @@ test("log case 2", async () => {
   `);
 });
 
+describe.concurrent("summary size column alignment", () => {
+  async function buildSummary(dir: string, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args, "--outdir=dist"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout.replace(/in \d+ms/g, "in {time}ms");
+  }
+
+  test("entry point outside --root", async () => {
+    using dir = tempDir("build-summary-outside-root", {
+      "src/x.js": `console.log(1);`,
+      "other/o.js": `console.log(2);`,
+    });
+
+    expect(await buildSummary(String(dir), ["--root=src", "./src/x.js", "./other/o.js"])).toMatchInlineSnapshot(`
+      "Bundled 2 modules in {time}ms
+
+        x.js             28 bytes  (entry point)
+        _.._/other/o.js  30 bytes  (entry point)
+
+      "
+    `);
+  });
+
+  test("outputs that share a directory", async () => {
+    using dir = tempDir("build-summary-shared-dir", {
+      "sub/a.js": `console.log(1);`,
+      "sub/bbb.js": `console.log(2);`,
+    });
+
+    expect(await buildSummary(String(dir), ["--root=.", "./sub/a.js", "./sub/bbb.js"])).toMatchInlineSnapshot(`
+      "Bundled 2 modules in {time}ms
+
+        sub/a.js    28 bytes  (entry point)
+        sub/bbb.js  30 bytes  (entry point)
+
+      "
+    `);
+  });
+});
+
 test("--outdir build succeeds when the output directory already exists with prior output", async () => {
   using dir = tempDir("build-outdir-reuse", {
     "entry.ts": `export const x: number = 1;\nconsole.log("built", x);`,


### PR DESCRIPTION
### Problem
- The per-file summary `bun build` prints after writing outputs has a misaligned size column whenever the output names do not all start with `./`, or all share a longer prefix:
  ```
  $ bun build --root=src ./src/x.js ./other/o.js --outdir=dist
    x.js            28 bytes  (entry point)
    _.._/other/o.js  30 bytes  (entry point)

  $ bun build --entry-naming='js/[name].[ext]' ./a.js ./bbb.js --outdir=dist
    js/a.js  24 bytes  (entry point)
    js/bbb.js  26 bytes  (entry point)
  ```
- The width pass (`src/runtime/cli/build_command.rs:838`) measures each name relative to `longest_common_path` of all `dest_path`s, but the print pass (`:1080`, `:1083`) prints `dest_path` with only a literal `./` trimmed. The two agree only when the common prefix happens to be exactly `./`.
- Prefix shorter than `./` (an entry outside `--root` gives `/`): every `./` row comes out one column short. Prefix longer than `./` (`./js/` from `--entry-naming`, `sub/` from `--root`): the width collapses and rows drift by the difference in name length.
- The width formula dates from when the printed name really was the path relative to that prefix (it used to be returned by `writeToDisk`). #17794 changed what is printed without changing the width pass; the Rust port carried that over.

### Fix
- One `summary_path()` helper (`dest_path` with `./` trimmed) feeds both passes: `max_path_len` is the longest printed name, and each row pads with `max_path_len - name.len() + 2`.
- Correct because a column is aligned exactly when every row pads the string it actually prints out to the same width; measuring a different string cannot guarantee that.
- Byte-for-byte identical output in the case that already worked: with a `./` prefix the old width was `max(dest.len())`, which is `max(name.len()) + 2`, so the old padding was the same `max(name.len()) - name.len() + 2`. The existing `log case 1` and `--outfile` + `--sourcemap` snapshots are unchanged.
- `from_path` stays because `OutputFile::write_to_disk` still takes it; #35644 drops that parameter, after which `from_path` and `all_paths` can go entirely.
- Verified with the three new cases in `test/bundler/cli.test.ts` (`summary size column alignment`): an entry outside `--root`, entries placed in a subdirectory by `--root`, and entries placed in a subdirectory by `--entry-naming`. On the current release all three fail with misaligned rows like the ones above; with this change they pass.
- `bun bd test test/bundler/cli.test.ts`: every test passes except the three `--compile` tests, which time out in my environment copying the debug binary and do not touch this code path.

### Background
- `dest_path` is the output path relative to `--outdir`, always with `/` separators. The default entry template is `[dir]/[name].[ext]`, which gives `./x.js` when the entry sits at `--root` and `sub/a.js` when it sits below it; an entry above `--root` gets `_.._/other/o.js`, because the bundler rewrites `..` segments so the output cannot escape the outdir. A value passed to `--entry-naming`, `--chunk-naming` or `--asset-naming` gets `./` prepended (`src/runtime/cli/Arguments.rs:2571`), so `js/[name].[ext]` produces `./js/a.js`.
- `resolve_path::longest_common_path` returns the shared directory prefix of its inputs, `/` when they share nothing, and the input itself when there is only one.
- The summary row is `two spaces, name, padding, size, two spaces, kind`, so the name plus its padding has to be the same width on every row for the sizes to line up.
