### PR TITLE
node:http2: destroy the accepted socket when an injected connection's TLS proxy is destroyed

### DIFF
--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -101,13 +101,22 @@ function tlsSocketWrite(this: TLSProxySocket, chunk: Buffer, encoding: string, c
 }
 
 // _destroy: called when the stream is destroyed (e.g. tlsSocket.destroy(err)).
-// Cleans up the native TLS handle.
+// Cleans up the native TLS handle and takes the raw socket down with it.
 // Mirrors net.ts Socket.prototype._destroy.
 function tlsSocketDestroy(this: TLSProxySocket, err: Error | null, callback: (err?: Error | null) => void) {
-  const h = this._ctx.nativeHandle;
+  const ctx = this._ctx;
+  const h = ctx.nativeHandle;
   if (h) {
     h.close();
-    this._ctx.nativeHandle = null;
+    ctx.nativeHandle = null;
+  }
+  // Closing the native handle only end()s the raw socket (close_notify + FIN), which keeps it
+  // open, and counted by the net.Server that accepted it, until the peer closes as well. Node's
+  // TLSWrap destroys the wrapped socket whenever the TLS socket goes down, so a failed handshake
+  // or a torn-down session releases the connection even if the peer never closes its side.
+  const rawSocket = ctx.rawSocket;
+  if (!rawSocket.destroyed) {
+    rawSocket.destroy();
   }
   // Must invoke pending write callback with error per Writable stream contract
   const writeCb = this._writeCallback;

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -16,6 +16,7 @@ import fs from "node:fs";
 import http2 from "node:http2";
 import net from "node:net";
 import path from "node:path";
+import { Duplex } from "node:stream";
 import { afterEach, describe, test } from "node:test";
 import tls from "node:tls";
 import { fileURLToPath } from "node:url";
@@ -457,6 +458,180 @@ describe("HTTP/2 upgrade — server TLS options", () => {
       assert.deepStrictEqual(outcome, { secureConnect: false, protocol: null });
     } finally {
       netServer.close();
+    }
+  });
+});
+
+// The net.Server keeps counting a connection it accepted until the socket it handed to
+// h2Server.emit("connection") is destroyed, and netServer.close(cb) only calls back once that count
+// is zero. Node destroys that socket together with the TLSSocket it wrapped it in, so the connection
+// is released no matter how the server side went down. Every case below tears the connection down
+// from the server side while the peer deliberately keeps its end of the TCP connection open, so the
+// accepted socket only gets released if the upgrade path releases it.
+describe("HTTP/2 upgrade — the accepted socket is released when the server side goes down", () => {
+  type Accepted = { raw: net.Socket; closed: Promise<boolean> };
+
+  async function acceptInto(h2Server: http2.Http2SecureServer) {
+    const accepted = Promise.withResolvers<Accepted>();
+    const netServer = net.createServer(raw => {
+      const closed = new Promise<boolean>(resolve => raw.once("close", hadError => resolve(hadError)));
+      accepted.resolve({ raw, closed });
+      h2Server.emit("connection", raw);
+    });
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+    return { netServer, port, accepted: accepted.promise };
+  }
+
+  // A TCP connection the peer never ends or destroys itself: the server's FIN only produces 'end'
+  // here (allowHalfOpen), so the server's accepted socket stays open until the server destroys it.
+  function connectHeldOpen(port: number) {
+    const tcp = net.connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+    // Writes into a connection the server has already closed are expected to fail.
+    tcp.on("error", () => {});
+    return tcp;
+  }
+
+  // A TLS client riding on a held-open TCP connection through an in-memory carrier: whatever the
+  // client's TLS layer does when the server closes the TLS session (end, destroy) stays on the
+  // carrier and never closes the TCP connection underneath.
+  function connectTlsHeldOpen(port: number, options: tls.ConnectionOptions) {
+    const tcp = connectHeldOpen(port);
+    const carrier = new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        // The client's reply to the server's close_notify may be written after the server (or the
+        // test's cleanup) has closed the connection; there is nobody left to deliver it to.
+        if (tcp.destroyed) return callback();
+        tcp.write(chunk, () => callback());
+      },
+      final(callback) {
+        callback();
+      },
+    });
+    tcp.on("data", chunk => carrier.push(chunk));
+    tcp.on("end", () => carrier.push(null));
+    const client = tls.connect({ socket: carrier, rejectUnauthorized: false, ...options });
+    client.on("error", () => {});
+    client.resume();
+    return { tcp, client };
+  }
+
+  // With the peer holding its side open, the accepted socket's 'close' can only come from the
+  // server destroying it; a server that merely end()s it leaves this waiting until the test times out.
+  async function assertReleased(netServer: net.Server, accepted: Promise<Accepted>) {
+    const { raw, closed } = await accepted;
+    // Torn down without an error, like the socket underneath a node TLSSocket.
+    assert.strictEqual(await closed, false);
+    assert.strictEqual(raw.destroyed, true);
+    const connections = await new Promise<number>((resolve, reject) => {
+      netServer.getConnections((err, count) => (err ? reject(err) : resolve(count)));
+    });
+    assert.strictEqual(connections, 0);
+    await new Promise<void>(resolve => netServer.close(() => resolve()));
+  }
+
+  function cleanup(netServer: net.Server, tcp: net.Socket) {
+    tcp.destroy();
+    if (netServer.listening) netServer.close();
+  }
+
+  for (const handleClientError of [false, true]) {
+    const variant = handleClientError ? "with a clientError listener" : "without a clientError listener";
+    test(`after a failed handshake (${variant})`, async () => {
+      const h2Server = http2.createSecureServer(TLS);
+      const reported: string[] = [];
+      if (handleClientError) h2Server.on("clientError", () => reported.push("clientError"));
+      const tlsClientError = once(h2Server, "tlsClientError").then(() => reported.push("tlsClientError"));
+      const { netServer, port, accepted } = await acceptInto(h2Server);
+
+      const tcp = connectHeldOpen(port);
+      tcp.on("connect", () => tcp.write("GET / HTTP/1.1\r\nHost: example\r\n\r\n"));
+      tcp.resume();
+      try {
+        await tlsClientError;
+        assert.deepStrictEqual(reported, handleClientError ? ["clientError", "tlsClientError"] : ["tlsClientError"]);
+        await assertReleased(netServer, accepted);
+      } finally {
+        cleanup(netServer, tcp);
+      }
+    });
+  }
+
+  for (const withError of [true, false]) {
+    test(`after the session is destroyed ${withError ? "with" : "without"} an error`, async () => {
+      const h2Server = http2.createSecureServer(TLS);
+      const sessionClosed = new Promise<void>(resolve => {
+        h2Server.once("session", (session: http2.ServerHttp2Session) => {
+          session.on("error", () => {});
+          session.once("close", resolve);
+          if (withError) session.destroy(new Error("torn down by the test"));
+          else session.destroy();
+        });
+      });
+      const { netServer, port, accepted } = await acceptInto(h2Server);
+
+      const { tcp } = connectTlsHeldOpen(port, { ALPNProtocols: ["h2"] });
+      try {
+        await sessionClosed;
+        await assertReleased(netServer, accepted);
+      } finally {
+        cleanup(netServer, tcp);
+      }
+    });
+  }
+
+  test("after the client certificate is rejected", async () => {
+    const h2Server = http2.createSecureServer({ ...TLS, requestCert: true, rejectUnauthorized: true });
+    h2Server.on("session", () => assert.fail("a rejected client must not get a session"));
+    const tlsClientError = once(h2Server, "tlsClientError");
+    const { netServer, port, accepted } = await acceptInto(h2Server);
+
+    // The client presents a certificate the server has no CA for.
+    const { tcp } = connectTlsHeldOpen(port, { ALPNProtocols: ["h2"], key: TLS.key, cert: TLS.cert });
+    try {
+      const [err] = await tlsClientError;
+      assert.ok(err instanceof Error);
+      await assertReleased(netServer, accepted);
+    } finally {
+      cleanup(netServer, tcp);
+    }
+  });
+
+  test("after a client that negotiated no protocol is turned away", async () => {
+    // Nothing handles 'unknownProtocol', so the server answers with a 403 and destroys the
+    // connection once unknownProtocolTimeout has passed.
+    const h2Server = http2.createSecureServer({ ...TLS, unknownProtocolTimeout: 0 });
+    h2Server.on("session", () => assert.fail("a client without ALPN must not get a session"));
+    const { netServer, port, accepted } = await acceptInto(h2Server);
+
+    const { tcp } = connectTlsHeldOpen(port, {});
+    try {
+      await assertReleased(netServer, accepted);
+    } finally {
+      cleanup(netServer, tcp);
+    }
+  });
+
+  test("but not while the session is alive", async () => {
+    const h2Server = http2.createSecureServer(TLS);
+    let session: http2.ServerHttp2Session | undefined;
+    const sessionStarted = once(h2Server, "session").then(([s]) => {
+      session = s;
+    });
+    const { netServer, port, accepted } = await acceptInto(h2Server);
+
+    const { tcp, client } = connectTlsHeldOpen(port, { ALPNProtocols: ["h2"] });
+    try {
+      await Promise.all([sessionStarted, once(client, "secureConnect")]);
+      const { raw } = await accepted;
+      assert.strictEqual(raw.destroyed, false);
+      const connections = await new Promise<number>(resolve => netServer.getConnections((_, count) => resolve(count)));
+      assert.strictEqual(connections, 1);
+    } finally {
+      session?.destroy();
+      cleanup(netServer, tcp);
     }
   });
 });


### PR DESCRIPTION
### Problem
- A connection handed to an `http2.createSecureServer()` instance with `h2Server.emit("connection", rawSocket)` (the pattern used by grpc-js's connection injector, http2-wrapper and similar) is never released once the server side gives up on it: after a failed TLS handshake `'tlsClientError'`/`'clientError'` fire and the peer gets a FIN, but `rawSocket.destroyed` stays `false`, `rawSocket` never emits `'close'`, the `net.Server` that accepted it keeps reporting it in `getConnections()` and `netServer.close(cb)` never calls back. Node v26.3.0 destroys the accepted socket right away (probe below).
- Same leak after a successful handshake whenever the server side tears the connection down: `session.destroy()`, a rejected client certificate (`requestCert` + `rejectUnauthorized`), or an `'unknownProtocol'` client being destroyed after `unknownProtocolTimeout`. A peer that keeps its side of the TCP connection open keeps the accepted socket (and the connection count) alive indefinitely.
- Cause: `upgradeRawSocketToH2` (`src/js/node/_http2_upgrade.ts`) runs the TLS engine over a proxy `Duplex`. When the proxy is destroyed, `tlsSocketDestroy` (`_http2_upgrade.ts:106`) only closed the native TLS handle, and the native side of a duplex upgrade only `end()`s the underlying stream (`UpgradedDuplex::on_close` in `src/runtime/socket/UpgradedDuplex.rs`, `call_write_or_end(None)`), so the raw socket was half-closed and left waiting for a FIN the peer never has to send. Nothing ever called `rawSocket.destroy()`.

### Fix
- `tlsSocketDestroy` destroys `ctx.rawSocket` (if not already destroyed) after closing the native handle. Every teardown of the injected connection ends in the proxy's `_destroy`: the handshake-failure and certificate-rejection branches of `socketHandshake`, `socketError`, `Http2SecureServer`'s own `'tlsClientError'` handler, the session's socket teardown, the `unknownProtocol` timer, and the native `close` callback (`socketClose`) that runs when the peer's close_notify or EOF arrives. So the raw socket is released in all of them from one place.
- This is node's behavior: `TLSWrap.prototype.close` destroys `_parentWrap` (the socket the `TLSSocket` was built on) whenever the `TLSSocket`'s handle closes, however it went down. The raw socket is destroyed without an error, so its `'close'` reports `hadError === false`, as node's `_parentWrap.destroy()` does.
- Timing is unchanged, only the final step differs: the proxy is destroyed at the same points as before (and the engine's writes to `rawSocket.write()` are plain TCP sends that complete before it), and on the graceful paths (`session.close()`, HTTP/1 fallback `res.end()`, `proxy.end()`) the engine only reports close once the peer's close_notify or EOF has arrived, which is also when node destroys its `TLSSocket` and the socket under it. Checked that the HTTP/1 fallback (`allowHTTP1: true`) over an injected connection still delivers its response with the change.
- `'tlsClientError'`/`'clientError'` are still emitted before the proxy is destroyed, so their listeners see the connection intact, as before.
- Companion to #38028, which fixes the same leak for the wraps `node:net`/`node:tls` create (`new TLSSocket(raw)`, `tls.connect({ socket })`, `tls.Server#emit('connection')`); those go through a different mechanism and that change does not reach this path.
- Tests: `test/js/node/http2/node-http2-upgrade.test.mts`, new block "the accepted socket is released when the server side goes down": failed handshake with and without a `'clientError'` listener (the two destroy sites on that path), `session.destroy(err)` and `session.destroy()`, rejected client certificate, `unknownProtocol` teardown, plus a control that a live session does not release the connection. In each case the peer holds its TCP side open (for the TLS cases the client runs over an in-memory carrier on top of a held-open `net.Socket`), and the test waits for the accepted socket's `'close'`, checks `getConnections() === 0` and that `netServer.close(cb)` calls back. The file also re-runs itself under node (existing "tests should run on node.js" case); all new cases pass on node v26.3.0.
- Without the `src/` change (main debug build and released bun 1.4.0) the six teardown cases time out waiting for the accepted socket's `'close'`; with it the whole file passes. Also run with the change: the vendored `test-http2-socket-close`, `-client-connection-tunnelling`, `-autoselect-protocol`, `-client-proxy-over-http2`, `-backpressure`, `-generic-streams(-sendfile)`, `-sensitive-headers`, `-session-unref`, `-write-finishes-after-stream-destroy` (all exit 0) and grpc-js's (currently `describe.todo`) connection-injector test, which passes when enabled.

### Background
- Injected connections: `Http2SecureServer` extends `tls.Server`, and node lets you feed it already-accepted plain sockets via `server.emit("connection", socket)`; the server then performs the TLS handshake itself. In bun, `Http2SecureServer#emit` routes a non-TLS socket to `upgradeRawSocketToH2`, which creates a proxy `Duplex` that the HTTP/2 session (or the HTTP/1 fallback) treats as its TLS socket, and starts the native TLS engine over the raw socket with `upgradeDuplexToTLS`. Ciphertext flows raw socket -> engine -> proxy `push()`, and proxy `_write()` -> engine -> `rawSocket.write()`. The proxy's `_destroy` (`tlsSocketDestroy`) is the one place every teardown of such a connection passes through.
- `net.Server` connection accounting: an accepted socket is counted in `server._connections` until its `_destroy` runs, and `server.close(cb)` emits `'close'` (calling `cb`) only when that count reaches zero. A socket that is only `end()`ed stays counted.
- `end()` vs `destroy()` on a socket: `end()` sends a FIN and leaves the socket open to keep reading until the peer also closes; `destroy()` closes the descriptor and emits `'close'` regardless of the peer. Node's `TLSWrap.close` uses the latter on the wrapped socket.

<details>
<summary>Probe from the report (peer keeps its side open after the server's FIN; state sampled after 'tlsClientError')</summary>

```
node v26.3.0: ["clientError","tlsClientError","raw-close","client-got-fin","connections=0","raw.destroyed=true","server-close-cb"]
bun 1.4.0:    ["clientError","tlsClientError","client-got-fin","connections=1","raw.destroyed=false","TIMEOUT"]
bun + fix:    ["clientError","tlsClientError","raw-close","client-got-fin","connections=0","raw.destroyed=true","server-close-cb"]
```

The same probe with a TLS peer that completes the handshake (carrier over a held-open TCP socket) and the server calling `session.destroy(err)` / `session.destroy()`, rejecting the client certificate, or turning away a client without ALPN: node and bun + fix release the connection; bun 1.4.0 and main time out in every case. (The error code bun reports for the non-TLS peer, `UNABLE_TO_GET_ISSUER_CERT` where node reports `ERR_SSL_HTTP_REQUEST`, is unchanged here and tracked separately.)
</details>
