### PR TITLE
run, install: honor --no-env-file / --env-file for scripts run through the bun exec hop

### DIFF
--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -247,6 +247,53 @@ pub fn replace_package_manager_run(
     Ok(())
 }
 
+/// argv for spawning a package.json script: `<shell> -c <script>` with the
+/// POSIX shell the caller found, otherwise (always on Windows)
+/// `bun exec --no-env-file <script>`.
+///
+/// The envp the caller spawns with is the script's entire environment either
+/// way: `sh` adds nothing to it, and `--no-env-file` keeps `bun exec` from
+/// loading the `.env*` files in the script's cwd on top of it.
+pub struct ScriptArgv<'a> {
+    /// Elements are bare nullable pointers (an `Option<*const c_char>` would
+    /// not be one word each); terminated by a null after the last argument,
+    /// which for the shell form is one slot early.
+    argv: [*const c_char; 5],
+    _borrowed: core::marker::PhantomData<&'a ZStr>,
+}
+
+impl<'a> ScriptArgv<'a> {
+    pub fn new(shell: Option<&'a ZStr>, script: &'a ZStr) -> Result<Self, crate::Error> {
+        // `find_shell` yields cmd.exe on Windows, which does not take `-c`.
+        let argv = match shell {
+            Some(shell) if cfg!(unix) => [
+                shell.as_ptr(),
+                c"-c".as_ptr(),
+                script.as_ptr(),
+                core::ptr::null(),
+                core::ptr::null(),
+            ],
+            _ => [
+                bun_core::self_exe_path()?.as_ptr(),
+                c"exec".as_ptr(),
+                c"--no-env-file".as_ptr(),
+                script.as_ptr(),
+                core::ptr::null(),
+            ],
+        };
+        Ok(Self {
+            argv,
+            _borrowed: core::marker::PhantomData,
+        })
+    }
+
+    /// The null-terminated array `spawn_process` takes; valid while `self`
+    /// (and the strings it borrows) is.
+    pub fn as_ptr(&self) -> *const *const c_char {
+        self.argv.as_ptr()
+    }
+}
+
 pub struct LifecycleScriptSubprocess<'a> {
     pub(crate) package_name: Box<[u8]>,
 
@@ -536,9 +583,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             replace_package_manager_run(&mut copy_script, original_script)?;
             copy_script.push(0);
 
-            // SAFETY: we just pushed a NUL byte at copy_script[len-1]; slice [..len-1] is the body.
-            let combined_script: &mut ZStr =
-                ZStr::from_raw_mut(copy_script.as_mut_ptr(), copy_script.len() - 1);
+            let combined_script: &ZStr = ZStr::from_slice_with_nul(&copy_script);
 
             if (*this).foreground && (*manager).options.log_level != crate::LogLevel::Silent {
                 Output::command(Output::CommandArgv::Single(combined_script.as_bytes()));
@@ -564,29 +609,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 bstr::BStr::new(combined_script.as_bytes())
             );
 
-            // `[_]?[*:0]const u8` argv array with trailing null. Element type MUST be
-            // bare `*const c_char` (null sentinel), never `Option<*const c_char>` —
-            // raw pointers are already nullable, and `Option<*const T>` is a 2-word
-            // (tag, ptr) pair, not niche-optimized. Casting a `[Option<*const c_char>; N]`
-            // to `Argv` would interleave discriminant words and EFAULT in the kernel.
-            let mut argv: [*const c_char; 4] = if (*this).shell_bin.is_some() && !cfg!(windows) {
-                [
-                    (*this).shell_bin.unwrap().as_ptr().cast::<c_char>(),
-                    c"-c".as_ptr(),
-                    combined_script.as_ptr().cast::<c_char>(),
-                    core::ptr::null(),
-                ]
-            } else {
-                [
-                    bun_core::self_exe_path()?.as_ptr().cast::<c_char>(),
-                    c"exec".as_ptr(),
-                    combined_script.as_ptr().cast::<c_char>(),
-                    core::ptr::null(),
-                ]
-            };
-            const _: () = assert!(
-                core::mem::size_of::<[*const c_char; 4]>() == 4 * core::mem::size_of::<usize>()
-            );
+            let argv = ScriptArgv::new((*this).shell_bin, combined_script)?;
 
             // OWNERSHIP:
             // `bun_io::Source::Pipe` owns a `Box<uv::Pipe>` AND
@@ -666,9 +689,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 .insert(this.cast::<LifecycleScriptSubprocess<'static>>());
             let spawned = match bun_spawn::spawn_process(
                 &spawn_options,
-                // argv is `[*const c_char; 4]` with trailing null — exactly the
-                // `[*:null]?[*:0]const u8` layout `spawn_process` expects (1 word/elt).
-                argv.as_mut_ptr().cast(),
+                argv.as_ptr(),
                 (*this).envp.as_ptr().cast::<*const c_char>(),
             ) {
                 Ok(Ok(s)) => s,

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -14,6 +14,7 @@ use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
 use bun_event_loop::EventLoopHandle;
 use bun_event_loop::MiniEventLoop::{self as MiniEventLoopMod, MiniEventLoop};
+use bun_install::lifecycle_script_runner::ScriptArgv;
 use bun_io::{BufferedReader, ReadState};
 use bun_resolver::package_json::{IncludeDependencies, IncludeScripts};
 use bun_sys as sys;
@@ -92,16 +93,7 @@ impl<'a> ProcessHandle<'a> {
         state.remaining_scripts += 1;
         let handle = self;
 
-        let argv: [*const c_char; 4] = [
-            state.shell_bin.as_ptr().cast(),
-            if cfg!(unix) {
-                c"-c".as_ptr()
-            } else {
-                c"exec".as_ptr()
-            },
-            handle.config.combined.as_ptr().cast(),
-            core::ptr::null(),
-        ];
+        let argv = ScriptArgv::new(state.shell_bin, handle.config.combined)?;
         handle.start_time = Some(Instant::now());
         let spawned: spawn::SpawnProcessResult = 'brk: {
             // Get the envp with the PATH configured
@@ -123,8 +115,8 @@ impl<'a> ProcessHandle<'a> {
             }
             // SAFETY: see above; reborrow through raw ptr to avoid overlapping &mut with guard.
             let envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
-            // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
-            // with argv[0] non-null; valid for this call.
+            // SAFETY: `argv` and `envp` are null-terminated C-string arrays
+            // (argv[0] non-null) owned by locals that outlive this call.
             break 'brk unsafe {
                 spawn::spawn_process(
                     &handle.options,
@@ -325,7 +317,8 @@ struct State<'a> {
     draw_buf: Vec<u8>,
     last_lines_written: usize,
     pretty_output: bool,
-    shell_bin: &'static ZStr, // intentionally leaked (process exits)
+    /// POSIX shell the scripts run under; `None` on Windows (see `ScriptArgv`).
+    shell_bin: Option<&'static ZStr>,
     aborted: bool,
     // Raw `*mut` — process-lifetime singleton owned
     // by Transpiler; ProcessHandle::start mutates `env.map` (PATH swap) so a
@@ -966,20 +959,16 @@ pub(crate) fn run_scripts_with_filter(
     bun_io::ParentDeathWatchdog::install_on_event_loop(MiniEventLoop::as_event_loop_ctx(unsafe {
         &mut *event_loop
     }));
-    let shell_bin: &'static ZStr = {
-        #[cfg(unix)]
-        {
-            RunCommand::find_shell(
-                // SAFETY: env_ptr is the live process-lifetime DotEnv loader.
-                unsafe { (*env_ptr).get(b"PATH") }.unwrap_or(b""),
-                fsinstance.top_level_dir,
-            )
-            .ok_or(crate::Error::MissingShell)?
-        }
-        #[cfg(not(unix))]
-        {
-            bun_core::self_exe_path().map_err(|_| crate::Error::MissingShell)?
-        }
+    let shell_bin: Option<&'static ZStr> = if cfg!(unix) {
+        let shell = RunCommand::find_shell(
+            // SAFETY: env_ptr is the live process-lifetime DotEnv loader.
+            unsafe { (*env_ptr).get(b"PATH") }.unwrap_or(b""),
+            fsinstance.top_level_dir,
+        )
+        .ok_or(crate::Error::MissingShell)?;
+        Some(shell)
+    } else {
+        None
     };
 
     let handles: Box<[ProcessHandle]> = Vec::with_capacity(scripts.len()).into();

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -6,9 +6,10 @@ use std::time::Instant;
 use crate::Error;
 use bun_collections::{StringArrayHashMap, VecExt};
 use bun_core::strings;
-use bun_core::{self as bun, Global, Output, UnwrapOrOom};
+use bun_core::{self as bun, Global, Output, UnwrapOrOom, ZStr};
 use bun_event_loop::EventLoopHandle;
 use bun_event_loop::MiniEventLoop::MiniEventLoop;
+use bun_install::lifecycle_script_runner::ScriptArgv;
 use bun_io::BufferedReader;
 use bun_paths::{self as path, PathBuffer};
 use bun_resolver::package_json::{IncludeDependencies, IncludeScripts};
@@ -143,17 +144,10 @@ impl<'a> ProcessHandle<'a> {
         let state = unsafe { &mut *self.state.cast_mut() };
         state.remaining_scripts += 1;
 
-        // Null-terminated argv array, as required by spawnProcess.
-        let argv: [*const c_char; 4] = [
-            state.shell_bin.as_ptr().cast::<c_char>(),
-            if cfg!(unix) {
-                c"-c".as_ptr()
-            } else {
-                c"exec".as_ptr()
-            },
-            self.config.command.as_ptr().cast::<c_char>(),
-            ptr::null(),
-        ];
+        let argv = ScriptArgv::new(
+            state.shell_bin,
+            ZStr::from_slice_with_nul(&self.config.command),
+        )?;
 
         self.start_time = Instant::now().into();
         let envp;
@@ -169,8 +163,8 @@ impl<'a> ProcessHandle<'a> {
             });
             // SAFETY: same loader; the `_restore` guard's closure has not fired yet.
             envp = unsafe { (*env_ptr).map.create_null_delimited_env_map()? };
-            // SAFETY: `argv`/`envp` are local null-terminated C-string arrays
-            // with argv[0] non-null; valid for this call.
+            // SAFETY: `argv` and `envp` are null-terminated C-string arrays
+            // (argv[0] non-null) owned by locals that outlive this call.
             unsafe {
                 spawn::spawn_process(
                     &self.options,
@@ -349,8 +343,8 @@ struct State<'a> {
     event_loop_handle: EventLoopHandle,
     remaining_scripts: usize,
     max_label_len: usize,
-    // NUL-terminated (last byte is 0) for argv[0].
-    shell_bin: Box<[u8]>,
+    /// POSIX shell the scripts run under; `None` on Windows (see `ScriptArgv`).
+    shell_bin: Option<&'static ZStr>,
     aborted: bool,
     no_exit_on_error: bool,
     env: *mut DotEnvLoader,
@@ -899,22 +893,14 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     bun_io::ParentDeathWatchdog::install_on_event_loop(event_loop_handle_to_ctx(
         EventLoopHandle::init_mini(event_loop),
     ));
-    // shell_bin is NUL-terminated ([:0]const u8) for argv use.
-    let shell_bin: Box<[u8]> = if cfg!(unix) {
+    let shell_bin: Option<&'static ZStr> = if cfg!(unix) {
         // SAFETY: env_ptr is the process-lifetime DotEnv loader; the &mut borrow passed to
         // init_global above has been released, so this read does not alias a live &mut.
         let path_env = unsafe { (*env_ptr).get(b"PATH") }.unwrap_or(b"");
-        Box::from(
-            RunCommand::find_shell(path_env, cwd)
-                .ok_or(crate::Error::MissingShell)?
-                .as_bytes_with_nul(),
-        )
+        let shell = RunCommand::find_shell(path_env, cwd).ok_or(crate::Error::MissingShell)?;
+        Some(shell)
     } else {
-        Box::from(
-            bun::self_exe_path()
-                .map_err(|_| crate::Error::MissingShell)?
-                .as_bytes_with_nul(),
-        )
+        None
     };
 
     // Build ScriptConfigs and ProcessHandles

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -299,6 +299,34 @@ test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a r
   expect(distance > 21_600_000_000_000n).toBe(true);
 });
 
+// The environment `bun install` built is all a lifecycle script gets. On
+// Windows (and on POSIX without a shell) the script runs through `bun exec`,
+// which used to load the .env* files of the script's own directory on top of
+// that, so a workspace package's .env reached its scripts there and nowhere else.
+test.concurrent("lifecycle scripts do not get the .env files of the package directory", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  const pkgDir = join(packageDir, "packages", "pkg1");
+
+  await mkdir(pkgDir, { recursive: true });
+  await Promise.all([
+    writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", workspaces: ["packages/*"] })),
+    writeFile(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        version: "1.0.0",
+        scripts: { postinstall: "echo PKG_DOTENV=$PKG_DOTENV INHERITED=$LIFECYCLE_INHERITED > seen.txt" },
+      }),
+    ),
+    writeFile(join(pkgDir, ".env"), "PKG_DOTENV=leaked"),
+  ]);
+
+  await runBunInstall({ ...env, PKG_DOTENV: undefined, LIFECYCLE_INHERITED: "from-install" }, packageDir);
+
+  expect((await file(join(pkgDir, "seen.txt")).text()).trim()).toBe("PKG_DOTENV= INHERITED=from-install");
+});
+
 test.concurrent("default trusted dependencies require the canonical registry tarball URL", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -773,6 +773,98 @@ describe.skipIf(!isWindows).each([
   );
 });
 
+// The script runner never passes the default .env* files into package.json
+// scripts (see "does not pass variables from .env files into scripts" in
+// env.test.ts): the script's own bun instance loads them, so a script such as
+// `NODE_ENV=production bun start` reads .env.production and not the
+// .env.development the runner would have picked (#9635). The environment the
+// runner did build is passed as envp, which on POSIX goes straight to `sh -c`.
+// On Windows `--filter` / `--parallel` go through a `bun exec` hop, which used
+// to auto-load the package directory's .env* files on top of envp, ignoring
+// the --no-env-file / --env-file given to the runner.
+describe.each([
+  { via: "--filter", argv: (script: string) => ["--filter", "app", script], cwd: (root: string) => root },
+  {
+    via: "run --parallel",
+    argv: (script: string) => ["--parallel", script],
+    cwd: (root: string) => join(root, "packages", "app"),
+  },
+])("$via: scripts only see the environment the runner built", ({ argv, cwd }) => {
+  function workspace() {
+    return tempDir("filter-env-files", {
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        scripts: {
+          "show-env": "echo ENV_FILE_NAME=$ENV_FILE_NAME CUSTOM=$CUSTOM_VAR INHERITED=$INHERITED_VAR",
+          "show-env-prod": `NODE_ENV=production "${bunExe()}" show-env.js`,
+        },
+      }),
+      "packages/app/show-env.js": `
+        const { ENV_FILE_NAME = "", CUSTOM_VAR = "", INHERITED_VAR = "" } = process.env;
+        console.log("ENV_FILE_NAME=" + ENV_FILE_NAME + " CUSTOM=" + CUSTOM_VAR + " INHERITED=" + INHERITED_VAR);
+      `,
+      // Whichever NODE_ENV the test runner itself is under, one of these is in
+      // the default set, so auto-loading shows up as a non-empty ENV_FILE_NAME.
+      "packages/app/.env": "ENV_FILE_NAME=.env",
+      "packages/app/.env.development": "ENV_FILE_NAME=.env.development",
+      "packages/app/.env.production": "ENV_FILE_NAME=.env.production",
+      "packages/app/.env.test": "ENV_FILE_NAME=.env.test",
+      "packages/app/.env.custom": "CUSTOM_VAR=from-custom",
+    });
+  }
+
+  async function run(root: string, runnerFlags: string[], script = "show-env") {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", ...runnerFlags, ...argv(script)],
+      cwd: cwd(root),
+      env: { ...bunEnv, ENV_FILE_NAME: undefined, CUSTOM_VAR: undefined, INHERITED_VAR: "from-parent" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const line = stdout.match(/ENV_FILE_NAME=(\S*) CUSTOM=(\S*) INHERITED=(\S*)/);
+    if (!line) throw new Error(`script output missing.\nstdout: ${stdout}\nstderr: ${stderr}`);
+    return { envFile: line[1], custom: line[2], inherited: line[3], exitCode };
+  }
+
+  test.concurrent("the package directory's .env* files are not loaded", async () => {
+    using dir = workspace();
+    expect(await run(String(dir), [])).toEqual({ envFile: "", custom: "", inherited: "from-parent", exitCode: 0 });
+  });
+
+  test.concurrent("--no-env-file", async () => {
+    using dir = workspace();
+    expect(await run(String(dir), ["--no-env-file"])).toEqual({
+      envFile: "",
+      custom: "",
+      inherited: "from-parent",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("--env-file loads only the requested file", async () => {
+    using dir = workspace();
+    const envFile = join(String(dir), "packages", "app", ".env.custom");
+    expect(await run(String(dir), ["--env-file", envFile])).toEqual({
+      envFile: "",
+      custom: "from-custom",
+      inherited: "from-parent",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("a script that sets its own NODE_ENV gets the matching .env file (#9635)", async () => {
+    using dir = workspace();
+    expect(await run(String(dir), [], "show-env-prod")).toEqual({
+      envFile: ".env.production",
+      custom: "",
+      inherited: "from-parent",
+      exitCode: 0,
+    });
+  });
+});
+
 describe("output timing", () => {
   // A script is finished when its process exits: output it already wrote is
   // drained at that point, but a detached child still holding the pipe write


### PR DESCRIPTION
### Problem

- Bun has three places that spawn a package.json script through a `bun exec "<script>"` hop instead of `sh -c "<script>"`: `bun run --filter` (`src/runtime/cli/filter_run.rs`), `bun run --parallel` / `--sequential` (`src/runtime/cli/multi_run.rs`), and `bun install` lifecycle scripts (`src/install/lifecycle_script_runner.rs`). The first two take the hop on every Windows spawn; lifecycle scripts take it on Windows and on POSIX systems with no shell.
- `bun exec` is an ordinary runtime command: `src/runtime/cli/exec_command.rs:54` runs the default `.env*` auto-load in its cwd (the package directory) on top of the envp it was handed, and only a `--no-env-file` on its own argv turns that off.
- Result, wherever the hop is taken:
  - scripts see the package directory's `.env` / `.env.<NODE_ENV>` / `.env.local`; for `bun install` that includes every workspace member's own `.env` reaching its `postinstall`;
  - `bun run --no-env-file --filter ...` still exposes them, and `--env-file X` gets the default files layered in underneath;
  - a script such as `NODE_ENV=production bun start` is pre-seeded with the `.env.development` values picked by the runner's NODE_ENV, so the bun it starts cannot read `.env.production`. This is #9635, which #9689 fixed for the script runner; the hop reintroduces it.
- Plain `bun run <script>` on Windows is not affected: it runs the script in-process with the runner's env map, which deliberately skips the default files (`run_command.rs:674`). `test/cli/run/env.test.ts` ("does not pass variables from .env files into scripts") pins that for both shells on every platform; the three hop sites were the only paths that did not follow it.

<details><summary>bun 1.4.0 on Windows x64 (fixtures from the tests; Linux prints an empty value in every case)</summary>

```
> bun run --filter app show-env
app show-env: ENV_FILE_NAME=.env.local CUSTOM= INHERITED=inherited
> bun run --no-env-file --filter app show-env
app show-env: ENV_FILE_NAME=.env.local CUSTOM= INHERITED=inherited
> bun run --env-file packages/app/.env.custom --filter app show-env
app show-env: ENV_FILE_NAME=.env.local CUSTOM=custom INHERITED=inherited
> cd packages/app && bun run --parallel show-env
show-env | ENV_FILE_NAME=.env.local CUSTOM= INHERITED=inherited
> bun run show-env
ENV_FILE_NAME= CUSTOM= INHERITED=inherited

> bun install        (workspace member pkg1 has .env with PKG_DOTENV=leaked and a postinstall that echoes it)
packages/pkg1/seen.txt: PKG_DOTENV=leaked INHERITED=from-install
```

</details>

### Fix

- New `ScriptArgv` in `lifecycle_script_runner.rs` (next to `replace_package_manager_run`, the helper these same three callers already share; `bun_install` is the lower crate) builds the argv: `<shell> -c <script>` when the caller found a POSIX shell, otherwise `bun exec --no-env-file <script>`. All three spawn sites use it, so the rule lives in one place.
- Why `--no-env-file` is right: at every site the envp passed to the spawn already is the environment the runner or installer decided on (process env plus any `--env-file` files for `bun run`; the installer's script env for lifecycle scripts). The hop exists only to be the shell, the role `sh` plays on POSIX, so it must add nothing; `--no-env-file` is the existing flag that makes `bun exec` use envp alone. `--env-file` values still arrive because they are in envp; a nested `NODE_ENV=production bun` reads its own files because nothing was pre-seeded. `bun exec` already accepts the flag (`BASE_PARAMS_`, `src/runtime/cli/Arguments.rs:98`) and the script stays `positionals[1]`.
- `filter_run.rs` / `multi_run.rs` now hold `Option<&ZStr>` for the shell (`None` on Windows) instead of resolving bun's own path as a fake shell up front; the helper resolves it when building argv, as the lifecycle runner always did. POSIX behavior is unchanged: both still fail with `MissingShell` when no shell is found.
- Overlap: #36672 (install env flags) carries the same `--no-env-file` for the lifecycle hop; whichever lands second has a small conflict in that one hunk.
- Verified:
  - `test/cli/run/filter-workspace.test.ts`: new `describe.each` over `--filter` and `run --parallel`, four cases each: defaults not loaded, `--no-env-file`, `--env-file` (requested file and inherited variables arrive, defaults do not), and the #9635 shape (script sets `NODE_ENV=production`, must see `.env.production`). Windows x64: 8 fail with bun 1.4.0 (`ENV_FILE_NAME=.env.development` in every case), 8 pass with this branch.
  - `test/cli/install/bun-install-lifecycle-scripts.test.ts`: a workspace member's `postinstall` must not see the member's `.env` while an inherited variable still arrives. Windows x64: fails with bun 1.4.0 (`PKG_DOTENV=leaked`), passes with this branch.
  - On Linux these cases pass before and after (a shell is always found there, so the hop is never taken); they pin the contract. The fail-before for this change is Windows-only by construction.
  - Also green on this branch: `filter-workspace.test.ts`, `multi-run.test.ts`, and `bun-install-lifecycle-scripts.test.ts` on Linux and Windows x64; `run-quote.test.ts` and `no-orphans.test.ts` on Windows x64.

### Background

- Default `.env*` loading: `dot_env::Loader::load` (`src/dotenv/env_loader.rs:649`) reads `.env`, `.env.<suffix>` (suffix from NODE_ENV) and `.env.local` from a directory unless asked to skip the defaults; `--no-env-file` asks for that skip; files named with `--env-file` are loaded either way. Values from these files never override variables already present in the process environment.
- Script runner rule: `RunCommand::configure_env_for_run` loads the process env and the `--env-file` files and skips the defaults, so a `.env*` value reaches a script only through a bun the script itself starts, which reads the files for the script's own NODE_ENV. Because process env wins over files, anything pre-seeded into the script's environment is something that nested bun can no longer correct; that is what #9635 was.
- The hop: there is no `sh` on Windows, so these runners use bun itself as the shell by spawning `bun exec <script>`, which interprets the script with Bun's shell. Unlike `sh`, `bun exec` runs the runtime's env setup in its cwd before interpreting anything. `find_shell` returns `cmd.exe` on Windows, which is why the helper keys the shell form on `cfg!(unix)` as the lifecycle runner did before.
- envp: the environment block passed to the spawned process. `filter_run` / `multi_run` rebuild it per script from the runner's env map with PATH adjusted per package; the lifecycle runner builds it once per script chain from the installer's env.
