### PR TITLE
MessagePort: ref the port when its first 'message' listener is added

### DIFF
--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -203,10 +203,14 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
 
-    // node: a callable handler starts the port and keeps the loop alive; assigning anything else
-    // clears the handler and lets the loop exit again.
+    // An installed handler is a 'message' listener: registering it started the port and, if it
+    // is the first listener, ref'd it (node's setupPortReferencing). The setter takes no ref of
+    // its own, so a handler added next to other listeners leaves an earlier unref() in force,
+    // as in node. Anything that cannot be called (a cleared handler, or an object
+    // setAttributeEventListener stores but JSEventListener never invokes) lets the loop exit
+    // again, as node's setter also only counts functions.
     if (value.isCallable())
-        thisObject.wrapped().jsRef(&lexicalGlobalObject);
+        thisObject.wrapped().didSetMessageHandler();
     else
         thisObject.wrapped().jsUnref(&lexicalGlobalObject);
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -60,14 +60,21 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
 {
     // The WeakPtrFactory must be initialized on the owning thread.
     EventTarget::initializeWeakPtrFactory();
-    // Any port with a 'message' listener refs the event loop (matching node: a
-    // listening port keeps its thread alive until closed or unref'd); otherwise a
-    // buffered message could be lost if its listener is added late.
+    // A port's first 'message' listener refs it (see onDidChangeListenerImpl), matching node:
+    // a listening port keeps its thread alive until it is closed or unref'd, so a buffered
+    // message is not lost to the loop exiting.
     onDidChangeListener = &MessagePort::onDidChangeListenerImpl;
 }
 
 MessagePort::~MessagePort()
 {
+    // A listening port becomes collectable as soon as its peer closes, possibly before the
+    // posted peerClosed() (which only holds a weak pointer to us) runs and releases the
+    // listener loop-ref. Release it here too, or it outlives the port and the loop never
+    // idles. m_hasRef cannot be set here: it holds a reference to this object.
+    ASSERT(!m_hasRef);
+    m_isRefd = false;
+    updateListenerEventLoopRef();
     if (!m_isDetached)
         m_pipe->close(m_side, MessagePortPipe::CloseKind::Collected);
 }
@@ -224,9 +231,8 @@ void MessagePort::close()
     // it in hasPendingActivity()); marking our side Closed is sufficient.
     m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
 
-    // Release the self-reference taken by jsRef() (set when .onmessage is
-    // assigned or .ref() is called from JS). The JS .close() binding calls
-    // jsUnref() first; stop() and contextDestroyed() do not.
+    // Release the self-reference taken by jsRef() (.ref() from JS). The JS .close()
+    // binding calls jsUnref() first; stop() and contextDestroyed() do not.
     if (m_hasRef) {
         m_hasRef = false;
         if (auto* context = scriptExecutionContext())
@@ -285,8 +291,8 @@ void MessagePort::peerClosed()
     // Fire 'close' (guarded against a double dispatch) and release this side's loop refs
     // so the loop can idle, matching node.
     dispatchCloseEvent();
-    // jsUnref() clears both the listener loop-ref (m_isRefd) and the onmessage/ref()
-    // keepalive (m_hasRef), so a listening transferred port stops pinning the loop.
+    // jsUnref() clears both the listener loop-ref (m_isRefd) and the .ref() keepalive
+    // (m_hasRef), so a listening transferred port stops pinning the loop.
     auto* globalObject = defaultGlobalObject(context->globalObject());
     jsUnref(globalObject);
 }
@@ -499,7 +505,11 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
     auto& port = static_cast<MessagePort&>(self);
     switch (kind) {
     case Add:
-        port.m_messageEventCount++;
+        // Node's setupPortReferencing calls port.ref() for the first 'message' listener, so
+        // listening re-refs a port that was unref()'d before anyone listened. on(),
+        // addEventListener(), once() and an installed onmessage handler all register here.
+        if (++port.m_messageEventCount == 1)
+            port.setRefd();
         break;
     case Remove:
         if (port.m_messageEventCount > 0)
@@ -510,6 +520,12 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
         break;
     }
     port.updateListenerEventLoopRef();
+}
+
+void MessagePort::didSetMessageHandler()
+{
+    if (m_messageEventCount == 1)
+        setRefd();
 }
 
 bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
@@ -550,24 +566,28 @@ WebCoreOpaqueRoot root(MessagePort* port)
     return WebCoreOpaqueRoot { port };
 }
 
-void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
+bool MessagePort::setRefd()
 {
     // A closed or transferred-away port can never receive messages again, so
-    // taking a self-ref (and an event-loop ref) here would only leak:
-    // close()/disentangle() have already run and nothing will ever release a
-    // ref taken afterwards. Same once the peer has closed: peerClosed() already
-    // ran jsUnref(), and nothing releases a ref re-taken after it, so `.ref()`
-    // or a late `onmessage =` would pin the loop forever. Node no-ops both.
-    // Only an explicit peer close counts: node never closes a channel because a
-    // port was collected, so keying on Closed alone made this GC-dependent.
+    // a ref taken now would only leak: close()/disentangle() have already run
+    // and nothing will ever release a ref taken afterwards. Same once the peer
+    // has closed: peerClosed() already ran jsUnref(), and nothing releases a ref
+    // re-taken after it, so `.ref()` or a late listener would pin the loop
+    // forever. Node no-ops both. Only an explicit peer close counts: node never
+    // closes a channel because a port was collected, so keying on Closed alone
+    // made this GC-dependent.
     if (!isEntangled() || m_pipe->isOtherSideClosedByRequest(m_side))
-        return;
+        return false;
 
-    // Re-acquire the message-listener loop-ref (if a listener is present) that .unref() released.
-    if (!m_isRefd) {
-        m_isRefd = true;
-        updateListenerEventLoopRef();
-    }
+    m_isRefd = true;
+    updateListenerEventLoopRef();
+    return true;
+}
+
+void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
+{
+    if (!setRefd())
+        return;
 
     if (!m_hasRef) {
         m_hasRef = true;

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -115,6 +115,11 @@ public:
 
     void jsRef(JSGlobalObject*);
     void jsUnref(JSGlobalObject*);
+    // The .onmessage setter installed a callable handler. Installing one is a listener add,
+    // which refs the port like any first 'message' listener; but node's setter also
+    // re-registers a replaced handler (removeListener, then newListener), so replacing the
+    // port's only 'message' listener refs it again even after an unref(). This covers that.
+    void didSetMessageHandler();
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
@@ -159,17 +164,24 @@ private:
     // Read from the GC thread: a port whose only listener is 'close' must survive
     // until that event is delivered, or the peer's close is lost to a collection.
     std::atomic<bool> m_hasCloseEventListener { false };
+    // The explicit .ref() hold: an event-loop ref plus a self-ref, so a ref()'d port with no
+    // listener pins the loop and outlives its wrapper (node never collects an open port).
     bool m_hasRef { false };
 
-    // Whether .ref()/.unref() want this port to keep the loop alive (default refd);
-    // independent of m_hasRef (the .onmessage=/.ref() keepalive).
-    bool m_isRefd { true };
+    // Node's ref flag as far as listeners are concerned: set by .ref() and by the first
+    // 'message' listener (node's setupPortReferencing calls port.ref() for it), cleared by
+    // .unref() and by close()/transfer/peer close. A fresh port is unref'd, as in node. It
+    // keeps the loop alive only while a 'message' listener is present.
+    bool m_isRefd { false };
     // Whether the message-listener mechanism currently holds an event-loop ref
     // (held iff m_isRefd && m_messageEventCount > 0).
     bool m_listenerLoopRefActive { false };
 
     uint32_t m_messageEventCount { 0 };
     static void onDidChangeListenerImpl(EventTarget& self, const AtomString& eventType, OnDidChangeListenerKind kind);
+    // Sets m_isRefd for .ref() and for the first 'message' listener; declines (returning false)
+    // once the port can no longer receive, see the definition.
+    bool setRefd();
     // Reconciles the listener event-loop ref with (m_isRefd && m_messageEventCount > 0).
     void updateListenerEventLoopRef();
 };

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -997,6 +997,288 @@ test("hasRef() survives collection of the unreferenced peer", () => {
   port1.close();
 });
 
+// Node's setupPortReferencing (lib/internal/worker/io.js) calls port.ref() when the first
+// 'message' listener is added, so listening re-refs a port that was unref()'d earlier; the
+// onmessage setter is just one way of registering that listener and refs nothing on its own.
+// Every expected value below is what node prints.
+test("the first 'message' listener refs the port like ref() does", () => {
+  const channels: MessageChannel[] = [];
+  function port(): MessagePort {
+    const channel = new MessageChannel();
+    channels.push(channel);
+    return channel.port1;
+  }
+  const f = () => {};
+  const g = () => {};
+  const seen: Record<string, boolean | boolean[]> = {};
+  let p: MessagePort;
+
+  // the first listener refs an unref()'d port, however it is registered
+  p = port();
+  p.unref();
+  p.on("message", f);
+  seen["unref(); on()"] = p.hasRef();
+
+  p = port();
+  p.unref();
+  p.addEventListener("message", f);
+  seen["unref(); addEventListener()"] = p.hasRef();
+
+  p = port();
+  p.unref();
+  p.addEventListener("message", { handleEvent() {} });
+  seen["unref(); addEventListener(handleEvent object)"] = p.hasRef();
+
+  p = port();
+  p.unref();
+  p.once("message", f);
+  seen["unref(); once()"] = p.hasRef();
+
+  p = port();
+  p.unref();
+  p.onmessage = f;
+  seen["unref(); onmessage ="] = p.hasRef();
+
+  p = port();
+  p.unref();
+  p.on("message", f);
+  p.off("message", f);
+  p.on("message", f);
+  seen["unref(); on(); off(); on()"] = p.hasRef();
+
+  // only the first listener refs: a handler installed next to another listener (or replacing
+  // one of several) leaves an unref() in force, while node's setter re-registers a replaced
+  // handler, so replacing the only listener refs again
+  p = port();
+  p.on("message", g);
+  p.unref();
+  p.onmessage = f;
+  seen["on(g); unref(); onmessage = f"] = p.hasRef();
+
+  p = port();
+  p.on("message", g);
+  p.unref();
+  p.on("message", f);
+  seen["on(g); unref(); on(f)"] = p.hasRef();
+
+  p = port();
+  p.on("message", f);
+  p.onmessage = g;
+  p.unref();
+  p.onmessage = () => {};
+  seen["on(f); onmessage = g; unref(); onmessage = h"] = p.hasRef();
+
+  p = port();
+  p.onmessage = f;
+  p.unref();
+  p.onmessage = g;
+  seen["onmessage = f; unref(); onmessage = g"] = p.hasRef();
+
+  // ...while replacing it with something that cannot be called unrefs, as clearing it does:
+  // the object stays stored as the handler but is never invoked
+  p = port();
+  p.onmessage = f;
+  p.onmessage = {} as any;
+  seen["onmessage = f; onmessage = {}"] = p.hasRef();
+
+  p = port();
+  p.onmessage = f;
+  p.unref();
+  p.onmessage = { handleEvent() {} } as any;
+  seen["onmessage = f; unref(); onmessage = { handleEvent }"] = p.hasRef();
+
+  // explicit ref()/unref() still win over a present listener
+  p = port();
+  p.on("message", f);
+  p.unref();
+  const afterUnref = p.hasRef();
+  p.ref();
+  seen["on(); unref(); ref()"] = [afterUnref, p.hasRef()];
+
+  // a listener added to a port that can no longer receive refs nothing
+  p = port();
+  p.close();
+  p.on("message", f);
+  seen["close(); on()"] = p.hasRef();
+
+  {
+    p = port();
+    const carrier = port();
+    carrier.postMessage(null, [p]);
+    p.on("message", f);
+    seen["transferred away; on()"] = p.hasRef();
+  }
+
+  // node's test-messageport-hasref up to its listener step (the file itself also needs the
+  // async_hooks MESSAGEPORT resource and close-event timing, so it is not vendored), plus
+  // the off() that undoes it
+  {
+    p = port();
+    const sequence = [p.hasRef()];
+    p.unref();
+    sequence.push(p.hasRef());
+    p.ref();
+    sequence.push(p.hasRef());
+    p.unref();
+    sequence.push(p.hasRef());
+    p.on("message", f);
+    sequence.push(p.hasRef());
+    p.off("message", f);
+    sequence.push(p.hasRef());
+    seen["fresh; unref(); ref(); unref(); on(); off()"] = sequence;
+  }
+
+  for (const { port1, port2 } of channels) {
+    port1.close();
+    port2.close();
+  }
+
+  expect(seen).toEqual({
+    "unref(); on()": true,
+    "unref(); addEventListener()": true,
+    "unref(); addEventListener(handleEvent object)": true,
+    "unref(); once()": true,
+    "unref(); onmessage =": true,
+    "unref(); on(); off(); on()": true,
+    "on(g); unref(); onmessage = f": false,
+    "on(g); unref(); on(f)": false,
+    "on(f); onmessage = g; unref(); onmessage = h": false,
+    "onmessage = f; unref(); onmessage = g": true,
+    "onmessage = f; onmessage = {}": false,
+    "onmessage = f; unref(); onmessage = { handleEvent }": false,
+    "on(); unref(); ref()": [false, true],
+    "close(); on()": false,
+    "transferred away; on()": false,
+    "fresh; unref(); ref(); unref(); on(); off()": [false, false, true, false, true, false],
+  });
+});
+
+// Once the peer's close has been delivered the port is as good as closed (node closes it
+// outright), so a first listener added afterwards must not take a loop ref either.
+test("a first 'message' listener added after the peer closed does not ref the port", async () => {
+  const { port1, port2 } = new MessageChannel();
+  const closed = new Promise<void>(resolve => port1.once("close", resolve));
+  port2.close();
+  await closed;
+  port1.on("message", () => {});
+  expect(port1.hasRef()).toBe(false);
+  port1.close();
+});
+
+// The process-level symptom of the flag above: whether the port keeps the loop alive. Each
+// script's only other work is an unref()'d timer, which can only fire if the port is
+// keeping the process up; a script that must exit on its own uses a long unref()'d timer
+// as a bounded way to report that it did not.
+describe.concurrent("a port's first 'message' listener and process lifetime", () => {
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const { MessageChannel } = require("worker_threads");\n${script}`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("unref() then on('message') keeps the process alive until the port closes", async () => {
+    const result = await run(`
+      const { port1, port2 } = new MessageChannel();
+      port1.unref();
+      port1.on("message", m => { console.log("got " + m); port1.close(); port2.close(); });
+      setTimeout(() => port2.postMessage("hi"), 50).unref();
+    `);
+    expect(result).toEqual({ stdout: "got hi\n", stderr: "", exitCode: 0 });
+  });
+
+  test("unref() then addEventListener('message') keeps the process alive until the port closes", async () => {
+    const result = await run(`
+      const { port1, port2 } = new MessageChannel();
+      port1.unref();
+      port1.addEventListener("message", e => { console.log("got " + e.data); port1.close(); port2.close(); });
+      setTimeout(() => port2.postMessage("hi"), 50).unref();
+    `);
+    expect(result).toEqual({ stdout: "got hi\n", stderr: "", exitCode: 0 });
+  });
+
+  test("onmessage = next to an existing listener does not re-ref an unref()'d port", async () => {
+    const result = await run(`
+      const { port1, port2 } = new MessageChannel();
+      globalThis.keep = port2;
+      port1.on("message", () => {});
+      port1.unref();
+      port1.onmessage = () => {};
+      setTimeout(() => { console.log("still pinned"); process.exit(1); }, 5_000).unref();
+      console.log("done");
+    `);
+    expect(result).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
+  });
+
+  // The listener's loop ref has to die with the port. A listening port nobody references is
+  // collectable as soon as its peer closes, and a GC can get to it before the peer-close
+  // notification (which only holds a weak pointer to the port) runs and releases the ref;
+  // the port must release it itself when it is destroyed, or the process never exits.
+  const listen = {
+    "on()": `port.on("message", () => {})`,
+    "addEventListener()": `port.addEventListener("message", () => {})`,
+    "onmessage =": `port.onmessage = () => {}`,
+  };
+  test.each(Object.entries(listen))(
+    "a port listening via %s that is collected after its peer closes releases its ref",
+    async (_, register) => {
+      const result = await run(`
+        (function () {
+          for (let i = 0; i < 20; i++) {
+            const { port1, port2: port } = new MessageChannel();
+            ${register};
+            port1.close();
+          }
+        })();
+        Bun.gc(true);
+        Bun.gc(true);
+        setTimeout(() => { console.log("still pinned"); process.exit(1); }, 5_000).unref();
+        console.log("done");
+      `);
+      expect(result).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
+    },
+  );
+
+  test("a listening port collected along with its peer releases its ref", async () => {
+    const result = await run(`
+      (function () {
+        for (let i = 0; i < 20; i++) new MessageChannel().port2.on("message", () => {});
+      })();
+      // The first collection takes the peers (nothing listens on them); that closes the
+      // listening sides' channels, and the second collection takes the listening sides.
+      Bun.gc(true);
+      Bun.gc(true);
+      setTimeout(() => { console.log("still pinned"); process.exit(1); }, 5_000).unref();
+      console.log("done");
+    `);
+    expect(result).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
+  });
+
+  // parentPort is the same MessagePort: unref()'d first and listened to afterwards, it keeps
+  // the worker alive (node), instead of the worker exiting before any message can reach it.
+  test("parentPort.unref() followed by on('message') keeps the worker alive", async () => {
+    const w = new Worker(
+      `const { parentPort } = require("worker_threads");
+       process.on("beforeExit", () => parentPort.postMessage("loop drained"));
+       parentPort.unref();
+       parentPort.on("message", m => { parentPort.postMessage("got " + m); parentPort.close(); });
+       setTimeout(() => parentPort.postMessage("still alive"), 50).unref();`,
+      { eval: true },
+    );
+    const seen: string[] = [];
+    const exited = new Promise<number>(resolve => w.on("exit", resolve));
+    w.on("message", m => {
+      seen.push(m);
+      if (m === "still alive") w.postMessage("hi");
+    });
+    expect({ exitCode: await exited, seen }).toEqual({ exitCode: 0, seen: ["still alive", "got hi"] });
+  });
+});
+
 // markAsUncloneable blocks *cloning*, not transfer: a marked port in the transfer
 // list is moved, so node lets it through and it still works on the far side.
 test("markAsUncloneable blocks cloning a port but not transferring it", async () => {

--- a/test/js/web/workers/message-port-context-destroy-leak.test.ts
+++ b/test/js/web/workers/message-port-context-destroy-leak.test.ts
@@ -2,11 +2,11 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 
 // MessagePort::jsRef() takes a self-ref() on the C++ MessagePort (plus an
-// event-loop ref) when .onmessage is assigned or .ref() is called. The only
-// path that released it was an explicit .close()/.unref() from JS. When a
-// Worker (or any owning context) is torn down without that, contextDestroyed()
-// → close() ran but never dropped the self-ref, so every such MessagePort
-// leaked for the lifetime of the process.
+// event-loop ref) when .ref() is called. The only path that released it was
+// an explicit .close()/.unref() from JS. When a Worker (or any owning context)
+// is torn down without that, contextDestroyed() → close() ran but never
+// dropped the self-ref, so every such MessagePort leaked for the lifetime of
+// the process.
 //
 // Skipped on Windows: RSS there does not drop after worker threads exit (the
 // per-thread mimalloc arenas stay committed), so the allocator residue from
@@ -25,7 +25,9 @@ test.skipIf(isWindows)(
           const keep = [];
           for (let i = 0; i < 8000; i++) {
             const { port1, port2 } = new MessageChannel();
-            // Assigning onmessage calls MessagePort::jsRef() → self-ref().
+            // ref() calls MessagePort::jsRef() → self-ref(). (A listener alone takes
+            // only an event-loop ref, so it is not what this test measures.)
+            port1.ref();
             port1.onmessage = () => {};
             keep.push(port1, port2);
           }


### PR DESCRIPTION
### Problem

- `port.unref(); port.on("message", f)` leaves `port.hasRef()` false and the process exits with the listener installed. Node prints `true` and stays alive until the port is closed or unref'd again. Same for `addEventListener("message")`, `once("message")`, and for a worker doing this on `parentPort` (the worker exits before any message can reach it). Node's own `test/parallel/test-messageport-hasref.js` asserts this (`unref(); ref(); unref(); on("message")`, then `hasRef() === true`).
- Cause: `MessagePort::onDidChangeListenerImpl()` (src/jsc/bindings/webcore/MessagePort.cpp) only counted listeners, and the listener loop ref is held while `m_isRefd && m_messageEventCount > 0`. `jsUnref()` clears `m_isRefd` and only an explicit `.ref()` set it again, so after an `unref()` the first listener took nothing. Node has one ref flag, and `setupPortReferencing` (lib/internal/worker/io.js) calls `port.ref()` when the first `'message'` listener is added.
- The `onmessage` setter (src/jsc/bindings/webcore/JSMessagePort.cpp) covered its own path by calling `jsRef()` on every callable assignment, which also made `port.on("message", g); port.unref(); port.onmessage = f` re-ref the port; node leaves it unref'd, that handler being the second listener.
- Found while fixing the above: a listening port that nobody references is collectable as soon as its peer closes, and a GC can collect it before the posted peer-close notification (which holds only a weak pointer to it, MessagePortPipe.cpp `notifyPeerClosed`) runs and releases its listener loop ref. The ref then outlived the port and the process could never exit. On main this already happens for `on()` / `addEventListener()` ports (repro in the new tests: 20 unreferenced listening ports, peers closed, `Bun.gc()`, process hangs); `onmessage` ports were shielded only by the self-reference the setter took, which this change removes.

### Fix

- The first `'message'` listener (count 0 to 1 in `onDidChangeListenerImpl()`) calls `setRefd()`, the half of `jsRef()` that sets `m_isRefd`, so it passes the same gate as `.ref()`: a closed or transferred port, or one whose peer closed by request, still takes nothing (node closes such a port outright; covered by the existing "ref()/onmessage after the peer closes" test and a new one). `m_isRefd` now defaults to false, which is also node's state for a fresh port; the first listener is what sets it.
- The `onmessage` setter no longer calls `jsRef()`. Installing a handler registers a `'message'` listener, so the hook refs the port when it is the first one and leaves it alone otherwise. The one transition the hook cannot see is a callable handler replacing an installed one (`setAttributeEventListener` swaps the function in place); node's setter re-registers it (`removeListener`, then `newListener`), so replacing the port's only listener refs again even after an `unref()`, and `didSetMessageHandler()` does exactly that case. The decision stays keyed on callability, as on main: a non-callable value (null, a string, or an object, which `setAttributeEventListener` stores but `JSEventListener` never invokes) unrefs, matching node, whose setter only counts functions.
- `~MessagePort()` releases the listener loop ref if the port still holds one. It is the only release path that does not need the port to still be alive when the peer's close is delivered; `m_hasRef` cannot be set there since it holds a reference to the port itself. This fixes the latent `on()`/`addEventListener()` hang on main and is what lets the setter drop its self-reference safely.
- Why this is correct: it is node's model. `setupPortReferencing` refs on the first listener regardless of what `ref()`/`unref()` did before, and the setter is an ordinary listener registration to it. Nothing is taken that is not released: the listener ref is still released by `unref()`, by the count dropping to zero, by `close()`/transfer/peer close, and now by destruction; the gate keeps it from being taken on a port nothing would ever release. Bun's internal ports (the `Worker` public port, the messaging hub ports, the stdio ports in src/js/node/worker_threads.ts and src/js/internal/worker/messaging.ts) add their listener first and `unref()` afterwards, so their behavior is unchanged; the upstream `test-worker-ref*`, `test-worker-parent-port-ref` and `test-worker-stdio*` tests below exercise them.
- Verified with the new tests in test/js/node/worker_threads/worker_threads.test.ts: a `hasRef()` matrix over the registration paths (7 rows plus node's `test-messageport-hasref` sequence fail on main), the peer-closed gate, and spawned scripts plus a worker that must stay alive or exit on their own, including the four collected-port scripts (`on()`, `addEventListener()` and the peer-collected one fail on main; the `onmessage` one passes on main and guards the setter change). 8 of the 10 new tests fail on main (release and debug+ASAN); all pass with the change.
  - worker_threads.test.ts as a whole (132 tests), test/js/web/workers/message-channel, message-event, worker-postmessage-transfer, message-port-closed-leak, message-port-context-destroy-leak and worker-transfer-terminate-stress pass. The context-destroy fixture now calls `port1.ref()` because `onmessage =` alone no longer takes the self-reference that test measures.
  - 34 upstream tests pass unchanged: `test-messagechannel`, `test-worker-message-port*`, `test-worker-message-channel`, `test-worker-workerdata-messageport`, `test-worker-message-event`, `test-worker-messaging`, `test-worker-onmessage*`, `test-worker-ref*`, `test-worker-parent-port-ref`, `test-worker-stdio*`, `test-worker-terminate-ref-public-port`, `test-worker-unref-from-message-during-exit`. No upstream test becomes vendorable by itself: `test-messageport-hasref` also needs the `MESSAGEPORT` async_hooks resource (#35366) and `hasRef()` around `close()` (#38019).
- Scope: the mirror image, where removing the last listener does not release an explicit `.ref()`, is #38009; the two compose (that one clears on the last removal, this one sets on the first add). #36434 contains a similar first-listener change inside a broader GC-pinning fix and is currently conflicting; this is only that piece, against current main. Not copied, and already different on main: node's `removeAllListeners()` bypasses its own hooks and leaves a listener-less port ref'd, and a non-callable `onmessage` value assigned to a port without a handler (`onmessage = null`, `onmessage = {}`) registers a handler entry and refs the port; in both node keeps the process alive with nothing that can run.

### Background

- A MessagePort "refs" its thread's event loop while it may still have something to deliver: a ref'd port keeps the process (or worker) alive, an unref'd one does not, and `hasRef()` reports which. Node keeps one flag on the libuv handle: `ref()`/`unref()` set and clear it, and `setupPortReferencing` sets it on the first `'message'` listener and clears it on the last removal.
- Bun holds two things behind that: `m_hasRef`, the explicit `.ref()` hold (an event-loop ref plus a reference to the port object itself, so a ref()'d port outlives a collected wrapper the way node's never-collected ports do), and a listener-driven event-loop ref held while `m_isRefd && m_messageEventCount > 0`. `hasRef()` reports either being held. `m_isRefd` is the piece this change turns into node's flag on the add side.
- `onDidChangeListener` is the hook `EventTarget` invokes after a listener was actually added, removed, or the list was cleared; duplicate adds do not invoke it, so the count is exact. Node-style `on()`/`once()`/`off()` on a port are a shim in src/js/node/worker_threads.ts over the native `addEventListener`/`removeEventListener`, and the `onmessage` setter registers a listener through the same `EventTarget` machinery, which is why one native hook covers every registration form.
- A port's JS wrapper is kept alive by `hasPendingActivity()` only while its peer is open or messages are queued for it, so once the peer closes an otherwise unreferenced listening port is garbage. The peer's close is delivered as a task posted to the port's thread that resolves a `ThreadSafeWeakPtr` to the port; a port collected in between is simply skipped, hence the release in the destructor.
- `MessagePortPipe` marks a side `ClosedByRequest` only for an explicit `close()`, as opposed to the wrapper being garbage collected; that is what lets `setRefd()` refuse a port whose peer really closed without making `.ref()` depend on GC timing.

<details>
<summary>hasRef() probe: node v26.3.0, bun main, this PR (each row is a fresh channel, peer kept reachable)</summary>

| scenario on port1 | node | main | this PR |
| --- | --- | --- | --- |
| unref; on | true | false | true |
| unref; addEventListener | true | false | true |
| unref; addEventListener(object with handleEvent) | true | false | true |
| unref; once | true | false | true |
| unref; on; off; on | true | false | true |
| unref; onmessage = f | true | true | true |
| on g; unref; onmessage = f | false | true | false |
| on f; onmessage = g; unref; onmessage = h | false | true | false |
| onmessage = f; unref; onmessage = g | true | true | true |
| onmessage = f; onmessage = {} | false | false | false |
| onmessage = f; unref; onmessage = { handleEvent } | false | false | false |
| on g; unref; on f | false | false | false |
| on; unref | false | false | false |
| on; unref; ref | true | true | true |
| fresh | false | false | false |
| unref; on('messageerror') / on('close') | false | false | false |
| fresh; unref; ref; unref; on; off | F,F,T,F,T,F | F,F,T,F,F,F | F,F,T,F,T,F |
| unref; onmessage = {} (node quirk, not copied) | true | false | false |

Process liveness, with an unref'd timer as the only other work: `unref; on` and `unref; addEventListener` stay alive in node and with this PR, exit on main; `on g; unref; onmessage = f` exits in node and with this PR, stays alive on main. 20 unreferenced listening ports whose peers are closed, followed by `Bun.gc(true)`: node and this PR exit; main exits for `onmessage =` but hangs for `on()` and `addEventListener()`. Rows that differ only on the removal side (`ref; on; off` and friends) are unchanged here and belong to #38009.

</details>
