### PR TITLE
process: report exit code 1 to 'exit' listeners on an unhandled rejection

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1235,9 +1235,12 @@ pub struct Run<'a> {
 static ANY_UNHANDLED: AtomicBool = AtomicBool::new(false);
 
 impl Run<'_> {
-    /// `onUnhandledRejectionBeforeClose` — record that *something* rejected so
-    /// `start()` sets a non-zero exit code, then route through the VM's
-    /// default error printer.
+    /// `onUnhandledRejectionBeforeClose` — print the error through the VM's
+    /// default error printer and fail the run. The exit code is set here, at
+    /// report time, so the `exit` event emitted later by `on_exit()` carries 1
+    /// (`process.exitCode` reads 1 inside the listeners) exactly as it does
+    /// after an uncaught exception, which `VirtualMachine::uncaught_exception`
+    /// records the same way. `ANY_UNHANDLED` only selects the version note.
     fn on_unhandled_rejection_before_close(
         this: &mut VirtualMachine,
         _global: &JSGlobalObject,
@@ -1248,6 +1251,7 @@ impl Run<'_> {
             .on_unhandled_rejection_exception_list
             .map(|p| unsafe { &mut *p.as_ptr() });
         this.run_error_handler(value, list);
+        this.exit_handler.exit_code = 1;
         ANY_UNHANDLED.store(true, Ordering::Relaxed);
     }
 
@@ -1569,7 +1573,7 @@ impl Run<'_> {
         vm.on_exit();
 
         if ANY_UNHANDLED.load(Ordering::Relaxed) {
-            print_unhandled_version_note(vm);
+            print_unhandled_version_note();
         }
 
         // These create undefined references to externally-defined C symbols
@@ -1637,8 +1641,7 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
     if ANY_UNHANDLED.load(Ordering::Relaxed) {
-        bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
-        pretty_errorln!("<r>\n<d>{}<r>", Global::unhandled_error_bun_version_string,);
+        print_unhandled_version_note();
     }
     vm.global_exit();
 }
@@ -1664,16 +1667,18 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &crate::Error) -> ! {
     exit_with_unhandled_note(vm);
 }
 
-/// Cold tail of `Run::start` when `ANY_UNHANDLED` tripped on an otherwise-clean
-/// exit: bump the exit code and print the sourcemap note + version string.
+/// Sourcemap note + version string, printed after `on_exit()` when
+/// `ANY_UNHANDLED` tripped. Deliberately does not touch the exit code: it was
+/// set to 1 when the error was reported (`on_unhandled_rejection_before_close`),
+/// and a `process.exitCode` assignment made by an `exit` listener since then
+/// stands, as in Node.
 #[cold]
 #[inline(never)]
 #[cfg_attr(
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn print_unhandled_version_note(vm: &mut VirtualMachine) {
-    vm.exit_handler.exit_code = 1;
+fn print_unhandled_version_note() {
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
     pretty_errorln!("<r>\n<d>{}<r>", Global::unhandled_error_bun_version_string,);
 }

--- a/test/js/bun/http/bun-serve-propagate-errors.test.ts
+++ b/test/js/bun/http/bun-serve-propagate-errors.test.ts
@@ -38,3 +38,33 @@ test("Bun.serve() propagates errors to the parent", async () => {
   expect(exitCode).toBe(1);
   expect(stderr.toString()).toContain("error: Test failed successfully");
 });
+
+test("under bun run, a fetch handler error with no error() handler fails the process and its exit listeners see it", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.on("exit", code => console.log("exit", code, process.exitCode));
+      const server = Bun.serve({
+        development: false,
+        port: 0,
+        fetch() {
+          throw new Error("Test failed successfully");
+        },
+      });
+      const res = await fetch(server.url);
+      console.log(res.status);
+      server.stop(true);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("error: Test failed successfully");
+  // The served 500 is reported like any other unhandled error, so the exit
+  // code is 1 by the time 'exit' is emitted, not only once the process exits.
+  expect(stdout).toBe("500\nexit 1 1\n");
+  expect(exitCode).toBe(1);
+});

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1659,6 +1659,97 @@ describe("process.exitCode", () => {
     );
   });
 
+  // The entry module above rejects the entry promise itself. The cases below
+  // are rejections the event loop reports later (no listener, default
+  // --unhandled-rejections mode). Node raises those as uncaught exceptions,
+  // which set process.exitCode = 1 before 'exit' is emitted and skip
+  // 'beforeExit'. Expected values were taken from node v26.
+  it("unhandled rejection reported by the event loop", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+      process.on("beforeExit", (code) => console.log("beforeExit", code, process.exitCode));
+
+      Promise.reject(new Error("oops"));
+    `,
+      "exit 1 1\n",
+      1,
+    );
+  });
+
+  it("unhandled rejection from a later event loop turn", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      setImmediate(() => {
+        Promise.reject(new Error("oops"));
+      });
+    `,
+      "exit 1 1\n",
+      1,
+    );
+  });
+
+  it("unhandled rejection replaces a process.exitCode set earlier", async () => {
+    await runInlineFixture(
+      `
+      process.exitCode = 5;
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+
+      Promise.reject(new Error("oops"));
+    `,
+      "exit 1 1\n",
+      1,
+    );
+  });
+
+  it("an exit listener can change the code set by an unhandled rejection", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => {
+        console.log("exit", code, process.exitCode);
+        process.exitCode = 98;
+      });
+
+      Promise.reject(new Error("oops"));
+    `,
+      "exit 1 1\n",
+      98,
+    );
+  });
+
+  it("an exit listener can change the code set by an uncaught exception from the event loop", async () => {
+    await runInlineFixture(
+      `
+      process.on("exit", (code) => {
+        console.log("exit", code, process.exitCode);
+        process.exitCode = 98;
+      });
+
+      setImmediate(() => {
+        throw new Error("oops");
+      });
+    `,
+      "exit 1 1\n",
+      98,
+    );
+  });
+
+  it("a rejection consumed by an unhandledRejection listener leaves the exit code alone", async () => {
+    await runInlineFixture(
+      `
+      process.on("unhandledRejection", (err) => console.log("unhandledRejection", err.message));
+      process.on("exit", (code) => console.log("exit", code, process.exitCode));
+      process.on("beforeExit", (code) => console.log("beforeExit", code, process.exitCode));
+
+      Promise.reject(new Error("oops"));
+    `,
+      "unhandledRejection oops\nbeforeExit 0 undefined\nexit 0 undefined\n",
+      0,
+    );
+  });
+
   it("exitsOnExitCodeSet", async () => {
     await runInlineFixture(
       `


### PR DESCRIPTION
### Problem

- In the default `--unhandled-rejections` mode (no flag, no `unhandledRejection` listener) an unhandled rejection reported by the event loop makes bun exit 1, but `process.on("exit", code => ...)` receives `0` and `process.exitCode` reads `undefined` inside the listener. Node passes `1` and reads `1`. Exit-time loggers, reporters and cleanup code that branch on the code see a clean exit from a process that is about to fail.
  ```
  bun  -e "process.on('exit', c => console.log(c, process.exitCode)); Promise.reject(new Error('x'))"   # 0 undefined, status 1
  node -e "process.on('exit', c => console.log(c, process.exitCode)); Promise.reject(new Error('x'))"   # 1 1, status 1
  ```
- Cause: the exit code for this path was written in the tail of `Run::start` (`print_unhandled_version_note`, `src/runtime/cli/run_command.rs`), which runs after `vm.on_exit()` has already emitted `exit`. The rejection itself only set the `ANY_UNHANDLED` flag in `on_unhandled_rejection_before_close`. The uncaught-exception path does not have the problem because `VirtualMachine::uncaught_exception` (`src/jsc/VirtualMachine.rs`) sets `exit_handler.exit_code = 1` before it invokes the same handler.
- Second effect of the same late write: it overwrote whatever an `exit` listener assigned to `process.exitCode`, both after a rejection and after an uncaught exception raised from a timer or immediate (`process.on("exit", () => { process.exitCode = 98 }); setImmediate(() => { throw ... })` exits 1 in bun, 98 in Node). The entry-point throw path already honored the listener (`exit_with_unhandled_note` sets the code before `on_exit()`), so bun disagreed with itself depending on when the error happened.

### Fix

- `on_unhandled_rejection_before_close` sets `exit_handler.exit_code = 1` when it reports the error, so the value is in place before `on_exit()` emits `exit`; `print_unhandled_version_note` now only prints the note and no longer touches the exit code. `exit_with_unhandled_note` is unchanged (the entry-point load-failure path has no reported error to set the code from) and now shares the printing helper.
- Why this is right: it matches Node, where the default mode raises the rejection as an uncaught exception, and that path sets `process.exitCode = 1`, emits `exit`, then exits with whatever `process.exitCode` holds. It also makes rejections take the exact route exceptions already take in bun (`uncaught_exception` sets the code, then invokes this handler). The handler is the one place that decides a `bun run` process has failed, which is why the code is set there rather than in `VirtualMachine::unhandled_rejection`: that function also feeds capture scopes (`expect(fn).toThrow()` under `bun run` swaps the handler out to consume the rejection), and those must not fail the process. This is the same shape as #34193, which does it in the worker's handler.
- Consequence to be aware of: `Bun.serve` with no `error()` handler reports a thrown fetch handler through the same handler while it keeps serving. Such a run already exited 1 on natural exit (pinned by `test/js/bun/http/serve-reused-response.test.ts`); the `exit` event argument now agrees with that status, and a bare `process.exit()` after a served error also exits 1 instead of 0. This is what Node's keep-running analogue (`--unhandled-rejections=warn-with-error-code`) does, and what bun's own `warn-with-error-code` arm already does by setting the same slot eagerly. Under `--hot` the code likewise stays set after an error was reported, as it already did for uncaught exceptions.
- Not changed: `bun test` (its own handler and exit-code logic), workers (#34193), `process.exitCode` reading `1` from ordinary code after a served error (the getter's observable flag is C++ state touched by #32814; inside `exit` listeners it reads `1` because `Process__dispatchOnExit` marks it observable for a non-zero code), and `beforeExit` still being emitted when the rejection comes from the last timer or immediate callback (#33354 moves that report earlier). #32814 lists the default-mode routing as out of scope; this PR does not route it through `uncaughtException`, it only fixes when the code is recorded, and touches nothing #32814 changes.
- Verification:
  - `test/js/node/process/process.test.js` (`process.exitCode` block): rejection reported after the entry module, rejection from a later loop turn, rejection replacing an earlier `process.exitCode = 5`, an `exit` listener overriding the code after a rejection and after an event-loop throw (5 fail on main), plus a guard that a rejection consumed by an `unhandledRejection` listener still exits 0 with `beforeExit`/`exit` seeing `0`/`undefined`. Expected values were taken from node v26.3.0.
  - `test/js/bun/http/bun-serve-propagate-errors.test.ts`: under `bun run`, a served handler error with no `error()` gives `exit 1 1` and status 1 (fails on main with `exit 0 undefined`).
  - Green on the debug build: the two files above, `serve-reused-response`, `spawn/exit-code`, `workerd/html-rewriter`, `serve-stream-body-error`, `serve-error-handler-stream`, `promise/reject-tostring`, `util/reportError`, `cron/in-process-cron`, `events/event-emitter`, `cli/hot/hot.test.ts`, `timers.promises`, `node-stream`, and node's `test-process-exit*.js`, `test-promise-unhandled-*.js`, `test-promises-*.js`, `test-worker-*process-exit*.js` (23 files). The only failures seen were pre-existing and unrelated (`process.env.USER` unset in the container; an LSan report for the `node:fs` binding that reproduces with plain `require("fs")` on main).

### Background

- `exit_handler.exit_code` is the one exit-code slot on the `VirtualMachine`. `process.exitCode = n` writes it, the `process.exitCode` getter reads it (once something non-zero or an assignment has made it observable), `on_exit()` passes it as the argument of the `exit` event, and `global_exit()` exits with whatever it holds after the listeners ran. Writing it before `on_exit()` is therefore what lets listeners both see the code and override it.
- `on_unhandled_rejection` is a function pointer on the VM. `bun run` installs `Run::on_unhandled_rejection_before_close` (prints the error and marks the run failed); `VirtualMachine::uncaught_exception` and `VirtualMachine::unhandled_rejection` call it once an error has no JS handler, and a few callers that consume rejections themselves temporarily swap in a capturing function. `Bun.serve` calls it directly for a handler error it answers with a 500.
- `ANY_UNHANDLED` is a static in `run_command.rs` set by that handler; after the fix it only decides whether the trailing "Bun vX.Y.Z" line is printed.

<details>
<summary>Probes against node v26.3.0 (all pass with this PR)</summary>

| script | bun before | bun after / node |
| --- | --- | --- |
| `Promise.reject(e)` with exit listener logging `(code, process.exitCode)` | `0 undefined`, status 1 | `1 1`, status 1 |
| same, rejection inside `setImmediate` / `setTimeout` | `0 undefined`, status 1 | `1 1`, status 1 |
| same, rejection from `fs.promises.readFile` of a missing file | `0 undefined`, status 1 | `1 1`, status 1 |
| `process.exitCode = 5` then `Promise.reject(e)` | `5 5`, status 1 | `1 1`, status 1 |
| exit listener sets `process.exitCode = 98` after `Promise.reject(e)` | status 1 | status 98 |
| exit listener sets `process.exitCode = 0` after `Promise.reject(e)` | status 1 | status 0 |
| exit listener sets `process.exitCode = 98` after `setImmediate(() => { throw e })` | status 1 | status 98 |
| exit listener sets `process.exitCode = 98` after a top-level `throw e` | status 98 | status 98 |
| `unhandledRejection` listener installed | `beforeExit 0 undefined`, `exit 0 undefined`, status 0 | unchanged |

</details>
