### PR TITLE
test: give worker-shutdown-post-leak an explicit 90s timeout

### DIFF
--- a/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
+++ b/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
@@ -46,4 +46,9 @@ test.skipIf(!isASAN || isWindows)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   },
+  // Worker boot + VM teardown alone take ~5s under debug+ASAN on a loaded
+  // machine, and when LSan does find a leak, symbolizing the report against
+  // the debug binary adds several seconds more; the 5s default turned both
+  // into a timeout.
+  90_000,
 );


### PR DESCRIPTION
### Problem
- `test/js/node/worker_threads/worker-shutdown-post-leak.test.ts` (ASAN-only, added in #34278) fails with `this test timed out after 5000ms.` when run with `bun bd test` on a debug+ASAN build on a busy machine.
- The scenario it spawns is healthy: run by hand with the test's env it exits 0 with empty output, but one worker boot plus `BUN_DESTRUCT_VM_ON_EXIT=1` teardown takes 4.7 to 7.1s under debug+ASAN here (load average 120 to 170 on a 12 CPU cgroup), so the file's 5s default per-test timeout has no headroom. Same binary, empty `-e 0`: 0.3 to 0.5s.
- The failure mode is cut off by the same budget: when LSan does find a leak, it symbolizes the leaked stacks against the ~1GB debug binary before exiting. Measured on this binary with an induced one-stack leak, that adds about 4.8s (0.5 to 0.6s with `detect_leaks=0`, 5.3 to 5.5s with the report). The test is watching for two allocations (ConcurrentTask + EventLoopTask), so a real regression would also be reported as a timeout, with the subprocess killed before the LSan report reaches the failure output.
- CI is not affected either way: the runner passes `--timeout=270000` on the asan lane, where this file's median is 442ms (`test/expected-durations.json`). The 5s default only applies to direct `bun bd test` runs, which is where this flaked.

### Fix
- Pass an explicit `90_000` per-test timeout, with a comment saying why.
- Why this is the right fix: the slow part is worker VM boot and teardown under debug+ASAN plus LSan symbolization, neither of which the test can make cheaper (it is already a single worker doing two writes), so the budget is what was wrong. This is the per-test-timeout-for-an-outlier case the root CLAUDE.md allows (test/CLAUDE.md's "no timeouts" rule is the default for ordinary tests), and 90s is the budget the other LSan guard tests of the same shape already use (`test/js/bun/shell/shell-worker-terminate-leak.test.ts`, `test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts`), for the same reason.
- An explicit per-test timeout overrides `--timeout` (verified), so on CI's asan lane the budget goes from 270s to 90s, still about 200x the measured median, and a real leak regression still fails the test there, now with the LSan report attached.
- Verified: `bun bd test test/js/node/worker_threads/worker-shutdown-post-leak.test.ts` timed out at 5008ms before the change on this machine; after it, three runs pass in 6.2s, 6.8s and 7.1s. Test-only change, no `src/` changes.

### Background
- LSan guard test: the test runs a scenario in a subprocess with `ASAN_OPTIONS=detect_leaks=1` and `BUN_DESTRUCT_VM_ON_EXIT=1` (tear the VM down fully at exit instead of calling `_exit`), so anything still allocated at exit is reported by LeakSanitizer as a leak and turns into non-empty stderr and exit code 1. The leak under guard here is the one fixed in #34278: a cross-thread task posted to a worker during its shutdown was enqueued onto a queue that is never drained again.
- Per-test timeout: `test(name, fn, ms)` sets the budget for that one test and takes precedence over the file default (5s) and over `bun test --timeout`, which CI uses to set the default per lane.

<details>
<summary>Timing probes (debug+ASAN build of b7a0431032, linux-x64, load average 120 to 170)</summary>

Scenario cost, three runs each, same env as the test:

```
empty -e, no leak env              : 0.42s, 0.31s, 0.29s
empty -e, BUN_DESTRUCT_VM_ON_EXIT+LSan: 0.52s, 0.54s, 0.48s
worker scenario, no leak env       : 5.44s, 5.18s, 5.94s
worker scenario, test env          : 5.94s, 6.54s, 5.31s
```

Where the time goes (stderr timestamps relative to `new Worker`): `require("worker_threads")` alone is ~1.3s, the worker's `online` event fires at +2.5 to +3.0s, `exit` at +3.1 to +3.8s. Release build of the same scenario: 0.08 to 0.10s total.

Failure-mode cost: a C function compiled with `bun:ffi` `cc` that mallocs three blocks and drops them, called from a `setTimeout` so the stack is not covered by `test/leaksan.supp`, run with the test's env:

```
detect_leaks=0 : 0.64s, 0.52s
leak reported  : 5.34s, 5.54s, 5.41s   (29-frame stack, SUMMARY: 195 byte(s) leaked in 3 allocation(s))
```

`bun bd test` on the unmodified file: `(fail) ... [5008.10ms] this test timed out after 5000ms.` With this change: `(pass) ... [6249.80ms]`, `[6762.09ms]`, `[7056.25ms]`.
</details>
