### PR TITLE
test(require-cache): skip the leak fixtures under debug builds

### DIFF
--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -6,6 +6,7 @@ import {
   isASAN,
   isBroken,
   isCI,
+  isDebug,
   isIntelMacOS,
   isMacOS,
   isMusl,
@@ -50,7 +51,14 @@ describe.concurrent("require.cache", () => {
     expect(exitCode).toBe(0);
   });
 
-  describe.skipIf(isBroken && isIntelMacOS)("files transpiled and loaded don't leak the output source code", () => {
+  // The three "don't leak" blocks below are skipped under a debug build (bun bd): one
+  // load of their larger modules takes 1-7 s there, so every fixture overruns its
+  // timeout, and since the tests are concurrent, bun test does not kill the timed-out
+  // children, which run on for up to half an hour holding the inherited stdio. ASAN's
+  // quarantine also makes their RSS bounds meaningless. CI has no debug lane; the
+  // release and release+ASAN lanes (isDebug is false on both) still run them.
+  const skipSourceLeakChecks = isDebug || (isBroken && isIntelMacOS);
+  describe.skipIf(skipSourceLeakChecks)("files transpiled and loaded don't leak the output source code", () => {
     test("via require() with a lot of long export names", async () => {
       let text = "";
       for (let i = 0; i < 10000; i++) {
@@ -281,7 +289,7 @@ describe.concurrent("require.cache", () => {
     ); // takes 4s on an M1 in release build
   });
 
-  describe("files transpiled and loaded don't leak the AST", () => {
+  describe.skipIf(isDebug)("files transpiled and loaded don't leak the AST", () => {
     test("via require()", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", join(import.meta.dir, "require-cache-bug-leak-fixture.js")],
@@ -309,8 +317,7 @@ describe.concurrent("require.cache", () => {
     }, 20000);
   });
 
-  // These tests are extra slow in debug builds
-  describe("files transpiled and loaded don't leak file paths", () => {
+  describe.skipIf(isDebug)("files transpiled and loaded don't leak file paths", () => {
     test("via require()", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "--smol", "run", join(import.meta.dir, "cjs-fixture-leak-small.js")],


### PR DESCRIPTION
### Problem

- `bun bd test test/cli/run/require-cache.test.ts` does not come back. `bun test` itself exits after ~94 s with 7 failures, every one of them `this test timed out after 60000ms` / `30000ms` / `20000ms` (the two standalone CJS fixtures additionally print `--fail--` once they finish, reported as 2 errors between tests), but it leaves the five leak fixtures it spawned running as orphans. They inherit stdio, so anything reading the run's output (a pipe, a tool, `tee`) waits until the last of them finishes; the `import()` long-export-names fixture alone needs about 33 minutes on a debug build.
- Cause 1, workload: the three "don't leak" describe blocks (`test/cli/run/require-cache.test.ts:53`, `:284`, `:313`) load a module 55 to 100k times with sizes chosen for release builds. Per load on a debug build here, measured standalone: 0.8 s (`require()` of the 1.1 MB long-names module, 550 loads), 1.2 s / 1.5 s (`require()` / `import()` of the 20k-call module, 500 loads each), 6.5 s (`import()` of the 1.2 MB long-export-names module, 300 loads). The release binary does the whole file in 14 to 18 s. The two standalone CJS fixtures do not fit either: `require-cache-bug-leak-fixture.js` takes 32 s alone against a 20 s test timeout, `cjs-fixture-leak-small.js` 28 s alone against 30 s (it timed out in the concurrent run, and fails its bound regardless, next bullet), and `esm-fixture-leak-small.mjs` several minutes against 30 s.
- Cause 2, orphans: `bun test` kills a timed-out test's subprocesses only when the timed-out group holds a single test (`src/runtime/test_runner/Execution.rs:301`, `handle_timeout`); this file is a `describe.concurrent`, where the children cannot be attributed to one test, so nothing is killed, and at the end of the file the tracker is cleared without killing (`src/runtime/cli/test_command.rs:3392`). The tests' own `await using proc` never runs because the test body is still parked on `await proc.exited` when the timeout fires.
- The bounds are not usable on a debug build even where the loops finish: the standalone fixtures detect ASAN by the `bun-asan` binary name, so under `bun-debug` (also ASAN) they apply the release bounds and report `leaked: "168 MB"` against 120 MB and `"62 MB"` against 48 MB with nothing leaking (ASAN quarantine); the inline fixtures use the harness `isASAN` bounds of 320 to 400 MB, which a leak only clears after hundreds of loads, i.e. the minutes-long workload above.

### Fix

- Test only: `describe.skipIf(isDebug)` on the three leak describe blocks (the first one keeps its existing `isBroken && isIntelMacOS` condition, folded into a const so the describe line still fits the print width and the 230-line body is not re-indented). The functional `require.cache` tests in the file are unchanged and still run everywhere.
- Why skipping rather than a smaller debug workload: a debug-sized loop that fits the timeouts cannot detect the leaks these fixtures exist for. Measured on the debug build with the four inline loops cut to 5 warm-up + 10 measured loads and run concurrently as the test does: 38 / 53 / 162 / 54 s of wall time, and RSS still moves by 15 to 40 MB with nothing leaking, while the leak these fixtures caught (~1.7 MB per load in v1.1.21) would add about 17 MB over 10 loads, inside that noise (table below). It would be a slower way of running nothing. This is the same call the other RSS-based leak tests in the tree make (`test/js/bun/util/password.test.ts`, `test/js/node/tls/node-tls-getpeercert-leak.test.ts`, `test/js/workerd/html-rewriter-leak.test.ts`), for the same two reasons (time and quarantine).
- Why CI coverage is unchanged: `isDebug` is `Bun.version.includes("debug")`, and the `-debug` suffix comes from the Debug build type (`src/bun_core/Global.rs:489`, `scripts/build/rust.ts:455`). CI's ASAN lane is the `release-asan` profile (Release build type, `scripts/build/profiles.ts`), so it and the release lanes keep running all eight leak tests exactly as before; no lane sees a difference, and the durations/allowlist files need no change.
- With nothing spawned on debug builds there is nothing to orphan, so cause 2 no longer shows up in this file. Whether `bun test` should reap the children of timed-out concurrent tests is a runtime question the `Execution.rs` comment already records as a deliberate trade-off; this PR does not change runtime behavior.
- Verified:
  - `bun bd test test/cli/run/require-cache.test.ts`: before, `bun test` exits after 93.8 s with 7 fail and 5 `bun-debug run ... fixture` processes left behind (reparented to pid 1, killed by hand); after, 8.2 s, 3 pass / 8 skip / 0 fail, no processes left.
  - `USE_SYSTEM_BUN=1 bun test test/cli/run/require-cache.test.ts` (release 1.4.0): 11 pass in 18 s before and after; every leak fixture runs and prints its RSS figures, so the release/CI path is not affected by the change.
  - CI on this branch, `x64-asan` test lane: `bun test v1.4.0-canary.1 (68792c97a)` ran the file unskipped, 11 pass in 52 s, with the four inline fixtures printing `RSS diff 46 / 220 / 127 / 151 MB` (i.e. `isDebug` is false on the release-asan build, as claimed above).
  - There is no src change, so there is no fail-before / pass-after proof to generate; the before/after runs above are the evidence.
- Composes with the open PRs on the same file: #37586 (rewrites the inline fixtures' measurement), #37562 (`esm-fixture-leak-small.mjs`) and #38135 (adds a describe block) change different lines; the only overlap is the `harness` import list, and the skip applies equally to their versions of the fixtures.

### Background

- `bun bd` builds the `debug` profile: Debug build type, ASAN on, and the debug WebKit prebuilt (JSC with its assertions enabled), which is what makes a single transpile+evaluate of a 1 MB module take seconds. CI has no lane built this way; its sanitizer lane is `release-asan` (optimized code plus ASAN), which is several times slower than release, not a hundred times.
- ASAN quarantine: ASAN holds freed allocations in a quarantine (256 MB by default) instead of returning them to the allocator, so a process's RSS grows with how much it has allocated and freed, not with what it retains. That is why these fixtures carry separate, much larger bounds for ASAN binaries, and why an RSS bound on an ASAN build only says something after enough loads to fill the quarantine before the baseline is taken.
- `bun test` timeouts and subprocesses: while a group of tests runs, `bun test` tracks the processes they spawn (`ProcessAutoKiller`). When a test times out it kills them only if the group contains that one test; in a `describe.concurrent` group the tracked set mixes every running test's children, so it is left alone. A timed-out test's body is not cancelled either; it stays suspended, so `await using` cleanup in it never runs.

<details>
<summary>Per-load timings and the unfixed run</summary>

Debug build (`bun bd`, linux x64, this container), each fixture's `index.js` loaded standalone with `--smol` and the transpiler cache disabled, 5 loads each:

| fixture | module | per load | loads in the test | total |
|---|---|---|---|---|
| `require()` long export names | 1.1 MB | ~0.82 s | 550 | ~7.5 min |
| `require()` 20k calls | 100 KB | ~1.2 s | 500 | ~10 min |
| `await import()` 20k calls | 100 KB | ~1.5 s | 500 | ~12 min |
| `import()` long export names | 1.2 MB | ~6.5 s | 300 | ~33 min |
| `require-cache-bug-leak-fixture.js` (AST) | 200 KB x 55 | | | 32 s, prints `leaked: "168 MB"` then `--fail--` |
| `cjs-fixture-leak-small.js` (file paths) | tiny x 10k | | | 28 s, prints `leaked: "62 MB"` then `--fail--` |

Debug-sized variant of the four inline loops (5 warm-up + 10 measured loads, nothing retained, the four processes running concurrently on the debug build as they would under `describe.concurrent`):

| loop | per load (concurrent) | wall | RSS diff with nothing leaking |
|---|---|---|---|
| `require()` long export names | 2.5 s | 38 s | 35 MB |
| `await import()` 20k calls | 3.5 s | 53 s | 17 MB |
| `import()` long export names | 10.7 s | 162 s | 40 MB |
| `require()` 20k calls | 3.6 s | 54 s | 15 MB |

Release (`bun` 1.4.0) for comparison: the `import()` long-export-names loop is about 58 ms per load, and the cost grows roughly 2.3x per doubling of the export count (5k: 17 ms, 10k: 42 ms, 20k: 101 ms, 40k: 233 ms), so the debug figure is debug-build slowness, not an algorithmic problem in the loader.

Unfixed run, `bun-debug test test/cli/run/require-cache.test.ts` with output redirected to a file: `Ran 11 tests across 1 file. [93.78s]`, 4 pass, 7 fail, 2 errors: all 7 failures are timeouts, and the 2 errors are `don't leak the AST > via require()` and `don't leak file paths > via require()` printing `leaked: "157 MB"` / `"66 MB"` and `--fail--` after their tests had already timed out. Immediately afterwards `ps` showed five `bun-debug run` fixture processes with ppid 1 still running (the four inline fixtures and `esm-fixture-leak-small.mjs`).

The one leak test that passed quickly on debug, `don't leak the AST > via import()`, does so because its fixture evicts by a `file://` key that never matches the cache, so it loads the module once; that is a separate pre-existing problem with `esm-bug-leak-fixture.mjs` and is being handled on its own, it is not what this PR addresses.

</details>
