### PR TITLE
Bun.serve: hold a pipelined request until the response ahead of it completes instead of closing the connection

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -700,7 +700,13 @@ void us_socket_local_address(us_socket_r s, char *nonnull_arg buf, int *nonnull_
 
 struct us_socket_t *us_socket_detach(us_socket_r s) nonnull_fn_decl;
 int us_socket_ipc_write_fd(us_socket_r s, const char *data, int length, int fd) nonnull_fn_decl;
-void us_socket_sendfile_needs_more(us_socket_r s) nonnull_fn_decl;
+/* Have on_writable dispatched once the socket is writable, as if a
+ * us_socket_write() had just come up short. For progress that has to be made
+ * from on_writable but was not queued through us_socket_write(): a sendfile
+ * that hit EAGAIN, HTTP request bytes parked behind a response that just
+ * completed. Safe to call from inside on_writable itself. Leaves a paused
+ * socket's read side alone. */
+void us_socket_request_writable(us_socket_r s) nonnull_fn_decl;
 void *us_listen_socket_ext(struct us_listen_socket_t *ls) nonnull_fn_decl;
 LIBUS_SOCKET_DESCRIPTOR us_listen_socket_get_fd(struct us_listen_socket_t *ls) nonnull_fn_decl;
 int us_listen_socket_port(struct us_listen_socket_t *ls) nonnull_fn_decl;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -408,6 +408,15 @@ static void us_internal_rearm_writable(struct us_socket_t *s) {
                    LIBUS_SOCKET_WRITABLE | ((s->flags.is_paused || s->read_eof) ? 0 : LIBUS_SOCKET_READABLE));
 }
 
+/* See libusockets.h. last_write_failed is what keeps the loop polling writable
+ * past the end of the dispatch this may be called from (loop.c drops the
+ * interest again after an on_writable that left it clear). */
+void us_socket_request_writable(struct us_socket_t *s) {
+    if (us_socket_is_closed(s)) return;
+    s->flags.last_write_failed = 1;
+    us_internal_rearm_writable(s);
+}
+
 /* See libusockets.h: whether a zero-progress write on a writable event proves
  * the peer is gone. Only the libuv backend has to ask the kernel. */
 int us_socket_stalled_write_means_peer_gone(struct us_socket_t *s) {

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -34,6 +34,7 @@
 #include <span>
 #include <array>
 #include <mutex>
+#include <utility>
 
 
 extern "C" void Bun__NodeHTTP__onReadsResumable(int ssl, struct us_socket_t *s);
@@ -117,11 +118,20 @@ private:
     static unsigned char socketKind() { return SSL ? US_SOCKET_KIND_UWS_HTTP_TLS : US_SOCKET_KIND_UWS_HTTP; }
 
 public:
-    /* node:http flood prevention: re-feed parked request bytes through the same
-     * parse path fresh socket data takes. The caller guarantees the buffer has
-     * LIBUS_RECV_BUFFER_PADDING of writable slack past `length`. */
-    static us_socket_t *feedNodeHttpData(us_socket_t *s, char *data, int length) {
-        return onData<true>(s, data, length);
+    /* Re-feed the bytes HttpParser parked (parkedRequestBytes) through the same
+     * parse path fresh socket data takes. Takes the parked bytes, so a dispatch
+     * during the replay that parks again starts a fresh batch behind them. The
+     * caller has already decided what to do about the paused read side. Returns
+     * what onData returns: the socket, closed, or the WebSocket it was upgraded
+     * into. */
+    template <bool IsNodeHttp>
+    static us_socket_t *replayParkedRequestBytes(us_socket_t *s) {
+        auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
+        WTF::Vector<char> parked = std::exchange(httpResponseData->parkedRequestBytes, {});
+        size_t length = parked.size();
+        /* The parser fences the buffer by writing past its logical end. */
+        parked.grow(length + LIBUS_RECV_BUFFER_PADDING);
+        return onData<IsNodeHttp>(s, parked.mutableSpan().data(), static_cast<int>(length));
     }
 
     us_socket_group_t *getSocketGroup() {
@@ -299,6 +309,19 @@ private:
         return us_socket_close(s, 0, nullptr);
     }
 
+    /* Bun.serve: whether the next request head on this connection must be parked
+     * instead of parsed (HttpParser::parkAtNextBoundary). Either the connection's
+     * one response slot is still taken, or the response in it is going to close
+     * the connection (Connection: close or HTTP/1.0 request, close requested by
+     * the app): nothing received behind such a request may be processed
+     * (RFC 9112 9.6), and parking it lets the close-after-drain gates discard it
+     * with the socket. Such bytes are never replayed: the only replay site runs
+     * behind onWritable's close gate, which fires on exactly the conditions the
+     * replay needs. */
+    static bool cannotDispatchAnotherRequest(HttpResponseData<SSL> *httpResponseData) {
+        return (httpResponseData->state & (HttpResponseData<SSL>::HTTP_RESPONSE_PENDING | HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE)) != 0;
+    }
+
     template <bool IsNodeHttp>
     static us_socket_t *onData(us_socket_t *s, char *data, int length) {
         // ref the socket to make sure we process it entirely before it is closed
@@ -392,6 +415,16 @@ private:
         httpContextData->parsingSocket = s;
         httpResponseData->isIdle = false;
 
+        /* Bun.serve: requests pipelined behind a response that is still pending
+         * (async handler, or a body the socket is still draining) are parked at
+         * the next request boundary and replayed from onWritable once it has
+         * completed. Re-derived on every read: a keep-alive request arriving
+         * after the response completed takes the ordinary path. Body bytes of the
+         * pending request itself never reach a boundary, so they are unaffected. */
+        if constexpr (!IsNodeHttp) {
+            httpResponseData->parkAtNextBoundary = cannotDispatchAnotherRequest(httpResponseData);
+        }
+
         /* node:http compat: maintain the headers/request timeout window (see
          * the requestHandler/dataHandler hooks and the post-parse check). */
         const bool trackNodeHttpTimings = IsNodeHttp && !httpResponseData->isConnectRequest;
@@ -440,13 +473,17 @@ private:
                 nodeHttpResponseData->headersCompleted = true;
             }
 
-            /* Are we not ready for another request yet? Terminate the connection.
-             * Important for denying async pipelining until, if ever, we want to support it.
-             * Otherwise requests can get mixed up on the same connection. We still support sync pipelining. */
+            /* Is the previous response on this connection still in flight? */
             bool hasQueuedPipelinedResponses = false;
             if constexpr (IsNodeHttp) hasQueuedPipelinedResponses = httpResponseData->nodeHttpQueuedPipelinedCount > 0;
             if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) || hasQueuedPipelinedResponses) {
                 if constexpr (!IsNodeHttp) {
+                    /* Bun.serve has one response slot per connection, so the parser
+                     * parks a head that arrives while it is taken (parkAtNextBoundary,
+                     * maintained by onData) instead of getting here. Dispatching onto
+                     * the in-flight response would interleave the two responses on the
+                     * wire; closing is the backstop. */
+                    ASSERT_NOT_REACHED();
                     us_socket_close((us_socket_t *) s, 0, nullptr);
                     return nullptr;
                 } else {
@@ -470,7 +507,7 @@ private:
                     httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED;
                     /* Also stop the request loop over the buffer being parsed
                      * right now — pausing the socket alone cannot bound it. */
-                    httpResponseData->nodeHttpParkAtNextBoundary = true;
+                    httpResponseData->parkAtNextBoundary = true;
                     ((HttpResponse<SSL> *) s)->pause();
                 }
                 }
@@ -503,7 +540,7 @@ private:
                      * and park already-received requests. No already-paused guard (replay clears the park flag only). */
                     if (((AsyncSocket<SSL> *) s)->getBufferedAmount() > 0) {
                         httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED;
-                        httpResponseData->nodeHttpParkAtNextBoundary = true;
+                        httpResponseData->parkAtNextBoundary = true;
                         ((HttpResponse<SSL> *) s)->pause();
                     }
                 }
@@ -629,6 +666,18 @@ private:
                     httpResponseData->inStream = nullptr;
                 }
             }
+
+            /* Bun.serve: the request message is complete (a bodiless request gets an
+             * empty fin right after dispatch), so the next request boundary is what
+             * the parser reaches next. The handler may have completed the response
+             * anywhere up to here, synchronously or from inside this body callback,
+             * which is why the decision to parse or park what follows is taken now
+             * and not at dispatch. */
+            if constexpr (!IsNodeHttp) {
+                if (fin) {
+                    httpResponseData->parkAtNextBoundary = cannotDispatchAnotherRequest(httpResponseData);
+                }
+            }
             return user;
         });
 
@@ -691,6 +740,23 @@ private:
             if (written > 0 || failed) {
                 /* All Http sockets timeout by this, and this behavior match the one in HttpResponse::cork */
                 ((HttpResponse<SSL> *) s)->resetTimeout();
+            }
+
+            /* Bun.serve: requests are parked on this connection. Invariant kept
+             * here and in markDone(): reads are paused while anything is parked
+             * (bounding it to one recv), and a replaying writable dispatch
+             * (onWritable) is armed as soon as the response ahead of them is
+             * complete, whichever of the two happened last. AsyncSocket::pause
+             * rather than HttpResponse::pause: the in-flight response's timeout
+             * must stay armed against a peer that pipelines and then stops
+             * reading. */
+            if constexpr (!IsNodeHttp) {
+                if (!httpResponseData->parkedRequestBytes.isEmpty()) [[unlikely]] {
+                    ((AsyncSocket<SSL> *) s)->pause();
+                    if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+                        us_socket_request_writable(s);
+                    }
+                }
             }
 
             /* We need to check if we should close this socket here now */
@@ -856,7 +922,34 @@ private:
         /* Expect another writable event, or another request within the timeout */
         reinterpret_cast<HttpResponse<SSL> *>(s)->resetTimeout();
 
+        if constexpr (!IsNodeHttp) {
+            return replayParkedRequestsIfResponseComplete(s);
+        }
         return s;
+    }
+
+    /* Bun.serve pipelining, replay half; the tail of every writable dispatch.
+     * Gets here either because the response the parked requests were waiting on
+     * completed inside callOnWritable above (a tryEnd tail draining), or via the
+     * dispatch markDone() / onData arm when it completed anywhere else. Nothing
+     * of the completed response is on the stack at this point, so the replayed
+     * request can take over the connection's response slot. Waits for the
+     * completed response's bytes to leave the buffer: the next dispatch is
+     * already owed while any are left. */
+    static us_socket_t *replayParkedRequestsIfResponseComplete(us_socket_t *s) {
+        if (us_socket_is_closed(s) || us_socket_is_shut_down(s)) {
+            return s;
+        }
+        auto *httpResponseData = reinterpret_cast<HttpResponseData<SSL> *>(us_socket_ext(s));
+        if (httpResponseData->parkedRequestBytes.isEmpty()
+            || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING)
+            || !reinterpret_cast<AsyncSocket<SSL> *>(s)->hasFullyDrained()) {
+            return s;
+        }
+        /* Paused by onData when it parked them; it pauses again if the replayed
+         * dispatch leaves a response pending with more requests behind it. */
+        reinterpret_cast<AsyncSocket<SSL> *>(s)->resume();
+        return replayParkedRequestBytes<false>(s);
     }
 
     template <bool IsNodeHttp>

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -594,12 +594,23 @@ struct HttpResponseData;
     private:
         std::string fallback;
     public:
-        /* node:http flood prevention. HTTP_NODE_READS_PAUSED (state bit) = the socket's raw reads are
-         * paused and stays set through spill replay; this flag = "the parse loop running now must stop
-         * at the next request boundary and park the rest", cleared for replay so it can make progress. */
-        bool nodeHttpParkAtNextBoundary = false;
+        /* "The parse loop running now must stop at the next request boundary and park
+         * the rest of the buffer, unparsed, in parkedRequestBytes." The boundary check
+         * also holds while bytes are already parked, so later reads queue up behind
+         * them and replay (HttpContext::replayParkedRequestBytes) keeps wire order.
+         *
+         * Bun.serve: HttpContext::onData derives it (at entry and after each
+         * request's body fin) from cannotDispatchAnotherRequest: requests pipelined
+         * behind a response that is still being produced or drained wait for it,
+         * and ones behind a response that will close the connection go down with
+         * it. Reads are paused while bytes are parked, bounding them to one recv.
+         *
+         * node:http flood prevention: set on the pause edge alongside
+         * HTTP_NODE_READS_PAUSED (which stays set through the replay) and cleared for
+         * the replay so it can make progress. */
+        bool parkAtNextBoundary = false;
         bool nodeHttpSpillReplayScheduled = false;
-        WTF::Vector<char> nodeHttpPausedSpill;
+        WTF::Vector<char> parkedRequestBytes;
     private:
          /* This guy really has only 30 bits since we reserve two highest bits to chunked encoding parsing state */
         uint64_t remainingStreamingBytes = 0;
@@ -1113,15 +1124,15 @@ struct HttpResponseData;
                 consumedTotal += length;
                 return HttpParserResult::success(consumedTotal, returnedUser);
             }
-            /* node:http flood prevention: a dispatch earlier in this buffer paused reads.
-             * Stop at this request boundary, park the rest, report it as consumed so the
-             * caller does not spill it into the size-capped header fallback buffer. */
-            if constexpr (IsNodeHttp) {
-                if (nodeHttpParkAtNextBoundary) [[unlikely]] {
-                    nodeHttpPausedSpill.append(std::span<const char>(data, length));
-                    consumedTotal += length;
-                    return HttpParserResult::success(consumedTotal, user);
-                }
+            /* This connection cannot take another request right now (see
+             * parkAtNextBoundary). Stop at this request boundary, before getHeaders
+             * touches the next head, park the rest verbatim and report it as consumed
+             * so the caller does not spill it into the size-capped header fallback
+             * buffer. */
+            if (parkAtNextBoundary || !parkedRequestBytes.isEmpty()) [[unlikely]] {
+                parkedRequestBytes.append(std::span<const char>(data, length));
+                consumedTotal += length;
+                return HttpParserResult::success(consumedTotal, user);
             }
             /* RFC 9112 2.2: ignore empty lines (CRLF) received prior to the
              * request-line, like Node/llhttp - e.g. a stray "\r\n" sent on an

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -378,13 +378,26 @@ public:
             }
         }
 
+        auto* responseData = getHttpResponseData();
+
+        /* Request bytes parked behind this handshake (HttpParser::parkedRequestBytes)
+         * go down with the HTTP state destructed below, like bytes trailing a
+         * synchronous upgrade in the same read (a client may not send anything
+         * before the 101 anyway, RFC 6455 4.1). Parking paused reads; the adopted
+         * WebSocket needs them flowing, and us_socket_adopt keeps the flag. Dropped
+         * before endUpgradeHandshake so markDone() does not arm a replay dispatch
+         * that would land on the WebSocket as a spurious drain. */
+        if (!responseData->parkedRequestBytes.isEmpty()) [[unlikely]] {
+            responseData->parkedRequestBytes.clear();
+            Super::resume();
+        }
+
         endUpgradeHandshake();
 
         /* Grab the httpContext from res */
         HttpContext<SSL> *httpContext = HttpContext<SSL>::fromSocket((struct us_socket_t *) this);
 
         /* Move any backpressure out of HttpResponse */
-        auto* responseData = getHttpResponseData();
         BackPressure backpressure(std::move(((AsyncSocketData<SSL> *) responseData)->buffer));
 
         auto* socketData = responseData->socketData;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -384,9 +384,11 @@ public:
          * go down with the HTTP state destructed below, like bytes trailing a
          * synchronous upgrade in the same read (a client may not send anything
          * before the 101 anyway, RFC 6455 4.1). Parking paused reads; the adopted
-         * WebSocket needs them flowing, and us_socket_adopt keeps the flag. Dropped
-         * before endUpgradeHandshake so markDone() does not arm a replay dispatch
-         * that would land on the WebSocket as a spurious drain. */
+         * WebSocket needs them flowing, and us_socket_adopt keeps the flag. The
+         * resume re-arms writable too, so the WebSocket gets one drain callback with
+         * nothing to drain right after open; dropping the bytes before
+         * endUpgradeHandshake() keeps markDone() from arming a second one for a
+         * replay that cannot happen. */
         if (!responseData->parkedRequestBytes.isEmpty()) [[unlikely]] {
             responseData->parkedRequestBytes.clear();
             Super::resume();

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -496,7 +496,16 @@ public:
     }
 
     HttpResponse *resume() {
-        Super::resume();
+        /* While requests are parked behind this response the pause belongs to the
+         * pipelining code (HttpContext resumes when it replays them, upgrade() when
+         * it drops them). The resumes arriving here release a request-body
+         * backpressure pause and can land after the body completed and the bytes
+         * behind it were parked; reading on would only queue more behind them, or
+         * take a FIN that closes the connection over them. node:http's flood
+         * prevention only gets here once its parked bytes are gone. */
+        if (getHttpResponseData()->parkedRequestBytes.isEmpty()) [[likely]] {
+            Super::resume();
+        }
         this->resetTimeout();
         return this;
     }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -59,8 +59,13 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
 
         HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
         /* A queued pipelined response (node:http) still owes output on this
-         * connection, so it is not idle between the responses. */
-        httpResponseData->isIdle = httpResponseData->nodeHttpQueuedPipelinedCount == 0;
+         * connection, and parked request bytes are received work it still owes a
+         * dispatch, so it is not idle in either case: a closeIdle() sweep (graceful
+         * stop) leaves it alone or marks it close-when-idle, and that mark takes
+         * effect from the markDone() of the last replayed request instead of
+         * closing over the parked ones here. */
+        httpResponseData->isIdle = httpResponseData->nodeHttpQueuedPipelinedCount == 0
+            && this->parkedRequestBytes.isEmpty();
 
         /* Requests are parked behind this response (Bun.serve pipelining). They
          * are replayed from HttpContext::onWritable rather than here: every caller

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -61,6 +61,17 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         /* A queued pipelined response (node:http) still owes output on this
          * connection, so it is not idle between the responses. */
         httpResponseData->isIdle = httpResponseData->nodeHttpQueuedPipelinedCount == 0;
+
+        /* Requests are parked behind this response (Bun.serve pipelining). They
+         * are replayed from HttpContext::onWritable rather than here: every caller
+         * (internalEnd, the uws_res_end* wrappers, the request context above them)
+         * still tears this response down after we return, and a dispatch now would
+         * land in the middle of that. node:http parks too (flood prevention); its
+         * onWritable hook tolerates the extra writable event and decides about
+         * replaying itself. */
+        if (!this->parkedRequestBytes.isEmpty()) [[unlikely]] {
+            us_socket_request_writable((us_socket_t *) uwsRes);
+        }
     }
 
     /* Caller of onWritable. It is possible onWritable calls markDone so we need to borrow it. */

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1349,7 +1349,11 @@ jsimd_ycc_rgb_convert_avx2.return                    [AVX, AVX2]
 # single-digit hit here is decode noise. Ceiling [AVX] so a multi-feature leak
 # still fails. On ELF each opcode handler has its own symbol, so layout shifts
 # can move the desync between llint_op_* siblings; add them here as they trip.
-# (2 symbols)
+# llint_op_jmp_wide32 decoded as one RDPMC (0f 33), not VEX: the bytes are the
+# embedded opcode id, and what they spell moves with the layout, so it is a
+# blanket pass (the guide's rule for confirmed data-in-.text misdecodes).
+# (3 symbols)
 # ----------------------------------------------------------------------------
 llint_op_enter_wide32  [AVX]
 llint_op_wide16_wide16  [AVX]
+llint_op_jmp_wide32

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -402,7 +402,7 @@ void JSNodeHTTPServerSocket::appendPipelinedResponse(JSC::VM& vm, WebCore::JSNod
     m_pipelinedResponses.last().set(vm, this, response);
 }
 
-/* node:http flood prevention, resume half. Parked pipelined requests (HttpParser::nodeHttpPausedSpill)
+/* node:http flood prevention, resume half. Parked pipelined requests (HttpParser::parkedRequestBytes)
  * must replay before fresh reads (ordering) and not synchronously inside the resuming JS operation.
  * Deferred as an event-loop task rooting the JS socket; reads resume once the spill drains without re-pausing. */
 template<bool SSL>
@@ -412,20 +412,16 @@ static void replayNodeHttpPausedSpill(us_socket_t* socket)
     httpResponseData->nodeHttpSpillReplayScheduled = false;
     /* Let the replay's own parse loop run; HTTP_NODE_READS_PAUSED stays set so
      * fresh socket bytes cannot race ahead of the spill. */
-    httpResponseData->nodeHttpParkAtNextBoundary = false;
-    WTF::Vector<char> spill = std::exchange(httpResponseData->nodeHttpPausedSpill, {});
-    if (!spill.isEmpty()) {
-        /* The parser's post-padded fence writes two bytes past the logical end. */
-        size_t spillLength = spill.size();
-        spill.grow(spillLength + LIBUS_RECV_BUFFER_PADDING);
-        us_socket_t* returned = uWS::HttpContext<SSL>::feedNodeHttpData(socket, spill.mutableSpan().data(), (int)spillLength);
+    httpResponseData->parkAtNextBoundary = false;
+    if (!httpResponseData->parkedRequestBytes.isEmpty()) {
+        us_socket_t* returned = uWS::HttpContext<SSL>::template replayParkedRequestBytes<true>(socket);
         if (!returned || us_socket_is_closed(returned)) {
             return;
         }
         socket = returned;
         httpResponseData = reinterpret_cast<uWS::NodeHttpResponseData<SSL>*>(us_socket_ext(socket));
     }
-    if (httpResponseData->nodeHttpParkAtNextBoundary) {
+    if (httpResponseData->parkAtNextBoundary) {
         /* A dispatch during the replay hit backpressure again and re-parked
          * the rest; stay paused until the next resumable event. */
         return;
@@ -451,13 +447,13 @@ static void onNodeHttpReadsResumable(us_socket_t* socket)
         if (reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket)->getBufferedAmount() > 0) {
             return;
         }
-        if (httpResponseData->nodeHttpPausedSpill.isEmpty()
+        if (httpResponseData->parkedRequestBytes.isEmpty()
             && httpResponseData->nodeHttpQueuedPipelinedCount > 0) {
             return;
         }
     }
-    if (httpResponseData->nodeHttpPausedSpill.isEmpty()) {
-        httpResponseData->nodeHttpParkAtNextBoundary = false;
+    if (httpResponseData->parkedRequestBytes.isEmpty()) {
+        httpResponseData->parkAtNextBoundary = false;
         httpResponseData->state &= ~uWS::HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED;
         reinterpret_cast<uWS::HttpResponse<SSL>*>(socket)->resume();
         return;
@@ -500,7 +496,7 @@ template<bool SSL>
 static void onNodeHttpReadsPaused(us_socket_t* socket)
 {
     auto* d = reinterpret_cast<uWS::NodeHttpResponseData<SSL>*>(us_socket_ext(socket));
-    d->nodeHttpParkAtNextBoundary = true;
+    d->parkAtNextBoundary = true;
     d->state |= uWS::HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED;
 }
 

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -428,7 +428,8 @@ impl<const SSL: bool> Response<SSL> {
     #[inline]
     pub(crate) fn mark_needs_more(&mut self) {
         if !SSL {
-            c::us_socket_mark_needs_more_not_ssl(self.as_raw())
+            // S008: `us_socket_t` is an `opaque_ffi!` ZST, so the deref is safe.
+            us_socket_t::opaque_mut(self.downcast_socket()).request_writable();
         }
     }
 
@@ -1163,7 +1164,6 @@ pub mod c {
         pub(crate) safe fn uws_res_mark_wrote_content_length_header(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_mark_wrote_date_header(ssl: i32, res: &mut uws_res);
         pub(crate) safe fn uws_res_write_mark(ssl: i32, res: &mut uws_res);
-        pub(crate) safe fn us_socket_mark_needs_more_not_ssl(socket: &mut uws_res);
         pub(crate) safe fn uws_res_state(ssl: c_int, res: &uws_res) -> State;
         pub(crate) safe fn uws_res_is_connect_request(ssl: i32, res: &mut uws_res) -> bool;
         // Out-params are `&mut` (non-null, valid for write); the C shim only

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1525,18 +1525,6 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     }
   }
 
-  void us_socket_mark_needs_more_not_ssl(uws_res_r res)
-  {
-    us_socket_r s = (us_socket_t *)res;
-    if(us_socket_is_closed(s)) return;
-    s->flags.last_write_failed = 1;
-    /* Same gate as us_internal_rearm_writable (socket.c): re-adding READABLE
-     * would undo a pause mid-backpressure and re-surface a consumed EOF on a
-     * half-open socket. */
-    us_poll_change(&s->p, s->group->loop,
-                   LIBUS_SOCKET_WRITABLE | ((s->flags.is_paused || s->read_eof) ? 0 : LIBUS_SOCKET_READABLE));
-  }
-
 __attribute__((callback (corker, ctx)))
   void uws_res_cork(int ssl, uws_res_r res, void *ctx,
                     void (*corker)(void *ctx)) nonnull_fn_decl;
@@ -1678,16 +1666,6 @@ __attribute__((callback (corker, ctx)))
     } else {
       return ((TCPWebSocket*)ws)->memoryCost();
     }
-  }
-
-  void us_socket_sendfile_needs_more(us_socket_r s) {
-    if(us_socket_is_closed(s)) return;
-    s->flags.last_write_failed = 1;
-    /* Same gate as us_internal_rearm_writable (socket.c): re-adding READABLE
-     * would undo a pause mid-backpressure and re-surface a consumed EOF on a
-     * half-open socket. */
-    us_poll_change(&s->p, s->group->loop,
-                   LIBUS_SOCKET_WRITABLE | ((s->flags.is_paused || s->read_eof) ? 0 : LIBUS_SOCKET_READABLE));
   }
 
   LIBUS_SOCKET_DESCRIPTOR us_socket_get_fd(us_socket_r s) {

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -696,7 +696,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
     pub fn mark_needs_more_for_sendfile(&self) {
         const { assert!(!IS_SSL, "SSL sockets do not support sendfile yet") };
         if let InternalSocket::Connected(s) = self.socket {
-            sock(s).send_file_needs_more();
+            sock(s).request_writable();
         }
     }
 

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -438,8 +438,8 @@ impl us_socket_t {
         c::us_socket_flush(self);
     }
 
-    pub(crate) fn send_file_needs_more(&mut self) {
-        c::us_socket_sendfile_needs_more(self);
+    pub(crate) fn request_writable(&mut self) {
+        c::us_socket_request_writable(self);
     }
 
     pub fn get_fd(&self) -> Fd {
@@ -575,7 +575,7 @@ mod c {
         ) -> i32;
         pub(super) safe fn us_socket_shutdown_read(s: &mut us_socket_t);
         pub(super) safe fn us_socket_is_shut_down(s: &us_socket_t) -> i32;
-        pub(super) safe fn us_socket_sendfile_needs_more(socket: &mut us_socket_t);
+        pub(super) safe fn us_socket_request_writable(s: &mut us_socket_t);
         pub(super) safe fn us_socket_get_fd(s: &us_socket_t) -> LIBUS_SOCKET_DESCRIPTOR;
         pub(super) safe fn us_socket_verify_error(s: &us_socket_t) -> us_bun_verify_error_t;
         pub(super) safe fn us_socket_get_error(s: &us_socket_t) -> c_int;

--- a/test/js/bun/http/bun-serve-pipelining.test.ts
+++ b/test/js/bun/http/bun-serve-pipelining.test.ts
@@ -569,6 +569,30 @@ describe("a request pipelined behind a Connection: close request", () => {
   });
 });
 
+// A graceful stop() closes idle connections and marks busy ones to close once
+// their work is done. A request that was received and held behind the response
+// in flight is part of that work: it is answered, and the connection closes after
+// it rather than over it.
+it("a held request is still answered when the server is stopped gracefully while the response ahead of it is pending, then the connection closes", async () => {
+  const handler = holdingHandler();
+  using server = Bun.serve({ ...tcp, fetch: handler.fetch });
+  using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+  client.write(request("/hold") + request("/after"));
+  await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
+  await probe(tcpOnly, server, "");
+  expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+
+  const stopped = server.stop();
+  handler.release("/hold");
+  await client.until(c => c.closed);
+  await stopped;
+  expect({ hits: handler.hits, responses: client.responses.map(summarize) }).toEqual({
+    hits: ["/hold", "/probe", "/after"],
+    responses: [ok("body of /hold"), ok("body of /after")],
+  });
+});
+
 // upgrade() is instantiated once per socket flavor, like the parking code; the
 // unix transport shares the plain instantiation.
 describe.each(transports.filter(t => t.name !== "unix"))("WebSocket upgrade over $name", transport => {

--- a/test/js/bun/http/bun-serve-pipelining.test.ts
+++ b/test/js/bun/http/bun-serve-pipelining.test.ts
@@ -9,7 +9,8 @@ import { join } from "node:path";
 // second request never answered. Such a request is now held until the response
 // ahead of it completes and is dispatched then, so responses stay in request
 // order (RFC 9112 9.3.2); one held behind a Connection: close request is dropped
-// with the connection (RFC 9112 9.6).
+// with the connection (RFC 9112 9.6), and one held behind a request that turns
+// the connection into a WebSocket is dropped with the HTTP state.
 
 type RawResponse = { statusLine: string; headers: Record<string, string>; body: string };
 
@@ -207,52 +208,85 @@ function holdingHandler() {
 // onWritable when the second request head is parsed.
 const BIG_BODY_LENGTH = 16 * 1024 * 1024;
 
+const big = Buffer.alloc(BIG_BODY_LENGTH, "x").toString("latin1");
+
+// The ways a big response body reaches the socket. The handler is synchronous
+// in each case, so the response is complete as far as the app is concerned when
+// the second head is parsed; what is still outstanding is the body transfer:
+// uWS draining a buffered body's tail through onWritable, or the runtime's file
+// pump (sendfile over plain TCP on Linux, read+write chunks elsewhere) for a
+// Bun.file() returned from the handler or served by a file route.
+type BigBody = {
+  name: string;
+  // How /big is served (`dir` holds big.txt). `hits` records every request
+  // that reaches the fetch handler; a route answers /big without it.
+  serve(dir: string, hits: string[]): { fetch(req: Request): Response; routes?: Record<string, Response> };
+  expectedHits: string[];
+};
+const recordingHandler = (hits: string[], bigResponse?: () => Response) => (req: Request) => {
+  const path = new URL(req.url).pathname;
+  hits.push(path);
+  return path === "/big" && bigResponse ? bigResponse() : plainResponse(req);
+};
+const bigBodies: BigBody[] = [
+  {
+    name: "a buffered body",
+    serve: (_dir, hits) => ({ fetch: recordingHandler(hits, () => new Response(big)) }),
+    expectedHits: ["/big", "/small"],
+  },
+  {
+    name: "a Bun.file() body returned from the handler",
+    serve: (dir, hits) => ({ fetch: recordingHandler(hits, () => new Response(Bun.file(join(dir, "big.txt")))) }),
+    expectedHits: ["/big", "/small"],
+  },
+  {
+    name: "a Bun.file() route",
+    serve: (dir, hits) => ({
+      routes: { "/big": new Response(Bun.file(join(dir, "big.txt"))) },
+      fetch: recordingHandler(hits),
+    }),
+    expectedHits: ["/small"],
+  },
+];
+
 describe.each(transports)("$name", transport => {
-  // The response ahead is complete as far as the (sync) handler is concerned;
-  // only uWS's drain of the buffered body's tail is outstanding.
-  it.if(transport.supported)(
-    "a request pipelined behind a buffered body larger than the socket buffer gets the whole body, then its own response",
-    async () => {
-      using dir = tempDir("serve-pipelining", {});
-      const big = Buffer.alloc(BIG_BODY_LENGTH, "x").toString("latin1");
-      const hits: string[] = [];
-      using server = Bun.serve({
-        ...transport.listen(String(dir)),
-        fetch(req) {
-          const path = new URL(req.url).pathname;
-          hits.push(path);
-          return path === "/big" ? new Response(big) : plainResponse(req);
-        },
-      });
-      using client = await RawClient.connect(transport.target(server, String(dir)));
+  describe.each(bigBodies)("$name", bigBody => {
+    it.if(transport.supported)(
+      "larger than the socket buffer is delivered whole to a client that pipelined a request behind it, which is then answered",
+      async () => {
+        using dir = tempDir("serve-pipelining", { "big.txt": big });
+        const hits: string[] = [];
+        using server = Bun.serve({ ...transport.listen(String(dir)), ...bigBody.serve(String(dir), hits) });
+        using client = await RawClient.connect(transport.target(server, String(dir)));
 
-      client.write(request("/big") + request("/small"));
-      await client.until(c => c.responses.length === 2);
+        client.write(request("/big") + request("/small"));
+        await client.until(c => c.responses.length === 2);
 
-      expect({
-        hits,
-        closed: client.closed,
-        responses: client.responses.map(({ statusLine, headers, body }) => ({
-          statusLine,
-          contentLength: headers["content-length"],
-          bodyLength: body.length,
-          bodyIsIntact: body === big || body === "body of /small",
-        })),
-      }).toEqual({
-        hits: ["/big", "/small"],
-        closed: false,
-        responses: [
-          {
-            statusLine: "HTTP/1.1 200 OK",
-            contentLength: String(BIG_BODY_LENGTH),
-            bodyLength: BIG_BODY_LENGTH,
-            bodyIsIntact: true,
-          },
-          { statusLine: "HTTP/1.1 200 OK", contentLength: "14", bodyLength: 14, bodyIsIntact: true },
-        ],
-      });
-    },
-  );
+        expect({
+          hits,
+          closed: client.closed,
+          responses: client.responses.map(({ statusLine, headers, body }) => ({
+            statusLine,
+            contentLength: headers["content-length"],
+            bodyLength: body.length,
+            bodyIsIntact: body === big || body === "body of /small",
+          })),
+        }).toEqual({
+          hits: bigBody.expectedHits,
+          closed: false,
+          responses: [
+            {
+              statusLine: "HTTP/1.1 200 OK",
+              contentLength: String(BIG_BODY_LENGTH),
+              bodyLength: BIG_BODY_LENGTH,
+              bodyIsIntact: true,
+            },
+            { statusLine: "HTTP/1.1 200 OK", contentLength: "14", bodyLength: 14, bodyIsIntact: true },
+          ],
+        });
+      },
+    );
+  });
 
   it.if(transport.supported)(
     "requests pipelined behind an async handler are dispatched one at a time, each after the response ahead of it",
@@ -344,6 +378,60 @@ it("a request pipelined behind a request body that the handler is still consumin
   });
 });
 
+// The held bytes are re-parsed from the top when they are released: a request
+// with a body gets its body back, and whatever is behind it is held again while
+// that request's own response is pending (here until a Connection: close request
+// ends the connection after its response).
+it("a held request with a body is dispatched with its body, and the request behind it waits for that response in turn", async () => {
+  const handler = holdingHandler();
+  const uploads: string[] = [];
+  using server = Bun.serve({
+    ...tcp,
+    async fetch(req) {
+      if (new URL(req.url).pathname !== "/upload") return handler.fetch(req);
+      handler.hits.push("/upload");
+      uploads.push(await req.text());
+      return new Response(`uploaded ${uploads.at(-1)}`);
+    },
+  });
+  using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+  client.write(
+    request("/hold") +
+      "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello" +
+      request("/last", "Connection: close\r\n"),
+  );
+  await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
+  await probe(tcpOnly, server, "");
+  expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+
+  handler.release("/hold");
+  await client.until(c => c.closed);
+  expect({ hits: handler.hits, uploads, responses: client.responses.map(summarize) }).toEqual({
+    hits: ["/hold", "/probe", "/upload", "/last"],
+    uploads: ["hello"],
+    responses: [ok("body of /hold"), ok("uploaded hello"), ok("body of /last")],
+  });
+});
+
+it("held bytes that are not a valid request get the error response after the response ahead of them, not instead of it", async () => {
+  const handler = holdingHandler();
+  using server = Bun.serve({ ...tcp, fetch: handler.fetch });
+  using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+  client.write(request("/hold") + "GET /bad HTTP/9.9\r\nHost: x\r\n\r\n");
+  await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
+  await probe(tcpOnly, server, "");
+  expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+
+  handler.release("/hold");
+  await client.until(c => c.closed);
+  expect({ hits: handler.hits, responses: client.responses.map(summarize) }).toEqual({
+    hits: ["/hold", "/probe"],
+    responses: [ok("body of /hold"), { statusLine: "HTTP/1.1 505 HTTP Version Not Supported", body: "" }],
+  });
+});
+
 describe("a request pipelined behind a Connection: close request", () => {
   // (An HTTP/1.0 request line marks the connection the same way.)
   const closingThenAnother = request("/hold", "Connection: close\r\n") + request("/never");
@@ -388,60 +476,107 @@ describe("a request pipelined behind a Connection: close request", () => {
   });
 });
 
-it("a WebSocket upgrade pipelined behind an async handler is performed once the response ahead of it is out", async () => {
-  const handler = holdingHandler();
-  using server = Bun.serve({
-    ...tcp,
-    fetch(req, server) {
-      if (new URL(req.url).pathname !== "/ws") return handler.fetch(req);
-      handler.hits.push("/ws");
-      return server.upgrade(req) ? undefined : new Response("not upgraded", { status: 400 });
-    },
-    websocket: {
-      message(ws, message) {
-        ws.send(message);
-      },
-    },
-  });
-  using client = await RawClient.connect(tcpOnly.target(server, ""));
-
-  client.write(
-    request("/hold") +
-      request(
-        "/ws",
-        "Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n",
-      ),
+describe("WebSocket upgrade", () => {
+  const upgradeRequest = request(
+    "/ws",
+    "Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n",
   );
-  await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
-  await probe(tcpOnly, server, "");
-  expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+  // RFC 6455 1.3: the accept value for the sample nonce above.
+  const switching = {
+    statusLine: "HTTP/1.1 101 Switching Protocols",
+    body: "",
+    accept: "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+  };
+  const withAccept = ({ statusLine, headers, body }: RawResponse) => ({
+    statusLine,
+    body,
+    accept: headers["sec-websocket-accept"] as string | undefined,
+  });
+  // A masked text frame "hi" (mask key 1 2 3 4); the server echoes it unmasked.
+  const maskedHiFrame = new Uint8Array([0x81, 0x82, 1, 2, 3, 4, "h".charCodeAt(0) ^ 1, "i".charCodeAt(0) ^ 2]);
+  const echoedHiFrame = [0x81, 0x02, "h".charCodeAt(0), "i".charCodeAt(0)];
 
-  handler.release("/hold");
-  await client.until(c => c.responses.length === 2);
-  expect({
-    hits: handler.hits,
-    closed: client.closed,
-    responses: client.responses.map(({ statusLine, headers, body }) => ({
-      statusLine,
-      body,
-      accept: headers["sec-websocket-accept"],
-    })),
-  }).toEqual({
-    hits: ["/hold", "/probe", "/ws"],
-    closed: false,
-    responses: [
-      { statusLine: "HTTP/1.1 200 OK", body: "body of /hold", accept: undefined },
-      // RFC 6455 1.3: the accept value for the sample nonce above.
-      { statusLine: "HTTP/1.1 101 Switching Protocols", body: "", accept: "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" },
-    ],
+  // /ws is upgraded from the handler itself, or (held: true) from a continuation
+  // the test releases; every other path is the holding handler's.
+  function serveWithUpgrade(handler: ReturnType<typeof holdingHandler>, { held }: { held: boolean }) {
+    const entered = Promise.withResolvers<void>();
+    const released = Promise.withResolvers<void>();
+    const server = Bun.serve({
+      ...tcp,
+      fetch(req, server) {
+        if (new URL(req.url).pathname !== "/ws") return handler.fetch(req);
+        handler.hits.push("/ws");
+        const upgrade = () => (server.upgrade(req) ? undefined : new Response("not upgraded", { status: 400 }));
+        if (!held) return upgrade();
+        entered.resolve();
+        return released.promise.then(upgrade);
+      },
+      websocket: {
+        message(ws, message) {
+          ws.send(message);
+        },
+      },
+    });
+    return { server, upgradeEntered: entered.promise, releaseUpgrade: released.resolve };
+  }
+
+  async function expectEcho(client: RawClient) {
+    client.write(maskedHiFrame);
+    await client.until(c => c.unparsed.length >= echoedHiFrame.length);
+    expect({ closed: client.closed, frame: [...client.unparsed] }).toEqual({ closed: false, frame: echoedHiFrame });
+  }
+
+  it("pipelined behind an async handler is performed once the response ahead of it is out", async () => {
+    const handler = holdingHandler();
+    using server = serveWithUpgrade(handler, { held: false }).server;
+    using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+    client.write(request("/hold") + upgradeRequest);
+    await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
+    await probe(tcpOnly, server, "");
+    expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+
+    handler.release("/hold");
+    await client.until(c => c.responses.length === 2);
+    expect({ hits: handler.hits, closed: client.closed, responses: client.responses.map(withAccept) }).toEqual({
+      hits: ["/hold", "/probe", "/ws"],
+      closed: false,
+      responses: [{ statusLine: "HTTP/1.1 200 OK", body: "body of /hold", accept: undefined }, switching],
+    });
+
+    // The connection is the WebSocket now.
+    await expectEcho(client);
   });
 
-  // The connection is the WebSocket now: a masked text frame "hi" (mask key
-  // 1 2 3 4) is echoed back as an unmasked one.
-  client.write(new Uint8Array([0x81, 0x82, 1, 2, 3, 4, "h".charCodeAt(0) ^ 1, "i".charCodeAt(0) ^ 2]));
-  await client.until(c => c.unparsed.length >= 4);
-  expect({ closed: client.closed, frame: [...client.unparsed] }).toEqual({
-    closed: false,
-    frame: [0x81, 0x02, "h".charCodeAt(0), "i".charCodeAt(0)],
+  // The request held behind the handshake is discarded with the HTTP state when
+  // the connection becomes a WebSocket (as bytes trailing a synchronous upgrade
+  // in the same read always were), and holding it must not leave the WebSocket's
+  // reads switched off.
+  it("performed by an async handler with a request pipelined behind it drops that request and reads frames", async () => {
+    const handler = holdingHandler();
+    const { upgradeEntered, releaseUpgrade, ...serving } = serveWithUpgrade(handler, { held: true });
+    using server = serving.server;
+    using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+    client.write(upgradeRequest + request("/never"));
+    await Promise.race([upgradeEntered, client.until(c => c.closed)]);
+    await probe(tcpOnly, server, "");
+    expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/ws", "/probe"], closed: false });
+
+    releaseUpgrade();
+    await client.until(c => c.responses.length === 1);
+    expect({ closed: client.closed, responses: client.responses.map(withAccept) }).toEqual({
+      closed: false,
+      responses: [switching],
+    });
+
+    await expectEcho(client);
+    // The echo round trip above means the server has long since processed
+    // everything it received before the frame; /never was not part of it.
+    await probe(tcpOnly, server, "");
+    expect({ hits: handler.hits, responses: client.responses.length }).toEqual({
+      hits: ["/ws", "/probe", "/probe"],
+      responses: 1,
+    });
   });
 });

--- a/test/js/bun/http/bun-serve-pipelining.test.ts
+++ b/test/js/bun/http/bun-serve-pipelining.test.ts
@@ -1,0 +1,447 @@
+import { describe, expect, it } from "bun:test";
+import { isPosix, tempDir, tls } from "harness";
+import { join } from "node:path";
+
+// A request pipelined behind a response that was still in flight (the handler had
+// not returned yet, or it had and uWS was still draining a body that did not fit
+// in the socket buffer) used to make uWS close the connection the moment it
+// parsed the second request head: the in-flight response was truncated and the
+// second request never answered. Such a request is now held until the response
+// ahead of it completes and is dispatched then, so responses stay in request
+// order (RFC 9112 9.3.2); one held behind a Connection: close request is dropped
+// with the connection (RFC 9112 9.6).
+
+type RawResponse = { statusLine: string; headers: Record<string, string>; body: string };
+
+// Splits the byte stream into Content-Length framed responses (a 101 has no
+// body). Bodies are accumulated as chunks so a multi-megabyte body does not get
+// re-concatenated on every read.
+class ResponseReader {
+  responses: RawResponse[] = [];
+  // Bytes after the last complete response that do not form a head yet (after
+  // a 101 these are WebSocket frames).
+  unparsed: Buffer = Buffer.alloc(0);
+  #head: { statusLine: string; headers: Record<string, string> } | undefined;
+  #bodyChunks: Buffer[] = [];
+  #bodyHave = 0;
+  #bodyNeed = 0;
+
+  push(chunk: Buffer) {
+    while (chunk.length > 0) {
+      if (!this.#head) {
+        this.unparsed = Buffer.concat([this.unparsed, chunk]);
+        const headEnd = this.unparsed.indexOf("\r\n\r\n");
+        if (headEnd === -1) return;
+        const [statusLine, ...lines] = this.unparsed.subarray(0, headEnd).toString("latin1").split("\r\n");
+        const headers: Record<string, string> = {};
+        for (const line of lines) {
+          const colon = line.indexOf(":");
+          headers[line.slice(0, colon).toLowerCase()] = line.slice(colon + 1).trim();
+        }
+        this.#head = { statusLine, headers };
+        this.#bodyNeed = Number(headers["content-length"] ?? 0);
+        chunk = this.unparsed.subarray(headEnd + 4);
+        this.unparsed = Buffer.alloc(0);
+      }
+      const take = chunk.subarray(0, this.#bodyNeed - this.#bodyHave);
+      this.#bodyChunks.push(take);
+      this.#bodyHave += take.length;
+      chunk = chunk.subarray(take.length);
+      if (this.#bodyHave < this.#bodyNeed) return;
+      this.responses.push({ ...this.#head, body: Buffer.concat(this.#bodyChunks).toString("latin1") });
+      this.#head = undefined;
+      this.#bodyChunks = [];
+      this.#bodyHave = 0;
+    }
+  }
+}
+
+type Target = ({ port: number; hostname: string } | { unix: string }) & { tls?: { ca: string } };
+
+class RawClient extends ResponseReader {
+  closed = false;
+  #socket!: Awaited<ReturnType<typeof Bun.connect>>;
+  #waiters: { condition: (client: RawClient) => boolean; resolve: () => void; reject: (error: Error) => void }[] = [];
+
+  static async connect(target: Target): Promise<RawClient> {
+    const client = new RawClient();
+    const handshake = Promise.withResolvers<void>();
+    client.#socket = await Bun.connect({
+      ...target,
+      socket: {
+        handshake: (_socket, success, error) => (success ? handshake.resolve() : handshake.reject(error)),
+        data: (_socket, chunk) => {
+          client.push(chunk);
+          client.#settle();
+        },
+        close: () => {
+          client.closed = true;
+          client.#settle();
+        },
+        error: (_socket, error) => client.#fail(error),
+        connectError: (_socket, error) => client.#fail(error),
+      },
+    });
+    if (target.tls) await handshake.promise;
+    return client;
+  }
+
+  write(data: string | Uint8Array) {
+    const length = typeof data === "string" ? Buffer.byteLength(data, "latin1") : data.byteLength;
+    expect(this.#socket.write(data)).toBe(length);
+  }
+
+  // Resolves once `condition` holds, or as soon as the server closes the
+  // connection, so that the assertions after it report what actually arrived.
+  until(condition: (client: RawClient) => boolean): Promise<void> {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    this.#waiters.push({ condition, resolve, reject });
+    this.#settle();
+    return promise;
+  }
+
+  #settle() {
+    this.#waiters = this.#waiters.filter(waiter => {
+      if (!this.closed && !waiter.condition(this)) return true;
+      waiter.resolve();
+      return false;
+    });
+  }
+
+  #fail(error: Error) {
+    const waiters = this.#waiters;
+    this.#waiters = [];
+    for (const waiter of waiters) waiter.reject(error);
+  }
+
+  [Symbol.dispose]() {
+    this.#socket.end();
+  }
+}
+
+// The parking/replay code is instantiated once per uWS socket flavor (plain and
+// TLS); a unix listener is the transport whose send buffer is smallest.
+type Transport = {
+  name: "tcp" | "tls" | "unix";
+  supported: boolean;
+  listen(dir: string): object;
+  target(server: Bun.Server<undefined>, dir: string): Target;
+  probe(server: Bun.Server<undefined>, dir: string): Promise<Response>;
+};
+const tcp = { port: 0, hostname: "127.0.0.1" };
+const transports: Transport[] = [
+  {
+    name: "tcp",
+    supported: true,
+    listen: () => tcp,
+    target: server => ({ port: server.port!, hostname: "127.0.0.1" }),
+    probe: server => fetch(`${server.url}probe`),
+  },
+  {
+    name: "tls",
+    supported: true,
+    listen: () => ({ ...tcp, tls }),
+    target: server => ({ port: server.port!, hostname: "127.0.0.1", tls: { ca: tls.cert } }),
+    probe: server => fetch(`${server.url}probe`, { tls: { ca: tls.cert } }),
+  },
+  {
+    name: "unix",
+    supported: isPosix,
+    listen: dir => ({ unix: join(dir, "pipeline.sock") }),
+    target: (_server, dir) => ({ unix: join(dir, "pipeline.sock") }),
+    probe: (_server, dir) => fetch("http://localhost/probe", { unix: join(dir, "pipeline.sock") }),
+  },
+];
+const tcpOnly = transports[0];
+
+const request = (path: string, extraHeaders = "") => `GET ${path} HTTP/1.1\r\nHost: x\r\n${extraHeaders}\r\n`;
+const ok = (body: string) => ({ statusLine: "HTTP/1.1 200 OK", body });
+const summarize = ({ statusLine, body }: RawResponse) => ({ statusLine, body });
+
+// Every handler below answers any path it does not treat specially with this.
+const plainResponse = (req: Request) => new Response(`body of ${new URL(req.url).pathname}`);
+
+// A round trip on a separate connection. Anything the pipelining client wrote
+// before this was readable on the server before the probe was even sent, so by
+// the time the probe has been answered the server has read it (and, with the
+// request ahead of it still pending, parked it). It also moves the test past the
+// microtask checkpoint Bun runs inside a dispatch: releasing a handler straight
+// from its `entered` promise would complete the response while the parser is
+// still inside that request's dispatch, which is the ordinary synchronous
+// pipelining path rather than the one under test.
+async function probe(transport: Transport, server: Bun.Server<undefined>, dir: string) {
+  expect(await (await transport.probe(server, dir)).text()).toBe("body of /probe");
+}
+
+// A handler that parks on `/hold*` paths until the test releases that path, and
+// records the order in which requests reached JS.
+function holdingHandler() {
+  type Gate = ReturnType<typeof Promise.withResolvers<void>>;
+  const hits: string[] = [];
+  const entered = new Map<string, Gate>();
+  const released = new Map<string, Gate>();
+  const gate = (map: Map<string, Gate>, path: string) => {
+    let resolvers = map.get(path);
+    if (!resolvers) map.set(path, (resolvers = Promise.withResolvers<void>()));
+    return resolvers;
+  };
+  return {
+    hits,
+    entered: (path: string) => gate(entered, path).promise,
+    release: (path: string) => gate(released, path).resolve(),
+    async fetch(req: Request) {
+      const path = new URL(req.url).pathname;
+      hits.push(path);
+      if (path.startsWith("/hold")) {
+        gate(entered, path).resolve();
+        await gate(released, path).promise;
+      }
+      return plainResponse(req);
+    },
+  };
+}
+
+// Large enough that the first tryEnd() cannot hand the whole body to the kernel
+// on any transport (loopback TCP takes at most a few MiB, a unix socket a couple
+// hundred KiB), so the rest of the body is still being drained through
+// onWritable when the second request head is parsed.
+const BIG_BODY_LENGTH = 16 * 1024 * 1024;
+
+describe.each(transports)("$name", transport => {
+  // The response ahead is complete as far as the (sync) handler is concerned;
+  // only uWS's drain of the buffered body's tail is outstanding.
+  it.if(transport.supported)(
+    "a request pipelined behind a buffered body larger than the socket buffer gets the whole body, then its own response",
+    async () => {
+      using dir = tempDir("serve-pipelining", {});
+      const big = Buffer.alloc(BIG_BODY_LENGTH, "x").toString("latin1");
+      const hits: string[] = [];
+      using server = Bun.serve({
+        ...transport.listen(String(dir)),
+        fetch(req) {
+          const path = new URL(req.url).pathname;
+          hits.push(path);
+          return path === "/big" ? new Response(big) : plainResponse(req);
+        },
+      });
+      using client = await RawClient.connect(transport.target(server, String(dir)));
+
+      client.write(request("/big") + request("/small"));
+      await client.until(c => c.responses.length === 2);
+
+      expect({
+        hits,
+        closed: client.closed,
+        responses: client.responses.map(({ statusLine, headers, body }) => ({
+          statusLine,
+          contentLength: headers["content-length"],
+          bodyLength: body.length,
+          bodyIsIntact: body === big || body === "body of /small",
+        })),
+      }).toEqual({
+        hits: ["/big", "/small"],
+        closed: false,
+        responses: [
+          {
+            statusLine: "HTTP/1.1 200 OK",
+            contentLength: String(BIG_BODY_LENGTH),
+            bodyLength: BIG_BODY_LENGTH,
+            bodyIsIntact: true,
+          },
+          { statusLine: "HTTP/1.1 200 OK", contentLength: "14", bodyLength: 14, bodyIsIntact: true },
+        ],
+      });
+    },
+  );
+
+  it.if(transport.supported)(
+    "requests pipelined behind an async handler are dispatched one at a time, each after the response ahead of it",
+    async () => {
+      using dir = tempDir("serve-pipelining", {});
+      const handler = holdingHandler();
+      using server = Bun.serve({ ...transport.listen(String(dir)), fetch: handler.fetch });
+      using client = await RawClient.connect(transport.target(server, String(dir)));
+      // (Or the server giving up on the connection, which is the failure mode.)
+      const enteredOrClosed = (path: string) => Promise.race([handler.entered(path), client.until(c => c.closed)]);
+
+      // All three heads arrive in one read.
+      client.write(request("/hold/1") + request("/hold/2") + request("/hold/3"));
+      await enteredOrClosed("/hold/1");
+      await probe(transport, server, String(dir));
+      expect(handler.hits).toEqual(["/hold/1", "/probe"]);
+
+      // Completing a response dispatches exactly the next request, which parks
+      // the one behind it again.
+      handler.release("/hold/1");
+      await enteredOrClosed("/hold/2");
+      await probe(transport, server, String(dir));
+      expect(handler.hits).toEqual(["/hold/1", "/probe", "/hold/2", "/probe"]);
+      await client.until(c => c.responses.length === 1);
+
+      handler.release("/hold/2");
+      await enteredOrClosed("/hold/3");
+      expect(handler.hits).toEqual(["/hold/1", "/probe", "/hold/2", "/probe", "/hold/3"]);
+
+      handler.release("/hold/3");
+      await client.until(c => c.responses.length === 3);
+      expect({ closed: client.closed, responses: client.responses.map(summarize) }).toEqual({
+        closed: false,
+        responses: [ok("body of /hold/1"), ok("body of /hold/2"), ok("body of /hold/3")],
+      });
+    },
+  );
+});
+
+it("a request arriving in a later read while the handler is still running waits for the response", async () => {
+  const handler = holdingHandler();
+  using server = Bun.serve({ ...tcp, fetch: handler.fetch });
+  using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+  client.write(request("/hold"));
+  await handler.entered("/hold");
+  client.write(request("/after"));
+  await probe(tcpOnly, server, "");
+  expect(handler.hits).toEqual(["/hold", "/probe"]);
+
+  handler.release("/hold");
+  await client.until(c => c.responses.length === 2);
+  expect({ hits: handler.hits, closed: client.closed, responses: client.responses.map(summarize) }).toEqual({
+    hits: ["/hold", "/probe", "/after"],
+    closed: false,
+    responses: [ok("body of /hold"), ok("body of /after")],
+  });
+});
+
+it("a request pipelined behind a request body that the handler is still consuming waits for the response", async () => {
+  const seen: string[] = [];
+  const bodyRead = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  using server = Bun.serve({
+    ...tcp,
+    async fetch(req) {
+      if (new URL(req.url).pathname !== "/upload") return plainResponse(req);
+      seen.push(await req.text());
+      bodyRead.resolve();
+      await release.promise;
+      return new Response(`uploaded ${seen[0]}`);
+    },
+  });
+  using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+  client.write("POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\n");
+  // The body and the next request share a read: the body belongs to the upload
+  // and must reach its handler, the request behind it must wait.
+  client.write("hello" + request("/after"));
+  await Promise.race([bodyRead.promise, client.until(c => c.closed)]);
+  await probe(tcpOnly, server, "");
+  expect({ seen, closed: client.closed }).toEqual({ seen: ["hello"], closed: false });
+
+  release.resolve();
+  await client.until(c => c.responses.length === 2);
+  expect({ closed: client.closed, responses: client.responses.map(summarize) }).toEqual({
+    closed: false,
+    responses: [ok("uploaded hello"), ok("body of /after")],
+  });
+});
+
+describe("a request pipelined behind a Connection: close request", () => {
+  // (An HTTP/1.0 request line marks the connection the same way.)
+  const closingThenAnother = request("/hold", "Connection: close\r\n") + request("/never");
+
+  it("is dropped when the response ahead of it completes later", async () => {
+    const handler = holdingHandler();
+    using server = Bun.serve({ ...tcp, fetch: handler.fetch });
+    using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+    client.write(closingThenAnother);
+    await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
+    await probe(tcpOnly, server, "");
+    expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+
+    handler.release("/hold");
+    await client.until(c => c.closed);
+    expect({ hits: handler.hits, responses: client.responses.map(summarize) }).toEqual({
+      hits: ["/hold", "/probe"],
+      responses: [ok("body of /hold")],
+    });
+  });
+
+  it("is dropped when the response ahead of it completes synchronously", async () => {
+    const hits: string[] = [];
+    using server = Bun.serve({
+      ...tcp,
+      fetch(req) {
+        hits.push(new URL(req.url).pathname);
+        return plainResponse(req);
+      },
+    });
+    using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+    client.write(closingThenAnother);
+    // Answering /never would keep the connection open, so also stop on its response.
+    await client.until(c => c.closed || c.responses.length === 2);
+    expect({ hits, closed: client.closed, responses: client.responses.map(summarize) }).toEqual({
+      hits: ["/hold"],
+      closed: true,
+      responses: [ok("body of /hold")],
+    });
+  });
+});
+
+it("a WebSocket upgrade pipelined behind an async handler is performed once the response ahead of it is out", async () => {
+  const handler = holdingHandler();
+  using server = Bun.serve({
+    ...tcp,
+    fetch(req, server) {
+      if (new URL(req.url).pathname !== "/ws") return handler.fetch(req);
+      handler.hits.push("/ws");
+      return server.upgrade(req) ? undefined : new Response("not upgraded", { status: 400 });
+    },
+    websocket: {
+      message(ws, message) {
+        ws.send(message);
+      },
+    },
+  });
+  using client = await RawClient.connect(tcpOnly.target(server, ""));
+
+  client.write(
+    request("/hold") +
+      request(
+        "/ws",
+        "Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n",
+      ),
+  );
+  await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
+  await probe(tcpOnly, server, "");
+  expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
+
+  handler.release("/hold");
+  await client.until(c => c.responses.length === 2);
+  expect({
+    hits: handler.hits,
+    closed: client.closed,
+    responses: client.responses.map(({ statusLine, headers, body }) => ({
+      statusLine,
+      body,
+      accept: headers["sec-websocket-accept"],
+    })),
+  }).toEqual({
+    hits: ["/hold", "/probe", "/ws"],
+    closed: false,
+    responses: [
+      { statusLine: "HTTP/1.1 200 OK", body: "body of /hold", accept: undefined },
+      // RFC 6455 1.3: the accept value for the sample nonce above.
+      { statusLine: "HTTP/1.1 101 Switching Protocols", body: "", accept: "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=" },
+    ],
+  });
+
+  // The connection is the WebSocket now: a masked text frame "hi" (mask key
+  // 1 2 3 4) is echoed back as an unmasked one.
+  client.write(new Uint8Array([0x81, 0x82, 1, 2, 3, 4, "h".charCodeAt(0) ^ 1, "i".charCodeAt(0) ^ 2]));
+  await client.until(c => c.unparsed.length >= 4);
+  expect({ closed: client.closed, frame: [...client.unparsed] }).toEqual({
+    closed: false,
+    frame: [0x81, 0x02, "h".charCodeAt(0), "i".charCodeAt(0)],
+  });
+});

--- a/test/js/bun/http/bun-serve-pipelining.test.ts
+++ b/test/js/bun/http/bun-serve-pipelining.test.ts
@@ -14,15 +14,18 @@ import { join } from "node:path";
 
 type RawResponse = { statusLine: string; headers: Record<string, string>; body: string };
 
-// Splits the byte stream into Content-Length framed responses (a 101 has no
-// body). Bodies are accumulated as chunks so a multi-megabyte body does not get
-// re-concatenated on every read.
+// Splits the byte stream into responses framed by Content-Length or chunked
+// encoding (a 101 has no body). Content-Length bodies are accumulated as chunks
+// so a multi-megabyte body does not get re-concatenated on every read; the
+// chunked bodies here are small and are simply re-scanned.
 class ResponseReader {
   responses: RawResponse[] = [];
   // Bytes after the last complete response that do not form a head yet (after
   // a 101 these are WebSocket frames).
   unparsed: Buffer = Buffer.alloc(0);
   #head: { statusLine: string; headers: Record<string, string> } | undefined;
+  #chunked = false;
+  #pendingChunked: Buffer = Buffer.alloc(0);
   #bodyChunks: Buffer[] = [];
   #bodyHave = 0;
   #bodyNeed = 0;
@@ -40,20 +43,48 @@ class ResponseReader {
           headers[line.slice(0, colon).toLowerCase()] = line.slice(colon + 1).trim();
         }
         this.#head = { statusLine, headers };
+        this.#chunked = headers["transfer-encoding"] === "chunked";
         this.#bodyNeed = Number(headers["content-length"] ?? 0);
         chunk = this.unparsed.subarray(headEnd + 4);
         this.unparsed = Buffer.alloc(0);
       }
-      const take = chunk.subarray(0, this.#bodyNeed - this.#bodyHave);
-      this.#bodyChunks.push(take);
-      this.#bodyHave += take.length;
-      chunk = chunk.subarray(take.length);
-      if (this.#bodyHave < this.#bodyNeed) return;
+      if (this.#chunked) {
+        const rest = this.#takeChunkedBody(chunk);
+        if (rest === undefined) return;
+        chunk = rest;
+      } else {
+        const take = chunk.subarray(0, this.#bodyNeed - this.#bodyHave);
+        this.#bodyChunks.push(take);
+        this.#bodyHave += take.length;
+        chunk = chunk.subarray(take.length);
+        if (this.#bodyHave < this.#bodyNeed) return;
+      }
       this.responses.push({ ...this.#head, body: Buffer.concat(this.#bodyChunks).toString("latin1") });
       this.#head = undefined;
       this.#bodyChunks = [];
       this.#bodyHave = 0;
     }
+  }
+
+  // Returns what follows the body once all of it has arrived, through the
+  // terminating zero-size chunk (nothing here sends trailers); else undefined.
+  #takeChunkedBody(chunk: Buffer): Buffer | undefined {
+    const pending = (this.#pendingChunked = Buffer.concat([this.#pendingChunked, chunk]));
+    const parts: Buffer[] = [];
+    let pos = 0;
+    while (true) {
+      const sizeLineEnd = pending.indexOf("\r\n", pos);
+      if (sizeLineEnd === -1) return undefined;
+      const size = parseInt(pending.subarray(pos, sizeLineEnd).toString("latin1"), 16);
+      pos = sizeLineEnd + 2;
+      if (pending.length < pos + size + 2) return undefined;
+      if (size === 0) break;
+      parts.push(pending.subarray(pos, pos + size));
+      pos += size + 2;
+    }
+    this.#bodyChunks = parts;
+    this.#pendingChunked = Buffer.alloc(0);
+    return pending.subarray(pos + 2);
   }
 }
 
@@ -321,6 +352,68 @@ describe.each(transports)("$name", transport => {
       expect({ closed: client.closed, responses: client.responses.map(summarize) }).toEqual({
         closed: false,
         responses: [ok("body of /hold/1"), ok("body of /hold/2"), ok("body of /hold/3")],
+      });
+    },
+  );
+
+  // The response ahead is still being produced by the app: a streaming body that
+  // ends when the test says so. Ending it makes the response sink resume() the
+  // socket itself (it releases a request-body pause), which must not reopen reads
+  // over the held request; the replay that follows is what reopens them.
+  it.if(transport.supported)(
+    "a request pipelined behind a streaming response is answered once the stream ends",
+    async () => {
+      using dir = tempDir("serve-pipelining", {});
+      const hits: string[] = [];
+      const streaming = Promise.withResolvers<void>();
+      const finish = Promise.withResolvers<void>();
+      using server = Bun.serve({
+        ...transport.listen(String(dir)),
+        fetch(req) {
+          const path = new URL(req.url).pathname;
+          hits.push(path);
+          if (path !== "/stream") return plainResponse(req);
+          let pulls = 0;
+          return new Response(
+            new ReadableStream({
+              async pull(controller) {
+                if (pulls++ === 0) {
+                  controller.enqueue("first,");
+                  streaming.resolve();
+                  return;
+                }
+                await finish.promise;
+                controller.enqueue("second");
+                controller.close();
+              },
+            }),
+          );
+        },
+      });
+      using client = await RawClient.connect(transport.target(server, String(dir)));
+
+      client.write(request("/stream") + request("/after"));
+      await Promise.race([streaming.promise, client.until(c => c.closed)]);
+      await probe(transport, server, String(dir));
+      expect({ hits, closed: client.closed }).toEqual({ hits: ["/stream", "/probe"], closed: false });
+
+      finish.resolve();
+      await client.until(c => c.responses.length === 2);
+      expect({
+        hits,
+        closed: client.closed,
+        responses: client.responses.map(({ statusLine, headers, body }) => ({
+          statusLine,
+          framing: headers["transfer-encoding"] ?? `content-length ${headers["content-length"]}`,
+          body,
+        })),
+      }).toEqual({
+        hits: ["/stream", "/probe", "/after"],
+        closed: false,
+        responses: [
+          { statusLine: "HTTP/1.1 200 OK", framing: "chunked", body: "first,second" },
+          { statusLine: "HTTP/1.1 200 OK", framing: "content-length 14", body: "body of /after" },
+        ],
       });
     },
   );

--- a/test/js/bun/http/bun-serve-pipelining.test.ts
+++ b/test/js/bun/http/bun-serve-pipelining.test.ts
@@ -476,7 +476,9 @@ describe("a request pipelined behind a Connection: close request", () => {
   });
 });
 
-describe("WebSocket upgrade", () => {
+// upgrade() is instantiated once per socket flavor, like the parking code; the
+// unix transport shares the plain instantiation.
+describe.each(transports.filter(t => t.name !== "unix"))("WebSocket upgrade over $name", transport => {
   const upgradeRequest = request(
     "/ws",
     "Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n",
@@ -502,7 +504,7 @@ describe("WebSocket upgrade", () => {
     const entered = Promise.withResolvers<void>();
     const released = Promise.withResolvers<void>();
     const server = Bun.serve({
-      ...tcp,
+      ...transport.listen(""),
       fetch(req, server) {
         if (new URL(req.url).pathname !== "/ws") return handler.fetch(req);
         handler.hits.push("/ws");
@@ -529,11 +531,11 @@ describe("WebSocket upgrade", () => {
   it("pipelined behind an async handler is performed once the response ahead of it is out", async () => {
     const handler = holdingHandler();
     using server = serveWithUpgrade(handler, { held: false }).server;
-    using client = await RawClient.connect(tcpOnly.target(server, ""));
+    using client = await RawClient.connect(transport.target(server, ""));
 
     client.write(request("/hold") + upgradeRequest);
     await Promise.race([handler.entered("/hold"), client.until(c => c.closed)]);
-    await probe(tcpOnly, server, "");
+    await probe(transport, server, "");
     expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/hold", "/probe"], closed: false });
 
     handler.release("/hold");
@@ -556,11 +558,11 @@ describe("WebSocket upgrade", () => {
     const handler = holdingHandler();
     const { upgradeEntered, releaseUpgrade, ...serving } = serveWithUpgrade(handler, { held: true });
     using server = serving.server;
-    using client = await RawClient.connect(tcpOnly.target(server, ""));
+    using client = await RawClient.connect(transport.target(server, ""));
 
     client.write(upgradeRequest + request("/never"));
     await Promise.race([upgradeEntered, client.until(c => c.closed)]);
-    await probe(tcpOnly, server, "");
+    await probe(transport, server, "");
     expect({ hits: handler.hits, closed: client.closed }).toEqual({ hits: ["/ws", "/probe"], closed: false });
 
     releaseUpgrade();
@@ -573,7 +575,7 @@ describe("WebSocket upgrade", () => {
     await expectEcho(client);
     // The echo round trip above means the server has long since processed
     // everything it received before the frame; /never was not part of it.
-    await probe(tcpOnly, server, "");
+    await probe(transport, server, "");
     expect({ hits: handler.hits, responses: client.responses.length }).toEqual({
       hits: ["/ws", "/probe", "/probe"],
       responses: 1,


### PR DESCRIPTION
### Problem

- `Bun.serve`: a client that pipelines a second HTTP/1.1 request behind one whose response is still in flight gets the connection closed the moment the second head is parsed. The first response is cut off mid-body and the second request is never answered. Over a `unix:` listener this happens on every connection whose first response is bigger than the socket buffer (~220 KB of a 4 MiB body arrives, then EOF); over loopback TCP it depends on how much of the body the first write manages to hand to the kernel. An 8 MiB `Bun.file()` response (handler or file route) stops at ~2.6 MB the same way, which is the shape of #6961, #22174, #26406 and #11228.
- The close is the `HTTP_RESPONSE_PENDING` branch of the per-request callback in `packages/bun-uws/src/HttpContext.h` (`us_socket_close`, "denying async pipelining"). It fires for every way a response can still be pending when the next head is parsed: a buffered body whose `tryEnd()` tail is still draining through `onWritable` (the case above), an async handler that has not returned yet, a streaming body, a file response.
- Found while testing this: a request pipelined behind a `Connection: close` (or HTTP/1.0) request was dispatched and answered, and the connection stayed open, because the next dispatch's `resetResponseState()` cleared the close mark before the close gate ran. RFC 9112 9.6 says nothing after such a request may be processed.

### Fix

- `HttpParser`: the request-boundary park that node:http compat already had for flood prevention is now shared. When `parkAtNextBoundary` is set (or bytes are already parked, which keeps wire order), the parse loop stops before `getHeaders` touches the next head and moves the rest of the read, verbatim, into `parkedRequestBytes`. Fields renamed from their `nodeHttp*` names since both servers use them; node:http's own pause/replay logic is unchanged (`replayParkedRequestBytes` replaces `feedNodeHttpData`, its only caller).
- `HttpContext::onData` (Bun.serve instantiation only): derives the flag from `cannotDispatchAnotherRequest()` (`HTTP_RESPONSE_PENDING | HTTP_CONNECTION_CLOSE`) at entry and again after each request's body fin, which is the last point the handler can have completed the response at (synchronously, or from inside the body callback), so synchronous pipelining still takes the existing path and never parks. After the parse, if anything was parked, reads are paused (`AsyncSocket::pause`, so the pending response's own timeout stays armed; verified that a peer that pipelines and then stops reading still times out exactly as before) and, if the response is already complete, a writable dispatch is armed.
- `HttpResponseData::markDone()`: if bytes are parked, arms one writable dispatch with `us_socket_request_writable()`. `HttpContext::onWritable` (Bun.serve) ends by replaying the parked bytes through `onData` when the response is complete and fully drained, resuming reads first. That is the one replay site. It is deliberately not done inside `markDone()`: every `markDone()` caller (`internalEnd`, the `uws_res_end*` wrappers, and the Rust `RequestContext` above them) keeps tearing the finished response down after it returns, so a dispatch from there would land in the middle of that teardown. The writable dispatch is the next point where the socket has nothing of the old response on the stack, which is also why this needs no changes on the Rust side. A `tryEnd` tail that finishes inside `onWritable`'s own callback reaches the replay in the same dispatch.
- Replayed bytes go through the ordinary parse path, so a held request gets its body, a request behind it is held again while its response is pending, and held bytes that are not a valid request get the parser's error response after the response ahead of them instead of replacing it.
- `Connection: close` requests: the same flag parks whatever follows them; the existing close-after-drain gates then discard it with the socket. `onWritable`'s close gate runs before the replay site on exactly the conditions the replay needs, so such bytes are never replayed.
- `HttpResponse::upgrade()`: if the pending response turns out to be a WebSocket upgrade, the bytes held behind it are dropped with the HTTP state (as bytes trailing a synchronous upgrade in the same read always were; a client may not send anything before the 101, RFC 6455 4.1) and reads are resumed. Without this the paused flag survived `us_socket_adopt`, so the WebSocket sent its 101 and then never read a frame. The resume re-arms writable as well, so the WebSocket gets one `drain` callback with nothing to drain right after `open` (verified; a plain upgrade gets none); dropping the bytes before `internalEnd()` keeps `markDone()` from arming a second one for a replay that cannot happen.
- `HttpResponse::resume()`: leaves the read side paused while bytes are parked. The pause belongs to the pipelining code (`onWritable` resumes right before replaying, `upgrade()` when dropping); the resumes that reach this function from the runtime release a request-body backpressure pause (`RequestContext::detach_response`, `on_request_body_stream_drained`, the response sink's `end()`) and can land after that body completed and the bytes behind it were parked. Reading on there only queues more bytes behind the parked ones, and on kqueue, which delivers the read and write filters separately, a peer FIN read that way reaches `onEnd` before the replay and closes the connection over the parked request. Not separately observable on epoll (the replaying writable dispatch runs before the read within the same event), so no dedicated test; node:http's flood prevention only calls `resume()` once its parked bytes are gone and is unaffected.
- The old close in the per-request callback stays as the backstop (with `ASSERT_NOT_REACHED()` in debug); with the flag maintained at both points above it is no longer reachable for Bun.serve.
- `us_socket_request_writable()` (socket.c) replaces two byte-identical helpers, `us_socket_sendfile_needs_more` and `us_socket_mark_needs_more_not_ssl`, whose job ("dispatch `on_writable` once, even if called from inside one") is what `markDone()` needs too; the sendfile callers now use it.
- `markDone()` no longer marks a connection idle while requests are parked on it (review finding): a graceful `server.stop()` marks busy connections close-when-idle, and that mark used to fire at the completion of the response ahead, closing over a request that had been received in full. The connection now becomes idle at the `markDone()` of the last replayed request, mirroring how node:http's queued-response count is treated on the same line.
- Hot-path cost: one flag store per read and per request, one predicted branch per request in the parse loop (the node:http instantiation already had it), one `isEmpty()` in `markDone()`, `upgrade()` and `resume()`. Per replayed request in a pipelined burst behind async handlers: the remainder of the recv is copied into a fresh vector when it is parked again, so a burst of N requests in one recv costs O(N x recv) bytes of copying spread over N dispatches, bounded by the one-recv park limit; requests behind synchronous handlers are unaffected. No new per-connection fields: the parser already carried the flag and vector for node:http.
- Verification: `test/js/bun/http/bun-serve-pipelining.test.ts`, 26 tests, all fail on current main (in under a second, no timeouts) and pass with this change:
  - a 16 MiB body as a buffered string, as a `Bun.file()` returned from the handler and as a `Bun.file()` route, each with a request pipelined behind it, over tcp, tls and unix (the tryEnd drain, sendfile and read+write file paths; the SSL instantiation; replay from inside `onWritable`);
  - three requests behind async handlers in one read, over tcp, tls and unix: each is dispatched only after the previous response completes, and the replay parks the rest again;
  - a request arriving in a later read while the handler is still running (the entry-time derivation);
  - a request behind a streaming response that the app ends later, over tcp, tls and unix. Ending the stream also makes the response sink call `resume()` on the socket while the request behind it is parked, so this drives the `HttpResponse::resume()` guard (confirmed by instrumenting it locally: taken once per transport here); the held request is answered after the stream's terminating chunk;
  - a request behind a request body the handler is still consuming (body delivered, request behind it held);
  - a held POST with a body, with a `Connection: close` request behind it: the body reaches the replayed handler, the last request is answered, then the connection closes;
  - held bytes that are a parse error: the response ahead of them arrives intact, then the 505;
  - `Connection: close` with a sync handler and with an async handler: first response delivered in full, connection closed, second handler never invoked;
  - graceful `server.stop()` while the response ahead of a held request is pending: the held request is answered, then the connection closes and `stop()` resolves (fails without the `isIdle` change: the held request is dropped);
  - a WebSocket upgrade pipelined behind an async handler, over tcp and tls: replayed, 101 with the right accept key, frames flow (`onWritable` returning the adopted socket);
  - an async upgrade with a request pipelined behind it, over tcp and tls: 101, the held request is dropped, frames flow (fails on this branch without the `upgrade()` change: the echo never arrives).
  - Also ran locally with the debug build: serve, bun-server, bun-serve-file, bun-serve-static, bun-serve-routes, bun-serve-ssl, websocket-server, request-smuggling, http-server-chunking, node-http, and the upstream `test-http-pipeline-*` (node:http's renamed park/replay path), `test-http-upgrade-*` (the shared `upgrade()`) and `*-timeout-pipelining` tests. The only failures are the ones the released build also has in this environment (IPv6, privileged ports, egress proxy, and the websocket send benchmark exceeding its 30 s budget under ASAN).
  - The test hunks of #33664, #35036 and #32868 were run against this branch as well: #33664's four cases pass as written; #35036's and #32868's cases deliver the in-flight response as they assert, and differ only where they pin the "then close the connection" behaviour those PRs implemented (this branch answers the pipelined request instead). The scenarios they covered that this file lacked are the file, POST-with-body, parse-error and upgrade-with-request-behind-it cases above.

### Background

- HTTP/1.1 pipelining: a client may send its next request on a keep-alive connection before reading the previous response; the server has to answer in request order (RFC 9112 9.3.2). uWS has one `HttpResponseData` per connection, so it can only work on one response at a time; `HTTP_RESPONSE_PENDING` is set when a request is dispatched and cleared by `markDone()` when the response has been fully handed to uWS.
- `tryEnd()`: how Bun.serve sends buffered bodies. It writes as much as the kernel accepts without copying the rest into uWS's backpressure buffer; Bun keeps the bytes and writes more from the `onWritable` callback each time the socket drains. Until the last byte is written the response counts as pending, even though the application finished long ago. This is why the bug hit plain `new Response(bigString)`. A `Bun.file()` body is pending the same way while the runtime's file pump (sendfile, or read+write chunks) moves it.
- `onWritable` dispatch: uSockets calls a socket's `on_writable` when the kernel reports the socket writable and keeps that interest only while a write has recently come up short (`last_write_failed`). `us_socket_request_writable()` sets that flag and re-arms the poll, which is the existing idiom (from the sendfile path) for "call me back from the event loop for this socket".
- `upgrade()`: writes the 101, destructs the connection's `HttpResponseData` and re-parents the socket into the WebSocket context with `us_socket_adopt`, which keeps the socket's flags (including paused) as they were.
- node:http compat dispatches pipelined requests immediately and queues responses in JS; what it shares with this change is only the parser-level park of unparsed bytes, which it uses when it pauses a flooding connection.

### Related

- #33664 (park and replay, but synchronously from inside the `uws_res_end*` wrappers, which is why it also had to adjust the Rust teardown paths), #35036 and #32868 (deliver the first response, then close) addressed the same close; their Bun.serve coverage is folded in here as described above, and they are being closed in favour of this PR. The node:http half of #32868 is already on main since #32488 (its node-http case passes there as written).
- #37099 adds `us_socket_mark_writable_pending()` for the same purpose as `us_socket_request_writable()` here; whichever lands second should reuse the other's helper. Nothing here depends on `pause()` arming writable interest, so the two compose either way.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 13 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 26 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-pipelining.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/bun-serve-pipelining.test.ts:
300 |             statusLine,
301 |             contentLength: headers["content-length"],
302 |             bodyLength: body.length,
303 |             bodyIsIntact: body === big || body === "body of /small",
304 |           })),
305 |         }).toEqual({
                 ^
error: expect(received).toEqual(expected)

  {
-   "closed": false,
+   "closed": true,
    "hits": [
      "/big",
-     "/small",
    ],
-   "responses": [
-     {
-       "bodyIsIntact": true,
-       "bodyLength": 16777216,
-       "contentLength": "16777216",
-       "statusLine": "HTTP/1.1 200 OK",
-     },
-     {
-       "bodyIsIntact": true,
-       "bodyLength": 14,
-       "contentLength": "14",
-       "statusLine": "HTTP/1.1 200 OK",
-     },
-   ],
+   "responses": [],
  }

- Expected  - 16
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-pipelining.test.ts:305:12)
(fail) tcp > a buffered body > large
... (truncated)

release without fix: 26 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/http/bun-serve-pipelining.test.ts:
300 |             statusLine,
301 |             contentLength: headers["content-length"],
302 |             bodyLength: body.length,
303 |             bodyIsIntact: body === big || body === "body of /small",
304 |           })),
305 |         }).toEqual({
                 ^
error: expect(received).toEqual(expected)

  {
-   "closed": false,
+   "closed": true,
    "hits": [
      "/big",
-     "/small",
    ],
-   "responses": [
-     {
-       "bodyIsIntact": true,
-       "bodyLength": 16777216,
-       "contentLength": "16777216",
-       "statusLine": "HTTP/1.1 200 OK",
-     },
-     {
-       "bodyIsIntact": true,
-       "bodyLength": 14,
-       "contentLength": "14",
-       "statusLine": "HTTP/1.1 200 OK",
-     },
-   ],
+   "responses": [],
  }

- Expected  - 16
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-pipelining.test.ts:305:12)
(fail) tcp > a buffered body > larger than the socket buffer is delivered whole to a client that pipelined a request behind it, which is then answered [18.06ms]
300 |             statusLine,
301 |          
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-pipelining.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/bun-serve-pipelining.test.ts:
(pass) tcp > a buffered body > larger than the socket buffer is delivered whole to a client that pipelined a request behind it, which is then answered [205.11ms]
(pass) tcp > a Bun.file() body returned from the handler > larger than the socket buffer is delivered whole to a client that pipelined a request behind it, which is then answered [150.47ms]
(pass) tcp > a Bun.file() route > larger than the socket buffer is delivered whole to a client that pipelined a request behind it, which is then answered [111.09ms]
(pass) tcp > requests pipelined behind an async handler are dispatched one at a time, each after the response ahead of it [89.45ms]
(pass) tcp > a request pipelined behind a streaming response is answered once the stream ends [61.70ms]
(pass) tls > a buffered body > larger than the socket buffer is delivered whole to a client that pipelined a request behind it, which is then answered [229.45ms]
(pass) tls > a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1622ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[2/28] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[3/28] cc obj/packages/bun-usockets/src/bsd.c.o
[4/28] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/28] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[6/28] cc obj/packages/bun-usockets/src/context.c.o
[7/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[8/28] cxx obj/src/jsc/bindings/bindings.cpp.o
[9/28] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[10/28] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[11/28] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[12/28] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[13/28] cc obj/packages/bun-usockets/src/fault_inject.c.o
[14/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[15/28] cc obj/packages/bun-usockets/src/loop.c.o
[16/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[17/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[18/28
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/libusockets.h          |   8 +-
 packages/bun-usockets/src/socket.c               |   9 +
 packages/bun-uws/src/HttpContext.h               | 113 +++-
 packages/bun-uws/src/HttpParser.h                |  39 +-
 packages/bun-uws/src/HttpResponse.h              |  28 +-
 packages/bun-uws/src/HttpResponseData.h          |  20 +-
 scripts/verify-baseline-static/allowlist-x64.txt |   6 +-
 src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp |  22 +-
 src/uws_sys/Response.rs                          |   4 +-
 src/uws_sys/libuwsockets.cpp                     |  22 -
 src/uws_sys/socket.rs                            |   2 +-
 src/uws_sys/us_socket_t.rs                       |   6 +-
 test/js/bun/http/bun-serve-pipelining.test.ts    | 701 +++++++++++++++++++++++
 13 files changed, 909 insertions(+), 71 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
packages/bun-usockets/src/libusockets.h               2      1      0
packages/bun-usockets/src/socket.c                    2      1      0
packages/bun-uws/src/HttpContext.h                   10     15      0
packages/bun-uws/src/HttpParser.h                     7      3      0
packages/bun-uws/src/HttpResponse.h                   6      3      0
packages/bun-uws/src/HttpResponseData.h               2      3      0
scripts/verify-baseline-static/allowlist-x64.txt      1      1      0
src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp      2      3      0
src/uws_sys/Response.rs                               1      3      0
src/uws_sys/libuwsockets.cpp                          5      3      0
src/uws_sys/socket.rs                                 1      1      0
src/uws_sys/us_socket_t.rs                            2      2      0
test/js/bun/http/bun-serve-pipelining.test.ts         5      8      0
```

</details>

<!-- robobun:evidence:end -->



