### PR TITLE
Free the .jsc sidecar blob handed to ResolvedSource.bytecode_cache

### DIFF
--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -41,6 +41,15 @@ pub struct ResolvedSource {
     /// This is for source_code
     pub source_code_needs_deref: bool,
     pub already_bundled: bool,
+    /// `bytecode_cache` is a `heap::into_raw`'d `Box<[u8]>` of `bytecode_cache_size`
+    /// bytes (a `.jsc` sidecar read by the transpiler) that whoever holds this struct
+    /// must free: `Zig::SourceProvider::create` hands it to the `JSC::CachedBytecode`
+    /// destructor, [`OwnedResolvedSource`] frees it if dropped before that.
+    ///
+    /// When `false`, `bytecode_cache` borrows memory owned elsewhere for the life of
+    /// the process (a Node compile cache entry, the bytecode section of a
+    /// `bun build --compile` executable) and must never be freed.
+    pub bytecode_cache_needs_free: bool,
 
     // -- Bytecode cache fields --
     pub bytecode_cache: *mut u8,
@@ -66,6 +75,7 @@ impl Default for ResolvedSource {
             tag: Tag::Javascript,
             source_code_needs_deref: true,
             already_bundled: false,
+            bytecode_cache_needs_free: false,
             bytecode_cache: core::ptr::null_mut(),
             bytecode_cache_size: 0,
             module_info: core::ptr::null_mut(),
@@ -86,7 +96,8 @@ impl Default for ResolvedSource {
 //
 // Hold the in-flight value as `OwnedResolvedSource`; the only way to extract
 // the raw `ResolvedSource` for FFI is `into_ffi()` (consumes, forgets). If the
-// owner is dropped instead, every contained `BunString` is `deref()`d.
+// owner is dropped instead, every contained `BunString` is `deref()`d and an
+// owned `bytecode_cache` blob (`bytecode_cache_needs_free`) is freed.
 //
 // The `module_info` pointer (a `Box<ModuleInfoDeserialized>` leaked via
 // `heap::into_raw`) is intentionally NOT freed here — its ownership protocol
@@ -142,5 +153,18 @@ impl Drop for OwnedResolvedSource {
         self.0.specifier.deref();
         self.0.source_url.deref();
         self.0.bytecode_origin_path.deref();
+        if self.0.bytecode_cache_needs_free {
+            // SAFETY: the flag is only set by the `.jsc` sidecar producers, which
+            // store the `heap::into_raw` pointer and length of a `Box<[u8]>` in
+            // `bytecode_cache` / `bytecode_cache_size`, and it is cleared by
+            // whoever takes the blob over (`Zig::SourceProvider::create`), so
+            // this owner is the unique holder of the allocation.
+            unsafe {
+                bun_core::heap::destroy(core::ptr::slice_from_raw_parts_mut(
+                    self.0.bytecode_cache,
+                    self.0.bytecode_cache_size,
+                ));
+            }
+        }
     }
 }

--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -41,14 +41,9 @@ pub struct ResolvedSource {
     /// This is for source_code
     pub source_code_needs_deref: bool,
     pub already_bundled: bool,
-    /// `bytecode_cache` is a `heap::into_raw`'d `Box<[u8]>` of `bytecode_cache_size`
-    /// bytes (a `.jsc` sidecar read by the transpiler) that whoever holds this struct
-    /// must free: `Zig::SourceProvider::create` hands it to the `JSC::CachedBytecode`
-    /// destructor, [`OwnedResolvedSource`] frees it if dropped before that.
-    ///
-    /// When `false`, `bytecode_cache` borrows memory owned elsewhere for the life of
-    /// the process (a Node compile cache entry, the bytecode section of a
-    /// `bun build --compile` executable) and must never be freed.
+    /// `bytecode_cache` is a `heap::into_raw`'d `Box<[u8]>` (a `.jsc` sidecar) that the
+    /// holder of this struct must free. Unset for blobs borrowed from the Node compile
+    /// cache or a standalone executable, which live as long as the process.
     pub bytecode_cache_needs_free: bool,
 
     // -- Bytecode cache fields --
@@ -154,11 +149,9 @@ impl Drop for OwnedResolvedSource {
         self.0.source_url.deref();
         self.0.bytecode_origin_path.deref();
         if self.0.bytecode_cache_needs_free {
-            // SAFETY: the flag is only set by the `.jsc` sidecar producers, which
-            // store the `heap::into_raw` pointer and length of a `Box<[u8]>` in
-            // `bytecode_cache` / `bytecode_cache_size`, and it is cleared by
-            // whoever takes the blob over (`Zig::SourceProvider::create`), so
-            // this owner is the unique holder of the allocation.
+            // SAFETY: while the flag is set, `bytecode_cache` / `bytecode_cache_size`
+            // are the `heap::into_raw` pointer and length of a `Box<[u8]>` that
+            // nothing else has taken over (taking it over clears the flag).
             unsafe {
                 bun_core::heap::destroy(core::ptr::slice_from_raw_parts_mut(
                     self.0.bytecode_cache,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1050,6 +1050,7 @@ impl TranspilerJob {
                 already_bundled: true,
                 bytecode_cache,
                 bytecode_cache_size,
+                bytecode_cache_needs_free: !bytecode_cache.is_null(),
                 is_commonjs_module,
                 tag: this_tag,
                 ..Default::default()

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1457,6 +1457,10 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
     if (JSValue compileFunction = this->m_overriddenCompile.get()) {
         auto& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
+        // The overridden _compile only gets the source text; no SourceProvider
+        // is created on any exit from this branch, so a .jsc sidecar blob has
+        // nowhere else to go.
+        Zig::freeOwnedBytecodeCache(source);
         if (!compileFunction) {
             throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
             return;
@@ -1472,9 +1476,6 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
             source.needsDeref = false;
             source.source_code.deref();
         }
-        // The overridden _compile only gets the source text; no SourceProvider
-        // is created, so a .jsc sidecar blob has nowhere else to go.
-        Zig::freeOwnedBytecodeCache(source);
         // Remove the wrapper from the source string, since the transpiler has added it.
         auto trimStart = sourceString.find('\n');
         WTF::String sourceStringWithoutWrapper;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1472,6 +1472,9 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
             source.needsDeref = false;
             source.source_code.deref();
         }
+        // The overridden _compile only gets the source text; no SourceProvider
+        // is created, so a .jsc sidecar blob has nowhere else to go.
+        Zig::freeOwnedBytecodeCache(source);
         // Remove the wrapper from the source string, since the transpiler has added it.
         auto trimStart = sourceString.find('\n');
         WTF::String sourceStringWithoutWrapper;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1457,9 +1457,7 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
     if (JSValue compileFunction = this->m_overriddenCompile.get()) {
         auto& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        // The overridden _compile only gets the source text; no SourceProvider
-        // is created on any exit from this branch, so a .jsc sidecar blob has
-        // nowhere else to go.
+        // This branch never creates a SourceProvider, which is what would take the blob.
         Zig::freeOwnedBytecodeCache(source);
         if (!compileFunction) {
             throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -63,8 +63,7 @@ public:
             res->result.value.needsDeref = false;
             res->result.value.source_code.impl.wtf->deref();
         }
-        // Still set only if no SourceProvider was created for this source, e.g.
-        // createCommonJSModule() found the module already in the require map.
+        // No-op once a SourceProvider has taken the blob.
         Zig::freeOwnedBytecodeCache(res->result.value);
     }
 

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -57,10 +57,15 @@ public:
 
     ~ResolvedSourceCodeHolder()
     {
-        if (res->success && res->result.value.source_code.tag == BunStringTag::WTFStringImpl && res->result.value.needsDeref) {
+        if (!res->success)
+            return;
+        if (res->result.value.source_code.tag == BunStringTag::WTFStringImpl && res->result.value.needsDeref) {
             res->result.value.needsDeref = false;
             res->result.value.source_code.impl.wtf->deref();
         }
+        // Still set only if no SourceProvider was created for this source, e.g.
+        // createCommonJSModule() found the module already in the require map.
+        Zig::freeOwnedBytecodeCache(res->result.value);
     }
 
     ErrorableResolvedSource* res;

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -59,6 +59,24 @@ extern "C" bool BunTest__shouldGenerateCodeCoverage(BunString sourceURL);
 extern "C" void Bun__addSourceProviderSourceMap(void* bun_vm, SourceProvider* opaque_source_provider, BunString* specifier);
 extern "C" void Bun__removeSourceProviderSourceMap(void* bun_vm, SourceProvider* opaque_source_provider, BunString* specifier);
 
+// An owned `bytecode_cache` was `heap::into_raw`'d from a Rust `Box<[u8]>` (the
+// global allocator); free with `defaultAllocatorFree` so it agrees with the
+// `#[global_allocator]`.
+static void freeSidecarBytecode(const void* ptr)
+{
+    Bun::defaultAllocatorFree(const_cast<void*>(ptr));
+}
+
+void freeOwnedBytecodeCache(ResolvedSource& resolvedSource)
+{
+    if (!resolvedSource.bytecode_cache_needs_free)
+        return;
+    resolvedSource.bytecode_cache_needs_free = false;
+    freeSidecarBytecode(resolvedSource.bytecode_cache);
+    resolvedSource.bytecode_cache = nullptr;
+    resolvedSource.bytecode_cache_size = 0;
+}
+
 Ref<SourceProvider> SourceProvider::create(
     Zig::GlobalObject* globalObject,
     ResolvedSource& resolvedSource,
@@ -103,20 +121,20 @@ Ref<SourceProvider> SourceProvider::create(
 
     const auto getProvider = [&]() -> Ref<SourceProvider> {
         if (resolvedSource.bytecode_cache != nullptr) {
-            const auto destructorPtr = [](const void* ptr) {
-                // `bytecode_cache` was `heap::into_raw`'d from a Rust `Box<[u8]>`
-                // (the global allocator); free with `defaultAllocatorFree` so
-                // it agrees with the `#[global_allocator]`.
-                Bun::defaultAllocatorFree(const_cast<void*>(ptr));
-            };
-            const auto destructorNoOp = [](const void* ptr) {
-                // no-op, for bun build --compile.
-            };
-            const auto destructor = resolvedSource.needsDeref ? destructorPtr : destructorNoOp;
+            // A blob borrowed from the Node compile cache or a `bun build --compile`
+            // executable gets no destructor. A `.jsc` sidecar blob is taken over by
+            // the CachedBytecode: clear the flag so that neither the copy stored in
+            // the provider below nor the caller's struct (ResolvedSourceCodeHolder)
+            // frees it again.
+            JSC::CachePayload::Destructor destructor;
+            if (resolvedSource.bytecode_cache_needs_free) {
+                resolvedSource.bytecode_cache_needs_free = false;
+                destructor = freeSidecarBytecode;
+            }
 
             auto origin = getSourceOrigin();
 
-            Ref<JSC::CachedBytecode> bytecode = JSC::CachedBytecode::create(std::span<uint8_t>(resolvedSource.bytecode_cache, resolvedSource.bytecode_cache_size), destructor, {});
+            Ref<JSC::CachedBytecode> bytecode = JSC::CachedBytecode::create(std::span<uint8_t>(resolvedSource.bytecode_cache, resolvedSource.bytecode_cache_size), WTF::move(destructor), {});
             auto provider = adoptRef(*new SourceProvider(
                 globalObject->bunVM(),
                 resolvedSource,

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -59,9 +59,7 @@ extern "C" bool BunTest__shouldGenerateCodeCoverage(BunString sourceURL);
 extern "C" void Bun__addSourceProviderSourceMap(void* bun_vm, SourceProvider* opaque_source_provider, BunString* specifier);
 extern "C" void Bun__removeSourceProviderSourceMap(void* bun_vm, SourceProvider* opaque_source_provider, BunString* specifier);
 
-// An owned `bytecode_cache` was `heap::into_raw`'d from a Rust `Box<[u8]>` (the
-// global allocator); free with `defaultAllocatorFree` so it agrees with the
-// `#[global_allocator]`.
+// An owned `bytecode_cache` is a Rust `Box<[u8]>`, hence `defaultAllocatorFree`.
 static void freeSidecarBytecode(const void* ptr)
 {
     Bun::defaultAllocatorFree(const_cast<void*>(ptr));
@@ -121,11 +119,9 @@ Ref<SourceProvider> SourceProvider::create(
 
     const auto getProvider = [&]() -> Ref<SourceProvider> {
         if (resolvedSource.bytecode_cache != nullptr) {
-            // A blob borrowed from the Node compile cache or a `bun build --compile`
-            // executable gets no destructor. A `.jsc` sidecar blob is taken over by
-            // the CachedBytecode: clear the flag so that neither the copy stored in
-            // the provider below nor the caller's struct (ResolvedSourceCodeHolder)
-            // frees it again.
+            // The CachedBytecode takes over an owned blob; clearing the flag keeps the
+            // copy stored in the provider and the caller's struct from freeing it too.
+            // Borrowed blobs (compile cache, standalone executable) get no destructor.
             JSC::CachePayload::Destructor destructor;
             if (resolvedSource.bytecode_cache_needs_free) {
                 resolvedSource.bytecode_cache_needs_free = false;

--- a/src/jsc/bindings/ZigSourceProvider.h
+++ b/src/jsc/bindings/ZigSourceProvider.h
@@ -23,10 +23,8 @@ class GlobalObject;
 JSC::SourceID sourceIDForSourceURL(const WTF::String& sourceURL);
 JSC::SourceOrigin toSourceOrigin(const String& sourceURL, bool isBuiltin);
 
-// Frees `bytecode_cache` if the ResolvedSource still owns it, i.e. a `.jsc`
-// sidecar blob that is being discarded without reaching SourceProvider::create
-// (which takes the blob over and clears `bytecode_cache_needs_free`). No-op for
-// blobs borrowed from the Node compile cache or a standalone executable.
+// Frees `bytecode_cache` if `bytecode_cache_needs_free` is still set, i.e. the
+// ResolvedSource is being discarded without a SourceProvider taking the blob.
 void freeOwnedBytecodeCache(ResolvedSource& resolvedSource);
 
 class SourceProvider final : public JSC::SourceProvider {

--- a/src/jsc/bindings/ZigSourceProvider.h
+++ b/src/jsc/bindings/ZigSourceProvider.h
@@ -22,6 +22,13 @@ class GlobalObject;
 
 JSC::SourceID sourceIDForSourceURL(const WTF::String& sourceURL);
 JSC::SourceOrigin toSourceOrigin(const String& sourceURL, bool isBuiltin);
+
+// Frees `bytecode_cache` if the ResolvedSource still owns it, i.e. a `.jsc`
+// sidecar blob that is being discarded without reaching SourceProvider::create
+// (which takes the blob over and clears `bytecode_cache_needs_free`). No-op for
+// blobs borrowed from the Node compile cache or a standalone executable.
+void freeOwnedBytecodeCache(ResolvedSource& resolvedSource);
+
 class SourceProvider final : public JSC::SourceProvider {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SourceProvider);
     using Base = JSC::SourceProvider;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -127,6 +127,11 @@ typedef struct ResolvedSource {
     uint32_t tag;
     bool needsDeref;
     bool already_bundled;
+    // When true, bytecode_cache is a Rust Box<[u8]> (a .jsc sidecar) that whoever holds
+    // this struct must free: Zig::SourceProvider::create hands it to the CachedBytecode,
+    // Zig::freeOwnedBytecodeCache releases it otherwise. When false, bytecode_cache
+    // borrows process-lifetime memory (Node compile cache, standalone executable).
+    bool bytecode_cache_needs_free;
     // -- Bytecode cache fields --
     uint8_t* bytecode_cache;
     size_t bytecode_cache_size;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -127,10 +127,8 @@ typedef struct ResolvedSource {
     uint32_t tag;
     bool needsDeref;
     bool already_bundled;
-    // When true, bytecode_cache is a Rust Box<[u8]> (a .jsc sidecar) that whoever holds
-    // this struct must free: Zig::SourceProvider::create hands it to the CachedBytecode,
-    // Zig::freeOwnedBytecodeCache releases it otherwise. When false, bytecode_cache
-    // borrows process-lifetime memory (Node compile cache, standalone executable).
+    // bytecode_cache is a Rust Box<[u8]> the holder must free (see ResolvedSource.rs);
+    // unset for blobs borrowed from the Node compile cache or a standalone executable.
     bool bytecode_cache_needs_free;
     // -- Bytecode cache fields --
     uint8_t* bytecode_cache;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2956,7 +2956,8 @@ fn transpile_source_code_inner(
                             if len == 0 {
                                 (core::ptr::null_mut(), 0)
                             } else {
-                                // C++ side becomes the owner.
+                                // Ownership travels with the `ResolvedSource`
+                                // (`bytecode_cache_needs_free` below).
                                 (bun_core::heap::into_raw(bytes).cast::<u8>(), len)
                             }
                         }
@@ -2969,6 +2970,7 @@ fn transpile_source_code_inner(
                         already_bundled: true,
                         bytecode_cache,
                         bytecode_cache_size,
+                        bytecode_cache_needs_free: !bytecode_cache.is_null(),
                         is_commonjs_module,
                         ..Default::default()
                     }));

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2956,8 +2956,6 @@ fn transpile_source_code_inner(
                             if len == 0 {
                                 (core::ptr::null_mut(), 0)
                             } else {
-                                // Ownership travels with the `ResolvedSource`
-                                // (`bytecode_cache_needs_free` below).
                                 (bun_core::heap::into_raw(bytes).cast::<u8>(), len)
                             }
                         }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "fs";
 import {
   bunEnv,
@@ -69,6 +69,121 @@ describe("Bun.build", () => {
     expect(build.outputs[0].kind).toBe("entry-point");
     expect(build.outputs[1].kind).toBe("bytecode");
     expect(await bunRun(build.outputs[0].path)).toSpawn("world");
+  });
+
+  describe("bytecode output does not leak the .jsc sidecar when the module is released", () => {
+    // Loading the entry point reads its .jsc sidecar into a fresh buffer. Whatever happens to the
+    // module afterwards, that buffer has to be freed once the module is released, or the process
+    // grows by one sidecar per load. Every variant below reads the sidecar on each load:
+    //  - require() transpiles on the JS thread and import() on the RuntimeTranspilerStore thread
+    //    pool; both hand the sidecar to the module's SourceProvider, which is released with the
+    //    module.
+    //  - import() of a file that require() already put in require.cache reads the file (and the
+    //    sidecar) again, then reuses the existing module, so that copy is discarded right away.
+    //  - An overridden module._compile only receives the source text, so the sidecar is discarded
+    //    right away as well.
+    //
+    // Many statements per function make the sidecar large (~640 KB) relative to the minified
+    // source (~110 KB) while keeping each load cheap: JSC decodes function bodies lazily and the
+    // functions are never called.
+    const FUNCTIONS = 8;
+    const STATEMENTS = 1000;
+    const LOADS = 60;
+    const variants = [
+      { name: "require()", load: "require(path)" },
+      { name: "import()", load: "(await import(path)).default" },
+      {
+        name: "require() followed by import() of the same file",
+        load: "(require(path), (await import(path)).default)",
+      },
+      {
+        name: "require() with an overridden module._compile",
+        setup: `
+          const Module = require("module");
+          const defaultLoader = Module._extensions[".js"];
+          Module._extensions[".js"] = function (module, filename) {
+            module._compile = function () {
+              this.exports = new Array(${FUNCTIONS});
+            };
+            return defaultLoader(module, filename);
+          };
+        `,
+        load: "require(path)",
+      },
+    ];
+
+    let dir: string;
+    let sidecarMB: number;
+    beforeAll(async () => {
+      let moduleSource = "";
+      for (let f = 0; f < FUNCTIONS; f++) {
+        moduleSource += `function f${f}(a, b) {\n  let x = a;\n`;
+        for (let i = 0; i < STATEMENTS; i++) moduleSource += `  x = x * ${i + 2} + b - ${i};\n`;
+        moduleSource += `  return x;\n}\n`;
+      }
+      moduleSource += `module.exports = [${Array.from({ length: FUNCTIONS }, (_, f) => `f${f}`).join(", ")}];\n`;
+
+      const fixtures: Record<string, string> = {};
+      variants.forEach(({ setup = "", load }, i) => {
+        fixtures[`fixture-${i}.js`] = `
+          const path = require.resolve("./out/index.js");
+          const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          if (!require("fs").readFileSync(path, "utf8").startsWith("// @bun @bytecode")) throw new Error("build output is not tagged as bytecode");
+          ${setup}
+          async function loadAndRelease() {
+            const mod = ${load};
+            if (mod.length !== ${FUNCTIONS}) throw new Error("module did not evaluate");
+            const entry = require.cache[path];
+            if (entry) entry.children = [];
+            delete require.cache[path];
+            module.children = [];
+          }
+          (async () => {
+            for (let i = 0; i < 3; i++) await loadAndRelease();
+            Bun.gc(true);
+            const baseline = rss();
+            for (let i = 0; i < ${LOADS}; i++) await loadAndRelease();
+            Bun.gc(true);
+            console.log(((rss() - baseline) / 1024 / 1024).toFixed(1));
+          })();
+        `;
+      });
+      dir = tempDirWithFiles("bun-build-api-bytecode-leak", { "index.js": moduleSource, ...fixtures });
+
+      const build = await Bun.build({
+        entrypoints: [join(dir, "index.js")],
+        outdir: join(dir, "out"),
+        target: "bun",
+        bytecode: true,
+        minify: true,
+      });
+      expect(build.outputs.map(output => output.kind)).toEqual(["entry-point", "bytecode"]);
+      sidecarMB = build.outputs[1].size / 1024 / 1024;
+      expect(sidecarMB).toBeGreaterThan(0.5);
+    }, 30000); // generating the bytecode takes ~1.5s in a debug build
+
+    variants.forEach(({ name }, i) => {
+      test(
+        name,
+        async () => {
+          const result = await bunRun(["--smol", "run", join(dir, `fixture-${i}.js`)], {
+            // Under ASAN, freed allocations sit in the quarantine (256 MB by default) and still
+            // count towards RSS, which would hide the difference between freeing the sidecars and
+            // leaking them. Ignored by non-ASAN builds.
+            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+          });
+          expect(result).toSpawn();
+
+          const growthMB = Number(result.stdout);
+          console.log(`${name}: sidecar ${sidecarMB.toFixed(2)} MB x ${LOADS} loads, RSS grew ${growthMB} MB`);
+          // Leaking retains at least one sidecar per load (LOADS * sidecarMB, ~37 MB). When they
+          // are freed, the growth is allocator noise plus whatever the last load still holds
+          // (under 10 MB in a debug build).
+          expect(growthMB).toBeLessThan((LOADS * sidecarMB) / 2);
+        },
+        30000, // ~2s each in a debug build
+      );
+    });
   });
 
   test("passing undefined doesnt segfault", () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -181,31 +181,27 @@ describe("Bun.build", () => {
       expect(build.outputs.map(output => output.kind)).toEqual(["entry-point", "bytecode"]);
       sidecarMB = build.outputs[1].size / 1024 / 1024;
       expect(sidecarMB).toBeGreaterThan(0.5);
-    }, 30000); // generating the bytecode takes ~1.5s in a debug build
+    });
 
     variants.forEach(({ name }, i) => {
-      test(
-        name,
-        async () => {
-          const result = await bunRun(["--smol", "run", join(dir, `fixture-${i}.js`)], {
-            // Under ASAN, freed allocations sit in the quarantine (256 MB by default) and still
-            // count towards RSS, which would hide the difference between freeing the sidecars and
-            // leaking them. Ignored by non-ASAN builds.
-            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
-          });
-          expect(result).toSpawn();
+      test.concurrent(name, async () => {
+        const result = await bunRun(["--smol", "run", join(dir, `fixture-${i}.js`)], {
+          // Under ASAN, freed allocations sit in the quarantine (256 MB by default) and still
+          // count towards RSS, which would hide the difference between freeing the sidecars and
+          // leaking them. Ignored by non-ASAN builds.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+        });
+        expect(result).toSpawn();
 
-          const growthMB = Number(result.stdout);
-          // A leak on any of the paths a variant goes through keeps at least one sidecar per load
-          // resident, so it adds at least leakMB (~37 MB). With the sidecars freed, what is left is
-          // allocator noise plus whatever the last load still holds: 1 to 12 MB across these
-          // variants in a debug build.
-          const leakMB = LOADS * sidecarMB;
-          console.log(`${name}: RSS grew ${growthMB} MB, a leak would add at least ${leakMB.toFixed(1)} MB`);
-          expect(growthMB).toBeLessThan((leakMB * 2) / 3);
-        },
-        30000, // ~2s each in a debug build
-      );
+        const growthMB = Number(result.stdout);
+        // A leak on any of the paths a variant goes through keeps at least one sidecar per load
+        // resident, so it adds at least leakMB (~37 MB). With the sidecars freed, what is left is
+        // allocator noise plus whatever the last load still holds: 1 to 12 MB across these
+        // variants in a debug build.
+        const leakMB = LOADS * sidecarMB;
+        console.log(`${name}: RSS grew ${growthMB} MB, a leak would add at least ${leakMB.toFixed(1)} MB`);
+        expect(growthMB).toBeLessThan((leakMB * 2) / 3);
+      });
     });
   });
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -81,7 +81,7 @@ describe("Bun.build", () => {
     //  - import() of a file that require() already put in require.cache reads the file (and the
     //    sidecar) again, then reuses the existing module, so that copy is discarded right away.
     //  - An overridden module._compile only receives the source text, so the sidecar is discarded
-    //    right away as well.
+    //    right away as well, whether or not the override turns out to be callable.
     //
     // Many statements per function make the sidecar large (~640 KB) relative to the minified
     // source (~110 KB) while keeping each load cheap: JSC decodes function bodies lazily and the
@@ -95,6 +95,7 @@ describe("Bun.build", () => {
       {
         name: "require() followed by import() of the same file",
         load: "(require(path), (await import(path)).default)",
+        sidecarReadsPerLoad: 2,
       },
       {
         name: "require() with an overridden module._compile",
@@ -109,6 +110,27 @@ describe("Bun.build", () => {
           };
         `,
         load: "require(path)",
+      },
+      {
+        name: "require() with module._compile overridden with a non-function",
+        setup: `
+          const Module = require("module");
+          const defaultLoader = Module._extensions[".js"];
+          Module._extensions[".js"] = function (module, filename) {
+            module._compile = {};
+            return defaultLoader(module, filename);
+          };
+          function requireExpectingTypeError() {
+            try {
+              require(path);
+            } catch (e) {
+              if (e instanceof TypeError) return new Array(${FUNCTIONS});
+              throw e;
+            }
+            throw new Error("require() did not throw");
+          }
+        `,
+        load: "requireExpectingTypeError()",
       },
     ];
 
@@ -162,7 +184,7 @@ describe("Bun.build", () => {
       expect(sidecarMB).toBeGreaterThan(0.5);
     }, 30000); // generating the bytecode takes ~1.5s in a debug build
 
-    variants.forEach(({ name }, i) => {
+    variants.forEach(({ name, sidecarReadsPerLoad = 1 }, i) => {
       test(
         name,
         async () => {
@@ -175,11 +197,12 @@ describe("Bun.build", () => {
           expect(result).toSpawn();
 
           const growthMB = Number(result.stdout);
-          console.log(`${name}: sidecar ${sidecarMB.toFixed(2)} MB x ${LOADS} loads, RSS grew ${growthMB} MB`);
-          // Leaking retains at least one sidecar per load (LOADS * sidecarMB, ~37 MB). When they
-          // are freed, the growth is allocator noise plus whatever the last load still holds
-          // (under 10 MB in a debug build).
-          expect(growthMB).toBeLessThan((LOADS * sidecarMB) / 2);
+          // Leaking keeps every sidecar read during the measured loads resident (~37 MB per read
+          // per load). When they are freed, what is left is allocator noise plus whatever the last
+          // load still holds: 1 to 12 MB across these variants in a debug build.
+          const leakMB = LOADS * sidecarReadsPerLoad * sidecarMB;
+          console.log(`${name}: RSS grew ${growthMB} MB, leaking would add ${leakMB.toFixed(1)} MB`);
+          expect(growthMB).toBeLessThan(leakMB / 2);
         },
         30000, // ~2s each in a debug build
       );

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -95,7 +95,6 @@ describe("Bun.build", () => {
       {
         name: "require() followed by import() of the same file",
         load: "(require(path), (await import(path)).default)",
-        sidecarReadsPerLoad: 2,
       },
       {
         name: "require() with an overridden module._compile",
@@ -184,7 +183,7 @@ describe("Bun.build", () => {
       expect(sidecarMB).toBeGreaterThan(0.5);
     }, 30000); // generating the bytecode takes ~1.5s in a debug build
 
-    variants.forEach(({ name, sidecarReadsPerLoad = 1 }, i) => {
+    variants.forEach(({ name }, i) => {
       test(
         name,
         async () => {
@@ -197,12 +196,13 @@ describe("Bun.build", () => {
           expect(result).toSpawn();
 
           const growthMB = Number(result.stdout);
-          // Leaking keeps every sidecar read during the measured loads resident (~37 MB per read
-          // per load). When they are freed, what is left is allocator noise plus whatever the last
-          // load still holds: 1 to 12 MB across these variants in a debug build.
-          const leakMB = LOADS * sidecarReadsPerLoad * sidecarMB;
-          console.log(`${name}: RSS grew ${growthMB} MB, leaking would add ${leakMB.toFixed(1)} MB`);
-          expect(growthMB).toBeLessThan(leakMB / 2);
+          // A leak on any of the paths a variant goes through keeps at least one sidecar per load
+          // resident, so it adds at least leakMB (~37 MB). With the sidecars freed, what is left is
+          // allocator noise plus whatever the last load still holds: 1 to 12 MB across these
+          // variants in a debug build.
+          const leakMB = LOADS * sidecarMB;
+          console.log(`${name}: RSS grew ${growthMB} MB, a leak would add at least ${leakMB.toFixed(1)} MB`);
+          expect(growthMB).toBeLessThan((leakMB * 2) / 3);
         },
         30000, // ~2s each in a debug build
       );


### PR DESCRIPTION
### Problem
- Every load of a module built with `bun build --target=bun --bytecode` leaks its `.jsc` sidecar: RSS grows by exactly the sidecar size per `require()` / `import()` (3.5 MB sidecar, 100 loads with `delete require.cache` in between: +340 MB; the same module built without `--bytecode` stays flat). Long-lived processes that reload such modules (`require.cache` busting, repeated workers) never get that memory back.
- `Zig::SourceProvider::create` (src/jsc/bindings/ZigSourceProvider.cpp) chose the `CachedBytecode` destructor with `resolvedSource.needsDeref ? free : noop`, but the same function sets `needsDeref = false` about 30 lines earlier for every non-builtin source (that is the `source_code` deref). So the destructor was always the no-op and the `Box<[u8]>` that `transpile_source_code_inner` (src/runtime/jsc_hooks.rs) and `TranspilerJob` (src/jsc/RuntimeTranspilerStore.rs) hand over via `heap::into_raw` was never freed.
- `needsDeref` cannot be the signal even when read at the right time: it is also `true` on the Node compile cache paths (`node_compile_cache::fetch`), whose blobs belong to the cache's entry map for the life of the process. The compile cache currently relies on the destructor being a no-op (this was called out and dismissed for that reason in the review of #34660), so the two cases need a dedicated bit.
- Smaller instances of the same leak: a sidecar that never reaches a `SourceProvider` (the `import()` of a file that `require()` already put in the require map re-reads the file and then reuses the existing module; an overridden `module._compile` only receives the source text) was dropped on the floor too, and `OwnedResolvedSource::drop` (src/jsc/ResolvedSource.rs) did not free it either.

### Fix
- Add `bytecode_cache_needs_free` to `ResolvedSource` (Rust struct and the C mirror in headers-handwritten.h; it lands in existing padding next to `needsDeref` / `already_bundled`, so the layout is otherwise unchanged). The two sidecar producers set it; everything else leaves the default `false`.
- `SourceProvider::create` installs the free destructor only when the bit is set and clears the bit as it hands the blob to the `CachedBytecode`, so neither the copy stored in the provider nor the caller's struct can free it again. Borrowed blobs (compile cache, standalone executables) get no destructor, which is what they got before.
- New `Zig::freeOwnedBytecodeCache()` releases a still-owned blob from `ResolvedSourceCodeHolder` (every fetch path in ModuleLoader.cpp) and from the overridden `_compile` branch of `evaluateWithPotentiallyOverriddenCompile`; `OwnedResolvedSource::drop` does the same on the Rust side.
- Why this is right: the blob is a `Box<[u8]>` from Rust's global allocator, so `Bun::defaultAllocatorFree` (the destructor already used here) and reconstructing the `Box<[u8]>` from `bytecode_cache` / `bytecode_cache_size` are the matching frees; the bit travels with the struct and is cleared by whoever takes the blob, so each blob is freed exactly once; and ownership is now stated by the producer instead of being inferred from an unrelated string refcount flag, which is what let the compile cache and sidecar cases collide.
- Verified with `test/bundler/bun-build-api.test.ts` ("bytecode output does not leak the .jsc sidecar when the module is released"): five variants covering both producers and all three release points, including `module._compile` overridden with a non-function, which returns early from that branch. Each variant loads a module with a 0.61 MB sidecar 60 times and requires RSS growth to stay under two thirds of one sidecar per load (24.5 MB): it grows 2 to 12 MB with this change and 40 to 80 MB without it (debug build; 41 to 44 MB on the 1.4.0 release for the plain variants). The `OwnedResolvedSource::drop` path is only reachable when a transpiler job is torn down before reaching C++, so it has no test.
- Also ran `test/regression/issue/26298.test.ts` (standalone executables with embedded bytecode) and the compile cache tests in `test/js/node/module/node-module-module.test.js` on the debug (ASAN) build to confirm the borrowed-blob paths still get no destructor.
- Textual overlap with #34801, which changes the type of the same `bytecode_cache` field; the two changes are independent.

### Background
- `bun build --target=bun --bytecode` emits `out.js` starting with `// @bun @bytecode @bun-cjs` plus `out.js.jsc`, JSC's serialized bytecode for it. When the runtime loads `out.js`, the parser stops at the pragma and the transpiler reads the sidecar into a `Box<[u8]>`; the bytes are returned to C++ in `ResolvedSource.bytecode_cache`.
- `ResolvedSource` is the plain `#[repr(C)]` struct the Rust module loader fills in for C++ (source text, specifier, bytecode, flags). It is `Copy`, so it carries no destructor; `OwnedResolvedSource` is the Rust-side RAII wrapper used while one is in flight, and `ResolvedSourceCodeHolder` is the C++ scope guard that releases what C++ did not consume.
- `Zig::SourceProvider` is Bun's `JSC::SourceProvider` for a module. When bytecode is present it wraps the bytes in a `JSC::CachedBytecode`, which JSC decodes instead of parsing; `CachedBytecode` takes a destructor callback that runs when it is released, and a null callback means the bytes belong to someone else. Bun has three sources of such bytes: the `.jsc` sidecar (a fresh heap allocation per load), the Node compile cache (process-lifetime entries), and the bytecode section of a `bun build --compile` executable (part of the binary image). Only the first one is the provider's to free.

<details>
<summary>Reproduction used to measure the leak</summary>

```js
// gen.js: write a module big enough to produce a multi-MB sidecar, then
//   bun build --target=bun --bytecode entry.js --outdir out
const N = 3000, lines = [];
for (let i = 0; i < N; i++) lines.push(`function f${i}(a, b) { var x = a + ${i}; return x > b ? x : [x, b].join(","); }`);
lines.push(`module.exports = [${Array.from({ length: N }, (_, i) => `f${i}`).join(",")}];`);
require("fs").writeFileSync("entry.js", lines.join("\n"));

// probe.js
const file = require("path").resolve("./out/entry.js");
function load() { require(file); delete require.cache[file]; module.children.length = 0; }
for (let i = 0; i < 5; i++) load();
Bun.gc(true);
const before = process.memoryUsage.rss();
for (let i = 0; i < 100; i++) load();
Bun.gc(true);
console.log(((process.memoryUsage.rss() - before) / 1048576).toFixed(1), "MB");
```

bun 1.4.0, 3.5 MB sidecar: `340.7 MB` (3.4 MB per load); the same module built without `--bytecode`: 15 to 22 MB of allocator noise at every checkpoint, no growth. `import()` instead of `require()` leaks the same way (222 MB over 60 loads), and `BUN_DEBUG_AsyncModule=1` confirms those loads go through the RuntimeTranspilerStore producer.
</details>
