### PR TITLE
build: remove the scratch that killed prebuilt and SDK fetches leave in the cache dir

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -42,6 +42,15 @@
  * process (0xC0000409) — no exception, just gone. Streaming avoids the
  * large native allocation and keeps peak memory flat regardless of
  * tarball size (WebKit is ~200MB).
+ *
+ * ## Scratch in the cache dir
+ *
+ * Prebuilt fetches (and the macOS SDK fetch in macos-sdk.ts) download and
+ * extract next to the cache entry they are producing and publish it with one
+ * rename. Every such path is named by `scratchSuffix()`, and every fetch
+ * starts by calling `removeAbandonedScratch()` on the cache dir, because a
+ * fetch that gets killed never deletes its own scratch and nothing else
+ * would ever look at it again.
  */
 
 import { spawnSync } from "node:child_process";
@@ -118,8 +127,7 @@ export async function tryPrefetchExtracted(dest: string, stampFile: string, expe
   console.log(`using prefetch cache: ${src}`);
   // Stage-then-rename so an interrupted copy doesn't leave a stamped-but-
   // incomplete tree at dest (same publish discipline as fetchPrebuilt).
-  const staging = `${dest}.${process.pid}.prefetch`;
-  await rm(staging, { recursive: true, force: true });
+  const staging = `${dest}${scratchSuffix()}.prefetch`;
   await mkdir(resolve(dest, ".."), { recursive: true });
   try {
     await cp(src, staging, { recursive: true });
@@ -145,6 +153,91 @@ async function chmodRecursiveWritable(root: string): Promise<void> {
   await chmod(root, st.mode | 0o200);
   if (!st.isDirectory()) return;
   for (const e of await readdir(root)) await chmodRecursiveWritable(resolve(root, e));
+}
+
+/**
+ * Suffix for the scratch a fetch writes next to the cache entry it is
+ * producing: `<entry>.<pid>.<start time in base36>.<kind>`. The kinds are
+ * `tar.gz` (fetchPrebuilt's download, which downloadWithRetry writes as
+ * `.tar.gz.<pid>.partial` first), `staging` (the extraction dir of
+ * fetchPrebuilt and ensureMacosSdk) and `prefetch` (tryPrefetchExtracted's
+ * copy). Unique per process so that builds sharing a cacheDir (every checkout
+ * on a machine does) never write into each other's scratch.
+ *
+ * `scratchName` must keep matching everything this produces: it is how
+ * removeAbandonedScratch() tells scratch from the cache entries proper.
+ */
+export function scratchSuffix(): string {
+  return `.${process.pid}.${Date.now().toString(36)}`;
+}
+
+// `{8}`: Date.now() has 8 base36 digits until 2059 (build-abandoned-scratch.test.ts
+// sweeps scratchSuffix() output, so it will say so when that stops holding).
+// Pinning the width keeps a merely version-looking name such as
+// `foo-1.2.3.tar.gz` from passing as scratch.
+const scratchName = /\.\d+\.[0-9a-z]{8}\.(?:tar\.gz(?:\.\d+\.partial)?|staging|prefetch)$/;
+
+/**
+ * Scratch whose own mtime is older than this has been abandoned. Live scratch
+ * never gets anywhere near this old: a download in progress keeps writing to
+ * its `.partial`, and the tarball and the staging/prefetch dirs are touched
+ * when their extraction or copy starts (a directory's mtime moves when its
+ * top-level entries are created, not on deeper writes), so while the fetch is
+ * alive their age is bounded by the length of one extraction or copy: minutes
+ * at most, even for the 2.3 GB debug-asan WebKit tree.
+ */
+export const scratchAbandonedAfterMs = 60 * 60 * 1000;
+
+/**
+ * Delete the scratch that earlier fetches abandoned in `dir`.
+ *
+ * fetchPrebuilt and ensureMacosSdk delete their scratch in a `finally`, which
+ * does not run when the build is killed mid-fetch (ctrl-c, OOM killer,
+ * ENOSPC, the container being stopped), and nothing revisits those names
+ * afterwards: the retry uses a fresh suffix, and once the entry exists (or
+ * its version has moved on) no fetch for it runs at all. In a long-lived
+ * cacheDir the half-extracted WebKit trees, 0.5 to 2.5 GB apiece, pile up
+ * until the disk is full. So every fetch first collects what its
+ * predecessors left behind.
+ *
+ * Staleness is judged by age alone; the pid in the name is deliberately not
+ * consulted. A cacheDir is commonly one host directory mounted into several
+ * containers, each with its own pid namespace, so a sibling container's
+ * in-flight extraction has a pid that looks dead from here, and checking it
+ * would delete that extraction out from under it. Age has no such problem:
+ * the mtimes come from the one filesystem everybody is writing to.
+ *
+ * Best effort: an entry that cannot be removed (a scanner holding one of its
+ * files open on Windows, say) is reported and left for the next fetch.
+ */
+export async function removeAbandonedScratch(dir: string): Promise<void> {
+  // Not there yet (first fetch into this cacheDir) or unreadable: nothing to
+  // collect. If the directory is genuinely broken the fetch itself will say so.
+  const names = await readdir(dir).catch(() => []);
+  const cutoff = Date.now() - scratchAbandonedAfterMs;
+  for (const name of names) {
+    if (!scratchName.test(name)) continue;
+    const path = resolve(dir, name);
+    try {
+      if ((await lstat(path)).mtimeMs > cutoff) continue;
+      console.log(`removing abandoned ${path}`);
+      await rmScratch(path);
+    } catch (err) {
+      // Already gone means a concurrent build's sweep got there first.
+      if (existsSync(path)) console.warn(`could not remove ${path}: ${describeError(err)}`);
+    }
+  }
+}
+
+async function rmScratch(path: string): Promise<void> {
+  try {
+    await rm(path, { recursive: true, force: true });
+  } catch {
+    // An interrupted tryPrefetchExtracted copy still has the prefetch tree's
+    // read-only modes, and nothing can be unlinked from a 555 directory.
+    await chmodRecursiveWritable(path).catch(() => {});
+    await rm(path, { recursive: true, force: true });
+  }
 }
 
 /** Retry schedule for one download. Sizing rationale: "Retry behavior" above. */
@@ -366,6 +459,13 @@ export async function fetchPrebuilt(
   rmPaths: string[] = [],
 ): Promise<void> {
   const stampPath = resolve(dest, ".identity");
+  const destParent = resolve(dest, "..");
+
+  // Before the short-circuit: ninja re-runs this edge whenever fetch-cli.ts
+  // is newer than the stamp (every fresh checkout against a warm shared
+  // cache), and each of those runs is a chance to collect what killed
+  // fetches left in the cache, at the cost of one readdir.
+  await removeAbandonedScratch(destParent);
 
   // ─── Short-circuit: already at this identity? ───
   if (existsSync(stampPath)) {
@@ -382,12 +482,9 @@ export async function fetchPrebuilt(
 
   console.log(`fetching ${url}`);
 
-  // Process-unique temp paths so concurrent builds (shared cacheDir across
-  // checkouts) can't stomp each other's download/extraction.
-  const suffix = `.${process.pid}.${Date.now().toString(36)}`;
+  const suffix = scratchSuffix();
 
   // ─── Download ───
-  const destParent = resolve(dest, "..");
   await mkdir(destParent, { recursive: true });
   const tarballPath = `${dest}${suffix}.tar.gz`;
   try {

--- a/scripts/build/macos-sdk.ts
+++ b/scripts/build/macos-sdk.ts
@@ -31,6 +31,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { mkdir, rename, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { removeAbandonedScratch, scratchSuffix } from "./download.ts";
 import { BuildError } from "./error.ts";
 
 /**
@@ -148,12 +149,14 @@ export async function ensureMacosSdk(cfg: {
 
   // Extract into a staging dir, then rename the .sdk into place — same
   // discipline as fetchPrebuilt() so an interrupted configure never leaves a
-  // half-extracted tree claiming to be an SDK. The downloaded .pkg itself is
-  // cached separately under <cacheDir>/xmac so a failed/interrupted
-  // extraction doesn't re-download ~60 MB.
-  const suffix = `.${process.pid}.${Date.now().toString(36)}`;
-  const staging = `${expected}${suffix}.staging`;
+  // half-extracted tree claiming to be an SDK, and the same scratch naming so
+  // that what an interrupted configure does leave behind is collected by the
+  // next fetch into this cacheDir. The downloaded .pkg itself is cached
+  // separately under <cacheDir>/xmac so a failed/interrupted extraction
+  // doesn't re-download ~60 MB.
+  const staging = `${expected}${scratchSuffix()}.staging`;
   await mkdir(cfg.cacheDir, { recursive: true });
+  await removeAbandonedScratch(cfg.cacheDir);
 
   try {
     const result = spawnSync(

--- a/test/internal/build-abandoned-scratch.test.ts
+++ b/test/internal/build-abandoned-scratch.test.ts
@@ -1,0 +1,173 @@
+/**
+ * fetchPrebuilt() and ensureMacosSdk() (scripts/build/) download and extract
+ * into scratch named after the cache entry they are producing and delete it
+ * in a `finally` that a build killed mid-fetch (ctrl-c, OOM killer, ENOSPC, a
+ * container being stopped) never reaches. Nothing used to look at those names
+ * again, so a machine-shared cache dir (~/.bun/build-cache) kept every
+ * half-extracted WebKit tree, 0.5 to 2.5 GB apiece, until the disk was full.
+ *
+ * Every fetch now starts by removing the scratch that earlier fetches
+ * abandoned in its cache dir. Abandonment is judged by the entry's age: the
+ * cache dir is routinely one host directory shared by containers with
+ * separate pid namespaces, so the pid in the name says nothing about whether
+ * the owner is alive, whereas a live fetch touches its scratch far more often
+ * than once an hour.
+ */
+import { expect, test } from "bun:test";
+import { isWindows, tempDir, type DirectoryTree } from "harness";
+import { chmodSync, existsSync, readdirSync, readFileSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  fetchPrebuilt,
+  removeAbandonedScratch,
+  scratchAbandonedAfterMs,
+  scratchSuffix,
+} from "../../scripts/build/download.ts";
+import { ensureMacosSdk, MACOS_SDK_VERSION, macosSdkCachePath } from "../../scripts/build/macos-sdk.ts";
+
+const webkit = "webkit-0123456789abcdef-debug-asan";
+const sdk = `MacOSX${MACOS_SDK_VERSION}.sdk`;
+
+/** What one fetch of `entry` by this process leaves behind if killed at each stage it can be killed at. */
+function scratchOf(entry: string): string[] {
+  const suffix = scratchSuffix();
+  return [
+    `${entry}${suffix}.tar.gz.${process.pid}.partial`, // while downloading
+    `${entry}${suffix}.tar.gz`, // while extracting, which leaves
+    `${entry}${suffix}.staging`, // both the tarball and the extraction dir
+    `${entry}${suffix}.prefetch`, // while copying a prefetched tree (CI images)
+  ];
+}
+
+/** A directory for every name that denotes one, a small file for the rest. */
+function treeOf(names: string[]): DirectoryTree {
+  const tree: DirectoryTree = {};
+  for (const name of names) {
+    tree[name] = /\.(?:staging|prefetch)$/.test(name) ? { "bun-webkit": { "x.h": "" } } : "bytes";
+  }
+  return tree;
+}
+
+/** Make each path (the entry itself; its contents don't matter) look untouched for longer than the threshold. */
+function abandon(...paths: string[]): void {
+  const then = new Date(Date.now() - scratchAbandonedAfterMs - 60_000);
+  for (const path of paths) utimesSync(path, then, then);
+}
+
+test.concurrent("every kind of abandoned scratch is removed; live scratch and the cache entries are not", async () => {
+  const abandoned = [
+    ...scratchOf(webkit),
+    // Entries no fetch will run for again: a WebKit version that has since
+    // been bumped, and the SDK extraction that macos-sdk.ts does.
+    "webkit-fedcba9876543210-debug-asan.4242.lz5k3x1q.staging",
+    `${sdk}.4243.lz5k3x1q.staging`,
+  ];
+  // Written moments ago: another build's fetch that is still running.
+  const live = scratchOf("webkit-0123456789abcdef");
+  // Not scratch, however old: published entries (dots in their names and
+  // all), the dep tarball cache, and a name that merely looks versioned.
+  const entries = [webkit, "nodejs-headers-26.3.0", sdk];
+  const others = ["node-v22.1.0.tar.gz", "tarballs"];
+  const tree = treeOf([...abandoned, ...live]);
+  for (const name of entries) tree[name] = { ".identity": "x\n" };
+  tree["node-v22.1.0.tar.gz"] = "bytes";
+  tree["tarballs"] = { "zstd-e010993a24072468.tar.gz": "bytes" };
+  using cache = tempDir("build-cache", tree);
+  const at = (name: string) => join(String(cache), name);
+
+  // An interrupted tryPrefetchExtracted() copy carries the prefetch tree's
+  // read-only modes, which a plain rm -rf cannot get through as a normal user.
+  chmodSync(join(at(abandoned.find(name => name.endsWith(".prefetch"))!), "bun-webkit"), 0o555);
+  abandon(...[...abandoned, ...entries, ...others].map(at));
+
+  await removeAbandonedScratch(String(cache));
+
+  expect(readdirSync(String(cache)).sort()).toEqual([...live, ...entries, ...others].sort());
+  expect(existsSync(at("tarballs/zstd-e010993a24072468.tar.gz"))).toBe(true);
+});
+
+test.concurrent("a cache dir that does not exist yet has nothing to remove", async () => {
+  using dir = tempDir("build-cache", {});
+  await removeAbandonedScratch(join(String(dir), "build-cache"));
+  expect(readdirSync(String(dir))).toEqual([]);
+});
+
+test.concurrent(
+  "fetchPrebuilt removes what a killed fetch left, leaves a concurrent one alone, and leaves nothing itself",
+  async () => {
+    const killed = scratchOf(webkit);
+    // Another checkout fetching the same WebKit right now, mid-extraction.
+    const concurrent = [`${webkit}.4242.lz5k3x1q.tar.gz`, `${webkit}.4242.lz5k3x1q.staging`];
+    using cache = tempDir("build-cache", treeOf([...killed, ...concurrent]));
+    abandon(...killed.map(name => join(String(cache), name)));
+
+    const tarball = await new Bun.Archive(
+      { "bun-webkit/lib/libJavaScriptCore.a": "prebuilt", "bun-webkit/include/JavaScriptCore/JSBase.h": "" },
+      { compress: "gzip" },
+    ).bytes();
+    await using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(tarball) });
+
+    const dest = join(String(cache), webkit);
+    await fetchPrebuilt(
+      "WebKit",
+      `http://127.0.0.1:${server.port}/bun-webkit.tar.gz`,
+      dest,
+      "0123456789abcdef-debug-asan",
+    );
+
+    expect(readFileSync(join(dest, ".identity"), "utf8")).toBe("0123456789abcdef-debug-asan\n");
+    expect(readFileSync(join(dest, "lib", "libJavaScriptCore.a"), "utf8")).toBe("prebuilt");
+    expect(readdirSync(String(cache)).sort()).toEqual([...concurrent, webkit].sort());
+  },
+);
+
+test.concurrent("fetchPrebuilt removes abandoned scratch even when its own entry is up to date", async () => {
+  const entry = "nodejs-headers-26.3.0";
+  const killed = scratchOf(entry);
+  const tree = treeOf(killed);
+  tree[entry] = { ".identity": "26.3.0\n", include: { node: { "node.h": "" } } };
+  using cache = tempDir("build-cache", tree);
+  abandon(...killed.map(name => join(String(cache), name)));
+
+  // Nothing listens on port 1: with the stamp matching, no download may be attempted.
+  await fetchPrebuilt("nodejs-headers", "http://127.0.0.1:1/node-headers.tar.gz", join(String(cache), entry), "26.3.0");
+
+  expect(readdirSync(String(cache))).toEqual([entry]);
+  expect(existsSync(join(String(cache), entry, "include", "node", "node.h"))).toBe(true);
+});
+
+// Stands in for `bun xmac.mjs splat ... --output <staging> ...` (ensureMacosSdk
+// execs cfg.bun with those arguments): lays out the one directory it looks
+// for under --output. A shell script, hence no Windows.
+const fakeXmac = `#!/bin/sh
+while [ $# -gt 0 ]; do
+  if [ "$1" = "--output" ]; then out="$2"; fi
+  shift
+done
+sdk="$out/SDKs/${sdk}/usr/include/sys"
+mkdir -p "$sdk" && : > "$sdk/syscall.h"
+`;
+
+test.concurrent.skipIf(isWindows)(
+  "ensureMacosSdk removes what a killed configure left, leaves a concurrent one alone, and leaves nothing itself",
+  async () => {
+    const [, , killed] = scratchOf(sdk);
+    const concurrent = `${sdk}.4242.lz5k3x1q.staging`;
+    using dir = tempDir("macos-sdk", { xmac: fakeXmac, cache: treeOf([killed!, concurrent]) });
+    chmodSync(join(String(dir), "xmac"), 0o755);
+    const cacheDir = join(String(dir), "cache");
+    abandon(join(cacheDir, killed!));
+
+    await ensureMacosSdk({
+      osxSysroot: macosSdkCachePath(cacheDir),
+      cacheDir,
+      darwin: true,
+      bun: join(String(dir), "xmac"),
+      host: { os: "linux" },
+    });
+
+    expect(existsSync(join(cacheDir, sdk, "usr", "include", "sys", "syscall.h"))).toBe(true);
+    expect(readdirSync(cacheDir).sort()).toEqual([concurrent, sdk].sort());
+  },
+);


### PR DESCRIPTION
### Problem
- `~/.bun/build-cache` (the cache `bun bd` shares across checkouts) fills up with `webkit-<id>-debug-asan.<pid>.<time>.staging/` dirs (0.2 to 2.3 GB each, partially extracted) and the matching `.tar.gz` files (about 500 MB each) from builds that were killed mid-fetch. One container had five such pairs, about 9.6 GB, next to the live tree; the host they share was at 100% disk and release builds were dying with ENOSPC.
- `fetchPrebuilt()` (`scripts/build/download.ts`) only deletes its tarball and staging dir in the `finally` of the same invocation. A build killed during the fetch (ctrl-c, OOM killer, ENOSPC, container stopped) never reaches it, and nothing looks at those names afterwards: the retry uses a fresh `<pid>.<time>` suffix, and once the entry is published (or its version is bumped) no fetch for it runs at all. `ensureMacosSdk()` (`scripts/build/macos-sdk.ts`) stages the same way and leaks the same way.

### Fix
- `fetchPrebuilt()` and `ensureMacosSdk()` start by calling a new `removeAbandonedScratch(dir)`: every entry in the cache dir whose name has the scratch shape (`<entry>.<pid>.<time>.{tar.gz,staging,prefetch}`, or the `.tar.gz.<pid>.partial` of a download in flight) and whose own mtime is more than an hour old is removed. Everything else in the directory, whatever its age, is left alone.
- `fetchPrebuilt()` sweeps before its up-to-date short-circuit. ninja re-runs the fetch edge once whenever `fetch-cli.ts` is newer than the stamp (every fresh checkout against a warm shared cache), so the cache gets collected far more often than entries get fetched, for the price of one `readdir`.
- Age, not the pid in the name, decides what is abandoned. The cache dir is routinely one host directory bind-mounted into several containers, each with its own pid namespace (the container this was found in started at 10:05 and already had seven WebKit trees in its cache that other containers fetched between 09:14 and 09:54, see below). From a sibling container a live fetch's pid looks dead, so the pid check suggested in the report would delete an extraction that is still running. The mtimes come from the one filesystem everybody writes to.
- An hour is safe because live scratch is always much younger than that: a download in progress keeps writing to its `.partial`, and the tarball and the staging dir are touched when extraction starts (a directory's mtime moves when its top-level entries are created, not on deeper writes), so while the fetch is alive their age is bounded by the length of one extraction, which is minutes even for the 2.3 GB debug-asan WebKit tree. The cost of the margin is that a leftover is collected by the next fetch into that cache dir that runs an hour or more later, rather than immediately.
- The scratch suffix now comes from one place, `scratchSuffix()`, defined next to the pattern that recognizes it, and `tryPrefetchExtracted()`'s staging copy carries the same suffix so its leftovers are recognized too. The shape on disk is unchanged, so the leftovers already sitting in shared caches are collected as well. The recognizer pins the 8-digit width of the time field so that a name that merely looks versioned (`foo-1.2.3.tar.gz`) is not scratch.
- Removal is best effort: an entry that cannot be removed is reported and left for the next fetch, and a read-only tree (what an interrupted prefetch copy leaves, since the prefetch tree is chmod'd read-only) is chmod'd and retried.
- Verified with `test/internal/build-abandoned-scratch.test.ts`: every scratch kind is removed once old while same-shaped fresh scratch, published entries (including dotted names like `nodejs-headers-26.3.0` and `MacOSX26.5.sdk`), the `tarballs/` dir and a version-looking tarball survive; `fetchPrebuilt()` removes a killed fetch's leftovers, keeps a concurrent fetch's, and leaves none of its own, both when it fetches and when it is up to date; `ensureMacosSdk()` does the same (driven with a stand-in for xmac, so it is skipped on Windows). The file fails against `main`'s build scripts and passes with this branch under `bun bd test`.
- `bun scripts/build.ts --configure-only` still configures, `test/internal/build-download-retry.test.ts` and `test/internal/macos-cross-config.test.ts` still pass, and the sweep was also exercised under node, which is what CI builds with.

### Background
- Prebuilt deps (WebKit, nodejs-headers) are not built; `fetch-cli.ts prebuilt` downloads a tarball, extracts it into a staging dir next to the destination and publishes the tree with a single rename, then writes a `.identity` stamp inside it. A later fetch that finds a matching stamp does nothing. For local builds the destination is in `$BUN_INSTALL/build-cache`, which every checkout and profile on the machine shares, so two builds can fetch into the same directory at the same time; the `<pid>.<time>` suffix is what keeps them apart, and it is why the sweep must not touch anything a live fetch owns.
- The prefetch cache is a read-only tree of pre-extracted deps baked into CI images; `tryPrefetchExtracted()` copies it into the cache dir through a staging dir of its own.
- `ensureMacosSdk()` runs at configure time when building for macOS from a Linux host and extracts Apple's SDK into the same cache dir through a staging dir of the same shape.

<details>
<summary>Cache dir of the container this was investigated in</summary>

The container's init process started at 10:05:32; the cache is a bind mount (`/dev/root on /root/.bun/build-cache`) and already held trees fetched by other containers earlier that morning:

```
drwx------  6 1001 1001 4096 2026-08-13 09:14:37 webkit-caad865eb1a6e5ca-debug-asan
drwx------  6 1001 1001 4096 2026-08-13 09:33:18 webkit-preview-pr-421-0855ba4b-debug-asan
drwx------  6 1001 1001 4096 2026-08-13 09:33:39 webkit-7b763944f0ecd0e1-debug-asan
drwx------  6 1001 1001 4096 2026-08-13 09:37:06 webkit-caad865eb1a6e5ca
drwx------  6 1001 1001 4096 2026-08-13 09:38:36 webkit-447082ab68972787-debug-asan
drwx------  6 1001 1001 4096 2026-08-13 09:42:22 webkit-7b763944f0ecd0e1
drwx------  6 1001 1001 4096 2026-08-13 09:54:08 webkit-preview-pr-390-0c51423a-debug-asan
```

Two of those fetches landed 21 seconds apart, so fetches from different containers overlapping in one cache dir is routine, not theoretical. `du` of `webkit-7b763944f0ecd0e1-debug-asan` is 2.3 GB (2751 files); the release tree is 1.5 GB. The disk went from 35 GB to 15 GB free during the hour this was being looked at.

Checked directly that a staging dir's mtime is the moment tar creates its top-level entry and does not move while the rest of the tree is extracted, which is what the age bound relies on.
</details>
