### PR TITLE
node:fs: recursive mkdir reports the stat error (ENOENT, ELOOP) for a symlink it cannot follow, not EEXIST

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,8 +437,7 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// `sys::exists_at_type` dispatched on path element width: on Windows `OSPathSliceZ`
-/// is already `&WStr`, so forward to the wide overload instead of re-widening.
+/// `sys::exists_at_type` for an `OSPathSliceZ`, which is already wide on Windows.
 #[inline]
 fn exists_at_type_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<sys::ExistsAtType> {
     #[cfg(not(windows))]

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,11 +437,8 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// What is at `(fd, path)` after `mkdir` reported it as existing — dispatches on path
-/// element width. On Windows `OSPathSliceZ` is already `&WStr`, so forward to the wide
-/// overload instead of narrowing to UTF-8 and re-widening. POSIX is a forwarder.
-/// The error is the probe's own (`ENOENT` for a symlink to nowhere, `ELOOP` for a
-/// symlink loop); callers decide whether to report it.
+/// `sys::exists_at_type` dispatched on path element width: on Windows `OSPathSliceZ`
+/// is already `&WStr`, so forward to the wide overload instead of re-widening.
 #[inline]
 fn exists_at_type_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<sys::ExistsAtType> {
     #[cfg(not(windows))]
@@ -5669,13 +5666,10 @@ impl NodeFS {
                 // it is unclear if macOS lies about if the existing item is
                 // a directory or not, so it is checked.
                 E::EISDIR | E::EEXIST => {
-                    // Same as node's MKDirpSync: an existing directory is success, an
-                    // existing non-directory is the mkdir's EEXIST, and an entry that
-                    // cannot be stat'd (a symlink to nowhere or a symlink loop) is
-                    // reported with the stat error rather than as EEXIST.
                     let errno = match exists_at_type_os_path(FD::INVALID, path) {
                         Ok(sys::ExistsAtType::Directory) => return Ok(StringOrUndefined::None),
                         Ok(sys::ExistsAtType::File) => err.errno,
+                        // Like node: a symlink to nowhere is ENOENT, a symlink loop ELOOP.
                         Err(stat_err) => stat_err.errno,
                     };
                     return Err(sys::Error {
@@ -5750,9 +5744,7 @@ impl NodeFS {
                         // is never observed with its terminator clobbered.
                         match err.get_errno() {
                             E::EEXIST => {
-                                // On Windows, this may happen if trying to mkdir replacing a file.
-                                // Anything else (a directory, or a probe failure) breaks out so
-                                // the mkdir of the next component reports what is wrong.
+                                // On Windows, this may happen if trying to mkdir replacing a file
                                 #[cfg(windows)]
                                 {
                                     if let Ok(sys::ExistsAtType::File) =

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,18 +437,20 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// Check whether a directory exists at `(fd, path)` — dispatches on path element width. On
-/// Windows `OSPathSliceZ` is already `&WStr`, so forward to the wide overload
-/// instead of narrowing to UTF-8 and re-widening. POSIX is a forwarder.
+/// What is at `(fd, path)` after `mkdir` reported it as existing — dispatches on path
+/// element width. On Windows `OSPathSliceZ` is already `&WStr`, so forward to the wide
+/// overload instead of narrowing to UTF-8 and re-widening. POSIX is a forwarder.
+/// The error is the probe's own (`ENOENT` for a symlink to nowhere, `ELOOP` for a
+/// symlink loop); callers decide whether to report it.
 #[inline]
-fn directory_exists_at_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<bool> {
+fn exists_at_type_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<sys::ExistsAtType> {
     #[cfg(not(windows))]
     {
-        sys::directory_exists_at(dir, path)
+        sys::exists_at_type(dir, path)
     }
     #[cfg(windows)]
     {
-        sys::directory_exists_at_w(dir, path.as_slice())
+        sys::exists_at_type_w(dir, path.as_slice())
     }
 }
 
@@ -5667,31 +5669,23 @@ impl NodeFS {
                 // it is unclear if macOS lies about if the existing item is
                 // a directory or not, so it is checked.
                 E::EISDIR | E::EEXIST => {
-                    return match directory_exists_at_os_path(FD::INVALID, path) {
-                        Err(_) => Err(sys::Error {
-                            errno: err.errno,
-                            syscall: sys::Tag::mkdir,
-                            path: self
-                                .os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
-                                .into(),
-                            ..Default::default()
-                        }),
-                        // if is a directory, OK. otherwise failure
-                        Ok(result) => {
-                            if result {
-                                Ok(StringOrUndefined::None)
-                            } else {
-                                Err(sys::Error {
-                                    errno: err.errno,
-                                    syscall: sys::Tag::mkdir,
-                                    path: self
-                                        .os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
-                                        .into(),
-                                    ..Default::default()
-                                })
-                            }
-                        }
+                    // Same as node's MKDirpSync: an existing directory is success, an
+                    // existing non-directory is the mkdir's EEXIST, and an entry that
+                    // cannot be stat'd (a symlink to nowhere or a symlink loop) is
+                    // reported with the stat error rather than as EEXIST.
+                    let errno = match exists_at_type_os_path(FD::INVALID, path) {
+                        Ok(sys::ExistsAtType::Directory) => return Ok(StringOrUndefined::None),
+                        Ok(sys::ExistsAtType::File) => err.errno,
+                        Err(stat_err) => stat_err.errno,
                     };
+                    return Err(sys::Error {
+                        errno,
+                        syscall: sys::Tag::mkdir,
+                        path: self
+                            .os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
+                            .into(),
+                        ..Default::default()
+                    });
                 }
                 // continue
                 E::ENOENT => {
@@ -5756,27 +5750,26 @@ impl NodeFS {
                         // is never observed with its terminator clobbered.
                         match err.get_errno() {
                             E::EEXIST => {
-                                // On Windows, this may happen if trying to mkdir replacing a file
+                                // On Windows, this may happen if trying to mkdir replacing a file.
+                                // Anything else (a directory, or a probe failure) breaks out so
+                                // the mkdir of the next component reports what is wrong.
                                 #[cfg(windows)]
                                 {
-                                    if let Ok(res) =
-                                        directory_exists_at_os_path(FD::INVALID, parent)
+                                    if let Ok(sys::ExistsAtType::File) =
+                                        exists_at_type_os_path(FD::INVALID, parent)
                                     {
-                                        // is a directory. break.
-                                        if !res {
-                                            // SAFETY: `working_mem` is not used after this return; the
-                                            // re-derived &mut PathBuffer is scoped to the call.
-                                            return Err(sys::Error {
-                                                errno: E::ENOTDIR as _,
-                                                syscall: sys::Tag::mkdir,
-                                                path: Self::os_path_into_buf(
-                                                    unsafe { &mut *sync_error_buf_ptr },
-                                                    without_nt_prefix(&(&path[..])[..len as usize]),
-                                                )
-                                                .into(),
-                                                ..Default::default()
-                                            });
-                                        }
+                                        // SAFETY: `working_mem` is not used after this return; the
+                                        // re-derived &mut PathBuffer is scoped to the call.
+                                        return Err(sys::Error {
+                                            errno: E::ENOTDIR as _,
+                                            syscall: sys::Tag::mkdir,
+                                            path: Self::os_path_into_buf(
+                                                unsafe { &mut *sync_error_buf_ptr },
+                                                without_nt_prefix(&(&path[..])[..len as usize]),
+                                            )
+                                            .into(),
+                                            ..Default::default()
+                                        });
                                     }
                                 }
                                 working_mem[i as usize] = paths::SEP as OSPathChar;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7414,7 +7414,7 @@ pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {
 /// `OSPathSliceZ`) and routes through
 /// `toNTPath16` instead of re-widening from UTF-8.
 #[cfg(windows)]
-pub(crate) fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
+pub fn exists_at_type_w(dir: Fd, sub: &[u16]) -> Maybe<ExistsAtType> {
     let mut wbuf = bun_paths::w_path_buffer_pool::get();
     let path = bun_paths::string_paths::to_nt_path16(&mut wbuf.0[..], sub).as_slice();
     exists_at_type_nt(dir, path)
@@ -7428,18 +7428,6 @@ pub fn directory_exists_at(dir: impl AsFd, sub: &ZStr) -> Maybe<bool> {
         Err(e) => Err(e),
     }
 }
-/// `directoryExistsAt` — wide-path (`u16`) overload for Windows
-/// `OSPathSliceZ` callers (mkdir-recursive, cpSync auto-detect). Avoids
-/// a UTF-16 → UTF-8 → UTF-16 round-trip.
-#[cfg(windows)]
-pub fn directory_exists_at_w(dir: Fd, sub: &[u16]) -> Maybe<bool> {
-    match exists_at_type_w(dir, sub) {
-        Ok(t) => Ok(t == ExistsAtType::Directory),
-        Err(e) if e.get_errno() == E::ENOENT => Ok(false),
-        Err(e) => Err(e),
-    }
-}
-
 // ── fcntl / nonblocking / dup ──
 
 /// `fcntl(fd, F_GETFL, 0)`.

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -8,7 +8,17 @@ import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, symlinkSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
-import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import {
+  bunExe,
+  isMacOS,
+  isPosix,
+  isWindows,
+  rss,
+  runWithErrorPromise,
+  tempDir,
+  tempDirWithFiles,
+  tmpdirSync,
+} from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -1228,7 +1238,7 @@ ${temp_dir}`
   });
 
   // `mkdir -p` on a name held by a symlink reports what stat() says about the
-  // link (as BSD mkdir and node's recursive mkdir do), not "File exists". Skipped
+  // link (as BSD mkdir and node's recursive mkdir do), not the EEXIST text. Skipped
   // on Windows, where the existence probe does not follow links yet.
   describe.skipIf(isWindows)("mkdir -p on a symlink", () => {
     let dir: string;
@@ -1254,12 +1264,14 @@ ${temp_dir}`
       expect(exitCode).toBe(1);
     });
 
-    test("to a directory succeeds, a file still reports File exists", async () => {
+    test("to a directory succeeds, a file still reports EEXIST", async () => {
       const dirlink = join(dir, "dirlink");
       expect((await $`mkdir -p ${dirlink}`).exitCode).toBe(0);
       const file = join(dir, "file");
       const { stderr, exitCode } = await $`mkdir -p ${file}`;
-      expect(stderr.toString()).toEqual(`mkdir: ${file}: File exists\n`);
+      // The shell's errno text follows the platform's strerror wording.
+      const eexist = isMacOS ? "File or folder exists" : "File exists";
+      expect(stderr.toString()).toEqual(`mkdir: ${file}: ${eexist}\n`);
       expect(exitCode).toBe(1);
     });
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, symlinkSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
@@ -1224,6 +1224,43 @@ ${temp_dir}`
           .split("\n")
           .sort(),
       );
+    });
+  });
+
+  // `mkdir -p` on a name held by a symlink reports what stat() says about the
+  // link (as BSD mkdir and node's recursive mkdir do), not "File exists". Skipped
+  // on Windows, where the existence probe does not follow links yet.
+  describe.skipIf(isWindows)("mkdir -p on a symlink", () => {
+    let dir: string;
+    beforeAll(() => {
+      dir = tempDirWithFiles("temp-mkdir-p", { file: "", realdir: {} });
+      symlinkSync("missing", join(dir, "dangling"));
+      symlinkSync("loop", join(dir, "loop"));
+      symlinkSync("realdir", join(dir, "dirlink"));
+    });
+
+    test("to a missing target", async () => {
+      const target = join(dir, "dangling");
+      const { stderr, exitCode } = await $`mkdir -p ${target}`;
+      expect(stderr.toString()).toEqual(`mkdir: ${target}: No such file or directory\n`);
+      expect(exitCode).toBe(1);
+      expect(existsSync(join(dir, "missing"))).toBe(false);
+    });
+
+    test("that loops", async () => {
+      const target = join(dir, "loop");
+      const { stderr, exitCode } = await $`mkdir -p ${target}`;
+      expect(stderr.toString()).toEqual(`mkdir: ${target}: Too many levels of symbolic links\n`);
+      expect(exitCode).toBe(1);
+    });
+
+    test("to a directory succeeds, a file still reports File exists", async () => {
+      const dirlink = join(dir, "dirlink");
+      expect((await $`mkdir -p ${dirlink}`).exitCode).toBe(0);
+      const file = join(dir, "file");
+      const { stderr, exitCode } = await $`mkdir -p ${file}`;
+      expect(stderr.toString()).toEqual(`mkdir: ${file}: File exists\n`);
+      expect(exitCode).toBe(1);
     });
   });
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -384,6 +384,28 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/hello/world/b.txt", "b");
     });
 
+    // Both of these options route through the ported implementation, which
+    // creates a missing destination parent with a recursive mkdir. When the
+    // parent's name is a symlink to a missing target, that mkdir reports ENOENT
+    // (as node's does); it used to report EEXIST. On Windows the mkdir's
+    // existence probe does not follow the link yet, so this is fixed separately.
+    for (const [what, src, options] of [
+      ["a directory with 'recursive: true'", "/from", { recursive: true }],
+      ["a file with 'force: false'", "/from/a.txt", { force: false }],
+    ] as const) {
+      test.skipIf(isWindows)(`${what} into a symlink-to-nowhere parent fails with ENOENT`, async () => {
+        await using basename = tempDir("cp", {
+          "from/a.txt": "a",
+        });
+        fs.symlinkSync("missing", basename + "/dangling");
+
+        const e = await copyShouldThrow(basename + src, basename + "/dangling/dest", options);
+        expect(e.code).toBe("ENOENT");
+
+        expect(fs.readdirSync(String(basename)).sort()).toEqual(["dangling", "from"]);
+      });
+    }
+
     test("relative paths for directories", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -384,11 +384,13 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/hello/world/b.txt", "b");
     });
 
-    // Both of these options route through the ported implementation, which
-    // creates a missing destination parent with a recursive mkdir. When the
-    // parent's name is a symlink to a missing target, that mkdir reports ENOENT
-    // (as node's does); it used to report EEXIST. On Windows the mkdir's
-    // existence probe does not follow the link yet, so this is fixed separately.
+    // The ported implementation creates a missing destination parent with a
+    // recursive mkdir. When the parent's name is a symlink to a missing target,
+    // that mkdir reports ENOENT (as node's does); it used to report EEXIST.
+    // `force: false` always takes the ported implementation; a directory does
+    // everywhere but macOS, where the native copy fails with the same ENOENT.
+    // On Windows the mkdir's existence probe does not follow the link yet, so
+    // that is fixed separately.
     for (const [what, src, options] of [
       ["a directory with 'recursive: true'", "/from", { recursive: true }],
       ["a file with 'force: false'", "/from/a.txt", { force: false }],

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -399,3 +399,97 @@ describe("fs.promises.mkdir", () => {
     expect(result).toBeUndefined();
   });
 });
+
+// When mkdir reports the path as existing, the recursive form stats it to find out
+// whether it is a directory. Like node, a failed stat is the error that gets reported:
+// ENOENT for a symlink whose target is missing, ELOOP for a symlink loop. Bun used to
+// report the mkdir's EEXIST for both. On Windows the existence probe describes the link
+// itself instead of following it, so the symlink cases there are a separate fix.
+describe.skipIf(isWindows)("fs.mkdir - recursive on a symlink", () => {
+  let tmpdir: string;
+  let missing: string;
+  let dangling: string;
+  let loop: string;
+  let file: string;
+  let fileLink: string;
+  let dir: string;
+  let dirLink: string;
+
+  const mkdirForms = {
+    mkdirSync: (pathname: string) => Promise.resolve().then(() => fs.mkdirSync(pathname, { recursive: true })),
+    mkdir: (pathname: string) =>
+      new Promise<string | undefined>((resolve, reject) =>
+        fs.mkdir(pathname, { recursive: true }, (err, result) => (err ? reject(err) : resolve(result))),
+      ),
+    "promises.mkdir": (pathname: string) => fs.promises.mkdir(pathname, { recursive: true }),
+  };
+  const forms = Object.keys(mkdirForms) as (keyof typeof mkdirForms)[];
+
+  beforeEach(() => {
+    tmpdir = getTmpDir();
+    missing = path.join(tmpdir, "missing");
+    dangling = path.join(tmpdir, "dangling");
+    fs.symlinkSync("missing", dangling);
+    loop = path.join(tmpdir, "loop");
+    fs.symlinkSync("loop", loop);
+    file = path.join(tmpdir, "file");
+    fs.writeFileSync(file, "");
+    fileLink = path.join(tmpdir, "file-link");
+    fs.symlinkSync("file", fileLink);
+    dir = path.join(tmpdir, "dir");
+    fs.mkdirSync(dir);
+    dirLink = path.join(tmpdir, "dir-link");
+    fs.symlinkSync("dir", dirLink);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe.each(forms)("%s", form => {
+    it("reports ENOENT for a symlink to a missing target and creates nothing", async () => {
+      await expect(mkdirForms[form](dangling)).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "mkdir",
+        path: dangling,
+      });
+      expect(fs.existsSync(missing)).toBe(false);
+      expect(fs.lstatSync(dangling).isSymbolicLink()).toBe(true);
+    });
+
+    it("reports ELOOP for a symlink loop", async () => {
+      await expect(mkdirForms[form](loop)).rejects.toMatchObject({
+        code: "ELOOP",
+        syscall: "mkdir",
+        path: loop,
+      });
+      expect(fs.lstatSync(loop).isSymbolicLink()).toBe(true);
+    });
+
+    it("still reports EEXIST for a file and for a symlink to a file", async () => {
+      await expect(mkdirForms[form](file)).rejects.toMatchObject({ code: "EEXIST", syscall: "mkdir", path: file });
+      await expect(mkdirForms[form](fileLink)).rejects.toMatchObject({
+        code: "EEXIST",
+        syscall: "mkdir",
+        path: fileLink,
+      });
+    });
+
+    it("still accepts a symlink to a directory", async () => {
+      expect(await mkdirForms[form](dirLink)).toBeUndefined();
+      expect(await mkdirForms[form](path.join(dirLink, "sub"))).toBe(path.join(dirLink, "sub"));
+      expect(fs.statSync(path.join(dir, "sub")).isDirectory()).toBe(true);
+    });
+
+    it("reports the error of the component below the symlink unchanged", async () => {
+      await expect(mkdirForms[form](path.join(dangling, "sub"))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(mkdirForms[form](path.join(loop, "sub"))).rejects.toMatchObject({ code: "ELOOP" });
+      await expect(mkdirForms[form](path.join(fileLink, "sub"))).rejects.toMatchObject({ code: "ENOTDIR" });
+      expect(fs.existsSync(missing)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `fs.mkdirSync(p, { recursive: true })` (and `fs.mkdir`, `fs.promises.mkdir`) throws `EEXIST: file already exists, mkdir 'p'` when `p` is a symlink whose target is missing or a symlink loop. Node v26.3.0 throws `ENOENT` for the first and `ELOOP` for the second (`syscall: "mkdir"`, `path` = the argument), in all three forms. A regular file, or a symlink to one, is `EEXIST` in both; the non-recursive form already matches node. Reproduces with bun 1.4.0 and main on Linux.
- Cause: when the first `mkdir` fails with `EEXIST`, `mkdir_recursive_os_path_impl` (`src/runtime/node/node_fs.rs`, the `E::EISDIR | E::EEXIST` arm) asks `directory_exists_at` whether the entry is a directory. That helper answers with a bool, so "stat failed" and "exists but is not a directory" both end up reporting the mkdir's `EEXIST`. Node's `MKDirpSync` / `MKDirpAsync` stat the entry and return the stat error when the stat fails.
- Same root cause downstream: the ported `fs.cp` / `fs.cpSync` (`src/js/internal/fs/cp.ts`, `cp-sync.ts`, `checkParentDir`) create a missing destination parent with this mkdir, so `fs.promises.cp(dir, "dangling/d", { recursive: true })` and `fs.cpSync("a.txt", "dangling/x", { force: false })` threw `EEXIST` where node's `promises.cp` throws `ENOENT mkdir 'dangling'`. The shell's `mkdir -p dangling` printed `File exists`.

### Fix
- The existing-path arm now uses the typed probe (`exists_at_type`; on Windows `exists_at_type_w`, made `pub`, its bool wrapper `directory_exists_at_w` had no other caller and is removed): `Directory` is success, `File` still returns the mkdir's `EEXIST`, and a probe error returns that error's errno, with `syscall: "mkdir"` and the argument path as before.
- Why this is right: after `mkdir` has said the name is taken, a stat that fails tells the caller what is actually wrong with the name (`ENOENT`: a link to nowhere, `ELOOP`: a loop), and nothing is going to be created. That is what node reports, and what BSD `mkdir -p` prints; the walk-up and walk-down parts of the routine are unchanged, so intermediate components report what they did before (`ENOENT` / `ELOOP` / `ENOTDIR`, which also matches node's sync form).
- The Windows walk-up arm (`mkdir -p X\sub` with `X` existing) now returns its `ENOTDIR` only when the probe says `File`. Before, a probe `ENOENT` (only possible when `X` is deleted between the two calls) also mapped to `ENOTDIR`; it now falls through and the next component's mkdir reports `ENOENT`. Other probe errors were already ignored there.
- On Windows the probe describes a link itself (`NtQueryAttributesFile` does not follow reparse points), so the symlink cases are unchanged there and the new tests are skipped on Windows. #38108 makes that probe follow links; once both are in, its Windows tests that pin `EEXIST` for a link to nowhere should expect `ENOENT`, which is what this arm will then produce (that PR's body anticipates this change). #38084 and #38108 touch the same probe and the same test file, so whichever lands later has a small rebase.
- Knock-on behaviour now: `fs.cp` / `fs.cpSync` via the ported implementation report `ENOENT` for a dest parent that is a link to nowhere (node's `promises.cp`: `ENOENT mkdir 'dangling'`; the default-options native copy is #38097); shell `mkdir -p` prints `No such file or directory` / `Too many levels of symbolic links` for these names (coreutils prints the stat error for the loop but `File exists` for the dangling case; BSD mkdir prints the stat error for both); `Bun.write("dangling/x", "")` rejects with `ENOENT` instead of `EEXIST` (non-empty writes already reported the open's `ENOENT`). `Bun__mkdirp` and the test-runner callers only look at ok/err.
- Verified with `test/js/node/fs/fs-mkdir.test.ts` (new block "recursive on a symlink", for `mkdirSync`, `fs.mkdir` and `fs.promises.mkdir`: ENOENT and ELOOP with syscall/path and nothing created, file and file-link still EEXIST, directory link still accepted, components below a link unchanged). With bun 1.4.0 the 6 ENOENT/ELOOP tests fail (EEXIST) and the rest pass; with this branch all 36 pass.
- `test/js/node/fs/cp.test.ts`: recursive directory and `force: false` file into a link-to-nowhere parent, for `cpSync` and `promises.cp`; 4 fail before (EEXIST), pass after. Whole file passes apart from the pre-existing recursive-copy UAF check, which hits its 5 s budget on this loaded debug/ASAN box (its child prints `ok` in 1.3 s when run directly).
- `test/js/bun/shell/bunshell.test.ts`: new "mkdir -p on a symlink" block; 2 of 3 fail before, file passes after (426 pass).
- Also run with this branch: `fs.test.ts -t mkdir` (32 pass), upstream `test-fs-mkdir*.js` and all 77 `test-fs-cp-*` (pass), `bun-write.test.js` (45 pass; 5 subprocess tests hit their 5 s budget on this box, which was at load average 150+, 4 of them pass when run as a smaller group and the fifth copies 256 MB in a debug child; their only recursive mkdir is of a fresh path, which does not reach the changed arm); `cargo check -p bun_sys -p bun_runtime` for `x86_64-pc-windows-msvc` and the host, `cargo fmt --check`.

### Background
- Recursive mkdir (`NodeFS::mkdir_recursive_os_path_impl`) backs `fs.mkdir*({ recursive })`, the shell `mkdir -p`, the parent creation in `fs.cp` and `Bun.write`, and the native `cp` destination. It first tries to create the full path; `mkdir` reports a file, a directory and a symlink at that name identically (`EEXIST`), so on `EEXIST` it has to look at the entry to tell "already there, fine" from a failure. Only on `ENOENT` does it walk up creating parents.
- `bun_sys::exists_at_type` is that look: `fstatat` without `AT_SYMLINK_NOFOLLOW` on POSIX, so it follows symlinks and fails with the kernel's reason when the link cannot be followed. `directory_exists_at` is its bool wrapper (`ENOENT` becomes `false`), which is what the arm used. `exists_at_type_w` is the UTF-16 entry point used on Windows, where the node:fs paths are already wide.
- A dangling symlink is a symlink whose target does not exist: following it gives `ENOENT`, while creating something with its name gives `EEXIST`. A symlink loop (`loop -> loop`) gives `ELOOP` when followed.

<details>
<summary>Repro, Linux</summary>

```
mkdir t && cd t && ln -s missing dangling && ln -s loop loop && echo f > file
bun -e 'const fs=require("fs"); for (const p of ["dangling","loop","file"]) { try { fs.mkdirSync(p,{recursive:true}); console.log(p,"ok") } catch(e) { console.log(p, e.code) } }'

bun 1.4.0:     dangling EEXIST / loop EEXIST  / file EEXIST    (fs.mkdir and fs.promises.mkdir: same)
this branch:   dangling ENOENT / loop ELOOP   / file EEXIST
node v26.3.0:  dangling ENOENT / loop ELOOP   / file EEXIST

mkdir -p (shell builtin), bun 1.4.0 -> this branch:
  dangling   "mkdir: .../dangling: File exists"  ->  "mkdir: .../dangling: No such file or directory"
  loop       "mkdir: .../loop: File exists"      ->  "mkdir: .../loop: Too many levels of symbolic links"
  file       "mkdir: .../file: File exists"      ->  unchanged
```
</details>
