### PR TITLE
bundler: use require() for embedded sqlite modules in cjs output

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -982,10 +982,6 @@ pub mod parse_worker {
                 //
                 // import.meta.require(unique_key, { type: "sqlite" }).db
                 //
-                // cjs output runs inside the `@bun-cjs` function wrapper (see
-                // postProcessJSChunk), where `import.meta` is a SyntaxError, so it
-                // calls the wrapper's `require` parameter instead. This AST skips the
-                // visit pass, so nothing later rewrites `import.meta` for us.
                 let import_path = Expr::init(
                     E::String {
                         data: path_to_use.into(),
@@ -994,6 +990,8 @@ pub mod parse_worker {
                     Loc { start: 0 },
                 );
 
+                // In cjs output `import.meta` is a SyntaxError inside the `@bun-cjs`
+                // wrapper, so call the wrapper's `require` parameter instead.
                 let require_target = if opts.output_format == js_parser::options::Format::Cjs {
                     Expr {
                         data: ast::ExprData::ERequireCallTarget,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -990,8 +990,7 @@ pub mod parse_worker {
                     Loc { start: 0 },
                 );
 
-                // In cjs output `import.meta` is a SyntaxError inside the `@bun-cjs`
-                // wrapper, so call the wrapper's `require` parameter instead.
+                // `import.meta` is a SyntaxError inside the cjs `@bun-cjs` wrapper.
                 let require_target = if opts.output_format == js_parser::options::Format::Cjs {
                     Expr {
                         data: ast::ExprData::ERequireCallTarget,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -980,8 +980,12 @@ pub mod parse_worker {
 
                 // This injects the following code:
                 //
-                // import.meta.require(unique_key).db
+                // import.meta.require(unique_key, { type: "sqlite" }).db
                 //
+                // cjs output runs inside the `@bun-cjs` function wrapper (see
+                // postProcessJSChunk), where `import.meta` is a SyntaxError, so it
+                // calls the wrapper's `require` parameter instead. This AST skips the
+                // visit pass, so nothing later rewrites `import.meta` for us.
                 let import_path = Expr::init(
                     E::String {
                         data: path_to_use.into(),
@@ -990,16 +994,23 @@ pub mod parse_worker {
                     Loc { start: 0 },
                 );
 
-                let import_meta = Expr::init(E::ImportMeta {}, Loc { start: 0 });
-                let require_property = Expr::init(
-                    E::Dot {
-                        target: import_meta,
-                        name_loc: Loc::EMPTY,
-                        name: b"require".into(),
-                        ..Default::default()
-                    },
-                    Loc { start: 0 },
-                );
+                let require_target = if opts.output_format == js_parser::options::Format::Cjs {
+                    Expr {
+                        data: ast::ExprData::ERequireCallTarget,
+                        loc: Loc { start: 0 },
+                    }
+                } else {
+                    let import_meta = Expr::init(E::ImportMeta {}, Loc { start: 0 });
+                    Expr::init(
+                        E::Dot {
+                            target: import_meta,
+                            name_loc: Loc::EMPTY,
+                            name: b"require".into(),
+                            ..Default::default()
+                        },
+                        Loc { start: 0 },
+                    )
+                };
                 let require_args = bump.alloc_slice_fill_default::<Expr>(2);
                 require_args[0] = import_path;
                 let object_properties = bump.alloc_slice_fill_default::<G::Property>(1);
@@ -1031,7 +1042,7 @@ pub mod parse_worker {
                 );
                 let require_call = Expr::init(
                     E::Call {
-                        target: require_property,
+                        target: require_target,
                         // SAFETY: bump-owned slice; never grown via this Vec.
                         args: unsafe { bun_ast::ExprNodeList::from_bump_slice(require_args) },
                         ..Default::default()

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -79,7 +79,35 @@ describe("bundler", () => {
       const out = api.readFile("/out/entry.js");
       expect(out).toContain("// @bun @bun-cjs\n");
       expect(out).not.toContain("import.meta");
-      expect(out).toMatch(/= require\("\.\/db-[a-z0-9]+\.sqlite", \{ type: "sqlite" \}\)\.db;/);
+      expect(out).toMatch(/^var db_default = require\("\.\/db-[a-z0-9]+\.sqlite", \{ type: "sqlite" \}\)\.db;$/m);
+    },
+    run: { stdout: "Hello, world!" },
+  });
+  // A dynamic import turns the synthesized module into `module.exports = ...`
+  // inside a __commonJS wrapper; that is the other shape the linker gives it.
+  itBundled("bun/embedded-sqlite-file-cjs-dynamic-import", {
+    target: "bun",
+    format: "cjs",
+    outfile: "",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+        import('./db.sqlite', { with: {type: "sqlite", embed: "true"} }).then(({ default: db }) => {
+          console.log(db.query("select message from messages LIMIT 1").get().message);
+        });
+      `,
+      "/db.sqlite": (() => {
+        const db = new Database(":memory:");
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        return db.serialize();
+      })(),
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out/entry.js");
+      expect(out).toContain("// @bun @bun-cjs\n");
+      expect(out).not.toContain("import.meta");
+      expect(out).toMatch(/\bmodule\d*\.exports = require\("\.\/db-[a-z0-9]+\.sqlite", \{ type: "sqlite" \}\)\.db;$/m);
     },
     run: { stdout: "Hello, world!" },
   });

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -129,6 +129,30 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!", setCwd: true },
   });
+  itBundled("bun/sqlite-file-cjs", {
+    target: "bun",
+    format: "cjs",
+    files: {
+      "/entry.ts": /* js */ `
+        import db from './db.sqlite' with {type: "sqlite"};
+        console.log(db.query("select message from messages LIMIT 1").get().message);
+      `,
+    },
+    runtimeFiles: {
+      "/db.sqlite": (() => {
+        const db = new Database(":memory:");
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        return db.serialize();
+      })(),
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("// @bun @bun-cjs\n");
+      expect(out).not.toContain("import.meta");
+    },
+    run: { stdout: "Hello, world!", setCwd: true },
+  });
   itBundled("bun/TargetBunNoSourcemapMessage", {
     target: "bun",
     files: {

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -56,6 +56,33 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  // cjs output is wrapped in the `@bun-cjs` function wrapper, where `import.meta`
+  // is a SyntaxError, so the synthesized module has to use the wrapper's `require`.
+  itBundled("bun/embedded-sqlite-file-cjs", {
+    target: "bun",
+    format: "cjs",
+    outfile: "",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+        import db from './db.sqlite' with {type: "sqlite", embed: "true"};
+        console.log(db.query("select message from messages LIMIT 1").get().message);
+      `,
+      "/db.sqlite": (() => {
+        const db = new Database(":memory:");
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        return db.serialize();
+      })(),
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out/entry.js");
+      expect(out).toContain("// @bun @bun-cjs\n");
+      expect(out).not.toContain("import.meta");
+      expect(out).toMatch(/= require\("\.\/db-[a-z0-9]+\.sqlite", \{ type: "sqlite" \}\)\.db;/);
+    },
+    run: { stdout: "Hello, world!" },
+  });
   itBundled("bun/sqlite-file", {
     target: "bun",
     files: {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -843,22 +843,44 @@ describe("bundler", () => {
       });
     }
   }
-  itBundled("compile/EmbeddedSqlite", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        import db from './db.sqlite' with {type: "sqlite", embed: "true"};
-        console.log(db.query("select message from messages LIMIT 1").get().message);
-      `,
-      "/db.sqlite": (() => {
-        const db = new Database(":memory:");
-        db.exec("create table messages (message text)");
-        db.exec("insert into messages values ('Hello, world!')");
-        return db.serialize();
-      })(),
-    },
-    run: { stdout: "Hello, world!" },
-  });
+  // The embedded database becomes a synthesized module whose body calls the
+  // module's require. In cjs output (which --bytecode defaults to) the chunk
+  // is wrapped in the `@bun-cjs` function wrapper, where `import.meta` is a
+  // SyntaxError, so that call has to go through the wrapper's `require`.
+  for (const variant of [
+    { suffix: "", options: {} },
+    { suffix: "+cjs", options: { format: "cjs" } },
+    { suffix: "+cjs+minify", options: { format: "cjs", minifySyntax: true, minifyWhitespace: true } },
+    { suffix: "+bytecode", options: { bytecode: true } },
+  ] as const) {
+    itBundled("compile/EmbeddedSqlite" + variant.suffix, {
+      compile: true,
+      ...variant.options,
+      files: {
+        "/entry.ts": /* js */ `
+          import db from './db.sqlite' with {type: "sqlite", embed: "true"};
+          console.log(db.query("select message from messages LIMIT 1").get().message);
+        `,
+        "/db.sqlite": (() => {
+          const db = new Database(":memory:");
+          db.exec("create table messages (message text)");
+          db.exec("insert into messages values ('Hello, world!')");
+          return db.serialize();
+        })(),
+      },
+      run: {
+        stdout: "Hello, world!",
+        ...("bytecode" in variant.options
+          ? {
+              env: { BUN_JSC_verboseDiskCache: "1" },
+              validate({ stderr }) {
+                expect(stderr).toContain("[Disk Cache] Cache hit for sourceCode");
+              },
+            }
+          : {}),
+      },
+    });
+  }
   itBundled("compile/sqlite-file", {
     compile: true,
     files: {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -850,7 +850,10 @@ describe("bundler", () => {
   for (const variant of [
     { suffix: "", options: {} },
     { suffix: "+cjs", options: { format: "cjs" } },
-    { suffix: "+cjs+minify", options: { format: "cjs", minifySyntax: true, minifyWhitespace: true } },
+    {
+      suffix: "+cjs+minify",
+      options: { format: "cjs", minifySyntax: true, minifyWhitespace: true, minifyIdentifiers: true },
+    },
     { suffix: "+bytecode", options: { bytecode: true } },
   ] as const) {
     itBundled("compile/EmbeddedSqlite" + variant.suffix, {


### PR DESCRIPTION
### Problem
- A program that embeds a sqlite database (`import db from "./db.sqlite" with { type: "sqlite", embed: "true" }`) fails at startup when built with `--compile --format=cjs`, or with `--compile --bytecode` (which defaults to cjs): `SyntaxError: import.meta is only valid inside modules.` The `--bytecode` build also prints `error: Failed to generate bytecode for ./entry.js`. Plain `bun build --target=bun --format=cjs` output fails the same way when run.
- The module the bundler synthesizes for the database is `import.meta.require(<embedded path>, { type: "sqlite" }).db` (`src/bundler/ParseTask.rs`, sqlite branch of `get_ast`). It is built directly as an AST and handed to `new_lazy_export_ast`, which does not run the visit pass, so nothing rewrites the `import.meta` and the printer emits it verbatim.
- cjs output for target bun is wrapped in `// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {` (`src/bundler/linker_context/postProcessJSChunk.rs`), and `import.meta` inside a function body is a SyntaxError.

### Fix
- When the output format is cjs, the synthesized call targets `ERequireCallTarget` instead of `import.meta.require`, so the module prints as `require(<embedded path>, { type: "sqlite" }).db`. Other formats keep `import.meta.require`.
- This is correct because the printer prints `ERequireCallTarget` as a bare `require` for cjs output (`require_ref` is `None` there, `src/bundler/LinkerContext.rs`), which binds to the wrapper's `require` parameter: the module's own CommonJS require, the same function `import.meta.require` returns, and it accepts the `{ type }` attributes object as its second argument. The napi loader a few lines below already builds its lazy export this way.
- Other formats are left alone on purpose: esm and iife output for target bun is loaded as an ES module (`// @bun`), where `import.meta.require` works today, and for a lazy export `ERequireCallTarget` would print the runtime's `__require` without linking in its definition.
- Verified with `bun bd test test/bundler/bundler_bun.test.ts` and `bun bd test test/bundler/bundler_compile.test.ts -t EmbeddedSqlite`:
  - `bun/embedded-sqlite-file-cjs` checks the printed output (`@bun-cjs` wrapper, `var db_default = require(...)`, no `import.meta`) and runs it. `bun/embedded-sqlite-file-cjs-dynamic-import` does the same for the other shape the linker gives a lazy export (`module.exports = require(...)` inside a `__commonJS` wrapper), which a dynamic import produces.
  - `compile/EmbeddedSqlite+cjs`, `+cjs+minify` (syntax, whitespace and identifiers), and `+bytecode` run the compiled executable; the bytecode variant also checks that the bytecode cache is hit, which fails while bytecode generation fails.
  - `bun/sqlite-file-cjs` covers the non-embedded loader (`type: "sqlite"` without `embed`) in cjs output. That path keeps the import external, so it never emitted `import.meta`; the test locks that shape in and runs the bundle.
  - The five embedded tests fail on the released build (`USE_SYSTEM_BUN=1`) with the SyntaxError above; the pre-existing esm tests (`bun/embedded-sqlite-file`, `compile/EmbeddedSqlite`) pass before and after.
  - Manually confirmed with the debug build that esm, iife, and `--compile --bytecode --format=esm` output for the same entry still runs.

### Background
- Lazy export: for non-JS loaders (json, toml, sqlite, napi, ...) the bundler does not parse anything; it builds one expression and wraps it as the module's default export via `new_lazy_export_ast`. Such ASTs skip the parser's visit pass, so format-dependent rewrites that normally happen there have to be made when the expression is built.
- `ERequireCallTarget`: the AST node for the `require` function itself. The printer emits it as the runtime's `__require` helper in esm/iife output and as the bare identifier `require` in cjs output.
- `@bun-cjs` wrapper: cjs output for target bun is emitted as a function taking `(exports, require, module, __filename, __dirname)`; Bun calls it with the module's CommonJS require, which is also what resolves embedded `$bunfs` paths in a compiled executable. `--bytecode` uses this format by default because bytecode is generated for a CommonJS program.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->