### PR TITLE
shell(cp): report ENAMETOOLONG instead of panicking on operands longer than the path buffers

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -4,7 +4,8 @@ use crate::node::PathLike;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, shell_join_path, shell_resolve_operand,
+    unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -605,26 +606,16 @@ impl ShellCpTask {
         &mut self,
         poster: &bun_jsc::ConcurrentPoster,
     ) -> Option<ShellErr> {
-        use resolve_path::{Platform, platform};
-
-        let mut buf2 = bun_paths::PathBuffer::uninit();
-        let mut buf3 = bun_paths::PathBuffer::uninit();
         // We have to give an absolute path to our cp implementation for it to
         // work with cwd.
-        let src: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.src) {
-            // `self.src` is the bare argv bytes (no NUL); re-terminate via
-            // the thread-local join buffer.
-            resolve_path::join_z::<platform::Auto>(&[&self.src])
-        } else {
-            resolve_path::join_z::<platform::Auto>(&[&self.cwd_path, &self.src])
+        let src = match shell_resolve_operand(bun_sys::Tag::copyfile, &self.cwd_path, &self.src) {
+            Ok(path) => path,
+            Err(e) => return Some(ShellErr::new_sys(&e)),
         };
-        let mut tgt: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.tgt) {
-            resolve_path::join_z_buf::<platform::Auto>(buf2.as_mut_slice(), &[&self.tgt])
-        } else {
-            resolve_path::join_z_buf::<platform::Auto>(
-                buf2.as_mut_slice(),
-                &[&self.cwd_path, &self.tgt],
-            )
+        let mut tgt = match shell_resolve_operand(bun_sys::Tag::copyfile, &self.cwd_path, &self.tgt)
+        {
+            Ok(path) => path,
+            Err(e) => return Some(ShellErr::new_sys(&e)),
         };
 
         // Cases:
@@ -635,7 +626,7 @@ impl ShellCpTask {
         //   folder -> folder
         // We need to check dest to see what it is; if it doesn't exist we
         // need to create it.
-        let src_is_dir = match Self::is_dir(src) {
+        let src_is_dir = match Self::is_dir(&src) {
             Ok(x) => x,
             Err(e) => return Some(ShellErr::new_sys(&e)),
         };
@@ -660,7 +651,7 @@ impl ShellCpTask {
             ));
         }
 
-        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
+        let (tgt_is_dir, tgt_exists) = match Self::is_dir(&tgt) {
             Ok(is_dir) => (is_dir, true),
             Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
                 // If it has a trailing directory separator, it's a directory.
@@ -678,10 +669,10 @@ impl ShellCpTask {
             // 2nd synopsis: -R source_files... -> target.
             if tgt_exists {
                 let basename = resolve_path::basename(src.as_bytes());
-                tgt = resolve_path::join_z_buf::<platform::Auto>(
-                    buf3.as_mut_slice(),
-                    &[tgt.as_bytes(), basename],
-                );
+                tgt = match shell_join_path(bun_sys::Tag::copyfile, &[tgt.as_bytes(), basename]) {
+                    Ok(path) => path,
+                    Err(e) => return Some(ShellErr::new_sys(&e)),
+                };
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -709,10 +700,10 @@ impl ShellCpTask {
                 ));
             }
             let basename = resolve_path::basename(src.as_bytes());
-            tgt = resolve_path::join_z_buf::<platform::Auto>(
-                buf3.as_mut_slice(),
-                &[tgt.as_bytes(), basename],
-            );
+            tgt = match shell_join_path(bun_sys::Tag::copyfile, &[tgt.as_bytes(), basename]) {
+                Ok(path) => path,
+                Err(e) => return Some(ShellErr::new_sys(&e)),
+            };
             _copying_many = true;
         }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2250,6 +2250,37 @@ pub(crate) fn shell_dup(fd: Fd) -> bun_sys::Result<Fd> {
     }
 }
 
+/// Joins argv-sized `parts` into an owned, normalized path. The fs layers the
+/// builtins hand their paths to copy them into `MAX_PATH_BYTES` buffers, so a
+/// result that would not fit one is `ENAMETOOLONG` (tagged `syscall`, naming
+/// the path) here instead.
+pub(crate) fn shell_join_path(
+    syscall: bun_sys::Tag,
+    parts: &[&[u8]],
+) -> bun_sys::Result<bun_core::ZBox> {
+    let mut spill = Vec::new();
+    let joined =
+        bun_paths::resolve_path::join_spill::<bun_paths::platform::Auto>(&mut spill, parts);
+    if joined.len() >= bun_paths::MAX_PATH_BYTES {
+        return Err(bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, syscall).with_path(joined));
+    }
+    Ok(bun_core::ZBox::from_bytes(joined))
+}
+
+/// A builtin's path `operand` made absolute against the shell's `cwd`, via
+/// [`shell_join_path`].
+pub(crate) fn shell_resolve_operand(
+    syscall: bun_sys::Tag,
+    cwd: &[u8],
+    operand: &[u8],
+) -> bun_sys::Result<bun_core::ZBox> {
+    if bun_paths::Platform::AUTO.is_absolute(operand) {
+        shell_join_path(syscall, &[operand])
+    } else {
+        shell_join_path(syscall, &[cwd, operand])
+    }
+}
+
 /// Windows-only: rewrite shell paths so POSIX-absolute `/foo` resolves onto
 /// `dirfd`'s drive root, `/dev/null` maps to `NUL`, and relative paths are
 /// joined against `dirfd`'s real path. Returns a NUL-terminated slice that

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +171,115 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+// The builtin resolved each operand (and `target/basename` when copying into a
+// directory) into fixed-size path buffers without checking that the result fit,
+// so an operand longer than the buffer aborted the whole process. Runs in a
+// child process so the abort shows up as a failed assertion; on POSIX the cp
+// builtin is experimental and must be enabled explicitly.
+test("operands longer than the path buffers are reported as ENAMETOOLONG", async () => {
+  using dir = tempDir("cp-long-operands", {
+    "f": "source",
+    "target": {},
+    "cp-long-operands-fixture.ts": /* ts */ `
+      import { $ } from "bun";
+      import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      $.nothrow();
+      const cwd = process.cwd();
+      // Longer than the path buffer on every platform (1024 bytes on macOS,
+      // 4096 on Linux, 98302 on Windows).
+      const over = Buffer.alloc(100_000, "a").toString();
+      // Applied in order; the deep directory below goes in front because its
+      // path starts with cwd.
+      const placeholders: [string, string][] = [[over, "<over>"], [cwd, "<cwd>"]];
+
+      async function cp(...args: string[]) {
+        const { exitCode, stderr } = await $\`cp \${args}\`.quiet();
+        let message = stderr.toString();
+        for (const [value, placeholder] of placeholders) message = message.replaceAll(value, placeholder);
+        return { exitCode, stderr: message };
+      }
+
+      const names: Record<string, string> = {};
+      const results: Record<string, unknown> = {};
+      results.longSource = await cp(over, "target");
+      results.longTarget = await cp("f", over);
+      results.longAbsoluteTarget = await cp("f", join(cwd, over));
+      results.longSourceAmongOthers = { ...(await cp("f", over, "target")), otherCopied: existsSync("target/f") };
+
+      // Copying into a directory appends the basename to the directory's path,
+      // which needs an existing directory just below the limit. Not reachable
+      // on Windows, where the buffer holds more than any directory path NT
+      // can address.
+      if (process.platform !== "win32") {
+        // A path of PATH_MAX - 1 bytes is the longest one the OS accepts.
+        const PATH_MAX = process.platform === "linux" ? 4096 : 1024;
+        // Nest directories until fewer than ~200 bytes remain below that, so
+        // the basenames straddling the limit are short enough to exist in the
+        // cwd (NAME_MAX is 255).
+        const segment = Buffer.alloc(200, "d").toString();
+        // Length of the name that makes \`dir/name\` exactly PATH_MAX - 1 bytes.
+        const atLimitNameLength = (dir: string) => PATH_MAX - 1 - (dir.length + 1);
+        let deep = join(cwd, segment);
+        while (atLimitNameLength(join(deep, segment)) >= 1) deep = join(deep, segment);
+        mkdirSync(deep, { recursive: true });
+        placeholders.unshift([deep, "<deep>"]);
+
+        const atLimitLength = atLimitNameLength(deep);
+        names.atLimit = Buffer.alloc(atLimitLength, "s").toString();
+        names.onePast = Buffer.alloc(atLimitLength + 1, "t").toString();
+        names.onePastDir = Buffer.alloc(atLimitLength + 1, "u").toString();
+        writeFileSync(names.atLimit, "at limit");
+        writeFileSync(names.onePast, "one past");
+        mkdirSync(names.onePastDir);
+
+        results.deepPathLengths = {
+          atLimit: join(deep, names.atLimit).length,
+          onePast: join(deep, names.onePast).length,
+        };
+        results.intoDeepDirAtLimit = {
+          ...(await cp(names.atLimit, deep)),
+          copied: existsSync(join(deep, names.atLimit)),
+        };
+        results.intoDeepDirOnePast = await cp(names.onePast, deep);
+        results.recursiveIntoDeepDir = await cp("-R", names.onePastDir, deep);
+      }
+
+      console.log(JSON.stringify({ names, results }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "cp-long-operands-fixture.ts"],
+    env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { names, results } = JSON.parse(stdout);
+
+  const tooLong = (path: string) => ({ exitCode: 1, stderr: `cp: File name too long: ${p(path)}\n` });
+  const PATH_MAX = process.platform === "linux" ? 4096 : 1024;
+  expect(results).toEqual({
+    longSource: tooLong("<cwd>/<over>"),
+    longTarget: tooLong("<cwd>/<over>"),
+    longAbsoluteTarget: tooLong("<cwd>/<over>"),
+    longSourceAmongOthers: { ...tooLong("<cwd>/<over>"), otherCopied: true },
+    ...(isWindows
+      ? {}
+      : {
+          // The fixture placed deep/<name> exactly at the OS limit and one byte past it.
+          deepPathLengths: { atLimit: PATH_MAX - 1, onePast: PATH_MAX },
+          intoDeepDirAtLimit: { exitCode: 0, stderr: "", copied: true },
+          intoDeepDirOnePast: tooLong(`<deep>/${names.onePast}`),
+          recursiveIntoDeepDir: tooLong(`<deep>/${names.onePastDir}`),
+        }),
+  });
+  expect(exitCode).toBe(0);
 });
 
 function expectSortedOutput(expected: string) {


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) takes the whole process down when a source or destination operand resolves to a path longer than its scratch buffers. In a directory `/tmp/cpl` containing a file `f`, on bun 1.4.0:
  ```sh
  BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'const r = await Bun.$`cp f ${"a".repeat(5000)}`.nothrow().quiet(); console.log(r.exitCode)'
  ```
  ```
  panic: range end index 5008 out of range for slice of length 4094
  oh no: Bun has crashed.
  ```
  A long source operand crashes the same way. coreutils prints `cp: cannot stat '...': File name too long` and exits 1.
- Copying into an existing directory whose path is just below PATH_MAX crashes too, once `dir/basename(src)` reaches PATH_MAX (`range end index 4095 out of range for slice of length 4094`), with and without `-R`.
- Cause: `ShellCpTask::run_from_thread_pool_impl` (`src/runtime/shell/builtin/cp.rs`) joins cwd + operand with `resolve_path::join_z` (4096-byte thread-local buffer on every platform, so on Windows even paths NT accepts crashed) and `join_z_buf` into two stack `PathBuffer`s, then joins `tgt + basename` into the second one. Those joins write the normalized result with unchecked slice indexing, so argv-sized input is a bounds panic on a work-pool thread. Same class as #37521 (rm) and #37527 (mv).

### Fix
- `shell_join_path` / `shell_resolve_operand` (`src/runtime/shell/interpreter.rs`, next to `shell_dup` / `shell_openat`, the other helpers shared by the builtins) join through `resolve_path::join_spill`, the existing variant that falls back to a `Vec` when the thread-local buffer is too small (used by rm, mv, Glob and readdir), copy the result into an owned `ZBox`, and return `ENAMETOOLONG` (as a `bun_sys::Error` tagged with the caller's syscall, naming the joined path) when the normalized result is not shorter than `MAX_PATH_BYTES`. They return `bun_sys::Result` so cp wraps at the call site exactly like its `is_dir` calls (`ShellErr` is too large to return directly; clippy's `result_large_err` is denied in this workspace).
- cp resolves `src`, `tgt` and the two `tgt/basename` sites through them, and hands the results to the node:fs task as before (`PathLike::owned`). Main now sets `src_absolute` / `tgt_absolute` in `cp_on_finish` from the paths the task moves back, so after the rebase those fields keep their upstream `Vec<u8>` type and this PR no longer touches them.
- Why that bound: the resolved paths are handed to the node:fs cp task, whose `os_path` copies them into `MAX_PATH_BYTES` buffers; on POSIX a longer `dest` becomes an empty path there (`PathLikeExt::slice_z`), so `dir/basename` has to be checked before the hand-off, it never reaches a syscall in this function. `MAX_PATH_BYTES` is PATH_MAX on POSIX (which counts the NUL), so a path of exactly `MAX_PATH_BYTES - 1` bytes, the longest the OS accepts, still passes; the test pins both sides of that boundary. On Windows it is the UTF-8 worst case of the NT limit, so anything rejected here could not have fit the wide buffer either, and shorter paths keep going through cp_async's existing wide-buffer check.
- Why all three joins are checked in the helper rather than leaving `src`/`tgt` to the kernel: one code path and one message; the length is checked after normalization, so a long operand that normalizes down still works as before.
- The error goes through the existing `ShellErr::Sys` rendering, so it reads like the kernel-reported errors cp already prints (`cp: File name too long: /abs/path`), exits 1, and the other source operands of the same invocation are still copied (one task per source). It is returned before the copy is handed off, so `cp_on_finish` never runs for it and on Windows it is not held back by the EBUSY pass.
- Behavior for everything that fits is unchanged: `join_spill` normalizes with the same function `join_z_buf` used; only the storage moved from two stack `PathBuffer`s (about 196 KB of stack per task on Windows) plus the thread-local buffer to the heap. A 23-case probe (all three synopses, trailing slashes, `..` segments, absolute operands, identical files, missing source, non-directory target, `-v` output, error messages) gives byte-identical output on the unfixed 1.4.0 binary and this build; list below.
- Scope: `rm` and `mv` have their own open PRs (#37521, #37527). `touch` (`touch.rs`, the same two-branch join into a `PathBuffer`) and `mkdir` (`mkdir.rs`, `join_z` for relative operands) still abort on the same input and are being handled separately; they can switch to these helpers in one or two lines each once this lands, which is why the helpers live in `interpreter.rs` and take the syscall tag.
- Test: `test/js/bun/shell/commands/cp.test.ts`, "operands longer than the path buffers are reported as ENAMETOOLONG". Runs the builtin in a child process (the in-process cp suite in that file is skipped on POSIX; `builtinDisabled("cp")` does not look at the env var) and covers a 100000-byte source, destination and absolute destination (longer than the buffer on every platform, so these run on Windows too), a long source next to a normal one (normal one copied, exit 1), and on POSIX a directory nested to just below PATH_MAX: a file whose `dir/name` is exactly PATH_MAX - 1 bytes is copied, one byte longer fails with `ENAMETOOLONG` naming `dir/name`, with and without `-R` (the two join sites). The fixture reports the lengths, so the boundary itself is asserted.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/cp.test.ts -t "path buffers"`: fails, the child aborts with the first panic above. Each of the two deep-directory overflow cases also aborts the unfixed binary on its own (second panic above); the at-limit case passes on both builds.
  - `bun bd test test/js/bun/shell/commands/cp.test.ts`: passes.
  - The file's in-process suite, forced on under Linux with the flag: every cp case passes; the only failures are the cases that start with `cat file > x`, which hang identically on the unfixed binary (cat builtin, #35337 / #37743).
  - `cargo clippy -p bun_runtime --no-deps`, `cargo fmt --check`, and `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` pass.

### Background
- Shell builtins live in `src/runtime/shell/builtin/` and run in-process. `cp` and `cat` are built everywhere but only dispatched by default on Windows; on POSIX `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` enables them, otherwise the system binary is spawned. The other builtins (mkdir, touch, rm, mv, ...) are on everywhere.
- `ShellCpTask` is created per source operand and runs on a work-pool thread: it resolves the operands to absolute paths, picks the POSIX cp synopsis (file to file, `-R` into a directory, files into a directory), then hands the copy to the node:fs `fs.cp` implementation (`cp_async` in `node_fs.rs`). That hand-off is why the shell-side paths must satisfy node:fs's buffer bound.
- `resolve_path::join*` concatenate their parts and normalize them (`.`, `..`, repeated separators; a trailing separator is kept, which `cp dir/` relies on) into a caller buffer (`join_z_buf`), a 4096-byte thread-local (`join`, `join_z`), or, for the `*_spill` variants, a caller-owned `Vec` when the parts would not fit. The non-spill variants do not bounds-check their output.
- `MAX_PATH_BYTES` is the size of bun's `PathBuffer`: 4096 on Linux and 1024 on macOS (both equal to PATH_MAX, which includes the NUL, so the longest usable path is one byte less), 98302 on Windows (3 bytes per UTF-16 unit of the 32767-unit NT limit, plus one).
- `ZBox` is bun's owned NUL-terminated byte string, the heap counterpart of the `&ZStr` the syscall wrappers take; it derefs to `ZStr` and on to `[u8]` (without the NUL).
- `ShellErr::Sys` is how builtins report errno failures; it renders as `<cmd>: <coreutils message>: <path>` and the builtin's state machine turns it into exit code 1.

<details>
<summary>Behavior-preservation probe (identical output on bun 1.4.0 and this build)</summary>

Run with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on Linux; exit code, stdout, stderr and resulting files compared for:
`cp -v file new`, `cp -v file existing`, `cp -v file dir`, `cp -v file dir/`, `cp -v file missing/` (error), `cp file missing` (creates it), `cp -v a b dir`, `cp a b file` (error), `cp a ./a` and `cp a /abs/a` (identical errors), `cp -R dir existingdir`, `cp -R dir newdir`, `cp -R dir/ newdir`, `cp -R dir existingdir/`, `cp -R file dir`, `cp -R a b missing` (error), `cp dir x` without `-R` (error), missing source (error message with absolute path), absolute source and destination, `cp dir/../a dir/./x/../b`, an empty operand, `cp dir/file .`, `cp -R dir/. dst`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->
