### PR TITLE
Bun.serve: default to production mode, require explicit development opt-in

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -200,6 +200,8 @@ Bun.serve({
 });
 ```
 
+Development mode is opt-in. Without the `development` option, `Bun.serve()` only enters development mode when `NODE_ENV=development` is set, and `NODE_ENV=production` keeps the server in production mode even if `development: true` is set (Bun prints a warning when it ignores the option). See [Development mode](/runtime/http/server#development-mode) for the full precedence.
+
 ### Development Mode Features
 
 When `development` is `true`, Bun:
@@ -270,7 +272,7 @@ serve({
 
 ### Runtime Bundling
 
-If you'd rather not add a build step, set `development: false` in `Bun.serve()`.
+If you'd rather not add a build step, run `Bun.serve()` in production mode, which is the default. Setting `development: false` makes this explicit and also wins over `NODE_ENV=development`.
 
 This:
 

--- a/docs/runtime/http/error-handling.mdx
+++ b/docs/runtime/http/error-handling.mdx
@@ -18,6 +18,8 @@ In development mode, Bun surfaces errors in-browser with a built-in error page.
 
 <Frame>![Bun's built-in 500 page](/images/exception_page.png)</Frame>
 
+Without `development: true`, the server runs in production mode (unless `NODE_ENV=development` is set) and responds to thrown errors with a generic plain-text `500` response that does not include the error. `NODE_ENV=production` forces production mode even when `development: true` is set. See [Development mode](/runtime/http/server#development-mode).
+
 ### `error` callback
 
 To handle server-side errors, implement an `error` handler. Return a `Response` to serve to the client when an error occurs. In `development` mode, this response replaces Bun's default error page.

--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -137,6 +137,27 @@ PORT=4002 bun server.ts
 NODE_PORT=4002 bun server.ts
 ```
 
+### Development mode
+
+`Bun.serve` runs in production mode unless you opt into development mode. Development mode renders an [error page](/runtime/http/error-handling) with stack traces instead of a generic 500 response, and for [HTML imports](/bundler/fullstack) it re-bundles on every request, serves sourcemaps, and enables hot module reloading. None of that should be exposed by a production server.
+
+```ts
+Bun.serve({
+  development: true, // [!code ++]
+  fetch(req) {
+    return new Response("Bun!");
+  },
+});
+```
+
+Bun decides the mode as follows:
+
+- `NODE_ENV=production` in the environment always selects production mode. If `development: true` is also set, it is ignored and Bun prints a warning.
+- Otherwise `development: true` (or a [configuration object](/bundler/fullstack#advanced-development-configuration)) selects development mode and `development: false` selects production mode.
+- When the `development` option is not set, `NODE_ENV=development` selects development mode. Any other value, including an unset `NODE_ENV`, selects production mode.
+
+`server.development` reports the mode the server ended up in.
+
 ---
 
 ## Unix domain sockets

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -539,8 +539,7 @@ declare module "bun" {
           /**
            * Enable Hot Module Replacement for routes (including React Fast Refresh, if React is in use)
            *
-           * @default true if process.env.NODE_ENV !== 'production'
-           *
+           * @default true
            */
           hmr?: boolean;
 
@@ -752,8 +751,24 @@ declare module "bun" {
       maxRequestBodySize?: number;
 
       /**
-       * Whether to render contextual errors with Bun's error page
-       * @default process.env.NODE_ENV !== 'production'
+       * Run the server in development mode.
+       *
+       * In development mode, errors thrown while handling a request are
+       * rendered as an HTML error page with stack traces instead of a generic
+       * `500` response, and HTML imports are re-bundled on every request,
+       * served with sourcemaps, and hot-reloaded. Pass an object to configure
+       * those development features.
+       *
+       * The mode is resolved as follows:
+       * - `NODE_ENV=production` always selects production mode. A
+       *   `development: true` set alongside it is ignored with a warning.
+       * - Otherwise `true` or an object selects development mode and `false`
+       *   selects production mode.
+       * - When this option is omitted, `NODE_ENV=development` selects
+       *   development mode; any other value (including an unset `NODE_ENV`)
+       *   selects production mode.
+       *
+       * @default process.env.NODE_ENV === 'development'
        */
       development?: Development;
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1,4 +1,5 @@
 use std::io::Write as _;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use bun_core::ZBox;
 
@@ -80,7 +81,7 @@ impl Default for ServerConfig {
             ssl_config: None,
             sni: None,
             max_request_body_size: 1024 * 1024 * 128,
-            development: DevelopmentOption::Development,
+            development: DevelopmentOption::Production,
             broadcast_console_log_from_browser_to_server_for_bake: false,
             enable_chrome_devtools_automatic_workspace_folders: true,
             on_error: JSValue::ZERO,
@@ -137,6 +138,19 @@ impl DevelopmentOption {
     pub(crate) fn is_development(self) -> bool {
         self == DevelopmentOption::Development || self == DevelopmentOption::DevelopmentWithoutHmr
     }
+}
+
+/// Printed at most once per process, like the idle-timeout warning in
+/// `server_body`.
+fn warn_development_ignored_in_production() {
+    static DID_WARN: AtomicBool = AtomicBool::new(false);
+    if DID_WARN.swap(true, Ordering::Relaxed) || crate::cli::Command::get().debug.silent {
+        return;
+    }
+    bun_core::pretty_errorln!(
+        "<r><yellow>[Bun.serve]<r><d>:<r> ignoring the <d><cyan>`development`<r> option because <d><cyan>NODE_ENV<r> is <d><cyan>\"production\"<r>. The server is running in production mode."
+    );
+    bun_core::Output::flush();
 }
 
 impl ServerConfig {
@@ -718,19 +732,30 @@ impl ServerConfig {
         let vm = arguments.vm;
         let env = vm.env_loader();
 
+        // Development mode is opt-in. Without a `development` option only
+        // NODE_ENV=development enables it, and NODE_ENV=production wins even
+        // over an explicit `development: true` so a flag hardcoded for local
+        // development cannot ship the error page, HMR, or sourcemaps.
+        let node_env = env.get(b"NODE_ENV").unwrap_or(b"");
+        let is_production_env = node_env == b"production" || vm.transpiler.options.production;
+        // `[serve.static] hmr = false` in bunfig.toml applies whenever the
+        // option itself does not say whether HMR is wanted.
+        let default_development =
+            if vm.transpiler.options.transform_options.serve_hmr == Some(false) {
+                DevelopmentOption::DevelopmentWithoutHmr
+            } else {
+                DevelopmentOption::Development
+            };
+
         let mut args = ServerConfig {
             address: Address::Tcp {
                 port: 3000,
                 hostname: None,
             },
-            development: if let Some(hmr) = vm.transpiler.options.transform_options.serve_hmr {
-                if !hmr {
-                    DevelopmentOption::DevelopmentWithoutHmr
-                } else {
-                    DevelopmentOption::Development
-                }
+            development: if !is_production_env && node_env == b"development" {
+                default_development
             } else {
-                DevelopmentOption::Development
+                DevelopmentOption::Production
             },
 
             // If this is a node:cluster child, let's default to SO_REUSEPORT.
@@ -739,14 +764,6 @@ impl ServerConfig {
             ..ServerConfig::default()
         };
         let mut has_hostname = false;
-
-        if env.get(b"NODE_ENV").unwrap_or(b"") == b"production" {
-            args.development = DevelopmentOption::Production;
-        }
-
-        if arguments.vm.transpiler.options.production {
-            args.development = DevelopmentOption::Production;
-        }
 
         // Set tcp port from env / options
         {
@@ -795,16 +812,12 @@ impl ServerConfig {
 
         // "development" impacts other settings like bake.
         if let Some(dev) = arg.get(global, "development")? {
-            if dev.is_object() {
-                if let Some(hmr) = dev.get_boolean_strict(global, "hmr")? {
-                    args.development = if !hmr {
-                        DevelopmentOption::DevelopmentWithoutHmr
-                    } else {
-                        DevelopmentOption::Development
-                    };
-                } else {
-                    args.development = DevelopmentOption::Development;
-                }
+            let requested = if dev.is_object() {
+                let requested = match dev.get_boolean_strict(global, "hmr")? {
+                    Some(true) => DevelopmentOption::Development,
+                    Some(false) => DevelopmentOption::DevelopmentWithoutHmr,
+                    None => default_development,
+                };
 
                 if let Some(console) = dev.get_boolean_strict(global, "console")? {
                     args.broadcast_console_log_from_browser_to_server_for_bake = console;
@@ -815,14 +828,20 @@ impl ServerConfig {
                 {
                     args.enable_chrome_devtools_automatic_workspace_folders = v;
                 }
+
+                requested
+            } else if dev.to_boolean() {
+                default_development
             } else {
-                args.development = if dev.to_boolean() {
-                    DevelopmentOption::Development
-                } else {
-                    DevelopmentOption::Production
-                };
+                DevelopmentOption::Production
+            };
+
+            if is_production_env && requested.is_development() {
+                warn_development_ignored_in_production();
+            } else {
+                args.development = requested;
             }
-            args.reuse_port = args.development == DevelopmentOption::Production;
+            args.reuse_port = requested == DevelopmentOption::Production;
         }
         if global.has_exception() {
             return Err(JsError::Thrown);

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -14,6 +14,8 @@ async function run({ closeActiveConnections = false, sendAnyRequests = true, web
     globalThis.pluginLoaded = undefined;
 
     const server = Bun.serve({
+      // The HTML route is only served by a DevServer (whose deinit this counts) in development mode.
+      development: true,
       routes: {
         "/": html,
       },
@@ -131,16 +133,16 @@ async function drainServerWrappers(target: number) {
 }
 
 // `objectTypeCounts` includes the (lazily created) prototype object once the
-// first server has been constructed. Create-and-stop one trivial server here
-// so the prototype is materialized but the instance is freed; the afterAll
-// check then asserts every dev-server case returns to this baseline (i.e. zero
-// live wrapper instances and the native boxes were actually freed). Captured
-// in beforeAll so the baseline exists even when a name filter skips the
-// baseline test.
+// first server has been constructed. Create-and-stop one trivial server here,
+// in the same (development) mode as the cases so the same prototype is
+// materialized but the instance is freed; the afterAll check then asserts
+// every dev-server case returns to this baseline (i.e. zero live wrapper
+// instances and the native boxes were actually freed). Captured in beforeAll
+// so the baseline exists even when a name filter skips the baseline test.
 let serverWrapperBaseline = 0;
 beforeAll(async () => {
   await (async () => {
-    const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    const server = Bun.serve({ port: 0, development: true, fetch: () => new Response("ok") });
     server.stop(true);
   })();
   await drainServerWrappers(1);

--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -743,7 +743,7 @@ test("development: false", {
   },
 });
 
-test("development: defaults to process.env.NODE_ENV !== 'production'", {
+test("development: computed from process.env.NODE_ENV", {
   development: process.env.NODE_ENV !== "production",
   port: 0,
   fetch() {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -1,6 +1,6 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tmpdirSync } from "../../../harness";
+import { bunEnv, bunExe, isWindows, tmpdirSync } from "../../../harness";
 
 const defaultHostname = "localhost";
 
@@ -260,6 +260,98 @@ describe("Bun.serve development options", () => {
     expect(server.port).toBeGreaterThan(0);
     expect(server.development).toBe(false);
     server.stop();
+  });
+
+  // `bun test` runs with NODE_ENV=test, which is neither "development" nor
+  // "production": development mode must be requested explicitly.
+  test("defaults to production mode", () => {
+    using server = serve({
+      port: 0,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    expect(server.development).toBe(false);
+    server.stop();
+  });
+
+  // One process per NODE_ENV value: Bun.serve() reads the environment the
+  // process started with. Each process reports the mode every form of the
+  // `development` option resolves to, plus how the option-less server answers
+  // a handler that returns nothing (200 welcome page in development, 204 in
+  // production).
+  const modeMatrixScript = /* js */ `
+    const options = {
+      omitted: {},
+      undefined: { development: undefined },
+      true: { development: true },
+      false: { development: false },
+      object: { development: {} },
+      "object with hmr: false": { development: { hmr: false } },
+    };
+    const modes = {};
+    for (const [name, extra] of Object.entries(options)) {
+      using server = Bun.serve({ port: 0, fetch: () => new Response("ok"), ...extra });
+      modes[name] = server.development;
+    }
+    using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch() {} });
+    const status = (await fetch(server.url)).status;
+    console.log(JSON.stringify({ modes, status }));
+  `;
+
+  async function resolveModes(NODE_ENV: string | undefined) {
+    const env = { ...bunEnv };
+    if (NODE_ENV !== undefined) env.NODE_ENV = NODE_ENV;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", modeMatrixScript],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The option-less server's empty handler also logs an "Expected a Response
+    // object" diagnostic in both modes, so only the warning is counted here.
+    if (exitCode !== 0) throw new Error(`exit code ${exitCode}\n${stdout}\n${stderr}`);
+    const warnings = stderr.split("[Bun.serve]: ignoring the `development` option because NODE_ENV").length - 1;
+    return { ...JSON.parse(stdout.trim()), warnings };
+  }
+
+  const productionOnly = {
+    omitted: false,
+    undefined: false,
+    true: false,
+    false: false,
+    object: false,
+    "object with hmr: false": false,
+  };
+
+  const explicitOptIn = {
+    omitted: false,
+    undefined: false,
+    true: true,
+    false: false,
+    object: true,
+    "object with hmr: false": true,
+  };
+
+  test.concurrent("without NODE_ENV, only the development option enables development mode", async () => {
+    expect(await resolveModes(undefined)).toEqual({ modes: explicitOptIn, status: 204, warnings: 0 });
+  });
+
+  test.concurrent("NODE_ENV=test behaves like an unset NODE_ENV", async () => {
+    expect(await resolveModes("test")).toEqual({ modes: explicitOptIn, status: 204, warnings: 0 });
+  });
+
+  test.concurrent("NODE_ENV=development enables development mode unless development: false", async () => {
+    expect(await resolveModes("development")).toEqual({
+      modes: { ...explicitOptIn, omitted: true, undefined: true },
+      status: 200,
+      warnings: 0,
+    });
+  });
+
+  test.concurrent("NODE_ENV=production forces production mode and warns once about development: true", async () => {
+    expect(await resolveModes("production")).toEqual({ modes: productionOnly, status: 204, warnings: 1 });
   });
 });
 

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -914,8 +914,13 @@ for (let development of [true, false, { hmr: false }]) {
 }
 
 describe("production headers and import.meta.env", () => {
-  async function collect(development: string) {
+  /**
+   * @param development source text for the `development` option; `undefined` omits the option
+   */
+  async function collect(development: string | undefined, bunfig?: string) {
+    const developmentOption = development === undefined ? "" : `development: ${development},`;
     const dir = tempDirWithFiles("html-prod-headers", {
+      ...(bunfig === undefined ? {} : { "bunfig.toml": bunfig }),
       "index.html": /*html*/ `<!DOCTYPE html>
 <html><head><link rel="stylesheet" href="./app.css">
 <script type="module" src="./app.ts"></script></head>
@@ -932,7 +937,7 @@ describe("production headers and import.meta.env", () => {
       `,
       "serve.ts": /*js*/ `
         import index from "./index.html";
-        const server = Bun.serve({ port: 0, development: ${development}, routes: { "/": index } });
+        const server = Bun.serve({ port: 0, ${developmentOption} routes: { "/": index } });
         const base = server.url.href;
         const htmlRes = await fetch(base);
         const html = await htmlRes.text();
@@ -1067,6 +1072,38 @@ describe("production headers and import.meta.env", () => {
     // Dev mode should not set aggressive Cache-Control.
     expect(out.htmlCacheControl).toBeNull();
     expect(out.jsCacheControl).toBeNull();
+  });
+
+  const modeSummary = (out: Awaited<ReturnType<typeof collect>>) => ({
+    result: out.result,
+    jsHasSourceMapURL: out.jsHasSourceMapURL,
+    mapStatus: out.mapStatus,
+    htmlCacheControl: out.htmlCacheControl,
+    jsCacheControl: out.jsCacheControl,
+  });
+
+  // The child runs without NODE_ENV, so omitting `development` must serve the
+  // same bundle as `development: false`: no sourcemaps, cacheable assets.
+  test("omitting development serves the production bundle", async () => {
+    expect(modeSummary(await collect(undefined))).toEqual({
+      result: { MODE: "production", DEV: false, PROD: true, SSR: false },
+      jsHasSourceMapURL: false,
+      mapStatus: 404,
+      htmlCacheControl: "no-cache",
+      jsCacheControl: "public, max-age=31536000, immutable",
+    });
+  });
+
+  // Same result as `development: { hmr: false }` above: development bundle,
+  // served by the plain HTML bundler instead of the HMR dev server.
+  test("bunfig [serve.static] hmr = false applies to development: true", async () => {
+    expect(modeSummary(await collect("true", "[serve.static]\nhmr = false"))).toEqual({
+      result: { MODE: "development", DEV: true, PROD: false, SSR: false },
+      jsHasSourceMapURL: true,
+      mapStatus: 200,
+      htmlCacheControl: null,
+      jsCacheControl: null,
+    });
   });
 
   test("distinct source maps get distinct ETags", async () => {

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -98,10 +98,10 @@ test.concurrent("mid-stream error: the chunked body is not terminated as complet
   });
 });
 
-// Under `development: true` (the default for a plain script) the mid-stream
-// error is reported by handle_reject_stream, and the connection must still be
-// aborted: development mode never has a dev_server() for a plain Bun.serve,
-// so the dev fallback page cannot swallow the force-close.
+// Under `development: true` the mid-stream error is reported by
+// handle_reject_stream, and the connection must still be aborted: development
+// mode never has a dev_server() for a plain Bun.serve, so the dev fallback page
+// cannot swallow the force-close.
 test.concurrent("mid-stream error in development mode: reported and not terminated as complete", async () => {
   const { stdout, stderr, exitCode } = await runFixture("mid-stream-reject", "development");
   expect({ result: JSON.parse(stdout), exitCode }).toEqual({

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -46,7 +46,9 @@ async function runTest({ port, ...serverOptions }: Serve<any>, test: (server: Se
   } else {
     while (!server) {
       try {
-        server = serve({ ...serverOptions, port: 0 });
+        // The mode is fixed when the server is created; reload() keeps it. The
+        // welcome-page test below needs the shared server to be a development server.
+        server = serve({ development: true, ...serverOptions, port: 0 });
         break;
       } catch (e: any) {
         console.log("catch:", e);

--- a/test/regression/issue/02499/02499.fixture.ts
+++ b/test/regression/issue/02499/02499.fixture.ts
@@ -1,5 +1,7 @@
 const server = Bun.serve({
   port: 0,
+  // The bug this reproduces is specific to development mode (see 02499.test.ts).
+  development: true,
   async fetch(req) {
     console.log(await req.json());
     return new Response();


### PR DESCRIPTION
Closes #36975

This is a behavior change: `Bun.serve()` now defaults to production mode.

### Problem
- `Bun.serve()` defaults to development mode unless `NODE_ENV=production` is set (the `development:` initializer in `ServerConfig::from_js`, `src/runtime/server/ServerConfig.rs`). A deployment that forgets `NODE_ENV` serves the HTML error page with stack traces, re-bundles HTML imports on every request, serves sourcemaps, and runs HMR.
- An explicit `development: true` also wins over `NODE_ENV=production`, so a flag hardcoded for local development ships the same dev-only behavior to production.
- The docs already tell users to set `development: true` to get development mode; the runtime did not require it.

### Fix
- The mode is resolved in one place in `ServerConfig::from_js`:
  - `NODE_ENV=production` (or the transpiler's production flag, which is derived from it) always selects production. A `development: true` / object passed alongside it is ignored and a `[Bun.serve]:` warning saying so is printed to stderr once per process (suppressed by `--silent`, like the existing idle-timeout warning).
  - Otherwise `development: true` or an object selects development and `development: false` selects production, as before.
  - With no `development` option, `NODE_ENV=development` selects development; anything else, including an unset `NODE_ENV`, selects production.
- `[serve.static] hmr = false` in bunfig.toml now also applies to `development: true` and to a `development` object without an `hmr` key. Previously it only applied when the option was omitted, which after this change would have made the setting nearly unreachable. An explicit `hmr` in the option object still wins.
- `reusePort` keeps its existing coupling to an explicit `development: false`. It is keyed on the value the caller passed, not on the resolved mode, so `development: true` under `NODE_ENV=production` does not start enabling `SO_REUSEPORT`.
- Callers inside Bun are unaffected: `bun ./index.html` (`src/js/internal/html.ts`) and the `bun init` React templates pass the option explicitly, and the bake test harness sets `NODE_ENV`. The node:http server and the inspector's WebSocket server now run in production mode, which only removes the dev-only `/bun:info` route and idle-timeout warning from them.
- Types (`packages/bun-types/serve.d.ts`) and docs (`docs/runtime/http/server.mdx`, `error-handling.mdx`, `docs/bundler/fullstack.mdx`) describe the new precedence.
- Tests:
  - `test/js/bun/http/bun-serve-args.test.ts`: the in-process default under `bun test` (`NODE_ENV=test`) is production, plus one child process per `NODE_ENV` value (unset, `test`, `development`, `production`) checking every form of the option, the 204-vs-welcome-page response of the option-less server, and that the production warning prints exactly once per process.
  - `test/js/bun/http/bun-serve-html.test.ts`: omitting `development` serves the production bundle (no sourcemaps, cache headers); bunfig `hmr = false` applies to `development: true`.
  - These new tests fail on the unmodified build and pass with this change.
  - Tests that relied on the implicit development default now ask for it: the shared server in `serve.test.ts` (`reload()` cannot change the mode, and its welcome-page test needs development), the `test/bake/fixtures/deinitialization` fixture (it counts DevServer deinits, and its baseline server must materialize the same prototype as the cases), and the `02499` regression fixture (the bug it covers is development-only). Two stale comments/names that described the old default were updated.
  - `test/js/bun/http/` was run in full, plus the bake, `test/cli/inspect`, node:http and bun-types suites that touch servers. The failures left in my environment (`localhost` connection refused, running as root, proxy, debug-build timeouts) reproduce with the unmodified release binary or are debug-build timing.
- Related: #35140 (type validation of the `development` value) touches the same block and is independent of this change.

### Background
- `development` selects which instantiation of the server is created (`DebugHTTPServer` vs `HTTPServer`, `src/runtime/api/BunObject.rs`), so the mode is fixed for the lifetime of a server and `server.reload()` keeps it. The debug instantiation renders the HTML error page for browser navigations, answers a handler that returns nothing with a welcome page instead of `204`, registers `/bun:info`, and warns about the default 10 second idle timeout. `HTMLBundle.rs` additionally reads the mode to choose between re-bundling per request with sourcemaps (development) and bundling once, minified, with `ETag`/`Cache-Control` (production).
- `DevelopmentOption` has three values: `Development` (HTML imports are served by the HMR dev server), `DevelopmentWithoutHmr` (development bundles served by the plain HTML bundler), and `Production`. `server.development` is `true` for the first two.
- `NODE_ENV` is read from Bun's env loader, i.e. the environment the process started with plus `.env` files, the same source `PORT` and `NODE_UNIQUE_ID` are read from a few lines above. Assigning `process.env.NODE_ENV` at runtime does not affect it (unchanged).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/integration/bun-types/fixture/serve-types.test.ts test/js/bun/http/bun-serve-args.test.ts test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->