### PR TITLE
fs.cpSync: replace a dest symlink that does not resolve instead of throwing

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -451,6 +451,17 @@ function copyDir(src, dest, opts) {
   }
 }
 
+// A link that does not resolve (dangling, looping) points at no directory, so
+// neither subdirectory guard in onLink applies and the link is just replaced,
+// as fs.promises.cp already does.
+function linkTargetIsDirectory(link) {
+  try {
+    return statSync(link).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function onLink(destStat, src, dest, opts) {
   let resolvedSrc = readlinkSync(src);
   if (!opts.verbatimSymlinks && !isAbsolute(resolvedSrc)) {
@@ -474,11 +485,7 @@ function onLink(destStat, src, dest, opts) {
   if (!isAbsolute(resolvedDest)) {
     resolvedDest = resolve(dirname(dest), resolvedDest);
   }
-  let srcIsDir = false;
-  try {
-    srcIsDir = statSync(src).isDirectory();
-  } catch {}
-  if (srcIsDir && isSrcSubdir(resolvedSrc, resolvedDest)) {
+  if (linkTargetIsDirectory(src) && isSrcSubdir(resolvedSrc, resolvedDest)) {
     throw fsCpEinvalError({
       message: `cannot copy ${resolvedSrc} to a subdirectory of self ${resolvedDest}`,
       path: dest,
@@ -490,7 +497,7 @@ function onLink(destStat, src, dest, opts) {
   // Prevent copy if src is a subdir of dest since unlinking
   // dest in this case would result in removing src contents
   // and therefore a broken symlink would be created.
-  if (statSync(dest).isDirectory() && isSrcSubdir(resolvedDest, resolvedSrc)) {
+  if (linkTargetIsDirectory(dest) && isSrcSubdir(resolvedDest, resolvedSrc)) {
     throw fsCpSymlinkToSubdirectoryError({
       message: `cannot overwrite ${resolvedDest} with ${resolvedSrc}`,
       path: dest,

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -281,6 +281,67 @@ for (const [name, copy] of impls) {
       expect(fs.readFileSync(copiedLink, "utf8")).toBe("a");
     });
 
+    // A symlink already present at the destination is replaced by the source
+    // link. That must also hold when the existing link does not resolve: the
+    // sync walker used to stat() through it to ask whether it points at a
+    // directory and let that ENOENT / ELOOP escape from cpSync.
+    test("symlinks - recursive copy replaces dest links that do not resolve", async () => {
+      await using basename = tempDir("cp", {
+        "target.txt": "t",
+        "from": {},
+        "result": {},
+      });
+      const target = join(basename, "target.txt");
+      fs.symlinkSync(target, join(basename, "from", "dangling"));
+      fs.symlinkSync(target, join(basename, "from", "loop"));
+      fs.symlinkSync("missing", join(basename, "result", "dangling"));
+      fs.symlinkSync("loop", join(basename, "result", "loop"));
+
+      await copy(join(basename, "from"), join(basename, "result"), { recursive: true });
+
+      expect({
+        dangling: fs.readlinkSync(join(basename, "result", "dangling")),
+        loop: fs.readlinkSync(join(basename, "result", "loop")),
+        danglingContent: fs.readFileSync(join(basename, "result", "dangling"), "utf8"),
+        loopContent: fs.readFileSync(join(basename, "result", "loop"), "utf8"),
+      }).toEqual({
+        dangling: target,
+        loop: target,
+        danglingContent: "t",
+        loopContent: "t",
+      });
+    });
+
+    test("symlinks - single link copied over a dangling dest link replaces it", async () => {
+      await using basename = tempDir("cp", {
+        "target.txt": "t",
+      });
+      const target = join(basename, "target.txt");
+      fs.symlinkSync(target, join(basename, "link"));
+      fs.symlinkSync("missing", join(basename, "result"));
+
+      await copy(join(basename, "link"), join(basename, "result"));
+
+      expect(fs.readlinkSync(join(basename, "result"))).toBe(target);
+      expect(fs.readFileSync(join(basename, "result"), "utf8")).toBe("t");
+    });
+
+    // The same stat() still drives the refusal when the dest link does resolve
+    // to a directory that contains the source link's target.
+    test("symlinks - dest link to a directory containing the source link's target is refused", async () => {
+      await using basename = tempDir("cp", {
+        "dir/sub": {},
+        "from": {},
+        "result": {},
+      });
+      fs.symlinkSync(join(basename, "dir", "sub"), join(basename, "from", "link"));
+      fs.symlinkSync(join(basename, "dir"), join(basename, "result", "link"));
+
+      const e = await copyShouldThrow(join(basename, "from"), join(basename, "result"), { recursive: true });
+      expect(e.code).toBe("ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY");
+      expect(fs.readlinkSync(join(basename, "result", "link"))).toBe(join(basename, "dir"));
+    });
+
     test.skipIf(isWindows)("recursive - file and directory modes are preserved into a fresh destination", async () => {
       await using basename = tempDir("cp", {
         "from/d/f.txt": "x",
@@ -653,6 +714,8 @@ test.skipIf(!isPosix)(
     expect(stdout.trim()).toBe("ok");
     expect(exitCode).toBe(0);
   },
+  // The 20 iterations take around 5s under a debug + ASAN build.
+  30_000,
 );
 
 test.skipIf(!isLinux)("fs.cp and fs.copyFile create the destination with the source file's mode", async () => {


### PR DESCRIPTION
### Problem
- `fs.cpSync` throws when the entry it is about to write as a symlink already exists as a symlink whose target is missing: `ENOENT: no such file or directory, stat 'w/dest/link'` (a looping link gives `ELOOP` the same way). Repro at the bottom; bun 1.4.0 and main, Linux.
- `fs.promises.cp` and `fs.cp` replace the stale link and succeed, in bun and in node.
- Cause: `onLink` in `src/js/internal/fs/cp-sync.ts` (line 493 on main) runs `statSync(dest).isDirectory()` to feed the "dest link points at a directory containing the source link's target" guard. `statSync` follows the link, so for a link that does not resolve it throws, and the error leaves `cpSync`. The `src` side of the same pair of guards already caught the stat failure four lines up.
- Node is not a usable reference for the sync form here: its `cpSync` gives `EEXIST` naming the parent directory when no `filter` is set (the C++ walker checks `exists()` through the link, skips the unlink, then fails on `create_symlink`), `ENOENT` when a `filter` is set (JS walker, same `statSync(dest)` as ours), and aborts the process on the single-file form (`CpSyncCheckPaths` lets a `std::filesystem_error` escape). The async form is consistent across node and bun, and node's own test for this area (`test-fs-cp-sync-copy-symlinks-to-existing-symlinks`) states the intent: a link in src may be copied over an existing link in dest that does not point at a directory.

### Fix
- `onLink` asks both questions through one helper, `linkTargetIsDirectory`, which returns false when the stat fails. A dest link that does not resolve is therefore "not a directory": the guard does not apply and `copyLink` unlinks it and writes the new link, the same outcome as `fs.promises.cp`.
- Why this is correct: the guard exists so that `cpSync` does not unlink a dest link that leads to the directory holding the source link's target. A link that resolves to nothing cannot lead there, so there is nothing for the guard to protect, and the unlink only removes the stale link itself. If removing it does fail (unwritable parent, for example), `unlinkSync` in `copyLink` still reports that.
- The guard itself is unchanged: when the dest link does resolve to a directory, `statSync` succeeds and the check runs exactly as before. This matters because the sync and async walkers intentionally differ on what they stat (sync: dest's target is a directory; async: src's target is a directory), and node's sync form refuses, for example, a src link to a file inside the directory the dest link points at while its async form replaces it. Bun matches node on both today, and switching the sync walker to the async rule would have changed that, so only the failure case is changed.
- The `src` side now shares the helper; its behavior is the same as before (it already swallowed the stat failure).
- The recursive-copy UAF test in `test/js/node/fs/cp.test.ts` gets a per-test timeout. Its 20 iterations take about 5s under a debug + ASAN build, so the file did not pass at the default budget even before this change (the test is unrelated to this fix; CI's larger budget was hiding it).
- Verified:
  - `test/js/node/fs/cp.test.ts`: the three new tests run for both `fs.cpSync` and `fs.promises.cp`. On the unfixed build the two `cpSync` "replaces" tests fail from `statSync` in `onLink`; with the fix the file passes (53 pass, 5 skipped on Linux). The third test pins that the guard still refuses a dest link to a directory containing the source link's target, for both forms.
  - All 77 `test/js/node/test/parallel/test-fs-cp-*` tests and `test/js/node/fs/cp-symlink-target.test.ts` pass with the fix.
  - The repro matrix below now gives the same result as `fs.promises.cp` for every `cpSync` option combination tried (`filter`, `force: false`, `verbatimSymlinks`, single-file form).

### Background
- `fs.cpSync` with anything other than a plain file-to-file copy runs the JS port of node's old `lib/internal/fs/cp/cp-sync.js` in `src/js/internal/fs/cp-sync.ts`; `fs.promises.cp` and `fs.cp` run the port of node's (still current) `cp.js` in `cp.ts`. Both walk the tree entry by entry; `onLink` is the step for a source entry that is a symlink.
- When the destination entry already exists, `onLink` reads both links' targets and applies two guards before replacing the dest link: the source link may not point at a directory that contains the dest link's target (`ERR_FS_CP_EINVAL`), and the dest link may not point at a directory that contains the source link's target (`ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY`). Existing symlinks at the destination are otherwise always replaced, regardless of `force`.
- `lstatSync` describes a symlink itself; `statSync` follows it and describes the target, so `statSync` on a dangling link fails with `ENOENT` and on a self-referencing one with `ELOOP`. The walker classifies entries with `lstatSync`, which is why a dangling link at the destination is seen as an existing entry at all.

<details>
<summary>Repro (Linux, the case from the report)</summary>

```js
import fs from "node:fs";
fs.mkdirSync("w/dest", { recursive: true });
fs.writeFileSync("w/new.txt", "new");
fs.mkdirSync("w/d");
fs.symlinkSync("../new.txt", "w/d/link");
fs.symlinkSync("does-not-exist", "w/dest/link"); // stale link already at the destination entry
fs.cpSync("w/d", "w/dest", { recursive: true });
console.log(fs.readlinkSync("w/dest/link"));
```

```
bun 1.4.0 / main:  ENOENT: no such file or directory, stat 'w/dest/link'
this branch:       /tmp/x/w/new.txt
fs.promises.cp (bun and node):  /tmp/x/w/new.txt
node v26.3.0 cpSync:  EEXIST, File exists 'w/dest'   (with filter: ENOENT; single-file form: process abort)
```

</details>

<details>
<summary>cpSync option matrix on this branch (all previously threw ENOENT)</summary>

```
recursive, no filter                 => ok; dest link -> /tmp/cprepro/w/new.txt
recursive, filter                    => ok; dest link -> /tmp/cprepro/w/new.txt
recursive, force:false               => ok; dest link -> /tmp/cprepro/w/new.txt
recursive, filter, force:false       => ok; dest link -> /tmp/cprepro/w/new.txt
single link -> dangling link         => ok; dest link -> /tmp/cprepro/w/new.txt
single link, force:false             => ok; dest link -> /tmp/cprepro/w/new.txt
recursive, verbatimSymlinks          => ok; dest link -> ../new.txt
```

Identical to the `fs.promises.cp` results for the same inputs on both bun and node. The guard case (dest link -> real dir D, src link -> D/file) still throws `ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY` from `cpSync`, as it does on node.

</details>
