### PR TITLE
Bun.write: throw ERR_BODY_ALREADY_USED for a consumed Response/Request source instead of truncating the destination

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5059,10 +5059,6 @@ pub(crate) fn write_file_internal(
         // `as_class_ref` is the safe shared-borrow downcast (one audited unsafe
         // in `JSValue`); `get_body_value` / `get_body_readable_stream` both
         // take `&self` (interior mutability for the body cell).
-        //
-        // Consumed bodies are rejected before dispatch: `use_()` on a `Used` body
-        // yields an empty blob (the write would truncate the destination), and a
-        // drained stream would wait in the Locked arm for a producer that is gone.
         if let Some(response) = data.as_class_ref::<Response>() {
             response.throw_if_body_unusable(global_this)?;
             let bv = std::ptr::from_mut(response.get_body_value());

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -21,7 +21,7 @@ use bun_http_types::MimeType::MimeType;
 use bun_jsc::{EncodedSliceJsc as _, StringJsc as _, bun_string_jsc};
 use bun_sys::{self, Fd};
 
-use crate::webcore::body::BodyMixin as _;
+use crate::webcore::body::BodyMixin;
 use crate::webcore::node_types::{PathLike, PathOrBlob, PathOrFileDescriptor};
 use crate::webcore::s3 as S3;
 use crate::webcore::{self, Lifetime, ReadableStream, Request, Response, streams};
@@ -4775,6 +4775,23 @@ pub(crate) fn write_file_with_source_destination(
 // writeFileInternal / writeFile (Bun.write)
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Throws `ERR_BODY_ALREADY_USED` for a `Response`/`Request` source whose body is consumed.
+fn throw_if_body_consumed<T: BodyMixin>(global_this: &JSGlobalObject, owner: &T) -> JsResult<()> {
+    owner.throw_if_body_unusable(global_this)?;
+    if let webcore::body::Value::Locked(locked) = owner.get_body_value() {
+        // Set by an earlier write (or the server) that is still waiting for the bytes.
+        if locked.on_receive_value.is_some() {
+            return Err(global_this
+                .err(
+                    jsc::ErrorCode::BODY_ALREADY_USED,
+                    format_args!("Body already used"),
+                )
+                .throw());
+        }
+    }
+    Ok(())
+}
+
 /// ## Errors
 /// - If `path_or_blob` is a detached blob
 /// ## Panics
@@ -5060,7 +5077,7 @@ pub(crate) fn write_file_internal(
         // in `JSValue`); `get_body_value` / `get_body_readable_stream` both
         // take `&self` (interior mutability for the body cell).
         if let Some(response) = data.as_class_ref::<Response>() {
-            response.throw_if_body_unusable(global_this)?;
+            throw_if_body_consumed(global_this, response)?;
             let bv = std::ptr::from_mut(response.get_body_value());
             match body_dispatch(bv, &mut || response.get_body_readable_stream())? {
                 core::ops::ControlFlow::Break(v) => return Ok(v),
@@ -5069,7 +5086,7 @@ pub(crate) fn write_file_internal(
         }
 
         if let Some(request) = data.as_class_ref::<Request>() {
-            request.throw_if_body_unusable(global_this)?;
+            throw_if_body_consumed(global_this, request)?;
             let bv = std::ptr::from_mut(request.get_body_value());
             match body_dispatch(bv, &mut || request.get_body_readable_stream())? {
                 core::ops::ControlFlow::Break(v) => return Ok(v),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -21,6 +21,7 @@ use bun_http_types::MimeType::MimeType;
 use bun_jsc::{EncodedSliceJsc as _, StringJsc as _, bun_string_jsc};
 use bun_sys::{self, Fd};
 
+use crate::webcore::body::BodyMixin as _;
 use crate::webcore::node_types::{PathLike, PathOrBlob, PathOrFileDescriptor};
 use crate::webcore::s3 as S3;
 use crate::webcore::{self, Lifetime, ReadableStream, Request, Response, streams};
@@ -5058,7 +5059,13 @@ pub(crate) fn write_file_internal(
         // `as_class_ref` is the safe shared-borrow downcast (one audited unsafe
         // in `JSValue`); `get_body_value` / `get_body_readable_stream` both
         // take `&self` (interior mutability for the body cell).
+        //
+        // A consumed body must be rejected before dispatch: `use_()` turns a
+        // `Used` body into an empty blob, which would replace the destination
+        // with 0 bytes and resolve 0, and a drained stream has no producer
+        // left to settle the locked-body wait.
         if let Some(response) = data.as_class_ref::<Response>() {
+            response.throw_if_body_unusable(global_this)?;
             let bv = std::ptr::from_mut(response.get_body_value());
             match body_dispatch(bv, &mut || response.get_body_readable_stream())? {
                 core::ops::ControlFlow::Break(v) => return Ok(v),
@@ -5067,6 +5074,7 @@ pub(crate) fn write_file_internal(
         }
 
         if let Some(request) = data.as_class_ref::<Request>() {
+            request.throw_if_body_unusable(global_this)?;
             let bv = std::ptr::from_mut(request.get_body_value());
             match body_dispatch(bv, &mut || request.get_body_readable_stream())? {
                 core::ops::ControlFlow::Break(v) => return Ok(v),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5060,10 +5060,9 @@ pub(crate) fn write_file_internal(
         // in `JSValue`); `get_body_value` / `get_body_readable_stream` both
         // take `&self` (interior mutability for the body cell).
         //
-        // A consumed body must be rejected before dispatch: `use_()` turns a
-        // `Used` body into an empty blob, which would replace the destination
-        // with 0 bytes and resolve 0, and a drained stream has no producer
-        // left to settle the locked-body wait.
+        // Consumed bodies are rejected before dispatch: `use_()` on a `Used` body
+        // yields an empty blob (the write would truncate the destination), and a
+        // drained stream would wait in the Locked arm for a producer that is gone.
         if let Some(response) = data.as_class_ref::<Response>() {
             response.throw_if_body_unusable(global_this)?;
             let bv = std::ptr::from_mut(response.get_body_value());

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1811,11 +1811,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         JSValue::from(self.body_stream_check(global_object, ReadableStream::is_disturbed))
     }
 
-    /// Throw a `TypeError` when "this is unusable", i.e. the body is non-null
-    /// and its stream is disturbed or locked
-    /// (<https://fetch.spec.whatwg.org/#body-unusable>). Step 1 of both
-    /// `clone()` algorithms; also the entry check for native consumers of a
-    /// whole body such as `Bun.write(dest, response)`.
+    /// Throw a `TypeError` when "this is unusable": the body is non-null and its
+    /// stream is disturbed or locked. <https://fetch.spec.whatwg.org/#body-unusable>
     fn throw_if_body_unusable(&self, global_object: &JSGlobalObject) -> JsResult<()> {
         let unusable =
             self.body_stream_check(global_object, |s, g| s.is_disturbed(g) || s.is_locked(g));

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1811,8 +1811,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         JSValue::from(self.body_stream_check(global_object, ReadableStream::is_disturbed))
     }
 
-    /// Throw a `TypeError` when "this is unusable": the body is non-null and its
-    /// stream is disturbed or locked. <https://fetch.spec.whatwg.org/#body-unusable>
+    /// Fetch spec step 1 of both `clone()` algorithms: throw a `TypeError`
+    /// when "this is unusable", i.e. the body is non-null and its stream is
+    /// disturbed or locked. <https://fetch.spec.whatwg.org/#body-unusable>
     fn throw_if_body_unusable(&self, global_object: &JSGlobalObject) -> JsResult<()> {
         let unusable =
             self.body_stream_check(global_object, |s, g| s.is_disturbed(g) || s.is_locked(g));

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1811,9 +1811,11 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         JSValue::from(self.body_stream_check(global_object, ReadableStream::is_disturbed))
     }
 
-    /// Fetch spec step 1 of both `clone()` algorithms: throw a `TypeError`
-    /// when "this is unusable", i.e. the body is non-null and its stream is
-    /// disturbed or locked. <https://fetch.spec.whatwg.org/#body-unusable>
+    /// Throw a `TypeError` when "this is unusable", i.e. the body is non-null
+    /// and its stream is disturbed or locked
+    /// (<https://fetch.spec.whatwg.org/#body-unusable>). Step 1 of both
+    /// `clone()` algorithms; also the entry check for native consumers of a
+    /// whole body such as `Bun.write(dest, response)`.
     fn throw_if_body_unusable(&self, global_object: &JSGlobalObject) -> JsResult<()> {
         let unusable =
             self.body_stream_check(global_object, |s, g| s.is_disturbed(g) || s.is_locked(g));

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -852,7 +852,9 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
           const resp = await fetch(\`http://127.0.0.1:\${server.port}/\`);
           ${expose}
           await Bun.sleep(5);
-          await Promise.race([Bun.write(${out}, resp).catch(() => {}), Bun.sleep(100)]);
+          // A disturbed body throws synchronously now; this test is about the
+          // heap-use-after-free only, not the rejection, so swallow both paths.
+          try { await Promise.race([Bun.write(${out}, resp), Bun.sleep(100)]); } catch {}
         }
         console.log("done");
         server.stop(true);
@@ -924,6 +926,123 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     openGate();
     await write;
     expect(await Bun.file(dest).text()).toBe("<p>x</p>");
+  });
+
+  describe("source body already consumed", () => {
+    const alreadyUsed = { name: "TypeError", code: "ERR_BODY_ALREADY_USED" };
+
+    // Not toThrow(): if the write is accepted it returns a promise, toThrow()
+    // waits for it, and a write that waits on a drained body never settles.
+    function syncThrow(write) {
+      try {
+        write();
+      } catch (error) {
+        return { name: error.name, code: error.code };
+      }
+      return "did not throw";
+    }
+
+    it.each([
+      [
+        "Response after .text()",
+        async () => {
+          const res = new Response("abc");
+          await res.text();
+          return res;
+        },
+      ],
+      [
+        "Response(Blob) after .arrayBuffer()",
+        async () => {
+          const res = new Response(new Blob(["abc"]));
+          await res.arrayBuffer();
+          return res;
+        },
+      ],
+      [
+        "Request after .text()",
+        async () => {
+          const req = new Request("http://example.com/", { method: "POST", body: "abc" });
+          await req.text();
+          return req;
+        },
+      ],
+      [
+        "Response drained through body.getReader()",
+        async () => {
+          const res = new Response("abc");
+          const reader = res.body.getReader();
+          while (!(await reader.read()).done);
+          reader.releaseLock();
+          return res;
+        },
+      ],
+      [
+        "Response whose body is locked by a reader",
+        async () => {
+          const res = new Response("abc");
+          res.body.getReader();
+          return res;
+        },
+      ],
+      [
+        "Response(ReadableStream) after .text()",
+        async () => {
+          const res = new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("abc"));
+                controller.close();
+              },
+            }),
+          );
+          await res.text();
+          return res;
+        },
+      ],
+    ])("Bun.write(path, %s) throws ERR_BODY_ALREADY_USED and leaves the destination alone", async (_name, consume) => {
+      using dir = tempDir("bun-write-used-body", { "dest.txt": "previous contents" });
+      const dest = join(String(dir), "dest.txt");
+      const body = await consume();
+
+      expect(syncThrow(() => Bun.write(dest, body))).toEqual(alreadyUsed);
+
+      expect(await Bun.file(dest).text()).toBe("previous contents");
+    });
+
+    it("Bun.write(path, fetch() response) after the body was read", async () => {
+      using dir = tempDir("bun-write-used-fetch-body", { "cache.json": "previous contents" });
+      const dest = join(String(dir), "cache.json");
+      await using server = Bun.serve({ port: 0, fetch: () => Response.json({ hello: "world" }) });
+      const res = await fetch(server.url);
+      expect(await res.json()).toEqual({ hello: "world" });
+
+      expect(syncThrow(() => Bun.write(dest, res))).toEqual(alreadyUsed);
+
+      expect(await Bun.file(dest).text()).toBe("previous contents");
+    });
+
+    it("BunFile.write(usedResponse) throws and does not create the file", async () => {
+      using dir = tempDir("bun-write-used-body-bunfile", {});
+      const dest = join(String(dir), "never-created.txt");
+      const res = new Response("abc");
+      await res.text();
+
+      expect(syncThrow(() => Bun.file(dest).write(res))).toEqual(alreadyUsed);
+
+      expect(fs.existsSync(dest)).toBe(false);
+    });
+
+    it("a consumed body does not stop the same destination from being written afterwards", async () => {
+      using dir = tempDir("bun-write-used-body-then-fresh", { "dest.txt": "previous contents" });
+      const dest = join(String(dir), "dest.txt");
+      const used = new Response("abc");
+      await used.text();
+      expect(syncThrow(() => Bun.write(dest, used))).toEqual(alreadyUsed);
+
+      expect(await Bun.write(dest, new Response("fresh body"))).toBe(10);
+      expect(await Bun.file(dest).text()).toBe("fresh body");
+    });
   });
 
   it("BunFile.name survives concurrent write() calls + GC", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1022,6 +1022,31 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(await Bun.file(dest).text()).toBe("previous contents");
     });
 
+    it("a second Bun.write() on a fetch() body the first one is still waiting for", async () => {
+      using dir = tempDir("bun-write-claimed-fetch-body", { "second.txt": "previous contents" });
+      const first = join(String(dir), "first.txt");
+      const second = join(String(dir), "second.txt");
+      const { promise: gate, resolve: openGate } = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(async function* () {
+            yield "hello ";
+            await gate;
+            yield "world";
+          }),
+      });
+      const res = await fetch(server.url);
+      const firstWrite = Bun.write(first, res);
+      const secondWrite = syncThrow(() => Bun.write(second, res));
+      openGate();
+
+      expect(secondWrite).toEqual(alreadyUsed);
+      expect(await firstWrite).toBe(11);
+      expect(await Bun.file(first).text()).toBe("hello world");
+      expect(await Bun.file(second).text()).toBe("previous contents");
+    });
+
     it("BunFile.write(usedResponse) throws and does not create the file", async () => {
       using dir = tempDir("bun-write-used-body-bunfile", {});
       const dest = join(String(dir), "never-created.txt");

--- a/test/js/bun/s3/s3-argument-validation.test.ts
+++ b/test/js/bun/s3/s3-argument-validation.test.ts
@@ -67,6 +67,15 @@ describe("S3Client instance method argument validation", () => {
     expect(() => (client as any).unlink({})).toThrow(expected);
   });
 
+  test("write() rejects a Response whose body was already consumed before any request is made", async () => {
+    const expected = expect.objectContaining({ name: "TypeError", code: "ERR_BODY_ALREADY_USED" });
+    const used = new Response("abc");
+    await used.text();
+    expect(() => client.write("some-key", used)).toThrow(expected);
+    expect(() => client.file("some-key").write(used)).toThrow(expected);
+    expect(() => Bun.write(client.file("some-key"), used)).toThrow(expected);
+  });
+
   test("S3 file writer() rejects a non-string type option before any request is made", () => {
     const s3file = client.file("some-key.bin");
     expect(() => s3file.writer({ type: 123 as any })).toThrow(


### PR DESCRIPTION
### Problem
- `Bun.write(dest, response)` with a body that was already consumed (`await response.text()` first, `bodyUsed === true`) resolves `0` and replaces `dest` with a 0 byte file. Same for `Request` sources, `Bun.file(dest).write(response)`, and S3 destinations (`S3Client.write`, `S3File.write`, `Bun.write(s3file, ...)`), which upload an empty object.
- A body whose stream was drained or locked through `response.body.getReader()` makes the same call return a promise that never settles.
- A second `Bun.write(other, response)` on a `fetch()` body that a first `Bun.write` is still waiting for silently takes the body over: the second write succeeds, the first promise never settles and its wait task leaks.
- The same objects reject their own second `.text()` with `TypeError [ERR_BODY_ALREADY_USED]`.
- Cause: `body_dispatch` in `write_file_internal` (src/runtime/webcore/Blob.rs) only distinguishes `Error` and `Locked` bodies. `Used` falls into the default arm, where `Value::use_()` returns an empty blob, and the empty-source path truncates the destination and resolves `0`. A drained stream is still `Locked`, so it takes the `Locked` arm and registers `WriteFileWaitFromLockedValueTask`, which only fires when a native producer later resolves the body; a stream that was read from JS has no such producer. A body a previous write is parked on is also `Locked`, and the arm overwrites that write's `on_receive_value`/`task` with its own.

### Fix
- Before dispatching a `Response` or `Request` source, run it through a new `throw_if_body_consumed` helper next to `write_file_internal`. It calls the existing `BodyMixin::throw_if_body_unusable` (the check `clone()` uses: `Used`, a `.text()`/`.json()`/... read pending, or a stream that is disturbed or locked), then also rejects a `Locked` body whose `on_receive_value` is set, which is how an earlier write (or the server rendering the response) marks that it is waiting for the bytes. Both cases throw `TypeError` with code `ERR_BODY_ALREADY_USED`.
- A body that is still usable (a `fetch()` response still streaming in, a server request body, an untouched `new Response(stream)`, an HTMLRewriter output) passes and takes the same path as before.
- The check runs before anything touches the destination, so the existing file keeps its contents and a missing file is not created. It is in `write_file_internal`, so every destination kind and entry point (`Bun.write`, `BunFile.write`, `S3File.write`, `S3Client.write`) gets it.
- The `on_receive_value` case is deliberately not folded into the shared `body_stream_check`: that would also change `bodyUsed` and make `clone()` throw on a body a write is parked on, and the existing HTMLRewriter `clone()` test in bun-write.test.js pins the current behaviour there.
- Throwing synchronously matches how this function already rejects a bad source (`Bun.write(path, undefined)`, the S3 arm's disturbed-stream check) and how `Bun.spawn({ stdin: usedResponse })` and `response.clone()` report the same condition; `.text()` on a used body rejects instead, but with the same code.
- Verified with `test/js/bun/io/bun-write.test.js` (`source body already consumed`: six consumed-body shapes for `Bun.write(path, ...)`, a `fetch()` response after `.json()`, a second write on a body the first write is waiting for (the server holds back the last chunk; the first write still resolves with all 11 bytes), `BunFile.write`, and that the destination is still writable afterwards) and `test/js/bun/s3/s3-argument-validation.test.ts` (the three S3 faces). All fail on the current build (`did not throw`, or an S3 error for the S3 faces) and pass with this change.
- The ASAN-only `freed FetchTasklet` test in bun-write.test.js now swallows the synchronous throw its `getReader()` variant gets; its other two variants still exercise the path it was written for. The rest of bun-write.test.js, the HTMLRewriter `Bun.write(file, res)` tests, the `Bun.write(file, req)` server test, and the S3 fetch-body upload test in s3.test.ts still pass.

### Background
- A `Response`/`Request` body is a `body::Value` state machine: in-memory variants (`WTFStringImpl`, `InternalBlob`, `Blob`), `Locked` (bytes still arriving or exposed as a `ReadableStream`), `Used` (consumed), `Error`, `Null`, `Empty`. `use_()` takes the bytes out of a value and leaves it `Used`; on an already `Used` value it returns an empty blob.
- `bodyUsed`, `clone()`, and `throw_if_body_unusable` share `body_stream_check`: `Used` is consumed, a `Locked` value with a pending read action is consumed, and otherwise the body's `ReadableStream` (if one exists) decides via its disturbed/locked flags. A `Locked` value with no stream and no pending read is a body that nothing on the JS side has consumed yet.
- `PendingValue::on_receive_value` is the native-consumer hook on a `Locked` body: `Value::resolve` calls it (instead of settling a JS promise) when the bytes arrive. `Bun.write` and the server's response rendering are its only registrants, and `Value::tee` / `locked_to_native_stream` in Body.rs already treat it as "someone owns this body"; the new helper applies the same reading to a second write.
- Not changed here: a usable `Locked` body that is backed by a JS `ReadableStream` (`Bun.write(path, new Response(stream))`) still never settles on a file destination; that is #32906, which adds the pump for that case in the `Locked` arm. This check runs before that arm, so the two changes are independent.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->