### PR TITLE
test(websocket): make the writev fault test reach the us_socket_write2 fast path

### DIFF
--- a/test/js/web/websocket/websocket-syscall-fault.test.ts
+++ b/test/js/web/websocket/websocket-syscall-fault.test.ts
@@ -325,30 +325,46 @@ describe.concurrent.skipIf(skip)("Bun.serve WebSocket server under injected sysc
     expect(exitCode).toBe(0);
   });
 
-  test("writev → zero (once) on a ≥16 KB server frame: client receives full payload", async () => {
-    // The Bun.serve WS plain-TCP fast path (≥16 KB, no backpressure) uses
-    // us_socket_write2 → bsd_write2/writev — keyed US_FAULT_WRITEV. This is
-    // the only test exercising that hook.
+  test("writev → zero (once) on a ≥16 KB server frame: send() reports backpressure, client receives full payload", async () => {
+    // The Bun.serve WS plain-TCP fast path (WebSocket.h send(): ≥16 KB frame,
+    // nothing buffered, empty cork buffer) writes header + payload with
+    // us_socket_write2 → bsd_write2, which is the writev hook; nothing else in
+    // this file reaches it.
+    //
+    // The send cannot be issued from open(): upgrade() keeps the 101 response
+    // corked so it can batch with the first frames, so inside open() the cork
+    // buffer is non-empty, send() takes the ordinary send path and a writev
+    // rule is never consumed. By the time the client's first frame reaches
+    // message() the handshake has been flushed.
+    //
+    // With writev returning 0 the fast path buffers the whole frame, a 4-byte
+    // header (FIN|binary, 126 marker, 16-bit length) plus the 20000 payload
+    // bytes, returns -1, and drains it on the next writable event.
     const fixture = /* js */ `
       const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const payload = Buffer.alloc(20000, 0x57);
+      let sent;
       const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
         fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", {status:426}); },
         websocket: {
-          open(ws) {
+          open() {},
+          message(ws) {
             fault.set({ syscall: "writev", action: "zero", repeat: 1 });
-            ws.send(Buffer.alloc(20000, 0x57));
+            const status = ws.send(payload);
+            fault.clear();
+            sent = { status, buffered: ws.getBufferedAmount() };
           },
-          message() {},
           close() {},
         } });
       const ws = new WebSocket("ws://127.0.0.1:" + s.port);
       ws.binaryType = "arraybuffer";
+      ws.onopen = () => ws.send("go");
       ws.onmessage = (e) => {
-        console.log(JSON.stringify({ len: e.data.byteLength }));
+        console.log(JSON.stringify({ ...sent, len: e.data.byteLength, intact: Buffer.from(e.data).equals(payload) }));
         ws.close();
       };
-      ws.onclose = () => { fault.clear(); s.stop(true); process.exit(0); };
-      ws.onerror = () => { console.log(JSON.stringify({ err: true })); process.exit(1); };
+      ws.onclose = () => { s.stop(true); process.exit(0); };
+      ws.onerror = () => { console.log(JSON.stringify({ ...sent, err: true })); process.exit(1); };
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -358,7 +374,7 @@ describe.concurrent.skipIf(skip)("Bun.serve WebSocket server under injected sysc
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ out: JSON.parse(stdout.trim() || "{}"), signal: proc.signalCode, stderr }).toEqual({
-      out: { len: 20000 },
+      out: { status: -1, buffered: 20004, len: 20000, intact: true },
       signal: null,
       stderr: expect.any(String),
     });


### PR DESCRIPTION
### Problem
- `test/js/web/websocket/websocket-syscall-fault.test.ts`, test "writev → zero (once) on a ≥16 KB server frame", is meant to cover the Bun.serve WebSocket fast path (`packages/bun-uws/src/WebSocket.h` `send()` → `us_socket_write2` → `bsd_write2`), the one caller of the `US_FAULT_WRITEV` hook in `bsd_write2` (`packages/bun-usockets/src/bsd.c`).
- The fixture armed the rule and sent from `open()`. `upgrade()` writes the 101 response with `keepCorked` (`packages/bun-uws/src/HttpResponse.h`, the open handler runs a few lines later) and the socket is only uncorked after the parser returns (`packages/bun-uws/src/HttpContext.h`, the `upgradedWebSocket` branch of `onData`), so inside `open()` the cork buffer is non-empty, `corkBufferEmpty` in `WebSocket.h` is false, and the 20 KB frame goes out through the regular send path. The writev rule was never consumed; the test passed without touching the code it was named after.
- Measured on a debug build: the same `ws.send(20000 bytes)` returns `20000` with `getBufferedAmount() == 0` inside `open()` (rule untouched), and `-1` with `getBufferedAmount() == 20004` from `message()` (rule fired).
- The test also only asserted the payload length, which holds whether or not the fault fires.

### Fix
- The fixture now sends from `message()`, triggered by the client's first frame; the client can only send that frame after it received the 101, so the handshake has left the cork buffer by then. `onData` corks the socket around `message()`, but with an empty cork buffer, which is exactly the state the fast path requires.
- The rule is armed immediately before the one `send()` and cleared right after it, so exactly one write is subject to it.
- The fixture reports `send()`'s return value and `getBufferedAmount()` next to the received payload, and the test asserts `{ status: -1, buffered: 20004, len: 20000, intact: true }`: `-1` is the BACKPRESSURE status the fast path returns when `us_socket_write2` wrote less than the frame; `20004` is the 4-byte frame header (FIN|binary, 126 length marker, 16-bit length) plus the payload, which is what the fast path buffers when writev returns 0; `intact` checks the drained frame byte for byte. On a loopback socket a 20 KB write to a fresh connection does not come back short on its own, so these values only appear when the injected fault fired.
- The comment claiming this was the only test exercising the hook was replaced: `bsd_writev` shares the hook and is already exercised elsewhere (`test/js/bun/net/tls-low-prio-queue-fixture.ts`, `test/js/node/http2/node-http2-writable-destroy-fixture.ts`); this test is the one that reaches `bsd_write2`.
- Test-only change; no runtime code is touched. Fault injection is compiled out of release builds, so the file is skipped under `USE_SYSTEM_BUN=1` as before.
- Verified with a local debug+ASAN build:
  - `bun bd test test/js/web/websocket/websocket-syscall-fault.test.ts`: 15 pass; the writev test passed in 6 further consecutive runs.
  - Mutation check, with the `US_FAULT_CHECK` line in `bsd_write2` removed locally and bun rebuilt: the previous version of the test still passes; this version fails with `status: 20000, buffered: 0`. The mutation was reverted before pushing.

### Background
- Socket fault injection (`bun:internal-for-testing` `socketFaultInjection`, `packages/bun-usockets/src/internal/fault_inject.h`) arms a process-wide rule for one `bsd_*` syscall wrapper; `{ syscall: "writev", action: "zero", repeat: 1 }` makes the next `bsd_writev`/`bsd_write2` call return 0 once. It is compiled in for debug/ASAN builds only.
- Corking (uWS `AsyncSocket::cork`/`uncork`): while a socket is corked, writes are appended to a per-loop cork buffer and flushed as one `send()` at uncork. uWS corks the socket for the duration of an HTTP parse and of a WebSocket `onData` dispatch.
- WebSocket send fast path (`WebSocket.h` `send()`): for a plain-TCP, uncompressed frame of 16 KB or more, with no user-space backpressure and an empty cork buffer, the header and payload are handed to `us_socket_write2`, which issues a single `writev` of both instead of copying the payload into a buffer. If the kernel takes fewer bytes than the frame, the remainder is appended to the socket's backpressure buffer, `send()` reports BACKPRESSURE (`-1` on the JS side, `src/runtime/server/ServerWebSocket.rs` `send_status_to_js`), and the buffer drains on the next writable event.
