### PR TITLE
node:http2: report an injected socket's error on the session instead of leaving it uncaught

### DIFF
--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -386,8 +386,14 @@ function upgradeRawSocketToH2(
       data: {},
     });
   } catch (e) {
-    rawSocket.destroy(e as Error);
-    tlsSocket.destroy(e as Error);
+    // The credentials are built on first use, so a bad key/cert is detected
+    // here, on the first injected connection. Report it the way tls.Server's
+    // own connection listener does, on the server's 'error' event; nothing
+    // listens on rawSocket yet, so an error handed to its destroy() would be
+    // an uncaught exception.
+    rawSocket.destroy();
+    tlsSocket.destroy();
+    server.emit("error", e);
     return true;
   }
 

--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -250,9 +250,7 @@ function socketHandshake(
 // Raw socket error forwarding and close cleanup
 // ---------------------------------------------------------------------------
 
-// A wrapped socket's errors belong to the TLS socket over it, as in node:
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
-// rawSocket outlives the session (onTlsClose keeps this listener), hence the guard.
+// Node reports a wrapped socket's errors on the TLS socket over it: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
 function onRawSocketError(this: TLSProxySocket, err: Error) {
   if (!this.destroyed) this.destroy(err);
 }
@@ -375,8 +373,7 @@ function upgradeRawSocketToH2(
       data: {},
     });
   } catch (e) {
-    // Credentials are built on first use and can fail here; same surface as
-    // tls.Server's own 'connection' listener (nothing listens on rawSocket).
+    // Same surface as tls.Server's own 'connection' listener when the credentials fail to build.
     rawSocket.destroy();
     tlsSocket.destroy();
     server.emit("error", e);

--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -247,12 +247,30 @@ function socketHandshake(
 }
 
 // ---------------------------------------------------------------------------
+// Raw socket listeners bound to tlsSocket
+// ---------------------------------------------------------------------------
+
+// error: the transport under the TLS layer failed (reset, EPIPE, destroy(err)).
+// Node's TLSSocket re-emits the wrapped socket's errors on itself, so they
+// reach the session's socket error handling and the socket handed in never
+// emits an unhandled 'error':
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
+// Stays attached for the raw socket's lifetime (it is still flushing after the
+// session is gone), hence the destroyed check.
+function onRawSocketError(this: TLSProxySocket, err: Error) {
+  if (!this.destroyed) {
+    this.destroy(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Close-cleanup handler
 // ---------------------------------------------------------------------------
 
 // onTlsClose: when the TLS socket closes (e.g. H2 session destroyed), clean up
 // the raw socket listeners to prevent memory leaks and stale callback references.
 // EventEmitter calls 'close' handlers with `this` = emitter (tlsSocket).
+// The 'error' listener is deliberately left in place (see onRawSocketError).
 function onTlsClose(this: TLSProxySocket) {
   const ctx = this._ctx;
   const raw = ctx.rawSocket;
@@ -386,6 +404,7 @@ function upgradeRawSocketToH2(
   rawSocket.on("end", events[1]);
   rawSocket.on("drain", events[2]);
   rawSocket.on("close", events[3]);
+  rawSocket.on("error", onRawSocketError.bind(tlsSocket));
 
   // When the TLS socket closes (e.g. H2 session destroyed), clean up the raw socket
   // listeners to prevent memory leaks and stale callback references.

--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -247,30 +247,19 @@ function socketHandshake(
 }
 
 // ---------------------------------------------------------------------------
-// Raw socket listeners bound to tlsSocket
+// Raw socket error forwarding and close cleanup
 // ---------------------------------------------------------------------------
 
-// error: the transport under the TLS layer failed (reset, EPIPE, destroy(err)).
-// Node's TLSSocket re-emits the wrapped socket's errors on itself, so they
-// reach the session's socket error handling and the socket handed in never
-// emits an unhandled 'error':
+// A wrapped socket's errors belong to the TLS socket over it, as in node:
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
-// Stays attached for the raw socket's lifetime (it is still flushing after the
-// session is gone), hence the destroyed check.
+// rawSocket outlives the session (onTlsClose keeps this listener), hence the guard.
 function onRawSocketError(this: TLSProxySocket, err: Error) {
-  if (!this.destroyed) {
-    this.destroy(err);
-  }
+  if (!this.destroyed) this.destroy(err);
 }
-
-// ---------------------------------------------------------------------------
-// Close-cleanup handler
-// ---------------------------------------------------------------------------
 
 // onTlsClose: when the TLS socket closes (e.g. H2 session destroyed), clean up
 // the raw socket listeners to prevent memory leaks and stale callback references.
 // EventEmitter calls 'close' handlers with `this` = emitter (tlsSocket).
-// The 'error' listener is deliberately left in place (see onRawSocketError).
 function onTlsClose(this: TLSProxySocket) {
   const ctx = this._ctx;
   const raw = ctx.rawSocket;
@@ -386,11 +375,8 @@ function upgradeRawSocketToH2(
       data: {},
     });
   } catch (e) {
-    // The credentials are built on first use, so a bad key/cert is detected
-    // here, on the first injected connection. Report it the way tls.Server's
-    // own connection listener does, on the server's 'error' event; nothing
-    // listens on rawSocket yet, so an error handed to its destroy() would be
-    // an uncaught exception.
+    // Credentials are built on first use and can fail here; same surface as
+    // tls.Server's own 'connection' listener (nothing listens on rawSocket).
     rawSocket.destroy();
     tlsSocket.destroy();
     server.emit("error", e);

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -310,13 +310,15 @@ describe("HTTP/2 upgrade — socket close ordering", () => {
     // Not events.once(): the session emits 'error' on its way to 'close'.
     const sessionClosed = new Promise<void>(resolve => h2Session.once("close", resolve));
 
-    rawSocket!.destroy(new Error("transport failed"));
+    const transportError = new Error("transport failed");
+    rawSocket!.destroy(transportError);
 
     await sessionClosed;
     const { err, session } = await sessionErrored.promise;
+    assert.strictEqual(err, transportError);
     assert.deepStrictEqual(
-      { message: err.message, sameSession: session === h2Session, destroyed: h2Session.destroyed },
-      { message: "transport failed", sameSession: true, destroyed: true },
+      { sameSession: session === h2Session, destroyed: h2Session.destroyed },
+      { sameSession: true, destroyed: true },
     );
 
     client.close();

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -504,6 +504,47 @@ describe("HTTP/2 upgrade — server TLS options", () => {
       netServer.close();
     }
   });
+
+  test("unusable credentials are the server's error, and the injected connection is closed", async () => {
+    // Node rejects the key inside createSecureServer(). Bun builds the
+    // credentials on first use, which for a server that never listens is the
+    // first injected connection, and then reports the failure the way
+    // tls.Server does for server.emit('connection'): on the server's 'error'
+    // event, with the connection closed quietly. In neither runtime is the
+    // injected socket, which nothing listens to, where the error surfaces.
+    let h2Server: http2.Http2SecureServer;
+    try {
+      h2Server = http2.createSecureServer({ key: "not a key", cert: "not a cert" });
+    } catch (err) {
+      assert.strictEqual((err as NodeJS.ErrnoException).code, "ERR_OSSL_PEM_NO_START_LINE");
+      return;
+    }
+    const surfaced = Promise.withResolvers<NodeJS.ErrnoException>();
+    h2Server.on("error", surfaced.resolve);
+
+    let rawSocket: net.Socket | undefined;
+    let emitReturned: boolean | undefined;
+    const netServer = net.createServer(socket => {
+      rawSocket = socket;
+      emitReturned = h2Server.emit("connection", socket);
+    });
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+
+    const client = net.connect(port, "127.0.0.1");
+    client.on("error", () => {});
+    try {
+      const err = await surfaced.promise;
+      assert.deepStrictEqual(
+        { code: err.code, emitReturned, rawDestroyed: rawSocket!.destroyed },
+        { code: "ERR_OSSL_PEM_NO_START_LINE", emitReturned: true, rawDestroyed: true },
+      );
+    } finally {
+      client.destroy();
+      netServer.close();
+    }
+  });
 });
 
 if (typeof Bun !== "undefined") {

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -277,6 +277,51 @@ describe("HTTP/2 upgrade — socket close ordering", () => {
     client.close();
     netServer.close();
   });
+
+  test("an error on rawSocket is the session's error, not an uncaught exception", async () => {
+    // Nothing but the upgrade listens on rawSocket once it has been handed
+    // over, so its error (a reset, EPIPE, a destroy(err) by its owner) has to
+    // be reported the way a TLSSocket reports its wrapped socket's errors: the
+    // session is destroyed with it and the server sees 'sessionError'.
+    let rawSocket: net.Socket | undefined;
+    const sessionReady = Promise.withResolvers<http2.Http2Session>();
+    const sessionErrored = Promise.withResolvers<{ err: Error; session: http2.Http2Session }>();
+
+    const h2Server = http2.createSecureServer(TLS, (_req, res) => {
+      res.writeHead(200);
+      res.end("done");
+    });
+    h2Server.on("error", () => {});
+    h2Server.on("session", s => sessionReady.resolve(s));
+    h2Server.on("sessionError", (err: Error, session: http2.Http2Session) => sessionErrored.resolve({ err, session }));
+
+    const netServer = net.createServer(socket => {
+      rawSocket = socket;
+      h2Server.emit("connection", socket);
+    });
+
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+
+    const client = connectClient(port);
+    await request(client, "GET", "/");
+    const h2Session = await sessionReady.promise;
+    // Not events.once(): the session emits 'error' on its way to 'close'.
+    const sessionClosed = new Promise<void>(resolve => h2Session.once("close", resolve));
+
+    rawSocket!.destroy(new Error("transport failed"));
+
+    await sessionClosed;
+    const { err, session } = await sessionErrored.promise;
+    assert.deepStrictEqual(
+      { message: err.message, sameSession: session === h2Session, destroyed: h2Session.destroyed },
+      { message: "transport failed", sameSession: true, destroyed: true },
+    );
+
+    client.close();
+    netServer.close();
+  });
 });
 
 describe("HTTP/2 upgrade — ALPN negotiation", () => {


### PR DESCRIPTION
### Problem
- `Http2SecureServer#emit('connection', rawSocket)` (the http2-wrapper / crawlee pattern for upgrading a plain connection to h2) upgrades `rawSocket` through the stream-level TLS engine, but only listens to its `'data'`, `'end'`, `'drain'` and `'close'` events (`src/js/node/_http2_upgrade.ts`, `upgradeRawSocketToH2`). Once the socket has been handed over nothing listens to its `'error'`, so a transport failure after the upgrade (a reset, EPIPE on a write the peer never read, the owner calling `rawSocket.destroy(err)`) is an uncaught exception: `error: transport failed` thrown from the socket's own `'error'` emission, and the process exits.
- Node reports the same failure as the server's `'sessionError'`: `tls.Server`'s connection listener wraps the injected socket in a `TLSSocket`, whose `_init` re-emits the wrapped socket's errors on itself (`lib/internal/tls/wrap.js` L977 in v26.3.0), and the session's socket error handler destroys the session with it.
- Same function, same shape (found in review): when the upgrade itself throws, which happens for unusable credentials since bun builds them on first use, the catch block did `rawSocket.destroy(e)`, so the credentials error was also thrown out of `rawSocket`'s `'error'`, even with an `'error'` listener on the server: `error: error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE`.
- The four `net.ts` sites that run the same engine (`tls.connect({ socket })`, `new TLSSocket(socket, { isServer: true })`) have the same missing listener; #37664 adds it there, so this PR only covers the http2 site.

### Fix
- `upgradeRawSocketToH2` attaches an `'error'` listener to `rawSocket` that destroys the proxy duplex the h2 session runs on with the error. That proxy is the `TLSSocket` stand-in for this path, and destroying it with an error is exactly what the engine's own `error` callback (`socketError`) already does for TLS-level failures, so the session teardown and the server's `'sessionError'` come out of the existing path.
- The listener is not removed in `onTlsClose` with the other four: the raw socket is still flushing `close_notify` after the session is gone, and a write failure at that point would otherwise be uncaught again. The `destroyed` check makes it a no-op once the proxy is down, which is also the net effect in node (the forwarded error reaches a session that is already destroyed).
- The catch block now closes the connection quietly and emits the error on the server, which is what `tls.Server`'s own connection listener does for the same lazily-detected credentials failure (`src/js/node/tls.ts`, the `'connection'` listener, and the existing "natively-rejected key on the server 'error' event" test in `node-tls-server.test.ts`). Node detects bad credentials in `createSecureServer()` itself, so the server is the closest equivalent surface; the injected socket is not a surface at all, nothing of the caller's listens on it.
- Verified with `test/js/node/http2/node-http2-upgrade.test.mts`, two new tests: "an error on rawSocket is the session's error, not an uncaught exception" and "unusable credentials are the server's error, and the injected connection is closed". Without the `_http2_upgrade.ts` change they fail with the two uncaught errors quoted above (Linux debug build and Windows x64 debug build); with it the whole file passes on both (17/17), and the file also runs itself under node v26.3.0 (16/16 there: node takes the credentials test's `createSecureServer()` branch).

### Background
- `upgradeDuplexToTLS` is the TLS engine node:tls uses when it cannot adopt a connection's fd into a native TLS socket: it runs BoringSSL over the stream's JS events and `write()`, and returns the handlers the caller has to attach to the stream. `_http2_upgrade.ts` uses it for every socket injected into an `Http2SecureServer`, feeding the decrypted bytes into a plain `Duplex` that the h2 session treats as its socket.
- `'sessionError'` is how an `Http2Server` surfaces a session-level error (a socket error included) to the application; it is what node emits for this scenario, and what bun emits once the proxy is destroyed with the error.
- `Http2SecureServer` is a `tls.Server`; its `'error'` event is where bun's `tls.Server` already reports credentials it cannot load (bun builds them lazily, node throws from the constructor), which is why the catch block reports there.
