### PR TITLE
sql: keep zero-padded numeric column names as string keys

### DIFF
--- a/src/sql/shared/ColumnIdentifier.rs
+++ b/src/sql/shared/ColumnIdentifier.rs
@@ -8,31 +8,11 @@ pub enum ColumnIdentifier {
 
 impl ColumnIdentifier {
     pub(crate) fn init(name: Data) -> Result<Self, bun_alloc::AllocError> {
-        const U32_MAX_DIGITS: usize = "4294967295".len();
-        let might_be_int = match name.slice().len() {
-            1..=U32_MAX_DIGITS => true,
-            0 => return Ok(Self::Name(Data::Empty)),
-            _ => false,
-        };
-        if might_be_int {
-            // Only `'0'..='9'` — not `parse_unsigned`, which skips embedded `_`
-            // separators and would turn a column named `2024_01` into `202401`.
-            // `U32_MAX_DIGITS` caps the length, so `u64` cannot overflow here.
-            let mut int: u64 = 0;
-            let mut all_digits = true;
-            for &byte in name.slice() {
-                match byte {
-                    b'0'..=b'9' => int = int * 10 + (byte - b'0') as u64,
-                    _ => {
-                        all_digits = false;
-                        break;
-                    }
-                }
-            }
-            // keep `<` (not ≤): JSC indexed-property bound
-            if all_digits && int < u32::MAX as u64 {
-                return Ok(Self::Index(int as u32));
-            }
+        if name.slice().is_empty() {
+            return Ok(Self::Name(Data::Empty));
+        }
+        if let Some(index) = parse_index(name.slice()) {
+            return Ok(Self::Index(index));
         }
 
         let owned = name.to_owned()?;
@@ -42,6 +22,34 @@ impl ColumnIdentifier {
         };
         Ok(Self::Name(Data::Owned(owned)))
     }
+}
+
+/// Mirrors JSC's `parseIndex`: a property key is an array index only when it is
+/// the canonical decimal spelling of an integer below `u32::MAX`. `"0"` and
+/// `"10"` are indices; `"00"`, `"007"`, `"2024_01"` and `"4294967295"` are
+/// names. Row objects store `Index` columns via `putDirectIndex` and `Name`
+/// columns as Structure properties, so this must classify exactly as JSC does:
+/// indexing `"007"` would surface the column as `"7"` and make
+/// `dedupe_columns` drop it when a real `"7"` column is also selected.
+/// Hand-rolled because `parse_unsigned` accepts `_` digit separators.
+fn parse_index(name: &[u8]) -> Option<u32> {
+    let (&first, rest) = name.split_first()?;
+    if !first.is_ascii_digit() || (first == b'0' && !rest.is_empty()) {
+        return None;
+    }
+    // Bounding the length keeps the accumulator from overflowing.
+    if name.len() > "4294967295".len() {
+        return None;
+    }
+    let mut value = u64::from(first - b'0');
+    for &byte in rest {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        value = value * 10 + u64::from(byte - b'0');
+    }
+    let index = u32::try_from(value).ok()?;
+    (index < u32::MAX).then_some(index)
 }
 
 // `deinit` dropped: the only work was `name.deinit()`, which Rust handles via

--- a/test/js/sql/sql-column-name-leading-zeros.test.ts
+++ b/test/js/sql/sql-column-name-leading-zeros.test.ts
@@ -1,0 +1,123 @@
+// The shared ColumnIdentifier classifier (src/sql/shared/ColumnIdentifier.rs)
+// decides whether a result column becomes an array-index key or a string key
+// on the row object. It used to treat any all-digit name as an index, so a
+// column aliased "01" came back as "1", and "007" collided with a real "7"
+// column and was dropped from the object (values() still had the cell). JS only
+// treats canonical integer strings as index keys: {"01": .., "1": ..} are two
+// distinct properties, which is also what Postgres/MySQL return and what
+// postgres.js / mysql2 hand back.
+//
+// Runs against the real docker-compose postgres/mysql services; the classifier
+// is shared by both decoders, and each adapter decodes column names on both its
+// prepared and its simple/text query path.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+const expectedRow = {
+  id: "row1",
+  "01": "jan",
+  "02": "feb",
+  "10": "oct",
+  "007": "bond",
+  "7": "seven",
+  "0": "zero",
+  "00": "dz",
+};
+// Index keys ("0", "7", "10") sort first; the rest keep column order.
+const expectedKeys = ["0", "7", "10", "id", "01", "02", "007", "00"];
+const expectedValues = ["row1", "jan", "feb", "oct", "bond", "seven", "zero", "dz"];
+
+// More columns than JSFinalObject's inline capacity (64), so the row is built
+// from the per-statement column-name array instead of a cached Structure.
+const wideNames = Array.from({ length: 70 }, (_, i) => String(i + 1).padStart(3, "0"));
+const expectedWideRow = { name: "n", "5": "i", ...Object.fromEntries(wideNames.map(n => [n, n])) };
+function wideSelect(quote: string) {
+  const alias = (value: string, name: string) => `'${value}' as ${quote}${name}${quote}`;
+  return `select ${[alias("n", "name"), alias("i", "5"), ...wideNames.map(n => alias(n, n))].join(", ")}`;
+}
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const options = () => ({
+    url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+    max: 1,
+    idleTimeout: 5,
+    connectionTimeout: 5,
+  });
+
+  test("zero-padded numeric aliases stay distinct string keys", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+
+    const query = () =>
+      sql`select 'row1' as "id", 'jan' as "01", 'feb' as "02", 'oct' as "10", 'bond' as "007", 'seven' as "7", 'zero' as "0", 'dz' as "00"`;
+
+    const [row] = await query();
+    expect(row).toEqual(expectedRow);
+    expect(Object.keys(row)).toEqual(expectedKeys);
+    expect((await query().values())[0]).toEqual(expectedValues);
+
+    const [simpleRow] = await query().simple();
+    expect(simpleRow).toEqual(expectedRow);
+    expect(Object.keys(simpleRow)).toEqual(expectedKeys);
+  });
+
+  test("a result made only of zero-padded aliases keeps every column", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+
+    expect(await sql`select 1 as "01", 2 as "1"`).toEqual([{ "01": 1, "1": 2 }]);
+    expect(await sql`select 'a' as "01", 'b' as "02", 'c' as "000"`).toEqual([{ "01": "a", "02": "b", "000": "c" }]);
+  });
+
+  test("zero-padded aliases survive past the inline property capacity", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+
+    expect(await sql.unsafe(wideSelect('"'))).toEqual([expectedWideRow]);
+  });
+});
+
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  const options = () => ({
+    url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+    max: 1,
+    idleTimeout: 5,
+    connectionTimeout: 5,
+  });
+
+  test("zero-padded numeric aliases stay distinct string keys", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+
+    const query = () =>
+      sql`select 'row1' as \`id\`, 'jan' as \`01\`, 'feb' as \`02\`, 'oct' as \`10\`, 'bond' as \`007\`, 'seven' as \`7\`, 'zero' as \`0\`, 'dz' as \`00\``;
+
+    const [row] = await query();
+    expect(row).toEqual(expectedRow);
+    expect(Object.keys(row)).toEqual(expectedKeys);
+    expect((await query().values())[0]).toEqual(expectedValues);
+
+    const [simpleRow] = await query().simple();
+    expect(simpleRow).toEqual(expectedRow);
+    expect(Object.keys(simpleRow)).toEqual(expectedKeys);
+  });
+
+  test("a result made only of zero-padded aliases keeps every column", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+
+    expect(await sql`select 1 as \`01\`, 2 as \`1\``).toEqual([{ "01": 1, "1": 2 }]);
+    expect(await sql`select 'a' as \`01\`, 'b' as \`02\`, 'c' as \`000\``).toEqual([
+      { "01": "a", "02": "b", "000": "c" },
+    ]);
+  });
+
+  test("zero-padded aliases survive past the inline property capacity", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+
+    expect(await sql.unsafe(wideSelect("`"))).toEqual([expectedWideRow]);
+  });
+});


### PR DESCRIPTION
### Problem
- `Bun.SQL` row objects rename zero-padded numeric column names: `select 'x' as "01"` comes back as `{ "1": "x" }`.
- When the canonical name is also selected, one column disappears from the object: `select 1 as "01", 2 as "1"` returns `{ "1": 2 }`. `.values()` still has both cells.
- Cause: `ColumnIdentifier::init` (`src/sql/shared/ColumnIdentifier.rs`) turned every all-digit name into `Index(parsed integer)`, so `"01"`, `"007"` and `"7"` all became `Index(1)` / `Index(7)`, lost their spelling, and `dedupe_columns` (`src/sql_jsc/shared/SQLDataCell.rs`) treated `"007"` and `"7"` as the same column.
- Postgres and MySQL both treat `"01"` and `"1"` as distinct identifiers, and JS objects hold `"01"` and `"1"` as two separate properties, so the exact names should survive. The classifier is shared by the Postgres (`FieldDescription`) and MySQL (`ColumnDefinition41`) decoders, so both adapters were affected.

### Fix
- `ColumnIdentifier::init` now only classifies a name as `Index` when it is the canonical decimal spelling of an integer below `u32::MAX` (`"0"`, `"7"`, `"10"`); anything with a leading zero (`"00"`, `"01"`, `"007"`) is a `Name` like any other string key. This is the same rule JSC's `parseIndex` applies to property keys, which is the rule the object-building code in `SQLClient.cpp` depends on (see Background).
- Canonical numeric names, duplicate handling (last one wins) and the `u32::MAX` boundary behave exactly as before; `"2024_01"` style names stay names as before.
- Verified with `test/js/sql/sql-column-name-leading-zeros.test.ts`, which runs against the real `postgres_plain` and `mysql_plain` services and checks the prepared and simple/text query paths, a result made only of zero-padded aliases, and a 72 column result (past the 64 inline property capacity, which takes a different object-building path). All 6 tests fail on the current release and pass with this change.
- Also re-ran the loopback stub from the report (all six names now come back as sent) and the existing `sql-mysql-column-name-digits`, `postgres-datarow-overrun`, `postgres-multi-statement-fields`, `sql-mysql-binary-null-indexed` and `sql-prepare-false` tests with a debug build.

### Background
- A result row is built natively in `src/jsc/bindings/SQLClient.cpp`. Each column is tagged ahead of time as `Name` or `Index`: `Name` columns are stored as regular properties (a cached JSC `Structure` built from the names, or `putDirect` with the name), `Index` columns are stored with `putDirectIndex(n)`. The tag has to match what JSC itself would consider an index key, because JSC will not accept an index-like key as a structure property, and storing a non-index name through `putDirectIndex` changes the key (this bug).
- In JavaScript only canonical integer strings are index keys: `"7"` is an index, `"07"` is an ordinary string property. `Object.keys` lists index keys first in numeric order, then string keys in insertion order, which is the key order the new test asserts.
- `dedupe_columns` runs before the row is built so that repeated column names keep only the last occurrence. It compares `Name` columns by their bytes and `Index` columns by their integer, so two different spellings that were both parsed to the same integer looked like duplicates.

<details>
<summary>Observed before / after (real Postgres, same for MySQL)</summary>

```
select 'row1' as "id", 'jan' as "01", 'feb' as "02", 'oct' as "10",
       'bond' as "007", 'seven' as "7", 'zero' as "0", 'dz' as "00"

before: {"0":"dz","1":"jan","2":"feb","7":"seven","10":"oct","id":"row1"}      (6 keys, "bond" and "zero" gone)
after:  {"0":"zero","7":"seven","10":"oct","id":"row1","01":"jan","02":"feb","007":"bond","00":"dz"}
values() both before and after: ["row1","jan","feb","oct","bond","seven","zero","dz"]
```
</details>
