### PR TITLE
node:http2: end a server response on its HEADERS frame when the stream was ended before respond()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2884,12 +2884,21 @@ class Http2Stream extends Duplex {
     if (session) {
       const native = session[bunHTTP2Native];
       if (native) {
-        if (this instanceof ServerHttp2Stream && !this.headersSent && (this.id & 1) === 0) {
-          // A locally-pushed (even-id) stream ended before respond() (HEAD/endStream pushes): an
-          // empty DATA frame would precede the response HEADERS on the wire. respond() forces
-          // endStream for these streams, so END_STREAM rides on the HEADERS frame and the
-          // onStreamEnd(5) dispatch completes this callback through markWritableDone.
-          this[bunHTTP2StreamFinal] = callback;
+        if (this instanceof ServerHttp2Stream && !this.headersSent) {
+          // Ended before respond(). A response begins with HEADERS (RFC 9113 §8.1), so the empty
+          // END_STREAM DATA frame written below must not go out now; respond() puts END_STREAM on
+          // the HEADERS frame instead (node: shutdown only marks the stream unwritable, and the
+          // response is then submitted without a body).
+          if ((this.id & 1) === 0) {
+            // A locally-pushed stream (HEAD/endStream pushes): respond() forces endStream and the
+            // onStreamEnd(5) dispatch completes this callback through markWritableDone.
+            this[bunHTTP2StreamFinal] = callback;
+            return;
+          }
+          // A client-initiated stream finishes its writable right away, as node's does, whether or
+          // not a respond() ever follows; FinalCalled is what tells respond() to end the stream.
+          this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
+          callback();
           return;
         }
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
@@ -3810,7 +3819,13 @@ class ServerHttp2Stream extends Http2Stream {
       statusCode === HTTP_STATUS_NO_CONTENT ||
       statusCode === HTTP_STATUS_RESET_CONTENT ||
       statusCode === HTTP_STATUS_NOT_MODIFIED ||
-      this.headRequest === true
+      this.headRequest === true ||
+      // _final already ran (the stream was ended before any headers went out), so no body can
+      // follow and END_STREAM has to ride on this HEADERS frame, as in node's SubmitResponse once
+      // the writable half is shut. writableEnded would be the wrong signal: it is already set
+      // during the implicit respond() that _write/_writev issue for chunks buffered behind cork()
+      // when end() was called before uncorking.
+      (this[bunHTTP2StreamStatus] & StreamState.FinalCalled) !== 0
     ) {
       // When endStream is true the HEADERS frame itself carries END_STREAM
       // and the stream moves to HALF_CLOSED_LOCAL inside native request().

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6369,6 +6369,16 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 JSValue::UNDEFINED,
                 JSValue::js_number(old_state as f64),
             );
+        } else if code == crate::api::h2::wire::ErrorCode::NoError.as_u32() {
+            // RST_STREAM(NO_ERROR) is a clean close (what a node server sends for a stream it
+            // close()s before responding): the stream ends like one that received END_STREAM, so
+            // 'end' still reaches an unconsumed readable. Same routing as end_stream and the
+            // legacy handle_rst_stream_frame; onStreamError would destroy it before 'end' fires.
+            self.dispatch_with_extra(
+                JSH2FrameParser::Gc::onStreamEnd,
+                stream_ctx,
+                JSValue::js_number(StreamState::CLOSED as u8 as f64),
+            );
         } else {
             self.dispatch_with_extra(
                 JSH2FrameParser::Gc::onStreamError,

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1361,12 +1361,13 @@ describe("inbound stream lifecycle", () => {
       stderr: "pipe",
     });
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The peer's RST_STREAM(NO_ERROR) closed the request cleanly before client.destroy() ran, so
+    // the session teardown has nothing left to cancel and the request emits no 'error'.
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
       "wantTrailers id=1
       toString:start
       toString:end
       sendTrailers:returned
-      req error ERR_HTTP2_STREAM_CANCEL
       req close"
     `);
     expect(proc.signalCode).toBeNull();
@@ -1620,6 +1621,255 @@ describe("inbound stream lifecycle", () => {
     } finally {
       c.destroy();
       server.close();
+    }
+  });
+});
+
+// A response begins with a HEADERS frame (RFC 9113 §8.1), so ending a server stream's writable
+// side before respond() cannot put anything on the wire by itself: the END_STREAM belongs on the
+// response HEADERS frame once respond() runs. (node: shutting the writable down only marks the
+// stream unwritable, and the response is then submitted without a body.) Before the fix the
+// writable's _final wrote an empty END_STREAM DATA frame ahead of any HEADERS, which closed the
+// stream natively and left a later respond() either throwing or sending HEADERS after END_STREAM.
+describe("server stream ended before respond() (RFC 9113 §8.1)", () => {
+  const END_STREAM = 0x1;
+
+  /**
+   * An h2c server whose single stream is handed to `onStream`, plus a raw client that has sent
+   * one request on stream 1. A GET arrives complete (the server stream is half-closed remote); a
+   * POST leaves the request body open, so the response END_STREAM only half-closes the stream.
+   */
+  async function requestOnStream1(method: "GET" | "POST", onStream: (stream: any, events: string[]) => void) {
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    const server = http2.createServer();
+    server.on("stream", (stream: any) => {
+      stream.on("error", (err: any) => events.push(`error ${err.code}`));
+      stream.on("aborted", () => events.push("aborted"));
+      stream.on("wantTrailers", () => events.push("wantTrailers"));
+      stream.on("finish", () => events.push("finish"));
+      stream.on("close", () => {
+        events.push(`close rstCode=${stream.rstCode}`);
+        closed.resolve();
+      });
+      onStream(stream, events);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    c.sendPreface();
+    c.sendEmptySettings();
+    c.sendFrame(FrameType.HEADERS, method === "GET" ? 0x4 | END_STREAM : 0x4, 1, requestHeaderBlock(method));
+    let pings = 0;
+    return {
+      c,
+      events,
+      closed: closed.promise,
+      /** Round-trips a PING: everything the server wrote for stream 1 before it is in `c.frames`. */
+      async settle() {
+        const payload = Buffer.alloc(8);
+        payload.writeUInt32BE(++pings, 4);
+        c.sendFrame(FrameType.PING, 0, 0, payload);
+        await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0 && f.payload.equals(payload));
+      },
+      stream1Frames: () => c.frames.filter(f => f.streamId === 1).map(f => ({ type: f.type, flags: f.flags })),
+      cleanup() {
+        c.destroy();
+        server.close();
+      },
+    };
+  }
+
+  const waitForResponseHeaders = (c: RawH2) => c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+
+  test("end() then respond() puts END_STREAM on the HEADERS frame and sends no DATA", async () => {
+    const r = await requestOnStream1("GET", stream => {
+      stream.end();
+      stream.respond({ ":status": 200 });
+    });
+    try {
+      await waitForResponseHeaders(r.c);
+      await r.closed;
+      await r.settle();
+      expect(r.stream1Frames()).toEqual([{ type: FrameType.HEADERS, flags: 0x4 | END_STREAM }]);
+      expect(r.events).toEqual(["finish", "close rstCode=0"]);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  test("end() finishes the writable immediately and sends nothing until respond()", async () => {
+    let writableFinishedAfterEnd: boolean | undefined;
+    const r = await requestOnStream1("GET", (stream, events) => {
+      stream.end();
+      writableFinishedAfterEnd = stream.writableFinished;
+      stream.once("finish", () => {
+        events.push(`writableFinished=${stream.writableFinished}`);
+        // Before the fix end() had already put END_STREAM on the wire: a respond() from here sent
+        // HEADERS behind it, and one issued any later threw ERR_HTTP2_INVALID_STREAM because the
+        // stream had been torn down by then.
+        try {
+          stream.respond({ ":status": 204 });
+        } catch (err: any) {
+          events.push(`respond threw ${err.code}`);
+        }
+      });
+    });
+    try {
+      await waitForResponseHeaders(r.c);
+      await r.closed;
+      await r.settle();
+      // node also finishes the writable asynchronously ('finish' is emitted from a later tick).
+      expect(writableFinishedAfterEnd).toBe(false);
+      expect(r.stream1Frames()).toEqual([{ type: FrameType.HEADERS, flags: 0x4 | END_STREAM }]);
+      expect(r.events).toEqual(["finish", "writableFinished=true", "close rstCode=0"]);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  test("end() without a respond() puts nothing on the wire", async () => {
+    const r = await requestOnStream1("GET", stream => stream.end());
+    try {
+      await r.settle();
+      expect(r.stream1Frames()).toEqual([]);
+      // The writable still finishes, as node's does; the stream stays open awaiting respond().
+      expect(r.events).toEqual(["finish"]);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  test("end() then respond({ waitForTrailers }) ends on the HEADERS frame without asking for trailers", async () => {
+    const r = await requestOnStream1("GET", stream => {
+      stream.end();
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+    });
+    try {
+      await waitForResponseHeaders(r.c);
+      await r.closed;
+      await r.settle();
+      expect(r.stream1Frames()).toEqual([{ type: FrameType.HEADERS, flags: 0x4 | END_STREAM }]);
+      // A response with no body never gets a 'wantTrailers' (node submits it without a data
+      // provider, which is what would have requested them).
+      expect(r.events).toEqual(["finish", "close rstCode=0"]);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  test("end() then respond() while the request body is still open half-closes the stream", async () => {
+    const r = await requestOnStream1("POST", stream => {
+      stream.resume();
+      stream.end();
+      stream.respond({ ":status": 200 });
+    });
+    try {
+      await waitForResponseHeaders(r.c);
+      await r.settle();
+      expect(r.stream1Frames()).toEqual([{ type: FrameType.HEADERS, flags: 0x4 | END_STREAM }]);
+      expect(r.events).toEqual(["finish"]);
+      // Finishing the request body is what closes the stream; nothing more is sent for it.
+      r.c.sendFrame(FrameType.DATA, END_STREAM, 1);
+      await r.closed;
+      await r.settle();
+      expect(r.stream1Frames()).toEqual([{ type: FrameType.HEADERS, flags: 0x4 | END_STREAM }]);
+      expect(r.events).toEqual(["finish", "close rstCode=0"]);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  // end() is already visible as writableEnded while the chunks cork() buffered are being written
+  // (and the implicit respond() for them is issued): END_STREAM must stay off the HEADERS frame
+  // then, or the body would be sent on a half-closed stream.
+  test("a body buffered behind cork() when end() is called still follows the HEADERS frame", async () => {
+    const r = await requestOnStream1("GET", stream => {
+      stream.cork();
+      stream.write("hel");
+      stream.write("lo");
+      stream.end();
+    });
+    try {
+      const headers = await waitForResponseHeaders(r.c);
+      expect(headers.flags & END_STREAM).toBe(0);
+      await r.closed;
+      await r.settle();
+      const dataFrames = r.c.frames.filter(f => f.streamId === 1 && f.type === FrameType.DATA);
+      expect(Buffer.concat(dataFrames.map(f => f.payload)).toString()).toBe("hello");
+      expect(dataFrames.at(-1)!.flags & END_STREAM).toBe(END_STREAM);
+      expect(r.events).toEqual(["finish", "close rstCode=0"]);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  test("a client sees the response of a stream that was ended before respond()", async () => {
+    const server = http2.createServer();
+    server.on("stream", (stream: any) => {
+      stream.end();
+      stream.respond({ ":status": 200, "x-ended-first": "1" });
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    try {
+      const events: string[] = [];
+      const closed = Promise.withResolvers<void>();
+      const req = client.request({ ":path": "/" });
+      req.on("error", (err: any) => events.push(`error ${err.code}`));
+      // Before the fix the bare END_STREAM DATA frame ended the request without a 'response'.
+      req.on("response", (headers: any, flags: number) =>
+        events.push(`response ${headers[":status"]} ${headers["x-ended-first"]} flags=${flags}`),
+      );
+      req.on("data", (chunk: Buffer) => events.push(`data ${chunk.length}`));
+      req.on("end", () => events.push("end"));
+      req.on("close", () => {
+        events.push(`close rstCode=${req.rstCode}`);
+        closed.resolve();
+      });
+      req.end();
+      await closed.promise;
+      expect(events).toEqual([`response 200 1 flags=${0x4 | END_STREAM}`, "end", "close rstCode=0"]);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
+// RST_STREAM(NO_ERROR) is how a node server closes a stream it never responded on (stream.close()
+// before respond()), and what a bun server now sends for it too. For the receiver it is a clean
+// end of the stream, not a stream error: node's client emits 'end' and then 'close' with rstCode 0
+// on a request nobody is reading. Routing it as a stream error destroyed the stream before the
+// readable could end, so 'end' never fired (test-http2-compat-write-head-after-close relies on it).
+describe("RST_STREAM(NO_ERROR) received by a client (RFC 9113 §6.4)", () => {
+  test("ends an unconsumed request cleanly", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    const events: string[] = [];
+    client.on("error", (err: any) => events.push(`session error ${err.code}`));
+    try {
+      const closed = Promise.withResolvers<void>();
+      const req = client.request({ ":path": "/" });
+      req.on("error", (err: any) => events.push(`error ${err.code}`));
+      req.on("response", () => events.push("response"));
+      req.on("aborted", () => events.push("aborted"));
+      req.on("end", () => events.push("end"));
+      req.on("close", () => {
+        events.push(`close rstCode=${req.rstCode}`);
+        closed.resolve();
+      });
+      req.end();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      raw.sendFrame(FrameType.RST_STREAM, 0, 1, Buffer.alloc(4)); // NO_ERROR
+      await closed.promise;
+      expect(events).toEqual(["end", "close rstCode=0"]);
+    } finally {
+      client.destroy();
+      raw.close();
     }
   });
 });


### PR DESCRIPTION
### Problem

- On a `node:http2` server, `stream.end()` before `stream.respond()` on a regular (client-initiated) stream puts an empty END_STREAM `DATA` frame on the wire for a stream that has not sent any `HEADERS`. Frames on stream 1 for a GET, against node v26.3.0 (`0x4` = END_HEADERS, `0x5` = END_HEADERS | END_STREAM):
  ```
  s.end(); s.respond({ ":status": 200 })     node: HEADERS 0x5        bun: DATA 0x1 len=0, HEADERS 0x4
  s.end()                                    node: (nothing)          bun: DATA 0x1 len=0
  ```
- User-visible: bun's own client gets `'end'`/`'close'` but never `'response'`; a `respond()` a tick later throws `ERR_HTTP2_INVALID_STREAM` (the frame already closed the stream); on 1.4.0 the same-tick `respond()` also raises an uncaught `ERR_HTTP2_SESSION_ERROR` on the server once the client rejects the late `HEADERS`. For a strict peer, `DATA` before the response `HEADERS` is a protocol error (RFC 9113 8.1).
- Cause: `Http2Stream#_final` (`src/js/node/http2.ts`) handled ended-before-respond only for pushed (even-id) streams; everything else fell through to `native.writeStream(id, "", ..., true)`, i.e. the empty END_STREAM `DATA` frame. Node's `_final` (`Http2Stream::DoShutdown`) only marks the stream unwritable, and `SubmitResponse` then submits the response without a body, so END_STREAM rides on the `HEADERS` frame.
- Second, pre-existing bug this exposes: `close()`/`destroy()` before `respond()` use the same `_final`, so the server now sends just `RST_STREAM(NO_ERROR)` for them (as node does), but a bun client receiving `RST_STREAM(NO_ERROR)` emitted `'close'` without `'end'`. `on_stream_reset` in `src/runtime/api/bun/h2_frame_parser.rs` (the inbound engine's bridge) dispatched every non-CANCEL code, NO_ERROR included, as `onStreamError`, which destroys the stream before its readable can end. Reproducible on main against a node server doing `stream.close()` (node's client: `end, close`; bun's: `close`), and it made the vendored `test-http2-compat-write-head-after-close.js` hang once the server side was fixed.

### Fix

- `_final` on a server stream without headers sent: a client-initiated stream sets `FinalCalled` and completes its callback without writing anything, so the writable finishes right away like node's, whether or not a `respond()` follows. The pushed-stream branch (parked callback) is unchanged.
- `respond()` forces `endStream` when `FinalCalled` is set, so END_STREAM goes on the `HEADERS` frame; that branch already strips `waitForTrailers`, and node likewise never asks for trailers on a response submitted without a body.
- Why `FinalCalled` is the right signal: it is the analog of node's `!is_writable()`. Data written before `respond()` triggers the implicit `respond()` in `_write`/`_writev`, so when `respond()` is still allowed to run, `_final` having run means `end()` was called with nothing written at all. `writableEnded` would be wrong: it is already true during that implicit `respond()` for chunks buffered behind `cork()` when `end()` is called before uncorking, and END_STREAM on the `HEADERS` would then put the body on a half-closed stream.
- `on_stream_reset`: a peer `RST_STREAM(NO_ERROR)` dispatches `onStreamEnd(CLOSED)`, the routing the local `end_stream` (and the dead legacy inbound `handle_rst_stream_frame`) already use; the `streamEnd` handlers push EOF and read, so the stream emits `'end'` then `'close'` with `rstCode` 0, matching node. Other codes unchanged.
- Result: every `end()`/`close()`/`destroy()`/`session.destroy()`-before-`respond()` variant measured now sends the same frames as node (table below). Streams whose headers were already sent are untouched.
- Tests, `test/js/node/http2/h2-conformance.test.ts` (raw-frame client against a real server): `end(); respond()` sends exactly one `HEADERS` carrying END_STREAM and the stream finishes and closes; `respond()` from `'finish'` works; `end()` alone sends nothing and still finishes; `waitForTrailers` variant emits no `'wantTrailers'`; request body still open (END_STREAM on `HEADERS` half-closes, the request's END_STREAM closes); body buffered behind `cork()` keeps END_STREAM off `HEADERS` (pins the signal choice, passes before and after); bun's client sees `response` (flags `0x5`), `end`, `close`; a client fed `RST_STREAM(NO_ERROR)` by a raw server emits `end, close rstCode=0`. 7 of the 8 new cases fail on main.
- The re-entrant `sendTrailers` inline snapshot in the same file loses its `req error ERR_HTTP2_STREAM_CANCEL` line. That fixture feeds the client a `RST_STREAM(NO_ERROR)` before `client.destroy()`; the error was the deferred error dispatch of that reset picking up the session's cancel error. The stream now closes cleanly, as node's does for a stream the peer already reset with NO_ERROR. The test's point (exit 0, no signal) is unchanged.
- Also run: all 261 vendored upstream `test-http2-*` files pass (`compat-write-head-after-close` needs the `on_stream_reset` hunk); `node-http2.test.js` (357 pass) and the other `test/js/node/http2/*` files; the http2 regression tests; `grpc-js` `test-server`/`test-metadata`; `undici-h2` (11/11).
- Related open PRs, neither covering the plain `end()` path: #38104 does the same END_STREAM-on-`HEADERS` for pushed streams, keyed on the parked callback (the conditions are additive; one-line rebase for whichever lands second). #33380 owns the `close()`/`destroy()` reset semantics (including the missing `closed` guard in `respond()`); it independently carries the same `RST_STREAM(NO_ERROR)` routing hunk and a bare-`end()` test, which this PR needs in order to stand on its own.

### Background

- A response begins with a `HEADERS` frame; END_STREAM is a flag on the last frame the sender emits for the stream, either a `DATA` frame or, for a body-less response, the `HEADERS` frame itself (RFC 9113 8.1).
- `_final` is the `stream.Writable` hook run once `end()` was called and all buffered chunks were written; `'finish'` is emitted (on a later tick) after its callback is invoked. `ServerHttp2Stream#_write`/`_writev` call `respond()` implicitly when data is written before it.
- `StreamState` in `http2.ts` is a per-stream bit set. `FinalCalled` was already set by the other `_final` paths; this is its first reader. The pushed-stream path instead parks the callback in `bunHTTP2StreamFinal` and completes it from the native END_STREAM dispatch (`markWritableDone`).
- `RST_STREAM` closes a stream abruptly; with code NO_ERROR it is the normal way to drop a stream without a complete response (node's `stream.close()` defaults to it). Inbound frames are parsed by the rewritten engine (`h2/connection.rs`), which calls into the `Sink` bridge in `h2_frame_parser.rs`; `on_stream_reset` is the bridge for a received `RST_STREAM`. `onStreamEnd` and `onStreamError` are the two JS dispatches it can choose between, handled by the `streamEnd` (end-of-stream bookkeeping, destroy once both halves are done) and `streamError` (destroy with an error) handlers in `http2.ts`.

<details>
<summary>Frames the server sends on stream 1 (GET unless noted): node v26.3.0, bun 1.4.0, this branch</summary>

Measured with a TCP proxy logging frame type/flags between bun's client and the server.

| server does | node | bun 1.4.0 | this branch |
| --- | --- | --- | --- |
| `end(); respond()` | `HEADERS 0x5` | `DATA 0x1, HEADERS 0x4` (+ session error) | `HEADERS 0x5` |
| `end(); respond()` (POST, body open) | `HEADERS 0x5` | `DATA 0x1, HEADERS 0x4` | `HEADERS 0x5` |
| `end()` only | nothing, `'finish'` | `DATA 0x1` | nothing, `'finish'` |
| `end()`, then `respond()` on `'finish'` / later | `HEADERS 0x5` | `DATA 0x1, HEADERS 0x5` / throws | `HEADERS 0x5` |
| `end(); respond({ waitForTrailers })` | `HEADERS 0x5`, no wantTrailers | `DATA 0x1, HEADERS 0x4` | `HEADERS 0x5`, no wantTrailers |
| `additionalHeaders(102); end(); respond()` | `HEADERS 0x4, HEADERS 0x5` | `DATA 0x1` | `HEADERS 0x4, HEADERS 0x5` |
| `end(); respondWithFD(fd)` | `HEADERS 0x5` | `DATA 0x1` | `HEADERS 0x5` |
| `respondWithFD(fd); end()` | `HEADERS 0x4, DATA, DATA 0x1` | same | same |
| `destroy()` | `RST_STREAM(0)` | `DATA 0x1` | `RST_STREAM(0)` |
| `close()` | `RST_STREAM(0)` | `DATA 0x1, RST_STREAM(0)` | `RST_STREAM(0)` |
| `close(REFUSED_STREAM)` | `RST_STREAM(7)`, client errors | `DATA 0x1` (reset lost, client sees a clean end) | `RST_STREAM(7)`, client errors |
| `close(); respond()` | throws, `RST_STREAM(0)` | `DATA 0x1, HEADERS 0x4, RST_STREAM(0)`, session errors | `HEADERS 0x5, RST_STREAM(0)` (the throw is #33380) |
| `end(); session.destroy()` | nothing | `DATA 0x1` | nothing |
| `cork(); write("hello"); end()` | `HEADERS 0x4, DATA(5) 0x1` | `HEADERS 0x4, DATA(5) 0x0, DATA(0) 0x1` | unchanged |
| `respond(); close(code)` (headers sent) | not touched by this PR | | |

</details>
