### PR TITLE
Accept and lower the `accessor` keyword in TypeScript files using experimentalDecorators

### DIFF
--- a/src/ast/g.rs
+++ b/src/ast/g.rs
@@ -101,7 +101,11 @@ impl Class {
                 return false;
             }
 
-            if property.kind == PropertyKind::Normal && f.contains(flags::Property::IsStatic) {
+            if matches!(
+                property.kind,
+                PropertyKind::Normal | PropertyKind::AutoAccessor
+            ) && f.contains(flags::Property::IsStatic)
+            {
                 for val in [property.value, property.initializer].into_iter().flatten() {
                     match val.data {
                         ExprData::EArrow(..) | ExprData::EFunction(..) => {}

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2945,6 +2945,11 @@ pub mod flags {
         IsStatic,
         WasShorthand,
         IsSpread,
+        /// The getter/setter pair generated for an `accessor` class member.
+        /// `ts_metadata` on the getter is the member's declared type; legacy
+        /// decorator metadata for the member describes that type, as tsc does
+        /// for `accessor` declarations, not the getter's signature.
+        IsLoweredAutoAccessor,
     }
     pub type PropertySet = EnumSet<Property>;
     pub const PROPERTY_NONE: PropertySet = EnumSet::empty();

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2946,9 +2946,10 @@ pub mod flags {
         WasShorthand,
         IsSpread,
         /// The getter/setter pair generated for an `accessor` class member.
-        /// `ts_metadata` on the getter is the member's declared type; legacy
-        /// decorator metadata for the member describes that type, as tsc does
-        /// for `accessor` declarations, not the getter's signature.
+        /// Whichever of the two carries the member's legacy decorators also
+        /// carries the member's declared type in `ts_metadata`; decorator
+        /// metadata for it describes that type, as tsc's does for `accessor`
+        /// declarations, rather than the getter's or setter's signature.
         IsLoweredAutoAccessor,
     }
     pub type PropertySet = EnumSet<Property>;

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2945,11 +2945,8 @@ pub mod flags {
         IsStatic,
         WasShorthand,
         IsSpread,
-        /// The getter/setter pair generated for an `accessor` class member.
-        /// Whichever of the two carries the member's legacy decorators also
-        /// carries the member's declared type in `ts_metadata`; decorator
-        /// metadata for it describes that type, as tsc's does for `accessor`
-        /// declarations, rather than the getter's or setter's signature.
+        /// Getter/setter pair generated for an `accessor` member; `ts_metadata`
+        /// on the one carrying the decorators is the member's declared type.
         IsLoweredAutoAccessor,
     }
     pub type PropertySet = EnumSet<Property>;

--- a/src/js_parser/lower/lower_auto_accessors.rs
+++ b/src/js_parser/lower/lower_auto_accessors.rs
@@ -1,0 +1,300 @@
+//! In-place lowering of `accessor` class members (auto-accessors).
+//!
+//! JavaScriptCore does not implement the keyword, so every auto-accessor has
+//! to be desugared. Classes that go through the standard-decorator lowering
+//! (`lower_decorators.rs`) get that done there. This pass covers the classes
+//! it never sees: TypeScript files compiled with `experimentalDecorators` /
+//! `emitDecoratorMetadata`, whose decorators `P::lower_class` lowers instead.
+//! Each accessor is replaced, at its own position in the class body, by the
+//! desugaring the decorators proposal defines for it (and the one tsc emits),
+//! so the order of keys and initializers is preserved and nothing leaves the
+//! class body:
+//!
+//! ```js
+//! class A { accessor x = 1; }
+//! // becomes
+//! class A { #x = 1; get x() { return this.#x; } set x(v) { this.#x = v; } }
+//! ```
+//!
+//! Legacy decorators on an accessor move to the generated getter, which is
+//! marked `IsLoweredAutoAccessor`. tsc decorates an auto-accessor the way it
+//! decorates a getter/setter pair (the decorator receives the property
+//! descriptor), which is what `lower_class` emits for a decorated method-like
+//! member; the flag makes its `emitDecoratorMetadata` output describe the
+//! member's declared type, as tsc's does.
+
+use bun_collections::VecExt;
+
+use crate::lexer as js_lexer;
+use crate::p::P;
+use crate::parser::Ref;
+use bun_ast::g::{DeclList, Property, PropertyKind};
+use bun_ast::{self as js_ast, B, DeclaredSymbol, E, Expr, Flags, G, S};
+
+type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
+
+impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+    /// Replaces every `PropertyKind::AutoAccessor` member of `class` with a
+    /// private backing field plus a getter/setter pair.
+    ///
+    /// Runs from `visit_class`, after the members have been visited and while
+    /// the class body scope is still the current scope: the backing fields are
+    /// declared in that scope, and the collision check has to see the private
+    /// names of this class and of the classes enclosing it.
+    pub(crate) fn lower_auto_accessors_in_place(&mut self, class: &mut G::Class) {
+        let accessor_count = class
+            .properties
+            .iter()
+            .filter(|prop| prop.kind == PropertyKind::AutoAccessor)
+            .count();
+        if accessor_count == 0 {
+            return;
+        }
+
+        let bump = self.arena;
+        let mut properties = BumpVec::<Property>::with_capacity_in(
+            class.properties.len() + 2 * accessor_count,
+            bump,
+        );
+        let mut generated_private_names =
+            BumpVec::<&'a [u8]>::with_capacity_in(accessor_count, bump);
+        let mut computed_key_decls = BumpVec::<G::Decl>::new_in(bump);
+
+        for slot in class.properties.slice_mut() {
+            let prop = core::mem::take(slot);
+            if prop.kind == PropertyKind::AutoAccessor {
+                self.lower_auto_accessor(
+                    prop,
+                    &mut properties,
+                    &mut generated_private_names,
+                    &mut computed_key_decls,
+                );
+            } else {
+                properties.push(prop);
+            }
+        }
+        class.properties = bun_ast::StoreSlice::from_bump(properties);
+
+        if !computed_key_decls.is_empty() {
+            let decl = self.s(
+                S::Local {
+                    decls: DeclList::from_bump_vec(computed_key_decls),
+                    ..Default::default()
+                },
+                class.body_loc,
+            );
+            self.nearest_stmt_list_mut()
+                .expect("classes are only visited from within a statement list")
+                .push(decl);
+        }
+    }
+
+    fn lower_auto_accessor(
+        &mut self,
+        mut accessor: Property,
+        out: &mut BumpVec<'a, Property>,
+        generated_private_names: &mut BumpVec<'a, &'a [u8]>,
+        computed_key_decls: &mut BumpVec<'a, G::Decl>,
+    ) {
+        let key = accessor
+            .key
+            .expect("infallible: auto-accessors always have a key");
+        let loc = key.loc;
+        let is_computed = accessor.flags.contains(Flags::Property::IsComputed);
+        let is_static = accessor.flags.contains(Flags::Property::IsStatic);
+
+        let preferred_name: &'a [u8] = match &key.data {
+            js_ast::ExprData::EString(name)
+                if !is_computed
+                    && name.is_utf8()
+                    && js_lexer::is_identifier(&name.data)
+                    && !name.eql_comptime(b"constructor") =>
+            {
+                self.bump_name2(b"#", &name.data)
+            }
+            // `accessor #p` keeps `#p` for its getter/setter pair.
+            js_ast::ExprData::EPrivateIdentifier(private) => {
+                let name = self.load_name_from_ref(private.ref_);
+                self.bump_name2(b"#_", &name[1..])
+            }
+            _ => b"#_accessor_storage",
+        };
+        let backing_name = self.unused_private_name(preferred_name, generated_private_names);
+        generated_private_names.push(backing_name);
+
+        let backing_kind = if is_static {
+            js_ast::symbol::Kind::PrivateStaticField
+        } else {
+            js_ast::symbol::Kind::PrivateField
+        };
+        let backing_ref = self.new_sym(backing_kind, backing_name);
+        self.record_declared_symbol(backing_ref);
+
+        // #x = <initializer>;
+        let mut backing_flags = accessor.flags;
+        backing_flags.remove(Flags::Property::IsComputed);
+        let backing_key = self.new_expr(E::PrivateIdentifier { ref_: backing_ref }, loc);
+        out.push(Property {
+            kind: PropertyKind::Normal,
+            flags: backing_flags,
+            key: Some(backing_key),
+            initializer: accessor.initializer.take(),
+            ..Default::default()
+        });
+
+        // A computed key expression must still be evaluated exactly once, at
+        // the accessor's position in the class body:
+        //   get [_computedKey = expr]() {} set [_computedKey]() {}
+        let needs_key_temp = is_computed
+            && !matches!(
+                key.data,
+                js_ast::ExprData::EString(_) | js_ast::ExprData::ENumber(_)
+            );
+        let (getter_key, setter_key) = if needs_key_temp {
+            let temp_ref = self.declare_var_temp_ref(b"_computedKey");
+            let binding = self.b(B::Identifier { r#ref: temp_ref }, loc);
+            computed_key_decls.push(G::Decl {
+                binding,
+                value: None,
+            });
+            let temp_for_getter = self.use_ref(temp_ref, loc);
+            let temp_for_setter = self.use_ref(temp_ref, loc);
+            (Expr::assign(temp_for_getter, key), temp_for_setter)
+        } else {
+            (key, key)
+        };
+
+        let mut pair_flags = accessor.flags;
+        pair_flags.insert(Flags::Property::IsMethod);
+        pair_flags.insert(Flags::Property::IsLoweredAutoAccessor);
+
+        // get x() { return this.#x; }
+        // The getter also takes over the member's legacy decorators and declared
+        // type, so `lower_class` decorates it the way tsc decorates an accessor:
+        // with the property descriptor, and with the declared type as metadata.
+        let getter_value = self.backing_field_access(backing_ref, loc);
+        let getter_body = self.s(
+            S::Return {
+                value: Some(getter_value),
+            },
+            loc,
+        );
+        let getter = G::Fn {
+            body: G::FnBody {
+                stmts: bun_ast::StoreSlice::new_mut(self.arena.alloc_slice_copy(&[getter_body])),
+                loc,
+            },
+            ..Default::default()
+        };
+        let getter_fn = self.new_expr(E::Function { func: getter }, loc);
+        out.push(Property {
+            kind: PropertyKind::Get,
+            flags: pair_flags,
+            key: Some(getter_key),
+            value: Some(getter_fn),
+            ts_decorators: bun_alloc::AstAlloc::take(&mut accessor.ts_decorators),
+            ts_metadata: core::mem::take(&mut accessor.ts_metadata),
+            ..Default::default()
+        });
+
+        // set x(v) { this.#x = v; }
+        let value_ref = self.new_sym(js_ast::symbol::Kind::Other, b"v");
+        let value_binding = self.b(B::Identifier { r#ref: value_ref }, loc);
+        let setter_arg = self.arena.alloc(G::Arg {
+            binding: value_binding,
+            ..Default::default()
+        });
+        let assignment_target = self.backing_field_access(backing_ref, loc);
+        let assigned_value = self.use_ref(value_ref, loc);
+        let setter_body = self.s(
+            S::SExpr {
+                value: Expr::assign(assignment_target, assigned_value),
+                ..Default::default()
+            },
+            loc,
+        );
+        let setter = G::Fn {
+            args: bun_ast::StoreSlice::new_mut(core::slice::from_mut(setter_arg)),
+            body: G::FnBody {
+                stmts: bun_ast::StoreSlice::new_mut(self.arena.alloc_slice_copy(&[setter_body])),
+                loc,
+            },
+            ..Default::default()
+        };
+        let setter_fn = self.new_expr(E::Function { func: setter }, loc);
+        out.push(Property {
+            kind: PropertyKind::Set,
+            flags: pair_flags,
+            key: Some(setter_key),
+            value: Some(setter_fn),
+            ..Default::default()
+        });
+    }
+
+    /// `preferred`, or `preferred2`, `preferred3`, ... if that spelling is
+    /// taken. Private names keep their spelling unless identifiers are
+    /// minified, so the generated name must differ from every private name
+    /// declared by this class or by an enclosing class (code in this class
+    /// body may refer to those) and from the ones generated earlier for this
+    /// class.
+    fn unused_private_name(&self, preferred: &'a [u8], generated: &[&'a [u8]]) -> &'a [u8] {
+        let mut candidate = preferred;
+        let mut suffix: usize = 2;
+        while generated.contains(&candidate) || self.is_declared_in_enclosing_scopes(candidate) {
+            candidate = self.bump_name(preferred, Some(suffix));
+            suffix += 1;
+        }
+        candidate
+    }
+
+    /// Creates the symbol for a `var` that `lower_auto_accessors_in_place`
+    /// declares in front of the statement containing the class. The symbol is
+    /// registered in the scope such a `var` hoists to, and recorded as a
+    /// top-level declaration of the current part when that scope is the module
+    /// scope, so the bundler's renamer treats it like any other top-level
+    /// `var` instead of letting a later file's top-level binding take the same
+    /// name.
+    fn declare_var_temp_ref(&mut self, name: &'a [u8]) -> Ref {
+        let mut scope = self.current_scope;
+        while !scope.kind_stops_hoisting() {
+            scope = scope
+                .parent
+                .expect("infallible: the module scope stops hoisting");
+        }
+        let ref_ = self.generate_temp_ref_with_scope(Some(name), scope);
+        self.declared_symbols
+            .append(DeclaredSymbol {
+                ref_,
+                is_top_level: scope == self.module_scope,
+            })
+            .expect("oom");
+        ref_
+    }
+
+    fn is_declared_in_enclosing_scopes(&self, name: &[u8]) -> bool {
+        let hash = js_ast::Scope::get_member_hash(name);
+        let mut scope = Some(self.current_scope);
+        while let Some(current) = scope {
+            if current.get_member_with_hash(name, hash).is_some() {
+                return true;
+            }
+            scope = current.parent;
+        }
+        false
+    }
+
+    /// `this.#x`
+    fn backing_field_access(&mut self, backing_ref: Ref, loc: bun_ast::Loc) -> Expr {
+        self.record_usage(backing_ref);
+        let target = self.new_expr(E::This {}, loc);
+        let index = self.new_expr(E::PrivateIdentifier { ref_: backing_ref }, loc);
+        self.new_expr(
+            E::Index {
+                target,
+                index,
+                optional_chain: None,
+            },
+            loc,
+        )
+    }
+}

--- a/src/js_parser/lower/lower_auto_accessors.rs
+++ b/src/js_parser/lower/lower_auto_accessors.rs
@@ -1,28 +1,9 @@
-//! In-place lowering of `accessor` class members (auto-accessors).
-//!
-//! JavaScriptCore does not implement the keyword, so every auto-accessor has
-//! to be desugared. Classes that go through the standard-decorator lowering
-//! (`lower_decorators.rs`) get that done there. This pass covers the classes
-//! it never sees: TypeScript files compiled with `experimentalDecorators` /
-//! `emitDecoratorMetadata`, whose decorators `P::lower_class` lowers instead.
-//! Each accessor is replaced, at its own position in the class body, by the
-//! desugaring the decorators proposal defines for it (and the one tsc emits),
-//! so the order of keys and initializers is preserved and nothing leaves the
-//! class body:
+//! Lowers `accessor` members of classes that skip the standard-decorator
+//! lowering (TypeScript with `experimentalDecorators`), in place:
 //!
 //! ```js
-//! class A { accessor x = 1; }
-//! // becomes
-//! class A { #x = 1; get x() { return this.#x; } set x(v) { this.#x = v; } }
+//! accessor x = 1;  // -> #x = 1; get x() { return this.#x; } set x(v) { this.#x = v; }
 //! ```
-//!
-//! Legacy decorators on an accessor move to the generated setter (the member
-//! of the pair whose key is the bare temporary when the key is computed). tsc
-//! decorates an auto-accessor the way it decorates a getter/setter pair (the
-//! decorator receives the property descriptor), which is what `lower_class`
-//! emits for a decorated method-like member; the pair is marked
-//! `IsLoweredAutoAccessor` so that its `emitDecoratorMetadata` output
-//! describes the member's declared type, as tsc's does.
 
 use bun_collections::VecExt;
 
@@ -35,13 +16,8 @@ use bun_ast::{self as js_ast, B, DeclaredSymbol, E, Expr, Flags, G, S};
 type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    /// Replaces every `PropertyKind::AutoAccessor` member of `class` with a
-    /// private backing field plus a getter/setter pair.
-    ///
-    /// Runs from `visit_class`, after the members have been visited and while
-    /// the class body scope is still the current scope: the backing fields are
-    /// declared in that scope, and the collision check has to see the private
-    /// names of this class and of the classes enclosing it.
+    /// Call with the visited class body scope still current: the backing
+    /// fields are declared in it.
     pub(crate) fn lower_auto_accessors_in_place(&mut self, class: &mut G::Class) {
         let accessor_count = class
             .properties
@@ -143,9 +119,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ..Default::default()
         });
 
-        // A computed key expression must still be evaluated exactly once, at
-        // the accessor's position in the class body:
-        //   get [_computedKey = expr]() {} set [_computedKey]() {}
+        // `get [_computedKey = expr]() {} set [_computedKey]() {}`
         let needs_key_temp = is_computed
             && !matches!(
                 key.data,
@@ -194,12 +168,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         });
 
         // set x(v) { this.#x = v; }
-        // The setter takes over the member's legacy decorators and declared type.
-        // `lower_class` then decorates it the way tsc decorates an accessor (with
-        // the property descriptor, and with the declared type as metadata), and
-        // since the setter's key is the bare temporary for a computed key, the
-        // decorate call it builds from that key does not evaluate the key
-        // expression a second time.
+        // The decorators go on the setter because `lower_class` reuses the decorated
+        // member's key, and the setter's is the one without the assignment.
         let value_ref = self.new_sym(js_ast::symbol::Kind::Other, b"v");
         let value_binding = self.b(B::Identifier { r#ref: value_ref }, loc);
         let setter_arg = self.arena.alloc(G::Arg {
@@ -235,12 +205,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         });
     }
 
-    /// `preferred`, or `preferred2`, `preferred3`, ... if that spelling is
-    /// taken. Private names keep their spelling unless identifiers are
-    /// minified, so the generated name must differ from every private name
-    /// declared by this class or by an enclosing class (code in this class
-    /// body may refer to those) and from the ones generated earlier for this
-    /// class.
+    /// Private names are printed as written (only the minifier renames them), so
+    /// the name must not be visible from this class body already.
     fn unused_private_name(&self, preferred: &'a [u8], generated: &[&'a [u8]]) -> &'a [u8] {
         let mut candidate = preferred;
         let mut suffix: usize = 2;
@@ -251,13 +217,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         candidate
     }
 
-    /// Creates the symbol for a `var` that `lower_auto_accessors_in_place`
-    /// declares in front of the statement containing the class. The symbol is
-    /// registered in the scope such a `var` hoists to, and recorded as a
-    /// top-level declaration of the current part when that scope is the module
-    /// scope, so the bundler's renamer treats it like any other top-level
-    /// `var` instead of letting a later file's top-level binding take the same
-    /// name.
+    /// Symbol for a `var` emitted next to the class: it lives in the scope the
+    /// `var` hoists to, and the bundler's renamer only sees module-level
+    /// symbols through `declared_symbols`.
     fn declare_var_temp_ref(&mut self, name: &'a [u8]) -> Ref {
         let mut scope = self.current_scope;
         while !scope.kind_stops_hoisting() {

--- a/src/js_parser/lower/lower_auto_accessors.rs
+++ b/src/js_parser/lower/lower_auto_accessors.rs
@@ -16,12 +16,13 @@
 //! class A { #x = 1; get x() { return this.#x; } set x(v) { this.#x = v; } }
 //! ```
 //!
-//! Legacy decorators on an accessor move to the generated getter, which is
-//! marked `IsLoweredAutoAccessor`. tsc decorates an auto-accessor the way it
-//! decorates a getter/setter pair (the decorator receives the property
-//! descriptor), which is what `lower_class` emits for a decorated method-like
-//! member; the flag makes its `emitDecoratorMetadata` output describe the
-//! member's declared type, as tsc's does.
+//! Legacy decorators on an accessor move to the generated setter (the member
+//! of the pair whose key is the bare temporary when the key is computed). tsc
+//! decorates an auto-accessor the way it decorates a getter/setter pair (the
+//! decorator receives the property descriptor), which is what `lower_class`
+//! emits for a decorated method-like member; the pair is marked
+//! `IsLoweredAutoAccessor` so that its `emitDecoratorMetadata` output
+//! describes the member's declared type, as tsc's does.
 
 use bun_collections::VecExt;
 
@@ -169,9 +170,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         pair_flags.insert(Flags::Property::IsLoweredAutoAccessor);
 
         // get x() { return this.#x; }
-        // The getter also takes over the member's legacy decorators and declared
-        // type, so `lower_class` decorates it the way tsc decorates an accessor:
-        // with the property descriptor, and with the declared type as metadata.
         let getter_value = self.backing_field_access(backing_ref, loc);
         let getter_body = self.s(
             S::Return {
@@ -192,12 +190,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             flags: pair_flags,
             key: Some(getter_key),
             value: Some(getter_fn),
-            ts_decorators: bun_alloc::AstAlloc::take(&mut accessor.ts_decorators),
-            ts_metadata: core::mem::take(&mut accessor.ts_metadata),
             ..Default::default()
         });
 
         // set x(v) { this.#x = v; }
+        // The setter takes over the member's legacy decorators and declared type.
+        // `lower_class` then decorates it the way tsc decorates an accessor (with
+        // the property descriptor, and with the declared type as metadata), and
+        // since the setter's key is the bare temporary for a computed key, the
+        // decorate call it builds from that key does not evaluate the key
+        // expression a second time.
         let value_ref = self.new_sym(js_ast::symbol::Kind::Other, b"v");
         let value_binding = self.b(B::Identifier { r#ref: value_ref }, loc);
         let setter_arg = self.arena.alloc(G::Arg {
@@ -227,6 +229,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             flags: pair_flags,
             key: Some(setter_key),
             value: Some(setter_fn),
+            ts_decorators: bun_alloc::AstAlloc::take(&mut accessor.ts_decorators),
+            ts_metadata: core::mem::take(&mut accessor.ts_metadata),
             ..Default::default()
         });
     }

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -146,7 +146,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// recordUsage + E.Identifier in one call.
     #[inline]
-    fn use_ref(&mut self, ref_: Ref, l: bun_ast::Loc) -> Expr {
+    pub(crate) fn use_ref(&mut self, ref_: Ref, l: bun_ast::Loc) -> Expr {
         self.record_usage(ref_);
         self.new_expr(
             E::Identifier {
@@ -166,7 +166,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// newSymbol + scope.generated.append in one call.
-    fn new_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
+    pub(crate) fn new_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
         let ref_ = self.new_symbol(kind, name);
         VecExt::append(&mut self.current_scope_mut().generated, ref_);
         ref_
@@ -394,8 +394,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Bump-format `_{prefix}{n}` (or just `_{prefix}` when n is omitted).
-    fn bump_name(&self, prefix: &[u8], n: Option<usize>) -> &'a [u8] {
+    /// Bump-format `{prefix}{n}` (or just `{prefix}` when n is omitted).
+    pub(crate) fn bump_name(&self, prefix: &[u8], n: Option<usize>) -> &'a [u8] {
         let mut v = BumpVec::<u8>::new_in(self.arena);
         v.extend_from_slice(prefix);
         if let Some(n) = n {
@@ -407,7 +407,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         v.into_bump_slice()
     }
 
-    fn bump_name2(&self, a: &[u8], b: &[u8]) -> &'a [u8] {
+    pub(crate) fn bump_name2(&self, a: &[u8], b: &[u8]) -> &'a [u8] {
         let mut v = BumpVec::<u8>::new_in(self.arena);
         v.extend_from_slice(a);
         v.extend_from_slice(b);

--- a/src/js_parser/lower/mod.rs
+++ b/src/js_parser/lower/mod.rs
@@ -1,2 +1,3 @@
+pub mod lower_auto_accessors;
 pub mod lower_decorators;
 pub mod lower_esm_exports_hmr;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6436,7 +6436,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let loc = descriptor_key.loc;
 
                         // A decorated `accessor` member reaches this point as its generated
-                        // getter (see lower_auto_accessors.rs), so like tsc it gets the
+                        // setter (see lower_auto_accessors.rs), so like tsc it gets the
                         // descriptor form.
                         let descriptor_kind: Expr =
                             if !prop.flags.contains(Flags::Property::IsMethod) {
@@ -6845,7 +6845,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
             }
-            PropertyKind::Get if prop.flags.contains(Flags::Property::IsLoweredAutoAccessor) => {
+            PropertyKind::Get | PropertyKind::Set
+                if prop.flags.contains(Flags::Property::IsLoweredAutoAccessor) =>
+            {
                 // typescript sets only design:type (the declared type) for an `accessor` member.
                 let v = self
                     .serialize_metadata(prop.ts_metadata.clone())
@@ -6921,7 +6923,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             PropertyKind::Spread | PropertyKind::Declare => {}
             // Already replaced by `lower_auto_accessors_in_place`; the accessor's type
-            // is emitted through its generated getter.
+            // is emitted through its generated setter.
             PropertyKind::AutoAccessor => {}
             PropertyKind::ClassStaticBlock => {} // not allowed to decorate this
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6435,9 +6435,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let descriptor_key = prop.key.expect("infallible: prop has key");
                         let loc = descriptor_key.loc;
 
-                        // A decorated `accessor` member reaches this point as its generated
-                        // setter (see lower_auto_accessors.rs), so like tsc it gets the
-                        // descriptor form.
                         let descriptor_kind: Expr =
                             if !prop.flags.contains(Flags::Property::IsMethod) {
                                 self.new_expr(E::Undefined {}, loc)
@@ -6922,9 +6919,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             PropertyKind::Spread | PropertyKind::Declare => {}
-            // Already replaced by `lower_auto_accessors_in_place`; the accessor's type
-            // is emitted through its generated setter.
-            PropertyKind::AutoAccessor => {}
+            PropertyKind::AutoAccessor => {} // lowered to a getter/setter pair before this runs
             PropertyKind::ClassStaticBlock => {} // not allowed to decorate this
         }
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6435,8 +6435,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let descriptor_key = prop.key.expect("infallible: prop has key");
                         let loc = descriptor_key.loc;
 
-                        // TODO: when we have the `accessor` modifier, add `and !prop.flags.contains(.has_accessor_modifier)` to
-                        // the if statement.
+                        // A decorated `accessor` member reaches this point as its generated
+                        // getter (see lower_auto_accessors.rs), so like tsc it gets the
+                        // descriptor form.
                         let descriptor_kind: Expr =
                             if !prop.flags.contains(Flags::Property::IsMethod) {
                                 self.new_expr(E::Undefined {}, loc)
@@ -6844,6 +6845,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
             }
+            PropertyKind::Get if prop.flags.contains(Flags::Property::IsLoweredAutoAccessor) => {
+                // typescript sets only design:type (the declared type) for an `accessor` member.
+                let v = self
+                    .serialize_metadata(prop.ts_metadata.clone())
+                    .expect("unreachable");
+                push_metadata!(b"design:type", v);
+            }
             PropertyKind::Get => {
                 if prop.flags.contains(Flags::Property::IsMethod) {
                     // typescript sets design:type to the return value & design:paramtypes to [].
@@ -6911,7 +6919,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
             }
-            PropertyKind::Spread | PropertyKind::Declare | PropertyKind::AutoAccessor => {} // not allowed in a class (auto_accessor is standard decorators only)
+            PropertyKind::Spread | PropertyKind::Declare => {}
+            // Already replaced by `lower_auto_accessors_in_place`; the accessor's type
+            // is emitted through its generated getter.
+            PropertyKind::AutoAccessor => {}
             PropertyKind::ClassStaticBlock => {} // not allowed to decorate this
         }
     }

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -449,8 +449,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             if let Some(prop) =
                                                 p.parse_property(kind, opts, None)?
                                             {
-                                                if prop.kind == PropertyKind::Normal
-                                                    && prop.value.is_none()
+                                                // tsc decorates an abstract accessor like an
+                                                // abstract field.
+                                                if matches!(
+                                                    prop.kind,
+                                                    PropertyKind::Normal
+                                                        | PropertyKind::AutoAccessor
+                                                ) && prop.value.is_none()
                                                     && opts.ts_decorators.len() > 0
                                                 {
                                                     let mut prop_ = prop;

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -463,10 +463,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         }
                                     }
                                     PropertyModifierKeyword::PAccessor => {
-                                        // "accessor" keyword for auto-accessor fields (TC39 standard decorators)
+                                        // "accessor" keyword for auto-accessor fields. The keyword
+                                        // comes from the TC39 decorators proposal, but TypeScript
+                                        // (4.9+) accepts it in every decorator mode, including
+                                        // `experimentalDecorators`, so it is not gated on
+                                        // `features.standard_decorators`.
                                         if opts.is_class
                                             && !p.lexer.has_newline_before
-                                            && p.options.features.standard_decorators
                                             && PropertyModifierKeyword::find(raw)
                                                 == Some(PropertyModifierKeyword::PAccessor)
                                         {

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -463,11 +463,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         }
                                     }
                                     PropertyModifierKeyword::PAccessor => {
-                                        // "accessor" keyword for auto-accessor fields. The keyword
-                                        // comes from the TC39 decorators proposal, but TypeScript
-                                        // (4.9+) accepts it in every decorator mode, including
-                                        // `experimentalDecorators`, so it is not gated on
-                                        // `features.standard_decorators`.
+                                        // "accessor" keyword for auto-accessor fields (valid in
+                                        // both decorator modes, like in TypeScript)
                                         if opts.is_class
                                             && !p.lexer.has_newline_before
                                             && PropertyModifierKeyword::find(raw)

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -449,13 +449,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             if let Some(prop) =
                                                 p.parse_property(kind, opts, None)?
                                             {
-                                                // tsc decorates an abstract accessor like an
-                                                // abstract field.
-                                                if matches!(
-                                                    prop.kind,
-                                                    PropertyKind::Normal
-                                                        | PropertyKind::AutoAccessor
-                                                ) && prop.value.is_none()
+                                                // Legacy mode decorates an abstract accessor
+                                                // like an abstract field (tsc parity).
+                                                if (prop.kind == PropertyKind::Normal
+                                                    || (prop.kind == PropertyKind::AutoAccessor
+                                                        && !p.options.features.standard_decorators))
+                                                    && prop.value.is_none()
                                                     && opts.ts_decorators.len() > 0
                                                 {
                                                     let mut prop_ = prop;

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -996,10 +996,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.fn_only_data_visit.is_this_nested = old_is_this_captured;
             }
 
-            // Classes headed for `lower_standard_decorators_*` keep their `accessor`
-            // members for it; any other class gets them desugared here, before the
-            // `useDefineForClassFields: false` lowering below so that the generated
-            // backing fields are relocated like the other instance fields.
+            // Before the useDefineForClassFields lowering below, which has to see
+            // the generated backing fields.
             if !class.should_lower_standard_decorators {
                 self.lower_auto_accessors_in_place(class);
             }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -996,6 +996,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.fn_only_data_visit.is_this_nested = old_is_this_captured;
             }
 
+            // Classes headed for `lower_standard_decorators_*` keep their `accessor`
+            // members for it; any other class gets them desugared here, before the
+            // `useDefineForClassFields: false` lowering below so that the generated
+            // backing fields are relocated like the other instance fields.
+            if !class.should_lower_standard_decorators {
+                self.lower_auto_accessors_in_place(class);
+            }
+
             if Self::IS_TYPESCRIPT_ENABLED {
                 // `lower_standard_decorators_stmt` owns field placement for such classes.
                 let use_define = self.options.use_define_for_class_fields

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,10 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: `Class::can_be_moved` counts a `static accessor` initializer as a
+/// side effect, so such classes are no longer hoisted above the bindings they
+/// read; older entries still hold the hoisted output.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1321,6 +1321,74 @@ describe("accessor keyword with experimentalDecorators", () => {
     `);
   });
 
+  test("TypeScript modifiers are stripped and decorated siblings are lowered as usual", () => {
+    // tsc accepts a class that mixes legacy decorators with accessor members, so
+    // the accessors must not make the rest of the class an error.
+    expect(
+      transpile(`
+        declare const dec: any;
+        abstract class Entity {
+          @dec id = 0;
+          accessor name = "";
+          private accessor b = 2;
+          protected readonly accessor c = 3;
+          public static accessor d = 4;
+          protected static override accessor e = 5;
+          abstract accessor f: number;
+          @dec save() {}
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      "class Entity {
+        constructor() {
+          this.id = 0;
+        }
+        #name = "";
+        get name() {
+          return this.#name;
+        }
+        set name(v) {
+          this.#name = v;
+        }
+        #b = 2;
+        get b() {
+          return this.#b;
+        }
+        set b(v) {
+          this.#b = v;
+        }
+        #c = 3;
+        get c() {
+          return this.#c;
+        }
+        set c(v) {
+          this.#c = v;
+        }
+        static #d = 4;
+        static get d() {
+          return this.#d;
+        }
+        static set d(v) {
+          this.#d = v;
+        }
+        static #e = 5;
+        static get e() {
+          return this.#e;
+        }
+        static set e(v) {
+          this.#e = v;
+        }
+        save() {}
+      }
+      __legacyDecorateClassTS([
+        dec
+      ], Entity.prototype, "id", undefined);
+      __legacyDecorateClassTS([
+        dec
+      ], Entity.prototype, "save", null);"
+    `);
+  });
+
   test("emitDecoratorMetadata describes the accessor's declared type, unlike a getter's signature", () => {
     expect(
       transpile(

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1323,7 +1323,8 @@ describe("accessor keyword with experimentalDecorators", () => {
 
   test("TypeScript modifiers are stripped and decorated siblings are lowered as usual", () => {
     // tsc accepts a class that mixes legacy decorators with accessor members, so
-    // the accessors must not make the rest of the class an error.
+    // the accessors must not make the rest of the class an error. A decorated
+    // abstract accessor is decorated like an abstract field (no body member).
     expect(
       transpile(`
         declare const dec: any;
@@ -1335,6 +1336,7 @@ describe("accessor keyword with experimentalDecorators", () => {
           public static accessor d = 4;
           protected static override accessor e = 5;
           abstract accessor f: number;
+          @dec abstract accessor g: number;
           @dec save() {}
         }
       `),
@@ -1383,6 +1385,9 @@ describe("accessor keyword with experimentalDecorators", () => {
       __legacyDecorateClassTS([
         dec
       ], Entity.prototype, "id", undefined);
+      __legacyDecorateClassTS([
+        dec
+      ], Entity.prototype, "g", undefined);
       __legacyDecorateClassTS([
         dec
       ], Entity.prototype, "save", null);"

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1276,13 +1276,17 @@ describe("accessor keyword with experimentalDecorators", () => {
     expect(
       transpile(`
         declare const dec: any;
+        declare const key: () => string;
         class A {
           @dec accessor x = 1;
           @dec static accessor s = 2;
+          @dec accessor [key()] = 3;
         }
       `),
     ).toMatchInlineSnapshot(`
-      "class A {
+      "var __bun_temp_ref_1$;
+
+      class A {
         #x = 1;
         get x() {
           return this.#x;
@@ -1297,10 +1301,20 @@ describe("accessor keyword with experimentalDecorators", () => {
         static set s(v) {
           this.#s = v;
         }
+        #_accessor_storage = 3;
+        get [__bun_temp_ref_1$ = key()]() {
+          return this.#_accessor_storage;
+        }
+        set [__bun_temp_ref_1$](v) {
+          this.#_accessor_storage = v;
+        }
       }
       __legacyDecorateClassTS([
         dec
       ], A.prototype, "x", null);
+      __legacyDecorateClassTS([
+        dec
+      ], A.prototype, __bun_temp_ref_1$, null);
       __legacyDecorateClassTS([
         dec
       ], A, "s", null);"
@@ -1476,13 +1490,13 @@ describe("accessor keyword with experimentalDecorators", () => {
           (Reflect as any).metadata = (k: string, v: any) => (_target: object, key: string) => {
             seen.push({ metadata: k, type: v.name, key });
           };
-          function record(target: object, key: string, desc: PropertyDescriptor) {
+          function record(target: object, key: string, desc?: PropertyDescriptor) {
             seen.push({
               key,
               onPrototype: target === A.prototype,
               onClass: target === A,
-              get: typeof desc.get,
-              set: typeof desc.set,
+              get: typeof desc?.get,
+              set: typeof desc?.set,
               args: arguments.length,
             });
           }
@@ -1490,15 +1504,18 @@ describe("accessor keyword with experimentalDecorators", () => {
             const { get } = desc;
             return { ...desc, get() { return get!.call(this) * 2; } };
           }
+          let keyEvaluations = 0;
+          const key = () => "k" + keyEvaluations++;
           class A {
             @record accessor x = 1;
             @double accessor n: number = 21;
+            @record accessor [key()] = 3;
             @record static accessor s = 2;
           }
-          const a = new A();
+          const a: any = new A();
           const nBefore = a.n;
           a.n = 5;
-          console.log(JSON.stringify({ seen, nBefore, nAfter: a.n, x: a.x, s: A.s }));
+          console.log(JSON.stringify({ seen, keyEvaluations, k0: a.k0, nBefore, nAfter: a.n, x: a.x, s: A.s }));
         `,
       },
       { emitDecoratorMetadata: true },
@@ -1509,9 +1526,13 @@ describe("accessor keyword with experimentalDecorators", () => {
         { metadata: "design:type", type: "Object", key: "x" },
         { key: "x", onPrototype: true, onClass: false, get: "function", set: "function", args: 3 },
         { metadata: "design:type", type: "Number", key: "n" },
+        { metadata: "design:type", type: "Object", key: "k0" },
+        { key: "k0", onPrototype: true, onClass: false, get: "function", set: "function", args: 3 },
         { metadata: "design:type", type: "Object", key: "s" },
         { key: "s", onPrototype: false, onClass: true, get: "function", set: "function", args: 3 },
       ],
+      keyEvaluations: 1,
+      k0: 3,
       nBefore: 42,
       nAfter: 10,
       x: 1,

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 import DecoratedClass from "./decorator-export-default-class-fixture";
 import DecoratedAnonClass from "./decorator-export-default-class-fixture-anon";
 
@@ -1105,3 +1106,504 @@ test("lowering many decorated instance fields into a large constructor body stay
   const { tSmall, tLarge } = JSON.parse(stdout);
   expect(tLarge).toBeLessThan(tSmall * 3);
 }, 90_000);
+
+// With experimentalDecorators the standard-decorator lowering (which also lowers
+// `accessor` members) is not used, so `accessor` is desugared in place instead:
+//   accessor x = 1  ->  #x = 1; get x() { return this.#x } set x(v) { this.#x = v }
+// tsc accepts the keyword in this mode too, and decorates such a member like a
+// getter/setter pair.
+describe("accessor keyword with experimentalDecorators", () => {
+  function transpile(code: string, compilerOptions: Record<string, unknown> = {}) {
+    const transpiler = new Bun.Transpiler({
+      loader: "ts",
+      tsconfig: { compilerOptions: { experimentalDecorators: true, ...compilerOptions } },
+    });
+    return transpiler
+      .transformSync(code)
+      .replace(/^import \{[\s\S]*?\} from "bun:wrap";\n/m, "")
+      .replace(/__legacy(\w+?)TS_\w+/g, "__legacy$1TS")
+      .trim();
+  }
+
+  async function run(name: string, files: Record<string, string>, compilerOptions: Record<string, unknown> = {}) {
+    using dir = tempDir(name, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true, ...compilerOptions } }),
+      ...files,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("is lowered to a private field plus a getter/setter pair", () => {
+    expect(transpile(`class A { accessor x = 1 }`)).toMatchInlineSnapshot(`
+      "class A {
+        #x = 1;
+        get x() {
+          return this.#x;
+        }
+        set x(v) {
+          this.#x = v;
+        }
+      }"
+    `);
+  });
+
+  test("static, private, literal and computed keys", () => {
+    expect(
+      transpile(`
+        const k = () => "dyn";
+        class A {
+          static accessor s = 1;
+          accessor #p = 2;
+          accessor [k()] = 3;
+          accessor ["lit"] = 4;
+          accessor 42 = 5;
+          accessor noInit: string;
+          getP() { return this.#p; }
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      "var __bun_temp_ref_1$;
+      const k = () => "dyn";
+
+      class A {
+        static #s = 1;
+        static get s() {
+          return this.#s;
+        }
+        static set s(v) {
+          this.#s = v;
+        }
+        #_p = 2;
+        get #p() {
+          return this.#_p;
+        }
+        set #p(v) {
+          this.#_p = v;
+        }
+        #_accessor_storage = 3;
+        get [__bun_temp_ref_1$ = k()]() {
+          return this.#_accessor_storage;
+        }
+        set [__bun_temp_ref_1$](v) {
+          this.#_accessor_storage = v;
+        }
+        #_accessor_storage2 = 4;
+        get ["lit"]() {
+          return this.#_accessor_storage2;
+        }
+        set ["lit"](v) {
+          this.#_accessor_storage2 = v;
+        }
+        #_accessor_storage3 = 5;
+        get 42() {
+          return this.#_accessor_storage3;
+        }
+        set 42(v) {
+          this.#_accessor_storage3 = v;
+        }
+        #noInit;
+        get noInit() {
+          return this.#noInit;
+        }
+        set noInit(v) {
+          this.#noInit = v;
+        }
+        getP() {
+          return this.#p;
+        }
+      }"
+    `);
+  });
+
+  test("backing fields avoid the private names of the class and of enclosing classes", () => {
+    expect(
+      transpile(`
+        class Outer {
+          #x = "outer";
+          accessor x = 1;
+          static accessor x = 2;
+          inner() {
+            return class Inner {
+              accessor x = 3;
+              outerX(o: Outer) { return o.#x; }
+            };
+          }
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      "class Outer {
+        #x = "outer";
+        #x2 = 1;
+        get x() {
+          return this.#x2;
+        }
+        set x(v) {
+          this.#x2 = v;
+        }
+        static #x3 = 2;
+        static get x() {
+          return this.#x3;
+        }
+        static set x(v) {
+          this.#x3 = v;
+        }
+        inner() {
+          return class Inner {
+            #x2 = 3;
+            get x() {
+              return this.#x2;
+            }
+            set x(v) {
+              this.#x2 = v;
+            }
+            outerX(o) {
+              return o.#x;
+            }
+          };
+        }
+      }"
+    `);
+  });
+
+  test("a decorated accessor is decorated like a getter/setter pair", () => {
+    expect(
+      transpile(`
+        declare const dec: any;
+        class A {
+          @dec accessor x = 1;
+          @dec static accessor s = 2;
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      "class A {
+        #x = 1;
+        get x() {
+          return this.#x;
+        }
+        set x(v) {
+          this.#x = v;
+        }
+        static #s = 2;
+        static get s() {
+          return this.#s;
+        }
+        static set s(v) {
+          this.#s = v;
+        }
+      }
+      __legacyDecorateClassTS([
+        dec
+      ], A.prototype, "x", null);
+      __legacyDecorateClassTS([
+        dec
+      ], A, "s", null);"
+    `);
+  });
+
+  test("emitDecoratorMetadata describes the accessor's declared type, unlike a getter's signature", () => {
+    expect(
+      transpile(
+        `
+          declare const dec: any;
+          class A {
+            @dec accessor x: number = 1;
+            @dec get y(): string { return ""; }
+          }
+        `,
+        { emitDecoratorMetadata: true },
+      ),
+    ).toMatchInlineSnapshot(`
+      "class A {
+        #x = 1;
+        get x() {
+          return this.#x;
+        }
+        set x(v) {
+          this.#x = v;
+        }
+        get y() {
+          return "";
+        }
+      }
+      __legacyDecorateClassTS([
+        dec,
+        __legacyMetadataTS("design:type", Number)
+      ], A.prototype, "x", null);
+      __legacyDecorateClassTS([
+        dec,
+        __legacyMetadataTS("design:type", String),
+        __legacyMetadataTS("design:paramtypes", [])
+      ], A.prototype, "y", null);"
+    `);
+  });
+
+  test("useDefineForClassFields: false moves the backing field's initializer into the constructor", () => {
+    expect(
+      transpile(
+        `
+          class A {
+            a = 1;
+            accessor x = this.a + 1;
+            b = 2;
+          }
+        `,
+        { useDefineForClassFields: false },
+      ),
+    ).toMatchInlineSnapshot(`
+      "class A {
+        constructor() {
+          this.a = 1;
+          this.#x = this.a + 1;
+          this.b = 2;
+        }
+        #x;
+        get x() {
+          return this.#x;
+        }
+        set x(v) {
+          this.#x = v;
+        }
+      }"
+    `);
+  });
+
+  test("accessor is still an ordinary member name", () => {
+    expect(
+      transpile(`
+        declare const computed: string;
+        class A {
+          accessor = 1;
+          static accessor: string = "s";
+          accessor
+          afterNewline = 2;
+          accessor
+          [computed] = 3;
+          accessor?: number;
+          accessor(): void {}
+        }
+        const o = { accessor: 1 };
+      `),
+    ).toMatchInlineSnapshot(`
+      "class A {
+        accessor = 1;
+        static accessor = "s";
+        accessor;
+        afterNewline = 2;
+        accessor;
+        [computed] = 3;
+        accessor;
+        accessor() {}
+      }
+      const o = { accessor: 1 };"
+    `);
+  });
+
+  test.concurrent("accessors behave like the native keyword at runtime", async () => {
+    const { stdout, stderr, exitCode } = await run("legacy-accessor-runtime", {
+      "index.ts": `
+        import Anon from "./anon";
+        const keyCalls: string[] = [];
+        const key = () => { keyCalls.push("key"); return "dyn"; };
+        class Base {
+          accessor name = "base";
+          static accessor count = 1;
+          accessor #secret = "s";
+          accessor [key()] = "d";
+          get secret() { return this.#secret; }
+          set secret(v: string) { this.#secret = v; }
+        }
+        class Derived extends Base {
+          accessor name = "derived";
+          superName() { return super.name; }
+        }
+        const Expr = class { accessor e = 1 };
+        const d: any = new Derived();
+        d.name = "changed";
+        d.dyn = "d2";
+        d.secret = "s2";
+        Base.count++;
+        console.log(JSON.stringify({
+          name: d.name,
+          superName: d.superName(),
+          baseName: new Base().name,
+          count: Base.count,
+          dyn: d.dyn,
+          keyCalls,
+          secret: d.secret,
+          protoKeys: Object.getOwnPropertyNames(Base.prototype),
+          ownKeys: Object.keys(d),
+          descriptor: typeof Object.getOwnPropertyDescriptor(Base.prototype, "name").set,
+          expr: new Expr().e,
+          anonName: Anon.name,
+          anonValue: new Anon().z,
+        }));
+      `,
+      "anon.ts": `export default class { accessor z = "z" }`,
+    });
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      name: "changed",
+      superName: "base",
+      baseName: "base",
+      count: 2,
+      dyn: "d2",
+      keyCalls: ["key"],
+      secret: "s2",
+      protoKeys: ["constructor", "name", "dyn", "secret"],
+      ownKeys: [],
+      descriptor: "function",
+      expr: 1,
+      anonName: "default",
+      anonValue: "z",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("legacy decorators on accessors receive the property descriptor", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      "legacy-accessor-decorated",
+      {
+        "index.ts": `
+          const seen: unknown[] = [];
+          // Stand-in for reflect-metadata: __legacyMetadataTS calls Reflect.metadata when it exists.
+          (Reflect as any).metadata = (k: string, v: any) => (_target: object, key: string) => {
+            seen.push({ metadata: k, type: v.name, key });
+          };
+          function record(target: object, key: string, desc: PropertyDescriptor) {
+            seen.push({
+              key,
+              onPrototype: target === A.prototype,
+              onClass: target === A,
+              get: typeof desc.get,
+              set: typeof desc.set,
+              args: arguments.length,
+            });
+          }
+          function double(_target: object, _key: string, desc: PropertyDescriptor): PropertyDescriptor {
+            const { get } = desc;
+            return { ...desc, get() { return get!.call(this) * 2; } };
+          }
+          class A {
+            @record accessor x = 1;
+            @double accessor n: number = 21;
+            @record static accessor s = 2;
+          }
+          const a = new A();
+          const nBefore = a.n;
+          a.n = 5;
+          console.log(JSON.stringify({ seen, nBefore, nAfter: a.n, x: a.x, s: A.s }));
+        `,
+      },
+      { emitDecoratorMetadata: true },
+    );
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      seen: [
+        { metadata: "design:type", type: "Object", key: "x" },
+        { key: "x", onPrototype: true, onClass: false, get: "function", set: "function", args: 3 },
+        { metadata: "design:type", type: "Number", key: "n" },
+        { metadata: "design:type", type: "Object", key: "s" },
+        { key: "s", onPrototype: false, onClass: true, get: "function", set: "function", args: 3 },
+      ],
+      nBefore: 42,
+      nAfter: 10,
+      x: 1,
+      s: 2,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent(
+    "useDefineForClassFields: false initializes accessors in source order with the other fields",
+    async () => {
+      const { stdout, stderr, exitCode } = await run(
+        "legacy-accessor-use-define",
+        {
+          "index.ts": `
+          const order: string[] = [];
+          class A {
+            a = (order.push("a"), 1);
+            accessor x = (order.push("x"), this.a + 1);
+            b = (order.push("b"), 2);
+            static accessor s = (order.push("s"), 3);
+            constructor() { order.push("ctor"); }
+          }
+          const a = new A();
+          console.log(JSON.stringify({ order, x: a.x, s: A.s, ownKeys: Object.keys(a) }));
+        `,
+        },
+        { useDefineForClassFields: false },
+      );
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ order: ["s", "a", "x", "b", "ctor"], x: 2, s: 3, ownKeys: ["a", "b"] });
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test.concurrent("bundling keeps the generated bindings of different files apart", async () => {
+    using dir = tempDir("legacy-accessor-bundle", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+      // b.ts is bundled first and its export keeps the name _computedKey, so both
+      // the temporary generated for B's computed key and the function declared
+      // below need fresh names. If those two ended up sharing a name, defining B
+      // would overwrite the function.
+      "index.ts": `
+        import { B, _computedKey as exported } from "./b";
+        function _computedKey() { return "function"; }
+        const key = () => "ka";
+        class A {
+          #x = "private";
+          accessor x = 1;
+          accessor [key()] = 2;
+          privateX() { return this.#x; }
+        }
+        const a: any = new A();
+        const b: any = new B();
+        console.log(JSON.stringify({
+          ax: a.x, aka: a.ka, privateX: a.privateX(), bx: b.x, bkb: b.kb, fn: _computedKey(), exported,
+        }));
+      `,
+      "b.ts": `
+        export const _computedKey = "exported";
+        const key = () => "kb";
+        export class B {
+          accessor x = 3;
+          accessor [key()] = 4;
+        }
+      `,
+    });
+    const build = await Bun.build({
+      entrypoints: [join(String(dir), "index.ts")],
+      outdir: join(String(dir), "out"),
+      target: "bun",
+    });
+    expect(build.logs).toEqual([]);
+    expect(build.success).toBe(true);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join("out", "index.js")],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      ax: 1,
+      aka: 2,
+      privateX: "private",
+      bx: 3,
+      bkb: 4,
+      fn: "function",
+      exported: "exported",
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1228,5 +1228,23 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("undefined\nworld\n");
       expect(exitCode).toBe(0);
     });
+
+    // tsc rejects standard decorators on abstract members (TS1270), so like a
+    // decorated abstract field the member is dropped from the output. Only the
+    // legacy-decorator path keeps its decorators.
+    test("decorated abstract accessor stays dropped in standard mode", () => {
+      const t = new Bun.Transpiler({ loader: "ts" });
+      const out = t.transformSync(`
+        declare const dec: any;
+        abstract class A {
+          @dec abstract accessor g: number;
+          x = 1;
+        }
+      `);
+      expect(out).toContain("x = 1");
+      expect(out).not.toContain('"g"');
+      expect(out).not.toContain("accessor g");
+      expect(out).not.toContain("__decorateElement");
+    });
   });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -958,6 +958,25 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("true\n");
       expect(exitCode).toBe(0);
     });
+
+    // Classes without side effects are hoisted to the top of the module at
+    // runtime; a static accessor's initializer is a side effect like a static
+    // field's, so these classes must stay below the binding they read.
+    test("classes with static accessor initializers are not hoisted above the bindings they use", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const names = ["p"];
+        class Stmt {
+          static accessor s = names[0] + "1";
+        }
+        export default class Def {
+          static accessor d = names[0] + "2";
+        }
+        console.log(Stmt.s, Def.d);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("p1 p2\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("anonymous class expressions with reserved-word inferred names", () => {


### PR DESCRIPTION
Fixes #29197

Replaces #29201 (closed) and the parked branch `farm/57075cac/ts-legacy-decorators-accessor`. #29201 routed these classes through the standard-decorator lowering and reported a compile error for a class that mixes legacy decorators with `accessor` members; tsc accepts that combination, so the in-place lowering here was kept. Its test file was run against this branch: every case passes except that deliberate error and a standard-mode (`experimentalDecorators` off) computed-key case, which belongs to #31926. The one case it covered that this suite lacked (TypeScript modifiers on accessors) was added here, together with the mixed class.

### Problem

- In a project whose tsconfig sets `experimentalDecorators` (or `emitDecoratorMetadata`), any `.ts` class using the `accessor` keyword fails to parse: `class A { accessor name = "A" }` gives `error: Expected ";" but found "name"`. The same file works when the tsconfig does not enable legacy decorators. tsc accepts the keyword in both decorator modes (it is class syntax from the decorators proposal, independent of which decorator flavor is configured).
- Cause: `src/js_parser/parse/parse_property.rs` only recognized the keyword when `features.standard_decorators` was set, and `ParseTask.rs` / `transpiler.rs` clear that flag for TypeScript files with `experimentalDecorators` or `emitDecoratorMetadata`. `accessor` then parsed as a field named `accessor`.
- Parsing alone is not enough: JavaScriptCore does not implement `accessor`, and the only lowering for it lives in the standard-decorator path (`lower_decorators.rs`), which these classes never take because their decorators are TypeScript legacy decorators lowered by `P::lower_class`.
- Adjacent bug, both modes: `Class::can_be_moved` (`src/ast/g.rs`) only looked at plain static fields, so a class whose only side effect is a `static accessor` initializer was hoisted to the top of the module by the runtime transpiler and read bindings before their declaration (`ReferenceError: Cannot access 'names' before initialization`). Reproduces on main with a `.js` file too.

### Fix

- `parse_property.rs`: recognize `accessor` in class bodies in every decorator mode. The newline (ASI) and raw-spelling checks are unchanged, so `accessor` as a member name still parses the way tsc parses it (covered by a snapshot test). In `experimentalDecorators` mode the `abstract` branch there turns a decorated `abstract accessor x` into the same `Abstract` property a decorated `abstract x` becomes, so its decorators are emitted as `__legacyDecorateClassTS(decorators, proto, "x", undefined)` plus `design:type`, which is what tsc emits; before, the member (and its decorators) was dropped like an undecorated abstract member. Standard-decorator mode is left as it was (the member is still dropped; tsc rejects standard decorators on abstract members), covered in `es-decorators.test.ts`.
- New `src/js_parser/lower/lower_auto_accessors.rs`, called from `visit_class` for classes that `should_lower_standard_decorators` does not claim. Each accessor is replaced at its own position by the desugaring the proposal defines and tsc emits:
  ```js
  accessor x = 1;   // -> #x = 1; get x() { return this.#x; } set x(v) { this.#x = v; }
  ```
  - Why in place: nothing leaves the class body, so key evaluation order, initializer order and private-name scoping are exactly those of the source, and it composes with the legacy decorator lowering that runs afterwards on the same class. Static accessors use `this`, like the proposal and the existing standard-mode output.
  - Why in `visit_class`, before the `useDefineForClassFields: false` block: the generated backing field is then relocated into the constructor in source order together with the other instance fields, which is what tsc emits for that option.
  - Backing name: `#x` (`#_p` for `accessor #p`, `#_accessor_storage` for other keys), with a numeric suffix when that spelling is declared by this class or by an enclosing class, found by walking the scope chain while the class body scope is still current. Private names are printed verbatim by the non-minifying renamer, and a name declared by an enclosing class may be referenced from inside this class body, so both sets have to be avoided.
  - Computed keys are evaluated once, at the accessor's position: `get [_computedKey = expr]() {} set [_computedKey]() {}`. The temporary comes from `generate_temp_ref` (collision-safe name in the runtime transpiler), is registered in the scope a `var` there hoists to, and is recorded as a top-level declared symbol of the part when that scope is the module scope, so the bundler's renamer gives it a name distinct from other files' top-level bindings. Without the last step, the temporary of an earlier file and a top-level binding of a later file could be assigned the same name (verified while writing the bundling test).
  - Legacy decorators on an accessor move to the generated setter. `lower_class` then emits `__legacyDecorateClassTS(decorators, target, key, null)`, which is what tsc's `__decorate` receives for a legacy-decorated accessor (the decorator gets the get/set descriptor and can replace it). The setter rather than the getter because `lower_class` reuses the decorated member's key expression in that call: the setter's key is the bare `_computedKey` temporary, so a computed key is still evaluated once (tsc emits `__decorate(..., _a, null)` the same way). The pair is flagged `IsLoweredAutoAccessor` (new `flags::Property` variant) and the setter carries the member's declared type, so `emitDecoratorMetadata` emits `design:type` only, as tsc does for accessors, instead of a getter's or setter's `design:type` + `design:paramtypes`.
  - Standard-decorator mode is unchanged: those classes always have `should_lower_standard_decorators` set, so the new pass never runs for them (checked that `bun build --no-bundle` output for JS/TS files without `experimentalDecorators` is byte-identical before and after). #31926, which makes the standard-mode lowering of accessor-only classes in place as well, is independent of this; the new pass is written so that path could share it later.
- `src/ast/g.rs`: `can_be_moved` also inspects `static accessor` initializers. Because this changes the output of files that already transpiled before (the other changes only affect files that used to fail to parse), `EXPECTED_VERSION` in `src/jsc/RuntimeTranspilerCache.rs` is bumped to 26; the cache key is source hash plus features, not the bun version, so without the bump a warm cache would keep serving the hoisted output for such files until they are edited.
- Small enablers: four helpers in `lower_decorators.rs` became `pub(crate)` for reuse; the obsolete `accessor` TODO in `lower_class` and the stale comment in `emit_decorator_metadata_for_prop` were removed.
- Verification:
  - `test/bundler/transpiler/decorators.test.ts`, new `describe("accessor keyword with experimentalDecorators")`: output shapes via `Bun.Transpiler` (basic, static/private/literal/computed keys, name collisions incl. an enclosing class, decorated instance/static/computed-key accessors, `private` / `protected readonly` / `public static` / `static override` / `abstract` / decorated `abstract` modifiers in a class whose other members carry legacy decorators, metadata vs. a real getter, `useDefineForClassFields: false`, `accessor` as a plain member name) and runtime fixtures with a tsconfig on disk (getter/setter semantics incl. subclass override and `super`, computed key evaluated once, anonymous `export default` keeps `.name === "default"`, legacy decorators receiving and replacing the descriptor plus `design:type`, including on a computed-key accessor whose key function must run exactly once, `useDefineForClassFields: false` ordering, and a two-file `Bun.build` where the temporaries, a user function and an export all want the same name). 11 of the 12 fail on the released build (parse error), all pass with this branch.
  - `test/bundler/transpiler/es-decorators.test.ts`: `.js` class statement and `export default class` with static accessor initializers are no longer hoisted above the binding they read; fails on the released build with the `ReferenceError` above.
  - `decorators`, `decorator-metadata`, `es-decorators`, `es-decorators-esbuild`, `ts-use-define-for-class-fields`, `bundler_decorator_metadata`, `esbuild/ts`, `esbuild/lower`, `bundler_edgecase` and the internal source lints pass with a debug build; `cargo clippy -p bun_js_parser` is clean.

### Background

- Auto-accessor: `accessor x = v` declares a getter/setter pair backed by a hidden per-instance slot; the proposal specifies it as exactly the `#x` + `get`/`set` desugaring above. TypeScript has accepted it since 4.9 under both `experimentalDecorators` and standard decorators, and its legacy decorator transform decorates such a member with the descriptor form (`__decorate(..., key, null)`), emitting only `design:type` as metadata.
- Decorator modes in bun: `.js` files and `.ts` files without `experimentalDecorators` use the standard (TC39) lowering in `lower_decorators.rs`, which also lowers accessors; `.ts` files with `experimentalDecorators` / `emitDecoratorMetadata` have `features.standard_decorators` cleared and get their decorators lowered by `P::lower_class` into `__legacyDecorateClassTS` calls after the class. `G::Class::should_lower_standard_decorators` is what routes a class to the former.
- `useDefineForClassFields: false`: tsc option under which instance field initializers are turned into `this.x = init` assignments in the constructor; bun implements it at the end of `visit_class`.
- Renamers: the runtime transpiler prints symbol names verbatim (generated names must be unique by construction, which `generate_temp_ref` provides), the bundler renames top-level symbols across all files of a chunk and then nested scopes per part (so a symbol declared by a top-level `var` has to be registered as a top-level declaration to take part in the cross-file pass), and private names are never renamed except by the minifier.
- `Class::can_be_moved`: the runtime transpiler hoists top-level classes without observable side effects to the top of the module to make some import cycles work; a static initializer is such a side effect.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/decorators.test.ts test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/decorators.test.ts:
(pass) decorator order of evaluation [49.87ms]
(pass) decorator factories order of evaluation [42.99ms]
(pass) parameter decorators [32.11ms]
(pass) decorators random [71.12ms]
(pass) class field order [9.58ms]
(pass) changing static method [10.67ms]
(pass) class extending from another class [16.62ms]
(pass) decorated fields moving to constructor [10.21ms]
(pass) only class decorator [5.48ms]
(pass) decorators with different property key types [13.39ms]
(pass) only property decorators [13.46ms]
(pass) only argument decorators [5.95ms]
(pass) no decorators [5.01ms]
(pass) constructor statements > with parameter properties [14.59ms]
(pass) constructor statements > class expressions (no decorators) [13.47ms]
(pass) constructor statements > with parameter properties and statements [7.93ms]
(pass) constructor statements > with parameter properties, statements, and decorators [10.97
... (truncated)

release without fix: 12 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/bundler/transpiler/decorators.test.ts:
(pass) decorator order of evaluation [0.46ms]
(pass) decorator factories order of evaluation [0.41ms]
(pass) parameter decorators [0.40ms]
(pass) decorators random [0.96ms]
(pass) class field order [0.12ms]
(pass) changing static method [0.11ms]
(pass) class extending from another class [0.18ms]
(pass) decorated fields moving to constructor [0.11ms]
(pass) only class decorator [0.05ms]
(pass) decorators with different property key types [0.20ms]
(pass) only property decorators [0.17ms]
(pass) only argument decorators [0.06ms]
(pass) no decorators [0.04ms]
(pass) constructor statements > with parameter properties [0.13ms]
(pass) constructor statements > class expressions (no decorators) [0.12ms]
(pass) constructor statements > with parameter properties and statements [0.07ms]
(pass) constructor statements > with parameter properties, statements, and decorators [0.10ms]
(pass) constructor statements > with more parameter properties, statements, and decorators [0.17ms]
(pass) constructor statements > expression with parameter properties and statements [0.10ms]
(pass) export default class 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/decorators.test.ts test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.1 (65362b53b)

test/bundler/transpiler/decorators.test.ts:
(pass) decorator order of evaluation [51.04ms]
(pass) decorator factories order of evaluation [39.84ms]
(pass) parameter decorators [30.21ms]
(pass) decorators random [66.84ms]
(pass) class field order [9.08ms]
(pass) changing static method [10.28ms]
(pass) class extending from another class [16.05ms]
(pass) decorated fields moving to constructor [9.51ms]
(pass) only class decorator [4.93ms]
(pass) decorators with different property key types [12.00ms]
(pass) only property decorators [11.36ms]
(pass) only argument decorators [5.53ms]
(pass) no decorators [4.32ms]
(pass) constructor statements > with parameter properties [12.95ms]
(pass) constructor statements > class expressions (no decorators) [12.28ms]
(pass) constructor statements > with parameter properties and statements [7.28ms]
(pass) constructor statements > with parameter properties, statements, and decorators [9.83ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e9b7b98728
  features     baseline

23 deps, 131 codegen, 1172 objects in 1260ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [24.00ms]
[3/1244] fetch zlib
[zlib] up to date
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/g.rs                                  |   6 +-
 src/ast/lib.rs                                |   3 +
 src/js_parser/lower/lower_auto_accessors.rs   | 266 ++++++++++++
 src/js_parser/lower/lower_decorators.rs       |  10 +-
 src/js_parser/lower/mod.rs                    |   1 +
 src/js_parser/p.rs                            |  14 +-
 src/js_parser/parse/parse_property.rs         |  10 +-
 src/js_parser/visit/mod.rs                    |   6 +
 src/jsc/RuntimeTranspilerCache.rs             |   5 +-
 test/bundler/transpiler/decorators.test.ts    | 598 +++++++++++++++++++++++++-
 test/bundler/transpiler/es-decorators.test.ts |  37 ++
 11 files changed, 942 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/ast/g.rs                                       0      0      0
src/ast/lib.rs                                     0      0      0
src/js_parser/lower/lower_auto_accessors.rs        0      0      0
src/js_parser/lower/lower_decorators.rs            0      0      0
src/js_parser/lower/mod.rs                         0      0      0
src/js_parser/p.rs                                 0      0      0
src/js_parser/parse/parse_property.rs              3      2      0
src/js_parser/visit/mod.rs                         0      0      0
src/jsc/RuntimeTranspilerCache.rs                  2      2      0
test/bundler/transpiler/decorators.test.ts         0      0      0
test/bundler/transpiler/es-decorators.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The parser did not support the `accessor` class-member keyword under TypeScript's experimentalDecorators mode, so auto-accessors were rejected or mishandled instead of being desugared like tsc does. The fix teaches the parser to accept `accessor` and adds a dedicated lowering pass that rewrites each `accessor x = init` into a private backing field with a generated getter and setter pair, attaching decorators and metadata to the setter so computed keys evaluate exactly once and only `design:type` is emitted. It also marks static accessor initializers as side effects in `Class::can_be_moved` …

<!-- robobun:evidence:end -->