### PR TITLE
jsc: release the cached Bun.main path in VirtualMachine::destroy()

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4738,6 +4738,11 @@ impl VirtualMachine {
         drop(core::mem::take(&mut self.resolved_path_dups));
 
         self.overridden_main.deinit();
+        // `Bun.main` cached the resolved entry path here as a +1 (usually an
+        // atom in this thread's table); `String` has no `Drop`, so release it
+        // here, on the owning thread.
+        self.main_resolved_path.deref();
+        self.main_resolved_path = bun_core::String::empty();
 
         // `timer`/`entry_point` live in the high-tier `RuntimeState` box, so
         // dispatch the reclaim through the hook.

--- a/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
+++ b/test/js/node/worker_threads/worker-shutdown-post-leak.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { join } from "path";
+
+const leaksanSupp = join(import.meta.dirname, "../../../leaksan.supp");
+
+// A failing run spends most of its time in LSan's report symbolization, which
+// takes tens of seconds on the debug binary; even a clean run takes several.
+const LEAK_TEST_TIMEOUT = 90_000;
 
 // A worker's shutdown used to drain its concurrent queue and only then mark
 // the context terminating. A cross-thread postTaskTo landing in between (the
@@ -38,7 +45,7 @@ test.skipIf(!isASAN || isWindows)(
         ...bunEnv,
         BUN_DESTRUCT_VM_ON_EXIT: "1",
         ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${leaksanSupp}`,
       },
       stdout: "pipe",
       stderr: "pipe",
@@ -46,4 +53,53 @@ test.skipIf(!isASAN || isWindows)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   },
+  LEAK_TEST_TIMEOUT,
+);
+
+// The Bun.main getter caches the worker's resolved entry path in its
+// VirtualMachine (an atom when the path is ASCII, a plain WTF string copy
+// otherwise). A node-kind worker reads Bun.main during bootstrap, when
+// process.mainModule is set up, so every Worker started from a file populated
+// it, and the worker's VM teardown never released it: one string leaked per
+// Worker. Eval workers have no file to resolve and never hit this.
+//
+// The string lives in WTF's allocator, which LSan cannot see through bmalloc;
+// Malloc=1 routes it through the system allocator. That also exposes the
+// worker thread's EventNames table, a separate per-thread leak (#38164) that
+// is not what this test checks, so it is tolerated on top of the shared
+// suppressions until that fix lands.
+test.concurrent.skipIf(!isASAN || isWindows).each([
+  ["ascii", "sub"],
+  ["non-ascii", "s\u00fcb"],
+])(
+  "a worker_threads Worker started from a file (%s path) does not leak its resolved Bun.main path",
+  async (_, subdir) => {
+    using dir = tempDir("worker-main-path-leak", {
+      "main.mjs": `
+        import { Worker } from "node:worker_threads";
+        import { join } from "node:path";
+        new Worker(join(import.meta.dirname, ${JSON.stringify(subdir)}, "worker.js")).on("exit", code =>
+          console.log("exit", code),
+        );
+      `,
+      [`${subdir}/worker.js`]: "",
+      "leaksan.supp": readFileSync(leaksanSupp, "utf8") + "\nleak:WebCore::eventNames\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        Malloc: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(String(dir), "leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "exit 0\n", stderr: "", exitCode: 0 });
+  },
+  LEAK_TEST_TIMEOUT,
 );


### PR DESCRIPTION
### Problem

- Every `node:worker_threads` Worker started from a file leaks one WTF string after the worker thread exits. LSan (ASAN build, `Malloc=1`): `Direct leak of 44 byte(s) in 1 object(s)` allocated from `BunString__tryCreateAtom (BunString.cpp:80)`, called from `bun_runtime::api::bun_object::get_main`. The size is 20 bytes plus the length of the resolved entry path; it scales with the number of workers. `eval: true` workers do not hit it.
- The `Bun.main` getter (`src/runtime/api/BunObject.rs:841-896`) resolves the entry path once and caches it in `vm.main_resolved_path` (`src/jsc/VirtualMachine.rs:159`) as a +1 on a WTF string: an atom when the path is ASCII, a `clone_utf8` copy otherwise.
- The only code that released it was the entry-point reload paths (`reload_entry_point`, `reload_entry_point_for_test_runner`, the test-isolation reset). `VirtualMachine::destroy()` (`src/jsc/VirtualMachine.rs:4681`) never did, and a worker's VM storage is freed with a raw `dealloc` (`src/jsc/web_worker.rs:1034`), so no field drop could do it either.
- A node-kind worker always populates the field: its bootstrap reifies `process.mainModule`, whose builder (`constructMainModuleProperty`, `src/jsc/bindings/BunProcess.cpp:4416`) reads `Bun.main`. A Web Worker or any other VM whose script reads `Bun.main` leaked the same way.

### Fix

- `VirtualMachine::destroy()` derefs `main_resolved_path` and resets it to empty, next to the `overridden_main.deinit()` it already does; this is the same two-line release the three reload paths use.
- Correct place: `destroy()` runs on the VM's own thread (worker teardown in `WebWorker::shutdown`, or the main thread under `BUN_DESTRUCT_VM_ON_EXIT`), and `get_main` only ever runs on that thread, so an atom is released in the table it was registered in. The JSC VM is already gone at this point, but a default-type JSC VM uses the thread's atom table (`VM.cpp:264`) and `~VM` leaves it alone; the table lives until the thread itself exits, after `shutdown()` returns.
- Safe to do unconditionally: `String::deref()` is a no-op on the empty tag (a VM that never read `Bun.main`, or whose reload path already released it), and nothing reads the field after `destroy()`; the only reader is `get_main`, and script is forbidden before teardown reaches `destroy()`.
- `bun_core::String` is `Copy` without a `Drop`, so the explicit release is the codebase's idiom for this field rather than a type change.
- Verified with `test/js/node/worker_threads/worker-shutdown-post-leak.test.ts`: two new cases run a file-based `worker_threads` Worker under LSan with `Malloc=1`, one with an ASCII path (atom branch) and one with a non-ASCII directory in the path (`clone_utf8` branch). With `src/` stashed and rebuilt they fail with `67 byte(s) ... BunString__tryCreateAtom` and `114 byte(s) ... BunString__fromUTF8 <- String::clone_utf8 <- get_main` respectively; with the fix all three tests in the file pass under `bun bd test`.
- The cases tolerate one unrelated leak on top of `test/leaksan.supp`: the worker thread's `EventNames` table, which every worker leaks today and which #38164 fixes. That line in the test can go once #38164 lands; the two PRs are otherwise independent (that PR's `worker_threads` cases use `eval: true` precisely to avoid the leak fixed here).
- Also ran `worker_threads.test.ts`, `web/workers/worker.test.ts` and `worker_destruction.test.ts` against the fixed build; the only failures are timing assumptions that this slow debug+ASAN container also fails on the unmodified tree (details below).
- The file's existing test gets the same explicit timeout as the new cases: each one starts a worker VM under debug+ASAN and then runs LSan, which takes 5 to 8 seconds here against the 5 second default.

### Background

- `bun_core::String` / `BunString`: the tagged string union shared with C++. When it holds a `WTFStringImpl` it carries a reference count; it is `Copy` and has no `Drop`, so whoever receives a +1 from a constructor such as `try_create_atom` or `clone_utf8` must call `deref()` explicitly.
- Atom: a string interned in a per-thread `AtomStringTable` so equal strings share one `StringImpl`. When its last reference goes away it removes itself from the current thread's table, which is why it has to be released on the thread that created it, while that table still exists.
- `VirtualMachine::destroy()`: the last step of `VirtualMachine::teardown`, after the JSC VM and the event loops are gone. It releases the Rust-side per-VM state explicitly because the VM's memory is then freed without running field drops.
- `Malloc=1`: makes WebKit's allocator (bmalloc) forward to the system allocator, so WTF strings become visible to LSan. Without it this leak, and any other fastMalloc'd one, is invisible to the ASAN lanes, which is why it went unnoticed.

<details>
<summary>Repro and unrelated local failures</summary>

Repro on the unfixed tree (debug ASAN build):

```sh
mkdir -p /tmp/nodedrain && cd /tmp/nodedrain
printf 'import { Worker } from "node:worker_threads";\nnew Worker(new URL("./worker.js", import.meta.url)).on("exit", c => console.log("exit", c));\n' > main.mjs
: > worker.js
BUN_DESTRUCT_VM_ON_EXIT=1 Malloc=1 ASAN_OPTIONS=detect_leaks=1 \
  LSAN_OPTIONS=suppressions=$BUN/test/leaksan.supp $BUN/build/debug/bun-debug main.mjs
```

```
Direct leak of 44 byte(s) in 1 object(s) allocated from:
    ...
    #29 in WTF::tryMakeAtomString<WTF::String>(...)
    #30 in BunString__tryCreateAtom src/jsc/bindings/BunString.cpp:80:21
```

(plus the 88-byte `EventNames` leak from #38164). With this change the run reports only the `EventNames` leak; the `tryCreateAtom` one is gone.

A Web Worker whose script reads `Bun.main` leaks the same +1, but LSan attributes that string to the module loader, which interned the path first (`JSC::Identifier::fromString`, suppressed in `leaksan.supp`), so it cannot serve as a failing test; the node bootstrap reads `Bun.main` before the entry module is loaded, which is what makes the leak attributable.

Pre-existing failures in this container, identical with and without this change (debug+ASAN, slow host): `worker_destruction.test.ts` hits the 5 second default timeout on its four spawn-based cases, and `web/workers/worker.test.ts` "a message flood from a worker does not starve the parent's event loop" sees zero messages within its three 10 ms timer turns because a worker takes longer than that to boot here.

</details>
