### PR TITLE
console: print nested String wrapper objects as [String: ...]

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3597,7 +3597,15 @@ pub mod formatter {
             };
             writer.add_for_new_line(str.length());
 
-            if self.quote_strings && js_type != jsc::JSType::RegExpObject {
+            // A String wrapper keeps its `[String: "..."]` rendering below when
+            // nested (like `[Number: 1]`) instead of being quoted like a
+            // primitive string.
+            if self.quote_strings
+                && !matches!(
+                    js_type,
+                    jsc::JSType::StringObject | jsc::JSType::RegExpObject
+                )
+            {
                 if str.is_empty() {
                     writer.write_all(b"\"\"");
                     if writer.failed {
@@ -3634,6 +3642,7 @@ pub mod formatter {
             }
 
             if js_type == jsc::JSType::StringObject {
+                writer.add_for_new_line("[String: \"\"]".len());
                 if C {
                     writer.print(format_args!("{}", pfmt!("<r><green>", C)));
                 }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -393,6 +393,43 @@ it("inspect", () => {
   );
 });
 
+it("String wrapper objects print as [String: ...] at every depth", () => {
+  class MyString extends String {}
+
+  // Top level. Bun.inspect quotes strings even at the top level, which used to
+  // turn the wrapper into a plain quoted string.
+  expect(Bun.inspect(new String("s"))).toBe('[String: "s"]');
+  expect(Bun.inspect(new String(""))).toBe('[String: ""]');
+  expect(Bun.inspect(new MyString("s"))).toBe('[String: "s"]');
+
+  // Nested in every container, alongside the other wrappers which already printed correctly.
+  expect(Bun.inspect({ n: new Number(3), b: new Boolean(true), s: new String("s") })).toBe(
+    '{\n  n: [Number: 3],\n  b: [Boolean: true],\n  s: [String: "s"],\n}',
+  );
+  expect(Bun.inspect([new String("s"), new String(""), new MyString("sub")])).toBe(
+    '[ [String: "s"], [String: ""], [String: "sub"] ]',
+  );
+  expect(Bun.inspect(new Map([[new String("k"), new String("v")]]))).toBe(
+    'Map(1) {\n  [String: "k"]: [String: "v"],\n}',
+  );
+  expect(Bun.inspect(new Set([new String("s")]))).toBe('Set(1) {\n  [String: "s"],\n}');
+
+  // The contents go through the same escaping as a quoted primitive string, for
+  // both the Latin-1 and the UTF-16 string representations.
+  expect(Bun.inspect({ s: new String('a"b\\c\n') })).toBe('{\n  s: [String: "a\\"b\\\\c\\n"],\n}');
+  expect(Bun.inspect({ s: new String("héllo") })).toBe('{\n  s: [String: "héllo"],\n}');
+  expect(Bun.inspect({ s: new String('日"本') })).toBe('{\n  s: [String: "日\\"本"],\n}');
+  expect(Bun.inspect({ s: new String("héllo 🌍") })).toBe('{\n  s: [String: "héllo 🌍"],\n}');
+
+  // Primitive strings and RegExps share the printer and keep their rendering.
+  expect(Bun.inspect({ s: "s", r: /r/g })).toBe('{\n  s: "s",\n  r: /r/g,\n}');
+  expect(Bun.inspect(["s", /r/g])).toBe('[ "s", /r/g ]');
+
+  // The colored printer is a separate instantiation of the same code.
+  expect(Bun.inspect([new String("s")], { colors: true })).toContain('\x1b[32m[String: "s"]\x1b[0m');
+  expect(Bun.inspect([new String("日本語")], { colors: true })).toContain('\x1b[32m[String: "日本語"]\x1b[0m');
+});
+
 describe("latin1 supplemental", () => {
   const fixture = [
     [["äbc"], '[ "äbc" ]'],

--- a/test/js/web/console/console-log.expected.txt
+++ b/test/js/web/console/console-log.expected.txt
@@ -20,6 +20,12 @@ Symbol(Symbol Description)
 [String: "Hello 👋🏼"]
 [Number: 5]
 [Boolean: true]
+{
+  s: [String: "Hello"],
+  n: [Number: 5],
+  b: [Boolean: true],
+}
+[ [String: "Hello"], [String: "Hello 👋🏼"], "Hello" ]
 [ 123, 456, 789 ]
 {
   name: "foo",

--- a/test/js/web/console/console-log.js
+++ b/test/js/web/console/console-log.js
@@ -18,6 +18,8 @@ console.log(new String("Hello"));
 console.log(new String("Hello 👋🏼"));
 console.log(new Number(5));
 console.log(new Boolean(true));
+console.log({ s: new String("Hello"), n: new Number(5), b: new Boolean(true) });
+console.log([new String("Hello"), new String("Hello 👋🏼"), "Hello"]);
 console.log([123, 456, 789]);
 console.log({ name: "foo" });
 console.log({ a: 123, b: 456, c: 789 });


### PR DESCRIPTION
### Problem

- A `new String(...)` wrapper nested inside an object, array, Map or Set is printed by `console.log` / `Bun.inspect` as a plain quoted string, while the Number and Boolean wrappers next to it print as wrappers:
  ```js
  console.log({ n: new Number(3), b: new Boolean(true), s: new String("s") });
  // bun:   s: "s"                 node:   s: [String: 's']
  console.log([new String("arr")]);
  // bun:   [ "arr" ]              node:   [ [String: 'arr'] ]
  Bun.inspect(new String("top"));
  // bun:   "top"                  node (util.inspect):   [String: 'top']
  ```
- `console.log(new String("top"))` alone was already `[String: "top"]`, so the wrapper rendering exists; it was just unreachable for nested values.
- Cause: in `print_string` (`src/jsc/ConsoleObject.rs`), the `if self.quote_strings` branch, which every value nested in a container takes (and which `Bun.inspect` also enables at the top level), JSON-quotes the string and returns before the `js_type == StringObject` branch below it is reached. Reproduces on released bun 1.4.0 and on main; the Rust port kept the branch order of the original Zig code.

### Fix

- The quoting branch now skips `StringObject` the same way it already skipped `RegExpObject`, so a String wrapper falls through to its `[String: "..."]` branch at every depth. The wrapper branch also adds the width of its decoration to the line-length estimate, like `print_double` does, so arrays of wrappers wrap at the right point.
- Correct because the wrapper branch is the rendering Bun already uses for this type at the top level, and the other boxed primitives are already rendered the same way regardless of depth; this only removes the one path that lost the wrapper. Output matches Node apart from Bun's usual double quotes. Primitive strings and RegExps take exactly the branches they took before.
- `class X extends String` instances are plain `StringObject` cells in JSC (`DerivedStringObjectType` is only used for `String.prototype` itself, see `StringPrototypeInlines.h`), so subclass instances are covered. `String.prototype` is intentionally left as is; #36660 handles it at the tagging layer.
- Verified:
  - `test/js/bun/util/inspect.test.js` ("String wrapper objects print as [String: ...] at every depth"): top level, object, array, Map key and value, Set, subclass instance, empty wrapper, Latin-1 and UTF-16 contents with escaping, colors, plus primitive string / RegExp unchanged. Fails on the released binary (`Received: ""s""`), passes with this change.
  - `test/js/web/console/console-log.js` + `.expected.txt`: the `console.log` form for an object and an array of wrappers next to the existing top-level wrapper lines. Fails on the released binary with `s: "Hello"`, passes with this change.
  - `bun bd test test/js/bun/util/inspect.test.js`, `test/js/bun/console`, `test/js/web/console`, `test/js/node/util/{bun-inspect,util}`, `test/js/bun/test/{expect,jest-extended,expect-label,jest-each}` all pass.
- Related open PRs: #36404 changes where `print_string` reads the wrapper's text from and its test currently asserts the old `Bun.inspect(new String("hello")) === '"hello"'` output, so whichever of the two lands second needs that assertion updated to `[String: "hello"]`. #33445 / #36404 also cover the separate issue of a String wrapper first argument being used as the format string; unchanged here.

### Background

- `Formatter` in `src/jsc/ConsoleObject.rs` is the native pretty printer shared by `console.log`, `Bun.inspect`, `bun test` failure messages and the error printer. Each value is classified into a `Tag`; `StringObject`, `RegExpObject` and primitive strings all map to `Tag::String` and are printed by `print_string`, which then distinguishes them by the value's `JSType`.
- `quote_strings` is a formatter flag: `console.log("x")` prints a bare `x`, but once the printer recurses into a container (or when the caller is `Bun.inspect`) the flag is set so strings print quoted. It is meant to affect primitive strings only; boxed `Number` / `Boolean` values are printed by `print_double` / `print_boolean` and never consult it.
- A boxed primitive (`new String("s")`, `new Number(3)`) is an object wrapping a primitive; Node's `util.inspect` renders it as `[String: 's']` / `[Number: 3]` so it cannot be confused with the primitive itself.
