### PR TITLE
Report a CommonJS entry's top-level throw before the microtasks it queued

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -68,10 +68,6 @@ pub type ExceptionList = Vec<crate::exception_list::JsException>;
 pub struct EntryPointResult {
     pub value: crate::strong::Optional, // jsc.Strong.Optional
     pub cjs_set_value: bool,
-    /// True when the entry module evaluated as CommonJS: Node reports a CJS
-    /// entry's top-level throw with origin `uncaughtException` but an ESM
-    /// entry rejection with `unhandledRejection`; the run command consults this.
-    pub evaluated_as_cjs: bool,
 }
 
 /// Downstream-compat alias: lib.rs previously exposed `virtual_machine::InitOptions`.
@@ -299,7 +295,9 @@ pub struct VirtualMachine {
     pub(crate) resolved_path_dups: Vec<Box<[u8]>>,
     pub pending_internal_promise: Option<*mut JSInternalPromise>,
     pub pending_internal_promise_is_protected: bool,
-    pub pending_internal_promise_reported_at: u32,
+    /// The `hot_reload_counter` generation whose entry-point failure has been
+    /// reported; see [`entry_point_failure_reported`](Self::entry_point_failure_reported).
+    pending_internal_promise_reported_at: u32,
     pub(crate) hot_reload_deferred: bool,
     pub entry_point_result: EntryPointResult,
 
@@ -1527,7 +1525,14 @@ impl VirtualMachine {
             // and exit, like node's fatal-exception path. Main thread only:
             // process_exit() RETURNS on a worker, so the panic would fire; a
             // worker falls through and exits 1 below (e.g. a beforeExit throw).
-            if self.exit_on_uncaught_exception && self.is_main_thread() {
+            // Not under --hot/--watch: there the loop draining (which is what
+            // armed this) is not the end of the run, the watcher keeps it going
+            // and reloads, so the error is reported below and the process goes
+            // on watching, as it does for an error in the first generation.
+            if self.exit_on_uncaught_exception
+                && self.is_main_thread()
+                && !self.is_watcher_enabled()
+            {
                 self.run_error_handler(err, None);
                 // `process_exit` emits `exit`, re-entering here if a listener
                 // throws. No handler is running, so drop the recursion guard or
@@ -3672,6 +3677,20 @@ impl VirtualMachine {
         (self.on_unhandled_rejection)(self, global_object, reason);
     }
 
+    /// Whether the failure of the current entry-point load (this hot-reload
+    /// generation's) has been reported already. A CommonJS entry's top-level
+    /// throw is reported from the throw site (`Bun__VM__reportEntryPointThrow`),
+    /// before the module loader rejects the entry promise with it; whoever then
+    /// observes that rejection (the run command, a worker's `spin`, the hot
+    /// reloader) consults this so it is reported exactly once.
+    pub fn entry_point_failure_reported(&self) -> bool {
+        self.pending_internal_promise_reported_at == self.hot_reload_counter
+    }
+
+    pub fn mark_entry_point_failure_reported(&mut self) {
+        self.pending_internal_promise_reported_at = self.hot_reload_counter;
+    }
+
     /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.
     pub fn report_exception_in_hot_reloaded_module_if_needed(&mut self) {
         let promise = match self.pending_internal_promise {
@@ -3688,8 +3707,8 @@ impl VirtualMachine {
                 return;
             }
             crate::js_promise::Status::Rejected => {
-                if self.pending_internal_promise_reported_at != self.hot_reload_counter {
-                    self.pending_internal_promise_reported_at = self.hot_reload_counter;
+                if !self.entry_point_failure_reported() {
+                    self.mark_entry_point_failure_reported();
                     // `global()` is `&'static`, so it survives the `&mut self`
                     // call below.
                     let global_ref = self.global();
@@ -3795,7 +3814,7 @@ impl VirtualMachine {
                     return;
                 }
                 crate::js_promise::Status::Rejected => {
-                    if self.pending_internal_promise_reported_at != self.hot_reload_counter {
+                    if !self.entry_point_failure_reported() {
                         self.hot_reload_deferred = true;
                         return;
                     }
@@ -5050,7 +5069,6 @@ impl VirtualMachine {
         self.overridden_main.deinit();
         self.entry_point_result.value.deinit();
         self.entry_point_result.cjs_set_value = false;
-        self.entry_point_result.evaluated_as_cjs = false;
         if let Some(promise) = self.pending_internal_promise {
             if self.pending_internal_promise_is_protected {
                 JSValue::from_cell(promise).unprotect();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -295,8 +295,7 @@ pub struct VirtualMachine {
     pub(crate) resolved_path_dups: Vec<Box<[u8]>>,
     pub pending_internal_promise: Option<*mut JSInternalPromise>,
     pub pending_internal_promise_is_protected: bool,
-    /// The `hot_reload_counter` generation whose entry-point failure has been
-    /// reported; see [`entry_point_failure_reported`](Self::entry_point_failure_reported).
+    /// See [`entry_point_failure_reported`](Self::entry_point_failure_reported).
     pending_internal_promise_reported_at: u32,
     pub(crate) hot_reload_deferred: bool,
     pub entry_point_result: EntryPointResult,
@@ -1525,10 +1524,8 @@ impl VirtualMachine {
             // and exit, like node's fatal-exception path. Main thread only:
             // process_exit() RETURNS on a worker, so the panic would fire; a
             // worker falls through and exits 1 below (e.g. a beforeExit throw).
-            // Not under --hot/--watch: there the loop draining (which is what
-            // armed this) is not the end of the run, the watcher keeps it going
-            // and reloads, so the error is reported below and the process goes
-            // on watching, as it does for an error in the first generation.
+            // Under --hot/--watch the drain that armed this was not the end of
+            // the run: report below and keep watching.
             if self.exit_on_uncaught_exception
                 && self.is_main_thread()
                 && !self.is_watcher_enabled()
@@ -3677,12 +3674,9 @@ impl VirtualMachine {
         (self.on_unhandled_rejection)(self, global_object, reason);
     }
 
-    /// Whether the failure of the current entry-point load (this hot-reload
-    /// generation's) has been reported already. A CommonJS entry's top-level
-    /// throw is reported from the throw site (`Bun__VM__reportEntryPointThrow`),
-    /// before the module loader rejects the entry promise with it; whoever then
-    /// observes that rejection (the run command, a worker's `spin`, the hot
-    /// reloader) consults this so it is reported exactly once.
+    /// Whether this hot-reload generation's entry-point failure was reported
+    /// already: a CommonJS entry's throw is reported from the throw site
+    /// (`Bun__VM__reportEntryPointThrow`) before the entry promise rejects with it.
     pub fn entry_point_failure_reported(&self) -> bool {
         self.pending_internal_promise_reported_at == self.hot_reload_counter
     }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -110,7 +110,7 @@ static bool canPerformFastEnumeration(Structure* s)
 
 extern "C" bool Bun__VM__specifierIsEvalEntryPoint(void*, EncodedJSValue);
 extern "C" void Bun__VM__setEntryPointEvalResultCJS(void*, EncodedJSValue);
-extern "C" void Bun__VM__noteCommonJSEvaluation(void*, EncodedJSValue);
+extern "C" void Bun__VM__reportEntryPointThrow(void*, EncodedJSValue);
 
 static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObject, JSCommonJSModule* moduleObject, JSString* dirname, JSValue filename)
 {
@@ -121,16 +121,6 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
     if (code.isNull()) [[unlikely]] {
         throwException(globalObject, scope, createError(globalObject, "Failed to evaluate module"_s));
         return false;
-    }
-
-    // Node reports a CJS entry's top-level throw as origin "uncaughtException", not
-    // "unhandledRejection"; record the entry mode for the run command. Only the root
-    // module (m_id == ".") can be the entry, so the FFI compare runs at most once.
-    if (auto* id = moduleObject->m_id.get(); id && id->length() == 1) [[unlikely]] {
-        auto view = id->view(globalObject);
-        RETURN_IF_EXCEPTION(scope, false);
-        if (view == "."_s)
-            Bun__VM__noteCommonJSEvaluation(globalObject->bunVM(), JSValue::encode(filename));
     }
 
     JSFunction* resolveFunction = nullptr;
@@ -1600,6 +1590,17 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
                                 // so that it can be re-evaluated on the next require.
                                 globalObject->requireMap()->remove(globalObject, moduleObject->filename());
                                 RETURN_IF_EXCEPTION(scope, {});
+
+                                // The entry point's own top-level throw is reported right here, as
+                                // Node's synchronous CJS runner reports it: surfacing it as the entry
+                                // promise's rejection would first run the microtasks the entry queued
+                                // before throwing. Does not return when the throw is fatal on the
+                                // main thread.
+                                auto key = Bun::toString(moduleKey.string());
+                                if (Bun__isBunMain(globalObject, &key)) [[unlikely]] {
+                                    Bun__VM__reportEntryPointThrow(globalObject->bunVM(), JSValue::encode(exception->value()));
+                                    RETURN_IF_EXCEPTION(scope, {});
+                                }
 
                                 scope.throwException(globalObject, exception);
                                 return;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1591,11 +1591,9 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
                                 globalObject->requireMap()->remove(globalObject, moduleObject->filename());
                                 RETURN_IF_EXCEPTION(scope, {});
 
-                                // The entry point's own top-level throw is reported right here, as
-                                // Node's synchronous CJS runner reports it: surfacing it as the entry
-                                // promise's rejection would first run the microtasks the entry queued
-                                // before throwing. Does not return when the throw is fatal on the
-                                // main thread.
+                                // The entry's own throw is reported now, as Node's synchronous CJS
+                                // runner would; left to surface as the entry promise's rejection, the
+                                // microtasks queued before it would run first. Exits if fatal on the main thread.
                                 auto key = Bun::toString(moduleKey.string());
                                 if (Bun__isBunMain(globalObject, &key)) [[unlikely]] {
                                     Bun__VM__reportEntryPointThrow(globalObject->bunVM(), JSValue::encode(exception->value()));

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -845,11 +845,8 @@ impl WebWorker {
         let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
             Ok(p) => p,
             Err(_) => {
-                // The worker may have stopped itself during the load, and then
-                // its exit code is already decided: process.exit() ran, or a
-                // CommonJS entry's top-level throw went unhandled (reported from
-                // the throw site, see `entry_point_failure_reported`; that set
-                // code 1 and ran the 'exit' handlers, which may have changed it).
+                // A process.exit() or an unhandled entry throw during the load
+                // already chose the code (the latter via the 'exit' handlers).
                 if !self.exit_called.load(Ordering::Relaxed) && !vm.entry_point_failure_reported() {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }
@@ -868,14 +865,9 @@ impl WebWorker {
         // loop turn: a rejection (immediate, or a top-level await rejecting
         // later) is the entry's uncaught error at that moment — the worker stops
         // unless a handler took it — and is reported exactly once. The loader
-        // marks this promise handled, so nothing else would report it.
-        //
-        // A CommonJS entry's top-level throw was reported from the throw site
-        // instead (`Bun__VM__reportEntryPointThrow`, same rule as the main
-        // thread); unhandled, it stopped the worker inside the load above, so
-        // seeing its rejection here means a handler took it. What is reported
-        // here is an ESM entry's rejection, origin "unhandledRejection" as in
-        // Node.
+        // marks this promise handled, so nothing else would report it. A CommonJS
+        // entry's throw was already reported from the throw site (unhandled, it
+        // ended the load above); what is reported here is an ESM rejection.
         let mut entry_rejection_seen = vm.entry_point_failure_reported();
         let mut observe_entry = |vm: &VirtualMachine| -> EntryOutcome {
             // SAFETY: `promise` is a live JSC heap cell, rooted below for the loop's duration.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -845,8 +845,12 @@ impl WebWorker {
         let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
             Ok(p) => p,
             Err(_) => {
-                // process.exit() may have run during load; don't clobber its code.
-                if !self.exit_called.load(Ordering::Relaxed) {
+                // The worker may have stopped itself during the load, and then
+                // its exit code is already decided: process.exit() ran, or a
+                // CommonJS entry's top-level throw went unhandled (reported from
+                // the throw site, see `entry_point_failure_reported`; that set
+                // code 1 and ran the 'exit' handlers, which may have changed it).
+                if !self.exit_called.load(Ordering::Relaxed) && !vm.entry_point_failure_reported() {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }
                 self.flush_logs(vm);
@@ -865,7 +869,14 @@ impl WebWorker {
         // later) is the entry's uncaught error at that moment — the worker stops
         // unless a handler took it — and is reported exactly once. The loader
         // marks this promise handled, so nothing else would report it.
-        let mut entry_rejection_seen = false;
+        //
+        // A CommonJS entry's top-level throw was reported from the throw site
+        // instead (`Bun__VM__reportEntryPointThrow`, same rule as the main
+        // thread); unhandled, it stopped the worker inside the load above, so
+        // seeing its rejection here means a handler took it. What is reported
+        // here is an ESM entry's rejection, origin "unhandledRejection" as in
+        // Node.
+        let mut entry_rejection_seen = vm.entry_point_failure_reported();
         let mut observe_entry = |vm: &VirtualMachine| -> EntryOutcome {
             // SAFETY: `promise` is a live JSC heap cell, rooted below for the loop's duration.
             unsafe {
@@ -874,14 +885,10 @@ impl WebWorker {
                     return EntryOutcome::Continue;
                 }
                 entry_rejection_seen = true;
-                // Same rule as the main thread (run_command): a CJS worker
-                // entry's top-level throw is an uncaughtException; only an
-                // ESM entry rejection reports origin "unhandledRejection".
-                let is_rejection = !vm.as_mut().entry_point_result.evaluated_as_cjs;
                 let handled = vm.as_mut().uncaught_exception(
                     vm.global(),
                     (*promise).result(vm.jsc_vm()),
-                    is_rejection,
+                    true,
                 );
                 if handled {
                     EntryOutcome::Continue

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1432,23 +1432,29 @@ impl Run<'_> {
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };
                 if promise.status() == PromiseStatus::Rejected {
-                    // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
-                    let result = promise.result(unsafe { &mut *vm.jsc_vm });
-                    let global = vm.global;
-                    // A CJS entry runs synchronously in Node, so its top-level
-                    // throw is an uncaughtException; only an ESM entry
-                    // rejection reports origin "unhandledRejection".
-                    let is_rejection = !vm.entry_point_result.evaluated_as_cjs;
-                    // SAFETY: `global` valid for VM lifetime.
-                    let handled = vm.uncaught_exception(unsafe { &*global }, result, is_rejection);
+                    // A CommonJS entry's top-level throw was already reported
+                    // from the throw site (`Bun__VM__reportEntryPointThrow`),
+                    // which exits unless a handler took it or --hot/--watch keeps
+                    // the process alive. What gets here unreported is an ESM
+                    // entry's rejection (or a load failure), which Node too
+                    // reports with origin "unhandledRejection".
+                    //
+                    // Either way, keep the process alive instead of hard-exiting
+                    // when --hot/--watch is on or a user `uncaughtException`
+                    // handler swallowed the error; the core run-loop below does
+                    // the actual waiting.
+                    let keep_alive = vm.entry_point_failure_reported() || {
+                        vm.mark_entry_point_failure_reported();
+                        // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
+                        let result = promise.result(unsafe { &mut *vm.jsc_vm });
+                        let global = vm.global;
+                        // SAFETY: `global` valid for VM lifetime.
+                        let handled = vm.uncaught_exception(unsafe { &*global }, result, true);
+                        vm.hot_reload != 0 || handled
+                    };
                     promise.set_handled();
-                    vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
 
-                    // When --hot/--watch is on (or a user
-                    // `uncaughtException` handler swallowed the error), keep the
-                    // process alive instead of hard-exiting on a rejected entry.
-                    // The core run-loop below does the actual waiting.
-                    if vm.hot_reload != 0 || handled {
+                    if keep_alive {
                         vm.add_main_to_watcher_if_needed();
                         // SAFETY: `event_loop` is a self-pointer into this VM;
                         // uniquely accessed here.
@@ -1623,17 +1629,19 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 }
 
 /// Cold tail shared by the rejected-entry-point and load-failure paths in
-/// `Run::start`: flag the exit code, run `on_exit`, optionally print the
-/// "unhandled error" sourcemap note + version string, then hard-exit. Hoisted
-/// out (and parked in `.text.unlikely` on linux) so the linker keeps it off the
-/// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
+/// `Run::start` and by a CommonJS entry's top-level throw, reported while the
+/// entry is still evaluating (`hw_exports::report_entry_point_throw`): flag the
+/// exit code, run `on_exit`, optionally print the "unhandled error" sourcemap
+/// note + version string, then hard-exit. Hoisted out (and parked in
+/// `.text.unlikely` on linux) so the linker keeps it off the `.text.hot`
+/// fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
 #[cfg_attr(
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
+pub(crate) fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
     if ANY_UNHANDLED.load(Ordering::Relaxed) {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1432,17 +1432,11 @@ impl Run<'_> {
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };
                 if promise.status() == PromiseStatus::Rejected {
-                    // A CommonJS entry's top-level throw was already reported
-                    // from the throw site (`Bun__VM__reportEntryPointThrow`),
-                    // which exits unless a handler took it or --hot/--watch keeps
-                    // the process alive. What gets here unreported is an ESM
-                    // entry's rejection (or a load failure), which Node too
-                    // reports with origin "unhandledRejection".
-                    //
-                    // Either way, keep the process alive instead of hard-exiting
-                    // when --hot/--watch is on or a user `uncaughtException`
-                    // handler swallowed the error; the core run-loop below does
-                    // the actual waiting.
+                    // A CommonJS entry's throw was reported from the throw site,
+                    // which exited unless a handler or --hot/--watch kept the
+                    // process alive; an unreported rejection is an ESM entry's
+                    // (origin "unhandledRejection", as in Node). Kept alive, the
+                    // core run-loop below does the waiting.
                     let keep_alive = vm.entry_point_failure_reported() || {
                         vm.mark_entry_point_failure_reported();
                         // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
@@ -1629,12 +1623,11 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 }
 
 /// Cold tail shared by the rejected-entry-point and load-failure paths in
-/// `Run::start` and by a CommonJS entry's top-level throw, reported while the
-/// entry is still evaluating (`hw_exports::report_entry_point_throw`): flag the
-/// exit code, run `on_exit`, optionally print the "unhandled error" sourcemap
-/// note + version string, then hard-exit. Hoisted out (and parked in
-/// `.text.unlikely` on linux) so the linker keeps it off the `.text.hot`
-/// fault-around window the `require('fs')` startup path pulls in.
+/// `Run::start` and by `hw_exports::report_entry_point_throw`: flag the exit
+/// code, run `on_exit`, optionally print the "unhandled error" sourcemap note +
+/// version string, then hard-exit. Hoisted out (and parked in `.text.unlikely`
+/// on linux) so the linker keeps it off the `.text.hot` fault-around window the
+/// `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
 #[cfg_attr(

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -146,22 +146,34 @@ pub fn specifier_is_eval_entry_point(this: &mut VirtualMachine, specifier: JSVal
     false
 }
 
-/// Called once by JSCommonJSModule.cpp for the root CJS module so the run command reports
-/// origin `uncaughtException`. `main()` compare filters out an ESM entry that `import`s CJS.
-// HOST_EXPORT(Bun__VM__noteCommonJSEvaluation, c)
-pub fn note_commonjs_evaluation(this: &mut VirtualMachine, specifier: JSValue) {
-    if this.entry_point_result.evaluated_as_cjs || this.main().is_empty() {
+/// Called by JSCommonJSModule.cpp when the entry point, evaluating as CommonJS,
+/// threw out of its top level; the module loader is about to reject the entry
+/// promise with it. Node runs a CommonJS entry synchronously, so its throw is
+/// the uncaught exception right there, ahead of anything the entry queued
+/// before throwing; observing the rejection instead (what the run command and a
+/// worker's `spin` do for an ESM entry) would drain those microtasks first. So
+/// the throw is reported here, `entry_point_failure_reported` tells the code
+/// observing the rejection that it was, and with no handler the main thread
+/// exits here, as it would have on the rejection (a worker's
+/// `on_unhandled_rejection` has requested the worker's stop by the time
+/// `uncaught_exception` returns).
+// HOST_EXPORT(Bun__VM__reportEntryPointThrow, c)
+pub fn report_entry_point_throw(this: &mut VirtualMachine, error: JSValue) {
+    let is_main_thread = this.worker_ref().is_none();
+    // The test runner reports a test file's top-level throw itself, as that
+    // file's failure, when it observes the rejection (test_command.rs). Workers
+    // started by a test file are ordinary workers.
+    if is_main_thread
+        && bun_jsc::virtual_machine::isBunTest.load(core::sync::atomic::Ordering::Relaxed)
+    {
         return;
     }
+    this.mark_entry_point_failure_reported();
     let global = this.global();
-    // A failed conversion just skips the note; must never panic at an FFI
-    // boundary.
-    let Ok(specifier_str) = bun_jsc::bun_string_jsc::from_js(specifier, global) else {
-        return;
-    };
-    let specifier_str = bun_core::OwnedString::new(specifier_str);
-    if specifier_str.eql_utf8(this.main()) {
-        this.entry_point_result.evaluated_as_cjs = true;
+    let handled = this.uncaught_exception(global, error, false);
+    // --hot / --watch keep the process alive on a failed entry and reload it.
+    if !handled && is_main_thread && this.hot_reload == 0 {
+        crate::cli::run_command::exit_with_unhandled_note(this);
     }
 }
 

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -146,23 +146,16 @@ pub fn specifier_is_eval_entry_point(this: &mut VirtualMachine, specifier: JSVal
     false
 }
 
-/// Called by JSCommonJSModule.cpp when the entry point, evaluating as CommonJS,
-/// threw out of its top level; the module loader is about to reject the entry
-/// promise with it. Node runs a CommonJS entry synchronously, so its throw is
-/// the uncaught exception right there, ahead of anything the entry queued
-/// before throwing; observing the rejection instead (what the run command and a
-/// worker's `spin` do for an ESM entry) would drain those microtasks first. So
-/// the throw is reported here, `entry_point_failure_reported` tells the code
-/// observing the rejection that it was, and with no handler the main thread
-/// exits here, as it would have on the rejection (a worker's
-/// `on_unhandled_rejection` has requested the worker's stop by the time
-/// `uncaught_exception` returns).
+/// Called by JSCommonJSModule.cpp when a CommonJS entry point threw out of its
+/// top level, before the module loader rejects the entry promise with it (which
+/// the run command and a worker's `spin` would only see after the microtasks the
+/// entry queued have run). Node's synchronous CJS runner reports it right here;
+/// unhandled, the main thread exits as the rejection path would have, and a
+/// worker's `on_unhandled_rejection` has requested its stop.
 // HOST_EXPORT(Bun__VM__reportEntryPointThrow, c)
 pub fn report_entry_point_throw(this: &mut VirtualMachine, error: JSValue) {
     let is_main_thread = this.worker_ref().is_none();
-    // The test runner reports a test file's top-level throw itself, as that
-    // file's failure, when it observes the rejection (test_command.rs). Workers
-    // started by a test file are ordinary workers.
+    // The test runner reports a test file's throw itself (test_command.rs).
     if is_main_thread
         && bun_jsc::virtual_machine::isBunTest.load(core::sync::atomic::Ordering::Relaxed)
     {

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -332,6 +332,63 @@ it(
   timeout,
 );
 
+// Once a generation's event loop drains ('beforeExit'), or once a generation has
+// failed, the VM is armed to exit outright on the next uncaught error, which is
+// right at the end of a normal run. Under --hot the drain is not the end of the
+// run: later generations' uncaught errors (from a callback, or thrown by the
+// entry itself while it loads) are reported and the process keeps watching, like
+// the first generation's would be.
+it(
+  "should keep watching through uncaught errors in later generations",
+  async () => {
+    const root = hotRunnerRoot;
+    writeFileSync(root, `process.on("beforeExit", () => console.log("[gen0] drained"));\n`);
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    let output = "";
+    let notify = () => {};
+    const exited = runner.exited.then(() => notify());
+    const collect = async (stream: ReadableStream<Uint8Array>) => {
+      for await (const chunk of stream) {
+        output += new TextDecoder().decode(chunk);
+        notify();
+      }
+    };
+    collect(runner.stdout);
+    collect(runner.stderr);
+    async function waitFor(text: string) {
+      while (!output.includes(text)) {
+        if (runner.exitCode !== null || runner.signalCode !== null) {
+          throw new Error(
+            `--hot process exited (${runner.exitCode}) before printing ${JSON.stringify(text)}:\n${output}`,
+          );
+        }
+        await new Promise<void>(resolve => (notify = resolve));
+      }
+    }
+
+    await waitFor("[gen0] drained");
+    writeFileSync(root, `setTimeout(() => { throw new Error("gen1 callback"); }, 1);\n`);
+    await waitFor("error: gen1 callback");
+    // require() makes this generation CommonJS, so its throw is reported while
+    // the entry is still loading, after the failed gen1 re-armed the exit.
+    writeFileSync(root, `require("node:fs");\nthrow new Error("gen2 entry");\n`);
+    await waitFor("error: gen2 entry");
+    writeFileSync(root, `console.log("[gen3] ok");\n`);
+    await waitFor("[gen3] ok");
+
+    runner.kill();
+    await exited;
+  },
+  timeout,
+);
+
 it(
   "should not hot reload when a random file is written",
   async () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1852,6 +1852,84 @@ describe("process.exitCode", () => {
   });
 });
 
+// Node runs a CommonJS entry synchronously, so a throw out of its top level is
+// the uncaught exception right there: the 'uncaughtException' listeners (or the
+// fatal exit) come before anything the entry queued while it ran. The same
+// scripts print the same stdout under Node.
+describe("a CommonJS entry's top-level throw", () => {
+  const queueWork = `
+    process.on("exit", code => console.log("exit", code));
+    process.nextTick(() => console.log("nextTick"));
+    Promise.resolve().then(() => console.log("then"));
+    queueMicrotask(() => console.log("microtask"));
+    setTimeout(() => console.log("timer"), 0);
+  `;
+
+  async function run(files, args) {
+    using dir = tempDir("cjs-entry-throw", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // With --preload, the entry is not the first CommonJS module of the process.
+  it.each([[[]], [["--preload", "./preload.cjs"]]])(
+    "unhandled: nothing queued before it runs (args: %j)",
+    async args => {
+      const { stdout, stderr, exitCode } = await run(
+        {
+          "preload.cjs": `console.log("preload");`,
+          "entry.cjs": `${queueWork} throw new Error("boom");`,
+        },
+        [...args, "entry.cjs"],
+      );
+      expect(stderr).toContain("error: boom");
+      expect(stdout).toBe(args.length ? "preload\nexit 1\n" : "exit 1\n");
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  it("handled: the uncaughtException listener runs before what was queued", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "entry.cjs": `
+          process.on("uncaughtException", (err, origin) => console.log("uncaughtException", err.message, origin));
+          ${queueWork}
+          throw new Error("boom");
+        `,
+      },
+      ["entry.cjs"],
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("uncaughtException boom uncaughtException\nnextTick\nthen\nmicrotask\ntimer\nexit 0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("an ES module entry's throw rejects its evaluation instead, after what it queued (as in Node)", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "entry.mjs": `
+          process.on("uncaughtException", (err, origin) => console.log("uncaughtException", err.message, origin));
+          process.on("exit", code => console.log("exit", code));
+          Promise.resolve().then(() => console.log("then"));
+          queueMicrotask(() => console.log("microtask"));
+          throw new Error("boom");
+        `,
+      },
+      ["entry.mjs"],
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("then\nmicrotask\nuncaughtException boom unhandledRejection\nexit 0\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("process._exiting", () => {
   expect(process._exiting).toBe(false);
 });

--- a/test/js/node/test/parallel/test-runner-tags-experimental-warning.mjs
+++ b/test/js/node/test/parallel/test-runner-tags-experimental-warning.mjs
@@ -46,7 +46,18 @@ test('the warning fires once per process for tag registration', () => {
   // second time for any of the registrations above.
 });
 
-test('--experimental-test-tag-filter fires the warning', () => {
+// Bun: as written upstream, the children of the CLI case and of the two cases
+// expecting one warning throw out of their top level in Bun (there is no
+// `--test` CLI mode, so the fixture runs as a plain script and its describe()
+// throws; run() rejects isolation: 'none'; it() throws outside of the test
+// runner), and a warning emitted right before a fatal top-level throw is never
+// printed, in Node as in Bun. So the CLI case is skipped, and those two drivers
+// trigger the warning through run() with process isolation, where the file's
+// own registrations happen in a child whose stderr becomes test:stderr events,
+// so only the driver process's warning is counted.
+const isBun = typeof Bun !== 'undefined';
+
+test('--experimental-test-tag-filter fires the warning', { skip: isBun && 'Bun has no --test CLI mode' }, () => {
   const { stderr } = runChild([
     '--test',
     '--test-reporter=tap',
@@ -63,7 +74,6 @@ test('programmatic testTagFilters fires the warning', () => {
     const { run } = require('node:test');
     run({
       files: [${JSON.stringify(fixture)}],
-      isolation: 'none',
       testTagFilters: ['db'],
     }).resume();
   `;
@@ -86,11 +96,12 @@ test('tags: [] does not fire the warning', () => {
 test('multiple triggers in one process emit the warning once', () => {
   const driver = `
     'use strict';
-    const { it, run } = require('node:test');
-    // Trigger 1: tag registration.
-    it('a', { tags: ['db'] }, () => {});
-    // Trigger 2: programmatic testTagFilters.
-    run({ files: [${JSON.stringify(fixture)}], isolation: 'none', testTagFilters: ['db'] }).resume();
+    const { run } = require('node:test');
+    // Trigger 1: programmatic testTagFilters (Bun: tag registration, the
+    // upstream first trigger, is only possible inside the test runner).
+    run({ files: [${JSON.stringify(fixture)}], testTagFilters: ['db'] }).resume();
+    // Trigger 2: programmatic testTagFilters again.
+    run({ files: [${JSON.stringify(fixture)}], testTagFilters: ['unit'] }).resume();
   `;
   const { stderr } = runChild(['-e', driver]);
   assert.strictEqual(countWarnings(stderr), 1, stderr);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2492,6 +2492,86 @@ test("terminate() while dns lookups keep completing in the worker", async () => 
   expect(exitCode).toBe(0);
 }, 30_000);
 
+// A CommonJS worker entry (eval: true, or a .cjs file) runs synchronously, as in
+// Node, so a throw out of its top level is the worker's uncaught exception right
+// there: the 'uncaughtException' listeners, or else the 'error' event and the
+// 'exit' handlers, come before anything the entry queued while it ran. Each
+// worker records what ran in shared memory its parent reads after 'exit'. The
+// parent is a subprocess because under `bun test` a worker's uncaught error is
+// routed to the test runner instead of the worker's own listeners. Only the
+// order is asserted for the fatal cases: whether the reactions queued before the
+// throw still get to run once the worker has been told to stop is the stop
+// request's business, not the report's (Node: they do not).
+describe("a CommonJS worker entry's top-level throw", () => {
+  const TAG = { exitHandler: 1, then: 2, microtask: 3, uncaughtListener: 4 } as const;
+  const scenarios = {
+    unhandled: "",
+    exitCodeFromExitHandler: `process.on("exit", () => { process.exitCode = 5; });`,
+    handled: `process.on("uncaughtException", () => put(${TAG.uncaughtListener}));`,
+  };
+  const workerSource = (setup: string) => `
+    const { workerData: log } = require("node:worker_threads");
+    const put = tag => { const i = Atomics.add(log, 0, 1) + 1; if (i < log.length) Atomics.store(log, i, tag); };
+    process.on("exit", () => put(${TAG.exitHandler}));
+    Promise.resolve().then(() => put(${TAG.then}));
+    queueMicrotask(() => put(${TAG.microtask}));
+    ${setup}
+    throw new Error("boom");
+  `;
+  const parentSource = `
+    import { Worker } from "node:worker_threads";
+    import { readFileSync } from "node:fs";
+    const [entry, ...names] = process.argv.slice(2);
+    const results = {};
+    await Promise.all(names.map(async name => {
+      const log = new Int32Array(new SharedArrayBuffer(4 * 8));
+      const file = new URL(\`./\${name}.cjs\`, import.meta.url);
+      const w = entry === "eval"
+        ? new Worker(readFileSync(file, "utf8"), { eval: true, workerData: log })
+        : new Worker(file, { workerData: log });
+      const errors = [];
+      w.on("error", e => errors.push(e.message));
+      const code = await new Promise(resolve => w.on("exit", resolve));
+      results[name] = { code, errors, ran: Array.from(log.subarray(1, 1 + log[0])) };
+    }));
+    console.log(JSON.stringify(results));
+  `;
+
+  test.concurrent.each(["eval", ".cjs"] as const)("%s entry", async entry => {
+    using dir = tempDir("cjs-worker-entry-throw", {
+      "parent.mjs": parentSource,
+      ...Object.fromEntries(Object.entries(scenarios).map(([name, setup]) => [`${name}.cjs`, workerSource(setup)])),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.mjs", entry, ...Object.keys(scenarios)],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const { unhandled, exitCodeFromExitHandler, handled } = JSON.parse(stdout);
+
+    // Fatal: the parent's 'error' event, and the 'exit' handlers run first (and
+    // still pick the exit code).
+    expect({ ...unhandled, ran: unhandled.ran[0] }).toEqual({ code: 1, errors: ["boom"], ran: TAG.exitHandler });
+    expect({ ...exitCodeFromExitHandler, ran: exitCodeFromExitHandler.ran[0] }).toEqual({
+      code: 5,
+      errors: ["boom"],
+      ran: TAG.exitHandler,
+    });
+    // Handled: the listener runs before the queued reactions, then the worker
+    // carries on and exits normally.
+    expect(handled).toEqual({
+      code: 0,
+      errors: [],
+      ran: [TAG.uncaughtListener, TAG.then, TAG.microtask, TAG.exitHandler],
+    });
+  });
+});
+
 // What a worker's own handlers may observe of its stop, in what order. Every
 // callback the worker could run appends a tag to a shared log the parent reads
 // after the thread is gone, so ordering is checked from outside the dying VM.


### PR DESCRIPTION
### Problem

- A CommonJS entry that throws out of its top level first runs everything it queued before throwing. With `mt.cjs` being
  ```js
  Promise.resolve().then(() => console.log("microtask ran"));
  throw new Error("boom");
  ```
  `bun mt.cjs` prints `microtask ran` and then `error: boom`; `node mt.cjs` prints only the error. With an `uncaughtException` listener the inversion is visible too: Bun runs the queued nextTicks and promise reactions, then the listener; Node runs the listener first. Same for a `worker_threads` worker whose entry is CommonJS (`eval: true` source or a `.cjs` file): the queued reactions ran before the worker's `'error'` event and `'exit'` handlers.
- Cause: the CommonJS entry body runs inside the module loader's promise chain (the synthetic module callback in `src/jsc/bindings/JSCommonJSModule.cpp`, `commonJSModuleSyntheticSourceCode`). Its throw becomes the entry promise's rejection, and Bun only looks at that promise after the microtask drain that reported it (`Run::start` in `src/runtime/cli/run_command.rs`; `observe_entry` in `WebWorker::spin`, `src/jsc/web_worker.rs`), by which time the drain has also run whatever the entry queued.
- This only concerns entries Bun evaluates as CommonJS (`.cjs`, or `.js` / `-e` / stdin / worker eval source that references CommonJS globals). Code Bun evaluates as ESM keeps the promise-based ordering, which is also Node's ordering for an ESM entry.

### Fix

- `JSCommonJSModule.cpp`: when the module that threw out of the synthetic CommonJS evaluation is the entry (`Bun__isBunMain` on the module key, the predicate behind `import.meta.main`), call the new `Bun__VM__reportEntryPointThrow` (`src/runtime/hw_exports.rs`) before rethrowing. It runs `uncaught_exception` with origin `uncaughtException` right there. With no listener, the main thread exits through `exit_with_unhandled_note`, the same tail the rejection path used (so the printed output is unchanged), and in a worker `on_unhandled_rejection` has already posted the `'error'` event, run the `'exit'` handlers and requested the stop. With a listener, the hook returns and the loader rejects the entry promise as before.
- `VirtualMachine::entry_point_failure_reported()` / `mark_entry_point_failure_reported()` wrap the existing hot-reload marker (`pending_internal_promise_reported_at == hot_reload_counter`). The hook sets it; `Run::start`, the hot reloader and `WebWorker::spin` consult it, so the rejection that follows is not reported a second time. The worker's failed-load arm also stops overwriting the exit code when the throw was reported that way (the `'exit'` handlers may have changed it, as in Node).
- `Bun__VM__noteCommonJSEvaluation` and `EntryPointResult.evaluated_as_cjs` (which existed to pick the origin string after the fact) are removed: a CommonJS entry's throw is now reported at the site, so whatever still reaches the rejection path is an ESM entry or a load failure and is reported with origin `unhandledRejection`, as in Node. As a side effect the origin is now right under `--preload` too, where the entry is not the root module.
- `uncaught_exception` skips the `exit_on_uncaught_exception` shortcut while a watcher (`--hot` / `--watch`) keeps the process alive. The flag is armed whenever a generation's loop drains (see Background), which is the end of a normal run but not of a watched one; it already made `bun --hot` exit on a callback throw in the generation after a drained one (reproducible on main), and it would have made it exit on the next generation's entry throw now that those go through `uncaught_exception`. The guard sits at the consumer rather than clearing the flag per generation because the watcher loop re-arms it on every drain, including the drain that happens while the next generation is still being transpiled and loaded (clearing it in `reload()` was tried first and left `hot.test.ts`'s "stale sourcemap" case, whose hot file is CommonJS, failing intermittently); what the shortcut actually depends on is whether the run is ending, and under a watcher it is not.
- Why this is correct: it is Node's model for a CommonJS entry, whose body runs synchronously under the runner, so the throw is the fatal exception (or the listeners' call) before any microtask checkpoint. The report itself is the same `uncaught_exception` call the rejection path made, only earlier, so listeners, `uncaughtExceptionMonitor`, the capture callback, `_fatalException` (exit 6), a throwing listener (exit 7), exit-handler exit codes and `--hot` keep-alive all behave as before; only the position of the report relative to the queued work changes.
- Not changed here: in a worker, the reactions queued before an unhandled entry throw still run after the `'error'` event and `'exit'` handlers, because the worker's stop request does not yet discard the microtask queue. That is #38016's change; with it, the combination gives Node's exact behaviour (nothing queued runs). The worker tests here assert the order only. (Node itself still runs `nextTick` callbacks queued before such a throw in a worker, an artifact of its entry running inside a message listener; not emulated.)
- Also not changed: a throwing CommonJS *preload* is still reported through the rejection path with origin `unhandledRejection`, as on main (the removed note only ever matched the entry). #38159 is about preloads; once this lands it can extend the throw-site check to the preload being loaded (it has the bookkeeping for that), which gives preloads the ordering fix along with the origin.
- The one CI casualty was the vendored `test/js/node/test/parallel/test-runner-tags-experimental-warning.mjs` (adapted in the second commit). Three of its cases spawn children that, as written upstream, throw out of their top level in Bun (there is no `--test` CLI mode, `run()` rejects `isolation: 'none'`, `it()` throws outside the runner) and counted the `ExperimentalWarning` those children had emitted just before dying. `process.emitWarning` prints from a nextTick, so that only worked because of the ordering fixed here; Node prints nothing in that situation either (`node -e 'process.emitWarning("w"); throw new Error("x")'` shows no warning). The CLI case is now skipped under Bun, and the other two trigger the warning through `run()` with process isolation, so they exercise the programmatic trigger for real (a file's own registrations then happen in a child whose stderr becomes `test:stderr` events, so exactly the driver's one warning is counted). Passes under the node-test runner configuration locally (4 pass, 1 skip); I kept the change to what the fix affected rather than un-vendoring the file, but deleting it instead is fine by me if that is preferred for upstream files.
- Verified:
  - `test/js/node/process/process.test.js`, new `describe("a CommonJS entry's top-level throw")`: unhandled (plain and under `--preload`), handled, and an ESM control case. The three CommonJS cases fail on main; the expected stdout is what Node v26 prints for the same scripts.
  - `test/js/node/worker_threads/worker_threads.test.ts`, new `describe("a CommonJS worker entry's top-level throw")`: eval and `.cjs` entries, each with the unhandled, exit-handler-exit-code and handled scenarios (parent in a subprocess, results in shared memory). Both fail on main; the handled scenario's full order matches Node.
  - `test/cli/hot/hot.test.ts`, new "should keep watching through uncaught errors in later generations": a callback throw after a drained generation, then a CommonJS entry throw after a failed one. Fails on main (the process exits after the first).
  - Passing with the change, on a local debug build: `process.test.js` (the remaining failures there are `USER` being unset in this container and 5s timeouts of worker-spawning tests that pass with a longer timeout), `worker_threads.test.ts` (124 pass), `hot.test.ts` (including "should not remap against a stale sourcemap after a partial-file reload", whose hot file is CommonJS and which exposed the `--hot` exit), `hot/watch.test.ts`, `watch/watch.test.ts`, `run-eval.test.ts` (CommonJS-sniffed `-e` and stdin entries), `run-cjs`, `commonjs-invalid`, `preload-test`, `node-module-module`, and the vendored `test-process-exit-code.js`, `test-process-uncaught-exception-monitor.js` (both exercise the new path: handled / unhandled / exit-handler exit codes / exit 6 / exit 7) and 18 `test-worker-*exit*` / `*uncaught*` / `*syntax-error*` tests.

### Background

- How a CommonJS entry is run: `bun:main` (a generated ESM wrapper) imports the entry. For a CommonJS file the loader gets a synthetic module whose generator (`commonJSModuleSyntheticSourceCode`) runs the CommonJS body; that generator is invoked from the loader's promise chain, i.e. inside a microtask drain. Its throw rejects the loader's promise, which `Run::start` / `spin` inspect after `load_entry_point` returns. ESM entries are the same shape, and for those Node also surfaces the throw as a rejection.
- Which files are CommonJS: `.cjs` always; `.js`, `-e`, stdin and worker eval source when they reference CommonJS globals (`require`, `module`, `exports`, `__filename`...); otherwise Bun evaluates them as ESM. Node would run most of those as CommonJS, but that is a module-format question this PR does not touch; it fixes the ordering for what Bun does evaluate as CommonJS.
- `uncaught_exception` (`src/jsc/VirtualMachine.rs`) is the one reporting function: it emits `uncaughtExceptionMonitor` / `uncaughtException` (or the capture callback), and if nothing handled the error it sets exit code 1 and calls the VM's `on_unhandled_rejection`, which on the main thread prints the error and in a worker posts it to the parent, runs the `'exit'` handlers and requests the worker's stop. Timer callbacks, event listeners and napi already report throws through it at the throw site; this PR does the same for the entry.
- `pending_internal_promise_reported_at`: the hot reloader bumps `hot_reload_counter` per generation and records in this field the generation whose entry failure it has printed, so that a rejection is printed once and a reload does not replace an entry promise whose error has not been reported yet. The new helpers expose that "already reported" state; the throw-site report sets it for the current generation.
- `exit_on_uncaught_exception`: armed when `'beforeExit'` is dispatched (`Process__dispatchOnBeforeExit`) or when the loop drains after a fatal error; it makes the next uncaught error print and exit immediately, since a draining run has no loop turn left in which the error could be reported normally. Under `--hot` / `--watch` the run command calls the same drain path and then keeps the process alive for file changes, so the flag stays armed across generations.


