### PR TITLE
types: declare allowPartialTrustChain, sessionTimeout, sigalgs and ecdhCurve on Bun.TLSOptions

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -705,6 +705,9 @@ interface WebSocketHandler<T = undefined> {
 }
 
 interface TLSOptions {
+  /** Accept an intermediate certificate listed in `ca` as a trust anchor */
+  allowPartialTrustChain?: boolean;
+
   /** Certificate authority chain */
   ca?: string | Buffer | BunFile | Array<string | Buffer | BunFile>;
 
@@ -713,6 +716,9 @@ interface TLSOptions {
 
   /** Path to DH parameters file */
   dhParamsFile?: string;
+
+  /** Key agreement group, or colon-separated list of groups (e.g. "X25519:P-256") */
+  ecdhCurve?: string;
 
   /** Private key */
   key?: string | Buffer | BunFile | Array<string | Buffer | BunFile>;
@@ -728,5 +734,11 @@ interface TLSOptions {
 
   /** Server name for SNI */
   serverName?: string;
+
+  /** Seconds a TLS 1.2 session stays resumable (0 = BoringSSL's default) */
+  sessionTimeout?: number;
+
+  /** Colon-separated signature algorithms (e.g. "rsa_pss_rsae_sha256:ecdsa_secp256r1_sha256") */
+  sigalgs?: string;
 }
 ```

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4259,6 +4259,56 @@ declare module "bun" {
     clientRenegotiationLimit?: number;
 
     clientRenegotiationWindow?: number;
+
+    /**
+     * Treat the intermediate (non self-signed) certificates in `ca` as trust
+     * anchors, so a peer certificate whose chain ends at one of them verifies
+     * even though the root that issued that intermediate is not in `ca`.
+     * Without it such a chain fails with `UNABLE_TO_GET_ISSUER_CERT`.
+     *
+     * Applies to whichever certificate this side verifies: the server's
+     * certificate when connecting, or the client's certificate when a server
+     * sets `requestCert`.
+     *
+     * @default false
+     */
+    allowPartialTrustChain?: boolean | undefined;
+
+    /**
+     * Lifetime in seconds of the TLS 1.2 sessions created with these options,
+     * i.e. how long a peer can resume one of them. Must be an integer; `0`
+     * keeps BoringSSL's default of two hours. TLS 1.3 session tickets are not
+     * affected by this option.
+     *
+     * @default 0
+     */
+    sessionTimeout?: number | undefined;
+
+    /**
+     * Colon-separated list of the signature algorithms this side signs with
+     * and accepts from the peer, replacing BoringSSL's default list. Entries
+     * are TLS 1.3 scheme names such as `"rsa_pss_rsae_sha256"` or
+     * `"ecdsa_secp256r1_sha256"`, or OpenSSL `"<signature>+<digest>"` pairs
+     * such as `"RSA-PSS+SHA256"`.
+     *
+     * The handshake fails when the peer, or the key behind this side's own
+     * `cert`, supports none of the listed algorithms. A list containing an
+     * unknown name is rejected when the options are applied.
+     */
+    sigalgs?: string | undefined;
+
+    /**
+     * Named group, or colon-separated list of groups in order of preference,
+     * to use for the handshake's key agreement, such as `"P-256"` or
+     * `"X25519:P-256:P-384"`. OpenSSL aliases like `"prime256v1"` and
+     * `"secp384r1"` are accepted as well. `"auto"` (the `node:tls` default)
+     * keeps BoringSSL's default list.
+     *
+     * The handshake fails when the peer supports none of the listed groups. A
+     * list containing an unknown name is rejected when the options are
+     * applied.
+     */
+    ecdhCurve?: string | undefined;
   }
 
   interface SocketAddress {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -367,36 +367,139 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
+  // The tests below run on debug builds too: spawning tsc over a single file
+  // is cheap, unlike the in-process LanguageService runs above.
+  async function expectSingleFileToTypeCheck(name: string, source: string) {
+    const checkDir = join(TEMP_DIR, `${name}-check`);
+    const fileName = `${name}.ts`;
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.include = [fileName];
+    tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, {
+      "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      [fileName]: source,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
-           view satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
-      });
+      await expectSingleFileToTypeCheck(
+        "mmap-options",
+        `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+         view satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+      );
+    });
+  });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+  describe("Bun.TLSOptions", () => {
+    test("declares allowPartialTrustChain, sessionTimeout, sigalgs and ecdhCurve on every API that takes a tls object", async () => {
+      await expectSingleFileToTypeCheck(
+        "tls-options-context-options",
+        `({ allowPartialTrustChain: true }) satisfies Bun.TLSOptions;
+         ({ allowPartialTrustChain: undefined }) satisfies Bun.TLSOptions;
+         ({ sessionTimeout: 300 }) satisfies Bun.TLSOptions;
+         ({ sessionTimeout: undefined }) satisfies Bun.TLSOptions;
+         ({ sigalgs: "rsa_pss_rsae_sha256:ecdsa_secp256r1_sha256" }) satisfies Bun.TLSOptions;
+         ({ sigalgs: undefined }) satisfies Bun.TLSOptions;
+         ({ ecdhCurve: "X25519:P-256" }) satisfies Bun.TLSOptions;
+         ({ ecdhCurve: "auto" }) satisfies Bun.TLSOptions;
+         ({ ecdhCurve: undefined }) satisfies Bun.TLSOptions;
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+         // The runtime converter is strict about each value type (a truthy
+         // non-boolean, a numeric string, ... are rejected), so the types are too.
+         // @ts-expect-error allowPartialTrustChain is a boolean
+         ({ allowPartialTrustChain: 1 }) satisfies Bun.TLSOptions;
+         // @ts-expect-error sessionTimeout is a number of seconds
+         ({ sessionTimeout: "300" }) satisfies Bun.TLSOptions;
+         // @ts-expect-error sigalgs is a colon-separated string, not an array
+         ({ sigalgs: ["rsa_pss_rsae_sha256"] }) satisfies Bun.TLSOptions;
+         // @ts-expect-error ecdhCurve is a colon-separated string, not an array
+         ({ ecdhCurve: ["P-256"] }) satisfies Bun.TLSOptions;
 
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+         // Written out per call rather than spread from a shared object: excess
+         // property checks, which is what catches an undeclared option, only
+         // apply to properties written inline in the literal.
+         Bun.serve({
+           fetch: () => new Response(),
+           tls: {
+             key: "key",
+             cert: "cert",
+             ca: "intermediate",
+             requestCert: true,
+             allowPartialTrustChain: true,
+             sessionTimeout: 300,
+             sigalgs: "rsa_pss_rsae_sha256",
+             ecdhCurve: "P-256",
+           },
+         });
+         Bun.serve({
+           fetch: () => new Response(),
+           tls: [
+             { key: "key", cert: "cert", sessionTimeout: 60, sigalgs: "rsa_pss_rsae_sha256" },
+             { serverName: "a.example.com", key: "key", cert: "cert", ecdhCurve: "P-384", allowPartialTrustChain: true },
+           ],
+         });
+         Bun.listen({
+           hostname: "localhost",
+           port: 0,
+           socket: { data() {} },
+           tls: {
+             key: "key",
+             cert: "cert",
+             allowPartialTrustChain: true,
+             sessionTimeout: 300,
+             sigalgs: "rsa_pss_rsae_sha256",
+             ecdhCurve: "P-256",
+           },
+         });
+         Bun.connect({
+           hostname: "localhost",
+           port: 0,
+           socket: { data() {} },
+           tls: {
+             ca: "intermediate",
+             allowPartialTrustChain: true,
+             sessionTimeout: 300,
+             sigalgs: "rsa_pss_rsae_sha256",
+             ecdhCurve: "P-256",
+           },
+         });
+         fetch("https://localhost", {
+           tls: {
+             ca: "intermediate",
+             allowPartialTrustChain: true,
+             sessionTimeout: 300,
+             sigalgs: "rsa_pss_rsae_sha256",
+             ecdhCurve: "P-256",
+           },
+         });
+         new WebSocket("wss://localhost", {
+           tls: {
+             ca: "intermediate",
+             allowPartialTrustChain: true,
+             sessionTimeout: 300,
+             sigalgs: "rsa_pss_rsae_sha256",
+             ecdhCurve: "P-256",
+           },
+         });`,
+      );
     });
   });
 

--- a/test/integration/bun-types/fixture/fetch.ts
+++ b/test/integration/bun-types/fixture/fetch.ts
@@ -332,3 +332,31 @@ if (typeof process !== "undefined") {
   // @ts-expect-error - Proxy must be string or object, not array
   fetch("https://example.com", { proxy: ["http://proxy.example.com"] });
 }
+
+{
+  // TLS context options shared with Bun.serve / Bun.listen / Bun.connect
+  fetch("https://example.com", { tls: { ca: "intermediate", allowPartialTrustChain: true } });
+  fetch("https://example.com", { tls: { sessionTimeout: 300 } });
+  fetch("https://example.com", { tls: { sigalgs: "rsa_pss_rsae_sha256:ecdsa_secp256r1_sha256" } });
+  fetch("https://example.com", { tls: { ecdhCurve: "X25519:P-256" } });
+}
+
+{
+  // @ts-expect-error - allowPartialTrustChain is a boolean
+  fetch("https://example.com", { tls: { allowPartialTrustChain: "yes" } });
+}
+
+{
+  // @ts-expect-error - sessionTimeout is a number of seconds
+  fetch("https://example.com", { tls: { sessionTimeout: "300" } });
+}
+
+{
+  // @ts-expect-error - sigalgs is a colon-separated string, not an array
+  fetch("https://example.com", { tls: { sigalgs: ["rsa_pss_rsae_sha256"] } });
+}
+
+{
+  // @ts-expect-error - ecdhCurve is a colon-separated string, not an array
+  fetch("https://example.com", { tls: { ecdhCurve: ["X25519", "P-256"] } });
+}

--- a/test/integration/bun-types/fixture/serve.ts
+++ b/test/integration/bun-types/fixture/serve.ts
@@ -84,3 +84,45 @@ const s4 = Bun.serve({
     },
   },
 });
+
+Bun.serve({
+  fetch: () => new Response("hello"),
+  tls: {
+    key: Bun.file("key.pem"),
+    cert: Bun.file("cert.pem"),
+    ca: Bun.file("intermediate-ca.pem"),
+    requestCert: true,
+    allowPartialTrustChain: true,
+    sessionTimeout: 300,
+    sigalgs: "rsa_pss_rsae_sha256:ecdsa_secp256r1_sha256",
+    ecdhCurve: "X25519:P-256",
+  },
+});
+
+Bun.serve({
+  fetch: () => new Response("hello"),
+  tls: [
+    { key: "key", cert: "cert", sessionTimeout: 60, sigalgs: "rsa_pss_rsae_sha256" },
+    { serverName: "p384.example.com", key: "key", cert: "cert", ecdhCurve: "P-384", allowPartialTrustChain: true },
+  ],
+});
+
+Bun.serve({
+  fetch: () => new Response("hello"),
+  // @ts-expect-error - allowPartialTrustChain is a boolean
+  tls: {
+    key: "key",
+    cert: "cert",
+    allowPartialTrustChain: "yes",
+  },
+});
+
+Bun.serve({
+  fetch: () => new Response("hello"),
+  // @ts-expect-error - sessionTimeout is a number of seconds
+  tls: {
+    key: "key",
+    cert: "cert",
+    sessionTimeout: "300",
+  },
+});

--- a/test/integration/bun-types/fixture/tcp.ts
+++ b/test/integration/bun-types/fixture/tcp.ts
@@ -115,6 +115,48 @@ Bun.listen({
       console.log("asdf");
     },
   },
+  hostname: "adsf",
+  port: 324,
+  tls: {
+    cert: "asdf",
+    key: Bun.file("adsf"),
+    ca: Buffer.from("asdf"),
+    requestCert: true,
+    allowPartialTrustChain: true,
+    sessionTimeout: 300,
+    sigalgs: "rsa_pss_rsae_sha256:ecdsa_secp256r1_sha256",
+    ecdhCurve: "X25519:P-256",
+  },
+});
+
+await Bun.connect({
+  data: { arg: "asdf" },
+  socket: {
+    data(socket) {
+      socket.data.arg.toLowerCase();
+    },
+  },
+  hostname: "adsf",
+  port: 324,
+  tls: {
+    ca: Bun.file("asdf"),
+    allowPartialTrustChain: true,
+    sessionTimeout: 300,
+    sigalgs: "rsa_pss_rsae_sha256",
+    ecdhCurve: "auto",
+  },
+});
+
+Bun.listen({
+  data: { arg: "asdf" },
+  socket: {
+    data(socket) {
+      socket.data.arg.toLowerCase();
+    },
+    open() {
+      console.log("asdf");
+    },
+  },
   unix: "asdf",
 });
 


### PR DESCRIPTION
### Problem
- Passing `allowPartialTrustChain`, `sessionTimeout`, `sigalgs` or `ecdhCurve` in a `tls` object to `Bun.serve`, `Bun.listen`, `Bun.connect`, `fetch` or `new WebSocket` fails to type-check: `error TS2353: Object literal may only specify known properties, and 'sessionTimeout' does not exist in type 'TLSOptions'` (`TS2769` on the overloaded APIs).
- The runtime accepts all four: `src/runtime/socket/SSLConfig.bindv2.ts:100-114` declares them (the first three since #32630, `ecdhCurve` since #34598), `src/runtime/socket/SSLConfig.rs:179-194` copies them into the shared `SSLConfig`, `src/http/ssl_config.rs:216-223` hands them to usockets, and `packages/bun-usockets/src/crypto/openssl.c:1325-1354` applies them (`SSL_CTX_set_timeout`, `X509_V_FLAG_PARTIAL_CHAIN`, `SSL_CTX_set1_sigalgs_list`, `SSL_CTX_set1_groups_list`).
- Every API above converts its `tls` object with that one converter (`SSLConfig::from_js`), so they all honor the options. Only `interface TLSOptions` in `packages/bun-types/bun.d.ts` never gained the members. `crl`, from the same sync, is #38092; this PR covers the rest.

### Fix
- `packages/bun-types/bun.d.ts`: add the four members to `Bun.TLSOptions`. `BunFetchRequestInitTLS` extends it and the serve/listen/connect/WebSocket option types reference it, so one declaration covers every API.
- Value types are the ones the converter enforces, checked on the released binary: `allowPartialTrustChain` is a strict boolean (`1` throws `ERR_INVALID_ARG_TYPE`), `sessionTimeout` an integer number (`1.5` throws `ERR_OUT_OF_RANGE`, `"300"` throws `ERR_INVALID_ARG_TYPE`), `sigalgs` and `ecdhCurve` strings (`42` / `7` throw `ERR_INVALID_ARG_TYPE`); explicit `undefined` is accepted for all four, hence `| undefined`.
- Each JSDoc claim was checked by running the option through the Bun APIs on the released binary (transcript below): the partial chain verifies on `fetch`, `Bun.connect` and a `requestCert` `Bun.serve` only with the flag; `sigalgs` accepts both TLS 1.3 names and `RSA-PSS+SHA256` style pairs and fails the handshake without an overlap on either side; `ecdhCurve` accepts single names, aliases, colon lists and `"auto"`, and fails the handshake without a shared group; `sessionTimeout: 7` makes the server's TLS 1.2 tickets advertise a 7 second lifetime.
- `sessionTimeout` is documented as applying to TLS 1.2 sessions because that is what the runtime does today: `SSL_CTX_set_timeout` only sets the TLS <= 1.2 lifetime in BoringSSL, and TLS 1.3 tickets keep the 2 day default (`172800` below, where Node prints `7`). That runtime gap is a separate fix in usockets; when it lands the sentence in the JSDoc goes away. Declaring the member now is still right: the option exists, is validated, and does what the JSDoc says.
- `docs/runtime/http/server.mdx`: list the four options in the `TLSOptions` reference block.
- Verification:
  - `test/integration/bun-types/bun-types.test.ts`, new `Bun.TLSOptions` case: type-checks the four members (and rejects the wrong value types) on `Bun.TLSOptions` itself, on `Bun.serve` (single and per-`serverName` array), `Bun.listen`, `Bun.connect`, `fetch` and `WebSocket`. It spawns `tsc` over one file, so it runs on debug builds too; the existing `Bun.mmap` case now shares that helper. Without the `bun.d.ts` hunk it fails with 16 diagnostics; `bun bd test test/integration/bun-types/bun-types.test.ts` passes with it.
  - `test/integration/bun-types/fixture/{serve,tcp,fetch}.ts`: usage lines so the release-only whole-fixture checks cover the members too. With a release build the full file passes (16/16, including `checks with lib.dom.d.ts` and tsgo); without the `bun.d.ts` hunk those cases fail with 17 diagnostics across the three fixtures.

### Background
- `Bun.TLSOptions` is the single TypeScript interface behind the `tls` option of `Bun.serve`, `Bun.listen`, `Bun.connect`, `fetch`, the WebSocket client and the SQL/Redis clients. At runtime all of them convert that object with `SSLConfig::from_js`, generated from `SSLConfig.bindv2.ts`, so the interface is meant to mirror that file's member list.
- A partial trust chain is a certificate chain that ends at an intermediate CA instead of a self-signed root. OpenSSL/BoringSSL normally insist on reaching a self-signed certificate in the trust store (`UNABLE_TO_GET_ISSUER_CERT` otherwise); `X509_V_FLAG_PARTIAL_CHAIN` lets any certificate in the store act as the anchor. Node added the same option in v22.9.
- `sigalgs` configures the TLS signature algorithms: BoringSSL's `SSL_CTX_set1_sigalgs_list` sets both the list this side signs with and the list it accepts from the peer, which is why a server whose key is RSA but whose `sigalgs` only names ECDSA schemes fails every handshake.
- `ecdhCurve` is Node's name for the list of key agreement groups (`SSL_CTX_set1_groups_list`); the handshake needs one group both sides list. `"auto"` is Node's documented default and `SSLConfig.rs:187-193` maps it to "leave BoringSSL's default list alone".
- `test/integration/bun-types` packs `packages/bun-types` and type-checks the `fixture/` directory against it with and without `lib.dom`. Those whole-fixture cases run on release builds only (the in-process TypeScript service is too slow under a debug build), which is why the new coverage also includes a single-file `tsc` case that runs everywhere.

<details>
<summary>Runtime probes on the released binary (bun 1.4.0, Node key fixtures; agent6 is issued by the ca3 intermediate, ca3 by the ca1 root, agent1 has an RSA key)</summary>

`allowPartialTrustChain`, trusting only `ca3`:

```
fetch        allowPartialTrustChain=false: rejected: UNABLE_TO_GET_ISSUER_CERT
fetch        allowPartialTrustChain=true:  HTTP 200
Bun.connect  allowPartialTrustChain=false: authorizationError=UNABLE_TO_GET_ISSUER_CERT
Bun.connect  allowPartialTrustChain=true:  authorizationError=ERR_TLS_CERT_ALTNAME_INVALID   (chain ok; agent6 has no SAN for 127.0.0.1)
Bun.serve    allowPartialTrustChain=false: rejected: ECONNRESET     (requestCert: true, client presents the agent6 leaf)
Bun.serve    allowPartialTrustChain=true:  HTTP 200
allowPartialTrustChain: 1 / "yes" -> ERR_INVALID_ARG_TYPE: TLSOptions.allowPartialTrustChain must be a boolean
```

`sigalgs` (server key is RSA):

```
fetch   (default):                                  HTTP 200
fetch   sigalgs: "rsa_pss_rsae_sha256":             HTTP 200
fetch   sigalgs: "RSA-PSS+SHA256":                  HTTP 200
fetch   sigalgs: "ECDSA+SHA256:RSA-PSS+SHA256":     HTTP 200
fetch   sigalgs: "ecdsa_secp256r1_sha256":          handshake fails
fetch   sigalgs: 42:                                ERR_INVALID_ARG_TYPE
serve   sigalgs: "rsa_pss_rsae_sha256", default client:     HTTP 200
serve   sigalgs: "ecdsa_secp256r1_sha256", default client:  handshake fails
serve   sigalgs: "not-a-sigalg" / "":   throws ERR_SSL_INVALID_SIGNATURE_ALGORITHM
serve   sigalgs: 42:                    throws ERR_INVALID_ARG_TYPE: TLSOptions.sigalgs must be a string
```

`ecdhCurve` (server pinned to `P-384`):

```
fetch   (default):                 HTTP 200
fetch   ecdhCurve: "P-384":        HTTP 200
fetch   ecdhCurve: "secp384r1":    HTTP 200
fetch   ecdhCurve: "auto":         HTTP 200
fetch   ecdhCurve: "X25519:P-256": handshake fails
fetch   ecdhCurve: 7:              ERR_INVALID_ARG_TYPE
serve   ecdhCurve: "auto" / "X25519:P-256:P-384" / "prime256v1" / "X25519MLKEM768": accepted
serve   ecdhCurve: "not-a-curve" / "":  throws ERR_SSL_UNSUPPORTED_ELLIPTIC_CURVE
serve   ecdhCurve: 7:                   throws ERR_INVALID_ARG_TYPE: TLSOptions.ecdhCurve must be a string
```

`sessionTimeout` (ticket lifetime hint seen by `openssl s_client`, server configured with `sessionTimeout: 7`):

```
bun  (Bun.serve and node:tls)   TLSv1.2: 7     TLSv1.3: 172800
node v26.3.0                    TLSv1.2: 7     TLSv1.3: 7
unset                           TLSv1.2: 7200  TLSv1.3: 172800
sessionTimeout: 1.5   -> ERR_OUT_OF_RANGE: TLSOptions.sessionTimeout must be an integer (received 1.5)
sessionTimeout: "300" -> ERR_INVALID_ARG_TYPE: TLSOptions.sessionTimeout must be a number
```

`Bun.listen` + `Bun.connect` and `new WebSocket(url, { tls })` with all four options set: handshake completes / socket opens.

Type-check failure on main, the new test's `tsc` output (trimmed):

```
tls-options-context-options.ts(1,4): error TS2353: ... 'allowPartialTrustChain' does not exist in type 'TLSOptions'.
tls-options-context-options.ts(32,14): error TS2353: ... 'allowPartialTrustChain' does not exist in type 'TLSOptions[] | TLSOptions'.
tls-options-context-options.ts(52,14): error TS2769: No overload matches this call.        (Bun.listen)
tls-options-context-options.ts(64,14): error TS2769: No overload matches this call.        (Bun.connect)
tls-options-context-options.ts(73,14): error TS2769: No overload matches this call.        (fetch)
tls-options-context-options.ts(80,12): error TS2769: No overload matches this call.        (WebSocket)
(16 diagnostics in total)
```

</details>
