### PR TITLE
js_printer: preserve JSON escaping in package manifests

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2626,7 +2626,7 @@ pub(crate) mod __gated_printer {
                 &mut writer,
                 quote,
                 ASCII_ONLY,
-                false,
+                IS_JSON,
             );
         }
 
@@ -2639,7 +2639,7 @@ pub(crate) mod __gated_printer {
                 &mut writer,
                 quote,
                 ASCII_ONLY,
-                false,
+                IS_JSON,
             );
         }
 
@@ -5079,10 +5079,7 @@ pub(crate) mod __gated_printer {
                             }
                         }
                     } else {
-                        let c = best_quote_char_for_string(key_str.slice16(), false);
-                        self.print(c);
-                        self.print_string_characters_utf16(key_str.slice16(), c);
-                        self.print(c);
+                        self.print_string_literal_e_string(&key_str, false);
                     }
                 }
                 _ => {
@@ -8221,6 +8218,52 @@ pub(crate) fn print_with_writer_and_platform<
         code: buffer.take_slice().into(),
         source_map,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn print_json_uses_json_escaping_for_utf16_keys_and_values() {
+        let mut ast_memory = bun_ast::ASTMemoryAllocator::default();
+        let _scope = ast_memory.enter();
+        // The quote exercises JSON's forced delimiter, while U+000B exercises
+        // JSON-only control escaping in both the UTF-16 key and value paths.
+        let key = bun_ast::E::String::init_utf16(&[b'"' as u16, 0x000B]);
+        let mut properties = bun_alloc::AstAlloc::vec();
+        properties.push(bun_ast::G::Property {
+            key: Some(bun_ast::Expr::init(key, bun_ast::Loc::EMPTY)),
+            value: Some(bun_ast::Expr::init(
+                bun_ast::E::String::init_utf16(&[0x000B]),
+                bun_ast::Loc::EMPTY,
+            )),
+            ..Default::default()
+        });
+        let expr = bun_ast::Expr::init(
+            bun_ast::E::Object {
+                properties,
+                is_single_line: true,
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        );
+        let source = bun_ast::Source::init_empty_file(b"print-json.test.js" as &[u8]);
+        let mut writer = BufferPrinter::init(BufferWriter::init());
+
+        print_json(
+            &mut writer,
+            expr,
+            &source,
+            PrintJsonOptions {
+                minify_whitespace: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(writer.ctx.written(), br#"{"\"\u000B":"\u000B"}"#);
+    }
 }
 
 /// Serializes ModuleInfo (its own string table, then its body) to an owned

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2,7 +2,16 @@ import type { BunLockFile } from "bun";
 import { $, file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import {
+  bunExe,
+  bunEnv as env,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+  toBeValidBin,
+  toBeWorkspaceLink,
+  toHaveBins,
+} from "harness";
 import { join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import {
@@ -93,6 +102,59 @@ it("should add existing package", async () => {
       2,
     ),
   );
+});
+
+it("should preserve JSON-compatible escapes when rewriting package.json", async () => {
+  using configDir = tempDir("bun-add-json-config", {});
+  const controls = Array.from({ length: 0x20 }, (_, codepoint) => String.fromCharCode(codepoint)).join("");
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "json-escapes",
+      version: "1.0.0",
+      metadata: { [controls]: controls },
+    }),
+  );
+  await writeFile(
+    join(add_dir, "package.json"),
+    JSON.stringify({
+      name: "local-dependency",
+      version: "1.0.0",
+    }),
+  );
+
+  const dependency = `file:${relative(package_dir, add_dir)}`.replace(/\\/g, "\\\\");
+  const proc = spawn({
+    cmd: [bunExe(), "add", dependency, "--ignore-scripts"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      HOME: String(configDir),
+      USERPROFILE: String(configDir),
+      XDG_CONFIG_HOME: String(configDir),
+    },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: expect.stringContaining("1 package installed"),
+    stderr: expect.stringContaining("Saved lockfile"),
+    exitCode: 0,
+  });
+  expect(stderr).not.toContain("error:");
+
+  const rewritten = await file(join(package_dir, "package.json")).text();
+  expect(rewritten).not.toMatch(/\\(?:v|x[0-9A-Fa-f]{2})/);
+  const parsed = JSON.parse(rewritten);
+  expect(parsed).toEqual({
+    name: "json-escapes",
+    version: "1.0.0",
+    metadata: { [controls]: controls },
+    dependencies: { "local-dependency": dependency.replace(/\\\\/g, "/") },
+  });
 });
 
 it("should reject missing package", async () => {


### PR DESCRIPTION
### What does this PR do?

`print_json` enables JSON mode, but its UTF-8 and UTF-16 character-writing helpers passed `false` to the JSON-aware escaper. This let `bun add` accept a valid JSON escape for U+001B, then rewrite it as JavaScript-only `\x1B` and leave an invalid `package.json`.

The change passes `IS_JSON` through both string paths and uses the canonical string-literal helper for UTF-16 property keys. Non-JSON printer modes keep their existing behavior.

Fixes #4823.

### How did you verify your code works?

- Added a network-free `bun add` regression covering every C0 control character in a JSON key and value. The unfixed build emits `\xNN`/`\v`; the patched build produces strict JSON and round-trips the decoded strings.
- Added a direct UTF-16 printer regression for JSON quoting and `U+000B` escaping. It is type-checked with `cargo check --locked -p bun_js_printer --tests`; this crate has no standalone native-link test runner, so I am not claiming that the Rust unit test ran.
- Ran the focused integration test (1 pass), the hermetic full `test/cli/install/bun-add.test.ts` file (55 pass), and the existing non-JSON UTF-8/UTF-16 macro matrix (15 pass).
- Ran Clippy with warnings denied, Rust formatting, Prettier, and `git diff --check`.
- All runtime tests ran on Linux x64; native Windows and macOS were not tested locally.
