### PR TITLE
auto-install: report why a root dependency could not be resolved

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -619,7 +619,7 @@ pub enum TrackInstalledBin {
     Basename(Box<[u8]>),
 }
 
-// MOVE_DOWN: data struct + accessors live in `bun_install_types::WakeHandler`
+// MOVE_DOWN: the data struct lives in `bun_install_types::WakeHandler`
 // (single definition the resolver also stores). The `handler` second arg is
 // erased to `*mut c_void` there because that crate cannot name
 // `PackageManager`; `wake_raw()` casts it back at the call site.
@@ -907,12 +907,10 @@ impl PackageManager {
         // only form field pointers via `addr_of!`/`addr_of_mut!` (no whole-struct
         // borrow) and `wakeup()` is internally synchronized for cross-thread use.
         unsafe {
-            let on_wake = &*core::ptr::addr_of!((*this).on_wake);
-            if let Some(ctx) = on_wake.context {
-                // `WakeHandler.handler`'s second arg is the erased
-                // `*mut PackageManager` (`bun_install_types` cannot name this
-                // type); cast back to `*mut c_void` here.
-                (on_wake.get_handler())(ctx.as_ptr(), this.cast::<c_void>());
+            if let Some(wake) = (*core::ptr::addr_of!((*this).on_wake)).0 {
+                // `handler`'s second arg is the erased `*mut PackageManager`
+                // (`bun_install_types` cannot name this type).
+                (wake.handler)(wake.context.as_ptr(), this.cast::<c_void>());
             }
             (*core::ptr::addr_of_mut!((*this).event_loop)).wakeup();
         }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -181,9 +181,8 @@ use crate::package_manager_task as Task;
 use crate::resolvers::folder_resolver::{Entry as FolderResolutionEntry, FolderResolution};
 use bun_install::lockfile::{self, Lockfile};
 use bun_install::{
-    Dependency, DependencyID, NetworkTask, PackageID, PackageManifestMap,
-    PackageNameAndVersionHash, PackageNameHash, PatchTask, PreinstallState, TaskCallbackContext,
-    initialize_store,
+    DependencyID, NetworkTask, PackageID, PackageManifestMap, PackageNameAndVersionHash,
+    PackageNameHash, PatchTask, PreinstallState, TaskCallbackContext, initialize_store,
 };
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -279,7 +278,6 @@ pub type PatchTaskQueue = UnboundedQueue<PatchTask /* , .next */>;
 pub type AsyncNetworkTaskQueue = UnboundedQueue<NetworkTask /* , .next */>;
 
 pub(crate) type SuccessFn = fn(&mut PackageManager, DependencyID, PackageID);
-pub(crate) type FailFn = fn(&mut PackageManager, &Dependency, PackageID, Error);
 
 // Default to a maximum of 64 simultaneous HTTP requests for bun install if no proxy is specified
 // if a proxy IS specified, default to 64. We have different values because we might change this in the future.
@@ -891,26 +889,6 @@ impl PackageManager {
 
     pub fn tls_reject_unauthorized(&self) -> bool {
         self.env().get_tls_reject_unauthorized()
-    }
-
-    pub(crate) fn fail_root_resolution(
-        &mut self,
-        dependency: &Dependency,
-        dependency_id: DependencyID,
-        err: Error,
-    ) {
-        if let Some(ctx) = self.on_wake.context {
-            // SAFETY: `ctx` is the `WakeHandler::context` registered alongside
-            // this callback (a live `*mut Queue`); see `runtime::jsc_hooks`.
-            unsafe {
-                (self.on_wake.get_on_dependency_error())(
-                    ctx.as_ptr(),
-                    dependency,
-                    dependency_id,
-                    err.name(),
-                );
-            }
-        }
     }
 
     /// Raw-pointer wake for concurrent task-thread callers (see

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -50,13 +50,6 @@ fn verbose_install() -> bool {
 // `PatchTask.callback` discriminant — routed to the real
 // `patch_install::Callback` enum (CalcHash / Apply).
 
-// `SuccessFn` is a bare `fn(&mut PackageManager, ...)` pointer; the real
-// bodies are inherent methods, so reference them via the type path.
-#[allow(non_upper_case_globals)]
-const assign_resolution: SuccessFn = PackageManager::assign_resolution;
-#[allow(non_upper_case_globals)]
-const assign_root_resolution: SuccessFn = PackageManager::assign_root_resolution;
-
 // The `use package_manager_real::PackageManager`
 // above already pulls the `declare_scope!`-generated `static PackageManager: ScopedLogger`
 // (value namespace) alongside the struct (type namespace), so re-declaring it here
@@ -83,7 +76,7 @@ pub fn enqueue_dependency_with_main(
         dependency,
         resolution,
         install_peer,
-        assign_resolution,
+        PackageManager::assign_resolution,
         false,
     )
 }
@@ -576,7 +569,7 @@ pub fn enqueue_dependency_to_root(
             &dependency,
             invalid_package_id,
             false,
-            assign_root_resolution,
+            PackageManager::assign_root_resolution,
             true,
         ) {
             return DependencyToEnqueue::Failure(err);
@@ -758,17 +751,10 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     resolution: PackageID,
     install_peer: bool,
     success_fn: SuccessFn,
-    // True for the dependencies runtime auto-install enqueues on the root
-    // (`enqueue_dependency_to_root`). Every resolution error of those goes to
-    // `this.log`, which the runtime attaches to the import's error, and the
-    // dependency stays unresolved; `bun install` propagates the ones that have
-    // no dedicated message below.
-    //
-    // The two `SuccessFn` candidates
-    // (`assign_resolution` / `assign_root_resolution`) have byte-identical
-    // bodies in release builds, so Apple ld64 (which ignores `.llvm_addrsig`)
-    // folds them and a runtime fn-pointer address comparison is unsound. Thread
-    // an explicit flag instead.
+    // True for runtime auto-install's root enqueues
+    // (`enqueue_dependency_to_root`): their resolution errors go to `this.log`
+    // instead of propagating. An explicit flag, not a `success_fn` address
+    // comparison: the linker may fold the byte-identical fn bodies.
     is_root: bool,
 ) -> crate::Result<()> {
     if dependency.behavior.is_optional_peer() {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -21,7 +21,7 @@ use crate::lockfile::PackageIndexEntry;
 use crate::lockfile::package::Package;
 use crate::lockfile_real as Lockfile;
 use crate::package_manager_real::{
-    self, FailFn, PackageManager, SuccessFn, TaskCallbackList, determine_preinstall_state,
+    self, PackageManager, SuccessFn, TaskCallbackList, determine_preinstall_state,
     get_cache_directory, get_preinstall_state, get_temporary_directory, run_tasks,
     set_preinstall_state,
 };
@@ -50,14 +50,12 @@ fn verbose_install() -> bool {
 // `PatchTask.callback` discriminant — routed to the real
 // `patch_install::Callback` enum (CalcHash / Apply).
 
-// `SuccessFn` / `FailFn` are bare `fn(&mut PackageManager, ...)` pointers; the
-// real bodies are inherent methods, so reference them via the type path.
+// `SuccessFn` is a bare `fn(&mut PackageManager, ...)` pointer; the real
+// bodies are inherent methods, so reference them via the type path.
 #[allow(non_upper_case_globals)]
 const assign_resolution: SuccessFn = PackageManager::assign_resolution;
 #[allow(non_upper_case_globals)]
 const assign_root_resolution: SuccessFn = PackageManager::assign_root_resolution;
-#[allow(non_upper_case_globals)]
-const fail_root_resolution: FailFn = PackageManager::fail_root_resolution;
 
 // The `use package_manager_real::PackageManager`
 // above already pulls the `declare_scope!`-generated `static PackageManager: ScopedLogger`
@@ -86,7 +84,6 @@ pub fn enqueue_dependency_with_main(
         resolution,
         install_peer,
         assign_resolution,
-        None,
         false,
     )
 }
@@ -580,7 +577,6 @@ pub fn enqueue_dependency_to_root(
             invalid_package_id,
             false,
             assign_root_resolution,
-            Some(fail_root_resolution),
             true,
         ) {
             return DependencyToEnqueue::Failure(err);
@@ -762,7 +758,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
     resolution: PackageID,
     install_peer: bool,
     success_fn: SuccessFn,
-    fail_fn: Option<FailFn>,
+    // True for the dependencies runtime auto-install enqueues on the root
+    // (`enqueue_dependency_to_root`). Every resolution error of those goes to
+    // `this.log`, which the runtime attaches to the import's error, and the
+    // dependency stays unresolved; `bun install` propagates the ones that have
+    // no dedicated message below.
+    //
     // The two `SuccessFn` candidates
     // (`assign_resolution` / `assign_root_resolution`) have byte-identical
     // bodies in release builds, so Apple ld64 (which ignores `.llvm_addrsig`)
@@ -914,31 +915,26 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         Err(err) => {
                             if err == crate::Error::DistTagNotFound {
                                 if dependency.behavior.is_required() {
-                                    if let Some(fail) = fail_fn {
-                                        fail(this, dependency, id, err);
-                                    } else if dependency.behavior.is_peer() {
+                                    if dependency.behavior.is_peer() {
                                         warn_unmet_peer_dependency(this, name, &version);
                                     } else {
-                                        this.log_mut()
-                    .add_error_fmt(
-                                                None,
-                                                bun_ast::Loc::EMPTY,
-                                                format_args!(
-                                                    "Package \"{}\" with tag \"{}\" not found, but package exists",
-                                                    bstr::BStr::new(this.lockfile.str(&name)),
-                                                    bstr::BStr::new(
-                                                        this.lockfile.str(&version.dist_tag().tag)
-                                                    ),
+                                        this.log_mut().add_error_fmt(
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            format_args!(
+                                                "Package \"{}\" with tag \"{}\" not found, but package exists",
+                                                bstr::BStr::new(this.lockfile.str(&name)),
+                                                bstr::BStr::new(
+                                                    this.lockfile.str(&version.dist_tag().tag)
                                                 ),
-                                            );
+                                            ),
+                                        );
                                     }
                                 }
                                 return Ok(());
                             } else if err == crate::Error::NoMatchingVersion {
                                 if dependency.behavior.is_required() {
-                                    if let Some(fail) = fail_fn {
-                                        fail(this, dependency, id, err);
-                                    } else if dependency.behavior.is_peer() {
+                                    if dependency.behavior.is_peer() {
                                         warn_unmet_peer_dependency(this, name, &version);
                                     } else {
                                         bun_ast::add_error_pretty!(
@@ -954,54 +950,45 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 return Ok(());
                             } else if err == crate::Error::TooRecentVersion {
                                 if dependency.behavior.is_required() {
-                                    if let Some(fail) = fail_fn {
-                                        fail(this, dependency, id, err);
+                                    let age_gate_ms =
+                                        this.options.minimum_release_age_ms.unwrap_or(0.0);
+                                    if version.tag == dependency::version::Tag::DistTag {
+                                        bun_ast::add_error_pretty!(
+                                            this.log_mut(),
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            "Package \"{}\" with tag \"{}\" not found<r> <d>(all versions blocked by minimum-release-age: {} seconds)<r>",
+                                            bstr::BStr::new(this.lockfile.str(&name)),
+                                            bstr::BStr::new(
+                                                this.lockfile.str(&version.dist_tag().tag)
+                                            ),
+                                            age_gate_ms / MS_PER_S,
+                                        );
                                     } else {
-                                        let age_gate_ms =
-                                            this.options.minimum_release_age_ms.unwrap_or(0.0);
-                                        if version.tag == dependency::version::Tag::DistTag {
-                                            bun_ast::add_error_pretty!(
-                                                this.log_mut(),
-                                                None,
-                                                bun_ast::Loc::EMPTY,
-                                                "Package \"{}\" with tag \"{}\" not found<r> <d>(all versions blocked by minimum-release-age: {} seconds)<r>",
-                                                bstr::BStr::new(this.lockfile.str(&name)),
-                                                bstr::BStr::new(
-                                                    this.lockfile.str(&version.dist_tag().tag)
-                                                ),
-                                                age_gate_ms / MS_PER_S,
-                                            );
-                                        } else {
-                                            bun_ast::add_error_pretty!(
-                                                this.log_mut(),
-                                                None,
-                                                bun_ast::Loc::EMPTY,
-                                                "No version matching \"{}\" found for specifier \"{}\"<r> <d>(blocked by minimum-release-age: {} seconds)<r>",
-                                                bstr::BStr::new(this.lockfile.str(&name)),
-                                                bstr::BStr::new(
-                                                    this.lockfile.str(&version.literal)
-                                                ),
-                                                age_gate_ms / MS_PER_S,
-                                            );
-                                        }
+                                        bun_ast::add_error_pretty!(
+                                            this.log_mut(),
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            "No version matching \"{}\" found for specifier \"{}\"<r> <d>(blocked by minimum-release-age: {} seconds)<r>",
+                                            bstr::BStr::new(this.lockfile.str(&name)),
+                                            bstr::BStr::new(this.lockfile.str(&version.literal)),
+                                            age_gate_ms / MS_PER_S,
+                                        );
                                     }
                                 }
                                 return Ok(());
                             } else if err == crate::Error::MissingPackageJSON {
                                 if dependency.behavior.is_required() {
-                                    if let Some(fail) = fail_fn {
-                                        fail(this, dependency, id, err);
-                                    } else if version.tag == dependency::version::Tag::Folder {
-                                        this.log_mut()
-                    .add_error_fmt(
-                                                None,
-                                                bun_ast::Loc::EMPTY,
-                                                format_args!(
-                                                    "Could not find package.json for \"file:{}\" dependency \"{}\"",
-                                                    bstr::BStr::new(this.lockfile.str(version.folder())),
-                                                    bstr::BStr::new(this.lockfile.str(&name)),
-                                                ),
-                                            );
+                                    if version.tag == dependency::version::Tag::Folder {
+                                        this.log_mut().add_error_fmt(
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            format_args!(
+                                                "Could not find package.json for \"file:{}\" dependency \"{}\"",
+                                                bstr::BStr::new(this.lockfile.str(version.folder())),
+                                                bstr::BStr::new(this.lockfile.str(&name)),
+                                            ),
+                                        );
                                     } else {
                                         this.log_mut().add_error_fmt(
                                             None,
@@ -1014,11 +1001,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     }
                                 }
                                 return Ok(());
+                            } else if is_root {
+                                this.log_mut().add_error_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "{} while resolving package \"{}\"",
+                                        err.name(),
+                                        bstr::BStr::new(this.lockfile.str(&name)),
+                                    ),
+                                );
+                                return Ok(());
                             } else {
-                                if let Some(fail) = fail_fn {
-                                    fail(this, dependency, id, err);
-                                    return Ok(());
-                                }
                                 return Err(err);
                             }
                         }

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -384,7 +384,6 @@ impl PackageManager {
                     resolution,
                     install_peer,
                     pm_resolution::assign_root_resolution,
-                    Some(PackageManager::fail_root_resolution),
                     true,
                 )?;
                 if let Some(ptr) = any_root {

--- a/src/install_types/lib.rs
+++ b/src/install_types/lib.rs
@@ -11,5 +11,5 @@ pub use resolver_hooks::{
     NegatableEnum, NegatableExt, NpmInfo, OperatingSystem, PackageID, PackageJsonView,
     PackageNameHash, PreinstallState, Repository, Resolution, ResolutionSlice, ResolutionTag,
     ResolutionValue, TagInfo, TarballInfo, TaskCallbackContext, TruncatedPackageNameHash, URI,
-    VersionSlice, VersionedURL, VersionedURLType, WakeHandler,
+    VersionSlice, VersionedURL, VersionedURLType, WakeHandler, WakeTarget,
 };

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1277,43 +1277,29 @@ pub struct TaskCallbackContext {
 }
 
 /// Opaque
-/// (ctx-ptr + 2 fn-ptrs) handle the runtime installs to nudge the JS event
+/// (ctx-ptr + fn-ptr) handle the runtime installs to nudge the JS event
 /// loop when a network task completes. The resolver only stores and forwards
 /// it; the fields are `Option` so `Default` is all-None.
 ///
 /// `handler`'s second parameter (`*PackageManager`) is erased to
 /// `*mut c_void` because that concrete type lives in `bun_install` (a higher
 /// tier); `bun_install::PackageManager::wake` casts at the call site.
-/// `on_dependency_error`'s `Dependency` parameter is *not* erased — the type
-/// lives in this crate — so callers pass the borrow directly.
 // Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
-// installed; the handler fn-ptrs are POD.
+// installed; the handler fn-ptr is POD.
 #[derive(Default, Copy, Clone)]
 pub struct WakeHandler {
     pub context: Option<NonNull<c_void>>,
     pub handler: Option<fn(*mut c_void, *mut c_void)>,
-    pub on_dependency_error:
-        Option<unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str)>,
 }
 
 impl WakeHandler {
     #[inline]
     pub fn get_handler(&self) -> fn(*mut c_void, *mut c_void) {
         // `handler` is Some whenever `context` is Some: the sole installer
-        // (runtime::jsc_hooks) sets `context`, `handler`, and
-        // `on_dependency_error` together in one struct literal, and callers
-        // gate on `context.is_some()` before invoking — so this unwrap cannot
-        // fire.
+        // (runtime::jsc_hooks) sets `context` and `handler` together in one
+        // struct literal, and callers gate on `context.is_some()` before
+        // invoking — so this unwrap cannot fire.
         self.handler.unwrap()
-    }
-
-    #[inline]
-    pub fn get_on_dependency_error(
-        &self,
-    ) -> unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str) {
-        // Same invariant as `get_handler`: set together with `context` by the
-        // sole installer; callers gate on `context.is_some()`.
-        self.on_dependency_error.unwrap()
     }
 }
 

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1276,31 +1276,21 @@ pub struct TaskCallbackContext {
     pub root_request_id: u32,
 }
 
-/// Opaque
-/// (ctx-ptr + fn-ptr) handle the runtime installs to nudge the JS event
-/// loop when a network task completes. The resolver only stores and forwards
-/// it; the fields are `Option` so `Default` is all-None.
-///
+/// Opaque (ctx-ptr + fn-ptr) handle the runtime installs to nudge the JS
+/// event loop when a network task completes. The resolver only stores and
+/// forwards it; `Default` is unregistered (`None`).
+// Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
+// installed; the fn-ptr is POD.
+#[derive(Default, Copy, Clone)]
+pub struct WakeHandler(pub Option<WakeTarget>);
+
 /// `handler`'s second parameter (`*PackageManager`) is erased to
 /// `*mut c_void` because that concrete type lives in `bun_install` (a higher
-/// tier); `bun_install::PackageManager::wake` casts at the call site.
-// Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
-// installed; the handler fn-ptr is POD.
-#[derive(Default, Copy, Clone)]
-pub struct WakeHandler {
-    pub context: Option<NonNull<c_void>>,
-    pub handler: Option<fn(*mut c_void, *mut c_void)>,
-}
-
-impl WakeHandler {
-    #[inline]
-    pub fn get_handler(&self) -> fn(*mut c_void, *mut c_void) {
-        // `handler` is Some whenever `context` is Some: the sole installer
-        // (runtime::jsc_hooks) sets `context` and `handler` together in one
-        // struct literal, and callers gate on `context.is_some()` before
-        // invoking — so this unwrap cannot fire.
-        self.handler.unwrap()
-    }
+/// tier); `bun_install::PackageManager::wake_raw` casts at the call site.
+#[derive(Copy, Clone)]
+pub struct WakeTarget {
+    pub context: NonNull<c_void>,
+    pub handler: fn(*mut c_void, *mut c_void),
 }
 
 // ─── DependencyGroup (lockfile::Package::DependencyGroup) ─────────────────

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -3,8 +3,7 @@ use core::ffi::c_void;
 use bun_alloc::Arena as ArenaAllocator;
 use bun_bundler::transpiler::ParseResult;
 use bun_core::{EncodedSlice, String as BunString};
-use bun_install::dependency::Dependency;
-use bun_install::{DependencyID, Resolution};
+use bun_install::Resolution;
 use bun_io::KeepAlive;
 use bun_resolver::fs as Fs;
 
@@ -74,10 +73,10 @@ pub struct Queue {
 }
 
 /// What the resolver's `WakeHandler` carries as its opaque context: the
-/// module queue (for the JS-thread dependency-error callback) and the VM's
-/// weak handle (for wake-ups from the process-wide install / HTTP threads,
-/// which outlive any one VM). Allocated once per VM at registration and kept
-/// for the VM's lifetime.
+/// module queue (the task a wake-up posts polls it on the JS thread) and the
+/// VM's weak handle (for wake-ups from the process-wide install / HTTP
+/// threads, which outlive any one VM). Allocated once per VM at registration
+/// and kept for the VM's lifetime.
 pub struct WakeContext {
     pub queue: *mut Queue,
     pub handle: crate::VmHandle,
@@ -262,56 +261,6 @@ impl Queue {
         self.vm().package_manager().drain_dependency_list();
     }
 
-    /// # Safety
-    /// `ctx` must point to a live [`Queue`] (the `WakeHandler::context`
-    /// registered in `runtime::jsc_hooks`).
-    pub unsafe fn on_dependency_error(
-        ctx: *mut c_void,
-        dependency: &Dependency,
-        root_dependency_id: DependencyID,
-        err: &'static str,
-    ) {
-        // SAFETY: ctx was registered as *Queue when installing this callback.
-        let this: &mut Queue = unsafe { bun_ptr::callback_ctx::<Queue>(ctx) };
-        bun_core::scoped_log!(
-            AsyncModule,
-            "onDependencyError: {}",
-            bstr::BStr::new(this.vm().package_manager().lockfile.str(&dependency.name))
-        );
-
-        // retain_mut lets Drop free removed modules.
-        this.map.retain_mut(|module| {
-            for pending in module.parse_result.pending_imports.iter() {
-                if pending.root_dependency_id != root_dependency_id {
-                    continue;
-                }
-                let import_record_id = pending.import_record_id;
-                // S017: per-thread VM singleton (safe accessor) instead of
-                // `container_of`-derived `*mut`; provenance is the original
-                // allocation, disjoint from the `&mut module` borrow above.
-                let vm = VirtualMachine::get().as_mut();
-                // reshaped for borrowck — `lockfile.str()` ties the
-                // returned slice to `&vm`, which conflicts with passing
-                // `&mut vm` to `resolve_error`. The lockfile string buffer is
-                // stable across `resolve_error` (no realloc on the error
-                // path); detach the borrow via raw ptr.
-                let name =
-                    bun_ptr::RawSlice::new(vm.package_manager().lockfile.str(&dependency.name));
-                module.resolve_error(
-                    vm,
-                    import_record_id,
-                    &PackageResolveError {
-                        name: name.slice(),
-                        err,
-                        url: b"",
-                        version: dependency.version.clone(),
-                    },
-                );
-                return false; // continue :outer — drop this module
-            }
-            true
-        });
-    }
 
     /// `WakeHandler::handler` — runs on install / HTTP-callback threads
     /// (`PackageManager::wake_raw`). `ctx` is the [`WakeContext`] registered in
@@ -326,15 +275,6 @@ impl Queue {
             // SAFETY: refused ⇒ we own the task box.
             unsafe { drop(bun_core::heap::take(task.as_ptr())) };
         }
-    }
-
-    /// `WakeHandler::on_dependency_error` context accessor — JS thread.
-    ///
-    /// # Safety
-    /// `ctx` is the leaked `WakeContext` registered in `runtime/jsc_hooks.rs`.
-    pub unsafe fn queue_from_wake_context(ctx: *mut c_void) -> *mut Queue {
-        // SAFETY: fn contract.
-        unsafe { (*ctx.cast::<WakeContext>()).queue }
     }
 
     pub fn on_poll(&mut self) {

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -260,7 +260,6 @@ impl Queue {
         self.vm().package_manager().drain_dependency_list();
     }
 
-
     /// `WakeHandler::handler` — runs on install / HTTP-callback threads
     /// (`PackageManager::wake_raw`). `ctx` is the [`WakeContext`] registered in
     /// `runtime/jsc_hooks.rs`; the VM is reached only through its handle.

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -339,6 +339,14 @@ impl Queue {
 
     pub fn on_poll(&mut self) {
         bun_core::scoped_log!(AsyncModule, "onPoll");
+        if self.map.is_empty() {
+            // The package manager wakes us for every completed task, including
+            // the ones a synchronous auto-install (`enqueue_dependency_to_root`)
+            // is blocked on. That waiter drains them itself and logs failures;
+            // draining them here would hand the failures to the callbacks
+            // below, which have no module to deliver them to and drop them.
+            return;
+        }
         self.run_tasks();
         self.poll_modules();
     }

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -72,11 +72,10 @@ pub struct Queue {
     pub(crate) scheduled: u32,
 }
 
-/// What the resolver's `WakeHandler` carries as its opaque context: the
-/// module queue (the task a wake-up posts polls it on the JS thread) and the
-/// VM's weak handle (for wake-ups from the process-wide install / HTTP
-/// threads, which outlive any one VM). Allocated once per VM at registration
-/// and kept for the VM's lifetime.
+/// The resolver `WakeHandler`'s opaque context: the module queue plus the
+/// VM's weak handle the process-wide install / HTTP threads (which outlive
+/// any one VM) post the poll task through. Allocated once per VM at
+/// registration and kept for the VM's lifetime.
 pub struct WakeContext {
     pub queue: *mut Queue,
     pub handle: crate::VmHandle,
@@ -280,11 +279,10 @@ impl Queue {
     pub fn on_poll(&mut self) {
         bun_core::scoped_log!(AsyncModule, "onPoll");
         if self.map.is_empty() {
-            // The package manager wakes us for every completed task, including
-            // the ones a synchronous auto-install (`enqueue_dependency_to_root`)
-            // is blocked on. That waiter drains them itself and logs failures;
-            // draining them here would hand the failures to the callbacks
-            // below, which have no module to deliver them to and drop them.
+            // Wakes also fire for tasks a synchronous auto-install
+            // (`enqueue_dependency_to_root`) is blocked on. That waiter drains
+            // them itself; draining here would drop their failures (no module
+            // to deliver them to).
             return;
         }
         self.run_tasks();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4715,18 +4715,21 @@ impl VirtualMachine {
             // reason a resolution failed (a `GET <tarball url> - 404`, an
             // unreadable directory, ...) as ordinary errors/warnings in the
             // scoped `log`, which dies with this frame. Carry them on the
-            // `ResolveMessage` as notes so they are printed with it.
+            // `ResolveMessage` as notes so they are printed with it. `_resolve`
+            // retries once after busting the directory cache, and a failure the
+            // package manager derives from a manifest it already has (no such
+            // version or tag) is logged again by the retry, so keep one copy of
+            // each line.
             let mut notes = core::mem::take(&mut msg.notes).into_vec();
-            notes.extend(
-                log.msgs
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, m)| {
-                        Some(*i) != resolve_msg_index
-                            && matches!(m.kind, bun_ast::Kind::Err | bun_ast::Kind::Warn)
-                    })
-                    .map(|(_, m)| m.data.clone()),
-            );
+            for (i, logged) in log.msgs.iter().enumerate() {
+                if Some(i) == resolve_msg_index
+                    || !matches!(logged.kind, bun_ast::Kind::Err | bun_ast::Kind::Warn)
+                    || notes.iter().any(|note| note.text == logged.data.text)
+                {
+                    continue;
+                }
+                notes.push(logged.data.clone());
+            }
             msg.notes = notes.into_boxed_slice();
             return Ok(Err(crate::ResolveMessage::create(
                 global,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4684,21 +4684,16 @@ impl VirtualMachine {
             mode.is_esm(),
             IS_A_FILE_PATH,
         );
-        if let Err(err_) = resolve_result {
-            let err = err_;
+        if let Err(err) = resolve_result {
             let import_kind = mode.import_kind();
             // Find a `.resolve`-metadata msg if the log has one.
-            let msg = log
+            let resolve_msg_index = log
                 .msgs
                 .iter()
-                .find_map(|m| {
-                    if let bun_ast::Metadata::Resolve(_) = &m.metadata {
-                        Some(m.clone())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| {
+                .position(|m| matches!(m.metadata, bun_ast::Metadata::Resolve(_)));
+            let mut msg = match resolve_msg_index {
+                Some(i) => log.msgs[i].clone(),
+                None => {
                     let printed = crate::ResolveMessage::fmt(
                         specifier_utf8.slice(),
                         source_utf8.slice(),
@@ -4714,7 +4709,25 @@ impl VirtualMachine {
                         }),
                         ..Default::default()
                     }
-                });
+                }
+            };
+            // The resolver and the auto-install package manager report the
+            // reason a resolution failed (a `GET <tarball url> - 404`, an
+            // unreadable directory, ...) as ordinary errors/warnings in the
+            // scoped `log`, which dies with this frame. Carry them on the
+            // `ResolveMessage` as notes so they are printed with it.
+            let mut notes = core::mem::take(&mut msg.notes).into_vec();
+            notes.extend(
+                log.msgs
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, m)| {
+                        Some(*i) != resolve_msg_index
+                            && matches!(m.kind, bun_ast::Kind::Err | bun_ast::Kind::Warn)
+                    })
+                    .map(|(_, m)| m.data.clone()),
+            );
+            msg.notes = notes.into_boxed_slice();
             return Ok(Err(crate::ResolveMessage::create(
                 global,
                 &msg,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4711,15 +4711,11 @@ impl VirtualMachine {
                     }
                 }
             };
-            // The resolver and the auto-install package manager report the
-            // reason a resolution failed (a `GET <tarball url> - 404`, an
-            // unreadable directory, ...) as ordinary errors/warnings in the
-            // scoped `log`, which dies with this frame. Carry them on the
-            // `ResolveMessage` as notes so they are printed with it. `_resolve`
-            // retries once after busting the directory cache, and a failure the
-            // package manager derives from a manifest it already has (no such
-            // version or tag) is logged again by the retry, so keep one copy of
-            // each line.
+            // The resolver and auto-install log why a resolution failed
+            // (`GET <url> - 404`, an unreadable directory, ...) in the scoped
+            // `log`, which dies with this frame; carry those lines as notes on
+            // the `ResolveMessage`. Dedup by text: `_resolve` retries once
+            // after busting the directory cache and can log a failure twice.
             let mut notes = core::mem::take(&mut msg.notes).into_vec();
             for (i, logged) in log.msgs.iter().enumerate() {
                 if Some(i) == resolve_msg_index

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -487,26 +487,6 @@ unsafe fn init_runtime_state(
                     t.resolver.on_wake_package_manager = bun_resolver::install_types::WakeHandler {
                         context: core::ptr::NonNull::new(wake_ctx.cast()),
                         handler: Some(bun_jsc::async_module::Queue::on_wake_handler),
-                        on_dependency_error: Some({
-                            unsafe fn adapter(
-                                ctx: *mut core::ffi::c_void,
-                                dep: &bun_resolver::install_types::Dependency,
-                                id: bun_resolver::install_types::DependencyID,
-                                err: &'static str,
-                            ) {
-                                // SAFETY: `ctx` is the `WakeContext` set just above; its queue is `(*vm).modules`.
-                                unsafe {
-                                    bun_jsc::async_module::Queue::on_dependency_error(
-                                        bun_jsc::async_module::Queue::queue_from_wake_context(ctx)
-                                            .cast(),
-                                        dep,
-                                        id,
-                                        err,
-                                    )
-                                }
-                            }
-                            adapter
-                        }),
                     };
                     // Branch on `opts.graph` here — with a module graph,
                     // auto_jsx=true would

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -477,17 +477,19 @@ unsafe fn init_runtime_state(
                     // from CLI args to the resolver so symlinked node_modules
                     // entries resolve via their link path (peer deps stay reachable).
                     t.resolver.opts.preserve_symlinks = preserve_symlinks;
-                    let wake_ctx: *mut bun_jsc::async_module::WakeContext = &raw mut **(*state)
+                    let wake_ctx: &mut bun_jsc::async_module::WakeContext = &mut **(*state)
                         .wake_ctx
                         .insert(Box::new(bun_jsc::async_module::WakeContext {
                             queue: &raw mut (*vm).modules,
                             handle: (*vm).handle(),
                             kind: (*vm).current_loop_kind(),
                         }));
-                    t.resolver.on_wake_package_manager = bun_resolver::install_types::WakeHandler {
-                        context: core::ptr::NonNull::new(wake_ctx.cast()),
-                        handler: Some(bun_jsc::async_module::Queue::on_wake_handler),
-                    };
+                    t.resolver.on_wake_package_manager = bun_resolver::install_types::WakeHandler(
+                        Some(bun_resolver::install_types::WakeTarget {
+                            context: core::ptr::NonNull::from(wake_ctx).cast(),
+                            handler: bun_jsc::async_module::Queue::on_wake_handler,
+                        }),
+                    );
                     // Branch on `opts.graph` here — with a module graph,
                     // auto_jsx=true would
                     // `read_dir_info(cwd)` and cache its tsconfig.json BEFORE

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -115,10 +115,10 @@ function registryWithMissingTarball(name: string) {
   };
 }
 
-async function runWithRegistry(registryOrigin: string, entry: string, source: string) {
+async function runWithRegistry(registryOrigin: string, entry: string, source: string, installOptions = "") {
   using dir = tempDir("autoinstall-error-report", {
     [entry]: source,
-    "bunfig.toml": `[install]\nregistry = "${registryOrigin}/"\n`,
+    "bunfig.toml": `[install]\nregistry = "${registryOrigin}/"\n${installOptions}`,
   });
   await using proc = Bun.spawn({
     cmd: [bunExe(), entry],
@@ -181,6 +181,107 @@ describe.concurrent("auto-install reports why a package could not be installed",
     expect(r.requests).toEqual([`/${name}`]);
     expect(stderr).toContain(`error: Cannot find package '${name}'`);
     expect(stderr).toContain(`note: GET ${r.origin}/${name} - 404`);
+    expect(exitCode).toBe(1);
+  });
+});
+
+// A registry whose every package has exactly one version, 1.0.0, published now.
+function registryWithOneFreshVersion() {
+  const registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const name = decodeURIComponent(new URL(req.url).pathname.slice(1));
+      return Response.json({
+        name,
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball: `http://127.0.0.1:1/${name}-1.0.0.tgz` } } },
+        time: { "1.0.0": new Date().toISOString() },
+      });
+    },
+  });
+  return {
+    origin: `http://127.0.0.1:${registry.port}`,
+    [Symbol.dispose]() {
+      registry.stop(true);
+    },
+  };
+}
+
+function noteLines(stderr: string) {
+  return stderr.split("\n").filter(line => line.startsWith("note: "));
+}
+
+// The manifest exists but nothing in it satisfies the request. These failures
+// belong to the dependency auto-install enqueues on the root, whose errors used
+// to go to a callback that never reported them, so they printed a bare
+// "Cannot find package". Each one now prints the same line `bun install` does,
+// exactly once: the runtime retries a failed resolve after busting its
+// directory cache, and the retry reports the same failure again.
+describe.concurrent("auto-install reports why a package could not be resolved", () => {
+  test("version the registry does not have", async () => {
+    using r = registryWithOneFreshVersion();
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "pkg-without-v2@2.0.0";\n`);
+
+    expect(stderr).toContain("error: Cannot find package 'pkg-without-v2@2.0.0'");
+    expect(noteLines(stderr)).toEqual([
+      'note: No version matching "2.0.0" found for specifier "pkg-without-v2" (but package exists)',
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("version the registry does not have, require()", async () => {
+    using r = registryWithOneFreshVersion();
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.cjs", `require("pkg-without-v2@2.0.0");\n`);
+
+    expect(stderr).toContain("error: Cannot find package 'pkg-without-v2@2.0.0'");
+    expect(noteLines(stderr)).toEqual([
+      'note: No version matching "2.0.0" found for specifier "pkg-without-v2" (but package exists)',
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("dist-tag the registry does not have", async () => {
+    using r = registryWithOneFreshVersion();
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "pkg-without-canary@canary";\n`);
+
+    expect(stderr).toContain("error: Cannot find package 'pkg-without-canary@canary'");
+    expect(noteLines(stderr)).toEqual([
+      'note: Package "pkg-without-canary" with tag "canary" not found, but package exists',
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("version blocked by minimumReleaseAge", async () => {
+    using r = registryWithOneFreshVersion();
+    const { stderr, exitCode } = await runWithRegistry(
+      r.origin,
+      "index.js",
+      `import "pkg-published-today@1.0.0";\n`,
+      "minimumReleaseAge = 86400\n",
+    );
+
+    expect(stderr).toContain("error: Cannot find package 'pkg-published-today@1.0.0'");
+    expect(noteLines(stderr)).toEqual([
+      expect.stringMatching(
+        /^note: No version matching "[^"]+" found for specifier "[^"]+" \(blocked by minimum-release-age: 86400 seconds\)$/,
+      ),
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("dist-tag whose versions are all blocked by minimumReleaseAge", async () => {
+    using r = registryWithOneFreshVersion();
+    const { stderr, exitCode } = await runWithRegistry(
+      r.origin,
+      "index.js",
+      `import "pkg-published-today";\n`,
+      "minimumReleaseAge = 86400\n",
+    );
+
+    expect(stderr).toContain("error: Cannot find package 'pkg-published-today'");
+    expect(noteLines(stderr)).toEqual([
+      'note: Package "pkg-published-today" with tag "latest" not found (all versions blocked by minimum-release-age: 86400 seconds)',
+    ]);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -186,15 +186,18 @@ describe.concurrent("auto-install reports why a package could not be installed",
 });
 
 // A registry whose every package has exactly one version, 1.0.0, published now.
+// `pkg-with-bad-tarball-url` exists too, but its manifest does not say where
+// the tarball is.
 function registryWithOneFreshVersion() {
   const registry = Bun.serve({
     port: 0,
     fetch(req) {
       const name = decodeURIComponent(new URL(req.url).pathname.slice(1));
+      const tarball = name === "pkg-with-bad-tarball-url" ? "not a url" : `http://127.0.0.1:1/${name}-1.0.0.tgz`;
       return Response.json({
         name,
         "dist-tags": { latest: "1.0.0" },
-        versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball: `http://127.0.0.1:1/${name}-1.0.0.tgz` } } },
+        versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball } } },
         time: { "1.0.0": new Date().toISOString() },
       });
     },
@@ -281,6 +284,21 @@ describe.concurrent("auto-install reports why a package could not be resolved", 
     expect(stderr).toContain("error: Cannot find package 'pkg-published-today'");
     expect(noteLines(stderr)).toEqual([
       'note: Package "pkg-published-today" with tag "latest" not found (all versions blocked by minimum-release-age: 86400 seconds)',
+    ]);
+    expect(exitCode).toBe(1);
+  });
+
+  // Any other error ends up named after its error code, like the
+  // "'main' returned error.InvalidURL" line `bun install` prints after the
+  // specific message.
+  test("error without a dedicated message", async () => {
+    using r = registryWithOneFreshVersion();
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "pkg-with-bad-tarball-url";\n`);
+
+    expect(stderr).toContain("while resolving package 'pkg-with-bad-tarball-url' from");
+    expect(noteLines(stderr)).toEqual([
+      'note: Expected tarball URL to start with https:// or http://, got "not a url" while fetching package "pkg-with-bad-tarball-url"',
+      'note: InvalidURL while resolving package "pkg-with-bad-tarball-url"',
     ]);
     expect(exitCode).toBe(1);
   });

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -85,6 +85,106 @@ test("auto-install in a project whose package.json has a name and version", asyn
   expect(exitCode).toBe(1);
 });
 
+// A registry that has a manifest for `name` whose only version points at a
+// tarball the registry then answers with a 404. Every other path is a 404 too.
+function registryWithMissingTarball(name: string) {
+  const requests: string[] = [];
+  const tarballPath = `/${name}/-/${name}-1.0.0.tgz`;
+  const registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      requests.push(pathname);
+      if (pathname !== `/${name}`) return new Response("not found", { status: 404 });
+      return Response.json({
+        name,
+        "dist-tags": { latest: "1.0.0" },
+        versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball: `${origin}${tarballPath}` } } },
+      });
+    },
+  });
+  const origin = `http://127.0.0.1:${registry.port}`;
+  return {
+    requests,
+    origin,
+    tarballPath,
+    tarballUrl: `${origin}${tarballPath}`,
+    [Symbol.dispose]() {
+      registry.stop(true);
+    },
+  };
+}
+
+async function runWithRegistry(registryOrigin: string, entry: string, source: string) {
+  using dir = tempDir("autoinstall-error-report", {
+    [entry]: source,
+    "bunfig.toml": `[install]\nregistry = "${registryOrigin}/"\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    cwd: String(dir),
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// While auto-installing, the package manager writes the reason a package could
+// not be installed (the tarball GET and its status, a network error name, ...)
+// into the log of the resolve that triggered it. Those lines are attached to
+// the ResolveMessage as notes; without them the only output is
+// "<error name> while resolving package '...'".
+describe.concurrent("auto-install reports why a package could not be installed", () => {
+  test("tarball 404, static import", async () => {
+    const name = "pkg-whose-tarball-is-missing";
+    using r = registryWithMissingTarball(name);
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "${name}";\n`);
+
+    expect(r.requests).toEqual([`/${name}`, r.tarballPath]);
+    expect(stderr).toContain(`note: GET ${r.tarballUrl} - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("tarball 404, require()", async () => {
+    const name = "pkg-whose-tarball-is-missing-cjs";
+    using r = registryWithMissingTarball(name);
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.cjs", `require("${name}");\n`);
+
+    expect(r.requests).toEqual([`/${name}`, r.tarballPath]);
+    expect(stderr).toContain(`note: GET ${r.tarballUrl} - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("tarball 404, dynamic import() caught and logged by the script", async () => {
+    const name = "pkg-whose-tarball-is-missing-dynamic";
+    using r = registryWithMissingTarball(name);
+    const { stdout, stderr, exitCode } = await runWithRegistry(
+      r.origin,
+      "index.js",
+      `try {\n  await import("${name}");\n} catch (err) {\n  console.log(err);\n}\n`,
+    );
+
+    expect(r.requests).toEqual([`/${name}`, r.tarballPath]);
+    expect(stdout).toContain(`package '${name}'`);
+    expect(stdout).toContain(`note: GET ${r.tarballUrl} - 404`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("manifest 404", async () => {
+    const name = "pkg-whose-manifest-is-missing";
+    using r = registryWithMissingTarball("some-other-package");
+    const { stderr, exitCode } = await runWithRegistry(r.origin, "index.js", `import "${name}";\n`);
+
+    expect(r.requests).toEqual([`/${name}`]);
+    expect(stderr).toContain(`error: Cannot find package '${name}'`);
+    expect(stderr).toContain(`note: GET ${r.origin}/${name} - 404`);
+    expect(exitCode).toBe(1);
+  });
+});
+
 test("--install=fallback to install missing packages", async () => {
   const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,8 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import path from "node:path";
 
 describe("ResolveMessage", () => {
+  it("carries what the resolver logged while failing as notes", async () => {
+    // The resolver records the reason it gave up (here: the dependency's
+    // package.json does not parse) in the log of the failing resolve. That
+    // used to be discarded, leaving a bare "Cannot find package".
+    using dir = tempDir("resolve-error-notes", {
+      "index.js": `import "badjson";\n`,
+      "node_modules/badjson/package.json": `{ "name": "badjson", "main":\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "error: Cannot find package 'badjson' from '<dir>/index.js'
+
+      1 | { "name": "badjson", "main":
+                                      ^
+      note: Unexpected end of file
+         at <dir>/node_modules/badjson/package.json:1:29
+
+      Bun v<bun-version>"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
   it("position object does not segfault", async () => {
     try {
       await import("./file-importing-nonexistent-file.js");


### PR DESCRIPTION
Stacked on #38121: the first commit here is that PR's commit, this PR is the commits after it. This will be rebased once #38121 lands.

Rebased onto main after d1d256c3a1, which added a `warn_unmet_peer_dependency` arm to the same `DistTagNotFound` / `NoMatchingVersion` branches this PR edits. Resolved by keeping that peer arm and dropping only the `fail_fn` arm, so unmet peers still warn and everything else logs the error as described below. A later rebase re-seated the notes logic onto main's reworked `resolve_maybe_needs_trailing_slash`, which now returns the `ResolveMessage` instead of writing an `ErrorableString` out-param. The notes themselves are unchanged.

### Problem

- With runtime auto-install (no `node_modules`), importing a package whose manifest exists but whose requested version, dist-tag, or age-filtered version does not, prints only `error: Cannot find package 'pkg@2.0.0' from '/app/index.js'`. `bun install` for the same request prints `No version matching "2.0.0" found for specifier "pkg" (but package exists)`; the runtime says nothing about the version. Same for `pkg@canary` (`Package "pkg" with tag "canary" not found, but package exists`) and for versions blocked by `minimumReleaseAge`.
- `enqueue_dependency_with_main_and_success_fn` (`src/install/PackageManager/PackageManagerEnqueue.rs:797`) only wrote those messages when no `fail_fn` was passed. The only callers passing one are the two root-dependency paths runtime auto-install uses (`enqueue_dependency_to_root`, and the `RootDependency` arm in `processDependencyList.rs`), and the `fail_fn` was `PackageManager::fail_root_resolution` (`src/install/PackageManager.rs:959`), which forwarded the error to `AsyncModule::Queue::on_dependency_error`. That walks `Queue::map`, which is always empty (nothing populates `ParseResult::pending_imports` any more), so root-dependency errors were discarded and `bun install` was the only caller that ever logged them.
- Once the line is logged it reaches the user through #38121, which attaches the per-resolve log to the `ResolveMessage` as notes. As written there, each of these lines would show up twice: `VirtualMachine::_resolve` retries a failed resolve once after busting the directory cache, and the retry re-derives the same failure from the manifest that is already in memory and logs it again (the tarball/manifest 404 cases in #38121 are not affected because the retry does not re-download, so nothing is logged twice there).

### Fix

- The four message branches log unconditionally; `fail_fn` / `FailFn` / `fail_root_resolution` are removed along with `WakeHandler::on_dependency_error`, its registration in `runtime/jsc_hooks.rs`, and `Queue::on_dependency_error` / `queue_from_wake_context`, which had no other callers. The catch-all branch uses the existing `is_root` flag: root dependencies log `<Err> while resolving package "x"` and stay unresolved (the same outcome as before, minus the silence), `bun install` keeps propagating the error. The callee has usually logged something more specific by then (for a manifest whose tarball field is not a URL: `Expected tarball URL to start with https:// or http://, ...`), so this line is the counterpart of the `'main' returned error.InvalidURL` line `bun install` prints after that message, and the fallback for a callee that logs nothing.
- `bun install` is unaffected: it never passed a `fail_fn`, so the branches it takes are unchanged. The runtime already pointed `pm.log` at the per-resolve log for the duration of the resolve, so logging is the channel that reaches the import's error; this is the first of the two approaches suggested when this was handed off, and it makes the runtime print the line `bun install` already prints instead of inventing a second wording.
- The notes loop from #38121 skips a log entry whose text is already attached, so the retried resolve contributes nothing new. The duplicate cannot be avoided on the install side (the retry is a genuine second resolution), and resetting the log between attempts would lose the 404 notes, which are only logged by the first attempt.
- Verified:
  - `test/cli/run/run-autoinstall.test.ts`, "auto-install reports why a package could not be resolved": missing version (static import and `require()`), missing dist-tag, exact version blocked by `minimumReleaseAge`, dist-tag with every version blocked, and the catch-all branch (manifest whose tarball field is not a URL). Each asserts the full list of `note:` lines, so it also pins "exactly once". All 6 fail on bun 1.4.0 canary and on #38121 alone (the root dependency's line is never logged), and the first 5 fail with the install-side change but without the text check (each note twice); all pass with `bun bd test` together with #38121's 4 tests and the rest of the file.
  - `bun bd test` on `test/cli/install/minimum-release-age.test.ts` (49 pass), the `bun-install.test.ts` cases asserting the `(but package exists)` message, `test/js/bun/resolve/` (incl. #38121's snapshot test), `test/js/node/missing-module.test.js`, `test/cli/run/tsconfig-override.test.ts`: pass.
  - `cargo fmt --check` and `cargo clippy` on `bun_install_types`, `bun_install`, `bun_jsc`, `bun_runtime`: clean.

### Background

- Runtime auto-install: when a bare import cannot be found and there is no `node_modules`, the resolver asks the in-process `PackageManager` to resolve the package. `enqueue_dependency_to_root` adds it as a dependency of the lockfile root, enqueues it, and blocks until the package manager has no pending tasks; if the dependency still has no resolution afterwards the resolver reports the import as not found. "Root dependency" in the install code means exactly these entries; `bun install` never creates them.
- `pm.log` is a `bun_ast::Log` the package manager appends its diagnostics to. The CLI prints it at the end of `bun install`; the runtime swaps in a fresh `Log` per resolve (`VirtualMachine::resolve_maybe_needs_trailing_slash`) and, with #38121, attaches its entries to the `ResolveMessage` as `note:` lines.
- `AsyncModule::Queue` is the remnant of an older asynchronous auto-install design: a list of modules whose imports are being installed, with callbacks that deliver per-package failures to those modules. Nothing adds modules to it today, so a callback that reports through it reports to nobody. `fail_root_resolution` was such a callback; this PR removes it and leaves the rest of the queue alone (#38121 adjusts `on_poll`).
- Not changed here: the argument order of the `minimumReleaseAge` message for ranges (#37895), and a separate bug found while writing the tests, where auto-install ignores the version range in the project's own package.json and resolves `latest` (handed off separately). The test for the range case therefore imports an explicit version.

<details>
<summary>Output before / after (local registry whose manifest for the package only has 1.0.0)</summary>

Before (identical with #38121 alone, since the line was never logged):

```
error: Cannot find package 'pkg-with-manifest@2.0.0' from '/tmp/proj/index.js'
```

After:

```
error: Cannot find package 'pkg-with-manifest@2.0.0' from '/tmp/proj/index.js'

note: No version matching "2.0.0" found for specifier "pkg-with-manifest" (but package exists)
```

```
error: Cannot find package 'pkg-with-manifest@canary' from '/tmp/proj/index.js'

note: Package "pkg-with-manifest" with tag "canary" not found, but package exists
```

With `minimumReleaseAge = 86400` in bunfig.toml and a package published today:

```
error: Cannot find package 'pkg-with-manifest' from '/tmp/proj/index.js'

note: Package "pkg-with-manifest" with tag "latest" not found (all versions blocked by minimum-release-age: 86400 seconds)
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->

