### PR TITLE
mimalloc: keep the idle sweep's state on the tld instead of in __thread variables (fixes Android SIGSEGV)

### DIFF
--- a/patches/mimalloc/sweep-state-on-tld.patch
+++ b/patches/mimalloc/sweep-state-on-tld.patch
@@ -1,0 +1,325 @@
+Keep the idle sweep's state on the tld being swept instead of in __thread
+variables (oven-sh/bun#38051).
+
+The hole-purging sweep kept a re-entrancy guard and its per-sweep counters
+in `__thread` variables in page.c, and read the guard from
+mi_page_free_collect_ex, i.e. from inside the allocator. Bun's Android
+target (aarch64-linux-android28) lowers `__thread` to emulated TLS, and
+emulated TLS materializes a thread's variables on first access by calling
+malloc(), which is mimalloc itself on that target. So the first time a
+thread collected a page with an empty free list (clang speculates the
+guard read ahead of the last word of the purged-holes check, so it runs
+for every such page), mimalloc re-entered itself from the middle of that
+collect; whenever the size class that emulated TLS asked
+for was itself on an exhausted page, serving it collected that page, read
+the still-unmaterialized guard again, and recursed until the stack was
+gone: an intermittent SIGSEGV in 30-70% of runs. The previous pin happened
+to write another `__thread` variable (__mi_theap_main) during thread init,
+while the thread had no pages yet, which materialized the emulated-TLS
+state at a harmless moment; the dev3 sync removed that variable.
+
+The sweep always runs for a specific tld (the owner's own in
+mi_on_thread_idle, or the parked thread's when the scavenger sweeps it),
+so that tld is where the state of the running sweep belongs. The guard is
+read back through the calling thread's default theap, which every TLS
+model can read without allocating; the sweep's own collects ask for no
+un-purging explicitly instead of relying on the guard. After this, the
+only `__thread` variable mimalloc still touches on Android is the one
+guarding message output in options.c.
+
+Belongs in oven-sh/mimalloc; carried here until the pin moves.
+--- a/include/mimalloc/internal.h
++++ b/include/mimalloc/internal.h
+@@ -889,7 +889,7 @@ static inline bool mi_page_all_free(const mi_page_t* page) {
+ // Page hole purging  (see the "Page hole purging" section in `page.c`)
+ // ------------------------------------------------------
+ 
+-void          _mi_page_purge_holes(mi_page_t* page);
++void          _mi_page_purge_holes(mi_page_t* page, mi_tld_t* tld);   // `tld`: the thread whose sweep this is (see `_mi_page_purge_holes_begin`)
+ void          _mi_page_purged_reset(mi_page_t* page);
+ bool          _mi_page_unpurge_run(mi_page_t* page);
+ void          _mi_page_unpurge_all(mi_page_t* page);
+@@ -898,12 +898,12 @@ void          _mi_page_unpurge_unformed_upto(mi_page_t* page, uintptr_t end);
+ size_t        _mi_page_unformed_purged_bytes(const mi_page_t* page);            // the bytes of this page's unformed tail that are discarded right now
+ bool          _mi_page_purge_os_page_blocks(size_t os_page_size, size_t block_size, uintptr_t page_start,
+                                             size_t capacity, size_t k, size_t* first, size_t* last);
+-bool          _mi_page_purge_holes_in_progress(void);
++bool          _mi_page_purge_holes_in_progress(void);            // is the calling thread inside a sweep of its own heaps?
+ void          _mi_page_holes_count_page_freed(void);
+ void          _mi_page_holes_count_ineligible(const mi_page_t* page);
+ void          _mi_page_holes_reset_ineligible(void);
+-void          _mi_page_purge_holes_begin(void);
+-void          _mi_page_purge_holes_end(void);
++void          _mi_page_purge_holes_begin(mi_tld_t* tld);         // around each pass of a sweep; `tld` is the thread being swept
++void          _mi_page_purge_holes_end(mi_tld_t* tld);
+ void          _mi_page_purge_holes_sweep_begin(mi_tld_t* tld);   // once per idle sweep, before its passes
+ 
+ // ------------------------------------------------------
+--- a/include/mimalloc/types.h
++++ b/include/mimalloc/types.h
+@@ -709,6 +709,16 @@ struct mi_tld_s {
+   mi_tld_t*             subproc_next;         // list of tlds in the subproc, so the scavenger can find parked threads
+   size_t                holes_sweep_seq;      // idle sweeps run over THIS tld's heaps (paces `purge_holes_full_every`)
+   mi_msecs_t            holes_sweep_last;     // when this tld's heaps were last swept (paces `purge_holes_min_interval`)
++
++  // State of the sweep that is currently running over this tld's heaps (on the owner, or on the
++  // scavenger while the owner is parked). It lives here and not in thread-locals of the sweeping
++  // thread: `_mi_page_purge_holes_in_progress` is read inside the allocator, and where `__thread`
++  // is emulated (Android before API 29) the first access to a thread-local on a thread calls
++  // malloc, which re-enters the very page collect that is reading it (oven-sh/bun#38051).
++  bool                  holes_sweeping;       // a pass of the sweep is rewriting free lists right now (see `_mi_page_purge_holes_begin`)
++  bool                  holes_sweep_full;     // this sweep ignores `page->swept_state` (see `_mi_page_purge_holes`)
++  size_t                holes_sweep_skipped;  // per-sweep counters, folded into the process-wide ones in `_mi_page_purge_holes_end`
++  size_t                holes_sweep_visited;
+ };
+ 
+ 
+--- a/src/arena.c
++++ b/src/arena.c
+@@ -1329,7 +1329,7 @@ void _mi_arenas_page_unabandon(mi_page_t* page, mi_theap_t* current_theapx) {
+ 
+ typedef struct mi_purge_holes_arg_s {
+   mi_bitmap_t* bitmap;
+-  mi_tld_t*    tld;      // whose park we are sweeping under; NULL when not a parked sweep
++  mi_tld_t*    tld;      // the thread whose sweep this is (its own, or the parked one the scavenger is sweeping for)
+ } mi_purge_holes_arg_t;
+ 
+ static bool mi_arena_page_purge_holes_at(size_t slice_index, size_t slice_count, mi_arena_t* arena, void* arg) {
+@@ -1337,7 +1337,7 @@ static bool mi_arena_page_purge_holes_at(size_t slice_index, size_t slice_count,
+   mi_purge_holes_arg_t* const parg = (mi_purge_holes_arg_t*)arg;
+   // this pass holds every page that ever became full, so it is most of a cold sweep: an owner
+   // waiting in `_mi_park_leave` cannot allocate until we stop
+-  if (parg->tld != NULL && mi_atomic_load_relaxed(&parg->tld->park_reclaim) != 0) return false;
++  if (mi_atomic_load_relaxed(&parg->tld->park_reclaim) != 0) return false;
+   mi_bitmap_t* const bitmap = parg->bitmap;
+ 
+   // Take the page out of the abandoned map first: this is the reader side of the protocol in
+@@ -1353,8 +1353,8 @@ static bool mi_arena_page_purge_holes_at(size_t slice_index, size_t slice_count,
+   }
+ 
+   // We own the page: no other thread can reclaim, unabandon, or free it now, and only the
+-  // atomic `xthread_free` can still change under us.
+-  _mi_page_free_collect(page, true);
++  // atomic `xthread_free` can still change under us. (No un-purging: we are about to purge.)
++  _mi_page_free_collect_no_unpurge(page, true);
+   if (mi_page_all_free(page)) {
+     mi_bitmap_set(bitmap, slice_index);   // `_mi_arenas_page_unabandon` expects it in the map
+     _mi_arenas_page_unabandon(page, NULL);
+@@ -1362,7 +1362,7 @@ static bool mi_arena_page_purge_holes_at(size_t slice_index, size_t slice_count,
+     _mi_page_holes_count_page_freed();
+     return true;
+   }
+-  _mi_page_purge_holes(page);
++  _mi_page_purge_holes(page, parg->tld);
+   mi_bitmap_set(bitmap, slice_index);     // back in the map *before* unowning: unown may free the page
+   mi_abandoned_page_unown(page, NULL);
+   return true;
+@@ -1372,9 +1372,9 @@ static bool mi_arena_page_purge_holes_at(size_t slice_index, size_t slice_count,
+ // A page abandoned while full is not mapped; it has no free blocks at that point, and once
+ // enough blocks are freed in it, `_mi_arenas_page_try_reabandon_to_mapped` puts it in the map.
+ void _mi_arenas_purge_abandoned_holes(mi_heap_t* heap, mi_tld_t* tld) {
+-  if (heap == NULL) return;
++  if (heap == NULL || tld == NULL) return;
+   if (!mi_option_is_enabled(mi_option_purge_holes)) return;
+-  _mi_page_purge_holes_begin();
++  _mi_page_purge_holes_begin(tld);
+   mi_forall_arenas(heap, ((mi_arena_t*)NULL), 0, arena) {
+     mi_arena_pages_t* const arena_pages = mi_heap_arena_pages(heap, arena);
+     if (arena_pages != NULL) {
+@@ -1389,7 +1389,7 @@ void _mi_arenas_purge_abandoned_holes(mi_heap_t* heap, mi_tld_t* tld) {
+     }
+   }
+   mi_forall_arenas_end();
+-  _mi_page_purge_holes_end();
++  _mi_page_purge_holes_end(tld);
+ }
+ 
+ // The read-only counterpart of the sweep above: account for the holes in the abandoned pages
+--- a/src/page.c
++++ b/src/page.c
+@@ -472,44 +472,54 @@ static void mi_holes_count_reuse(size_t bytes, size_t blocks, bool reused) {
+   mi_atomic_addi64_relaxed(&mi_holes_blocks, -(int64_t)blocks);
+ }
+ 
+-// Re-entrancy guard: while the idle sweep is rewriting a page's free list and
+-// bitmap, a nested `mi_malloc` (only reachable through a user output function
+-// from a warning message) must not un-purge a hole from under it.
+-static mi_decl_thread bool mi_purging_holes;
+-
+-// Per-sweep counters. The sweep runs over every page of the thread, so a process-wide atomic
+-// per page would be a real cost on the very path we are making cheap: accumulate thread-locally
+-// and fold them in once per pass, in `_mi_page_purge_holes_end`.
+-static mi_decl_thread size_t mi_holes_sweep_skipped;
+-static mi_decl_thread size_t mi_holes_sweep_visited;
+-
+-// Whether THIS sweep ignores `page->swept_state` (see `_mi_page_purge_holes`). Set once per idle
+-// sweep, in `_mi_page_purge_holes_sweep_begin`; the sequence it is paced by lives on the tld being
+-// swept, since one scavenger thread runs the sweeps of many.
+-static mi_decl_thread bool   mi_holes_sweep_full;
+-
+-bool _mi_page_purge_holes_in_progress(void) { return mi_purging_holes; }
+-void _mi_page_purge_holes_begin(void) { mi_assert_internal(!mi_purging_holes); mi_purging_holes = true; }
+-
+-void _mi_page_purge_holes_end(void) {
+-  mi_assert_internal(mi_purging_holes);
+-  mi_purging_holes = false;
+-  if (mi_holes_sweep_skipped > 0) {
+-    mi_atomic_addi64_relaxed(&mi_holes_pages_skipped, (int64_t)mi_holes_sweep_skipped);
+-    mi_holes_sweep_skipped = 0;
+-  }
+-  if (mi_holes_sweep_visited > 0) {
+-    mi_atomic_addi64_relaxed(&mi_holes_blocks_visited, (int64_t)mi_holes_sweep_visited);
+-    mi_holes_sweep_visited = 0;
+-  }
+-}
+-
+-// Called once per idle sweep of `tld`'s heaps, before its passes (`mi_purge_holes_of`).
++// The state of a running sweep lives on the tld being swept (`tld->holes_sweep*`, see `types.h`),
++// never in thread-locals of the sweeping thread. Besides the scavenger sweeping many tlds from one
++// thread, this must not touch a `__thread` variable at all: `_mi_page_purge_holes_in_progress` is
++// read from `mi_page_free_collect_ex`, inside the allocator, and on targets where `__thread` is
++// emulated (Android before API 29) the first access on a thread allocates -- re-entering the
++// collect that is reading it, without bound (oven-sh/bun#38051). The tld of the calling thread is
++// reached through the default theap, which every TLS model can read without allocating.
++
++// Re-entrancy guard: while a sweep is rewriting a page's free list and bitmap, a nested `mi_malloc`
++// on the sweeping thread (only reachable through a user output function from a warning message)
++// must not un-purge a hole from under it. That nested allocation comes out of the calling thread's
++// own theaps, so it is its own tld that matters here: on the owner that is the tld being swept;
++// the scavenger has no theaps of its own being swept (it sweeps a parked thread's theaps, and the
++// abandoned pages it touches are claimed), so un-purging there is harmless.
++bool _mi_page_purge_holes_in_progress(void) {
++  mi_theap_t* const theap = _mi_theap_default();
++  if (theap == NULL || theap->tld == NULL) return false;
++  return theap->tld->holes_sweeping;
++}
++
++void _mi_page_purge_holes_begin(mi_tld_t* tld) {
++  mi_assert_internal(tld != NULL && !tld->holes_sweeping);
++  tld->holes_sweeping = true;
++}
++
++// Also folds the per-sweep counters into the process-wide ones. The sweep runs over every page of
++// the thread, so a process-wide atomic per page would be a real cost on the very path we are making
++// cheap: they accumulate on the tld and are folded in once per pass.
++void _mi_page_purge_holes_end(mi_tld_t* tld) {
++  mi_assert_internal(tld != NULL && tld->holes_sweeping);
++  tld->holes_sweeping = false;
++  if (tld->holes_sweep_skipped > 0) {
++    mi_atomic_addi64_relaxed(&mi_holes_pages_skipped, (int64_t)tld->holes_sweep_skipped);
++    tld->holes_sweep_skipped = 0;
++  }
++  if (tld->holes_sweep_visited > 0) {
++    mi_atomic_addi64_relaxed(&mi_holes_blocks_visited, (int64_t)tld->holes_sweep_visited);
++    tld->holes_sweep_visited = 0;
++  }
++}
++
++// Called once per idle sweep of `tld`'s heaps, before its passes (`mi_purge_holes_of`): decides
++// whether this sweep ignores `page->swept_state` (see `_mi_page_purge_holes`).
+ void _mi_page_purge_holes_sweep_begin(mi_tld_t* tld) {
+   const long every = mi_option_get(mi_option_purge_holes_full_every);
+   const size_t seq = ++tld->holes_sweep_seq;
+-  mi_holes_sweep_full = (every > 0 && (seq % (size_t)every) == 0);
+-  if (mi_holes_sweep_full) { mi_atomic_addi64_relaxed(&mi_holes_full_sweeps, 1); }
++  tld->holes_sweep_full = (every > 0 && (seq % (size_t)every) == 0);
++  if (tld->holes_sweep_full) { mi_atomic_addi64_relaxed(&mi_holes_full_sweeps, 1); }
+ }
+ 
+ static inline bool mi_page_bits_at(const uint64_t* bits, size_t k) {
+@@ -678,7 +688,7 @@ void _mi_page_unpurge_unformed_upto(mi_page_t* page, uintptr_t end) {
+ // Walk the free list of a page and discard every OS page in it that holds no live block.
+ // Returns false if any discard failed: those blocks went straight back on the free list and the
+ // page must be swept again, so the caller must not record it as swept.
+-static bool mi_page_purge_holes_walk(mi_page_t* page) {
++static bool mi_page_purge_holes_walk(mi_page_t* page, mi_tld_t* tld) {
+   if (page->free == NULL) return true;                    // nothing to take off the free list
+ 
+   const size_t os_size = _mi_os_page_size();
+@@ -703,7 +713,7 @@ static bool mi_page_purge_holes_walk(mi_page_t* page) {
+       nfree[k]++;
+     }
+   }
+-  mi_holes_sweep_visited += nvisited;   // folded into the process-wide counter at the end of the sweep
++  tld->holes_sweep_visited += nvisited;   // folded into the process-wide counter at the end of the pass
+ 
+   // 2. an OS page can be discarded when *every* block overlapping it is free -- either on the
+   //    free list, or purged already. Of the blocks overlapping an OS page, only the first and
+@@ -789,26 +799,27 @@ static bool mi_page_purge_holes_walk(mi_page_t* page) {
+ // regardless, which caps the delay of a missed discard at N parks for 1/N of the old cost.
+ // (An exact "was anything freed in this page" bit is the alternative, and it costs a store in
+ // `mi_free` itself -- the hot path this whole feature stays off.)
+-void _mi_page_purge_holes(mi_page_t* page) {
+-  mi_assert_internal(page != NULL);
++void _mi_page_purge_holes(mi_page_t* page, mi_tld_t* tld) {
++  mi_assert_internal(page != NULL && tld != NULL);
++  mi_assert_internal(tld->holes_sweeping);
+   if (!mi_option_is_enabled(mi_option_purge_holes)) return;
+   if (mi_page_all_free(page)) return;                     // the page itself is about to be freed
+   if (mi_option_get(mi_option_purge_delay) < 0) return;   // purging disabled
+   mi_page_purge_unformed_tail(page);                      // the blocks that are not formed yet: resident, but never handed out
+   if (!mi_page_can_purge_holes(page)) { _mi_page_holes_count_ineligible(page); return; }
+ 
+-  if (!mi_holes_sweep_full && page->swept_state == mi_page_sweep_state(page)) {
+-    mi_holes_sweep_skipped++;   // nothing was allocated or freed in this page since we swept it
++  if (!tld->holes_sweep_full && page->swept_state == mi_page_sweep_state(page)) {
++    tld->holes_sweep_skipped++;   // nothing was allocated or freed in this page since we swept it
+     return;
+   }
+   // Record the state we LEAVE the page in, read back from the page: a nested `mi_malloc` (see
+-  // `mi_purging_holes`) may have taken a block out of it while we walked.
++  // `_mi_page_purge_holes_in_progress`) may have taken a block out of it while we walked.
+   //
+   // Only if the walk got everything. A failed `_mi_os_discard` (ENOMEM under pressure) puts its
+   // blocks straight back, and changes neither `capacity` nor `used` -- so recording here would
+   // say "already swept" for a page that still has holes, and the skip check would then park them
+   // until the next full sweep, or forever with `purge_holes_full_every=0`.
+-  if (mi_page_purge_holes_walk(page)) {
++  if (mi_page_purge_holes_walk(page, tld)) {
+     page->swept_state = mi_page_sweep_state(page);
+   }
+ }
+--- a/src/theap.c
++++ b/src/theap.c
+@@ -165,20 +165,23 @@ void _mi_theap_collect_abandon(mi_theap_t* theap) {
+ // that are still partially used. Meant to be called when the application knows
+ // it is idle (e.g. from an event loop about to park): it costs a few madvise
+ // calls and nothing on the alloc/free hot path.
+-static bool mi_theap_page_purge_holes(mi_theap_t* theap, mi_page_queue_t* pq, mi_page_t* page, void* arg1, void* arg2) {
+-  MI_UNUSED(arg1); MI_UNUSED(arg2);
++static bool mi_theap_page_purge_holes(mi_theap_t* theap, mi_page_queue_t* pq, mi_page_t* page, void* arg_tld, void* arg2) {
++  MI_UNUSED(arg2);
++  mi_tld_t* const tld = (mi_tld_t*)arg_tld;   // the tld being swept (== theap->tld)
+   // When the scavenger is doing this for a parked thread, the owner may wake at any moment and
+   // has to wait for us. Stopping between pages bounds that wait to one page's walk; the pages we
+   // skip are simply swept at the next park (`swept_state` makes the re-walk cheap).
+   if (theap->tld != NULL && mi_atomic_load_relaxed(&theap->tld->park_reclaim) != 0) return false;
+-  _mi_page_free_collect(page, true);   // force: fold local_free (and thread_free) into `free` first
++  // force: fold local_free (and thread_free) into `free` first. Never un-purge here: we are about
++  // to purge, and a run brought back now would be discarded again right away (see `mi_theap_page_collect`).
++  _mi_page_free_collect_no_unpurge(page, true);
+   if (mi_page_all_free(page)) {
+     // the forced collect emptied the page: hand it back instead of leaving it resident
+     _mi_page_holes_count_page_freed();
+     _mi_page_free(page, pq);
+     return true;
+   }
+-  _mi_page_purge_holes(page);
++  _mi_page_purge_holes(page, tld);
+   mi_assert_expensive(_mi_page_is_valid(page));
+   return true; // continue
+ }
+@@ -193,9 +196,10 @@ static void mi_theap_purge_holes(mi_theap_t* theap) mi_attr_noexcept {
+   if (theap->tld == NULL) return;
+   if (theap->tld->thread_id != _mi_thread_id() &&
+       mi_atomic_load_acquire(&theap->tld->park_state) != MI_PARK_SWEEPING) return;
+-  _mi_page_purge_holes_begin();
+-  mi_theap_visit_pages(theap, &mi_theap_page_purge_holes, true /* include full pages */, NULL, NULL);
+-  _mi_page_purge_holes_end();
++  mi_tld_t* const tld = theap->tld;
++  _mi_page_purge_holes_begin(tld);
++  mi_theap_visit_pages(theap, &mi_theap_page_purge_holes, true /* include full pages */, tld, NULL);
++  _mi_page_purge_holes_end(tld);
+ }
+ 
+ // Purge the holes in every page this thread may safely touch:

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -24,6 +24,13 @@ export const mimalloc: Dependency = {
     commit: MIMALLOC_COMMIT,
   }),
 
+  // The idle sweep's guard/counters must not be `__thread` variables: the
+  // Android target (API 28) compiles `__thread` to emulated TLS, whose first
+  // access on a thread calls malloc, i.e. mimalloc re-entering itself from
+  // inside a page collect (#38051). The patch keeps that state on the tld
+  // being swept. Drop it once the pin includes it.
+  patches: ["patches/mimalloc/sweep-state-on-tld.patch"],
+
   build: cfg => {
     // ─── Override behavior (global malloc replacement) ───
     //   ASAN:    OFF — ASAN interceptors must see the real malloc.


### PR DESCRIPTION
> Superseded as a patch by oven-sh/mimalloc#17, at the maintainers' request. This PR stays as a draft and will turn into the pin bump once that one is merged; the analysis below still describes the bug and the change.

### Problem
- Android arm64 builds SIGSEGV intermittently (30-70% of runs of `bunmicro -profile`) since the mimalloc pin bump in #36431 (#38051).
- Reproduced on linux-x64 by building mimalloc the way the Android target builds it (see below). The crash is a stack overflow from unbounded recursion; every level looks like this:
  ```
  _mi_malloc_generic (size=16)                       page.c:1963
  __emutls_get_address
  mi_page_free_collect_ex                            page.c:1213   <- reads the __thread sweep guard
  _mi_page_free_collect / mi_page_queue_find_free_ex page.c:1754
  mi_find_free_page / mi_find_page                   page.c:1865 / 1951
  _mi_malloc_generic (size=16)                       page.c:2001
  __emutls_get_address
  ...
  ```
- Cause: the fork's hole-purging sweep keeps its re-entrancy guard and per-sweep counters in `__thread` variables (`vendor/mimalloc/src/page.c:478-489`) and reads the guard from `mi_page_free_collect_ex` (`page.c:1213`), i.e. from inside the allocator. Bun's Android target is `aarch64-linux-android28`, and for API < 29 clang lowers every `__thread` to emulated TLS: `__emutls_get_address` materializes a thread's variables on first access with `malloc()`, which on that target is mimalloc itself. Clang also speculates the read ahead of the last word of the `mi_page_has_purged` check, so it fires the first time a thread collects any page with an empty free list. If the size class emulated TLS asks for (128 bytes for its per-thread array, 16 for the flag) is itself sitting on an exhausted page at that moment, serving it collects that page, reads the still-unmaterialized guard again, and recurses until the stack is gone.
- Why #36431 exposed it: the previous pin wrote another `__thread` variable (`__mi_theap_main`) during thread init, while the thread had no pages yet, which materialized each thread's emulated-TLS state at a harmless moment (confirmed with a breakpoint on `__emutls_get_address`: `malloc(128)` + `malloc(23)` from `_mi_theap_default_set`). The dev3 sync removed that variable, so the first emulated-TLS allocation moved into the collect path. glibc/musl/macOS/Windows use native TLS and are unaffected.

### Fix
- `patches/mimalloc/sweep-state-on-tld.patch` (applied through the existing `patches:` mechanism in `scripts/build/deps/mimalloc.ts`; robobun cannot push to oven-sh/mimalloc, so this is carried the same way earlier mimalloc fixes were until the pin moves): the state of a running sweep moves onto the `mi_tld_t` being swept (`holes_sweeping`, `holes_sweep_full`, `holes_sweep_skipped`, `holes_sweep_visited`, appended to the zero-initialized tail of the struct). `_mi_page_purge_holes_begin/end` and `_mi_page_purge_holes` take that tld; both callers (`theap.c`, `arena.c`) already have it.
- `_mi_page_purge_holes_in_progress()` now answers "is the calling thread inside a sweep of its own heaps" by reading `_mi_theap_default()->tld->holes_sweeping`. The default theap is the one thread-local every TLS model reads without allocating (a pthread key on Android). On the owner path this is exactly the old semantics; on the scavenger path the guard only ever protected the scavenger's own (never swept) pages, so reading false there is harmless.
- The sweep's own collects (`theap.c`, `arena.c`) call `_mi_page_free_collect_no_unpurge` explicitly instead of relying on the guard, so the "do not un-purge what we are about to purge" behavior no longer depends on thread-local state at all.
- Result: the only `__thread` variable mimalloc still touches on Android is the message-output guard in `options.c` (`recurse`), which is only reached when mimalloc prints a warning or error. `mi_page_free_collect_ex` contains no `__emutls_get_address` call; the binary references it only from `mi_recurse_enter_prim`/`mi_recurse_exit_prim`.
- Verification (all on linux-x64, mimalloc built as the Android target builds it: `-femulated-tls`, `MI_MALLOC_OVERRIDE`, `MI_TLS_MODEL_PTHREADS`, compiler-rt's emutls):
  - reproducer below: current pin SIGSEGV 10/10, previous pin (`acd9924a`) ok 10/10, current pin + this patch ok 10/10
  - thread-churn stress (threads creating/destroying heaps, parking, TLS destructors allocating after thread exit): current pin 13/60 SIGSEGV, previous pin 0/60, patched 0/60
  - native TLS, both `MI_TLS_MODEL_LOCAL` and `MI_TLS_MODEL_PTHREADS`, release and `MI_DEBUG=3`: a sweep discards 6 hole runs and the following allocations hand all 6 back (`reuse_calls=6`, `purged_blocks=0`), identical numbers before and after the patch; the stress runs clean under the new assertions
  - `bun bd` (MI_DEBUG=3) builds with the patch applied; `test/js/bun/jsc/heapStats-mimalloc.test.ts` passes; a script that churns memory on the main thread and a Worker runs clean with the scavenger sweeping the parked threads, with `MIMALLOC_SCAVENGER=0` (inline owner sweeps, 36 passes observed via breakpoints), and with `MIMALLOC_PURGE_HOLES_MIN_INTERVAL=0 MIMALLOC_PURGE_HOLES_FULL_EVERY=1`; `process.versions.mimalloc` is unchanged
- No `test/` change: every CI platform uses native TLS, where the bug is unreachable, so nothing under `bun test` can fail before and pass after. The C reproducer below is the regression test; it needs a from-source build of mimalloc with `-femulated-tls`. @jjtseng93, if you can run your 30x `bunmicro -profile` loop on an Android build of this branch, that would confirm it on the real target.
- #34739 also adds a `patches:` entry to `mimalloc.ts`; whichever lands second needs a one-line merge.

### Background
- Emulated TLS: for targets without native ELF TLS (Android before API 29), the compiler turns each `__thread` variable into a descriptor and replaces every access with a call to `__emutls_get_address` (compiler-rt), which keeps a per-thread array in a pthread key and allocates both the array and each variable's storage with `malloc()` the first time a thread touches them. Native TLS is a register-relative load and never allocates, which is why the same code is fine on every other Bun target.
- theap / tld: in this mimalloc a thread's state is a `mi_tld_t` (one per thread) owning one `mi_theap_t` per heap the thread allocates from; pages belong to a theap.
- Idle sweep (fork feature): `mi_on_thread_idle()` walks a thread's pages and discards ("purges") the memory of free blocks that fill whole OS pages, taking those blocks off the free lists. When a page with purged holes later runs out of free blocks, `mi_page_free_collect_ex` brings one run back (`_mi_page_unpurge_run`). The guard exists so that a `mi_malloc` nested inside the sweep itself (reachable from a warning's output hook) does not un-purge a page the sweep is in the middle of rewriting.
- Scavenger: a background thread; Bun's event loop parks via `mi_on_thread_idle_start()` around `epoll_wait`, and the scavenger runs the sweep for parked threads. That is why the sweep already carried the target tld everywhere, and why per-thread state of the sweeping thread was the wrong place for this data even on native TLS.

<details>
<summary>Reproducer (linux-x64, no device needed)</summary>

`repro.c`:
```c
#include <pthread.h>
#include <stdio.h>
#include <stdlib.h>
#define EXTEND 4096   // mimalloc formats one OS page worth of blocks at a time
static void* victim(void* arg) {
  (void)arg;
  static void *a128[EXTEND / 128], *a16[EXTEND / 16], *a8[EXTEND / 8 + 1];
  // use up exactly the formatted blocks of a 128-byte page (emulated TLS's per-thread array)
  // and a 16-byte page (the guard's own storage); nothing has been collected yet
  for (size_t i = 0; i < EXTEND / 128; i++) a128[i] = malloc(128);
  for (size_t i = 0; i < EXTEND / 16;  i++) a16[i]  = malloc(16);
  // exhaust an 8-byte page and ask for one more: collects it -> first guard access on this thread
  for (size_t i = 0; i < EXTEND / 8 + 1; i++) a8[i] = malloc(8);
  for (size_t i = 0; i < EXTEND / 8 + 1; i++) free(a8[i]);
  for (size_t i = 0; i < EXTEND / 16;  i++) free(a16[i]);
  for (size_t i = 0; i < EXTEND / 128; i++) free(a128[i]);
  return NULL;
}
int main(void) {
  pthread_t t;
  pthread_create(&t, NULL, victim, NULL);
  pthread_join(t, NULL);
  puts("ok");
  return 0;
}
```

Build against a mimalloc tree (`vendor/mimalloc` after `bun bd` has the patch applied; a plain extract of the pin does not):
```sh
clang++ -x c++ -std=gnu++20 -O2 -DNDEBUG -DMI_BUILD_RELEASE -DMI_CMAKE_BUILD_TYPE=release \
  -DMI_STATIC_LIB -DMI_SKIP_COLLECT_ON_EXIT=1 -DMI_NO_PROCESS_DETACH=1 -DMI_DEFAULT_ALLOW_THP=0 \
  -DMI_MALLOC_OVERRIDE -fno-builtin-malloc -DMI_TLS_MODEL_PTHREADS=1 \
  -femulated-tls -fPIC -pthread -I$MI/include -c $MI/src/static.c -o mimalloc.o
clang -O1 -pthread -c repro.c -o repro.o
clang++ -pthread --rtlib=compiler-rt repro.o mimalloc.o -o repro   # --rtlib=compiler-rt: emutls from libclang_rt, as on the NDK
./repro
```
(`MI_TLS_MODEL_PTHREADS` is what `prim-tls.h` selects for `__ANDROID__`; the previous pin spells it `MI_TLS_MODEL_DYNAMIC_PTHREADS`.) `nm repro | grep __emutls_v` lists the `__thread` variables that ended up emulated: 6 on the current pin, 2 after the patch (`recurse` and the never-read `__mi_thread_id_helper`).

Results: current pin, exit 139 x10; previous pin, `ok` x10; patched, `ok` x10.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->
