### PR TITLE
test: cover the \p{RGI_Emoji} miss cost fixed by the WebKit 09e477744721 sync

### DIFF
--- a/test/js/bun/jsc/webkit-upgrade-09e47774.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-09e47774.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { withoutAggressiveGC } from "harness";
+
+// Coverage for the WebKit 09e477744721 sync (oven-sh/WebKit#299, pinned by
+// oven-sh/bun#37352), which fixes oven-sh/bun#37290. Yarr expands a v-mode
+// class of strings into one alternative per string (a few thousand for
+// \p{RGI_Emoji}) and used to try them one at a time, so every non-emoji input
+// paid for the whole list. It now dispatches the group on the input's first
+// code point, so a miss costs one dispatch. string-width runs /^\p{RGI_Emoji}$/v
+// on every grapheme, which is how this regex came to dominate Ink TUIs.
+
+// The issue's input: box drawing starts no emoji sequence, so every position
+// below is a miss. The subject has to be 16-bit (anything outside Latin-1) for
+// this to have been slow before the fix; on an 8-bit subject the old code
+// already skipped the list when scanning unanchored.
+const boxDrawing = "\u2500".repeat(4000);
+
+const rgiEmoji = /\p{RGI_Emoji}/v;
+const rgiEmojiInClass = /[\p{RGI_Emoji}]/v;
+// A property of code points does the same work per position (one class check),
+// so dividing by it cancels out machine speed and build type.
+const codePointProperty = /\p{Extended_Pictographic}/u;
+
+/** Best of five interleaved rounds of one `.test()` over `boxDrawing`, in milliseconds, per regex. */
+function missMilliseconds(regexes: RegExp[]): number[] {
+  for (const re of regexes) expect(re.test(boxDrawing)).toBe(false); // compiles the regex and flattens the subject
+  const best = regexes.map(() => Infinity);
+  for (let round = 0; round < 5; round++) {
+    regexes.forEach((re, i) => {
+      const start = performance.now();
+      re.test(boxDrawing);
+      best[i] = Math.min(best[i], performance.now() - start);
+    });
+  }
+  return best;
+}
+
+describe("WebKit 09e477744721 upgrade", () => {
+  test("a \\p{RGI_Emoji} miss does not walk every emoji sequence (#37290)", () => {
+    withoutAggressiveGC(() => {
+      const [control, bare, inClass] = missMilliseconds([codePointProperty, rgiEmoji, rgiEmojiInClass]);
+      // Ratios measured on linux x64. Before oven-sh/WebKit#299: ~10,000x in
+      // release, ~1,700x in debug. After: 1.3x to 1.5x in debug, 2.2x to 2.6x
+      // in release (node 26: 3.1x). The fixed build run with
+      // BUN_JSC_useRegExpAlternationDispatch=0, which turns the first code
+      // point dispatch back off, measures ~570x in release and 115x to 210x in
+      // debug, so 50 also catches a WebKit bump that loses only the dispatch.
+      expect(bare / control).toBeLessThan(50);
+      expect(inClass / control).toBeLessThan(50);
+    });
+  });
+
+  test("the dispatched class still matches whole sequences, longest first", () => {
+    // Guards the test above against a class that got fast by matching less.
+    // The first code point of the first three sequences is an RGI emoji by
+    // itself (thumbs up, man, black flag), so each match also has to be the
+    // longest alternative rather than the first one that fits.
+    const sequences = [
+      "\u{1F44D}\u{1F3FD}", // thumbs up + medium skin tone
+      "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}", // family: man, woman, girl
+      "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}", // flag: England
+      "\u{1F1EB}\u{1F1F7}", // flag: France
+      "#\uFE0F\u20E3", // keycap: #
+    ];
+    const notEmoji = ["#", "\u{1F1EB}"]; // a keycap base and a regional indicator on their own
+    for (const re of [rgiEmoji, rgiEmojiInClass]) {
+      expect([...sequences, ...notEmoji].map(text => re.exec(`\u2500${text}\u2500`)?.[0] ?? null)).toEqual([
+        ...sequences,
+        null,
+        null,
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
Test-only. Adds bun-side coverage for the part of the WebKit `09e477744721` sync (oven-sh/WebKit#299, pinned by #37352) that fixed #37290. Replaces the now superseded #37294, which carried the only test for this and was closed because its WebKit change is no longer needed.

### Problem
- #37290: `/^\p{RGI_Emoji}$/v.test()` on a non-emoji character took ~30 us per call on bun 1.4.0 (Node: 0.07 us). string-width runs that regex on every grapheme, so Ink TUIs printing box drawing spent most of their CPU in it.
- Cause: Yarr expands a class of strings into one alternative per string (a few thousand for `\p{RGI_Emoji}`) and tried them one at a time on every miss.
- oven-sh/WebKit#299 fixed it (the group is now dispatched on the input's first code point) and main picked it up in #37352 (`WEBKIT_VERSION` went straight to the #299 squash commit `09e477744721`; the current pin `caad865eb1a6` is 8 commits past it). Neither #37352 nor the earlier preview PR #36789 added a test, and `test/` has no other `RGI_Emoji` coverage, so the next WebKit bump can lose this silently.

### Fix
- `test/js/bun/jsc/webkit-upgrade-09e47774.test.ts`, following the existing `webkit-upgrade-<hash>.test.ts` files in that directory.
- The perf test times one unanchored `.test()` of `/\p{RGI_Emoji}/v` and `/[\p{RGI_Emoji}]/v` over 4000 box drawing characters (every position is a miss) and divides by the same scan with `/\p{Extended_Pictographic}/u`, a property of code points. Best of five interleaved rounds, under `withoutAggressiveGC`, threshold 50x.
- Why a ratio over one long subject: dividing by the code point property cancels machine speed and build type, and putting 4000 misses in one call keeps the per-call overhead of a debug build out of the number. #37294's test looped anchored `.test()` calls instead; on a debug build that overhead (15 to 40 us per call, even for `/^a$/`) hides the walk, and its ratio check passed on the unfixed engine (measured 2.4x to 3.5x against its 30x threshold), so it only meant anything in release.
- Why the subject is U+2500: the issue's input, and on an 8-bit (Latin-1) subject the old code already skipped the list for an unanchored scan (0 ms on the unfixed build), so only a 16-bit subject reproduces the walk.
- Why 50: measured ratios after the fix are 1.3x to 2.6x on linux x64, 2.1x to 3.4x on windows x64 and 1.7x on windows arm64 (node 26: 3.0x to 4.3x); ~10,000x (release) and ~1,700x (debug) on the engine before it; and between ~115x (linux debug) and ~700x on the current engine with `BUN_JSC_useRegExpAlternationDispatch=0`, the option #299 added to turn the dispatch off. So the threshold also fails a future bump that keeps the expansion but loses the dispatch.
- The second test checks `exec()` on both regexes returns whole sequences (thumbs up + skin tone, a family ZWJ sequence, the England tag sequence, a flag, a keycap) and rejects `#` and a lone regional indicator, so the perf test cannot be satisfied by a class that matches less. The first three sequences start with a code point that is RGI on its own, which also pins the longest-alternative-first order.
- Verified:
  - `bun bd test test/js/bun/jsc/webkit-upgrade-09e47774.test.ts`: passes (7 runs, 3 of them with the CI runner's `BUN_GARBAGE_COLLECTOR_LEVEL=1 BUN_JSC_randomIntegrityAuditRate=1.0`; ~0.8 s + ~1.0 s per test in debug, almost all of it the four Yarr compiles).
  - `USE_SYSTEM_BUN=1 bun test ...` on canary `da3851e57`, which predates #37352: fails at 8,589x.
  - A debug (coverage instrumented) build of `da3851e57`: fails at 1,873x. Current canary `b7a043103` (release): passes twice.
  - Current debug and release builds with `BUN_JSC_useRegExpAlternationDispatch=0`: fail at 116x to 209x and 563x to 600x.
- The fix this covers is already on main, so the file passes on main as is; the fail-before evidence is the pre-#37352 binary above rather than a `src/` diff.

### Background
- Yarr is JavaScriptCore's regex engine; bun gets it from the oven-sh/WebKit fork at the commit pinned in `scripts/build/deps/webkit.ts`, so engine fixes reach bun as pin bumps and regress the same way.
- A class of strings is a `/v` (unicodeSets) class that can contain multi code point members: `\q{...}`, the emoji properties of strings such as `\p{RGI_Emoji}`, and set operations on them. Yarr compiles one by listing every member string as an alternative, longest first, followed by the single code points.
- First code point dispatch (oven-sh/WebKit#299): the JIT indexes a group's alternatives by the code point they can start with and jumps straight to the (usually empty) list for the input's first code point, instead of trying each alternative in turn. It is behind the `useRegExpAlternationDispatch` JSC option, which the test comment and the numbers above use to show what a regression would look like.
- `withoutAggressiveGC` (test harness) clears the `BUN_GARBAGE_COLLECTOR_LEVEL` setting the CI runner gives test processes for the duration of the measurement, the usual pattern for timing-sensitive tests here.

<details>
<summary>Measurements (the test's exact method: 4000 positions, best of 5 interleaved rounds)</summary>

linux x64:

| build | `\p{RGI_Emoji}` / control | `[\p{RGI_Emoji}]` / control |
|---|---|---|
| canary da3851e57, release (before #37352) | 9,206x to 10,498x | 9,921x to 10,061x |
| da3851e57, debug (coverage instrumented) | 1,681x | 1,593x |
| canary b7a043103 (current main), release | 2.2x to 2.4x | 2.3x to 2.6x |
| b7a043103, debug (`bun bd`) | 1.3x to 1.5x | 1.4x |
| b7a043103 release, `BUN_JSC_useRegExpAlternationDispatch=0` | 608x to 683x | 541x to 637x |
| b7a043103 debug, `BUN_JSC_useRegExpAlternationDispatch=0` | 121x to 141x | 124x to 130x |
| node v26.3.0 | 3.1x | 3.1x |

canary b7a043103 (release) on Windows, 5 runs each, plus the JIT's arm64 backend:

| platform | default | `BUN_JSC_useRegExpAlternationDispatch=0` | node v26.3.0 |
|---|---|---|---|
| windows x64 | 2.1x to 3.4x | 440x to 510x | 2.9x to 3.0x |
| windows arm64 | 1.7x | 254x to 261x | 4.3x |

Absolute numbers for the miss itself: ~120 ms per 4000 positions before, ~0.02 ms (release) / ~0.04 ms (debug) after. The issue's own benchmark (156 anchored calls) went from 3.67 ms on da3851e57 to 0.020 ms on b7a043103; node 26 takes 0.02 ms.

Not covered here: the interpreter tier (`BUN_JSC_useRegExpJIT=0`) still measures ~150x on the current engine, since the dispatch is a JIT feature; CI runs with the JIT on. #5197 (the isbot regex, fixed by the same WebKit change) also has no bun-side test yet.
</details>
