### PR TITLE
Read console stdin with ReadConsoleW on Windows so non-ASCII input survives (REPL, prompt(), bun -)

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3621,6 +3621,13 @@ mod windows_impl {
         if fd.kind() == FdKind::Uv {
             return sys_uv::read(fd, buf);
         }
+        // A console delivers UTF-16; `ReadFile` would run it through conhost's
+        // broken CP_UTF8 conversion. Only stdin is ever a console here.
+        if fd == Fd::stdin()
+            && let Some(result) = w::console_stdin::read(fd, buf)
+        {
+            return result;
+        }
         let adjusted_len = buf.len().min(MAX_COUNT) as w::DWORD;
         // Stdin callers route through this function (via
         // `File::stdin().read_to_end_into` / `output_sink().read`), so the

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3621,8 +3621,7 @@ mod windows_impl {
         if fd.kind() == FdKind::Uv {
             return sys_uv::read(fd, buf);
         }
-        // A console delivers UTF-16; `ReadFile` would run it through conhost's
-        // broken CP_UTF8 conversion. Only stdin is ever a console here.
+        // Stdin is the only fd that can be a console here.
         if fd == Fd::stdin()
             && let Some(result) = w::console_stdin::read(fd, buf)
         {

--- a/src/sys/windows/console_stdin.rs
+++ b/src/sys/windows/console_stdin.rs
@@ -129,7 +129,7 @@ fn read_units(fd: Fd, out: &mut [u16]) -> Maybe<usize> {
             )
         };
         let err = Win32Error::get();
-        // Ctrl+C / Ctrl+Break surface as a failure or an empty success; retried like ReadFile's path.
+        // Ctrl+C / Ctrl+Break surface as a failure or an empty success; retried like ReadFile.
         if err == Win32Error::OPERATION_ABORTED && (ok == 0 || n == 0) {
             continue;
         }

--- a/src/sys/windows/console_stdin.rs
+++ b/src/sys/windows/console_stdin.rs
@@ -87,8 +87,9 @@ impl State {
     /// `Ok(false)` is end of input; `Ok(true)` can leave `bytes` empty (lone high surrogate).
     fn refill(&mut self, fd: Fd, line_input: bool) -> Maybe<bool> {
         let has_lead = self.pending_lead != 0;
-        self.units[0] = core::mem::take(&mut self.pending_lead);
+        self.units[0] = self.pending_lead;
         let n = read_units(fd, &mut self.units[1..])?;
+        self.pending_lead = 0;
         let continues_line = self.mid_line;
         self.mid_line = line_input && n > 0 && self.units[n] != LF;
         let first = if has_lead { 0 } else { 1 };

--- a/src/sys/windows/console_stdin.rs
+++ b/src/sys/windows/console_stdin.rs
@@ -1,0 +1,155 @@
+//! `read()` for the process stdin while it is a console.
+//!
+//! `ReadFile` on a console handle is the ANSI console API: conhost converts the
+//! typed UTF-16 through the console input code page, and for CP_UTF8 (which bun
+//! selects at startup) the conhost shipped with Windows 10 / Server 2019 hands
+//! back one garbage byte per non-ASCII character (oven-sh/bun#27556). Reading
+//! with `ReadConsoleW` and transcoding here gives the REPL, `prompt()` and the
+//! CLI prompts the UTF-8 they expect. Pipes and files never come through here,
+//! so redirected stdin stays byte-exact.
+
+use core::ffi::c_void;
+use core::ptr;
+
+use bun_core::strings;
+
+use super::{BOOL, DWORD, ENABLE_LINE_INPUT, HANDLE, Win32Error, Win32ErrorExt as _, kernel32};
+use crate::{Error, Fd, Maybe, Tag};
+
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn ReadConsoleW(
+        hConsoleInput: HANDLE,
+        lpBuffer: *mut u16,
+        nNumberOfCharsToRead: DWORD,
+        lpNumberOfCharsRead: &mut DWORD,
+        pInputControl: *const c_void,
+    ) -> BOOL;
+}
+
+const CTRL_Z: u16 = 0x1A;
+
+/// UTF-16 units requested from the console per call. In line-input mode the
+/// conhost of Windows 10 / Server 2019 stops accepting keystrokes once the line
+/// fills the requested count, so this, not the caller's buffer, is the longest
+/// line `prompt()` and friends accept; 8192 is what `bun -` used to pass to
+/// `ReadFile`. Newer consoles hand out a longer line over several calls.
+const UNITS_PER_READ: usize = 8192;
+/// Slot 0 holds a high surrogate carried over from the previous chunk.
+const UNITS_CAPACITY: usize = UNITS_PER_READ + 1;
+/// Worst case is three bytes of UTF-8 per unit (a surrogate pair is four bytes
+/// for two units, an unpaired surrogate becomes the three-byte U+FFFD).
+const BYTES_CAPACITY: usize = 3 * UNITS_CAPACITY;
+
+/// The most recent chunk from the console, transcoded, handed out over as many
+/// `read()` calls as the caller needs (`alert()` and `confirm()` read one byte
+/// at a time, `prompt()` 4 KiB at a time).
+struct State {
+    units: [u16; UNITS_CAPACITY],
+    bytes: [u8; BYTES_CAPACITY],
+    /// `bytes[start..end]` has not been handed out yet.
+    start: usize,
+    end: usize,
+    /// High surrogate that ended the previous chunk; its low surrogate is the
+    /// first unit of the next one. 0 when none.
+    pending_lead: u16,
+}
+
+// Stdin is one stream per process. The lock is held across the blocking read:
+// concurrent readers would have to take turns anyway.
+static STATE: bun_core::Mutex<State> = bun_core::Mutex::new(State {
+    units: [0; UNITS_CAPACITY],
+    bytes: [0; BYTES_CAPACITY],
+    start: 0,
+    end: 0,
+    pending_lead: 0,
+});
+
+/// `Some` when `fd` (the process stdin) is a console, `None` when it is a pipe
+/// or file and the caller should `ReadFile` it as usual.
+pub(crate) fn read(fd: Fd, buf: &mut [u8]) -> Option<Maybe<usize>> {
+    let mut mode: DWORD = 0;
+    if super::kernel32_2::GetConsoleMode(fd.native(), &mut mode) == 0 {
+        return None;
+    }
+    if buf.is_empty() {
+        return Some(Ok(0));
+    }
+    let line_input = mode & ENABLE_LINE_INPUT != 0;
+    Some(STATE.lock().read(fd, line_input, buf))
+}
+
+impl State {
+    fn read(&mut self, fd: Fd, line_input: bool, buf: &mut [u8]) -> Maybe<usize> {
+        while self.start == self.end {
+            if !self.refill(fd, line_input)? {
+                return Ok(0);
+            }
+        }
+        let n = (self.end - self.start).min(buf.len());
+        buf[..n].copy_from_slice(&self.bytes[self.start..self.start + n]);
+        self.start += n;
+        Ok(n)
+    }
+
+    /// Reads the next chunk into `bytes`. `Ok(false)` is end of input. `Ok(true)`
+    /// with nothing in `bytes` is possible (the chunk was a lone high surrogate)
+    /// and means: read again.
+    fn refill(&mut self, fd: Fd, line_input: bool) -> Maybe<bool> {
+        let has_lead = self.pending_lead != 0;
+        self.units[0] = core::mem::take(&mut self.pending_lead);
+        let n = read_units(fd, &mut self.units[1..])?;
+        let first = if has_lead { 0 } else { 1 };
+        let mut end = 1 + n;
+        if first == end {
+            return Ok(false);
+        }
+        // Same as ReadFile: in line-input mode a line that starts with Ctrl+Z is
+        // end of input and the rest of the line is dropped. A line-input read
+        // returns exactly one line, so the chunk starts where the line does;
+        // a carried-over surrogate means this chunk continues the previous one.
+        if line_input && !has_lead && self.units[1] == CTRL_Z {
+            return Ok(false);
+        }
+        // The low half of a pair that ends the chunk is still in the console;
+        // at end of input (n == 0) there is nothing to wait for and the lone
+        // surrogate becomes U+FFFD below.
+        if n > 0 && strings::u16_is_lead(self.units[end - 1]) {
+            end -= 1;
+            self.pending_lead = self.units[end];
+        }
+        let r = strings::copy_utf16_into_utf8(&mut self.bytes, &self.units[first..end]);
+        debug_assert_eq!(r.read as usize, end - first);
+        self.start = 0;
+        self.end = r.written as usize;
+        Ok(true)
+    }
+}
+
+fn read_units(fd: Fd, out: &mut [u16]) -> Maybe<usize> {
+    loop {
+        let mut n: DWORD = 0;
+        kernel32::SetLastError(0);
+        // SAFETY: `out` is valid for `out.len()` u16 writes for the duration of
+        // the call and `n` outlives it; a null `pInputControl` is allowed.
+        let ok = unsafe {
+            ReadConsoleW(
+                fd.native(),
+                out.as_mut_ptr(),
+                out.len() as DWORD,
+                &mut n,
+                ptr::null(),
+            )
+        };
+        let err = Win32Error::get();
+        // Ctrl+C / Ctrl+Break cancel the wait, reported either as a failure or
+        // as a successful zero-length read; the ReadFile path retries as well.
+        if err == Win32Error::OPERATION_ABORTED && (ok == 0 || n == 0) {
+            continue;
+        }
+        if ok == 0 {
+            return Err(Error::new(err.to_e(), Tag::read).with_fd(fd));
+        }
+        return Ok(n as usize);
+    }
+}

--- a/src/sys/windows/console_stdin.rs
+++ b/src/sys/windows/console_stdin.rs
@@ -28,6 +28,7 @@ unsafe extern "system" {
 }
 
 const CTRL_Z: u16 = 0x1A;
+const LF: u16 = b'\n' as u16;
 
 /// UTF-16 units requested from the console per call. In line-input mode the
 /// conhost of Windows 10 / Server 2019 stops accepting keystrokes once the line
@@ -53,6 +54,10 @@ struct State {
     /// High surrogate that ended the previous chunk; its low surrogate is the
     /// first unit of the next one. 0 when none.
     pending_lead: u16,
+    /// The previous chunk was line input that did not end in '\n': the line is
+    /// longer than a chunk (newer consoles deliver such a line over several
+    /// reads), so the next chunk continues it instead of starting a line.
+    mid_line: bool,
 }
 
 // Stdin is one stream per process. The lock is held across the blocking read:
@@ -63,6 +68,7 @@ static STATE: bun_core::Mutex<State> = bun_core::Mutex::new(State {
     start: 0,
     end: 0,
     pending_lead: 0,
+    mid_line: false,
 });
 
 /// `Some` when `fd` (the process stdin) is a console, `None` when it is a pipe
@@ -99,16 +105,16 @@ impl State {
         let has_lead = self.pending_lead != 0;
         self.units[0] = core::mem::take(&mut self.pending_lead);
         let n = read_units(fd, &mut self.units[1..])?;
+        let continues_line = self.mid_line;
+        self.mid_line = line_input && n > 0 && self.units[n] != LF;
         let first = if has_lead { 0 } else { 1 };
         let mut end = 1 + n;
         if first == end {
             return Ok(false);
         }
         // Same as ReadFile: in line-input mode a line that starts with Ctrl+Z is
-        // end of input and the rest of the line is dropped. A line-input read
-        // returns exactly one line, so the chunk starts where the line does;
-        // a carried-over surrogate means this chunk continues the previous one.
-        if line_input && !has_lead && self.units[1] == CTRL_Z {
+        // end of input and is not delivered.
+        if line_input && n > 0 && !continues_line && self.units[1] == CTRL_Z {
             return Ok(false);
         }
         // The low half of a pair that ends the chunk is still in the console;

--- a/src/sys/windows/console_stdin.rs
+++ b/src/sys/windows/console_stdin.rs
@@ -1,12 +1,7 @@
-//! `read()` for the process stdin while it is a console.
-//!
-//! `ReadFile` on a console handle is the ANSI console API: conhost converts the
-//! typed UTF-16 through the console input code page, and for CP_UTF8 (which bun
-//! selects at startup) the conhost shipped with Windows 10 / Server 2019 hands
-//! back one garbage byte per non-ASCII character (oven-sh/bun#27556). Reading
-//! with `ReadConsoleW` and transcoding here gives the REPL, `prompt()` and the
-//! CLI prompts the UTF-8 they expect. Pipes and files never come through here,
-//! so redirected stdin stays byte-exact.
+//! `read()` for the process stdin while it is a console: `ReadConsoleW` plus UTF-8
+//! transcoding. `ReadFile` on a console converts through the input code page, and
+//! conhost's conversion to the UTF-8 code page bun selects returns one garbage byte
+//! per non-ASCII character (oven-sh/bun#27556). Pipes and files never come here.
 
 use core::ffi::c_void;
 use core::ptr;
@@ -30,38 +25,30 @@ unsafe extern "system" {
 const CTRL_Z: u16 = 0x1A;
 const LF: u16 = b'\n' as u16;
 
-/// UTF-16 units requested from the console per call. In line-input mode the
-/// conhost of Windows 10 / Server 2019 stops accepting keystrokes once the line
-/// fills the requested count, so this, not the caller's buffer, is the longest
-/// line `prompt()` and friends accept; 8192 is what `bun -` used to pass to
-/// `ReadFile`. Newer consoles hand out a longer line over several calls.
+/// Per `ReadConsoleW` call. In line-input mode this is also the longest line the user
+/// can type: the Windows 10 / Server 2019 conhost ignores keystrokes beyond it (newer
+/// consoles return a longer line over several calls). `bun -` passed 8192 to `ReadFile`.
 const UNITS_PER_READ: usize = 8192;
 /// Slot 0 holds a high surrogate carried over from the previous chunk.
 const UNITS_CAPACITY: usize = UNITS_PER_READ + 1;
-/// Worst case is three bytes of UTF-8 per unit (a surrogate pair is four bytes
-/// for two units, an unpaired surrogate becomes the three-byte U+FFFD).
+/// UTF-8 is at most three bytes per UTF-16 unit (a pair is four bytes for two units).
 const BYTES_CAPACITY: usize = 3 * UNITS_CAPACITY;
 
-/// The most recent chunk from the console, transcoded, handed out over as many
-/// `read()` calls as the caller needs (`alert()` and `confirm()` read one byte
-/// at a time, `prompt()` 4 KiB at a time).
+/// The latest chunk from the console, transcoded; `read()` hands it out piecemeal.
 struct State {
     units: [u16; UNITS_CAPACITY],
     bytes: [u8; BYTES_CAPACITY],
     /// `bytes[start..end]` has not been handed out yet.
     start: usize,
     end: usize,
-    /// High surrogate that ended the previous chunk; its low surrogate is the
-    /// first unit of the next one. 0 when none.
+    /// High surrogate that ended the previous chunk, to be paired with the next one's first unit.
     pending_lead: u16,
-    /// The previous chunk was line input that did not end in '\n': the line is
-    /// longer than a chunk (newer consoles deliver such a line over several
-    /// reads), so the next chunk continues it instead of starting a line.
+    /// The previous line-input chunk did not end its line (the line was longer than a
+    /// chunk), so the next chunk continues that line instead of starting one.
     mid_line: bool,
 }
 
-// Stdin is one stream per process. The lock is held across the blocking read:
-// concurrent readers would have to take turns anyway.
+// Locked across the blocking read: readers of the one stdin have to take turns anyway.
 static STATE: bun_core::Mutex<State> = bun_core::Mutex::new(State {
     units: [0; UNITS_CAPACITY],
     bytes: [0; BYTES_CAPACITY],
@@ -71,8 +58,7 @@ static STATE: bun_core::Mutex<State> = bun_core::Mutex::new(State {
     mid_line: false,
 });
 
-/// `Some` when `fd` (the process stdin) is a console, `None` when it is a pipe
-/// or file and the caller should `ReadFile` it as usual.
+/// `None` when `fd` is not a console (pipes and files stay on the `ReadFile` path).
 pub(crate) fn read(fd: Fd, buf: &mut [u8]) -> Option<Maybe<usize>> {
     let mut mode: DWORD = 0;
     if super::kernel32_2::GetConsoleMode(fd.native(), &mut mode) == 0 {
@@ -98,9 +84,7 @@ impl State {
         Ok(n)
     }
 
-    /// Reads the next chunk into `bytes`. `Ok(false)` is end of input. `Ok(true)`
-    /// with nothing in `bytes` is possible (the chunk was a lone high surrogate)
-    /// and means: read again.
+    /// `Ok(false)` is end of input; `Ok(true)` can leave `bytes` empty (lone high surrogate).
     fn refill(&mut self, fd: Fd, line_input: bool) -> Maybe<bool> {
         let has_lead = self.pending_lead != 0;
         self.units[0] = core::mem::take(&mut self.pending_lead);
@@ -112,14 +96,11 @@ impl State {
         if first == end {
             return Ok(false);
         }
-        // Same as ReadFile: in line-input mode a line that starts with Ctrl+Z is
-        // end of input and is not delivered.
+        // Like ReadFile: a line-input line that starts with Ctrl+Z is end of input, and dropped.
         if line_input && n > 0 && !continues_line && self.units[1] == CTRL_Z {
             return Ok(false);
         }
-        // The low half of a pair that ends the chunk is still in the console;
-        // at end of input (n == 0) there is nothing to wait for and the lone
-        // surrogate becomes U+FFFD below.
+        // A trailing high surrogate's other half is still in the console, unless this is EOF.
         if n > 0 && strings::u16_is_lead(self.units[end - 1]) {
             end -= 1;
             self.pending_lead = self.units[end];
@@ -148,8 +129,7 @@ fn read_units(fd: Fd, out: &mut [u16]) -> Maybe<usize> {
             )
         };
         let err = Win32Error::get();
-        // Ctrl+C / Ctrl+Break cancel the wait, reported either as a failure or
-        // as a successful zero-length read; the ReadFile path retries as well.
+        // Ctrl+C / Ctrl+Break surface as a failure or an empty success; retried like ReadFile's path.
         if err == Win32Error::OPERATION_ABORTED && (ok == 0 || n == 0) {
             continue;
         }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -2094,6 +2094,7 @@ pub fn GetEnvironmentVariableW(
     Ok(rc)
 }
 
+pub(crate) mod console_stdin;
 pub mod env;
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/windows/console-stdin-driver-fixture.ts
+++ b/test/js/bun/windows/console-stdin-driver-fixture.ts
@@ -1,0 +1,191 @@
+// Runs a command on a real (headless) Windows console and types into it.
+//
+// Usage: bun console-stdin-driver-fixture.ts <spec.json>
+//   spec: { cmd: string, cwd: string, keys: string[] }
+// Prints { exit, timedOut } for the command as JSON on stdout.
+//
+// This is a separate process because a process has at most one console and
+// swapping it (FreeConsole + AllocConsole) would take the test runner off its
+// own. keys[0] is queued with WriteConsoleInputW before the command starts:
+// conhost interprets queued input with whatever mode is in effect when the
+// program reads (cooked line input for prompt(), raw for the REPL), so no
+// synchronization with the child is needed for it. Every further entry is typed
+// once the child has drained the input queue, so the child gets it in a
+// separate read from everything before it. The child is put in a job object
+// that kills it when this process goes away, so a hung child cannot outlive
+// the test.
+import { dlopen, FFIType, ptr } from "bun:ffi";
+import { readFileSync } from "node:fs";
+
+const spec: { cmd: string; cwd: string; keys: string[] } = JSON.parse(readFileSync(process.argv[2], "utf8"));
+
+const kernel32 = dlopen("kernel32.dll", {
+  FreeConsole: { args: [], returns: FFIType.i32 },
+  AllocConsole: { args: [], returns: FFIType.i32 },
+  GetLastError: { args: [], returns: FFIType.u32 },
+  CreateFileW: {
+    args: [FFIType.ptr, FFIType.u32, FFIType.u32, FFIType.ptr, FFIType.u32, FFIType.u32, FFIType.ptr],
+    returns: FFIType.u64,
+  },
+  WriteConsoleInputW: { args: [FFIType.u64, FFIType.ptr, FFIType.u32, FFIType.ptr], returns: FFIType.i32 },
+  GetNumberOfConsoleInputEvents: { args: [FFIType.u64, FFIType.ptr], returns: FFIType.i32 },
+  CreateJobObjectW: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.u64 },
+  SetInformationJobObject: { args: [FFIType.u64, FFIType.u32, FFIType.ptr, FFIType.u32], returns: FFIType.i32 },
+  AssignProcessToJobObject: { args: [FFIType.u64, FFIType.u64], returns: FFIType.i32 },
+  CreateProcessW: {
+    args: [
+      FFIType.ptr,
+      FFIType.ptr,
+      FFIType.ptr,
+      FFIType.ptr,
+      FFIType.i32,
+      FFIType.u32,
+      FFIType.ptr,
+      FFIType.ptr,
+      FFIType.ptr,
+      FFIType.ptr,
+    ],
+    returns: FFIType.i32,
+  },
+  ResumeThread: { args: [FFIType.u64], returns: FFIType.u32 },
+  WaitForSingleObject: { args: [FFIType.u64, FFIType.u32], returns: FFIType.u32 },
+  GetExitCodeProcess: { args: [FFIType.u64, FFIType.ptr], returns: FFIType.i32 },
+  TerminateProcess: { args: [FFIType.u64, FFIType.u32], returns: FFIType.i32 },
+  CloseHandle: { args: [FFIType.u64], returns: FFIType.i32 },
+}).symbols;
+
+const INVALID_HANDLE_VALUE = 0xffffffffffffffffn;
+const WAIT_OBJECT_0 = 0;
+const wstr = (s: string) => Buffer.from(s + "\0", "utf16le");
+const fail = (what: string): never => {
+  throw new Error(`${what} failed, GetLastError=${kernel32.GetLastError()}`);
+};
+
+kernel32.FreeConsole();
+if (kernel32.AllocConsole() === 0) fail("AllocConsole");
+
+// SECURITY_ATTRIBUTES { DWORD nLength; LPVOID lpSecurityDescriptor; BOOL bInheritHandle }
+const inheritable = Buffer.alloc(24);
+inheritable.writeUInt32LE(24, 0);
+inheritable.writeInt32LE(1, 16);
+function openConsoleDevice(name: string): bigint {
+  const GENERIC_READ_WRITE = 0xc0000000;
+  const FILE_SHARE_READ_WRITE = 3;
+  const OPEN_EXISTING = 3;
+  const path = wstr(name);
+  const handle = kernel32.CreateFileW(
+    ptr(path),
+    GENERIC_READ_WRITE,
+    FILE_SHARE_READ_WRITE,
+    ptr(inheritable),
+    OPEN_EXISTING,
+    0,
+    null,
+  ) as bigint;
+  if (handle === INVALID_HANDLE_VALUE) fail(`CreateFileW(${name})`);
+  return handle;
+}
+const conin = openConsoleDevice("CONIN$");
+const conout = openConsoleDevice("CONOUT$");
+
+// One KEY_EVENT INPUT_RECORD (20 bytes) per UTF-16 code unit, key down then
+// key up, exactly as conhost would queue them for typing. "\r" is Enter and
+// "\x1a" is Ctrl+Z; everything else is delivered purely through UnicodeChar.
+function keyEvents(text: string): Buffer {
+  const KEY_EVENT = 0x0001;
+  const VK_RETURN = 0x0d;
+  const LEFT_CTRL_PRESSED = 0x0008;
+  const records = Buffer.alloc(text.length * 2 * 20);
+  let offset = 0;
+  for (let i = 0; i < text.length; i++) {
+    const unit = text.charCodeAt(i);
+    const [virtualKey, controlKeyState] =
+      unit === 0x0d ? [VK_RETURN, 0] : unit === 0x1a ? ["Z".charCodeAt(0), LEFT_CTRL_PRESSED] : [0, 0];
+    for (const keyDown of [1, 0]) {
+      records.writeUInt16LE(KEY_EVENT, offset);
+      records.writeInt32LE(keyDown, offset + 4);
+      records.writeUInt16LE(1, offset + 8); // wRepeatCount
+      records.writeUInt16LE(virtualKey, offset + 10);
+      records.writeUInt16LE(unit, offset + 14); // uChar.UnicodeChar
+      records.writeUInt32LE(controlKeyState, offset + 16);
+      offset += 20;
+    }
+  }
+  return records;
+}
+
+const dword = Buffer.alloc(4);
+function type(text: string) {
+  const records = keyEvents(text);
+  const count = records.length / 20;
+  if (kernel32.WriteConsoleInputW(conin, ptr(records), count, ptr(dword)) === 0) fail("WriteConsoleInputW");
+  if (dword.readUInt32LE(0) !== count)
+    throw new Error(`WriteConsoleInputW queued ${dword.readUInt32LE(0)} of ${count}`);
+}
+function queuedInputEvents(): number {
+  if (kernel32.GetNumberOfConsoleInputEvents(conin, ptr(dword)) === 0) fail("GetNumberOfConsoleInputEvents");
+  return dword.readUInt32LE(0);
+}
+
+type(spec.keys[0]);
+
+const job = kernel32.CreateJobObjectW(null, null) as bigint;
+if (job === 0n) fail("CreateJobObjectW");
+// JOBOBJECT_EXTENDED_LIMIT_INFORMATION with BasicLimitInformation.LimitFlags =
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.
+const JobObjectExtendedLimitInformation = 9;
+const limits = Buffer.alloc(144);
+limits.writeUInt32LE(0x2000, 16);
+if (kernel32.SetInformationJobObject(job, JobObjectExtendedLimitInformation, ptr(limits), limits.length) === 0) {
+  fail("SetInformationJobObject");
+}
+
+// STARTUPINFOW: cb @0, dwFlags @60, hStdInput @80, hStdOutput @88, hStdError @96.
+// Without STARTF_USESTDHANDLES the child would get copies of this process's
+// pipes as stdio rather than the console.
+const STARTF_USESTDHANDLES = 0x100;
+const CREATE_SUSPENDED = 0x4;
+const startupInfo = Buffer.alloc(104);
+startupInfo.writeUInt32LE(startupInfo.length, 0);
+startupInfo.writeUInt32LE(STARTF_USESTDHANDLES, 60);
+startupInfo.writeBigUInt64LE(conin, 80);
+startupInfo.writeBigUInt64LE(conout, 88);
+startupInfo.writeBigUInt64LE(conout, 96);
+const processInfo = Buffer.alloc(24);
+const commandLine = wstr(spec.cmd);
+const cwd = wstr(spec.cwd);
+if (
+  kernel32.CreateProcessW(
+    null,
+    ptr(commandLine),
+    null,
+    null,
+    1,
+    CREATE_SUSPENDED,
+    null,
+    ptr(cwd),
+    ptr(startupInfo),
+    ptr(processInfo),
+  ) === 0
+) {
+  fail("CreateProcessW");
+}
+const hProcess = processInfo.readBigUInt64LE(0);
+const hThread = processInfo.readBigUInt64LE(8);
+if (kernel32.AssignProcessToJobObject(job, hProcess) === 0) fail("AssignProcessToJobObject");
+kernel32.ResumeThread(hThread);
+
+const deadline = Date.now() + 30_000;
+const childExited = (waitMs: number) => kernel32.WaitForSingleObject(hProcess, waitMs) === WAIT_OBJECT_0;
+for (const text of spec.keys.slice(1)) {
+  while (queuedInputEvents() > 0 && Date.now() < deadline && !childExited(0)) {
+    await Bun.sleep(1);
+  }
+  type(text);
+}
+const timedOut = !childExited(Math.max(0, deadline - Date.now()));
+if (timedOut) kernel32.TerminateProcess(hProcess, 1);
+kernel32.GetExitCodeProcess(hProcess, ptr(dword));
+kernel32.CloseHandle(hThread);
+kernel32.CloseHandle(hProcess);
+console.log(JSON.stringify({ exit: dword.readUInt32LE(0), timedOut }));

--- a/test/js/bun/windows/console-stdin-prompt-fixture.js
+++ b/test/js/bun/windows/console-stdin-prompt-fixture.js
@@ -1,0 +1,17 @@
+// Reads eight lines from the console with the blocking Web dialogs and records
+// what came back. alert() and confirm() read stdin one byte at a time, prompt()
+// through a 4 KiB buffer, so the same console input is read both ways.
+const { writeFileSync } = require("node:fs");
+
+alert("first line is discarded by alert()");
+const result = {
+  stdinIsTTY: require("node:tty").isatty(0),
+  prompt1: prompt("p1"),
+  confirm: confirm("c"),
+  prompt2: prompt("p2"),
+  prompt3: prompt("p3"),
+  prompt4: prompt("p4"),
+  prompt5: prompt("p5"),
+  prompt6: prompt("p6"),
+};
+writeFileSync(process.env.CONSOLE_STDIN_RESULT, JSON.stringify(result));

--- a/test/js/bun/windows/console-stdin.test.ts
+++ b/test/js/bun/windows/console-stdin.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Bun's own stdin readers (prompt()/alert()/confirm(), the REPL, `bun -`, the
+// CLI prompts) read the process stdin handle directly, not through libuv. When
+// that handle is a console, reading it with ReadFile goes through conhost's
+// code page conversion, which returns garbage for non-ASCII input under the
+// UTF-8 code page bun selects (oven-sh/bun#27556); the console has to be read
+// with ReadConsoleW. These tests type into a real console, see
+// console-stdin-driver-fixture.ts. The program under test writes what it read
+// to CONSOLE_STDIN_RESULT, since its stdout is the console.
+
+const TEXT = "a\u4e2db\u{1F600}";
+
+/**
+ * Runs `bun <args>` on a console. `keys[0]` is typed before it starts; each
+ * later entry is typed only after everything before it has been consumed, so it
+ * is guaranteed to arrive in a separate read.
+ */
+async function typeIntoConsole(args: string[], keys: string[]) {
+  using dir = tempDir("console-stdin", {});
+  const resultPath = join(String(dir), "result.json");
+  const specPath = join(String(dir), "spec.json");
+  const cmd = [bunExe(), ...args].map(arg => `"${arg}"`).join(" ");
+  await Bun.write(specPath, JSON.stringify({ cmd, cwd: String(dir), keys }));
+
+  await using driver = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "console-stdin-driver-fixture.ts"), specPath],
+    env: {
+      ...bunEnv,
+      CONSOLE_STDIN_RESULT: resultPath,
+      // Keeps the REPL's history file out of the real home directory.
+      HOME: String(dir),
+      USERPROFILE: String(dir),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([driver.stdout.text(), driver.stderr.text(), driver.exited]);
+  if (exitCode !== 0) throw new Error(`console driver exited with ${exitCode}:\n${stderr}`);
+
+  return {
+    child: JSON.parse(stdout),
+    result: existsSync(resultPath) ? JSON.parse(readFileSync(resultPath, "utf8")) : "result file was not written",
+  };
+}
+
+describe.skipIf(!isWindows)("reading non-ASCII input from a Windows console", () => {
+  test.concurrent("prompt(), alert() and confirm()", async () => {
+    // Longer than both prompt()'s 4 KiB read buffer and the 4094 characters a
+    // line could have when that buffer was what got passed to the console.
+    const longLine = Buffer.alloc(5000, "x").toString();
+    const lines = [
+      // alert(): one-byte reads, so each character is handed out byte by byte.
+      "\u4e2d\u{1F600}",
+      TEXT,
+      "y",
+      "\ud55c\uad6d\uc5b4",
+      // Ctrl+Z inside a line is an ordinary character...
+      "ab\x1acd",
+      // ...while a line starting with Ctrl+Z is end of input, as with ReadFile,
+      "\x1a",
+      // and end of input on a console is not sticky.
+      "after",
+      longLine,
+    ];
+    const fixture = join(import.meta.dir, "console-stdin-prompt-fixture.js");
+    expect(await typeIntoConsole([fixture], [lines.join("\r") + "\r"])).toEqual({
+      child: { exit: 0, timedOut: false },
+      result: {
+        stdinIsTTY: true,
+        prompt1: TEXT,
+        confirm: true,
+        prompt2: "\ud55c\uad6d\uc5b4",
+        prompt3: "ab\x1acd",
+        prompt4: null,
+        prompt5: "after",
+        prompt6: longLine,
+      },
+    });
+  });
+
+  test.concurrent("the REPL line editor (raw console mode)", async () => {
+    const script = `require("fs").writeFileSync(process.env.CONSOLE_STDIN_RESULT, JSON.stringify("${TEXT}"))`;
+    // The emoji's high surrogate is delivered in a read of its own (raw mode
+    // returns whatever has been typed so far), so it has to be held back until
+    // the low surrogate arrives with the next read.
+    const high = script.indexOf(TEXT) + TEXT.length - 2;
+    const keys = [script.slice(0, high), script[high], script.slice(high + 1) + "\r.exit\r"];
+    expect(await typeIntoConsole(["repl"], keys)).toEqual({
+      child: { exit: 0, timedOut: false },
+      result: TEXT,
+    });
+  });
+
+  test.concurrent("a script typed into `bun -` and ended with Ctrl+Z", async () => {
+    const script = `require("fs").writeFileSync(process.env.CONSOLE_STDIN_RESULT, JSON.stringify("${TEXT}"))`;
+    expect(await typeIntoConsole(["-"], [`${script}\r\x1a\r`])).toEqual({
+      child: { exit: 0, timedOut: false },
+      result: TEXT,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- On Windows, everything bun reads from an interactive console through its own stdin readers comes back garbled for non-ASCII characters: `bun repl` silently drops them, `prompt()` returns one junk byte per character (typing `a中b😀` into `prompt()` returned `"a b"` on one run and `a` + U+FFFD + `b` on another; the junk byte varies per run and the emoji's two UTF-16 units come back as two NULs), and a script typed into `bun -` gets the same junk in its source. `한국어` came back as three junk bytes. This is the Windows half of #27556; #31876 fixed the POSIX line editor.
- Cause: `bun_sys::read()` for HANDLE-backed fds (`src/sys/lib.rs`, `windows_impl::read`) calls `ReadFile`. On a console handle that is the ANSI console API: conhost converts the typed UTF-16 through the console input code page, and its CP_UTF8 conversion (bun sets code page 65001 at startup in `src/bun_core/output.rs`) does not produce multi-byte UTF-8 on Windows 10 / Server 2019. Every native stdin reader ends up in this one function: the REPL's `read_byte` (`File::stdin().read`, 256-byte buffer), `prompt()` through the 4 KiB `BufferedStdin`, `alert()`/`confirm()`/`bun init`/`bun update -i` through one-byte `StdinReader` reads, `bun publish`'s OTP prompt, and `bun -` through `read_to_end_into`.
- `process.stdin`, `Bun.stdin` and `fs.readSync(0)` go through libuv (fd 0 is a Uv-kind fd) and were never affected; they are not touched.

### Fix
- `read()` hands the process stdin to a new `bun_sys::windows::console_stdin` module when `GetConsoleMode` succeeds on it. The module reads 8192 UTF-16 units at a time with `ReadConsoleW` into a process-wide buffer, transcodes the chunk with `bun_core::strings::copy_utf16_into_utf8`, and serves `read()` calls of any size from the transcoded bytes. Pipes and files still take the `ReadFile` path, so redirected stdin stays byte-exact. The dispatch is keyed on `fd == Fd::stdin()`, so ordinary file reads do not pay for a `GetConsoleMode` call; stdin is the only console handle bun reads this way.
- Reading the console with the W API and converting in the program is what every Unicode-aware console program does on Windows (libuv's tty reader, Python since PEP 528, Rust's std); the ANSI conversion is the broken piece, not the code page.
- The chunk size is fixed instead of derived from the caller's buffer because on the Windows 10 / Server 2019 conhost the count passed to a line-input read is also the longest line the console lets the user type. Measured here: `prompt()` accepted 4094 characters with `ReadFile` (its 4 KiB buffer), a first version of this change that requested `buf.len() / 3` units cut that to 1022, and with 8192 units `prompt()` takes 8190 and `bun -` keeps the 8190 it had (its `ReadFile` requests were 8 KiB). A 5000-character line is part of the test.
- A high surrogate that ends a chunk is held back and prepended to the next chunk, so a pair split across two reads (in raw mode the console returns whatever has been typed so far) becomes one character instead of two U+FFFD; a chunk consisting only of such a surrogate makes `read()` go straight back to the console rather than report end of input.
- End-of-input behaviour is unchanged from `ReadFile`, measured on Server 2019 before the change: in line-input mode a line that starts with Ctrl+Z is end of input (`prompt()` returns `null`, `bun -` runs the script), Ctrl+Z elsewhere in a line is an ordinary character, and end of input is not sticky (the next line is readable). `ReadConsoleW` itself has no Ctrl+Z rule, so it is applied here, to chunks that start a line (a newer console delivers a line longer than one chunk over several reads, and the continuation chunks are not checked); raw mode (the REPL) gets byte 0x1A as before. Ctrl+C / Ctrl+Break cancel a console read with `ERROR_OPERATION_ABORTED`, which is retried exactly like the `ReadFile` path does; a Ctrl+C probe against `prompt()` and the REPL behaves identically before and after (details below).
- Verified with `test/js/bun/windows/console-stdin.test.ts`. `console-stdin-driver-fixture.ts` gives bun a real headless console (`AllocConsole`, the child gets the console as its stdio) and types into it with `WriteConsoleInputW`; the program under test writes what it read to a file. Three cases: `prompt()`/`alert()`/`confirm()` with the Ctrl+Z lines above and the 5000-character line; the REPL in raw mode, where the emoji's high surrogate is typed only after the REPL has consumed everything before it (the driver waits for the console input queue to drain) so it arrives in a read of its own; and `bun -` ended with a Ctrl+Z line. On windows-x64 all three fail with bun 1.4.0-canary.1 (`USE_SYSTEM_BUN=1`, output below) and pass with `bun bd test`; in CI the file runs and passes on both the Windows Server 2019 x64 and the Windows 11 aarch64 test lanes (the old and the new console), and is skipped on other platforms, so the Linux gate cannot exercise it. A temporarily instrumented build confirmed the REPL case reaches the surrogate hold-back with a one-unit chunk.
- Also ran `cargo check -p bun_sys` for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`, clippy on the Windows target (nothing reported in the new code), `test/internal/source-lints/`, and the test typecheck for the new files. `cargo test -p bun_sys` cannot link (bun_core needs the C++ objects), so the module has no Rust unit tests; the console cases cover the large-buffer, one-byte, split-surrogate, raw-mode, long-line and end-of-input paths.

### Background
- Windows has two console input APIs. `ReadConsoleW` returns the typed text as UTF-16. `ReadFile` on a console handle is routed to the ANSI variant, which converts that text to bytes using the console input code page; that conversion is what misbehaves for code page 65001 on the conhost versions in question, which is why Unicode-aware programs read consoles with `ReadConsoleW` and convert themselves.
- Console input mode: with `ENABLE_LINE_INPUT` set (the default, used by `prompt()` and the CLI prompts) a read returns one line at a time after Enter, terminated by `\r\n`, and on the older conhost the requested count is the line-length limit; newer consoles return a longer line over several reads. With the flag cleared (the REPL's raw mode) a read returns whatever keys are available. The mode is applied when the program reads, not when the user types, which is what lets the test queue keystrokes before launching the child.
- On Windows, bun's `Fd` is either Uv-kind (a CRT fd owned by libuv, such as fd 0 used by `process.stdin` and `fs`) or System-kind (a raw HANDLE). The cached process stdin behind `File::stdin()` and `Output`'s stdin readers is System-kind, which is why these readers reach the `ReadFile` branch of `read()`.

<details>
<summary>Measurements behind the Ctrl+Z and Ctrl+C rules and the fail-before output (Windows Server 2019, typed through the same console harness)</summary>

`prompt()` with the released build (`ReadFile`) and with this change (`ReadConsoleW`) agree on every row:

| typed | prompt() returns | following prompt() |
| --- | --- | --- |
| `^Z` Enter | `null` | reads the next line |
| `^Zabc` Enter | `null` | reads the next line |
| `abc^Z` Enter | `"abc\x1a"` | |
| `ab^Zcd` Enter | `"ab\x1acd"` | |
| `^Z` without Enter | blocks, as before | |

Line length in line-input mode: released build, `prompt()` 4094 characters, `bun -` first line about 8190; this change, `prompt()` 8190, `bun -` 8190 (a 9000-character line is cut at 8190 by the console in both cases).

Ctrl+C sent with `GenerateConsoleCtrlEvent` while blocked, released build and this change identical: `prompt()` with no SIGINT listener exits with `STATUS_CONTROL_C_EXIT`; `prompt()` with a `process.on("SIGINT")` listener keeps blocking in the read (the listener cannot run while the main thread is blocked, same as before); the REPL exits with `STATUS_CONTROL_C_EXIT` (pre-existing Windows REPL behaviour, reported separately).

New test against bun 1.4.0-canary.1+9a543cc18 (`USE_SYSTEM_BUN=1`) on windows-x64:

```
-     "prompt1": "a中b😀",
-     "prompt2": "한국어",
+     "prompt1": "a�b",
+     "prompt2": "���",
-     "prompt6": "xxxx... (5000 characters)
+     "prompt6": "xxxx... (cut at 4094 by the console)
...
-   "result": "a中b😀",      (REPL)
+   "result": "ab",
...
-   "result": "a中b😀",      (bun -)
+   "result": "ab",
```
</details>
