### PR TITLE
resolver: report why auto-install failed on the ResolveMessage

### DIFF
--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -400,6 +400,14 @@ impl Queue {
 
     pub fn on_poll(&mut self) {
         bun_core::scoped_log!(AsyncModule, "onPoll");
+        if self.map.is_empty() {
+            // The package manager wakes us for every completed task, including
+            // the ones a synchronous auto-install (`enqueue_dependency_to_root`)
+            // is blocked on. That waiter drains them itself and logs failures;
+            // draining them here would hand the failures to the callbacks
+            // below, which have no module to deliver them to and drop them.
+            return;
+        }
         self.run_tasks();
         self.poll_modules();
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4628,21 +4628,16 @@ impl VirtualMachine {
             mode.is_esm(),
             IS_A_FILE_PATH,
         );
-        if let Err(err_) = resolve_result {
-            let err = err_;
+        if let Err(err) = resolve_result {
             let import_kind = mode.import_kind();
             // Find a `.resolve`-metadata msg if the log has one.
-            let msg = log
+            let resolve_msg_index = log
                 .msgs
                 .iter()
-                .find_map(|m| {
-                    if let bun_ast::Metadata::Resolve(_) = &m.metadata {
-                        Some(m.clone())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| {
+                .position(|m| matches!(m.metadata, bun_ast::Metadata::Resolve(_)));
+            let mut msg = match resolve_msg_index {
+                Some(i) => log.msgs[i].clone(),
+                None => {
                     let printed = crate::ResolveMessage::fmt(
                         specifier_utf8.slice(),
                         source_utf8.slice(),
@@ -4658,7 +4653,25 @@ impl VirtualMachine {
                         }),
                         ..Default::default()
                     }
-                });
+                }
+            };
+            // The resolver and the auto-install package manager report the
+            // reason a resolution failed (a `GET <tarball url> - 404`, an
+            // unreadable directory, ...) as ordinary errors/warnings in the
+            // scoped `log`, which dies with this frame. Carry them on the
+            // `ResolveMessage` as notes so they are printed with it.
+            let mut notes = core::mem::take(&mut msg.notes).into_vec();
+            notes.extend(
+                log.msgs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, m)| {
+                        Some(*i) != resolve_msg_index
+                            && matches!(m.kind, bun_ast::Kind::Err | bun_ast::Kind::Warn)
+                    })
+                    .map(|(_, m)| m.data.clone()),
+            );
+            msg.notes = notes.into_boxed_slice();
             *res = ErrorableString::err(
                 ErrorCode(ErrorCode::JS_ERROR_OBJECT),
                 crate::ResolveMessage::create(global, &msg, source_utf8.slice())?,

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -85,6 +85,106 @@ test("auto-install in a project whose package.json has a name and version", asyn
   expect(exitCode).toBe(1);
 });
 
+// A registry that has a manifest for `name` whose only version points at a
+// tarball the registry then answers with a 404. Every other path is a 404 too.
+function registryWithMissingTarball(name: string) {
+  const requests: string[] = [];
+  const tarballPath = `/${name}/-/${name}-1.0.0.tgz`;
+  const registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      requests.push(pathname);
+      if (pathname !== `/${name}`) return new Response("not found", { status: 404 });
+      return Response.json({
+        name,
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball: `${origin}${tarballPath}` } } },
+      });
+    },
+  });
+  const origin = `http://127.0.0.1:${registry.port}`;
+  return {
+    requests,
+    origin,
+    tarballPath,
+    tarballUrl: `${origin}${tarballPath}`,
+    [Symbol.dispose]() {
+      registry.stop(true);
+    },
+  };
+}
+
+async function runWithRegistry(registryOrigin: string, entry: string, source: string) {
+  using dir = tempDir("autoinstall-error-report", {
+    [entry]: source,
+    "bunfig.toml": `[install]\nregistry = "${registryOrigin}/"\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// While auto-installing, the package manager writes the reason a package could
+// not be installed (the tarball GET and its status, a network error name, ...)
+// into the log of the resolve that triggered it. Those lines are attached to
+// the ResolveMessage as notes; without them the only output is
+// "<error name> while resolving package '...'".
+describe.concurrent("auto-install reports why a package could not be installed", () => {
+  test("tarball 404, static import", async () => {
+    const name = "pkg-whose-tarball-is-missing";
+    using r = registryWithMissingTarball(name);
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "${name}";\n`);
+
+    expect(r.requests).toEqual([`/${name}`, r.tarballPath]);
+    expect(stderr).toContain(`note: GET ${r.tarballUrl} - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("tarball 404, require()", async () => {
+    const name = "pkg-whose-tarball-is-missing-cjs";
+    using r = registryWithMissingTarball(name);
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.cjs", `require("${name}");\n`);
+
+    expect(r.requests).toEqual([`/${name}`, r.tarballPath]);
+    expect(stderr).toContain(`note: GET ${r.tarballUrl} - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("tarball 404, dynamic import() caught and logged by the script", async () => {
+    const name = "pkg-whose-tarball-is-missing-dynamic";
+    using r = registryWithMissingTarball(name);
+    const { stdout, stderr, exitCode } = await runWithRegistry(
+      r.origin,
+      "index.js",
+      `try {\n  await import("${name}");\n} catch (err) {\n  console.log(err);\n}\n`,
+    );
+
+    expect(r.requests).toEqual([`/${name}`, r.tarballPath]);
+    expect(stdout).toContain(`package '${name}'`);
+    expect(stdout).toContain(`note: GET ${r.tarballUrl} - 404`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("manifest 404", async () => {
+    const name = "pkg-whose-manifest-is-missing";
+    using r = registryWithMissingTarball("some-other-package");
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "${name}";\n`);
+
+    expect(r.requests).toEqual([`/${name}`]);
+    expect(stderr).toContain(`error: Cannot find package '${name}'`);
+    expect(stderr).toContain(`note: GET ${r.origin}/${name} - 404`);
+    expect(exitCode).toBe(1);
+  });
+});
+
 test("--install=fallback to install missing packages", async () => {
   const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,8 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import path from "node:path";
 
 describe("ResolveMessage", () => {
+  it("carries what the resolver logged while failing as notes", async () => {
+    // The resolver records the reason it gave up (here: the dependency's
+    // package.json does not parse) in the log of the failing resolve. That
+    // used to be discarded, leaving a bare "Cannot find package".
+    using dir = tempDir("resolve-error-notes", {
+      "index.js": `import "badjson";\n`,
+      "node_modules/badjson/package.json": `{ "name": "badjson", "main":\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "error: Cannot find package 'badjson' from '<dir>/index.js'
+
+      1 | { "name": "badjson", "main":
+                                      ^
+      note: Unexpected end of file
+         at <dir>/node_modules/badjson/package.json:1:29
+
+      Bun v<bun-version>"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
   it("position object does not segfault", async () => {
     try {
       await import("./file-importing-nonexistent-file.js");


### PR DESCRIPTION
### Problem

- Auto-install (`bun index.js` with `import "pkg"` and no `node_modules`) whose manifest request succeeds but whose tarball download fails prints only `error: Unexpected while resolving package 'pkg' from '/path/index.js'`. Nothing names the tarball URL or the HTTP status. A caught `import()` rejects with a `ResolveMessage` that carries the same text and nothing else. (Bun 1.3.x printed `ENOENT while resolving package ...`; the request details were never shown.)
- The package manager does report it: the void-callback `run_tasks` used by the synchronous auto-install wait logs `GET <tarball url> - 404` (and `<Err> downloading tarball x@1.0.0`, `<Err> extracting tarball from x`, `GET <manifest url> - 404`, ...) into `pm.log`, which `VirtualMachine::resolve_maybe_needs_trailing_slash` points at a per-resolve `Log` (`src/jsc/VirtualMachine.rs:4575`). On failure that function only keeps the resolve-tagged message (or synthesizes one) and the rest of the log is dropped with the stack frame (`src/jsc/VirtualMachine.rs:4631`). The resolver's own diagnostics are lost the same way: a dependency whose `package.json` does not parse also comes out as a bare `Cannot find package 'x'`.
- About half of the time the line never reaches that log at all. `PackageManager::wake_raw` calls the `AsyncModule::Queue` wake handler on every completed task, and the resulting `on_poll` (`src/jsc/AsyncModule.rs:401`) ran `run_tasks` with the queue's callbacks while the synchronous waiter in `enqueue_dependency_to_root` was ticking the event loop. Those callbacks deliver failures to modules in `Queue::map`, but nothing populates that map any more (no code path fills `ParseResult::pending_imports`), so whichever completion the queue drained first was discarded. Which side won depended on whether the response landed before the waiter's `is_done` poll or inside the event loop tick.

### Fix

- `resolve_maybe_needs_trailing_slash`: after picking or synthesizing the resolve message, append every other error/warning `Msg` in the per-resolve log to it as notes (`Msg::notes`). `Msg::write_format` already prints notes under the error, and the uncaught-error printer, `console.log(err)` and the test runner all format a `ResolveMessage` through it, so the reason shows up wherever the error is printed. `.message`, `.code`, `.specifier` and friends are unchanged. Existing notes on the message are kept in front, so PRs that add hint notes to the synthesized message (#35446) compose with this.
- This is the right layer because the log is the channel both producers already use: `pm.log` and `resolver.log` are deliberately pointed at this `Log` for the duration of the resolve, and the failure enum that crosses the resolver/install boundary is `bun_core::Error`, which cannot carry a URL or status (everything install-specific maps to `Unexpected`). Formatting a new message in the resolver would duplicate text the package manager already wrote.
- `Queue::on_poll`: return early when `map` is empty. With no module waiting there is nothing the queue's callbacks can deliver to; the synchronous waiter drains the same completions through `is_done` and logs the failures. `wake_raw` still calls `event_loop.wakeup()`, so the waiter is still woken; the posted task just stops stealing the completions. A non-empty map behaves exactly as before.
- Verified:
  - `test/cli/run/run-autoinstall.test.ts`: tarball 404 via static import, `require()`, and a caught `import()` that `console.log`s the error; manifest 404 (now `error: Cannot find package ...` followed by `note: GET <manifest url> - 404`). Each asserts the exact requests the local registry received and the `note: GET <url> - 404` line. All four fail on bun 1.4.0 (no note) and pass with this change.
  - `test/js/bun/resolve/resolve-error.test.ts`: a dependency with a malformed `package.json` now prints the JSON error and its location under `Cannot find package` (inline snapshot); fails before, passes after.
  - 36/36 runs of a 2 scenarios x 6 entry styles matrix (static, dynamic, `require`, `require.resolve`, `Bun.resolveSync`, `import.meta.resolve`) print the note; before the `on_poll` change the notes change alone produced it in roughly half of them.
  - 80 timed runs of the tarball-404 script on the fixed debug build vs 40 on the unfixed one show the same manifest-to-tarball latency distribution (mean 159 ms vs 249 ms, one outlier above 1 s in each), so the early return does not stall the waiter. The latency itself comes from the waiter spinning the JS event loop and is what #36159 addresses.
  - `bun bd test` on the two files above plus `test/js/bun/resolve/*.test.*`, `test/js/node/missing-module.test.js`, `test/js/node/module/*`, `test/cli/run/run-autoinstall*.test.ts`, `test/cli/run/autoinstall-cached-manifest.test.ts`, `test/regression/issue/25622.test.ts`: all pass. Resolve failures that log nothing (relative paths, missing package with `node_modules` present) print exactly what they printed before.

### Background

- Runtime auto-install: when a bare specifier cannot be found and there is no `node_modules`, the resolver asks the in-process `PackageManager` to resolve and download the package synchronously. `enqueue_dependency_to_root` enqueues the work and then blocks in `sleep_until`, which alternates between an `is_done` poll (running `run_tasks` with `VoidRunTasksCallbacks`, whose failure path writes to `pm.log`) and a tick of the JS event loop. When it returns, the resolver looks the package up in the global cache; if the download failed the lookup fails and the resolver returns a generic error.
- `bun_ast::Log` / `Msg`: the diagnostics container shared by the parser, resolver and package manager. A `Msg` has a headline `Data` plus `notes: Box<[Data]>`, printed as `note:` lines under the headline. A `ResolveMessage` is the JS error object wrapping one `Msg`; the resolve-tagged `Msg` (`Metadata::Resolve`) is the one that provides `.specifier`/`.code`.
- `AsyncModule::Queue`: the queue of modules whose imports are being installed asynchronously, from an older auto-install design. The package manager's wake handler posts a "poll pending modules" task to the JS event loop on every completed task; `on_poll` drives `run_tasks` with callbacks that report per-module. The queue is still registered as the wake handler, but nothing enqueues modules into it today.
- The unused `LoaderHooks::resolve` body in `src/runtime/jsc_hooks.rs` duplicates this function but is never dispatched (`ModuleLoader.rs` never calls the field; the tests here confirm the `VirtualMachine` copy is the live one), so it is left alone.
- The headline `Unexpected` comes from `From<install::Error> for bun_core::Error` collapsing the cache lookup's `ENOENT`; #36659 reworks that mapping and is independent of this change. Version/dist-tag resolution failures of the auto-installed package (`fail_root_resolution`) are routed to the same empty queue and are still unexplained; that is handed off separately since the fix lives in `src/install`.

<details>
<summary>Output before / after (local registry serving a manifest whose tarball is a 404)</summary>

Before:

```
error: Unexpected while resolving package 'pkg-missing-from-registry' from '/tmp/proj/index.js'
```

After:

```
error: Unexpected while resolving package 'pkg-missing-from-registry' from '/tmp/proj/index.js'

note: GET http://127.0.0.1:41911/pkg-missing-from-registry/-/pkg-missing-from-registry-1.0.0.tgz - 404
```

Tarball host refusing connections (after retries):

```
error: Unexpected while resolving package 'pkg-with-manifest' from '/tmp/proj/index.js'

note: ConnectionRefused downloading tarball pkg-with-manifest@1.0.0
```

Dependency with a malformed package.json (no package manager involved):

```
error: Cannot find package 'badjson' from '/tmp/proj/a.js'

1 | { "name": "badjson", "main":
                                ^
note: Unexpected end of file
   at /tmp/proj/node_modules/badjson/package.json:1:29
```

</details>
