### PR TITLE
node:module: check for an exception after wrapping a runMain override's return value

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2316,10 +2316,6 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         argv1: JSValue,
     ) -> JSValue;
-    safe fn JSC__JSInternalPromise__resolvedPromise(
-        global: &JSGlobalObject,
-        value: JSValue,
-    ) -> *mut JSInternalPromise;
 }
 
 fn get_origin_timestamp() -> u64 {
@@ -2711,7 +2707,9 @@ impl VirtualMachine {
                     if let Some(stored) = self.pending_internal_promise {
                         return Ok(stored);
                     }
-                    let resolved = JSC__JSInternalPromise__resolvedPromise(global_ref, ret);
+                    let resolved =
+                        crate::cpp::JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
+                            .map_err(|_| crate::CrateError::JSError)?;
                     self.pending_internal_promise = Some(resolved);
                     self.pending_internal_promise_is_protected = false;
                     return Ok(resolved);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4069,6 +4069,9 @@ void JSC__JSInternalPromise__resolve(JSC::JSPromise* arg0, JSC::JSGlobalObject* 
     arg0->resolve(arg1, arg1->vm(), JSC::JSValue::decode(JSValue2));
 }
 
+// `JSPromise::resolvedPromise` runs `promiseResolve`, which reads `.constructor`
+// off a promise argument and returns null when that getter throws.
+[[ZIG_EXPORT(check_slow)]]
 JSC::JSPromise* JSC__JSInternalPromise__resolvedPromise(JSC::JSGlobalObject* arg0,
     JSC::EncodedJSValue JSValue1)
 {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -568,6 +568,12 @@ console.log("survived", require("./late.js"));`,
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });
 
+  // BUN_JSC_validateExceptionChecks=1 makes a debug build abort on the first
+  // JSC call whose exception state is never checked; it is a no-op in release
+  // builds. The runMain override path wraps the override's return value in a
+  // promise natively, so these run under it.
+  const validateExceptions = { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" };
+
   test("Module.runMain", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -576,14 +582,13 @@ console.log("survived", require("./late.js"));`,
         path.join(import.meta.dir, "overwrite-module-run-main-1.cjs"),
         path.join(import.meta.dir, "overwrite-module-run-main-2.cjs"),
       ],
-      env: bunEnv,
-      stderr: "inherit",
+      env: validateExceptions,
+      stderr: "pipe",
       stdout: "pipe",
     });
 
-    const stdout = await proc.stdout.text();
-    expect(stdout.trim()).toBe("pass");
-    expect(await proc.exited).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "pass", stderr: "", exitCode: 0 });
   });
   test("Module.runMain 2", async () => {
     await using proc = Bun.spawn({
@@ -593,14 +598,64 @@ console.log("survived", require("./late.js"));`,
         path.join(import.meta.dir, "overwrite-module-run-main-3.cjs"),
         path.join(import.meta.dir, "overwrite-module-run-main-2.cjs"),
       ],
-      env: bunEnv,
-      stderr: "inherit",
+      env: validateExceptions,
+      stderr: "pipe",
       stdout: "pipe",
     });
 
-    const stdout = await proc.stdout.text();
-    expect(stdout.trim()).toBe("pass");
-    expect(await proc.exited).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "pass", stderr: "", exitCode: 0 });
+  });
+
+  // When an override does not call the original runMain, bun adopts whatever
+  // it returned (Promise.resolve semantics) as the entry point promise.
+  test.each([
+    {
+      name: "a plain value",
+      runMain: `() => { console.log("override ran"); return 42; }`,
+      expected: { stdout: "override ran\n", stderr: "", exitCode: 0 },
+    },
+    {
+      name: "a pending promise that fulfills",
+      runMain: `async () => { await 0; console.log("override resolved"); }`,
+      expected: { stdout: "override resolved\n", stderr: "", exitCode: 0 },
+    },
+    {
+      name: "a thenable that fulfills",
+      runMain: `() => ({ then(resolve) { console.log("thenable adopted"); resolve(); } })`,
+      expected: { stdout: "thenable adopted\n", stderr: "", exitCode: 0 },
+    },
+    {
+      name: "a thenable that rejects",
+      runMain: `() => ({ then(_, reject) { reject(new Error("thenable rejected")); } })`,
+      expected: { stdout: "", stderr: expect.stringContaining("thenable rejected"), exitCode: 1 },
+    },
+    {
+      // Promise.resolve(p) reads p.constructor; the getter throwing is the one
+      // way adopting the return value itself throws.
+      name: "a promise whose constructor getter throws",
+      runMain: `() => {
+        const p = Promise.resolve();
+        Object.defineProperty(p, "constructor", { get() { throw new Error("constructor getter threw"); } });
+        return p;
+      }`,
+      expected: { stdout: "", stderr: expect.stringContaining("Error occurred loading entry point"), exitCode: 1 },
+    },
+  ])("Module.runMain override returning $name", async ({ runMain, expected }) => {
+    using dir = tempDir("run-main-override", {
+      "preload.cjs": `require("module").runMain = ${runMain};`,
+      "main.cjs": `console.log("main ran");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--require", "./preload.cjs", "./main.cjs"],
+      env: validateExceptions,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual(expected);
   });
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- A `--require` preload that replaces `Module.runMain` with a function that does not call the original makes bun wrap the override's return value in a promise. That wrap is never checked for an exception. On a debug build this aborts under JSC's exception-check validator with the existing test fixtures as-is:
  ```
  cd test/js/node/module
  BUN_JSC_validateExceptionChecks=1 bun-debug --require ./overwrite-module-run-main-3.cjs ./overwrite-module-run-main-2.cjs
  ERROR: Unchecked JS exception:
      This scope can throw a JS exception: promiseResolve @ vendor/WebKit/Source/JavaScriptCore/runtime/JSPromise.cpp:1154
      But the exception was unchecked as of this scope: <rust> @ src/jsc/VirtualMachine.rs:607
  ASSERTION FAILED: exception check validation failed
  ```
- When the wrap really does throw, release builds crash instead. An override returning a promise whose `constructor` getter throws gives `panic: opaque_deref: null FFI handle` (bun 1.4.0 canary, linux x64), because the null result is stored as the entry point promise and then dereferenced in `load_entry_point` / `Run::start`.
- Cause: `JSC__JSInternalPromise__resolvedPromise` (src/jsc/bindings/bindings.cpp:4072) is a bare wrapper over `JSC::JSPromise::resolvedPromise`, which runs `promiseResolve` and returns null if it throws. Its only caller, the `has_patched_run_main` branch of `reload_entry_point` (src/jsc/VirtualMachine.rs:2714), used the result directly. The override call two lines above it is wrapped in `from_js_host_call_generic`; this call was not.
- CI does not see it: the ASAN lanes skip the validator for `test/js/node/module/node-module-module.test.js` (`test/no-validate-exceptions.txt`), and the Node fixture `monkey-patch-run-main.js` calls through to the original `runMain`, which takes the other branch.

### Fix
- Mark `JSC__JSInternalPromise__resolvedPromise` `[[ZIG_EXPORT(check_slow)]]`, matching the `JSC__JSInternalPromise__resolve` / `__reject` bindings next to it, and have `reload_entry_point` call the generated `crate::cpp::` wrapper, which opens a scope around the call and returns `Err` when an exception is pending. The hand-written `extern "C"` declaration goes away (`src/jsc/cpp.rs` asks new code to use the generated wrappers instead of redeclaring).
- The error is mapped to `CrateError::JSError`, exactly like the override call on the line above, so a throw while adopting the return value is reported the same way as a throw inside the override (`Error occurred loading entry point`, exit 1) instead of a crash. Making that report print the underlying error, and a non-callable `runMain` override crashing, are separate defects being handled separately; both sites will pick up whatever that change does.
- Why `check_slow` rather than `null_is_throw`: JSC's own callers of `JSPromise::resolvedPromise` do `RETURN_IF_EXCEPTION` and then trust the pointer (JSPromiseConstructor.cpp, JSWebAssembly.cpp). `check_slow` is that exact shape, and it also covers the case where `promiseResolve` returns a promise but leaves a termination exception pending. Once the wrapper returns `Ok`, the pointer is non-null by the same contract JSC relies on.
- Non-throwing behaviour is unchanged: the same promise is created and stored; the only addition is the exception check.
- Verified with `test/js/node/module/node-module-module.test.js`:
  - `Module.runMain` / `Module.runMain 2` now run their fixtures under `BUN_JSC_validateExceptionChecks=1` and assert empty stderr.
  - New `Module.runMain override returning ...` table covers each way `promiseResolve` can go: a plain value, a pending native promise, a fulfilling thenable, a rejecting thenable (error reported, exit 1), and a promise whose `constructor` getter throws (exit 1, no crash).
  - Unfixed debug build: 6 of the 7 fail (validator abort with the report above; the `constructor` getter case crashes). Fixed debug build: all 7 pass, whole file 44 pass.
  - `test/js/node/test/parallel/test-module-run-main-monkey-patch.js` passes on the fixed build, with and without the validator.
  - The file stays in `test/no-validate-exceptions.txt`: running it under the validator still trips the `Module.wrap` site owned by #34745 (and #38099 covers the `_resolveFilename` path). Once those land the entry can be dropped.
  - `BUN_JSC_validateExceptionChecks` is a no-op on release builds, so there the new table only adds the `constructor` getter case as a before/after difference.

### Background
- **runMain override path**: during preloads, assigning `Module.runMain` sets `vm.has_patched_run_main`. `reload_entry_point` then calls the override instead of loading the entry itself. If the override called the original `runMain`, that stored the module promise as `pending_internal_promise`; otherwise bun adopts the override's return value with Promise.resolve semantics and stores that, so an async override's rejection is reported as the entry point failing.
- **`promiseResolve`**: the spec's PromiseResolve. For a promise argument it reads `.constructor` (observable user code, can throw) to decide whether to return the promise as-is; a thenable is adopted via a microtask; anything else becomes a fulfilled promise. A throwing `then` getter does not throw here (it rejects the new promise); the `constructor` getter is the throwing case.
- **Exception-check validator** (`BUN_JSC_validateExceptionChecks=1`, debug builds only): every JSC throw scope records on destruction that its caller owes an exception check; creating the next scope before that check happens aborts and prints both locations. That is why even the non-throwing plain-value fixture aborts: nothing between the wrap and the next scope ever looked at the exception state.
- **`[[ZIG_EXPORT(mode)]]`**: attribute read by `src/codegen/cppbind.ts`, which generates a Rust wrapper in `bun_jsc::cpp` for each annotated C++ function. `check_slow` means the return value says nothing about whether the call threw, so the wrapper opens a `TopExceptionScope`, makes the call, and converts a pending exception into `Err(JsError::Thrown)`; `null_is_throw` instead asserts that a null return and a pending exception always coincide.

<details>
<summary>Behaviour of each return shape on the unfixed build (debug + validator unless noted)</summary>

| override returns | unfixed | fixed |
| --- | --- | --- |
| plain value (`overwrite-module-run-main-3.cjs`) | validator abort at `promiseResolve` | exit 0 |
| `async () => { await 0; ... }` (pending native promise) | validator abort | exit 0 |
| fulfilling thenable | validator abort | `then` runs, exit 0 |
| rejecting thenable | validator abort | error printed, exit 1 |
| promise with throwing `constructor` getter | `panic: opaque_deref: null FFI handle` (release too) | `Error occurred loading entry point`, exit 1 |
| already-rejected promise, or thenable whose `then` getter throws | error printed, exit 1 (passes by accident: `load_entry_point` returns early on an already-rejected promise and the reporting path checks the exception state) | unchanged |
| override calls the original `runMain` (`overwrite-module-run-main-1.cjs`, Node's `monkey-patch-run-main.js`) | clean, other branch | unchanged |

</details>
