### PR TITLE
shell: make shellInternals.builtinDisabled honor BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -83,7 +83,9 @@ export const shellInternals = {
   lex: (a, ...b) => shellLex(a.raw, b),
   parse: (a, ...b) => shellParse(a.raw, b),
   /**
-   * Checks if the given builtin is disabled on the current platform
+   * Checks if the shell runs the system binary instead of the given builtin in
+   * this process: true on POSIX for the builtins gated behind
+   * `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS` unless that variable is set.
    *
    * @example
    * ```typescript

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -107,7 +107,7 @@ macro_rules! shell_builtins {
             }
 
             /// argv[0] → `Kind`, no POSIX gating.
-            fn from_argv0_raw(s: &[u8]) -> Option<Kind> {
+            pub(crate) fn from_argv0_raw(s: &[u8]) -> Option<Kind> {
                 $( if s == $u_name.as_bytes() { return Some(Kind::$UV); } )*
                 $( if s == $i_name.as_bytes() { return Some(Kind::$IV); } )*
                 $( if s == $b_name.as_bytes() { return Some(Kind::$BV); } )*
@@ -203,14 +203,20 @@ impl Kind {
             .unwrap_or(false)
     }
 
+    /// The only gate between argv[0] naming a builtin and the shell running it;
+    /// `shellInternals.builtinDisabled` reports this same answer to tests.
+    pub(crate) fn disabled_on_this_platform(self) -> bool {
+        if cfg!(windows) || Self::force_enable_on_posix() {
+            return false;
+        }
+        Self::DISABLED_ON_POSIX.contains(&self)
+    }
+
     /// Maps argv[0] to a builtin kind, or `None` to fall through to
     /// subprocess spawn.
     pub(crate) fn from_argv0(s: &[u8]) -> Option<Kind> {
         let result = Self::from_argv0_raw(s)?;
-        if cfg!(windows) || Self::force_enable_on_posix() {
-            return Some(result);
-        }
-        if Self::DISABLED_ON_POSIX.contains(&result) {
+        if result.disabled_on_this_platform() {
             return None;
         }
         Some(result)

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -746,43 +746,33 @@ impl<'a> ShellSrcBuilder<'a> {
 /// Used in JS tests, see `internal-for-testing.ts` and shell tests.
 pub mod testing_apis {
     use super::*;
+    use crate::shell::builtin::Kind;
 
+    /// `shellInternals.builtinDisabled(name)`: true when `name` is a builtin
+    /// that `Kind::from_argv0` would not dispatch in this process.
     #[bun_jsc::host_fn]
     pub(crate) fn disabled_on_this_platform(
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        #[cfg(windows)]
-        {
-            let _ = (global, callframe);
-            return Ok(JSValue::FALSE);
-        }
-        #[cfg(not(windows))]
-        {
-            // SAFETY: bun_vm() is non-null for a Bun-owned global.
-            let vm = global.bun_vm();
-            let mut arguments = jsc::ArgumentsSlice::init(vm, callframe.arguments());
-            let string: JSValue = match arguments.next_eat() {
-                Some(s) => s,
-                None => {
-                    return Err(global.throw(format_args!(
-                        "shellInternals.disabledOnPosix: expected 1 arguments, got 0"
-                    )));
-                }
-            };
-
-            let bunstr = OwnedString::new(string.to_bun_string(global)?);
-            let utf8str = bunstr.to_utf8();
-
-            for disabled in crate::shell::builtin::Kind::DISABLED_ON_POSIX {
-                // `strum::IntoStaticStr` would yield the PascalCase variant name
-                // ("Cp"), so use `Kind::as_str` for the lowercase name.
-                if utf8str.slice() == disabled.as_str().as_bytes() {
-                    return Ok(JSValue::TRUE);
-                }
+        // SAFETY: bun_vm() is non-null for a Bun-owned global.
+        let vm = global.bun_vm();
+        let mut arguments = jsc::ArgumentsSlice::init(vm, callframe.arguments());
+        let string: JSValue = match arguments.next_eat() {
+            Some(s) => s,
+            None => {
+                return Err(global.throw(format_args!(
+                    "shellInternals.builtinDisabled: expected 1 arguments, got 0"
+                )));
             }
-            Ok(JSValue::FALSE)
-        }
+        };
+
+        let bunstr = OwnedString::new(string.to_bun_string(global)?);
+        let utf8str = bunstr.to_utf8();
+
+        let disabled =
+            Kind::from_argv0_raw(utf8str.slice()).is_some_and(Kind::disabled_on_this_platform);
+        Ok(JSValue::js_boolean(disabled))
     }
 
     /// Codegen (`generated_js2native.rs`) wraps this with `host_fn_result`, so we

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDirWithFiles } from "harness";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +171,53 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+describe("shellInternals.builtinDisabled", () => {
+  // The describe.if gate above is only trustworthy if builtinDisabled() matches
+  // what the interpreter actually dispatches. The env var is read once per
+  // process, so each configuration runs in its own child. With an empty PATH a
+  // name the interpreter does not run as a builtin fails with "command not
+  // found" instead of reaching the system binary.
+  const report = /* ts */ `
+    import { $ } from "bun";
+    import { shellInternals } from "bun:internal-for-testing";
+    const out = {};
+    for (const name of ["cp", "cat", "ls", "not-a-builtin"]) {
+      const { stderr } = await $\`\${name} /definitely/missing\`.env({ PATH: "" }).nothrow().quiet();
+      out[name] = {
+        builtinDisabled: shellInternals.builtinDisabled(name),
+        ranAsBuiltin: !stderr.toString().includes("command not found: " + name),
+      };
+    }
+    console.log(JSON.stringify(out));
+  `;
+
+  test.concurrent.each([
+    ["set", "1", false],
+    ["unset", undefined, !isWindows],
+  ] as const)(
+    "agrees with dispatch when BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS is %s",
+    async (_, value, gatedDisabled) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", report],
+        env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: value },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      const gated = { builtinDisabled: gatedDisabled, ranAsBuiltin: !gatedDisabled };
+      expect(JSON.parse(stdout)).toEqual({
+        cp: gated,
+        cat: gated,
+        ls: { builtinDisabled: false, ranAsBuiltin: true },
+        "not-a-builtin": { builtinDisabled: false, ranAsBuiltin: false },
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
 });
 
 function expectSortedOutput(expected: string) {


### PR DESCRIPTION
### Problem
- `shellInternals.builtinDisabled("cp")` (and `"cat"`) returns `true` on Linux/macOS even when `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is set, so `describe.if(!builtinDisabled("cp"))` in `test/js/bun/shell/commands/cp.test.ts` skips all 30 tests with the flag set (`BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun test test/js/bun/shell/commands/cp.test.ts` -> 30 skip).
- With the same flag the interpreter does run `cp` and `cat` as builtins: `Kind::from_argv0` (`src/runtime/shell/Builtin.rs`) checks `force_enable_on_posix()` before `DISABLED_ON_POSIX`.
- `testing_apis::disabled_on_this_platform` (`src/runtime/shell/shell_body.rs`, the binding behind `builtinDisabled`) only scanned `DISABLED_ON_POSIX` and never looked at the flag, so it disagreed with the dispatch decision it exists to report. On POSIX the cp/cat builtin suites were only runnable on Windows; cp PRs have been working around this by spawning a child bun with the flag per test.

### Fix
- Adds `Kind::disabled_on_this_platform(self)`, holding the gate that used to be inlined in `from_argv0` (Windows or flag set -> never disabled; otherwise `DISABLED_ON_POSIX`). `from_argv0` uses it.
- The testing API becomes `Kind::from_argv0_raw(name).is_some_and(Kind::disabled_on_this_platform)`, so `builtinDisabled(name)` is by construction "`name` is a builtin and `from_argv0` would not dispatch it". The Windows `#[cfg]` special case goes away because the predicate already covers it. The JSDoc on `shellInternals.builtinDisabled` now says that this is what it reports.
- Why this is correct: the only consumer of this API is the `describe.if` skip gate, whose purpose is to skip the builtin suite exactly when the builtin is not what runs. Sharing the predicate with dispatch is the only way the two cannot drift again. Observable behavior is unchanged everywhere except the flag-set case on POSIX: Windows still reports `false` for everything, POSIX without the flag still reports `true` for `cp`/`cat`, builtins outside the list and unknown names still report `false`, and `from_argv0` makes the same decisions as before.
- Test: `test/js/bun/shell/commands/cp.test.ts`, `describe("shellInternals.builtinDisabled")`. Each configuration (flag set, flag unset) runs in a child process because the flag is cached per process. The child reports `builtinDisabled(name)` next to whether the interpreter actually ran `name` as a builtin (`PATH` is emptied, so a non-builtin dispatch fails with `command not found`) for `cp`, `cat`, `ls` and a non-builtin name, and the test pins both columns.
  - Before the fix (system bun and `bun bd` with `src/` stashed): the flag-set case fails with `builtinDisabled: true` next to `ranAsBuiltin: true` for `cp` and `cat`; the flag-unset case passes both before and after.
  - `bun bd test test/js/bun/shell/commands/cp.test.ts`: 2 pass, 30 skip (flag not set).
  - `bun bd test test/js/bun/shell/exec.test.ts test/js/bun/shell/yield.test.ts`: pass.
- With the flag set, the cp suite now runs on Linux (22 pass). The 10 tests that fail all start with a `cat file > x` setup step and hit the builtin `cat` regular-file bug that #35337 fixes; they are unrelated to `cp` or to this change, and CI does not set the flag.

### Background
- `Kind` (`src/runtime/shell/Builtin.rs`) is the enum of shell builtins. `Kind::DISABLED_ON_POSIX` (currently `cat`, `cp`) lists builtins that, on Linux/macOS, the shell spawns as system binaries instead of running itself; `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS` is the feature flag that turns them back on. On Windows every builtin always runs as a builtin.
- `Kind::from_argv0` is the interpreter's dispatch decision (`states/Cmd.rs`): `Some(kind)` runs the builtin, `None` falls through to a subprocess. `from_argv0_raw` is the same name lookup without the gate.
- `bun:internal-for-testing` (`src/js/internal-for-testing.ts`) exposes `shellInternals.builtinDisabled`, which the shell test suites use to skip the builtin tests on platforms where the builtin is not what runs. Feature flags from `bun_core::env_var` are read once and cached for the life of the process, which is why the test has to spawn a child per configuration.

<details>
<summary>Repro against bun 1.4.0 (Linux)</summary>

```
$ cat repro.ts
import { shellInternals } from "bun:internal-for-testing";
console.log(shellInternals.builtinDisabled("cp"), shellInternals.builtinDisabled("cat"));

$ BUN_GARBAGE_COLLECTOR_LEVEL=0 BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun repro.ts
true true
$ BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 BUN_GARBAGE_COLLECTOR_LEVEL=0 BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun repro.ts
true true          # expected: false false

$ bun -e 'await Bun.$`cp`.nothrow()'
cp: missing file operand                      # system cp
$ BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'await Bun.$`cp`.nothrow()'
usage: cp [-R [-H | -L | -P]] [-fi | -n] ...  # builtin cp
```

After the fix the second `repro.ts` run prints `false false`; the other three outputs are unchanged.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->