### PR TITLE
Bun.serve: queue the parse-error response behind the buffered response instead of truncating it

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -180,6 +180,11 @@ private:
         asyncSocket->uncork();
         if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) && !asyncSocket->hasFullyDrained()) {
             httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE | HttpResponseData<SSL>::HTTP_PARSING_STOPPED;
+            /* onData marked the connection busy for these bytes; nothing is in
+             * flight on it anymore, so a graceful stop (App::closeIdle) sweeps it
+             * like any other idle keep-alive connection instead of waiting for
+             * the peer to read. */
+            httpResponseData->isIdle = true;
             ((HttpResponse<SSL> *) s)->resetTimeout();
             return;
         }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -155,6 +155,39 @@ public:
     }
 
 private:
+    /* Answers a parse error on a Bun.serve connection (node:http routes these
+     * through 'clientError'). The canned response is written through the
+     * AsyncSocket layer so it queues behind whatever the previous response on
+     * this keep-alive connection still has in AsyncSocketData::buffer; a raw
+     * us_socket_write() would overtake those bytes and the close would discard
+     * them. While anything is buffered, onWritable's shouldCloseConnection()
+     * gate closes the socket once it has flushed (the idle timeout bounds a peer
+     * that stops reading) and HTTP_PARSING_STOPPED discards whatever the peer
+     * sends until then. A response still in flight can no longer complete, so
+     * that connection is torn down right away (firing its onAborted), as when a
+     * pipelined request arrives mid-response. */
+    static void writeHttpErrorAndClose(us_socket_t *s, unsigned int httpErrorStatusCode) {
+        if (us_socket_is_closed(s)) {
+            return;
+        }
+        auto *asyncSocket = (AsyncSocket<SSL> *) s;
+        auto *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
+        std::string_view response = httpErrorResponses[httpErrorStatusCode];
+        asyncSocket->write(response.data(), (int) response.length());
+        /* Corked since the top of onData: the cork buffer has to reach the socket
+         * before hasFullyDrained() is meaningful, and before shutdown() would
+         * make the socket refuse it. */
+        asyncSocket->uncork();
+        if (!(httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) && !asyncSocket->hasFullyDrained()) {
+            httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE | HttpResponseData<SSL>::HTTP_PARSING_STOPPED;
+            ((HttpResponse<SSL> *) s)->resetTimeout();
+            return;
+        }
+        asyncSocket->shutdown();
+        /* Force close after the FIN so the peer cannot keep sending. */
+        asyncSocket->close();
+    }
+
     /* ── vtable handlers ─────────────────────────────────────────────────── */
 
     static void onHandshake(us_socket_t *s, int success, struct us_bun_verify_error_t verify_error, void * /*custom_data*/) {
@@ -314,12 +347,13 @@ private:
 
         HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
 
-        /* node:http compat: HTTP parsing stopped on this connection (a parse error
-         * was already delivered to 'clientError', or the JS layer freed the
-         * parser); ignore further request bytes. CONNECT/Upgrade tunnels are not
+        /* HTTP parsing stopped on this connection (HTTP_PARSING_STOPPED); ignore
+         * further request bytes. node:http's CONNECT/Upgrade tunnels are not
          * parsed as HTTP and keep flowing below. */
-        if constexpr (IsNodeHttp) {
-            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED) && !httpResponseData->isConnectRequest) {
+        if (httpResponseData->state & HttpResponseData<SSL>::HTTP_PARSING_STOPPED) [[unlikely]] {
+            bool isTunnel = false;
+            if constexpr (IsNodeHttp) isTunnel = httpResponseData->isConnectRequest;
+            if (!isTunnel) {
                 us_socket_unref(s);
                 return s;
             }
@@ -372,7 +406,7 @@ private:
              * connection (the user emitted 'close' on the socket - Node frees
              * the parser there); abandon the rest of the buffer. */
             if constexpr (IsNodeHttp) {
-                if (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED) {
+                if (httpResponseData->state & HttpResponseData<SSL>::HTTP_PARSING_STOPPED) {
                     return nullptr;
                 }
             }
@@ -594,7 +628,7 @@ private:
              * connection down, exactly like Node. The native layer only stops
              * parsing further requests on this connection. */
             if (IsNodeHttp && httpContextData->onClientError) {
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED;
+                httpResponseData->state |= HttpResponseData<SSL>::HTTP_PARSING_STOPPED;
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
                 if (!us_socket_is_closed(s)) {
                     /* Balance the parsing ref taken at the top of onData (the
@@ -609,11 +643,12 @@ private:
             if(httpContextData->onClientError) {
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
             }
-            /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */
-            us_socket_write(s, httpErrorResponses[httpErrorStatusCode].data(), (int) httpErrorResponses[httpErrorStatusCode].length());
-            us_socket_shutdown(s);
-            /* Close any socket on HTTP errors */
-            us_socket_close(s, 0, nullptr);
+            writeHttpErrorAndClose(s, httpErrorStatusCode);
+            if (!us_socket_is_closed(s)) {
+                /* Still draining the error response behind buffered response
+                 * bytes: balance the parsing ref as above. */
+                us_socket_unref(s);
+            }
         }
 
         auto returnedData = result.returnedData;
@@ -833,10 +868,10 @@ private:
                 return s;
             }
 
-            if (httpContextData->onClientError && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED)
+            if (httpContextData->onClientError && !(httpResponseData->state & HttpResponseData<SSL>::HTTP_PARSING_STOPPED)
                 && (httpResponseData->hasBufferedPartialRequestHeaders()
                     || httpResponseData->hasIncompleteRequestBody())) {
-                httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED;
+                httpResponseData->state |= HttpResponseData<SSL>::HTTP_PARSING_STOPPED;
                 httpContextData->onClientError(SSL, s, HTTP_PARSER_ERROR_INVALID_EOF, nullptr, 0);
                 if (us_socket_is_closed(s)) {
                     return s;

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -105,6 +105,13 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * no Content-Length and no chunked framing, then close. Used by node:http
          * when the user removed the framing headers. */
         HTTP_CLOSE_DELIMITED = 1 << 10,
+        /* HTTP parsing has stopped on this connection: onData ignores whatever
+         * else the peer sends. Set by a parse error whose error response is still
+         * draining behind the previous response (HttpContext::writeHttpErrorAndClose)
+         * and, for node:http, once a parse error has been handed to 'clientError' or
+         * the JS layer freed the parser (Node does so when 'close' is emitted on
+         * the socket). */
+        HTTP_PARSING_STOPPED = 1 << 12,
 
         /* The node:http bits below are only ever set on a node:http compat
          * connection, but they live in the shared word (rather than in
@@ -118,10 +125,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * JSNodeHTTPServerSocket::startPipelinedResponse(). Only meaningful while
          * the request handler dispatch is on the stack. */
         HTTP_NODE_PIPELINED_DISPATCH = 1 << 11,
-        /* The JS layer stopped HTTP processing on this connection (Node frees the
-         * parser when 'close' is emitted on the socket); any further request data
-         * in the buffer is not parsed. */
-        HTTP_NODE_PARSING_STOPPED = 1 << 12,
         /* Socket reads were paused because pipelined responses are (or were)
          * queued. Reads resume once the queue has drained AND the socket has no
          * outgoing backpressure left (Node's flood prevention pauses the socket
@@ -156,7 +159,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * There is one HttpResponseData per socket, reused by every request on a
          * keep-alive connection, so starting a new response clears the rest of the
          * word (resetResponseState) - these have to survive that. */
-        HTTP_CONNECTION_SCOPED = HTTP_NODE_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
+        HTTP_CONNECTION_SCOPED = HTTP_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
             | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN | HTTP_CLOSE_WHEN_IDLE,
     };
 

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -588,9 +588,9 @@ void JSNodeHTTPServerSocket::stopHTTPParsing()
         return;
     }
     if (is_ssl) {
-        reinterpret_cast<uWS::HttpResponseData<true>*>(us_socket_ext(socket))->state |= uWS::HttpResponseData<true>::HTTP_NODE_PARSING_STOPPED;
+        reinterpret_cast<uWS::HttpResponseData<true>*>(us_socket_ext(socket))->state |= uWS::HttpResponseData<true>::HTTP_PARSING_STOPPED;
     } else {
-        reinterpret_cast<uWS::HttpResponseData<false>*>(us_socket_ext(socket))->state |= uWS::HttpResponseData<false>::HTTP_NODE_PARSING_STOPPED;
+        reinterpret_cast<uWS::HttpResponseData<false>*>(us_socket_ext(socket))->state |= uWS::HttpResponseData<false>::HTTP_PARSING_STOPPED;
     }
 }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -4370,6 +4370,231 @@ describe("a client half-close after the request does not truncate a large respon
   });
 });
 
+// A malformed request pipelined behind a response whose tail uWS still holds in
+// its own buffer (the client has not read anything yet) gets its canned 4xx/5xx
+// written through that same buffer, and the connection is shut down only once
+// everything has flushed: the client sees the complete first response, then
+// exactly the error response, then FIN. An error response written straight to
+// the socket would overtake the buffered tail, which the close then discards.
+describe("a malformed pipelined request does not truncate the buffered response ahead of it", () => {
+  const CHUNK = Buffer.alloc(1024 * 1024, "a");
+  const MAX_CHUNKS = 64;
+  const REQUEST = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+  const MALFORMED = {
+    "400 from a malformed request-line": ["GARBAGE\r\n\r\n", "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n"],
+    "431 from an oversized header": [
+      `GET / HTTP/1.1\r\nHost: localhost\r\nX-Big: ${Buffer.alloc(32 * 1024, "b").toString()}\r\n\r\n`,
+      "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n",
+    ],
+    "505 from an unsupported HTTP version": [
+      "GET / HTTP/9.9\r\nHost: localhost\r\n\r\n",
+      "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\n\r\n",
+    ],
+  } as const;
+
+  // The handler streams CHUNKs synchronously until uWS reports backpressure
+  // (controller.write() returns a pending promise once the kernel stops taking
+  // bytes, so the rest of that chunk already sits in uWS's buffer), adds one
+  // more CHUNK to make that buffered tail about a megabyte, and ends the
+  // response, which queues the terminating chunk behind it. `queued` resolves
+  // with the body length once all of that has been handed to uWS, which is
+  // before the test sends anything else on the connection. Any other path is
+  // answered with a plain "ok"; `served` lists the paths dispatched so far.
+  function streamingServer(options: { tls?: typeof tls } = {}) {
+    const queued = Promise.withResolvers<number>();
+    const served: string[] = [];
+    const server = serve({
+      port: 0,
+      ...options,
+      fetch(req) {
+        const { pathname } = new URL(req.url);
+        served.push(pathname);
+        if (pathname !== "/") return new Response("ok");
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            pull(controller) {
+              let written = 0;
+              let backpressure = false;
+              while (!backpressure && written < MAX_CHUNKS) {
+                backpressure = controller.write(CHUNK) instanceof Promise;
+                written++;
+              }
+              if (!backpressure) {
+                controller.end();
+                queued.reject(new Error(`no backpressure after ${written} MiB: the client is reading`));
+                return;
+              }
+              controller.write(CHUNK);
+              written++;
+              controller.end();
+              queued.resolve(written * CHUNK.length);
+            },
+          }),
+        );
+      },
+    });
+    return { server, queued: queued.promise, served };
+  }
+
+  function receiveUntilClose(socket: net.Socket | nodeTls.TLSSocket) {
+    const received: Buffer[] = [];
+    let ended = false;
+    const closed = Promise.withResolvers<{ raw: Buffer; ended: boolean }>();
+    socket.on("data", chunk => received.push(chunk));
+    socket.on("end", () => (ended = true));
+    socket.on("error", closed.reject);
+    socket.on("close", () => closed.resolve({ raw: Buffer.concat(received), ended }));
+    return closed.promise;
+  }
+
+  // Decodes the first (chunked) response out of everything the client received
+  // and reports what followed its terminating chunk.
+  function decode(raw: Buffer, ended: boolean) {
+    const headEnd = raw.indexOf("\r\n\r\n");
+    const statusLine = raw.subarray(0, Math.max(headEnd, 0)).toString("latin1").split("\r\n")[0];
+    const body: Buffer[] = [];
+    let terminated = false;
+    let offset = headEnd + 4;
+    while (headEnd >= 0) {
+      const sizeEnd = raw.indexOf("\r\n", offset);
+      if (sizeEnd < 0) break;
+      const size = parseInt(raw.subarray(offset, sizeEnd).toString("latin1"), 16);
+      if (!(size >= 0) || sizeEnd + 2 + size + 2 > raw.length) break;
+      offset = sizeEnd + 2;
+      if (size === 0) {
+        terminated = raw.subarray(offset, offset + 2).toString("latin1") === "\r\n";
+        offset += 2;
+        break;
+      }
+      body.push(raw.subarray(offset, offset + size));
+      offset += size + 2;
+    }
+    const bodyBytes = Buffer.concat(body);
+    const afterBody = raw.subarray(offset).toString("latin1");
+    return {
+      statusLine,
+      bodyLength: bodyBytes.length,
+      bodyIsChunkData: bodyBytes.equals(Buffer.alloc(bodyBytes.length, "a")),
+      terminated,
+      // Keep a failure's diff readable when a truncated body ends up here.
+      afterBody: afterBody.length > 256 ? `${afterBody.slice(0, 64)}... (${afterBody.length} bytes)` : afterBody,
+      ended,
+    };
+  }
+
+  function expected(bodyLength: number, errorResponse: string) {
+    return {
+      statusLine: "HTTP/1.1 200 OK",
+      bodyLength,
+      bodyIsChunkData: true,
+      terminated: true,
+      afterBody: errorResponse,
+      ended: true,
+    };
+  }
+
+  // `socket` is connected and paused, so the server's bytes stay unread until
+  // `pipeline` has put the malformed request (and whatever else) on the wire.
+  async function exchange(
+    socket: net.Socket | nodeTls.TLSSocket,
+    queued: Promise<number>,
+    pipeline: () => Promise<void> | void,
+  ) {
+    const closed = receiveUntilClose(socket);
+    try {
+      socket.write(REQUEST);
+      const bodyLength = await queued;
+      await pipeline();
+      socket.resume();
+      const { raw, ended } = await closed;
+      return { received: decode(raw, ended), bodyLength };
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  it.each(Object.entries(MALFORMED))("%s", async (_, [malformedRequest, errorResponse]) => {
+    const { server, queued } = streamingServer();
+    using _server = server;
+    const socket = connect(server.port, "127.0.0.1");
+    socket.pause();
+    await new Promise<void>(r => socket.once("connect", () => r()));
+    const { received, bodyLength } = await exchange(socket, queued, () => {
+      socket.write(malformedRequest);
+    });
+    expect(received).toEqual(expected(bodyLength, errorResponse));
+  });
+
+  it("over TLS", async () => {
+    const [malformedRequest, errorResponse] = MALFORMED["400 from a malformed request-line"];
+    const { server, queued } = streamingServer({ tls });
+    using _server = server;
+    const socket = nodeTls.connect({ port: server.port, host: "127.0.0.1", rejectUnauthorized: false });
+    await new Promise<void>(r => socket.once("secureConnect", () => r()));
+    socket.pause();
+    const { received, bodyLength } = await exchange(socket, queued, () => {
+      socket.write(malformedRequest);
+    });
+    expect(received).toEqual(expected(bodyLength, errorResponse));
+  });
+
+  // Once the error response is queued, the connection is done with HTTP: a
+  // well-formed request that arrives while it is still draining is neither
+  // dispatched nor answered.
+  it("ignores a request that arrives while the error response is still draining", async () => {
+    const [malformedRequest, errorResponse] = MALFORMED["400 from a malformed request-line"];
+    const { server, queued, served } = streamingServer();
+    using _server = server;
+    const socket = connect(server.port, "127.0.0.1");
+    socket.pause();
+    await new Promise<void>(r => socket.once("connect", () => r()));
+    const { received, bodyLength } = await exchange(socket, queued, async () => {
+      socket.write(malformedRequest);
+      // The well-formed request has to reach the server in a read of its own
+      // (arriving together with the malformed line, it would be dropped along
+      // with it by the failed parse). A request on another connection, opened
+      // only now, cannot be answered before the server has taken the read that
+      // was already pending on this connection, so once it is answered the
+      // malformed line has been parsed by itself.
+      const barrier = await fetch(new URL("/barrier", server.url));
+      expect(await barrier.text()).toBe("ok");
+      socket.write(REQUEST);
+    });
+    expect({ ...received, served }).toEqual({ ...expected(bodyLength, errorResponse), served: ["/", "/barrier"] });
+  });
+
+  // Control: with nothing buffered ahead of it, the error response is answered
+  // and the connection closed right away, on both transports.
+  it.each([
+    ["http", false],
+    ["https", true],
+  ])("%s: nothing buffered ahead of the malformed request", async (_, secure) => {
+    const [malformedRequest, errorResponse] = MALFORMED["400 from a malformed request-line"];
+    let requests = 0;
+    using server = serve({
+      port: 0,
+      ...(secure ? { tls } : {}),
+      fetch() {
+        requests++;
+        return new Response("unreachable");
+      },
+    });
+    const socket = secure
+      ? nodeTls.connect({ port: server.port, host: "127.0.0.1", rejectUnauthorized: false })
+      : connect(server.port, "127.0.0.1");
+    await new Promise<void>(r => socket.once(secure ? "secureConnect" : "connect", () => r()));
+    const closed = receiveUntilClose(socket);
+    socket.write(malformedRequest);
+    const { raw, ended } = await closed;
+    expect({ response: raw.toString("latin1"), ended, requests }).toEqual({
+      response: errorResponse,
+      ended: true,
+      requests: 0,
+    });
+  });
+});
+
 // The node:http compat parser tolerates empty lines (and a bare CR/LF) before the
 // request-line like llhttp's s_start state. That leniency must stay behind the
 // node-http flag: Bun.serve still rejects a request that does not begin with the

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -4400,7 +4400,7 @@ describe("a malformed pipelined request does not truncate the buffered response 
   // with the body length once all of that has been handed to uWS, which is
   // before the test sends anything else on the connection. Any other path is
   // answered with a plain "ok"; `served` lists the paths dispatched so far.
-  function streamingServer(options: { tls?: typeof tls } = {}) {
+  function streamingServer(options: { tls?: typeof tls; idleTimeout?: number } = {}) {
     const queued = Promise.withResolvers<number>();
     const served: string[] = [];
     const server = serve({
@@ -4514,6 +4514,15 @@ describe("a malformed pipelined request does not truncate the buffered response 
     }
   }
 
+  // Resolves once the server has taken (and parsed) every read that was already
+  // pending when this is called: a request on a connection opened only now can
+  // only be read after its accept has been dispatched, and every read pending
+  // before that accept is dispatched no later than the accept itself.
+  async function serverHasParsedEverythingSentSoFar(server: Server) {
+    const barrier = await fetch(new URL("/barrier", server.url));
+    expect(await barrier.text()).toBe("ok");
+  }
+
   it.each(Object.entries(MALFORMED))("%s", async (_, [malformedRequest, errorResponse]) => {
     const { server, queued } = streamingServer();
     using _server = server;
@@ -4551,17 +4560,38 @@ describe("a malformed pipelined request does not truncate the buffered response 
     await new Promise<void>(r => socket.once("connect", () => r()));
     const { received, bodyLength } = await exchange(socket, queued, async () => {
       socket.write(malformedRequest);
-      // The well-formed request has to reach the server in a read of its own
-      // (arriving together with the malformed line, it would be dropped along
-      // with it by the failed parse). A request on another connection, opened
-      // only now, cannot be answered before the server has taken the read that
-      // was already pending on this connection, so once it is answered the
-      // malformed line has been parsed by itself.
-      const barrier = await fetch(new URL("/barrier", server.url));
-      expect(await barrier.text()).toBe("ok");
+      // Arriving in the same read as the malformed line, the well-formed
+      // request would simply be dropped with it by the failed parse; it has to
+      // arrive once that parse is over.
+      await serverHasParsedEverythingSentSoFar(server);
       socket.write(REQUEST);
     });
     expect({ ...received, served }).toEqual({ ...expected(bodyLength, errorResponse), served: ["/", "/barrier"] });
+  });
+
+  // With the error response queued, the connection is finished with HTTP. A
+  // graceful stop() therefore sweeps it like an idle keep-alive connection
+  // rather than waiting for a client that is not reading; idleTimeout is long
+  // enough that nothing else can close it within the test.
+  it("is swept by a graceful server.stop() while the error response drains", async () => {
+    const [malformedRequest] = MALFORMED["400 from a malformed request-line"];
+    const { server, queued } = streamingServer({ idleTimeout: 255 });
+    const socket = connect(server.port, "127.0.0.1");
+    socket.pause();
+    try {
+      await new Promise<void>(r => socket.once("connect", () => r()));
+      const closed = receiveUntilClose(socket);
+      socket.write(REQUEST);
+      await queued;
+      socket.write(malformedRequest);
+      await serverHasParsedEverythingSentSoFar(server);
+      await server.stop(false);
+      socket.resume();
+      expect((await closed).ended).toBe(true);
+    } finally {
+      server.stop(true);
+      socket.destroy();
+    }
   });
 
   // Control: with nothing buffered ahead of it, the error response is answered


### PR DESCRIPTION
### Problem
- On a `Bun.serve` keep-alive connection, a malformed request that arrives while the previous response still has bytes queued inside uWS truncates that response: the client receives part of the body, then `HTTP/1.1 400 Bad Request` (or 431/505) spliced into it, and the rest of the body, including the terminating chunk, never arrives.
- Cause: the parse-error path in `packages/bun-uws/src/HttpContext.h` (`onData`, around line 613 on main) writes the canned error response with a raw `us_socket_write()` and then closes the socket at once. `us_socket_write()` bypasses `AsyncSocketData::buffer`, where the previous response's unflushed tail sits, so the error response overtakes the tail, and the immediate close discards the tail.
- Reachable with a streaming response under backpressure: once the stream ends, the terminating chunk is queued into the buffer and the response is no longer pending, so the next bytes from the client are parsed while the buffer is still non-empty. Repro: stream a few MiB to a client that has not started reading, then send `GARBAGE\r\n\r\n` on the same connection and read.
- Found while working on #38128 (pre-existing, not fixed there). #35299 reshapes the same block (adds Date/Content-Length to the canned responses) but keeps the raw write and immediate close, so the two are independent; whichever lands second needs a trivial merge of these lines.

### Fix
- `HttpContext::writeHttpErrorAndClose()` writes the canned response through `AsyncSocket::write()` and uncorks, so it is queued behind whatever the buffer already holds. This is the line that fixes the ordering.
- If the buffer (or the TLS spill) is not empty afterwards and no response is in flight, the connection is marked `HTTP_CONNECTION_CLOSE` and left open; the existing `shouldCloseConnection()` gate in `onWritable` shuts it down once everything has flushed, and the idle timeout (re-armed here, refreshed by `onWritable` while draining) bounds a peer that stops reading. With nothing buffered the socket is shut down and closed right away, exactly as before.
- The deferred connection is also marked idle again (`onData` had marked it busy for the malformed bytes). A graceful `server.stop()` calls `App::closeIdle()`, which closes idle connections at once and waits for busy ones; without this, a client that sent junk and stopped reading would hold up `stop()` until the idle timeout (forever with `idleTimeout: 0`), where today the connection is closed immediately. This keeps the shutdown behavior unchanged and matches how a completed response with a buffered tail is already treated.
- A response still in flight (`HTTP_RESPONSE_PENDING`, i.e. the failing request's own body was malformed, or junk arrived mid-response) still closes at once: that response can no longer complete and its handler needs `onAborted`, which is also what the pipelining-while-pending path does today. Deferring there would let the handler keep writing behind the error response.
- While the error response drains, the connection must not parse anything else, or a well-formed request arriving behind the junk would be dispatched and would clear the close mark again. The node:http-only `HTTP_NODE_PARSING_STOPPED` already means exactly this, so it is renamed `HTTP_PARSING_STOPPED`, set here, and its check at the top of `onData` now runs for both instantiations (one bit test on a word `onData` touches anyway; the node:http tunnel exemption stays node-only, so node:http behavior is unchanged). The `onData` error path also balances the parsing `us_socket_ref` when the socket stays open, as the node:http branch above it does.
- Why this is correct: response bytes already accepted by `write()`/`end()` are owed to the client, and the buffer plus the drain gate are the mechanisms uWS already uses to honour that for `Connection: close` responses and for a peer FIN (`onEnd`); the error response is just one more message that has to take its turn in the same queue. The canned responses carry `Connection: close` and no body framing, so closing after they flush is also what makes them well-formed for the client.
- Tests (`test/js/bun/http/serve.test.ts`, describe `a malformed pipelined request does not truncate the buffered response ahead of it`): 400/431/505 over http, 400 over https, a well-formed request sent while the error response is draining (must not be dispatched, connection must still close), a graceful `server.stop()` while it is draining (must sweep the connection rather than wait), plus control cases with nothing buffered on both transports. The five buffered-tail cases fail on the released build (2 of 4 MiB received, no terminating chunk) and pass with this change; the "still draining" case also fails if only the parsing-stopped bit is dropped (the follow-up request gets served and the connection never closes), and the `stop()` case fails if only the idle mark is dropped (`stop()` never resolves); the `stop()` case and the controls pass before and after, since the released build closes the connection immediately.
- Also run on this build: the rest of `serve.test.ts`, `request-smuggling.test.ts`, `http-server-chunking.test.ts`, `node-http-transfer-encoding.test.ts`, `node-http.test.ts`, `node-http-server-timeouts.test.ts`, `bun-server.test.ts`, `serve-direct-readable-stream.test.ts`, and the node `test-http-*client-error*`, `*max-header*`, `*invalid-te*`, `*double-content-length*`, `*reject-cr-no-lf*`, `*parser-finish-error*` parallel tests. The only failures (IPv6, root port range, a proxy test, two sandbox-dependent `bun-server` cases) fail identically with the released binary in this container.

### Background
- `AsyncSocket` (`packages/bun-uws/src/AsyncSocket.h`) is uWS's layer over a uSockets socket. `write()` tries the kernel first and appends whatever the kernel did not take to the per-socket `AsyncSocketData::buffer`; `onWritable` flushes that buffer later. Bytes in it are already "written" from the application's point of view. `us_socket_write()` is the layer underneath and knows nothing about that buffer.
- Corking: `onData` corks the socket before parsing, so small writes made during the dispatch collect in a per-loop cork buffer and are handed to the socket on `uncork()`. The helper uncorks before deciding anything because `hasFullyDrained()` does not see the cork buffer, and a socket that has been shut down refuses writes.
- `hasFullyDrained()` is true when the buffer is empty and, for TLS, no ciphertext is parked in the loop's spill slot. It is what the existing close-after-drain gates (`HttpResponse::closeIfDoneAndMarked`, `onWritable`, `onEnd`) use, and `shouldCloseConnection()` is the predicate those gates test; `HTTP_CONNECTION_CLOSE` is its normal input (a `Connection: close` request sets the same bit).
- `HttpResponseData::state` holds per-response bits that `resetResponseState()` clears when a new request is dispatched, plus connection-scoped bits that survive it; `HTTP_PARSING_STOPPED` is connection-scoped, which is why it (and not `HTTP_CONNECTION_CLOSE` alone) can keep a later request from reopening the connection.
- `HttpContext::onData` is instantiated twice, for `Bun.serve` and for node:http compat (`IsNodeHttp`). node:http hands parse errors to JS (`'clientError'`) and is not affected by this bug; the block changed here is the `Bun.serve` one.

<details>
<summary>Repro output (released build vs this change)</summary>

Released build, 3 MiB streamed body followed by `GARBAGE\r\n\r\n` on the same connection:

```
server queued 3 MiB; backpressure observed: true
total bytes received: 2621579 (expected body 3145728)
terminating chunk found: false; error response at offset 2621532 of 2621579
body truncated
```

This change:

```
server queued 3 MiB; backpressure observed: true
total bytes received: 3145934
terminating chunk found: true; error response immediately after the terminating chunk, then FIN
```
</details>
