### PR TITLE
Bun.write: create the destination for an empty source when there is no directory to create

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4397,7 +4397,8 @@ pub struct WriteFileOptions {
     pub(crate) mode: Option<bun_sys::Mode>,
 }
 
-/// Write an empty string to a file by truncating it.
+/// Write an empty string to a file by truncating it, creating the file if it
+/// does not exist.
 ///
 /// This behavior matches what we do with the fast path.
 fn write_file_with_empty_source_to_destination(
@@ -4438,79 +4439,52 @@ fn write_file_with_empty_source_to_destination(
             );
 
             if let bun_sys::Result::Err(ref mut err) = result {
-                let errno = err.get_errno();
-                let mut was_eperm = false;
                 'err: {
-                    let mut current = errno;
-                    loop {
-                        match current {
-                            // truncate might return EPERM when the parent directory doesn't exist
-                            // #6336
-                            bun_sys::E::EPERM => {
-                                was_eperm = true;
-                                err.errno = bun_sys::E::ENOENT as _;
-                                current = bun_sys::E::ENOENT;
-                                continue;
+                    // An fd always refers to an existing file; only a path can still be created.
+                    let PathOrFileDescriptor::Path(path) = &file.pathlike else {
+                        break 'err;
+                    };
+                    // truncate(2) cannot create the file, and might report a missing
+                    // parent directory as EPERM rather than ENOENT (#6336).
+                    if !matches!(err.get_errno(), bun_sys::E::ENOENT | bun_sys::E::EPERM) {
+                        break 'err;
+                    }
+                    // A bare filename has no directory to create; the file itself is
+                    // still created below.
+                    if options.mkdirp_if_not_exists.unwrap_or(true) {
+                        if let Some(dirpath) = bun_core::dirname(path.slice()) {
+                            let mkdir_result = node_fs.mkdir_recursive(&node::fs::args::Mkdir {
+                                path: node::PathLike::String(
+                                    bun_ptr::cow_slice::CowSlice::init_unchecked(dirpath, false),
+                                ),
+                                recursive: true,
+                                always_return_none: true,
+                                ..Default::default()
+                            });
+                            if let bun_sys::Result::Err(e) = mkdir_result {
+                                *err = e;
+                                break 'err;
                             }
-                            bun_sys::E::ENOENT => {
-                                if options.mkdirp_if_not_exists == Some(false) {
-                                    break 'err;
-                                }
-                                let dirpath: &[u8] = match &file.pathlike {
-                                    PathOrFileDescriptor::Path(path) => {
-                                        match bun_core::dirname(path.slice()) {
-                                            Some(d) => d,
-                                            None => break 'err,
-                                        }
-                                    }
-                                    PathOrFileDescriptor::Fd(_) => {
-                                        // NOTE: if this is an fd, it means the file
-                                        // exists, so we shouldn't try to mkdir it
-                                        if was_eperm {
-                                            err.errno = bun_sys::E::EPERM as _;
-                                        }
-                                        break 'err;
-                                    }
-                                };
-                                let mkdir_result =
-                                    node_fs.mkdir_recursive(&node::fs::args::Mkdir {
-                                        path: node::PathLike::String(
-                                            bun_ptr::cow_slice::CowSlice::init_unchecked(
-                                                dirpath, false,
-                                            ),
-                                        ),
-                                        recursive: true,
-                                        always_return_none: true,
-                                        ..Default::default()
-                                    });
-                                if let bun_sys::Result::Err(e) = mkdir_result {
-                                    *err = e;
-                                    break 'err;
-                                }
+                        }
+                    }
 
-                                // SAFETY: we check if `file.pathlike` is an fd above, returning if it is.
-                                let mut buf = bun_paths::PathBuffer::uninit();
-                                let mode: bun_sys::Mode =
-                                    options.mode.unwrap_or(node::fs::DEFAULT_PERMISSION);
-                                match bun_sys::File::open(
-                                    file.pathlike.path().slice_z(&mut buf),
-                                    bun_sys::O::CREAT | bun_sys::O::TRUNC,
-                                    mode,
-                                ) {
-                                    bun_sys::Result::Err(e) => {
-                                        *err = e;
-                                        break 'err;
-                                    }
-                                    bun_sys::Result::Ok(f) => {
-                                        let _ = f.close(); // close error is non-actionable
-                                        return Ok(JSPromise::resolved_promise_value(
-                                            ctx,
-                                            JSValue::js_number(0.0),
-                                        ));
-                                    }
-                                }
-                            }
-                            _ => break 'err,
+                    let mut buf = bun_paths::PathBuffer::uninit();
+                    let mode: bun_sys::Mode = options.mode.unwrap_or(node::fs::DEFAULT_PERMISSION);
+                    match bun_sys::File::open(
+                        path.slice_z(&mut buf),
+                        bun_sys::O::CREAT | bun_sys::O::TRUNC,
+                        mode,
+                    ) {
+                        bun_sys::Result::Err(e) => {
+                            *err = e;
+                            break 'err;
+                        }
+                        bun_sys::Result::Ok(f) => {
+                            let _ = f.close(); // close error is non-actionable
+                            return Ok(JSPromise::resolved_promise_value(
+                                ctx,
+                                JSValue::js_number(0.0),
+                            ));
                         }
                     }
                 }

--- a/test/js/bun/bun-object/write.spec.ts
+++ b/test/js/bun/bun-object/write.spec.ts
@@ -92,6 +92,24 @@ describe("Bun.write() on file paths", () => {
         expect(stats.mode & default_mode).toBe(default_mode);
         expect(stats.mode & constants.S_IFDIR).toBe(0); // not a directory
       });
+
+      it("When content is an empty Blob, creates the file with default permissions", async () => {
+        const result = await Bun.write(filepath, new Blob([]));
+        expect(result).toBe(0);
+        expect(await fs.readFile(filepath, "utf-8")).toBe("");
+        const stats = await fs.stat(filepath);
+        expect(stats.mode & default_mode).toBe(default_mode);
+        expect(stats.mode & constants.S_IFDIR).toBe(0); // not a directory
+      });
+
+      it("When content is an empty Blob and options.createPath is false, creates the file with default permissions", async () => {
+        const result = await Bun.write(filepath, new Blob([]), { createPath: false });
+        expect(result).toBe(0);
+        expect(await fs.readFile(filepath, "utf-8")).toBe("");
+        const stats = await fs.stat(filepath);
+        expect(stats.mode & default_mode).toBe(default_mode);
+        expect(stats.mode & constants.S_IFDIR).toBe(0); // not a directory
+      });
     }); // </When the file does not exist>
 
     describe("When the file exists and has content", () => {
@@ -148,6 +166,12 @@ describe("Bun.write() on file paths", () => {
         expect(result).toBe(0);
         expect(await fs.readFile(filepath, "utf-8")).toBe("");
       });
+
+      it("When an empty Blob is written, recursively creates the directory and writes the file", async () => {
+        const result = await Bun.write(filepath, new Blob([]));
+        expect(result).toBe(0);
+        expect(await fs.readFile(filepath, "utf-8")).toBe("");
+      });
     }); // </When no options are provided>
 
     describe("When options.createPath is false", () => {
@@ -155,6 +179,11 @@ describe("Bun.write() on file paths", () => {
 
       it.each(["", "Hello, world!"])("When '%s' is written, throws ENOENT", async content => {
         await expect(() => Bun.write(filepath, content, options)).toThrowWithCodeAsync(Error, "ENOENT");
+      });
+
+      it("When an empty Blob is written, throws ENOENT and does not create the directory", async () => {
+        await expect(() => Bun.write(filepath, new Blob([]), options)).toThrowWithCodeAsync(Error, "ENOENT");
+        await expect(fs.access(rootdir, constants.F_OK)).rejects.toMatchObject({ code: "ENOENT" });
       });
     }); // </When options.createPath is false>
   });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -767,6 +767,72 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     });
   });
 
+  // A zero-byte Blob/Response/array source takes the truncate() path, which
+  // cannot create a file on its own. The fallback that creates it must also
+  // run when there is no directory to create first: a bare filename relative
+  // to cwd, or { createPath: false } with the directory already present.
+  it("empty source creates a missing destination without a directory to create", async () => {
+    using dir = tempDir("bun-write-empty-source-bare", {
+      "existing.bin": "stale contents",
+      sub: {},
+    });
+    const fixture = `
+      const results = {};
+      const attempt = async (label, write) => {
+        try {
+          results[label] = await write();
+        } catch (e) {
+          results[label] = e.code;
+        }
+      };
+      await attempt("blob.bin", () => Bun.write("blob.bin", new Blob([])));
+      await attempt("response.bin", () => Bun.write("response.bin", new Response("")));
+      await attempt("array.bin", () => Bun.write("array.bin", []));
+      await attempt("bunfile.bin", () => Bun.write(Bun.file("bunfile.bin"), new Blob([])));
+      await attempt("bunfile-write.bin", () => Bun.file("bunfile-write.bin").write(new Blob([])));
+      await attempt("existing.bin", () => Bun.write("existing.bin", new Blob([])));
+      await attempt("no-create-path.bin", () => Bun.write("no-create-path.bin", new Blob([]), { createPath: false }));
+      await attempt("sub/no-create-path.bin", () =>
+        Bun.write("sub/no-create-path.bin", new Blob([]), { createPath: false }),
+      );
+      await attempt("created/dir/file.bin", () => Bun.write("created/dir/file.bin", new Blob([])));
+      await attempt("missing/file.bin", () => Bun.write("missing/file.bin", new Blob([]), { createPath: false }));
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const expected = {
+      "blob.bin": 0,
+      "response.bin": 0,
+      "array.bin": 0,
+      "bunfile.bin": 0,
+      "bunfile-write.bin": 0,
+      "existing.bin": 0,
+      "no-create-path.bin": 0,
+      "sub/no-create-path.bin": 0,
+      "created/dir/file.bin": 0,
+      "missing/file.bin": "ENOENT",
+    };
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
+
+    // Every write that resolved 0 left a zero-byte file behind (existing.bin
+    // was truncated); the rejected one created nothing.
+    const sizesOnDisk = Object.fromEntries(
+      Object.keys(expected).map(name => {
+        const file = join(String(dir), name);
+        return [name, fs.existsSync(file) ? fs.statSync(file).size : "missing"];
+      }),
+    );
+    expect(sizesOnDisk).toEqual({ ...expected, "missing/file.bin": "missing" });
+  });
+
   test("timed output should work", async () => {
     const producer_file = path.join(import.meta.dir, "timed-stderr-output.js");
 


### PR DESCRIPTION
### Problem

- `Bun.write("out.bin", new Blob([]))` run in a directory where `out.bin` does not exist rejects instead of creating the empty file:
  ```
  ENOENT: no such file or directory, truncate 'out.bin'
  ```
  The same call spelled `"./out.bin"` or with an absolute path resolves `0` and creates the file.
- `Bun.write(path, new Blob([]), { createPath: false })` rejects with the same `ENOENT` for any missing `path`, even when its directory exists. The non-empty equivalent (`Bun.write(path, "x", { createPath: false })`) creates the file.
- Every zero-byte in-memory source takes this path: `new Blob([])`, `new Response("")`, `[]`, a `Response`/`Request` whose body turned out to be empty (for example a `fetch()` that returned 204, written to a bare filename), and `Bun.file(...).write(...)` with any of those. Non-empty sources open the destination with `O_CREAT` and are unaffected.
- Cause: `write_file_with_empty_source_to_destination` (src/runtime/webcore/Blob.rs) implements the empty write as `truncate(path, 0)`, which cannot create a file. Its `ENOENT` recovery first created the parent directory and only then opened the destination with `O_CREAT`, and the open was nested inside the mkdir branch. With nothing to mkdir, because `dirname()` returns `None` for a bare filename or because `createPath: false` was passed, it fell out of the recovery and rejected with the `truncate` error before the creating open was reached.

### Fix

- Restructure the recovery so that, once `truncate` reports `ENOENT` (or `EPERM`, which was already treated as `ENOENT`) on a path destination, the `O_CREAT | O_TRUNC` open always runs. Creating the parent directory is now the optional step before it: skipped when `createPath: false` or when the path has no directory component.
- This is the documented contract of the function since it was introduced (#18561: resolve when the file "doesn't exist and is created"), and it matches what the non-empty paths already do, since they open with `O_CREAT` regardless of `createPath`. `createPath` only controls directory creation.
- Fd destinations are unchanged: they break out of the recovery immediately with the untouched `ftruncate` error, which makes the `was_eperm` errno rewrite and its restore dead, so they are removed. Other errnos (`EACCES`, `EISDIR`, `EINVAL`, ...) still reject as before.
- Only observable change besides the fix: `createPath: false` with a missing directory now reports the `ENOENT` from `open` rather than from `truncate` (same `code` and `path`); the non-empty path already reported `open`. No test in the suite asserts the old syscall name.
- Verified with `test/js/bun/io/bun-write.test.js` (new test spawns bun with `cwd` set to a temp dir and writes bare filenames: `Bun.write`, `Bun.file().write()`, `Blob`/`Response`/array sources, `createPath: false` with an existing directory, plus the unchanged cases: truncating an existing file, creating a missing directory by default, and `createPath: false` with a missing directory still rejecting `ENOENT` without creating anything) and `test/js/bun/bun-object/write.spec.ts` (empty `Blob` variants next to the existing empty-string cases). Both files fail on the unfixed build (7 cases and 1 case respectively) and pass with the fix.
- Related, not a duplicate: #32890 changes the same function for non-regular-file and fd destinations (`EINVAL`), but keeps the `dirname() == None` early exit, so it does not cover this.

### Background

- `Bun.write(dest, src)` with a zero-length in-memory source produces a `Blob` with no backing store; `write_file_with_source_destination` routes such sources to `write_file_with_empty_source_to_destination`, which "writes" by truncating the destination to 0 bytes. Sources with data go through `WriteFile`, which opens the destination itself with `O_CREAT`.
- `truncate(2)` only operates on existing files; on POSIX a missing destination is `ENOENT`. On Windows `NodeFS::truncate` opens the path with `O_CREAT` first, so this only reproduced on POSIX.
- `createPath` (default `true`) is the `Bun.write` option that controls whether missing parent directories are created with `mkdir -p`.
- `bun_core::dirname` returns `None` when the path has no directory component (`"out.bin"`), and `Some(".")` / `Some("/")` / `Some("sub")` otherwise.
