### PR TITLE
test(install): keep bun-update-security-provider on the dummy registry, assert the update, run concurrently

### DIFF
--- a/test/cli/install/bun-update-security-provider.test.ts
+++ b/test/cli/install/bun-update-security-provider.test.ts
@@ -1,152 +1,158 @@
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { file } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { join } from "node:path";
 import {
+  createTestContext,
+  destroyTestContext,
   dummyAfterAll,
-  dummyAfterEach,
   dummyBeforeAll,
-  dummyBeforeEach,
-  dummyRegistry,
-  package_dir,
-  setHandler,
-  write,
+  dummyRegistryForContext,
+  setContextHandler,
+  type TestContext,
 } from "./dummy.registry.js";
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-beforeEach(async () => {
-  await dummyBeforeEach();
-});
-afterEach(dummyAfterEach);
 
-test("security scanner blocks bun update on fatal advisory", async () => {
+// Reports what it was asked to scan, then flags all of it as fatal: an update
+// that consults this scanner cannot succeed, so a successful update proves the
+// scanner was never run.
+const scannerSource = `
+  export const scanner = {
+    version: "1",
+    scan: async ({ packages }) => {
+      console.log("scanner received: " + packages.map(pkg => pkg.name + "@" + pkg.version).join(", "));
+      return packages.map(pkg => ({
+        package: pkg.name,
+        description: "Fatal security issue detected",
+        level: "fatal",
+        url: "https://example.com/critical",
+      }));
+    },
+  };
+`;
+
+// The three things `bun update moo` changes: the package.json range, the
+// lockfile resolution and the package on disk. Every test starts from this state.
+const installedState = { range: ">=0.1.0", locked: "moo@0.1.0", installed: "0.1.0" };
+
+async function mooState(ctx: TestContext) {
+  const [packageJson, lockfile, installed] = await Promise.all([
+    file(join(ctx.package_dir, "package.json")).json(),
+    file(join(ctx.package_dir, "bun.lock")).text(),
+    file(join(ctx.package_dir, "node_modules/moo/package.json")).json(),
+  ]);
+  return {
+    range: packageJson.dependencies.moo,
+    locked: (Bun.JSONC.parse(lockfile) as { packages: Record<string, [string, ...unknown[]]> }).packages.moo[0],
+    installed: installed.version,
+  };
+}
+
+// Writes out what `bun install` leaves behind for `installedState` (the
+// lockfile and node_modules entry are what it writes against this registry),
+// which saves spawning an install per test. The registry has since published
+// 0.2.0. The scanner file always exists; only bunfig.toml decides whether bun
+// uses it.
+async function projectWithMooInstalled({ scanner }: { scanner: boolean }) {
+  const ctx = await createTestContext();
   const urls: string[] = [];
-  setHandler(
-    dummyRegistry(urls, {
-      "0.1.0": {},
-      "0.2.0": {},
-    }),
-  );
+  setContextHandler(ctx, dummyRegistryForContext(ctx, urls, { "0.1.0": {}, "0.2.0": {} }));
 
-  const scannerCode = `
-    export const scanner = {
-      version: "1",
-      scan: async ({ packages }) => {
-        if (packages.length === 0) return [];
-        return [
-          {
-            package: "moo",
-            description: "Fatal security issue detected",
-            level: "fatal",
-            url: "https://example.com/critical",
-          },
-        ];
+  const files = {
+    "bunfig.toml": Bun.TOML.stringify({
+      install: {
+        // Without this, manifests and tarballs come from the machine-wide cache
+        // and the requests asserted below never reach the registry.
+        cache: false,
+        registry: ctx.registry_url,
+        security: scanner ? { scanner: "./scanner.ts" } : undefined,
       },
-    };
-  `;
+    })!,
+    "scanner.ts": scannerSource,
+    "package.json": JSON.stringify({ name: "my-app", version: "1.0.0", dependencies: { moo: installedState.range } }),
+    "bun.lock": JSON.stringify({
+      lockfileVersion: 1,
+      configVersion: 1,
+      workspaces: { "": { name: "my-app", dependencies: { moo: installedState.range } } },
+      packages: { moo: [installedState.locked, `${ctx.registry_url}moo-${installedState.installed}.tgz`, {}, ""] },
+    }),
+    "node_modules/moo/package.json": JSON.stringify({ name: "moo", version: installedState.installed }),
+  };
+  await Promise.all(Object.entries(files).map(([name, contents]) => Bun.write(join(ctx.package_dir, name), contents)));
+  return { ctx, urls };
+}
 
-  await write("./scanner.ts", scannerCode);
-  await write("package.json", {
-    name: "my-app",
-    version: "1.0.0",
-    dependencies: {
-      moo: "0.1.0",
-    },
-  });
-
-  // First install without security scanning (to have something to update)
-  await using installProc = Bun.spawn({
-    cmd: [bunExe(), "install", "--no-summary"],
-    env: bunEnv,
-    cwd: package_dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  await installProc.stdout.text();
-  await installProc.stderr.text();
-  await installProc.exited;
-
-  await write(
-    "./bunfig.toml",
-    `
-[install]
-saveTextLockfile = false
-
-[install.security]
-scanner = "./scanner.ts"
-`,
-  );
-
-  await using updateProc = Bun.spawn({
+async function updateMoo(ctx: TestContext) {
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "update", "moo"],
+    cwd: ctx.package_dir,
     env: bunEnv,
-    cwd: package_dir,
     stdout: "pipe",
     stderr: "pipe",
   });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return {
+    stdout: normalizeBunSnapshot(stdout),
+    // Only printed when the scanner takes over a second, i.e. on slow debug builds.
+    stderr: normalizeBunSnapshot(stderr.replace(/^\[\.\/scanner\.ts\] Scanning 1 package took \d+ms\r?\n/m, "")),
+    exitCode,
+  };
+}
 
-  const [updateOut, updateErr, updateExitCode] = await Promise.all([
-    updateProc.stdout.text(),
-    updateProc.stderr.text(),
-    updateProc.exited,
-  ]);
+test.concurrent("security scanner blocks bun update on fatal advisory", async () => {
+  const { ctx, urls } = await projectWithMooInstalled({ scanner: true });
+  try {
+    const { stdout, stderr, exitCode } = await updateMoo(ctx);
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+      scanner received: moo@0.2.0
 
-  expect(updateOut).toContain("FATAL: moo");
-  expect(updateOut).toContain("Fatal security issue detected");
-  expect(updateOut).toContain("Installation aborted due to fatal security advisories");
+        FATAL: moo
+          via my-app › moo
+          Fatal security issue detected
+          https://example.com/critical
 
-  expect(updateExitCode).toBe(1);
+      1 advisory (1 fatal)
+      Installation aborted due to fatal security advisories"
+    `);
+    expect(stderr).toMatchInlineSnapshot(`
+      "Resolving dependencies
+      Resolved, downloaded and extracted [2]"
+    `);
+    expect(exitCode).toBe(1);
+
+    // The advisory stopped the update right after resolution: the 0.2.0
+    // tarball was never downloaded and nothing on disk moved off 0.1.0.
+    expect(urls).toEqual([`${ctx.registry_url}moo`]);
+    expect(await mooState(ctx)).toEqual(installedState);
+  } finally {
+    destroyTestContext(ctx);
+  }
 });
 
-test("security scanner does not run on bun update when disabled", async () => {
-  const urls: string[] = [];
-  setHandler(
-    dummyRegistry(urls, {
-      "0.1.0": {},
-      "0.2.0": {},
-    }),
-  );
+test.concurrent("security scanner does not run on bun update when not configured", async () => {
+  const { ctx, urls } = await projectWithMooInstalled({ scanner: false });
+  try {
+    const { stdout, stderr, exitCode } = await updateMoo(ctx);
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
 
-  await write("package.json", {
-    name: "my-app",
-    version: "1.0.0",
-    dependencies: {
-      moo: "0.1.0",
-    },
-  });
+      installed moo@0.2.0
 
-  // Remove bunfig.toml to ensure no security scanner
-  await write("bunfig.toml", "");
+      1 package installed"
+    `);
+    expect(stderr).toMatchInlineSnapshot(`
+      "Resolving dependencies
+      Resolved, downloaded and extracted [4]
+      Saved lockfile"
+    `);
+    expect(exitCode).toBe(0);
 
-  await using installProc = Bun.spawn({
-    cmd: [bunExe(), "install", "--no-summary"],
-    env: bunEnv,
-    cwd: package_dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  await installProc.stdout.text();
-  await installProc.stderr.text();
-  await installProc.exited;
-
-  await using updateProc = Bun.spawn({
-    cmd: [bunExe(), "update", "moo"],
-    env: bunEnv,
-    cwd: package_dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [updateOut, updateErr, updateExitCode] = await Promise.all([
-    updateProc.stdout.text(),
-    updateProc.stderr.text(),
-    updateProc.exited,
-  ]);
-
-  expect(updateOut).not.toContain("Security scanner");
-  expect(updateOut).not.toContain("WARN:");
-  expect(updateOut).not.toContain("FATAL:");
-
-  expect(updateExitCode).toBe(0);
+    expect(urls).toEqual([`${ctx.registry_url}moo`, `${ctx.registry_url}moo-0.2.0.tgz`]);
+    expect(await mooState(ctx)).toEqual({ range: "^0.2.0", locked: "moo@0.2.0", installed: "0.2.0" });
+  } finally {
+    destroyTestContext(ctx);
+  }
 });


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-update-security-provider.test.ts` is one of the slow files on the x64 ASAN lane (6.5s in `test/expected-durations.json`, 0.1-0.3s on the other lanes): two serial tests, each spawning `bun install` and then `bun update moo` through the shared legacy `package_dir`, so four debug `bun` processes plus the scanner child run back to back.
- Both tests rewrite `bunfig.toml` without the `registry` line `dummyBeforeEach` put there, so the first test's `bun update moo` and the second test's `bun install` and `bun update moo` resolve `moo` from registry.npmjs.org. With non-local traffic blackholed (`HTTPS_PROXY` pointing at a closed port, localhost exempt) both tests fail on main; the registry `urls` each test collects are empty for those steps.
- The second test pins `moo` to `0.1.0`, so its `bun update moo` changes nothing, and it only asserts strings that are absent from stdout.
- Neither test looks at the install's output, the update's stderr, the `urls` it collects, or package.json / lockfile / node_modules afterwards, so a scanner that failed to block (or an update that silently did nothing) would still pass the second test and most of the first.

### Fix
- Each test gets its own registry context (`createTestContext`) serving moo 0.1.0 and 0.2.0, and starts from the files `bun install` leaves behind for moo@0.1.0 against that registry (package.json with `>=0.1.0`, `bun.lock`, `node_modules/moo/package.json`), written directly. The only process a test spawns is `bun update moo`, and the two tests run with `test.concurrent`.
- The fixture matches a real install: I first wrote the file with a real `bun install` step and captured the update snapshots, request lists and end states, then replaced the install with the files it had written; all four snapshots and every other assertion stayed byte-identical.
- The generated bunfig keeps `cache = false` (as `dummyBeforeEach` does) so every manifest and tarball request reaches the test's own registry and the `urls` assertions mean something.
- Assertions now, fatal case: exact stdout (the scanner reports it was handed `moo@0.2.0`, the FATAL block, the abort line), exact stderr, exit code 1, the registry saw only the manifest request (the 0.2.0 tarball was never fetched), and package.json / bun.lock / node_modules are still at 0.1.0.
- Assertions now, scanner not configured: the same always-fatal scanner file is on disk but not referenced from bunfig.toml; exact stdout (`installed moo@0.2.0`), exact stderr (`Saved lockfile`), exit code 0, the registry saw the manifest and the 0.2.0 tarball, package.json is `^0.2.0`, bun.lock resolves `moo@0.2.0`, node_modules holds 0.2.0.
- The `[./scanner.ts] Scanning 1 package took Nms` line bun prints when the scanner takes over a second (it does on debug builds, not on release) is stripped before snapshotting so both kinds of lanes share the snapshots.
- Verified with `bun bd test test/cli/install/bun-update-security-provider.test.ts`; it also passes under the release build and with non-local network blackholed.
- Timing, debug build, whole-file wall clock reported by `bun test`, four interleaved before/after runs on the same machine: before 7.35s, 7.62s, 8.46s, 8.93s; after 5.66s, 5.94s, 5.98s, 6.08s. A file with a single trivial test takes 3.2-4.5s on this machine (runner start plus harness import), so the tests' own time goes from roughly 4-5s to about 2.3s: per-test durations were 2.7-3.8s followed by 0.8-1.6s, and are now 2.2s and 1.0s overlapping. bun processes per run: 4 plus the scanner, now 2 plus the scanner.
- Mutation checks, each reverted afterwards: making the scanner return `warn` instead of `fatal` fails the first test on the stdout snapshot; configuring the scanner unconditionally fails the second test; expecting the 0.2.0 tarball request in the fatal test fails; expecting `^0.3.0` in the second test fails.

### Background
- Dummy registry contexts: `test/cli/install/dummy.registry.ts` runs one local HTTP server per test file. `createTestContext()` gives a test its own URL prefix (`http://localhost:PORT/test-N/`), handler and temp dir, which is what allows tests in one file to run concurrently. `dummyRegistryForContext` serves a manifest listing the given versions and serves tarballs from the `.tgz` fixtures next to the file (`moo-0.1.0.tgz`, `moo-0.2.0.tgz`), pushing every request URL into the array it is given.
- Security scanner: `[install.security] scanner` in bunfig.toml names a module that bun runs in a child process once dependencies are resolved, before anything is downloaded or linked. A `fatal` advisory aborts the command with exit code 1. When a scanner is configured bun also disables tarball prefetching (`PREFETCH_RESOLVED_TARBALLS` in `src/install/PackageManager/PackageManagerOptions.rs`), which is why the fatal case's registry only ever sees the manifest request.
