### PR TITLE
node:module: throw instead of crashing when module._compile is set to a non-function

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1447,13 +1447,11 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
     if (JSValue compileFunction = this->m_overriddenCompile.get()) {
         auto& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        if (!compileFunction) {
-            throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
-            return;
-        }
-        JSC::CallData callData = JSC::getCallData(compileFunction.asCell());
+        // setterUnderscoreCompile stores whatever was assigned, primitives
+        // included, so this has to be the JSValue overload, not asCell().
+        JSC::CallData callData = JSC::getCallData(compileFunction);
         if (callData.type == JSC::CallData::Type::None) {
-            throwTypeError(globalObject, scope, "overridden module._compile is not a function (called from overridden Module._extensions)"_s);
+            throwTypeError(globalObject, scope, "module._compile is not a function"_s);
             return;
         }
         WTF::String sourceString = source.source_code.transferToWTFString();

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1447,8 +1447,6 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
     if (JSValue compileFunction = this->m_overriddenCompile.get()) {
         auto& vm = globalObject->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        // setterUnderscoreCompile stores whatever was assigned, primitives
-        // included, so this has to be the JSValue overload, not asCell().
         JSC::CallData callData = JSC::getCallData(compileFunction);
         if (callData.type == JSC::CallData::Type::None) {
             throwTypeError(globalObject, scope, "module._compile is not a function"_s);

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -618,12 +618,12 @@ void evaluateCommonJSCustomExtension(
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (!extension) {
-        throwTypeError(globalObject, scope, makeString("require.extension is not a function"_s));
+        throwTypeError(globalObject, scope, "require.extension is not a function"_s);
         return;
     }
-    JSC::CallData callData = JSC::getCallData(extension.asCell());
+    JSC::CallData callData = JSC::getCallData(extension);
     if (callData.type == JSC::CallData::Type::None) {
-        throwTypeError(globalObject, scope, makeString("require.extension is not a function"_s));
+        throwTypeError(globalObject, scope, "require.extension is not a function"_s);
         return;
     }
     MarkedArgumentBuffer arguments;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2865,11 +2865,6 @@ fn transpile_source_code_inner(
                     let already_bundled = core::mem::take(&mut parse_result.already_bundled);
                     let is_commonjs_module = already_bundled.is_common_js();
                     let bytecode_cache = Bytecode::owned(already_bundled.into_bytecode());
-                    // Mirrors the `is_main` handling on the print path below.
-                    if is_main {
-                        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                        unsafe { (*jsc_vm).has_loaded = true };
-                    }
                     return Ok(ResolvedSource {
                         source_code: bun_core::String::clone_latin1(&source.contents),
                         source_url: input_specifier.create_if_different(path.text),
@@ -2999,11 +2994,6 @@ fn transpile_source_code_inner(
                     } else {
                         ResolvedSourceTag::Javascript
                     };
-                    // Mirrors the `is_main` handling on the print path below.
-                    if is_main {
-                        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                        unsafe { (*jsc_vm).has_loaded = true };
-                    }
                     return Ok(ResolvedSource {
                         source_code,
                         source_url: input_specifier.create_if_different(path.text),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2865,6 +2865,11 @@ fn transpile_source_code_inner(
                     let already_bundled = core::mem::take(&mut parse_result.already_bundled);
                     let is_commonjs_module = already_bundled.is_common_js();
                     let bytecode_cache = Bytecode::owned(already_bundled.into_bytecode());
+                    // Mirrors the `is_main` handling on the print path below.
+                    if is_main {
+                        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                        unsafe { (*jsc_vm).has_loaded = true };
+                    }
                     return Ok(ResolvedSource {
                         source_code: bun_core::String::clone_latin1(&source.contents),
                         source_url: input_specifier.create_if_different(path.text),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2994,6 +2994,11 @@ fn transpile_source_code_inner(
                     } else {
                         ResolvedSourceTag::Javascript
                     };
+                    // Mirrors the `is_main` handling on the print path below.
+                    if is_main {
+                        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                        unsafe { (*jsc_vm).has_loaded = true };
+                    }
                     return Ok(ResolvedSource {
                         source_code,
                         source_url: input_specifier.create_if_different(path.text),

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -238,6 +238,43 @@ test("default loader throws when module._compile was replaced with a non-functio
   });
   expect(exitCode).toBe(0);
 });
+test("custom require extension still applies when the entry is a transpiler cache hit", async () => {
+  // A main module restored from the runtime transpiler cache used to leave the
+  // VM in its pre-load state, so require() of an unknown extension skipped
+  // require.extensions and fell back to the JS loader on warm-cache runs.
+  const padding = "// " + Buffer.alloc(4096, "x").toString() + "\n";
+  using dir = tempDir("extensions-transpiler-cache", {
+    "transpiler-cache/.keep": "",
+    "c.custom": `module.exports = 'c dot custom';`,
+    // Padded past the cache's minimum source size so the entry is cached.
+    "main.cjs": `require("module")._extensions[".custom"] = function (module, filename) {
+  module._compile("module.exports = 'custom';", filename);
+};
+console.log(require("./c.custom"));
+${padding}`,
+  });
+  const env = {
+    ...bunEnv,
+    BUN_RUNTIME_TRANSPILER_CACHE_PATH: path.join(String(dir), "transpiler-cache"),
+    // Debug builds save cache entries but ignore them on load unless this is set.
+    BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE: "1",
+  };
+  // Run twice: the first run populates the cache, the second must still
+  // dispatch to the custom extension.
+  for (let run = 0; run < 2; run++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("custom\n");
+    expect(exitCode).toBe(0);
+  }
+});
 test("mutating extensions is banned by some files", () => {
   // vercel is not allowed to mutate require.extensions
   const files = ["node_modules/next/dist/build/next-config-ts/index.js", "node_modules/@meteorjs/babel/index.js"];

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -275,6 +275,46 @@ ${padding}`,
     expect(exitCode).toBe(0);
   }
 });
+test("custom require extension still applies when the entry is a prebundled module", async () => {
+  // An already-bundled main module (the `// @bun` pragma emitted by
+  // `bun build --target=bun`) takes the same early return as a transpiler
+  // cache hit and used to leave the VM in its pre-load state.
+  using dir = tempDir("extensions-already-bundled", {
+    "c.custom": `module.exports = 'c dot custom';`,
+    "entry.js": `const Module = require("module");
+Module._extensions[".custom"] = function (module, filename) {
+  module._compile("module.exports = 'custom';", filename);
+};
+console.log(require("./c.custom"));
+`,
+  });
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.js", "--target=bun", "--format=cjs", "--external=*.custom", "--outfile=out.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [buildStdout, buildStderr, buildExit] = await Promise.all([
+    build.stdout.text(),
+    build.stderr.text(),
+    build.exited,
+  ]);
+  expect(buildStderr).toBe("");
+  expect(buildExit).toBe(0);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "out.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("custom\n");
+  expect(exitCode).toBe(0);
+});
 test("mutating extensions is banned by some files", () => {
   // vercel is not allowed to mutate require.extensions
   const files = ["node_modules/next/dist/build/next-config-ts/index.js", "node_modules/@meteorjs/babel/index.js"];

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { expect, mock, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("require.extensions shape makes sense", () => {
@@ -161,6 +161,82 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
   } finally {
     require.extensions[".cjs"] = original;
   }
+});
+test("default loader throws when module._compile was replaced with a non-function", async () => {
+  // Spawned because the unfixed behavior for primitives is a segfault, not an exception.
+  using dir = tempDir("extensions-bad-compile", {
+    "plain.js": `module.exports = "plain";`,
+    "plain.ts": `const value: string = "plain ts"; module.exports = value;`,
+    "run.cjs": `
+      const Module = require("module");
+      const path = require("path");
+      const file = path.join(__dirname, "plain.js");
+      const original = Module._extensions[".js"];
+      const values = [
+        ["undefined", undefined],
+        ["null", null],
+        ["number", 42],
+        ["boolean", true],
+        ["string", "not a function"],
+        ["object", {}],
+        ["symbol", Symbol("compile")],
+        ["bigint", 1n],
+      ];
+      const caught = fn => {
+        try {
+          fn();
+          return { threw: false };
+        } catch (e) {
+          return { isTypeError: e instanceof TypeError, message: e.message };
+        }
+      };
+
+      const viaRequire = values.map(([kind, value]) => {
+        Module._extensions[".js"] = function (module, filename) {
+          module._compile = value;
+          return original(module, filename);
+        };
+        return { kind, ...caught(() => require(file)), cached: file in require.cache };
+      });
+      Module._extensions[".js"] = original;
+      const afterwards = require(file);
+
+      const viaDirectCall = values.map(([kind, value]) => {
+        const m = new Module(file, module);
+        m.filename = file;
+        m._compile = value;
+        return { kind, ...caught(() => original(m, file)) };
+      });
+
+      const tsFile = path.join(__dirname, "plain.ts");
+      const tsModule = new Module(tsFile, module);
+      tsModule.filename = tsFile;
+      tsModule._compile = undefined;
+      const viaTsLoader = caught(() => Module._extensions[".ts"](tsModule, tsFile));
+
+      console.log(JSON.stringify({ viaRequire, afterwards, viaDirectCall, viaTsLoader }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.cjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const kinds = ["undefined", "null", "number", "boolean", "string", "object", "symbol", "bigint"];
+  const typeError = { isTypeError: true, message: "module._compile is not a function" };
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    viaRequire: kinds.map(kind => ({ kind, ...typeError, cached: false })),
+    afterwards: "plain",
+    viaDirectCall: kinds.map(kind => ({ kind, ...typeError })),
+    viaTsLoader: typeError,
+  });
+  expect(exitCode).toBe(0);
 });
 test("mutating extensions is banned by some files", () => {
   // vercel is not allowed to mutate require.extensions


### PR DESCRIPTION
### Problem
- A `require.extensions` hook that assigns a non-function to `module._compile` and then calls the default loader crashes the process: `panic(main thread): Segmentation fault at address 0xF` on the 1.4.0 release, `ASSERTION FAILED: isCell()` on a debug build. Node throws `TypeError: module._compile is not a function`.
- Reproduces with `undefined`, `null`, a number or a boolean. Objects and strings already threw, with a Bun-specific message.
- Also reachable without `require()`: `new Module(file)`, assign `_compile`, call `Module._extensions[".js"](m, file)` (and the `.ts` loader, which shares the implementation).
- Cause: `JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile` (src/jsc/bindings/JSCommonJSModule.cpp:1457) calls `JSC::getCallData(compileFunction.asCell())`. The setter (`setterUnderscoreCompile`, same file) stores any assigned value in `m_overriddenCompile`, so for a primitive `asCell()` reinterprets the tagged immediate as a `JSCell*` and `getCallData` reads its type byte (`0xA` for undefined plus the header offset gives the `0xF` in the crash). The `if (!compileFunction)` guard above it never fires: `JSValue::operator bool` only tests for the empty value, and the enclosing `if` already excluded that.

### Fix
- Call the `JSValue` overload of `JSC::getCallData`, which returns `CallData::Type::None` for non-cells, and drop the dead guard. Every non-callable value now reaches the existing TypeError path.
- The message becomes `module._compile is not a function`, which is what Node's `Module._extensions['.js']` produces when it calls `module._compile(source, filename, format)` (lib/internal/modules/cjs/loader.js). This is the only observable change for objects and strings, which already threw.
- Correct because callability is the only thing this code needs from the value, and `getCallData(JSValue)` is how the neighbouring code (`JSCommonJSExtensions::onAssign`, the `_resolveFilename` and `runMain` setters) already asks that question; the failed `require()` is still removed from `require.cache` by `finishRequireWithError`, so the file loads normally afterwards (covered by the test).
- Test: `test/js/node/module/require-extensions.test.ts`, "default loader throws when module._compile was replaced with a non-function". Spawns one process that tries all eight value kinds through both `require()` with a wrapping hook and a direct call of the default `.js` loader, plus `undefined` through the `.ts` loader, and checks every case throws the TypeError, that nothing stays in `require.cache`, and that the file still loads once the hook is removed. Fails on the release build (segfault) and on an unfixed debug build (`ASSERTION FAILED: isCell()`), passes with the fix.
- Also ran the rest of `require-extensions.test.ts`, `test/regression/issue/require-extensions-override.test.ts`, `test/regression/issue/30717.test.ts` and `test/js/node/module/node-module-module.test.js` on the debug build: all pass.
- An earlier commit here added a missing `RETURN_IF_EXCEPTION` after the `jsSubstring` call in the `new Module()` constructor (flagged by `BUN_JSC_validateExceptionChecks=1` on the ASAN lane). The same fix has since landed on main, so the rebase dropped that commit from this PR.
- `evaluateCommonJSCustomExtension` (src/jsc/bindings/ModuleLoader.cpp:646) had the same `getCallData(x.asCell())` pattern; switched to the `JSValue` overload there too. Not user-reachable today (`JSCommonJSExtensions::onAssign` filters non-callables before storage), so this is the same fix applied to the copy-pasted sibling. Its `if (!extension)` guard stays: `extension` is a plain parameter with no enclosing empty-value check.
- A second `require.extensions` bug found while running this test file on release builds, now fixed on main: a main module served from the runtime transpiler cache, or an already-bundled one (`// @bun` pragma, `--bytecode`), returned early from `transpile_source_code_inner` (src/runtime/jsc_hooks.rs) without setting `vm.has_loaded`. The VM stayed in its pre-load state, so later `require()` calls of unknown extensions took the "potentially the main module" loader fallback instead of dispatching to `require.extensions`. This PR fixed both early returns at its old base; main has since hoisted one `has_loaded` write above all of them, so the rebase drops this PR's writes as redundant.
- Two tests for that bug stay as regression coverage: "custom require extension still applies when the entry is a transpiler cache hit" (runs the same script twice against a shared cache directory; debug builds only restore cache entries when `BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE=1`, which the test sets) and "... when the entry is a prebundled module" (bundles at test time, then runs the output). Both failed at the old base on both build profiles and pass on current main. They guard the hoisted write against a future un-hoist.

### Background
- `JSValue` is JSC's NaN-boxed value: objects, functions, strings, symbols and bigints are heap cells (pointers), while `undefined`, `null`, booleans and small numbers are encoded inline. `asCell()` assumes the value is a pointer; `getCallData(JSValue)` checks `isCell()` first and reports inline values as not callable.
- `module._compile` on Bun's CommonJS module objects is a native accessor. Reading it returns the built-in implementation unless something was assigned; assigning stores the value in the module's `m_overriddenCompile` slot. When the default `Module._extensions` loader (`builtinLoader` in JSCommonJSExtensions.cpp) evaluates a module, `evaluateWithPotentiallyOverriddenCompile` calls that stored value with the module source instead of evaluating directly. This is the hook register-style tools (pirates, nyc, ts-node) rely on.

<details>
<summary>Reproduction</summary>

```js
// plain.js
module.exports = 42;

// run.js
const Module = require("module");
const defaultLoader = Module._extensions[".js"];
Module._extensions[".js"] = function (module, filename) {
  module._compile = undefined; // also null, 42, true
  return defaultLoader(module, filename);
};
try {
  require("./plain.js");
} catch (e) {
  console.log("threw:", e.name, e.message);
}
```

```
$ node run.js
threw: TypeError module._compile is not a function

$ bun run.js      # 1.4.0
panic(main thread): Segmentation fault at address 0xF
(exit 139)

$ bun run.js      # this branch
threw: TypeError module._compile is not a function
```

</details>

<details>
<summary>Related open PRs (none fix this)</summary>

#35773, #38138 and #38166 edit the same function but keep the `asCell()` call; #38166 moves the `vm`/`scope` declarations two lines above this change, so one of the two will need a trivial rebase.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/require-extensions.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/module/require-extensions.test.ts:
(pass) require.extensions shape makes sense [14.63ms]
(pass) custom require extension 1 [49.97ms]
(pass) custom require extension overwrite default loader [12.76ms]
(pass) custom require extension overwrite default loader with other default loader [8.27ms]
(pass) test that assigning properties weirdly wont do anything bad [3.43ms]
(pass) wrapping an existing extension with no logic [8.40ms]
(pass) wrapping an existing extension with mutated compile function [12.43ms]
(pass) wrapping an existing extension with mutated compile function ts [15.29ms]
(pass) wrapping an existing extension but it's secretly sync esm [20.26ms]
227 |   });
228 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
229 | 
230 |   const kinds = ["undefined", "null", "number", "boolean", "string", "object", "symbol", "bigint"];
231 |   const typeError = { isTypeError: true, message: "
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (fa3776a32)

test/js/node/module/require-extensions.test.ts:
(pass) require.extensions shape makes sense [0.08ms]
(pass) custom require extension 1 [0.72ms]
(pass) custom require extension overwrite default loader [0.25ms]
(pass) custom require extension overwrite default loader with other default loader [0.22ms]
(pass) test that assigning properties weirdly wont do anything bad [0.04ms]
(pass) wrapping an existing extension with no logic [0.16ms]
(pass) wrapping an existing extension with mutated compile function [0.21ms]
(pass) wrapping an existing extension with mutated compile function ts [0.26ms]
(pass) wrapping an existing extension but it's secretly sync esm [0.32ms]
(pass) default loader throws when module._compile was replaced with a non-function [9.12ms]
(pass) custom require extension still applies when the entry is a transpiler cache hit [11.87ms]
(pass) custom require extension still applies when the entry is a prebundled module [11.76ms]
(pass) mutating extensions is banned by some files [1.22ms]

 13 pass
 0 fail
 60 expect() calls
Ran 13 tests across 1 file. [134.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/require-extensions.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/module/require-extensions.test.ts:
(pass) require.extensions shape makes sense [13.85ms]
(pass) custom require extension 1 [43.63ms]
(pass) custom require extension overwrite default loader [12.25ms]
(pass) custom require extension overwrite default loader with other default loader [8.22ms]
(pass) test that assigning properties weirdly wont do anything bad [3.47ms]
(pass) wrapping an existing extension with no logic [8.32ms]
(pass) wrapping an existing extension with mutated compile function [12.49ms]
(pass) wrapping an existing extension with mutated compile function ts [14.56ms]
(pass) wrapping an existing extension but it's secretly sync esm [20.50ms]
(pass) default loader throws when module._compile was replaced with a non-function [437.13ms]
(pass) custom require extension still applies when the entry is a transpiler cache hit [568.27ms]
(pass) custom require extension still applies when the entry is a prebundled module [572.35ms]
(pass) mutat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 641ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 243 extern-C blocks audited
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCommonJSModule.cpp          |   8 +-
 src/jsc/bindings/ModuleLoader.cpp              |   6 +-
 test/js/node/module/require-extensions.test.ts | 155 ++++++++++++++++++++++++-
 3 files changed, 159 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/jsc/bindings/JSCommonJSModule.cpp               0      0      0
src/jsc/bindings/ModuleLoader.cpp                   1      1      0
test/js/node/module/require-extensions.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->

