### PR TITLE
usockets: keep the writable poll armed after a short us_socket_write2 from inside drain()

### DIFF
--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -409,11 +409,15 @@ struct us_socket_t *us_socket_pair(struct us_socket_group_t *group, unsigned cha
 #endif
 }
 
-/* Re-arm writable for a backpressured write without resuming the read side of
- * a paused socket: us_poll_change sets absolute flags, so including READABLE
- * unconditionally would silently undo us_socket_pause mid-backpressure and
- * deliver data the caller asked to defer. */
+/* Re-arm writable for a backpressured write. The flag is what keeps the poll
+ * armed when the write was issued from inside the writable dispatch itself (a
+ * WebSocket drain handler sending more): loop.c clears it before on_writable and
+ * drops writable interest again afterwards unless a write set it, so the poll
+ * change alone would be undone there. READABLE is not added back unconditionally
+ * because us_poll_change sets absolute flags, and doing so would silently undo
+ * us_socket_pause mid-backpressure and deliver data the caller asked to defer. */
 static void us_internal_rearm_writable(struct us_socket_t *s) {
+    s->flags.last_write_failed = 1;
     us_poll_change(&s->p, s->group->loop,
                    LIBUS_SOCKET_WRITABLE | ((s->flags.is_paused || s->read_eof) ? 0 : LIBUS_SOCKET_READABLE));
 }
@@ -510,7 +514,6 @@ int us_socket_write(struct us_socket_t *s, const char *data, int length) {
 
     int written = bsd_send(us_poll_fd(&s->p), data, length);
     if (written != length) {
-        s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
 
@@ -565,7 +568,6 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
          * classifying them as fatal made the node:net drain path drop the
          * buffered bytes on a socket that kept flowing. */
         if (bsd_would_block() || bsd_send_is_transient_error()) {
-            s->flags.last_write_failed = 1;
             us_internal_rearm_writable(s);
             return 0;
         }
@@ -588,7 +590,6 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
         if (!us_internal_send_errno_is_peer_gone(errno) &&
             s->unclassified_send_failures < US_UNCLASSIFIED_SEND_RETRY_LIMIT) {
             s->unclassified_send_failures++;
-            s->flags.last_write_failed = 1;
             us_internal_rearm_writable(s);
             return 0;
         }
@@ -614,7 +615,6 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
     }
     s->unclassified_send_failures = 0;
     if (written != length) {
-        s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
     return written;
@@ -631,7 +631,6 @@ int us_socket_raw_writev(struct us_socket_t *s, const struct us_iovec_t *iov, in
 
     ssize_t written = bsd_writev(us_poll_fd(&s->p), iov, count);
     if (written != (ssize_t)total) {
-        s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
 
@@ -650,7 +649,6 @@ int us_socket_raw_write(struct us_socket_t *s, const char *data, int length) {
 
     int written = bsd_send(us_poll_fd(&s->p), data, length);
     if (written != length) {
-        s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
 
@@ -696,7 +694,6 @@ int us_socket_ipc_write_fd(struct us_socket_t *s, const char *data, int length, 
     }
 
     if (sent != length) {
-        s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
 

--- a/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
+++ b/test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts
@@ -1,7 +1,10 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { isWindows } from "harness";
 import crypto from "node:crypto";
 import net from "node:net";
+
+type ServerWS = import("bun").ServerWebSocket<unknown>;
 
 // Drives the uws BackPressure buffer through its append / erase / resize paths
 // and verifies the bytes that reach the client exactly match what was sent.
@@ -234,4 +237,219 @@ describe("BackPressure buffer", () => {
     expect(received).toBe(target);
     expect(hash.digest("hex")).toBe(expectedHash);
   });
+});
+
+// A >=16KB send with nothing buffered is written straight to the socket with
+// writev (us_socket_write2). drain() runs inside the socket's writable dispatch,
+// which afterwards drops writable interest unless a write in between flagged the
+// socket as backpressured. A short writev from inside drain() therefore has to
+// set that flag like every other write path does; otherwise the tail that send()
+// buffered is never flushed, bufferedAmount stays > 0 and drain() never fires
+// again. Without the fix both tests hang waiting for the drain() after the short
+// write.
+describe("direct send from drain()", () => {
+  // Unexpected closes reject whichever step the test is currently awaiting.
+  function failure() {
+    const failed = Promise.withResolvers<never>();
+    // Only observed through until(); the closes at the end of a passing test
+    // also call fail() and must not surface as an unhandled rejection.
+    failed.promise.catch(() => {});
+    return {
+      fail: (why: string) => failed.reject(new Error(why)),
+      until: <T>(step: Promise<T>) => Promise.race([step, failed.promise]),
+    };
+  }
+
+  // Unmasked server frame with a 64-bit extended length, as sent for payloads >= 64KB.
+  function binaryFrame(payload: Buffer): Buffer {
+    const header = Buffer.alloc(10);
+    header[0] = 0x82;
+    header[1] = 0x7f;
+    header.writeBigUInt64BE(BigInt(payload.length), 2);
+    return Buffer.concat([header, payload]);
+  }
+
+  // Every send here starts with an empty buffer, so each one takes the direct
+  // path and the one returning -1 is the one whose writev came up short.
+  function sendUntilBackpressure(ws: ServerWS, payload: Buffer): { sends: number; last: number } {
+    const MAX_SENDS = 512;
+    let last = 0;
+    for (let sends = 1; sends <= MAX_SENDS; sends++) {
+      last = ws.sendBinary(payload);
+      if (last !== payload.length) return { sends, last };
+    }
+    return { sends: MAX_SENDS, last };
+  }
+
+  // Skipped on Windows for the same reason as above: loopback never backpressures.
+  it.skipIf(isWindows)("keeps draining after a send from drain() comes up short on the kernel buffer", async () => {
+    const CHUNK = 256 * 1024;
+    const payload = patternBuffer(CHUNK, 0x5eed);
+    const frame = binaryFrame(payload);
+    const { fail, until } = failure();
+
+    let sent = 0;
+    const opened = Promise.withResolvers<ServerWS>();
+    const drainFill = Promise.withResolvers<{ last: number; buffered: number }>();
+    const drainAfterShortWrite = Promise.withResolvers<void>();
+    let filledFromDrain = false;
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("no", { status: 500 });
+      },
+      websocket: {
+        // The idle-timeout ping goes through the buffered write path, which
+        // would flush a stalled tail and hide the stall.
+        idleTimeout: 0,
+        open(ws) {
+          opened.resolve(ws);
+        },
+        drain(ws) {
+          // Partial progress: the tail of a frame is still buffered, so a send
+          // from here would not take the direct path.
+          if (ws.getBufferedAmount() !== 0) return;
+          if (filledFromDrain) {
+            drainAfterShortWrite.resolve();
+            return;
+          }
+          filledFromDrain = true;
+          const { sends, last } = sendUntilBackpressure(ws, payload);
+          sent += sends;
+          drainFill.resolve({ last, buffered: ws.getBufferedAmount() });
+        },
+        message() {},
+        close(_ws, code, reason) {
+          fail(`server websocket closed early (${code} ${reason})`);
+        },
+      },
+    });
+
+    const { sock, initial } = await pausedClient(server.port);
+    const ws = await until(opened.promise);
+
+    // Phase 1, from outside any handler: fill the paused client's kernel buffers
+    // so that the writable event which empties the buffer runs drain().
+    const first = sendUntilBackpressure(ws, payload);
+    sent += first.sends;
+    expect(first.last).toBe(-1);
+    expect(ws.getBufferedAmount()).toBeGreaterThan(0);
+
+    const hash = crypto.createHash("sha1");
+    let received = initial.length;
+    hash.update(initial);
+    let target = Infinity;
+    const allReceived = Promise.withResolvers<void>();
+    sock.on("data", (chunk: Buffer) => {
+      hash.update(chunk);
+      received += chunk.length;
+      if (received >= target) allReceived.resolve();
+    });
+    sock.on("close", () => fail(`client socket closed after ${received} of ${target} bytes`));
+    sock.resume();
+
+    // Phase 2 happens in drain(); the last of its sends is the short write under test.
+    const fill = await until(drainFill.promise);
+    expect(fill.last).toBe(-1);
+    expect(fill.buffered).toBeGreaterThan(0);
+    target = sent * frame.length;
+    if (received >= target) allReceived.resolve();
+
+    await until(drainAfterShortWrite.promise);
+    await until(allReceived.promise);
+    expect(ws.getBufferedAmount()).toBe(0);
+    sock.destroy();
+
+    const expected = crypto.createHash("sha1");
+    for (let i = 0; i < sent; i++) expected.update(frame);
+    expect(received).toBe(target);
+    expect(hash.digest("hex")).toBe(expected.digest("hex"));
+  });
+
+  // Same stall, driven deterministically: a writev that writes 0 bytes stands
+  // in for a full kernel buffer, so this does not depend on loopback buffer
+  // sizes. 16KB is the smallest message that takes the direct path.
+  it.skipIf(!fault.available() || isWindows)(
+    "keeps draining after a send from drain() hits an injected zero-byte writev",
+    async () => {
+      const SIZE = 16 * 1024;
+      const payload = patternBuffer(SIZE, 0xf00d);
+      const FRAME_LENGTH = SIZE + 4; // header with a 16-bit extended length
+      const { fail, until } = failure();
+
+      const opened = Promise.withResolvers<ServerWS>();
+      const drainSend = Promise.withResolvers<{ status: number; buffered: number }>();
+      const drainAfterShortWrite = Promise.withResolvers<void>();
+      let sentFromDrain = false;
+      await using server = Bun.serve({
+        port: 0,
+        fetch(req, s) {
+          if (s.upgrade(req)) return;
+          return new Response("no", { status: 500 });
+        },
+        websocket: {
+          idleTimeout: 0,
+          open(ws) {
+            opened.resolve(ws);
+          },
+          drain(ws) {
+            if (ws.getBufferedAmount() !== 0) return;
+            if (sentFromDrain) {
+              drainAfterShortWrite.resolve();
+              return;
+            }
+            // This writable dispatch just flushed the first message. Send the
+            // second one from in here with its writev forced to write nothing,
+            // so the whole frame ends up buffered.
+            sentFromDrain = true;
+            fault.set({ syscall: "writev", action: "zero", repeat: 1 });
+            const status = ws.sendBinary(payload);
+            drainSend.resolve({ status, buffered: ws.getBufferedAmount() });
+          },
+          message() {},
+          close(_ws, code, reason) {
+            fail(`server websocket closed early (${code} ${reason})`);
+          },
+        },
+      });
+
+      const messages: Buffer[] = [];
+      const clientOpen = Promise.withResolvers<void>();
+      const twoMessages = Promise.withResolvers<void>();
+      const client = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+      client.binaryType = "arraybuffer";
+      client.onopen = () => clientOpen.resolve();
+      client.onmessage = ev => {
+        messages.push(Buffer.from(ev.data as ArrayBuffer));
+        if (messages.length === 2) twoMessages.resolve();
+      };
+      client.onclose = ev => fail(`client closed after ${messages.length} messages (${ev.code} ${ev.reason})`);
+
+      try {
+        const ws = await until(opened.promise);
+        // The 101 response stays in the cork buffer until the upgrade returns,
+        // and a send with corked data does not take the direct path. Once the
+        // client has seen the 101 the handshake is flushed.
+        await until(clientOpen.promise);
+
+        // Outside of any handler a short direct write arms the writable poll
+        // fine either way; this one only sets up the writable dispatch that
+        // runs drain() with an empty buffer.
+        fault.set({ syscall: "writev", action: "zero", repeat: 1 });
+        const status = ws.sendBinary(payload);
+        expect({ status, buffered: ws.getBufferedAmount() }).toEqual({ status: -1, buffered: FRAME_LENGTH });
+
+        expect(await until(drainSend.promise)).toEqual({ status: -1, buffered: FRAME_LENGTH });
+        await until(drainAfterShortWrite.promise);
+        await until(twoMessages.promise);
+        expect(ws.getBufferedAmount()).toBe(0);
+      } finally {
+        fault.clear();
+        client.close();
+      }
+
+      expect(messages).toEqual([payload, payload]);
+    },
+  );
 });


### PR DESCRIPTION
### Problem

- A plain (non-TLS) `Bun.serve` WebSocket server whose `drain(ws)` handler sends a message of 16 KiB or more can stall: whatever part of that frame the kernel did not take stays in `ws.getBufferedAmount()` and `drain` never fires again. It only gets unstuck when the app calls `send()` again or the peer sends something (with the default `idleTimeout` the automatic ping does that after about two minutes; with `idleTimeout: 0` or `sendPings: false` it stays stuck).
- Such sends bypass the cork buffer and go out with one `writev` through `us_socket_write2` (`packages/bun-uws/src/WebSocket.h:147-165`). On a short write the remainder is appended to the backpressure buffer and the code relies on the next writable event to flush it.
- `us_socket_write2` (`packages/bun-usockets/src/socket.c:435`) re-arms the writable poll on a short write but, unlike every other write helper in the file, never sets `s->flags.last_write_failed`.
- The writable dispatch clears that flag before calling `on_writable` and removes writable interest afterwards if it is still clear (`packages/bun-usockets/src/loop.c:590` and `609-610`). `drain` runs inside that dispatch, so a short `write2` issued from it has its re-arm undone as soon as the handler returns.
- The function has been like this since it was added; found by reading `socket.c` while working on #38128.

### Fix

- `us_internal_rearm_writable` now sets `last_write_failed` itself. Every short-write path (`us_socket_write`, `us_socket_write_check_error`, `us_socket_raw_writev`, `us_socket_raw_write`, `us_socket_ipc_write_fd` and now `us_socket_write2`) goes through it, so the per-call-site copies of the assignment are removed. The EAGAIN branch of `us_socket_ipc_write_fd` does its own poll change and keeps its own assignment; it is not touched.
- Correct because the flag has exactly one reader, the dispatch epilogue in `loop.c`, and it means "a write came up short, keep polling writable", which is precisely the condition under which the helper is called. For the existing callers the assignment moves from the line before the call to the first line of the helper, so their behavior is unchanged. A flag set outside a writable dispatch is cleared at the start of the next one, so it has no other effect.
- The other two `us_socket_write2` callers could not hit the stall and just stop depending on that: `src/runtime/socket/socket_body.rs` only reaches it while native-buffered data exists, and inside a writable dispatch that data can only be there because a short write earlier in the same dispatch (the flush that runs before the JS drain callback, or an earlier write from that callback) already set the flag; `src/runtime/webview/WebKitBackend.cpp` runs no JS from its `on_writable`, so its frames are never written from inside one.
- Tests, in `test/js/bun/websocket/websocket-server-backpressure-buffer.test.ts` next to the existing direct-send coverage:
  - kernel backpressure: a raw client pauses after the upgrade, the test fills until `send()` returns -1, resumes the client, and `drain` fills again from inside the handler; asserts the send from `drain` came up short, that `drain` fires again afterwards, and that the client receives every frame byte for byte.
  - deterministic variant (debug/ASAN builds, where the syscall fault injection is compiled in): the same sequence with a 16 KiB message (the smallest one that takes the direct path) and an injected zero-byte `writev` standing in for the full kernel buffer; asserts both sends returned -1 with the full frame buffered and that both messages arrive.
  - Both hang and time out without the `socket.c` change (a 1.4.0 canary release build at da3851e57 and a debug build of main at b7a0431032); with it they pass in 228 ms and 71 ms on the debug build.
- Also ran with the fix: the rest of `test/js/bun/websocket/`, `socket-syscall-fault`, `websocket-syscall-fault`, `ws-syscall-fault`, `serve-syscall-fault`, `net-syscall-fault`, `tls-syscall-fault`, `node-http-backpressure`: pass.
- No Windows test: loopback there accepts the whole payload and the `writev` fault hook is POSIX-only. The changed code and the `loop.c` epilogue are shared by the libuv backend.
- Not changed here: `us_socket_mark_needs_more_not_ssl` and `us_socket_sendfile_needs_more` in `src/uws_sys/libuwsockets.cpp` set the flag and replicate the helper's poll gate by hand because the helper is static; #38128 is adding an exported `us_socket_request_writable` for that, so folding them is left to it.
- Related open PRs: #34510 would route `write2` through a flag-setting helper as a side effect of a larger TLS change; #37099 and #38128 each add a caller that sets the flag before calling the helper, which stays correct (just redundant) with this change.

### Background

- usockets writable polling: a connected socket normally polls READABLE only. When a write helper cannot write everything it switches the poll to READABLE|WRITABLE. When the writable event is delivered, `loop.c` clears `last_write_failed`, calls the socket's `on_writable`, and then switches WRITABLE off again unless some write during the callback set the flag (leaving it on would make every idle socket spin, since a socket with free send buffer is always writable). So across an `on_writable` callback the flag, not the poll change, is what carries "still backpressured".
- uWS `drain`: `WebSocketContext::onWritable` (`packages/bun-uws/src/WebSocketContext.h:350-395`) is the `on_writable` of a WebSocket. It flushes the backpressure buffer and then invokes the app's `drain` handler, so everything the handler sends runs inside the dispatch described above.
- Direct send path: for an uncompressed message of 16 KiB or more on a plain TCP socket with nothing buffered, `WebSocket::send` writes header and payload with a single `writev` via `us_socket_write2` instead of going through the cork buffer. Whatever was not written is appended to the backpressure buffer and `ws.send()` returns -1.

<details>
<summary>Standalone repro output (1.4.0 canary at da3851e57 vs this branch)</summary>

Plain `Bun.serve` websocket, raw `net` client paused after the upgrade, 256 KiB chunks sent until `-1`, client resumed, `drain` sends until `-1` again, then wait for every byte.

```
# 1.4.0 canary (da3851e57), 3/3 runs
phase1: sent=10 chunks, buffered=100
drain #1 phase=draining buffered=0
short write from inside drain; sent=21 buffered=231759
Error: STALL: received=5273475/5505234 buffered=231759 drainCalls=1

# this branch (debug build), 3/3 runs
short write from inside drain; sent=21 buffered=231759
OK: received=5505234 target=5505234 drainCalls=2
```

`received + buffered` in the stalled run is exactly the target: the missing bytes are the tail `send()` buffered from inside `drain`.

</details>
