### PR TITLE
install: allow bun info and pm view without a package.json

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -802,16 +802,15 @@ impl PackageManager {
         init(ctx, cli, subcommand)
     }
 
-    /// Initializes a registry view, allowing a missing root manifest only when
-    /// `spec` names an npm package; path, URL, and empty specs stay project-bound.
+    /// Initializes a registry view, allowing a missing root manifest only for
+    /// npm package selectors; path, URL, and empty specs stay project-bound.
     pub fn init_for_registry_view(
         ctx: Command::Context,
         cli: CommandLineArguments,
         subcommand: Subcommand,
         spec: &[u8],
     ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
-        let (package_name, _) = crate::dependency::split_name_and_version_or_latest(spec);
-        let root_manifest_requirement = if strings::is_npm_package_name(package_name) {
+        let root_manifest_requirement = if crate::dependency::is_registry_package_spec(spec) {
             RootManifestRequirement::OptionalForRegistryView
         } else {
             RootManifestRequirement::Required

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -801,6 +801,22 @@ impl PackageManager {
     ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
         init(ctx, cli, subcommand)
     }
+
+    pub fn init_for_registry_view(
+        ctx: Command::Context,
+        cli: CommandLineArguments,
+        subcommand: Subcommand,
+        spec: &[u8],
+    ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
+        let (package_name, _) = crate::dependency::split_name_and_version_or_latest(spec);
+        let root_manifest_requirement = if strings::is_npm_package_name(package_name) {
+            RootManifestRequirement::OptionalForRegistryView
+        } else {
+            RootManifestRequirement::Required
+        };
+
+        init_with_manifest_requirement(ctx, cli, subcommand, root_manifest_requirement)
+    }
 }
 
 // Only consumer is `hasEnoughTimePassedBetweenWaitingMessages`.
@@ -1451,6 +1467,21 @@ pub fn init(
     cli: CommandLineArguments,
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
+    init_with_manifest_requirement(ctx, cli, subcommand, RootManifestRequirement::Required)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RootManifestRequirement {
+    Required,
+    OptionalForRegistryView,
+}
+
+fn init_with_manifest_requirement(
+    ctx: Command::Context,
+    cli: CommandLineArguments,
+    subcommand: Subcommand,
+    root_manifest_requirement: RootManifestRequirement,
+) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
     if cli.global {
         // Non-consuming peek: `ctx.install` is
         // `Option<Box<BunInstall>>` borrowed via `&mut ContextData`; reborrow with
@@ -1612,8 +1643,14 @@ pub fn init(
                     break 'child attempt_to_create_package_json_and_open()?;
                 }
             }
+            if root_manifest_requirement == RootManifestRequirement::OptionalForRegistryView {
+                this_cwd = original_cwd;
+                break 'child bun_sys::File::from_fd(Fd::invalid());
+            }
             return Err(crate::Error::MissingPackageJSON);
         };
+
+        let has_root_manifest = child_json.handle.is_valid();
 
         debug_assert!(strings::eql_long(
             &original_package_json_path_buf[..this_cwd.len()],
@@ -1632,7 +1669,7 @@ pub fn init(
         let child_cwd = &original_package_json_path.as_bytes()[..this_cwd.len()];
 
         // Check if this is a workspace; if so, use root package
-        if subcommand.should_chdir_to_root() {
+        if has_root_manifest && subcommand.should_chdir_to_root() {
             if !created_package_json {
                 while let Some(parent) = bun_core::dirname(this_cwd) {
                     let parent_without_trailing_slash = strings::without_trailing_slash(parent);
@@ -1794,6 +1831,7 @@ pub fn init(
         fs.set_top_level_dir(fs.dirname_store().append(child_cwd)?);
         break 'root_package_json_file child_json;
     };
+    let has_root_manifest = root_package_json_file.handle.is_valid();
 
     let top_level_dir_z = ZBox::from_bytes(fs.top_level_dir());
     bun_sys::chdir(&top_level_dir_z)?;
@@ -1816,13 +1854,15 @@ pub fn init(
         // until now). The slice excludes the NUL — `top_level_dir` is `[]u8`.
         // PathBuffer is repr(transparent) over [u8; N], so the raw cast is sound.
         fs.set_top_level_dir(bun_core::ffi::slice(CWD_BUF.get().cast::<u8>(), tld.len()));
-        // bun_sys exposes the non-Z `get_fd_path`;
-        // append the NUL ourselves so the static `&ZStr` invariant holds.
-        let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
-        let p = bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?;
-        let plen = p.len();
-        root_buf[plen] = 0;
-        ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
+        if has_root_manifest {
+            // bun_sys exposes the non-Z `get_fd_path`;
+            // append the NUL ourselves so the static `&ZStr` invariant holds.
+            let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
+            let p = bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?;
+            let plen = p.len();
+            root_buf[plen] = 0;
+            ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
+        }
     }
 
     // Returns the resolver's BSSMap-owned
@@ -2104,7 +2144,7 @@ pub fn init(
     // (`Box::new(Lockfile::default())`) so we never construct a zeroed
     // `Lockfile` only to drop it.
 
-    {
+    if has_root_manifest {
         // make sure folder packages can find the root package without creating a new one
         // Posix-normalize the
         // separators before hashing; `FolderResolution.hash` is always fed `/`-separated

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -802,6 +802,8 @@ impl PackageManager {
         init(ctx, cli, subcommand)
     }
 
+    /// Initializes a registry view, allowing a missing root manifest only when
+    /// `spec` names an npm package; path, URL, and empty specs stay project-bound.
     pub fn init_for_registry_view(
         ctx: Command::Context,
         cli: CommandLineArguments,

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -532,13 +532,13 @@ pub fn is_registry_package_spec(spec: &[u8]) -> bool {
     }
 
     match Tag::infer(selector) {
-        Tag::Npm | Tag::DistTag => {
-            is_valid_registry_dist_tag(selector)
-                || (!selector.starts_with(b"npm:")
-                    && !selector.starts_with(b"patch:")
-                    && Semver::query::is_valid(selector, SlicedString::init(selector, selector))
-                        .unwrap_or_else(|_| bun_core::out_of_memory()))
+        Tag::Npm => {
+            !selector.starts_with(b"npm:")
+                && !selector.starts_with(b"patch:")
+                && Semver::query::is_valid(selector, SlicedString::init(selector, selector))
+                    .unwrap_or_else(|_| bun_core::out_of_memory())
         }
+        Tag::DistTag => is_valid_registry_dist_tag(selector),
         _ => false,
     }
 }

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -519,6 +519,38 @@ pub fn split_name_and_version_or_latest(str: &[u8]) -> (&[u8], &[u8]) {
     (name, version.unwrap_or(b"latest"))
 }
 
+/// Returns whether `spec` can be satisfied from npm registry metadata without
+/// project context. Named file, URL, git, alias, and workspace specs are not
+/// registry views even though they begin with a valid package name.
+pub fn is_registry_package_spec(spec: &[u8]) -> bool {
+    let (selector, package_name) = split_version_and_maybe_name(spec);
+    let Some(package_name) = package_name else {
+        return strings::is_npm_package_name(selector);
+    };
+    if !strings::is_npm_package_name(package_name) {
+        return false;
+    }
+
+    match Tag::infer(selector) {
+        Tag::Npm => !selector.starts_with(b"npm:") && !selector.starts_with(b"patch:"),
+        Tag::DistTag => is_valid_registry_dist_tag(selector),
+        _ => false,
+    }
+}
+
+/// npm-package-arg accepts dist-tags only when `encodeURIComponent` would
+/// leave them unchanged. An empty selector is the omitted `latest` selector.
+#[inline]
+fn is_valid_registry_dist_tag(selector: &[u8]) -> bool {
+    selector.iter().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(
+                c,
+                b'-' | b'_' | b'.' | b'!' | b'~' | b'*' | b'\'' | b'(' | b')'
+            )
+    })
+}
+
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub(crate) enum SplitNameError {
     #[error("MissingVersion")]

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -532,8 +532,13 @@ pub fn is_registry_package_spec(spec: &[u8]) -> bool {
     }
 
     match Tag::infer(selector) {
-        Tag::Npm => !selector.starts_with(b"npm:") && !selector.starts_with(b"patch:"),
-        Tag::DistTag => is_valid_registry_dist_tag(selector),
+        Tag::Npm | Tag::DistTag => {
+            is_valid_registry_dist_tag(selector)
+                || (!selector.starts_with(b"npm:")
+                    && !selector.starts_with(b"patch:")
+                    && Semver::query::is_valid(selector, SlicedString::init(selector, selector))
+                        .unwrap_or_else(|_| bun_core::out_of_memory()))
+        }
         _ => false,
     }
 }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1938,29 +1938,18 @@ To create a project with the official Next.js scaffolding tool, run\n\
         // Parse arguments manually since the standard flow doesn't work for standalone commands
         let cli = CommandLineArguments::parse(PmSubcommand::Info)?;
         let json_output = cli.json_output;
+
+        // `positionals[0]` is the `info` keyword itself.
+        let positionals = match cli.positionals {
+            [b"info", rest @ ..] => rest,
+            rest => rest,
+        };
+        let package_name: &[u8] = positionals.first().copied().unwrap_or_default();
+        let property_path: Option<&[u8]> = positionals.get(1).copied();
+
         let ctx = init(Tag::InfoCommand, log)?;
-        let (pm, _) = PackageManager::init(ctx, cli, Subcommand::Info)?;
-
-        // Handle arguments correctly for standalone info command
-        let mut package_name: &[u8] = b"";
-        let mut property_path: Option<&[u8]> = None;
-
-        // Find non-flag arguments starting from argv[2] (after "bun info").
-        let mut found_package = false;
-        let argv = bun::argv();
-        for arg in argv.iter().skip(2) {
-            // Skip flags
-            if !arg.is_empty() && arg[0] == b'-' {
-                continue;
-            }
-            if !found_package {
-                package_name = arg;
-                found_package = true;
-            } else {
-                property_path = Some(arg);
-                break;
-            }
-        }
+        let (pm, _) =
+            PackageManager::init_for_registry_view(ctx, cli, Subcommand::Info, package_name)?;
 
         super::pm_view_command::view(pm, package_name, property_path, json_output)
     }

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -202,7 +202,19 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             .is_some_and(|arg| strings::eql_comptime(arg.as_bytes(), b"whoami"));
 
         let cli = CommandLineArguments::parse(Subcommand::Pm)?;
-        let (pm, cwd) = match PackageManager::init(&mut *ctx, cli, Subcommand::Pm) {
+        let mut positionals = cli.positionals;
+        let subcommand = Self::get_subcommand(&mut positionals);
+        let init_result = if strings::eql_comptime(subcommand, b"view") {
+            PackageManager::init_for_registry_view(
+                &mut *ctx,
+                cli,
+                Subcommand::Pm,
+                positionals.get(1).copied().unwrap_or_default(),
+            )
+        } else {
+            PackageManager::init(&mut *ctx, cli, Subcommand::Pm)
+        };
+        let (pm, cwd) = match init_result {
             Ok(v) => v,
             Err(err) => {
                 if err == bun_install::Error::MissingPackageJSON {

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -204,13 +204,10 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
         let cli = CommandLineArguments::parse(Subcommand::Pm)?;
         let mut positionals = cli.positionals;
         let subcommand = Self::get_subcommand(&mut positionals);
-        let init_result = if strings::eql_comptime(subcommand, b"view") {
-            PackageManager::init_for_registry_view(
-                &mut *ctx,
-                cli,
-                Subcommand::Pm,
-                positionals.get(1).copied().unwrap_or_default(),
-            )
+        let view_spec = strings::eql_comptime(subcommand, b"view")
+            .then(|| positionals.get(1).copied().unwrap_or_default());
+        let init_result = if let Some(view_spec) = view_spec {
+            PackageManager::init_for_registry_view(&mut *ctx, cli, Subcommand::Pm, view_spec)
         } else {
             PackageManager::init(&mut *ctx, cli, Subcommand::Pm)
         };
@@ -297,13 +294,13 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             } else {
                 None
             };
-            let spec = if pm.options.positionals.len() > 1 {
-                pm.options.positionals[1]
-            } else {
-                b"".as_slice()
-            };
             let json_output = pm.options.json_output;
-            PmViewCommand::view(pm, spec, property_path, json_output)?;
+            PmViewCommand::view(
+                pm,
+                view_spec.unwrap_or_default(),
+                property_path,
+                json_output,
+            )?;
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"bin") {
             // SAFETY: `FileSystem::instance()` is initialised during

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -943,7 +943,7 @@ fn parse_with_validity(input: &[u8], sliced: SlicedString) -> Result<(Group, boo
 
         if !skip_round {
             let parse_result = Version::parse(sliced.sub(&input[i..]));
-            valid &= parse_result.valid && parse_result.has_version;
+            valid &= parse_result.strict_valid;
             let version = parse_result.version.min();
             if version.tag.has_build() {
                 list.flags.set(Flags::BUILD);
@@ -996,7 +996,7 @@ fn parse_with_validity(input: &[u8], sliced: SlicedString) -> Result<(Group, boo
 
             if hyphenate {
                 let second_parsed = Version::parse(sliced.sub(&input[i..]));
-                valid &= second_parsed.valid && second_parsed.has_version;
+                valid &= second_parsed.strict_valid;
                 let mut second_version = second_parsed.version.min();
                 if second_version.tag.has_build() {
                     list.flags.set(Flags::BUILD);

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -810,6 +810,17 @@ impl Token {
 }
 
 pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
+    parse_with_validity(input, sliced).map(|(group, _)| group)
+}
+
+/// Parses a version range and reports whether every token was valid range
+/// syntax. [`parse`] intentionally preserves permissive recovery from unknown
+/// tokens for existing callers.
+pub fn is_valid(input: &[u8], sliced: SlicedString) -> Result<bool, AllocError> {
+    parse_with_validity(input, sliced).map(|(_, valid)| valid)
+}
+
+fn parse_with_validity(input: &[u8], sliced: SlicedString) -> Result<(Group, bool), AllocError> {
     let mut i: usize = 0;
     let mut list = Group {
         input: std::ptr::from_ref::<[u8]>(input),
@@ -823,6 +834,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
     let mut count: u32 = 0;
     let mut skip_round;
     let mut is_or = false;
+    let mut valid = true;
 
     while i < input.len() {
         skip_round = false;
@@ -886,11 +898,13 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 is_or = true;
             }
             b'|' => {
+                let pipe_start = i;
                 i += 1;
 
                 while i < input.len() && input[i] == b'|' {
                     i += 1;
                 }
+                valid &= i - pipe_start == 2;
                 while i < input.len() && input[i] == b' ' {
                     i += 1;
                 }
@@ -899,6 +913,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 skip_round = true;
             }
             b'-' => {
+                valid = false;
                 i += 1;
                 while i < input.len() && input[i] == b' ' {
                     i += 1;
@@ -912,6 +927,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
                 skip_round = true;
             }
             _ => {
+                valid = false;
                 i += 1;
                 token.tag = TokenTag::None;
 
@@ -927,6 +943,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
 
         if !skip_round {
             let parse_result = Version::parse(sliced.sub(&input[i..]));
+            valid &= parse_result.valid && parse_result.has_version;
             let version = parse_result.version.min();
             if version.tag.has_build() {
                 list.flags.set(Flags::BUILD);
@@ -979,6 +996,7 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
 
             if hyphenate {
                 let second_parsed = Version::parse(sliced.sub(&input[i..]));
+                valid &= second_parsed.valid && second_parsed.has_version;
                 let mut second_version = second_parsed.version.min();
                 if second_version.tag.has_build() {
                     list.flags.set(Flags::BUILD);
@@ -1096,5 +1114,5 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
         }
     }
 
-    Ok(list)
+    Ok((list, valid))
 }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -645,6 +645,7 @@ impl<T: VersionInt> VersionType<T> {
             }
         }
 
+        result.has_version = part_i > 0;
         result.len = u32::try_from(i).expect("int cast");
 
         result
@@ -1197,6 +1198,7 @@ pub struct TagResult {
 pub struct ParseResult<T: VersionInt> {
     pub wildcard: Wildcard,
     pub valid: bool,
+    pub has_version: bool,
     pub version: Partial<T>,
     pub(crate) len: u32,
 }
@@ -1206,6 +1208,7 @@ impl<T: VersionInt> Default for ParseResult<T> {
         Self {
             wildcard: Wildcard::None,
             valid: true,
+            has_version: false,
             version: Partial::default(),
             len: 0,
         }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -467,6 +467,7 @@ impl<T: VersionInt> VersionType<T> {
 
         if input.is_empty() {
             result.valid = false;
+            result.strict_valid = false;
             return result;
         }
         let mut is_done = false;
@@ -495,6 +496,7 @@ impl<T: VersionInt> VersionType<T> {
 
         if i == input.len() {
             result.valid = false;
+            result.strict_valid = false;
             result.wildcard = Wildcard::Major;
             result.len = u32::try_from(i).expect("int cast");
             return result;
@@ -528,18 +530,24 @@ impl<T: VersionInt> VersionType<T> {
 
                     match part_i {
                         0 => {
-                            result.version.major =
-                                Self::parse_version_number(&input[part_start_i..last_char_i]);
+                            result.version.major = Self::parse_version_number(
+                                &input[part_start_i..last_char_i],
+                                &mut result.strict_valid,
+                            );
                             part_i = 1;
                         }
                         1 => {
-                            result.version.minor =
-                                Self::parse_version_number(&input[part_start_i..last_char_i]);
+                            result.version.minor = Self::parse_version_number(
+                                &input[part_start_i..last_char_i],
+                                &mut result.strict_valid,
+                            );
                             part_i = 2;
                         }
                         2 => {
-                            result.version.patch =
-                                Self::parse_version_number(&input[part_start_i..last_char_i]);
+                            result.version.patch = Self::parse_version_number(
+                                &input[part_start_i..last_char_i],
+                                &mut result.strict_valid,
+                            );
                             part_i = 3;
                         }
                         _ => {}
@@ -553,6 +561,8 @@ impl<T: VersionInt> VersionType<T> {
                         }
                     {
                         i += 1;
+                        result.strict_valid &=
+                            i < input.len() && matches!(input[i], b'0'..=b'9' | b'x' | b'X' | b'*');
                     }
                 }
                 b'.' => {
@@ -645,17 +655,19 @@ impl<T: VersionInt> VersionType<T> {
             }
         }
 
-        result.has_version = part_i > 0;
+        result.strict_valid &= result.valid && part_i > 0;
         result.len = u32::try_from(i).expect("int cast");
 
         result
     }
 
-    fn parse_version_number(input: &[u8]) -> Option<T> {
+    fn parse_version_number(input: &[u8], strict_valid: &mut bool) -> Option<T> {
         // Callers slice `input` from the first digit to the first non-digit,
         // so every byte is already `b'0'..=b'9'` and the slice is non-empty.
         debug_assert!(!input.is_empty() && input.iter().all(u8::is_ascii_digit));
-        Some(T::parse_ascii(input).unwrap_or(T::ZERO))
+        let parsed = T::parse_ascii(input);
+        *strict_valid &= parsed.is_some();
+        Some(parsed.unwrap_or(T::ZERO))
     }
 }
 
@@ -1198,7 +1210,7 @@ pub struct TagResult {
 pub struct ParseResult<T: VersionInt> {
     pub wildcard: Wildcard,
     pub valid: bool,
-    pub has_version: bool,
+    pub strict_valid: bool,
     pub version: Partial<T>,
     pub(crate) len: u32,
 }
@@ -1208,7 +1220,7 @@ impl<T: VersionInt> Default for ParseResult<T> {
         Self {
             wildcard: Wildcard::None,
             valid: true,
-            has_version: false,
+            strict_valid: true,
             version: Partial::default(),
             len: 0,
         }

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -417,6 +417,18 @@ describe.concurrent("bun info", () => {
         config: "env-empty-selector",
       },
       {
+        name: "bun info with a valid compact union range",
+        args: ["info", "manifestless-range-pkg@1||2", "name"],
+        packageName: "manifestless-range-pkg",
+        config: "env-union-range",
+      },
+      {
+        name: "bun info with a valid prefixed range",
+        args: ["info", "manifestless-range-pkg@~v1", "name"],
+        packageName: "manifestless-range-pkg",
+        config: "env-caret-range",
+      },
+      {
         name: "bun info with --registry before the spec",
         args: ["info", "--registry", "$REGISTRY", "manifestless-option-before-pkg@1.0.0", "name"],
         packageName: "manifestless-option-before-pkg",
@@ -513,6 +525,8 @@ describe.concurrent("bun info", () => {
       { name: "bun info with a named path", args: ["info", "pkg@file:./local"] },
       { name: "bun info with a named URL", args: ["info", "pkg@https://example.com/package.tgz"] },
       { name: "bun info with an unsupported named selector", args: ["info", "pkg@workspace:*"] },
+      { name: "bun info with a malformed named range", args: ["info", "pkg@foo|bar"] },
+      { name: "bun info with a malformed range operand", args: ["info", "pkg@^^1"] },
       { name: "bun info with malformed package syntax", args: ["info", "@"] },
       { name: "bun info with only a valued registry option", args: ["info", "--registry", "$REGISTRY"] },
       { name: "bun pm view", args: ["pm", "view"] },
@@ -525,6 +539,8 @@ describe.concurrent("bun info", () => {
         args: ["pm", "view", "pkg@https://example.com/package.tgz"],
       },
       { name: "bun pm view with an unsupported named selector", args: ["pm", "view", "pkg@foo:bar"] },
+      { name: "bun pm view with a malformed named range", args: ["pm", "view", "pkg@foo|bar"] },
+      { name: "bun pm view with a malformed range operand", args: ["pm", "view", "pkg@^^1"] },
       { name: "bun pm view with malformed package syntax", args: ["pm", "view", "@"] },
     ])("$name still requires project context", async ({ args }) => {
       let requestCount = 0;

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -429,6 +429,18 @@ describe.concurrent("bun info", () => {
         config: "env-caret-range",
       },
       {
+        name: "bun pm view with a valid compact union range",
+        args: ["pm", "view", "manifestless-range-pkg@1||2", "name"],
+        packageName: "manifestless-range-pkg",
+        config: "env-pm-view-union-range",
+      },
+      {
+        name: "bun pm view with a valid prefixed range",
+        args: ["pm", "view", "manifestless-range-pkg@~v1", "name"],
+        packageName: "manifestless-range-pkg",
+        config: "env-pm-view-caret-range",
+      },
+      {
         name: "bun info with --registry before the spec",
         args: ["info", "--registry", "$REGISTRY", "manifestless-option-before-pkg@1.0.0", "name"],
         packageName: "manifestless-option-before-pkg",
@@ -527,6 +539,17 @@ describe.concurrent("bun info", () => {
       { name: "bun info with an unsupported named selector", args: ["info", "pkg@workspace:*"] },
       { name: "bun info with a malformed named range", args: ["info", "pkg@foo|bar"] },
       { name: "bun info with a malformed range operand", args: ["info", "pkg@^^1"] },
+      { name: "bun info with an incomplete major version", args: ["info", "pkg@1."] },
+      { name: "bun info with an incomplete minor version", args: ["info", "pkg@1.2."] },
+      { name: "bun info with an incomplete range operand", args: ["info", "pkg@1.||2"] },
+      {
+        name: "bun info with an incomplete hyphen-range operand",
+        args: ["info", "pkg@1.0.0 - 2.||3"],
+      },
+      {
+        name: "bun info with an overflowing range operand",
+        args: ["info", "pkg@18446744073709551616"],
+      },
       { name: "bun info with malformed package syntax", args: ["info", "@"] },
       { name: "bun info with only a valued registry option", args: ["info", "--registry", "$REGISTRY"] },
       { name: "bun pm view", args: ["pm", "view"] },
@@ -541,6 +564,17 @@ describe.concurrent("bun info", () => {
       { name: "bun pm view with an unsupported named selector", args: ["pm", "view", "pkg@foo:bar"] },
       { name: "bun pm view with a malformed named range", args: ["pm", "view", "pkg@foo|bar"] },
       { name: "bun pm view with a malformed range operand", args: ["pm", "view", "pkg@^^1"] },
+      { name: "bun pm view with an incomplete major version", args: ["pm", "view", "pkg@1."] },
+      { name: "bun pm view with an incomplete minor version", args: ["pm", "view", "pkg@1.2."] },
+      { name: "bun pm view with an incomplete range operand", args: ["pm", "view", "pkg@1.||2"] },
+      {
+        name: "bun pm view with an incomplete hyphen-range operand",
+        args: ["pm", "view", "pkg@1.0.0 - 2.||3"],
+      },
+      {
+        name: "bun pm view with an overflowing range operand",
+        args: ["pm", "view", "pkg@18446744073709551616"],
+      },
       { name: "bun pm view with malformed package syntax", args: ["pm", "view", "@"] },
     ])("$name still requires project context", async ({ args }) => {
       let requestCount = 0;

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -405,6 +405,12 @@ describe.concurrent("bun info", () => {
         config: "env",
       },
       {
+        name: "bun info with an unversioned spec and environment config",
+        args: ["info", "manifestless-latest-pkg", "name"],
+        packageName: "manifestless-latest-pkg",
+        config: "env-latest",
+      },
+      {
         name: "bun info with --registry before the spec",
         args: ["info", "--registry", "$REGISTRY", "manifestless-option-before-pkg@1.0.0", "name"],
         packageName: "manifestless-option-before-pkg",
@@ -532,8 +538,8 @@ describe.concurrent("bun info", () => {
         isolatedRegistryEnv(homeDir, xdgConfigDir),
       );
 
-      expect(code).toBe(1);
       expect(error).toContain("package.json");
+      expect(code).toBe(1);
       expect(requestCount).toBe(0);
       expect(readdirSync(testDir).sort()).toEqual(filesBefore);
       expect(readdirSync(homeDir).sort()).toEqual(homeFilesBefore);

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -411,6 +411,12 @@ describe.concurrent("bun info", () => {
         config: "env-latest",
       },
       {
+        name: "bun info with an empty selector resolves latest",
+        args: ["info", "manifestless-latest-pkg@", "name"],
+        packageName: "manifestless-latest-pkg",
+        config: "env-empty-selector",
+      },
+      {
         name: "bun info with --registry before the spec",
         args: ["info", "--registry", "$REGISTRY", "manifestless-option-before-pkg@1.0.0", "name"],
         packageName: "manifestless-option-before-pkg",
@@ -504,12 +510,21 @@ describe.concurrent("bun info", () => {
       { name: "bun info .", args: ["info", "."] },
       { name: "bun info with a path", args: ["info", "./package.json"] },
       { name: "bun info with a URL", args: ["info", "https://example.com/package.tgz"] },
+      { name: "bun info with a named path", args: ["info", "pkg@file:./local"] },
+      { name: "bun info with a named URL", args: ["info", "pkg@https://example.com/package.tgz"] },
+      { name: "bun info with an unsupported named selector", args: ["info", "pkg@workspace:*"] },
       { name: "bun info with malformed package syntax", args: ["info", "@"] },
       { name: "bun info with only a valued registry option", args: ["info", "--registry", "$REGISTRY"] },
       { name: "bun pm view", args: ["pm", "view"] },
       { name: "bun pm view .", args: ["pm", "view", "."] },
       { name: "bun pm view with a path", args: ["pm", "view", "./package.json"] },
       { name: "bun pm view with a URL", args: ["pm", "view", "https://example.com/package.tgz"] },
+      { name: "bun pm view with a named path", args: ["pm", "view", "pkg@file:./local"] },
+      {
+        name: "bun pm view with a named URL",
+        args: ["pm", "view", "pkg@https://example.com/package.tgz"],
+      },
+      { name: "bun pm view with an unsupported named selector", args: ["pm", "view", "pkg@foo:bar"] },
       { name: "bun pm view with malformed package syntax", args: ["pm", "view", "@"] },
     ])("$name still requires project context", async ({ args }) => {
       let requestCount = 0;

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 describe.concurrent("bun info", () => {
@@ -17,14 +18,14 @@ describe.concurrent("bun info", () => {
     return testDir;
   }
 
-  async function runCommand(cmd: string[], testDir: string, expectSuccess = true) {
+  async function runCommand(cmd: string[], testDir: string, env = bunEnv) {
     const { stdout, stderr, exited } = spawn({
       cmd,
       cwd: testDir,
       stdout: "pipe",
       stdin: "ignore",
       stderr: "pipe",
-      env: bunEnv,
+      env,
     });
 
     const [output, error, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
@@ -88,7 +89,7 @@ describe.concurrent("bun info", () => {
 
     it("should handle missing arguments", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand([bunExe(), "info"], testDir, false);
+      const { output, error, code } = await runCommand([bunExe(), "info"], testDir);
 
       expect(output).toMatchInlineSnapshot(`
         "fs@0.0.1-security | ISC | deps: 0 | versions: 3
@@ -213,11 +214,7 @@ describe.concurrent("bun info", () => {
 
     it("should handle non-existent package", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand(
-        [bunExe(), "pm", "view", "nonexistent-package-12345"],
-        testDir,
-        false,
-      );
+      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "nonexistent-package-12345"], testDir);
 
       expect(code).toBe(1);
       expect(error).toContain("Not Found");
@@ -227,7 +224,7 @@ describe.concurrent("bun info", () => {
     // TODO: Version validation needs to be fixed - currently falls back to first version instead of failing
     it("should handle non-existent version", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "is-number@999.0.0"], testDir, false);
+      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "is-number@999.0.0"], testDir);
 
       expect(error).toMatchInlineSnapshot(`
         "error: No version of "is-number" satisfying "999.0.0" found
@@ -246,11 +243,7 @@ describe.concurrent("bun info", () => {
 
     it("should handle non-existent property", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand(
-        [bunExe(), "pm", "view", "is-number", "nonexistent"],
-        testDir,
-        false,
-      );
+      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "is-number", "nonexistent"], testDir);
 
       expect(error).toMatchInlineSnapshot(`
         "error: Property nonexistent not found
@@ -261,7 +254,7 @@ describe.concurrent("bun info", () => {
 
     it("should handle malformed package specifier", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "@"], testDir, false);
+      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "@"], testDir);
 
       expect(code).toBe(1);
       expect(error).toContain("Method Not Allowed");
@@ -280,7 +273,7 @@ describe.concurrent("bun info", () => {
 
     it("should handle .", async () => {
       const testDir = await setupTest();
-      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "."], testDir, false);
+      const { output, error, code } = await runCommand([bunExe(), "pm", "view", "."], testDir);
 
       expect(output).toMatchInlineSnapshot(`
         "fs@0.0.1-security | ISC | deps: 0 | versions: 3
@@ -368,6 +361,183 @@ describe.concurrent("bun info", () => {
         Published: 2016-08-23T17:56:58.976Z
         "
       `);
+    });
+  });
+
+  describe("without a package.json", () => {
+    function isolatedRegistryEnv(homeDir: string, xdgConfigDir: string, overrides: Record<string, string> = {}) {
+      return {
+        ...bunEnv,
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        XDG_CONFIG_HOME: xdgConfigDir,
+        BUN_CONFIG_REGISTRY: "",
+        NPM_CONFIG_REGISTRY: "",
+        npm_config_registry: "",
+        BUN_CONFIG_TOKEN: "",
+        NPM_CONFIG_TOKEN: "",
+        npm_config_token: "",
+        http_proxy: "",
+        https_proxy: "",
+        HTTP_PROXY: "",
+        HTTPS_PROXY: "",
+        ...overrides,
+      };
+    }
+
+    const manifestlessCases = [
+      {
+        name: "bun info with a versioned spec and bunfig.toml",
+        args: ["info", "manifestless-pkg@1.0.0", "name"],
+        packageName: "manifestless-pkg",
+        config: "bunfig",
+      },
+      {
+        name: "bun pm view with a scoped versioned spec and .npmrc",
+        args: ["pm", "view", "@scope/manifestless-pkg@1.0.0", "name"],
+        packageName: "@scope/manifestless-pkg",
+        config: "npmrc",
+      },
+      {
+        name: "bun info with a versioned spec and environment config",
+        args: ["info", "manifestless-env-pkg@1.0.0", "name"],
+        packageName: "manifestless-env-pkg",
+        config: "env",
+      },
+      {
+        name: "bun info with --registry before the spec",
+        args: ["info", "--registry", "$REGISTRY", "manifestless-option-before-pkg@1.0.0", "name"],
+        packageName: "manifestless-option-before-pkg",
+        config: "option-before",
+      },
+      {
+        name: "bun info with --registry after the spec",
+        args: ["info", "manifestless-option-after-pkg@1.0.0", "--registry", "$REGISTRY", "name"],
+        packageName: "manifestless-option-after-pkg",
+        config: "option-after",
+      },
+      {
+        name: "bun info with a leading-hyphen package after --",
+        args: ["info", "--", "-manifestless-pkg@1.0.0", "name"],
+        packageName: "-manifestless-pkg",
+        config: "env-leading-hyphen",
+      },
+    ] as const;
+
+    test.each(manifestlessCases)("$name", async ({ args, packageName, config }) => {
+      const token = "manifestless-registry-token";
+      const manifest = JSON.stringify({
+        name: packageName,
+        "dist-tags": { latest: "1.0.0" },
+        versions: {
+          "1.0.0": {
+            name: packageName,
+            version: "1.0.0",
+            dist: {
+              tarball: "http://localhost/manifestless-pkg-1.0.0.tgz",
+              shasum: "0".repeat(40),
+            },
+          },
+        },
+        time: { "1.0.0": "2020-01-01T00:00:00.000Z" },
+      });
+      const requests: { packageName: string; authorization: string | null }[] = [];
+      await using server = Bun.serve({
+        port: 0,
+        fetch(request) {
+          requests.push({
+            packageName: decodeURIComponent(new URL(request.url).pathname.slice(1)),
+            authorization: request.headers.get("authorization"),
+          });
+          return new Response(manifest, { headers: { "content-type": "application/json" } });
+        },
+      });
+      const registry = `http://127.0.0.1:${server.port}/`;
+      const testDir = tempDirWithFiles(`bun-info-manifestless-${config}`, {
+        ...(config === "bunfig"
+          ? {
+              "bunfig.toml": `[install.registry]\nurl = "${registry}"\ntoken = "${token}"\n`,
+            }
+          : config === "npmrc"
+            ? {
+                ".npmrc": `registry=${registry}\n//127.0.0.1:${server.port}/:_authToken=${token}\n`,
+              }
+            : {}),
+      });
+      const homeDir = tempDirWithFiles(`bun-info-manifestless-home-${config}`, {});
+      const xdgConfigDir = tempDirWithFiles(`bun-info-manifestless-xdg-${config}`, {});
+      const filesBefore = readdirSync(testDir).sort();
+      const homeFilesBefore = readdirSync(homeDir).sort();
+      const xdgFilesBefore = readdirSync(xdgConfigDir).sort();
+      expect(homeFilesBefore).toEqual([]);
+      expect(xdgFilesBefore).toEqual([]);
+      const resolvedArgs = args.map(arg => (arg === "$REGISTRY" ? registry : arg));
+
+      const { output, error, code } = await runCommand(
+        [bunExe(), ...resolvedArgs],
+        testDir,
+        isolatedRegistryEnv(homeDir, xdgConfigDir, {
+          BUN_CONFIG_REGISTRY: config.startsWith("env") ? registry : "",
+          BUN_CONFIG_TOKEN: config.startsWith("env") ? token : "",
+        }),
+      );
+
+      expect({ output, error, code, requests, files: readdirSync(testDir).sort() }).toEqual({
+        output: `${packageName}\n`,
+        error: "",
+        code: 0,
+        requests: [{ packageName, authorization: config.startsWith("option") ? null : `Bearer ${token}` }],
+        files: filesBefore,
+      });
+      expect(readdirSync(homeDir).sort()).toEqual(homeFilesBefore);
+      expect(readdirSync(xdgConfigDir).sort()).toEqual(xdgFilesBefore);
+    });
+
+    test.each([
+      { name: "bun info", args: ["info"] },
+      { name: "bun info .", args: ["info", "."] },
+      { name: "bun info with a path", args: ["info", "./package.json"] },
+      { name: "bun info with a URL", args: ["info", "https://example.com/package.tgz"] },
+      { name: "bun info with malformed package syntax", args: ["info", "@"] },
+      { name: "bun info with only a valued registry option", args: ["info", "--registry", "$REGISTRY"] },
+      { name: "bun pm view", args: ["pm", "view"] },
+      { name: "bun pm view .", args: ["pm", "view", "."] },
+      { name: "bun pm view with a path", args: ["pm", "view", "./package.json"] },
+      { name: "bun pm view with a URL", args: ["pm", "view", "https://example.com/package.tgz"] },
+      { name: "bun pm view with malformed package syntax", args: ["pm", "view", "@"] },
+    ])("$name still requires project context", async ({ args }) => {
+      let requestCount = 0;
+      await using server = Bun.serve({
+        port: 0,
+        fetch() {
+          requestCount++;
+          return new Response(null, { status: 500 });
+        },
+      });
+      const testDir = tempDirWithFiles("bun-info-project-context", {
+        "bunfig.toml": `install.registry = "http://127.0.0.1:${server.port}/"\n`,
+      });
+      const homeDir = tempDirWithFiles("bun-info-project-context-home", {});
+      const xdgConfigDir = tempDirWithFiles("bun-info-project-context-xdg", {});
+      const filesBefore = readdirSync(testDir).sort();
+      const homeFilesBefore = readdirSync(homeDir).sort();
+      const xdgFilesBefore = readdirSync(xdgConfigDir).sort();
+      expect(homeFilesBefore).toEqual([]);
+      expect(xdgFilesBefore).toEqual([]);
+      const resolvedArgs = args.map(arg => (arg === "$REGISTRY" ? `http://127.0.0.1:${server.port}/` : arg));
+
+      const { error, code } = await runCommand(
+        [bunExe(), ...resolvedArgs],
+        testDir,
+        isolatedRegistryEnv(homeDir, xdgConfigDir),
+      );
+
+      expect(code).toBe(1);
+      expect(error).toContain("package.json");
+      expect(requestCount).toBe(0);
+      expect(readdirSync(testDir).sort()).toEqual(filesBefore);
+      expect(readdirSync(homeDir).sort()).toEqual(homeFilesBefore);
+      expect(readdirSync(xdgConfigDir).sort()).toEqual(xdgFilesBefore);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

`bun info <package>` and `bun pm view <package>` currently enter `PackageManager::init`, which returns a missing-`package.json` error before a registry lookup can start. This adds a narrow registry-view initialization mode that makes the root manifest optional only when the complete explicit spec is an npm registry selector.

Normal package-manager initialization stays strict. Empty, `.`, path, URL, workspace, alias and malformed inputs—including named forms such as `pkg@file:./local`—still require project context and make no registry request. Manifestless lookups continue to honor `bunfig.toml`, `.npmrc` and environment registry/auth configuration, without creating a root manifest, lockfile or `node_modules`.

The parsed-positionals change in `bun_info` is adapted from @robobun's #36644.

Fixes #20673.

### How did you verify your code works?

- Added hermetic loopback-registry coverage for both entry points, including `bunfig.toml`, `.npmrc`, environment configuration, option placement, post-`--` input, project-bound controls and filesystem side effects. The subprocesses use isolated `HOME`, `USERPROFILE` and `XDG_CONFIG_HOME` directories.
- On the unfixed build, both manifestless repros fail before contacting the configured registry. With this change, the focused matrix passes 43/43 with 308 expectations, including both CLI routes, unversioned and empty-selector `latest` lookups, valid semver ranges, and zero-request controls for named non-registry, incomplete, overflowing, or otherwise malformed selectors.
- Before the latest selector-boundary additions, the full `test/cli/install/bun-info.test.ts` file passed 45/45 tests, 11 snapshots and 237 expectations. The final selector matrix was rerun focused as described above.
- Ran `cargo check -p bun_install -p bun_runtime`, Rust formatting, Prettier, and `git diff --check`.
- All runtime tests ran on Linux x64; native Windows and macOS were not tested locally.
