### PR TITLE
node:fs: recursive mkdir on Windows no longer accepts a directory link to nowhere as an existing directory

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,8 +437,7 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// `exists_at_type` over an `OSPathSliceZ`: `fstatat` on POSIX, the link-following wide
-/// arm on Windows (where `OSPathSliceZ` is already `&WStr`), so both follow symlinks.
+/// Follows symlinks on both platforms (`fstatat`; the wide arm on Windows).
 #[inline]
 fn exists_at_type_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<sys::ExistsAtType> {
     #[cfg(not(windows))]
@@ -5741,8 +5740,7 @@ impl NodeFS {
                         // is never observed with its terminator clobbered.
                         match err.get_errno() {
                             E::EEXIST => {
-                                // Only a file is ENOTDIR here; an unfollowable link falls through
-                                // to the next mkdir's ENOENT.
+                                // Files: ENOTDIR. Unfollowable links: the next mkdir's ENOENT.
                                 #[cfg(windows)]
                                 {
                                     if let Ok(sys::ExistsAtType::File) =

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,11 +437,8 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// What `mkdir -p` found at a `(fd, path)` that `mkdir` reported as existing, following
-/// symlinks on both platforms (`fstatat`; on Windows the wide arm, which resolves the
-/// reparse point, so a directory link whose target is gone is an error rather than a
-/// directory). Dispatches on path element width: on Windows `OSPathSliceZ` is already
-/// `&WStr`, so forward to the wide overload instead of narrowing to UTF-8 and re-widening.
+/// `exists_at_type` over an `OSPathSliceZ`: `fstatat` on POSIX, the link-following wide
+/// arm on Windows (where `OSPathSliceZ` is already `&WStr`), so both follow symlinks.
 #[inline]
 fn exists_at_type_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<sys::ExistsAtType> {
     #[cfg(not(windows))]
@@ -5669,8 +5666,6 @@ impl NodeFS {
                 // it is unclear if macOS lies about if the existing item is
                 // a directory or not, so it is checked.
                 E::EISDIR | E::EEXIST => {
-                    // A directory (or a link that resolves to one) is fine; anything
-                    // else, including a link that cannot be followed, is a failure.
                     return match exists_at_type_os_path(FD::INVALID, path) {
                         Ok(sys::ExistsAtType::Directory) => Ok(StringOrUndefined::None),
                         Ok(sys::ExistsAtType::File) | Err(_) => Err(sys::Error {
@@ -5746,11 +5741,8 @@ impl NodeFS {
                         // is never observed with its terminator clobbered.
                         match err.get_errno() {
                             E::EEXIST => {
-                                // On Windows, this may happen if trying to mkdir replacing a file
-                                // (`CreateDirectoryW` under a file reports ENOENT, so the POSIX
-                                // ENOTDIR has to be produced here). A link that cannot be
-                                // followed (`Err`) breaks out like a directory so the mkdir of
-                                // the next component reports ENOENT, as it does on POSIX.
+                                // Only a file is ENOTDIR here; an unfollowable link falls through
+                                // to the next mkdir's ENOENT.
                                 #[cfg(windows)]
                                 {
                                     if let Ok(sys::ExistsAtType::File) =

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,18 +437,20 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// Check whether a directory exists at `(fd, path)` — dispatches on path element width. On
-/// Windows `OSPathSliceZ` is already `&WStr`, so forward to the wide overload
-/// instead of narrowing to UTF-8 and re-widening. POSIX is a forwarder.
+/// What `mkdir -p` found at a `(fd, path)` that `mkdir` reported as existing, following
+/// symlinks on both platforms (`fstatat`; on Windows the wide arm, which resolves the
+/// reparse point, so a directory link whose target is gone is an error rather than a
+/// directory). Dispatches on path element width: on Windows `OSPathSliceZ` is already
+/// `&WStr`, so forward to the wide overload instead of narrowing to UTF-8 and re-widening.
 #[inline]
-fn directory_exists_at_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<bool> {
+fn exists_at_type_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<sys::ExistsAtType> {
     #[cfg(not(windows))]
     {
-        sys::directory_exists_at(dir, path)
+        sys::exists_at_type(dir, path)
     }
     #[cfg(windows)]
     {
-        sys::directory_exists_at_w(dir, path.as_slice())
+        sys::exists_at_type_w(dir, path.as_slice())
     }
 }
 
@@ -5667,8 +5669,11 @@ impl NodeFS {
                 // it is unclear if macOS lies about if the existing item is
                 // a directory or not, so it is checked.
                 E::EISDIR | E::EEXIST => {
-                    return match directory_exists_at_os_path(FD::INVALID, path) {
-                        Err(_) => Err(sys::Error {
+                    // A directory (or a link that resolves to one) is fine; anything
+                    // else, including a link that cannot be followed, is a failure.
+                    return match exists_at_type_os_path(FD::INVALID, path) {
+                        Ok(sys::ExistsAtType::Directory) => Ok(StringOrUndefined::None),
+                        Ok(sys::ExistsAtType::File) | Err(_) => Err(sys::Error {
                             errno: err.errno,
                             syscall: sys::Tag::mkdir,
                             path: self
@@ -5676,21 +5681,6 @@ impl NodeFS {
                                 .into(),
                             ..Default::default()
                         }),
-                        // if is a directory, OK. otherwise failure
-                        Ok(result) => {
-                            if result {
-                                Ok(StringOrUndefined::None)
-                            } else {
-                                Err(sys::Error {
-                                    errno: err.errno,
-                                    syscall: sys::Tag::mkdir,
-                                    path: self
-                                        .os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
-                                        .into(),
-                                    ..Default::default()
-                                })
-                            }
-                        }
                     };
                 }
                 // continue
@@ -5757,26 +5747,27 @@ impl NodeFS {
                         match err.get_errno() {
                             E::EEXIST => {
                                 // On Windows, this may happen if trying to mkdir replacing a file
+                                // (`CreateDirectoryW` under a file reports ENOENT, so the POSIX
+                                // ENOTDIR has to be produced here). A link that cannot be
+                                // followed (`Err`) breaks out like a directory so the mkdir of
+                                // the next component reports ENOENT, as it does on POSIX.
                                 #[cfg(windows)]
                                 {
-                                    if let Ok(res) =
-                                        directory_exists_at_os_path(FD::INVALID, parent)
+                                    if let Ok(sys::ExistsAtType::File) =
+                                        exists_at_type_os_path(FD::INVALID, parent)
                                     {
-                                        // is a directory. break.
-                                        if !res {
-                                            // SAFETY: `working_mem` is not used after this return; the
-                                            // re-derived &mut PathBuffer is scoped to the call.
-                                            return Err(sys::Error {
-                                                errno: E::ENOTDIR as _,
-                                                syscall: sys::Tag::mkdir,
-                                                path: Self::os_path_into_buf(
-                                                    unsafe { &mut *sync_error_buf_ptr },
-                                                    without_nt_prefix(&(&path[..])[..len as usize]),
-                                                )
-                                                .into(),
-                                                ..Default::default()
-                                            });
-                                        }
+                                        // SAFETY: `working_mem` is not used after this return; the
+                                        // re-derived &mut PathBuffer is scoped to the call.
+                                        return Err(sys::Error {
+                                            errno: E::ENOTDIR as _,
+                                            syscall: sys::Tag::mkdir,
+                                            path: Self::os_path_into_buf(
+                                                unsafe { &mut *sync_error_buf_ptr },
+                                                without_nt_prefix(&(&path[..])[..len as usize]),
+                                            )
+                                            .into(),
+                                            ..Default::default()
+                                        });
                                     }
                                 }
                                 working_mem[i as usize] = paths::SEP as OSPathChar;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7333,12 +7333,13 @@ pub enum ExistsAtType {
     Directory,
 }
 /// Windows tail — `NtQueryAttributesFile` against an
-/// OBJECT_ATTRIBUTES built from an already NT-prefixed wide path. Shared by the
-/// UTF-8 (`exists_at_type`) and UTF-16 (`exists_at_type_w`) entry points so the
-/// width dispatch does not
-/// duplicate the syscall body.
+/// OBJECT_ATTRIBUTES built from an already NT-prefixed wide path, returning the
+/// entry's `FileAttributes`. Shared by the UTF-8 (`exists_at_type`) and UTF-16
+/// (`exists_at_type_w`) entry points so the width dispatch does not duplicate
+/// the syscall body. Like `GetFileAttributesW`, this describes a reparse point
+/// (symlink, junction) itself, not what it points at.
 #[cfg(windows)]
-fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
+fn query_attributes_nt(dir: Fd, mut path: &[u16]) -> Maybe<u32> {
     use bun_windows_sys::externs as w;
     // Trim leading `.\` — NtQueryAttributesFile expects relative paths
     // without it.
@@ -7379,18 +7380,22 @@ fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
             Tag::access,
         ));
     }
-    // `FILE_ATTRIBUTE_READONLY` on a directory is a folder-customization
-    // marker (OneDrive sets it) and does not affect directory-ness; only
-    // `FILE_ATTRIBUTE_DIRECTORY` decides the type.
-    Ok(
-        if (basic_info.FileAttributes & w::FILE_ATTRIBUTE_DIRECTORY) != 0 {
-            ExistsAtType::Directory
-        } else {
-            ExistsAtType::File
-        },
-    )
+    Ok(basic_info.FileAttributes)
 }
-/// `fstatat` then `S_ISDIR`.
+/// `FILE_ATTRIBUTE_READONLY` on a directory is a folder-customization
+/// marker (OneDrive sets it) and does not affect directory-ness; only
+/// `FILE_ATTRIBUTE_DIRECTORY` decides the type.
+#[cfg(windows)]
+fn exists_at_type_from_attributes(attributes: u32) -> ExistsAtType {
+    if (attributes & bun_windows_sys::FILE_ATTRIBUTE_DIRECTORY) != 0 {
+        ExistsAtType::Directory
+    } else {
+        ExistsAtType::File
+    }
+}
+/// `fstatat` then `S_ISDIR`. The Windows arm answers from the entry's own
+/// attributes, so unlike `fstatat` it does not follow a symlink or junction;
+/// `exists_at_type_w` is the arm that does.
 pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
     #[cfg(unix)]
     {
@@ -7407,33 +7412,50 @@ pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
         // built from the (optionally NT-prefixed) wide path.
         let mut wbuf = bun_paths::w_path_buffer_pool::get();
         let path = bun_paths::string_paths::to_nt_path(&mut wbuf.0[..], sub.as_bytes()).as_slice();
-        exists_at_type_nt(dir, path)
+        query_attributes_nt(dir, path).map(exists_at_type_from_attributes)
     }
 }
-/// Wide-path arm of `exists_at_type`. Takes an already-wide path (Windows
-/// `OSPathSliceZ`) and routes through
-/// `toNTPath16` instead of re-widening from UTF-8.
+/// Wide-path arm of `exists_at_type` for node:fs' recursive mkdir, which asks
+/// about a path `mkdir` just reported as existing. It follows a symlink or
+/// junction the way the POSIX arm's `fstatat` does: a directory-type link
+/// carries `FILE_ATTRIBUTE_DIRECTORY` itself whether or not its target exists,
+/// so answering from the link's own attributes would let `mkdir -p` accept a
+/// link to nowhere as an existing directory. A link that cannot be followed
+/// fails with the open error (ENOENT when it points nowhere).
 #[cfg(windows)]
-pub(crate) fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
-    let mut wbuf = bun_paths::w_path_buffer_pool::get();
-    let path = bun_paths::string_paths::to_nt_path16(&mut wbuf.0[..], sub).as_slice();
-    exists_at_type_nt(dir, path)
+pub fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
+    use bun_windows_sys::externs as w;
+    let attributes = {
+        let mut wbuf = bun_paths::w_path_buffer_pool::get();
+        let path = bun_paths::string_paths::to_nt_path16(&mut wbuf.0[..], sub);
+        query_attributes_nt(dir, path.as_slice())?
+    };
+    if (attributes & w::FILE_ATTRIBUTE_REPARSE_POINT) == 0 {
+        return Ok(exists_at_type_from_attributes(attributes));
+    }
+    // No `FILE_OPEN_REPARSE_POINT`, so this opens whatever the link resolves to.
+    let fd = open_file_at_windows(
+        dir,
+        sub,
+        NtCreateFileOptions {
+            access_mask: w::FILE_READ_ATTRIBUTES | w::SYNCHRONIZE,
+            disposition: w::FILE_OPEN,
+            options: w::FILE_SYNCHRONOUS_IO_NONALERT,
+            ..Default::default()
+        },
+    )?;
+    let _close = CloseOnDrop::new(fd);
+    let st = fstat(fd)?;
+    Ok(if S::ISDIR(st.st_mode as _) {
+        ExistsAtType::Directory
+    } else {
+        ExistsAtType::File
+    })
 }
 /// `directoryExistsAt(dir, sub)`. ENOENT → `Ok(false)`.
 pub fn directory_exists_at(dir: impl AsFd, sub: &ZStr) -> Maybe<bool> {
     let dir = dir.as_fd();
     match exists_at_type(dir, sub) {
-        Ok(t) => Ok(t == ExistsAtType::Directory),
-        Err(e) if e.get_errno() == E::ENOENT => Ok(false),
-        Err(e) => Err(e),
-    }
-}
-/// `directoryExistsAt` — wide-path (`u16`) overload for Windows
-/// `OSPathSliceZ` callers (mkdir-recursive, cpSync auto-detect). Avoids
-/// a UTF-16 → UTF-8 → UTF-16 round-trip.
-#[cfg(windows)]
-pub fn directory_exists_at_w(dir: Fd, sub: &[u16]) -> Maybe<bool> {
-    match exists_at_type_w(dir, sub) {
         Ok(t) => Ok(t == ExistsAtType::Directory),
         Err(e) if e.get_errno() == E::ENOENT => Ok(false),
         Err(e) => Err(e),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7332,12 +7332,9 @@ pub enum ExistsAtType {
     File,
     Directory,
 }
-/// Windows tail — `NtQueryAttributesFile` against an
-/// OBJECT_ATTRIBUTES built from an already NT-prefixed wide path, returning the
-/// entry's `FileAttributes`. Shared by the UTF-8 (`exists_at_type`) and UTF-16
-/// (`exists_at_type_w`) entry points so the width dispatch does not duplicate
-/// the syscall body. Like `GetFileAttributesW`, this describes a reparse point
-/// (symlink, junction) itself, not what it points at.
+/// `FileAttributes` of an already NT-prefixed wide path via `NtQueryAttributesFile`,
+/// shared by `exists_at_type` and `exists_at_type_w`. Like `GetFileAttributesW` it
+/// describes a reparse point itself, not what it points at.
 #[cfg(windows)]
 fn query_attributes_nt(dir: Fd, mut path: &[u16]) -> Maybe<u32> {
     use bun_windows_sys::externs as w;
@@ -7393,9 +7390,8 @@ fn exists_at_type_from_attributes(attributes: u32) -> ExistsAtType {
         ExistsAtType::File
     }
 }
-/// `fstatat` then `S_ISDIR`. The Windows arm answers from the entry's own
-/// attributes, so unlike `fstatat` it does not follow a symlink or junction;
-/// `exists_at_type_w` is the arm that does.
+/// `fstatat` then `S_ISDIR`. The Windows arm does not follow a symlink or
+/// junction (`exists_at_type_w` does).
 pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
     #[cfg(unix)]
     {
@@ -7415,13 +7411,8 @@ pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
         query_attributes_nt(dir, path).map(exists_at_type_from_attributes)
     }
 }
-/// Wide-path arm of `exists_at_type` for node:fs' recursive mkdir, which asks
-/// about a path `mkdir` just reported as existing. It follows a symlink or
-/// junction the way the POSIX arm's `fstatat` does: a directory-type link
-/// carries `FILE_ATTRIBUTE_DIRECTORY` itself whether or not its target exists,
-/// so answering from the link's own attributes would let `mkdir -p` accept a
-/// link to nowhere as an existing directory. A link that cannot be followed
-/// fails with the open error (ENOENT when it points nowhere).
+/// Wide-path arm of `exists_at_type` that follows a symlink or junction like the
+/// POSIX arm's `fstatat`, failing with the open error when it cannot be followed.
 #[cfg(windows)]
 pub fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
     use bun_windows_sys::externs as w;
@@ -7433,7 +7424,8 @@ pub fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
     if (attributes & w::FILE_ATTRIBUTE_REPARSE_POINT) == 0 {
         return Ok(exists_at_type_from_attributes(attributes));
     }
-    // No `FILE_OPEN_REPARSE_POINT`, so this opens whatever the link resolves to.
+    // A directory-type link carries FILE_ATTRIBUTE_DIRECTORY even when it points nowhere;
+    // without FILE_OPEN_REPARSE_POINT this open lands on whatever the link resolves to.
     let fd = open_file_at_windows(
         dir,
         sub,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7332,9 +7332,7 @@ pub enum ExistsAtType {
     File,
     Directory,
 }
-/// `FileAttributes` of an already NT-prefixed wide path via `NtQueryAttributesFile`,
-/// shared by `exists_at_type` and `exists_at_type_w`. Like `GetFileAttributesW` it
-/// describes a reparse point itself, not what it points at.
+/// Like `GetFileAttributesW`, this describes a reparse point itself, not its target.
 #[cfg(windows)]
 fn query_attributes_nt(dir: Fd, mut path: &[u16]) -> Maybe<u32> {
     use bun_windows_sys::externs as w;
@@ -7379,9 +7377,7 @@ fn query_attributes_nt(dir: Fd, mut path: &[u16]) -> Maybe<u32> {
     }
     Ok(basic_info.FileAttributes)
 }
-/// `FILE_ATTRIBUTE_READONLY` on a directory is a folder-customization
-/// marker (OneDrive sets it) and does not affect directory-ness; only
-/// `FILE_ATTRIBUTE_DIRECTORY` decides the type.
+/// Only `FILE_ATTRIBUTE_DIRECTORY` counts: OneDrive sets `FILE_ATTRIBUTE_READONLY` on folders.
 #[cfg(windows)]
 fn exists_at_type_from_attributes(attributes: u32) -> ExistsAtType {
     if (attributes & bun_windows_sys::FILE_ATTRIBUTE_DIRECTORY) != 0 {
@@ -7390,8 +7386,7 @@ fn exists_at_type_from_attributes(attributes: u32) -> ExistsAtType {
         ExistsAtType::File
     }
 }
-/// `fstatat` then `S_ISDIR`. The Windows arm does not follow a symlink or
-/// junction (`exists_at_type_w` does).
+/// `fstatat` then `S_ISDIR`; on Windows this does not follow links (`exists_at_type_w` does).
 pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
     #[cfg(unix)]
     {
@@ -7411,8 +7406,7 @@ pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
         query_attributes_nt(dir, path).map(exists_at_type_from_attributes)
     }
 }
-/// Wide-path arm of `exists_at_type` that follows a symlink or junction like the
-/// POSIX arm's `fstatat`, failing with the open error when it cannot be followed.
+/// Wide-path `exists_at_type` that follows symlinks and junctions, like `fstatat`.
 #[cfg(windows)]
 pub fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
     use bun_windows_sys::externs as w;
@@ -7424,8 +7418,7 @@ pub fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
     if (attributes & w::FILE_ATTRIBUTE_REPARSE_POINT) == 0 {
         return Ok(exists_at_type_from_attributes(attributes));
     }
-    // A directory-type link carries FILE_ATTRIBUTE_DIRECTORY even when it points nowhere;
-    // without FILE_OPEN_REPARSE_POINT this open lands on whatever the link resolves to.
+    // A directory-type link has FILE_ATTRIBUTE_DIRECTORY even when it points nowhere.
     let fd = open_file_at_windows(
         dir,
         sub,

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -345,10 +345,11 @@ describe.skipIf(!isWindows)("fs.mkdir - recursive with ReadOnly attribute (Windo
 });
 
 // A directory symlink or junction carries the directory attribute itself, whether or
-// not its target exists. The recursive mkdir's "already exists, is it a directory?"
-// check used to read that attribute, so a link to nowhere passed as an existing
-// directory and mkdir reported success for a path nothing can be created under.
-// POSIX builds fail the same calls with EEXIST (and ENOENT below a link to nowhere).
+// not it can be followed. The recursive mkdir's "already exists, is it a directory?"
+// check used to read that attribute, so a link to nowhere (or to itself) passed as an
+// existing directory and mkdir reported success for a path nothing can be created
+// under. POSIX builds fail the same calls with EEXIST (and ENOENT below a link to
+// nowhere).
 describe.skipIf(!isWindows)("fs.mkdir - recursive on a directory link (Windows)", () => {
   let tmpdir: string;
   let real: string;
@@ -359,6 +360,7 @@ describe.skipIf(!isWindows)("fs.mkdir - recursive on a directory link (Windows)"
   let junctionTarget: string;
   let danglingFileLink: string;
   let linkTarget: string;
+  let loopLink: string;
 
   const mkdirForms = {
     mkdirSync: (pathname: string) => Promise.resolve().then(() => fs.mkdirSync(pathname, { recursive: true })),
@@ -391,6 +393,8 @@ describe.skipIf(!isWindows)("fs.mkdir - recursive on a directory link (Windows)"
     danglingJunction = path.join(tmpdir, "dangling-junction");
     fs.symlinkSync(junctionTarget, danglingJunction, "junction");
     fs.rmdirSync(junctionTarget);
+    loopLink = path.join(tmpdir, "loop");
+    fs.symlinkSync(loopLink, loopLink, "dir");
   });
 
   afterEach(() => {
@@ -412,6 +416,11 @@ describe.skipIf(!isWindows)("fs.mkdir - recursive on a directory link (Windows)"
       await expect(mkdirForms[form](danglingJunction)).rejects.toMatchObject({ code: "EEXIST", syscall: "mkdir" });
       expect(fs.existsSync(junctionTarget)).toBe(false);
       expect(fs.lstatSync(danglingJunction).isSymbolicLink()).toBe(true);
+    });
+
+    it("fails with EEXIST on a directory symlink that points at itself", async () => {
+      await expect(mkdirForms[form](loopLink)).rejects.toMatchObject({ code: "EEXIST", syscall: "mkdir" });
+      expect(fs.lstatSync(loopLink).isSymbolicLink()).toBe(true);
     });
 
     it("fails with ENOENT below a directory symlink to nowhere", async () => {

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -344,6 +344,106 @@ describe.skipIf(!isWindows)("fs.mkdir - recursive with ReadOnly attribute (Windo
   });
 });
 
+// A directory symlink or junction carries the directory attribute itself, whether or
+// not its target exists. The recursive mkdir's "already exists, is it a directory?"
+// check used to read that attribute, so a link to nowhere passed as an existing
+// directory and mkdir reported success for a path nothing can be created under.
+// POSIX builds fail the same calls with EEXIST (and ENOENT below a link to nowhere).
+describe.skipIf(!isWindows)("fs.mkdir - recursive on a directory link (Windows)", () => {
+  let tmpdir: string;
+  let real: string;
+  let link: string;
+  let junction: string;
+  let danglingLink: string;
+  let danglingJunction: string;
+  let junctionTarget: string;
+  let danglingFileLink: string;
+  let linkTarget: string;
+
+  const mkdirForms = {
+    mkdirSync: (pathname: string) => Promise.resolve().then(() => fs.mkdirSync(pathname, { recursive: true })),
+    mkdir: (pathname: string) =>
+      new Promise<string | undefined>((resolve, reject) =>
+        fs.mkdir(pathname, { recursive: true }, (err, result) => (err ? reject(err) : resolve(result))),
+      ),
+    "promises.mkdir": (pathname: string) => fs.promises.mkdir(pathname, { recursive: true }),
+  };
+  const forms = Object.keys(mkdirForms) as (keyof typeof mkdirForms)[];
+
+  beforeEach(() => {
+    tmpdir = getTmpDir();
+    real = path.join(tmpdir, "real");
+    fs.mkdirSync(real);
+    link = path.join(tmpdir, "link");
+    fs.symlinkSync(real, link, "dir");
+    junction = path.join(tmpdir, "junction");
+    fs.symlinkSync(real, junction, "junction");
+
+    linkTarget = path.join(tmpdir, "missing");
+    danglingLink = path.join(tmpdir, "dangling-link");
+    fs.symlinkSync(linkTarget, danglingLink, "dir");
+    danglingFileLink = path.join(tmpdir, "dangling-file-link");
+    fs.symlinkSync(linkTarget, danglingFileLink, "file");
+    // A junction needs an existing target at creation time; removing the target
+    // afterwards leaves a junction to nowhere.
+    junctionTarget = path.join(tmpdir, "junction-target");
+    fs.mkdirSync(junctionTarget);
+    danglingJunction = path.join(tmpdir, "dangling-junction");
+    fs.symlinkSync(junctionTarget, danglingJunction, "junction");
+    fs.rmdirSync(junctionTarget);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe.each(forms)("%s", form => {
+    it("fails with EEXIST on a directory symlink to nowhere and creates nothing", async () => {
+      await expect(mkdirForms[form](danglingLink)).rejects.toMatchObject({ code: "EEXIST", syscall: "mkdir" });
+      expect(fs.existsSync(linkTarget)).toBe(false);
+      expect(fs.lstatSync(danglingLink).isSymbolicLink()).toBe(true);
+    });
+
+    it("fails with EEXIST on a junction to nowhere and creates nothing", async () => {
+      await expect(mkdirForms[form](danglingJunction)).rejects.toMatchObject({ code: "EEXIST", syscall: "mkdir" });
+      expect(fs.existsSync(junctionTarget)).toBe(false);
+      expect(fs.lstatSync(danglingJunction).isSymbolicLink()).toBe(true);
+    });
+
+    it("fails with ENOENT below a directory symlink to nowhere", async () => {
+      await expect(mkdirForms[form](path.join(danglingLink, "sub"))).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "mkdir",
+      });
+      expect(fs.existsSync(linkTarget)).toBe(false);
+    });
+
+    it("fails with ENOENT below a file symlink to nowhere", async () => {
+      await expect(mkdirForms[form](path.join(danglingFileLink, "sub"))).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "mkdir",
+      });
+      expect(fs.existsSync(linkTarget)).toBe(false);
+    });
+
+    it("accepts a symlink or junction to an existing directory", async () => {
+      expect(await mkdirForms[form](link)).toBeUndefined();
+      expect(await mkdirForms[form](junction)).toBeUndefined();
+    });
+
+    it("creates subdirectories through a symlink or junction to an existing directory", async () => {
+      expect(await mkdirForms[form](path.join(link, "a", "b"))).toBe(path.toNamespacedPath(path.join(link, "a")));
+      expect(await mkdirForms[form](path.join(junction, "c"))).toBe(path.toNamespacedPath(path.join(junction, "c")));
+      expect(fs.readdirSync(real).sort()).toEqual(["a", "c"]);
+      expect(fs.statSync(path.join(real, "a", "b")).isDirectory()).toBe(true);
+    });
+  });
+});
+
 describe("fs.promises.mkdir", () => {
   let tmpdir: string;
 


### PR DESCRIPTION
### Problem
- On Windows, `fs.mkdirSync(link, { recursive: true })` returns `undefined` when `link` is a directory symlink or a junction whose target does not exist, and creates nothing (`fs.mkdir` and `fs.promises.mkdir` likewise). Bun 1.4.0 on Linux throws `EEXIST: file already exists, mkdir 'link'` for the same call; node v26.3.0 throws on both platforms (`ENOENT`, see Fix).
- The native recursive copy creates its destination with the same routine (`src/runtime/node/node_fs.rs:2017`, reached from the shell `cp` builtin; `cp_sync_inner` at `:8382` is the same shape). With a directory link to nowhere as the destination it therefore accepts the link as the target directory and the per-file copies create the link's target: with #37956's operand routing, `cp -R srcdir dangling` exits 0 and `missing\inner.txt` appears, where Linux prints `cp: File exists: .../dangling` and exits 1 (reproduced both ways on Windows x64, transcript below). On main the builtin never hands the link itself to this routine, so the `fs.mkdir` forms above are the way to reach it today.
- Cause: when `CreateDirectoryW` reports that the path exists, `mkdir_recursive_os_path_impl` asks `directory_exists_at_os_path` whether it is a directory (`node_fs.rs:5670`). On Windows that is `NtQueryAttributesFile` on the path (`src/sys/lib.rs:7341`), which, like `GetFileAttributesW`, returns the attributes of the reparse point itself, and a directory-type link carries `FILE_ATTRIBUTE_DIRECTORY` whether or not its target exists. The POSIX arm is `fstatat` without `AT_SYMLINK_NOFOLLOW`, which follows the link and fails when it points nowhere.

### Fix
- `bun_sys::exists_at_type_w` (the wide arm, whose only caller is this mkdir) keeps answering from `NtQueryAttributesFile` for a plain entry; when the attributes carry `FILE_ATTRIBUTE_REPARSE_POINT` it opens the path without `FILE_OPEN_REPARSE_POINT` (read-attributes access only) and classifies what the open landed on with `fstat`, so a link to nowhere fails with the open error (`ENOENT`; a link to itself, `ELOOP`). That is the `fstatat` semantics of the POSIX arm, and the same open libuv's `uv_fs_stat` makes for node (libuv additionally falls back to a directory listing when that open is denied; a link whose target denies even read-attributes access is not handled here and fails like any other unfollowable link). Entries that are not links run the same single syscall as before. The shared tail now returns the attributes (`query_attributes_nt`) so the wide arm can see the reparse bit; the narrow `exists_at_type`, which the resolver and install probes use, is unchanged apart from a doc line saying it does not follow links.
- `node_fs.rs`: the helper becomes `exists_at_type_os_path`, returning the type, and the existing-path arm accepts only `Directory`; `File` and an error both return the mkdir's `EEXIST` as before (on POSIX this is exactly what `directory_exists_at` did, so nothing changes there; on Windows a link to nowhere now lands in the error case). This is the line that fixes the bug.
- The Windows walk-back arm (`node_fs.rs:5756` on this branch, reached for `mkdir -p X\sub` when `X` exists) returns its `ENOTDIR` only for `File`. An unfollowable link falls through like a directory so the next component's `CreateDirectoryW` reports `ENOENT`, which is what POSIX and node report for `mkdir -p dangling/sub`; a file-type link to nowhere used to yield `ENOTDIR` here and now yields `ENOENT` like the other platforms. `directory_exists_at_w` is removed: its only caller was the replaced helper.
- The errno stays `EEXIST` on purpose: it is what bun returns on POSIX and what `mkdir -p` prints; node returns the `stat` error (`ENOENT`) on every platform, which is a separate, pre-existing cross-platform difference already reported from #38097. That change will need the Windows probe to fail for a link to nowhere, which is what this PR makes it do.
- #38084 fixes a different bug in the same probe (`.`/`..` components) and will conflict textually with this one; whichever lands second rebases, the two changes are independent (that one picks how the name is built, this one what happens once the attributes say reparse point).
- Verified with `test/js/node/fs/fs-mkdir.test.ts`, new Windows-only block "recursive on a directory link", for `mkdirSync`, `fs.mkdir` and `fs.promises.mkdir`: a symlink to nowhere, a junction to nowhere and a symlink to itself fail with `EEXIST` and create nothing, `mkdir -p` below a directory link and below a file link to nowhere fail with `ENOENT`, and a symlink and a junction to an existing directory are still accepted and still have subdirectories created through them (return value pinned). On Windows x64 with bun 1.4.0, 12 of the 21 new tests fail (the nine EEXIST ones resolve, the three below-a-file-link ones throw `ENOTDIR`); with this branch all 44 tests in the file pass. The block is skipped on POSIX, where the file passes unchanged. CI on the first revision ran the block on the Windows x64 and aarch64 lanes (41 pass there, before the loop case was added).
- Other runs on Windows x64 with this branch: `test/js/bun/shell/commands/cp.test.ts` (30 pass), `test/js/node/fs/cp.test.ts` (44 pass), `fs.test.ts -t mkdir` (32 pass), upstream `test-fs-mkdir.js` and `test-fs-mkdir-rmdir.js` pass (`test-fs-mkdir-recursive-eaccess.js` fails identically with 1.4.0 on that box). Linux debug build: `fs-mkdir.test.ts`, `fs.test.ts -t mkdir`, `cp-symlink-target.test.ts` pass; in `cp.test.ts` the only failure is the pre-existing 5 s timeout of the recursive-copy UAF check, whose child prints `ok` when run directly. `cargo check -p bun_sys --target x86_64-pc-windows-msvc` and `cargo fmt --check` are clean.

### Background
- Recursive mkdir (`mkdir_recursive_os_path_impl`): tries to create the full path first; on "already exists" it has to find out whether the existing entry is usable as a directory, because `mkdir` reports a file and a directory at that name the same way (`EEXIST` on POSIX, `ERROR_ALREADY_EXISTS` from `CreateDirectoryW`). If the first attempt fails with `ENOENT` it walks up creating parents, and the same question is asked about each parent that turns out to exist. The native `cp -R` and `cpSync` call this routine to create the destination directory before copying entries into it.
- Reparse points: a Windows symlink or junction is a directory entry with `FILE_ATTRIBUTE_REPARSE_POINT` plus the type of thing it stands for (`FILE_ATTRIBUTE_DIRECTORY` for a directory symlink or junction). APIs that describe the entry itself (`GetFileAttributesW`, `NtQueryAttributesFile`, `lstat`) report those attributes regardless of whether the target exists; an open without `FILE_OPEN_REPARSE_POINT` follows the link and fails when the target is missing, which is the `stat` side of the distinction. `CreateDirectoryW` on such a name reports "already exists" without following it, which is how the probe came to be asked about the link.
- `bun_sys::exists_at_type` / `exists_at_type_w`: the "what is at this path" probe, UTF-8 and UTF-16 entry points over one NT tail. The wide one exists for the node:fs mkdir, whose paths are already UTF-16 on Windows; the narrow one has many callers (resolver, install, `bun create`), which is why only the wide arm changes behaviour here.

<details>
<summary>Windows x64 transcripts</summary>

`fs.mkdir` forms, bun 1.4.0 vs this branch vs node v26.3.0 (`dangling-sym` is a directory symlink to a missing path, `dangling-junction` a junction whose target was removed):

```
                                              bun 1.4.0   this branch   node 26.3.0
mkdirSync(dangling-sym, recursive)            ok          EEXIST        ENOENT
mkdirSync(dangling-junction, recursive)       ok          EEXIST        ENOENT
promises.mkdir(dangling-sym, recursive)       ok          EEXIST        ENOENT
mkdirSync(loop -> loop, recursive)            ok          EEXIST        ELOOP
mkdirSync(dangling-sym\sub, recursive)        ENOENT      ENOENT        ENOENT
mkdirSync(loop\sub, recursive)                ELOOP       ELOOP         ELOOP
mkdirSync(dangling-file-sym\sub, recursive)   ENOTDIR     ENOENT        ENOENT
mkdirSync(valid-sym, recursive)               ok          ok            ok
mkdirSync(valid-junction, recursive)          ok          ok            ok
mkdirSync(valid-sym\sub, recursive)           creates     creates       creates
mkdirSync(afile, recursive)                   EEXIST      EEXIST        EEXIST
mkdirSync(afile\sub, recursive)               ENOTDIR     ENOTDIR       ENOTDIR
```

Bun 1.4.0 on Linux for the first row: `EEXIST` (`mkdir -p dangling` from coreutils: "cannot create directory 'dangling': File exists").

Shell builtin with #37956's `cp.rs` applied on top, `srcdir/inner.txt` and `dangling -> missing` (directory symlink):

```
await Bun.$`cp -R srcdir dangling`.nothrow().quiet()

without this change:  exit 0, stderr "", missing\inner.txt created
with this change:     exit 1, stderr "cp: File exists: <base>\dangling\n", nothing created   (same as Linux)
```
</details>
