### PR TITLE
ci: comment-cop should scan the live base...head compare, not the PR's cached file list

### DIFF
--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -34,9 +34,11 @@ jobs:
             const repo = context.repo.repo;
             const pull_number = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
+            const baseRef = context.payload.pull_request.base.ref;
 
             const SRC_EXT = /\.(rs|c|cc|cpp|h|hpp|m|mm|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
             const MIN_LINES = 2;
+            const MAX_COMMENTS_PER_RUN = 25;
 
             function isCommentLine(line) {
               const t = line.trimStart();
@@ -89,9 +91,15 @@ jobs:
               return out;
             }
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number, per_page: 100,
+            // Not pulls.listFiles: right after a rebase or a merge from main, the PR's
+            // cached diff can still be relative to the old base and list every file
+            // main touched since the PR was opened. The compare is computed live; its
+            // files (at most 300) all come on the first page, per_page only pages commits.
+            const { data: compare } = await github.rest.repos.compareCommitsWithBasehead({
+              owner, repo, basehead: `${baseRef}...${headSha}`, per_page: 1,
             });
+            const files = compare.files ?? [];
+            core.info(`${files.length} file(s) in ${baseRef}...${headSha.slice(0, 10)} (merge base ${compare.merge_base_commit.sha.slice(0, 10)}).`);
 
             const groups = [];
             for (const f of files) {
@@ -167,8 +175,12 @@ jobs:
               `<!-- comment-cop:${keyFor(g)} -->\n` +
               `If you need a paragraph-long comment to justify why the workaround is OK, the code is wrong — fix the code\n\n`;
 
+            if (fresh.length > MAX_COMMENTS_PER_RUN) {
+              core.warning(`${fresh.length} new comment groups; posting the first ${MAX_COMMENTS_PER_RUN} only.`);
+            }
+
             let posted = 0;
-            for (const g of fresh) {
+            for (const g of fresh.slice(0, MAX_COMMENTS_PER_RUN)) {
               const params = {
                 owner, repo, pull_number,
                 commit_id: headSha,


### PR DESCRIPTION
### What does this PR do?

#### Problem

- Comment Cop posts `If you need a paragraph-long comment to justify why the workaround is OK, the code is wrong` review threads on files a PR does not touch. On #35988 two runs ([31678330598](https://github.com/oven-sh/bun/actions/runs/31678330598), [31680070931](https://github.com/oven-sh/bun/actions/runs/31680070931)) posted 240 threads across 67 files, none of them in the PR's 20-file diff. #35635 (6-file PR, 172 such threads), #35708 (2 files, 154), #36713 (11 files, 123), #35596 (8 files, 65) and #36956 (21 files, 59) got the same treatment.
- Cause, `.github/workflows/comment-cop.yml:92`: the file list comes from `pulls.listFiles`. The workflow runs on `synchronize`, and right after a rebase or a merge from main the PR's cached diff can still be relative to the base the PR was opened against, so it lists every file main touched since then. #35988 reported `changed_files: 3133` against a base from July 25 (`git diff 44f6469e..90ef0cdc` is exactly 3133 files) for over an hour; #36713 still reports 1946 files against an August 1 base while its live diff is 11 files.
- `.github/workflows/comment-cop.yml:170`: one `createReviewComment` per group with nothing bounding the count, so every such run posted until the job's `timeout-minutes: 5` cancelled it (about 120 threads per push, both runs above ended `cancelled`). Because the inflated list is walked in path order, the run was usually cancelled before reaching the files the PR did change, so the comments it exists to post were not posted either.

#### Fix

- Take the diff from `repos.compareCommitsWithBasehead` with `base.ref...head.sha`. GitHub computes that from the current merge base at request time, so it is the PR's actual diff no matter what the PR's cached diff says; the file entries have the same shape (`filename`, `status`, `patch`) as `pulls.listFiles`, so the parser and the dedup keys are unchanged. Requested with `per_page: 1`: the changed files all come on the first page (at most 300), `per_page` only pages the commit list.
- Post at most 25 new comments per run (`MAX_COMMENTS_PER_RUN`), with a warning annotation when the cap is hit, so a run's write volume is bounded by design instead of by the job timeout. Groups left over are still in the diff on the next push and get posted then (dedup is per group, unchanged). Of about 30 claude PRs I scanned with the new script, all but one have 12 or fewer groups in their real diff; the exception, #35596, has 40 (33 of them in one file) and would get 25 on the first run and the other 15 on the push after.
- Since `presentKeys` now comes from the real diff, the existing auto-resolve step identifies the bogus threads as stale (240 on #35988) and resolves them once #36959 gives it a token that can.
- Log the file count and merge base of the compare so the next incident of this kind is visible in the run log.

### How did you verify your code works?

The workflow runs on `pull_request_target` from the base branch, so CI on this PR does not exercise it. I dry-ran the embedded script (extracted from the YAML, real GitHub reads, `createReviewComment` and the resolve mutation recorded instead of sent) against live PRs:

- #36713, whose cached diff is stale right now (`changed_files: 1946`, live compare 11 files): the script on main would post 1832 comments across 396 files; this branch's script posts 7 comments across 5 files, all in the PR's diff.
- #35988 after its latest push: 20 files from the compare, 5 comments on 4 files in the diff, 240 stale threads selected for resolution.
- #33632, #38020, #37898 (cached diff accurate, existing threads ignored so every group is emitted): the scripts on main and on this branch emit identical sets of comments (19, 4 and 7), same paths, line ranges and dedup keys.
- Cap path (base forced to an old commit so the compare is large): compare returns its 300-file maximum, the script finds 36 groups, warns, posts 25.
- `repos.compareCommitsWithBasehead` is present in the pinned `actions/github-script` bundle (`GET /repos/{owner}/{repo}/compare/{basehead}`); a fork PR's head SHA works as the head of the compare (checked against #34264 and #38080), and octokit's percent-encoding of a base branch containing `/` is accepted by the endpoint. Prettier passes on the file.

Does not overlap with #37948 (which groups count as a comment) or #36959 (token used to resolve threads); both touch other parts of the same script.

<details>
<summary>Per-PR audit of existing Comment Cop threads against each PR's live compare</summary>

```
PR #35635: cop_comments=174 on_files_outside_live_diff=172 | pr.changed_files=6    live_compare_files=6
PR #35708: cop_comments=155 on_files_outside_live_diff=154 | pr.changed_files=2    live_compare_files=2
PR #36713: cop_comments=126 on_files_outside_live_diff=123 | pr.changed_files=1946 live_compare_files=11
PR #35596: cop_comments=70  on_files_outside_live_diff=65  | pr.changed_files=8    live_compare_files=8
PR #36956: cop_comments=64  on_files_outside_live_diff=59  | pr.changed_files=21   live_compare_files=21
PR #33632: cop_comments=31  on_files_outside_live_diff=26  | pr.changed_files=10   live_compare_files=10
PR #36534: cop_comments=25  on_files_outside_live_diff=20  | pr.changed_files=9    live_compare_files=9
PR #32435: cop_comments=24  on_files_outside_live_diff=20  | pr.changed_files=13   live_compare_files=13
PR #28531: cop_comments=21  on_files_outside_live_diff=14  | pr.changed_files=11   live_compare_files=11
PR #35988: cop_comments=245 on_files_outside_live_diff=241 | pr.changed_files=3133 live_compare_files=20
```

For #35635, #35708 and #36713, 43 of 45, 53 of 54 and 37 of 40 of the commented-on paths were never touched by any non-merge commit on the branch (`git log --no-merges --name-only origin/main..<head>`), and the threads were posted in one burst per push lasting until the 5 minute timeout (for example #35635: 160 threads between 03:08 and 03:13 UTC on Aug 13, right after a rebase). `pr.changed_files` for most of these has since been recomputed to the right number; the threads were posted while it was not.

</details>
