### PR TITLE
node:http: listen through the cluster primary's shared handle so workers share one port

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -756,6 +756,12 @@ public:
         return std::move(*this);
     }
 
+    /* already-bound descriptor, options, callback */
+    TemplatedApp &&listen_fd(LIBUS_SOCKET_DESCRIPTOR fd, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
+        handler(httpContext ? trackListenSocket(httpContext->listen_fd(sslCtxOrNull(), fd, options)) : nullptr);
+        return std::move(*this);
+    }
+
     void setOnSocketClosed(HttpContextData<SSL>::OnSocketClosedCallback onClose) {
         httpContext->getSocketContextData()->onSocketClosed = onClose;
     }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -35,6 +35,7 @@
 #include <span>
 #include <array>
 #include <mutex>
+#include <cerrno>
 
 
 extern "C" void Bun__NodeHTTP__onReadsResumable(int ssl, struct us_socket_t *s);
@@ -1069,6 +1070,26 @@ public:
         }
 
         return socket;
+    }
+
+    /* Accept on a descriptor that is already bound (node:cluster's shared listen handle:
+     * the primary bound it, every worker listen()s and accepts on its own copy). The fd
+     * is owned by the returned listen socket; on failure the caller still owns it. */
+    us_listen_socket_t *listen_fd(struct ssl_ctx_st *sslCtx, LIBUS_SOCKET_DESCRIPTOR fd, int options) {
+        int error = 0;
+        auto* socket = us_socket_group_listen_fd(&group, socketKind(), sslCtx, fd, 512, options | LIBUS_LISTEN_DEFER_ACCEPT, socketExtSize(), &error);
+        if (socket) {
+            // we dont depend on libuv ref for keeping it alive
+            us_socket_unref(&socket->s);
+            return socket;
+        }
+#ifndef _WIN32
+        /* Bun.serve's listen-failure path reads errno (see us_socket_group_listen). */
+        if (error) {
+            errno = error;
+        }
+#endif
+        return nullptr;
     }
 };
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1072,9 +1072,8 @@ public:
         return socket;
     }
 
-    /* Accept on a descriptor that is already bound (node:cluster's shared listen handle:
-     * the primary bound it, every worker listen()s and accepts on its own copy). The fd
-     * is owned by the returned listen socket; on failure the caller still owns it. */
+    /* Accept on an already-bound fd (a cluster primary's shared listen socket). The returned
+     * listen socket owns the fd; on failure (nullptr) the caller still does. */
     us_listen_socket_t *listen_fd(struct ssl_ctx_st *sslCtx, LIBUS_SOCKET_DESCRIPTOR fd, int options) {
         int error = 0;
         auto* socket = us_socket_group_listen_fd(&group, socketKind(), sslCtx, fd, 512, options | LIBUS_LISTEN_DEFER_ACCEPT, socketExtSize(), &error);

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1072,8 +1072,7 @@ public:
         return socket;
     }
 
-    /* Accept on an already-bound fd (a cluster primary's shared listen socket). The returned
-     * listen socket owns the fd; on failure (nullptr) the caller still does. */
+    /* Accept on an already-bound fd; the returned listen socket owns it, on failure (nullptr) the caller still does. */
     us_listen_socket_t *listen_fd(struct ssl_ctx_st *sslCtx, LIBUS_SOCKET_DESCRIPTOR fd, int options) {
         int error = 0;
         auto* socket = us_socket_group_listen_fd(&group, socketKind(), sslCtx, fd, 512, options | LIBUS_LISTEN_DEFER_ACCEPT, socketExtSize(), &error);

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -231,8 +231,9 @@ function queryServer(worker, message) {
   if (cachedHandle && !cachedHandle.has(worker)) handle = cachedHandle;
 
   const kSharedOnlyHint =
-    "TLS and non-TLS cluster workers cannot share the same address:port under SCHED_RR " +
-    "(Bun's TLS accept is native and cannot adopt round-robin connection fds)";
+    "tls, https and http servers in cluster workers accept natively, so they can only share a listening socket, " +
+    "while under SCHED_RR the primary hands a net server its connections one by one; " +
+    "the two kinds cannot share one address:port (use different ports, or cluster.schedulingPolicy = cluster.SCHED_NONE)";
   if (handle !== undefined && message.sharedOnly === true && handle instanceof RoundRobinHandle) {
     send(worker, { errno: UV_EINVAL, key, ack: message.seq, data: handle.data, bunHint: kSharedOnlyHint }, null);
     return;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1,7 +1,7 @@
 // Hardcoded module "node:_http_server"
 const EventEmitter: typeof import("node:events").EventEmitter = require("node:events");
 const { Stream } = require("node:stream");
-const { Socket: NetSocket } = require("node:net");
+const { Socket: NetSocket, isIP } = require("node:net");
 const {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   chunkExpression,
@@ -18,7 +18,15 @@ const {
   validateFunction,
   validateOneOf,
 } = require("internal/validators");
-const { ConnResetException, hasObserver, startPerf, stopPerf, kInternalSendOptions } = require("internal/shared");
+const {
+  ConnResetException,
+  ExceptionWithHostPort,
+  hasObserver,
+  startPerf,
+  stopPerf,
+  kClusterOwner,
+  kInternalSendOptions,
+} = require("internal/shared");
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
@@ -93,6 +101,10 @@ const {
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
+// Cluster worker state: the primary's shared listen handle this server accepts on, and the
+// counter that tells a late primary reply that close() or a newer listen() superseded it.
+const kClusterHandle = Symbol("http.server.clusterHandle");
+const kClusterListeningId = Symbol("http.server.clusterListeningId");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
 // only created on the first request, and emission is gated per-request on the
@@ -504,6 +516,7 @@ Server.prototype.closeAllConnections = function () {
   clearInterval(this[kConnectionsCheckingInterval]);
   this.listening = false;
 
+  releaseClusterHandle(this);
   server.stop(true);
 };
 
@@ -525,6 +538,8 @@ Server.prototype.closeIdleConnections = function () {
 
 Server.prototype.close = function (optionalCallback?) {
   const server = this[serverSymbol];
+  // Invalidates a cluster listen() whose primary reply has not arrived yet (see listenInCluster).
+  this[kClusterListeningId] = (this[kClusterListeningId] || 0) + 1;
   // Node.js's httpServerPreClose clears the connections-checking interval
   // even when the server was never listening.
   clearInterval(this[kConnectionsCheckingInterval]);
@@ -537,6 +552,7 @@ Server.prototype.close = function (optionalCallback?) {
   this[serverSymbol] = undefined;
   if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
   this.listening = false;
+  releaseClusterHandle(this);
   server.closeIdleConnections();
   server.stop();
   return this;
@@ -587,6 +603,8 @@ Server.prototype.listen = function () {
   const server = this;
   let port, host, onListen;
   let socketPath;
+  let exclusive = false;
+  let reusePort = false;
   let tls = this[tlsSymbol];
 
   // This logic must align with:
@@ -599,6 +617,9 @@ Server.prototype.listen = function () {
       port = arg0.port;
       host = arg0.host;
       socketPath = arg0.path;
+      // As in net.Server#listen, reusePort implies exclusive: the worker binds its own socket.
+      reusePort = arg0.reusePort === true;
+      exclusive = !!arg0.exclusive || reusePort;
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
@@ -644,45 +665,26 @@ Server.prototype.listen = function () {
 
     if (cluster === undefined) cluster = require("node:cluster");
 
-    // const serverQuery = {
-    //   // address: address,
-    //   port: port,
-    //   addressType: 4,
-    //   // fd: fd,
-    //   // flags,
-    //   // backlog,
-    //   // ...options,
-    // };
-    // cluster._getServer(server, serverQuery, function listenOnPrimaryHandle(err, handle) {
-    //   // err = checkBindError(err, port, handle);
-    //   // if (err) {
-    //   //   throw new ExceptionWithHostPort(err, "bind", address, port);
-    //   // }
-    //   if (err) {
-    //     throw err;
-    //   }
-    //   server[kRealListen](port, host, socketPath, onListen);
-    // });
+    // The worker binds its own socket when node would (exclusive, or reusePort which implies
+    // it), when there is no primary to ask (NODE_UNIQUE_ID inherited by a plain child, or
+    // already disconnected), when the arguments are nothing the primary could bind (Bun.serve
+    // reports them), and on Windows: processes accepting on copies of one listening socket
+    // block each other in accept() there, and the primary's alternative of handing over each
+    // accepted connection is something Bun.serve's native accept loop cannot take.
+    if (
+      exclusive ||
+      !process.connected ||
+      process.platform === "win32" ||
+      !isBindableByPrimary(port, host, socketPath)
+    ) {
+      notifyPrimaryWhenListening(server, port, host, socketPath);
+      // Only an exclusive listen gets to opt out of SO_REUSEPORT: the other cases still need
+      // it for the workers to end up on one port at all.
+      server[kRealListen](tls, port, host, socketPath, exclusive ? reusePort : true, onListen);
+      return this;
+    }
 
-    server.once("listening", () => {
-      // No channel (NODE_UNIQUE_ID inherited by a plain child, or already disconnected): nothing to notify.
-      if (!process.connected) return;
-      cluster.worker.state = "listening";
-      const address = server.address();
-      const isObjectAddress = address !== null && typeof address === "object";
-      const boundHost = host && isObjectAddress ? address : null;
-      const message = {
-        cmd: "NODE_CLUSTER",
-        act: "listening",
-        port: socketPath ? -1 : (isObjectAddress && address.port) || port,
-        data: null,
-        address: socketPath ?? (boundHost && boundHost.address) ?? null,
-        addressType: socketPath ? -1 : boundHost && boundHost.family === "IPv6" ? 6 : 4,
-      };
-      process.send(message, undefined, kInternalSendOptions);
-    });
-
-    server[kRealListen](tls, port, host, socketPath, true, onListen);
+    listenInCluster(server, tls, port, host, socketPath, onListen);
   } catch (err) {
     setTimeout(() => server.emit("error", err), 1);
   }
@@ -690,7 +692,109 @@ Server.prototype.listen = function () {
   return this;
 };
 
-Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort, onListen) {
+function isBindableByPrimary(port, host, socketPath) {
+  if (socketPath) return typeof socketPath === "string";
+  if (host != null && typeof host !== "string") return false;
+  return typeof port === "number" && port === (port | 0) && port >= 0 && port <= 65535;
+}
+
+// A worker that bound its own socket still reports it, so cluster.on("listening") fires.
+function notifyPrimaryWhenListening(server, port, host, socketPath) {
+  server.once("listening", () => {
+    if (!process.connected) return;
+    cluster.worker.state = "listening";
+    const address = server.address();
+    const isObjectAddress = address !== null && typeof address === "object";
+    const boundHost = host && isObjectAddress ? address : null;
+    const message = {
+      cmd: "NODE_CLUSTER",
+      act: "listening",
+      port: socketPath ? -1 : (isObjectAddress && address.port) || port,
+      data: null,
+      address: socketPath ?? (boundHost && boundHost.address) ?? null,
+      addressType: socketPath ? -1 : boundHost && boundHost.family === "IPv6" ? 6 : 4,
+    };
+    process.send(message, undefined, kInternalSendOptions);
+  });
+}
+
+// Like net's listenInCluster: the primary binds the address once (or hands out the socket it
+// already bound for this key, which is how every worker's listen(0) ends up on one port) and
+// sends each worker the descriptor to accept on. Bun.serve accepts natively, so the server
+// always asks for a shared handle (sharedOnly), the same way a TLS net.Server does.
+function listenInCluster(server, tls, port, host, socketPath, onListen) {
+  const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);
+  const listenArgs = { server, listeningId, tls, port, host, socketPath, onListen };
+
+  // Same (address, port, addressType) tuple net.Server sends, so the primary keys the handle
+  // the way node does: pipes are port -1 / addressType -1, and _getServer adds the per-listen
+  // index that makes each worker's first listen(0) land on the same handle.
+  if (socketPath) {
+    queryPrimary(listenArgs, socketPath, -1, -1);
+  } else if (!host) {
+    queryPrimary(listenArgs, null, port, 4);
+  } else if (isIP(host) !== 0) {
+    queryPrimary(listenArgs, host, port, isIP(host));
+  } else {
+    // The primary binds an address, not a name; node resolves it in the worker first.
+    require("node:dns").lookup(host, (err, ip, family) => {
+      if (listeningId !== server[kClusterListeningId]) return;
+      if (err) {
+        server.emit("error", err);
+        return;
+      }
+      queryPrimary(listenArgs, ip, port, family === 6 ? 6 : 4);
+    });
+  }
+}
+
+function queryPrimary({ server, listeningId, tls, port, host, socketPath, onListen }, address, queryPort, addressType) {
+  const serverQuery = { address, port: queryPort, addressType, fd: undefined, flags: 0, sharedOnly: true };
+  cluster._getServer(server, serverQuery, function listenOnPrimaryHandle(err, handle, reply) {
+    if (listeningId !== server[kClusterListeningId]) {
+      // close() or another listen() came first; give the primary's handle straight back.
+      handle?.close();
+      return;
+    }
+    const sharedFd = handle?.sharedFd;
+    if (!err && typeof sharedFd !== "number") {
+      // A primary that answers a sharedOnly query with a round-robin handle is not Bun's;
+      // connections handed over one at a time cannot be fed to Bun.serve.
+      handle?.close();
+      err = process.binding("uv").UV_EINVAL;
+    }
+    if (err) {
+      const ex = new ExceptionWithHostPort(err, "bind", address, queryPort);
+      if (typeof reply?.bunHint === "string") ex.message += `\n  note: ${reply.bunHint}`;
+      server.emit("error", ex);
+      return;
+    }
+    server[kClusterHandle] = handle;
+    // Lets worker.disconnect() close this server along with the worker's other servers.
+    handle[kClusterOwner] = server;
+    // Once adopted, the listener owns the descriptor and releasing the handle must not close
+    // it; a failed Bun.serve() never took it, so the release below closes it after all.
+    handle.adopted = true;
+    try {
+      server[kRealListen](tls, port, host, socketPath, false, onListen, sharedFd);
+    } catch (err) {
+      handle.adopted = false;
+      releaseClusterHandle(server);
+      setTimeout(() => server.emit("error", err), 1);
+    }
+  });
+}
+
+// The primary keeps the socket bound until every worker that asked for it has let go.
+function releaseClusterHandle(server) {
+  const handle = server[kClusterHandle];
+  if (handle === undefined) return;
+  server[kClusterHandle] = undefined;
+  handle[kClusterOwner] = null;
+  handle.close();
+}
+
+Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort, onListen, fd) {
   {
     const ResponseClass = this[optionsSymbol].ServerResponse || ServerResponse;
     const RequestClass = this[optionsSymbol].IncomingMessage || IncomingMessage;
@@ -708,6 +812,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       hostname: host,
       unix: socketPath,
       reusePort,
+      // Set when the cluster primary bound the socket: accept on its descriptor instead of binding.
+      fd,
       // Bindings to be used for WS Server
       websocket: {
         open(ws) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -101,9 +101,9 @@ const {
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
-// Cluster worker state: the primary's shared listen handle this server accepts on, and the
-// counter that tells a late primary reply that close() or a newer listen() superseded it.
+// The cluster primary's shared listen handle this server accepts on (workers only).
 const kClusterHandle = Symbol("http.server.clusterHandle");
+// Bumped by listen() and close(); a primary reply carrying an older value is stale.
 const kClusterListeningId = Symbol("http.server.clusterListeningId");
 
 // node.http trace events ('http.server.request' b/e). The agent module is
@@ -666,21 +666,12 @@ Server.prototype.listen = function () {
 
     if (cluster === undefined) cluster = require("node:cluster");
 
-    // The worker binds its own socket when node would (exclusive, or reusePort which implies
-    // it), when there is no primary to ask (NODE_UNIQUE_ID inherited by a plain child, or
-    // already disconnected), when the arguments are nothing the primary could bind (Bun.serve
-    // reports them), and on Windows: processes accepting on copies of one listening socket
-    // block each other in accept() there, and the primary's alternative of handing over each
-    // accepted connection is something Bun.serve's native accept loop cannot take.
-    if (
-      exclusive ||
-      !process.connected ||
-      process.platform === "win32" ||
-      !isBindableByPrimary(port, host, socketPath)
-    ) {
+    // Windows: processes accepting on copies of one listening socket block each other in accept().
+    const bindsInWorker =
+      exclusive || !process.connected || process.platform === "win32" || !isBindableByPrimary(port, host, socketPath);
+    if (bindsInWorker) {
       notifyPrimaryWhenListening(server, port, host, socketPath);
-      // Only an exclusive listen gets to opt out of SO_REUSEPORT: the other cases still need
-      // it for the workers to end up on one port at all.
+      // Non-exclusive workers still share a fixed port through SO_REUSEPORT.
       server[kRealListen](tls, port, host, socketPath, exclusive ? reusePort : true, onListen);
       return this;
     }
@@ -693,8 +684,7 @@ Server.prototype.listen = function () {
   return this;
 };
 
-// A listen() that failed after Bun.serve() had already returned (while wiring the listener up)
-// must not leave that listener running behind the 'error' it reports.
+// A listener that Bun.serve() created before the failure must not stay up behind the 'error'.
 function emitListenError(server, err, previousBunServer) {
   if (server[serverSymbol] !== previousBunServer) server.close();
   setTimeout(() => server.emit("error", err), 1);
@@ -726,17 +716,13 @@ function notifyPrimaryWhenListening(server, port, host, socketPath) {
   });
 }
 
-// Like net's listenInCluster: the primary binds the address once (or hands out the socket it
-// already bound for this key, which is how every worker's listen(0) ends up on one port) and
-// sends each worker the descriptor to accept on. Bun.serve accepts natively, so the server
-// always asks for a shared handle (sharedOnly), the same way a TLS net.Server does.
+// net.Server's listenInCluster, minus round-robin: Bun.serve accepts natively, so like a TLS
+// net.Server it always asks for the shared handle (the primary's bound socket) of its key.
 function listenInCluster(server, tls, port, host, socketPath, onListen) {
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);
   const listenArgs = { server, listeningId, tls, port, host, socketPath, onListen };
 
-  // Same (address, port, addressType) tuple net.Server sends, so the primary keys the handle
-  // the way node does: pipes are port -1 / addressType -1, and _getServer adds the per-listen
-  // index that makes each worker's first listen(0) land on the same handle.
+  // The (address, port, addressType) tuple must match net.Server's, since it keys the primary's handles.
   if (socketPath) {
     queryPrimary(listenArgs, socketPath, -1, -1);
     return;
@@ -745,14 +731,13 @@ function listenInCluster(server, tls, port, host, socketPath, onListen) {
     queryPrimary(listenArgs, null, port, 4);
     return;
   }
-  // Bun.serve() (the other way a worker binds) takes an IPv6 literal in brackets; the primary's
-  // bind, like isIP, wants it bare. `host` itself still goes to Bun.serve for reporting.
+  // Bun.serve() accepts "[::1]"; the primary's bind (and isIP) want it bare.
   const address = host.length > 2 && host.charCodeAt(0) === 0x5b /* [ */ ? host.slice(1, -1) : host;
   const addressType = isIP(address);
   if (addressType !== 0) {
     queryPrimary(listenArgs, address, port, addressType);
   } else {
-    // The primary binds an address, not a name; node resolves it in the worker first.
+    // The primary binds addresses, not names (node resolves in the worker too).
     require("node:dns").lookup(address, (err, ip, family) => {
       if (listeningId !== server[kClusterListeningId]) return;
       if (err) {
@@ -774,8 +759,7 @@ function queryPrimary({ server, listeningId, tls, port, host, socketPath, onList
     }
     const sharedFd = handle?.sharedFd;
     if (!err && typeof sharedFd !== "number") {
-      // A primary that answers a sharedOnly query with a round-robin handle is not Bun's;
-      // connections handed over one at a time cannot be fed to Bun.serve.
+      // A round-robin handle despite sharedOnly (a foreign primary): Bun.serve cannot use it.
       handle?.close();
       err = process.binding("uv").UV_EINVAL;
     }
@@ -788,16 +772,14 @@ function queryPrimary({ server, listeningId, tls, port, host, socketPath, onList
     server[kClusterHandle] = handle;
     // Lets worker.disconnect() close this server along with the worker's other servers.
     handle[kClusterOwner] = server;
-    // Once Bun.serve() returns, its listener owns the descriptor and releasing the handle must
-    // only notify the primary; until then the descriptor is ours to close.
+    // adopted: the handle's close() leaves the descriptor to the listener and only notifies the primary.
     handle.adopted = true;
     const previousBunServer = server[serverSymbol];
     try {
       server[kRealListen](tls, port, host, socketPath, false, onListen, sharedFd);
     } catch (err) {
       if (server[serverSymbol] === previousBunServer) {
-        // Bun.serve() itself failed, so the descriptor is still ours. (Otherwise the listener
-        // has it, and the close() in emitListenError releases the handle along with it.)
+        // Bun.serve() itself failed: no listener took the descriptor, so close it here.
         handle.adopted = false;
         releaseClusterHandle(server);
       }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -731,7 +731,10 @@ function listenInCluster(server, tls, port, host, socketPath, onListen) {
     return;
   }
   // Bun.serve() accepts "[::1]"; the primary's bind (and isIP) want it bare.
-  const address = host.length > 2 && host.charCodeAt(0) === 0x5b /* [ */ ? host.slice(1, -1) : host;
+  const address =
+    host.length > 2 && host.charCodeAt(0) === 0x5b /* [ */ && host.charCodeAt(host.length - 1) === 0x5d /* ] */
+      ? host.slice(1, -1)
+      : host;
   const addressType = isIP(address);
   if (addressType !== 0) {
     queryPrimary(listenArgs, address, port, addressType);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -716,8 +716,7 @@ function notifyPrimaryWhenListening(server, port, host, socketPath) {
   });
 }
 
-// net.Server's listenInCluster, minus round-robin: Bun.serve accepts natively, so like a TLS
-// net.Server it always asks for the shared handle (the primary's bound socket) of its key.
+// net.Server's listenInCluster, but always sharedOnly (like TLS there): Bun.serve accepts natively.
 function listenInCluster(server, tls, port, host, socketPath, onListen) {
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);
   const listenArgs = { server, listeningId, tls, port, host, socketPath, onListen };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -655,6 +655,7 @@ Server.prototype.listen = function () {
     onListen = lastArg;
   }
 
+  const previousBunServer = server[serverSymbol];
   try {
     // listenInCluster
 
@@ -686,11 +687,18 @@ Server.prototype.listen = function () {
 
     listenInCluster(server, tls, port, host, socketPath, onListen);
   } catch (err) {
-    setTimeout(() => server.emit("error", err), 1);
+    emitListenError(server, err, previousBunServer);
   }
 
   return this;
 };
+
+// A listen() that failed after Bun.serve() had already returned (while wiring the listener up)
+// must not leave that listener running behind the 'error' it reports.
+function emitListenError(server, err, previousBunServer) {
+  if (server[serverSymbol] !== previousBunServer) server.close();
+  setTimeout(() => server.emit("error", err), 1);
+}
 
 function isBindableByPrimary(port, host, socketPath) {
   if (socketPath) return typeof socketPath === "string";
@@ -731,13 +739,21 @@ function listenInCluster(server, tls, port, host, socketPath, onListen) {
   // index that makes each worker's first listen(0) land on the same handle.
   if (socketPath) {
     queryPrimary(listenArgs, socketPath, -1, -1);
-  } else if (!host) {
+    return;
+  }
+  if (!host) {
     queryPrimary(listenArgs, null, port, 4);
-  } else if (isIP(host) !== 0) {
-    queryPrimary(listenArgs, host, port, isIP(host));
+    return;
+  }
+  // Bun.serve() (the other way a worker binds) takes an IPv6 literal in brackets; the primary's
+  // bind, like isIP, wants it bare. `host` itself still goes to Bun.serve for reporting.
+  const address = host.length > 2 && host.charCodeAt(0) === 0x5b /* [ */ ? host.slice(1, -1) : host;
+  const addressType = isIP(address);
+  if (addressType !== 0) {
+    queryPrimary(listenArgs, address, port, addressType);
   } else {
     // The primary binds an address, not a name; node resolves it in the worker first.
-    require("node:dns").lookup(host, (err, ip, family) => {
+    require("node:dns").lookup(address, (err, ip, family) => {
       if (listeningId !== server[kClusterListeningId]) return;
       if (err) {
         server.emit("error", err);
@@ -772,15 +788,20 @@ function queryPrimary({ server, listeningId, tls, port, host, socketPath, onList
     server[kClusterHandle] = handle;
     // Lets worker.disconnect() close this server along with the worker's other servers.
     handle[kClusterOwner] = server;
-    // Once adopted, the listener owns the descriptor and releasing the handle must not close
-    // it; a failed Bun.serve() never took it, so the release below closes it after all.
+    // Once Bun.serve() returns, its listener owns the descriptor and releasing the handle must
+    // only notify the primary; until then the descriptor is ours to close.
     handle.adopted = true;
+    const previousBunServer = server[serverSymbol];
     try {
       server[kRealListen](tls, port, host, socketPath, false, onListen, sharedFd);
     } catch (err) {
-      handle.adopted = false;
-      releaseClusterHandle(server);
-      setTimeout(() => server.emit("error", err), 1);
+      if (server[serverSymbol] === previousBunServer) {
+        // Bun.serve() itself failed, so the descriptor is still ours. (Otherwise the listener
+        // has it, and the close() in emitListenError releases the handle along with it.)
+        handle.adopted = false;
+        releaseClusterHandle(server);
+      }
+      emitListenError(server, err, previousBunServer);
     }
   });
 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -55,6 +55,12 @@ pub struct ServerConfig {
     pub(crate) websocket: Option<WebSocketServerContext>,
 
     pub(crate) reuse_port: bool,
+    /// Accept on this already-bound descriptor instead of binding `address`.
+    /// Set by node:http in a cluster worker, which receives the primary's
+    /// shared listen socket; `address` still describes what was bound so
+    /// `address`/`url`/errors report it. Consumed by the listen socket on
+    /// success; a failed listen leaves it to the caller.
+    pub(crate) listen_fd: Option<uws::LIBUS_SOCKET_DESCRIPTOR>,
     pub(crate) id: Box<[u8]>,
     pub(crate) allow_hot: bool,
     pub(crate) ipv6_only: bool,
@@ -88,6 +94,7 @@ impl Default for ServerConfig {
             on_node_http_request: JSValue::ZERO,
             websocket: None,
             reuse_port: false,
+            listen_fd: None,
             id: Box::default(),
             allow_hot: true,
             ipv6_only: false,
@@ -274,6 +281,7 @@ impl ServerConfig {
             on_node_http_request: self.on_node_http_request,
             websocket: self.websocket.take(),
             reuse_port: self.reuse_port,
+            listen_fd: self.listen_fd,
             id: core::mem::take(&mut self.id),
             allow_hot: self.allow_hot,
             ipv6_only: self.ipv6_only,
@@ -621,6 +629,23 @@ impl ServerConfig {
 }
 
 // ─── from_js + JS-side parsing ───────────────────────────────────────────────
+
+/// A JS `fd` number as the OS descriptor `us_socket_group_listen_fd` accepts:
+/// the POSIX int, or (as for `Bun.listen({ fd })`) the raw Windows SOCKET value.
+fn listen_fd_from_number(number: f64) -> Option<uws::LIBUS_SOCKET_DESCRIPTOR> {
+    if !(number >= 0.0 && number.fract() == 0.0) {
+        return None;
+    }
+    #[cfg(not(windows))]
+    {
+        (number <= i32::MAX as f64).then(|| number as uws::LIBUS_SOCKET_DESCRIPTOR)
+    }
+    #[cfg(windows)]
+    {
+        // Exact in f64 up to 2^53; a SOCKET is a kernel handle, far below that.
+        (number < (1u64 << 53) as f64).then(|| number as u64 as uws::LIBUS_SOCKET_DESCRIPTOR)
+    }
+}
 
 fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     // Already validated by the caller
@@ -1355,6 +1380,23 @@ impl ServerConfig {
                 )));
             }
             args.on_node_http_request = on_request_;
+
+            // Only node:http servers may hand over a descriptor (see `listen_fd`);
+            // for a plain `Bun.serve()` the key is not an option and is left alone.
+            if let Some(fd) = arg.get(global, "fd")? {
+                let Some(fd) = fd.get_number().and_then(listen_fd_from_number) else {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "Expected fd to be a non-negative integer"
+                    )));
+                };
+                args.listen_fd = Some(fd);
+                // The descriptor is consumed by this listen; a `--hot` reload
+                // matching a previous server by address would silently drop it.
+                args.allow_hot = false;
+            }
+        }
+        if global.has_exception() {
+            return Err(JsError::Thrown);
         }
 
         if let Some(on_request_) = arg.get_truthy(global, "fetch")? {
@@ -1467,6 +1509,11 @@ impl ServerConfig {
         if !args.http1 && matches!(args.address, Address::Unix(_)) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "Cannot disable http1 with a unix socket — HTTP/3 over AF_UNIX is not supported",
+            )));
+        }
+        if args.http3 && args.listen_fd.is_some() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Cannot combine http3 with an inherited listen fd"
             )));
         }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -55,11 +55,8 @@ pub struct ServerConfig {
     pub(crate) websocket: Option<WebSocketServerContext>,
 
     pub(crate) reuse_port: bool,
-    /// Accept on this already-bound descriptor instead of binding `address`.
-    /// Set by node:http in a cluster worker, which receives the primary's
-    /// shared listen socket; `address` still describes what was bound so
-    /// `address`/`url`/errors report it. Consumed by the listen socket on
-    /// success; a failed listen leaves it to the caller.
+    /// Accept on this already-bound descriptor (node:http in a cluster worker) instead
+    /// of binding `address`, which still describes it for `address`/`url`/errors.
     pub(crate) listen_fd: Option<uws::LIBUS_SOCKET_DESCRIPTOR>,
     pub(crate) id: Box<[u8]>,
     pub(crate) allow_hot: bool,
@@ -630,8 +627,7 @@ impl ServerConfig {
 
 // ─── from_js + JS-side parsing ───────────────────────────────────────────────
 
-/// A JS `fd` number as the OS descriptor `us_socket_group_listen_fd` accepts:
-/// the POSIX int, or (as for `Bun.listen({ fd })`) the raw Windows SOCKET value.
+/// POSIX fd, or (like `Bun.listen({ fd })`) the raw SOCKET value on Windows.
 fn listen_fd_from_number(number: f64) -> Option<uws::LIBUS_SOCKET_DESCRIPTOR> {
     if !(number >= 0.0 && number.fract() == 0.0) {
         return None;
@@ -642,7 +638,6 @@ fn listen_fd_from_number(number: f64) -> Option<uws::LIBUS_SOCKET_DESCRIPTOR> {
     }
     #[cfg(windows)]
     {
-        // Exact in f64 up to 2^53; a SOCKET is a kernel handle, far below that.
         (number < (1u64 << 53) as f64).then(|| number as u64 as uws::LIBUS_SOCKET_DESCRIPTOR)
     }
 }
@@ -1381,8 +1376,7 @@ impl ServerConfig {
             }
             args.on_node_http_request = on_request_;
 
-            // Only node:http servers may hand over a descriptor (see `listen_fd`);
-            // for a plain `Bun.serve()` the key is not an option and is left alone.
+            // `fd` is not a public Bun.serve() option: only node:http servers get to pass one.
             if let Some(fd) = arg.get(global, "fd")? {
                 let Some(fd) = fd.get_number().and_then(listen_fd_from_number) else {
                     return Err(global.throw_invalid_arguments(format_args!(
@@ -1390,8 +1384,7 @@ impl ServerConfig {
                     )));
                 };
                 args.listen_fd = Some(fd);
-                // The descriptor is consumed by this listen; a `--hot` reload
-                // matching a previous server by address would silently drop it.
+                // A `--hot` reload reusing the old server by address would drop the descriptor.
                 args.allow_hot = false;
             }
         }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -55,8 +55,7 @@ pub struct ServerConfig {
     pub(crate) websocket: Option<WebSocketServerContext>,
 
     pub(crate) reuse_port: bool,
-    /// Accept on this already-bound descriptor (node:http in a cluster worker) instead
-    /// of binding `address`, which still describes it for `address`/`url`/errors.
+    /// Accept on this already-bound descriptor instead of binding `address` (which still describes it).
     pub(crate) listen_fd: Option<uws::LIBUS_SOCKET_DESCRIPTOR>,
     pub(crate) id: Box<[u8]>,
     pub(crate) allow_hot: bool,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1719,10 +1719,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
         self.notify_inspector_server_stopped();
 
-        if let server_config::Address::Unix(path) = &self.config.address {
-            let bytes = path.as_bytes();
-            if !bytes.is_empty() && bytes[0] != 0 {
-                let _ = bun_sys::unlink(path.as_zstr());
+        // An inherited descriptor's socket file belongs to whoever bound it (the
+        // cluster primary unlinks it once the last worker lets go).
+        if self.config.listen_fd.is_none() {
+            if let server_config::Address::Unix(path) = &self.config.address {
+                let bytes = path.as_bytes();
+                if !bytes.is_empty() && bytes[0] != 0 {
+                    let _ = bun_sys::unlink(path.as_zstr());
+                }
             }
         }
 
@@ -1986,6 +1990,21 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub(crate) fn on_listen_failed(&mut self) {
         self.listener = None;
         let global = self.global_this();
+
+        if self.config.listen_fd.is_some() {
+            // Nothing was bound here: the descriptor itself could not be
+            // listened on (HttpContext::listen_fd stores the cause in errno).
+            // EINVAL is what node reports for a descriptor it cannot serve on.
+            let errno = match bun_sys::get_errno(-1i32) {
+                bun_sys::E::SUCCESS => bun_sys::E::EINVAL,
+                e => e,
+            };
+            let err = jsc::SystemError::from(
+                bun_sys::Error::from_code(errno, bun_sys::Tag::listen).to_system_error(),
+            );
+            let _ = global.throw_value(err.to_error_instance(global));
+            return;
+        }
 
         let error_instance = match &self.config.address {
             server_config::Address::Tcp {
@@ -2997,11 +3016,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         enum Addr {
             Tcp { port: u16, host: *const c_char },
             Unix { ptr: *const u8, len: usize },
+            Fd(uws_sys::LIBUS_SOCKET_DESCRIPTOR),
         }
         let (addr, http1, options) = {
             let cfg = &this_ref.get().config;
-            let addr = match &cfg.address {
-                server_config::Address::Tcp { port, hostname } => {
+            let addr = match (cfg.listen_fd, &cfg.address) {
+                (Some(fd), _) => Addr::Fd(fd),
+                (None, server_config::Address::Tcp { port, hostname }) => {
                     let mut host: *const c_char = core::ptr::null();
                     if let Some(existing) = hostname.as_deref() {
                         let bytes = existing.as_bytes();
@@ -3016,7 +3037,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     }
                     Addr::Tcp { port: *port, host }
                 }
-                server_config::Address::Unix(unix) => Addr::Unix {
+                (None, server_config::Address::Unix(unix)) => Addr::Unix {
                     ptr: unix.as_ptr().cast(),
                     len: unix.as_bytes().len(),
                 },
@@ -3025,6 +3046,21 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         };
 
         match addr {
+            Addr::Fd(fd) => {
+                // `ServerConfig::from_js` rejects http3 together with a descriptor,
+                // so there is no H3 listener to pair with it.
+                // SAFETY: app is a live uws handle owned by this server. No
+                // `&*this` is live across this call; the trampoline's
+                // `&mut *this` is the sole borrow while it runs.
+                unsafe {
+                    (*app).listen_fd(
+                        Some(trampoline::on_listen::<SSL, DEBUG>),
+                        this.cast::<c_void>(),
+                        fd,
+                        options,
+                    );
+                }
+            }
             Addr::Tcp { port, host } => {
                 // With `{port: 0, http3: true}` we bind TCP:0 (kernel picks N),
                 // then must bind UDP:N for QUIC so Alt-Svc works. UDP:N may

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3045,6 +3045,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         match addr {
             Addr::Fd(fd) => {
                 // No H3 listener to pair with it: `from_js` rejects http3 together with a descriptor.
+
                 // SAFETY: app is a live uws handle owned by this server. No
                 // `&*this` is live across this call; the trampoline's
                 // `&mut *this` is the sole borrow while it runs.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1719,8 +1719,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         }
         self.notify_inspector_server_stopped();
 
-        // An inherited descriptor's socket file belongs to whoever bound it (the
-        // cluster primary unlinks it once the last worker lets go).
+        // A shared socket's file is unlinked by whoever bound it (the cluster primary).
         if self.config.listen_fd.is_none() {
             if let server_config::Address::Unix(path) = &self.config.address {
                 let bytes = path.as_bytes();
@@ -1992,9 +1991,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         let global = self.global_this();
 
         if self.config.listen_fd.is_some() {
-            // Nothing was bound here: the descriptor itself could not be
-            // listened on (HttpContext::listen_fd stores the cause in errno).
-            // EINVAL is what node reports for a descriptor it cannot serve on.
+            // HttpContext::listen_fd left the cause in errno; EINVAL is node's answer for an unusable fd.
             let errno = match bun_sys::get_errno(-1i32) {
                 bun_sys::E::SUCCESS => bun_sys::E::EINVAL,
                 e => e,
@@ -3047,8 +3044,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         match addr {
             Addr::Fd(fd) => {
-                // `ServerConfig::from_js` rejects http3 together with a descriptor,
-                // so there is no H3 listener to pair with it.
+                // No H3 listener to pair with it: `from_js` rejects http3 together with a descriptor.
                 // SAFETY: app is a live uws handle owned by this server. No
                 // `&*this` is live across this call; the trampoline's
                 // `&mut *this` is the sole borrow while it runs.

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -8,8 +8,8 @@ use bun_http_types::Method::Method;
 use crate::socket_context::BunSocketContextOptions;
 use crate::web_socket::c::uws_ws;
 use crate::{
-    ListenSocket as UwsListenSocket, Opcode, Request, SendStatus, WebSocketBehavior, us_socket_t,
-    uws_res,
+    LIBUS_SOCKET_DESCRIPTOR, ListenSocket as UwsListenSocket, Opcode, Request, SendStatus,
+    WebSocketBehavior, us_socket_t, uws_res,
 };
 
 // This file provides Rust bindings for the uWebSockets App class.
@@ -281,6 +281,31 @@ impl<const SSL: bool> App<SSL> {
                 config.host,
                 u16::try_from(config.port).expect("int cast"),
                 config.options,
+                handler,
+                user_data,
+            )
+        }
+    }
+
+    /// Accept on `fd`, a descriptor something else already bound (node:cluster's
+    /// shared listen handle). The listen socket takes ownership of `fd` when the
+    /// handler receives a non-null socket; otherwise the caller still owns it.
+    pub fn listen_fd(
+        &mut self,
+        handler: c::uws_listen_handler,
+        user_data: *mut c_void,
+        fd: LIBUS_SOCKET_DESCRIPTOR,
+        options: i32,
+    ) {
+        // Callers supply the C-ABI shim directly.
+        // SAFETY: self is a valid app; `fd` is a plain value and `handler`/`user_data`
+        // are only invoked synchronously inside this call.
+        unsafe {
+            c::uws_app_listen_fd(
+                Self::SSL_FLAG,
+                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                fd,
+                options,
                 handler,
                 user_data,
             )
@@ -597,6 +622,14 @@ pub mod c {
             app: *mut uws_app_t,
             host: *const c_char,
             port: u16,
+            options: i32,
+            handler: uws_listen_handler,
+            user_data: *mut c_void,
+        );
+        pub(crate) fn uws_app_listen_fd(
+            ssl: i32,
+            app: *mut uws_app_t,
+            fd: LIBUS_SOCKET_DESCRIPTOR,
             options: i32,
             handler: uws_listen_handler,
             user_data: *mut c_void,

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -287,9 +287,8 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    /// Accept on `fd`, a descriptor something else already bound (node:cluster's
-    /// shared listen handle). The listen socket takes ownership of `fd` when the
-    /// handler receives a non-null socket; otherwise the caller still owns it.
+    /// Accept on an already-bound `fd`; it is owned by the listen socket the handler
+    /// receives, or still by the caller when the handler receives null.
     pub fn listen_fd(
         &mut self,
         handler: c::uws_listen_handler,
@@ -298,8 +297,7 @@ impl<const SSL: bool> App<SSL> {
         options: i32,
     ) {
         // Callers supply the C-ABI shim directly.
-        // SAFETY: self is a valid app; `fd` is a plain value and `handler`/`user_data`
-        // are only invoked synchronously inside this call.
+        // SAFETY: self is a valid app; the handler is only invoked synchronously inside this call.
         unsafe {
             c::uws_app_listen_fd(
                 Self::SSL_FLAG,

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -287,8 +287,7 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
-    /// Accept on an already-bound `fd`; it is owned by the listen socket the handler
-    /// receives, or still by the caller when the handler receives null.
+    /// Accept on an already-bound `fd`, owned by the listen socket on success and still by the caller on null.
     pub fn listen_fd(
         &mut self,
         handler: c::uws_listen_handler,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -479,6 +479,31 @@ extern "C"
     }
   }
 
+  void uws_app_listen_fd(int ssl, uws_app_t *app, LIBUS_SOCKET_DESCRIPTOR fd, int32_t options,
+                         uws_listen_handler handler, void *user_data)
+  {
+    if (ssl)
+    {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->listen_fd(
+          fd, options,
+          [handler, user_data](struct us_listen_socket_t *listen_socket)
+          {
+            handler((struct us_listen_socket_t *)listen_socket, user_data);
+          });
+    }
+    else
+    {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->listen_fd(
+          fd, options,
+          [handler, user_data](struct us_listen_socket_t *listen_socket)
+          {
+            handler((struct us_listen_socket_t *)listen_socket, user_data);
+          });
+    }
+  }
+
   /* callback, path to unix domain socket */
   void uws_app_listen_domain(int ssl, uws_app_t *app, const char *domain, size_t pathlen, uws_listen_domain_handler handler, void *user_data)
   {

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1276,3 +1276,362 @@ if (cluster.isPrimary) {
   });
   expect(exitCode).toBe(0);
 }, 30_000);
+
+// node:http servers are backed by Bun.serve, whose accept loop is native, so in a worker they
+// take the shared-handle path (the primary binds once and ships the descriptor) rather than
+// round-robin. On Windows a worker still binds its own SO_REUSEADDR socket, because several
+// processes accepting on copies of one listening socket block each other in accept() there.
+const httpListenZeroFixture = /* js */ `
+const cluster = require("node:cluster");
+const fs = require("node:fs");
+const path = require("node:path");
+const kind = process.env.MODULE;
+const mod = require("node:" + kind);
+const serverOptions =
+  kind === "https"
+    ? { key: fs.readFileSync(path.join(__dirname, "key.pem")), cert: fs.readFileSync(path.join(__dirname, "cert.pem")) }
+    : {};
+const workerCount = 2;
+
+if (cluster.isPrimary) {
+  const fail = reason => {
+    console.log(JSON.stringify({ failed: reason }));
+    process.exit(1);
+  };
+  cluster.on("exit", (worker, code, signal) => fail("worker " + worker.id + " exited early: " + (signal ?? code)));
+  // What cluster's 'listening' event reported for each worker, keyed by worker id.
+  const listeningPorts = {};
+  cluster.on("listening", (worker, address) => (listeningPorts[worker.id] = address.port));
+  // Resolves with the port the worker itself sees in server.address(). The worker's 'listening'
+  // notification to the primary precedes the message it sends from its listen callback.
+  const forkAndWaitForPort = env =>
+    new Promise(resolve => {
+      const worker = cluster.fork(env);
+      worker.once("message", message => {
+        if (message.error) fail("worker " + worker.id + " listen error: " + message.error);
+        resolve({ id: worker.id, port: message.port });
+      });
+    });
+
+  (async () => {
+    const [exclusive, ...shared] = await Promise.all([
+      forkAndWaitForPort({ EXCLUSIVE: "1" }),
+      ...Array.from({ length: workerCount }, () => forkAndWaitForPort()),
+    ]);
+
+    const port = shared[0].port;
+    let served = 0;
+    for (let i = 0; i < 4; i++) {
+      const response = await fetch(kind + "://127.0.0.1:" + port + "/", { tls: { rejectUnauthorized: false } });
+      if ((await response.text()).startsWith("worker ")) served++;
+    }
+
+    console.log(
+      JSON.stringify({
+        workers: shared.length,
+        distinctReportedPorts: new Set(shared.map(worker => worker.port)).size,
+        distinctListeningPorts: new Set(shared.map(worker => listeningPorts[worker.id])).size,
+        listeningMatchesReported: shared.every(worker => listeningPorts[worker.id] === worker.port),
+        exclusiveWorkerHasOwnPort: exclusive.port > 0 && exclusive.port !== port,
+        exclusiveListeningMatchesReported: listeningPorts[exclusive.id] === exclusive.port,
+        served,
+      }),
+    );
+    cluster.removeAllListeners("exit");
+    for (const id in cluster.workers) cluster.workers[id].process.kill();
+    process.exit(0);
+  })().catch(error => fail(String(error)));
+} else {
+  const server = mod.createServer(serverOptions, (req, res) => {
+    res.setHeader("Connection", "close");
+    res.end("worker " + cluster.worker.id);
+  });
+  server.on("error", error => process.send({ error: error.code }));
+  const report = () => process.send({ port: server.address().port });
+  if (process.env.EXCLUSIVE) server.listen({ port: 0, exclusive: true }, report);
+  else server.listen(0, report);
+}
+`;
+
+test.skipIf(isWindows).each(["http", "https"])(
+  "%s workers all share the one port the primary picked for listen(0)",
+  async kind => {
+    using dir = tempDir("cluster-http-listen0", {
+      "cert.pem": tlsCerts.cert,
+      "key.pem": tlsCerts.key,
+      "fixture.js": httpListenZeroFixture,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: { ...bunEnv, MODULE: kind },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr }).toEqual({
+      out: {
+        workers: 2,
+        distinctReportedPorts: 1,
+        distinctListeningPorts: 1,
+        listeningMatchesReported: true,
+        exclusiveWorkerHasOwnPort: true,
+        exclusiveListeningMatchesReported: true,
+        served: 4,
+      },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "http workers listening on one unix path share the primary's socket",
+  async () => {
+    using dir = tempDir("cluster-http-unix", {
+      "fixture.js": /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const SOCK = path.join(__dirname, "shared.sock");
+
+if (cluster.isPrimary) {
+  const fail = reason => {
+    console.log(JSON.stringify({ failed: reason }));
+    process.exit(1);
+  };
+  cluster.on("exit", (worker, code, signal) => fail("worker " + worker.id + " exited early: " + (signal ?? code)));
+  const listening = [];
+  cluster.on("listening", (_worker, address) => listening.push(address));
+  const nextMessage = worker =>
+    new Promise(resolve =>
+      worker.once("message", message => {
+        if (message.error) fail("worker " + worker.id + ": " + message.error);
+        resolve(message);
+      }),
+    );
+  const get = async () => {
+    const response = await fetch("http://localhost/", { unix: SOCK });
+    return response.text();
+  };
+  const workers = [cluster.fork(), cluster.fork()];
+
+  (async () => {
+    const addresses = (await Promise.all(workers.map(nextMessage))).map(message => message.address);
+    const bodies = await Promise.all([get(), get(), get(), get()]);
+
+    workers[0].send("close");
+    await nextMessage(workers[0]);
+    const existsAfterFirstClose = fs.existsSync(SOCK);
+    const bodyAfterFirstClose = await get();
+
+    workers[1].send("close");
+    await nextMessage(workers[1]);
+    // The worker's release (act: close) is sent before its reply, so the primary has handled it.
+    const existsAfterLastClose = fs.existsSync(SOCK);
+
+    console.log(
+      JSON.stringify({
+        addresses: addresses.map(address => address === SOCK),
+        listening: listening.map(address => ({ ...address, address: address.address === SOCK })),
+        served: bodies.filter(body => body.startsWith("worker ")).length,
+        existsAfterFirstClose,
+        servedAfterFirstClose: bodyAfterFirstClose.startsWith("worker "),
+        existsAfterLastClose,
+      }),
+    );
+    cluster.removeAllListeners("exit");
+    for (const worker of workers) worker.process.kill();
+    process.exit(0);
+  })().catch(error => fail(String(error)));
+} else {
+  const server = http.createServer((req, res) => {
+    res.setHeader("Connection", "close");
+    res.end("worker " + cluster.worker.id);
+  });
+  server.on("error", error => process.send({ error: error.code }));
+  process.on("message", () => server.close(() => process.send({ closed: true })));
+  server.listen(SOCK, () => process.send({ address: server.address() }));
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr }).toEqual({
+      out: {
+        addresses: [true, true],
+        listening: [
+          { address: true, addressType: -1, port: -1 },
+          { address: true, addressType: -1, port: -1 },
+        ],
+        served: 4,
+        existsAfterFirstClose: true,
+        servedAfterFirstClose: true,
+        existsAfterLastClose: false,
+      },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "http worker reports a port the primary cannot bind the way node does",
+  async () => {
+    using dir = tempDir("cluster-http-bind-error", {
+      "fixture.js": /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+const net = require("node:net");
+
+if (cluster.isPrimary) {
+  const blocker = net.createServer();
+  blocker.listen(0, "127.0.0.1", () => {
+    const port = blocker.address().port;
+    const worker = cluster.fork({ BUSY_PORT: String(port) });
+    worker.on("message", error => {
+      console.log(JSON.stringify({ ...error, portMatches: error.port === port, message: error.message.replace(":" + port, ":PORT") }));
+      worker.process.kill();
+      blocker.close();
+    });
+  });
+} else {
+  const server = http.createServer();
+  server.on("error", error =>
+    process.send({ code: error.code, syscall: error.syscall, address: error.address, port: error.port, message: error.message }),
+  );
+  server.listen(+process.env.BUSY_PORT, "127.0.0.1");
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: {
+        code: "EADDRINUSE",
+        syscall: "bind",
+        address: "127.0.0.1",
+        port: expect.any(Number),
+        portMatches: true,
+        message: "bind EADDRINUSE 127.0.0.1:PORT",
+      },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "http worker's close() releases the shared port so it can listen on it again",
+  async () => {
+    using dir = tempDir("cluster-http-relisten", {
+      "fixture.js": /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  worker.on("message", result => {
+    console.log(JSON.stringify(result));
+    worker.process.kill();
+  });
+} else {
+  const first = http.createServer();
+  first.listen(0, "127.0.0.1", () => {
+    const port = first.address().port;
+    first.close();
+    const second = http.createServer();
+    second.on("error", error => process.send({ relisten: error.code }));
+    second.listen(port, "127.0.0.1", () => process.send({ relisten: "ok", samePort: second.address().port === port }));
+  });
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { relisten: "ok", samePort: true },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "worker.disconnect() closes the worker's http server before the channel goes away",
+  async () => {
+    using dir = tempDir("cluster-http-disconnect", {
+      "fixture.js": /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  let port;
+  worker.on("message", message => (port = message.port));
+  const exited = new Promise(resolve => worker.on("exit", (code, signal) => resolve({ code, signal })));
+  worker.on("disconnect", async () => {
+    const connectAfterDisconnect = await new Promise(resolve => {
+      http
+        .get({ host: "127.0.0.1", port }, response => {
+          response.resume();
+          resolve("served " + response.statusCode);
+        })
+        .on("error", error => resolve(error.code));
+    });
+    // A worker whose server is still up never exits on its own.
+    const killed = connectAfterDisconnect !== "ECONNREFUSED";
+    if (killed) worker.process.kill();
+    console.log(JSON.stringify({ connectAfterDisconnect, killed, exit: await exited }));
+  });
+} else {
+  const server = http.createServer((req, res) => res.end("still here"));
+  server.on("close", () => console.log("worker: server closed"));
+  server.listen(0, "127.0.0.1", () => {
+    process.send({ port: server.address().port });
+    cluster.worker.disconnect();
+  });
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const lines = stdout.trim().split("\n");
+    expect({ workerLines: lines.slice(0, -1), out: JSON.parse(lines.at(-1)!), stderr }).toEqual({
+      workerLines: ["worker: server closed"],
+      out: { connectAfterDisconnect: "ECONNREFUSED", killed: false, exit: { code: 0, signal: null } },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1746,6 +1746,14 @@ test.skipIf(isWindows || !isIPv6())(
 );
 
 test.skipIf(isWindows)(
+  "http worker listen(0, '[::1') is a name lookup that fails, not a bind of ::",
+  async () => {
+    expect(await runHttpHostFormFixture("[::1")).toEqual({ error: "ENOTFOUND" });
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
   "http worker listen(0, 'localhost') resolves the name before asking the primary",
   async () => {
     const out = await runHttpHostFormFixture("localhost");

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -203,7 +203,7 @@ if (cluster.isPrimary) {
   });
   const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
   expect(stdout).toContain("tls listen error code: EINVAL");
-  expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
+  expect(stdout).toContain("the two kinds cannot share one address:port");
 });
 
 test("cluster pipe listen error carries no port suffix", async () => {
@@ -842,7 +842,7 @@ if (cluster.isPrimary) {
   });
   const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
   expect(stdout).toContain("net listen error code: EINVAL");
-  expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
+  expect(stdout).toContain("the two kinds cannot share one address:port");
 }, 30_000);
 
 test.skipIf(isWindows)(
@@ -1629,6 +1629,177 @@ if (cluster.isPrimary) {
     expect({ workerLines: lines.slice(0, -1), out: JSON.parse(lines.at(-1)!), stderr }).toEqual({
       workerLines: ["worker: server closed"],
       out: { connectAfterDisconnect: "ECONNREFUSED", killed: false, exit: { code: 0, signal: null } },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "http worker's listen(0) on the key a net worker's round-robin handle owns fails with EINVAL",
+  async () => {
+    // Like the TLS variant above: a worker's first listen(0) on an address always gets index 0,
+    // so both workers ask for the same key and the http worker's shared-only query meets the
+    // round-robin handle the net worker got. The hint has to describe http now, not just TLS.
+    using dir = tempDir("cluster-http-mixed-kinds", {
+      "fixture.js": /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+const net = require("node:net");
+
+if (cluster.isPrimary) {
+  const netWorker = cluster.fork({ ROLE: "net" });
+  cluster.once("listening", () => {
+    const httpWorker = cluster.fork({ ROLE: "http" });
+    httpWorker.on("message", error => {
+      console.log(JSON.stringify(error));
+      netWorker.process.kill();
+      httpWorker.process.kill();
+    });
+  });
+} else if (process.env.ROLE === "net") {
+  net.createServer(() => {}).listen(0, "127.0.0.1");
+} else {
+  const server = http.createServer();
+  server.on("error", error =>
+    process.send({
+      code: error.code,
+      syscall: error.syscall,
+      firstLine: error.message.split("\\n")[0],
+      namesHttp: error.message.includes("http servers"),
+      hasHint: error.message.includes("cannot share one address:port"),
+    }),
+  );
+  server.on("listening", () => process.send({ unexpected: "listening" }));
+  server.listen(0, "127.0.0.1");
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { code: "EINVAL", syscall: "bind", firstLine: "bind EINVAL 127.0.0.1", namesHttp: true, hasHint: true },
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+// One fixture for the host spellings a worker has to translate before asking the primary: the
+// primary binds addresses, so a name is resolved first and an IPv6 literal loses the brackets
+// Bun.serve() accepts. HOST is what the worker passes to listen(); the primary prints what the
+// 'listening' event reported next to what the worker's server.address() says it bound.
+const httpHostFormFixture = /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+
+if (cluster.isPrimary) {
+  let listening;
+  cluster.on("listening", (_worker, address) => (listening = address));
+  const worker = cluster.fork();
+  worker.on("message", ({ error, bound }) => {
+    console.log(JSON.stringify({ error, listening: listening && { address: listening.address, addressType: listening.addressType }, bound }));
+    worker.process.kill();
+  });
+} else {
+  const server = http.createServer();
+  server.on("error", error => process.send({ error: error.code }));
+  server.listen(0, process.env.HOST, () => {
+    const { address, family, port } = server.address();
+    process.send({ bound: { address, family, hasPort: port > 0 } });
+  });
+}
+`;
+
+async function runHttpHostFormFixture(host: string) {
+  using dir = tempDir("cluster-http-host-form", { "fixture.js": httpHostFormFixture });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: { ...bunEnv, HOST: host },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toEqual(expect.any(String));
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout.trim());
+}
+
+test.skipIf(isWindows || !isIPv6())(
+  "http worker listen(0, '[::1]') binds ::1 through the primary",
+  async () => {
+    expect(await runHttpHostFormFixture("[::1]")).toEqual({
+      listening: { address: "::1", addressType: 6 },
+      bound: { address: "::1", family: "IPv6", hasPort: true },
+    });
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "http worker listen(0, 'localhost') resolves the name before asking the primary",
+  async () => {
+    const out = await runHttpHostFormFixture("localhost");
+    expect(out).toEqual({
+      listening: { address: out.bound.address, addressType: out.bound.family === "IPv6" ? 6 : 4 },
+      bound: { address: expect.any(String), family: expect.stringMatching(/^IPv[46]$/), hasPort: true },
+    });
+    expect(net.isIP(out.bound.address)).toBeGreaterThan(0);
+  },
+  30_000,
+);
+
+test.skipIf(isWindows)(
+  "http worker whose listen fails after Bun.serve() took the shared socket is left not running",
+  async () => {
+    using dir = tempDir("cluster-http-listen-late-failure", {
+      "fixture.js": /* js */ `
+const cluster = require("node:cluster");
+const http = require("node:http");
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  worker.on("message", result => {
+    console.log(JSON.stringify(result));
+    worker.process.kill();
+  });
+} else {
+  const server = http.createServer();
+  // requireHostHeader is pushed to the native listener right after Bun.serve() returns, so a
+  // throwing getter fails listen() at the point where the listener already owns the descriptor.
+  Object.defineProperty(server, "requireHostHeader", {
+    configurable: true,
+    get() {
+      throw new Error("boom from requireHostHeader");
+    },
+  });
+  server.on("listening", () => process.send({ unexpected: "listening" }));
+  server.on("error", error => {
+    server.close(closeError => process.send({ listenError: error.message, closeError: closeError?.code ?? null }));
+  });
+  server.listen(0, "127.0.0.1");
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { listenError: "boom from requireHostHeader", closeError: "ERR_SERVER_NOT_RUNNING" },
       stderr: expect.any(String),
     });
     expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem
- In a `node:cluster` worker, `http.createServer().listen(0)` binds a different ephemeral port in every worker. Node resolves `listen(0)` once in the primary, so `server.address().port` and every `cluster.on("listening")` payload report the same port in all workers (3 workers: node prints one port three times, bun prints three different ports; repro below).
- Cause: `Server.prototype.listen` in `src/js/node/_http_server.ts` never asked the primary. In a worker it called `Bun.serve({ port, reusePort: true })` directly (old lines 667-685), so each worker got its own `SO_REUSEPORT` socket and, for port 0, its own kernel-chosen port. `node:net` has gone through `cluster._getServer` since #31829; `node:http` was left on the direct bind.
- Same root cause, also visible: `listen(path)` in two workers fails the second one with `EADDRINUSE` (only one worker can ever serve a unix path), bind errors have Bun.serve's shape (`listen EADDRINUSE ... Failed to start server. Is port N in use?`, no `address`/`port`) instead of node's `bind EADDRINUSE 127.0.0.1:N`, and `worker.disconnect()` does not close http servers because the cluster never learns about them, so the worker never exits.

### Fix
- `_http_server.ts`: a worker's `listen()` now goes through `cluster._getServer` with the same `(address, port, addressType)` query `net.Server` sends plus `sharedOnly: true`. The primary binds the address once per key (or reuses the handle it already has for that key) and ships the descriptor; the worker then calls `Bun.serve({ ..., fd })` and accepts on it. A non-IP host is resolved with `dns.lookup` first, like `net` and node, and an IPv6 literal in brackets (which Bun.serve accepts) is unbracketed for the query. Bind errors become `ExceptionWithHostPort(err, "bind", address, port)` like `net`. `close()`/`closeAllConnections()` release the handle (`act: "close"` to the primary); the handle's owner is the server, so `worker.disconnect()` closes it the way it closes `net` servers. A stale reply (server closed or re-listened before the primary answered) hands the descriptor straight back. If `Bun.serve()` itself throws, the descriptor is closed and the handle released; if `listen()` fails after `Bun.serve()` returned, the listener already owns the descriptor, so the server is torn down through `close()` (which now also applies to a late failure on the other listen paths, instead of leaving a listener running behind the `'error'`).
- `sharedOnly` is correct here for the same reason it is used for TLS `net` servers: Bun.serve accepts (and parses) natively, so it can take a listening socket but not the connections the round-robin handle passes one by one. This is node's shared-handle (`SCHED_NONE`) behavior for http servers; the port/path semantics, which is what this fixes, are identical under both policies.
- Still binds in the worker, with the previous `reusePort: true` unless `exclusive` was asked for: `exclusive: true` / `reusePort: true` (node binds in the worker too), a process that inherited `NODE_UNIQUE_ID` without an IPC channel (previous behavior), arguments the primary could not bind (Bun.serve reports them as before), and Windows. On Windows several processes accepting on copies of one listening socket block each other in `accept()` (see #37815), and the round-robin alternative is exactly what Bun.serve cannot take, so Windows keeps the current per-worker bind and the `listen(0)` divergence remains there for now.
- `internal/cluster/primary.ts`: the hint attached to the EINVAL a shared-only query gets when its key is held by a round-robin handle (and vice versa) only talked about TLS; http/https servers now reach it too (e.g. a `net` worker and an `http` worker both calling `listen(0)`), so it describes the natively accepting kinds vs `net` and names the remedies. The two existing assertions on it are updated.
- `Bun.serve` learns to accept on an existing descriptor: `HttpContext::listen_fd` / `TemplatedApp::listen_fd` / `uws_app_listen_fd` / `App::listen_fd` wrap the `us_socket_group_listen_fd` that `Bun.listen({ fd })` already uses; `ServerConfig.listen_fd` is only read for node:http servers (the `onNodeHTTPRequest` branch), so it is not a new public option, and it disables `--hot` server reuse, which would otherwise drop the descriptor. `config.address` still carries the port/host or unix path, so `address`, `url`, `requestIP` and error messages behave as before, and `stop_listening` no longer unlinks a unix socket file when the descriptor was inherited (the primary owns the file and unlinks it when the last worker releases the handle, as node does). A descriptor that cannot be listened on throws a `SystemError` with the real errno (`ENOTSOCK`, `EBADF`, ...), `EINVAL` if none is available, and is left open for the caller, matching `us_socket_group_listen_fd`'s contract.
- Tests, `test/js/node/cluster.test.ts`: http and https workers share one port for `listen(0)` while an `exclusive` worker gets its own; two workers share a unix path, the file survives the first worker's `close()` and disappears after the last; a busy port reports node's `bind EADDRINUSE 127.0.0.1:N` shape; `close()` releases the port so the same worker can listen on it again; `worker.disconnect()` closes the http server before the channel goes and the worker exits 0. Also: an `http` worker's `listen(0)` on a key a `net` worker's round-robin handle holds gets EINVAL with the new hint; `listen(0, "[::1]")` binds `::1` through the primary; `listen(0, "localhost")` resolves first and reports the address it bound; a `listen()` that throws after `Bun.serve()` returned leaves the server not running (`close()` reports `ERR_SERVER_NOT_RUNNING`). On the unfixed build the listen(0), unix, bind-error, disconnect, mixed-kind and late-failure tests fail (`distinctReportedPorts: 2`, `EADDRINUSE` for the second unix worker, `syscall: "listen"`, `served 200` after disconnect, an unexpected `'listening'`, `closeError: null`); the re-listen, `[::1]` and `localhost` ones guard the release and the address handling.
- Also run: the existing `cluster 'listening' reports the address a http server bound` test (127.0.0.1, wildcard, ::1 and a unix path now all take the new path), all 80 vendored `test-cluster-*.js` plus `test-http-server-drop-connections-in-cluster.js`, `test-cluster-http-pipe.js`, `test-tls-ticket-cluster.js` and the fork-net tests (all exit 0), `test/js/node/cluster/test-docs-http-server.ts` (every CPU's worker on one fixed port) and `test-worker-no-exit-http.ts`, `test/js/node/http/node-http.test.ts`, `test/js/bun/http/serve-listen.test.ts`; `cargo check -p bun_runtime --target x86_64-pc-windows-msvc`.
- Related: #34659 also adds a `Bun.serve` fd path (for `listen({ fd })`) but keeps `listen(0)` on the direct bind; #33025 and #30603 were the pre-#31829 attempts at this; #30548's "disconnect() with an http server never exits" case is covered here as a side effect, its other cases are not. Raw `Bun.serve` in workers (#13611, #14727) is unchanged.

### Background
- A cluster worker's `server.listen()` does not bind. It sends the primary a `queryServer` message keyed by `address:port:addressType:fd` (plus a per-listen index when the port is 0, which is why every worker's first `listen(0)` lands on the same key). The primary answers from a handle object it keeps per key.
- Round-robin handle (node's default `SCHED_RR`): the primary listens, accepts, and sends each accepted connection to a worker over the IPC channel; the worker's server sits on a faux handle. Shared handle (`SCHED_NONE`): the primary only binds, sends the bound descriptor to each worker, and every worker calls `listen(2)` and accepts on its own copy. `sharedOnly` in the query forces the shared kind; Bun uses it for TLS `net` servers because their accept is native. The descriptor crosses the channel as `SCM_RIGHTS` ancillary data and arrives in `child.ts` as `handle.sharedFd`; `handle.adopted` tells its `close()` that a listener owns the fd now and it must only notify the primary.
- `us_socket_group_listen_fd` (usockets) turns an already bound descriptor into a listen socket: `listen(2)`, non-blocking, register with the event loop. On success the listen socket owns the fd; on failure the caller still does. `Bun.listen({ fd })` is built on it; this PR gives the uws HTTP app (what `Bun.serve` is built on) the same entry point.
- `ServerConfig.address` is what `Bun.serve` reports and formats (`server.address`, `server.url`, EADDRINUSE text, unix-vs-tcp decisions such as `requestIP`); the listen socket's real port is read back from the socket, so with an inherited descriptor the configured port 0 is reported as the shared port.

<details>
<summary>Repro and before/after output</summary>

```js
import cluster from "node:cluster";
import http from "node:http";
if (cluster.isPrimary) {
  for (let i = 0; i < 3; i++) cluster.fork();
  cluster.on("listening", (w, a) => console.log(a.port));
} else {
  http.createServer((req, res) => res.end("ok")).listen(0);
}
```

```
node v26.3.0:  35591 35591 35591
bun 1.4.0:     43451 34189 38921
this branch:   one port, repeated (test "http workers all share the one port the primary picked for listen(0)")
```

Bind error shape for a port the primary cannot bind, worker side:

```
node:          {"code":"EADDRINUSE","syscall":"bind","address":"127.0.0.1","port":44359,"message":"bind EADDRINUSE 127.0.0.1:44359"}
bun 1.4.0:     {"code":"EADDRINUSE","syscall":"listen","message":"Failed to start server. Is port 32837 in use?"}
this branch:   same as node
```

Native failure paths of the new fd option (internal, needs `onNodeHTTPRequest`): a regular file reports `ENOTSOCK: socket operation on non-socket, listen` and stays open, fd 9999 reports `EBADF`, `-1` / `1.5` are rejected while parsing options, and a plain `Bun.serve({ fd })` ignores the key.
</details>
