### PR TITLE
Bun.write(file, file): check the source before opening the destination

### DIFF
--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -244,24 +244,20 @@ impl CopyFile {
         Ok(())
     }
 
-    /// Creates or truncates the destination: only call this once the source
-    /// has been checked, so a rejected copy leaves the destination untouched.
     #[cfg(not(windows))]
     fn open_destination(&mut self) -> Result<(), crate::Error> {
+        // Not slice_z(): its &ZStr borrows self, which mkdir_if_not_exists() needs mutably.
         let mut path_buf = bun_paths::path_buffer_pool::get();
+        let capacity = path_buf.len() - 1;
+        let dest_len = bun_core::strings::copy(
+            &mut path_buf[..capacity],
+            self.destination_file_store.pathlike.path().slice(),
+        )
+        .len();
+        path_buf[dest_len] = 0;
+        let dest: &bun_core::ZStr = bun_core::ZStr::from_buf(&path_buf[..], dest_len);
+        let mode = self.destination_mode.unwrap_or(node_fs::DEFAULT_PERMISSION);
         loop {
-            // detach `dest` lifetime from `self` (borrowck) — slice_z
-            // copies into path_buf, so build the ZStr directly from the buffer.
-            let dest_len = {
-                let s = self.destination_file_store.pathlike.path().slice();
-                let n = s.len().min(path_buf.len() - 1);
-                path_buf[..n].copy_from_slice(&s[..n]);
-                path_buf[n] = 0;
-                n
-            };
-            // SAFETY: path_buf[dest_len] == 0 written above.
-            let dest: &bun_core::ZStr = bun_core::ZStr::from_buf(&path_buf[..], dest_len);
-            let mode = self.destination_mode.unwrap_or(node_fs::DEFAULT_PERMISSION);
             match bun_sys::open(dest, OPEN_DESTINATION_FLAGS, mode) {
                 bun_sys::Result::Ok(result) => {
                     match result.make_lib_uv_owned_for_syscall(
@@ -297,11 +293,10 @@ impl CopyFile {
         Ok(())
     }
 
-    /// `None` when this source/destination pair isn't supported, e.g. a FIFO
-    /// source with a regular-file destination.
+    /// `None`: no syscall copies this pair (a FIFO into a regular file, for one).
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn pick_copy_syscall(&self, source_mode: Mode) -> Option<TryWith> {
-        // 0: the destination store was never stat'ed (Bun.write(path, ...)).
+        // 0 when the destination store was never stat'ed (Bun.write(path, ...)).
         let destination_mode = self.destination_file_store.mode;
 
         // Bun.write(Bun.file("a"), Bun.file("b"))
@@ -653,8 +648,7 @@ impl CopyFile {
                 self.source_fd = *fd;
             }
 
-            // First, we attempt to clonefile() on macOS
-            // This is the fastest way to copy a file.
+            // clonefile() is the fastest copy on macOS, so it goes first.
             #[cfg(target_os = "macos")]
             {
                 if self.offset == 0
@@ -670,8 +664,6 @@ impl CopyFile {
                     'do_clonefile: {
                         let mut path_buf = bun_paths::path_buffer_pool::get();
 
-                        // stat the output file, make sure it:
-                        // 1. Exists
                         match bun_sys::stat(
                             self.source_file_store
                                 .pathlike
@@ -691,7 +683,6 @@ impl CopyFile {
                                 }
                             }
                             bun_sys::Result::Err(err) => {
-                                // If we can't stat it, we also can't copy it.
                                 self.system_error = Some(err.to_system_error());
                                 return;
                             }
@@ -704,7 +695,6 @@ impl CopyFile {
                                     && self.max_length
                                         < SizeType::try_from(stat_size).expect("int cast")
                                 {
-                                    // If this fails...well, there's not much we can do about it.
                                     // SAFETY: NUL-terminated path in path_buf; libc truncate(2).
                                     let _ = unsafe {
                                         bun_sys::c::truncate(
@@ -741,10 +731,7 @@ impl CopyFile {
                                 return;
                             }
                             Err(_) => {
-                                // this may still fail, in which case we just continue trying with fcopyfile
-                                // it can fail when the input file already exists
-                                // or if the output is not a directory
-                                // or if it's a network volume
+                                // An existing destination, another volume or a network mount: fcopyfile below still works.
                                 self.system_error = None;
                             }
                         }
@@ -757,8 +744,7 @@ impl CopyFile {
             }
             debug_assert!(self.source_fd.is_valid());
 
-            // Everything that can reject the source happens here, before
-            // open_destination() creates or truncates the destination.
+            // Every source check runs before open_destination() creates or truncates the destination.
             let stat: Stat = match stat_ {
                 Some(s) => s,
                 None => match bun_sys::fstat(self.source_fd) {
@@ -1408,8 +1394,7 @@ impl<'a> CopyFileWindows<'a> {
     }
 
     fn prepare_read_write_loop(&mut self) {
-        // Opening the destination creates or truncates it, so a source that
-        // can't be opened has to fail before that.
+        // The source first: opening the destination creates or truncates it.
         self.read_write_loop.source_fd = match Self::prepare_pathlike(
             &mut Store::data_mut(&self.source_file_store)
                 .as_file_mut()
@@ -1434,8 +1419,7 @@ impl<'a> CopyFileWindows<'a> {
             bun_sys::Result::Ok(fd) => fd,
             bun_sys::Result::Err(err) => {
                 if self.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
-                    // on_mkdirp_complete() re-enters copyfile(), which opens
-                    // the source again.
+                    // on_mkdirp_complete() re-enters copyfile(), which reopens the source.
                     self.read_write_loop.close();
                     self.mkdirp();
                     return;

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -214,25 +214,61 @@ impl CopyFile {
     }
 
     #[cfg(not(windows))]
-    pub(crate) fn do_open_file<const WHICH: IOWhich>(&mut self) -> Result<(), crate::Error> {
-        let mut path_buf1 = bun_paths::path_buffer_pool::get();
-        // open source file first
-        // if it fails, we don't want the extra destination file hanging out
-        if matches!(WHICH, IOWhich::Both | IOWhich::Source) {
-            self.source_fd = match bun_sys::open(
-                self.source_file_store
-                    .pathlike
-                    .path()
-                    .slice_z(&mut path_buf1),
-                OPEN_SOURCE_FLAGS,
-                0,
-            ) {
+    fn open_source(&mut self) -> Result<(), crate::Error> {
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+        self.source_fd = match bun_sys::open(
+            self.source_file_store
+                .pathlike
+                .path()
+                .slice_z(&mut path_buf),
+            OPEN_SOURCE_FLAGS,
+            0,
+        ) {
+            bun_sys::Result::Ok(result) => {
+                match result.make_lib_uv_owned_for_syscall(
+                    bun_sys::Tag::open,
+                    bun_sys::ErrorCase::CloseOnFail,
+                ) {
+                    bun_sys::Result::Ok(result_fd) => result_fd,
+                    bun_sys::Result::Err(errno) => {
+                        self.system_error = Some(errno.to_system_error());
+                        return Err(bun_errno::from_errno(errno.errno as i32).into());
+                    }
+                }
+            }
+            bun_sys::Result::Err(errno) => {
+                self.system_error = Some(errno.to_system_error());
+                return Err(bun_errno::from_errno(errno.errno as i32).into());
+            }
+        };
+        Ok(())
+    }
+
+    /// Creates or truncates the destination: only call this once the source
+    /// has been checked, so a rejected copy leaves the destination untouched.
+    #[cfg(not(windows))]
+    fn open_destination(&mut self) -> Result<(), crate::Error> {
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+        loop {
+            // detach `dest` lifetime from `self` (borrowck) — slice_z
+            // copies into path_buf, so build the ZStr directly from the buffer.
+            let dest_len = {
+                let s = self.destination_file_store.pathlike.path().slice();
+                let n = s.len().min(path_buf.len() - 1);
+                path_buf[..n].copy_from_slice(&s[..n]);
+                path_buf[n] = 0;
+                n
+            };
+            // SAFETY: path_buf[dest_len] == 0 written above.
+            let dest: &bun_core::ZStr = bun_core::ZStr::from_buf(&path_buf[..], dest_len);
+            let mode = self.destination_mode.unwrap_or(node_fs::DEFAULT_PERMISSION);
+            match bun_sys::open(dest, OPEN_DESTINATION_FLAGS, mode) {
                 bun_sys::Result::Ok(result) => {
                     match result.make_lib_uv_owned_for_syscall(
                         bun_sys::Tag::open,
                         bun_sys::ErrorCase::CloseOnFail,
                     ) {
-                        bun_sys::Result::Ok(result_fd) => result_fd,
+                        bun_sys::Result::Ok(result_fd) => self.destination_fd = result_fd,
                         bun_sys::Result::Err(errno) => {
                             self.system_error = Some(errno.to_system_error());
                             return Err(bun_errno::from_errno(errno.errno as i32).into());
@@ -240,69 +276,54 @@ impl CopyFile {
                     }
                 }
                 bun_sys::Result::Err(errno) => {
-                    self.system_error = Some(errno.to_system_error());
+                    match blob::mkdir_if_not_exists(self, &errno, dest, dest.as_bytes()) {
+                        Retry::Continue => continue,
+                        Retry::Fail => {
+                            return Err(bun_errno::from_errno(errno.errno as i32).into());
+                        }
+                        Retry::No => {}
+                    }
+
+                    self.system_error = Some(
+                        errno
+                            .with_path(self.destination_file_store.pathlike.path().slice())
+                            .to_system_error(),
+                    );
                     return Err(bun_errno::from_errno(errno.errno as i32).into());
                 }
-            };
-        }
-
-        if matches!(WHICH, IOWhich::Both | IOWhich::Destination) {
-            loop {
-                // detach `dest` lifetime from `self` (borrowck) — slice_z
-                // copies into path_buf1, so build the ZStr directly from the buffer.
-                let dest_len = {
-                    let s = self.destination_file_store.pathlike.path().slice();
-                    let n = s.len().min(path_buf1.len() - 1);
-                    path_buf1[..n].copy_from_slice(&s[..n]);
-                    path_buf1[n] = 0;
-                    n
-                };
-                // SAFETY: path_buf1[dest_len] == 0 written above.
-                let dest: &bun_core::ZStr = bun_core::ZStr::from_buf(&path_buf1[..], dest_len);
-                let mode = self.destination_mode.unwrap_or(node_fs::DEFAULT_PERMISSION);
-                match bun_sys::open(dest, OPEN_DESTINATION_FLAGS, mode) {
-                    bun_sys::Result::Ok(result) => {
-                        match result.make_lib_uv_owned_for_syscall(
-                            bun_sys::Tag::open,
-                            bun_sys::ErrorCase::CloseOnFail,
-                        ) {
-                            bun_sys::Result::Ok(result_fd) => self.destination_fd = result_fd,
-                            bun_sys::Result::Err(errno) => {
-                                self.system_error = Some(errno.to_system_error());
-                                return Err(bun_errno::from_errno(errno.errno as i32).into());
-                            }
-                        }
-                    }
-                    bun_sys::Result::Err(errno) => {
-                        match blob::mkdir_if_not_exists(self, &errno, dest, dest.as_bytes()) {
-                            Retry::Continue => continue,
-                            Retry::Fail => {
-                                if matches!(WHICH, IOWhich::Both) {
-                                    self.source_fd.close();
-                                    self.source_fd = Fd::INVALID;
-                                }
-                                return Err(bun_errno::from_errno(errno.errno as i32).into());
-                            }
-                            Retry::No => {}
-                        }
-
-                        if matches!(WHICH, IOWhich::Both) {
-                            self.source_fd.close();
-                            self.source_fd = Fd::INVALID;
-                        }
-
-                        self.system_error = Some(
-                            errno
-                                .with_path(self.destination_file_store.pathlike.path().slice())
-                                .to_system_error(),
-                        );
-                        return Err(bun_errno::from_errno(errno.errno as i32).into());
-                    }
-                }
-                break;
             }
+            break;
         }
         Ok(())
+    }
+
+    /// `None` when this source/destination pair isn't supported, e.g. a FIFO
+    /// source with a regular-file destination.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn pick_copy_syscall(&self, source_mode: Mode) -> Option<TryWith> {
+        // 0: the destination store was never stat'ed (Bun.write(path, ...)).
+        let destination_mode = self.destination_file_store.mode;
+
+        // Bun.write(Bun.file("a"), Bun.file("b"))
+        if bun_sys::S::ISREG(source_mode)
+            && (bun_sys::S::ISREG(destination_mode) || destination_mode == 0)
+        {
+            return Some(TryWith::CopyFileRange);
+        }
+
+        // $ bun run foo.js | bun run bar.js
+        if bun_sys::S::ISFIFO(source_mode) && bun_sys::S::ISFIFO(destination_mode) {
+            return Some(TryWith::Splice);
+        }
+
+        if bun_sys::S::ISREG(source_mode)
+            || bun_sys::S::ISCHR(source_mode)
+            || bun_sys::S::ISSOCK(source_mode)
+        {
+            return Some(TryWith::Sendfile);
+        }
+
+        None
     }
 
     /// Copies the rest of the file with [`read_write_fallback`] when
@@ -632,147 +653,119 @@ impl CopyFile {
                 self.source_fd = *fd;
             }
 
-            // Do we need to open both files?
-            if self.destination_fd == Fd::INVALID && self.source_fd == Fd::INVALID {
-                // First, we attempt to clonefile() on macOS
-                // This is the fastest way to copy a file.
-                #[cfg(target_os = "macos")]
+            // First, we attempt to clonefile() on macOS
+            // This is the fastest way to copy a file.
+            #[cfg(target_os = "macos")]
+            {
+                if self.offset == 0
+                    && matches!(
+                        self.source_file_store.pathlike,
+                        PathOrFileDescriptor::Path(_)
+                    )
+                    && matches!(
+                        self.destination_file_store.pathlike,
+                        PathOrFileDescriptor::Path(_)
+                    )
                 {
-                    if self.offset == 0
-                        && matches!(
-                            self.source_file_store.pathlike,
-                            PathOrFileDescriptor::Path(_)
-                        )
-                        && matches!(
-                            self.destination_file_store.pathlike,
-                            PathOrFileDescriptor::Path(_)
-                        )
-                    {
-                        'do_clonefile: {
-                            let mut path_buf = bun_paths::path_buffer_pool::get();
+                    'do_clonefile: {
+                        let mut path_buf = bun_paths::path_buffer_pool::get();
 
-                            // stat the output file, make sure it:
-                            // 1. Exists
-                            match bun_sys::stat(
-                                self.source_file_store
-                                    .pathlike
-                                    .path()
-                                    .slice_z(&mut path_buf),
-                            ) {
-                                bun_sys::Result::Ok(result) => {
-                                    stat_ = Some(result);
+                        // stat the output file, make sure it:
+                        // 1. Exists
+                        match bun_sys::stat(
+                            self.source_file_store
+                                .pathlike
+                                .path()
+                                .slice_z(&mut path_buf),
+                        ) {
+                            bun_sys::Result::Ok(result) => {
+                                stat_ = Some(result);
 
-                                    if bun_sys::S::ISDIR(result.st_mode as u32) {
-                                        self.system_error = Some(unsupported_directory_error());
-                                        return;
-                                    }
-
-                                    if !bun_sys::S::ISREG(result.st_mode as u32) {
-                                        break 'do_clonefile;
-                                    }
-                                }
-                                bun_sys::Result::Err(err) => {
-                                    // If we can't stat it, we also can't copy it.
-                                    self.system_error = Some(err.to_system_error());
+                                if bun_sys::S::ISDIR(result.st_mode as u32) {
+                                    self.system_error = Some(unsupported_directory_error());
                                     return;
                                 }
-                            }
 
-                            match self.do_clonefile() {
-                                Ok(()) => {
-                                    let stat_size = stat_.unwrap().st_size;
-                                    if self.max_length != MAX_SIZE
-                                        && self.max_length
-                                            < SizeType::try_from(stat_size).expect("int cast")
-                                    {
-                                        // If this fails...well, there's not much we can do about it.
-                                        // SAFETY: NUL-terminated path in path_buf; libc truncate(2).
-                                        let _ = unsafe {
-                                            bun_sys::c::truncate(
-                                                self.destination_file_store
-                                                    .pathlike
-                                                    .path()
-                                                    .slice_z(&mut path_buf)
-                                                    .as_ptr(),
-                                                i64::try_from(self.max_length).expect("int cast"),
-                                            )
-                                        };
-                                        self.read_len =
-                                            SizeType::try_from(self.max_length).expect("int cast");
-                                    } else {
-                                        self.read_len =
-                                            SizeType::try_from(stat_size).expect("int cast");
-                                    }
-                                    // Apply destination mode if specified (clonefile copies source permissions)
-                                    if let Some(mode) = self.destination_mode {
-                                        match bun_sys::chmod(
+                                if !bun_sys::S::ISREG(result.st_mode as u32) {
+                                    break 'do_clonefile;
+                                }
+                            }
+                            bun_sys::Result::Err(err) => {
+                                // If we can't stat it, we also can't copy it.
+                                self.system_error = Some(err.to_system_error());
+                                return;
+                            }
+                        }
+
+                        match self.do_clonefile() {
+                            Ok(()) => {
+                                let stat_size = stat_.unwrap().st_size;
+                                if self.max_length != MAX_SIZE
+                                    && self.max_length
+                                        < SizeType::try_from(stat_size).expect("int cast")
+                                {
+                                    // If this fails...well, there's not much we can do about it.
+                                    // SAFETY: NUL-terminated path in path_buf; libc truncate(2).
+                                    let _ = unsafe {
+                                        bun_sys::c::truncate(
                                             self.destination_file_store
                                                 .pathlike
                                                 .path()
-                                                .slice_z(&mut path_buf),
-                                            mode,
-                                        ) {
-                                            bun_sys::Result::Err(err) => {
-                                                self.system_error = Some(err.to_system_error());
-                                                return;
-                                            }
-                                            bun_sys::Result::Ok(()) => {}
+                                                .slice_z(&mut path_buf)
+                                                .as_ptr(),
+                                            i64::try_from(self.max_length).expect("int cast"),
+                                        )
+                                    };
+                                    self.read_len =
+                                        SizeType::try_from(self.max_length).expect("int cast");
+                                } else {
+                                    self.read_len =
+                                        SizeType::try_from(stat_size).expect("int cast");
+                                }
+                                // Apply destination mode if specified (clonefile copies source permissions)
+                                if let Some(mode) = self.destination_mode {
+                                    match bun_sys::chmod(
+                                        self.destination_file_store
+                                            .pathlike
+                                            .path()
+                                            .slice_z(&mut path_buf),
+                                        mode,
+                                    ) {
+                                        bun_sys::Result::Err(err) => {
+                                            self.system_error = Some(err.to_system_error());
+                                            return;
                                         }
+                                        bun_sys::Result::Ok(()) => {}
                                     }
-                                    return;
                                 }
-                                Err(_) => {
-                                    // this may still fail, in which case we just continue trying with fcopyfile
-                                    // it can fail when the input file already exists
-                                    // or if the output is not a directory
-                                    // or if it's a network volume
-                                    self.system_error = None;
-                                }
+                                return;
+                            }
+                            Err(_) => {
+                                // this may still fail, in which case we just continue trying with fcopyfile
+                                // it can fail when the input file already exists
+                                // or if the output is not a directory
+                                // or if it's a network volume
+                                self.system_error = None;
                             }
                         }
                     }
                 }
-
-                if self.do_open_file::<{ IOWhich::Both }>().is_err() {
-                    return;
-                }
-                // Do we need to open only one file?
-            } else if self.destination_fd == Fd::INVALID {
-                self.source_fd = self.source_file_store.pathlike.fd();
-
-                if self.do_open_file::<{ IOWhich::Destination }>().is_err() {
-                    return;
-                }
-                // Do we need to open only one file?
-            } else if self.source_fd == Fd::INVALID {
-                self.destination_fd = self.destination_file_store.pathlike.fd();
-
-                if self.do_open_file::<{ IOWhich::Source }>().is_err() {
-                    return;
-                }
             }
 
-            if self.system_error.is_some() {
+            if self.source_fd == Fd::INVALID && self.open_source().is_err() {
                 return;
             }
-
-            debug_assert!(self.destination_fd.is_valid());
             debug_assert!(self.source_fd.is_valid());
 
-            if matches!(
-                self.destination_file_store.pathlike,
-                PathOrFileDescriptor::Fd(_)
-            ) {
-                // nothing to do for the Fd case
-            }
-
+            // Everything that can reject the source happens here, before
+            // open_destination() creates or truncates the destination.
             let stat: Stat = match stat_ {
                 Some(s) => s,
                 None => match bun_sys::fstat(self.source_fd) {
                     bun_sys::Result::Ok(result) => result,
                     bun_sys::Result::Err(err) => {
-                        self.do_close();
                         self.system_error = Some(err.to_system_error());
+                        self.do_close();
                         return;
                     }
                 },
@@ -783,6 +776,22 @@ impl CopyFile {
                 self.do_close();
                 return;
             }
+
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            let copy_syscall = match self.pick_copy_syscall(stat.st_mode as Mode) {
+                Some(copy_syscall) => copy_syscall,
+                None => {
+                    self.system_error = Some(unsupported_non_regular_file_error());
+                    self.do_close();
+                    return;
+                }
+            };
+
+            if self.destination_fd == Fd::INVALID && self.open_destination().is_err() {
+                self.do_close();
+                return;
+            }
+            debug_assert!(self.destination_fd.is_valid());
 
             // BSD fstat on a pipe reports bytes currently buffered in st_size;
             // only a regular-file st_size is a length.
@@ -815,50 +824,24 @@ impl CopyFile {
 
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
-                // Bun.write(Bun.file("a"), Bun.file("b"))
-                if bun_sys::S::ISREG(stat.st_mode as _)
-                    && (bun_sys::S::ISREG(self.destination_file_store.mode as _)
-                        || self.destination_file_store.mode == 0)
-                {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
-                        let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }, true>();
-                    } else {
-                        let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }, false>();
+                let is_atty = self.destination_file_store.is_atty.unwrap_or(false);
+                let _ = match copy_syscall {
+                    TryWith::CopyFileRange if is_atty => {
+                        self.do_copy_file_range::<{ TryWith::CopyFileRange }, true>()
                     }
-
-                    self.do_close();
-                    return;
-                }
-
-                // $ bun run foo.js | bun run bar.js
-                if bun_sys::S::ISFIFO(stat.st_mode as _)
-                    && bun_sys::S::ISFIFO(self.destination_file_store.mode as _)
-                {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
-                        let _ = self.do_copy_file_range::<{ TryWith::Splice }, true>();
-                    } else {
-                        let _ = self.do_copy_file_range::<{ TryWith::Splice }, false>();
+                    TryWith::CopyFileRange => {
+                        self.do_copy_file_range::<{ TryWith::CopyFileRange }, false>()
                     }
-
-                    self.do_close();
-                    return;
-                }
-
-                if bun_sys::S::ISREG(stat.st_mode as _)
-                    || bun_sys::S::ISCHR(stat.st_mode as _)
-                    || bun_sys::S::ISSOCK(stat.st_mode as _)
-                {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
-                        let _ = self.do_copy_file_range::<{ TryWith::Sendfile }, true>();
-                    } else {
-                        let _ = self.do_copy_file_range::<{ TryWith::Sendfile }, false>();
+                    TryWith::Splice if is_atty => {
+                        self.do_copy_file_range::<{ TryWith::Splice }, true>()
                     }
+                    TryWith::Splice => self.do_copy_file_range::<{ TryWith::Splice }, false>(),
+                    TryWith::Sendfile if is_atty => {
+                        self.do_copy_file_range::<{ TryWith::Sendfile }, true>()
+                    }
+                    TryWith::Sendfile => self.do_copy_file_range::<{ TryWith::Sendfile }, false>(),
+                };
 
-                    self.do_close();
-                    return;
-                }
-
-                self.system_error = Some(unsupported_non_regular_file_error());
                 self.do_close();
                 return;
             }
@@ -1425,9 +1408,22 @@ impl<'a> CopyFileWindows<'a> {
     }
 
     fn prepare_read_write_loop(&mut self) {
-        // Open the destination first, so that if we need to call
-        // mkdirp(), we don't spend extra time opening the file handle for
-        // the source.
+        // Opening the destination creates or truncates it, so a source that
+        // can't be opened has to fail before that.
+        self.read_write_loop.source_fd = match Self::prepare_pathlike(
+            &mut Store::data_mut(&self.source_file_store)
+                .as_file_mut()
+                .pathlike,
+            &mut self.read_write_loop.must_close_source_fd,
+            true,
+        ) {
+            bun_sys::Result::Ok(fd) => fd,
+            bun_sys::Result::Err(err) => {
+                self.throw(err);
+                return;
+            }
+        };
+
         self.read_write_loop.destination_fd = match Self::prepare_pathlike(
             &mut Store::data_mut(&self.destination_file_store)
                 .as_file_mut()
@@ -1438,24 +1434,13 @@ impl<'a> CopyFileWindows<'a> {
             bun_sys::Result::Ok(fd) => fd,
             bun_sys::Result::Err(err) => {
                 if self.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
+                    // on_mkdirp_complete() re-enters copyfile(), which opens
+                    // the source again.
+                    self.read_write_loop.close();
                     self.mkdirp();
                     return;
                 }
 
-                self.throw(err);
-                return;
-            }
-        };
-
-        self.read_write_loop.source_fd = match Self::prepare_pathlike(
-            &mut Store::data_mut(&self.source_file_store)
-                .as_file_mut()
-                .pathlike,
-            &mut self.read_write_loop.must_close_source_fd,
-            true,
-        ) {
-            bun_sys::Result::Ok(fd) => fd,
-            bun_sys::Result::Err(err) => {
                 self.throw(err);
                 return;
             }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -7,10 +7,12 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isLinux,
   isWindows,
   tempDir,
   withoutAggressiveGC,
 } from "harness";
+import { mkfifo } from "mkfifo";
 import { once } from "node:events";
 import http from "node:http";
 import path, { join } from "path";
@@ -537,6 +539,94 @@ const IS_UV_FS_COPYFILE_DISABLED =
       resolved: String(size),
     });
     expect(exitCode).toBe(0);
+  });
+
+  // The destination is opened with O_CREAT | O_TRUNC, so every check that can
+  // reject the source has to run before it is opened: a rejected copy must
+  // leave the destination exactly as it was.
+  describe("Bun.write(dest, Bun.file(unusable source)) leaves the destination alone", () => {
+    const original = Buffer.alloc(16384, "Z").toString();
+    const settle = promise =>
+      promise.then(
+        value => ({ resolved: value }),
+        error => ({ rejected: error.message }),
+      );
+
+    // Windows copies through uv_fs_copyfile(), which reports a directory
+    // source as a generic copyfile failure (and never touches the
+    // destination); the message below is the POSIX CopyFile one.
+    describe.skipIf(isWindows)("directory source", () => {
+      it.each([
+        { dest: "path", src: "path" },
+        { dest: "Bun.file", src: "path" },
+        { dest: "path", src: "fd" },
+        { dest: "Bun.file", src: "fd" },
+      ])("$dest destination, directory $src source", async ({ dest: destKind, src: srcKind }) => {
+        using dir = tempDir("bun-write-dir-src", { "important.db": original });
+        const destPath = join(String(dir), "important.db");
+        const dest = destKind === "Bun.file" ? Bun.file(destPath) : destPath;
+        const dirFd = srcKind === "fd" ? fs.openSync(String(dir), "r") : -1;
+        try {
+          const outcome = await settle(Bun.write(dest, Bun.file(srcKind === "fd" ? dirFd : String(dir))));
+          expect({ outcome, content: fs.readFileSync(destPath, "utf8") }).toEqual({
+            outcome: { rejected: "That doesn't work on folders" },
+            content: original,
+          });
+        } finally {
+          if (dirFd !== -1) fs.closeSync(dirFd);
+        }
+      });
+
+      it("does not create a missing destination", async () => {
+        using dir = tempDir("bun-write-dir-src-absent", {});
+        const destPath = join(String(dir), "new.db");
+
+        const outcome = await settle(Bun.write(destPath, Bun.file(String(dir))));
+
+        expect({ outcome, destExists: fs.existsSync(destPath) }).toEqual({
+          outcome: { rejected: "That doesn't work on folders" },
+          destExists: false,
+        });
+      });
+    });
+
+    // Only Linux rejects a FIFO -> regular file copy (macOS falls back to a
+    // read/write loop and copies it). Holding the FIFO open read/write from
+    // this process gives Bun's O_RDONLY open a writer, so it returns at once.
+    it.skipIf(!isLinux)("FIFO source", async () => {
+      using dir = tempDir("bun-write-fifo-src", { "important.db": original });
+      const destPath = join(String(dir), "important.db");
+      const fifoPath = join(String(dir), "fifo");
+      mkfifo(fifoPath);
+      const holder = fs.openSync(fifoPath, "r+");
+      try {
+        const outcome = await settle(Bun.write(destPath, Bun.file(fifoPath)));
+        expect({ outcome, content: fs.readFileSync(destPath, "utf8") }).toEqual({
+          outcome: { rejected: "Non-regular files aren't supported yet" },
+          content: original,
+        });
+      } finally {
+        fs.closeSync(holder);
+      }
+    });
+
+    // Also covers the Windows read/write fallback (this file re-runs itself
+    // with BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE=1 on Windows), which used
+    // to open the destination before the source.
+    it("missing source", async () => {
+      using dir = tempDir("bun-write-missing-src-keeps-dest", { "important.db": original });
+      const destPath = join(String(dir), "important.db");
+
+      const outcome = await Bun.write(destPath, Bun.file(join(String(dir), "missing.txt"))).then(
+        value => ({ resolved: value }),
+        error => ({ rejected: error.code }),
+      );
+
+      expect({ outcome, content: fs.readFileSync(destPath, "utf8") }).toEqual({
+        outcome: { rejected: "ENOENT" },
+        content: original,
+      });
+    });
   });
 
   it("Bun.file(0) survives GC", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -627,6 +627,41 @@ const IS_UV_FS_COPYFILE_DISABLED =
         content: original,
       });
     });
+
+    // A Bun.file(fd) source is never opened by Bun, so the first thing that
+    // can fail is the fstat. Runs in a fresh process so the fd is known to be
+    // closed. Windows validates an fd source with GetFileType() before either
+    // copy path runs, and its flag-only read/write fallback has no fstat step.
+    it.skipIf(isWindows)("closed file descriptor source", async () => {
+      using dir = tempDir("bun-write-bad-fd-src", { "important.db": original });
+      const destPath = join(String(dir), "important.db");
+      const fixture = `
+        const fs = require("fs");
+        const fd = 987;
+        let precondition;
+        try {
+          fs.fstatSync(fd);
+          precondition = "fd " + fd + " is unexpectedly open";
+        } catch (e) {
+          precondition = e.code;
+        }
+        const outcome = await Bun.write(${JSON.stringify(destPath)}, Bun.file(fd)).then(
+          value => ({ resolved: value }),
+          error => ({ rejected: error.code, syscall: error.syscall }),
+        );
+        console.log(JSON.stringify({ precondition, outcome }));
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ ...JSON.parse(stdout.trim() || "{}"), stderr, content: fs.readFileSync(destPath, "utf8") }).toEqual({
+        precondition: "EBADF",
+        outcome: { rejected: "EBADF", syscall: "fstat" },
+        stderr: "",
+        content: original,
+      });
+      expect(exitCode).toBe(0);
+    });
   });
 
   it("Bun.file(0) survives GC", async () => {


### PR DESCRIPTION
### Problem

- `Bun.write(dest, Bun.file(dir))` rejects with `That doesn't work on folders`, but `dest` is 0 bytes afterwards. Same with a directory fd as the source, with a `Bun.file(fd)` source whose fd is closed (`EBADF` from `fstat`), with a FIFO source on Linux (`Non-regular files aren't supported yet`), and with a `Bun.file(dest)` destination; a destination that did not exist is left behind as an empty file.
- Cause: `CopyFile::do_open_file` in `src/runtime/webcore/blob/copy_file.rs` opened the source and right after it the destination with `O_CREAT | O_WRONLY | O_TRUNC`. The source `fstat`, the directory check and the Linux source-kind dispatch (where the FIFO rejection comes from) all ran later, in `run_async`.
- `fs.copyFile` and `cp` refuse the same inputs without touching the destination, and `Bun.write` with a missing source already did, because the source open happened first.

### Fix

- `run_async` now opens the source (if it is a path), `fstat`s it, rejects a directory, picks the Linux copy syscall, and only then calls `open_destination()`. The position of that call is the fix; the checks themselves are the existing ones.
- `do_open_file<IOWhich>` is split into `open_source` / `open_destination`. Its `Both` mode encoded the old order; the dest-open failure path now closes a Bun-opened source through the existing `do_close()`.
- `pick_copy_syscall` is the dispatch block's three conditions, unchanged, returning `None` for the unsupported case so it can be evaluated before the destination exists; the dispatch block now matches on its result.
- The macOS `clonefile` attempt, size clamp, preallocate and copy code are unchanged apart from indentation. The dead `if destination is Fd {}` block and the redundant `system_error.is_some()` check in the rewritten region are removed.
- Windows default path (`uv_fs_copyfile`) never touches the destination for an unusable source (probed with a directory, a directory fd and a missing source), so it is unchanged.
- Windows read/write fallback (`prepare_read_write_loop`) had the same order: under `BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE=1` a missing source truncated the destination. It now opens the source first, and closes it before a mkdirp retry because `copyfile()` re-runs from the top. It still cannot recognise a directory source at open time (`GetFileType` reports directories as files); with a path source that fallback is only reachable under the test flag, so that is left alone.
- Verification:
  - `test/js/bun/io/bun-write.test.js`, `Bun.write(dest, Bun.file(unusable source)) leaves the destination alone`: directory source for {path, `Bun.file`} destination x {path, fd} source, directory source with an absent destination, FIFO source (Linux only; macOS copies FIFOs through its read/write fallback), closed fd source (`Bun.file(987)` in a fresh process, POSIX), missing source. The seven directory/FIFO/closed-fd cases fail on the released build and pass with this change. The missing-source case passes on POSIX either way; it is there for the Windows fallback, where it failed before (the file re-runs itself with the flag on Windows).
  - Windows x64 debug build: the file passes in both modes.
  - `cargo check -p bun_runtime` for `aarch64-apple-darwin` and `x86_64-unknown-freebsd`, `cargo clippy -p bun_runtime`, `cargo fmt --check`: clean.
- Related open PRs, not duplicates: #32859 (copying a file onto itself) moves the truncation to an explicit `ftruncate` after the source `fstat`, which would still create an absent destination and still truncate before the Linux FIFO rejection. #36692 would make Linux copy FIFO sources; if it lands, the FIFO case here becomes a successful copy and that test goes away. #31515 (source slice windows) contains the same Windows `prepare_read_write_loop` reorder as part of its Windows plumbing but leaves the POSIX order alone; whichever lands second has a trivial conflict in that one Windows function.

### Background

- A file-to-file `Bun.write` is handled by `CopyFile` (POSIX) and `CopyFileWindows`, not by the generic blob write path. `CopyFile::run_async` runs on the work pool and reports through `self.system_error`: set it and return, and `then()` rejects the promise with it.
- Each side is either a path, which Bun opens and closes itself, or a caller-supplied fd (`Bun.stdout`, `Bun.file(fd)`), which Bun never opens, truncates or closes. That is why both opens are conditional on `*_fd == Fd::INVALID` and why `do_close()` only closes what Bun opened.
- On Linux the copy uses `copy_file_range` (regular to regular), `splice` (pipe to pipe) or `sendfile` (regular file, char device or socket source), each with a read/write fallback; any other source kind is rejected. The choice depends only on the source's `st_mode` and the destination store's cached mode, so it can be made before the destination is opened.
- `destination_file_store.mode` is 0 unless that `BunFile` was stat'ed earlier (`.size`, `.lastModified`, or an fd store like `Bun.stdout`); `pick_copy_syscall` keeps the existing rule that 0 counts as a regular file.

<details>
<summary>Local note on an unrelated test in the same file</summary>

`should work when copyFileRange is not available > on large files` exceeds the 5 s default per-test timeout in my environment with both the released and the patched build (it moves 256 MB through the disk; CI runs the file with a much larger per-test timeout). #37792 is already about that test.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->
