### PR TITLE
module loader: report module source text to the GC as extra memory

### DIFF
--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -141,6 +141,17 @@ Ref<SourceProvider> SourceProvider::create(
 
     auto provider = getProvider();
 
+    // The source text is freed when the GC drops the last reference to this provider
+    // (executables, code blocks, VM::sourceProviderCacheMap until the next full GC), so it
+    // has to count as allocation like a JSString's StringImpl does. Otherwise modules whose
+    // JS footprint is tiny next to their source (require() + delete require.cache in a
+    // loop) never request a collection and one copy of the source piles up per load.
+    // cost() reports a StringImpl once and is 0 for static strings. Builtins live as long
+    // as the VM, so reporting them would only be pressure with nothing to reclaim.
+    if (!isBuiltin) {
+        globalObject->vm().heap.deprecatedReportExtraMemory(provider->m_source->cost());
+    }
+
     if (shouldGenerateCodeCoverage) {
         ByteRangeMapping__generate(Bun::toString(provider->sourceURL()), Bun::toString(provider->source().toStringWithoutCopying()), provider->asID());
     }

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -281,6 +281,127 @@ describe.concurrent("require.cache", () => {
     ); // takes 4s on an M1 in release build
   });
 
+  // A module's source text is native memory that is only released by the GC (the
+  // SourceProvider dies with the executables that reference it). The loader reports
+  // that memory to JSC, so loading modules counts as GC pressure like any other string
+  // allocation. The fixtures below check that on a fresh VM, where the only thing
+  // that can trigger a collection is the loads themselves.
+  describe("module source text is reported to the GC", () => {
+    // Every fixture module is one big string literal, so the transpiled output is at
+    // least LITERAL_LENGTH bytes while evaluating it allocates a few hundred bytes on
+    // the JS heap: without the report, nothing about these loads is visible to the GC.
+    const LITERAL_LENGTH = 1024 * 1024;
+    const literal = Buffer.alloc(LITERAL_LENGTH, "a").toString();
+    const modules = {
+      "cjs.js": `const big = "${literal}";\nmodule.exports = big.length;\n`,
+      "esm.mjs": `const big = "${literal}";\nexport default big.length;\n`,
+      // The same modules as `bun build --target=bun` emits them: the "// @bun" pragma
+      // makes the loader hand the file to JSC as-is, which is much cheaper than
+      // transpiling 1 MB per iteration of the loop below, and covers that loader path.
+      "prebuilt-cjs.js": `// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {const big = "${literal}";\nmodule.exports = big.length;\n})`,
+      "prebuilt-esm.mjs": `// @bun\nconst big = "${literal}";\nexport default big.length;\n`,
+    };
+
+    async function runFixture(name: string, fixture: string) {
+      await using dir = tempDir(name, { ...modules, "report-source-fixture.js": fixture });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", join(String(dir), "report-source-fixture.js")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    // process.memoryUsage().external is JSC's extra memory counter, which is what the
+    // loader reports into. It only goes down on a full collection, and one load is far
+    // below the budget that would request one, so the growth is what the load reported.
+    // The fixtures print the growth per module; this turns it into a per-module verdict.
+    function reportedBytes(growthByModule: Record<string, number>) {
+      return Object.fromEntries(
+        Object.entries(growthByModule).map(([file, growth]) => [
+          file,
+          growth >= LITERAL_LENGTH ? "reported" : `reported only ${growth} bytes for a ${LITERAL_LENGTH} byte literal`,
+        ]),
+      );
+    }
+
+    test("require() reports the size of the module's source", async () => {
+      const growth = await runFixture(
+        "require-cache-report-source-cjs",
+        `
+          const growth = {};
+          for (const file of ["./cjs.js", "./prebuilt-cjs.js"]) {
+            Bun.gc(true);
+            const before = process.memoryUsage().external;
+            require(file);
+            growth[file] = process.memoryUsage().external - before;
+          }
+          console.log(JSON.stringify(growth));
+        `,
+      );
+      expect(reportedBytes(growth)).toEqual({ "./cjs.js": "reported", "./prebuilt-cjs.js": "reported" });
+    });
+
+    test("import() reports the size of the module's source", async () => {
+      const growth = await runFixture(
+        "require-cache-report-source-esm",
+        `
+          (async () => {
+            const growth = {};
+            for (const file of ["./esm.mjs", "./prebuilt-esm.mjs"]) {
+              Bun.gc(true);
+              const before = process.memoryUsage().external;
+              await import(file);
+              growth[file] = process.memoryUsage().external - before;
+            }
+            console.log(JSON.stringify(growth));
+          })();
+        `,
+      );
+      expect(reportedBytes(growth)).toEqual({ "./esm.mjs": "reported", "./prebuilt-esm.mjs": "reported" });
+    });
+
+    // The scenario the report exists for: a synchronous loop that loads a module and drops
+    // it again. Nothing runs between iterations (no event loop turn, so no GC timer), so a
+    // collection during the loop can only be requested by the loads themselves. Without
+    // the report none is, and every iteration's Module object (and the source copy behind
+    // it) is still alive at the end. With it, JSC collects every few MB of loaded source,
+    // so at most the last few iterations are.
+    test("a synchronous require() + delete require.cache loop triggers collections", async () => {
+      const LOADS = 32;
+      const result = await runFixture(
+        "require-cache-report-source-loop",
+        `
+          const { heapStats } = require("bun:jsc");
+          const file = require.resolve("./prebuilt-cjs.js");
+          const liveModules = () => heapStats().objectTypeCounts.Module;
+          function load() {
+            require(file);
+            delete require.cache[file];
+            module.children.length = 0;
+          }
+
+          Bun.gc(true);
+          const baseline = liveModules();
+          load();
+          // A single load stays below the GC budget, so the counter must see exactly that module.
+          const afterOneLoad = liveModules() - baseline;
+          for (let i = 1; i < ${LOADS}; i++) load();
+          const afterLoop = liveModules() - baseline;
+          console.log(JSON.stringify({ afterOneLoad, afterLoop }));
+        `,
+      );
+      expect(result).toEqual({ afterOneLoad: 1, afterLoop: expect.any(Number) });
+      // Collections are requested every ~8 MB of loaded source (the eden budget), so this
+      // is around 6 on any build; without the report it is exactly LOADS.
+      expect(result.afterLoop).toBeLessThanOrEqual(LOADS / 2);
+    });
+  });
+
   describe("files transpiled and loaded don't leak the AST", () => {
     test("via require()", async () => {
       await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem

- `require(file); delete require.cache[file]` in a loop grows RSS by about the module's source size on every load, without bound: 1023 KB per load for a module holding a 1 MB string literal, still linear after 600 loads. `await import(file); delete require.cache[file]` does the same (1024 KB per load). The JS heap stays flat the whole time.
- Nothing is leaked: every load copies the transpiled source into a `WTF::StringImpl` owned by the module's `Zig::SourceProvider` (`src/jsc/bindings/ZigSourceProvider.cpp`, `SourceProvider::create`), and `Bun.gc(true)` frees all of the copies (the live allocations of a 50 load loop drop from 54 x 1 MB to the baseline). The copies pile up because no collection ever runs: JSC was never told those bytes exist, and evaluating such a module allocates about 200 bytes on the JS heap (`BUN_JSC_logGC`: `normal bytes: 168`), so its 8 MB allocation budget is never reached. Bun's own GC timer does not run inside a synchronous loop either, and in the `import()` case it asks for an unscoped collection once a second, which JSC runs as an eden collection since nothing has scheduled a full one, and eden collections do not release the strings (see Background).
- The measurements that surfaced this concluded the retention tracked string literal bytes. It tracks source size; the control module it used (1 MB of `var` statements) allocates enough JS heap per load to trigger collections on its own, which is also why the existing fixtures in `require-cache.test.ts` (10000 exports or 20000 calls per module) never saw this.

### Fix

- `SourceProvider::create` reports the source's `StringImpl::cost()` through `Heap::deprecatedReportExtraMemory` for non builtin modules.
- This is the accounting a `JSString` applies to its own `StringImpl` (`JSString::finishCreation` reports `cost()`); a module's source is the same kind of object, native bytes whose lifetime ends when the GC drops the cells referencing them, so it has to count toward the allocation budget the same way. `deprecatedReportExtraMemory` is JSC's API for memory that is not owned by a single cell (it is what `JSReportExtraMemoryCost` and WebCore's image and document wrappers use); there is no cell here whose lifetime matches the provider's.
- The deprecated variant is also what makes the fix work, not just a convenience: the reported bytes drive `didAllocate`, so a burst of loads requests an eden collection about every 8 MB of source, and they stay in `extraMemorySize()` until a full collection, so after that eden collection the old generation ratio check (`minEdenToOldGenerationRatio`) schedules the full collection that clears `sourceProviderCacheMap` and frees the strings. A plain `reportExtraMemoryAllocated` with no cell would only ever produce eden collections, which free nothing here. With `BUN_JSC_logGC=1`, a 40 load loop now shows 3 eden and 2 full collections, each requested at `oversized bytes: 7340900` or so, i.e. by the reported sources.
- `cost()` reports a given `StringImpl` once and is 0 for static strings, so a provider built over a string that already went through a `JSString` (plugins) or a shared string is not counted twice. Builtins are skipped because they live as long as the VM, so reporting them would be pressure with nothing to reclaim; `process.memoryUsage().external` after requiring 7 builtins is unchanged (834 bytes before and after).
- Results (release build): the 1 MB module loop goes from 1023 KB per load to 3 KB per load over 300 loads (7 KB over 600); a module that is a 150k element array literal goes from 1044 to 45 KB per load; the `import()` + `delete require.cache` loop from 1024 to 59 KB per load; live allocations after a 50 load loop with no manual GC: 5 x 1 MB instead of 54. Loading a 1000 module graph (12 MB of source) and 200 modules of 100 KB string data (20 MB, the shape that gains the most collections: 3 instead of 1) take the same wall time as before within noise (medians 245 vs 239 ms and 39 vs 41 ms); `test/js/bun/resolve/load-same-js-file-a-lot.test.ts` (10000 imports) is unchanged within noise.
- Tests: `test/cli/run/require-cache.test.ts`, describe `module source text is reported to the GC`. Two fixtures check that `process.memoryUsage().external` (which is `extraMemorySize()`) grows by at least the literal's size after loading a transpiled and a `// @bun` prebuilt module, via `require()` and via `import()`; before this change they report 0 bytes (1571 for the ESM record). The third runs the synchronous loop over a prebuilt 1 MB module and reads `heapStats().objectTypeCounts.Module` without forcing a GC: before this change exactly 32 of 32 Module objects are still alive, after it about 6 (the last budget's worth; the bound is 16). The fixtures are JSC level rather than RSS based so they hold under ASAN, where freed strings sit in the quarantine, and they run in fresh processes so the loads are the only possible trigger. The prebuilt form is used for the loop because it skips transpiling 1 MB per iteration in debug builds; it reaches the same `SourceProvider::create`.
- Verified: the three new tests fail on the build without the change and pass with it, in both debug (`bun bd test`) and release; the whole file passes in release (the 7 other leak fixtures in it time out under debug builds with or without this change, as noted in their own timeouts). `gc-controller-cadence`, `crypto-extra-memory` and `v8-module` tests pass. As a GC safety check for the new request point, `BUN_JSC_gcMaxHeapSize=8192` (a collection requested at nearly every `create()`) over `test/cli/run` module loading tests and `test/js/bun/resolve` ran 379 tests with no crashes.

### Background

- `Zig::SourceProvider` is Bun's `JSC::SourceProvider`: it owns the module's source text as a `WTF::StringImpl` and is reference counted from the `SourceCode` objects held by JSC's executables and code blocks, so it is destroyed by GC when those cells die. For CommonJS it is created in `JSCommonJSModule.cpp`, for ESM in `ModuleLoader.cpp`; both go through `SourceProvider::create`.
- `VM::sourceProviderCacheMap` is a JSC parser cache keyed by `RefPtr<SourceProvider>`. Every `Parser` construction adds its provider to it, and it is cleared in `Heap::deleteSourceProviderCaches`, which only does so after a full collection. This is why module sources are released by full collections specifically, and why an eden collection (what Bun's timer or a plain allocation trigger produces) does not help.
- JSC's extra memory accounting: `reportExtraMemoryAllocated(cell, bytes)` / `reportExtraMemoryVisited` tie native bytes to a cell; `deprecatedReportExtraMemory(bytes)` adds them to a counter that is reset at the next full collection. Both feed `Heap::didAllocate`, and a collection is requested once the bytes allocated in the current cycle exceed the budget (Bun sets the initial budget, `largeHeapSize`, to 8 MB). Reports of 64 KB or more count as oversized and are ignored while the last one is more than a third of the cycle's allocation, which with equal sized modules means a collection is requested by the third load at the latest. `process.memoryUsage().external` and `bun:jsc`'s `heapStats().extraMemorySize` both expose `extraMemorySize()`.
- `StringImpl::cost()` returns the string's byte size the first time it is called on an impl and 0 afterwards (and always 0 for static strings); it exists for exactly this kind of one time report.
- `// @bun` / `// @bun @bun-cjs` is the pragma `bun build --target=bun` puts at the top of its output; the runtime loader passes such files to JSC without transpiling them.
