### PR TITLE
build: declare the eval bundles bundle-modules writes and feed them to the cargo edge

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -25,10 +25,16 @@
  * of the step one build late. That is why emitBindgen/emitBindgenV2 declare
  * the per-file Generated*.h headers and not just the .cpp that gets compiled.
  *
- * Files nothing compiles may stay undeclared (.d.ts twins, bundle-modules'
- * eval/ dir, JSSink.lut.txt consumed within its own step). The remaining
- * #included exception is BunBuiltinNames+extras.h from bundle-functions.ts,
- * reached through the PCH.
+ * The same goes for generated files the Rust side include!s or embeds
+ * (include_str! under bun_codegen_embed, i.e. non-debug profiles): declared,
+ * and in `rustInputs` for the profiles that embed them, which is what
+ * re-invokes cargo in the run that changed them (emitBakeCodegen, and the
+ * eval/ bundles in emitJsModules).
+ *
+ * Files nothing compiles or embeds may stay undeclared (.d.ts twins,
+ * JSSink.lut.txt consumed within its own step). The remaining #included
+ * exception is BunBuiltinNames+extras.h from bundle-functions.ts, reached
+ * through the PCH.
  */
 
 import { spawnSync } from "node:child_process";
@@ -193,10 +199,10 @@ export interface CodegenOutputs {
   /** All codegen outputs — use for phony target `codegen`. */
   all: string[];
 
-  /** Outputs the cargo step depends on (generated .rs that gets `include!`d). */
+  /** Outputs the cargo step depends on: generated .rs that gets `include!`d, files release builds embed. */
   rustInputs: string[];
 
-  /** Outputs the cargo step needs to exist but doesn't embed (debug bake runtime). */
+  /** Outputs the cargo step needs to exist but doesn't embed (files debug builds load at runtime). */
   rustOrderOnly: string[];
 
   /** Generated .cpp files. Compiled alongside handwritten C++ in bun.ts. */
@@ -700,7 +706,7 @@ function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.rustInputs.push(outputRs);
 }
 
-function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bundle-modules.ts");
 
   // InternalModuleRegistry.cpp is read by the script (for a sanity check).
@@ -732,8 +738,16 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
     o.internalModulesBin,
   ];
 
+  // The script also bundles each src/js/eval/*.ts to eval/<name>. Like the
+  // bake bundles these are embedded by release builds (run_command.rs) and
+  // read at runtime by debug builds, so they are routed the way
+  // emitBakeCodegen routes its outputs.
+  const evalOutputs = sources.js
+    .filter(src => src.endsWith(".ts") && dirname(src).replace(/\\/g, "/").endsWith("/src/js/eval"))
+    .map(src => resolve(cfg.codegenDir, "eval", basename(src)));
+
   n.build({
-    outputs,
+    outputs: [...outputs, ...evalOutputs],
     rule: "codegen",
     inputs: [script, ...sources.js, ...sources.jsCodegen, extraInput, errorCodeInput],
     orderOnlyInputs: [dirStamp],
@@ -746,10 +760,15 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
     },
   });
 
-  o.all.push(...outputs);
+  o.all.push(...outputs, ...evalOutputs);
   o.rustInputs.push(...outputs);
   o.cppSources.push(outputs[0]!); // WebCoreJSBuiltins.cpp
   o.cppHeaders.push(...outputs.filter(p => p.endsWith(".h")));
+  if (cfg.debug) {
+    o.rustOrderOnly.push(...evalOutputs);
+  } else {
+    o.rustInputs.push(...evalOutputs);
+  }
 }
 
 function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
@@ -793,7 +812,7 @@ function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   }
 }
 
-/** Exported (with emitBindgen) for test/internal/build-codegen-declared-outputs.test.ts. */
+/** Exported (with emitBindgen and emitJsModules) for test/internal/build-codegen-declared-outputs.test.ts. */
 export function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bindgenv2", "script.ts");
 

--- a/test/internal/build-codegen-declared-outputs.test.ts
+++ b/test/internal/build-codegen-declared-outputs.test.ts
@@ -1,7 +1,7 @@
 /**
- * The two bindgen steps in scripts/build/codegen.ts have to declare every file
- * their script writes, the Generated*.h headers included, not only the .cpp
- * that gets compiled.
+ * Codegen steps in scripts/build/codegen.ts have to declare every file their
+ * script writes that something downstream consumes, not only the file the step
+ * is named after.
  *
  * Compiles only order-depend on codegen; the compiler's depfile is what rebuilds
  * a TU when a generated header changes, and within one build ninja re-checks a
@@ -10,24 +10,56 @@
  * a TU including one (BunObject.cpp includes GeneratedBunObject.h; the generated
  * GeneratedSSLConfig.cpp includes the header-only union types next to it) was
  * recompiled by the build AFTER the one that regenerated the header, and the
- * first build linked the stale object against the fresh generated code.
+ * first build linked the stale object against the fresh generated code. The
+ * cargo edge has it stricter still: it is re-invoked only for the files listed
+ * as its inputs, so a generated file that release builds embed (the eval/
+ * bundles of bundle-modules.ts) has to be declared and routed into rustInputs,
+ * or an edit to it never reaches libbun_rust.a.
  *
- * Each step is checked twice: what its emitter declares, and what its script
- * writes when run for real into a scratch dir. The bindgenv2 cases use a probe
- * .bindv2.ts with one header-only type (a union) and one type with a header and
- * a .cpp (an enumeration); bindgen.ts finds the repo's .bind.ts files on its own,
- * so its step is checked against those.
+ * The bindgen steps are checked twice: what the emitter declares, and what the
+ * script writes when run for real into a scratch dir. The bindgenv2 case uses a
+ * probe .bindv2.ts with one header-only type (a union) and one type with a
+ * header and a .cpp (an enumeration); bindgen.ts finds the repo's .bind.ts files
+ * on its own, so its step is checked against those. bundle-modules.ts bundles
+ * the whole of src/js, so only its emitter is checked.
  */
 import { describe, expect, test } from "bun:test";
-import { bunExe, bunRun, tempDir } from "harness";
+import { bunEnv, bunExe, isCI, tempDir, type BunRunResult } from "harness";
 import { readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { emitBindgen, emitBindgenV2, registerCodegenRules, type CodegenOutputs } from "../../scripts/build/codegen.ts";
+import {
+  emitBindgen,
+  emitBindgenV2,
+  emitJsModules,
+  registerCodegenRules,
+  type CodegenOutputs,
+} from "../../scripts/build/codegen.ts";
 import { registerDirStamps } from "../../scripts/build/compile.ts";
 import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
 import { Ninja } from "../../scripts/build/ninja.ts";
 import type { Sources } from "../../scripts/glob-sources.ts";
+
+/**
+ * The bun the generator scripts run under. The build runs them under the host
+ * bun (findBun() in tools.ts), never under the binary it is building, and a
+ * release bun loads them in a fraction of the time a debug build takes; CI
+ * keeps the binary under test, the one bun it is sure to have (same choice as
+ * VerdaccioRegistry in harness.ts).
+ */
+const codegenBun = isCI ? bunExe() : Bun.which("bun") || bunExe();
+
+async function runGenerator(script: string, args: string[]): Promise<BunRunResult> {
+  await using proc = Bun.spawn({
+    cmd: [codegenBun, "run", script, ...args],
+    env: bunEnv,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signalCode: proc.signalCode };
+}
 
 /** A fully-populated fake toolchain; `bun` is the one entry that gets spawned (bindgenv2 list-outputs). */
 function mockToolchain(): Toolchain {
@@ -49,8 +81,8 @@ function mockToolchain(): Toolchain {
     strip: "/fake/bin/strip",
     llvmStrip: "/fake/llvm/bin/llvm-strip",
     dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: bunExe(),
-    jsRuntime: bunExe(),
+    bun: codegenBun,
+    jsRuntime: codegenBun,
     esbuild: "/fake/bin/esbuild",
     ccache: undefined,
     cmake: "/fake/bin/cmake",
@@ -72,14 +104,14 @@ interface Configured {
 }
 
 /**
- * A linux-x64 debug target in `buildDir` (resolves on every host once told where
- * its sysroot is; the path is only recorded), with the rules the codegen
- * emitters reference registered and the empty output groups emitCodegen hands
- * them. Nothing is written to `buildDir`.
+ * A linux-x64 target in `buildDir` (resolves on every host once told where its
+ * sysroot is; the path is only recorded), with the rules the codegen emitters
+ * reference registered and the empty output groups emitCodegen hands them.
+ * Nothing is written to `buildDir`.
  */
-function configure(buildDir: string): Configured {
+function configure(buildDir: string, buildType: "Debug" | "Release" = "Debug"): Configured {
   const cfg = resolveConfig(
-    { os: "linux", arch: "x64", abi: "gnu", buildType: "Debug", buildDir, linuxSysroot: buildDir },
+    { os: "linux", arch: "x64", abi: "gnu", buildType, buildDir, linuxSysroot: buildDir },
     mockToolchain(),
   );
   const n = new Ninja({ buildDir });
@@ -156,17 +188,10 @@ function writeProbe(dir: string, cfg: Config): string {
   return probe;
 }
 
-const probeFiles = ["GeneratedProbeEnum.cpp", "GeneratedProbeEnum.h", "GeneratedProbeUnion.h"];
-
-// The tests below that run a generator script run it under the build being
-// tested; a debug build takes a few seconds to load one, more than the 5s
-// default allows for.
-const generatorTimeout = 60_000;
-
 describe("emitBindgenV2", () => {
-  test(
-    "declares the header of every type and the .cpp of the types that have one, on one edge",
-    () => {
+  test.concurrent(
+    "declares, on one edge, the header of every type and the .cpp of the types that have one: what generate writes",
+    async () => {
       using dir = tempDir("build-codegen-bindgenv2", {});
       const c = configure(String(dir));
       const { cfg, n, o, dirStamp } = c;
@@ -179,37 +204,21 @@ describe("emitBindgenV2", () => {
         resolve(cfg.codegenDir, "GeneratedProbeEnum.h"),
         resolve(cfg.codegenDir, "GeneratedProbeUnion.h"),
       ];
-      expect(edgeOutputs(n, cpp)).toEqual(inCodegenDir(c, probeFiles));
+      const declared = edgeOutputs(n, cpp);
+      expect(declared).toEqual(
+        inCodegenDir(c, ["GeneratedProbeEnum.cpp", "GeneratedProbeEnum.h", "GeneratedProbeUnion.h"]),
+      );
       // Headers go in the group the PCH and every cxx edge order-depend on; the
       // .cpp is compiled like the other bindgenv2 sources.
       expect(normalized(o.cppHeaders)).toEqual(headers);
       expect(normalized(o.bindgenV2Cpp)).toEqual([cpp]);
       expect(normalized(o.all)).toEqual([cpp, ...headers]);
-    },
-    generatorTimeout,
-  );
 
-  test.concurrent(
-    "list-outputs names exactly the files generate writes",
-    async () => {
-      using dir = tempDir("build-codegen-bindgenv2-generate", {});
-      const { cfg } = configure(String(dir));
-      const probe = writeProbe(String(dir), cfg);
       const script = resolve(cfg.cwd, "src", "codegen", "bindgenv2", "script.ts");
-      const args = [`--sources=${probe}`, `--codegen-path=${cfg.codegenDir}`];
-
-      const [listed, generated] = await Promise.all([
-        bunRun(["run", script, "--command=list-outputs", ...args]),
-        bunRun(["run", script, "--command=generate", ...args]),
-      ]);
-      expect(listed).toSpawn();
-      expect(generated).toSpawn("");
-
-      const expected = probeFiles.map(name => resolve(cfg.codegenDir, name));
-      expect(normalized(listed.stdout.split(";"))).toEqual(expected);
-      expect(readdirSync(cfg.codegenDir).sort()).toEqual(probeFiles);
+      const args = ["--command=generate", `--sources=${probe}`, `--codegen-path=${cfg.codegenDir}`];
+      expect(await runGenerator(script, args)).toSpawn("");
+      expect(inCodegenDir(c, readdirSync(cfg.codegenDir))).toEqual(declared);
     },
-    generatorTimeout,
   );
 });
 
@@ -235,25 +244,85 @@ describe("emitBindgen", () => {
     expect(normalized(o.all)).toEqual([cpp, ...headers]);
   });
 
-  test.concurrent(
-    "declares exactly the files bindgen.ts writes for the repo's .bind.ts files",
-    async () => {
-      using dir = tempDir("build-codegen-bindgen-generate", {});
-      const c = configure(String(dir));
-      const { cfg, n, o, dirStamp } = c;
-      const bindgen = repoBindFiles(cfg);
-      expect(bindgen).not.toBeEmpty();
+  test.concurrent("declares exactly the files bindgen.ts writes for the repo's .bind.ts files", async () => {
+    using dir = tempDir("build-codegen-bindgen-generate", {});
+    const c = configure(String(dir));
+    const { cfg, n, o, dirStamp } = c;
+    const bindgen = repoBindFiles(cfg);
+    expect(bindgen).not.toBeEmpty();
 
-      emitBindgen({ n, cfg, sources: sourceLists({ bindgen }), o, dirStamp });
+    emitBindgen({ n, cfg, sources: sourceLists({ bindgen }), o, dirStamp });
 
-      const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
-      expect(await bunRun(["run", script, "--debug=ON", `--codegen-root=${cfg.codegenDir}`])).toSpawn("");
+    const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
+    expect(await runGenerator(script, ["--debug=ON", `--codegen-root=${cfg.codegenDir}`])).toSpawn("");
 
-      // GeneratedBindings.cpp plus one header per .bind.ts, and nothing else.
-      const written = readdirSync(cfg.codegenDir).sort();
-      expect(written).toHaveLength(bindgen.length + 1);
-      expect(edgeOutputs(n, resolve(cfg.codegenDir, "GeneratedBindings.cpp"))).toEqual(inCodegenDir(c, written));
-    },
-    generatorTimeout,
-  );
+    // GeneratedBindings.cpp plus one header per .bind.ts, and nothing else.
+    const written = readdirSync(cfg.codegenDir).sort();
+    expect(written).toHaveLength(bindgen.length + 1);
+    expect(edgeOutputs(n, resolve(cfg.codegenDir, "GeneratedBindings.cpp"))).toEqual(inCodegenDir(c, written));
+  });
+});
+
+describe("emitJsModules", () => {
+  /**
+   * bundle-modules.ts writes eval/<name> for src/js/eval/*.ts (that directory
+   * only, .ts only); every other file in sources.js ends up inside the outputs
+   * the step already declares.
+   */
+  function jsSources(cfg: Config): string[] {
+    const js = (...parts: string[]) => resolve(cfg.cwd, "src", "js", ...parts);
+    return [
+      js("eval", "node-repl.ts"),
+      js("eval", "feedback.ts"),
+      js("eval", "notes.js"),
+      js("eval", "nested", "helper.ts"),
+      js("node", "fs.ts"),
+      js("internal", "eval", "helper.ts"),
+    ];
+  }
+
+  /** The entries of `paths` (absolute) that are directly inside the codegen eval/ dir, normalized and sorted. */
+  function evalEntries({ cfg }: Configured, paths: string[]): string[] {
+    const evalDir = resolve(cfg.codegenDir, "eval");
+    return normalized(paths.filter(p => resolve(p, "..") === evalDir));
+  }
+
+  /** What the bundle-modules edge declares under eval/. */
+  function declaredEval(c: Configured): string[] {
+    const edge = edgeOutputs(c.n, resolve(c.cfg.codegenDir, "WebCoreJSBuiltins.cpp"));
+    return evalEntries(
+      c,
+      edge.map(rel => resolve(c.cfg.buildDir, rel)),
+    );
+  }
+
+  function expectedEval({ cfg }: Configured): string[] {
+    return [resolve(cfg.codegenDir, "eval", "feedback.ts"), resolve(cfg.codegenDir, "eval", "node-repl.ts")];
+  }
+
+  test("declares eval/<name> for each src/js/eval/*.ts; release builds embed them, so they are cargo inputs", () => {
+    using dir = tempDir("build-codegen-js-modules-release", {});
+    const c = configure(String(dir), "Release");
+    const { cfg, n, o, dirStamp } = c;
+
+    emitJsModules({ n, cfg, sources: sourceLists({ js: jsSources(cfg), jsCodegen: [] }), o, dirStamp });
+
+    expect(declaredEval(c)).toEqual(expectedEval(c));
+    expect(evalEntries(c, o.all)).toEqual(expectedEval(c));
+    expect(evalEntries(c, o.rustInputs)).toEqual(expectedEval(c));
+    expect(o.rustOrderOnly).toEqual([]);
+  });
+
+  test("debug builds load the eval bundles at runtime: generated, but not cargo inputs", () => {
+    using dir = tempDir("build-codegen-js-modules-debug", {});
+    const c = configure(String(dir), "Debug");
+    const { cfg, n, o, dirStamp } = c;
+
+    emitJsModules({ n, cfg, sources: sourceLists({ js: jsSources(cfg), jsCodegen: [] }), o, dirStamp });
+
+    expect(declaredEval(c)).toEqual(expectedEval(c));
+    expect(evalEntries(c, o.all)).toEqual(expectedEval(c));
+    expect(normalized(o.rustOrderOnly)).toEqual(expectedEval(c));
+    expect(evalEntries(c, o.rustInputs)).toEqual([]);
+  });
 });


### PR DESCRIPTION
Follow-up to #38035, from reviewing it after the merge.

### Problem
- In a release tree, editing `src/js/eval/node-repl.ts` (the REPL bootstrap) or `src/js/eval/feedback.ts` re-runs bundle-modules but never rebuilds `libbun_rust.a`: the binary keeps the old script until some `.rs` file changes.
- `bundle-modules.ts` bundles each `src/js/eval/*.ts` to `codegen/eval/<name>` (`src/codegen/bundle-modules.ts:653-671`), and non-debug profiles `include_str!` two of them into the Rust side via `runtime_embed_file!(Codegen, "eval/...")` (`src/runtime/cli/run_command.rs:2875` and `:3132`; `rust.ts` passes `--cfg=bun_codegen_embed` for every `!cfg.debug` profile). `emitJsModules` did not declare these files, so they were not in `rustInputs` and not inputs of the cargo edge.
- The cargo edge (`rust.ts`, `libbun_rust.a`) is re-invoked only when one of its listed implicit inputs changes; cargo's own fingerprinting, which would notice the `include_str!` target, never gets to run. On the warm `build/release` here, rustc's dep-info (`libbun_rust.d`) lists 42 `codegen/` files; `comm` against the edge's inputs from `ninja -t query` left exactly `codegen/eval/feedback.ts` and `codegen/eval/node-repl.ts`, and `ninja -t query codegen/eval/node-repl.ts` reported an unknown target.
- The "Undeclared outputs" comment #38035 added to `codegen.ts` listed the `eval/` dir as something nothing consumes, which certified the gap.

### Fix
- `emitJsModules` derives `eval/<name>` for the `src/js/eval/*.ts` entries of `sources.js` (the list the edge already takes as inputs; same directory-and-extension rule as the script's glob), declares them on the bundle-modules edge, and routes them exactly like `emitBakeCodegen` routes the bake bundles: `rustInputs` in the profiles that embed them, `rustOrderOnly` in debug, where `runtime_embed_file!` reads them from disk at runtime.
- Why this layer: it is the build's existing design for embedded generated files (bake.*.js, bun-error, node-fallbacks and runtime.out.js all go through `rustInputs`); the eval bundles were the one embedded set outside it. The script already writes them with `writeIfNotChanged`, so `restat` prunes cargo when a `src/js` edit leaves them unchanged (most edits; they only change for the three eval files). Existing trees run bundle-modules once more on the next build (the new outputs have no build-log entry) and nothing downstream, since no command line changes.
- #38026 (cargo dep-info as the edge's depfile) is complementary, not overlapping: a dep-info entry for an undeclared generated file is a node ninja stats once at startup, so on its own it would pick up an eval edit one build late, the same lag #38035 fixed for the C++ headers; declared and in `rustInputs`, the change is seen in the run that makes it. The two PRs touch different files. #37992 edits the same comment block; the conflict is two lines either way.
- The comment now states the rule for embedded files and no longer exempts `eval/`; the `rustInputs`/`rustOrderOnly` docstrings say what the groups hold now that more than bake uses the split.
- Test changes (`test/internal/build-codegen-declared-outputs.test.ts`):
  - New `emitJsModules` cases for Release and Debug: exactly `eval/feedback.ts` and `eval/node-repl.ts` are declared from a `sources.js` that also contains a `.js` file in `eval/`, a `.ts` in a subdirectory of it, a module elsewhere and an unrelated `eval/` directory (none of which the script bundles), and they land in `rustInputs` (Release) or `rustOrderOnly` (Debug) and nowhere else.
  - The generator scripts now run under the host bun outside CI (`isCI ? bunExe() : Bun.which("bun") || bunExe()`, the choice `VerdaccioRegistry` in harness.ts makes; the build itself runs these scripts under the host bun via `findBun()`, never under the binary it builds). Booting the debug binary per script was what the three 60s per-test timeouts in #38035 were covering for; they are gone. The file went from 15-19s to about 7s here, in line with the other `build-*` tests on the same box.
  - The bindgenv2 case now runs `generate` and compares the written files against the declared edge directly, as the bindgen case already did, instead of a second test comparing against a literal; one fewer spawn, same assertions.
- Verified:
  - `bun bd test test/internal/build-codegen-declared-outputs.test.ts`: 5 pass. Replacing the derived eval list with `[]` fails exactly the two `emitJsModules` cases (the other three pass); swapping the debug/release routing fails exactly the same two; with `scripts/` stashed the file fails to import.
  - Reconfigured `build/release` and `build/debug` before/after: `build.ninja` differs only in the bundle-modules edge's outputs (+3 `codegen/eval/*.ts`), the `codegen` phony, and the cargo edge's inputs (implicit in release, order-only in debug, listed next to the bake files). The `comm` above is now empty: every `codegen/` file rustc reads is an input of the cargo edge.
  - `build-post-link-ordering` and `build-debug-info-flags` still pass; `tsc -p scripts/build` reports the same pre-existing diagnostics as main.
- Not changed here: the in-tree (non-generated) files Rust embeds with `include_str!`/`include_bytes!` (completions, `bun init`/`bun create` templates, FFI and napi headers, ...) are a `rust.ts`/glob-sources matter and are what #38026 addresses.

### Background
- **Cargo edge**: `rust.ts` emits one ninja edge whose command is `cargo build -p bun_bin` and whose output is `libbun_rust.a`. Its implicit inputs are the globbed `.rs`/`Cargo.toml` files plus `CodegenOutputs.rustInputs`; ninja runs the command only if one of those is newer than the `.a`, and `restat` prunes the link when cargo decides nothing changed. `rustOrderOnly` entries only have to exist before it runs.
- **`bun_codegen_embed`**: rustc cfg set for every non-debug profile. `runtime_embed_file!(Codegen, p)` expands to `include_str!("$BUN_CODEGEN_DIR/p")` under it (the binary is self-contained) and to a runtime `read_to_string` of the same path without it (debug builds pick up codegen changes without relinking), see `src/bun_core/util.rs`.
- **Declared output + restat** (as in #38035): a file an edge declares is re-checked by ninja after the edge runs, so a change made during the build propagates in the same run, and an unchanged mtime (the scripts write with `writeIfNotChanged`) prunes whatever depends on it. A file no edge declares is stat'd once at startup.

<details>
<summary>Release build.ninja, before and after (the debug diff is the same with <code>||</code> instead of <code>|</code> on the cargo edge)</summary>

```
 build codegen/WebCoreJSBuiltins.cpp ... codegen/InternalModuleRegistryConstants.S $
-    codegen/InternalModuleRegistryConstants.bin: codegen ../../src/codegen/bundle-modules.ts ...
+    codegen/InternalModuleRegistryConstants.bin codegen/eval/feedback.ts codegen/eval/fuzzilli-reprl.ts $
+    codegen/eval/node-repl.ts: codegen ../../src/codegen/bundle-modules.ts ...

 build rust-target/x86_64-unknown-linux-gnu/release/libbun_rust.a: rust_build_cross | ... $
-    codegen/InternalModuleRegistryConstants.bin codegen/bake.client.js codegen/bake.server.js codegen/bake.error.js $
+    codegen/InternalModuleRegistryConstants.bin codegen/eval/feedback.ts codegen/eval/fuzzilli-reprl.ts $
+    codegen/eval/node-repl.ts codegen/bake.client.js codegen/bake.server.js codegen/bake.error.js $
```

`eval/fuzzilli-reprl.ts` is written by the script too (its Rust consumer `include_bytes!`s the source file directly), so it is declared with the others; being in `rustInputs` means an edit to that source also re-invokes cargo, which then rebuilds for the `include_bytes!` it tracks itself.

</details>
