### PR TITLE
node:module: throw instead of crashing when a preload sets runMain to a non-callable, and report a throwing override

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2850,8 +2850,7 @@ impl VirtualMachine {
                             if let Some(stored) = self.pending_internal_promise {
                                 return Ok(stored);
                             }
-                            // `Promise.resolve(ret)` reads `ret.constructor` / `ret.then`,
-                            // which may throw.
+                            // `Promise.resolve(ret)` reads `ret.constructor` / `ret.then`: may throw.
                             jsc::call_check_slow(global_ref, || {
                                 JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
                             })

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -68,10 +68,9 @@ pub type ExceptionList = Vec<crate::exception_list::JsException>;
 pub struct EntryPointResult {
     pub value: crate::strong::Optional, // jsc.Strong.Optional
     pub cjs_set_value: bool,
-    /// True when the entry module evaluated as CommonJS (or a preload's
-    /// `Module.runMain` override threw synchronously): Node reports those with
-    /// origin `uncaughtException` but an ESM entry rejection with
-    /// `unhandledRejection`; the run command consults this.
+    /// The run command reports the entry's failure with Node's origin
+    /// `uncaughtException` when set (CJS entry, or a throwing `Module.runMain`
+    /// override), `unhandledRejection` otherwise (ESM).
     pub evaluated_as_cjs: bool,
 }
 
@@ -2451,8 +2450,7 @@ unsafe extern "C" {
         ctx: *mut c_void,
         callback: extern "C" fn(ctx: *mut c_void),
     );
-    /// `[[ZIG_EXPORT(zero_is_throw)]]` shape: returns zero iff it threw (the
-    /// override is not callable, or threw itself).
+    /// Returns zero iff it threw (override not callable, or threw).
     safe fn NodeModuleModule__callOverriddenRunMain(
         global: &JSGlobalObject,
         argv1: JSValue,
@@ -2850,8 +2848,8 @@ impl VirtualMachine {
                     });
                     let promise: *mut JSInternalPromise = match result {
                         Ok(ret) => {
-                            // If the override stored a promise itself (by calling the
-                            // original runMain), use that; otherwise wrap its return value.
+                            // Calling the original runMain stores a promise; otherwise
+                            // wrap the override's return value.
                             if let Some(stored) = self.pending_internal_promise {
                                 return Ok(stored);
                             }
@@ -2863,12 +2861,10 @@ impl VirtualMachine {
                             .map_err(|_| crate::CrateError::JSError)?
                         }
                         Err(err) => {
-                            // Not callable, or threw: hand the exception back as the entry
-                            // point's rejection so the caller reports it like an entry module
-                            // that throws. Marked handled up front, like the module loader's
-                            // own promises, so the caller is the only one reporting it. Node
-                            // throws this synchronously from its bootstrap, hence the
-                            // `uncaughtException` origin of a CJS entry.
+                            // Hand the exception back as the entry point's rejection,
+                            // marked handled so only the caller reports it, with a CJS
+                            // entry's `uncaughtException` origin (Node throws this
+                            // synchronously from its bootstrap).
                             self.entry_point_result.evaluated_as_cjs = true;
                             let promise = crate::JSPromise::create(global_ref);
                             promise.set_handled();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -68,9 +68,10 @@ pub type ExceptionList = Vec<crate::exception_list::JsException>;
 pub struct EntryPointResult {
     pub value: crate::strong::Optional, // jsc.Strong.Optional
     pub cjs_set_value: bool,
-    /// True when the entry module evaluated as CommonJS: Node reports a CJS
-    /// entry's top-level throw with origin `uncaughtException` but an ESM
-    /// entry rejection with `unhandledRejection`; the run command consults this.
+    /// True when the entry module evaluated as CommonJS (or a preload's
+    /// `Module.runMain` override threw synchronously): Node reports those with
+    /// origin `uncaughtException` but an ESM entry rejection with
+    /// `unhandledRejection`; the run command consults this.
     pub evaluated_as_cjs: bool,
 }
 
@@ -2450,6 +2451,8 @@ unsafe extern "C" {
         ctx: *mut c_void,
         callback: extern "C" fn(ctx: *mut c_void),
     );
+    /// `[[ZIG_EXPORT(zero_is_throw)]]` shape: returns zero iff it threw (the
+    /// override is not callable, or threw itself).
     safe fn NodeModuleModule__callOverriddenRunMain(
         global: &JSGlobalObject,
         argv1: JSValue,
@@ -2842,24 +2845,42 @@ impl VirtualMachine {
                     let global_ref = self.global();
                     let argv1 = bun_string_jsc::create_utf8_for_js(global_ref, MAIN_FILE_NAME)
                         .map_err(|_| crate::CrateError::JSError)?;
-                    let ret = jsc::from_js_host_call_generic(global_ref, || {
+                    let result = jsc::from_js_host_call(global_ref, || {
                         NodeModuleModule__callOverriddenRunMain(global_ref, argv1)
-                    })
-                    .map_err(|_| crate::CrateError::JSError)?;
-                    // If the override stored a promise itself, use that; otherwise
-                    // wrap its return value.
-                    if let Some(stored) = self.pending_internal_promise {
-                        return Ok(stored);
-                    }
-                    // `Promise.resolve(ret)` reads `ret.constructor` / `ret.then`,
-                    // which may throw.
-                    let resolved = jsc::call_check_slow(global_ref, || {
-                        JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
-                    })
-                    .map_err(|_| crate::CrateError::JSError)?;
-                    self.pending_internal_promise = Some(resolved);
+                    });
+                    let promise: *mut JSInternalPromise = match result {
+                        Ok(ret) => {
+                            // If the override stored a promise itself (by calling the
+                            // original runMain), use that; otherwise wrap its return value.
+                            if let Some(stored) = self.pending_internal_promise {
+                                return Ok(stored);
+                            }
+                            // `Promise.resolve(ret)` reads `ret.constructor` / `ret.then`,
+                            // which may throw.
+                            jsc::call_check_slow(global_ref, || {
+                                JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
+                            })
+                            .map_err(|_| crate::CrateError::JSError)?
+                        }
+                        Err(err) => {
+                            // Not callable, or threw: hand the exception back as the entry
+                            // point's rejection so the caller reports it like an entry module
+                            // that throws. Marked handled up front, like the module loader's
+                            // own promises, so the caller is the only one reporting it. Node
+                            // throws this synchronously from its bootstrap, hence the
+                            // `uncaughtException` origin of a CJS entry.
+                            self.entry_point_result.evaluated_as_cjs = true;
+                            let promise = crate::JSPromise::create(global_ref);
+                            promise.set_handled();
+                            promise
+                                .reject(global_ref, Err(err))
+                                .map_err(|_| crate::CrateError::JSError)?;
+                            promise
+                        }
+                    };
+                    self.pending_internal_promise = Some(promise);
                     self.pending_internal_promise_is_protected = false;
-                    return Ok(resolved);
+                    return Ok(promise);
                 }
             }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -68,9 +68,7 @@ pub type ExceptionList = Vec<crate::exception_list::JsException>;
 pub struct EntryPointResult {
     pub value: crate::strong::Optional, // jsc.Strong.Optional
     pub cjs_set_value: bool,
-    /// The run command reports the entry's failure with Node's origin
-    /// `uncaughtException` when set (CJS entry, or a throwing `Module.runMain`
-    /// override), `unhandledRejection` otherwise (ESM).
+    /// CJS entry or throwing runMain override: reported with Node's `uncaughtException` origin, not `unhandledRejection`.
     pub evaluated_as_cjs: bool,
 }
 
@@ -2848,8 +2846,7 @@ impl VirtualMachine {
                     });
                     let promise: *mut JSInternalPromise = match result {
                         Ok(ret) => {
-                            // Calling the original runMain stores a promise; otherwise
-                            // wrap the override's return value.
+                            // Calling the original runMain stores a promise; else wrap the return value.
                             if let Some(stored) = self.pending_internal_promise {
                                 return Ok(stored);
                             }
@@ -2861,10 +2858,7 @@ impl VirtualMachine {
                             .map_err(|_| crate::CrateError::JSError)?
                         }
                         Err(err) => {
-                            // Hand the exception back as the entry point's rejection,
-                            // marked handled so only the caller reports it, with a CJS
-                            // entry's `uncaughtException` origin (Node throws this
-                            // synchronously from its bootstrap).
+                            // Marked handled so only the caller reports the rejection.
                             self.entry_point_result.evaluated_as_cjs = true;
                             let promise = crate::JSPromise::create(global_ref);
                             promise.set_handled();

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -486,7 +486,7 @@ public:
     /* TODO: these should use LazyProperty */                                                                \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleResolveFilenameFunction)                           \
-    V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_moduleRunMainFunction)                               \
     /* Last value assigned to `require("module").runMain`; empty while it is the original function. */       \
     /* Holds non-callables too (Node's is a plain data property): callability is checked at call time. */    \
     V(public, WriteBarrier<JSC::Unknown>, m_moduleRunMainOverride)                                           \

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -487,8 +487,7 @@ public:
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleResolveFilenameFunction)                           \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_moduleRunMainFunction)                               \
-    /* Last value assigned to `require("module").runMain`; empty while it is the original function. */       \
-    /* Holds non-callables too (Node's is a plain data property): callability is checked at call time. */    \
+    /* Last value assigned to `Module.runMain` (may be non-callable); empty while original. */               \
     V(public, WriteBarrier<JSC::Unknown>, m_moduleRunMainOverride)                                           \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -487,6 +487,9 @@ public:
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleResolveFilenameFunction)                           \
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
+    /* Last value assigned to `require("module").runMain`; empty while it is the original function. */       \
+    /* Holds non-callables too (Node's is a plain data property): callability is checked at call time. */    \
+    V(public, WriteBarrier<JSC::Unknown>, m_moduleRunMainOverride)                                           \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_nodeModuleConstructor)                                 \
@@ -782,8 +785,6 @@ public:
     bool hasOverriddenModuleResolveFilenameFunction = false;
     // De-optimization once `require("module").wrapper` or `require("module").wrap` is written to
     bool hasOverriddenModuleWrapper = false;
-    // De-optimization once `require("module").runMain` is written to
-    bool hasOverriddenModuleRunMain = false;
 
     // node:crypto deprecation warnings are emitted at most once per realm, like Node, whose
     // flags live in per-realm module state (lib/internal/crypto/keys.js). They must not be

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -812,8 +812,7 @@ JSC_DEFINE_CUSTOM_GETTER(moduleRunMain,
 extern "C" void Bun__VirtualMachine__setOverrideModuleRunMain(void* bunVM, bool isPatched);
 
 // Called by VirtualMachine::reload_entry_point when a preload replaced
-// `Module.runMain`. Throws (returns zero) if the replacement is not callable or
-// throws; Rust reports that as the entry point's failure.
+// `Module.runMain`. Returns zero if the replacement is not callable or throws.
 extern "C" JSC::EncodedJSValue NodeModuleModule__callOverriddenRunMain(Zig::GlobalObject* global, JSC::EncodedJSValue encodedArgv1)
 {
     auto& vm = JSC::getVM(global);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -811,8 +811,7 @@ JSC_DEFINE_CUSTOM_GETTER(moduleRunMain,
 
 extern "C" void Bun__VirtualMachine__setOverrideModuleRunMain(void* bunVM, bool isPatched);
 
-// Called by VirtualMachine::reload_entry_point when a preload replaced
-// `Module.runMain`. Returns zero if the replacement is not callable or throws.
+// Calls the runMain replacement set by a preload; returns zero if it is not callable or throws.
 extern "C" JSC::EncodedJSValue NodeModuleModule__callOverriddenRunMain(Zig::GlobalObject* global, JSC::EncodedJSValue encodedArgv1)
 {
     auto& vm = JSC::getVM(global);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -794,25 +794,38 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
+static JSValue currentModuleRunMain(Zig::GlobalObject* globalObject)
+{
+    if (JSValue replacement = globalObject->m_moduleRunMainOverride.get())
+        return replacement;
+    return globalObject->m_moduleRunMainFunction.getInitializedOnMainThread(globalObject);
+}
+
 JSC_DEFINE_CUSTOM_GETTER(moduleRunMain,
     (JSGlobalObject * lexicalGlobalObject,
         EncodedJSValue thisValue,
         PropertyName propertyName))
 {
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-
-    return JSValue::encode(
-        globalObject->m_moduleRunMainFunction.getInitializedOnMainThread(
-            globalObject));
+    return JSValue::encode(currentModuleRunMain(defaultGlobalObject(lexicalGlobalObject)));
 }
 
-extern "C" void Bun__VirtualMachine__setOverrideModuleRunMain(void* bunVM, bool isOriginal);
-extern "C" JSC::EncodedJSValue NodeModuleModule__callOverriddenRunMain(Zig::GlobalObject* global, JSValue argv1)
+extern "C" void Bun__VirtualMachine__setOverrideModuleRunMain(void* bunVM, bool isPatched);
+
+// Called by VirtualMachine::reload_entry_point when a preload replaced
+// `Module.runMain`. Throws (returns zero) if the replacement is not callable or
+// throws; Rust reports that as the entry point's failure.
+extern "C" JSC::EncodedJSValue NodeModuleModule__callOverriddenRunMain(Zig::GlobalObject* global, JSC::EncodedJSValue encodedArgv1)
 {
-    auto overrideHandler = uncheckedDowncast<JSObject>(global->m_moduleRunMainFunction.get(global));
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     MarkedArgumentBuffer args;
-    args.append(argv1);
-    return JSC::JSValue::encode(JSC::profiledCall(global, JSC::ProfilingReason::API, overrideHandler, JSC::getCallData(overrideHandler), global, args));
+    args.append(JSValue::decode(encodedArgv1));
+    // Node calls it as `Module.runMain(mainPath)`, so `this` is the Module object.
+    JSValue thisValue = global->m_nodeModuleConstructor.getInitializedOnMainThread(global);
+    JSValue result = JSC::call(global, currentModuleRunMain(global), thisValue, args, "Module.runMain is not a function"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(result);
 }
 
 JSC_DEFINE_CUSTOM_SETTER(setModuleRunMain,
@@ -822,20 +835,14 @@ JSC_DEFINE_CUSTOM_SETTER(setModuleRunMain,
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto value = JSValue::decode(encodedValue);
-    if (value.isCell()) {
-        bool isOriginal = false;
-        if (value.isCallable()) {
-            JSC::CallData callData = JSC::getCallData(value);
-            if (callData.type == JSC::CallData::Type::Native) {
-                if (callData.native.function.untaggedPtr() == &jsFunctionRunMain) {
-                    isOriginal = true;
-                }
-            }
-        }
-        Bun__VirtualMachine__setOverrideModuleRunMain(globalObject->bunVM(), !isOriginal);
-        globalObject->m_moduleRunMainFunction.set(
-            lexicalGlobalObject->vm(), globalObject, value.asCell());
+    JSC::CallData callData = JSC::getCallData(value);
+    bool isOriginal = callData.type == JSC::CallData::Type::Native && callData.native.function.untaggedPtr() == &jsFunctionRunMain;
+    if (isOriginal) {
+        globalObject->m_moduleRunMainOverride.clear();
+    } else {
+        globalObject->m_moduleRunMainOverride.set(lexicalGlobalObject->vm(), globalObject, value);
     }
+    Bun__VirtualMachine__setOverrideModuleRunMain(globalObject->bunVM(), !isOriginal);
 
     return true;
 }

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1134,7 +1134,7 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
         });
 
     globalObject->m_moduleRunMainFunction.initLater(
-        [](const Zig::GlobalObject::Initializer<JSCell>& init) {
+        [](const Zig::GlobalObject::Initializer<JSFunction>& init) {
             JSFunction* runMainFunction = JSFunction::create(
                 init.vm, init.owner, 2, "runMain"_s,
                 jsFunctionRunMain, JSC::ImplementationVisibility::Public,

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, ospath, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -870,6 +870,111 @@ console.log("survived", require("./late.js"));`,
     expect(stdout.trim()).toBe("pass");
     expect(await proc.exited).toBe(0);
   });
+
+  // Runs main.js with a preload that replaces Module.runMain, the way Node's
+  // bootstrap calls it: `Module.runMain(main)` after the preloads ran.
+  async function runWithRunMainPreload(preloadSource) {
+    using dir = tempDir("module-run-main", {
+      "preload.cjs": preloadSource,
+      "main.js": `console.log("main ran");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--require", "./preload.cjs", "./main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      stdout: normalizeBunSnapshot(stdout, String(dir)),
+      stderr: normalizeBunSnapshot(stderr, String(dir)),
+      exitCode,
+    };
+  }
+
+  test("Module.runMain override is called with Module as this", async () => {
+    const { stdout, stderr, exitCode } = await runWithRunMainPreload(`
+      const Module = require("module");
+      const original = Module.runMain;
+      Module.runMain = function (...args) {
+        console.log("this is Module:", this === Module);
+        return original.apply(this, args);
+      };
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "this is Module: true
+      main ran"
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // Node stores whatever is assigned and fails when its bootstrap calls it;
+  // the object and string cases used to segfault here, the primitives were
+  // silently ignored and main ran anyway.
+  test.each(["{}", '"not a function"', "undefined", "null", "5"])(
+    "Module.runMain = %s in a preload throws instead of running main",
+    async source => {
+      const { stdout, stderr, exitCode } = await runWithRunMainPreload(`require("module").runMain = ${source};`);
+      expect(stderr).toContain("TypeError: Module.runMain is not a function");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  test.each([
+    ["a function that throws", `() => { throw new TypeError("runMain override threw"); }`, "runMain override threw"],
+    ["a class", `class NotCallable {}`, "class constructor"],
+  ])("Module.runMain override that throws (%s) reports the exception", async (_, source, expectedError) => {
+    const { stdout, stderr, exitCode } = await runWithRunMainPreload(`require("module").runMain = ${source};`);
+    expect(stderr).toContain(expectedError);
+    expect(stderr).not.toContain("Error occurred loading entry point");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test.each([
+    ["a function that throws", `() => { throw new TypeError("runMain override threw"); }`, "runMain override threw"],
+    ["a non-callable", `{}`, "Module.runMain is not a function"],
+  ])("Module.runMain override failure (%s) goes to process.on('uncaughtException')", async (_, source, message) => {
+    const { stdout, stderr, exitCode } = await runWithRunMainPreload(`
+      process.on("uncaughtException", (err, origin) => console.log("caught:", err.message, origin));
+      require("module").runMain = ${source};
+    `);
+    expect(stdout).toBe(`caught: ${message} uncaughtException`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Module.runMain reads back whatever was assigned", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const Module = require("module");
+          const original = Module.runMain;
+          const roundTrips = [];
+          for (const value of [undefined, null, 5, "str", {}]) {
+            Module.runMain = value;
+            roundTrips.push(Module.runMain === value);
+          }
+          Module.runMain = original;
+          roundTrips.push(Module.runMain === original);
+          console.log(JSON.stringify(roundTrips));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("[true,true,true,true,true,true]\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -947,6 +947,40 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  // A Worker's own preloads go through the same path; the failure has to end
+  // up as that worker's error (the non-callable case took down the whole process).
+  test.each([
+    ["a function that throws", `() => { throw new TypeError("runMain override threw"); }`, "runMain override threw"],
+    ["a non-callable", `{}`, "Module.runMain is not a function"],
+  ])(
+    "Module.runMain override failure (%s) in a Worker preload is reported as the worker's error",
+    async (_, source, message) => {
+      using dir = tempDir("module-run-main-worker", {
+        "preload.cjs": `require("module").runMain = ${source};`,
+        "worker.js": `console.log("worker ran");`,
+        "main.js": `
+          const worker = new Worker("./worker.js", { preload: ["./preload.cjs"] });
+          worker.onerror = event => console.log("worker error mentions it:", event.message.includes(${JSON.stringify(message)}));
+          worker.addEventListener("close", event => console.log("worker exit code:", event.code));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "./main.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+        "worker error mentions it: true
+        worker exit code: 1"
+      `);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test("Module.runMain reads back whatever was assigned", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Problem
- A preload that assigns a non-function to `require("module").runMain` crashes when Bun goes to run the entry point: `panic(main thread): Segmentation fault at address 0x4` in release builds (`ASSERTION FAILED: Expected object to be callable but received 0` in debug builds). Repro: `echo 'require("module").runMain = {}' > preload.cjs; bun -r ./preload.cjs main.js`. A string (`runMain = "x"`) crashes the same way. Node exits 1 with `TypeError: ... runMain is not a function`.
- `runMain = undefined` / `null` / `5` were silently ignored: the property still read back as the builtin and main ran. Node stores the value and then fails with the same TypeError.
- A callable override that throws (or a class, which throws when called without `new`) is reported only as `Error occurred loading entry point: JSError`, exit 1. The exception itself is never printed and `process.on("uncaughtException")` listeners are not consulted. Node prints the error / runs the listeners.
- The same two things happen when the preload comes from a Worker's `preload` option: a non-callable `runMain` there segfaults the whole process, and a throwing one closes the worker with exit code 1 but never fires its `error` event.
- Causes, at b7a0431032:
  - `setModuleRunMain` (`src/jsc/modules/NodeModuleModule.cpp:832`) stores any cell into `m_moduleRunMainFunction` and drops non-cells; `NodeModuleModule__callOverriddenRunMain` (`:824`) downcasts the stored cell to `JSObject` and calls it without checking that it is callable.
  - `reload_entry_point` (`src/jsc/VirtualMachine.rs:2705`) maps any exception from that call to `CrateError::JSError`, and `entry_point_load_failed` (`src/runtime/cli/run_command.rs:1653`) prints only the error name.

### Fix
- The assigned value now lives in a new `WriteBarrier<JSC::Unknown>` slot (`m_moduleRunMainOverride`), empty while the property holds the builtin. The setter stores any value there (assigning the builtin back clears it), the getter returns it, and `m_moduleRunMainFunction` only ever holds the builtin (typed `LazyProperty<JSFunction>` accordingly). The unused `hasOverriddenModuleRunMain` bool is removed; the slot being non-empty is that state.
- `NodeModuleModule__callOverriddenRunMain` calls the current value through `JSC::call(..., "Module.runMain is not a function"_s)`, which throws that TypeError for anything without call data and otherwise propagates what the override throws. It now follows the zero-means-threw convention, and passes the Module object as `this`, which is how Node's bootstrap calls it (`Module.runMain(main)`); previously `this` was the global object.
- On the Rust side, an exception from that call becomes the entry point's promise: a fresh promise marked handled and rejected with the exception, stored as `pending_internal_promise` and returned, so the run command reports it exactly like an entry module that throws (prints it, or consults `uncaughtException` listeners, `--hot` keeps running), and a worker's startup code reports it as that worker's `error` event. `evaluated_as_cjs` is set so the origin passed to listeners is `uncaughtException`, matching Node, where this throw happens synchronously in the bootstrap. The success path (use the promise the override stored by calling the builtin, else wrap the return value) is unchanged, so an `async` override that rejects is still reported as a rejection with origin `unhandledRejection`, also as in Node.
- Why this is correct: it matches Node. `Module.runMain` there is a plain data property, so assignment always succeeds and reads back, and the failure happens when the bootstrap calls it, as an ordinary uncaught exception. Checking callability at call time (not in the setter) also keeps code working that assigns a placeholder and restores the function before main runs. Marking the rejected promise handled up front is what the module loader does for its own entry promises, so the failure is reported once, by the caller, and never also as an unhandled rejection.
- Verified with the new tests in `test/js/node/module/node-module-module.test.js`: non-callable values (`{}`, a string, `undefined`, `null`, `5`) exit 1 with the TypeError and main does not run; a throwing function and a class report the actual error; both failure kinds reach `process.on("uncaughtException")` with origin `uncaughtException`; assigned values read back and restoring the builtin works; an override is called with `Module` as `this` and can call through to the builtin; a throwing and a non-callable override in a Worker's `preload` surface as that worker's `error` event with exit code 1. All 13 fail on the released build (the object/string rows crash the child) and pass with this change; the two existing `Module.runMain` tests still pass.
- Also ran with the debug build: `test/cli/run/preload-test.test.js`, `test/config/bunfig/preload.test.ts`, `test/js/bun/resolve/bun-main-entry-point.test.ts`, `test/internal/source-lints/`, and the repro scripts under `BUN_JSC_validateExceptionChecks=1`.
- #38089 fixes the same setter/call pattern for `Module._resolveFilename` and deliberately left `runMain` to this change because of the reporting half; the two touch adjacent lines of `ZigGlobalObject.h` and are otherwise independent.

### Background
- `-r` / `--require` / bunfig `preload` scripts run before the entry point. `require("module").runMain` is a custom accessor on the `node:module` object; when a preload assigns it, the setter tells the VM (`has_patched_run_main`) and `reload_entry_point` then runs the entry point by calling the assigned value instead of loading `bun:main` itself, mirroring Node, whose bootstrap ends with `Module.runMain(mainPath)` so that preloads can wrap it. The builtin `runMain` loads the entry and hands its promise to the VM via `setOverrideModuleRunMainPromise`.
- `reload_entry_point` returns the entry point's promise to the run command (`run_command.rs`) or the worker startup code. If that promise is already rejected, they report the rejection through `uncaught_exception`, which prints the error or dispatches it to `process.on("uncaughtException")` listeners with an origin string chosen from `entry_point_result.evaluated_as_cjs` (`uncaughtException` for a synchronously thrown CJS entry, `unhandledRejection` otherwise). Returning `Err` instead goes to `entry_point_load_failed`, which only knows the error's name.
- JSC's promise rejection tracker reports a rejected promise as unhandled unless the promise was marked handled before it was rejected; Bun's module loader pre-marks the entry promises it returns, so the caller that inspects them is their only reporter. The new rejected promise follows the same rule.
- `LazyProperty<T>` is a create-on-first-use slot that can only hold a `T*` cell, which is why the old setter had to drop primitives. `WriteBarrier<Unknown>` is a GC-visited slot holding any `JSValue`; members declared in `FOR_EACH_GLOBALOBJECT_GC_MEMBER` are visited automatically. `Error.prepareStackTrace` on the same global object already uses this builtin-in-LazyProperty plus user-value-in-WriteBarrier arrangement.
- `JSC::call(globalObject, callee, thisValue, args, message)` looks up the callee's `CallData` (functions, bound functions and callable proxies qualify; primitives, plain objects and strings do not), throws a TypeError with `message` if there is none, and otherwise performs the call. Returning an empty `EncodedJSValue` with an exception pending is the convention `from_js_host_call` checks on the Rust side.


Rebase note: rebased on main after #40410 (jsc-exception-lint). One conflict in `src/jsc/VirtualMachine.rs`: kept this PR's Ok/Err handling of the override call and adopted main's `call_check_slow` check around `JSC__JSInternalPromise__resolvedPromise`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
