### PR TITLE
install: set npm_config_local_prefix and npm_package_config_* for lifecycle scripts

### DIFF
--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -14,6 +14,8 @@ use bun_semver::string::Builder as SemverStringBuilder;
 use bun_sys as Syscall;
 
 use crate::bun_fs::FileSystem;
+use crate::bun_json;
+use crate::initialize_store;
 
 use super::directories;
 use crate::lifecycle_script_runner::{
@@ -386,6 +388,8 @@ impl PackageManager {
         path.append(original_path.as_slice())?;
         script_env.put(b"PATH", path.slice())?;
 
+        put_npm_package_config_env(&mut script_env, cwd)?;
+
         // Ownership transfers to `LifecycleScriptSubprocess`, which
         // re-uses it across every `spawn_next_script` in the chain. Move the
         // owning `NullDelimitedEnvMap` by value so its `K=V\0` buffers outlive
@@ -460,6 +464,42 @@ impl PackageManager {
 
         set
     }
+}
+
+/// The package's own `config` strings as `npm_package_config_<key>`, the subset `bun run` exports.
+fn put_npm_package_config_env(
+    script_env: &mut bun_dotenv::Map,
+    package_dir: &[u8],
+) -> Result<(), crate::Error> {
+    let package_json_path = join_abs_string_z::<platform::Auto>(package_dir, &[b"package.json"]);
+    let Ok(json_buf) = Syscall::File::read_from(Syscall::Fd::cwd(), package_json_path.as_bytes())
+    else {
+        return Ok(());
+    };
+    let json_src =
+        bun_ast::Source::init_path_string(package_json_path.as_bytes(), json_buf.as_slice());
+    let mut log = bun_ast::Log::init();
+
+    initialize_store();
+
+    let Ok(parsed) = bun_json::ParsedJson::parse_package_json(&json_src, &mut log) else {
+        return Ok(());
+    };
+    let Some(config) = parsed.root.get(b"config") else {
+        return Ok(());
+    };
+
+    config.try_for_each_property(|key, _key_loc, value| {
+        let Some(value) = value.as_utf8_string_literal() else {
+            return Ok(());
+        };
+        if key.is_empty() || value.is_empty() {
+            return Ok(());
+        }
+        script_env.put(&strings::concat(&[b"npm_package_config_", key]), value)
+    })?;
+
+    Ok(())
 }
 
 fn add_package_to_set(

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -851,9 +851,13 @@ impl RunCommand {
             }
         }
 
-        // DirInfo walk / npm_package_* seeding is performed by the T6 impl
-        // (`bun_runtime::cli::RunCommand::configure_env_for_run`); install
-        // callers discard the return value.
+        // Overwrite like npm: an outer `bun run` in another project may have left a stale value.
+        env_loader.map.put(
+            b"npm_config_local_prefix",
+            bun_fs::FileSystem::instance().top_level_dir(),
+        )?;
+
+        // `npm_package_*` is per package; see `spawn_package_lifecycle_scripts`.
         Ok(core::ptr::null_mut())
     }
 }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1400,6 +1400,96 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
+    test("npm_config_local_prefix and npm_package_config_* are set for root and dependency scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      // Each script dumps the variables under test into env.json in its own cwd.
+      const captureEnv = `
+      require("fs").writeFileSync(
+        "env.json",
+        JSON.stringify({
+          localPrefix: process.env.npm_config_local_prefix,
+          config: Object.fromEntries(
+            Object.entries(process.env).filter(([name]) => name.startsWith("npm_package_config_")),
+          ),
+        }),
+      );
+      `;
+
+      await mkdir(join(packageDir, "dep"));
+      await Promise.all([
+        writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "root-project",
+            version: "1.0.0",
+            config: {
+              port: "8080",
+              shared: "from-root",
+              // Like `bun run`, only non-empty top-level string values are exported.
+              retries: 3,
+              nested: { key: "value" },
+              blank: "",
+            },
+            scripts: { postinstall: `${bunExe()} capture-env.js` },
+            dependencies: { "my-dep": "file:./dep" },
+            trustedDependencies: ["my-dep"],
+          }),
+        ),
+        writeFile(join(packageDir, "capture-env.js"), captureEnv),
+        writeFile(
+          join(packageDir, "dep", "package.json"),
+          JSON.stringify({
+            name: "my-dep",
+            version: "2.0.0",
+            config: { depkey: "dep-value", shared: "from-dep" },
+            scripts: { postinstall: `${bunExe()} capture-env.js` },
+          }),
+        ),
+        writeFile(join(packageDir, "dep", "capture-env.js"), captureEnv),
+      ]);
+
+      // `bun run`/`npm run` leave their own values in the environment of the commands they
+      // run (including this test under `bun run`); the install must replace them with its own.
+      const installEnv: Record<string, string> = Object.fromEntries(
+        Object.entries(testEnv).filter(([name]) => !name.startsWith("npm_package_config_")),
+      );
+      installEnv.npm_config_local_prefix = "/some/other/project";
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: installEnv,
+      });
+
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("+ my-dep@dep");
+      expect(exitCode).toBe(0);
+
+      expect(await file(join(packageDir, "env.json")).json()).toEqual({
+        localPrefix: packageDir,
+        config: {
+          npm_package_config_port: "8080",
+          npm_package_config_shared: "from-root",
+        },
+      });
+
+      // A dependency sees its own `config`, not the root's.
+      expect(await file(join(packageDir, "node_modules", "my-dep", "env.json")).json()).toEqual({
+        localPrefix: packageDir,
+        config: {
+          npm_package_config_depkey: "dep-value",
+          npm_package_config_shared: "from-dep",
+        },
+      });
+    });
+
     test("INIT_CWD is set to the correct directory", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;


### PR DESCRIPTION
### Problem
- Lifecycle scripts run by `bun install` (and `bun pm trust`) no longer see `npm_config_local_prefix` or `npm_package_config_<key>`. Bun 1.3.14 and npm set both; 1.4.0 prints `prefix=[] cfg=[]` for the repro below.
- Real consumers: install scripts locate the project they are being installed into through `npm_config_local_prefix`, and packages read their own `package.json` `config` through `npm_package_config_*` (for example `sharp`'s install check reads `npm_package_config_libvips`).
- Cause: `PackageManager::configure_env_for_scripts_run` (`src/install/PackageManager.rs:1136`) calls the install-tier shim `RunCommand::configure_env_for_run` in `src/install/lib.rs`. The shim only seeds `npm_config_user_agent`, `npm_execpath` and `BUN_FEATURE_FLAG_NO_ORPHANS`; its closing comment deferred the rest to the runtime implementation, which the install path never calls. In 1.3.14 the package manager called the full `RunCommand.configureEnvForRun`, which also exported the prefix and the root `package.json`'s `config`.
- `npm_package_name` / `npm_package_version` / `npm_package_json` went missing in the same way; #36690 (open) adds those, so this PR leaves them alone.

### Fix
- `src/install/lib.rs`: the shim now sets `npm_config_local_prefix` to `top_level_dir`. `PackageManager::init` has already moved that to the project root (the workspace root when installing from inside a workspace member), which is the directory npm exports, and it is the same value `INIT_CWD` is derived from a few lines later.
- It is written with `put`, not `put_default`, because npm overwrites this variable on every run and the only way a value is already present is an outer `bun run` / `npm run`, possibly from a different project; inheriting it would send scripts to the wrong root. #38071 makes the same change for `bun run`.
- `src/install/PackageManager/PackageManagerLifecycle.rs`: `spawn_package_lifecycle_scripts` reads the `package.json` at the script's cwd and exports its `config` entries as `npm_package_config_<key>` into that package's script env. Reading the manifest of the package being run (rather than exporting the root's `config` into the shared base env as 1.3.14 did) is what npm does: a dependency's install script sees the dependency's own `config`, and the root's keys do not leak into it. The root's scripts get the root's `config` exactly as before.
- Exported subset is the one `bun run` already uses (`bun_resolver::PackageJSON::config`, also what 1.3.14 exported): top-level entries whose key and string value are non-empty. Nested objects and non-string values are skipped here as they are for `bun run`; changing that would be a separate change to both paths.
- The read and parse follow `Scripts::fill_from_package_json` in the same crate (`initialize_store()` + `ParsedJson::parse_package_json`); a missing or unparsable manifest just leaves the variables unset. This runs once per package that actually has scripts to run, after `PATH` is built, so every caller (`install_with_manager` root scripts, `PackageInstaller` / `runTasks` dependency and workspace scripts, `bun pm trust`) gets it.
- Test: `test/cli/install/bun-install-lifecycle-scripts.test.ts`, "npm_config_local_prefix and npm_package_config_* are set for root and dependency scripts". One install with a root `config` (string, number, nested object, empty string) and a trusted `file:` dependency with its own `config` sharing one key with the root; each postinstall dumps `npm_config_local_prefix` and every `npm_package_config_*` variable, and the test compares the exact sets. The install is spawned with a stale `npm_config_local_prefix` in its environment to cover the overwrite. Before the fix it fails with `config: {}` and the stale prefix; with the fix it passes in both the default and waiter-thread variants.
- Also run: the rest of `bun-install-lifecycle-scripts.test.ts` (the three `PATH=""` tests fail identically without this change in this container and pass in CI on main), the `$npm_package_config_*` tests in `bun-run.test.ts` and `bun-workspaces.test.ts`, `cargo fmt`, `cargo clippy -p bun_install`.

### Background
- `npm_config_local_prefix` is npm's name for the project root an install operates on; npm exports it to every lifecycle script, including dependencies' scripts, and `npm_package_config_<key>` is how npm exposes a `package.json` `config` object to that package's own scripts.
- Lifecycle script env in the install path: `configure_env_for_scripts_run` builds one base env map once per process (PATH additions, `INIT_CWD`, node-gyp setup, the shim above); `spawn_package_lifecycle_scripts` clones it per package with scripts, adds that package's `PATH`, and hands the result to the subprocess. Process-wide values belong in the shim, per-package values in the spawn function, which is why the two variables land in different files.
- The install crate cannot call the runtime's `configure_env_for_run` (the runtime crate depends on the install crate), hence the shim.
- `initialize_store()` creates or resets the thread-local AST store that parsed JSON values are materialized into; every transient `package.json` parse during an install calls it first, and the long-lived manifests (`WorkspacePackageJSONCache`) are deep-cloned into their own arenas so these resets cannot invalidate them.

<details>
<summary>Repro</summary>

```sh
mkdir /tmp/inst && cd /tmp/inst
cat > package.json <<'EOF'
{"name":"inst-root","version":"3.3.3","config":{"port":"8080"},
 "scripts":{"postinstall":"echo prefix=[$npm_config_local_prefix] cfg=[$npm_package_config_port]"}}
EOF
bun install
```

bun 1.3.14 and npm: `prefix=[/tmp/inst] cfg=[8080]`
bun 1.4.0: `prefix=[] cfg=[]`
this branch: `prefix=[/tmp/inst] cfg=[8080]`; a trusted dependency with its own `config` sees its own keys and the project root as the prefix.

</details>
