### PR TITLE
bundler: honor the loader chosen by a native onBeforeParse plugin

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2220,7 +2220,7 @@ pub mod parse_worker {
             .unwrap_or(Loader::File);
 
         let mut contents_came_from_plugin: bool = false;
-        let result = get_code_for_parse_task(
+        let entry = match get_code_for_parse_task(
             task,
             log,
             transpiler,
@@ -2229,12 +2229,19 @@ pub mod parse_worker {
             &mut file_path,
             &mut loader,
             &mut contents_came_from_plugin,
-        );
-        if result.is_err() {
-            // SAFETY: `transpiler` is live; no other borrow of it is held here.
-            unsafe { (*transpiler).reset_store() };
-        }
-        result
+        ) {
+            Ok(entry) => entry,
+            Err(e) => {
+                // SAFETY: `transpiler` is live; no other borrow of it is held here.
+                unsafe { (*transpiler).reset_store() };
+                return Err(e);
+            }
+        };
+        // An onBeforeParse plugin may have chosen a different loader for the
+        // source it handed back. `run_with_source_code` (the next stage, possibly
+        // on another thread) re-derives the loader from `task`, so store it there.
+        task.loader = Some(loader);
+        Ok(entry)
     }
 
     // ───────────────────────────────────────────────────────────────────────────

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7113,7 +7113,26 @@ pub mod bv2_impl {
                     }
 
                     // Record which loader we used for this file
-                    this.graph.input_files.items_loader_mut()[result_source_index] = result.loader;
+                    let enqueued_loader = core::mem::replace(
+                        &mut this.graph.input_files.items_loader_mut()[result_source_index],
+                        result.loader,
+                    );
+                    // A native onBeforeParse plugin can switch loaders on the parse
+                    // thread. `process_resolve_queue` & co. already did the
+                    // copy-for-bundling bookkeeping for `enqueued_loader`, so redo it
+                    // if the plugin moved the file into or out of that class.
+                    if result.loader.should_copy_for_bundling()
+                        != enqueued_loader.should_copy_for_bundling()
+                    {
+                        let side_effects = if result.loader.should_copy_for_bundling() {
+                            this.graph.estimated_file_loader_count += 1;
+                            bun_ast::SideEffects::NoSideEffectsPureData
+                        } else {
+                            result.side_effects
+                        };
+                        this.graph.input_files.items_side_effects_mut()[result_source_index] =
+                            side_effects;
+                    }
 
                     bun_core::scoped_log!(
                         Bundle,

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -744,6 +744,169 @@ console.log(JSON.stringify(json))
     expect(exitCode).toBe(0);
   });
 
+  // `OnBeforeParseResult.loader` lets the plugin choose how Bun parses the file,
+  // overriding the loader implied by the extension.
+  describe("result loader", () => {
+    async function buildWithLoaderPlugin(opts: {
+      dir: string;
+      files: Record<string, string>;
+      entrypoint: string;
+      filter: RegExp;
+      symbol: string;
+      external?: unknown;
+    }) {
+      const dir = path.join(tempdir, "loader_tests", opts.dir);
+      await Promise.all(
+        Object.entries(opts.files).map(([name, contents]) => Bun.write(path.join(dir, name), contents)),
+      );
+      const napiModule = loadPlugin();
+
+      const result = await Bun.build({
+        outdir: path.join(dir, "out"),
+        entrypoints: [path.join(dir, opts.entrypoint)],
+        target: "bun",
+        plugins: [
+          {
+            name: "loader-test",
+            setup(build) {
+              build.onBeforeParse(
+                { filter: opts.filter },
+                { napiModule, symbol: opts.symbol, external: opts.external },
+              );
+            },
+          },
+        ],
+      });
+      expect(result.logs).toBeEmpty();
+      expect(result.success).toBeTrue();
+      return result;
+    }
+
+    function loadPlugin() {
+      return require(path.join(tempdir, "build/Release/xXx123_foo_counter_321xXx.node"));
+    }
+
+    async function run(entrypoint: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), entrypoint],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout;
+    }
+
+    it("parses replaced source with the loader the plugin set", async () => {
+      const napiModule = loadPlugin();
+      const external = napiModule.createExternal();
+      const result = await buildWithLoaderPlugin({
+        dir: "compile_to_js_import",
+        files: {
+          "index.ts": `import message from "./message.foo";\nconsole.log(message);\n`,
+          "message.foo": "hello from foo",
+        },
+        entrypoint: "index.ts",
+        filter: /\.foo$/,
+        symbol: "plugin_impl_compile_to_js",
+        external,
+      });
+
+      // With the extension's `file` loader, message.foo would be copied to the
+      // outdir as an asset and the import would evaluate to its path.
+      expect(result.outputs.map(output => output.kind)).toEqual(["entry-point"]);
+      expect(await run(result.outputs[0].path)).toBe("hello from foo\n");
+      expect(napiModule.getCompilationCtxFreedCount(external)).toBe(1);
+    });
+
+    it("parses a replaced entry point with the loader the plugin set", async () => {
+      const result = await buildWithLoaderPlugin({
+        dir: "compile_to_js_entry",
+        files: {
+          "page.foo": "hello from the entry point",
+        },
+        entrypoint: "page.foo",
+        filter: /\.foo$/,
+        symbol: "plugin_impl_compile_to_js",
+      });
+
+      expect(result.outputs.map(output => [output.kind, path.basename(output.path)])).toEqual([
+        ["entry-point", "page.js"],
+      ]);
+      expect(await result.outputs[0].text()).toContain('"hello from the entry point"');
+    });
+
+    it("parses the original source with the loader the plugin set", async () => {
+      const result = await buildWithLoaderPlugin({
+        dir: "parse_as_js",
+        files: {
+          "index.ts": `import answer from "./answer.txt";\nconsole.log(answer);\n`,
+          // The extension's `text` loader would export this string verbatim.
+          "answer.txt": "export default 40 + 2;",
+        },
+        entrypoint: "index.ts",
+        filter: /\.txt$/,
+        symbol: "plugin_impl_parse_as_js",
+      });
+
+      expect(await run(result.outputs[0].path)).toBe("42\n");
+    });
+
+    it("honors a non-JavaScript loader set by the plugin", async () => {
+      const result = await buildWithLoaderPlugin({
+        dir: "parse_as_json",
+        files: {
+          "index.ts": `import data from "./data.txt";\nconsole.log(JSON.stringify(data), typeof data);\n`,
+          "data.txt": `{ "answer": 42 }`,
+        },
+        entrypoint: "index.ts",
+        filter: /\.txt$/,
+        symbol: "plugin_impl_parse_as_json",
+      });
+
+      expect(await run(result.outputs[0].path)).toBe('{"answer":42} object\n');
+    });
+
+    it("keeps the side effects of a file the plugin moved off the file loader", async () => {
+      const result = await buildWithLoaderPlugin({
+        dir: "file_to_js_side_effects",
+        files: {
+          "index.ts": `import "./effect.foo";\nconsole.log("index");\n`,
+          // .foo defaults to the `file` loader, and a bare import of a `file`
+          // loader module is dropped as side-effect free.
+          "effect.foo": `console.log("effect");`,
+        },
+        entrypoint: "index.ts",
+        filter: /\.foo$/,
+        symbol: "plugin_impl_parse_as_js",
+      });
+
+      expect(await run(result.outputs[0].path)).toBe("effect\nindex\n");
+    });
+
+    it("copies the file as an asset when the plugin switches it to the file loader", async () => {
+      const result = await buildWithLoaderPlugin({
+        dir: "js_to_file",
+        files: {
+          "index.ts": `import url from "./thing.js";\nconsole.log(url);\n`,
+          "thing.js": `export default "bundled as js";`,
+        },
+        entrypoint: "index.ts",
+        // Nothing else in this build uses the file loader, so the asset only
+        // gets written if the plugin's choice is accounted for.
+        filter: /thing\.js$/,
+        symbol: "plugin_impl_parse_as_file",
+      });
+
+      expect(result.outputs.map(output => output.kind)).toEqual(["entry-point", "asset"]);
+      const [entry, asset] = result.outputs;
+      expect(await asset.text()).toBe(`export default "bundled as js";`);
+      expect(await run(entry.path)).toBe(`./${path.basename(asset.path)}\n`);
+    });
+  });
+
   type AdditionalFile = {
     name: string;
     contents: BunFile | string;

--- a/test/bundler/native_plugin.cc
+++ b/test/bundler/native_plugin.cc
@@ -181,6 +181,79 @@ plugin_impl_baz(const OnBeforeParseArguments *args,
   plugin_impl_with_needle(args, result, "baz");
 }
 
+/*
+  Replaces the source with a JS module that default-exports the original
+  contents as a string literal, and tells Bun to parse the replacement with the
+  JS loader no matter what the file extension's loader is (the same shape as a
+  plugin compiling e.g. .mdx into JS).
+
+  The original contents are spliced into a double-quoted literal verbatim, so
+  the tests only feed it contents without quotes, backslashes or newlines.
+*/
+extern "C" BUN_PLUGIN_EXPORT void
+plugin_impl_compile_to_js(const OnBeforeParseArguments *args,
+                          OnBeforeParseResult *result) {
+  if (result->fetchSourceCode(args, result) != 0) {
+    exit(1);
+  }
+
+  static const char prefix[] = "export default \"";
+  static const char suffix[] = "\";";
+  const size_t prefix_len = sizeof(prefix) - 1;
+  const size_t suffix_len = sizeof(suffix) - 1;
+
+  size_t new_len = prefix_len + result->source_len + suffix_len;
+  char *new_source = (char *)malloc(new_len);
+  if (new_source == nullptr) {
+    exit(1);
+  }
+  memcpy(new_source, prefix, prefix_len);
+  memcpy(new_source + prefix_len, result->source_ptr, result->source_len);
+  memcpy(new_source + prefix_len + result->source_len, suffix, suffix_len);
+
+  std::atomic<size_t> *free_counter = nullptr;
+  if (args->external) {
+    free_counter = &((External *)args->external)->compilation_ctx_freed_count;
+  }
+
+  result->source_ptr = (uint8_t *)new_source;
+  result->source_len = new_len;
+  result->loader = BUN_LOADER_JS;
+  result->plugin_source_code_context =
+      compilation_ctx_new(new_source, new_len, free_counter);
+  result->free_plugin_source_code_context =
+      (void (*)(void *))compilation_ctx_free;
+}
+
+/*
+  Leaves the source untouched and only overrides the loader Bun parses it with.
+*/
+static void parse_with_loader(const OnBeforeParseArguments *args,
+                              OnBeforeParseResult *result, BunLoader loader) {
+  if (result->fetchSourceCode(args, result) != 0) {
+    exit(1);
+  }
+  result->loader = loader;
+}
+
+extern "C" BUN_PLUGIN_EXPORT void
+plugin_impl_parse_as_js(const OnBeforeParseArguments *args,
+                        OnBeforeParseResult *result) {
+  parse_with_loader(args, result, BUN_LOADER_JS);
+}
+
+extern "C" BUN_PLUGIN_EXPORT void
+plugin_impl_parse_as_json(const OnBeforeParseArguments *args,
+                          OnBeforeParseResult *result) {
+  parse_with_loader(args, result, BUN_LOADER_JSON);
+}
+
+extern "C" BUN_PLUGIN_EXPORT void
+plugin_impl_parse_as_file(const OnBeforeParseArguments *args,
+                          OnBeforeParseResult *result) {
+  parse_with_loader(args, result, BUN_LOADER_FILE);
+}
+
 extern "C" void finalizer(napi_env env, void *data, void *hint) {
   External *external = (External *)data;
   if (external != nullptr) {


### PR DESCRIPTION
### Problem

- A native bundler plugin (`build.onBeforeParse` with a `napiModule`) can replace a file's source and set `OnBeforeParseResult.loader` to say how the replacement should be parsed. This is the documented way to compile e.g. `.mdx` into JSX (`handle.set_output_source_code(code, BunLoader::BUN_LOADER_JSX)` in docs/bundler/plugins.mdx; `packages/bun-build-mdx-rs` does exactly that). `Bun.build` uses the replaced source but ignores the loader: the file is still processed with the loader implied by its extension.
- Repro: a plugin that returns `export default 42;` with the JS loader for `data.foo` (unknown extension, so the `file` loader). The build succeeds, emits `data-<hash>.foo` as an asset whose contents are literally `export default 42;`, and the bundle contains `var data_default = "./data-<hash>.foo"`. Setting only the loader (keeping the source, `set_output_loader` in bun-native-plugin-rs) is ignored the same way.
- Cause: since #17577 split the parse task into two stages (so file reads can run on the I/O pool), `get_source_code` (src/bundler/ParseTask.rs:2216) computes the loader into a local, `OnBeforeParsePlugin::run` writes the plugin's choice into that local (ParseTask.rs:2149), and `get_source_code` returns only the file contents. `run_with_source_code` (ParseTask.rs:2288) then derives the loader from `task.loader` again, which still holds the extension's loader. Before the split both halves shared one local, so the plugin's loader used to take effect.

### Fix

- `get_source_code` stores the loader it settled on back into `task.loader`, so `run_with_source_code` parses with it and reports it in `Success.loader` (which is what the graph records). Every enqueue site already sets `task.loader`, so when no plugin runs this writes back the same value.
- `on_parse_task_complete` compares the loader the file was enqueued with against the one the parse used. If a plugin moved the file into or out of the copy-for-bundling loaders (`file`, `napi`, `wasm`, `sqlite`), it redoes the bookkeeping the enqueue sites did for the original loader (bundle_v2.rs:6723-6734): bumps `estimated_file_loader_count` and marks the file pure data when it became an asset, or restores the parse task's own side-effect flag when it stopped being one. Both were needed once the loader started taking effect:
  - switching a `.js` import to the `file` loader in a build with no other assets left `estimated_file_loader_count` at 0, so `process_files_to_copy` (bundle_v2.rs:4175) never ran and chunk generation hit `assertion failed: !additional_files.is_empty()` in `append_isolated_hashes_for_imported_chunks` (release: "Internal error: missing asset file");
  - compiling a `.foo` (`file` loader) into JS left the enqueue-time `NoSideEffectsPureData` mark in place, so `import "./x.foo"` was tree-shaken away along with the module's side effects (LinkerContext.rs:2809-2813). A JS `onLoad` plugin returning `loader: "js"` for the same file keeps them, because for JS plugins the bookkeeping is deferred until the loader is known.
- This comparison is a no-op for every existing flow: without a native plugin the parse stage never changes the loader (data: URLs are enqueued as `dataurl` and parsed as js/css/json, all outside the copy class; JS `onLoad` plugins update the graph's loader before the parse task runs).
- Related, not changed here: `BUN_LOADER_TOML` through `BUN_LOADER_TEXT` in `bundler_plugin.h` and bun-native-plugin-rs are one off from the runtime's numbering since `jsonc` was inserted; #37095 corrects them. The constants the new tests use (`JS`, `JSON`, `FILE`) agree in both numberings. Until #37095 lands, a plugin built against the stale header that asks for one of those six loaders gets the neighbouring loader instead of, as before this change, being ignored.
- Verified with the new `result loader` block in test/bundler/native-plugin.test.ts (six tests: replaced source + JS loader for an import and for an entry point, loader-only override to JS and to JSON, `file` -> JS keeping side effects, JS -> `file` emitting the asset), driven by four new hooks in test/bundler/native_plugin.cc.
  - `USE_SYSTEM_BUN=1 bun test test/bundler/native-plugin.test.ts -t "result loader"`: 6 fail (asset emitted / text loader applied / side effect dropped / no asset).
  - `bun bd test test/bundler/native-plugin.test.ts`: 25 pass, 1 skip (pre-existing ASAN skip).
  - With only the ParseTask.rs change built, ad hoc builds of the same two scenarios as the last two tests failed as described above (the linker assertion; the converted module's `console.log` missing from the bundle), which is what motivated the bundle_v2.rs part.
  - `bun bd test` on bundler_loader, bundler_files, bundler_plugin, bundler_plugin_chain, bundler_edgecase, bundler_html, bun-build-api, esbuild/loader, esbuild/dce: all pass except `Bun.build can be called thousands of times in one process`, which hit its 180s ceiling under the debug+ASAN build in this container (400 builds x 500 modules) and is unrelated.

### Background

- Loader: the per-file strategy the bundler uses to turn bytes into a module (`js`, `ts`, `json`, `text`, `file`, ...). It is normally chosen from the file extension when the import is resolved and stored both on the `ParseTask` and in the graph's `input_files` column.
- Copy-for-bundling loaders (`Loader::should_copy_for_bundling`): `file`, `napi`, `wasm`, `sqlite`. Such a file is not parsed; its module becomes `export default "<unique key>"` and the bytes are written to the outdir as an asset by `process_files_to_copy`, which only runs if `estimated_file_loader_count` is non-zero. The enqueue sites increment that counter and mark the file `NoSideEffectsPureData` as soon as they pick such a loader.
- `SideEffects` on an input file: anything other than `HasSideEffects` tells the tree shaker that a bare `import "x"` of that file can be dropped.
- `onBeforeParse` native plugins run on the parse worker thread, inside the parse task, unlike JS `onLoad` plugins which answer on the bundler thread before the parse task is scheduled. That is why the loader they choose is only visible to the bundler thread when the parse result comes back, in `on_parse_task_complete`.
- Parse task stages: `get_source_code` (reads the file or runs the native plugin; may run on the I/O pool) hands a `CacheEntry` of bytes to `run_with_source_code` (parses; runs on the worker pool). The `ParseTask` itself is the only state shared between the two stages.
