### PR TITLE
test: move the recursive cp error race test to the shell cp builtin

### DIFF
--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, DirectoryTree, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +173,67 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+// The builtin's `cp -R` copies the files of a directory as concurrent work-pool
+// tasks sharing one parent task. A file copy that fails records its error on
+// the parent, which has to stay alive until the sibling copies still running
+// have let go of it (before oven-sh/bun#30162 it was freed as soon as the error
+// was recorded, a heap-use-after-free that ASAN builds abort on). fs.cp walks
+// directories in JS on Linux and Windows, so this builtin is what reaches that
+// code. The builtin is the default only on Windows; on POSIX it is enabled by
+// an env var, so the copies run in a child bun.
+test("cp -R survives a file copy failing while its siblings are still being copied", async () => {
+  const files: DirectoryTree = {
+    "src/000-bad.txt": "x",
+    // dst exists, so `cp -R src dst` copies into dst/src. A directory already
+    // sitting where 000-bad.txt goes makes that one file's copy fail.
+    "dst/src/000-bad.txt": {},
+  };
+  // Enough siblings that some are still in flight when 000-bad.txt fails.
+  for (let i = 0; i < 32; i++) files[`src/f${i}.txt`] = "x";
+  using dir = tempDir("shell-cp-failed-sibling", files);
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const outcomes = new Set();
+      for (let i = 0; i < 20; i++) {
+        const { exitCode, stderr } = await Bun.$\`cp -R src dst\`.nothrow().quiet();
+        outcomes.add(JSON.stringify({ exitCode, stderr: stderr.toString() }));
+      }
+      console.log(JSON.stringify([...outcomes].map(outcome => JSON.parse(outcome))));
+      `,
+    ],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1",
+      // An ASAN abort (the pre-fix behaviour) spends several seconds in
+      // llvm-symbolizer, which would turn the failure into a timeout; the
+      // report header in stderr is what identifies it.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // Every run failed on that one file. The message is the builtin's; the
+  // system cp, which the shell falls back to without the env var, words it
+  // differently.
+  expect(JSON.parse(stdout)).toEqual([
+    {
+      exitCode: 1,
+      stderr: `cp: ${isWindows ? "Operation not permitted" : "Is a directory"}: ${join(String(dir), "dst", "src", "000-bad.txt")}\n`,
+    },
+  ]);
+  expect(exitCode).toBe(0);
+  // The failure does not stop the siblings from being copied, which is what
+  // leaves them touching the parent after the error.
+  expect(readdirSync(join(String(dir), "dst", "src"))).toHaveLength(33);
 });
 
 function expectSortedOutput(expected: string) {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { mkfifo } from "mkfifo";
 import { isAbsolute, join } from "path";
 
@@ -144,6 +144,20 @@ for (const [name, copy] of impls) {
       expect(e.path).toBe(basename + "/result/a.txt");
 
       assertContent(basename + "/result/a.txt", "win");
+    });
+
+    test("recursive directory structure - a file whose destination is a directory throws", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+        "from/b.txt": "b",
+        "result/b.txt": {},
+      });
+
+      const e = await copyShouldThrow(basename + "/from", basename + "/result", { recursive: true });
+      expect(e.code).toBe("ERR_FS_CP_NON_DIR_TO_DIR");
+      // Entries are reported with the path cp built for them, not a caller string.
+      expect(e.path).toBe(join(String(basename), "result", "b.txt"));
+      expect(fs.statSync(basename + "/result/b.txt").isDirectory()).toBe(true);
     });
 
     test("symlinks - single file", async () => {
@@ -590,68 +604,6 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
       expect(stdout.trim()).toBe("ENAMETOOLONG");
       expect(exitCode).toBe(0);
     });
-  },
-);
-
-// fs.promises.cp recursive: when one SingleTask copy fails while siblings are
-// still in flight on the thread pool, the parent AsyncCpTask must not be
-// destroyed until every subtask has dropped its reference. Before the fix,
-// the failing subtask enqueued runFromJSThread immediately and the JS thread
-// freed the parent while other subtasks were still dereferencing it
-// (heap-use-after-free under ASAN).
-//
-// POSIX-only: uses a pre-existing directory at the destination path of one
-// file so that its SingleTask fails with EISDIR. This works even when running
-// as root. On macOS the pre-existing dst/ makes clonefile() fail with EEXIST
-// and fall through to the per-file SingleTask path being tested.
-test.skipIf(!isPosix)(
-  "fs.promises.cp recursive does not free parent task while subtasks are in flight after an error",
-  async () => {
-    const files: Record<string, string | object> = {};
-    // Enough siblings so several SingleTasks are running on the thread pool
-    // when the failing one errors.
-    for (let i = 0; i < 32; i++) files[`src/f${i}.txt`] = "x";
-    files["src/000-bad.txt"] = "x";
-    // The destination for 000-bad.txt is a directory → copying into it fails.
-    files["dst/000-bad.txt"] = { ".keep": "" };
-    using dir = tempDir("cp-uaf", files);
-    const base = String(dir);
-
-    // Run the copy in a subprocess: before the fix this is a
-    // heap-use-after-free that ASAN aborts on. The subprocess loops to make
-    // the race reliable. It must reject with EISDIR each iteration and exit 0.
-    const script = `
-      const fs = require("fs");
-      const path = require("path");
-      const base = ${JSON.stringify(base)};
-      const src = path.join(base, "src");
-      const dst = path.join(base, "dst");
-      (async () => {
-        for (let i = 0; i < 20; i++) {
-          try {
-            await fs.promises.cp(src, dst, { recursive: true });
-            console.log("UNEXPECTED-SUCCESS");
-            process.exit(1);
-          } catch (e) {
-            if (e?.code !== "ERR_FS_CP_NON_DIR_TO_DIR") {
-              console.log("UNEXPECTED-ERROR:" + (e?.code ?? e?.message));
-              process.exit(1);
-            }
-          }
-        }
-        console.log("ok");
-      })();
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("ok");
-    expect(exitCode).toBe(0);
   },
 );
 


### PR DESCRIPTION
### Problem
- `test/js/node/fs/cp.test.ts` > "fs.promises.cp recursive does not free parent task while subtasks are in flight after an error" fails on every debug/ASAN run, alone or with the file: `^ this test timed out after 5000ms.` (#37954 ran into the same timeout.)
- The child it spawns needs about 5s on a debug build: ~1.3s of startup plus 20 iterations of a recursive `fs.promises.cp` of 33 files at ~180ms each. On a release build the same child takes well under a second.
- The 20 iterations no longer buy anything. The test was written for #30162, a use-after-free between the native per-file copy tasks of a recursive copy. Since #31830, `fs.promises.cp` of a directory whose destination already exists goes through the JS walker on every platform (`src/js/node/fs.promises.ts:187-192` -> `tryNativeFastPath` in `src/js/internal/fs/cp.ts`, which only takes the native path for a directory on macOS when the destination is missing). The walker's `copyDir` (`src/js/internal/fs/cp.ts:337`) awaits one entry at a time, so there are no concurrent tasks for the loop to race, and every iteration just re-observes the same `ERR_FS_CP_NON_DIR_TO_DIR` rejection.
- The native fan-out is still live code: the shell's `cp -R` builtin drives the same `NewAsyncCpTask` / `CpSingleTask` (`src/runtime/node/node_fs.rs:1359-1502`) on every platform, and nothing exercised its "one file fails while its siblings are still copying" path.

### Fix
- Test-only change; the defect is the test's time budget, so there is no `src/` diff and no fail-before against `src/`.
- `test/js/node/fs/cp.test.ts`: the subprocess test is replaced by a case in the existing per-implementation loop (so it covers `cpSync` and `promises.cp`, on all platforms): a recursive copy where one entry's destination is a directory throws `ERR_FS_CP_NON_DIR_TO_DIR` with the entry's path and leaves the directory in place. This is what the removed test was actually checking; it now takes ~30ms on a debug build and runs in-process.
- `test/js/bun/shell/commands/cp.test.ts`: new test that runs `cp -R src dst` 20 times in a child bun with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`, against 32 regular files plus one whose destination is a directory. Every run has to exit 1 with the builtin's own message (the system `cp`, which the shell falls back to without the env var, words it differently), the child has to exit 0 with an empty stderr, and all 32 siblings have to be in `dst/src` afterwards, which is what leaves them touching the shared parent task after the error was recorded. The child gets `ASAN_OPTIONS=symbolize=0`, as the other tests of this kind in the repo do, so an ASAN abort fails the assertion instead of timing the test out while llvm-symbolizer runs.
- Why this is the right place: the shell builtin is the one caller of the native recursive copy that runs on Linux, so it is the only way the ASAN lane can see this race. The test lives outside the file's `describe.if(!builtinDisabled("cp"))` block because that block is skipped on POSIX (CI does not set the env var), matching how the other recent shell `cp` tests are written.
- Verified:
  - `bun bd test test/js/node/fs/cp.test.ts`: 48 pass, 5 skip (before: 1 fail by timeout, every run).
  - `bun bd test test/js/bun/shell/commands/cp.test.ts --rerun-each=10`: 10/10 pass, 0.5s to 0.9s each on the debug/ASAN build.
  - To check that the moved test still guards what the old one was written for, I temporarily put the #30162 bug back in `node_fs.rs` (`finish_concurrently` posting the completion as soon as a result is recorded, and the failing `CpSingleTask` keeping its reference). The new shell test then fails in under a second with `ERROR: AddressSanitizer: heap-use-after-free` in 10 out of 10 runs, after 1 to 9 of the 20 iterations (report below). The removed `fs.promises.cp` test passes on that same broken build, since it never reaches this code.
  - Windows (the canary at the same commit, `USE_SYSTEM_BUN=1`): `shell/commands/cp.test.ts` 31 pass, `fs/cp.test.ts` 46 pass, 7 skip. The builtin is always on there and reports the failed file as `Operation not permitted`, which the test expects on that platform.

### Background
- `fs.cp` / `fs.promises.cp` (`src/js/node/fs.promises.ts`) validate in JS and then either hand the copy to the native `fs.cp` binding or walk the tree with the node-ported walker in `src/js/internal/fs/cp.ts`. After #31830 the native path is taken for single regular files and, on macOS only, for a directory tree with no existing destination (a single `clonefile()`); everything else, including any copy into an existing directory, is the JS walker.
- `NewAsyncCpTask` (`src/runtime/node/node_fs.rs`) is the native recursive copy: a work-pool task scans the directory and spawns one `CpSingleTask` per file, all holding a pointer to the parent. `subtask_count` is a refcount; the parent is destroyed on the JS thread once it reaches zero. #30162 fixed the version of this where a failing file copy destroyed the parent immediately, while sibling copies were still using it.
- The shell `cp` builtin (`src/runtime/shell/builtin/cp.rs`) resolves its operands and then starts the same `NewAsyncCpTask` (as `ShellAsyncCpTask`). On Linux and macOS the builtin is off by default and the shell runs the system `cp` instead; `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` turns it on, and it is read once at startup, which is why the copies run in a child process. On Windows it is always on.
- `ASAN_OPTIONS=symbolize=0`: when ASAN aborts a debug `bun` it symbolizes the report first, which takes several seconds on this binary; with symbolization off the report header still lands in stderr and the abort is immediate.

<details>
<summary>What the new shell test reports with the #30162 bug put back (debug/ASAN build, symbolized run)</summary>

```
==32674==ERROR: AddressSanitizer: heap-use-after-free on address 0x7b97798e01ed at pc 0x00000e4b54aa bp 0x7a57247e8520 sp 0x7a57247e8518
READ of size 1 at 0x7b97798e01ed thread T10 (Bun Pool 7)
    #0 <bun_runtime::shell::builtins::cp::ShellCpTask>::cp_on_copy src/runtime/shell/builtin/cp.rs:459:13
    #1 <bun_runtime::node::fs::_async_tasks::NewAsyncCpTask<true>>::on_copy src/runtime/node/node_fs.rs:1534:18
    #2 <bun_runtime::node::fs::_async_tasks::CpSingleTask<true>>::run_owned src/runtime/node/node_fs.rs:1493:32
    #3 <bun_runtime::node::fs::_async_tasks::CpSingleTask<true> as bun_threading::work_pool::OwnedTask>::run src/threading/work_pool.rs:118:53
    ...
freed by thread T0 here:
    ...
    #9  <alloc::boxed::Box<bun_runtime::shell::builtins::cp::ShellCpTask> as core::ops::drop::Drop>::drop
    #11 <bun_runtime::shell::builtins::cp::Cp>::print_shell_cp_task src/runtime/shell/builtin/cp.rs:326:5
    #12 <bun_runtime::shell::builtins::cp::Cp>::on_shell_cp_task_done src/runtime/shell/builtin/cp.rs:304:9
    #16 <bun_runtime::shell::builtins::cp::ShellCpTask>::cp_on_finish src/runtime/shell/builtin/cp.rs:494:13
    #17 <bun_runtime::node::fs::_async_tasks::NewAsyncCpTask<true>>::run_from_js_thread src/runtime/node/node_fs.rs:1713:26
```

10 runs of the child loop on that build: ASAN fired in all 10, after 1, 3, 1, 2, 2, 1, 3, 9, 6 and 5 completed iterations.
</details>

<details>
<summary>Timing of the removed test's child on this machine</summary>

```
debug build:   files=32 iters=20 total=3572ms per-iter=178.6ms startup-to-main=1249ms
release build: files=32 iters=20 total=680ms  per-iter=34.0ms  startup-to-main=42ms
```
</details>
