### PR TITLE
tls: apply sessionTimeout to TLS 1.3 sessions too

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1323,7 +1323,11 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
   }
 
   if (options.session_timeout > 0) {
+    /* OpenSSL (so Node) stamps SSL_CTX_set_timeout onto every session;
+     * BoringSSL's SSL_CTX_set_timeout only covers TLS <= 1.2 and keeps the
+     * TLS 1.3 ticket lifetime in a separate knob, so set both. */
     SSL_CTX_set_timeout(ssl_context, options.session_timeout);
+    SSL_CTX_set_session_psk_dhe_timeout(ssl_context, options.session_timeout);
   }
 
   if (options.allow_partial_trust_chain) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -511,7 +511,9 @@ struct us_bun_socket_context_options_t {
     int request_cert;
     unsigned int client_renegotiation_limit;
     unsigned int client_renegotiation_window;
-    /* Session timeout in seconds applied via SSL_CTX_set_timeout; 0 = library default. */
+    /* Lifetime in seconds of the sessions this context creates, for every
+     * protocol version (SSL_CTX_set_timeout for TLS <= 1.2 plus
+     * SSL_CTX_set_session_psk_dhe_timeout for TLS 1.3); 0 = library defaults. */
     int session_timeout;
     /* PEM-encoded CRLs added to the context's X509_STORE (enables CRL checking). */
     const char * const *crl;

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "bun:test";
 
 import { bunEnv, bunExe, tempDir } from "harness";
 import { X509Certificate } from "node:crypto";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
 import { AddressInfo } from "node:net";
 import { join } from "node:path";
@@ -777,4 +778,140 @@ it("validates sigalgs on every secure context like Node's configSecureContext", 
   expect(() => tls.createSecureContext({ sigalgs: 42 as never })).toThrow(
     expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
   );
+});
+
+describe("sessionTimeout", () => {
+  // The 'session' event carries BoringSSL's serialized SSL_SESSION
+  // (vendor/boringssl/ssl/ssl_asn1.cc):
+  //   SSLSession ::= SEQUENCE { ..., timeout [2] INTEGER, ..., ticketLifetimeHint [9] INTEGER OPTIONAL, ... }
+  // timeout is the lifetime the client will honour. For a TLS 1.3 session it
+  // is the lifetime the server put in its NewSessionTicket, capped by the
+  // client's own sessionTimeout; a TLS 1.2 session keeps the client's own
+  // lifetime there and records the server's value as ticketLifetimeHint.
+  function sessionLifetimes(der: Uint8Array) {
+    let pos = 0;
+    function readHeader() {
+      const tag = der[pos++];
+      let length = der[pos++];
+      if (length & 0x80) {
+        const lengthBytes = length & 0x7f;
+        length = 0;
+        for (let i = 0; i < lengthBytes; i++) length = length * 256 + der[pos++];
+      }
+      return { tag, end: pos + length };
+    }
+    function readInteger(end: number) {
+      const integer = readHeader();
+      expect(integer.tag).toBe(0x02);
+      expect(integer.end).toBe(end);
+      let value = 0;
+      for (; pos < integer.end; pos++) value = value * 256 + der[pos];
+      return value;
+    }
+    const sequence = readHeader();
+    expect(sequence.tag).toBe(0x30);
+    let timeout: number | undefined;
+    let ticketLifetimeHint: number | undefined;
+    while (pos < sequence.end) {
+      const element = readHeader();
+      if (element.tag === 0xa2) timeout = readInteger(element.end);
+      else if (element.tag === 0xa9) ticketLifetimeHint = readInteger(element.end);
+      pos = element.end;
+    }
+    return { timeout, ticketLifetimeHint };
+  }
+
+  type Observed = ReturnType<typeof sessionLifetimes> & { protocol: string | null; skew: number };
+
+  // BoringSSL holds TLS 1.3 tickets back until the server's first write, so
+  // every server below writes something; `request` is what the client has to
+  // send first to provoke that write.
+  async function firstSessionFrom(
+    port: number,
+    clientOptions: tls.ConnectionOptions = {},
+    request?: string,
+  ): Promise<Observed> {
+    const startedAt = Date.now();
+    const socket = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false, ...clientOptions });
+    try {
+      socket.resume();
+      if (request !== undefined) {
+        await once(socket, "secureConnect");
+        socket.write(request);
+      }
+      const session = await new Promise<Buffer>((resolve, reject) => {
+        socket.once("session", resolve);
+        socket.once("error", reject);
+        socket.once("close", () => reject(new Error("connection closed before the server issued a session")));
+      });
+      // Both peers count a lifetime from ticket issuance, so a connection that
+      // straddles second boundaries reports that many seconds less than was
+      // configured. `skew` bounds how many it can have straddled.
+      const skew = Math.ceil((Date.now() - startedAt) / 1000) + 1;
+      return { protocol: socket.getProtocol(), ...sessionLifetimes(session), skew };
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  function expectLifetime(actual: number | undefined, configured: number, { skew }: Observed) {
+    expect(actual).toBeWithin(configured - skew, configured + 1);
+  }
+
+  async function withTlsServer(options: tls.TlsOptions, clientOptions?: tls.ConnectionOptions) {
+    const server = tls.createServer({ key: agent1Key, cert: agent1Cert, ...options }, socket => socket.end("x"));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      return await firstSessionFrom((server.address() as AddressInfo).port, clientOptions);
+    } finally {
+      server.close();
+    }
+  }
+
+  const TWO_HOURS = 2 * 60 * 60; // SSL_DEFAULT_SESSION_TIMEOUT
+  const TWO_DAYS = 2 * 24 * 60 * 60; // SSL_DEFAULT_SESSION_PSK_DHE_TIMEOUT
+
+  it("tls.createServer({ sessionTimeout }) is the lifetime of the TLS 1.3 tickets it issues", async () => {
+    const observed = await withTlsServer({ sessionTimeout: 7 });
+    expect(observed.protocol).toBe("TLSv1.3");
+    expectLifetime(observed.timeout, 7, observed);
+  });
+
+  it("tls.createServer({ sessionTimeout }) is the lifetime hint of the TLS 1.2 tickets it issues", async () => {
+    const observed = await withTlsServer({ sessionTimeout: 7, maxVersion: "TLSv1.2" });
+    expect(observed.protocol).toBe("TLSv1.2");
+    expectLifetime(observed.ticketLifetimeHint, 7, observed);
+    expectLifetime(observed.timeout, TWO_HOURS, observed);
+  });
+
+  it("tls.connect({ sessionTimeout }) caps the lifetime of the TLS 1.3 sessions the client keeps", async () => {
+    const observed = await withTlsServer({}, { sessionTimeout: 9 } as tls.ConnectionOptions);
+    expect(observed.protocol).toBe("TLSv1.3");
+    expectLifetime(observed.timeout, 9, observed);
+  });
+
+  it("leaves BoringSSL's per-version defaults alone when the option is not given", async () => {
+    const tls13 = await withTlsServer({});
+    expect(tls13.protocol).toBe("TLSv1.3");
+    expect(tls13.ticketLifetimeHint).toBeUndefined();
+    expectLifetime(tls13.timeout, TWO_DAYS, tls13);
+
+    const tls12 = await withTlsServer({ maxVersion: "TLSv1.2" });
+    expect(tls12.protocol).toBe("TLSv1.2");
+    expectLifetime(tls12.ticketLifetimeHint, TWO_HOURS, tls12);
+    expectLifetime(tls12.timeout, TWO_HOURS, tls12);
+  });
+
+  it("Bun.serve({ tls: { sessionTimeout } }) is the lifetime of the TLS 1.3 tickets it issues", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: { key: agent1Key, cert: agent1Cert, sessionTimeout: 7 } as Bun.TLSOptions,
+      fetch: () => new Response("ok"),
+    });
+    const observed = await firstSessionFrom(server.port!, {}, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+    expect(observed.protocol).toBe("TLSv1.3");
+    expectLifetime(observed.timeout, 7, observed);
+  });
 });


### PR DESCRIPTION
### Problem
- The `sessionTimeout` TLS option (`tls.createServer` / `createSecureContext` / `tls.connect`, `Bun.serve({ tls })`, `Bun.listen({ tls })`) only changes the lifetime of TLS 1.2 sessions. TLS 1.3 tickets, which is what every current client negotiates, still carry BoringSSL's 2-day default and stay resumable for 2 days no matter what was configured.
- `tls.createServer({ key, cert, sessionTimeout: 7 })`, read back with `openssl s_client -sess_out` + `openssl sess_id -text`:

  |  | TLSv1.2 ticket lifetime hint | TLSv1.3 ticket lifetime hint |
  | --- | --- | --- |
  | node v26.3.0 | 7 | 7 |
  | bun 1.4.0 | 7 | 172800 |

- Cause: `us_ssl_ctx_build_raw` (`packages/bun-usockets/src/crypto/openssl.c:1325`) applies the option with `SSL_CTX_set_timeout()` alone. In BoringSSL that function sets the lifetime of "TLS 1.2 (or earlier) sessions" only (`vendor/boringssl/include/openssl/ssl.h`, `SSL_CTX_set_timeout`); TLS 1.3 sessions take theirs from `SSL_CTX`'s `session_psk_dhe_timeout` (`vendor/boringssl/ssl/ssl_session.cc`, `ssl_get_new_session`), which nothing in bun ever set.

### Fix
- `us_ssl_ctx_build_raw` also calls `SSL_CTX_set_session_psk_dhe_timeout()` with the same value, inside the existing `> 0` guard, so omitting the option (or `0`) still leaves both BoringSSL defaults in place.
- Correct because it matches Node: Node calls OpenSSL's `SSL_CTX_set_timeout()`, and in OpenSSL that one value is stamped onto sessions of every protocol version. Bun exposes one option too, so it has to reach both of BoringSSL's knobs. Every TLS 1.3 lifetime in BoringSSL (fresh tickets, tickets re-issued on resumption, and the client-side cap on received tickets) reads `session_psk_dhe_timeout`, so this one call covers all of them.
- `us_ssl_ctx_build_raw` is the single place any `SSL_CTX` is built (`us_ssl_ctx_from_options` for node:tls, `Bun.serve` including SNI contexts, `Bun.listen`/`Bun.connect`; `quic.c` directly for HTTP/3, which is TLS 1.3 only and so ignored the option entirely until now), so every entry point picks this up.
- Tests: `describe("sessionTimeout")` in `test/js/node/tls/node-tls-context.test.ts` reads the lifetime out of the client's serialized session (`'session'` event) for `tls.createServer` on TLS 1.3 and TLS 1.2, `tls.connect({ sessionTimeout })` (client-side cap), `Bun.serve({ tls })`, and the defaults when the option is omitted. The three TLS 1.3 cases fail on the current build with `172800`, the TLS 1.2 and defaults cases pass before and after; all five pass with the fix.
- Also checked with the fix: the `openssl s_client` probe above prints 7 for both versions; a `sessionTimeout: 3` server resumes a TLS 1.3 ticket right away and refuses it after 4 s (before the fix it still resumed it), same as TLS 1.2 already did; `ssl-ctx-cache.test.ts`, `node-tls-server.test.ts` and Node's `test-tls-session-timeout*.js` still pass.
- Related: #33513 is an older, now conflicting attempt at plumbing the option that predates #32630 (which landed the plumbing but only the TLS 1.2 call); this PR is the remaining TLS 1.3 half. #38134 adds the `Bun.TLSOptions` typings for this option and currently documents it as TLS 1.2 only; its wording can drop that caveat once this lands.

### Background
- TLS session resumption: after a full handshake the server hands the client a ticket (TLS 1.2 `NewSessionTicket` right after the handshake; TLS 1.3 one or more `NewSessionTicket` messages after it, which BoringSSL flushes with the server's first write). The ticket carries a lifetime in seconds; the server refuses tickets older than that and the client stops offering them. `sessionTimeout` is that lifetime.
- BoringSSL keeps two lifetimes on an `SSL_CTX` because it treats the two protocol versions differently: `session_timeout` (set by `SSL_CTX_set_timeout`, default 2 hours) for TLS <= 1.2, where resumption reuses the old key material, and `session_psk_dhe_timeout` (set by `SSL_CTX_set_session_psk_dhe_timeout`, default 2 days) for TLS 1.3, where resumption mixes in a fresh key exchange. OpenSSL has a single timeout for both, which is why the one Node option maps onto one OpenSSL call but two BoringSSL calls.
- The test reads the lifetime from the DER that bun's `'session'` event emits (`i2d_SSL_SESSION`): a TLS 1.3 client session stores `min(server's ticket lifetime, client's own psk_dhe timeout)` in its `timeout` field, a TLS 1.2 client session stores the server's value in `ticketLifetimeHint` and the client's own timeout in `timeout`. Both peers count lifetimes from ticket issuance, so a handshake that straddles second boundaries reports that many seconds less than configured; the test allows for the seconds the connection took instead of asserting an exact value.
