### PR TITLE
bun:jsc: add noDFG and use it for the jsc-stress preload's noDFG global

### DIFF
--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -14,7 +14,26 @@ declare module "bun:jsc" {
   function setRandomSeed(value: number): void;
   function isRope(input: string): boolean;
   function callerSourceOrigin(): string;
-  function noFTL(func: (...args: any[]) => any): (...args: any[]) => any;
+  /**
+   * Prevents JavaScriptCore from inlining `func` into its callers.
+   *
+   * Call it before `func` runs for the first time.
+   */
+  function noInline(func: (...args: any[]) => any): void;
+  /**
+   * Keeps `func` out of both optimizing JIT tiers (DFG and FTL), so it only
+   * ever runs in the interpreter or the baseline JIT. Same as `noDFG` in the
+   * `jsc` shell.
+   *
+   * Call it before `func` runs for the first time.
+   */
+  function noDFG(func: (...args: any[]) => any): void;
+  /**
+   * Keeps `func` out of the FTL tier only; it can still be compiled by the DFG.
+   *
+   * Call it before `func` runs for the first time.
+   */
+  function noFTL(func: (...args: any[]) => any): void;
   function noOSRExitFuzzing(func: (...args: any[]) => any): (...args: any[]) => any;
   function optimizeNextInvocation(func: (...args: any[]) => any): void;
   function numberOfDFGCompiles(func: (...args: any[]) => any): number;

--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -34,7 +34,7 @@ declare module "bun:jsc" {
    * Call it before `func` runs for the first time.
    */
   function noFTL(func: (...args: any[]) => any): void;
-  function noOSRExitFuzzing(func: (...args: any[]) => any): (...args: any[]) => any;
+  function noOSRExitFuzzing(func: (...args: any[]) => any): void;
   function optimizeNextInvocation(func: (...args: any[]) => any): void;
   function numberOfDFGCompiles(func: (...args: any[]) => any): number;
   function releaseWeakRefs(): void;

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -547,8 +547,6 @@ JSC_DEFINE_HOST_FUNCTION(functionCallerSourceOrigin,
     return JSValue::encode(jsString(vm, sourceOrigin.string()));
 }
 
-// Same as the jsc shell's noDFG: the function never enters an optimizing tier
-// (DFG or FTL), unlike noFTL below, which only keeps it out of the FTL.
 JSC_DECLARE_HOST_FUNCTION(functionNoDFG);
 JSC_DEFINE_HOST_FUNCTION(functionNoDFG,
     (JSGlobalObject * globalObject,

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -547,6 +547,16 @@ JSC_DEFINE_HOST_FUNCTION(functionCallerSourceOrigin,
     return JSValue::encode(jsString(vm, sourceOrigin.string()));
 }
 
+// Same as the jsc shell's noDFG: the function never enters an optimizing tier
+// (DFG or FTL), unlike noFTL below, which only keeps it out of the FTL.
+JSC_DECLARE_HOST_FUNCTION(functionNoDFG);
+JSC_DEFINE_HOST_FUNCTION(functionNoDFG,
+    (JSGlobalObject * globalObject,
+        CallFrame* callFrame))
+{
+    return JSValue::encode(setNeverOptimize(globalObject, callFrame));
+}
+
 JSC_DECLARE_HOST_FUNCTION(functionNoFTL);
 JSC_DEFINE_HOST_FUNCTION(functionNoFTL,
     (JSGlobalObject*, CallFrame* callFrame))
@@ -994,6 +1004,7 @@ JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * 
     noInline                            functionNeverInlineFunction                 Function    0
     isRope                              functionIsRope                              Function    0
     memoryUsage                         functionCreateMemoryFootprint               Function    0
+    noDFG                               functionNoDFG                               Function    0
     noFTL                               functionNoFTL                               Function    0
     noOSRExitFuzzing                    functionNoOSRExitFuzzing                    Function    0
     numberOfDFGCompiles                 functionNumberOfDFGCompiles                 Function    0
@@ -1017,7 +1028,7 @@ JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * 
 namespace Zig {
 DEFINE_NATIVE_MODULE(BunJSC)
 {
-    INIT_NATIVE_MODULE(BunJSC, 36);
+    INIT_NATIVE_MODULE(BunJSC, 37);
 
     putNativeFn(Identifier::fromString(vm, "callerSourceOrigin"_s), functionCallerSourceOrigin);
     putNativeFn(Identifier::fromString(vm, "jscDescribe"_s), functionDescribe);
@@ -1034,6 +1045,7 @@ DEFINE_NATIVE_MODULE(BunJSC)
     putNativeFn(Identifier::fromString(vm, "noInline"_s), functionNeverInlineFunction);
     putNativeFn(Identifier::fromString(vm, "isRope"_s), functionIsRope);
     putNativeFn(Identifier::fromString(vm, "memoryUsage"_s), functionCreateMemoryFootprint);
+    putNativeFn(Identifier::fromString(vm, "noDFG"_s), functionNoDFG);
     putNativeFn(Identifier::fromString(vm, "noFTL"_s), functionNoFTL);
     putNativeFn(Identifier::fromString(vm, "noOSRExitFuzzing"_s), functionNoOSRExitFuzzing);
     putNativeFn(Identifier::fromString(vm, "numberOfDFGCompiles"_s), functionNumberOfDFGCompiles);

--- a/test/integration/bun-types/fixture/jsc.ts
+++ b/test/integration/bun-types/fixture/jsc.ts
@@ -1,5 +1,5 @@
 import { deepEquals } from "bun";
-import { deserialize, noDFG, noFTL, noInline, numberOfDFGCompiles, serialize } from "bun:jsc";
+import { deserialize, noDFG, noFTL, noInline, noOSRExitFuzzing, numberOfDFGCompiles, serialize } from "bun:jsc";
 import { expectType } from "./utilities";
 const obj = { a: 1, b: 2 };
 const buffer = serialize(obj);
@@ -16,4 +16,5 @@ function add(a: number, b: number) {
 expectType(noInline(add)).is<void>();
 expectType(noDFG(add)).is<void>();
 expectType(noFTL(add)).is<void>();
+expectType(noOSRExitFuzzing(add)).is<void>();
 expectType(numberOfDFGCompiles(add)).is<number>();

--- a/test/integration/bun-types/fixture/jsc.ts
+++ b/test/integration/bun-types/fixture/jsc.ts
@@ -1,5 +1,6 @@
 import { deepEquals } from "bun";
-import { deserialize, serialize } from "bun:jsc";
+import { deserialize, noDFG, noFTL, noInline, numberOfDFGCompiles, serialize } from "bun:jsc";
+import { expectType } from "./utilities";
 const obj = { a: 1, b: 2 };
 const buffer = serialize(obj);
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -8,3 +9,11 @@ const clone = deserialize(buffer);
 if (deepEquals(obj, clone)) {
   console.log("They are equal!");
 }
+
+function add(a: number, b: number) {
+  return a + b;
+}
+expectType(noInline(add)).is<void>();
+expectType(noDFG(add)).is<void>();
+expectType(noFTL(add)).is<void>();
+expectType(numberOfDFGCompiles(add)).is<number>();

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -315,3 +315,35 @@ describe.concurrent("JSC JIT Stress Tests", () => {
     }
   });
 });
+
+// The ffi fixtures compare a hot function against a twin they pin with noDFG,
+// which in the jsc shell keeps the twin in the interpreter/baseline so that it
+// serves as the oracle for the DFG and FTL. The preload has to give noDFG that
+// same meaning: a twin that still tiers up (as it did while noDFG aliased
+// noFTL) would compare DFG code against DFG code.
+test(
+  "preload.js noDFG keeps the pinned twin out of the DFG",
+  async () => {
+    const script = `
+      function ref(i) { return i + 1; }
+      function hot(i) { return i + 1; }
+      noDFG(ref);
+      noInline(ref);
+      noInline(hot);
+      for (let i = 0; i < 1_000_000 && numberOfDFGCompiles(hot) === 0; i++) {
+        ref(i);
+        hot(i);
+      }
+      print(JSON.stringify({ ref: numberOfDFGCompiles(ref), hotTieredUp: numberOfDFGCompiles(hot) > 0 }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", preloadPath, "-e", script],
+      env: fixtureEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '{"ref":0,"hotTieredUp":true}\n', stderr: "", exitCode: 0 });
+  },
+  fixtureTimeout,
+);

--- a/test/js/bun/jsc-stress/preload.js
+++ b/test/js/bun/jsc-stress/preload.js
@@ -1,7 +1,7 @@
 // JSC test harness polyfills for Bun
 // These globals are used by JSC stress tests but are not available in Bun.
 
-// noInline: hints JSC to not inline the function. No-op in Bun.
+// noInline: marks the function as never inlined, same as the jsc shell.
 globalThis.noInline = require("bun:jsc").noInline;
 
 // Debug builds (incl. `bun bd`) run JIT code far slower; reduce loop counts
@@ -31,4 +31,4 @@ globalThis.gc = () => Bun.gc(true);
 globalThis.fullGC = jsc.fullGC;
 globalThis.edenGC = jsc.edenGC;
 globalThis.numberOfDFGCompiles = jsc.numberOfDFGCompiles;
-globalThis.noDFG = jsc.noFTL;
+globalThis.noDFG = jsc.noDFG;

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -13,6 +13,9 @@ import {
   isRope,
   describe as jscDescribe,
   memoryUsage,
+  noDFG,
+  noFTL,
+  noInline,
   numberOfDFGCompiles,
   optimizeNextInvocation,
   profile,
@@ -81,7 +84,42 @@ describe("bun:jsc", () => {
   it("callerSourceOrigin", () => {
     expect(callerSourceOrigin()).toBe(import.meta.url);
   });
-  it("noFTL", () => {});
+  it("noDFG keeps a function out of the DFG, noFTL only keeps it out of the FTL", () => {
+    function pinned(i: number) {
+      return i + 1;
+    }
+    function ftlPinned(i: number) {
+      return i + 1;
+    }
+    function unpinned(i: number) {
+      return i + 1;
+    }
+    expect(noDFG(pinned)).toBeUndefined();
+    expect(noFTL(ftlPinned)).toBeUndefined();
+    noInline(pinned);
+    noInline(ftlPinned);
+    noInline(unpinned);
+
+    // numberOfDFGCompiles() becomes non-zero once DFG (or FTL) code has replaced
+    // the function's baseline code. The DFG compiles on a background thread, so
+    // keep calling all three until the two that are allowed to tier up have
+    // done so; the noDFG'd twin receives the same calls and must still be at 0.
+    for (
+      let i = 0;
+      i < 1_000_000 && (numberOfDFGCompiles(ftlPinned) === 0 || numberOfDFGCompiles(unpinned) === 0);
+      i++
+    ) {
+      pinned(i);
+      ftlPinned(i);
+      unpinned(i);
+    }
+
+    expect({
+      pinned: numberOfDFGCompiles(pinned),
+      ftlPinnedTieredUp: numberOfDFGCompiles(ftlPinned) > 0,
+      unpinnedTieredUp: numberOfDFGCompiles(unpinned) > 0,
+    }).toEqual({ pinned: 0, ftlPinnedTieredUp: true, unpinnedTieredUp: true });
+  });
   it("noOSRExitFuzzing", () => {});
   it("optimizeNextInvocation", () => {
     count();


### PR DESCRIPTION
### Problem
- `test/js/bun/jsc-stress/preload.js` defined the `noDFG` global the jsc-stress fixtures use as `require("bun:jsc").noFTL`, because `bun:jsc` had no `noDFG`.
- `noFTL` (`src/jsc/modules/BunJSCModule.h`, `functionNoFTL`) only sets `neverFTLOptimize`, which JSC consults in `FTLCapabilities.cpp` alone. The jsc shell's `noDFG` is JSC's `setNeverOptimize` (`jsc.cpp`, `functionNoDFG`), which sets `neverOptimize`; `DFGCapabilities.cpp` then reports the function as not compilable, so it never leaves the interpreter/baseline.
- Seven ffi fixtures (`ffi-view-args.js`, `ffi-buffer-length.js`, `ffi-tailcall.js`, `ffi-untyped-float-args.js`, `ffi-ptr-object-arg.js`, `ffi-non-int32-int-args.js`, `ffi-untyped-int-stack-args.js`) are tier differentials: a hot function is compared on every call against a `noDFG`-pinned twin that is supposed to be the out-of-line C++ conversion oracle. With the alias, the twins were DFG-compiled too, so the fixtures compared the DFG's FFI lowering against itself and a bug shared by the DFG and FTL paths would cancel out. Running `ffi-buffer-length.js` under the old preload and printing `numberOfDFGCompiles` of its oracles gives `refByteLength: 1, refLastByte: 1`; the fixtures passed, they just covered less than their comments claim.

### Fix
- `src/jsc/modules/BunJSCModule.h`: export `noDFG` from `bun:jsc`, implemented as `setNeverOptimize(globalObject, callFrame)`, the same TestRunnerUtils call the jsc shell's `noDFG` makes (and the same shape as the module's existing `noInline`, which is `setNeverInline`). The export count passed to `INIT_NATIVE_MODULE` goes from 36 to 37.
- `test/js/bun/jsc-stress/preload.js`: `globalThis.noDFG = jsc.noDFG` (the fixing line). Also corrects the comment that called `noInline` a no-op; it has been the real `setNeverInline` since the preload was added.
- Correct because the fixtures are written for the jsc shell and now get the shell's exact mechanism: `neverOptimize` blocks both the DFG and the FTL, so the oracle twins stay in LLInt/baseline and the fixtures compare the JIT tiers against the C++ conversion path, as they describe. The fixtures themselves are untouched: they are verbatim copies of `vendor/WebKit/JSTests/stress/ffi-*.js`, so the guard lives in the test runner instead.
- `packages/bun-types/jsc.d.ts`: declare `noDFG`, declare `noInline` (exported but previously untyped), and change `noFTL` and `noOSRExitFuzzing` to return `void`; both were declared as returning a function but their host functions return `jsUndefined()` (checked at runtime: all four helpers return `undefined`). The three tier helpers get a one-line JSDoc saying which tiers they block. `test/integration/bun-types/fixture/jsc.ts` compiles the four.
- Tests:
  - `test/js/bun/jsc/bun-jsc.test.ts`: three identical functions warmed by one loop; the `noDFG` one must report `numberOfDFGCompiles() === 0` while the `noFTL` one and the unpinned one tier up. Replaces the empty `noFTL` placeholder test. Without the export the file fails to link (`Export named 'noDFG' not found in module 'bun:jsc'`).
  - `test/js/bun/jsc-stress/jsc-stress.test.ts`: runs a twin pair under `--preload preload.js` exactly as the fixtures do and asserts the pinned twin stays at 0 DFG compiles. Fails on the unfixed build (`noDFG is not a function`) and, checked separately, also fails against the old `noFTL` alias (`ref: 1` in 5 of 5 runs). It uses only `bun:jsc`, so unlike the ffi fixtures it does not need `$vm` and runs on every lane.
- Verified: `bun bd test test/js/bun/jsc/bun-jsc.test.ts` (36 pass) and `bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts` (116 pass, the ffi fixtures now running against truly pinned oracles); `bun test test/integration/bun-types/bun-types.test.ts` (15 pass); under `USE_SYSTEM_BUN=1` both new tests fail as described above. The slowest ffi fixtures take the same time with either preload on a debug build (`ffi-view-args.js` 79s before, 71s after; `ffi-ptr-object-arg.js` 39s before, 42s after), so the change does not move them toward the per-fixture timeout.

### Background
- JSC runs a function in up to four tiers: LLInt (interpreter), baseline JIT, DFG, and FTL. The DFG and FTL are the optimizing tiers; a hot function tiers up through them over time.
- `ScriptExecutable` carries two test-only flags: `neverOptimize` (checked by `DFG::mightCompile*`, so the function is never admitted to the DFG, and therefore never reaches the FTL either) and `neverFTLOptimize` (checked only when the DFG considers handing the function to the FTL). The jsc shell exposes them as `noDFG` and `noFTL`; `noInline` is a third flag that keeps the function from being inlined into callers, which these tests need so the twins get their own code blocks.
- `numberOfDFGCompiles(fn)` (already exported by `bun:jsc`) returns non-zero once an optimizing-tier code block has replaced the function's baseline code, which is how the tests observe whether a function tiered up.
- A tier-differential test pins a reference copy of a function below the optimizing tiers and compares it against a hot copy on every call; the reference is only an oracle if it genuinely runs the unoptimized path.
- `$vm` (`--useDollarVM`) is JSC's debugging object; in Bun's WebKit it carries the `ffiFunction` helpers the ffi fixtures use, and it is only built into assertion-enabled binaries, which is why the fixtures themselves only run on those lanes.
