### PR TITLE
test: make the import() AST leak fixture actually evict the module

### DIFF
--- a/test/cli/run/esm-bug-leak-fixture.mjs
+++ b/test/cli/run/esm-bug-leak-fixture.mjs
@@ -1,6 +1,8 @@
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
-const dest = await import.meta.resolve("./esm-leak-fixture-large-ast.mjs");
+// require.cache is keyed by absolute path; the file:// URL import.meta.resolve()
+// returns never matches an entry, so deleting it would not evict the module.
+const dest = require.resolve("./esm-leak-fixture-large-ast.mjs");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
@@ -13,6 +15,11 @@ if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {
   delete require.cache[dest];
   await import(dest);
+}
+if (!(dest in require.cache)) {
+  console.log("require.cache has no entry for", dest, "so deleting it never evicts the module");
+  console.log("\n--fail--\n");
+  process.exit(1);
 }
 if (typeof Bun !== "undefined") Bun.gc(true);
 const baseline = rss();


### PR DESCRIPTION
### Problem

- `require.cache > files transpiled and loaded don't leak the AST > via import()` (`test/cli/run/require-cache.test.ts:298`) spawns `test/cli/run/esm-bug-leak-fixture.mjs`, which is supposed to load the 200 KB `esm-leak-fixture-large-ast.mjs` 55 times and check that RSS stays flat.
- The fixture evicts with `delete require.cache[dest]` where `dest = await import.meta.resolve(...)` (`esm-bug-leak-fixture.mjs:3`). Since #5827 that is a `file://` URL string; `require.cache` is keyed by absolute path, so the delete never matches anything. The module is transpiled and evaluated once and the other 54 `import(dest)` calls are cache hits, so the RSS check measures nothing. (When the fixture was written in #6790, `import.meta.resolve()` returned a promise of an absolute path, hence the `await`. #5827 switched `esm-fixture-leak-small.mjs` to `require.resolve()` but left this fixture on the old key.)
- Measured with a copy of the large module that counts its own evaluations: 1 evaluation with the `file://` key, 55 with the `require.resolve()` key. On a debug+ASAN build the test passes in 1.8 s while its `require()` sibling, which does the same 55 loads of a same-sized module for real, times out at 20 s.

### Fix

- Key the eviction with `require.resolve()`, as `require-cache-bug-leak-fixture.js`, `esm-fixture-leak-small.mjs` and `cjs-fixture-leak-small.js` already do.
- After the warm-up loop, print `--fail--` and exit 1 if `dest` is not a key in `require.cache`. A key the cache does not use now fails the test instead of passing it; the previous `file://` key trips this check on the first run.
- This is the right key because `require.cache` exposes the runtime module cache under the resolved absolute path, which is exactly what `require.resolve()` returns: after `import(url)`, `path in require.cache` is true and `url in require.cache` is false, and `delete require.cache[path]` followed by `import()` evaluates the module again (checked on both the release and the debug build).
- The one check is enough to prove the loop reloads: `in` and `delete` on `require.cache` are the `has` and `deleteProperty` traps in `src/js/builtins/CommonJS.ts:388`, and both look up the ES module registry by the same key, so a key that `in` finds is the key `delete` evicts.
- The bounds (120 MB, 400 MB under ASAN) are unchanged. With the 55 loads now real, the fixture reports 0 to 20 MB across 7 release runs on linux x64. On the ASAN debug build it reports 179 MB against the `require()` sibling's 169 MB for the same workload, so on the `release-asan` lane it should behave like the sibling, which has been running there against the same 400 MB bound.
- Cost on release: about 1.2 s standalone and 1.8 to 2.1 s when run next to its sibling (the sibling takes 1.0 s and 1.1 to 2.0 s), against the test's 20 s timeout.
- Verified:
  - `USE_SYSTEM_BUN=1 bun test test/cli/run/require-cache.test.ts`: 11 pass; `via import()` now takes about as long as `via require()`.
  - `bun bd test test/cli/run/require-cache.test.ts -t "leak the AST"`: before, `via import()` passes in 1.8 s and `via require()` times out; after, both time out the same way, since debug builds run the 200 KB workload at a fraction of release speed. #38148 skips these blocks on debug builds; CI has no debug lane, so no CI lane is affected by that.
  - Test-only change, so there is no src fail-before/pass-after to show; the evaluation counts above are the before/after evidence.
- Touches only `esm-bug-leak-fixture.mjs`. #38148 (`require-cache.test.ts`), #37586 and #34159 (inline fixtures in the test file), #37562 (`esm-fixture-leak-small.mjs`) and #35081 (the ASAN detection lines of the standalone fixtures) change other lines.

### Background

- `require.cache` in Bun is a view of the runtime's module cache and also lists ES modules (Node only lists CommonJS there). Keys are resolved absolute paths. Deleting a key evicts the module, so the next `import()` or `require()` of that path reads, transpiles and evaluates the file again; that is what lets these fixtures run the transpiler many times in one process and watch RSS.
- `import.meta.resolve()` follows Node: it is synchronous and returns a `file://` URL string. Bun's original version returned a promise of an absolute path, which is what this fixture was written against.
- ASAN quarantine: ASAN keeps freed allocations in a quarantine (256 MB by default) instead of handing them back to the allocator, so RSS on an ASAN build grows with what was allocated and freed rather than with what is retained. That is why the fixtures have a separate, larger bound for ASAN binaries.

<details>
<summary>Evaluation-count probe and measurements</summary>

`large.mjs` is a copy of `esm-leak-fixture-large-ast.mjs` with `globalThis.__evals = (globalThis.__evals ?? 0) + 1;` appended; the probe runs the fixture's two loops against it with either key (`BUN_RUNTIME_TRANSPILER_CACHE_PATH=0`, as the test harness sets):

```
release, key = import.meta.resolve():  evals: 1,  measured loop: 0 ms
release, key = require.resolve():      evals: 55, measured loop: 383 ms
debug+ASAN, import.meta.resolve():     evals: 1,  measured loop: 164 ms
debug+ASAN, require.resolve():         evals: 55, measured loop: 80.8 s
```

Fixture output with this change, release linux x64, 7 runs: `leaked` = 0, 4, 15, 20, 3, 16, 10 MB (bound 120). Debug+ASAN build: esm fixture 179 MB, `require-cache-bug-leak-fixture.js` 169 MB (the fixtures apply the 120 MB bound there because they detect ASAN by the `bun-asan` binary name; #35081 is about that).

Same fixture with the `file://` key put back, to exercise the new check:

```
require.cache has no entry for file:///.../test/cli/run/esm-leak-fixture-large-ast.mjs so deleting it never evicts the module

--fail--
```

`bun bd test test/cli/run/require-cache.test.ts -t "leak the AST"` on main: `via import()` passes in 1811 ms, `via require()` times out after 20000 ms. With this change: both time out after 20000 ms.

</details>
