### PR TITLE
bun build --no-bundle: write copied entry points (wasm, napi, file, ...) into --outdir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,6 @@ dependencies = [
  "bun_threading",
  "bun_url",
  "bun_watcher",
- "bun_wyhash",
  "bun_zstd",
  "const_format",
  "enum-map",

--- a/src/ast/target.rs
+++ b/src/ast/target.rs
@@ -57,6 +57,18 @@ impl Target {
         matches!(self, Target::Node)
     }
 
+    /// What `[target]` expands to in `--entry-naming` and friends.
+    #[inline]
+    pub fn naming_placeholder(self) -> &'static [u8] {
+        match self {
+            Target::Browser => b"browser",
+            Target::Bun => b"bun",
+            Target::Node => b"node",
+            Target::BunMacro => b"macro",
+            Target::ServerComponentsSsr => b"ssr",
+        }
+    }
+
     #[inline]
     pub fn process_browser_define_value(self) -> Option<&'static str> {
         match self {

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -128,14 +128,7 @@ pub type Index = bun_core::GenericIndex<u32, OutputFile>;
 pub type IndexOptional = bun_core::GenericIndexOptional<u32, OutputFile>;
 
 #[derive(Clone)]
-pub struct FileOperation {
-    // Owned copy so the field has a single, obvious lifetime.
-    pub pathname: Box<[u8]>,
-}
-
-#[derive(Clone)]
 pub enum Value {
-    Copy(FileOperation),
     Noop,
     Buffer { bytes: Box<[u8]> },
     Saved(SavedFile),
@@ -173,8 +166,8 @@ impl Value {
                     noop,
                 )
             }
-            Value::Copy(_) | Value::Saved(_) => {
-                bun_core::todo_panic!("to_bun_string_ref: Copy/Saved")
+            Value::Saved(_) => {
+                bun_core::todo_panic!("to_bun_string_ref: Saved")
             }
         }
     }
@@ -248,21 +241,17 @@ impl OutputFile {
         }
     }
 
-    pub fn write_to_disk(&self, root_dir: Fd, root_dir_path: &[u8]) -> Result<(), Error> {
+    /// `dest_path` is relative to `root_dir`.
+    pub fn write_to_disk(&self, root_dir: Fd) -> Result<(), Error> {
         match &self.value {
             Value::Noop => {}
             Value::Saved(_) => {
                 // already written to disk
             }
             Value::Buffer { bytes } => {
-                let mut rel_path: &[u8] = &self.dest_path;
-                if self.dest_path.len() > root_dir_path.len() {
-                    rel_path = resolve_path::relative(root_dir_path, &self.dest_path);
-                    // `dirname` returns `b""` when there's no separator.
-                    let parent = resolve_path::dirname::<platform::Auto>(rel_path);
-                    if !parent.is_empty() {
-                        bun_sys::Dir::borrow(&root_dir).make_path(parent)?;
-                    }
+                let parent = resolve_path::dirname::<platform::Auto>(&self.dest_path);
+                if !parent.is_empty() && parent != b"." {
+                    bun_sys::Dir::borrow(&root_dir).make_path(parent)?;
                 }
 
                 let mut path_buf = PathBuffer::uninit();
@@ -273,44 +262,12 @@ impl OutputFile {
                         encoding: bun_sys::WriteFileEncoding::Buffer,
                         mode: if self.is_executable { 0o755 } else { 0o644 },
                         dirfd: root_dir,
-                        file: bun_sys::PathOrFileDescriptor::Path(rel_path),
+                        file: bun_sys::PathOrFileDescriptor::Path(&self.dest_path),
                     },
                 )?;
             }
-            Value::Copy(value) => {
-                self.copy_to(root_dir_path, &value.pathname, root_dir)?;
-            }
         }
         Ok(())
-    }
-
-    pub(crate) fn copy_to(&self, _: &[u8], rel_path: &[u8], dir: Fd) -> Result<(), Error> {
-        let mut out_buf = PathBuffer::uninit();
-        let fd_out = bun_sys::openat(
-            dir,
-            resolve_path::z(rel_path, &mut out_buf),
-            bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
-            0o644,
-        )?;
-        let mut in_buf = PathBuffer::uninit();
-        let fd_in = bun_sys::openat(
-            Fd::cwd(),
-            resolve_path::z(self.src_path.text, &mut in_buf),
-            bun_sys::O::RDONLY,
-            0,
-        )?;
-
-        #[cfg(windows)]
-        {
-            let _ = (fd_out, fd_in);
-            // use paths instead of bun.getFdPathW()
-            panic!("TODO windows");
-        }
-        #[cfg(not(windows))]
-        {
-            bun_sys::copy_file(fd_in, fd_out)?;
-            Ok(())
-        }
     }
 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4260,10 +4260,7 @@ pub mod bv2_impl {
                             }
 
                             if template.needs(options::PlaceholderField::Target) {
-                                template.placeholder.target = <&'static str>::from(target)
-                                    .as_bytes()
-                                    .to_vec()
-                                    .into_boxed_slice();
+                                template.placeholder.target = target.naming_placeholder().into();
                             }
                             let mut v = Vec::new();
                             template

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -4,7 +4,6 @@ use std::io::Write as _;
 
 use bun_ast::Log;
 use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag};
-use bun_collections::HashMap;
 use bun_paths::{self, SEP};
 // two `fs` shapes are in play here. `bun_resolver::fs` (`Fs`) holds
 // the singleton `FileSystem` / `DirnameStore`; `bun_paths::fs` (`PFs`) defines
@@ -15,7 +14,6 @@ use bun_core::strings;
 use bun_paths::fs as PFs;
 use bun_resolver::fs as Fs;
 use bun_resolver::{self as resolver, Resolver};
-use bun_sys::Fd;
 use bun_url::URL;
 
 use crate::options::{self, BundleOptions, ImportPathFormat};
@@ -23,12 +21,6 @@ use crate::options_impl::Target as BundleTarget;
 use crate::transpiler::{
     BunPluginTarget, ParseResult, PluginResolver, PluginRunner, ResolveQueue, ResolveResults,
 };
-
-type HashedFileNameMap = HashMap<u64, &'static [u8]>;
-
-// Matches `Transpiler::IS_CACHE_ENABLED`; inlined so `get_hashed_filename`
-// doesn't need a `Transpiler` handle.
-const IS_CACHE_ENABLED: bool = false;
 
 pub struct Linker {
     // arena field dropped — global mimalloc (callers pass `bun.default_allocator`)
@@ -43,7 +35,6 @@ pub struct Linker {
     pub(crate) resolve_queue: *mut ResolveQueue,
     pub resolver: *mut Resolver<'static>,
     pub(crate) resolve_results: *mut ResolveResults,
-    pub(crate) hashed_filenames: HashedFileNameMap,
 
     pub plugin_runner: Option<*mut dyn PluginResolver>,
 }
@@ -131,12 +122,6 @@ pub(crate) fn dupe(src: &[u8]) -> &'static [u8] {
     // a slice borrowing that storage; the returned borrow is `'static`-valid
     // by construction.
     unsafe { ImportPathsList::append(relative_paths_list_ptr(), &src).expect("OOM") }
-}
-#[inline]
-fn intern(buf: Vec<u8>) -> &'static [u8] {
-    let r = dupe(buf.as_slice());
-    drop(buf);
-    r
 }
 impl Linker {
     // ── raw-pointer field accessors ──────────────────────────────────────
@@ -251,7 +236,6 @@ impl Linker {
             resolve_queue,
             resolver,
             resolve_results,
-            hashed_filenames: HashedFileNameMap::default(),
             plugin_runner: None,
         }
     }
@@ -276,77 +260,6 @@ impl Linker {
         self.resolver = resolver;
         self.resolve_results = resolve_results;
         self.fs = fs;
-    }
-
-    // ── getModKey / getHashedFilename ────────────────────────────────────
-    // `ModKey` lives at module scope (`bun_resolver::fs::ModKey`)
-    // alongside `RealFS`. `file_path` is typed `PFs::Path` (not `Fs::Path`)
-    // so `get_hashed_filename` — whose callers all build `PFs::Path` — can
-    // forward directly; only `.text` (a `&[u8]`) is read.
-    pub(crate) fn get_mod_key(
-        &mut self,
-        file_path: &PFs::Path<'_>,
-        fd: Option<Fd>,
-    ) -> crate::Result<Fs::ModKey> {
-        // Borrow the cached fd; own the freshly-opened one.
-        let _owned: Option<bun_sys::File>;
-        let raw_fd = match fd {
-            Some(f) => {
-                _owned = None;
-                f
-            }
-            None => {
-                let f = bun_sys::open_file(file_path.text, bun_sys::OpenFlags::READ_ONLY)?;
-                let raw = f.handle();
-                _owned = Some(f);
-                raw
-            }
-        };
-        let file = bun_sys::File::borrow(&raw_fd);
-        Fs::FileSystem::set_max_fd(file.handle().native());
-        // spec called `Fs.FileSystem.RealFS.ModKey.generate(&this.fs.fs,
-        // path, file)`; both leading args are unread (fs.rs:1386). The inline
-        // `bun_resolver::fs::RealFS` (which `self.fs.fs` is) and the full-port
-        // `fs_full::RealFS` are distinct types, so route through the
-        // RealFS-agnostic `from_file` wrapper added alongside the `ModKey`
-        // re-export.
-        Ok(Fs::ModKey::from_file(file)?)
-    }
-
-    pub(crate) fn get_hashed_filename(
-        &mut self,
-        file_path: &PFs::Path<'_>,
-        fd: Option<Fd>,
-    ) -> crate::Result<&'static [u8]> {
-        if IS_CACHE_ENABLED {
-            let hashed = bun_wyhash::hash(file_path.text);
-            if let Some(v) = self.hashed_filenames.get(&hashed) {
-                return Ok(*v);
-            }
-        }
-
-        let modkey = self.get_mod_key(file_path, fd)?;
-        // `ModKey::hash_name` writes into a caller-supplied buffer (1 KiB)
-        // and returns a borrow of it; `dupe` copies the bytes into the
-        // process-lifetime interner to satisfy this fn's `'static` return.
-        // Note: `IS_CACHE_ENABLED` is a hard `const false` (see above), so
-        // the `hashed_filenames` cache never dedups — every call interns a
-        // fresh copy for the life of the process. Accepted: the `'static`
-        // return contract forces a copy anyway, and the alternative (the old
-        // threadlocal slice return) was unsound. `dupe` also aborts on OOM
-        // where the old path propagated `?` — consistent with the
-        // `bun.handleOom` idiom for interner allocations.
-        // Spec passes `file_path.text` even though the param is named
-        // `basename`; preserved verbatim.
-        let mut hash_name_buf = [0u8; 1024];
-        let hash_name = dupe(modkey.hash_name(file_path.text, &mut hash_name_buf)?);
-
-        if IS_CACHE_ENABLED {
-            let hashed = bun_wyhash::hash(file_path.text);
-            self.hashed_filenames.insert(hashed, hash_name);
-        }
-
-        Ok(hash_name)
     }
 
     /// This modifies the Ast in-place! It resolves import records and
@@ -415,7 +328,6 @@ impl Linker {
                                 import_record.path = self.generate_import_path(
                                     source_dir,
                                     RUNTIME_SOURCE_PATH,
-                                    false,
                                     b"bun",
                                     origin,
                                     import_path_format,
@@ -502,7 +414,6 @@ impl Linker {
                                 import_record.path = self.generate_import_path(
                                     source_dir,
                                     path.text,
-                                    false,
                                     path.namespace,
                                     origin,
                                     import_path_format,
@@ -605,7 +516,6 @@ impl Linker {
         &mut self,
         source_dir: &[u8],
         source_path: &'static [u8],
-        use_hashed_name: bool,
         namespace: &'static [u8],
         origin: &URL<'_>,
         import_path_format: ImportPathFormat,
@@ -632,32 +542,15 @@ impl Linker {
             ImportPathFormat::Relative => {
                 let relative_name = bun_paths::resolve_path::relative(source_dir, source_path);
 
-                let pretty: &'static [u8];
-                let relative_name_out: &'static [u8];
-                if use_hashed_name {
-                    let basepath = PFs::Path::init(source_path);
-                    let basename = self.get_hashed_filename(&basepath, None)?;
-                    let name = basepath.name();
-                    let dir = name.dir_with_trailing_slash();
-                    let mut _pretty: Vec<u8> =
-                        Vec::with_capacity(dir.len() + basename.len() + name.ext.len());
-                    _pretty.extend_from_slice(dir);
-                    _pretty.extend_from_slice(basename);
-                    _pretty.extend_from_slice(name.ext);
-                    pretty = intern(_pretty);
-                    relative_name_out = dupe(relative_name);
+                let pretty: &'static [u8] = if relative_name.len() > 1
+                    && !(relative_name[0] == SEP || relative_name[0] == b'.')
+                {
+                    dupe(&strings::concat(&[b"./", relative_name]))
                 } else {
-                    if relative_name.len() > 1
-                        && !(relative_name[0] == SEP || relative_name[0] == b'.')
-                    {
-                        pretty = dupe(&strings::concat(&[b"./", relative_name]));
-                    } else {
-                        pretty = dupe(relative_name);
-                    }
-                    relative_name_out = pretty;
-                }
+                    dupe(relative_name)
+                };
 
-                Ok(PFs::Path::init_with_pretty(pretty, relative_name_out))
+                Ok(PFs::Path::init_with_pretty(pretty, pretty))
             }
 
             ImportPathFormat::AbsoluteUrl => {
@@ -693,12 +586,7 @@ impl Linker {
 
                     let dirname = bun_core::dirname(base).unwrap_or(b"");
 
-                    let mut basename: &[u8] = bun_paths::basename(base);
-
-                    if use_hashed_name {
-                        let basepath = PFs::Path::init(source_path);
-                        basename = self.get_hashed_filename(&basepath, None)?;
-                    }
+                    let basename: &[u8] = bun_paths::basename(base);
 
                     Ok(PFs::Path::init(dupe(&origin.join_alloc(
                         b"",

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -627,13 +627,7 @@ pub(crate) fn compute_chunks(
         if chunk.template.needs(PlaceholderField::Target) {
             // Determine the target from the AST of the entry point source
             let chunk_target = ast_targets[chunk.entry_point.source_index() as usize];
-            chunk.template.placeholder.target = match chunk_target {
-                Target::Browser => b"browser".to_vec().into_boxed_slice(),
-                Target::Bun => b"bun".to_vec().into_boxed_slice(),
-                Target::Node => b"node".to_vec().into_boxed_slice(),
-                Target::BunMacro => b"macro".to_vec().into_boxed_slice(),
-                Target::ServerComponentsSsr => b"ssr".to_vec().into_boxed_slice(),
-            };
+            chunk.template.placeholder.target = chunk_target.naming_placeholder().into();
         }
 
         if chunk.template.needs(PlaceholderField::Dir) {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2830,28 +2830,23 @@ impl<'a> Transpiler<'a> {
             return Ok(None);
         };
         // `resolver::Result.path_pair` carries `bun_resolver::fs::Path<'_>`;
-        // downstream `linker.link`/`get_hashed_filename` and `OutputFile.src_path`
-        // expect `bun_paths::fs::Path<'_>` / `bun_paths::fs::Path<'static>`. Re-init via
+        // downstream `linker.link` and `OutputFile.src_path` expect
+        // `bun_paths::fs::Path<'_>` / `bun_paths::fs::Path<'static>`. Re-init via
         // `text` (the only field both shapes share semantically).
         let file_path_text: &'static [u8] = crate::linker::dupe(file_path_ref.text);
-        let file_path_ext: &'static [u8] = crate::linker::dupe(file_path_ref.name().ext);
 
         // Step 1. Parse & scan
         // Key the loader on the ORIGINAL resolve
         // result's extension *before* the `client_entry_point` path override.
         // Compute it here, then apply the override.
-        let loader = self.options.loader(file_path_ext);
+        let loader = self.options.loader(file_path_ref.name().ext);
 
         // `client_entry_point_` is always `None` from the only in-tree caller;
         // its source path uses the `bun_paths::fs::Path<'static>` shape, so just override
-        // text/ext when present.
-        let (file_path_text, file_path_ext) = if let Some(cep) = client_entry_point_.as_deref() {
-            (
-                crate::linker::dupe(cep.source.path.text),
-                crate::linker::dupe(cep.source.path.name().ext),
-            )
-        } else {
-            (file_path_text, file_path_ext)
+        // the text when present.
+        let file_path_text = match client_entry_point_.as_deref() {
+            Some(cep) => crate::linker::dupe(cep.source.path.text),
+            None => file_path_text,
         };
 
         let mut file_path = Fs::Path::init(file_path_text);
@@ -2997,11 +2992,57 @@ impl<'a> Transpiler<'a> {
             | options::Loader::Wasm
             | options::Loader::File
             | options::Loader::Napi => {
-                output_file.value = self.build_copied_file_output(file_path_text, file_path_ext)?;
+                let Some(bytes) = self.read_copied_file(file_path_text, file_path.pretty) else {
+                    return Ok(None);
+                };
+                output_file.size = bytes.len();
+                output_file.dest_path = self.transform_only_dest_path(
+                    file_path_text,
+                    file_path.name().ext_without_leading_dot(),
+                    &bytes,
+                );
+                output_file.value = crate::output_file::Value::Buffer { bytes };
             }
         }
 
         Ok(Some(output_file))
+    }
+
+    /// Mirrors the entry-point naming in `computeChunks`: `--entry-naming`
+    /// (default `[dir]/[name].[ext]`) applied to the path relative to `--root`,
+    /// producing a posix path relative to `--outdir`.
+    fn transform_only_dest_path(
+        &self,
+        file_path_text: &[u8],
+        ext: &[u8],
+        output: &[u8],
+    ) -> Box<[u8]> {
+        let rel_to_root = bun_paths::resolve_path::relative_platform::<
+            bun_paths::resolve_path::platform::Loose,
+            false,
+        >(&self.options.root_dir, file_path_text);
+        let pathname = Fs::PathName::init(rel_to_root);
+
+        let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
+        if !self.options.entry_naming.is_empty() {
+            template.data.clone_from(&self.options.entry_naming);
+        }
+        template.placeholder.dir = pathname.dir.into();
+        template.placeholder.name = pathname.base.into();
+        template.placeholder.ext = ext.into();
+        if template.needs(options::PlaceholderField::Target) {
+            template.placeholder.target = self.options.target.naming_placeholder().into();
+        }
+        if template.needs(options::PlaceholderField::Hash) {
+            template.placeholder.hash = Some(crate::ContentHasher::run(output));
+        }
+
+        let mut dest_path = Vec::new();
+        template
+            .print(&mut dest_path, true)
+            .expect("write to Vec<u8>");
+        bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut dest_path);
+        dest_path.into_boxed_slice()
     }
 
     /// Cold path: `bun build` of a `.css` entry. Split out of
@@ -3121,25 +3162,31 @@ impl<'a> Transpiler<'a> {
 
     /// Cold path: `bun build` of a non-JS asset copied verbatim (`.html`,
     /// `.wasm`, `.node`, sqlite, bunsh, generic `file`). Split out so it
-    /// isn't interleaved (post-LTO) with the hot JS/TS transpile path.
+    /// isn't interleaved (post-LTO) with the hot JS/TS transpile path. Read
+    /// with `bun_sys` rather than the resolver's file cache, which strips BOMs.
+    /// Returns `None` after logging when the file cannot be read.
     #[cold]
     #[inline(never)]
-    fn build_copied_file_output(
+    fn read_copied_file(
         &mut self,
-        file_path_text: &'static [u8],
-        file_path_ext: &[u8],
-    ) -> crate::Result<crate::output_file::Value> {
-        let hashed_name = self
-            .linker
-            .get_hashed_filename(&bun_paths::fs::Path::init(file_path_text), None)?;
-        let mut pathname = Vec::with_capacity(hashed_name.len() + file_path_ext.len());
-        pathname.extend_from_slice(hashed_name);
-        pathname.extend_from_slice(file_path_ext);
-        Ok(crate::output_file::Value::Copy(
-            crate::output_file::FileOperation {
-                pathname: pathname.into_boxed_slice(),
-            },
-        ))
+        file_path_text: &[u8],
+        file_path_pretty: &[u8],
+    ) -> Option<Box<[u8]>> {
+        match bun_sys::File::read_from(FD::cwd(), file_path_text) {
+            Ok(bytes) => Some(bytes.into_boxed_slice()),
+            Err(err) => {
+                self.log_mut().add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "{} reading \"{}\"",
+                        bstr::BStr::new(err.name()),
+                        bstr::BStr::new(file_path_pretty),
+                    ),
+                );
+                None
+            }
+        }
     }
 }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2826,24 +2826,14 @@ impl<'a> Transpiler<'a> {
         let Some(file_path_ref) = resolve_result.path_const() else {
             return Ok(None);
         };
-        // `resolver::Result.path_pair` carries `bun_resolver::fs::Path<'_>`;
-        // downstream `linker.link` and `OutputFile.src_path` expect
-        // `bun_paths::fs::Path<'_>` / `bun_paths::fs::Path<'static>`. Re-init via
-        // `text` (the only field both shapes share semantically).
-        let file_path_text: &'static [u8] = crate::linker::dupe(file_path_ref.text);
-
         // Step 1. Parse & scan
-        // Key the loader on the ORIGINAL resolve
-        // result's extension *before* the `client_entry_point` path override.
-        // Compute it here, then apply the override.
+        // The loader is keyed on the resolved extension, not on the
+        // `client_entry_point` override below.
         let loader = self.options.loader(file_path_ref.name().ext);
 
-        // `client_entry_point_` is always `None` from the only in-tree caller;
-        // its source path uses the `bun_paths::fs::Path<'static>` shape, so just override
-        // the text when present.
-        let file_path_text = match client_entry_point_.as_deref() {
-            Some(cep) => crate::linker::dupe(cep.source.path.text),
-            None => file_path_text,
+        let file_path_text: &'static [u8] = match client_entry_point_.as_deref() {
+            Some(cep) => cep.source.path.text,
+            None => file_path_ref.text,
         };
 
         let mut file_path = Fs::Path::init(file_path_text);
@@ -3005,9 +2995,7 @@ impl<'a> Transpiler<'a> {
         Ok(Some(output_file))
     }
 
-    /// Mirrors the entry-point naming in `computeChunks`: `--entry-naming`
-    /// (default `[dir]/[name].[ext]`) applied to the path relative to `--root`,
-    /// producing a posix path relative to `--outdir`.
+    /// `--entry-naming` relative to `--root`, as `computeChunks` names entry points.
     fn transform_only_dest_path(
         &self,
         file_path_text: &[u8],
@@ -3157,11 +3145,8 @@ impl<'a> Transpiler<'a> {
         })
     }
 
-    /// Cold path: `bun build` of a non-JS asset copied verbatim (`.html`,
-    /// `.wasm`, `.node`, sqlite, bunsh, generic `file`). Split out so it
-    /// isn't interleaved (post-LTO) with the hot JS/TS transpile path. Read
-    /// with `bun_sys` rather than the resolver's file cache, which strips BOMs.
-    /// Returns `None` after logging when the file cannot be read.
+    /// Cold path like `build_css_output`. Reads through `bun_sys` because the
+    /// resolver's file cache strips BOMs, which a copied file has to keep.
     #[cold]
     #[inline(never)]
     fn read_copied_file(

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1282,10 +1282,7 @@ impl<'a> Transpiler<'a> {
         // Construct directly into the caller-owned storage instead of building a
         // stack temporary and returning it. All fallible work is done; every
         // field below is written exactly once. `Linker::init` gets null
-        // back-pointers — `core::mem::zeroed()` is NOT a
-        // valid analogue (`Linker.hashed_filenames: HashMap` carries a `NonNull`
-        // niche, so all-zeroes is instant UB); the value fields get their proper
-        // defaults and `configure_linker_with_auto_jsx` overwrites the
+        // back-pointers; `configure_linker_with_auto_jsx` overwrites the
         // self-referential pointers before any deref.
         let p = dst.as_mut_ptr();
         // SAFETY: `dst` is an exclusively-borrowed, currently-uninitialised

--- a/src/resolver/Cargo.toml
+++ b/src/resolver/Cargo.toml
@@ -43,6 +43,5 @@ bun_sys.workspace = true
 bun_threading.workspace = true
 bun_watcher.workspace = true
 bun_url.workspace = true
-bun_wyhash.workspace = true
 bun_hash.workspace = true
 bun_zstd.workspace = true

--- a/src/resolver/error.rs
+++ b/src/resolver/error.rs
@@ -1,7 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("Unusable")]
-    Unusable,
     #[error("InvalidDataURL")]
     InvalidDataURL,
     #[error("MissingResolveDir")]
@@ -28,7 +26,6 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
-            Self::Unusable => "Unusable",
             Self::InvalidDataURL => "InvalidDataURL",
             Self::MissingResolveDir => "MissingResolveDir",
             Self::InvalidResolveDir => "InvalidResolveDir",

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -1,6 +1,5 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::borrow::Cow;
-use std::io::Write as _;
 
 use bstr::BStr;
 
@@ -659,54 +658,6 @@ impl DirEntry {
 
 // `data` drops itself and `dir` is interned in DirnameStore (see the comment
 // on `DirEntry::dir`). Body would be empty, so no `impl Drop`.
-
-#[derive(Default, Clone, Copy)]
-pub struct ModKey {
-    pub(crate) size: u64,
-    pub(crate) mtime: i128,
-}
-
-impl ModKey {
-    /// Writes `basename` + `-` + the hex hash into `out` and returns the
-    /// written prefix.
-    pub fn hash_name<'out>(
-        &self,
-        basename: &[u8],
-        out: &'out mut [u8],
-    ) -> crate::CrateResult<&'out [u8]> {
-        let hex_int = self.hash();
-
-        let len = out.len();
-        let mut cursor = &mut out[..];
-        // `BStr`'s `Display` would
-        // lossily emit U+FFFD for non-UTF-8 bytes (and 1→3 expand), so write
-        // the basename verbatim via raw `io::Write`.
-        cursor
-            .write_all(basename)
-            .map_err(|_| crate::Error::Sys(bun_errno::SystemErrno::ENOSPC))?;
-        cursor
-            .write_all(b"-")
-            .map_err(|_| crate::Error::Sys(bun_errno::SystemErrno::ENOSPC))?;
-        write!(&mut cursor, "{:x}", hex_int)
-            .map_err(|_| crate::Error::Sys(bun_errno::SystemErrno::ENOSPC))?;
-        let written = len - cursor.len();
-        Ok(&out[..written])
-    }
-
-    pub(crate) fn hash(&self) -> u64 {
-        let mut hash_bytes = [0u8; 32];
-        // We shouldn't just read the contents of the ModKey into memory
-        // The hash should be deterministic across computers and operating systems.
-        // inode is non-deterministic across volumes within the same compuiter
-        // so if we're not going to do a full content hash, we should use mtime and size.
-        // even mtime is debatable.
-        hash_bytes[0..8].copy_from_slice(&self.size.to_le_bytes());
-        hash_bytes[8..24].copy_from_slice(&self.mtime.to_le_bytes());
-        debug_assert!(hash_bytes[24..].len() == 8);
-        hash_bytes[24..32].copy_from_slice(&0u64.to_ne_bytes());
-        bun_wyhash::hash(&hash_bytes)
-    }
-}
 
 // SAFETY: ARENA — `Entry` lives in the `BSSList` singleton; `*mut Entry` raw
 // pointers are the only !Send/!Sync field. All access is serialized through

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1742,48 +1742,6 @@ pub mod fs {
     pub use super::fs_full::stat_hash;
     pub use super::fs_full::stat_hash::StatHash;
 
-    /// Re-export `ModKey` from the full `fs.rs` port so `linker::get_mod_key`
-    /// can hash files.
-    pub use super::fs_full::ModKey;
-    impl ModKey {
-        /// Builds a `ModKey` from an open file's stat.
-        pub fn from_file(file: &bun_sys::File) -> crate::CrateResult<Self> {
-            let stat = file.stat()?;
-
-            const NS_PER_S: i128 = 1_000_000_000;
-            // `bun_sys::Stat` is `libc::stat`.
-            // Reconstruct `mtime` (i128 ns) from `st_mtime` (sec) +
-            // `st_mtime_nsec` (ns). The `libc` crate flattens BSD/Darwin
-            // `st_mtimespec` into `st_mtime`/`st_mtime_nsec`, so the access is
-            // uniform on all `unix`.
-            #[cfg(unix)]
-            let mtime: i128 = (stat.st_mtime as i128) * NS_PER_S + stat.st_mtime_nsec as i128;
-            #[cfg(windows)]
-            let mtime: i128 = (stat.mtim.sec as i128) * NS_PER_S + stat.mtim.nsec as i128;
-            let seconds = mtime / NS_PER_S;
-
-            // We can't detect changes if the file system zeros out the
-            // modification time
-            if seconds == 0 && NS_PER_S == 0 {
-                return Err(crate::Error::Unusable);
-            }
-
-            // Don't generate a modification key if the file is too new
-            let now = bun_core::time::nano_timestamp();
-            let now_seconds = now / NS_PER_S;
-            // `seconds > seconds` is always false — intentionally kept
-            #[allow(clippy::eq_op)]
-            if seconds > seconds || (seconds == now_seconds && mtime > now) {
-                return Err(crate::Error::Unusable);
-            }
-
-            Ok(ModKey {
-                size: stat.st_size as u64,
-                mtime,
-            })
-        }
-    }
-
     pub mod file_system {
         pub use super::{DirEntry, DirnameStore, Entry, EntryKind, FilenameStore, RealFS};
         pub mod real_fs {

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -67,31 +67,6 @@ impl OutputFileJsc for OutputFile {
         let mime = self.loader.to_mime_type(&[mime_hint]);
 
         match value {
-            OutputFileValue::Copy(copy) => {
-                let file_blob = match BlobStore::init_file(
-                    PathOrFileDescriptor::Path(dupe_path_like(copy.pathname.as_ref())),
-                    Some(mime),
-                ) {
-                    Ok(b) => b,
-                    Err(err) => Output::panic(format_args!(
-                        "error: Unable to create file blob: \"{}\"",
-                        err.name()
-                    )),
-                };
-
-                let build_output = Box::new(BuildArtifact {
-                    blob: Blob::init_with_store(file_blob, global_object),
-                    hash: self.hash,
-                    loader: self.input_loader,
-                    output_kind: self.output_kind,
-                    path: Box::<[u8]>::from(copy.pathname.as_ref()),
-                });
-
-                // Ownership transfers to the JS `BuildArtifact` wrapper
-                // (`finalize` reclaims it). Typed `Box`-taking entry point —
-                // the leak/from_raw pair lives once in the `#[js_class]` shim.
-                BuildArtifact::to_js_boxed(build_output, global_object)
-            }
             OutputFileValue::Saved(_) => {
                 let path_to_use: &[u8] = owned_pathname.unwrap_or(self.src_path.text);
 
@@ -124,7 +99,9 @@ impl OutputFileJsc for OutputFile {
                     path: Box::<[u8]>::from(path_to_use),
                 });
 
-                // See `Copy` arm.
+                // Ownership transfers to the JS `BuildArtifact` wrapper
+                // (`finalize` reclaims it). Typed `Box`-taking entry point:
+                // the leak/from_raw pair lives once in the `#[js_class]` shim.
                 BuildArtifact::to_js_boxed(build_output, global_object)
             }
             OutputFileValue::Buffer { bytes } => {
@@ -146,7 +123,7 @@ impl OutputFileJsc for OutputFile {
                     path,
                 });
 
-                // See `Copy` arm.
+                // See `Saved` arm.
                 BuildArtifact::to_js_boxed(build_output, global_object)
             }
             OutputFileValue::Noop => {
@@ -173,13 +150,6 @@ impl OutputFileJsc for OutputFile {
             .to_mime_type(&[self.dest_path.as_ref(), self.src_path.text]);
 
         match value {
-            OutputFileValue::Copy(copy) => {
-                let file_blob = BlobStore::init_file(
-                    PathOrFileDescriptor::Path(dupe_path_like(copy.pathname.as_ref())),
-                    Some(mime),
-                )?;
-                Ok(Blob::init_with_store(file_blob, global_this))
-            }
             OutputFileValue::Saved(_) => {
                 let file_blob = BlobStore::init_file(
                     PathOrFileDescriptor::Path(dupe_path_like(self.src_path.text)),

--- a/src/runtime/api/output_file_jsc.rs
+++ b/src/runtime/api/output_file_jsc.rs
@@ -99,9 +99,6 @@ impl OutputFileJsc for OutputFile {
                     path: Box::<[u8]>::from(path_to_use),
                 });
 
-                // Ownership transfers to the JS `BuildArtifact` wrapper
-                // (`finalize` reclaims it). Typed `Box`-taking entry point:
-                // the leak/from_raw pair lives once in the `#[js_class]` shim.
                 BuildArtifact::to_js_boxed(build_output, global_object)
             }
             OutputFileValue::Buffer { bytes } => {
@@ -123,7 +120,6 @@ impl OutputFileJsc for OutputFile {
                     path,
                 });
 
-                // See `Saved` arm.
                 BuildArtifact::to_js_boxed(build_output, global_object)
             }
             OutputFileValue::Noop => {

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -703,7 +703,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             match side {
                 bun_bundler::options::Side::Client => {
                     // Client-side resources will be written to disk for usage on the client side
-                    if let Err(err) = file.write_to_disk(root_dir.fd(), b".") {
+                    if let Err(err) = file.write_to_disk(root_dir.fd()) {
                         bun_core::handle_error_return_trace(err);
                         Output::err(
                             err,
@@ -714,7 +714,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 }
                 bun_bundler::options::Side::Server => {
                     if ctx.bundler_options.bake_debug_dump_server {
-                        if let Err(err) = file.write_to_disk(root_dir.fd(), b".") {
+                        if let Err(err) = file.write_to_disk(root_dir.fd()) {
                             bun_core::handle_error_return_trace(err);
                             Output::err(
                                 err,
@@ -794,7 +794,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         });
         if any_client_chunks {
             let runtime_file: &OutputFile = &bundled_outputs_list[runtime_file_index as usize];
-            if let Err(err) = runtime_file.write_to_disk(root_dir.fd(), b".") {
+            if let Err(err) = runtime_file.write_to_disk(root_dir.fd()) {
                 bun_core::handle_error_return_trace(err);
                 Output::err(
                     err,

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1065,7 +1065,7 @@ impl BuildCommand {
             }
 
             for f in output_files.iter() {
-                if let Err(err) = f.write_to_disk(root_dir.fd, from_path) {
+                if let Err(err) = f.write_to_disk(root_dir.fd) {
                     Output::err(
                         err,
                         "failed to write file '{}'",

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync } from "node:fs";
 import { ESBUILD, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -191,6 +192,49 @@ describe("bundler", () => {
         stdout: "./lib/second/test.file",
       },
     ],
+  });
+  itBundled("naming/EntryNamingTarget", {
+    files: {
+      "/src/entry.js": /* js */ `
+        console.log(1);
+      `,
+    },
+    root: "/src",
+    target: "bun",
+    entryNaming: "[target]/[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir)).toEqual(["bun"]);
+    },
+    run: {
+      file: "/out/bun/entry.js",
+      stdout: "1",
+    },
+  });
+  itBundled("naming/AssetNamingTarget", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import file from "./data.file";
+        console.log(file);
+      `,
+      "/src/data.file": `
+        this is a file
+      `,
+    },
+    root: "/src",
+    target: "bun",
+    assetNaming: "[target]/[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    loader: {
+      ".file": "file",
+    },
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["bun", "entry.js"]);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "./bun/data.file",
+    },
   });
   itBundled("naming/AssetNoOverwrite", {
     todo: true,

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -471,12 +471,17 @@ test("multi-entry build writes each entry point into the output directory", asyn
 // The copy used to be written next to the source under a hashed name instead
 // of into --outdir, and the summary listed it with an empty name and 0 KB.
 describe.concurrent("--no-bundle with entry points that are copied verbatim", () => {
-  // Not valid UTF-8 (and starts with the wasm magic), so a byte-for-byte
-  // comparison proves the file was copied rather than decoded and re-encoded.
+  // `wasm` is not valid UTF-8, and the two BOM fixtures start with exactly the
+  // bytes the resolver's file cache (which the transpiled loaders read through)
+  // strips or re-encodes as UTF-8. Byte equality on the outputs pins the copy
+  // being verbatim.
   const wasm = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0xff, 0xfe, 0x80]);
   const addon = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01]);
   const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
   const sqlite = Buffer.from("SQLite format 3\0");
+  const utf8Bom = Buffer.from([0xef, 0xbb, 0xbf]);
+  const utf8BomData = Buffer.concat([utf8Bom, Buffer.from("data")]);
+  const utf16BomData = Buffer.from([0xff, 0xfe, 0x5a, 0x5a]);
 
   async function build(cwd: string, args: string[]) {
     await using proc = Bun.spawn({
@@ -517,19 +522,20 @@ describe.concurrent("--no-bundle with entry points that are copied verbatim", ()
     expect(listFiles(path.join(String(dir), "src"))).toEqual(["x.wasm"]);
   });
 
-  test("copies the wasm, napi, sqlite, and file loaders", async () => {
-    using dir = tempDir("no-bundle-copy-loaders", {
-      "src/x.wasm": wasm,
-      "src/y.node": addon,
-      "src/z.png": png,
-      "src/w.db": sqlite,
-    });
+  test("copies the wasm, napi, sqlite, and file loaders byte for byte, BOMs included", async () => {
+    const files: Record<string, Buffer> = {
+      "x.wasm": wasm,
+      "y.node": addon,
+      "z.png": png,
+      "w.db": sqlite,
+      "v.bin": utf8BomData,
+      "t.bin": utf16BomData,
+    };
+    const names = Object.keys(files).sort();
+    using dir = tempDir("no-bundle-copy-loaders", Object.fromEntries(names.map(name => [`src/${name}`, files[name]])));
 
     const { stdout, stderr, exitCode } = await build(String(dir), [
-      "./src/x.wasm",
-      "./src/y.node",
-      "./src/z.png",
-      "./src/w.db",
+      ...names.map(name => `./src/${name}`),
       "--loader",
       ".db:sqlite",
       "--outdir=dist",
@@ -538,17 +544,12 @@ describe.concurrent("--no-bundle with entry points that are copied verbatim", ()
     expect(exitCode).toBe(0);
 
     const dist = path.join(String(dir), "dist");
-    expect(listFiles(dist)).toEqual(["w.db", "x.wasm", "y.node", "z.png"]);
-    expect({
-      "w.db": fs.readFileSync(path.join(dist, "w.db")),
-      "x.wasm": fs.readFileSync(path.join(dist, "x.wasm")),
-      "y.node": fs.readFileSync(path.join(dist, "y.node")),
-      "z.png": fs.readFileSync(path.join(dist, "z.png")),
-    }).toEqual({ "w.db": sqlite, "x.wasm": wasm, "y.node": addon, "z.png": png });
-    for (const name of ["w.db", "x.wasm", "y.node", "z.png"]) {
+    expect(listFiles(dist)).toEqual(names);
+    expect(Object.fromEntries(names.map(name => [name, fs.readFileSync(path.join(dist, name))]))).toEqual(files);
+    for (const name of names) {
       expect(stdout).toContain(name);
     }
-    expect(listFiles(path.join(String(dir), "src"))).toEqual(["w.db", "x.wasm", "y.node", "z.png"]);
+    expect(listFiles(path.join(String(dir), "src"))).toEqual(names);
   });
 
   test("keeps directories relative to the common root, so same-named files do not collide", async () => {
@@ -609,7 +610,9 @@ describe.concurrent("--no-bundle with entry points that are copied verbatim", ()
   test("fills [name], [ext], and a content-derived [hash] in --entry-naming", async () => {
     using dir = tempDir("no-bundle-copy-hash", {
       "a.wasm": wasm,
-      "b.wasm": png,
+      // Same bytes as a behind a UTF-8 BOM: the hash has to cover the file as
+      // written, not the BOM-stripped form the file cache would hand back.
+      "b.wasm": Buffer.concat([utf8Bom, wasm]),
       "c.wasm": wasm,
     });
 
@@ -631,9 +634,9 @@ describe.concurrent("--no-bundle with entry points that are copied verbatim", ()
       expect.stringMatching(/^c-[0-9a-z]{8}\.wasm$/),
     ]);
     const hashOf = (file: string) => file.slice(2, -".wasm".length);
-    // a and c have the same bytes; b differs.
     expect(hashOf(files[2])).toBe(hashOf(files[0]));
     expect(hashOf(files[1])).not.toBe(hashOf(files[0]));
+    expect(fs.readFileSync(path.join(String(dir), "dist", files[1]))).toEqual(Buffer.concat([utf8Bom, wasm]));
     for (const file of files) {
       expect(stdout).toContain(file);
     }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -466,6 +466,257 @@ test("multi-entry build writes each entry point into the output directory", asyn
   expect(b).toContain('"B"');
 });
 
+// Entry points whose loader has nothing to transpile (wasm, napi, sqlite, the
+// `file` fallback for unknown extensions) are copied through by `--no-bundle`.
+// The copy used to be written next to the source under a hashed name instead
+// of into --outdir, and the summary listed it with an empty name and 0 KB.
+describe.concurrent("--no-bundle with entry points that are copied verbatim", () => {
+  // Not valid UTF-8 (and starts with the wasm magic), so a byte-for-byte
+  // comparison proves the file was copied rather than decoded and re-encoded.
+  const wasm = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0xff, 0xfe, 0x80]);
+  const addon = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01]);
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+  const sqlite = Buffer.from("SQLite format 3\0");
+
+  async function build(cwd: string, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", ...args],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function listFiles(dir: string): string[] {
+    return fs
+      .readdirSync(dir, { recursive: true, withFileTypes: true })
+      .filter(entry => entry.isFile())
+      .map(entry => path.relative(dir, path.join(entry.parentPath, entry.name)).replaceAll(path.sep, "/"))
+      .sort();
+  }
+
+  test("copies a .wasm entry point into --outdir and lists it in the summary", async () => {
+    using dir = tempDir("no-bundle-copy-wasm", { "src/x.wasm": wasm });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["./src/x.wasm", "--outdir=dist"]);
+    expect(stderr).toBe("");
+    expect(stdout.replace(/in \d+ms/, "in {time}ms")).toMatchInlineSnapshot(`
+      "Transpiled file in {time}ms
+
+        x.wasm  11 bytes  (chunk)
+
+      "
+    `);
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(path.join(String(dir), "dist"))).toEqual(["x.wasm"]);
+    expect(fs.readFileSync(path.join(String(dir), "dist", "x.wasm"))).toEqual(wasm);
+    expect(listFiles(path.join(String(dir), "src"))).toEqual(["x.wasm"]);
+  });
+
+  test("copies the wasm, napi, sqlite, and file loaders", async () => {
+    using dir = tempDir("no-bundle-copy-loaders", {
+      "src/x.wasm": wasm,
+      "src/y.node": addon,
+      "src/z.png": png,
+      "src/w.db": sqlite,
+    });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), [
+      "./src/x.wasm",
+      "./src/y.node",
+      "./src/z.png",
+      "./src/w.db",
+      "--loader",
+      ".db:sqlite",
+      "--outdir=dist",
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const dist = path.join(String(dir), "dist");
+    expect(listFiles(dist)).toEqual(["w.db", "x.wasm", "y.node", "z.png"]);
+    expect({
+      "w.db": fs.readFileSync(path.join(dist, "w.db")),
+      "x.wasm": fs.readFileSync(path.join(dist, "x.wasm")),
+      "y.node": fs.readFileSync(path.join(dist, "y.node")),
+      "z.png": fs.readFileSync(path.join(dist, "z.png")),
+    }).toEqual({ "w.db": sqlite, "x.wasm": wasm, "y.node": addon, "z.png": png });
+    for (const name of ["w.db", "x.wasm", "y.node", "z.png"]) {
+      expect(stdout).toContain(name);
+    }
+    expect(listFiles(path.join(String(dir), "src"))).toEqual(["w.db", "x.wasm", "y.node", "z.png"]);
+  });
+
+  test("keeps directories relative to the common root, so same-named files do not collide", async () => {
+    using dir = tempDir("no-bundle-copy-dirs", {
+      "src/a/x.wasm": wasm,
+      "src/b/x.wasm": png,
+    });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), [
+      "./src/a/x.wasm",
+      "./src/b/x.wasm",
+      "--outdir=dist",
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("a/x.wasm");
+    expect(stdout).toContain("b/x.wasm");
+    expect(exitCode).toBe(0);
+
+    const dist = path.join(String(dir), "dist");
+    expect(listFiles(dist)).toEqual(["a/x.wasm", "b/x.wasm"]);
+    expect(fs.readFileSync(path.join(dist, "a", "x.wasm"))).toEqual(wasm);
+    expect(fs.readFileSync(path.join(dist, "b", "x.wasm"))).toEqual(png);
+  });
+
+  test("creates the output directories implied by --root", async () => {
+    using dir = tempDir("no-bundle-copy-root", { "src/nested/x.wasm": wasm });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["--root=.", "./src/nested/x.wasm", "--outdir=dist"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("src/nested/x.wasm");
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(path.join(String(dir), "dist"))).toEqual(["src/nested/x.wasm"]);
+    expect(fs.readFileSync(path.join(String(dir), "dist", "src", "nested", "x.wasm"))).toEqual(wasm);
+  });
+
+  test("does not escape --outdir for an entry point outside --root", async () => {
+    using dir = tempDir("no-bundle-copy-outside-root", {
+      "src/a.wasm": wasm,
+      "other/b.wasm": png,
+    });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), [
+      "--root=src",
+      "./src/a.wasm",
+      "./other/b.wasm",
+      "--outdir=dist",
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("_.._/other/b.wasm");
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(path.join(String(dir), "dist"))).toEqual(["_.._/other/b.wasm", "a.wasm"]);
+    expect(fs.readFileSync(path.join(String(dir), "dist", "_.._", "other", "b.wasm"))).toEqual(png);
+    expect(listFiles(path.join(String(dir), "other"))).toEqual(["b.wasm"]);
+  });
+
+  test("fills [name], [ext], and a content-derived [hash] in --entry-naming", async () => {
+    using dir = tempDir("no-bundle-copy-hash", {
+      "a.wasm": wasm,
+      "b.wasm": png,
+      "c.wasm": wasm,
+    });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), [
+      "./a.wasm",
+      "./b.wasm",
+      "./c.wasm",
+      "--outdir=dist",
+      "--entry-naming",
+      "[name]-[hash].[ext]",
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const files = listFiles(path.join(String(dir), "dist"));
+    expect(files).toEqual([
+      expect.stringMatching(/^a-[0-9a-z]{8}\.wasm$/),
+      expect.stringMatching(/^b-[0-9a-z]{8}\.wasm$/),
+      expect.stringMatching(/^c-[0-9a-z]{8}\.wasm$/),
+    ]);
+    const hashOf = (file: string) => file.slice(2, -".wasm".length);
+    // a and c have the same bytes; b differs.
+    expect(hashOf(files[2])).toBe(hashOf(files[0]));
+    expect(hashOf(files[1])).not.toBe(hashOf(files[0]));
+    for (const file of files) {
+      expect(stdout).toContain(file);
+    }
+  });
+
+  test.each([
+    ["browser", []],
+    ["bun", ["--target=bun"]],
+    ["node", ["--target=node"]],
+  ])("fills [target] in --entry-naming with %s", async (expected, targetArgs) => {
+    using dir = tempDir("no-bundle-copy-target", { "x.wasm": wasm });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), [
+      ...targetArgs,
+      "./x.wasm",
+      "--outdir=dist",
+      "--entry-naming",
+      "[target]/[name].[ext]",
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain(`${expected}/x.wasm`);
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(path.join(String(dir), "dist"))).toEqual([`${expected}/x.wasm`]);
+  });
+
+  test("copies to the path given by --outfile", async () => {
+    using dir = tempDir("no-bundle-copy-outfile", { "src/x.wasm": wasm });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["./src/x.wasm", "--outfile=out/renamed.wasm"]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("renamed.wasm");
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(path.join(String(dir), "out"))).toEqual(["renamed.wasm"]);
+    expect(fs.readFileSync(path.join(String(dir), "out", "renamed.wasm"))).toEqual(wasm);
+    expect(listFiles(path.join(String(dir), "src"))).toEqual(["x.wasm"]);
+  });
+
+  test("writes the bytes to stdout without --outdir or --outfile", async () => {
+    using dir = tempDir("no-bundle-copy-stdout", { "src/x.wasm": wasm });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./src/x.wasm"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(Buffer.from(stdout)).toEqual(wasm);
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(String(dir))).toEqual(["src/x.wasm"]);
+  });
+
+  test("leaves the file intact when --outdir . makes the output path the source path", async () => {
+    using dir = tempDir("no-bundle-copy-in-place", { "x.wasm": wasm });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["./x.wasm", "--outdir", "."]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("x.wasm");
+    expect(exitCode).toBe(0);
+
+    expect(listFiles(String(dir))).toEqual(["x.wasm"]);
+    expect(fs.readFileSync(path.join(String(dir), "x.wasm"))).toEqual(wasm);
+  });
+
+  // Root can read a mode 000 file, and Windows has no such mode bit.
+  test.skipIf(isWindows || process.getuid?.() === 0)("fails the build when the file cannot be read", async () => {
+    using dir = tempDir("no-bundle-copy-unreadable", { "src/x.wasm": wasm });
+    fs.chmodSync(path.join(String(dir), "src", "x.wasm"), 0o000);
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ["./src/x.wasm", "--outdir=dist"]);
+    expect(stderr).toContain('error: EACCES reading "src/x.wasm"');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+
+    expect(fs.existsSync(path.join(String(dir), "dist", "x.wasm"))).toBe(false);
+  });
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });


### PR DESCRIPTION
### Problem
- `bun build --no-bundle ./src/x.wasm --outdir=dist` leaves `dist/` empty, writes `src/x.wasm-<hash>.wasm` next to the source, exits 0, and the summary line is `    0 KB  (chunk)` with no file name.
- Affects every entry point that takes the copy arm in `Transpiler::build_with_resolve_result_eager` (src/bundler/transpiler.rs): `.wasm`, `.node`, sqlite, bunsh, html, and the `file` loader that unknown extensions fall back to. `--outfile` is ignored the same way; with neither flag nothing is written to stdout.
- Cause: the arm built `Value::Copy(FileOperation { pathname })` with `pathname` = absolute source path + mtime/size hash (`Linker::get_hashed_filename`). `OutputFile::write_to_disk` (src/bundler/OutputFile.rs) `openat()`ed that absolute path against the outdir fd, which ignores the fd for absolute paths. `dest_path` and `size` were never set.
- The hashed name is a leftover of the old dev server; nothing references it (`generate_import_path` is only called with `use_hashed_name = false`), and the behavior predates the Rust port.
- Raised in the review of #35644, which fixes `--no-bundle --outdir` for the transpiled JS/CSS outputs and leaves this arm alone on purpose.

### Fix
- The copy arm reads the file byte for byte (`bun_sys::File::read_from`) into a normal `Value::Buffer` and sets `size`.
- `dest_path` comes from the same `PathTemplate` the bundler uses for entry points: `--entry-naming` (default `[dir]/[name].[ext]`) over the path relative to `--root`, `[ext]` = the file's own extension, `[hash]` = content hash (`ContentHasher`, as for bundle-mode assets), `[target]` = target name, `..` sanitized to `_.._`. `src/x.wasm` lands at `dist/x.wasm` for the same reason `src/a.ts` lands at `dist/a.js`.
- Being a Buffer, the output then goes through the existing `--outdir`, `--outfile`, stdout, and summary code with no special cases, and reading before writing makes `--outdir .` a harmless rewrite rather than a truncation of the source.
- A read failure is logged like the css arm logs one (`error: EACCES reading "src/x.wasm"`) and fails the build.
- `write_to_disk` treats `dest_path` as outdir-relative and creates its parent directory. The old `relative(longest_common_path(dest_paths), dest_path)` only worked when all outputs shared a prefix: for `a.wasm` + `nested/b.wasm` the common path is `/`, `relative()` resolves against the cwd, and the file goes to `dist/<cwd>/nested/b.wasm`. The other caller (bake production, which passed `"."`) behaves the same as before; test/bake/dev/production.test.ts passes.
- `Target::naming_placeholder()` (src/ast/target.rs) is now the one table for `[target]`, used here, in `computeChunks`, and in `process_files_to_copy`. The last of these used the variant name, so `--asset-naming '[target]/...'` wrote `Browser/` where `--entry-naming` wrote `browser/`; it now writes `browser/`.
- Relationship to #35644: the `naming_placeholder`, `write_to_disk`, and `bundler_naming` test hunks are identical to that PR, so they merge cleanly in either order. The copy arm is the one real overlap: if #35644 lands second, its end-of-function `dest_path` assignment must skip outputs that already have one. `transform_only_dest_path` takes the extension as a parameter so the JS/CSS arms can pass `js`/`css` and share it.
- Deleted because nothing produces or calls them anymore: `Value::Copy`, `FileOperation`, `copy_to` (which also leaked both fds and was `panic!("TODO windows")` on Windows), the `Copy` arms of `to_js`/`to_blob`; and in the second commit `get_hashed_filename`/`get_mod_key`, the never-enabled `hashed_filenames` cache, the always-false `use_hashed_name` parameter, `ModKey` (`from_file`/`hash_name`), resolver `Error::Unusable` (only `from_file` produced it), and the resolver's `bun_wyhash` dependency (only `ModKey::hash` used it).
- Verified: test/bundler/cli.test.ts, new `--no-bundle with entry points that are copied verbatim` block: `--outdir` with a summary snapshot, wasm/napi/sqlite/file loaders, same basename in two directories, `--root` creating directories, an entry outside `--root`, `[name]`/`[ext]`/`[hash]`, `[target]` for browser/bun/node, `--outfile`, stdout, `--outdir .`, and an unreadable file (skipped as root and on Windows). All 12 fail on the released build and pass with this change; the unreadable-file one was checked both ways as a non-root user.
- test/bundler/bundler_naming.test.ts: `naming/EntryNamingTarget` and `naming/AssetNamingTarget` (the asset one fails on the released build).
- Also run with the change: the rest of cli.test.ts, bundler_naming.test.ts, test/bake/dev/production.test.ts, test/js/bun/plugin/plugins.test.ts (the runtime still uses the old linker), test/internal/source-lints.

### Background
- `--no-bundle` makes `bun build` transpile each entry point separately through `Transpiler::transform` instead of `BundleV2`; the bundler's linker, which normally names and writes outputs, is not involved, so this path fills in each `OutputFile` itself. `Transpiler::transform` is only reached from the `bun build` CLI.
- An `OutputFile` has a `dest_path` (outdir-relative path that the CLI prints and writes to) and a `value`: `Buffer` (bytes still to write), `Saved` (already written by the bundler), or `Noop`.
- `PathTemplate` is the `[dir]/[name].[ext]` template behind `--entry-naming`, `--chunk-naming`, and `--asset-naming`. `--root` is the directory `[dir]` is computed relative to; it defaults to the entry points' common ancestor. Printing with `sanitize_parent_dirs` rewrites `..` so an entry outside `--root` cannot write outside `--outdir`.
- The old linker (src/bundler/linker.rs) is the pre-bundler import rewriter; the runtime module loader still uses its `link()`. `get_hashed_filename` named copied files `name-<mtime/size hash>` for the dev server it once served.
