### PR TITLE
sql(mysql): ref the event loop when a query is enqueued on an idle connection

### DIFF
--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -363,6 +363,10 @@ impl JSMySQLConnection {
     pub(crate) fn enqueue_request(&self, item: *mut JSMySQLQuery) {
         bun_core::scoped_log!(MySQLConnection, "enqueueRequest");
         self.connection_mut().enqueue_request(item);
+        // An idle connection has unref'd the event loop (see `on_data`); this
+        // request makes it busy again, so re-ref or the process may exit while
+        // the server's reply is still in flight.
+        self.update_reference_type();
         self.reset_connection_timeout();
         self.register_auto_flusher();
     }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -363,9 +363,7 @@ impl JSMySQLConnection {
     pub(crate) fn enqueue_request(&self, item: *mut JSMySQLQuery) {
         bun_core::scoped_log!(MySQLConnection, "enqueueRequest");
         self.connection_mut().enqueue_request(item);
-        // An idle connection has unref'd the event loop (see `on_data`); this
-        // request makes it busy again, so re-ref or the process may exit while
-        // the server's reply is still in flight.
+        // Re-refs the event loop if the connection was idle (unref'd by `on_data`).
         self.update_reference_type();
         self.reset_connection_timeout();
         self.register_auto_flusher();

--- a/test/js/sql/sql-mysql-query-on-idle-connection-fixture.ts
+++ b/test/js/sql/sql-mysql-query-on-idle-connection-fixture.ts
@@ -21,6 +21,9 @@
 // bug. With the delay, a build with the bug always exits before "second query
 // done" is printed, leaving the exit code at 1.
 //
+// Queries use the text protocol (`unsafe` without parameters) so that the mock
+// server in the test only has to answer COM_QUERY.
+//
 // This runs as its own process because `bun test` keeps the event loop alive
 // by itself. The work is wrapped in main() on purpose: while an entry module's
 // top-level await is pending the runtime keeps polling regardless of what is
@@ -45,17 +48,17 @@ async function main() {
 
       if (scenario === "begin") {
         await sql.begin(async tx => {
-          await tx`select 1`;
+          await tx.unsafe("select 1 as x");
         });
       } else {
         const reserved = await sql.reserve();
-        await reserved`select 1`;
+        await reserved.unsafe("select 1 as x");
         await reserved.release();
       }
       break;
     }
     case "turn":
-      await sql`select 1`;
+      await sql.unsafe("select 1 as x");
       await new Promise(resolve => setImmediate(resolve));
       break;
     default:

--- a/test/js/sql/sql-mysql-query-on-idle-connection-fixture.ts
+++ b/test/js/sql/sql-mysql-query-on-idle-connection-fixture.ts
@@ -1,23 +1,30 @@
-// A query handed to a pool connection that is already idle must keep the
-// process alive until the server answers. In every scenario below the second
-// query is issued on a connection that has gone idle:
+// A query handed to a connection that is already idle (one that has unref'd
+// the event loop) must keep the process alive until the server answers.
 //
-//   begin    max: 2. The transaction runs on the first connection; releasing
-//            it appends it to the end of the pool's ready set, so the next
-//            query is routed to the second connection, which has been idle
-//            since its handshake finished.
+// A connection only stays ref'd by accident when the next query is enqueued on
+// it while its previous reply is still being processed, so every scenario makes
+// sure that is not the case:
+//
+//   begin    max: 2. Both connections are established and released up front, so
+//            they are idle before anything runs on them. The transaction's own
+//            BEGIN goes to an idle connection, and the connection it used is
+//            appended to the end of the pool's ready set on release, so the
+//            final query is routed to the other, still untouched, connection.
 //   reserve  Same as begin, via reserve() + release().
-//   turn     max: 1. One event loop turn passes between the two queries, so
-//            the only connection is idle when the second one is issued.
+//   turn     max: 1. An event loop turn passes between the two queries, so the
+//            only connection has unref'd itself by the time the second one is
+//            issued.
+//
+// The final query sleeps server side: before exiting, the runtime polls the
+// sockets once more without blocking, and against a server on the same machine
+// an instant reply can land inside that poll and rescue a build that has the
+// bug. With the delay, a build with the bug always exits before "second query
+// done" is printed, leaving the exit code at 1.
 //
 // This runs as its own process because `bun test` keeps the event loop alive
 // by itself. The work is wrapped in main() on purpose: while an entry module's
-// top-level await is pending the runtime keeps ticking the event loop whether
-// or not anything is ref'd, which would hide the bug.
-//
-// Passes by printing both lines and exiting with code 0. With the bug, the
-// process exits right after "first step done" with the second query still
-// pending, so the exit code stays 1.
+// top-level await is pending the runtime keeps polling regardless of what is
+// ref'd, which would also hide the bug.
 import { SQL } from "bun";
 
 process.exitCode = 1;
@@ -31,14 +38,20 @@ async function main() {
 
   switch (scenario) {
     case "begin":
-      await sql.begin(async tx => {
-        await tx`select 1`;
-      });
-      break;
     case "reserve": {
-      const reserved = await sql.reserve();
-      await reserved`select 1`;
-      await reserved.release();
+      const [first, second] = await Promise.all([sql.reserve(), sql.reserve()]);
+      await first.release();
+      await second.release();
+
+      if (scenario === "begin") {
+        await sql.begin(async tx => {
+          await tx`select 1`;
+        });
+      } else {
+        const reserved = await sql.reserve();
+        await reserved`select 1`;
+        await reserved.release();
+      }
       break;
     }
     case "turn":
@@ -50,12 +63,17 @@ async function main() {
   }
   console.log("first step done");
 
-  const [row] = await sql`select 2 as x`;
+  const [row] = await sql.unsafe("select sleep(0.2) as slept, 2 as x");
   console.log(`second query done: ${row.x}`);
-
-  // Deliberately no sql.close(): once the reply is in, the connections are idle
-  // again and must stop keeping the process alive on their own.
   process.exitCode = 0;
+
+  // Deliberately no sql.close(): the connections are idle again and must stop
+  // keeping the process alive on their own. The timer is unref'd, so it only
+  // ever fires if they don't.
+  setTimeout(() => {
+    console.error("the idle connections kept the process alive");
+    process.exit(3);
+  }, 2_000).unref();
 }
 
 main().catch(err => {

--- a/test/js/sql/sql-mysql-query-on-idle-connection-fixture.ts
+++ b/test/js/sql/sql-mysql-query-on-idle-connection-fixture.ts
@@ -1,0 +1,64 @@
+// A query handed to a pool connection that is already idle must keep the
+// process alive until the server answers. In every scenario below the second
+// query is issued on a connection that has gone idle:
+//
+//   begin    max: 2. The transaction runs on the first connection; releasing
+//            it appends it to the end of the pool's ready set, so the next
+//            query is routed to the second connection, which has been idle
+//            since its handshake finished.
+//   reserve  Same as begin, via reserve() + release().
+//   turn     max: 1. One event loop turn passes between the two queries, so
+//            the only connection is idle when the second one is issued.
+//
+// This runs as its own process because `bun test` keeps the event loop alive
+// by itself. The work is wrapped in main() on purpose: while an entry module's
+// top-level await is pending the runtime keeps ticking the event loop whether
+// or not anything is ref'd, which would hide the bug.
+//
+// Passes by printing both lines and exiting with code 0. With the bug, the
+// process exits right after "first step done" with the second query still
+// pending, so the exit code stays 1.
+import { SQL } from "bun";
+
+process.exitCode = 1;
+
+const url = process.env.MYSQL_URL;
+if (!url) throw new Error("MYSQL_URL is required");
+const scenario = process.argv[2];
+
+async function main() {
+  const sql = new SQL({ url, max: scenario === "turn" ? 1 : 2 });
+
+  switch (scenario) {
+    case "begin":
+      await sql.begin(async tx => {
+        await tx`select 1`;
+      });
+      break;
+    case "reserve": {
+      const reserved = await sql.reserve();
+      await reserved`select 1`;
+      await reserved.release();
+      break;
+    }
+    case "turn":
+      await sql`select 1`;
+      await new Promise(resolve => setImmediate(resolve));
+      break;
+    default:
+      throw new Error(`unknown scenario: ${scenario}`);
+  }
+  console.log("first step done");
+
+  const [row] = await sql`select 2 as x`;
+  console.log(`second query done: ${row.x}`);
+
+  // Deliberately no sql.close(): once the reply is in, the connections are idle
+  // again and must stop keeping the process alive on their own.
+  process.exitCode = 0;
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(2);
+});

--- a/test/js/sql/sql-mysql-query-on-idle-connection.test.ts
+++ b/test/js/sql/sql-mysql-query-on-idle-connection.test.ts
@@ -4,28 +4,84 @@
 // reserve() + release(), or simply on a later event loop turn) exits with code
 // 0 while that query is still pending. Each scenario runs in its own process
 // because the test runner keeps the event loop alive on its own; see the
-// fixture for what each scenario sets up.
-import { expect, test } from "bun:test";
+// fixture for what each scenario sets up. The scenarios run against a mock
+// server (everywhere, including platforms without docker) and against a real
+// one.
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, describeWithContainer, normalizeBunSnapshot } from "harness";
+import type { Socket } from "node:net";
 import path from "path";
+import { listeningServer, mysqlHandshakeV10, mysqlOkPacket, mysqlReadPackets, mysqlTextResultSet } from "./wire-frames";
 
 const fixture = path.join(import.meta.dir, "sql-mysql-query-on-idle-connection-fixture.ts");
+const scenarios = ["begin", "reserve", "turn"];
 
-describeWithContainer("mysql", { image: "mysql_plain", concurrent: true }, container => {
-  test.each(["begin", "reserve", "turn"])("the process stays alive for a query issued after %s", async scenario => {
-    await container.ready;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), fixture, scenario],
-      env: { ...bunEnv, MYSQL_URL: `mysql://root@${container.host}:${container.port}/bun_sql_test` },
-      stdout: "pipe",
-      stderr: "pipe",
+const COM_QUERY = 0x03;
+const MYSQL_TYPE_LONGLONG = 0x08;
+
+// Answers the handshake and every text-protocol query (a result set for
+// selects, OK for BEGIN/COMMIT), and, like a real server would, answers a
+// query that calls sleep() late.
+async function mockServer() {
+  return await listeningServer((socket: Socket) => {
+    let buffered = Buffer.alloc(0);
+    let authenticated = false;
+    socket.on("error", () => {});
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authenticated) {
+          authenticated = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        if (payload[0] !== COM_QUERY) {
+          socket.end();
+          return;
+        }
+        const query = payload.subarray(1).toString().toLowerCase();
+        const reply = query.startsWith("select")
+          ? mysqlTextResultSet(1, [{ name: "x", type: MYSQL_TYPE_LONGLONG }], [["2"]])
+          : mysqlOkPacket(1);
+        if (!query.includes("sleep(")) {
+          socket.write(reply);
+          return;
+        }
+        setTimeout(() => {
+          if (!socket.destroyed) socket.write(reply);
+        }, 200);
+      });
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr.split(/\r?\n/).filter(line => line && !line.startsWith("WARNING: ASAN interferes"))).toEqual([]);
-    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
-      "first step done
-      second query done: 2"
-    `);
-    expect(exitCode).toBe(0);
+  });
+}
+
+async function expectFixtureToFinish(url: string, scenario: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, scenario],
+    env: { ...bunEnv, MYSQL_URL: url },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.split(/\r?\n/).filter(line => line && !line.startsWith("WARNING: ASAN interferes"))).toEqual([]);
+  expect(normalizeBunSnapshot(stdout)).toBe("first step done\nsecond query done: 2");
+  expect(exitCode).toBe(0);
+}
+
+describe.concurrent("against a mock server", () => {
+  test.each(scenarios)("the process stays alive for a query issued after %s", async scenario => {
+    const { server, port } = await mockServer();
+    try {
+      await expectFixtureToFinish(`mysql://root@127.0.0.1:${port}/db`, scenario);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+});
+
+describeWithContainer("against mysql", { image: "mysql_plain", concurrent: true }, container => {
+  test.each(scenarios)("the process stays alive for a query issued after %s", async scenario => {
+    await container.ready;
+    await expectFixtureToFinish(`mysql://root@${container.host}:${container.port}/bun_sql_test`, scenario);
   });
 });

--- a/test/js/sql/sql-mysql-query-on-idle-connection.test.ts
+++ b/test/js/sql/sql-mysql-query-on-idle-connection.test.ts
@@ -1,0 +1,31 @@
+// A MySQL connection unrefs the event loop once it has nothing in flight.
+// Enqueueing a query on it has to ref the loop again, otherwise a script whose
+// next query lands on an idle pool connection (after sql.begin(), after
+// reserve() + release(), or simply on a later event loop turn) exits with code
+// 0 while that query is still pending. Each scenario runs in its own process
+// because the test runner keeps the event loop alive on its own; see the
+// fixture for what each scenario sets up.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer, normalizeBunSnapshot } from "harness";
+import path from "path";
+
+const fixture = path.join(import.meta.dir, "sql-mysql-query-on-idle-connection-fixture.ts");
+
+describeWithContainer("mysql", { image: "mysql_plain", concurrent: true }, container => {
+  test.each(["begin", "reserve", "turn"])("the process stays alive for a query issued after %s", async scenario => {
+    await container.ready;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture, scenario],
+      env: { ...bunEnv, MYSQL_URL: `mysql://root@${container.host}:${container.port}/bun_sql_test` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.split(/\r?\n/).filter(line => line && !line.startsWith("WARNING: ASAN interferes"))).toEqual([]);
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "first step done
+      second query done: 2"
+    `);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- With the mysql adapter, a script whose next query lands on an idle pool connection exits with code 0 while that query is still pending. Its promise never settles and nothing is printed. Fixes #27102 (the issue's own repro stops mid-step in its `REPRO_TX=true` modes; the autocommit mode happens to work).
- Typical shapes: `await sql.begin(...)` followed by a query, `reserve()` + `release()` followed by a query, or two queries with any event loop turn between them (a `setImmediate`, an `fs.promises` call, a timer).
- Cause: `JSMySQLConnection::update_reference_type()` (`src/sql_jsc/mysql/JSMySQLConnection.rs:424`) is what syncs the connection's `poll_ref` with its state, and it unrefs the event loop when a connected connection has nothing queued. It runs after every `on_data`, so a connection unrefs as soon as its last reply is read (for pool connections that never ran a query, right after the auth handshake). `enqueue_request()` (`JSMySQLConnection.rs:363`) did not call it, so a query queued on an idle connection never ref'd the loop again.
- Why the simple "query, await, query" case works: the second query is enqueued inside the first reply's microtask drain, on the same connection, before that connection's deferred `update_reference_type()` runs, which then sees the queue non-empty and keeps the ref. After `begin()`/`reserve()` the released connection is re-added at the end of the pool's ready set, so the next query is routed to the other connection, which unref'd after its handshake. The transaction's connection then goes idle, unrefs, the loop's active count hits 0 and the process exits with the query written to the socket but nothing waiting for the reply.

### Fix
- `enqueue_request()` calls `update_reference_type()` after adding the request to the queue. With a request queued, `is_idle()` is false, so a `Connected` connection refs the loop; a still-connecting connection is already ref'd; a `Failed`/`Disconnected` one stays unref'd, as today.
- This is the only idle -> busy transition: requests enter the queue here and nowhere else. The busy -> idle side is already handled by the `on_data` defer, which unrefs once the reply has been consumed, so processes still exit on their own once every connection is idle (covered by the existing `process should exit when idle` test and by the new fixture, which never calls `close()` and fails if the process lingers).
- The postgres adapter has done the equivalent since its Zig days: `PostgresSQLQuery::do_run` refs `poll_ref` right after `requests.write_item(...)`. The same scripts work with postgres today.
- Verified:
  - `test/js/sql/sql-mysql-query-on-idle-connection.test.ts` spawns a fixture for three scenarios (`begin`, `reserve`, one event loop turn between two queries on a `max: 1` pool), once against a mock server built from `wire-frames.ts` (runs on every platform) and once against the docker MySQL. The fixture establishes both pool connections up front so every query it issues goes to an idle connection, and its final query is answered late (`sleep(0.2)`, which the mock emulates) so the exit path's last non-blocking poll (see Background) cannot rescue a build with the bug. On 1.4.0 all six fail: the three scenarios exit before printing `second query done` in 60/60 runs each against the local MariaDB on a heavily loaded box, and the same happens on Windows against the mock. With this change the file passes repeatedly under the debug build.
  - Issue repro (chris-kreidl/bun-sql-bug-repro) against MariaDB 11.8: `single` and `split` with `REPRO_TX=true` stop before `scenario:done` on 1.4.0 and complete with this change.
  - `sql-mysql.transactions.test.ts` plus the non-docker-gated mysql suites in `test/js/sql` (60 tests across 13 files) pass with the debug build.

### Background
- `poll_ref` is a `KeepAlive`: an active/inactive flag over the event loop's active handle count. Bun exits when that count reaches 0, so a connection waiting on a server reply must hold it active, and an idle one must not, or scripts would never exit without an explicit `sql.close()`.
- A MySQL connection's request queue holds every query that has been sent or is waiting to be sent. `is_idle()` is "queue empty and write buffer empty".
- `on_data` enters the event loop before parsing, so the microtask drain (user continuations, and therefore possibly the next `do_run`/`enqueue_request`) happens on exit, and only then does its defer block call `update_reference_type()`. That ordering is what made same-connection follow-up queries work by accident and every other routing fail.
- `Bun.SQL` starts all `max` connections on first use. Each one that finishes its handshake without work unrefs immediately, so with the default pool of 10, nine connections are idle and unref'd from the start, and the pool prefers them over a just-released one.
- Before exiting, `auto_tick` (`src/runtime/jsc_hooks.rs`) polls an inactive loop once more without blocking. If the server's reply is already in the socket buffer at that point, `on_data` runs and its defer refs the connection, so against a server on the same machine a build with the bug occasionally gets away with it; with any real network latency the failure is deterministic, which matches the reports.
- While an entry module's top-level await is pending the runtime keeps polling regardless of refs (#33283), which is why top-level-await reductions of this bug appear to pass; the fixture wraps its work in `main()` for that reason. #24130 and #25552 describe the same query sequence in top-level-await form (and report hangs on Windows); that form completes on current Linux and Windows builds without this change (checked on Windows against the mock), so neither is claimed as fixed here.
