### PR TITLE
Bun.serve: finish a Bun.file() response after the client half-closes

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -744,9 +744,17 @@ private:
                  * nothing in AsyncSocketData::buffer). A retry that moves zero bytes
                  * after the peer's FIN is EPIPE; close instead of spinning. Except
                  * on libuv, where the retry can stall while the TLS layer's spill
-                 * is still blocked on a healthy socket; there the kernel is asked. */
+                 * is still blocked on a healthy socket; there the kernel is asked.
+                 * HTTP_END_CALLED (with HTTP_RESPONSE_PENDING) is what identifies a
+                 * tryEnd tail; it is the only deferred shape whose progress shows
+                 * up in `offset`. A deferred file body (HTTP_FIXED_LENGTH_FILE_BODY)
+                 * moves bytes with sendfile()/write() without touching it and
+                 * would read as stalled here every time; it notices a dead peer on
+                 * its own (a failed sendfile force-closes, a failed write() lands
+                 * in the buffer and trips the flushed == 0 check above). */
                 if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)
                     && (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING)
+                    && (httpResponseData->state & HttpResponseData<SSL>::HTTP_END_CALLED)
                     && httpResponseData->offset == offsetBefore
                     && asyncSocket->hasFullyDrained()
                     && us_socket_stalled_write_means_peer_gone((us_socket_t *) asyncSocket)) {
@@ -861,22 +869,26 @@ private:
                 return s;
             }
         } else {
-            /* Bun.serve: response bytes already handed to uWS must drain before
-             * the connection shuts down (from the existing shouldCloseConnection()
-             * gates), not be discarded by the close() below. Only a response that
-             * is fully determined qualifies: a tryEnd tail (content-length path
-             * sets HTTP_END_CALLED while offset < total keeps HTTP_RESPONSE_PENDING)
-             * or a completed response that has not fully drained. A streaming body
-             * the application is still producing (HTTP_END_CALLED clear,
-             * HTTP_RESPONSE_PENDING set) closes here so onAborted / request.signal
-             * fires on client disconnect. */
+            /* Bun.serve: a response that is already fully determined must finish
+             * and drain before the connection shuts down (from the existing
+             * shouldCloseConnection() gates), not be cut off by the close() below.
+             * That is a tryEnd tail (the content-length path sets HTTP_END_CALLED
+             * while offset < total keeps HTTP_RESPONSE_PENDING), a file body the
+             * runtime is still delivering under a Content-Length that has already
+             * gone out (HTTP_FIXED_LENGTH_FILE_BODY), or a completed response that
+             * has not fully drained. A streaming body the application is still
+             * producing (neither bit, HTTP_RESPONSE_PENDING set) closes here so
+             * onAborted / request.signal fires on client disconnect. A deferred
+             * connection whose peer is really gone still closes: the kernel
+             * reports the reset, or the next write()/sendfile() fails (onWritable
+             * above, FileResponseStream). */
             HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
             uint32_t state = httpResponseData->state;
-            bool tryEndTail = (state & HttpResponseData<SSL>::HTTP_END_CALLED)
+            bool determinedTail = (state & (HttpResponseData<SSL>::HTTP_END_CALLED | HttpResponseData<SSL>::HTTP_FIXED_LENGTH_FILE_BODY))
                 && (state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING);
             bool doneButBuffered = !(state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING)
                 && !asyncSocket->hasFullyDrained();
-            if (tryEndTail || doneButBuffered) {
+            if (determinedTail || doneButBuffered) {
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN;
                 return s;
             }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -134,7 +134,8 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * 'upgrade' listener's socket. */
         HTTP_NODE_TUNNEL_AFTER_BODY = 1 << 14,
         /* The peer half-closed (FIN) while there was still something to flush
-         * before teardown: buffered/pinned response bytes, or (with
+         * before teardown: buffered/pinned response bytes, a file body still
+         * being delivered (HTTP_FIXED_LENGTH_FILE_BODY), or (with
          * httpAllowHalfOpen) an in-flight or queued pipelined response. The
          * connection is shut down from the shouldCloseConnection()/onWritable
          * gates once those have drained. Without httpAllowHalfOpen, onWritable
@@ -151,6 +152,17 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * shutdown sweep; the shouldCloseConnection() gates act on it once the
          * in-flight work completes. */
         HTTP_CLOSE_WHEN_IDLE = 1 << 17,
+        /* The response in flight is a file of known size whose Content-Length
+         * is already on the wire, delivered by the runtime itself
+         * (FileResponseStream: sendfile() from the fd, or read()+write()
+         * chunks) rather than handed to uWS up front. Unlike a tryEnd tail
+         * nothing else in this object shows that such a response is already
+         * fully determined, so onEnd<false> needs this bit to let it finish
+         * after a peer FIN instead of closing on it (which leaves the client a
+         * short body under that Content-Length). Per-response: cleared by
+         * resetResponseState(), moot once markDone() clears
+         * HTTP_RESPONSE_PENDING. */
+        HTTP_FIXED_LENGTH_FILE_BODY = 1 << 18,
 
         /* Bits that describe the connection rather than the response in flight.
          * There is one HttpResponseData per socket, reused by every request on a

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -108,7 +108,10 @@ pub(crate) struct StartOptions {
     /// Byte offset into the file to begin reading from.
     pub offset: u64,
     /// Maximum bytes to send; `None` reads to EOF. For regular files this
-    /// should be `stat.size - offset` (after Range/slice clamping).
+    /// should be `stat.size - offset` (after Range/slice clamping), and the
+    /// caller must already have written it as the response's Content-Length:
+    /// `start()` tells uWS the body is fixed-length on that basis, which is
+    /// what keeps a client's half-close from cutting the transfer short.
     pub length: Option<u64>,
     pub idle_timeout: u8,
     pub ctx: *mut c_void,
@@ -158,6 +161,11 @@ impl FileResponseStream {
 
         let resp = this_ref.resp.get();
         resp.timeout(opts.idle_timeout);
+        // A `None` body (pipe, socket) is chunked and open-ended, so a peer
+        // FIN aborts it like any other stream.
+        if opts.length.is_some() {
+            resp.mark_fixed_length_file_body();
+        }
         resp.on_aborted(
             |p: *mut FileResponseStream, r| {
                 // SAFETY: uWS hands back the userdata pointer set below; the

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -108,10 +108,8 @@ pub(crate) struct StartOptions {
     /// Byte offset into the file to begin reading from.
     pub offset: u64,
     /// Maximum bytes to send; `None` reads to EOF. For regular files this
-    /// should be `stat.size - offset` (after Range/slice clamping), and the
-    /// caller must already have written it as the response's Content-Length:
-    /// `start()` tells uWS the body is fixed-length on that basis, which is
-    /// what keeps a client's half-close from cutting the transfer short.
+    /// should be `stat.size - offset` (after Range/slice clamping), already
+    /// written by the caller as the Content-Length.
     pub length: Option<u64>,
     pub idle_timeout: u8,
     pub ctx: *mut c_void,
@@ -161,8 +159,6 @@ impl FileResponseStream {
 
         let resp = this_ref.resp.get();
         resp.timeout(opts.idle_timeout);
-        // A `None` body (pipe, socket) is chunked and open-ended, so a peer
-        // FIN aborts it like any other stream.
         if opts.length.is_some() {
             resp.mark_fixed_length_file_body();
         }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -108,8 +108,7 @@ pub(crate) struct StartOptions {
     /// Byte offset into the file to begin reading from.
     pub offset: u64,
     /// Maximum bytes to send; `None` reads to EOF. For regular files this
-    /// should be `stat.size - offset` (after Range/slice clamping), already
-    /// written by the caller as the Content-Length.
+    /// should be `stat.size - offset` (after Range/slice clamping).
     pub length: Option<u64>,
     pub idle_timeout: u8,
     pub ctx: *mut c_void,

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -322,6 +322,15 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), self.as_raw())
     }
 
+    /// The body is a file of known size being delivered by the runtime under
+    /// a Content-Length that is already on the wire. uWS then finishes it after
+    /// a peer FIN (`HttpContext::onEnd`) the way it drains a `try_end` tail,
+    /// instead of closing on the FIN as it does for a body the application is
+    /// still producing.
+    pub(crate) fn mark_fixed_length_file_body(&mut self) {
+        c::uws_res_mark_fixed_length_file_body(Self::ssl_flag(), self.as_raw())
+    }
+
     pub(crate) fn mark_wrote_date_header(&mut self) {
         c::uws_res_mark_wrote_date_header(Self::ssl_flag(), self.as_raw())
     }
@@ -721,6 +730,11 @@ impl AnyResponse {
         any_dispatch!(self, |r| r.mark_wrote_content_length_header())
     }
 
+    /// See `Response::mark_fixed_length_file_body`.
+    pub fn mark_fixed_length_file_body(self) {
+        any_dispatch!(self, |r| r.mark_fixed_length_file_body())
+    }
+
     pub fn mark_wrote_date_header(self) {
         any_dispatch!(self, |r| r.mark_wrote_date_header())
     }
@@ -1081,6 +1095,7 @@ pub mod c {
     // unsafe.
     unsafe extern "C" {
         pub(crate) safe fn uws_res_mark_wrote_content_length_header(ssl: i32, res: &mut uws_res);
+        pub(crate) safe fn uws_res_mark_fixed_length_file_body(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_mark_wrote_date_header(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_write_mark(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn us_socket_mark_needs_more_not_ssl(socket: &mut uws_res);

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -322,11 +322,7 @@ impl<const SSL: bool> Response<SSL> {
         c::uws_res_mark_wrote_content_length_header(Self::ssl_flag(), self.as_raw())
     }
 
-    /// The body is a file of known size being delivered by the runtime under
-    /// a Content-Length that is already on the wire. uWS then finishes it after
-    /// a peer FIN (`HttpContext::onEnd`) the way it drains a `try_end` tail,
-    /// instead of closing on the FIN as it does for a body the application is
-    /// still producing.
+    /// Sets `HTTP_FIXED_LENGTH_FILE_BODY`; see `HttpResponseData.h`.
     pub(crate) fn mark_fixed_length_file_body(&mut self) {
         c::uws_res_mark_fixed_length_file_body(Self::ssl_flag(), self.as_raw())
     }

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -145,8 +145,7 @@ impl Response {
     pub(crate) fn mark_wrote_content_length_header(&mut self) {
         c::uws_h3_res_mark_wrote_content_length_header(self)
     }
-    /// Only consulted by the TCP peer-FIN handling in `HttpContext::onEnd`;
-    /// an H3 stream has no equivalent.
+    /// No-op: only the TCP peer-FIN handling reads this bit.
     pub(crate) fn mark_fixed_length_file_body(&mut self) {}
     pub(crate) fn mark_wrote_date_header(&mut self) {
         c::uws_h3_res_mark_wrote_date_header(self)

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -145,6 +145,9 @@ impl Response {
     pub(crate) fn mark_wrote_content_length_header(&mut self) {
         c::uws_h3_res_mark_wrote_content_length_header(self)
     }
+    /// Only consulted by the TCP peer-FIN handling in `HttpContext::onEnd`;
+    /// an H3 stream has no equivalent.
+    pub(crate) fn mark_fixed_length_file_body(&mut self) {}
     pub(crate) fn mark_wrote_date_header(&mut self) {
         c::uws_h3_res_mark_wrote_date_header(self)
     }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1277,6 +1277,16 @@ extern "C"
     }
   }
 
+  void uws_res_mark_fixed_length_file_body(int ssl, uws_res_r res) {
+    if (ssl) {
+      uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
+      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<true>::HTTP_FIXED_LENGTH_FILE_BODY;
+    } else {
+      uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
+      uwsRes->getHttpResponseData()->state |= uWS::HttpResponseData<false>::HTTP_FIXED_LENGTH_FILE_BODY;
+    }
+  }
+
   void uws_res_mark_wrote_date_header(int ssl, uws_res_r res) {
     if (ssl) {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -4235,11 +4235,12 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
 });
 
 // A client that half-closes its write side right after the request (the raw
-// socket.end(request) pattern) must receive every response byte already handed
-// to uWS, not just what the kernel accepted on the first send. No
-// Connection: close on the request: the post-drain shutdown is driven by the
-// HTTP_NODE_RECEIVED_FIN clause of shouldCloseConnection(), not by
-// HTTP_CONNECTION_CLOSE.
+// socket.end(request) pattern) must receive the whole of a response whose
+// length is already settled: a body handed to uWS up front, or a file body the
+// runtime streams itself under a Content-Length it has already sent. Not just
+// what the kernel accepted on the first send. No Connection: close on the
+// request: the post-drain shutdown is driven by the HTTP_NODE_RECEIVED_FIN
+// clause of shouldCloseConnection(), not by HTTP_CONNECTION_CLOSE.
 describe("a client half-close after the request does not truncate a large response body", () => {
   const BODY = 8 * 1024 * 1024;
 
@@ -4264,14 +4265,20 @@ describe("a client half-close after the request does not truncate a large respon
     return out;
   }
 
-  async function halfCloseRequest(port: number): Promise<{ body: number; ended: boolean }> {
-    const socket = connect(port, "127.0.0.1");
+  async function halfCloseRequest(port: number, secure = false): Promise<{ body: number; ended: boolean }> {
+    const socket = secure
+      ? nodeTls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false })
+      : connect(port, "127.0.0.1");
     const out = countBody(socket);
     const closed = new Promise<void>(r => socket.once("close", () => r()));
-    await new Promise<void>(r => socket.once("connect", () => r()));
+    await new Promise<void>(r => socket.once(secure ? "secureConnect" : "connect", () => r()));
     socket.end("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
     await closed;
     return out;
+  }
+
+  function bigFile(prefix: string) {
+    return tempDir(prefix, { "big.bin": Buffer.alloc(BODY, "a") });
   }
 
   it("fetch handler (tryEnd tail)", async () => {
@@ -4299,13 +4306,36 @@ describe("a client half-close after the request does not truncate a large respon
       tls,
       fetch: () => new Response(Buffer.alloc(BODY, "a"), { headers: { "content-length": String(BODY) } }),
     });
-    const socket = nodeTls.connect({ port: server.port, host: "127.0.0.1", rejectUnauthorized: false });
-    const out = countBody(socket);
-    const closed = new Promise<void>(r => socket.once("close", () => r()));
-    await new Promise<void>(r => socket.once("secureConnect", () => r()));
-    socket.end("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
-    await closed;
-    expect(out).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port, true)).toEqual({ body: BODY, ended: true });
+  });
+
+  // A file body is not handed to uWS up front: FileResponseStream writes the
+  // Content-Length, then moves the bytes itself (sendfile() on Linux over plain
+  // TCP, read()+write() chunks over TLS and on the other platforms), so uWS
+  // only knows the response is settled because the stream marks it as such
+  // (HTTP_FIXED_LENGTH_FILE_BODY). Without that mark the FIN closed the socket
+  // mid-transfer: a 200 with Content-Length: 8388608 followed by a few MiB and
+  // then the server's FIN.
+  it("fetch handler returning Bun.file() (file body)", async () => {
+    using dir = bigFile("half-close-file");
+    using server = serve({ port: 0, fetch: () => new Response(file(join(String(dir), "big.bin"))) });
+    expect(await halfCloseRequest(server.port)).toEqual({ body: BODY, ended: true });
+  });
+
+  it("Bun.file() route (file body)", async () => {
+    using dir = bigFile("half-close-file-route");
+    using server = serve({
+      port: 0,
+      routes: { "/": file(join(String(dir), "big.bin")) },
+      fetch: () => new Response("miss", { status: 404 }),
+    });
+    expect(await halfCloseRequest(server.port)).toEqual({ body: BODY, ended: true });
+  });
+
+  it("https fetch handler returning Bun.file() (file body)", async () => {
+    using dir = bigFile("half-close-file-tls");
+    using server = serve({ port: 0, tls, fetch: () => new Response(file(join(String(dir), "big.bin"))) });
+    expect(await halfCloseRequest(server.port, true)).toEqual({ body: BODY, ended: true });
   });
 
   // The deferred connection must close promptly, not spin the writable
@@ -4337,9 +4367,38 @@ describe("a client half-close after the request does not truncate a large respon
     expect(server.pendingRequests).toBe(0);
   });
 
+  // Same for a deferred file body. It is not covered by onWritable's
+  // zero-progress check (its progress never shows up in the uWS write offset,
+  // which is why that check is scoped to tryEnd tails): the peer's reset is
+  // reported by the kernel, or the next sendfile()/write() fails and the
+  // stream tears the request down itself. Either way the request must not sit
+  // there until idleTimeout.
+  it("a file body closes without spinning when the peer goes away mid-transfer", async () => {
+    using dir = bigFile("half-close-file-peer-gone");
+    const dispatched = Promise.withResolvers<void>();
+    using server = serve({
+      port: 0,
+      idleTimeout: 60,
+      fetch() {
+        dispatched.resolve();
+        return new Response(file(join(String(dir), "big.bin")));
+      },
+    });
+    const socket = connect(server.port, "127.0.0.1");
+    socket.on("error", () => {});
+    await new Promise<void>(r => socket.once("connect", () => r()));
+    socket.end("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    socket.once("data", () => socket.destroy());
+    await dispatched.promise;
+    const deadline = Date.now() + 4000;
+    while (server.pendingRequests > 0 && Date.now() < deadline) await Bun.sleep(5);
+    expect(server.pendingRequests).toBe(0);
+  });
+
   // The defer in onEnd is gated on the response being fully determined
-  // (HTTP_END_CALLED). A streaming body the handler is still producing must
-  // close on client FIN so onAborted / request.signal fires.
+  // (HTTP_END_CALLED or HTTP_FIXED_LENGTH_FILE_BODY). A streaming body the
+  // handler is still producing must close on client FIN so onAborted /
+  // request.signal fires.
   it("request.signal still fires on client FIN for a streaming body", async () => {
     const aborted = Promise.withResolvers<void>();
     using server = serve({

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -4244,8 +4244,12 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
 describe("a client half-close after the request does not truncate a large response body", () => {
   const BODY = 8 * 1024 * 1024;
 
+  // The advertised Content-Length, the body bytes actually delivered, and
+  // whether the server closed cleanly (FIN rather than a reset).
+  const WHOLE_RESPONSE = { contentLength: BODY, body: BODY, ended: true };
+
   function countBody(socket: net.Socket | nodeTls.TLSSocket) {
-    const out = { body: 0, ended: false };
+    const out = { contentLength: -1, body: 0, ended: false };
     let head = "";
     let gotHead = false;
     socket.on("data", chunk => {
@@ -4254,6 +4258,7 @@ describe("a client half-close after the request does not truncate a large respon
         const i = head.indexOf("\r\n\r\n");
         if (i >= 0) {
           gotHead = true;
+          out.contentLength = Number(/^content-length:\s*(\d+)/im.exec(head.slice(0, i))?.[1] ?? -1);
           out.body = Buffer.byteLength(head.slice(i + 4), "latin1");
         }
       } else {
@@ -4265,7 +4270,7 @@ describe("a client half-close after the request does not truncate a large respon
     return out;
   }
 
-  async function halfCloseRequest(port: number, secure = false): Promise<{ body: number; ended: boolean }> {
+  async function halfCloseRequest(port: number, secure = false): Promise<typeof WHOLE_RESPONSE> {
     const socket = secure
       ? nodeTls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false })
       : connect(port, "127.0.0.1");
@@ -4286,7 +4291,7 @@ describe("a client half-close after the request does not truncate a large respon
       port: 0,
       fetch: () => new Response(Buffer.alloc(BODY, "a"), { headers: { "content-length": String(BODY) } }),
     });
-    expect(await halfCloseRequest(server.port)).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port)).toEqual(WHOLE_RESPONSE);
   });
 
   it("static route (tryEnd tail)", async () => {
@@ -4297,7 +4302,7 @@ describe("a client half-close after the request does not truncate a large respon
       },
       fetch: () => new Response("miss", { status: 404 }),
     });
-    expect(await halfCloseRequest(server.port)).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port)).toEqual(WHOLE_RESPONSE);
   });
 
   it("https fetch handler (tryEnd tail)", async () => {
@@ -4306,7 +4311,7 @@ describe("a client half-close after the request does not truncate a large respon
       tls,
       fetch: () => new Response(Buffer.alloc(BODY, "a"), { headers: { "content-length": String(BODY) } }),
     });
-    expect(await halfCloseRequest(server.port, true)).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port, true)).toEqual(WHOLE_RESPONSE);
   });
 
   // A file body is not handed to uWS up front: FileResponseStream writes the
@@ -4319,7 +4324,7 @@ describe("a client half-close after the request does not truncate a large respon
   it("fetch handler returning Bun.file() (file body)", async () => {
     using dir = bigFile("half-close-file");
     using server = serve({ port: 0, fetch: () => new Response(file(join(String(dir), "big.bin"))) });
-    expect(await halfCloseRequest(server.port)).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port)).toEqual(WHOLE_RESPONSE);
   });
 
   it("Bun.file() route (file body)", async () => {
@@ -4329,13 +4334,13 @@ describe("a client half-close after the request does not truncate a large respon
       routes: { "/": file(join(String(dir), "big.bin")) },
       fetch: () => new Response("miss", { status: 404 }),
     });
-    expect(await halfCloseRequest(server.port)).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port)).toEqual(WHOLE_RESPONSE);
   });
 
   it("https fetch handler returning Bun.file() (file body)", async () => {
     using dir = bigFile("half-close-file-tls");
     using server = serve({ port: 0, tls, fetch: () => new Response(file(join(String(dir), "big.bin"))) });
-    expect(await halfCloseRequest(server.port, true)).toEqual({ body: BODY, ended: true });
+    expect(await halfCloseRequest(server.port, true)).toEqual(WHOLE_RESPONSE);
   });
 
   // The deferred connection must close promptly, not spin the writable


### PR DESCRIPTION
### Problem

- `Bun.serve` answering `new Response(Bun.file(f))` (8 MiB) to a client that half-closes right after its request sends `Content-Length: 8388608`, then 2 to 6 MiB of body, then FIN: a short body under the advertised Content-Length. Same for a `Bun.file()` route, over TLS, and over `unix:` (cut at one socket buffer, ~196 KiB here). Every in-memory body type (string, Buffer, Blob, static route) reaches the same client whole.
- Cause: `HttpContext::onEnd<false>` (packages/bun-uws/src/HttpContext.h) keeps a connection open past a peer FIN only for a tryEnd tail (`HTTP_END_CALLED` + `HTTP_RESPONSE_PENDING`) or a completed response that has not drained (#35088). A file body is delivered by `FileResponseStream` (src/runtime/server/FileResponseStream.rs): it writes the Content-Length and then moves the bytes itself with `sendfile()` or `read()`+`write()` chunks, so neither state applies while it is in flight and the FIN closes the socket as if the application were still producing the body. #35088 listed this path as a follow-up needing a new state bit.
- A client that half-closes after its request: `nc -N`, `socat`, Go `CloseWrite`, HTTP/1.0-style fetchers, some health checkers. Browsers and `fetch` never do this.

### Fix

- `HttpResponseData`: new per-response bit `HTTP_FIXED_LENGTH_FILE_BODY`, exposed as `uws_res_mark_fixed_length_file_body` / `AnyResponse::mark_fixed_length_file_body` (no-op for HTTP/3, which has no TCP FIN). `FileResponseStream::start()` sets it when the body length is known; every caller (`RequestContext`, `FileRoute`, `DirectoryRoute`) has written that length as the Content-Length by then. Pipe and socket bodies (`length: None`, chunked, open-ended) do not set it and still close on FIN like any other stream.
- `onEnd<false>` defers the close for this bit exactly as for a tryEnd tail; the existing `shouldCloseConnection()` gates (`close_if_done_and_marked` after `end_send_file`, `internalEnd` after the last chunk) shut the connection down once the file has been sent, since `HTTP_NODE_RECEIVED_FIN` is set.
- `onWritable`'s zero-progress close after a FIN now also requires `HTTP_END_CALLED`. It compares the uWS write offset before and after the callback, and only a tryEnd tail advances that offset; a deferred file body never touches it and would have been closed on its first writable event. A file body whose peer is actually gone is still torn down: the kernel reports the reset (onClose, onAborted), or the next `sendfile()` fails and `FileResponseStream` force-closes, or the failed `write()` lands in the buffer and trips the existing `flushed == 0` check.
- Verified: test/js/bun/http/serve.test.ts, describe "a client half-close after the request does not truncate a large response body". New cases: fetch handler returning `Bun.file()` (sendfile on Linux), `Bun.file()` route, https fetch handler returning `Bun.file()` (read+write path), and a file body whose peer destroys the connection mid-transfer (`pendingRequests` reaches 0). Every completion case (these and the existing tryEnd ones) now asserts the advertised Content-Length as well as the bytes delivered; the three file cases receive 2691072 / 2691072 / 2752512 of an advertised 8388608 bytes on the released build and the full body with this change.
- Also run: the ledger script (`/file` half-close 10/10 complete, was 0/10), a unix-socket variant (5/5, was 0/5), serve.test.ts (remaining failures are this container's IPv6, root-port and egress-proxy environment, same without the change), bun-serve-file, bun-serve-static, bun-serve-routes, serve-directory-routes, bun-serve-ssl, node-http-backpressure, node-http-halfclose-midupload.

### Background

- Half-close: a TCP peer can shut down its sending side (`shutdown(SHUT_WR)`, `socket.end()`) and keep reading. The server sees EOF on reads; writes still work. uSockets delivers that EOF as `on_end`, and HTTP server sockets opt into half-open (`allow_half_open`, #35088) so `onEnd` gets to decide between closing at once and letting output finish.
- tryEnd tail: for an in-memory body uWS writes Content-Length plus as much of the body as the kernel accepts in one go; the remainder is a "tail" it resends from `onWritable`, tracked as `HTTP_END_CALLED` set with `HTTP_RESPONSE_PENDING` still set and `offset < total`.
- `FileResponseStream`: the runtime's file body pump. On Linux over plain TCP (files of at least 1 MiB) it calls `sendfile()` on the socket fd directly, asking uWS only for writable notifications; elsewhere (TLS, macOS, Windows, smaller files) it reads chunks and hands them to `write()`, ending with `end()`. Either way uWS never holds the remaining body, which is why the response needs an explicit marker to be recognized as already determined.
- Why streams still close on FIN: for a `ReadableStream` body the application is producing data, and closing on the FIN is what makes `request.signal` / `onAborted` fire on client disconnect (#35088). The existing test for that case is unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->
