### PR TITLE
sql: decode a result column named "" instead of crashing

### DIFF
--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -37,6 +37,15 @@ typedef struct ExternColumnIdentifier {
     bool isIndexedColumn() const { return tag == 1; }
     bool isNamedColumn() const { return tag == 2; }
     bool isDuplicateColumn() const { return tag == 0; }
+
+    // A column named "" arrives as the empty BunString, which plain toWTFString()
+    // converts to a null WTF::String, and Identifier::fromString dereferences
+    // the null impl. NonNull maps it to the empty string instead.
+    Identifier propertyName(VM& vm) const
+    {
+        ASSERT(isNamedColumn());
+        return Identifier::fromString(vm, name.toWTFString(BunString::NonNull));
+    }
 } ExternColumnIdentifier;
 
 typedef struct DataCellArray {
@@ -319,8 +328,7 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                 ASSERT(!cell.isIndexedColumn());
                 ASSERT(cell.isNamedColumn());
                 if (names.has_value()) {
-                    auto name = names.value()[i];
-                    object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
+                    object->putDirect(vm, names.value()[i].propertyName(vm), value);
                 } else {
                     // CachedStructure::build_from_columns guarantees one offset
                     // per column on this path; never drop a value silently.
@@ -373,8 +381,7 @@ static JSC::JSValue toJS(JSC::Structure* structure, DataCell* cells, uint32_t co
                             structureOffsetIndex++;
                         }
                         if (structureOffsetIndex < namesCount) {
-                            auto name = names.value()[structureOffsetIndex++];
-                            object->putDirect(vm, Identifier::fromString(vm, name.name.toWTFString()), value);
+                            object->putDirect(vm, names.value()[structureOffsetIndex++].propertyName(vm), value);
                         }
                     } else {
                         // JSC__createStructure added one offset per named
@@ -456,7 +463,7 @@ extern "C" EncodedJSValue JSC__createStructure(JSC::JSGlobalObject* globalObject
     for (uint32_t i = 0; i < capacity; i++) {
         ExternColumnIdentifier& name = names[i];
         if (name.isNamedColumn()) {
-            propertyNames.add(Identifier::fromString(vm, name.name.toWTFString()));
+            propertyNames.add(name.propertyName(vm));
         }
         nonDuplicateCount += !name.isDuplicateColumn();
         if (nonDuplicateCount == JSFinalObject::maxInlineCapacity) {

--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -38,12 +38,10 @@ typedef struct ExternColumnIdentifier {
     bool isNamedColumn() const { return tag == 2; }
     bool isDuplicateColumn() const { return tag == 0; }
 
-    // A column named "" arrives as the empty BunString, which plain toWTFString()
-    // converts to a null WTF::String, and Identifier::fromString dereferences
-    // the null impl. NonNull maps it to the empty string instead.
     Identifier propertyName(VM& vm) const
     {
         ASSERT(isNamedColumn());
+        // NonNull: a column named "" is the empty BunString, and Identifier::fromString cannot take a null String.
         return Identifier::fromString(vm, name.toWTFString(BunString::NonNull));
     }
 } ExternColumnIdentifier;

--- a/test/js/sql/sql-empty-column-name.fixture.ts
+++ b/test/js/sql/sql-empty-column-name.fixture.ts
@@ -1,0 +1,148 @@
+// Spawned by sql-empty-column-name.test.ts. Serves one result set whose
+// column names are given on the command line from an in-process mock server,
+// queries it with Bun.SQL and prints the decoded rows as JSON. It runs in its
+// own process because the bug under test takes the whole process down.
+//
+// Usage: <adapter: postgres | mysql> <protocol: simple | prepared> <JSON array of column names>
+// Every column holds the text value "v<index>". The mock servers ignore the
+// statement text; the result set they return is defined entirely by the names.
+//
+// All wire bytes come from ./wire-frames.ts.
+
+import { SQL } from "bun";
+import {
+  listeningServer,
+  mysqlColumnDefinition,
+  mysqlHandshakeV10,
+  mysqlLenencInt,
+  mysqlLenencStr,
+  mysqlOkPacket,
+  mysqlRawPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+  mysqlTextResultSet,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+const [adapter, protocol, namesJson] = process.argv.slice(2);
+const names: string[] = JSON.parse(namesJson);
+const values = names.map((_, i) => `v${i}`);
+
+const PG_TEXT_OID = 25;
+const COM_QUERY = 0x03;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+const COM_STMT_CLOSE = 0x19;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+async function postgresServer() {
+  const resultRows = Buffer.concat([pgDataRow(values.map(v => Buffer.from(v))), pgCommandComplete("SELECT 1")]);
+  return listeningServer(socket => {
+    socket.on("error", () => {});
+    let startup = true;
+    let buffered = Buffer.alloc(0);
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      const out: Buffer[] = [];
+      buffered = pgReadFrontendMessages(Buffer.concat([buffered, data]), type => {
+        switch (String.fromCharCode(type)) {
+          case "Q": // simple query
+            out.push(
+              pgRowDescription(names.map(name => ({ name, typeOid: PG_TEXT_OID }))),
+              resultRows,
+              pgReadyForQuery(),
+            );
+            break;
+          case "P": // Parse
+            out.push(pgParseComplete());
+            break;
+          case "D": // Describe (statement)
+            out.push(pgParameterDescription([]), pgRowDescription(names.map(name => ({ name, typeOid: PG_TEXT_OID }))));
+            break;
+          case "B": // Bind
+            out.push(pgBindComplete());
+            break;
+          case "E": // Execute
+            out.push(resultRows);
+            break;
+          case "S": // Sync
+            out.push(pgReadyForQuery());
+            break;
+        }
+      });
+      if (out.length) socket.write(Buffer.concat(out));
+    });
+  });
+}
+
+async function mysqlServer() {
+  const columns = names.map(name => ({ name, type: MYSQL_TYPE_VAR_STRING }));
+  const columnDefinitions = (firstSeq: number) =>
+    Buffer.concat(columns.map((column, i) => mysqlColumnDefinition(firstSeq + i, column)));
+  // Binary protocol row: 0x00 header, NULL bitmap with a 2-bit offset, then
+  // one string<lenenc> per VAR_STRING column.
+  const binaryRow = Buffer.concat([
+    Buffer.from([0x00]),
+    Buffer.alloc(Math.floor((names.length + 7 + 2) / 8)),
+    ...values.map(v => mysqlLenencStr(v)),
+  ]);
+  return listeningServer(socket => {
+    socket.on("error", () => {});
+    socket.write(mysqlHandshakeV10());
+    let authed = false;
+    let buffered = Buffer.alloc(0);
+    socket.on("data", data => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, data]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        switch (payload[0]) {
+          case COM_QUERY:
+            socket.write(mysqlTextResultSet(1, columns, [values]));
+            break;
+          case COM_STMT_PREPARE:
+            socket.write(Buffer.concat([mysqlStmtPrepareOk(1, 1, names.length, 0), columnDefinitions(2)]));
+            break;
+          case COM_STMT_EXECUTE:
+            socket.write(
+              Buffer.concat([
+                mysqlRawPacket(1, mysqlLenencInt(names.length)),
+                columnDefinitions(2),
+                mysqlRawPacket(2 + names.length, binaryRow),
+                mysqlOkPacket(3 + names.length, 0xfe),
+              ]),
+            );
+            break;
+          case COM_STMT_CLOSE:
+            break; // no response
+          default: // COM_QUIT
+            socket.end();
+        }
+      });
+    });
+  });
+}
+
+const { server, port } = adapter === "postgres" ? await postgresServer() : await mysqlServer();
+try {
+  await using sql = new SQL({ url: `${adapter}://u@127.0.0.1:${port}/db`, max: 1 });
+  const query = sql`select 1`;
+  const rows = await (protocol === "simple" ? query.simple() : query);
+  console.log(JSON.stringify(rows));
+} finally {
+  server.close();
+}

--- a/test/js/sql/sql-empty-column-name.test.ts
+++ b/test/js/sql/sql-empty-column-name.test.ts
@@ -1,0 +1,117 @@
+// A result column whose name is the empty string crashed the process (null
+// dereference while building the row object) on both the Postgres and the
+// MySQL adapter: the name reaches SQLClient.cpp as an empty BunString, which
+// toWTFString() turns into a null WTF::String, and Identifier::fromString
+// dereferences the null impl. The row must instead decode to an object with a
+// "" key, the same as `({ "": value })` in JavaScript.
+//
+// MySQL and MariaDB name an un-aliased literal after its text, so an honest
+// server returns such a column for plain `select ''` (real-server coverage at
+// the bottom). Postgres itself rejects `as ""` (zero-length delimited
+// identifier), so for that adapter an empty name only comes from a proxy or a
+// misbehaving server; the mock servers in sql-empty-column-name.fixture.ts
+// cover it for both adapters. The fixture runs in a child process because the
+// failure mode is the process dying. All wire bytes come from ./wire-frames.ts.
+
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer, isCI, isDockerEnabled } from "harness";
+import path from "node:path";
+
+const fixture = path.join(import.meta.dir, "sql-empty-column-name.fixture.ts");
+
+// A result set wider than JSFinalObject::maxInlineCapacity (62) is built by a
+// different path than a narrow one: the column names are kept on the side and
+// put onto each row object individually instead of being baked into a
+// Structure once. The "7" column is stored as an array index rather than a
+// name, which selects a third path that interleaves the two kinds.
+const wide = (...overrides: [index: number, name: string][]) => {
+  const names = Array.from({ length: 80 }, (_, i) => `c${i}`);
+  for (const [index, name] of overrides) names[index] = name;
+  return names;
+};
+const scenarios: Record<string, string[]> = {
+  "a single unnamed column": [""],
+  "an unnamed column between a named and an indexed column": ["x", "", "7"],
+  "an unnamed column in a wide result set": wide([40, ""]),
+  "an unnamed column in a wide result set with an indexed column": wide([40, ""], [41, "7"]),
+};
+
+async function decodeThroughMockServer(
+  adapter: "postgres" | "mysql",
+  protocol: "simple" | "prepared",
+  names: string[],
+) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, adapter, protocol, JSON.stringify(names)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let rows: unknown = null;
+  try {
+    rows = JSON.parse(stdout);
+  } catch {}
+  // stderr is not asserted (debug/ASan builds print benign notes); it is part
+  // of the compared object so the crash report shows up when the fixture dies.
+  return { rows, exitCode, signalCode: proc.signalCode, stderr };
+}
+
+function expectedRow(names: string[]) {
+  return Object.fromEntries(names.map((name, i) => [name, `v${i}`]));
+}
+
+describe.each(["postgres", "mysql"] as const)("%s: a result set with an empty column name", adapter => {
+  // The text protocol of each adapter carries every scenario; the row object is
+  // built the same way on both protocols, so the prepared (binary) protocol
+  // only needs to prove it reaches the same place.
+  test.concurrent.each(Object.entries(scenarios))(
+    '%s decodes to a row with a "" key',
+    async (_, names) => {
+      expect(await decodeThroughMockServer(adapter, "simple", names)).toEqual({
+        rows: [expectedRow(names)],
+        exitCode: 0,
+        signalCode: null,
+        stderr: expect.any(String),
+      });
+    },
+    30_000,
+  );
+
+  test.concurrent(
+    "a single unnamed column decodes over the prepared-statement protocol",
+    async () => {
+      expect(await decodeThroughMockServer(adapter, "prepared", [""])).toEqual({
+        rows: [{ "": "v0" }],
+        exitCode: 0,
+        signalCode: null,
+        stderr: expect.any(String),
+      });
+    },
+    30_000,
+  );
+});
+
+// Real-server coverage: `select ''` is enough to get an unnamed column out of
+// MySQL and MariaDB; the client decodes both servers' result sets identically.
+// Same gating as sql-mariadb-json.test.ts: only attempt the container when
+// something can provide it, since a half-working local docker would fail the
+// suite instead of skipping it.
+const mariadbProvided =
+  !!process.env.BUN_TEST_SERVICE_mariadb_plain || !!process.env.BUN_DOCKER_COORDINATOR || (isCI && isDockerEnabled());
+if (!mariadbProvided) {
+  describe.todo("mariadb: select '' returns a row with a \"\" key");
+} else {
+  describeWithContainer("mariadb", { image: "mariadb_plain" }, container => {
+    test("select '' returns a row with a \"\" key", async () => {
+      await container.ready;
+      await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+
+      expect(await sql`select ''`).toEqual([{ "": "" }]);
+      expect(await sql`select ''`.simple()).toEqual([{ "": "" }]);
+      expect(await sql`select '', 'abc', 1 as n`).toEqual([{ "": "", abc: "abc", n: 1 }]);
+    });
+  });
+}


### PR DESCRIPTION
### Problem
- A `Bun.SQL` result set containing a column whose name is `""` crashes the process while the row object is built: `Segmentation fault at address 0x0` on release builds, `ASSERTION FAILED: m_ptr` (`RefPtr<WTF::AtomStringImpl>::operator*`) on debug builds.
- Both adapters are affected. MySQL and MariaDB name an un-aliased literal after its text, so a plain `select ''` against a real server is enough (verified against MariaDB 11.8: Bun 1.4.0 exits 139). Postgres itself rejects `as ""`, so on that adapter the name only arrives from a proxy or a non-Postgres server speaking the protocol, but the client still has to survive it.
- Cause: `src/sql_jsc/shared/CachedStructure.rs:90` interns each column name with `create_atom_if_possible`, which returns `String::EMPTY` for zero bytes. In `src/jsc/bindings/SQLClient.cpp` the three property-name sites (`JSC__createStructure`, and the two `putDirect` calls in `toJS` used for result sets wider than the inline capacity) converted it with `BunString::toWTFString()`, which maps the empty tag to a null `WTF::String`. `Identifier::fromString` then calls `AtomStringImpl::addWithStringTableProvider`, which returns null for a null impl, and `Identifier::add` dereferences it.

### Fix
- `ExternColumnIdentifier` gets a `propertyName(vm)` helper that converts with `toWTFString(BunString::NonNull)`, the existing overload that yields `emptyString()` instead of a null string, and the three sites call it. The row now decodes to an object with a `""` key, the same as `({ "": value })` in JavaScript; non-empty names take exactly the same path as before (both overloads wrap the same `WTFStringImpl`).
- Fixing the consumer covers every producer: Postgres `RowDescription`, MySQL text and binary result sets, and both the narrow (Structure) and wide (per-row names) object builders.
- Verified with `test/js/sql/sql-empty-column-name.test.ts`: a mock Postgres and a mock MySQL server are run in a child process (the failure mode is the process dying) and return a `""` column in a narrow result set, next to named and all-digit columns, and in 80-column result sets with and without an all-digit column, over both the text and the prepared protocol of each adapter. All 10 cases exit 139 / `SIGSEGV` on the release binary and pass on the debug build. A real-server case (`select ''` against the `mariadb_plain` container, gated the same way as `sql-mariadb-json.test.ts`) is included for CI; its assertions were checked by hand against a local MariaDB 11.8 with the fixed build.
- Also re-ran the existing numeric / duplicate / mixed / wider-than-inline column-name behaviours against a real Postgres with the fixed build; unchanged.

### Background
- `BunString` is the string representation shared between Rust and C++. It is a tagged value; one tag (`Empty`) represents the empty string without any backing storage. `BunString::toWTFString()` turns that tag into a null `WTF::String`, while the `toWTFString(BunString::NonNull)` overload turns it into WTF's shared empty string, which has a real (static, already atomized) `StringImpl`.
- `JSC::Identifier` is JSC's property key type. `Identifier::fromString(vm, String)` atomizes the string's impl and assumes the impl exists; an empty identifier is valid and is what `obj[""]` uses.
- `ExternColumnIdentifier` is the per-column record Rust hands to `SQLClient.cpp` for each result set: either an array index (all-digit column names become indexed properties), a name, or a marker for a duplicate column to skip. For result sets that fit in a `JSFinalObject`'s inline capacity (62 properties) the names are baked into one cached `Structure` in `JSC__createStructure`; wider result sets keep the array and `toJS` puts each name onto every row object, which is why there are three conversion sites.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-empty-column-name.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/sql/sql-empty-column-name.test.ts:
68 |   // built the same way on both protocols, so the prepared (binary) protocol
69 |   // only needs to prove it reaches the same place.
70 |   test.concurrent.each(Object.entries(scenarios))(
71 |     '%s decodes to a row with a "" key',
72 |     async (_, names) => {
73 |       expect(await decodeThroughMockServer(adapter, "simple", names)).toEqual({
                                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "rows": [
-     {
-       "": "v0",
-     },
-   ],
-   "signalCode": null,
-   "stderr": Any<String>,
+   "exitCode": 134,
+   "rows": null,
+   "signalCode": "SIGABRT",
+   "stderr": 
+ "ASSERTION FAILED: m_ptr
+ /root/.bun/build-cache/webkit-c6cfe90c6064bd80-debug-asan/include/wtf/RefPtr.h(126) : T &WTF::RefPtr<WTF::AtomStringImpl>::operator*() const [T = WTF::AtomStringImpl, _PtrTraits = WTF::RawPtrTraits<WTF::AtomStringImpl>
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/sql/sql-empty-column-name.test.ts:
68 |   // built the same way on both protocols, so the prepared (binary) protocol
69 |   // only needs to prove it reaches the same place.
70 |   test.concurrent.each(Object.entries(scenarios))(
71 |     '%s decodes to a row with a "" key',
72 |     async (_, names) => {
73 |       expect(await decodeThroughMockServer(adapter, "simple", names)).toEqual({
                                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "rows": [
-     {
-       "": "v0",
-     },
-   ],
-   "signalCode": null,
-   "stderr": Any<String>,
+   "exitCode": 139,
+   "rows": null,
+   "signalCode": "SIGSEGV",
+   "stderr": 
+ "============================================================
+ Bun Canary v1.4.0-canary.1 (8326d1bd3) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "/workspace/bun/test/js/sql/sql-empty-column-name.fixture.ts" "mysql" "simple" "[\"\"]"
+ Features: bunfig jsc tsconfig(3) tsconfig_paths 
+ Builtins: "bun:main" "node:net" 
+ 
+ Ela
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-empty-column-name.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/sql/sql-empty-column-name.test.ts:
(pass) postgres: a result set with an empty column name > a single unnamed column decodes over the prepared-statement protocol [1807.35ms]
(pass) postgres: a result set with an empty column name > an unnamed column between a named and an indexed column decodes to a row with a "" key [1830.64ms]
(pass) postgres: a result set with an empty column name > a single unnamed column decodes to a row with a "" key [1870.11ms]
(pass) postgres: a result set with an empty column name > an unnamed column in a wide result set with an indexed column decodes to a row with a "" key [1875.69ms]
(pass) postgres: a result set with an empty column name > an unnamed column in a wide result set decodes to a row with a "" key [1903.03ms]
(pass) mysql: a result set with an empty column name > a single unnamed column decodes to a row with a "" key [1785.17ms]
(pass) mysql: a result set with an empty column name > an unnamed column between a named an
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 666ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen cpp.rs (cppbind)
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/SQLClient.cpp               |  15 ++-
 test/js/sql/sql-empty-column-name.fixture.ts | 148 +++++++++++++++++++++++++++
 test/js/sql/sql-empty-column-name.test.ts    | 117 +++++++++++++++++++++
 3 files changed, 275 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/SQLClient.cpp                    6      4      0
test/js/sql/sql-empty-column-name.fixture.ts      0      2      0
test/js/sql/sql-empty-column-name.test.ts         0      1      0
```

</details>

<!-- robobun:evidence:end -->