### PR TITLE
node:module: pass the module body to an overridden module._compile for bundled CommonJS

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1449,24 +1449,12 @@ void JSCommonJSModule::evaluate(
     evaluateCommonJSModuleOnce(vm, globalObject, this, this->m_dirname.get(), this->m_filename.get());
 }
 
-// The source code of a CommonJS module arrives here as a function expression that
-// evaluateCommonJSModuleOnce() calls. Two producers emit it:
-//
-//   the transpiler (js_parser, WrapMode::BunCommonjs):
-//     (function(exports, require, module, __filename, __dirname) {\n...\n});\n
-//     followed by "//# sourceMappingURL=" and "//# sourceURL=" lines when the inspector is attached;
-//     an empty .cjs file is the synthetic "(function(){})"
-//
-//   `bun build --target=bun --format=cjs` (postProcessJSChunk), loaded verbatim because of the pragma:
-//     [#!...\n]// @bun [@bytecode ]@bun-cjs\n(function(exports, require, module, __filename, __dirname) {...})\n
-//     followed by "//# debugId=" and "//# sourceMappingURL=" lines with --sourcemap; --minify leaves
-//     the last statement directly in front of the "})"
-//
-// Returns the source with the wrapper removed: every line in front of the wrapper is replaced
-// by an empty line so the body keeps the line numbers of the source text, and the comment lines
-// after the wrapper are kept. Returns nullopt when the source is not shaped like the above, for
-// example `bun build --footer` with code after the wrapper; the caller then evaluates the source
-// as it is.
+// Accepts the two shapes of wrapped CommonJS source, the transpiler's
+//   (function(exports, require, module, __filename, __dirname) {\n...\n});\n       ("(function(){})" for an empty .cjs file)
+// and the verbatim output of `bun build --target=bun --format=cjs`
+//   [#!...\n]// @bun [@bytecode ]@bun-cjs\n(function(exports, require, module, __filename, __dirname) {...})\n
+// each optionally followed by "//# sourceMappingURL=" style comment lines. Skipped leading lines become
+// empty lines so the body keeps its line numbers; nullopt for anything else (e.g. a --footer with code).
 static std::optional<WTF::String> commonJSSourceWithoutWrapper(const WTF::String& source)
 {
     StringView text { source };
@@ -1487,8 +1475,6 @@ static std::optional<WTF::String> commonJSSourceWithoutWrapper(const WTF::String
         return std::nullopt;
     unsigned bodyStart = openingBrace + 1;
 
-    // Walk back over what may follow the closing "})": whitespace, line comments and the ";"
-    // the transpiler prints after the expression statement.
     unsigned end = text.length();
     unsigned lineStart = 0;
     while (true) {
@@ -1507,9 +1493,7 @@ static std::optional<WTF::String> commonJSSourceWithoutWrapper(const WTF::String
     if (end < bodyStart + 2 || text[end - 2] != '}' || text[end - 1] != ')')
         return std::nullopt;
     unsigned bodyEnd = end - 2;
-    // Both producers put the closing "})" either on a line of its own or, when the whole module is
-    // one line, on the line that opened the wrapper. A "})" ending a line of other code is the end
-    // of something else, such as a `bun build --footer`.
+    // A "})" ending a line of other code closes something in a --footer, not the wrapper.
     if (lineStart != bodyEnd && lineStart >= bodyStart)
         return std::nullopt;
 
@@ -1549,9 +1533,7 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
             return;
         }
         WTF::String sourceString = source.source_code.toWTFString(BunString::ZeroCopy);
-        // module._compile(code, filename) receives the module body, which Module.prototype._compile
-        // wraps again. Without a recognizable wrapper there is no body to hand over, so such a
-        // module is evaluated as-is below.
+        // Module.prototype._compile wraps the body again; a source without a recognizable wrapper is evaluated as-is below.
         if (auto body = commonJSSourceWithoutWrapper(sourceString)) {
             if (source.needsDeref) {
                 source.needsDeref = false;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1465,7 +1465,8 @@ void JSCommonJSModule::evaluate(
 // Returns the source with the wrapper removed: every line in front of the wrapper is replaced
 // by an empty line so the body keeps the line numbers of the source text, and the comment lines
 // after the wrapper are kept. Returns nullopt when the source is not shaped like the above, for
-// example `bun build --footer` with code after the wrapper.
+// example `bun build --footer` with code after the wrapper; the caller then evaluates the source
+// as it is.
 static std::optional<WTF::String> commonJSSourceWithoutWrapper(const WTF::String& source)
 {
     StringView text { source };
@@ -1489,22 +1490,28 @@ static std::optional<WTF::String> commonJSSourceWithoutWrapper(const WTF::String
     // Walk back over what may follow the closing "})": whitespace, line comments and the ";"
     // the transpiler prints after the expression statement.
     unsigned end = text.length();
+    unsigned lineStart = 0;
     while (true) {
         while (end > bodyStart && isASCIIWhitespace(text[end - 1]))
             end--;
         if (end <= bodyStart)
-            break;
+            return std::nullopt;
         size_t previousNewline = text.reverseFind('\n', end - 1);
-        unsigned lineStart = previousNewline == WTF::notFound ? 0 : previousNewline + 1;
+        lineStart = previousNewline == WTF::notFound ? 0 : previousNewline + 1;
         if (lineStart < bodyStart || !text.hasInfixStartingAt("//"_s, lineStart))
             break;
         end = lineStart;
     }
-    if (end > bodyStart && text[end - 1] == ';')
+    if (text[end - 1] == ';')
         end--;
     if (end < bodyStart + 2 || text[end - 2] != '}' || text[end - 1] != ')')
         return std::nullopt;
     unsigned bodyEnd = end - 2;
+    // Both producers put the closing "})" either on a line of its own or, when the whole module is
+    // one line, on the line that opened the wrapper. A "})" ending a line of other code is the end
+    // of something else, such as a `bun build --footer`.
+    if (lineStart != bodyEnd && lineStart >= bodyStart)
+        return std::nullopt;
 
     StringView afterWrapper = text.substring(bodyEnd + 2);
     if (afterWrapper.startsWith(';'))

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -78,6 +78,7 @@
 #include "wtf/NakedPtr.h"
 #include "wtf/URL.h"
 #include "wtf/text/StringImpl.h"
+#include <wtf/text/StringBuilder.h>
 #include "JSCommonJSExtensions.h"
 
 #include "ErrorCode.h"
@@ -1448,15 +1449,89 @@ void JSCommonJSModule::evaluate(
     evaluateCommonJSModuleOnce(vm, globalObject, this, this->m_dirname.get(), this->m_filename.get());
 }
 
+// The source code of a CommonJS module arrives here as a function expression that
+// evaluateCommonJSModuleOnce() calls. Two producers emit it:
+//
+//   the transpiler (js_parser, WrapMode::BunCommonjs):
+//     (function(exports, require, module, __filename, __dirname) {\n...\n});\n
+//     followed by "//# sourceMappingURL=" and "//# sourceURL=" lines when the inspector is attached;
+//     an empty .cjs file is the synthetic "(function(){})"
+//
+//   `bun build --target=bun --format=cjs` (postProcessJSChunk), loaded verbatim because of the pragma:
+//     [#!...\n]// @bun [@bytecode ]@bun-cjs\n(function(exports, require, module, __filename, __dirname) {...})\n
+//     followed by "//# debugId=" and "//# sourceMappingURL=" lines with --sourcemap; --minify leaves
+//     the last statement directly in front of the "})"
+//
+// Returns the source with the wrapper removed: every line in front of the wrapper is replaced
+// by an empty line so the body keeps the line numbers of the source text, and the comment lines
+// after the wrapper are kept. Returns nullopt when the source is not shaped like the above, for
+// example `bun build --footer` with code after the wrapper.
+static std::optional<WTF::String> commonJSSourceWithoutWrapper(const WTF::String& source)
+{
+    StringView text { source };
+
+    unsigned linesBeforeWrapper = 0;
+    unsigned wrapperStart = 0;
+    while (text.hasInfixStartingAt("//"_s, wrapperStart) || text.hasInfixStartingAt("#!"_s, wrapperStart)) {
+        size_t lineEnd = text.find('\n', wrapperStart);
+        if (lineEnd == WTF::notFound)
+            return std::nullopt;
+        wrapperStart = lineEnd + 1;
+        linesBeforeWrapper++;
+    }
+    if (!text.hasInfixStartingAt("(function("_s, wrapperStart))
+        return std::nullopt;
+    size_t openingBrace = text.find('{', wrapperStart);
+    if (openingBrace == WTF::notFound)
+        return std::nullopt;
+    unsigned bodyStart = openingBrace + 1;
+
+    // Walk back over what may follow the closing "})": whitespace, line comments and the ";"
+    // the transpiler prints after the expression statement.
+    unsigned end = text.length();
+    while (true) {
+        while (end > bodyStart && isASCIIWhitespace(text[end - 1]))
+            end--;
+        if (end <= bodyStart)
+            break;
+        size_t previousNewline = text.reverseFind('\n', end - 1);
+        unsigned lineStart = previousNewline == WTF::notFound ? 0 : previousNewline + 1;
+        if (lineStart < bodyStart || !text.hasInfixStartingAt("//"_s, lineStart))
+            break;
+        end = lineStart;
+    }
+    if (end > bodyStart && text[end - 1] == ';')
+        end--;
+    if (end < bodyStart + 2 || text[end - 2] != '}' || text[end - 1] != ')')
+        return std::nullopt;
+    unsigned bodyEnd = end - 2;
+
+    StringView afterWrapper = text.substring(bodyEnd + 2);
+    if (afterWrapper.startsWith(';'))
+        afterWrapper = afterWrapper.substring(1);
+    if (afterWrapper.containsOnly<isASCIIWhitespace>())
+        afterWrapper = {};
+
+    if (!linesBeforeWrapper && afterWrapper.isEmpty())
+        return source.substring(bodyStart, bodyEnd - bodyStart);
+
+    StringBuilder result;
+    for (unsigned i = 0; i < linesBeforeWrapper; i++)
+        result.append('\n');
+    result.append(text.substring(bodyStart, bodyEnd - bodyStart));
+    result.append(afterWrapper);
+    return result.toString();
+}
+
 void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
     Zig::GlobalObject* globalObject,
     const WTF::String& key,
     JSValue keyJSString,
     ResolvedSource& source)
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     if (JSValue compileFunction = this->m_overriddenCompile.get()) {
-        auto& vm = globalObject->vm();
-        auto scope = DECLARE_THROW_SCOPE(vm);
         if (!compileFunction) {
             throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
             return;
@@ -1467,32 +1542,24 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
             return;
         }
         WTF::String sourceString = source.source_code.toWTFString(BunString::ZeroCopy);
-        RETURN_IF_EXCEPTION(scope, );
-        if (source.needsDeref) {
-            source.needsDeref = false;
-            source.source_code.deref();
-        }
-        // Remove the wrapper from the source string, since the transpiler has added it.
-        auto trimStart = sourceString.find('\n');
-        WTF::String sourceStringWithoutWrapper;
-        if (trimStart != WTF::notFound) {
-            auto wrapperStart = globalObject->m_moduleWrapperStart;
-            auto wrapperEnd = globalObject->m_moduleWrapperEnd;
-            sourceStringWithoutWrapper = sourceString.substring(trimStart, sourceString.length() - trimStart - 4);
-        } else {
-            sourceStringWithoutWrapper = sourceString;
-        }
-        RETURN_IF_EXCEPTION(scope, );
+        // module._compile(code, filename) receives the module body, which Module.prototype._compile
+        // wraps again. Without a recognizable wrapper there is no body to hand over, so such a
+        // module is evaluated as-is below.
+        if (auto body = commonJSSourceWithoutWrapper(sourceString)) {
+            if (source.needsDeref) {
+                source.needsDeref = false;
+                source.source_code.deref();
+            }
 
-        // _compile(source, filename)
-        MarkedArgumentBuffer arguments;
-        arguments.append(jsString(vm, sourceStringWithoutWrapper));
-        arguments.append(keyJSString);
-        JSC::profiledCall(globalObject, ProfilingReason::API, compileFunction, callData, this, arguments);
-        RETURN_IF_EXCEPTION(scope, );
-        return;
+            MarkedArgumentBuffer arguments;
+            arguments.append(jsString(vm, WTF::move(*body)));
+            arguments.append(keyJSString);
+            JSC::profiledCall(globalObject, ProfilingReason::API, compileFunction, callData, this, arguments);
+            RETURN_IF_EXCEPTION(scope, );
+            return;
+        }
     }
-    this->evaluate(globalObject, key, source, false);
+    RELEASE_AND_RETURN(scope, this->evaluate(globalObject, key, source, false));
 }
 
 static JSC::SourceCode commonJSModuleSyntheticSourceCode(const SourceOrigin& sourceOrigin, const WTF::String& sourceURL);

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -220,7 +220,7 @@ describe("module._compile override receives the module body", () => {
   const wrapper = "(function(exports, require, module, __filename, __dirname) {";
 
   test("files with the // @bun @bun-cjs pragma, in every shape bun build --target=bun --format=cjs emits", () => {
-    using dir = tempDir("compile-hook-pragma", {
+    const files = {
       "pragma.js": `// @bun @bun-cjs\n${wrapper}// entry.cjs\nmodule.exports = { shape: "pragma" };\n})\n`,
       "bytecode.js": `// @bun @bytecode @bun-cjs\n${wrapper}// entry.cjs\nmodule.exports = { shape: "bytecode" };\n})\n`,
       "hashbang.js": `#!/usr/bin/env bun\n// @bun @bun-cjs\n${wrapper}\n// entry.cjs\nmodule.exports = { shape: "hashbang" };\n})\n`,
@@ -228,12 +228,15 @@ describe("module._compile override receives the module body", () => {
       "sourcemap.js": `// @bun @bun-cjs\n${wrapper}\nmodule.exports = { shape: "sourcemap" };\n})\n\n//# debugId=0123456789ABCDEF\n//# sourceMappingURL=data:application/json;base64,e30=\n`,
       "crlf.js": `// @bun @bun-cjs\r\n${wrapper}\r\nmodule.exports = { shape: "crlf" };\r\n})\r\n`,
       // Code after the wrapper is not something the body extraction understands, so the file
-      // is evaluated as-is instead of being handed to _compile.
+      // is evaluated as-is instead of being handed to _compile. That includes a footer whose
+      // own last characters are "})".
       "footer.js": `// @bun @bun-cjs\n${wrapper}\nmodule.exports = { shape: "footer" };\n})\n\nvar afterTheWrapper = 1;\n`,
-    });
+      "footerEndingInClose.js": `// @bun @bun-cjs\n${wrapper}\nmodule.exports = { shape: "footerEndingInClose" };\n})\n\nvar afterTheWrapper = String(function(){})\n`,
+    };
+    using dir = tempDir("compile-hook-pragma", files);
     const results: Record<string, unknown> = {};
-    for (const name of ["pragma", "bytecode", "hashbang", "minified", "sourcemap", "crlf", "footer"]) {
-      results[name] = requireThroughCompileHook(".js", path.join(String(dir), `${name}.js`));
+    for (const file of Object.keys(files)) {
+      results[path.basename(file, ".js")] = requireThroughCompileHook(".js", path.join(String(dir), file));
     }
     // Every line in front of the wrapper is replaced by an empty line, so the body keeps the line
     // numbers it has in the file; the comment lines after the wrapper are kept.
@@ -251,6 +254,7 @@ describe("module._compile override receives the module body", () => {
       },
       crlf: { code: '\n\r\nmodule.exports = { shape: "crlf" };\r\n', exports: { shape: "crlf" } },
       footer: { code: undefined, exports: { shape: "footer" } },
+      footerEndingInClose: { code: undefined, exports: { shape: "footerEndingInClose" } },
     });
   });
 

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
-import { expect, mock, test } from "bun:test";
-import { tempDir } from "harness";
+import { describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("require.extensions shape makes sense", () => {
@@ -190,4 +190,173 @@ test("mutating extensions is banned by some files", () => {
     n++;
     expect(globalThis.pass).toBe(n);
   }
+});
+
+describe("module._compile override receives the module body", () => {
+  // The pirates / nyc / ts-node pattern: wrap the default loader, record what it passes to
+  // module._compile, and compile that text with the original implementation. `code` stays
+  // undefined when the default loader evaluated the module without calling _compile.
+  function requireThroughCompileHook(extension: string, file: string) {
+    const original = require.extensions[extension];
+    const defaultLoader = require.extensions[".js"];
+    let code: string | undefined;
+    require.extensions[extension] = function (module: any, filename: string) {
+      const originalCompile = module._compile;
+      module._compile = function (content: string, compiledFilename: string) {
+        code = content;
+        return originalCompile.call(this, content, compiledFilename);
+      };
+      return defaultLoader(module, filename);
+    };
+    try {
+      const exports = require(file);
+      return { code, exports };
+    } finally {
+      if (original) require.extensions[extension] = original;
+      else delete require.extensions[extension];
+    }
+  }
+
+  const wrapper = "(function(exports, require, module, __filename, __dirname) {";
+
+  test("files with the // @bun @bun-cjs pragma, in every shape bun build --target=bun --format=cjs emits", () => {
+    using dir = tempDir("compile-hook-pragma", {
+      "pragma.js": `// @bun @bun-cjs\n${wrapper}// entry.cjs\nmodule.exports = { shape: "pragma" };\n})\n`,
+      "bytecode.js": `// @bun @bytecode @bun-cjs\n${wrapper}// entry.cjs\nmodule.exports = { shape: "bytecode" };\n})\n`,
+      "hashbang.js": `#!/usr/bin/env bun\n// @bun @bun-cjs\n${wrapper}\n// entry.cjs\nmodule.exports = { shape: "hashbang" };\n})\n`,
+      "minified.js": `// @bun @bun-cjs\n${wrapper}module.exports={shape:"minified"};})\n`,
+      "sourcemap.js": `// @bun @bun-cjs\n${wrapper}\nmodule.exports = { shape: "sourcemap" };\n})\n\n//# debugId=0123456789ABCDEF\n//# sourceMappingURL=data:application/json;base64,e30=\n`,
+      "crlf.js": `// @bun @bun-cjs\r\n${wrapper}\r\nmodule.exports = { shape: "crlf" };\r\n})\r\n`,
+      // Code after the wrapper is not something the body extraction understands, so the file
+      // is evaluated as-is instead of being handed to _compile.
+      "footer.js": `// @bun @bun-cjs\n${wrapper}\nmodule.exports = { shape: "footer" };\n})\n\nvar afterTheWrapper = 1;\n`,
+    });
+    const results: Record<string, unknown> = {};
+    for (const name of ["pragma", "bytecode", "hashbang", "minified", "sourcemap", "crlf", "footer"]) {
+      results[name] = requireThroughCompileHook(".js", path.join(String(dir), `${name}.js`));
+    }
+    // Every line in front of the wrapper is replaced by an empty line, so the body keeps the line
+    // numbers it has in the file; the comment lines after the wrapper are kept.
+    expect(results).toEqual({
+      pragma: { code: '\n// entry.cjs\nmodule.exports = { shape: "pragma" };\n', exports: { shape: "pragma" } },
+      bytecode: { code: '\n// entry.cjs\nmodule.exports = { shape: "bytecode" };\n', exports: { shape: "bytecode" } },
+      hashbang: {
+        code: '\n\n\n// entry.cjs\nmodule.exports = { shape: "hashbang" };\n',
+        exports: { shape: "hashbang" },
+      },
+      minified: { code: '\nmodule.exports={shape:"minified"};', exports: { shape: "minified" } },
+      sourcemap: {
+        code: '\n\nmodule.exports = { shape: "sourcemap" };\n\n\n//# debugId=0123456789ABCDEF\n//# sourceMappingURL=data:application/json;base64,e30=\n',
+        exports: { shape: "sourcemap" },
+      },
+      crlf: { code: '\n\r\nmodule.exports = { shape: "crlf" };\r\n', exports: { shape: "crlf" } },
+      footer: { code: undefined, exports: { shape: "footer" } },
+    });
+  });
+
+  test("errors thrown by a pragma file compiled through the override keep their line numbers", () => {
+    using dir = tempDir("compile-hook-pragma-lines", {
+      "lines.js": `// @bun @bun-cjs\n${wrapper}\nmodule.exports = new Error("line 3").stack;\n})\n`,
+    });
+    expect(requireThroughCompileHook(".js", path.join(String(dir), "lines.js"))).toEqual({
+      code: '\n\nmodule.exports = new Error("line 3").stack;\n',
+      exports: expect.stringMatching(/lines\.js:3:\d+/),
+    });
+  });
+
+  test("real bun build --target=bun --format=cjs output", async () => {
+    using dir = tempDir("compile-hook-bun-build", {
+      "entry.cjs": `module.exports = { built: true };\n`,
+      "hashbang.cjs": `#!/usr/bin/env bun\nmodule.exports = { built: true };\n`,
+    });
+    const variants: Record<string, Partial<Parameters<typeof Bun.build>[0]>> = {
+      plain: {},
+      bytecode: { bytecode: true },
+      minify: { minify: true },
+      sourcemap: { sourcemap: "inline" },
+      hashbang: { entrypoints: [path.join(String(dir), "hashbang.cjs")] },
+      commentFooter: { footer: "// license" },
+    };
+    const results: Record<string, unknown> = {};
+    for (const [name, options] of Object.entries(variants)) {
+      const outdir = path.join(String(dir), "out", name);
+      const { success, logs, outputs } = await Bun.build({
+        entrypoints: [path.join(String(dir), "entry.cjs")],
+        target: "bun",
+        format: "cjs",
+        outdir,
+        ...options,
+      });
+      if (!success) throw new AggregateError(logs);
+      const outfile = outputs.find(output => output.kind === "entry-point")!.path;
+      const text = await Bun.file(outfile).text();
+      results[name] = {
+        // What the file looks like around the wrapper, so the hand-written fixtures above
+        // can be checked against the real output.
+        header: text.slice(0, text.indexOf("{") + 1),
+        closeOnOwnLine: text.includes("\n})"),
+        trailer: text.slice(text.lastIndexOf("})")),
+        ...requireThroughCompileHook(".js", outfile),
+      };
+    }
+    const loaded = { code: expect.stringContaining("module.exports"), exports: { built: true } };
+    const plainShape = { header: `// @bun @bun-cjs\n${wrapper}`, closeOnOwnLine: true, trailer: "})\n" };
+    expect(results).toEqual({
+      plain: { ...plainShape, ...loaded },
+      bytecode: { ...plainShape, header: `// @bun @bytecode @bun-cjs\n${wrapper}`, ...loaded },
+      minify: { ...plainShape, closeOnOwnLine: false, ...loaded },
+      sourcemap: {
+        ...plainShape,
+        trailer: expect.stringContaining("\n//# sourceMappingURL=data:"),
+        ...loaded,
+        code: expect.stringMatching(/module\.exports[^]*\n\/\/# sourceMappingURL=data:/),
+      },
+      hashbang: { ...plainShape, header: `#!/usr/bin/env bun\n// @bun @bun-cjs\n${wrapper}`, ...loaded },
+      commentFooter: {
+        ...plainShape,
+        trailer: expect.stringMatching(/^\}\)\n+\/\/ license\n$/),
+        ...loaded,
+        code: expect.stringMatching(/module\.exports[^]*\n\/\/ license\n$/),
+      },
+    });
+  });
+
+  test("an empty .cjs file, which the loader turns into a synthetic wrapper", () => {
+    using dir = tempDir("compile-hook-empty", { "empty.cjs": "" });
+    expect(requireThroughCompileHook(".cjs", path.join(String(dir), "empty.cjs"))).toEqual({ code: "", exports: {} });
+  });
+
+  test("transpiled files while the inspector appends source map comments after the wrapper", async () => {
+    using dir = tempDir("compile-hook-inspector", {
+      "plain.js": `module.exports = 42;\n`,
+      "run.js": `
+        const Module = require("module");
+        const defaultLoader = Module._extensions[".js"];
+        Module._extensions[".js"] = function (module, filename) {
+          module._compile = function (code, filename) {
+            globalThis.code = code;
+            return Module.prototype._compile.call(this, code, filename);
+          };
+          return defaultLoader(module, filename);
+        };
+        const loaded = require("./plain.js");
+        console.log(JSON.stringify({ code: globalThis.code, exports: loaded }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--inspect=127.0.0.1:0", "run.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr carries the inspector banner, so it is only shown on failure.
+    expect(stdout, stderr).toStartWith("{");
+    expect(JSON.parse(stdout)).toEqual({
+      code: expect.stringMatching(/^\n  module\.exports = 42;\n\s*\/\/# sourceMappingURL=data:/),
+      exports: 42,
+    });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem

- A require hook that overrides `module._compile` and then calls the default `Module._extensions['.js']` (the pirates / nyc / ts-node pattern) receives broken source text for every file produced by `bun build --target=bun --format=cjs`, with or without `--bytecode`. Plain output fails with `SyntaxError: Unexpected end of script` (`TypeError: Expected CommonJS module to have a function wrapper` on 1.4.0); output built with `--sourcemap` or a `--footer` loads as `module.exports === {}` without an error. Plain, transpiled files work.
- The same hook breaks on every transpiled CommonJS file when the process runs under `bun --inspect` (`SyntaxError: Parser error`).
- Cause: `JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile` (`src/jsc/bindings/JSCommonJSModule.cpp`, previously lines 1475-1484) removed the wrapper by dropping everything up to the first `\n` and the last four characters of the source. That only matches the text the transpiler prints (`(function(...) {` on line 1, `});\n` at the end). Files starting with the `// @bun @bun-cjs` pragma are loaded verbatim (`already_bundled` in `src/runtime/jsc_hooks.rs` / `src/jsc/RuntimeTranspilerStore.rs`), so line 1 is the pragma comment and the file ends in `})\n`, optionally followed by `//# debugId` / `//# sourceMappingURL` lines or a footer; under the inspector the transpiler appends `//# sourceMappingURL` / `//# sourceURL` lines after `});`. In every one of these cases the cut removed the wrong text and left the wrapper header in the string handed to `_compile`, which `Module.prototype._compile` then wrapped a second time.

### Fix

- `commonJSSourceWithoutWrapper` locates the wrapper by its shape: it skips leading `#!` and `//` lines, requires `(function(` next, walks back from the end over whitespace, `//` comment lines and the transpiler's `;`, and requires a `})` there that is either alone on its line (transpiler output, non-minified bundles) or on the line that opened the wrapper (`--minify` bundles, the synthetic wrapper of an empty `.cjs` file). It returns the text between the wrapper's `{` and that `})`, with one empty line per skipped header line in front of it and the trailing comment lines after it. `evaluateWithPotentiallyOverriddenCompile` passes that to `_compile`.
- When no such `})` exists, the module is evaluated as-is, the same way it is without a `_compile` override; the hook is not called. This is what happens to a `bun build --footer` that contains code, including one whose code itself ends in `})` (`var x = String(function(){})`), which ends a line of other code and is therefore not taken for the wrapper's close. Before, every file of this kind was handed over and silently ended up as `{}`; none of them worked. Not covered: a multi-line footer whose last line is exactly `})`, which is accepted; the hook then receives the body plus the footer, and because `Module.prototype._compile` appends `\n})`, re-wrapping reproduces the original program, so the module behaves exactly as it does without the hook.
- Why this is correct: the contract of `_compile(code, filename)` is that `Module.prototype._compile` (which wraps `code` in its own function header and `\n})`) evaluates it as the module, and a hook gets to transform `code` first; for these sources the text satisfying that is the body between the wrapper's braces. For transpiled files the result is byte for byte what the old code produced (the existing "mutated compile function" tests in the same file pin that text), so hooks on ordinary files see no change. Replacing the skipped header lines with empty lines keeps the body on the same line numbers as the file on disk, so stack traces and the file's source map stay right; keeping the trailing `//#` lines lets hooks such as nyc find the inline source map, as they would in Node, where `_compile` receives the whole file.
- Also declares the throw scope for the whole function so the fall-through path satisfies `BUN_JSC_validateExceptionChecks`.
- Verified with `test/js/node/module/require-extensions.test.ts`, new `describe("module._compile override receives the module body")`: hand-written fixtures for each shape `bun build` emits (pragma, `@bytecode` pragma, hashbang, `--minify`, trailing source map comments, CRLF) plus the two code-footer shapes that have to be left alone (one ending in `1;`, one ending in `})`), a line-number check, real `Bun.build({ target: "bun", format: "cjs" })` output in six configurations (plain, `bytecode`, `minify`, `sourcemap: "inline"`, hashbang entry, comment footer) including a check that the fixtures match the real output's header and trailer, the synthetic wrapper of an empty `.cjs` file, and a transpiled file under `--inspect`. All five tests fail on the released binary and pass with this change; the `})` footer fixture also fails against the first revision of this PR, which handed the hook `...})\n\nvar afterTheWrapper = String(function(){`.
- Also run: `test/js/node/module/` and `test/regression/issue/require-extensions-override.test.ts` (111 pass), `test/regression/issue/22929-module-extensions-asi.test.ts`, and the test file above under `BUN_JSC_validateExceptionChecks=1`.
- Related open PRs touching the same function: #38090 replaces the same lines for the `Module.wrapper` case with a helper that requires a newline before `})`, which `--minify` output does not have; #38138 adds a line above them. Whichever lands second has a small rebase; the helper here is written so the `Module.wrapper` paths can use it too.

### Background

- A CommonJS module's source reaches the evaluator as one function expression, `(function(exports, require, module, __filename, __dirname) { ... })`; `evaluateCommonJSModuleOnce` evaluates the program and calls the resulting function. The transpiler prints that expression for ordinary files. `bun build --target=bun --format=cjs` writes it into the output file itself, preceded by a `// @bun @bun-cjs` (or `// @bun @bytecode @bun-cjs`) pragma line; the runtime recognizes the pragma and loads such files without transpiling them, so their text is exactly what is on disk.
- `Module._extensions['.js']` is Node's per-extension loader; hooks wrap it and set `module._compile` on the module object before calling the original. Bun's implementation (`builtinLoader` in `JSCommonJSExtensions.cpp`) transpiles the file and then calls `evaluateWithPotentiallyOverriddenCompile`, which is the only place where Bun has to turn the wrapped text back into a body. `Module.prototype._compile` (`functionJSCommonJSModule_compile`) does no transpiling: it prepends the wrapper header, appends `\n})` and evaluates.
- `ResolvedSource` is the struct the Rust loader returns; `needsDeref` says whether the C++ side still owns a reference to `source_code`. The `_compile` branch releases it once it has the text (as before); on the evaluate-as-is path it is left for `Zig::SourceProvider::create` to release, as in the non-override path.

<details>
<summary>Repro</summary>

```js
// pragma.js, as written by `bun build --target=bun --format=cjs`
// @bun @bun-cjs
(function(exports, require, module, __filename, __dirname) {module.exports = 42;
})
```

```js
// run.js
const Module = require("module");
const defaultLoader = Module._extensions[".js"];
Module._extensions[".js"] = function (module, filename) {
  module._compile = function (code, filename) {
    console.log(JSON.stringify(code));
    return Module.prototype._compile.call(this, code, filename);
  };
  return defaultLoader(module, filename);
};
console.log(require("./pragma.js"));
```

```
$ bun run.js            # 1.4.0
"\n(function(exports, require, module, __filename, __dirname) {module.exports = 42;"
SyntaxError: Unexpected end of script

$ bun-debug run.js      # this branch
"\nmodule.exports = 42;\n"
42
```

Same hook on a plain `module.exports = 42;` file under `bun --inspect=127.0.0.1:0 run.js` on 1.4.0: `_compile` receives `"\n  module.exports = 42;\n});\n\n//# sourceMappingURL=data:..."` and throws `SyntaxError: Parser error`; with this branch it receives the body followed by the comment lines and the module loads.

</details>
