### PR TITLE
js_parser: drop decorated declare/abstract fields under standard decorators

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -211,7 +211,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if opts.allow_ts_decorators {
                 opts.ts_decorators = p.parse_type_script_decorators()?;
                 opts.has_class_decorators = class_opts.ts_decorators.len() > 0;
-                has_decorators = has_decorators || opts.ts_decorators.len() > 0;
             }
 
             // This property may turn out to be a type in TypeScript, which should be ignored
@@ -240,12 +239,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
-                has_decorators = has_decorators || opts.has_argument_decorators;
+                has_decorators =
+                    has_decorators || opts.ts_decorators.len() > 0 || opts.has_argument_decorators;
             } else {
                 // The property was dropped (e.g. a TypeScript overload signature or
-                // abstract method), which drops its decorators and computed key too.
-                // Discard any scopes recorded while parsing them or the visit pass
-                // will hit a scope order mismatch.
+                // abstract method), which drops its decorators and computed key too,
+                // so they must not count towards `has_decorators`. Discard any scopes
+                // recorded while parsing them or the visit pass will hit a scope
+                // order mismatch.
                 p.discard_scopes_up_to(property_scope_index);
             }
         }

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -23,6 +23,23 @@ use js_ast::{
 use js_lexer::T;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+    /// A `declare`/`abstract` field emits nothing, so it is normally dropped at
+    /// parse time. With `experimentalDecorators`, tsc still applies the field's
+    /// decorators, so `lower_class` needs the field kept around as a
+    /// `PropertyKind::Declare`/`Abstract` marker to emit `__legacyDecorateClassTS`.
+    /// Standard decorators have no such rule (tsc reports TS1206 and drops the
+    /// member), and `lower_decorators.rs` would treat the marker as a real field.
+    fn keeps_legacy_decorated_ambient_field(
+        &self,
+        prop: &G::Property,
+        opts: &PropertyOpts,
+    ) -> bool {
+        prop.kind == PropertyKind::Normal
+            && prop.value.is_none()
+            && opts.ts_decorators.len() > 0
+            && !self.options.features.standard_decorators
+    }
+
     fn parse_method_expression(
         &mut self,
         kind: PropertyKind,
@@ -420,17 +437,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             && raw == b"declare"
                                         {
                                             let scope_index = p.scopes_in_order.len();
-                                            if let Some(_prop) =
+                                            if let Some(mut prop) =
                                                 p.parse_property(kind, opts, None)?
+                                                && p.keeps_legacy_decorated_ambient_field(
+                                                    &prop, opts,
+                                                )
                                             {
-                                                let mut prop = _prop;
-                                                if prop.kind == PropertyKind::Normal
-                                                    && prop.value.is_none()
-                                                    && opts.ts_decorators.len() > 0
-                                                {
-                                                    prop.kind = PropertyKind::Declare;
-                                                    return Ok(Some(prop));
-                                                }
+                                                prop.kind = PropertyKind::Declare;
+                                                return Ok(Some(prop));
                                             }
 
                                             p.discard_scopes_up_to(scope_index);
@@ -446,17 +460,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         {
                                             opts.is_ts_abstract = true;
                                             let scope_index = p.scopes_in_order.len();
-                                            if let Some(prop) =
+                                            if let Some(mut prop) =
                                                 p.parse_property(kind, opts, None)?
+                                                && p.keeps_legacy_decorated_ambient_field(
+                                                    &prop, opts,
+                                                )
                                             {
-                                                if prop.kind == PropertyKind::Normal
-                                                    && prop.value.is_none()
-                                                    && opts.ts_decorators.len() > 0
-                                                {
-                                                    let mut prop_ = prop;
-                                                    prop_.kind = PropertyKind::Abstract;
-                                                    return Ok(Some(prop_));
-                                                }
+                                                prop.kind = PropertyKind::Abstract;
+                                                return Ok(Some(prop));
                                             }
                                             p.discard_scopes_up_to(scope_index);
                                             return Ok(None);

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -31,6 +31,21 @@ async function runDecorator(code: string) {
   return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
+async function runDecoratorTS(code: string) {
+  using dir = tempDir("es-dec-ts", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": code,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: filterStderr(rawStderr), exitCode };
+}
+
 describe("ES Decorators", () => {
   describe("class decorators", () => {
     test("basic class decorator", async () => {
@@ -391,21 +406,6 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
-    async function runDecoratorTS(code: string) {
-      using dir = tempDir("es-dec-ts", {
-        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-        "test.ts": code,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout, stderr: filterStderr(rawStderr), exitCode };
-    }
-
     test("non-null assertion in decorator member expression", async () => {
       const { stdout, stderr, exitCode } = await runDecoratorTS(`
         const ns = {
@@ -677,6 +677,120 @@ describe("ES Decorators", () => {
       expect(filterStderr(rawStderr)).toBe("");
       expect(stdout).toBe("class Foo\n");
       expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("decorators on members TypeScript erases", () => {
+    // Without experimentalDecorators, tsc (TS1206/TS1249) and esbuild drop a
+    // decorated `declare`/`abstract` field, overload signature or index
+    // signature along with its decorators: the decorator expression is never
+    // evaluated and the class is emitted as if the member were not written.
+    const transpiler = new Bun.Transpiler({ loader: "ts", target: "bun" });
+    const transform = (code: string) => transpiler.transformSync(code);
+
+    // [member as written, what is left of it after erasure]
+    const erased: [string, string][] = [
+      ["@dec declare x: number;", ""],
+      ["@dec static declare x: number;", ""],
+      ["@dec public declare readonly x: number;", ""],
+      ["@dec declare [key]: number;", ""],
+      ["@dec foo(): void; foo() {}", "foo() {}"],
+      ["@dec [key: string]: unknown;", ""],
+    ];
+    const wrappers = {
+      "class statement": (body: string) => `class A { ${body} y = 1 }`,
+      "class expression": (body: string) => `const A = class { ${body} y = 1 };`,
+      "export default class": (body: string) => `export default class { ${body} y = 1 }`,
+    };
+    for (const [name, wrap] of Object.entries(wrappers)) {
+      test.each(erased)(`${name}: %s`, (member, remaining) => {
+        expect(transform(wrap(member))).toBe(transform(wrap(remaining)));
+      });
+    }
+
+    const erasedAbstract = [
+      "@dec abstract x: number;",
+      "@dec abstract readonly x: number;",
+      "@dec abstract m(): void;",
+      "@dec abstract get x(): number;",
+    ];
+    const abstractWrappers = {
+      "abstract class statement": (body: string) => `abstract class A { ${body} y = 1 }`,
+      "export default abstract class": (body: string) => `export default abstract class { ${body} y = 1 }`,
+    };
+    for (const [name, wrap] of Object.entries(abstractWrappers)) {
+      test.each(erasedAbstract)(`${name}: %s`, member => {
+        expect(transform(wrap(member))).toBe(transform(wrap("")));
+      });
+    }
+
+    test("erased members still vanish from a class that has other decorated members", () => {
+      const kept = "@dec m() {} @dec z = 1;";
+      expect(transform(`abstract class A { @dec declare x: number; ${kept} @dec abstract w: string; }`)).toBe(
+        transform(`abstract class A { ${kept} }`),
+      );
+    });
+
+    test.concurrent("decorators on erased members are not evaluated or applied at runtime", async () => {
+      const { stdout, stderr, exitCode } = await runDecoratorTS(`
+        const applied: string[] = [];
+        function dec(_: unknown, ctx: { kind: string; name: string | symbol }) {
+          applied.push(ctx.kind + " " + String(ctx.name));
+        }
+        let evaluated = 0;
+        function erasedDec() {
+          evaluated++;
+          return dec;
+        }
+        class A {
+          @erasedDec() declare x: number;
+          @dec y = 1;
+        }
+        const B = class {
+          @erasedDec() declare x: number;
+          y = 1;
+        };
+        abstract class C {
+          @erasedDec() abstract x: number;
+          y = 1;
+        }
+        class D extends C {
+          x = 2;
+        }
+        console.log(JSON.stringify({
+          evaluated,
+          applied,
+          a: Object.keys(new A()),
+          b: Object.keys(new B()),
+          d: Object.keys(new D()),
+          ownSymbolsOfB: Object.getOwnPropertySymbols(B).length,
+        }));
+      `);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        evaluated: 0,
+        applied: ["field y"],
+        a: ["y"],
+        b: ["y"],
+        d: ["y", "x"],
+        ownSymbolsOfB: 0,
+      });
+      expect(exitCode).toBe(0);
+    });
+
+    test("experimentalDecorators keeps applying decorators to declare and abstract fields", () => {
+      const legacy = new Bun.Transpiler({
+        loader: "ts",
+        target: "bun",
+        tsconfig: { compilerOptions: { experimentalDecorators: true } },
+      });
+      const output = legacy.transformSync(`
+        class A { @dec declare x: number; y = 1 }
+        abstract class B { @dec abstract x: number; y = 1 }
+      `);
+      expect(output).toContain('A.prototype, "x"');
+      expect(output).toContain('B.prototype, "x"');
+      expect(output).not.toContain("this.x");
     });
   });
 


### PR DESCRIPTION
### Problem
- In standard (TC39) decorator mode, i.e. a `.ts` file without `experimentalDecorators`, `class A { @dec declare x: number }` runs `dec` with `kind: "field"` and every instance gets an own `x` property. Same for `@dec abstract x: T`, and for class expressions and `export default class`.
- tsc reports TS1206 ("Decorators are not valid here") on such a member and its emit drops the member together with its decorators; esbuild does the same (0.18) or rejects the file (0.21+). Either way the decorator expression is never evaluated and `Object.keys(new A())` does not contain `x`.
- Cause: `parse_property` (`src/js_parser/parse/parse_property.rs`, `PDeclare`/`PAbstract` branches) turns a decorated `declare`/`abstract` field into a `PropertyKind::Declare`/`Abstract` marker whenever it has decorators, regardless of decorator mode. That marker exists so the legacy lowering in `lower_class` (`src/js_parser/p.rs`) can emit `__legacyDecorateClassTS` for it. The standard lowering (`src/js_parser/lower/lower_decorators.rs`) never looks at those kinds and handles the marker like a plain decorated field.
- A second, smaller divergence: `parse_class` (`src/js_parser/parse/mod.rs`) sets `has_decorators` as soon as a member's decorators are parsed, before knowing whether the member is kept. A class whose only decorators sit on erased members (a `declare`/`abstract` field, an overload signature, an index signature) therefore still goes through decorator lowering: in standard mode it gets `__decoratorStart`/`__decoratorMetadata` boilerplate and an own `Symbol.metadata` property, and in both modes an anonymous `export default class {}` gets a synthesized name instead of `"default"`. tsc emits such a class unchanged.

### Fix
- `parse_property`: keep the `Declare`/`Abstract` marker only when `features.standard_decorators` is off (the legacy lowering is the marker's only consumer). Otherwise the field falls through to the existing discard path used by undecorated `declare`/`abstract` fields. The shared condition moves into `keeps_legacy_decorated_ambient_field`.
- `parse_class`: only count a member's decorators toward `has_decorators` when `parse_property` actually returns the member. The scopes of a dropped member's decorators were already being discarded at that point (#31340); the flag now agrees with that.
- Why dropping is right: tsc applies decorators on `declare`/`abstract` fields only under `experimentalDecorators`. Without it the member has no runtime form, so parsing the class as if the member were not written is exactly tsc's emit.
- Why a silent drop rather than a parse error: Bun does not report tsc's type-level diagnostics, and it already drops decorators on the neighbouring erased members (overload signatures, abstract methods, index signatures) silently in both modes; this makes `declare`/`abstract` fields take that same path.
- Why the `has_decorators` change is safe: the flag describes decorator work the class needs, and a member that is not in `properties` needs none in either mode (tsc legacy ignores decorators on overloads, abstract methods and index signatures too). The invariant that `lower_class` relies on, that a class with a decorated kept member or parameter decorator has `has_decorators` set and therefore a name, is untouched because only contributions from dropped members are removed. JS files are unaffected: every member-dropping path is TypeScript-only.
- Legacy output for kept markers is unchanged: `bun build --no-bundle` of decorated `declare`/`abstract`/`static declare`/computed-key fields, with and without `emitDecoratorMetadata`, is byte-identical to the current release. The only legacy difference is that `export default class { @dec foo(): void; foo() {} }` no longer gets a synthesized class name, which matches tsc.
- Verified with `test/bundler/transpiler/es-decorators.test.ts`, new `decorators on members TypeScript erases` block: transpiler output of each erased member form in class statements, class expressions, `export default` and `abstract` classes must equal the output without the member; a runtime check that the decorator expression is neither evaluated nor applied; a check that the `experimentalDecorators` emit still decorates these fields. 28 of the new cases fail on the current release and pass with this change.
  - `bun bd test test/bundler/transpiler/es-decorators.test.ts`: 88 pass
  - `bun bd test` on `decorators`, `es-decorators-esbuild`, `decorator-metadata`, `bundler_decorator_metadata`, `scope-mismatch-panic`, `ts-use-define-for-class-fields`, `transpiler.test.js`, `esbuild/ts`, regression 27526/27575: pass
  - debug build run of a class mixing erased decorated members (decorator and computed key both creating scopes) with later block scopes, the #31340 pattern: no scope mismatch
  - `cargo fmt` and `cargo clippy -p bun_js_parser`: clean

### Background
- Bun supports two decorator flavours. *Legacy (experimental) decorators* are TypeScript's `experimentalDecorators`, lowered by `lower_class` into `__legacyDecorateClassTS(...)` statements after a class declaration. *Standard decorators* are the TC39 proposal, used for all `.js` files and for `.ts` files without `experimentalDecorators`; they are lowered by `lower_decorators.rs`. `features.standard_decorators` selects between them per file.
- `declare x: T` and `abstract x: T` class members are TypeScript-only declarations with no JavaScript output, so the parser normally drops them while parsing the class body. Under `experimentalDecorators`, tsc nevertheless applies decorators written on them (`__decorate([...], A.prototype, "x", void 0)`), so Bun keeps them as `PropertyKind::Declare`/`Abstract` placeholders purely to drive that emit.
- `Class.has_decorators` tells later passes that a class needs decorator work: it selects the lowering, blocks hoisting of the class (`can_be_moved`) and makes `export default class {}` receive a binding name so the generated statements can refer to it.
- This is separate from #38095, which fixes a printer panic for the same markers in legacy-mode class expressions; that PR does not touch standard mode and the two do not overlap in files.
