### PR TITLE
Report a CommonJS preload's top-level throw with origin uncaughtException

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -68,10 +68,17 @@ pub type ExceptionList = Vec<crate::exception_list::JsException>;
 pub struct EntryPointResult {
     pub value: crate::strong::Optional, // jsc.Strong.Optional
     pub cjs_set_value: bool,
-    /// True when the entry module evaluated as CommonJS: Node reports a CJS
-    /// entry's top-level throw with origin `uncaughtException` but an ESM
-    /// entry rejection with `unhandledRejection`; the run command consults this.
+    /// True when the module whose load promise `reload_entry_point` handed back
+    /// (the preload that rejected, else the entry) evaluated as CommonJS. Node
+    /// `require()`s both synchronously, so their top-level throw is reported
+    /// with origin `uncaughtException`; an ESM rejection keeps
+    /// `unhandledRejection`. Set by `Bun__VM__noteCommonJSEvaluation`, read by
+    /// the run command and the worker entry loop once the promise rejected.
     pub evaluated_as_cjs: bool,
+    /// Resolved path of the preload `load_preloads` is importing, so that a
+    /// CommonJS evaluation is matched against it instead of against
+    /// `VirtualMachine::main`. `None` while nothing but the entry is loading.
+    pub loading_preload: Option<Box<[u8]>>,
 }
 
 /// Downstream-compat alias: lib.rs previously exposed `virtual_machine::InitOptions`.

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -123,16 +123,6 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         return false;
     }
 
-    // Node reports a CJS entry's top-level throw as origin "uncaughtException", not
-    // "unhandledRejection"; record the entry mode for the run command. Only the root
-    // module (m_id == ".") can be the entry, so the FFI compare runs at most once.
-    if (auto* id = moduleObject->m_id.get(); id && id->length() == 1) [[unlikely]] {
-        auto view = id->view(globalObject);
-        RETURN_IF_EXCEPTION(scope, false);
-        if (view == "."_s)
-            Bun__VM__noteCommonJSEvaluation(globalObject->bunVM(), JSValue::encode(filename));
-    }
-
     JSFunction* resolveFunction = nullptr;
     JSFunction* requireFunction = nullptr;
     const auto initializeModuleObject = [&]() {
@@ -1585,6 +1575,11 @@ static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sou
                 if (entry) {
                     if (auto* moduleObject = dynamicDowncast<JSCommonJSModule>(entry)) {
                         if (!moduleObject->hasEvaluated) {
+                            // Only the module loader (not require()) evaluates the entry and
+                            // preloads, so this is where the VM learns that the module it is
+                            // loading at top level is CommonJS, whose top-level throw Node
+                            // reports with origin "uncaughtException".
+                            Bun__VM__noteCommonJSEvaluation(globalObject->bunVM(), JSValue::encode(keyValue));
                             evaluateCommonJSModuleOnce(
                                 vm,
                                 globalObject,

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -875,8 +875,8 @@ impl WebWorker {
                 }
                 entry_rejection_seen = true;
                 // Same rule as the main thread (run_command): a CJS worker
-                // entry's top-level throw is an uncaughtException; only an
-                // ESM entry rejection reports origin "unhandledRejection".
+                // entry's (or preload's) top-level throw is an uncaughtException;
+                // only an ESM rejection reports origin "unhandledRejection".
                 let is_rejection = !vm.as_mut().entry_point_result.evaluated_as_cjs;
                 let handled = vm.as_mut().uncaught_exception(
                     vm.global(),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1435,8 +1435,9 @@ impl Run<'_> {
                     // SAFETY: `vm.jsc_vm` set in `init`; FFI takes `*mut`.
                     let result = promise.result(unsafe { &mut *vm.jsc_vm });
                     let global = vm.global;
-                    // A CJS entry runs synchronously in Node, so its top-level
-                    // throw is an uncaughtException; only an ESM entry
+                    // `promise` belongs to the entry or to the preload that
+                    // rejected. Node `require()`s a CJS one synchronously, so
+                    // its top-level throw is an uncaughtException; only an ESM
                     // rejection reports origin "unhandledRejection".
                     let is_rejection = !vm.entry_point_result.evaluated_as_cjs;
                     // SAFETY: `global` valid for VM lifetime.

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -146,11 +146,21 @@ pub fn specifier_is_eval_entry_point(this: &mut VirtualMachine, specifier: JSVal
     false
 }
 
-/// Called once by JSCommonJSModule.cpp for the root CJS module so the run command reports
-/// origin `uncaughtException`. `main()` compare filters out an ESM entry that `import`s CJS.
+/// Called by JSCommonJSModule.cpp right before the module loader evaluates
+/// `specifier` as CommonJS. Marks `evaluated_as_cjs` when that module is the one
+/// being loaded at top level (the preload `load_preloads` is importing, else the
+/// entry); the path compare filters out CJS that an ESM preload or entry `import`s.
 // HOST_EXPORT(Bun__VM__noteCommonJSEvaluation, c)
 pub fn note_commonjs_evaluation(this: &mut VirtualMachine, specifier: JSValue) {
-    if this.entry_point_result.evaluated_as_cjs || this.main().is_empty() {
+    if this.entry_point_result.evaluated_as_cjs || !specifier.is_string() {
+        return;
+    }
+    let loading = this
+        .entry_point_result
+        .loading_preload
+        .as_deref()
+        .unwrap_or(this.main());
+    if loading.is_empty() {
         return;
     }
     let global = this.global();
@@ -160,7 +170,7 @@ pub fn note_commonjs_evaluation(this: &mut VirtualMachine, specifier: JSValue) {
         return;
     };
     let specifier_str = bun_core::OwnedString::new(specifier_str);
-    if specifier_str.eql_utf8(this.main()) {
+    if specifier_str.eql_utf8(loading) {
         this.entry_point_result.evaluated_as_cjs = true;
     }
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -709,7 +709,8 @@ fn generate_entry_point(_vm: &VirtualMachine, watch: bool, entry_path: &[u8]) ->
 }
 
 /// `loadPreloads()` — runs `--preload` scripts. Returns the first rejected
-/// preload promise if any, else null.
+/// preload promise if any (with `entry_point_result.evaluated_as_cjs` telling
+/// whether that preload was CommonJS), else null.
 ///
 /// Error mapping: resolver `Failure` returns the resolver error,
 /// `Pending`/`NotFound` returns `error.ModuleNotFound`,
@@ -733,7 +734,10 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
     let vm_for_guard = vm;
     scopeguard::defer! {
         // SAFETY: per fn contract.
-        unsafe { (*vm_for_guard).is_in_preload = false };
+        unsafe {
+            (*vm_for_guard).is_in_preload = false;
+            (*vm_for_guard).entry_point_result.loading_preload = None;
+        }
     }
 
     // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
@@ -770,8 +774,8 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         // resolves them internally. node:worker_threads is preloaded this way so
         // its node-style worker bootstrap (stdio rebinding) runs before user code;
         // this also means `bun --import node:*` works like Node's.
-        let module_name = if normalized.starts_with(b"node:") {
-            bun_core::String::from_bytes(normalized)
+        let module_path: &[u8] = if normalized.starts_with(b"node:") {
+            normalized
         } else {
             // ── resolve ─────────────────────────────────────────────────────
             // SAFETY: per fn contract; `top_level_dir` is the `'static` fs
@@ -819,13 +823,21 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                 }
             };
 
-            // ── import ──────────────────────────────────────────────────────
-            let path_text = result
+            result
                 .path()
                 .expect("resolver Success result has a primary path")
-                .text;
-            bun_core::String::from_bytes(path_text)
+                .text
         };
+
+        // ── import ──────────────────────────────────────────────────────────
+        let module_name = bun_core::String::from_bytes(module_path);
+        // Until this import settles, a CommonJS evaluation of `module_path` is
+        // what `Bun__VM__noteCommonJSEvaluation` records (see `EntryPointResult`).
+        // SAFETY: per fn contract.
+        unsafe {
+            (*vm).entry_point_result.evaluated_as_cjs = false;
+            (*vm).entry_point_result.loading_preload = Some(module_path.into());
+        }
         // Note: use `import_ptr` (not `import`) so the `*mut` we store in
         // `pending_internal_promise` keeps the FFI's mutable provenance instead
         // of being laundered through `&JSInternalPromise -> *const -> *mut`
@@ -892,6 +904,10 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         if unsafe { &*promise }.status() == PromiseStatus::Rejected {
             return Ok(promise);
         }
+        // Only a rejected preload is reported on; don't let this one's verdict
+        // leak into whatever loads next.
+        // SAFETY: per fn contract.
+        unsafe { (*vm).entry_point_result.evaluated_as_cjs = false };
         // A stop was requested (worker terminate()/exit) while it loaded: the
         // caller checks the same and shuts down; load nothing more.
         // SAFETY: per fn contract.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1533,6 +1533,113 @@ describe.concurrent(() => {
   });
 });
 
+// Node require()s -r preloads and a CommonJS entry synchronously, so a throw at
+// their top level reaches uncaughtException listeners with origin
+// "uncaughtException"; an ES module (--import preload or entry) rejects instead,
+// which reports origin "unhandledRejection".
+describe("origin of a top-level throw in a preload or entry", () => {
+  const listener = `process.on("uncaughtException", (e, origin) => console.log("caught", e.message, origin));`;
+  // `module.exports` keeps a fixture CommonJS regardless of how bun sniffs it.
+  const throwingCjs = message => `${listener}\nmodule.exports = {};\nthrow new Error(${JSON.stringify(message)});\n`;
+  const throwingEsm = message => `${listener}\nthrow new Error(${JSON.stringify(message)});\n`;
+  const okPreload = `module.exports = {};\nconsole.log("ok preload ran");\n`;
+
+  async function run(files, args) {
+    using dir = tempDir("uncaught-origin", { "main.js": "", ...files });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent("CommonJS -r preload: uncaughtException", async () => {
+    expect(await run({ "preload.cjs": throwingCjs("preload boom") }, ["-r", "./preload.cjs", "main.js"])).toEqual({
+      stdout: "caught preload boom uncaughtException\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("CommonJS bunfig preload: uncaughtException", async () => {
+    expect(
+      await run({ "bunfig.toml": `preload = ["./preload.cjs"]\n`, "preload.cjs": throwingCjs("preload boom") }, [
+        "main.js",
+      ]),
+    ).toEqual({ stdout: "caught preload boom uncaughtException\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("CommonJS preload that is not the first preload: uncaughtException", async () => {
+    expect(
+      await run({ "ok.cjs": okPreload, "preload.cjs": throwingCjs("preload boom") }, [
+        "-r",
+        "./ok.cjs",
+        "-r",
+        "./preload.cjs",
+        "main.js",
+      ]),
+    ).toEqual({ stdout: "ok preload ran\ncaught preload boom uncaughtException\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("ES module preload: unhandledRejection", async () => {
+    expect(await run({ "preload.mjs": throwingEsm("preload boom") }, ["-r", "./preload.mjs", "main.js"])).toEqual({
+      stdout: "caught preload boom unhandledRejection\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("ES module preload whose CommonJS import throws: unhandledRejection", async () => {
+    // The CommonJS module evaluated here is a dependency, not the preload itself.
+    expect(
+      await run(
+        {
+          "preload.mjs": `${listener}\nawait import("./dep.cjs");\n`,
+          "dep.cjs": `module.exports = {};\nthrow new Error("dep boom");\n`,
+        },
+        ["-r", "./preload.mjs", "main.js"],
+      ),
+    ).toEqual({ stdout: "caught dep boom unhandledRejection\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("CommonJS entry after a CommonJS preload: uncaughtException", async () => {
+    expect(
+      await run({ "ok.cjs": okPreload, "entry.cjs": throwingCjs("entry boom") }, ["-r", "./ok.cjs", "entry.cjs"]),
+    ).toEqual({ stdout: "ok preload ran\ncaught entry boom uncaughtException\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("ES module entry after a CommonJS preload: unhandledRejection", async () => {
+    expect(
+      await run({ "ok.cjs": okPreload, "entry.mjs": throwingEsm("entry boom") }, ["-r", "./ok.cjs", "entry.mjs"]),
+    ).toEqual({ stdout: "ok preload ran\ncaught entry boom unhandledRejection\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent(
+    "CommonJS preload of a worker_threads Worker: uncaughtException",
+    async () => {
+      expect(
+        await run(
+          {
+            "preload.cjs": throwingCjs("worker preload boom"),
+            "worker.js": "",
+            "index.js": `const { Worker } = require("node:worker_threads");
+                         const path = require("node:path");
+                         new Worker(path.join(__dirname, "worker.js"), { preload: [path.join(__dirname, "preload.cjs")] })
+                           .on("exit", code => console.log("worker exit", code));`,
+          },
+          ["index.js"],
+        ),
+      ).toEqual({ stdout: "caught worker preload boom uncaughtException\nworker exit 0\n", stderr: "", exitCode: 0 });
+    },
+    // Starting a Worker alone takes several seconds in a debug + ASAN build.
+    60_000,
+  );
+});
+
 it("process.hasUncaughtExceptionCaptureCallback", () => {
   process.setUncaughtExceptionCaptureCallback(null);
   expect(process.hasUncaughtExceptionCaptureCallback()).toBe(false);


### PR DESCRIPTION
### Problem

- `bun -r ./preload.cjs main.js` (or a bunfig `preload`) whose CommonJS preload throws at top level calls `uncaughtException` listeners with origin `"unhandledRejection"`. `node -r` passes `"uncaughtException"`. Same for a `worker_threads` Worker started with `preload`.
- A CommonJS entry run after any CommonJS preload (`bun -r ./ok.cjs entry.cjs`) is reported as `"unhandledRejection"` as well, although the same entry on its own is already reported as `"uncaughtException"` since #31831.
- Cause: `evaluateCommonJSModuleOnce` (src/jsc/bindings/JSCommonJSModule.cpp:129) only called `Bun__VM__noteCommonJSEvaluation` for the module whose id is `"."`, which is the first CommonJS module created in the process, and `note_commonjs_evaluation` (src/runtime/hw_exports.rs:152) only compared that module against `vm.main()`. A preload is never `main`, and once a CommonJS preload has taken the `"."` id the entry never reaches the note either. The origin string is picked from `entry_point_result.evaluated_as_cjs` in `Run::start` (src/runtime/cli/run_command.rs:1441) and in `WebWorker::spin` (src/jsc/web_worker.rs:880).

### Fix

- The note is now made by the synthetic CommonJS module generator (`commonJSModuleSyntheticSourceCode`) right before it runs a module's body, passing the module loader key; the `"."` gate is gone. That generator is the only way the entry and the preloads get evaluated (`require()` uses a different path), so it fires once per module the loader evaluates as CommonJS and never for `require()`d dependencies.
- `load_preloads` records the resolved path of the preload it is importing in the new `EntryPointResult.loading_preload` (cleared when it returns). `note_commonjs_evaluation` compares against that path while it is set, otherwise against `main()` as before. `load_preloads` also clears `evaluated_as_cjs` before each import and after an import that fulfilled, so the flag describes exactly the module whose promise `reload_entry_point` hands back: the preload that rejected, else the entry.
- Why this is right: Node `require()`s `-r` preloads and the entry synchronously, so a throw out of either is a synchronous uncaught exception (origin `uncaughtException`), while an ES module (`--import`, ESM entry) goes through the async loader and surfaces as a rejection (`unhandledRejection`). Bun has one preload list for `-r`, `--preload`, `--import` and bunfig, so it keys the origin on the module's actual format, which is what it already does for the entry; a preload is loaded and reported through the same machinery as the entry, so the same rule applies to it. Comparing the loader key is what keeps a CommonJS dependency of an ES module preload or entry from flipping the origin, and dropping a fulfilled preload's verdict is what keeps a CommonJS preload from flipping a later ES module entry's.
- Verified with test/js/node/process/process.test.js, new `describe("origin of a top-level throw in a preload or entry")`. Five cases fail on main: CommonJS `-r` preload, bunfig preload, a CommonJS preload that is not the first preload, a CommonJS entry after a CommonJS preload, and a Worker `preload`. Three guard what has to stay `unhandledRejection`: an ES module preload, an ES module preload whose CommonJS import throws, and an ES module entry after a CommonJS preload. The expected output of each is what node v26 prints for the `-r` / `--import` equivalent.
- Also run on a debug build: the rest of process.test.js (its remaining failures here are `USER` being unset in this container and 5 s timeouts of worker-spawning tests, identical on main), cli/run/run-eval.test.ts, node/module/node-module-module.test.js, cli/run/preload-test, the bun:test preload suites, cli/test/isolation preload cases, the web Worker and worker_threads preload tests, and the vendored test-process-uncaught-exception-monitor.js and test-promise-unhandled-*.js.
- Related open PRs: #38119 sets `evaluated_as_cjs` for a throwing `runMain` override; it composes with this change, since the preloads have finished and cleared the flag by the time it runs. #38141 reports a CommonJS entry's throw at the throw site and removes the flag; as written it still reports a CommonJS preload's throw as `unhandledRejection`. If it lands first, this change reduces to widening its "key is the entry" check to "key is the entry or `loading_preload`", with the tests here unchanged.
- Not fixed here: a `.cjs` file that references none of the CommonJS globals is evaluated as ESM when it is imported or preloaded (the concurrent transpiler path ignores the extension), so such a preload still reports `unhandledRejection`. That is a separate module-format bug, reported separately; the fixtures here use `module.exports` so their format does not depend on it.

### Background

- Preloads: `-r`, `--preload`, `--import` and bunfig `preload` all end up in `vm.preload`. `load_preloads` (src/runtime/jsc_hooks.rs) imports them one at a time through the module loader and waits for each; the first one that rejects is returned from `reload_entry_point` in place of the entry's promise and the entry is not loaded. `Run::start` and `WebWorker::spin` report whichever promise they got through `uncaught_exception(error, is_rejection)`, where `is_rejection` selects the origin string passed to the listeners.
- CommonJS under the module loader: when the loader imports a file Bun transpiled as CommonJS (the entry, via the generated `bun:main` wrapper; a preload; or a CommonJS file imported from ESM), `createCommonJSModule` registers a synthetic module whose generator runs the CommonJS body, and a throw there rejects the import. `require()` runs modules through `JSCommonJSModule::load` instead and never reaches that generator.
- `module.id`: Bun gives `"."` to the first CommonJS module created in the process (Node uses it for the main module). With a CommonJS preload that is the preload, which is what the removed gate keyed on.
