### PR TITLE
bundler: inline import.meta paths in iife output for browser and node targets

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2594,6 +2594,16 @@ pub mod parse_worker {
             opts.lower_import_meta_main_for_node_js = true;
         }
 
+        // `import.meta` is a SyntaxError in anything that is not loaded as an ES module:
+        // cjs output always (for bun it gets the `@bun-cjs` wrapper, see postProcessJSChunk),
+        // iife output unless it targets bun, which loads the `// @bun` file as a module.
+        opts.inline_import_meta_paths = opts.framework.is_some()
+            || match output_format {
+                options::Format::Cjs => true,
+                options::Format::Iife => !target.is_bun(),
+                options::Format::Esm | options::Format::InternalBakeDev => false,
+            };
+
         opts.tree_shaking = if task.source_index.is_runtime() {
             true
         } else {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1565,6 +1565,7 @@ impl<'a> Transpiler<'a> {
                     transform_only: self.options.transform_only,
                     import_meta_main_value: None,
                     lower_import_meta_main_for_node_js: false,
+                    inline_import_meta_paths: false,
                     framework: None,
                     repl_mode: self.options.repl_mode,
                 };

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -3,7 +3,7 @@ use bun_collections::VecExt;
 use bun_core::feature_flags as FeatureFlags;
 
 use crate::p::P;
-use crate::parser::{self as js_parser, IdentifierOpts, RelocateVars, RelocateVarsMode};
+use crate::parser::{IdentifierOpts, RelocateVars, RelocateVarsMode};
 use bun_ast::ast_result::CommonJSNamedExport;
 use bun_ast::{self as js_ast, Binding, E, Expr, Flags, G, LocRef, S};
 
@@ -510,11 +510,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         });
                     }
 
-                    // Inline import.meta properties for Bake
-                    if p.options.framework.is_some()
-                        || (p.options.bundle
-                            && p.options.output_format == js_parser::options::Format::Cjs)
-                    {
+                    if p.options.inline_import_meta_paths {
                         if name == b"dir" || name == b"dirname" {
                             // Inline import.meta.dir
                             return Some(

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -93,6 +93,11 @@ pub struct Options<'a> {
     /// Used for inlining the state of import.meta.main during visiting
     pub import_meta_main_value: Option<bool>,
     pub lower_import_meta_main_for_node_js: bool,
+    /// Replace `import.meta.{dir,dirname,file,path,url}` with string literals
+    /// computed from the source file's path. Set by the bundler when the output
+    /// is not loaded as an ES module (so `import.meta` would be a SyntaxError in
+    /// it) and by Bake.
+    pub inline_import_meta_paths: bool,
 
     /// When using react fast refresh or server components, the framework is
     /// able to customize what import sources are used.
@@ -133,6 +138,7 @@ impl<'a> Default for Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            inline_import_meta_paths: false,
             framework: None,
             repl_mode: false,
         }
@@ -216,6 +222,7 @@ impl<'a> Options<'a> {
             transform_only: self.transform_only,
             import_meta_main_value: self.import_meta_main_value,
             lower_import_meta_main_for_node_js: self.lower_import_meta_main_for_node_js,
+            inline_import_meta_paths: self.inline_import_meta_paths,
             framework: self.framework,
             repl_mode: self.repl_mode,
         }
@@ -287,6 +294,7 @@ impl<'a> Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            inline_import_meta_paths: false,
             framework: None,
             repl_mode: false,
         };

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isBroken, isWindows, tempDir } from "harness";
 import { readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
 
 // A public path composes with the referenced file's path relative to the output
@@ -2085,6 +2086,83 @@ describe("bundler", () => {
       stdout: `side-effect-ran`,
     },
   });
+  // cjs and iife output is loaded as a script, where `import.meta` is a SyntaxError, so the
+  // file-location properties of `import.meta` are resolved at bundle time, per source file,
+  // like `__dirname` is. The output runs under node as a `.cjs` file because that is what
+  // rejects a leftover `import.meta`: node re-parses a `.js` file as an ES module on that
+  // error, and bun's runtime accepts `import.meta` in CommonJS too.
+  const importMetaPathsFiles = {
+    "/entry.js": /* js */ `
+      import { dep } from "./lib/dep.js";
+      console.log(
+        JSON.stringify([
+          import.meta.dir,
+          import.meta.dirname,
+          import.meta.file,
+          import.meta.path,
+          import.meta.url,
+          typeof import.meta.url,
+          dep,
+        ]),
+      );
+    `,
+    "/lib/dep.js": /* js */ `
+      export const dep = [import.meta.dir, import.meta.file, import.meta.url];
+    `,
+  };
+  const importMetaPathsStdout = (root: string) =>
+    JSON.stringify([
+      root,
+      root,
+      "entry.js",
+      join(root, "entry.js"),
+      pathToFileURL(join(root, "entry.js")).href,
+      "string",
+      [join(root, "lib"), "dep.js", pathToFileURL(join(root, "lib", "dep.js")).href],
+    ]);
+  itBundled("edgecase/ImportMetaPathsInlinedIIFE", ({ root }) => ({
+    files: importMetaPathsFiles,
+    format: "iife",
+    target: "browser",
+    outfile: "out.cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.cjs").not.toContain("import.meta");
+    },
+    run: { runtime: "node", stdout: importMetaPathsStdout(root) },
+  }));
+  itBundled("edgecase/ImportMetaPathsInlinedIIFETargetNode", ({ root }) => ({
+    files: importMetaPathsFiles,
+    format: "iife",
+    target: "node",
+    outfile: "out.cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.cjs").not.toContain("import.meta");
+    },
+    run: { runtime: "node", stdout: importMetaPathsStdout(root) },
+  }));
+  itBundled("edgecase/ImportMetaPathsInlinedCJS", ({ root }) => ({
+    files: importMetaPathsFiles,
+    format: "cjs",
+    target: "node",
+    outfile: "out.cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.cjs").not.toContain("import.meta");
+    },
+    run: { runtime: "node", stdout: importMetaPathsStdout(root) },
+  }));
+  // Bun loads its own iife output (it starts with `// @bun`) as an ES module, so there
+  // `import.meta` stays as written and refers to the bundle, exactly as in esm output.
+  itBundled("edgecase/ImportMetaKeptIIFETargetBun", ({ root }) => ({
+    files: {
+      "/entry.js": /* js */ `console.log(import.meta.url);`,
+    },
+    format: "iife",
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("import.meta.url");
+    },
+    run: { stdout: pathToFileURL(join(root, "out.js")).href },
+  }));
   itBundled("edgecase/ImportMetaMain", {
     files: {
       "/entry.ts": /* js */ `


### PR DESCRIPTION
### Problem
- `bun build --format=iife` (target `browser` or `node`) prints the user's `import.meta.url` / `import.meta.dir` / `dirname` / `file` / `path` into the output unchanged. An iife is loaded as a classic script (a `<script>` tag, or a `.cjs` file under node), where that is a load-time `SyntaxError: Cannot use 'import.meta' outside a module`, so the whole bundle fails to load.
- `--format=cjs` already folds those properties to string literals. The fold in `src/js_parser/fold.rs` (`EImportMeta` arm of the property-access folding) was gated on `output_format == Cjs`, so iife fell through to the generic "print the `E::Dot` as is" path.

```console
$ echo 'console.log(import.meta.url, import.meta.dir)' > e.js
$ bun build e.js --format=iife --outfile=out.cjs && node out.cjs
SyntaxError: Cannot use 'import.meta' outside a module
$ bun build e.js --format=cjs --target=node          # already fine
console.log("file:///tmp/x/e.js", "/tmp/x");
```

### Fix
- New parser option `inline_import_meta_paths` (`src/js_parser/parse/parse_entry.rs`). `fold.rs` checks it instead of `framework.is_some() || (bundle && output_format == Cjs)`. The folded values are unchanged.
- `src/bundler/ParseTask.rs` sets it from what the linker is going to do with the output: Bake as before, `cjs` always (with `--target=bun` the output gets the `@bun-cjs` CommonJS wrapper), `iife` unless the file targets bun. `esm` and the dev server format never set it, so their output is unchanged.
- `--target=bun --format=iife` is deliberately left alone: the linker emits that output with a `// @bun` pragma and Bun loads it as an ES module, so `import.meta` there is valid and refers to the bundle, exactly like esm output (and `--compile --format=iife` keeps reporting the executable's `$bunfs` path). Inlining there would have changed working output for no gain.
- Why build-time paths are the right value: it is what cjs output and Bake already do for these properties, and what `__dirname` / `__filename` are folded to in every format and target. A user `--define import.meta.url=...` still wins, since defines are applied before this fold.
- `import.meta.filename` is still not in the folded set; #35961 adds it to the same block and, once both land, covers iife as well. The properties outside this set (`import.meta.env`, `import.meta.resolve`, a bare `import.meta`) are printed verbatim in cjs output today too and are a separate issue.
- Verified with `test/bundler/bundler_edgecase.test.ts`:
  - `edgecase/ImportMetaPathsInlinedIIFE`, `...IIFETargetNode`: entry plus an imported file in a subdirectory, `outfile: out.cjs`, run under node, exact values per source file; fail on the released binary, pass with this change. The `.cjs` extension matters: node re-parses a `.js` file as an ES module on this error and Bun's runtime accepts `import.meta` in CommonJS, so only this setup exercises the failure.
  - `edgecase/ImportMetaPathsInlinedCJS`: same files in cjs output, guards the existing behavior the gate was moved out of.
  - `edgecase/ImportMetaKeptIIFETargetBun`: bun-target iife keeps `import.meta.url` and it resolves to the bundle at runtime.
  - `bundler_edgecase.test.ts`, `bundler_cjs.test.ts`, `esbuild/default.test.ts -t "ImportMeta|Define"`, `bake/dev/import-meta-inline*.test.ts` and `bundler_compile.test.ts -t "ImportMeta|bytecode"` pass with the debug build (`edgecase/DeepImportDiamondDAG` times out locally in the debug build; it is a 20k-module esm stress test unrelated to this change).

### Background
- `import.meta` is syntax that only exists inside ES modules. Anything loaded as a script (a CommonJS file, a `<script>` tag, `new Function`) rejects it at parse time, before any code runs.
- How each output format is loaded (`src/bundler/linker_context/postProcessJSChunk.rs`): `esm` output is a module everywhere. `cjs` output is a CommonJS script; for `--target=bun` it is wrapped in `// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {...})`. `iife` output is a script for browser and node targets, but for `--target=bun` it is prefixed with `// @bun`, which Bun's runtime loads as an ES module.
- Parser options in `ParseTask`: the parser does not know the target. Target-dependent behavior is expressed as options computed per file in `ParseTask.rs` next to the existing `import.meta.main` ones (`import_meta_main_value`, `lower_import_meta_main_for_node_js`); this change adds one more. `target` there is per file, the same value `lower_using` is derived from.
- The fold itself predates this change: it was added for Bake (`p.options.framework`), then enabled for cjs output in #23803 so `--bytecode` builds (which are cjs) could use `import.meta.dir`; `p.source.path` is the source file being parsed, which is why each file gets its own values.
