### PR TITLE
node:fs: normalize copyFile paths on Windows before adding the \\?\ prefix

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -969,6 +969,9 @@ pub fn normalize_string_generic_tz<
                 }
                 buf[buf_i + vol_len] = separator;
                 buf_i += vol_len + 1;
+                // Like the drive-letter and rooted cases below: `..` stops at
+                // the share root instead of eating the share and server names.
+                dotdot = buf_i;
                 path_begin = vol_len + 1;
 
                 // it is just a volume name
@@ -2274,7 +2277,7 @@ impl PosixToWinNormalizer {
                     };
                     // The cwd root (arbitrarily long for UNC cwds) plus the
                     // path must fit `buf` with one byte of headroom: the
-                    // joined result feeds `normalize_buf`, whose UNC-root
+                    // joined result feeds `normalize_string_buf`, whose UNC-root
                     // handling writes one past the input when the cwd is a
                     // bare share root with no trailing separator. Such a
                     // combination can't exist on NT anyway, so error out
@@ -2630,5 +2633,60 @@ mod tests {
             join_string_buf_w_same::<platform::Windows>(&mut out, &[&long, &rest]),
             &expected[..]
         );
+    }
+
+    fn normalize_windows<const ALLOW_ABOVE_ROOT: bool>(path: &str) -> String {
+        let mut buf = [0u8; 256];
+        let out = normalize_string_buf::<ALLOW_ABOVE_ROOT, platform::Windows, false>(
+            path.as_bytes(),
+            &mut buf,
+        );
+        String::from_utf8(out.to_vec()).unwrap()
+    }
+
+    #[test]
+    fn dotdot_stops_at_the_unc_share_root() {
+        // Used to walk back through the share and server names (`\\server\x`).
+        assert_eq!(
+            normalize_windows::<false>(r"\\server\share\..\..\x"),
+            r"\\server\share\x"
+        );
+        assert_eq!(
+            normalize_windows::<true>(r"\\server\share\..\x"),
+            r"\\server\share\..\x"
+        );
+        assert_eq!(
+            normalize_windows::<false>(r"\\server\share\a\b\..\..\c"),
+            r"\\server\share\c"
+        );
+        assert_eq!(
+            normalize_windows::<false>(r"\\server\share\a\..\b\"),
+            r"\\server\share\b"
+        );
+        assert_eq!(
+            normalize_windows::<false>(r"\\server\share\.."),
+            r"\\server\share\"
+        );
+        assert_eq!(
+            normalize_windows::<false>(r"\\server\share"),
+            r"\\server\share\"
+        );
+    }
+
+    #[test]
+    fn dotdot_stops_at_the_drive_root() {
+        assert_eq!(normalize_windows::<false>(r"C:\..\..\x\"), r"C:\x");
+        assert_eq!(normalize_windows::<false>(r"C:\a\..\.."), r"C:\");
+        assert_eq!(normalize_windows::<false>(r"\..\x"), r"\x");
+    }
+
+    #[test]
+    fn relative_paths_keep_a_leading_dotdot_and_may_normalize_to_nothing() {
+        assert_eq!(normalize_windows::<true>(r"..\x\"), r"..\x");
+        assert_eq!(normalize_windows::<true>(r"C:..\x"), r"C:..\x");
+        for path in [".", "./", r".\", "./.", "a/..", r"missing\..\"] {
+            assert_eq!(normalize_windows::<true>(path), "", "{path:?}");
+        }
+        assert_eq!(normalize_windows::<true>(""), "");
     }
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5262,24 +5262,25 @@ impl NodeFS {
 
         #[cfg(windows)]
         {
-            // Paths whose UTF-16 form exceeds the wide buffers can't exist on
-            // disk; reject instead of overflowing the conversion below.
-            for path in [&args.src, &args.dest] {
-                if !strings::fits_in_wide_path_buffer(path.slice()) {
-                    return Err(sys::Error {
-                        errno: E::ENAMETOOLONG as _,
-                        syscall: sys::Tag::copyfile,
-                        path: path.slice().into(),
-                        ..Default::default()
-                    });
-                }
-            }
-            let mut dest_buf = paths::os_path_buffer_pool::get();
-            let src = strings::to_kernel32_path(
-                bun_core::cast_slice_mut::<u8, u16>(&mut self.sync_error_buf),
-                args.src.slice(),
-            );
-            let dest = strings::to_kernel32_path(&mut *dest_buf, args.dest.slice());
+            // `\\?\`-prefixed paths bypass Win32's own normalization, so both
+            // operands are normalized (`.`, `..`, repeated and trailing
+            // separators) before the prefix is added, like node's
+            // `path.toNamespacedPath`.
+            let name_too_long = |path: &PathLike| sys::Error {
+                errno: E::ENAMETOOLONG as _,
+                syscall: sys::Tag::copyfile,
+                path: path.slice().into(),
+                ..Default::default()
+            };
+            let mut dest_buf = paths::path_buffer_pool::get();
+            let src = args
+                .src
+                .os_path_kernel32(&mut self.sync_error_buf)
+                .map_err(|NameTooLong| name_too_long(&args.src))?;
+            let dest = args
+                .dest
+                .os_path_kernel32(&mut *dest_buf)
+                .map_err(|NameTooLong| name_too_long(&args.dest))?;
             // SAFETY: src/dest are NUL-terminated wide paths; CopyFileW is the Win32 FFI
             if unsafe {
                 windows::CopyFileW(

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1110,9 +1110,9 @@ impl PathLikeExt for PathLike {
             if !s.is_empty() && bun_paths::is_sep_any(s[0]) {
                 // Bail before the cwd resolution + normalization below write
                 // into fixed u8 buffers: UNC-shaped inputs pass through the
-                // resolver untouched and can reach `normalize_buf` at full
-                // MAX_PATH_BYTES length, whose root handling writes one past
-                // the input length.
+                // resolver untouched and can reach `normalize_string_buf` at
+                // full MAX_PATH_BYTES length, whose root handling writes one
+                // past the input length.
                 if !strings::fits_in_wide_path_buffer(s) {
                     return Err(NameTooLong);
                 }
@@ -1128,10 +1128,11 @@ impl PathLikeExt for PathLike {
                     Err(bun_paths::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG)) => return Err(NameTooLong),
                     Err(e) => panic!("Error while resolving path: {e:?}"),
                 };
-                // Like the drive-letter branch below, this drops a trailing
-                // separator (as `path.toNamespacedPath` does): Win32 rejects `file\`.
+                // `resolve` is volume-qualified (`C:\...` or `\\server\share\...`),
+                // so like `path.toNamespacedPath` this clamps `..` at the root
+                // and drops a trailing separator, which Win32 rejects on a file.
                 let normal = bun_paths::resolve_path::normalize_string_buf::<
-                    true,
+                    false,
                     bun_paths::platform::Windows,
                     false,
                 >(resolve, &mut b[..]);
@@ -1143,17 +1144,30 @@ impl PathLikeExt for PathLike {
                 let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
                 return Ok(strings::to_kernel32_path(buf_u16, normal));
             }
-            // Handle "." specially since normalizeStringBuf strips it to an empty string
-            if s.len() == 1 && s[0] == b'.' {
-                // SAFETY: see alignment note above (PathBuffer reinterpreted as [u16]).
-                let buf_u16 = unsafe { bun_core::bytes_as_slice_mut::<u16>(&mut buf[..]) };
-                return Ok(strings::to_kernel32_path(buf_u16, b"."));
-            }
-            let normal = bun_paths::resolve_path::normalize_string_buf::<
-                true,
-                bun_paths::platform::Windows,
-                false,
-            >(s, &mut b[..]);
+            // Only `X:\...` is absolute here (separator-first paths were handled
+            // above); relative and drive-relative (`X:dir`) paths keep a leading
+            // `..` for Win32 to resolve against the (drive's) current directory.
+            let normal: &[u8] = if bun_paths::is_absolute(s) {
+                bun_paths::resolve_path::normalize_string_buf::<
+                    false,
+                    bun_paths::platform::Windows,
+                    false,
+                >(s, &mut b[..])
+            } else {
+                bun_paths::resolve_path::normalize_string_buf::<
+                    true,
+                    bun_paths::platform::Windows,
+                    false,
+                >(s, &mut b[..])
+            };
+            // A relative path whose components cancel out (`.`, `./`, `dir/..`)
+            // normalizes to nothing but names the current directory; `""` would
+            // fail with ENOENT (oven-sh/bun#26631).
+            let normal: &[u8] = if normal.is_empty() && !s.is_empty() {
+                b"."
+            } else {
+                normal
+            };
             if !strings::fits_in_wide_path_buffer(normal) {
                 return Err(NameTooLong);
             }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1128,10 +1128,13 @@ impl PathLikeExt for PathLike {
                     Err(bun_paths::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG)) => return Err(NameTooLong),
                     Err(e) => panic!("Error while resolving path: {e:?}"),
                 };
-                let normal = bun_paths::resolve_path::normalize_buf::<bun_paths::platform::Windows>(
-                    resolve,
-                    &mut b[..],
-                );
+                // Like the drive-letter branch below, this drops a trailing
+                // separator (as `path.toNamespacedPath` does): Win32 rejects `file\`.
+                let normal = bun_paths::resolve_path::normalize_string_buf::<
+                    true,
+                    bun_paths::platform::Windows,
+                    false,
+                >(resolve, &mut b[..]);
                 if !strings::fits_in_wide_path_buffer(normal) {
                     return Err(NameTooLong);
                 }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5790,13 +5790,20 @@ describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix 
     ["fs.copyFile", (src, dest) => promisify(fs.copyFile)(src, dest)],
     ["fs.promises.copyFile", (src, dest) => promises.copyFile(src, dest)],
   ];
-  // Ways of spelling `${dir}\${name}` that only work once the path is normalized.
+  // `\\localhost\X$\...` is the administrative-share spelling of `X:\...`, which
+  // the "windows path handling" suite above relies on as well.
+  const uncShare = (dir: string) => `\\\\localhost\\${dir[0]}$`;
+  // Ways of spelling `${dir}\${name}` (dir is `X:\...`) that only work once the
+  // path is normalized.
   const spellings: [string, (dir: string, name: string) => string][] = [
     ["trailing backslash", (dir, name) => `${dir}\\${name}\\`],
     ["trailing slash", (dir, name) => `${dir}/${name}/`],
     ["`..` component", (dir, name) => `${dir}\\missing\\..\\${name}`],
+    ["`..` above the drive root", (dir, name) => `${dir.slice(0, 2)}\\..\\..${dir.slice(2)}\\${name}`],
     ["`.` component", (dir, name) => `${dir}\\.\\${name}`],
     ["doubled separator", (dir, name) => `${dir}\\\\${name}`],
+    ["UNC path with a trailing backslash", (dir, name) => `${uncShare(dir)}${dir.slice(2)}\\${name}\\`],
+    ["UNC path with `..` above the share root", (dir, name) => `${uncShare(dir)}\\..\\..${dir.slice(2)}\\${name}`],
   ];
 
   describe.each(copyFileApis)("%s", (_, copyFile) => {
@@ -5822,32 +5829,51 @@ describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix 
 
   // Relative paths and rooted paths (`\dir\file`, no drive letter: resolved
   // against the cwd's drive) depend on the cwd, so they run in a child
-  // started inside the temp dir.
+  // started inside the temp dir. Every result is collected into one object so
+  // a failure shows the whole matrix.
   it("relative and rooted spellings", async () => {
     using dir = tempDir("fs-kernel32-normalize", { "src.txt": "payload" });
     const fixture = `
       const fs = require("node:fs");
       const { sep } = require("node:path");
       const cwd = process.cwd();
+      const drive = cwd.slice(0, 2);
       const rooted = cwd.slice(2);
       const out = { cwd };
-      function copy(key, src, dest, created) {
+      function attempt(key, fn) {
         try {
-          fs.copyFileSync(src, dest);
-          out[key] = fs.readFileSync(created, "utf8");
+          out[key] = fn();
         } catch (e) {
           out[key] = e.code;
         }
+      }
+      function copy(key, src, dest, created) {
+        attempt(key, () => {
+          fs.copyFileSync(src, dest);
+          return created ? fs.readFileSync(created, "utf8") : "copied";
+        });
       }
       copy("relativeDestTrailingSep", "src.txt", "a" + sep, "a");
       copy("relativeSrcTrailingSep", "src.txt" + sep, "b", "b");
       copy("rootedDestTrailingSep", "src.txt", rooted + sep + "c" + sep, "c");
       copy("rootedSrcTrailingSep", rooted + sep + "src.txt" + sep, "d", "d");
-      copy("rootedDestDotDot", "src.txt", rooted + sep + "missing" + sep + ".." + sep + "e", "e");
-      out.existsRootedFileTrailingSep = fs.existsSync(rooted + sep + "src.txt" + sep);
-      out.existsDriveFileTrailingSep = fs.existsSync(cwd + sep + "src.txt" + sep);
-      out.mkdirRootedTrailingSep = fs.mkdirSync(rooted + sep + "made-rooted" + sep, { recursive: true });
-      out.mkdirDriveTrailingSep = fs.mkdirSync(cwd + sep + "made-drive" + sep, { recursive: true });
+      copy("rootedSrcDotDotAboveRoot", sep + ".." + rooted + sep + "src.txt", "e", "e");
+      // Spellings of the current directory itself: copying onto a directory is
+      // EPERM (as it already was for "."), unlike the ENOENT of an empty path.
+      copy("destCwdSpelledDotSlash", "src.txt", "." + sep);
+      copy("destCwdSpelledDirDotDot", "src.txt", "missing" + sep + "..");
+      copy("destEmpty", "src.txt", "");
+      attempt("existsCwdSpelledDotSlash", () => fs.existsSync("." + sep));
+      attempt("existsCwdSpelledDirDotDot", () => fs.existsSync("missing/.."));
+      attempt("existsEmpty", () => fs.existsSync(""));
+      attempt("existsRootedFileTrailingSep", () => fs.existsSync(rooted + sep + "src.txt" + sep));
+      attempt("existsRootedFileDotDotAboveRoot", () => fs.existsSync(sep + ".." + rooted + sep + "src.txt"));
+      attempt("existsDriveFileTrailingSep", () => fs.existsSync(cwd + sep + "src.txt" + sep));
+      attempt("mkdirRootedTrailingSep", () => fs.mkdirSync(rooted + sep + "made-rooted" + sep, { recursive: true }));
+      attempt("mkdirDriveTrailingSep", () => fs.mkdirSync(cwd + sep + "made-drive" + sep, { recursive: true }));
+      attempt("mkdirDriveDotDotAboveRoot", () =>
+        fs.mkdirSync(drive + sep + ".." + rooted + sep + "made-above", { recursive: true }),
+      );
       process.stdout.write(JSON.stringify(out));
     `;
     await using proc = Bun.spawn({
@@ -5865,11 +5891,19 @@ describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix 
       relativeSrcTrailingSep: "payload",
       rootedDestTrailingSep: "payload",
       rootedSrcTrailingSep: "payload",
-      rootedDestDotDot: "payload",
+      rootedSrcDotDotAboveRoot: "payload",
+      destCwdSpelledDotSlash: "EPERM",
+      destCwdSpelledDirDotDot: "EPERM",
+      destEmpty: "ENOENT",
+      existsCwdSpelledDotSlash: true,
+      existsCwdSpelledDirDotDot: true,
+      existsEmpty: false,
       existsRootedFileTrailingSep: true,
+      existsRootedFileDotDotAboveRoot: true,
       existsDriveFileTrailingSep: true,
       mkdirRootedTrailingSep: `\\\\?\\${join(cwd, "made-rooted")}`,
       mkdirDriveTrailingSep: `\\\\?\\${join(cwd, "made-drive")}`,
+      mkdirDriveDotDotAboveRoot: `\\\\?\\${join(cwd, "made-above")}`,
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5828,9 +5828,10 @@ describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix 
   });
 
   // Relative paths and rooted paths (`\dir\file`, no drive letter: resolved
-  // against the cwd's drive) depend on the cwd, so they run in a child
-  // started inside the temp dir. Every result is collected into one object so
-  // a failure shows the whole matrix.
+  // against the cwd's drive) depend on the cwd, so they run in a child started
+  // inside the temp dir, together with the existsSync/mkdirSync cases that use
+  // the same converter. Every result is collected into one object so a
+  // failure shows the whole matrix.
   it("relative and rooted spellings", async () => {
     using dir = tempDir("fs-kernel32-normalize", { "src.txt": "payload" });
     const fixture = `
@@ -5869,6 +5870,9 @@ describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix 
       attempt("existsRootedFileTrailingSep", () => fs.existsSync(rooted + sep + "src.txt" + sep));
       attempt("existsRootedFileDotDotAboveRoot", () => fs.existsSync(sep + ".." + rooted + sep + "src.txt"));
       attempt("existsDriveFileTrailingSep", () => fs.existsSync(cwd + sep + "src.txt" + sep));
+      attempt("existsUncFileDotDotAboveShareRoot", () =>
+        fs.existsSync(sep + sep + "localhost" + sep + drive[0] + "$" + sep + ".." + sep + ".." + rooted + sep + "src.txt"),
+      );
       attempt("mkdirRootedTrailingSep", () => fs.mkdirSync(rooted + sep + "made-rooted" + sep, { recursive: true }));
       attempt("mkdirDriveTrailingSep", () => fs.mkdirSync(cwd + sep + "made-drive" + sep, { recursive: true }));
       attempt("mkdirDriveDotDotAboveRoot", () =>
@@ -5901,6 +5905,7 @@ describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix 
       existsRootedFileTrailingSep: true,
       existsRootedFileDotDotAboveRoot: true,
       existsDriveFileTrailingSep: true,
+      existsUncFileDotDotAboveShareRoot: true,
       mkdirRootedTrailingSep: `\\\\?\\${join(cwd, "made-rooted")}`,
       mkdirDriveTrailingSep: `\\\\?\\${join(cwd, "made-drive")}`,
       mkdirDriveDotDotAboveRoot: `\\\\?\\${join(cwd, "made-above")}`,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5780,6 +5780,101 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
   }
 });
 
+// copyFile, existsSync and recursive mkdirSync hand kernel32 `\\?\`-prefixed
+// paths, which Windows does not normalize itself, so node:fs has to resolve
+// `.`, `..`, repeated and trailing separators first, the way node's
+// path.toNamespacedPath() does for every fs call.
+describe.if(isWindows)("kernel32 paths are normalized before the \\\\?\\ prefix is added", () => {
+  const copyFileApis: [string, (src: string, dest: string) => Promise<void>][] = [
+    ["copyFileSync", async (src, dest) => copyFileSync(src, dest)],
+    ["fs.copyFile", (src, dest) => promisify(fs.copyFile)(src, dest)],
+    ["fs.promises.copyFile", (src, dest) => promises.copyFile(src, dest)],
+  ];
+  // Ways of spelling `${dir}\${name}` that only work once the path is normalized.
+  const spellings: [string, (dir: string, name: string) => string][] = [
+    ["trailing backslash", (dir, name) => `${dir}\\${name}\\`],
+    ["trailing slash", (dir, name) => `${dir}/${name}/`],
+    ["`..` component", (dir, name) => `${dir}\\missing\\..\\${name}`],
+    ["`.` component", (dir, name) => `${dir}\\.\\${name}`],
+    ["doubled separator", (dir, name) => `${dir}\\\\${name}`],
+  ];
+
+  describe.each(copyFileApis)("%s", (_, copyFile) => {
+    it.each(spellings)("creates a destination spelled with a %s", async (_, spell) => {
+      using dir = tempDir("fs-kernel32-normalize", { "src.txt": "payload" });
+      await copyFile(join(String(dir), "src.txt"), spell(String(dir), "dest.txt"));
+      expect(readFileSync(join(String(dir), "dest.txt"), "utf8")).toBe("payload");
+    });
+
+    it.each(spellings)("reads a source spelled with a %s", async (_, spell) => {
+      using dir = tempDir("fs-kernel32-normalize", { "src.txt": "payload" });
+      await copyFile(spell(String(dir), "src.txt"), join(String(dir), "dest.txt"));
+      expect(readFileSync(join(String(dir), "dest.txt"), "utf8")).toBe("payload");
+    });
+  });
+
+  it("copyFileSync onto a directory spelled with a trailing separator reports EPERM like node, not ENOENT", () => {
+    using dir = tempDir("fs-kernel32-normalize", { "src.txt": "payload", "sub/.keep": "" });
+    expect(() => copyFileSync(join(String(dir), "src.txt"), join(String(dir), "sub") + "\\")).toThrow(
+      expect.objectContaining({ code: "EPERM", syscall: "copyfile" }),
+    );
+  });
+
+  // Relative paths and rooted paths (`\dir\file`, no drive letter: resolved
+  // against the cwd's drive) depend on the cwd, so they run in a child
+  // started inside the temp dir.
+  it("relative and rooted spellings", async () => {
+    using dir = tempDir("fs-kernel32-normalize", { "src.txt": "payload" });
+    const fixture = `
+      const fs = require("node:fs");
+      const { sep } = require("node:path");
+      const cwd = process.cwd();
+      const rooted = cwd.slice(2);
+      const out = { cwd };
+      function copy(key, src, dest, created) {
+        try {
+          fs.copyFileSync(src, dest);
+          out[key] = fs.readFileSync(created, "utf8");
+        } catch (e) {
+          out[key] = e.code;
+        }
+      }
+      copy("relativeDestTrailingSep", "src.txt", "a" + sep, "a");
+      copy("relativeSrcTrailingSep", "src.txt" + sep, "b", "b");
+      copy("rootedDestTrailingSep", "src.txt", rooted + sep + "c" + sep, "c");
+      copy("rootedSrcTrailingSep", rooted + sep + "src.txt" + sep, "d", "d");
+      copy("rootedDestDotDot", "src.txt", rooted + sep + "missing" + sep + ".." + sep + "e", "e");
+      out.existsRootedFileTrailingSep = fs.existsSync(rooted + sep + "src.txt" + sep);
+      out.existsDriveFileTrailingSep = fs.existsSync(cwd + sep + "src.txt" + sep);
+      out.mkdirRootedTrailingSep = fs.mkdirSync(rooted + sep + "made-rooted" + sep, { recursive: true });
+      out.mkdirDriveTrailingSep = fs.mkdirSync(cwd + sep + "made-drive" + sep, { recursive: true });
+      process.stdout.write(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { cwd, ...results } = JSON.parse(stdout);
+    expect(results).toEqual({
+      relativeDestTrailingSep: "payload",
+      relativeSrcTrailingSep: "payload",
+      rootedDestTrailingSep: "payload",
+      rootedSrcTrailingSep: "payload",
+      rootedDestDotDot: "payload",
+      existsRootedFileTrailingSep: true,
+      existsDriveFileTrailingSep: true,
+      mkdirRootedTrailingSep: `\\\\?\\${join(cwd, "made-rooted")}`,
+      mkdirDriveTrailingSep: `\\\\?\\${join(cwd, "made-drive")}`,
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("overflowing mode doesn't crash", () => {
   // this is easiest to test on windows since mode_t is a u16 there
   expect(() => openSync("./a.txt", 65 * 1024)).toThrow(


### PR DESCRIPTION
### Problem
- On Windows, `fs.copyFileSync(src, dir + "\\newfile\\")` throws `ENOENT: no such file or directory, copyfile '<src>' -> '<dest>'` and creates nothing; node (v26.3.0) creates `newfile`. Same for `fs.copyFile` and `fs.promises.copyFile`, and the same ENOENT for either operand spelled with a trailing `/` or `\`, a `.` or `..` component, or a doubled separator. Every other `node:fs` operation accepts the `.`/`..`/doubled spellings (matrix below).
- Cause: the Windows arm of `copy_file_inner` (`src/runtime/node/node_fs.rs`) converted both operands with `to_kernel32_path` (`src/paths/string_paths.rs`), which only converts slashes and adds the `\\?\` prefix. Windows passes a prefixed path to the kernel verbatim, so `\\?\C:\dir\newfile\` or `\\?\C:\dir\sub\..\newfile` is rejected as a file name. Node resolves every fs path first (`path.toNamespacedPath`); `copyFile` was the only `node:fs` operation converting the raw argument this way.
- The converter the other kernel32-based operations use, `PathLikeExt::os_path_kernel32` (`src/runtime/node/types.rs`, callers: `existsSync`, recursive `mkdirSync`), has three gaps of its own that show up as soon as `copyFile` goes through it, and are visible through `existsSync` today (node returns `true` in all of these, the fixed build too):
  - a trailing separator was kept on rooted paths (`\dir\file\`, no drive letter) although it is dropped on drive-letter paths: `existsSync(rootedFile + "\\")` was `false`, and recursive `mkdirSync(rooted + "\\x\\")` returned `\\?\C:\...\x\`;
  - `..` at a root was emitted literally (`C:\..\x` became `\\?\C:\\..\x`): `existsSync("C:\\..\\" + rest)` was `false`, recursive `mkdirSync` of it threw EPERM;
  - a relative path whose components cancel out (`./`, `.\`, `dir/..`) normalized to `""`; only the literal `.` was special-cased (#26631): `existsSync("./")` was `false`, and `copyFileSync(src, "sub/..")`, EPERM today because Win32 resolves the unprefixed spelling itself, would have turned into ENOENT.
- Underneath, the shared Windows normalizer (`normalize_string_generic_tz`, `src/paths/resolve_path.rs`) never anchored `..` at a UNC share root: `\\server\share\..\..\x` normalized to `\\server\x`, i.e. into a different share (or nothing), so `existsSync` of such a path was `false` and recursive `mkdirSync` failed with EUNKNOWN. Drive-letter and rooted paths already anchor there.

### Fix
- `copy_file_inner` converts both operands with `os_path_kernel32` (normalize, then prefix drive-letter paths, which is what `toNamespacedPath` does), mapping its `NameTooLong` to the same ENAMETOOLONG the removed `fits_in_wide_path_buffer` loop produced. `copy_file` still fills in `path`/`dest` from the arguments, so error objects carry the caller's spellings as before.
- `os_path_kernel32`: the separator-first branch (rooted and UNC input, always volume-qualified after `resolve_cwd_with_external_buf`) and drive-absolute input (`X:\...`) now normalize with `ALLOW_ABOVE_ROOT = false`, which is `path.resolve`'s rule for absolute paths (`..` at the root is a no-op) and also drops the trailing separator, exactly as the drive-letter path already did; relative and drive-relative (`X:dir`) input keeps `ALLOW_ABOVE_ROOT = true` so a leading `..` survives for Win32 to resolve. The `.` special case becomes "a non-empty input that normalizes to nothing is `.`", which covers all spellings of the current directory; an empty input still converts to `""` (ENOENT, as in node). Callers are `exists`, `mkdir_recursive_impl` (also behind `Bun.write`'s parent creation, the test reporters and the shell `mkdir -p`, all of which pass directory paths that are unaffected unless spelled in one of the ways above) and, once #37952 lands, `cp`, whose `cp_append_entry` tolerates both trailing-separator shapes.
- `normalize_string_generic_tz` sets the `..` anchor after writing a UNC volume, as the drive-letter and rooted branches do. In-depth `..` produces byte-identical output (it stops at the same separator); only `..` at the share root changes: dropped with `ALLOW_ABOVE_ROOT = false`, kept literally with `true`, instead of consuming the share and server names. This applies to every Windows caller of the normalizer, but the NT-path operations (`readFileSync`, `statSync`, `openSync`, `accessSync`) already handled this spelling on main and still do (probed), so the observable change is in the kernel32 converter's callers. Unit tests in `resolve_path.rs` pin the new UNC behavior and the two modes `os_path_kernel32` now relies on (`cargo test -p bun_paths --lib`; the UNC test fails without the anchor, yielding `\\server\x`). They live in the test module #37526 added (rebased onto it; its highway stubs serve these tests too) and pass under `bun run rust:miri -p bun_paths` as well, which CI runs for this crate.
- Not changed (documented so nobody looks for them here): relative spellings are still not prefixed, so a relative name with a trailing dot is still stripped by Win32 (#33034 covers that and also switches `copyFile` to `os_path_kernel32`, so one of the two will need a trivial rebase); `open`/`readFile`/`access`/`cp` of a file spelled with a trailing separator still fail because they go through the separate `slice_z` converter (reported separately); recursive `mkdirSync(".")` throws EEXIST on main because of an NT-layer query of `"."` (reported separately), so the other spellings of the cwd now share that result instead of ENOENT; bun keeps spelling UNC results without node's `\\?\UNC\` prefix.
- Tests, `test/js/node/fs/fs.test.ts`, Windows-only block "kernel32 paths are normalized before the `\\?\` prefix is added": 8 spellings (trailing `\`, trailing `/`, `..` component, `..` above the drive root, `.` component, doubled separator, UNC with trailing `\`, UNC with `..` above the share root) as destination and as source for each of `copyFileSync`, `fs.copyFile`, `fs.promises.copyFile`; EPERM for a directory destination spelled with a trailing separator; and a child started in the temp dir collecting relative, rooted, cwd-spelling, above-root and UNC results for `copyFileSync`, `existsSync` and recursive `mkdirSync` into one object compared with node's values. On a Windows x64 box: 44 of 50 fail on bun 1.4.0 (`USE_SYSTEM_BUN=1`), all 50 pass with this branch. The 6 that pass on 1.4.0 (copyFile with UNC `..` above the share root, which Win32 used to clamp itself) plus the `destCwdSpelledDirDotDot` and `rootedSrcDotDotAboveRoot` fields guard against the regressions the first version of this change (copyFile through the unfixed converter) would have introduced; the UNC anchor's fail-before against main is `existsUncFileDotDotAboveShareRoot` and the unit test.
- Also run on Windows with the debug build: the rest of `fs.test.ts` (only `readSync > works on large files` fails, a 4.9 GB write that times out on this disk with bun 1.4.0 as well), `fs-path-length.test.ts` (its copyFileSync ENAMETOOLONG and multi-byte cases), `fs-mkdir.test.ts`, `cp.test.ts`, `regression/issue/26631.test.ts`, `bun-write.test.js`, shell `file-io.test.ts`, `test/js/node/path` (one pre-existing `toNamespacedPath` failure, identical on 1.4.0), `test/js/bun/resolve` (only debug-build timeouts of the 10000-iteration tests), and node's `test-fs-copyfile*.js`, `test-fs-exists.js`, `test-fs-existssync-false.js`, `test-fs-promises-exists.js`, `test-fs-mkdir.js`, `test-fs-mkdir-rmdir.js`, `test-fs-access.js`. `cargo fmt --check` and `cargo check -p bun_paths` are clean on Linux. Apart from the normalizer line and its unit tests, the source change is inside `#[cfg(windows)]` blocks, and the new fs tests are skipped on other platforms.

### Background
- `\\?\` prefix: Win32 file APIs (`CopyFileW`, `GetFileAttributesW`, `CreateDirectoryW`, ...) normally normalize the path they get (resolve `.`/`..`, collapse separators, accept `/`) and limit it to 260 characters. A path spelled `\\?\C:\...` bypasses the limit but is passed to the kernel as written, so the caller has to normalize it. A trailing separator on a file name fails in both spellings (`CopyFileW` rejected the relative and rooted forms too), which is why stripping it is part of normalizing.
- `toNamespacedPath`: on Windows node runs every `fs` path through `path.toNamespacedPath()`, which is `path.resolve()` (drops `.`, `..`, repeated and trailing separators, treats `..` at a root as a no-op, resolves against the cwd) followed by the `\\?\` prefix. Matching node therefore means normalizing before prefixing.
- Rooted path: a Windows path starting with a separator but without a drive letter (`\Users\x`); resolved against the drive of the current directory by node and by `os_path_kernel32` alike. UNC path: `\\server\share\...`; `\\localhost\C$\...` is the administrative-share spelling of `C:\...` that this test file already uses, so the UNC cases need no extra setup.
- The two converters in `src/runtime/node/types.rs`: `os_path_kernel32` builds Win32 paths for the operations implemented with kernel32 calls (`copyFile`, `existsSync`, recursive `mkdirSync`); `slice_z` builds the input of the NT-level syscalls everything else uses. This PR touches the kernel32 side only.
- `ALLOW_ABOVE_ROOT` in the normalizer: with `true`, a `..` that cannot pop a component is kept in the output (needed for relative paths, `..\x`); with `false` it is dropped (absolute paths). The normalizer records where popping must stop (`dotdot`) when it writes a drive letter or a leading separator; the UNC branch did not, which is the one-line change.

<details>
<summary>Probe results (Windows Server, node v26.3.0 vs bun 1.4.0 vs this branch)</summary>

Existing file `f.txt` spelled in different ways, one row per operation (node succeeds in every cell):

```
bun 1.4.0
op                trailing-sep  dotdot  dot     doubled  rooted-trailing  rel-trailing
existsSync        true          true    true    true     false            true
statSync          true          true    true    true     true             true
accessSync        ENOENT        true    true    true     ENOENT           ENOENT
readFileSync      ENOENT        x       x       x        ENOENT           ENOENT
openSync          ENOENT        true    true    true     ENOENT           ENOENT
copyFileSync src  ENOENT        ENOENT  ENOENT  ENOENT   ENOENT           ENOENT
cpSync src        ENOENT        true    true    true     ENOENT           ENOENT
```

This branch: the `copyFileSync` row succeeds in every column and `existsSync` rooted-trailing is `true`. The remaining `accessSync`/`readFileSync`/`openSync`/`cpSync` trailing-separator cells are the separate `slice_z` issue.

Destination forms for `copyFileSync`, `fs.promises.copyFile` and callback `fs.copyFile` (identical across the three in every build): abs trailing `\`, abs trailing `/`, relative trailing `/` and `\`, abs `..` component, abs `.` component, abs doubled separator, rooted trailing `\`, drive-relative `C:name/`, UNC trailing `\`: node creates the file, bun 1.4.0 throws ENOENT, this branch creates the file. Unchanged and equal to node: existing directory as destination (EPERM; its trailing-separator spelling moves from ENOENT to EPERM), missing parent (ENOENT), empty string (ENOENT).

Spellings of the cwd (`./`, `.\`, `./.`, `sub/..`, `missing\..\`), node / 1.4.0 / branch: `copyFileSync` onto or from them EPERM / ENOENT (EPERM for `./.` and `sub/..`, which Win32 resolved itself) / EPERM; `existsSync` true / false / true; recursive `mkdirSync` undefined / ENOENT / EEXIST (the `"."` issue reported separately). Empty string: ENOENT / false / ENOENT everywhere, unchanged.

`..` above the root, node / 1.4.0 / branch: drive `C:\..\..\<rest>\f.txt`: exists true / false / true, copy both ways ok / ENOENT / ok, recursive mkdir returns the path / EPERM / returns the path. Rooted `\..\<rest>\f.txt`: exists true / false / true, copy ok / ok / ok. UNC `\\localhost\C$\..\..\<rest>\f.txt`: exists true / false / true, copy ok / ok / ok, recursive mkdir returns the path / EUNKNOWN / returns the path (bun's spelling, without `\\?\UNC\`). `readFileSync`/`statSync`/`accessSync`/`openSync` of the UNC spelling: ok in all three.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->