### PR TITLE
yaml: apply a node's tag in the parser instead of baking it into the next scanned scalar

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -404,7 +404,7 @@ pub trait Encoding: Copy + 'static {
     /// route through this
     /// method — identity for `u8` encodings, byte-reinterpret (`len * 2`) for
     /// `Utf16`. Byte-reinterpret preserves key uniqueness; do **not** use this
-    /// for text (see `NodeScalar::to_expr` for the encoding-aware string path).
+    /// for text (see `YamlString::to_expr` for the encoding-aware string path).
     fn key_bytes(s: &[Self::Unit]) -> &[u8];
 
     /// Construct a Unit from a `u16` code unit. Only meaningful for `Utf16`
@@ -770,6 +770,31 @@ impl<Enc: Encoding> YamlString<Enc> {
             YamlString::List(list) => list.len(),
         }
     }
+
+    pub(crate) fn to_expr(&self, pos: Pos, input: &[Enc::Unit], bump: &bun_alloc::Arena) -> Expr {
+        // For `Utf16` we route through `E::String::init_utf16`.
+        //
+        // LIFETIME: `YamlString::List` is a global-alloc `Vec` that is
+        // dropped with the scalar token shortly after this returns — the
+        // resulting `EString.data` would dangle. Dupe the list bytes into
+        // the bump arena; `.range` already borrows `input` (source text)
+        // which outlives the Expr → JS conversion.
+        let s: &[Enc::Unit] = match self {
+            YamlString::Range(range) => range.slice(input),
+            YamlString::List(list) => bump.alloc_slice_copy(list.as_slice()),
+        };
+        let estring = match Enc::KIND {
+            EncodingKind::Utf16 => {
+                // SAFETY: `Enc::Unit == u16` when `KIND == Utf16`; reinterpret
+                // with the same element count for `E::String::init_utf16`
+                // (which sets `is_utf16`).
+                let s16 = unsafe { core::slice::from_raw_parts(s.as_ptr().cast::<u16>(), s.len()) };
+                E::String::init_utf16(s16)
+            }
+            _ => E::String::init(Enc::key_bytes(s)),
+        };
+        Expr::init(estring, pos.loc())
+    }
 }
 
 // Plain-scalar string builder. `whitespace_buf` is taken from the parser by
@@ -922,52 +947,37 @@ pub(crate) struct ScalarResolverCtx<'i, Enc: Encoding> {
     pub(crate) str_builder: StringBuilder<'i, Enc>,
 
     pub(crate) resolved: bool,
-    pub(crate) scalar: Option<NodeScalar<Enc>>,
-    pub(crate) tag: NodeTag,
+    pub(crate) scalar: Option<NodeScalar>,
 
     pub(crate) resolved_scalar_len: usize,
 
     pub(crate) start: Pos,
     pub(crate) line: Line,
     pub(crate) line_indent: Indent,
-    pub(crate) multiline: bool,
 }
 
 impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
     pub(crate) fn done(self, parser: &mut Parser<'i, Enc>) -> Token<Enc> {
-        let multiline = self.multiline;
         let start = self.start;
         let line_indent = self.line_indent;
         let line = self.line;
         let resolved_scalar_len = self.resolved_scalar_len;
-        let scalar_opt = self.scalar;
-
-        let scalar: TokenScalar<Enc> = 'scalar: {
-            let scalar_str = self.str_builder.done(parser);
-
-            if let Some(scalar) = scalar_opt {
-                if scalar_str.len() == resolved_scalar_len {
-                    drop(scalar_str);
-                    break 'scalar TokenScalar {
-                        style: ScalarStyle::Plain { multiline },
-                        data: scalar,
-                    };
-                }
-                // the first characters resolved to something
-                // but there were more characters afterwards
-            }
-
-            break 'scalar TokenScalar {
-                style: ScalarStyle::Plain { multiline },
-                data: NodeScalar::String(scalar_str),
-            };
-        };
+        // The first characters may have resolved to something that more
+        // characters then followed (`true_story`); that is a string.
+        let resolved = self
+            .scalar
+            .filter(|_| self.str_builder.len() == resolved_scalar_len);
+        let text = self.str_builder.done(parser);
 
         Token::scalar(ScalarInit {
             start,
             indent: line_indent,
             line,
-            resolved: scalar,
+            scalar: TokenScalar {
+                text,
+                resolved,
+                style: ScalarStyle::Plain,
+            },
         })
     }
 
@@ -975,8 +985,6 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
         if self.str_builder.len() == 0 {
             self.line_indent = parser.line_indent;
             self.line = parser.line;
-        } else if self.line != parser.line {
-            self.multiline = true;
         }
     }
 
@@ -1038,7 +1046,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
 
     pub(crate) fn resolve(
         &mut self,
-        scalar: NodeScalar<Enc>,
+        scalar: NodeScalar,
         off: Pos,
         text: impl AsRef<[Enc::Unit]>,
     ) -> Result<(), AllocError> {
@@ -1047,46 +1055,8 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
             .append_expected_source_slice(off, off.add(text.len()), text)?;
 
         self.resolved = true;
-
-        match self.tag {
-            NodeTag::None => {
-                self.resolved_scalar_len = self.str_builder.len();
-                self.scalar = Some(scalar);
-            }
-            NodeTag::NonSpecific => {
-                // always becomes string
-            }
-            NodeTag::Bool => {
-                if matches!(scalar, NodeScalar::Boolean(_)) {
-                    self.resolved_scalar_len = self.str_builder.len();
-                    self.scalar = Some(scalar);
-                }
-            }
-            NodeTag::Int => {
-                if matches!(scalar, NodeScalar::Number(_)) {
-                    self.resolved_scalar_len = self.str_builder.len();
-                    self.scalar = Some(scalar);
-                }
-            }
-            NodeTag::Float => {
-                if matches!(scalar, NodeScalar::Number(_)) {
-                    self.resolved_scalar_len = self.str_builder.len();
-                    self.scalar = Some(scalar);
-                }
-            }
-            NodeTag::Null => {
-                if matches!(scalar, NodeScalar::Null) {
-                    self.resolved_scalar_len = self.str_builder.len();
-                    self.scalar = Some(scalar);
-                }
-            }
-            NodeTag::Str => {
-                // always becomes string
-            }
-            NodeTag::Verbatim(_) | NodeTag::Unknown(_) => {
-                // also always becomes a string
-            }
-        }
+        self.resolved_scalar_len = self.str_builder.len();
+        self.scalar = Some(scalar);
         Ok(())
     }
 
@@ -1381,13 +1351,13 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
         }
 
         let lexed = parser.slice(start, end);
-        let mut scalar: NodeScalar<Enc> = 'scalar: {
+        let mut number: f64 = 'number: {
             if x || o || hex {
                 let unsigned = match parse_unsigned_radix0::<Enc>(lexed) {
                     Ok(v) => v,
                     Err(_) => return Ok(()),
                 };
-                break 'scalar NodeScalar::Number(unsigned as f64);
+                break 'number unsigned as f64;
             }
             // [10.2.1.4] Core schema float/int regex. The lexer loop above is
             // permissive (accepts `+`/`-`/`e`/`.` at any position) and
@@ -1396,28 +1366,18 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
             if !is_core_schema_number::<Enc>(lexed, first_char) {
                 return Ok(());
             }
-            let float = match parse_double_generic::<Enc>(lexed) {
+            match parse_double_generic::<Enc>(lexed) {
                 Ok(v) => v,
                 Err(_) => return Ok(()),
-            };
-
-            break 'scalar NodeScalar::Number(float);
+            }
         };
+        if first_char == FirstChar::Negative {
+            number = -number;
+        }
 
         self.resolved = true;
-
-        match self.tag {
-            NodeTag::None | NodeTag::Float | NodeTag::Int => {
-                self.resolved_scalar_len = self.str_builder.len();
-                if first_char == FirstChar::Negative {
-                    if let NodeScalar::Number(n) = &mut scalar {
-                        *n = -*n;
-                    }
-                }
-                self.scalar = Some(scalar);
-            }
-            _ => {}
-        }
+        self.resolved_scalar_len = self.str_builder.len();
+        self.scalar = Some(NodeScalar::Number(number));
         Ok(())
     }
 }
@@ -1553,49 +1513,39 @@ impl NodeTag {
             NodeTag::NonSpecific | NodeTag::Str => Expr::init(E::String::default(), loc),
         }
     }
+
+    /// Whether a plain scalar the core schema resolves to `scalar` is that
+    /// value under this tag. Otherwise the scalar is its text: a tag of
+    /// another kind only switches the core-schema resolution off, it does
+    /// not validate the text (`!!int foo` is the string "foo").
+    pub(crate) fn keeps(self, scalar: NodeScalar) -> bool {
+        match self {
+            NodeTag::None => true,
+            NodeTag::Null => matches!(scalar, NodeScalar::Null),
+            NodeTag::Bool => matches!(scalar, NodeScalar::Boolean(_)),
+            NodeTag::Int | NodeTag::Float => matches!(scalar, NodeScalar::Number(_)),
+            NodeTag::NonSpecific | NodeTag::Str | NodeTag::Verbatim(_) | NodeTag::Unknown(_) => {
+                false
+            }
+        }
+    }
 }
 
-#[derive(Clone)]
-pub enum NodeScalar<Enc: Encoding> {
+/// [10.2.1.2] What the core schema resolves a plain scalar's text to when
+/// that is not a string.
+#[derive(Clone, Copy)]
+pub enum NodeScalar {
     Null,
     Boolean(bool),
     Number(f64),
-    String(YamlString<Enc>),
 }
 
-impl<Enc: Encoding> NodeScalar<Enc> {
-    pub(crate) fn to_expr(&self, pos: Pos, input: &[Enc::Unit], bump: &bun_alloc::Arena) -> Expr {
+impl NodeScalar {
+    pub(crate) fn to_expr(self, pos: Pos) -> Expr {
         match self {
             NodeScalar::Null => Expr::init(E::Null {}, pos.loc()),
-            NodeScalar::Boolean(value) => Expr::init(E::Boolean { value: *value }, pos.loc()),
-            NodeScalar::Number(value) => Expr::init(E::Number::new(*value), pos.loc()),
-            NodeScalar::String(value) => {
-                // For `Utf16` we route through `E::String::init_utf16`.
-                //
-                // LIFETIME: `YamlString::List` is a global-alloc `Vec` that is
-                // dropped with the local `scalar` immediately after this
-                // returns — the resulting `EString.data` would dangle. Dupe
-                // the list bytes into the bump arena; `.range` already borrows
-                // `input` (source text) which outlives the Expr → JS
-                // conversion.
-                let s: &[Enc::Unit] = match value {
-                    YamlString::Range(range) => range.slice(input),
-                    YamlString::List(list) => bump.alloc_slice_copy(list.as_slice()),
-                };
-                let estring = match Enc::KIND {
-                    EncodingKind::Utf16 => {
-                        // SAFETY: `Enc::Unit == u16` when `KIND == Utf16`;
-                        // reinterpret with the same element count for
-                        // `E::String::init_utf16` (which sets `is_utf16`).
-                        let s16 = unsafe {
-                            core::slice::from_raw_parts(s.as_ptr().cast::<u16>(), s.len())
-                        };
-                        E::String::init_utf16(s16)
-                    }
-                    _ => E::String::init(Enc::key_bytes(s)),
-                };
-                Expr::init(estring, pos.loc())
-            }
+            NodeScalar::Boolean(value) => Expr::init(E::Boolean { value }, pos.loc()),
+            NodeScalar::Number(value) => Expr::init(E::Number::new(value), pos.loc()),
         }
     }
 }
@@ -1731,19 +1681,36 @@ pub enum TokenData<Enc: Encoding> {
 
 #[derive(Clone)]
 pub struct TokenScalar<Enc: Encoding> {
-    pub(crate) data: NodeScalar<Enc>,
+    pub(crate) text: YamlString<Enc>,
+    /// The core-schema value of a plain `text`, if it has one. Whether the
+    /// node is that value or `text` depends on the node's tag, which only
+    /// the parser knows (the token after a property may not even belong to
+    /// the tagged node), so the scanner records both and `to_expr` decides.
+    pub(crate) resolved: Option<NodeScalar>,
     pub(crate) style: ScalarStyle,
 }
 
-/// How a scalar token was written in the source. Only `Plain` carries
-/// `multiline`: the sole reader (`parse_block_indented`'s tag-neutral
-/// rewind) cares exclusively about plain single-line scalars, and the
-/// value has no well-defined meaning for quoted or block styles.
+impl<Enc: Encoding> TokenScalar<Enc> {
+    /// The scalar as the node carrying `tag` (`NodeTag::None` when untagged).
+    pub(crate) fn to_expr(
+        &self,
+        tag: NodeTag,
+        pos: Pos,
+        input: &[Enc::Unit],
+        bump: &bun_alloc::Arena,
+    ) -> Expr {
+        match self.resolved {
+            Some(resolved) if tag.keeps(resolved) => resolved.to_expr(pos),
+            _ => self.text.to_expr(pos, input, bump),
+        }
+    }
+}
+
+/// How a scalar token was written in the source.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ScalarStyle {
-    /// [131] ns-plain. `multiline` = source text spans more than one line,
-    /// tracked by `ScalarResolverCtx::check_append`.
-    Plain { multiline: bool },
+    /// [131] ns-plain.
+    Plain,
     /// [170] `|` literal or [174] `>` folded.
     Block,
     /// [120] single-quoted or [109] double-quoted.
@@ -1772,7 +1739,7 @@ pub(crate) struct ScalarInit<Enc: Encoding> {
     pub(crate) start: Pos,
     pub(crate) indent: Indent,
     pub(crate) line: Line,
-    pub(crate) resolved: TokenScalar<Enc>,
+    pub(crate) scalar: TokenScalar<Enc>,
 }
 
 impl<Enc: Encoding> Token<Enc> {
@@ -1909,7 +1876,7 @@ impl<Enc: Encoding> Token<Enc> {
             start: init.start,
             indent: init.indent,
             line: init.line,
-            data: TokenData::Scalar(init.resolved),
+            data: TokenData::Scalar(init.scalar),
         }
     }
 }
@@ -2117,7 +2084,7 @@ pub struct Parser<'i, Enc: Encoding> {
     /// Growable buffers use the global
     /// allocator (and `Drop`); the arena is threaded for the few places that
     /// must hand a borrowed slice into the long-lived `Expr` tree (see
-    /// `NodeScalar::to_expr`).
+    /// `YamlString::to_expr`).
     pub(crate) bump: &'i bun_alloc::Arena,
 
     pub(crate) context: ContextStack,
@@ -2488,17 +2455,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 }
                 _ => break,
             }
-            let tag = match &scanned_tag {
-                Some(Token {
-                    data: TokenData::Tag(t),
-                    ..
-                }) => *t,
-                _ => NodeTag::None,
-            };
-            self.scan(ScanOptions {
-                tag,
-                ..Default::default()
-            })?;
+            self.scan(ScanOptions::default())?;
             if matches!(
                 self.token.data,
                 TokenData::MappingValue
@@ -3566,27 +3523,14 @@ impl<Enc: Encoding> Default for ParseNodeOptions<Enc> {
 // ScanOptions
 // ───────────────────────────────────────────────────────────────────────────
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct ScanOptions {
     /// Used by compact sequences. We need to add the parent indentation
     pub(crate) additional_parent_indent: Option<Indent>,
-    /// If a scalar is scanned, this tag might be used.
-    pub(crate) tag: NodeTag,
     /// The scanner only counts indentation after a newline (or in compact
     /// collections). First scan needs to count indentation.
     pub(crate) first_scan: bool,
     pub(crate) outside_context: bool,
-}
-
-impl Default for ScanOptions {
-    fn default() -> Self {
-        Self {
-            additional_parent_indent: None,
-            tag: NodeTag::None,
-            first_scan: false,
-            outside_context: false,
-        }
-    }
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -3663,34 +3607,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.token.indent.is_less_than_or_equal(n)
                 };
                 if belongs_to_parent {
-                    // The post-property re-scan baked `value_tag` into a plain
-                    // scalar's resolution (`ScanOptions.tag`); if that scalar
-                    // is now abandoned to the parent, rewind to its start and
-                    // re-scan tag-neutral so the sibling key resolves under
-                    // the default schema. Only plain single-line scalars are
-                    // tag-resolved at scan time; quoted/block scalars ignore
-                    // ScanOptions.tag (and their token.start is past the
-                    // opening indicator, so rewind would be wrong); multiline
-                    // plain scalars may have advanced parser state across
-                    // lines that a positional rewind cannot fully restore.
-                    if value_tag.is_some()
-                        && matches!(
-                            &self.token.data,
-                            TokenData::Scalar(TokenScalar {
-                                style: ScalarStyle::Plain { multiline: false },
-                                ..
-                            })
-                        )
-                    {
-                        self.pos = self.token.start;
-                        self.line = self.token.line;
-                        self.line_indent = self.token.indent;
-                        // tab_after_indent is preserved: the original scan
-                        // recorded it for this token's leading whitespace,
-                        // and the re-scan (in_indent_position=false) won't
-                        // re-detect it since pos is already past the tab.
-                        self.scan(ScanOptions::default())?;
-                    }
                     return self.props_to_e_node(&value_tag, value_anchor, indicator_start.loc());
                 }
             }
@@ -3742,17 +3658,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             }
 
             // recorded a property — re-dispatch on what follows
-            let tag = match &value_tag {
-                Some(Token {
-                    data: TokenData::Tag(t),
-                    ..
-                }) => *t,
-                _ => NodeTag::None,
-            };
-            self.scan(ScanOptions {
-                tag,
-                ..Default::default()
-            })?;
+            self.scan(ScanOptions::default())?;
         }
     }
 
@@ -3868,20 +3774,13 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                 TokenData::Anchor(name) => {
                     node_props.set_anchor(PendingAnchor::new(&self.token, *name))?;
-                    self.scan(ScanOptions {
-                        tag: node_props.tag(),
-                        ..Default::default()
-                    })?;
+                    self.scan(ScanOptions::default())?;
                     continue;
                 }
 
-                TokenData::Tag(tag) => {
-                    let tag = *tag;
+                TokenData::Tag(_) => {
                     node_props.set_tag(self.token.clone())?;
-                    self.scan(ScanOptions {
-                        tag,
-                        ..Default::default()
-                    })?;
+                    self.scan(ScanOptions::default())?;
                     continue;
                 }
 
@@ -4211,13 +4110,18 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         _ => unreachable!("token.data was Scalar at match guard"),
                     };
 
+                    // The collected properties are this scalar's, unless it
+                    // turns out to be an implicit key they precede on an
+                    // earlier line: then they are the [200] block mapping's
+                    // (the tag analogue of `take_implicit_key_anchors`).
+                    let tag = node_props.tag();
+
                     let json_key = if scalar.style == ScalarStyle::Quoted {
                         self.maybe_set_json_key(opts.flow_pair_allowed)?
                     } else {
                         false
                     };
                     let r = self.scan(ScanOptions {
-                        tag: node_props.tag(),
                         outside_context: true,
                         ..Default::default()
                     });
@@ -4234,7 +4138,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             // `:` belongs to an outer construct (e.g. the
                             // explicit-value indicator after `? - a` or
                             // `? sky\n: blue`). This scalar is not a key.
-                            break 'node scalar.data.to_expr(scalar_start, self.input, self.bump);
+                            break 'node scalar.to_expr(tag, scalar_start, self.input, self.bump);
                         }
                         // [192] ns-l-block-map-implicit-entry: the key is at
                         // s-indent(n) (spaces only). A tab between s-indent
@@ -4249,7 +4153,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         if let Some(current_mapping_indent) = opts.current_mapping_indent {
                             if current_mapping_indent == scalar_indent {
                                 // 3
-                                break 'node scalar.data.to_expr(
+                                break 'node scalar.to_expr(
+                                    tag,
                                     scalar_start,
                                     self.input,
                                     self.bump,
@@ -4260,7 +4165,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         match self.context.get() {
                             Context::FlowKey => {
                                 // 1
-                                break 'node scalar.data.to_expr(
+                                break 'node scalar.to_expr(
+                                    tag,
                                     scalar_start,
                                     self.input,
                                     self.bump,
@@ -4280,10 +4186,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         // covers the multiline-property case where they
                         // diverge.
                         if self.context.get() == Context::FlowIn && !opts.flow_pair_allowed {
-                            break 'node scalar.data.to_expr(scalar_start, self.input, self.bump);
+                            break 'node scalar.to_expr(tag, scalar_start, self.input, self.bump);
                         }
 
-                        let implicit_key = scalar.data.to_expr(scalar_start, self.input, self.bump);
+                        let key_tag = if node_props.tag_line() == Some(scalar_line) {
+                            tag
+                        } else {
+                            NodeTag::None
+                        };
+                        let implicit_key =
+                            scalar.to_expr(key_tag, scalar_start, self.input, self.bump);
 
                         let anchors = node_props.take_implicit_key_anchors(scalar_line)?;
                         if let Some(key_anchor) = anchors.key_anchor {
@@ -4302,7 +4214,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         return Ok(mapping);
                     }
 
-                    break 'node scalar.data.to_expr(scalar_start, self.input, self.bump);
+                    break 'node scalar.to_expr(tag, scalar_start, self.input, self.bump);
                 }
 
                 TokenData::Directive => return Err(Self::unexpected_token()),
@@ -4414,17 +4326,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
     // This is the largest function in the file: a labeled-switch state machine
     // with an inner `ScalarResolverCtx`.
 
-    fn scan_plain_scalar(&mut self, opts: ScanOptions) -> Result<Token<Enc>, ParseError> {
+    fn scan_plain_scalar(&mut self) -> Result<Token<Enc>, ParseError> {
         let mut ctx = ScalarResolverCtx::<Enc> {
             str_builder: self.string_builder(),
             resolved: false,
             scalar: None,
-            tag: opts.tag,
             resolved_scalar_len: 0,
             start: self.pos,
             line: self.line,
             line_indent: self.line_indent,
-            multiline: false,
         };
 
         // labeled-switch loop
@@ -4926,8 +4836,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     start: self.start,
                     indent: self.content_indent,
                     line: self.line,
-                    resolved: TokenScalar {
-                        data: NodeScalar::String(YamlString::List(self.text)),
+                    scalar: TokenScalar {
+                        text: YamlString::List(self.text),
+                        resolved: None,
                         style: ScalarStyle::Block,
                     },
                 }))
@@ -5309,9 +5220,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         start,
                         indent: scalar_indent,
                         line: scalar_line,
-                        resolved: TokenScalar {
+                        scalar: TokenScalar {
+                            text: YamlString::List(text),
+                            resolved: None,
                             style: ScalarStyle::Quoted,
-                            data: NodeScalar::String(YamlString::List(text)),
                         },
                     }));
                 }
@@ -5385,9 +5297,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         start,
                         indent: scalar_indent,
                         line: scalar_line,
-                        resolved: TokenScalar {
+                        scalar: TokenScalar {
+                            text: YamlString::List(text),
+                            resolved: None,
                             style: ScalarStyle::Quoted,
-                            data: NodeScalar::String(YamlString::List(text)),
                         },
                     }));
                 }
@@ -5751,7 +5664,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             // scanPlainScalar
                         }
                     }
-                    break 'next self.scan_plain_scalar(opts)?;
+                    break 'next self.scan_plain_scalar()?;
                 }
                 0x2E /* '.' */ => {
                     let start = self.pos;
@@ -5763,7 +5676,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         self.inc(3);
                         break 'next Token::document_end(self.token_init(start));
                     }
-                    break 'next self.scan_plain_scalar(opts)?;
+                    break 'next self.scan_plain_scalar()?;
                 }
                 0x3F /* '?' */ => {
                     let start = self.pos;
@@ -5781,7 +5694,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         },
                         _ => {}
                     }
-                    break 'next self.scan_plain_scalar(opts)?;
+                    break 'next self.scan_plain_scalar()?;
                 }
                 0x3A /* ':' */ => {
                     let start = self.pos;
@@ -5805,7 +5718,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             }
                         },
                     }
-                    break 'next self.scan_plain_scalar(opts)?;
+                    break 'next self.scan_plain_scalar()?;
                 }
                 0x2C /* ',' */ => {
                     let start = self.pos;
@@ -5816,7 +5729,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                         Context::BlockIn | Context::BlockOut => {}
                     }
-                    break 'next self.scan_plain_scalar(opts)?;
+                    break 'next self.scan_plain_scalar()?;
                 }
                 0x5B /* '[' */ => {
                     let start = self.pos;
@@ -6016,7 +5929,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     continue;
                 }
                 _ => {
-                    break 'next self.scan_plain_scalar(opts)?;
+                    break 'next self.scan_plain_scalar()?;
                 }
             }
         };

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -772,13 +772,7 @@ impl<Enc: Encoding> YamlString<Enc> {
     }
 
     pub(crate) fn to_expr(&self, pos: Pos, input: &[Enc::Unit], bump: &bun_alloc::Arena) -> Expr {
-        // For `Utf16` we route through `E::String::init_utf16`.
-        //
-        // LIFETIME: `YamlString::List` is a global-alloc `Vec` that is
-        // dropped with the scalar token shortly after this returns — the
-        // resulting `EString.data` would dangle. Dupe the list bytes into
-        // the bump arena; `.range` already borrows `input` (source text)
-        // which outlives the Expr → JS conversion.
+        // A `List` is freed with the token, so the Expr gets a copy that lives in the arena.
         let s: &[Enc::Unit] = match self {
             YamlString::Range(range) => range.slice(input),
             YamlString::List(list) => bump.alloc_slice_copy(list.as_slice()),
@@ -962,8 +956,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
         let line_indent = self.line_indent;
         let line = self.line;
         let resolved_scalar_len = self.resolved_scalar_len;
-        // The first characters may have resolved to something that more
-        // characters then followed (`true_story`); that is a string.
+        // A resolved prefix that more text followed (`true_story`) is a string.
         let resolved = self
             .scalar
             .filter(|_| self.str_builder.len() == resolved_scalar_len);
@@ -1514,10 +1507,7 @@ impl NodeTag {
         }
     }
 
-    /// Whether a plain scalar the core schema resolves to `scalar` is that
-    /// value under this tag. Otherwise the scalar is its text: a tag of
-    /// another kind only switches the core-schema resolution off, it does
-    /// not validate the text (`!!int foo` is the string "foo").
+    /// Whether a plain scalar resolving to `scalar` keeps it under this tag; otherwise it is its text.
     pub(crate) fn keeps(self, scalar: NodeScalar) -> bool {
         match self {
             NodeTag::None => true,
@@ -1531,8 +1521,7 @@ impl NodeTag {
     }
 }
 
-/// [10.2.1.2] What the core schema resolves a plain scalar's text to when
-/// that is not a string.
+/// [10.2.1.2] Core-schema value of a plain scalar that is not a string.
 #[derive(Clone, Copy)]
 pub enum NodeScalar {
     Null,
@@ -1682,10 +1671,7 @@ pub enum TokenData<Enc: Encoding> {
 #[derive(Clone)]
 pub struct TokenScalar<Enc: Encoding> {
     pub(crate) text: YamlString<Enc>,
-    /// The core-schema value of a plain `text`, if it has one. Whether the
-    /// node is that value or `text` depends on the node's tag, which only
-    /// the parser knows (the token after a property may not even belong to
-    /// the tagged node), so the scanner records both and `to_expr` decides.
+    /// Core-schema value of a plain `text`; only the parser knows the tag that picks between them.
     pub(crate) resolved: Option<NodeScalar>,
     pub(crate) style: ScalarStyle,
 }
@@ -4110,10 +4096,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         _ => unreachable!("token.data was Scalar at match guard"),
                     };
 
-                    // The collected properties are this scalar's, unless it
-                    // turns out to be an implicit key they precede on an
-                    // earlier line: then they are the [200] block mapping's
-                    // (the tag analogue of `take_implicit_key_anchors`).
                     let tag = node_props.tag();
 
                     let json_key = if scalar.style == ScalarStyle::Quoted {
@@ -4189,6 +4171,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                             break 'node scalar.to_expr(tag, scalar_start, self.input, self.bump);
                         }
 
+                        // [200] A tag on an earlier line is the mapping's, like the anchors below.
                         let key_tag = if node_props.tag_line() == Some(scalar_line) {
                             tag
                         } else {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1580,6 +1580,21 @@ folded: >
           expect(YAML.parse("? !!str\n  0x10\n: a\n")).toEqual({ "0x10": "a" });
         });
 
+        test("property on the line before a flow-sequence pair's key annotates the pair mapping", () => {
+          // [154] wants an implicit key's properties on its line (js-yaml and
+          // yaml reject these). Accepted leniently; a tag goes where an anchor
+          // in the same position already went.
+          const r = YAML.parse("[&a\n0x10: 1, *a]\n");
+          expect(r).toEqual([{ 16: 1 }, { 16: 1 }]);
+          expect(r[1]).toBe(r[0]);
+          expect(YAML.parse("[!!str\n0x10: a]\n")).toEqual([{ 16: "a" }]);
+          // A flow mapping's key has no pair mapping of its own to annotate.
+          expect(YAML.parse("{!!str\n0x10: a}\n")).toEqual({ "0x10": "a" });
+          // Valid single-line pair: the tag is the key's.
+          expect(YAML.parse("[!!str 0x10: a]\n")).toEqual([{ "0x10": "a" }]);
+          expect(YAML.parse("[&k 0x10: 1, *k]\n")).toEqual([{ 16: 1 }, 16]);
+        });
+
         test("tag on e-node resolves per resolve_null", () => {
           expect(YAML.parse("a: !!null\nb: y\n")).toEqual({ a: null, b: "y" });
           expect(YAML.parse("a: !!str\nb: y\n").a).toBe("");

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1462,13 +1462,10 @@ folded: >
           expect(() => YAML.parse("key:\n|\n text\n")).toThrow("Unexpected token");
         });
 
-        test("rewind only applies to plain single-line scalars", () => {
-          // Quoted scalars: token.start is past the opening quote, and
-          // ScanOptions.tag doesn't affect their resolution anyway.
+        test("tag on an e-node leaves a quoted or block sibling alone", () => {
           expect(YAML.parse('a: !!str\n"b": c\n')).toEqual({ a: "", b: "c" });
           expect(YAML.parse("a: !!str\n'b': c\n")).toEqual({ a: "", b: "c" });
-          // Same for a seq entry; the tag resolves e-scalar and the quoted
-          // sibling is not re-scanned.
+          // Same for a seq entry; the tag resolves e-scalar.
           expect(YAML.parse('- !!str\n- "123"\n')).toEqual(["", "123"]);
           expect(YAML.parse("- !!str\n- '123'\n")).toEqual(["", "123"]);
           // A quoted scalar that *is* content (indent > n) takes the tag as-is.
@@ -1500,15 +1497,87 @@ folded: >
         });
 
         test("tag does not leak to abandoned sibling key", () => {
-          // The post-tag re-scan resolves a plain scalar under that tag; when
-          // belongs_to_parent then abandons it, the sibling key must be
-          // re-scanned tag-neutral.
+          // The token after the tag is the sibling key, not the tagged
+          // node's content; the tag resolves the e-scalar and the key
+          // resolves under the core schema.
           expect(YAML.parse("a: !!str\n0xFF: c\n")).toEqual({ a: "", 255: "c" });
           expect(YAML.parse("a: !!str\n~: c\n")).toEqual({ a: "", null: "c" });
           expect(YAML.parse("a: !!int\ntrue: c\n")).toEqual({ a: null, true: "c" });
           // Content (indent > n) keeps the tag.
           expect(YAML.parse("a: !!str\n  0xFF\n")).toEqual({ a: "0xFF" });
           expect(YAML.parse("a:\n  !!str\n  0xFF\n")).toEqual({ a: "0xFF" });
+        });
+
+        test("tag on a scalar value does not leak into the next key", () => {
+          // The tag applies to the scalar it precedes; the key on the next
+          // line resolves under the core schema like any other key.
+          expect(YAML.parse("a: !!str b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !!str b\n~: x\n")).toEqual({ a: "b", null: "x" });
+          // Same text as value and as key: only the value carries the tag.
+          expect(YAML.parse("a: !!str 0x10\n0x10: x\n")).toEqual({ a: "0x10", 16: "x" });
+          expect(YAML.parse("a: !!str b\n0x10: x\n0o10: y\nc: z\n")).toEqual({ a: "b", 16: "x", 8: "y", c: "z" });
+        });
+
+        test("every tag kind on a value leaves the next key alone", () => {
+          // !!str / ! / !local / verbatim force a string; !!int, !!float,
+          // !!bool and !!null each only resolve their own kind, so any of
+          // them mis-resolves a key of another kind if carried over.
+          expect(YAML.parse("a: ! b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !foo b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !<tag:yaml.org,2002:str> b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !!int 1\n~: x\n")).toEqual({ a: 1, null: "x" });
+          expect(YAML.parse("a: !!float 1.5\n~: x\n")).toEqual({ a: 1.5, null: "x" });
+          expect(YAML.parse("a: !!bool true\n0x10: x\n")).toEqual({ a: true, 16: "x" });
+          expect(YAML.parse("a: !!null ~\n0x10: x\n")).toEqual({ a: null, 16: "x" });
+        });
+
+        test("tagged value of any scalar style does not leak into the next key", () => {
+          expect(YAML.parse('a: !!str "b"\n0x10: x\n')).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !!str 'b'\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !!str |\n  b\n0x10: x\n")).toEqual({ a: "b\n", 16: "x" });
+          expect(YAML.parse("a: !!str >-\n  b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          // Tag on the `:` line, content on the next line.
+          expect(YAML.parse("a: !!str\n  b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          // Anchor and tag together, in both orders.
+          expect(YAML.parse("a: &x !!str b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          expect(YAML.parse("a: !!str &x b\n~: x\n")).toEqual({ a: "b", null: "x" });
+        });
+
+        test("tagged scalar does not leak into the next key, wherever that key is", () => {
+          // Explicit key with no value.
+          expect(YAML.parse("? !!str a\n0x10: x\n")).toEqual({ a: null, 16: "x" });
+          // Explicit value.
+          expect(YAML.parse("? a\n: !!str b\n0x10: x\n")).toEqual({ a: "b", 16: "x" });
+          // Compact mapping inside a sequence item.
+          expect(YAML.parse("- a: !!str b\n  0x10: x\n")).toEqual([{ a: "b", 16: "x" }]);
+          // Nested mapping.
+          expect(YAML.parse("m:\n  a: !!str b\n  0x10: x\n")).toEqual({ m: { a: "b", 16: "x" } });
+          // The next key closes one or more inner collections and belongs
+          // to an outer mapping.
+          expect(YAML.parse("m:\n  a: !!str b\n0x10: x\n")).toEqual({ m: { a: "b" }, 16: "x" });
+          expect(YAML.parse("s:\n- !!str b\n0x10: x\n")).toEqual({ s: ["b"], 16: "x" });
+          expect(YAML.parse("s:\n  - a: !!str b\n0x10: x\n")).toEqual({ s: [{ a: "b" }], 16: "x" });
+          expect(YAML.parse("m:\n  s:\n    - !!str b\n~: x\n")).toEqual({ m: { s: ["b"] }, null: "x" });
+          // Flow form of the same mapping.
+          expect(YAML.parse("{a: !!str b, 0x10: x}\n")).toEqual({ a: "b", 16: "x" });
+        });
+
+        test("tag on a line before an implicit key is the [200] block mapping's, not the key's", () => {
+          // Same split as `take_implicit_key_anchors`: `&m\n0x10: a` anchors
+          // the mapping and the key still resolves to 16.
+          expect(YAML.parse("&m\n0x10: a\n")).toEqual({ 16: "a" });
+          expect(YAML.parse("!!map\n0x10: a\n")).toEqual({ 16: "a" });
+          expect(YAML.parse("x: !!map\n  0x10: a\n")).toEqual({ x: { 16: "a" } });
+          expect(YAML.parse("x: !!map\n  ~: a\n")).toEqual({ x: { null: "a" } });
+          expect(YAML.parse("x:\n  !!map\n  0x10: a\n")).toEqual({ x: { 16: "a" } });
+          expect(YAML.parse("- !!map\n  0x10: a\n")).toEqual([{ 16: "a" }]);
+          // On the key's own line the tag is the key's.
+          expect(YAML.parse("!!str 0x10: a\n")).toEqual({ "0x10": "a" });
+          expect(YAML.parse("x:\n  !!str 0x10: a\n")).toEqual({ x: { "0x10": "a" } });
+          expect(YAML.parse("!!map\n!!str 0x10: a\n")).toEqual({ "0x10": "a" });
+          // A scalar that is not a key takes a tag from an earlier line.
+          expect(YAML.parse("!!str\n0x10\n")).toBe("0x10");
+          expect(YAML.parse("? !!str\n  0x10\n: a\n")).toEqual({ "0x10": "a" });
         });
 
         test("tag on e-node resolves per resolve_null", () => {
@@ -1576,7 +1645,7 @@ folded: >
           expect(() => YAML.parse("a: 1\n\tb: 2\n")).toThrow(TAB_ERR);
           expect(() => YAML.parse("foo:\n  a: 1\n  \tb: 2\n")).toThrow(TAB_ERR);
           expect(() => YAML.parse("? a\n\t? b\n")).toThrow(TAB_ERR);
-          // Tag-neutral rewind in the helper preserves the taint.
+          // Also when a property precedes the sibling.
           expect(() => YAML.parse("a: !!str\n\tb: 2\n")).toThrow(TAB_ERR);
         });
 
@@ -1653,10 +1722,10 @@ folded: >
           expect(YAML.parse("a: 1\n  \tb\n")).toEqual({ a: "1 b" });
         });
 
-        // The tag-neutral rewind in parse_block_indented re-scans an
-        // abandoned scalar from token.start (past the tab), so the original
-        // taint must be preserved across the rewind. Exhaustive over each
-        // indicator × each property prefix × each tab position.
+        // A sibling abandoned to the parent by parse_block_indented's
+        // property loop must keep the taint recorded when it was scanned.
+        // Exhaustive over each indicator × each property prefix × each tab
+        // position.
         describe("property prefix does not lose tab taint on abandoned sibling", () => {
           const indicators = [
             ["map-value", (n: string, p: string, t: string) => `${n}a: ${p}\n${t}b: 2\n`],
@@ -2475,6 +2544,27 @@ explicit_null: !!null "anything"
         explicit_bool: "yes",
         explicit_null: "anything",
       });
+    });
+
+    test("explicit tag on a plain scalar keeps the core-schema value only if it is of the tag's kind", () => {
+      const yaml = `
+- [!!int 0x10, !!int -5, !!float 1.5, !!float .inf, !!int 1.5, !!float 0x10]
+- [!!int true, !!int ~, !!int foo, !!float true]
+- [!!bool true, !!bool False, !!bool 1, !!bool ~, !!bool foo]
+- [!!null ~, !!null null, !!null 0, !!null false, !!null foo]
+- [!!str 0x10, !!str -5, !!str true, !!str ~, !!str .inf, !!str foo]
+- [! 1, ! true, ! ~, !local 1, !local ~, !<tag:yaml.org,2002:str> 1]
+- [&a !!str 1, !!str &b 1, *a, *b]
+`;
+      expect(YAML.parse(yaml)).toEqual([
+        [16, -5, 1.5, Infinity, 1.5, 16],
+        ["true", "~", "foo", "true"],
+        [true, false, "1", "~", "foo"],
+        [null, null, "0", "false", "foo"],
+        ["0x10", "-5", "true", "~", ".inf", "foo"],
+        ["1", "true", "~", "1", "~", "1"],
+        ["1", "1", "1", "1"],
+      ]);
     });
 
     test("handles strings that look like numbers", () => {


### PR DESCRIPTION
### Problem
- A tag on one node changes how an unrelated plain scalar resolves:
  - `Bun.YAML.parse("a: !!str b\n0x10: x")` gives `{ a: "b", "0x10": "x" }`; the key should be `16`, as it is without the tag.
  - `Bun.YAML.parse("a: !!str b\n~: x")` gives `{ a: "b", "~": "x" }`; the key should be `null`.
  - `Bun.YAML.parse("x: !!map\n  0x10: a")` gives `{ x: { "0x10": "a" } }`; the key should be `16`.
- The first two shapes leak for every tag kind (`!!str`, `!`, `!local`, `!<verbatim>`, and `!!int`/`!!float`/`!!bool`/`!!null`, which block keys of any other kind), after a tagged value of any scalar style (plain, quoted, block), and wherever the next key lives (same mapping, `?` key, `:` value, compact mapping in a sequence item, or an outer mapping reached by dedenting). js-yaml and the `yaml` package resolve the key independently in all of these.
- Cause: the scanner resolves a plain scalar under `ScanOptions.tag` at scan time (src/parsers/yaml.rs, `ScalarResolverCtx::resolve` / `try_resolve_number`). The parser passed the tag to more scans than the one that produces the tagged node's content: `parse_node`'s `Scalar` arm passed it to the scan that steps past the tagged scalar (whose result is the next key), and the `Tag` arm / `parse_block_indented` pass it to the scan after a tag even when that token turns out to be a block mapping's first key rather than the tagged node. `parse_block_indented` already carried a rewind-and-rescan workaround for a third instance (`a: !!str\n0x10: x`).

### Fix
- The scanner no longer takes a tag. A plain scalar token now carries both its text and, when the text has one, its core-schema value (`TokenScalar { text, resolved, style }`).
- `parse_node`'s `Scalar` arm is the only consumer of scalar tokens; it applies the node's tag there via `TokenScalar::to_expr`, using the same keep-or-string table the scanner used (`NodeTag::keeps`). For an implicit key it only applies a tag that sits on the key's line; a tag on an earlier line belongs to the block mapping (YAML [200]), which is the rule `take_implicit_key_anchors` already applies to anchors.
- Correct because a tag belongs to exactly one node, and the parser is the only place that knows which node that is; resolving at scan time required guessing, and every scan that received the tag for a token that was not that node's content produced one of the bugs above. Resolution of the tagged scalar itself is unchanged: `keeps` is the table that was in `resolve`/`try_resolve_number`, and the new table test pins it.
- Deleted along the way: `ScanOptions.tag`, the rewind in `parse_block_indented`, and `ScalarStyle::Plain { multiline }` (only the rewind read it). `Token` grows from 56 to 72 bytes; the parser holds one token at a time, so this is a per-token copy, not a buffer.
- One other visible change, on invalid input only: a flow-sequence pair whose tag sits on the line before the key, `[!!str\n0x10: a]`, now gives `[{ 16: "a" }]` instead of `[{ "0x10": "a" }]`, because the tag goes where an anchor in that position already went (`[&a\n0x10: 1, *a]` aliases the pair mapping, before and after). js-yaml and the `yaml` package reject that input; the valid `[!!str 0x10: a]` is unchanged. Pinned by the "flow-sequence pair" test.
- Verified:
  - test/js/bun/yaml/yaml.test.ts: six new tests under "anchor/tag on empty node" (next key after a tagged value, per tag kind, per scalar style, per key position including dedent, the [200] first-key case, and the flow-pair rule above) fail on the current release and pass with this change; "explicit tag on a plain scalar keeps the core-schema value only if it is of the tag's kind" pins the unchanged resolution table (passes before and after).
  - yaml.test.ts, yaml-test-suite.test.ts, yaml-block-scalar-matrix.test.ts (2134 tests), resolve/yaml, bundler yaml, and the pnpm-lock migration tests pass with the debug build; `cargo clippy -p bun_parsers` and `cargo fmt` are clean.

### Background
- Core schema: an untagged plain scalar resolves by its text (`0x10` is 16, `~` is null, `true` is a boolean, anything else is a string). This applies to keys and values alike.
- Tags: `!!str`, `!!int`, `!foo`, ... annotate the single node they precede. In this parser a tag of a different kind does not validate the text, it only switches the core-schema resolution off (`!!str 0x10` is the string "0x10", `!!int foo` is the string "foo"); that behavior is unchanged here.
- Properties before a block mapping ([200]): in `!!map\n0x10: a` or `&m\n0x10: a`, the property on the earlier line annotates the mapping, while in `!!str 0x10: a` it annotates the key. The parser cannot tell which until it has scanned the key and seen the `:`, which is why the decision has to live in the parser rather than the scanner.
- Parser structure: `scan()` produces one token at a time into `self.token`; `parse_node` collects a node's properties (anchor, tag), dispatches on the content token, and for a scalar scans once more to see whether a `:` follows (implicit key) before returning. `parse_block_indented` is the shared property loop for the token after `:`, `?`, or `-`; when the token after the properties belongs to the parent, the properties annotate an empty node.


