### PR TITLE
test(bun-types): assert the checkout is untouched from afterAll so it also runs when setup fails

### DIFF
--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -33,9 +33,7 @@ const DEFAULT_COMPILER_OPTIONS = ts.parseJsonConfigFileContent(
 const $ = Shell.cwd(BUN_REPO_ROOT);
 
 // What `bun run build` generates. beforeAll builds into a copy of the package under
-// TEMP_DIR, so none of this may change in the checkout (it used to be built in place,
-// with package.json restored afterwards, which left the tree dirty whenever beforeAll
-// was interrupted).
+// TEMP_DIR, so none of this may change in the checkout; the afterAll below checks that.
 function snapshotBunTypesCheckout() {
   return {
     "package.json": readFileSync(join(BUN_TYPES_PACKAGE_ROOT, "package.json"), "utf8"),
@@ -313,13 +311,14 @@ afterAll(async () => {
       await rm(TEMP_DIR, { recursive: true, force: true });
     }
   }
+
+  // Checked here rather than in a test: when beforeAll throws or times out the tests are
+  // skipped but afterAll still runs, and an interrupted beforeAll is exactly when building
+  // in place used to leave its residue behind.
+  expect(snapshotBunTypesCheckout()).toEqual(bunTypesCheckoutBeforeSetup);
 });
 
 describe("@types/bun integration test", () => {
-  test("building and packing bun-types leaves packages/bun-types untouched", () => {
-    expect(snapshotBunTypesCheckout()).toEqual(bunTypesCheckoutBeforeSetup);
-  });
-
   test("packed bun-types includes CLAUDE.md", async () => {
     const claude = Bun.file(join(BASE_FIXTURE_DIR, "node_modules", "bun-types", "CLAUDE.md"));
     expect(await claude.exists()).toBe(true);


### PR DESCRIPTION
Follow-up to #37990.

### Problem
- #37990 added `building and packing bun-types leaves packages/bun-types untouched` as an ordinary test inside the file's `describe`. When the top-level `beforeAll` throws or times out, `bun:test` skips every test in the file and only runs `afterAll`, so that assertion never ran on the interrupted-setup path, which is the path on which the old in-place build left `package.json`, `CLAUDE.md` and `docs/` behind. On that path the run only reported the hook failure.

### Fix
- The comparison of `snapshotBunTypesCheckout()` against the module-load snapshot moves into the existing top-level `afterAll`, after the temp dir cleanup, and the describe-scoped test is removed. `afterAll` runs whether `beforeAll` completed, threw or timed out, and a failing `expect()` there is reported as a failure (with the `toEqual` diff naming the leftover files) and fails the run. Placing it after the cleanup keeps a residue failure from skipping the `rm` of the temp dir.
- Verified with `bun test test/integration/bun-types/bun-types.test.ts`: 14 pass, tree clean. With the pre-#37990 `build.ts` swapped in, the run now reports the `bun pm pack` failure in `beforeAll` and a second failure from `afterAll` whose diff shows `CLAUDE.md`/`docs` appearing and `"version"` added to `package.json`; on main only the hook failure is reported. With the registry unreachable (`beforeAll` fails without touching the checkout) the run reports exactly the hook failure, so the check does not misfire when setup fails for unrelated reasons. `bun bd test` on the file: 2 pass, 12 skipped on debug as before.

### Background
- In `bun:test`, a failing or timed out `beforeAll` skips the tests in its scope and jumps to that scope's `afterAll` hooks; assertions inside hooks are reported as `(unnamed)` failures and set a non-zero exit code. Hooks declared in the same scope run in declaration order, and a failing hook stops the ones after it, which is why the assertion sits at the end of the cleanup hook rather than in front of it.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/integration/bun-types/bun-types.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (7f9a1ecbe)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [11.85ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [2110.92ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation produces type errors for invalid flags
(skip) @types/bun integration test > bun:bundle feature() > without Registry augmentation, feature() accepts any string
(skip) @types/bun integration test > Bunland reaching for JSX > Bun.markdown.react() returns type compatible with React.ReactElement
(skip) @types/bun integration test > Bunland reaching for JSX > Bun.markdown.react() returns unknown if React is not installed
(skip) @types/bun integration test > lib configuration > checks with no lib at all
(skip) @types/bun integration test > lib configuration > fails with types: [] and no jsx
(skip) @types/bun integration test > lib configuration > checks with lib.dom.d.ts

 2 pass
 12 skip
 0 fail
 5 expect() calls
Ran 14 tests across 1 file. [39.91s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/integration/bun-types/bun-types.test.ts | 13 ++++++-------
 1 file changed, 6 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/integration/bun-types/bun-types.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->