### PR TITLE
worker: free the thread's event name table when the worker thread exits

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -373,9 +373,9 @@ static char* shared_header_buffer_get()
     return buffer.get();
 }
 
-// A Worker returns out of shutdown() instead of calling pthread_exit, and the process can exit
-// before its TLS destructors run, so the worker releases this explicitly at teardown. The getter
-// re-allocates on demand.
+// Bun compiles with -fno-c++-static-destructors, so the thread_local above is never destroyed when
+// a worker thread exits; the worker releases it explicitly at teardown (WebWorker::shutdown). The
+// getter re-allocates on demand.
 extern "C" void Bun__freeSharedHeaderBufferForThreadExit()
 {
     shared_header_buffer_slot().reset();

--- a/src/jsc/bindings/webcore/EventNames.cpp
+++ b/src/jsc/bindings/webcore/EventNames.cpp
@@ -43,6 +43,15 @@ const EventNames& eventNames()
     return *eventNames_;
 }
 
+// Bun compiles with -fno-c++-static-destructors, so eventNames_ is never destroyed when its thread
+// exits. A worker thread frees its table on the way out (WebWorker::shutdown), while the thread's
+// AtomStringTable that holds these atoms is still alive; WebCore does the same in
+// ThreadGlobalData::destroy().
+extern "C" void Bun__destroyEventNamesForThreadExit()
+{
+    eventNames_.reset();
+}
+
 enum class DOMEventName : uint8_t {
     rename = 0,
     change = 1,

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -146,6 +146,7 @@ unsafe extern "C" {
         message: &mut BunString,
         err: JSValue,
     );
+    safe fn Bun__destroyEventNamesForThreadExit();
     safe fn Bun__freeSharedHeaderBufferForThreadExit();
     // Raw FFI (no RAII guard) so `thread_main` can take the API lock and abandon
     // it with the VM — see the note there.
@@ -1047,9 +1048,11 @@ impl WebWorker {
             // gone so its raw `transpiler.env` borrow is dead.
             drop(unsafe { bun_core::heap::take(env_loader) });
         }
-        // This thread's C++ thread_local destructors are not guaranteed to run
-        // before the process exits, so free the HPACK scratch buffer that any
-        // http2 session on this thread allocated.
+        // C++ is built with -fno-c++-static-destructors, so nothing a C++
+        // thread_local owns is freed when this thread returns: release the
+        // per-thread state script on this thread populated (the event-name
+        // atoms, any http2 session's HPACK scratch buffer) by hand.
+        Bun__destroyEventNamesForThreadExit();
         Bun__freeSharedHeaderBufferForThreadExit();
         drop(arena.take());
         log!(

--- a/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
+++ b/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
@@ -1,6 +1,11 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { join } from "path";
+
+// Every test here starts a worker VM under debug+ASAN and then runs LSan over
+// the exiting process, which already takes a few seconds on a loaded machine;
+// symbolizing a report against the debug binary takes tens of seconds more.
+const LEAK_TEST_TIMEOUT = 90_000;
 
 // A worker's shutdown used to drain its concurrent queue and only then mark
 // the context terminating. A cross-thread postTaskTo landing in between (the
@@ -46,4 +51,93 @@ test.skipIf(!isASAN || isWindows)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   },
+  LEAK_TEST_TIMEOUT,
 );
+
+// WebCore::eventNames() keeps its table of event-name atoms in a C++
+// thread_local, and Bun compiles with -fno-c++-static-destructors, so the table
+// was never freed when a worker thread exited. Every worker allocates one the
+// moment it comes online (WorkerMessagingProxy::workerGlobalScopeStarted, right
+// after its entry script has run), even a worker whose script is empty, so the
+// cases below only differ in how the thread ends; a worker that exits or
+// registers listeners itself does so from a callback, once it is online.
+// Malloc=1 makes WTF's fastMalloc use the system allocator, which is what lets
+// LSan see the table at all.
+describe.concurrent("a worker thread frees its event name table when it exits", () => {
+  const lsanEnv = {
+    ...bunEnv,
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
+    Malloc: "1",
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+  };
+
+  test.skipIf(!isASAN || isWindows).each([
+    {
+      route: "worker_threads Worker whose event loop drains",
+      files: {
+        "main.mjs": `
+          import { Worker } from "node:worker_threads";
+          new Worker("", { eval: true }).on("exit", code => console.log("exit", code));
+        `,
+      },
+      stdout: "exit 0\n",
+    },
+    {
+      route: "worker_threads Worker that calls process.exit()",
+      files: {
+        "main.mjs": `
+          import { Worker } from "node:worker_threads";
+          new Worker("setImmediate(() => process.exit(7));", { eval: true }).on("exit", code => console.log("exit", code));
+        `,
+      },
+      stdout: "exit 7\n",
+    },
+    {
+      route: "worker_threads Worker terminated by its parent while it listens on parentPort",
+      files: {
+        "main.mjs": `
+          import { Worker } from "node:worker_threads";
+          const worker = new Worker(
+            \`
+              const { parentPort } = require("node:worker_threads");
+              setImmediate(() => {
+                parentPort.on("message", () => {});
+                parentPort.postMessage("listening");
+              });
+            \`,
+            { eval: true },
+          );
+          worker.on("message", () => worker.terminate());
+          worker.on("exit", () => console.log("terminated"));
+        `,
+      },
+      stdout: "terminated\n",
+    },
+    {
+      route: "Web Worker whose event loop drains",
+      files: {
+        "main.mjs": `
+          new Worker(new URL("./worker.js", import.meta.url)).addEventListener("close", () => console.log("close"));
+        `,
+        "worker.js": "",
+      },
+      stdout: "close\n",
+    },
+  ])(
+    "$route",
+    async ({ files, stdout: expectedStdout }) => {
+      using dir = tempDir("worker-event-names", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.mjs"],
+        cwd: String(dir),
+        env: lsanEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: expectedStdout, stderr: "", exitCode: 0 });
+    },
+    LEAK_TEST_TIMEOUT,
+  );
+});


### PR DESCRIPTION
### Problem

- Every worker thread leaks its `WebCore::EventNames` table when it exits. LSan (ASAN build, `Malloc=1`): `Direct leak of 88 byte(s) ... WebCore::EventNames::create<>() EventNames.h:62 / WebCore::eventNames() EventNames.cpp:42`, plus the table's atoms as indirect leaks; about 270 bytes per worker, one report per worker that ever ran.
- Every worker allocates the table: `WorkerMessagingProxy::workerGlobalScopeStarted` (WorkerMessagingProxy.cpp:392) calls `eventNames()` on the worker thread when the worker comes online, so an empty worker leaks it too.
- Cause: the table lives in `thread_local std::unique_ptr<EventNames> eventNames_` (src/jsc/bindings/webcore/EventNames.cpp:37). Bun compiles all C++ with `-fno-c++-static-destructors` (scripts/build/flags.ts:354), which also covers thread-storage variables, so no destructor is ever registered for it: the TLS wrapper emitted for `eventNames_` is a bare address computation with no `__tls_init` / `__cxa_thread_atexit` call. When the worker thread returns, nothing frees the table. The main thread's copy is reachable through its TLS until process exit, so only workers leak.

### Fix

- `EventNames.cpp`: add `Bun__destroyEventNamesForThreadExit()`, which resets the thread's `eventNames_`.
- `web_worker.rs` (`WebWorker::shutdown`): call it after `VirtualMachine::teardown`, next to `Bun__freeSharedHeaderBufferForThreadExit()`, which already frees the other heap-owning C++ thread_local (the http2 HPACK buffer) for exactly this reason. `shutdown()` is the one exit funnel for every worker: natural drain, `process.exit()` in the worker, `terminate()` from the parent, and both `worker_threads` and Web `Worker` kinds. On the early-terminate paths that never built a VM the reset is a no-op.
- Why this point is correct: the table's atoms live in the worker thread's own `AtomStringTable` (a Default-type JSC VM shares the thread's table, VM.cpp:264, and `~VM` leaves it alone), which belongs to the `WTF::Thread` and is destroyed only when the thread itself exits, so releasing the atoms here removes them from the table they were registered in. No script can run at this point (teardown forbade it and the JSC VM is gone), and nothing that runs later on the thread calls `eventNames()` (`workerGlobalScopeDestroyed` only posts a task to the parent), so the table is not re-created. Nothing stores a reference to the `EventNames` struct; every caller reads `eventNames().xEvent` transiently.
- This mirrors WebCore, where the table hangs off `ThreadGlobalData` and the worker thread calls `threadGlobalData().destroy()` before it exits; Bun replaced `ThreadGlobalData` with the bare thread_local and dropped that step.
- Considered `[[clang::always_destroy]]` on the variable instead: it would also run the destructor during `exit()` on the main thread (bun exits through `exit()` on macOS and in ASAN builds) and makes the atom release depend on the platform's ordering of C++ TLS destructors versus pthread-key destructors (which is what tears down the `WTF::Thread` and its atom table). The explicit call runs at one known point, on worker threads only.
- Updated the comment on the HPACK sibling in `c-bindings.cpp`, which attributed the missing destructor to process exit rather than to the compiler flag.
- Verification: `test/js/node/worker_threads/worker-shutdown-post-leak.test.ts` gains four LSan cases (`Malloc=1` so WTF's fastMalloc goes through the system allocator and LSan can see the table): `worker_threads` worker draining, calling `process.exit()`, terminated by the parent while listening on `parentPort`, and a Web Worker draining. With `src/` stashed and rebuilt all four fail with the 88-byte `EventNames` leak above; with the fix all five tests in the file pass (`bun bd test`). The file's existing test gets the same explicit timeout as the new cases: each of these spawns a worker VM under debug+ASAN and then runs LSan, which already takes 4 to 7 seconds on a loaded machine against the 5 second default.
- Also ran `worker_destruction`, `worker-transfer-terminate-stress`, `worker-terminate-lifetime`, `worker-terminate-funnels`, `message-port-context-destroy-leak`, `message-port-closed-leak`, `performance-observer-leak` and `shell-worker-terminate-leak` against the fixed build; the only failures were the same five the unmodified tree produces here (listed under details).
- Out of scope, reported separately: with this fixed, a file-based (non-`eval`) `worker_threads` worker still leaks its resolved entry path string because `VirtualMachine::destroy()` never releases `main_resolved_path`. That is why the new `worker_threads` cases use `eval: true`.

### Background

- `eventNames()`: WebCore's per-thread struct of pre-atomized event type names (`closeEvent`, `messageEvent`, ...) used by EventTarget code (`MessagePort`, `AbortSignal`, `Worker`, ...) to compare and dispatch event types without re-atomizing strings.
- `AtomString` / `AtomStringTable`: an `AtomString` is a string interned in a per-thread table so equal strings share one `StringImpl` and compare by pointer. The table holds raw pointers; when the last reference to an atom is dropped, the `StringImpl` removes itself from the current thread's table, so an atom must be released on the thread that created it while that table still exists.
- `-fno-c++-static-destructors`: Clang flag that suppresses exit-time destructor registration for every static-storage and thread-storage variable (the same effect as marking each one `[[clang::no_destroy]]`). Bun uses it because JSC assumes no destructors run at process exit; the side effect is that a `thread_local` that owns heap memory must be freed by hand when a thread that used it exits.
- `WebWorker::shutdown()` (src/jsc/web_worker.rs): the last thing a worker thread runs: exit handlers, `VirtualMachine::teardown` (stop phase, JSC VM destruction, loop teardown), freeing of the thread's remaining state, then `workerGlobalScopeDestroyed`, after which the parent joins the thread.

<details>
<summary>Probes and pre-existing failures seen while verifying</summary>

TLS wrapper Clang emits for the variable in the debug binary (no init or destructor registration call):

```
<TLS wrapper function for WebCore::eventNames_>:
  push %rbp
  mov  %rsp,%rbp
  mov  %fs:0x0,%rax
  lea  -0x4770(%rax),%rax
  pop  %rbp
  ret
```

Unfixed tree, three workers (repro from the report), `BUN_DESTRUCT_VM_ON_EXIT=1 Malloc=1` with `test/leaksan.supp`:

```
Direct leak of 264 byte(s) in 3 object(s) allocated from:
    ... WebCore::EventNames::create<>() EventNames.h:62
    ... WebCore::eventNames() EventNames.cpp:42
Indirect leak of 447 byte(s) in 15 object(s) ...
SUMMARY: AddressSanitizer: 711 byte(s) leaked in 18 allocation(s).
```

With an empty worker the allocating frame is `WorkerMessagingProxy::workerGlobalScopeStarted`, called from `WebWorker::spin` once the entry script has run. A table first created by top-level script code is attributed to module evaluation, which `leaksan.supp` suppresses, which is why the new cases register listeners and exit from callbacks.

Failures that are identical with and without this change on this machine (debug ASAN build, heavily loaded host):

- `worker-terminate-lifetime.test.ts` "terminate() while dns.lookup() is in flight": LSan reports a 4104 byte `node_fs_binding::Binding` box; already tracked by #35159.
- `worker_destruction.test.ts`: four cases (Bun.connect / Bun.listen / fetch in a terminating worker, child process with pending stdin write) hit the 5 second default timeout at 5.0 seconds; they take that long here regardless of this change.

</details>
