### PR TITLE
node:module: report a rejecting runMain override result once

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2712,10 +2712,8 @@ impl VirtualMachine {
                         return Ok(stored);
                     }
                     let resolved = JSC__JSInternalPromise__resolvedPromise(global_ref, ret);
-                    // The run command reports this promise's rejection once it
-                    // settles, like the module loader's promises (which JSC
-                    // creates already marked handled). Otherwise the unhandled
-                    // rejection tracker reports a late rejection a second time.
+                    // Reported by the caller once it settles, like the module loader's
+                    // (already handled) promises; keep the rejection tracker off it.
                     crate::JSPromise::opaque_mut(resolved).set_handled();
                     self.pending_internal_promise = Some(resolved);
                     self.pending_internal_promise_is_protected = false;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2712,8 +2712,7 @@ impl VirtualMachine {
                         return Ok(stored);
                     }
                     let resolved = JSC__JSInternalPromise__resolvedPromise(global_ref, ret);
-                    // Reported by the caller once it settles, like the module loader's
-                    // (already handled) promises; keep the rejection tracker off it.
+                    // Only the caller reports this promise, like the module loader's own.
                     crate::JSPromise::opaque_mut(resolved).set_handled();
                     self.pending_internal_promise = Some(resolved);
                     self.pending_internal_promise_is_protected = false;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2712,6 +2712,11 @@ impl VirtualMachine {
                         return Ok(stored);
                     }
                     let resolved = JSC__JSInternalPromise__resolvedPromise(global_ref, ret);
+                    // The run command reports this promise's rejection once it
+                    // settles, like the module loader's promises (which JSC
+                    // creates already marked handled). Otherwise the unhandled
+                    // rejection tracker reports a late rejection a second time.
+                    crate::JSPromise::opaque_mut(resolved).set_handled();
                     self.pending_internal_promise = Some(resolved);
                     self.pending_internal_promise_is_protected = false;
                     return Ok(resolved);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -602,6 +602,66 @@ console.log("survived", require("./late.js"));`,
     expect(stdout.trim()).toBe("pass");
     expect(await proc.exited).toBe(0);
   });
+
+  // When an override does not call the original runMain, bun adopts its return
+  // value as the entry point promise. A rejection is then the entry point
+  // failing, and it must be reported exactly once no matter when the promise
+  // rejects: before it was returned, or later while bun is waiting on it.
+  const rejectingRunMainOverrides = [
+    ["an already rejected promise", `async () => { throw new Error("run-main-boom"); }`],
+    ["a promise that rejects later", `async () => { await 0; throw new Error("run-main-boom"); }`],
+    ["a thenable that rejects", `() => ({ then(_, reject) { reject(new Error("run-main-boom")); } })`],
+  ];
+  test.each(rejectingRunMainOverrides)(
+    "Module.runMain override returning %s prints the error once",
+    async (_, runMain) => {
+      using dir = tempDir("run-main-rejection", {
+        "preload.cjs": `require("module").runMain = ${runMain};`,
+        "main.cjs": `console.log("main ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--require", "./preload.cjs", "./main.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, errorsPrinted: stderr.split("error: run-main-boom").length - 1, exitCode }).toEqual({
+        stdout: "",
+        errorsPrinted: 1,
+        exitCode: 1,
+      });
+    },
+  );
+  test.each(rejectingRunMainOverrides)(
+    "Module.runMain override returning %s reports the error to process once, as the entry point failing",
+    async (_, runMain) => {
+      using dir = tempDir("run-main-rejection-listeners", {
+        "preload.cjs": `
+          process.on("unhandledRejection", err => console.log("unhandledRejection:", err.message));
+          process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));
+          require("module").runMain = ${runMain};
+        `,
+        "main.cjs": `console.log("main ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--require", "./preload.cjs", "./main.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "uncaughtException: run-main-boom unhandledRejection\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -635,15 +635,16 @@ console.log("survived", require("./late.js"));`,
       });
     },
   );
+  const listenersThenOverride = runMain => `
+    process.on("unhandledRejection", err => console.log("unhandledRejection:", err.message));
+    process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));
+    require("module").runMain = ${runMain};
+  `;
   test.each(rejectingRunMainOverrides)(
     "Module.runMain override returning %s reports the error to process once, as the entry point failing",
     async (_, runMain) => {
       using dir = tempDir("run-main-rejection-listeners", {
-        "preload.cjs": `
-          process.on("unhandledRejection", err => console.log("unhandledRejection:", err.message));
-          process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));
-          require("module").runMain = ${runMain};
-        `,
+        "preload.cjs": listenersThenOverride(runMain),
         "main.cjs": `console.log("main ran");`,
       });
       await using proc = Bun.spawn({
@@ -662,6 +663,35 @@ console.log("survived", require("./late.js"));`,
       });
     },
   );
+  // A worker's preload can override runMain too; the worker checks its own entry
+  // point promise the same way the main thread does.
+  test("Module.runMain override in a worker preload reports a late rejection to the worker's process once", async () => {
+    const [, lateRejection] = rejectingRunMainOverrides[1];
+    using dir = tempDir("run-main-rejection-worker", {
+      "preload.cjs": listenersThenOverride(lateRejection),
+      "body.cjs": `console.log("worker body ran");`,
+      "main.cjs": `
+        const { Worker } = require("worker_threads");
+        const path = require("path");
+        const worker = new Worker(path.join(__dirname, "body.cjs"), { preload: [path.join(__dirname, "preload.cjs")] });
+        worker.on("exit", code => { process.exitCode = code; });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "uncaughtException: run-main-boom unhandledRejection\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],


### PR DESCRIPTION
### Problem
- A `--require` preload that replaces `Module.runMain` with a function returning a promise (or thenable) that is still pending when it returns and rejects later gets the rejection reported twice: the `error: ...` block is printed twice before exiting 1, and with listeners installed both `unhandledRejection` and `uncaughtException` fire for the same error.
- An override whose promise is already rejected when it returns, and a plain entry point that throws after a top-level `await`, are reported once.
- Cause: `reload_entry_point` (src/jsc/VirtualMachine.rs:2714) adopts the override's return value with `JSPromise::resolvedPromise` and stores it as `pending_internal_promise`, which `Run::start` (src/runtime/cli/run_command.rs:1434) reports once it is rejected. Every other promise stored in that field comes from the module loader, which creates them marked as handled. The adopted promise was not, so when it rejected during the event loop spin in `load_entry_point`, the rejection tracker reported it at the end of that tick, and then `Run::start` reported it again.
- The same store is reached by a worker whose `preload` option overrides `runMain`; there the worker's own entry check (src/jsc/web_worker.rs, `observe_entry`, which also relies on the promise being handled) is the second reporter, so both listeners fire inside the worker as well.
- Repro:
  ```js
  // preload.cjs
  require("module").runMain = async () => { await 0; throw new Error("boom"); };
  ```
  `bun --require ./preload.cjs ./main.cjs` prints `error: boom` twice. Same with `() => ({ then(_, reject) { reject(new Error("boom")); } })`.

### Fix
- Mark the adopted promise as handled at the point it is stored as the entry point promise, so the tracker never sees it and `Run::start` stays the single reporter.
- Correct because the runtime does consume this promise: it waits for it and reports its rejection as the entry point failing. That is the same contract the module loader's promises already have (JSC marks them handled on creation for the same reason), and it is what `Run::start` does to the promise after reporting it anyway. The result is the already-rejected case and the late-rejecting case now behave identically: printed once, delivered once to `uncaughtException` listeners with origin `unhandledRejection`, and a passthrough override that calls the original `runMain` is unaffected (it stores the loader's promise, which was already handled).
- Behaviour change for anyone relying on the bug: an `unhandledRejection` listener no longer also fires for a late-rejecting override result; it did not fire for an already-rejected one before either.
- Independent of #38113 (exception check after `resolvedPromise`) and #38119 (non-callable / throwing override); the three touch neighbouring lines and compose, whichever lands first.
- Verified with `test/js/node/module/node-module-module.test.js`: seven new cases (already rejected promise, promise that rejects later, rejecting thenable, each checked for the stderr count and for listener delivery on the main thread, plus the late-rejecting override installed by a worker `preload`). Five of them fail on the unfixed binary (`errorsPrinted: 2`, both listeners firing) and all pass with the fix; the two already-rejected cases pass both ways and pin the behaviour the other cases are aligned with.
- Also run with the fix: the rest of that file, `test/js/node/test/parallel/test-module-run-main-monkey-patch.js`, `test/cli/run/preload-test.test.js`, `test/js/bun/resolve/bun-main-entry-point.test.ts`.

### Background
- `Module.runMain` override: if a preload assigns `require("module").runMain`, bun calls the override instead of evaluating the entry point itself. If the override calls the original `runMain`, the module loader's promise is stored as the entry point promise; otherwise the override's return value is adopted with `Promise.resolve` semantics (a native promise is used as is, a thenable is wrapped) and stored instead.
- `pending_internal_promise`: the VM field holding the entry point promise. `load_entry_point` spins the event loop until it settles, then `Run::start` prints a rejection through the uncaught exception path (`uncaughtException` listeners, origin `unhandledRejection`) and exits 1.
- Unhandled rejection tracker: JSC notifies the host when a promise with no handlers rejects; bun queues those promises and reports them (`unhandledRejection` listeners, otherwise print) at the end of each event loop tick. A promise whose handled flag is set is skipped by both the notification and the queue. JSC's own module loader sets that flag on the promises it hands to embedders because the embedder, not the tracker, reports them.

<details>
<summary>Probes on the release binary (before) and the debug build (after)</summary>

```
# before (1.4.0-canary da3851e57)
override: async () => { await 0; throw }        -> error block printed twice, exit 1
override: () => ({ then(_, reject) { reject() }}) -> error block printed twice, exit 1
override: async () => { throw }                  -> printed once, exit 1
plain main.mjs with `await 0; throw`             -> printed once, exit 1
late override + unhandledRejection/uncaughtExceptionMonitor listeners
  -> "unhandledRejection handler" AND "uncaughtExceptionMonitor ... unhandledRejection", then printed, exit 1
--hot with the late override                     -> printed twice
worker with { preload } overriding runMain (late), listeners in the worker
  -> both "unhandledRejection" and "uncaughtException ... unhandledRejection" logged by the worker
worker, same override, no listeners              -> one 'error' event in the parent, worker exit 1
  (the worker's first report swaps in a quiet handler, so the duplicate is only visible via listeners)

# after (debug build of this branch)
late override / thenable / already rejected      -> printed once, exit 1
late override + listeners                        -> only "uncaughtExceptionMonitor ... unhandledRejection", printed once
passthrough override (calls original runMain) + main.mjs that throws after await -> printed once, exit 1
--hot with the late override                     -> printed once
worker with { preload } override, listeners      -> only "uncaughtException ... unhandledRejection"
worker, no listeners                             -> still one 'error' event, worker exit 1
```
</details>
