### PR TITLE
node:tls: report a wrapped socket's connect failure on the TLSSocket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2027,7 +2027,9 @@ Socket.prototype.connect = function connect(...args) {
             }
           } else {
             // wait to be connected
-            connection.once("connect", () => {
+            const onConnect = () => {
+              connection.removeListener("error", onError);
+              connection.removeListener("close", onClose);
               // The TLS socket may have been destroyed before the underlying
               // socket connected (e.g. tls.connect({ socket }).destroy()); don't
               // start a handshake on a dead socket.
@@ -2073,7 +2075,27 @@ Socket.prototype.connect = function connect(...args) {
                   throw new Error("Invalid socket");
                 }
               }
-            });
+            };
+            // Until the upgrade above happens nothing ties this socket to the
+            // connection, so a connect failure would leave it pending forever.
+            // Node re-emits the wrapped socket's 'error' here and destroys the
+            // TLS socket when the wrapped socket closes:
+            // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
+            // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L740
+            const onError = error => {
+              // The connection keeps connecting after this socket is destroyed
+              // (onConnect tears it down); its failure must not surface as an
+              // 'error' after this socket's 'close'.
+              if (!this.destroyed) this._emitTLSError(error);
+            };
+            const onClose = () => {
+              connection.removeListener("connect", onConnect);
+              connection.removeListener("error", onError);
+              this.destroy();
+            };
+            connection.once("connect", onConnect);
+            connection.on("error", onError);
+            connection.once("close", onClose);
           }
         }
       } catch (error) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2076,16 +2076,9 @@ Socket.prototype.connect = function connect(...args) {
                 }
               }
             };
-            // Until the upgrade above happens nothing ties this socket to the
-            // connection, so a connect failure would leave it pending forever.
-            // Node re-emits the wrapped socket's 'error' here and destroys the
-            // TLS socket when the wrapped socket closes:
-            // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
-            // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L740
+            // Until then, route the connection's failure like node's wrap (internal/tls/wrap.js _init / _wrapHandle).
             const onError = error => {
-              // The connection keeps connecting after this socket is destroyed
-              // (onConnect tears it down); its failure must not surface as an
-              // 'error' after this socket's 'close'.
+              // Not once this socket was destroyed while waiting (onConnect tears the connection down).
               if (!this.destroyed) this._emitTLSError(error);
             };
             const onClose = () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1529,4 +1529,32 @@ describe("tls.connect({ socket }) over a net.Socket whose connect has not comple
 
     expect(log).toEqual(["tls close hadError=false"]);
   });
+
+  it("a socket reconnected after the failure is no longer tied to the closed TLSSocket", async () => {
+    await using refused = await refusedPort();
+    // resume() so whatever the client sends is discarded and the accepted
+    // socket can reach 'end' -> autoDestroy, letting the disposal close() finish.
+    await using plain = net.createServer(socket => {
+      socket.resume();
+      socket.end("plain");
+    });
+    await once(plain.listen(0, "127.0.0.1"), "listening");
+    const log: string[] = [];
+    const raw = net.connect(refused.port, "127.0.0.1");
+    raw.on("error", () => {});
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    observe("tls", client, log);
+    await closed(raw);
+
+    // The wrap's 'connect' listener used to stay armed and upgrade whatever
+    // the socket connected to next, so the plain reply below reached the
+    // TLSSocket as ERR_SSL_WRONG_VERSION_NUMBER.
+    raw.connect((plain.address() as AddressInfo).port, "127.0.0.1");
+    const received: Buffer[] = [];
+    raw.on("data", chunk => received.push(chunk));
+    await closed(raw);
+
+    expect(Buffer.concat(received).toString()).toBe("plain");
+    expect(log).toEqual(["tls error ECONNREFUSED", "tls close hadError=false"]);
+  });
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1426,3 +1426,107 @@ describe("throwing 'secureConnect' listener", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("tls.connect({ socket }) over a net.Socket whose connect has not completed yet", () => {
+  // The upgrade to TLS only happens once the wrapped socket emits 'connect'.
+  // Until then node forwards the wrapped socket's 'error' to the TLSSocket and
+  // destroys the TLSSocket when the wrapped socket closes; the event sequences
+  // asserted below are the ones node v26.3.0 produces.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L740
+
+  // A port on 127.0.0.1 that refuses connections: it is the local port of a
+  // live connection, so nothing listens on it and, unlike a port that was
+  // bound and released again, a concurrent listen(0) cannot be handed it.
+  async function refusedPort(): Promise<{ port: number } & AsyncDisposable> {
+    const sink = net.createServer();
+    await once(sink.listen(0, "127.0.0.1"), "listening");
+    const holder = net.connect((sink.address() as AddressInfo).port, "127.0.0.1");
+    const [[accepted]] = await Promise.all([once(sink, "connection"), once(holder, "connect")]);
+    return {
+      port: (holder.address() as AddressInfo).port,
+      async [Symbol.asyncDispose]() {
+        holder.destroy();
+        accepted.destroy();
+        sink.close();
+        await once(sink, "close");
+      },
+    };
+  }
+
+  function observe(name: string, socket: net.Socket, log: string[], errors: Error[] = []) {
+    socket.on("error", err => {
+      errors.push(err);
+      log.push(`${name} error ${(err as NodeJS.ErrnoException).code}`);
+    });
+    socket.on("close", hadError => log.push(`${name} close hadError=${hadError}`));
+  }
+
+  // events.once() would reject on the 'error' these tests expect first.
+  function closed(socket: net.Socket): Promise<void> {
+    return new Promise(resolve => socket.once("close", () => resolve()));
+  }
+
+  it("a refused connect is emitted as the TLSSocket's 'error', then its 'close'", async () => {
+    await using refused = await refusedPort();
+    const log: string[] = [];
+    const errors: Error[] = [];
+    const raw = net.connect(refused.port, "127.0.0.1");
+    observe("raw", raw, log, errors);
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    observe("tls", client, log, errors);
+
+    await closed(client);
+
+    expect(log).toEqual([
+      "raw error ECONNREFUSED",
+      "tls error ECONNREFUSED",
+      "raw close hadError=true",
+      "tls close hadError=false",
+    ]);
+    // The TLSSocket re-emits the wrapped socket's error object itself.
+    expect(errors[1]).toBe(errors[0]);
+  });
+
+  it("a socket that starts connecting after being wrapped reports the failure to TLSSocket listeners alone", async () => {
+    await using refused = await refusedPort();
+    const log: string[] = [];
+    const raw = new net.Socket();
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    observe("tls", client, log);
+    raw.connect(refused.port, "127.0.0.1");
+
+    await closed(client);
+
+    expect(log).toEqual(["tls error ECONNREFUSED", "tls close hadError=false"]);
+  });
+
+  it("destroying the socket before it connects closes the TLSSocket without an error", async () => {
+    await using refused = await refusedPort();
+    const log: string[] = [];
+    const raw = net.connect(refused.port, "127.0.0.1");
+    observe("raw", raw, log);
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    observe("tls", client, log);
+    raw.destroy();
+
+    await closed(client);
+
+    expect(log).toEqual(["raw close hadError=false", "tls close hadError=false"]);
+  });
+
+  it("a connect that fails after the TLSSocket was destroyed is neither emitted on it nor left unhandled", async () => {
+    await using refused = await refusedPort();
+    const log: string[] = [];
+    // No listeners on the wrapped socket: its refused connect used to surface
+    // as an uncaught exception here.
+    const raw = net.connect(refused.port, "127.0.0.1");
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    observe("tls", client, log);
+    client.destroy();
+
+    await closed(raw);
+
+    expect(log).toEqual(["tls close hadError=false"]);
+  });
+});


### PR DESCRIPTION
### Problem
- `tls.connect({ socket })` over a `net.Socket` whose connect is still in flight (`net.connect(...)` passed straight in, or a `new net.Socket()` connected after being wrapped) never reports a failed connect: the plain socket emits `error` + `close`, the TLSSocket emits nothing, and a caller waiting on its `secureConnect` / `error` / `close` hangs.
- If the caller only listens on the TLSSocket (the documented usage), the plain socket's `ECONNREFUSED` is an uncaught exception instead. Same after `tls.connect({ socket }).destroy()` while the socket was still connecting.
- The `connect` listener also stays armed after the failure: a `net.Socket` that is reconnected afterwards (retry logic reusing the socket) is upgraded to TLS by the dead wrap, so a plain server gets a ClientHello and the orphaned TLSSocket reports `ERR_SSL_WRONG_VERSION_NUMBER`.
- Cause: the wait-for-connect arm of `Socket.prototype.connect` (src/js/node/net.ts, around line 2030) only registers `connection.once("connect", ...)`. Nothing links the two sockets until that upgrade runs, so the connection's `error` / `close` go nowhere. The already-connected arm (`upgradeTLSDeferred`) and the duplex arm (`upgradeDuplexToTLS` wires `close`) do not have this gap.
- Node prints `raw error ECONNREFUSED`, `tls error ECONNREFUSED`, `raw close`, `tls close` for the repro; bun printed only the two `raw` lines.

### Fix
- While waiting for `connect`, also listen for the connection's `error` (re-emitted on the TLSSocket through `_emitTLSError`) and `close` (destroys the TLSSocket). `connect` removes both listeners before upgrading; `close` removes the `connect` listener, which is what stops the dead wrap from upgrading a later reconnect.
- Matches node: `_init` does `wrap.on('error', err => this._emitTLSError(err))` and `_wrapHandle` does `wrap.on('close', () => this.destroy())` (lib/internal/tls/wrap.js L977 / L740 in v26.3.0). Going through `_emitTLSError` keeps node's `_controlReleased` semantics, and the resulting events (`error` carrying the connection's own error object, then `close` with `hadError === false`) are exactly node's.
- The listeners are scoped to the waiting period because after the upgrade the adopted native handle (or the duplex engine) already reports the connection's errors and close to the TLSSocket itself, and a `net.Socket` can be reconnected after it closes, so listeners left behind would act on a TLSSocket that has moved on.
- `error` is ignored once the TLSSocket is already destroyed: bun keeps the connection connecting until `connect` fires after `tls.connect({ socket }).destroy()`, and its failure must not surface as an `error` after the TLSSocket's `close`. The listener still absorbs it, so it is no longer an uncaught exception either.
- Complementary to #37664 / #34507, which tear the wrapped socket down when the TLSSocket is destroyed (the other direction); neither makes a failed connect reach the TLSSocket. One more neighbour: a client TLSSocket built with `new tls.TLSSocket(socket)` and then explicitly `connect({ socket })`ed keeps the stream as its `_handle`, and `destroy()` on such a socket throws `handle.close is not a function` on main today (#35842 fixes that); `tls.connect({ socket })`, the path this PR is about, has no `_handle` while waiting.
- Verified with the five new tests in test/js/node/tls/node-tls-connect.test.ts (`describe("tls.connect({ socket }) over a net.Socket whose connect has not completed yet")`): connect in flight, connect started after wrapping with listeners on the TLSSocket only, `raw.destroy()` while connecting, `tlsSocket.destroy()` while connecting, and reconnecting the socket after the failure. All five fail without the src change (two time out, two die on the unhandled `ECONNREFUSED`, the reconnect one gets `ERR_SSL_WRONG_VERSION_NUMBER`; checked with `USE_SYSTEM_BUN=1` for all five and with a `bun bd` build of main for the first four), pass with the fix, and stayed green over repeated runs.
- The rest of node-tls-connect.test.ts, node-tls-connect-hostname-verification.test.ts, node-http-connect.test.ts's https CONNECT case (wraps a still-connecting socket and expects the handshake to succeed), and the vendored test-tls-net-socket-keepalive, test-tls-connect-given-socket, test-socket-writes-before-passed-to-tls-socket, test-tls-connect-stream-writes, test-tls-socket-close, test-tls-socket-destroy, test-tls-connect-pipe, test-tls-connect-simple, test-tls-connect-abort-controller, test-tls-socket-allow-half-open-option, test-tls-socket-failed-handshake-emits-error pass. node-net.test.ts has the same 12 failures with and without the change (this container resolves `localhost` to `::1` for the server and `127.0.0.1` for the client; node behaves the same here).

### Background
- `tls.connect({ socket })` builds a TLSSocket over a transport the caller owns instead of opening its own TCP connection. In bun the TLS layer is attached in `Socket.prototype.connect`, in one of three ways: a connected `net.Socket` has its native handle adopted on the spot (`upgradeTLSDeferred`), a generic duplex / named pipe gets a stream-level TLS engine (`upgradeDuplexToTLS`), and a `net.Socket` that has no handle yet or is still connecting waits for its `connect` event and then takes one of the first two paths. Only that third, waiting state had no link between the two sockets.
- `_emitTLSError` is node's routing for errors that happen on a TLSSocket's underlying transport: it emits `_tlsError` and, once `_releaseControl()` has handed the socket to the user (which `tls.connect()` does right away), emits `error`. It does not destroy the socket; in node the socket is destroyed by the transport's `close`, which is why the TLSSocket's `close` carries `hadError === false` in this flow.

<details>
<summary>Repro and node / bun output</summary>

```js
import net from "node:net";
import tls from "node:tls";
const srv = net.createServer().listen(0, "127.0.0.1", () => {
  const port = srv.address().port;
  srv.close(() => {
    const raw = net.connect({ port, host: "127.0.0.1" }); // still connecting when wrapped
    raw.on("error", e => console.log("raw error", e.code));
    raw.on("close", hadError => console.log("raw close", hadError));
    const c = tls.connect({ socket: raw, rejectUnauthorized: false });
    c.on("error", e => console.log("tls error", e.code));
    c.on("close", hadError => console.log("tls close", hadError));
  });
});
```

node v26.3.0 and bun with this change:

```
raw error ECONNREFUSED
tls error ECONNREFUSED
raw close true
tls close false
```

bun 1.4.0 (and a debug build of main):

```
raw error ECONNREFUSED
raw close true
```

The same probe with `raw.destroy()` right after wrapping prints `raw close false` / `tls close false` on node and with this change, only `raw close false` before. With `c.destroy()` right after wrapping and no listeners on `raw`, bun before this change exits with an uncaught `ECONNREFUSED`; node and bun with this change print `tls close false` and exit cleanly.
</details>
