### PR TITLE
Make custom inspect on web platform prototypes writable

### DIFF
--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -41,6 +41,7 @@
 #include "JSEventListener.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
+#include "streams/WebStreamsInspectCustom.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
@@ -238,8 +239,7 @@ void JSBroadcastChannelPrototype::finishCreation(VM& vm, JSGlobalObject* globalO
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSBroadcastChannel::info(), JSBroadcastChannelPrototypeTableValues, *this);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
-    BunBuiltinNames& builtinNames = WebCore::builtinNames(vm);
-    putDirectNativeFunction(vm, globalObject, builtinNames.inspectCustomPublicName(), 2, jsBroadcastChannelPrototype_inspectCustom, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
+    Bun::WebStreams::installInspectCustom(vm, this, jsBroadcastChannelPrototype_inspectCustom);
 }
 
 const ClassInfo JSBroadcastChannel::s_info = { "BroadcastChannel"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBroadcastChannel) };

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -108,8 +108,7 @@ WTF::String constructorNameOf(JSGlobalObject* lexicalGlobalObject, JSValue thisV
 void installInspectCustom(VM& vm, JSObject* prototype, NativeFunction nativeFunction)
 {
     auto* globalObject = prototype->globalObject();
-    // Node defines this property as { writable: true, enumerable: false, configurable: true }.
-    // It must stay writable so strict-mode code can shadow it with an instance property.
+    // Matches Node: { writable: true, enumerable: false, configurable: true }.
     prototype->putDirectNativeFunction(vm, globalObject, WebCore::builtinNames(vm).inspectCustomPublicName(), 2,
         nativeFunction, ImplementationVisibility::Public, NoIntrinsic,
         static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -108,9 +108,11 @@ WTF::String constructorNameOf(JSGlobalObject* lexicalGlobalObject, JSValue thisV
 void installInspectCustom(VM& vm, JSObject* prototype, NativeFunction nativeFunction)
 {
     auto* globalObject = prototype->globalObject();
+    // Node defines this property as { writable: true, enumerable: false, configurable: true }.
+    // It must stay writable so strict-mode code can shadow it with an instance property.
     prototype->putDirectNativeFunction(vm, globalObject, WebCore::builtinNames(vm).inspectCustomPublicName(), 2,
         nativeFunction, ImplementationVisibility::Public, NoIntrinsic,
-        static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum));
+        static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
 }
 
 } // namespace WebStreams

--- a/test/regression/issue/38087.test.ts
+++ b/test/regression/issue/38087.test.ts
@@ -11,6 +11,7 @@ test("custom inspect on web platform prototypes is writable like in Node", () =>
     TransformStream,
     ReadableStreamDefaultReader,
     WritableStreamDefaultWriter,
+    BroadcastChannel,
   ]) {
     const descriptor = Object.getOwnPropertyDescriptor(Class.prototype, inspectSymbol);
     expect(descriptor, Class.name).toMatchObject({

--- a/test/regression/issue/38087.test.ts
+++ b/test/regression/issue/38087.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+
+const inspectSymbol = Symbol.for("nodejs.util.inspect.custom");
+
+test("custom inspect on web platform prototypes is writable like in Node", () => {
+  for (const Class of [
+    URL,
+    URLSearchParams,
+    ReadableStream,
+    WritableStream,
+    TransformStream,
+    ReadableStreamDefaultReader,
+    WritableStreamDefaultWriter,
+  ]) {
+    const descriptor = Object.getOwnPropertyDescriptor(Class.prototype, inspectSymbol);
+    expect(descriptor, Class.name).toMatchObject({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+});
+
+test("assigning an instance-level custom inspect to a URL succeeds in strict mode", () => {
+  // SvelteKit's make_trackable does exactly this during SSR (issue #38087).
+  const url = new URL("https://example.com/");
+  const custom = () => "custom";
+  url[inspectSymbol] = custom;
+  expect(Object.getOwnPropertyDescriptor(url, inspectSymbol)).toEqual({
+    value: custom,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Bun.inspect(url)).toBe("custom");
+});


### PR DESCRIPTION
### Problem

- Assigning `Symbol.for('nodejs.util.inspect.custom')` on a `URL` instance throws `TypeError: Attempted to assign to readonly property.` in strict-mode code (ES modules), and is silently ignored in sloppy mode. This breaks SvelteKit SSR, whose `make_trackable` assigns an instance-level custom inspect function to a `URL`. Fixes #38087.
- Regression from #34660: `installInspectCustom` (src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp) defined the prototype property with `PropertyAttribute::ReadOnly`. The same installer is used by `URL`, `URLSearchParams`, `CryptoKey`, and all the web stream prototypes.
- `BroadcastChannel.prototype` had the same bug via a separate direct install with `ReadOnly | DontDelete` (JSBroadcastChannel.cpp), which additionally made the property non-configurable.
- Node defines this property as `{ writable: true, enumerable: false, configurable: true }` on every one of these classes, so a non-writable prototype property is a compat divergence: a strict-mode `instance[sym] = fn` throws instead of creating an own property that shadows the prototype.

### Fix

- Drop `ReadOnly` from the shared installer, keeping `DontEnum`. The resulting descriptor matches Node exactly.
- Route the `BroadcastChannel` install site through the shared installer so every `nodejs.util.inspect.custom` definition shares one set of attributes.
- Verified with test/regression/issue/38087.test.ts: checks the prototype descriptor on URL, URLSearchParams, BroadcastChannel, and the stream classes, and that a strict-mode instance assignment succeeds and is honored by `Bun.inspect`.
- Fails on the current canary (readonly descriptor, assignment throws), passes with this change.
- test/js/bun/util/inspect.test.js, test/js/node/util/custom-inspect.test.js, and test/js/node/test/parallel/test-webstream-encoding-inspect.js still pass; `Bun.inspect(new BroadcastChannel('x'))` output is unchanged.

### Background

- `nodejs.util.inspect.custom` is a well-known symbol Node's `util.inspect` looks up on an object to let it customize its own console output. Bun installs a native implementation of it on web platform prototypes so `console.log(new URL(...))` prints nicely.
- In strict mode, assigning to a property whose prototype holds a non-writable data property throws instead of creating an own property; in sloppy mode the same assignment is silently dropped. That is why the breakage only shows up in ES modules.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/38087.test.ts"
bun test v1.4.0 (8f3774470)

test/regression/issue/38087.test.ts:
12 |     ReadableStreamDefaultReader,
13 |     WritableStreamDefaultWriter,
14 |     BroadcastChannel,
15 |   ]) {
16 |     const descriptor = Object.getOwnPropertyDescriptor(Class.prototype, inspectSymbol);
17 |     expect(descriptor, Class.name).toMatchObject({
                                        ^
error: URL

  {
    "configurable": true,
    "enumerable": false,
-   "writable": true,
+   "value": [Function: anonymous],
+   "writable": false,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/38087.test.ts:17:36)
(fail) custom inspect on web platform prototypes is writable like in Node [22.15ms]
24 | 
25 | test("assigning an instance-level custom inspect to a URL succeeds in strict mode", () => {
26 |   // SvelteKit's make_trackable does exactly this during SSR (issue #38087).
27 |   const url = new URL("https://example.com/");
28 |   const custom = () => "custom";
29 |   url[inspe
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/regression/issue/38087.test.ts:
12 |     ReadableStreamDefaultReader,
13 |     WritableStreamDefaultWriter,
14 |     BroadcastChannel,
15 |   ]) {
16 |     const descriptor = Object.getOwnPropertyDescriptor(Class.prototype, inspectSymbol);
17 |     expect(descriptor, Class.name).toMatchObject({
                                        ^
error: URL

  {
    "configurable": true,
    "enumerable": false,
-   "writable": true,
+   "value": [Function: anonymous],
+   "writable": false,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/38087.test.ts:17:36)
(fail) custom inspect on web platform prototypes is writable like in Node [0.46ms]
24 | 
25 | test("assigning an instance-level custom inspect to a URL succeeds in strict mode", () => {
26 |   // SvelteKit's make_trackable does exactly this during SSR (issue #38087).
27 |   const url = new URL("https://example.com/");
28 |   const custom = () => "custom";
29 |   url[inspectSymbol] = custom;
       ^
TypeError: Attempted to assign to readonly property.
      at <anonymous> (/workspace/bun/test/regression/issue/38087.test.ts:29:3)
(f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/38087.test.ts"
bun test v1.4.0 (8f3774470)

test/regression/issue/38087.test.ts:
(pass) custom inspect on web platform prototypes is writable like in Node [39.12ms]
(pass) assigning an instance-level custom inspect to a URL succeeds in strict mode [112.80ms]

 2 pass
 0 fail
 10 expect() calls
Ran 2 tests across 1 file. [4.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 968ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp.o
[2/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 01s
[4/7] link bun-profile
[6/7] strip bun
[6/7] bun-profile --revision
1.4.0-canary.1+8f3774470
[build] done
bun test v1.4.0-canary.1 (8f3774470)

test/regression/issue/38087.test.ts:
(pass) custom inspect on web platform prototypes is writable like in Node [0.39ms]
(pass) assigning an instance-level custom inspect to a URL succeeds in strict mode [1.59ms]

 2 pass
 0 fail
 10 expect() calls
Ran 2 tests across 1 file. [1370.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSBroadcastChannel.cpp    |  4 +--
 .../webcore/streams/WebStreamsInspectCustom.cpp    |  3 +-
 test/regression/issue/38087.test.ts                | 37 ++++++++++++++++++++++
 3 files changed, 41 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/JSBroadcastChannel.cpp               1      2      0
…sc/bindings/webcore/streams/WebStreamsInspectCustom.cpp      2      4      0
test/regression/issue/38087.test.ts                           0      2      0
```

</details>

<!-- robobun:evidence:end -->