### PR TITLE
bun test --todo: report a todo body that times out as todo instead of a failure

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -768,7 +768,14 @@ impl Execution {
         let Some((sequence_ptr, _group_ptr)) =
             self.get_current_and_valid_execution_sequence(user_data)
         else {
-            return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
+            // The entry this error belongs to already finished, typically a test body settling
+            // after it timed out. The result is final either way; for a todo body (--todo) the
+            // late failure is the failure the todo mark already accounts for.
+            return if self.is_todo_test_body(user_data) {
+                HandleUncaughtExceptionResult::HideError
+            } else {
+                HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests
+            };
         };
         // SAFETY: sequence_ptr points into self.sequences; `self` is not accessed for the
         // remainder of this function, so this is the unique live `&mut` to that element.
@@ -803,6 +810,29 @@ impl Execution {
                 HandleUncaughtExceptionResult::ShowHandledError
             }
         }
+    }
+
+    /// Whether `data` was issued for the test callback (not a hook) of a `test.todo`, regardless
+    /// of whether that sequence is still running it. Unlike
+    /// [`Self::get_current_and_valid_execution_sequence`] this also answers for entries that
+    /// already completed; the group/sequence tables never shrink, so the indices stay valid.
+    fn is_todo_test_body(&self, data: &RefDataValue) -> bool {
+        let RefDataValue::Execution { group_index, entry_data: Some(entry_data) } = data else {
+            return false;
+        };
+        let Some(group) = self.groups.get(*group_index) else {
+            return false;
+        };
+        let seq_abs = group.sequence_start + entry_data.sequence_index;
+        if seq_abs >= group.sequence_end {
+            return false;
+        }
+        let sequence = &self.sequences[seq_abs];
+        let Some(test_entry) = sequence.test_entry else {
+            return false;
+        };
+        core::ptr::eq(test_entry.as_ptr().cast_const().cast::<()>(), entry_data.entry)
+            && sequence.entry_mode() == ScopeMode::Todo
     }
 }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1299,8 +1299,9 @@ impl BunTest {
 
         let handle_status: HandleUncaughtExceptionResult = match self.phase {
             Phase::Collection => self.collection.handle_uncaught_exception(user_data),
-            Phase::Done => HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests,
-            Phase::Execution => self.execution.handle_uncaught_exception(user_data),
+            // Once done, every entry is stale; Execution still knows which test body (if any)
+            // the error came from, e.g. a todo that settles while the loop drains after the file.
+            Phase::Execution | Phase::Done => self.execution.handle_uncaught_exception(user_data),
         };
 
         bun_core::scoped_log!(bun_test_group, "onUncaughtException -> {}", <&'static str>::from(handle_status));
@@ -1959,10 +1960,14 @@ impl ExecutionEntry {
                 .test_entry
                 .is_some_and(|p| core::ptr::eq(p.as_ptr().cast_const(), self));
             sequence.result = if is_test_entry {
-                if self.has_done_parameter {
-                    Execution::Result::FailBecauseTimeoutWithDoneCallback
-                } else {
-                    Execution::Result::FailBecauseTimeout
+                match self.base.mode {
+                    // Mirrors the todo arm of Execution::handle_uncaught_exception: a todo body
+                    // (only run under --todo) that never finishes is still a failing todo; only a
+                    // passing one fails the run. `.failing` is intentionally not mapped: a timeout
+                    // still fails a failing test.
+                    ScopeMode::Todo => Execution::Result::Todo,
+                    _ if self.has_done_parameter => Execution::Result::FailBecauseTimeoutWithDoneCallback,
+                    _ => Execution::Result::FailBecauseTimeout,
                 }
             } else if self.has_done_parameter {
                 Execution::Result::FailBecauseHookTimeoutWithDoneCallback

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -223,6 +223,105 @@ describe("bun test", () => {
         `,
       });
       expect(stderr).toContain("should run");
+    });
+
+    async function runTodo(fixture: string, env: Record<string, string> = {}) {
+      using dir = tempDir("bun-test-todo", { "todo.test.ts": fixture });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--todo", "todo.test.ts"],
+        cwd: String(dir),
+        env: { ...bunEnv, ...env },
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      return { stderr: normalizeBunSnapshot(stderr, String(dir)), exitCode };
+    }
+
+    test.concurrent("a todo whose body times out is still a todo", async () => {
+      const { stderr, exitCode } = await runTodo(`
+        import { describe, test } from "bun:test";
+        const late = Promise.withResolvers<void>();
+        test.todo("never settles", () => new Promise(() => {}), 1);
+        test.todo("never calls done", done => {}, 1);
+        describe.todo("describe.todo", () => {
+          test("never settles", () => new Promise(() => {}), 1);
+        });
+        test.todo("fails after it timed out", async () => {
+          await late.promise;
+          throw new Error("still a todo");
+        }, 1);
+        test("the next test is not blamed for the late failure", async () => {
+          late.resolve();
+          await Bun.sleep(0);
+        });
+      `);
+      expect(stderr).toMatchInlineSnapshot(`
+        "todo.test.ts:
+        (todo) never settles
+        (todo) never calls done
+        (todo) describe.todo > never settles
+        (todo) fails after it timed out
+        (pass) the next test is not blamed for the late failure
+
+         1 pass
+         4 todo
+         0 fail
+        Ran 5 tests across 1 file."
+      `);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("timeouts outside a todo body still fail under --todo", async () => {
+      const { stderr, exitCode } = await runTodo(`
+        import { beforeEach, describe, test } from "bun:test";
+        const late = Promise.withResolvers<void>();
+        test("fails after it timed out", async () => {
+          await late.promise;
+          throw new Error("late failure");
+        }, 1);
+        describe("hanging beforeEach", () => {
+          beforeEach(() => new Promise(() => {}), 1);
+          test.todo("todo", () => {});
+        });
+        test("releases the late failure", async () => {
+          late.resolve();
+          await Bun.sleep(0);
+        });
+      `);
+      expect(stderr).toContain("(fail) fails after it timed out\n  ^ this test timed out after 1ms.");
+      expect(stderr).toContain(
+        "(fail) hanging beforeEach > todo\n  ^ a beforeEach/afterEach hook timed out for this test.",
+      );
+      expect(stderr).toContain("# Unhandled error between tests");
+      expect(stderr).toContain("error: late failure");
+      expect(stderr).toContain(" 2 fail\n 1 error\n");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("a timed out todo that fails after the file finished is not an unhandled error", async () => {
+      // BUN_TEST_DRAIN_EVENT_LOOP keeps the file alive after its last test, so
+      // the body settles once the runner is already done with the file.
+      const { stderr, exitCode } = await runTodo(
+        `
+          import { test } from "bun:test";
+          test.todo("fails after the file is done", async () => {
+            await Bun.sleep(50);
+            throw new Error("still a todo");
+          }, 1);
+        `,
+        { BUN_TEST_DRAIN_EVENT_LOOP: "1" },
+      );
+      expect(stderr).toMatchInlineSnapshot(`
+        "todo.test.ts:
+        (todo) fails after the file is done
+
+         0 pass
+         1 todo
+         0 fail
+        Ran 1 test across 1 file."
+      `);
+      expect(exitCode).toBe(0);
     });
   });
   describe("only", () => {


### PR DESCRIPTION
### Problem
- Under `bun test --todo`, a `test.todo()` whose body times out is printed as `(fail) <name>` / `^ this test timed out after Nms.`, counted in the fail total, and the run exits 1. A todo body that throws or fails an `expect()` is printed `(todo)` and does not fail the run, which is the documented contract of `--todo` (docs/test/writing-tests.mdx: "failing todo tests do not cause an error, but todo tests that pass are marked as failing").
- Cause: `ExecutionEntry::evaluate_timeout` (src/runtime/test_runner/bun_test.rs:1962) stores `FailBecauseTimeout` / `FailBecauseTimeoutWithDoneCallback` for every test entry without looking at its mode. The exception path, `Execution::handle_uncaught_exception` (src/runtime/test_runner/Execution.rs:800), maps `ScopeMode::Todo` to `Result::Todo`.
- Second half of the same bug: a timed out body usually settles later (the runner kills the processes it was waiting on, the awaited promise resolves, the next `expect()` throws). That rejection reaches `handle_uncaught_exception` carrying data for an entry that already finished and is printed as `# Unhandled error between tests`, which also exits 1. `test/js/bun/terminal/terminal-platform-gaps.test.ts` has Windows todos of exactly this shape, so `bun test --todo` cannot be used on it to find todos that started passing.

### Fix
- `evaluate_timeout`: a test entry in `ScopeMode::Todo` gets `Result::Todo` instead of a timeout failure. The reporter then prints `(todo) <name> [Nms]`, counts it under todo, writes `<skipped message="TODO"/>` to junit and emits no GitHub annotation, the same as a todo that threw.
- `handle_uncaught_exception`: when the data is stale (the entry it names is no longer running) and it names the test callback of a todo sequence, return `HideError`; every other stale error is still reported between tests. The lookup is the new `Execution::is_todo_test_body`: the group and sequence tables are fixed for the life of the file and entries live as long as the `BunTest`, so stale indices and the pointer comparison are safe without dereferencing the stale entry pointer.
- `BunTest::on_uncaught_exception` routes `Phase::Done` through the same classification instead of a hard-coded between-tests result, so a body that settles after the file's last test (reachable with `BUN_TEST_DRAIN_EVENT_LOOP=1`) is treated the same. In `Done` every lookup is stale, so nothing else changes.
- Why this is the right result: `--todo` exists to find todos that pass; a body that never finishes, or fails after its deadline, is a todo that still fails, and the throw path already reports that as todo. node:test registers its todo tests through `test.todo`, and Node also reports a todo test that times out as todo rather than failing the run.
- Deliberately unchanged: a beforeEach/afterEach timing out for a todo test is still `FailBecauseHookTimeout` (the exception path also fails hooks regardless of the test's mode), and a `.failing` test that times out still fails (pinned by `test/js/bun/test/test-failing.test.ts`, "timeouts still count as failures"). The late error of a todo is hidden rather than printed because its test line was already printed, and `ShowHandledError` would record it into the junit failure buffer that the next reported test consumes.
- Verified with three tests added to the `--todo` block of `test/cli/test/bun-test.test.ts`: the timeout variants (`test.todo`, done callback, test inside `describe.todo`, body failing late while the next test runs) exit 0 and snapshot as `(todo)`; the drain-mode variant covers the `Phase::Done` path; a contrast test pins that a plain test's timeout plus late failure is still `(fail)` plus an unhandled error and that a hook timeout for a todo test still fails. Without the fix the two todo tests fail (`3 fail`, `1 error`, exit 1); with it all pass, stable over 8 reruns.
- Also green with the fix: `test/js/bun/test/{test-failing,bun_test,test-test}.test.ts`, `test/regression/issue/{08768,23865}.test.ts`, `test/cli/test/test-timeout-behavior.test.ts`, `test/js/node/test_runner/node-test.test.ts`, `test/js/junit-reporter/junit.test.js`.

### Background
- `ScopeMode` is the marker a test or describe was declared with (`Normal`, `Skip`, `Todo`, `Failing`, `FilteredOut`), inherited from the enclosing describe. A `Todo` entry only gets a callback under `--todo`; otherwise it has none and is reported as todo without running, so the timeout path can only see a `Todo` entry under `--todo`.
- Each test runs as an `ExecutionSequence` (beforeEach hooks, the test, afterEach hooks) with a single `Execution::Result`. The detailed variants such as `FailBecauseTimeout` exist so the reporter can print the matching note and junit element; `basic_result()` collapses them to pass/fail/skip/todo for counting.
- `RefDataValue` is the token attached to a test callback's returned promise and `done` callback. It records group index, sequence index, the entry pointer and the repeat count; `get_current_and_valid_execution_sequence` accepts it only while that entry is still the sequence's active one. After a timeout the runner advances, so a later settlement arrives with a stale token, which is how late results are told apart from in-time ones.
- `HandleUncaughtExceptionResult`: `HideError` consumes the error silently, `ShowHandledError` prints it as part of the running test, `ShowUnhandledErrorBetweenTests` prints it under the `# Unhandled error between tests` banner and bumps the counter that makes the run exit 1.
