### PR TITLE
node:fs: resolve drive-relative paths (C:dir) on Windows before the NT-relative operations

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2164,6 +2164,14 @@ mod _async_tasks {
         /// Heap-owned, NUL-terminated (`[path.., 0]`); freed on drop.
         pub(crate) root_path: Box<[u8]>,
 
+        /// What the root directory is actually opened with: `root_path` as
+        /// the slicer spells it for the syscalls (on Windows, rooted and
+        /// drive-relative arguments become absolute paths there, as they do
+        /// for every other readdir flavor via `readdir_inner`). `root_path`
+        /// itself stays as given, since it is what parentPath and error
+        /// messages are built from. Heap-owned, NUL-terminated like `root_path`.
+        pub(crate) root_open_path: Box<[u8]>,
+
         pub(crate) pending_err: Option<sys::Error>,
         pub(crate) pending_err_mutex: bun_threading::Mutex,
     }
@@ -2190,16 +2198,16 @@ mod _async_tasks {
         ) -> Option<bun_jsc::Completion<Self>> {
             this.done = Some(done);
             let mut buf = PathBuffer::uninit();
-            let root_path_z = {
+            let root_open_path_z = {
                 let bytes: &'static [u8] =
-                    // SAFETY: `root_path` is a NUL-terminated `Box<[u8]>` fixed for the
-                    // task's lifetime; `perform_work` mutates other fields only.
-                    unsafe { bun_ptr::detach_lifetime(&this.root_path[..]) };
+                    // SAFETY: `root_open_path` is a NUL-terminated `Box<[u8]>` fixed
+                    // for the task's lifetime; `perform_work` mutates other fields only.
+                    unsafe { bun_ptr::detach_lifetime(&this.root_open_path[..]) };
                 ZStr::from_buf(bytes, bytes.len() - 1)
             };
             // May finish synchronously (no subdirectories) or fan out; the last
             // subtask finishes the token.
-            this.perform_work(root_path_z, &mut buf, true);
+            this.perform_work(root_open_path_z, &mut buf, true);
             None
         }
 
@@ -2374,12 +2382,16 @@ mod _async_tasks {
             };
             // Subtasks read the root path outside the VM borrow, so it must be an
             // owned copy rather than the (possibly JS-backed) argument. NUL-terminated.
-            let root_path = {
-                let src = args.path.slice();
+            let nul_terminated = |src: &[u8]| -> Box<[u8]> {
                 let mut owned = Vec::with_capacity(src.len() + 1);
                 owned.extend_from_slice(src);
                 owned.push(0);
                 owned.into_boxed_slice()
+            };
+            let root_path = nul_terminated(args.path.slice());
+            let root_open_path = {
+                let mut buf = paths::path_buffer_pool::get();
+                nul_terminated(args.path.slice_z(&mut buf).as_bytes())
             };
             let tracker = AsyncTaskTracker::init(vm);
             tracker.did_schedule(global_object);
@@ -2395,6 +2407,7 @@ mod _async_tasks {
                     has_result: AtomicBool::new(false),
                     subtask_count: AtomicUsize::new(1),
                     root_path,
+                    root_open_path,
                     result_list,
                     result_list_count: AtomicUsize::new(0),
                     result_list_queue: UnboundedQueue::default(),
@@ -6543,8 +6556,8 @@ impl NodeFS {
             };
             let utf8_name = current.name.slice();
 
-            // The root subtask's basename *is* root_path; the caller passes
-            // `is_root` explicitly.
+            // The root subtask's basename is `root_open_path`, which must not
+            // leak into results; the caller passes `is_root` explicitly.
             let name_to_copy: &[u8] = if is_root {
                 utf8_name
             } else {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -930,37 +930,62 @@ fn is_drive_relative_windows(path: &[u8]) -> bool {
         && (path.len() == 2 || !bun_paths::is_sep_any(path[2]))
 }
 
-/// Resolve a drive-relative path (see [`is_drive_relative_windows`]) to the
-/// absolute path Win32 would open for it, written into `scratch`.
+/// Turn a drive-relative path (see [`is_drive_relative_windows`]) into the
+/// unnormalized absolute path it stands for, `<directory of that drive>\name`,
+/// written into `scratch`. The caller then treats it exactly like an absolute
+/// argument.
 ///
-/// Node's fs gets this resolution for free because libuv hands the string to
-/// Win32, and so do bun's libuv-backed operations. The ones that open through
-/// bun's own `NtCreateFile` paths relative to the cwd handle (readdir,
-/// recursive rm, writeFile, the mkdir -p existence probe) do not: to NT,
-/// `C:foo` relative to a directory names a file `C` with an alternate data
-/// stream `foo`, so they reported ENOENT or, for writeFile, created that
-/// stream. Resolving here hands them the same absolute path Win32 would use.
+/// Node's fs resolves these before the syscall, and so, in effect, do bun's
+/// libuv-backed operations, because Win32 resolves them itself. The operations
+/// that open through bun's own `NtCreateFile` paths relative to the cwd handle
+/// (readdir, recursive rm, writeFile, the mkdir -p existence probe) did not:
+/// to NT, `C:foo` relative to a directory names a file `C` with an alternate
+/// data stream `foo`, so they reported ENOENT or, for writeFile, created that
+/// stream.
 ///
-/// `None` when Win32 cannot resolve the path; the caller then keeps its
-/// existing handling of the path as given.
+/// Only the bare drive designator is handed to Win32: which directory `C:`
+/// currently stands for is Win32 state (the cwd for the cwd's drive, otherwise
+/// the drive's own current directory). Resolving the whole string with it
+/// would also apply Win32's name rules, stripping trailing dots and spaces and
+/// turning `nul.txt` into the NUL device, which neither the absolute branches
+/// nor node apply; joining the name here keeps `C:foo` equivalent to the
+/// absolute spelling of the same name.
+///
+/// `None` when the directory cannot be determined or the result does not fit;
+/// the caller then keeps its existing handling of the path as given.
 #[cfg(windows)]
 fn resolve_drive_relative_windows<'a>(
     path: &[u8],
     scratch: &'a mut PathBuffer,
 ) -> Option<&'a [u8]> {
     debug_assert!(is_drive_relative_windows(path));
-    if !strings::fits_in_wide_path_buffer(path) {
-        return None;
-    }
-    let mut wide_path = bun_paths::w_path_buffer_pool::get();
-    let mut wide_resolved = bun_paths::w_path_buffer_pool::get();
-    let resolved = bun_sys::windows::get_full_path_name_w(
-        strings::paths::to_w_path(&mut wide_path[..], path),
-        &mut wide_resolved[..],
+    let name = &path[2..];
+    let designator = [u16::from(path[0]), u16::from(b':'), 0];
+    let mut wide_dir = bun_paths::w_path_buffer_pool::get();
+    let dir = bun_sys::windows::get_full_path_name_w(
+        WStr::from_slice_with_nul(&designator),
+        &mut wide_dir[..],
     )?;
     // `MAX_PATH_BYTES` is sized so that any wide path re-encodes into a
     // `PathBuffer`, so this cannot truncate.
-    Some(strings::paths::from_w_path(&mut scratch[..], resolved.as_slice()).as_bytes())
+    let dir_len = strings::paths::from_w_path(&mut scratch[..], dir.as_slice()).len();
+    if !bun_paths::is_absolute(&scratch[..dir_len]) {
+        return None;
+    }
+    if name.is_empty() {
+        return Some(&scratch[..dir_len]);
+    }
+    // A drive root (`C:\`) already ends with its separator.
+    let sep_len = usize::from(!bun_paths::is_sep_any(scratch[dir_len - 1]));
+    let total = dir_len + sep_len + name.len();
+    if total > scratch.len() {
+        return None;
+    }
+    if sep_len != 0 {
+        scratch[dir_len] = b'\\';
+    }
+    scratch[dir_len + sep_len..total].copy_from_slice(name);
+    Some(&scratch[..total])
 }
 
 impl PathLikeExt for PathLike {
@@ -975,11 +1000,11 @@ impl PathLikeExt for PathLike {
 
         #[cfg(windows)]
         {
-            // A drive-relative path is rebound to the absolute path Win32
-            // resolves it to, so the drive-absolute branch below handles it
-            // like any other absolute argument. The scratch is declared before
-            // the shadowing `sliced` so it outlives the borrow; the plain copy
-            // at the bottom still sees the argument as given.
+            // A drive-relative argument is rebound to the absolute path it
+            // stands for, so the branch below handles it like any other
+            // absolute argument. The scratch is declared before the shadowing
+            // `sliced` so it outlives the borrow; the plain copy at the bottom
+            // still sees the argument as given.
             let mut drive_relative_scratch;
             let sliced = if is_drive_relative_windows(sliced) {
                 drive_relative_scratch = bun_paths::path_buffer_pool::get();
@@ -1163,11 +1188,11 @@ impl PathLikeExt for PathLike {
                 return Ok(strings::to_kernel32_path(buf_u16, normal));
             }
             if is_drive_relative_windows(s) {
-                // Same buffer roles as the rooted branch above. The resolved
-                // path is drive-absolute, so `to_kernel32_path` prefixes it
-                // with `\\?\` and mkdir -p's NT-level existence probe gets an
-                // absolute object name. If Win32 cannot resolve it, the path
-                // is passed on as given, below.
+                // Same buffer roles as the rooted branch above. The result is
+                // absolute, so it gets the `\\?\` prefix like an absolute
+                // argument and mkdir -p's NT-level existence probe receives an
+                // absolute object name. If the drive's directory cannot be
+                // determined, the path is passed on as given, below.
                 if let Some(resolved) = resolve_drive_relative_windows(s, buf) {
                     let normal = bun_paths::resolve_path::normalize_buf::<
                         bun_paths::platform::Windows,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -918,6 +918,51 @@ pub(crate) trait PathOrFdExt {
         Self: Sized;
 }
 
+/// `C:foo` or `C:`: a drive letter and colon not followed by a separator.
+/// Win32 resolves such a path against that drive's current directory. An
+/// alternate data stream name (`file.txt:stream`) has more than one character
+/// before its colon and is not one of these.
+#[cfg(windows)]
+fn is_drive_relative_windows(path: &[u8]) -> bool {
+    path.len() >= 2
+        && bun_paths::is_drive_letter(path[0])
+        && path[1] == b':'
+        && (path.len() == 2 || !bun_paths::is_sep_any(path[2]))
+}
+
+/// Resolve a drive-relative path (see [`is_drive_relative_windows`]) to the
+/// absolute path Win32 would open for it, written into `scratch`.
+///
+/// Node's fs gets this resolution for free because libuv hands the string to
+/// Win32, and so do bun's libuv-backed operations. The ones that open through
+/// bun's own `NtCreateFile` paths relative to the cwd handle (readdir,
+/// recursive rm, writeFile, the mkdir -p existence probe) do not: to NT,
+/// `C:foo` relative to a directory names a file `C` with an alternate data
+/// stream `foo`, so they reported ENOENT or, for writeFile, created that
+/// stream. Resolving here hands them the same absolute path Win32 would use.
+///
+/// `None` when Win32 cannot resolve the path; the caller then keeps its
+/// existing handling of the path as given.
+#[cfg(windows)]
+fn resolve_drive_relative_windows<'a>(
+    path: &[u8],
+    scratch: &'a mut PathBuffer,
+) -> Option<&'a [u8]> {
+    debug_assert!(is_drive_relative_windows(path));
+    if !strings::fits_in_wide_path_buffer(path) {
+        return None;
+    }
+    let mut wide_path = bun_paths::w_path_buffer_pool::get();
+    let mut wide_resolved = bun_paths::w_path_buffer_pool::get();
+    let resolved = bun_sys::windows::get_full_path_name_w(
+        strings::paths::to_w_path(&mut wide_path[..], path),
+        &mut wide_resolved[..],
+    )?;
+    // `MAX_PATH_BYTES` is sized so that any wide path re-encodes into a
+    // `PathBuffer`, so this cannot truncate.
+    Some(strings::paths::from_w_path(&mut scratch[..], resolved.as_slice()).as_bytes())
+}
+
 impl PathLikeExt for PathLike {
     // Const-generics can't change return mutability, so this always returns
     // `&ZStr`. A future force=true caller that needs `&mut ZStr` will need a
@@ -930,6 +975,19 @@ impl PathLikeExt for PathLike {
 
         #[cfg(windows)]
         {
+            // A drive-relative path is rebound to the absolute path Win32
+            // resolves it to, so the drive-absolute branch below handles it
+            // like any other absolute argument. The scratch is declared before
+            // the shadowing `sliced` so it outlives the borrow; the plain copy
+            // at the bottom still sees the argument as given.
+            let mut drive_relative_scratch;
+            let sliced = if is_drive_relative_windows(sliced) {
+                drive_relative_scratch = bun_paths::path_buffer_pool::get();
+                resolve_drive_relative_windows(sliced, &mut drive_relative_scratch)
+                    .unwrap_or(sliced)
+            } else {
+                sliced
+            };
             // Only take the fast path for paths that can exist on NT at
             // all (≤ ~32757 UTF-16 units). That bounds the `\\?\`-prefixed
             // copy below in bytes too (≤ 3×32757 + 5 < MAX_PATH_BYTES);
@@ -1103,6 +1161,24 @@ impl PathLikeExt for PathLike {
                 // SAFETY: same alignment note as above.
                 let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
                 return Ok(strings::to_kernel32_path(buf_u16, normal));
+            }
+            if is_drive_relative_windows(s) {
+                // Same buffer roles as the rooted branch above. The resolved
+                // path is drive-absolute, so `to_kernel32_path` prefixes it
+                // with `\\?\` and mkdir -p's NT-level existence probe gets an
+                // absolute object name. If Win32 cannot resolve it, the path
+                // is passed on as given, below.
+                if let Some(resolved) = resolve_drive_relative_windows(s, buf) {
+                    let normal = bun_paths::resolve_path::normalize_buf::<
+                        bun_paths::platform::Windows,
+                    >(resolved, &mut b[..]);
+                    if !strings::fits_in_wide_path_buffer(normal) {
+                        return Err(NameTooLong);
+                    }
+                    // SAFETY: same alignment note as above.
+                    let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
+                    return Ok(strings::to_kernel32_path(buf_u16, normal));
+                }
             }
             // Handle "." specially since normalizeStringBuf strips it to an empty string
             if s.len() == 1 && s[0] == b'.' {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -983,6 +983,46 @@ pub(crate) fn GetFinalPathNameByHandle(
     Ok(ret)
 }
 
+/// `GetFullPathNameW`: the resolution Win32 applies to a path before opening
+/// it (`CreateFileW` and friends run the same routine), written into `out`.
+/// This is the only way to resolve a drive-relative path (`C:foo`) the way
+/// Win32 does: against the process cwd when `C:` is the cwd's drive, otherwise
+/// against that drive's own current directory (the hidden `=C:` environment
+/// variable), falling back to the drive root. Pure string processing, no
+/// filesystem access. `None` when the call fails or the result does not fit.
+pub fn get_full_path_name_w<'a>(
+    path: &bun_core::WStr,
+    out: &'a mut [u16],
+) -> Option<&'a bun_core::WStr> {
+    // SAFETY: `path` is NUL-terminated by `WStr`'s invariant; `out` is valid
+    // for `out.len()` units, which is the length passed to the API.
+    let n = unsafe {
+        externs::GetFullPathNameW(
+            path.as_ptr(),
+            out.len() as DWORD,
+            out.as_mut_ptr(),
+            ptr::null_mut(),
+        )
+    } as usize;
+    // 0 is failure; a value >= the buffer length is the size the result would
+    // need (including its NUL), i.e. it did not fit. Otherwise the result was
+    // written and NUL-terminated at `out[n]`.
+    if n == 0 || n >= out.len() {
+        bun_sys::syslog!(
+            "GetFullPathNameW({}) = {}",
+            bun_core::fmt::utf16(path.as_slice()),
+            n
+        );
+        return None;
+    }
+    bun_sys::syslog!(
+        "GetFullPathNameW({}) = {}",
+        bun_core::fmt::utf16(path.as_slice()),
+        bun_core::fmt::utf16(&out[..n])
+    );
+    Some(bun_core::WStr::from_buf(out, n))
+}
+
 const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: DWORD = 0x00000002;
 const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: DWORD = 0x00000004;
 
@@ -2186,5 +2226,52 @@ mod tests {
         assert!((*letter as u8).is_ascii_uppercase());
         let prefix: Vec<u16> = "\\Device\\".encode_utf16().collect();
         assert!(device.starts_with(&prefix));
+    }
+
+    fn full_path_name(path: &str) -> Option<String> {
+        let wide: Vec<u16> = path.encode_utf16().chain(core::iter::once(0)).collect();
+        let mut out = bun_paths::w_path_buffer_pool::get();
+        let resolved = super::get_full_path_name_w(
+            bun_core::WStr::from_slice_with_nul(&wide),
+            &mut out.0[..],
+        )?;
+        Some(String::from_utf16(resolved.as_slice()).unwrap())
+    }
+
+    /// A drive-relative name on the cwd's drive resolves against the cwd;
+    /// the test binary's cwd is always drive-letter rooted.
+    #[test]
+    fn full_path_name_resolves_drive_relative_against_cwd() {
+        let cwd = std::env::current_dir()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let drive = &cwd[..2];
+        assert_eq!(drive.as_bytes()[1], b':', "{cwd}");
+        let expected = format!("{}\\x", cwd.trim_end_matches('\\'));
+        assert_eq!(
+            full_path_name(&format!("{drive}x")).as_deref(),
+            Some(&*expected)
+        );
+        assert_eq!(
+            full_path_name(&format!("{}x", drive.to_ascii_lowercase())).as_deref(),
+            Some(&*expected)
+        );
+        assert_eq!(
+            full_path_name(&format!("{drive}a\\..\\x")).as_deref(),
+            Some(&*expected)
+        );
+        assert_eq!(full_path_name(drive).as_deref(), Some(&*cwd));
+    }
+
+    #[test]
+    fn full_path_name_rejects_too_small_buffer() {
+        let wide: Vec<u16> = "C:x".encode_utf16().chain(core::iter::once(0)).collect();
+        let mut out = [0u16; 4];
+        assert!(
+            super::get_full_path_name_w(bun_core::WStr::from_slice_with_nul(&wide), &mut out)
+                .is_none()
+        );
     }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -2238,10 +2238,11 @@ mod tests {
         Some(String::from_utf16(resolved.as_slice()).unwrap())
     }
 
-    /// A drive-relative name on the cwd's drive resolves against the cwd;
-    /// the test binary's cwd is always drive-letter rooted.
+    /// The bare designator of the cwd's drive, in either case, stands for the
+    /// cwd itself; this is what `node:fs` resolves drive-relative paths with.
+    /// The test binary's cwd is always drive-letter rooted.
     #[test]
-    fn full_path_name_resolves_drive_relative_against_cwd() {
+    fn full_path_name_of_bare_drive_designator_is_the_cwd() {
         let cwd = std::env::current_dir()
             .unwrap()
             .to_str()
@@ -2249,20 +2250,15 @@ mod tests {
             .to_owned();
         let drive = &cwd[..2];
         assert_eq!(drive.as_bytes()[1], b':', "{cwd}");
-        let expected = format!("{}\\x", cwd.trim_end_matches('\\'));
-        assert_eq!(
-            full_path_name(&format!("{drive}x")).as_deref(),
-            Some(&*expected)
-        );
-        assert_eq!(
-            full_path_name(&format!("{}x", drive.to_ascii_lowercase())).as_deref(),
-            Some(&*expected)
-        );
-        assert_eq!(
-            full_path_name(&format!("{drive}a\\..\\x")).as_deref(),
-            Some(&*expected)
-        );
         assert_eq!(full_path_name(drive).as_deref(), Some(&*cwd));
+        assert_eq!(
+            full_path_name(&drive.to_ascii_lowercase()).as_deref(),
+            Some(&*cwd)
+        );
+        assert_eq!(
+            full_path_name(&drive.to_ascii_uppercase()).as_deref(),
+            Some(&*cwd)
+        );
     }
 
     #[test]

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -985,11 +985,11 @@ pub(crate) fn GetFinalPathNameByHandle(
 
 /// `GetFullPathNameW`: the resolution Win32 applies to a path before opening
 /// it (`CreateFileW` and friends run the same routine), written into `out`.
-/// This is the only way to resolve a drive-relative path (`C:foo`) the way
-/// Win32 does: against the process cwd when `C:` is the cwd's drive, otherwise
-/// against that drive's own current directory (the hidden `=C:` environment
-/// variable), falling back to the drive root. Pure string processing, no
-/// filesystem access. `None` when the call fails or the result does not fit.
+/// For a drive-relative path (`C:foo`) that means the process cwd when `C:`
+/// is the cwd's drive, otherwise that drive's own current directory (the
+/// hidden `=C:` environment variable), otherwise the drive root; `.` and `..`
+/// are collapsed as well. Pure string processing, no filesystem access.
+/// `None` when the call fails or the result does not fit `out`.
 pub fn get_full_path_name_w<'a>(
     path: &bun_core::WStr,
     out: &'a mut [u16],

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -985,8 +985,8 @@ pub mod kernel32 {
     }
     // Re-export externs declared at the crate root so `kernel32::Foo` resolves.
     pub use super::{
-        CreateFileW, GetCurrentDirectoryW, GetFileAttributesW, GetSystemDirectoryW, GetSystemInfo,
-        SYSTEM_INFO, SetCurrentDirectoryW, SetFilePointerEx,
+        CreateFileW, GetCurrentDirectoryW, GetFileAttributesW, GetFullPathNameW,
+        GetSystemDirectoryW, GetSystemInfo, SYSTEM_INFO, SetCurrentDirectoryW, SetFilePointerEx,
     };
     pub use super::{
         GetConsoleCP, GetConsoleMode, GetConsoleOutputCP, SetConsoleCP, SetConsoleMode,
@@ -1402,6 +1402,13 @@ unsafe extern "system" {
     pub fn SetCurrentDirectoryW(lpPathName: LPCWSTR) -> BOOL;
 
     pub fn GetCurrentDirectoryW(nBufferLength: DWORD, lpBuffer: LPWSTR) -> DWORD;
+
+    pub fn GetFullPathNameW(
+        lpFileName: LPCWSTR,
+        nBufferLength: DWORD,
+        lpBuffer: LPWSTR,
+        lpFilePart: *mut LPWSTR,
+    ) -> DWORD;
 
     pub fn GetSystemDirectoryW(lpBuffer: LPWSTR, uSize: DWORD) -> DWORD;
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5345,6 +5345,235 @@ describe.if(isWindows)("windows path handling", () => {
   }
 });
 
+// "C:dir" (a drive letter and colon with no separator) is drive-relative: Win32
+// resolves it against that drive's current directory, which for the cwd's drive
+// is the cwd itself, and node gets that from Win32 on every fs call. The bun
+// operations that open through NT relative to the cwd handle (readdir,
+// recursive rm, writeFile, mkdir -p's existence probe) used to read it as a
+// stream named "dir" on a file named "C" instead. Every fixture below runs in a
+// child whose cwd is a fresh temp dir and spells its paths as that cwd's drive
+// followed directly by a name relative to the cwd.
+describe.if(isWindows)("windows drive-relative paths", () => {
+  async function runFixture(cwd: string, body: string): Promise<unknown> {
+    const source = `
+      import fs from "node:fs";
+      import path from "node:path";
+      const cwd = process.cwd();
+      const drive = cwd.slice(0, 2);
+      const rel = name => drive + name;
+      const code = fn => {
+        try {
+          fn();
+          return "ok";
+        } catch (e) {
+          return e.code;
+        }
+      };
+      const out = {};
+      ${body}
+      process.stdout.write(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) return { stdout, stderr, exitCode };
+    return JSON.parse(stdout);
+  }
+
+  const recursiveListing = ["inner.txt", "sub", "sub\\deep.txt"];
+
+  it.concurrent("readdir lists the directory the path names", async () => {
+    using dir = tempDir("fs-drive-relative", {
+      "dir/inner.txt": "",
+      "dir/sub/deep.txt": "",
+    });
+    expect(
+      await runFixture(
+        String(dir),
+        `
+          const direntsExist = dirents => dirents.map(dirent => fs.existsSync(path.join(dirent.parentPath, dirent.name)));
+          const callback = await new Promise((resolve, reject) =>
+            fs.readdir(rel("dir"), { recursive: true }, (err, names) => (err ? reject(err) : resolve(names))),
+          );
+          const opendir = fs.opendirSync(rel("dir"));
+          try {
+            out.opendir = opendir.readSync().name;
+          } finally {
+            opendir.closeSync();
+          }
+          Object.assign(out, {
+            sync: fs.readdirSync(rel("dir")),
+            lowercaseDrive: fs.readdirSync(drive.toLowerCase() + "dir"),
+            nested: fs.readdirSync(rel(path.join("dir", "sub"))),
+            bareDrive: fs.readdirSync(drive),
+            direntsExist: direntsExist(fs.readdirSync(rel("dir"), { withFileTypes: true })),
+            recursiveSync: fs.readdirSync(rel("dir"), { recursive: true }).sort(),
+            recursiveCallback: callback.sort(),
+            recursivePromise: (await fs.promises.readdir(rel("dir"), { recursive: true })).sort(),
+            recursiveDirentsExist: direntsExist(
+              await fs.promises.readdir(rel("dir"), { recursive: true, withFileTypes: true }),
+            ),
+            promise: await fs.promises.readdir(rel("dir")),
+            missing: code(() => fs.readdirSync(rel("missing"))),
+          });
+        `,
+      ),
+    ).toEqual({
+      opendir: "inner.txt",
+      sync: ["inner.txt", "sub"],
+      lowercaseDrive: ["inner.txt", "sub"],
+      nested: ["deep.txt"],
+      bareDrive: ["dir"],
+      direntsExist: [true, true],
+      recursiveSync: recursiveListing,
+      recursiveCallback: recursiveListing,
+      recursivePromise: recursiveListing,
+      recursiveDirentsExist: [true, true, true],
+      promise: ["inner.txt", "sub"],
+      missing: "ENOENT",
+    });
+  });
+
+  it.concurrent("writeFile writes the file the path names", async () => {
+    using dir = tempDir("fs-drive-relative", {});
+    expect(
+      await runFixture(
+        String(dir),
+        `
+          // The file an NT-relative open of "C:name" would attach the data to,
+          // as a stream named "name".
+          fs.writeFileSync(drive[0], "unrelated");
+          fs.writeFileSync(rel("sync"), "sync contents");
+          await fs.promises.writeFile(rel("promise"), "promise contents");
+          Object.assign(out, {
+            listing: fs.readdirSync(".").filter(name => name !== drive[0]).sort(),
+            sync: fs.readFileSync("sync", "utf8"),
+            promise: fs.readFileSync("promise", "utf8"),
+            letterFile: fs.readFileSync(drive[0], "utf8"),
+          });
+        `,
+      ),
+    ).toEqual({
+      listing: ["promise", "sync"],
+      sync: "sync contents",
+      promise: "promise contents",
+      letterFile: "unrelated",
+    });
+  });
+
+  it.concurrent("rm and mkdir operate on the directory the path names", async () => {
+    using dir = tempDir("fs-drive-relative", {
+      "tree/sub/deep.txt": "",
+      "file.txt": "",
+      "promise-tree/inner.txt": "",
+      "existing/.keep": "",
+    });
+    expect(
+      await runFixture(
+        String(dir),
+        `
+          let missingError;
+          try {
+            fs.rmSync(rel("missing"), { recursive: true });
+          } catch (e) {
+            missingError = e;
+          }
+          await fs.promises.rm(rel("promise-tree"), { recursive: true });
+          const created = fs.mkdirSync(rel(path.join("created", "nested")), { recursive: true });
+          Object.assign(out, {
+            tree: code(() => fs.rmSync(rel("tree"), { recursive: true })),
+            file: code(() => fs.rmSync(rel("file.txt"), { recursive: true })),
+            missingForced: code(() => fs.rmSync(rel("missing"), { recursive: true, force: true })),
+            missing: missingError.code,
+            missingPathAsGiven: missingError.path === rel("missing"),
+            existing: fs.mkdirSync(rel("existing"), { recursive: true }) ?? null,
+            created,
+            // Node returns the first directory it created as the namespaced
+            // form of the absolute path the argument resolved to.
+            createdIsNamespacedCwdPath: created === ${JSON.stringify("\\\\?\\")} + path.join(cwd, "created"),
+            createdAgain: fs.mkdirSync(rel(path.join("created", "nested")), { recursive: true }) ?? null,
+            nestedIsDirectory: fs.statSync(path.join("created", "nested")).isDirectory(),
+            listing: fs.readdirSync(".").sort(),
+          });
+        `,
+      ),
+    ).toEqual({
+      tree: "ok",
+      file: "ok",
+      missingForced: "ok",
+      missing: "ENOENT",
+      missingPathAsGiven: true,
+      existing: null,
+      created: expect.any(String),
+      createdIsNamespacedCwdPath: true,
+      createdAgain: null,
+      nestedIsDirectory: true,
+      listing: ["created", "existing"],
+    });
+  });
+
+  // A drive letter with no drive behind it. Drive-relative paths on it must
+  // fail rather than resolve against this process's cwd, which is on another
+  // drive; multi-component ones used to do exactly that.
+  const missingDrive = isWindows
+    ? [..."ZYXWVUTSRQPONMLKJIHGFE"].find(letter => !existsSync(`${letter}:\\`))
+    : undefined;
+
+  it.concurrent.skipIf(!missingDrive)("paths on other drives do not resolve against the cwd", async () => {
+    using dir = tempDir("fs-drive-relative", { "dir/sub/inner.txt": "" });
+    expect(
+      await runFixture(
+        String(dir),
+        `
+          const other = name => ${JSON.stringify(missingDrive)} + ":" + name;
+          Object.assign(out, {
+            readdir: code(() => fs.readdirSync(other("dir"))),
+            readdirNested: code(() => fs.readdirSync(other(path.join("dir", "sub")))),
+            rm: code(() => fs.rmSync(other("dir"), { recursive: true, force: true })),
+            rmNested: code(() => fs.rmSync(other(path.join("dir", "sub")), { recursive: true, force: true })),
+            writeFile: code(() => fs.writeFileSync(other(path.join("dir", "new.txt")), "")),
+            survivors: fs.readdirSync("dir", { recursive: true }).sort(),
+          });
+        `,
+      ),
+    ).toEqual({
+      readdir: "ENOENT",
+      readdirNested: "ENOENT",
+      rm: "ok",
+      rmNested: "ok",
+      writeFile: "ENOENT",
+      survivors: ["sub", "sub\\inner.txt"],
+    });
+  });
+
+  it.concurrent("alternate data stream names are not drive-relative", async () => {
+    using dir = tempDir("fs-drive-relative", {});
+    expect(
+      await runFixture(
+        String(dir),
+        `
+          fs.writeFileSync("ads.txt", "main");
+          fs.writeFileSync("ads.txt:meta", "stream");
+          Object.assign(out, {
+            main: fs.readFileSync("ads.txt", "utf8"),
+            stream: fs.readFileSync("ads.txt:meta", "utf8"),
+            listing: fs.readdirSync("."),
+          });
+        `,
+      ),
+    ).toEqual({
+      main: "main",
+      stream: "stream",
+      listing: ["ads.txt"],
+    });
+  });
+});
+
 it("using writeFile on an fd does not truncate it", () => {
   const filepath = join(tmpdir(), `file-${Math.random().toString(32).slice(2)}.txt`);
   const fd = fs.openSync(filepath, "w+");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5351,8 +5351,8 @@ describe.if(isWindows)("windows path handling", () => {
 // operations that open through NT relative to the cwd handle (readdir,
 // recursive rm, writeFile, mkdir -p's existence probe) used to read it as a
 // stream named "dir" on a file named "C" instead. Every fixture below runs in a
-// child whose cwd is a fresh temp dir and spells its paths as that cwd's drive
-// followed directly by a name relative to the cwd.
+// child whose cwd is a fresh temp dir and spells its paths from that cwd: the
+// cwd's drive followed directly by a name relative to it.
 describe.if(isWindows)("windows drive-relative paths", () => {
   async function runFixture(cwd: string, body: string): Promise<unknown> {
     const source = `
@@ -5439,6 +5439,45 @@ describe.if(isWindows)("windows drive-relative paths", () => {
     });
   });
 
+  // The other spelling Win32 completes from the cwd: rooted but without a
+  // drive (`\dir`, the cwd's drive). The async recursive readdir used to be the
+  // one flavor that opened its root without going through the same path
+  // translation as the others.
+  it.concurrent("recursive readdir accepts a rooted path without a drive in every flavor", async () => {
+    using dir = tempDir("fs-drive-relative", {
+      "dir/inner.txt": "",
+      "dir/sub/deep.txt": "",
+    });
+    expect(
+      await runFixture(
+        String(dir),
+        `
+          const rooted = path.join(cwd.slice(2), "dir");
+          const callback = await new Promise((resolve, reject) =>
+            fs.readdir(rooted, { recursive: true }, (err, names) => (err ? reject(err) : resolve(names))),
+          );
+          Object.assign(out, {
+            rootedHasNoDrive: rooted.startsWith(path.sep),
+            sync: fs.readdirSync(rooted),
+            recursiveSync: fs.readdirSync(rooted, { recursive: true }).sort(),
+            recursiveCallback: callback.sort(),
+            recursivePromise: (await fs.promises.readdir(rooted, { recursive: true })).sort(),
+            recursivePromiseDirents: (await fs.promises.readdir(rooted, { recursive: true, withFileTypes: true }))
+              .map(dirent => dirent.name)
+              .sort(),
+          });
+        `,
+      ),
+    ).toEqual({
+      rootedHasNoDrive: true,
+      sync: ["inner.txt", "sub"],
+      recursiveSync: recursiveListing,
+      recursiveCallback: recursiveListing,
+      recursivePromise: recursiveListing,
+      recursivePromiseDirents: ["deep.txt", "inner.txt", "sub"],
+    });
+  });
+
   it.concurrent("writeFile writes the file the path names", async () => {
     using dir = tempDir("fs-drive-relative", {});
     expect(
@@ -5450,18 +5489,27 @@ describe.if(isWindows)("windows drive-relative paths", () => {
           fs.writeFileSync(drive[0], "unrelated");
           fs.writeFileSync(rel("sync"), "sync contents");
           await fs.promises.writeFile(rel("promise"), "promise contents");
+          // The name itself is taken literally, as it is for the absolute
+          // spelling: Win32's own rules would drop the trailing dot and send
+          // nul.txt to the NUL device.
+          fs.writeFileSync(rel("dot."), "dot contents");
+          fs.writeFileSync(rel("nul.txt"), "nul contents");
           Object.assign(out, {
             listing: fs.readdirSync(".").filter(name => name !== drive[0]).sort(),
             sync: fs.readFileSync("sync", "utf8"),
             promise: fs.readFileSync("promise", "utf8"),
+            dot: fs.readFileSync(rel("dot."), "utf8"),
+            nul: fs.readFileSync(rel("nul.txt"), "utf8"),
             letterFile: fs.readFileSync(drive[0], "utf8"),
           });
         `,
       ),
     ).toEqual({
-      listing: ["promise", "sync"],
+      listing: ["dot.", "nul.txt", "promise", "sync"],
       sync: "sync contents",
       promise: "promise contents",
+      dot: "dot contents",
+      nul: "nul contents",
       letterFile: "unrelated",
     });
   });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5477,20 +5477,14 @@ describe.if(isWindows)("windows drive-relative paths", () => {
       await runFixture(
         String(dir),
         `
-          let missingError;
-          try {
-            fs.rmSync(rel("missing"), { recursive: true });
-          } catch (e) {
-            missingError = e;
-          }
-          await fs.promises.rm(rel("promise-tree"), { recursive: true });
+          // force: true used to turn the misread path into a silent no-op.
+          await fs.promises.rm(rel("promise-tree"), { recursive: true, force: true });
           const created = fs.mkdirSync(rel(path.join("created", "nested")), { recursive: true });
           Object.assign(out, {
             tree: code(() => fs.rmSync(rel("tree"), { recursive: true })),
             file: code(() => fs.rmSync(rel("file.txt"), { recursive: true })),
+            missing: code(() => fs.rmSync(rel("missing"), { recursive: true })),
             missingForced: code(() => fs.rmSync(rel("missing"), { recursive: true, force: true })),
-            missing: missingError.code,
-            missingPathAsGiven: missingError.path === rel("missing"),
             existing: fs.mkdirSync(rel("existing"), { recursive: true }) ?? null,
             created,
             // Node returns the first directory it created as the namespaced
@@ -5505,9 +5499,8 @@ describe.if(isWindows)("windows drive-relative paths", () => {
     ).toEqual({
       tree: "ok",
       file: "ok",
-      missingForced: "ok",
       missing: "ENOENT",
-      missingPathAsGiven: true,
+      missingForced: "ok",
       existing: null,
       created: expect.any(String),
       createdIsNamespacedCwdPath: true,


### PR DESCRIPTION
### Problem

On Windows, a drive-relative path (`C:dir`: drive letter and colon with no separator after them) works for most `node:fs` operations but not for the ones that open through bun's own NT code. With the cwd on `C:` and `dir` inside it (bun 1.4.0 canary, node v26 as the reference):

- `fs.readdirSync("C:dir")`: `ENOENT: no such file or directory, scandir 'C:dir'`. Same for `fs.promises.readdir`, the callback form, `{ recursive: true }` in every flavor, and `opendirSync`. Node lists the directory.
- `fs.writeFileSync("C:name", data)`: creates a file named `C` in the cwd and writes the data into an alternate data stream `name` on it. Node creates `name`. (A name containing a dot happened to work, see below.)
- `fs.rmSync("C:dir", { recursive: true })`: `ENOENT`; with `force: true` it silently leaves the tree in place.
- `fs.mkdirSync("C:dir", { recursive: true })` on an existing directory: `EEXIST`; node returns without error.
- With a separator in the name the drive letter was ignored instead: with no `Z:` drive, `fs.writeFileSync("Z:dir\\new.txt", "")` created `dir\new.txt` in the cwd on `C:` and `fs.readdirSync("Z:dir\\sub")` listed the cwd's `dir\sub`.

Cause:

- These operations take the argument through `PathLike::slice_z` (`src/runtime/node/types.rs`), which rewrites absolute and rooted-but-driveless arguments but copies everything else through as is, and then open it relative to the cwd handle with `NtCreateFile` (`sys::open_dir_at_windows_a`, `sys::openat` / `unlinkat` via `zig_delete_tree`, `sys::openat` in `write_file`; for recursive mkdir the `CreateDirectoryW` call itself works but the `EEXIST` probe `directory_exists_at_os_path` is NT-relative too). An NT name relative to a directory has no notion of drives: `C:dir` there is the stream `dir` of a file named `C`, so lookups fail and `writeFile` creates exactly that.
- `normalize_path_windows` (`src/sys/lib.rs`) strips a leading drive letter only on its multi-component branch, and then resolves against the cwd handle whatever the letter was. That is why `C:dir\sub` and `C:wf.txt` (the `.` routes to that branch) appeared to work, and why `Z:dir\sub` acted on `C:`.
- The async recursive readdir (`AsyncReaddirRecursiveTask::create`) did not go through `slice_z` at all, so it also failed for rooted-but-driveless arguments (`/Users/.../dir`: `EINVAL`) that the other readdir flavors accept.
- The libuv-backed operations (`readFileSync`, `statSync`, `existsSync`, `unlinkSync`, `renameSync`, ...) were unaffected because they hand the string to Win32, which resolves drive-relative paths itself.

### Fix

- `src/runtime/node/types.rs`: `slice_z_with_force_copy` and `os_path_kernel32` resolve a drive-relative argument with `GetFullPathNameW` (`resolve_drive_relative_windows`) and then take their existing drive-absolute branches, so the NT-level operations receive the same `\\?\C:\...` object name an absolute argument would produce. `is_drive_relative_windows` only matches a single letter followed by `:` with no separator after it; `file.txt:stream` and plain relative names are untouched. If Win32 cannot resolve the path, the argument is passed through as before.
- `src/sys/windows/mod.rs`, `src/windows_sys/externs.rs`: `get_full_path_name_w`, a wrapper over the new `GetFullPathNameW` extern, next to the other kernel32 path wrappers.
- `src/runtime/node/node_fs.rs`: the async recursive readdir opens its root through `slice_z` (`root_open_path`), like `readdir_inner` does for the other flavors. `root_path` stays as given because `Dirent.parentPath` and error paths are built from it, so nothing else about its output changes.
- Why this is right: a drive-relative path is a Win32 spelling, and `GetFullPathNameW` is the resolution `CreateFileW` applies to it, so after this change one spelling names one file across all of `node:fs` (the libuv-backed operations already resolved it this way), and the result is what node produces (node's fs also reaches Win32 with the path; see Background for the one case where node's own pre-resolution differs). Fixing it in the slicer rather than in `normalize_path_windows` is deliberate: the NT layer cannot know which drive a directory handle is on without the mount-manager query that #33874 removed, and stripping the letter regardless is the wrong-drive behavior described above. Resolving before the path reaches it is correct for every drive and also fixes the multi-component case.
- Side effect: `mkdirSync("C:new\\sub", { recursive: true })` now returns `\\?\C:\<cwd>\new` instead of `C:new`, which is what node returns. `Dirent.parentPath` for a drive-relative argument to a non-recursive or sync-recursive readdir is the resolved path, following what bun already does for rooted-but-driveless arguments (#33034 changes that convention separately); the async recursive flavor reports it as given, like node.
- Related open PRs, not duplicates: #33034 (cwd join for plain relative names, explicitly leaves `C:foo` alone) and #38053 (trailing separators; its drive-relative form skips the directory operations because of this bug). Both compose with this change.
- Tests: `test/js/node/fs/fs.test.ts`, `describe("windows drive-relative paths")`, five fixtures run in a child whose cwd is a temp dir: readdir in every flavor plus `opendir`, a lowercase drive letter, bare `C:`, `writeFile` next to a file named after the drive letter, recursive `rm` of a tree and of a file, `force: true`, recursive mkdir on an existing directory and its return value, paths on a drive letter that does not exist (they must fail, not touch the cwd), and an alternate data stream name. On Windows x64, 4 of the 5 fail on the unfixed canary at the base commit and all 5 pass with this branch; the ADS one is a guard and passes both ways. The describe is skipped on other platforms, where the behavior does not exist.
- Also run on Windows x64 with the debug build: `fs.test.ts` (505 pass; the one failure, `readSync > works on large files`, is a 4.9 GB sparse write that times out on the debug build and does not involve paths), `cp`, `dir`, `fs-mkdir`, `fs-path-length`, `promises`, `readdir-windows-ntstatus`, `readdirSync-recursive-error-leak`, `rm-windows-ntstatus`, `translate-uv-error-windows`, `fs-writeSync-stdio-windows`, `glob` (181 pass, 0 fail); a 40-operation drive-relative matrix over the libuv-backed operations is byte-identical before and after apart from `cpSync` of a directory, which now works. On Linux: `fs.test.ts`, `promises.test.js`, `readdirSync-recursive-error-leak` with `bun bd` (the only failure is the `readdirSync recursive x 100` debug-build timeout; the sync path is untouched here). `cargo clippy -p bun_runtime` on Linux is clean; the two `bun_sys` unit tests compile for the Windows target (`cargo check --tests`) and their assertions were confirmed against the API on the Windows box, since `cargo test` for these crates does not link without bun's native deps.

### Background

- Drive-relative path: Win32 keeps a current directory per drive. `C:dir` means `dir` inside the current directory of drive `C`; for the drive the process cwd is on, that is the process cwd. For other drives Win32 reads the hidden `=X:` environment variable that shells maintain, and falls back to the drive root. `GetFullPathNameW` performs exactly this resolution (plus `.`/`..` collapsing) as pure string processing; it is what `CreateFileW` does internally before opening. Node's fs pre-resolves arguments in JS with `path.resolve`, which consults `=C:` even for the cwd's drive, so node differs from Win32 (and from this change) only when a parent started the process with a cwd that disagrees with an inherited `=C:`; bun's libuv-backed operations have always used the Win32 answer, and this change makes the rest of `node:fs` agree with them.
- Alternate data stream (ADS): NTFS files can carry named streams addressed as `name:stream`. This is why `:` is legal inside a relative NT name and why the unfixed code ended up creating a stream; it is also why the new check requires exactly one character before the colon.
- NT object names: bun's own file operations on Windows call `NtCreateFile` with either a full object name (`\??\C:\...`) or a name relative to a directory handle (`RootDirectory`). The relative form is resolved purely inside the filesystem, so none of Win32's path conventions (drive-relative paths, per-drive directories, `..`) apply to it. `PathLike::slice_z` is where `node:fs` translates the Win32 conventions it accepts into something these calls understand; rooted-but-driveless paths (`\dir`) were already handled there.
- The `\\?\` prefix: the Win32 form of an absolute path that skips Win32 normalization and the `MAX_PATH` limit. `slice_z` already produces it for every absolute argument; `to_nt_path` turns it into `\??\` for `NtCreateFile`, and libuv passes it to Win32 unchanged.

<details>
<summary>node vs bun before/after, cwd on C: (Windows Server, node v26.3.0, bun 1.4.0 canary at the base commit, then this branch)</summary>

```
                                          node                 bun before                          bun after
readdirSync("C:dir")                      [inner.txt, sub]     ENOENT                              [inner.txt, sub]
readdirSync("c:dir")                      [inner.txt, sub]     ENOENT                              [inner.txt, sub]
readdirSync("C:dir", {recursive})         3 entries            ENOENT                              3 entries
promises.readdir("C:dir", {recursive})    3 entries            ENOTDIR/ENOENT                      3 entries
opendirSync("C:dir").readSync()           inner.txt            ENOENT                              inner.txt
writeFileSync("C:wf2")                    creates wf2          creates file "C" (stream wf2)       creates wf2
writeFileSync("C:wf.txt")                 creates wf.txt       creates wf.txt                      creates wf.txt
mkdirSync("C:dir", {recursive}) existing  ok                   EEXIST                              ok
mkdirSync("C:m\\sub", {recursive})        \\?\C:\<cwd>\m       "C:m"                               \\?\C:\<cwd>\m
rmSync("C:m", {recursive})                removed              ENOENT                              removed
rmSync("C:m2", {recursive, force})        removed              nothing removed, no error           removed
rmSync("C:f2", {recursive}) (file)        removed              ENOENT                              removed
cpSync("C:dir", "C:copy", {recursive})    copied               ENOTDIR/ENOENT                      copied
readdirSync("Z:dir\\sub"), no Z: drive    ENOENT               lists cwd\dir\sub                   ENOENT
writeFileSync("Z:dir\\new.txt"), no Z:    ENOENT               creates cwd\dir\new.txt             ENOENT
writeFileSync("ads.txt:stream")           writes the stream    writes the stream                   writes the stream
```

Unchanged and identical before/after (drive-relative spelling): readFileSync, openSync, accessSync, existsSync, statSync, lstatSync, realpathSync.native, appendFileSync, truncateSync, utimesSync, chmodSync, copyFileSync, linkSync, symlinkSync (target stored as given), readlinkSync, renameSync, unlinkSync, non-recursive rmSync, non-recursive mkdirSync, rmdirSync, mkdtempSync, statfsSync, Bun.file, Bun.write, promises.readFile/stat/access, cpSync of a file, and error `.path` values (reported as given, as for every other bun fs error).
</details>
