### PR TITLE
tls: send a post-handshake ticket flight larger than 64 KiB

### DIFF
--- a/patches/boringssl/oversize-pending-flight.patch
+++ b/patches/boringssl/oversize-pending-flight.patch
@@ -1,0 +1,56 @@
+Let do_tls_write send a pending flight larger than write_buffer.
+
+A TLS 1.3 server queues its NewSessionTickets (two by default) after the
+client's Finished and, over TCP, holds them in pending_flight until the
+first SSL_write (tls13_server.cc, do_send_new_session_ticket). Each ticket
+serializes the whole session, including the client's certificate chain
+(ssl_asn1.cc, kCertChainTag), so with requestCert the flight is about twice
+the size of whatever chain the client chose to send.
+
+do_tls_write copies that flight into write_buffer ahead of the record it is
+about to seal. SSLBuffer keeps 16-bit lengths, so EnsureCap refuses anything
+over 0xffff bytes with ERR_R_INTERNAL_ERROR. A client chain over ~32 KB
+therefore completed the handshake and then made every SSL_write (and the
+close_notify) fail before a single byte reached the BIO; the connection
+stayed open and silent.
+
+Write a flight that does not fit straight to the BIO instead, the way
+tls_flush writes flights during the handshake, and buffer only the record.
+Flights that fit keep taking the existing single-buffer path.
+
+--- a/ssl/s3_pkt.cc
++++ b/ssl/s3_pkt.cc
+@@ -191,6 +191,33 @@
+     return 1;
+   }
+ 
++  // `write_buffer` holds at most 0xffff bytes (see `SSLBuffer::EnsureCap`),
++  // but `pending_flight` is sized by the handshake, not the record layer: a
++  // TLS 1.3 server queues `num_tickets` NewSessionTickets, each embedding the
++  // client's whole certificate chain, so the flight may not fit in the buffer
++  // alongside the record. Write such a flight to the transport directly, as
++  // `tls_flush` does during the handshake, and buffer only the record. A short
++  // write is resumed from `pending_flight_offset` when the caller retries after
++  // `SSL_ERROR_WANT_WRITE`. `wbio` was checked by `ssl_write_buffer_flush`.
++  if (!pending_flight.empty() && max_out > 0xffff) {
++    const BUF_MEM *flight = ssl->s3->pending_flight.get();
++    while (ssl->s3->pending_flight_offset < flight->length) {
++      size_t written;
++      if (!BIO_write_ex(ssl->wbio.get(),
++                        flight->data + ssl->s3->pending_flight_offset,
++                        flight->length - ssl->s3->pending_flight_offset,
++                        &written)) {
++        ssl->s3->rwstate = SSL_ERROR_WANT_WRITE;
++        return -1;
++      }
++      ssl->s3->pending_flight_offset += static_cast<uint32_t>(written);
++    }
++    ssl->s3->pending_flight.reset();
++    ssl->s3->pending_flight_offset = 0;
++    max_out -= pending_flight.size();
++    pending_flight = Span<const uint8_t>();
++  }
++
+   if (!buf->EnsureCap(pending_flight.size() + tls_seal_align_prefix_len(ssl),
+                       max_out)) {
+     return -1;

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,10 +36,17 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
-  // Upstream mem.cc gates OPENSSL_memory_* weak-symbol overrides on __ELF__;
-  // on Mach-O/COFF the hooks compile to static nullptr and OPENSSL_malloc goes
-  // straight to libc. Declare them as plain externs so lib.rs binds everywhere.
-  patches: ["patches/boringssl/require-memory-hooks.patch"],
+  // require-memory-hooks: upstream mem.cc gates OPENSSL_memory_* weak-symbol
+  // overrides on __ELF__; on Mach-O/COFF the hooks compile to static nullptr
+  // and OPENSSL_malloc goes straight to libc. Declare them as plain externs so
+  // lib.rs binds everywhere.
+  //
+  // oversize-pending-flight: a TLS 1.3 server's deferred NewSessionTicket
+  // flight embeds the client's certificate chain and did not fit the 64 KB
+  // record write buffer once that chain passed ~32 KB, so the first SSL_write
+  // after a requestCert handshake failed and the connection went silent. The
+  // patch header has the details.
+  patches: ["patches/boringssl/require-memory-hooks.patch", "patches/boringssl/oversize-pending-flight.patch"],
 
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -934,6 +934,47 @@ it("keeps socket.authorized false when a client without a certificate resumes a 
   ]);
 });
 
+it("replies to a requestCert client whose certificate chain is larger than 32 KiB over TLSv1.3", async () => {
+  // After a TLSv1.3 handshake the server queues two NewSessionTickets, each
+  // embedding the client's whole chain, and sends them along with its first
+  // write. Past ~32 KiB of chain that flight no longer fit the record layer's
+  // 64 KiB write buffer: the handshake completed, but the server never sent
+  // another byte.
+  const fixtures = join(import.meta.dir, "fixtures");
+  const agent1Key = readFileSync(join(fixtures, "agent1-key.pem"), "utf8");
+  const agent1Cert = readFileSync(join(fixtures, "agent1-cert.pem"), "utf8");
+  const ca1 = readFileSync(join(fixtures, "ca1-cert.pem"), "utf8");
+  // 52 copies of ca1 (920 bytes of DER each) pad the chain the client sends to
+  // ~48 KiB; agent1 still verifies against ca1. Chains past ~64 KiB are a
+  // different case: BoringSSL declines to issue tickets for them at all.
+  const paddedChain = agent1Cert + Buffer.alloc(ca1.length * 52, ca1).toString();
+
+  const accepted = Promise.withResolvers<{ authorized: boolean; protocol: string | null }>();
+  await using server = createServer(
+    { key: agent1Key, cert: agent1Cert, ca: [ca1], requestCert: true, minVersion: "TLSv1.3", maxVersion: "TLSv1.3" },
+    socket => {
+      accepted.resolve({ authorized: socket.authorized, protocol: socket.getProtocol() });
+      socket.on("data", chunk => socket.write(`pong:${chunk}`));
+    },
+  );
+  server.on("tlsClientError", accepted.reject);
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = connect({ port, host: "127.0.0.1", key: agent1Key, cert: paddedChain, rejectUnauthorized: false });
+  await once(client, "secureConnect");
+  expect(await accepted.promise).toEqual({ authorized: true, protocol: "TLSv1.3" });
+
+  // Without the fix this is where it hangs: the server's write() returns true,
+  // but nothing reaches the wire.
+  client.write("ping");
+  const [reply] = await once(client, "data");
+  client.end();
+  await once(client, "close");
+
+  expect(String(reply)).toBe("pong:ping");
+});
+
 it("keeps socket.authorized false when a client without a certificate resumes a TLSv1.3 session against an https server", async () => {
   type Verdict = { authorized: boolean | undefined; authorizationError: unknown };
   const verdicts: Verdict[] = [];


### PR DESCRIPTION
### Problem
- `tls.createServer` / `Bun.serve({ tls })` / `Bun.listen({ tls })` with `requestCert: true`, TLS 1.3: when the client's certificate chain is between ~32 KiB and ~64 KiB, the handshake completes (`secureConnection` fires, `authorized` is true), the server's first `write()` returns true, and no byte ever leaves the server again. Same on 1.4.0 and main; node serves every chain size.
- After the client's Finished, BoringSSL queues two NewSessionTickets and holds them until the server's first write (`ssl/tls13_server.cc`, `do_send_new_session_ticket`). Each ticket serializes the session including the client's whole chain (`ssl/ssl_asn1.cc`, `kCertChainTag`), so the flight is about twice the chain size.
- `do_tls_write` (`ssl/s3_pkt.cc:194`) copies that flight plus the new record into `write_buffer`, and `SSLBuffer::EnsureCap` (`ssl/ssl_buffer.cc:50`) rejects anything over 0xffff bytes with `ERR_R_INTERNAL_ERROR`, before anything is handed to the BIO. `SSL_write` fails, `us_internal_ssl_write` returns 0, and the layers above treat that as backpressure. Upstream BoringSSL master has the same code.
- Chains over ~64 KiB happen to work because `ssl_encrypt_ticket` declines to issue a ticket that large at all, which is why the failure is a window rather than a threshold.

### Fix
- `patches/boringssl/oversize-pending-flight.patch`: when the pending flight does not fit in `write_buffer` together with the record, `do_tls_write` writes the flight to the BIO directly (the same loop `tls_flush` uses for handshake flights, resumable through `pending_flight_offset` on `SSL_ERROR_WANT_WRITE`) and then buffers and seals only the record. Flights that fit keep taking the existing single-buffer path, so the normal case is unchanged.
- The flight still precedes the record on the wire, so ticket delivery order is unchanged; `key_update_pending` is still cleared after the flight goes out, as before.
- Verified with `test/js/node/tls/node-tls-server.test.ts` ("replies to a requestCert client whose certificate chain is larger than 32 KiB over TLSv1.3"): times out on the released bun, passes with this build.
- A probe across chain sizes on the patched build gets a reply at every size, and the client now receives both tickets inside the window (details below).
- Bun.serve and Bun.listen with `requestCert` and the same 48 KiB chain: no response / no reply on 1.4.0, both reply with this build.

### Background
- `requestCert` makes the server ask the client for a certificate; the client sends its leaf plus whatever extra certificates were configured in `cert`, and the server keeps that whole chain on the session.
- In TLS 1.3 session resumption uses NewSessionTicket messages: the server encrypts its copy of the session and sends it to the client, which presents it later to resume. BoringSSL sends two per connection and, over TCP, defers them to the first application write so a client that never reads cannot block the server.
- A "flight" is a group of handshake records BoringSSL seals and sends together (`pending_flight`). During the handshake it is written straight to the BIO; after the handshake `do_tls_write` prepends it to the next record via `write_buffer`, a buffer with 16-bit length fields, which is the limit this change routes around.
- Vendored dependencies are patched at fetch time from `patches/<dep>/`; the patch list in `scripts/build/deps/boringssl.ts` is part of the source identity, so adding one re-extracts and rebuilds BoringSSL.

<details>
<summary>Probe: chain size vs reply, 1.4.0 and patched build</summary>

Client chain = agent1 leaf + N copies of ca1 (920 bytes of DER each), server has `requestCert: true`, TLS 1.3 pinned, client writes `ping` after `secureConnect`.

```
bun 1.4.0
copies=0  chainDER~1004B  reply=pong:ping sessions=2
copies=20 chainDER~19404B reply=pong:ping sessions=2
copies=34 chainDER~32284B reply=pong:ping sessions=2
copies=36 chainDER~34124B reply=TIMEOUT   sessions=0
copies=52 chainDER~48844B reply=TIMEOUT   sessions=0
copies=68 chainDER~63564B reply=TIMEOUT   sessions=0
copies=72 chainDER~67244B reply=pong:ping sessions=0   (no tickets issued)
copies=80 chainDER~74604B reply=pong:ping sessions=0   (no tickets issued)

patched debug build
copies=0  chainDER~1004B  reply=pong:ping sessions=2
copies=20 chainDER~19404B reply=pong:ping sessions=2
copies=34 chainDER~32284B reply=pong:ping sessions=2
copies=36 chainDER~34124B reply=pong:ping sessions=2
copies=52 chainDER~48844B reply=pong:ping sessions=2
copies=68 chainDER~63564B reply=pong:ping sessions=0   (tickets arrive; the client-side 64 KiB cap on parked sessions drops them)
copies=72 chainDER~67244B reply=pong:ping sessions=0   (no tickets issued)
copies=80 chainDER~74604B reply=pong:ping sessions=0   (no tickets issued)
```

`sessions` counts the client's `'session'` events, i.e. tickets delivered.

Also ran on the patched build: `node-tls-server.test.ts` (70 pass; "SNICallback runs even when the requested servername matches the bind hostname" fails identically on the released bun here because this container resolves `localhost` to `::1` first, node behaves the same), `node-tls-connect`, `node-tls-cert`, `node-tls-context`, `renegotiation`, `bun-serve-ssl` (108 pass, 0 fail).
</details>
