### PR TITLE
bundler: keep import.meta.main in iife output for bun

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2219,7 +2219,10 @@ impl<'a> LinkerContext<'a> {
             require_or_import_meta_for_source_callback:
                 js_printer::RequireOrImportMetaCallback::init(self),
             line_offset_tables: Some(line_offset_table),
-            target: self.options.target,
+            // The file's target, not the bundle's: an entry point starting with
+            // `#!/usr/bin/env bun` is parsed for bun and its chunk gets the `// @bun`
+            // pragma, which is what decides how `import.meta.main` has to be printed.
+            target: ast.target,
 
             hmr_ref: if self.options.output_format == Format::InternalBakeDev {
                 ast.wrapper_ref

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2590,8 +2590,8 @@ pub mod parse_worker {
         // in which we inline `true`.
         if topts.inline_entrypoint_import_meta_main || !task.is_entry_point {
             opts.import_meta_main_value = Some(task.is_entry_point && !topts.has_dev_server());
-        } else if target == options::Target::Node {
-            opts.lower_import_meta_main_for_node_js = true;
+        } else if !output_format.keeps_import_meta_main(target) {
+            opts.lower_import_meta_main = true;
         }
 
         opts.tree_shaking = if task.source_index.is_runtime() {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1564,7 +1564,7 @@ impl<'a> Transpiler<'a> {
                     output_format: p_opts::Format::Esm,
                     transform_only: self.options.transform_only,
                     import_meta_main_value: None,
-                    lower_import_meta_main_for_node_js: false,
+                    lower_import_meta_main: false,
                     framework: None,
                     repl_mode: self.options.repl_mode,
                 };

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5367,8 +5367,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }),
             };
         }
-        // Node.js does not have import.meta.main, so we end up lowering
-        // this to `require.main === module`, but with the ESM format,
+        // When the output has no import.meta.main (e.g. ESM for Node.js), this
+        // is lowered to `require.main === module`, but with the ESM format,
         // both `require` and `module` are not present, so the code
         // generation we need is:
         //
@@ -5378,7 +5378,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         //
         // The printer can handle this for us, but we need to reference
         // a handle to the `__require` function.
-        if self.options.lower_import_meta_main_for_node_js {
+        if self.options.lower_import_meta_main {
             self.record_usage_of_runtime_require();
         }
         Expr {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -92,7 +92,11 @@ pub struct Options<'a> {
 
     /// Used for inlining the state of import.meta.main during visiting
     pub import_meta_main_value: Option<bool>,
-    pub lower_import_meta_main_for_node_js: bool,
+    /// The printer lowers this file's `import.meta.main` to `require.main == module`
+    /// (see `bun_options_types::Format::keeps_import_meta_main`), printing `require`
+    /// as the runtime's `__require` outside of cjs output, so the file has to record
+    /// a use of it.
+    pub lower_import_meta_main: bool,
 
     /// When using react fast refresh or server components, the framework is
     /// able to customize what import sources are used.
@@ -132,7 +136,7 @@ impl<'a> Default for Options<'a> {
             output_format: options::Format::Esm,
             transform_only: false,
             import_meta_main_value: None,
-            lower_import_meta_main_for_node_js: false,
+            lower_import_meta_main: false,
             framework: None,
             repl_mode: false,
         }
@@ -215,7 +219,7 @@ impl<'a> Options<'a> {
             output_format: self.output_format,
             transform_only: self.transform_only,
             import_meta_main_value: self.import_meta_main_value,
-            lower_import_meta_main_for_node_js: self.lower_import_meta_main_for_node_js,
+            lower_import_meta_main: self.lower_import_meta_main,
             framework: self.framework,
             repl_mode: self.repl_mode,
         }
@@ -286,7 +290,7 @@ impl<'a> Options<'a> {
             output_format: options::Format::Esm,
             transform_only: false,
             import_meta_main_value: None,
-            lower_import_meta_main_for_node_js: false,
+            lower_import_meta_main: false,
             framework: None,
             repl_mode: false,
         };

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2991,11 +2991,11 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::EImportMetaMain(data) => {
-                    if self.options.module_type == bundle_opts::Format::Esm
-                        && self.options.target != bun_ast::Target::Node
+                    if self
+                        .options
+                        .module_type
+                        .keeps_import_meta_main(self.options.target)
                     {
-                        // Node.js doesn't support import.meta.main
-                        // Most of the time, leave it in there
                         if data.inverted {
                             self.add_source_mapping(expr.loc);
                             self.print(b"!");

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -47,6 +47,21 @@ impl Format {
         self == Format::Esm
     }
 
+    /// Whether an entry point's `import.meta.main` is printed as written. When
+    /// this is false it is lowered to a `require.main == module` comparison,
+    /// which needs the output to be loaded as CommonJS.
+    ///
+    /// Node has no `import.meta.main`. Output for bun is marked with a `// @bun`
+    /// pragma that makes bun load it as an ES module unless the format is cjs,
+    /// so an iife for bun has `import.meta.main` and no `module` binding.
+    pub fn keeps_import_meta_main(self, target: Target) -> bool {
+        match self {
+            Format::Esm => !target.is_node(),
+            Format::Iife => target.is_bun(),
+            Format::Cjs | Format::InternalBakeDev => false,
+        }
+    }
+
     pub const MAP: __ComptimeStringMap_FORMAT_MAP = __ComptimeStringMap_FORMAT_MAP(());
 
     // `to_js`/`from_js` live as extension-trait methods in the `*_jsc` crate.

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2124,6 +2124,76 @@ describe("bundler", () => {
       api.expectFile("/out.js").not.toMatch(/[^\.:]module/); // `.module` and `node:module` are ok.
     },
   });
+  // Output for bun starts with a `// @bun` pragma, which makes bun load it as an
+  // ES module in every format but cjs. `import.meta.main` works there and
+  // `module` does not exist, so the `require.main == module` lowering is only
+  // right for cjs output.
+  const importMetaMainFiles = {
+    "/entry.ts": /* js */ `
+      import {other} from './other';
+      console.log(capture(import.meta.main), capture(require.main === module), ...other);
+    `,
+    "/other.ts": /* js */ `
+      globalThis['ca' + 'pture'] = x => x;
+
+      export const other = [capture(require.main === module), capture(import.meta.main)];
+    `,
+  };
+  itBundled("edgecase/ImportMetaMainIIFETargetBun", {
+    files: importMetaMainFiles,
+    target: "bun",
+    format: "iife",
+    capture: ["false", "false", "import.meta.main", "import.meta.main"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith("// @bun\n");
+      api.expectFile("/out.js").not.toContain("require");
+      api.expectFile("/out.js").not.toContain("module");
+    },
+    run: { stdout: "true true false false" },
+  });
+  itBundled("edgecase/ImportMetaMainCJSTargetBun", {
+    files: importMetaMainFiles,
+    target: "bun",
+    format: "cjs",
+    capture: ["false", "false", "require.main == module", "require.main == module"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith("// @bun @bun-cjs\n");
+    },
+    run: { stdout: "true true false false" },
+  });
+  // A `#!/usr/bin/env bun` hashbang switches the entry point to target bun, so
+  // its output gets the pragma no matter which target the bundle was built for.
+  const importMetaMainBunHashbangFiles = {
+    "/entry.ts": /* js */ `
+      #!/usr/bin/env bun
+      import {other} from './other';
+      console.log(capture(import.meta.main), capture(require.main === module), ...other);
+    `,
+    "/other.ts": importMetaMainFiles["/other.ts"],
+  };
+  itBundled("edgecase/ImportMetaMainBunHashbangTargetNode", {
+    files: importMetaMainBunHashbangFiles,
+    target: "node",
+    capture: ["false", "false", "import.meta.main", "import.meta.main"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith("#!/usr/bin/env bun\n// @bun\n");
+      api.expectFile("/out.js").not.toContain("require");
+      api.expectFile("/out.js").not.toContain("module");
+    },
+    run: { stdout: "true true false false" },
+  });
+  itBundled("edgecase/ImportMetaMainIIFEBunHashbangTargetNode", {
+    files: importMetaMainBunHashbangFiles,
+    target: "node",
+    format: "iife",
+    capture: ["false", "false", "import.meta.main", "import.meta.main"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toStartWith("#!/usr/bin/env bun\n// @bun\n");
+      api.expectFile("/out.js").not.toContain("require");
+      api.expectFile("/out.js").not.toContain("module");
+    },
+    run: { stdout: "true true false false" },
+  });
   itBundled("edgecase/build-cjs-module#20308", {
     files: {
       "/entry.ts": /* js */ `


### PR DESCRIPTION
Related: #24540 (that report is the dynamic `require()` case, fixed by #38077; this PR is the `import.meta.main` case, which #38077 leaves out). Does not close it on its own.

### Problem
- An entry point that uses `import.meta.main` (or `require.main === module`, which the parser folds to the same node) bundled with `bun build --target=bun --format=iife` throws when the output is loaded: `ReferenceError: __require is not defined` today, `ReferenceError: module is not defined` once #38077 defines `__require` for iife output.
- The printer (`ExprData::EImportMetaMain` in `src/js_printer/lib.rs:2993`) keeps `import.meta.main` only for esm output and lowers it to `<require>.main == module` for every other format. That lowering assumes the output is loaded as a CommonJS script. Output for bun starts with a `// @bun` pragma (`src/bundler/linker_context/postProcessJSChunk.rs:352`), and Bun loads a `// @bun` file as an ES module unless the pragma also says `@bun-cjs` (cjs output only): `import.meta.main` works in that file and neither `module` nor `require` exist.
- The same happens to an entry point whose first line is `#!/usr/bin/env bun` when the bundle is built for another target: `src/bundler/ParseTask.rs:2403` switches that file to target bun and its chunk gets the pragma, but the printer was given the bundle's target (`src/bundler/LinkerContext.rs:2222`). With `--target=node` the esm output is `__require.main == __require.module` with `__require` never defined, because the parser (which used the file's target) did not record the use that the printer (which used the bundle's) relied on.

### Fix
- `src/options_types/bundle_enums.rs`: `Format::keeps_import_meta_main(target)` is the one place that says whether `import.meta.main` stays as written: esm output except for node (node has no `import.meta.main`), and iife output for bun. cjs and the dev server format are lowered as before.
- `src/js_printer/lib.rs` decides with that predicate. The only output it changes is iife for bun, which now contains `import.meta.main` itself; esm, cjs and iife for browser/node print exactly what they printed before.
- `src/bundler/ParseTask.rs` uses the same predicate to set the parser option that records the runtime `__require` use the lowering needs. The option is renamed from `lower_import_meta_main_for_node_js` to `lower_import_meta_main` because it is no longer node specific. Recording is a no-op unless the output imports the runtime's `__require` (`auto_polyfill_require`, esm only today), so on this branch the parser's output is unchanged; once #38077 turns that on for iife, this keeps an iife for bun from carrying an unused `var __require = import.meta.require;` while browser/node iife get the `__require` they print. (#38077 adds an `|| !output_format.is_esm()` to the same `if` in `p.rs`; whichever lands second can drop that, since this option covers it.)
- `src/bundler/LinkerContext.rs` passes the file's own `ast.target` to the printer instead of the bundle's. Inside the bundler the printer reads `target` only in the `EImportMetaMain` arm, so this changes nothing except for the hashbang case, where the file's target is the one the pragma (and the parser) already follow. The same function already passed `ast.target` as the positional target of `print_with_writer` (`LinkerContext.rs:2276`); the options struct was the one place still using the bundle's. The `require.main == module` lowering stays for cjs output for bun: that output is wrapped in a CommonJS function by the `@bun-cjs` pragma, where it is correct.
- Verified with `test/bundler/bundler_edgecase.test.ts`: `edgecase/ImportMetaMainIIFETargetBun` (the report), `edgecase/ImportMetaMainBunHashbangTargetNode` and `edgecase/ImportMetaMainIIFEBunHashbangTargetNode` (the hashbang entry, esm and iife) check the printed expression, that the output contains no `require`/`module` at all, and run the bundle under bun expecting `true true false false`. All three fail on the released binary (they print `__require.main == module` / `__require.main == __require.module`). `edgecase/ImportMetaMainCJSTargetBun` pins the cjs boundary and passes before and after.
- Also passing with the debug build: the rest of `bundler_edgecase.test.ts` (`DeepImportDiamondDAG` times out locally, a 20k-module stress test unrelated to this), `bundler_cjs.test.ts`, `bundler_banner.test.ts` (hashbang handling), `minify/RequireMainToImportMetaMain`, `compile/ImportMetaMain`, `esbuild/default.test.ts -t "DefineImportMeta|IIFE"`, `test/js/bun/resolve/import-meta.test.js` and `bake/dev/bundle.test.ts -t import.meta.main`.
- Not changed here: a CommonJS entry point in iife output is wrapped in `__commonJS` and never called (#37843), and browser/node iife output still lacks the `__require` binding it prints (#38077). With this change a bun-target iife prints `import.meta.main` inside such a wrapper as well, so it works once #37843 calls it.

### Background
- `import.meta.main` is a Bun feature: true in the module the process was started with. Outside esm output the bundler lowers it to a `require.main == module` comparison, which only makes sense where the output is evaluated as a CommonJS module (so that `require` and `module` exist). Non-entry files are folded to `false` by the parser; `--compile` folds the entry point to `true`; only a plain `bun build` entry point reaches the printer.
- `// @bun` pragma: the linker puts it at the top of every chunk built for bun. When Bun later runs such a file it skips transpiling it and loads it as is, as an ES module; `// @bun @bun-cjs` (cjs output) instead tells it the file is the CommonJS function wrapper that follows. This is why iife output for bun has to keep `import.meta.main` while cjs output for bun has to lower it.
- Runtime `__require`: for output formats that import the bundler's runtime helper, references to a dynamic `require` (including this lowering) are printed as the runtime's `__require` symbol, and the part defining it is only kept in the output if some file recorded a use of it during parsing. The parser does not know the target, so `ParseTask` passes target-dependent decisions to it as options; `lower_import_meta_main` is such an option.
- Hashbang target switch: `ParseTask` parses the first entry point with target bun when its first line is exactly `#!/usr/bin/env bun`, whatever `--target` says, and stores that on the file's AST; the pragma is emitted from the entry point's AST target.

<details>
<summary>Repro on the released binary</summary>

```console
$ echo 'console.log(import.meta.main)' > entry.js
$ bun build entry.js --target=bun --format=iife --outfile=out.js && bun out.js
ReferenceError: __require is not defined
$ cat out.js
// @bun
(() => {
  console.log(__require.main == module);
})();

$ printf '#!/usr/bin/env bun\nconsole.log(import.meta.main)\n' > hb.js
$ bun build hb.js --target=node --outfile=hb.out.js && bun hb.out.js
ReferenceError: __require is not defined
$ cat hb.out.js
#!/usr/bin/env bun
// @bun
console.log(__require.main == __require.module);
```

Both print `true` with this change; the output is `import.meta.main` in each case. A `// @bun` file printing `typeof module, typeof require` gives `undefined undefined`.
</details>
