### PR TITLE
install: preserve and display resolved npm aliases

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1539,6 +1539,7 @@ pub(crate) fn edit(
                             }
                         }
                         if request.version.tag == dependency::Tag::DistTag
+                            || request.resolve_npm_alias
                             || (manager.subcommand == Subcommand::Update
                                 && request.version.tag == dependency::Tag::Npm
                                 && !request.version.npm().version.is_exact())
@@ -1560,23 +1561,19 @@ pub(crate) fn edit(
                                 v
                             };
 
-                            if request.version.tag == dependency::Tag::Npm
-                                && request.version.npm().is_alias
-                            {
-                                let dep_literal =
-                                    request.version.literal.slice(request.version_buf());
-                                if let Some(at_index) = strings::index_of_char(dep_literal, b'@') {
-                                    let at_index = at_index as usize;
-                                    let mut v = Vec::new();
-                                    write!(
-                                        &mut v,
-                                        "{}@{}",
-                                        bstr::BStr::new(&dep_literal[0..at_index]),
-                                        bstr::BStr::new(&new_version)
-                                    )
-                                    .unwrap();
-                                    break 'npm arena_str(arena, &v);
-                                }
+                            if request.resolve_npm_alias {
+                                let alias_name = manager.lockfile.packages.items_name()
+                                    [request.package_id as usize]
+                                    .slice(manager.lockfile.buffers.string_bytes.as_slice());
+                                let mut v = Vec::new();
+                                write!(
+                                    &mut v,
+                                    "npm:{}@{}",
+                                    bstr::BStr::new(alias_name),
+                                    bstr::BStr::new(&new_version)
+                                )
+                                .unwrap();
+                                break 'npm arena_str(arena, &v);
                             }
 
                             break 'npm arena_str(arena, &new_version);

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1555,7 +1555,7 @@ pub(crate) fn edit(
                                 request.resolved_npm_specifier(
                                     resolved_name,
                                     resolutions[request.package_id as usize].npm().version,
-                                    request.version_buf(),
+                                    string_buf,
                                     options.exact_versions,
                                 )
                             )

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1544,39 +1544,23 @@ pub(crate) fn edit(
                                 && request.version.tag == dependency::Tag::Npm
                                 && !request.version.npm().version.is_exact())
                         {
-                            let new_version: Vec<u8> = {
-                                // `tag == Npm` matched at the top of this arm.
-                                let version_fmt = resolutions[request.package_id as usize]
-                                    .npm()
-                                    .version
-                                    .fmt(request.version_buf());
-                                let mut v = Vec::new();
-                                if options.exact_versions {
-                                    write!(&mut v, "{}", version_fmt)
-                                        .expect("infallible: in-memory write");
-                                } else {
-                                    write!(&mut v, "^{}", version_fmt)
-                                        .expect("infallible: in-memory write");
-                                }
-                                v
-                            };
-
-                            if request.resolve_npm_alias {
-                                let alias_name = manager.lockfile.packages.items_name()
-                                    [request.package_id as usize]
-                                    .slice(manager.lockfile.buffers.string_bytes.as_slice());
-                                let mut v = Vec::new();
-                                write!(
-                                    &mut v,
-                                    "npm:{}@{}",
-                                    bstr::BStr::new(alias_name),
-                                    bstr::BStr::new(&new_version)
+                            let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+                            let resolved_name = manager.lockfile.packages.items_name()
+                                [request.package_id as usize]
+                                .slice(string_buf);
+                            let mut specifier = Vec::new();
+                            write!(
+                                &mut specifier,
+                                "{}",
+                                request.resolved_npm_specifier(
+                                    resolved_name,
+                                    resolutions[request.package_id as usize].npm().version,
+                                    request.version_buf(),
+                                    options.exact_versions,
                                 )
-                                .unwrap();
-                                break 'npm arena_str(arena, &v);
-                            }
-
-                            break 'npm arena_str(arena, &new_version);
+                            )
+                            .expect("infallible: in-memory write");
+                            break 'npm arena_str(arena, &specifier);
                         }
 
                         arena_dup(arena, request.version.literal.slice(request.version_buf()))

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -32,6 +32,7 @@ pub struct UpdateRequest {
     pub(crate) version_buf: bun_ptr::RawSlice<u8>,
     pub(crate) package_id: PackageID,
     pub(crate) is_aliased: bool,
+    pub(crate) resolve_npm_alias: bool,
     pub failed: bool,
     /// This must be cloned to handle when the AST store resets.
     /// ARENA-owned (AST `Expr.Data` store) — raw pointer per LIFETIMES.tsv;
@@ -48,6 +49,7 @@ impl Default for UpdateRequest {
             version_buf: bun_ptr::RawSlice::EMPTY,
             package_id: INVALID_PACKAGE_ID,
             is_aliased: false,
+            resolve_npm_alias: false,
             failed: false,
             e_string: None,
         }
@@ -283,9 +285,18 @@ impl UpdateRequest {
                 return Err(crate::Error::UnrecognizedDependencyFormat);
             }
 
+            let resolve_npm_alias = match version.tag {
+                dependency::Tag::DistTag => value.starts_with(b"npm:"),
+                dependency::Tag::Npm => {
+                    version.npm().is_alias
+                        && value.len() == b"npm:".len() + version.npm().name.slice(input).len()
+                }
+                _ => false,
+            };
             let mut request = UpdateRequest {
                 version,
                 version_buf: bun_ptr::RawSlice::new(input),
+                resolve_npm_alias,
                 ..UpdateRequest::default()
             };
             if let Some(name) = alias {

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -1,4 +1,5 @@
 use crate::lockfile::package::PackageColumns as _;
+use core::fmt;
 use std::io::Write as _;
 
 use bun_ast::{Loc, Log};
@@ -72,6 +73,21 @@ fn anchor_cli_bytes(b: Box<[u8]>) -> &'static [u8] {
 }
 
 impl UpdateRequest {
+    pub(crate) fn resolved_npm_specifier<'a>(
+        &self,
+        resolved_name: &'a [u8],
+        resolved_version: bun_semver::Version,
+        string_buf: &'a [u8],
+        exact: bool,
+    ) -> ResolvedNpmSpecifier<'a> {
+        ResolvedNpmSpecifier {
+            alias_target: self.resolve_npm_alias.then_some(resolved_name),
+            version: resolved_version,
+            string_buf,
+            exact,
+        }
+    }
+
     /// Is `name` one of the `bun update <name>` targets? `false` for a bare `bun update`.
     #[inline]
     pub fn contains_name(
@@ -317,6 +333,25 @@ impl UpdateRequest {
         }
 
         Ok(update_requests.as_mut_slice())
+    }
+}
+
+pub(crate) struct ResolvedNpmSpecifier<'a> {
+    alias_target: Option<&'a [u8]>,
+    version: bun_semver::Version,
+    string_buf: &'a [u8],
+    exact: bool,
+}
+
+impl fmt::Display for ResolvedNpmSpecifier<'_> {
+    fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(alias_target) = self.alias_target {
+            write!(writer, "npm:{}@", bstr::BStr::new(alias_target))?;
+        }
+        if !self.exact {
+            write!(writer, "^")?;
+        }
+        write!(writer, "{}", self.version.fmt(self.string_buf))
     }
 }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -739,23 +739,13 @@ impl Lockfile {
 
                                 let npm_ver = res.npm().version;
                                 let string_buf = string_builder.string_bytes.as_slice();
-                                let len = if update.resolve_npm_alias {
-                                    bun_core::fmt::count(format_args!(
-                                        "npm:{}@{}{}",
-                                        bstr::BStr::new(
-                                            package_names[old_resolution as usize]
-                                                .slice(string_buf)
-                                        ),
-                                        if exact_versions { "" } else { "^" },
-                                        npm_ver.fmt(string_buf),
-                                    ))
-                                } else {
-                                    bun_core::fmt::count(format_args!(
-                                        "{}{}",
-                                        if exact_versions { "" } else { "^" },
-                                        npm_ver.fmt(string_buf),
-                                    ))
-                                };
+                                let specifier = update.resolved_npm_specifier(
+                                    package_names[old_resolution as usize].slice(string_buf),
+                                    npm_ver,
+                                    string_buf,
+                                    exact_versions,
+                                );
+                                let len = bun_core::fmt::count(format_args!("{specifier}"));
 
                                 if len >= SemverString::MAX_INLINE_LEN {
                                     string_builder.cap += len;
@@ -808,27 +798,17 @@ impl Lockfile {
                                 let npm_ver = res.npm().version;
                                 let string_buf = string_builder.string_bytes.as_slice();
                                 let mut buf = Vec::new();
-                                if update.resolve_npm_alias {
-                                    write!(
-                                        &mut buf,
-                                        "npm:{}@{}{}",
-                                        bstr::BStr::new(
-                                            package_names[old_resolution as usize]
-                                                .slice(string_buf)
-                                        ),
-                                        if exact_versions { "" } else { "^" },
-                                        npm_ver.fmt(string_buf),
+                                write!(
+                                    &mut buf,
+                                    "{}",
+                                    update.resolved_npm_specifier(
+                                        package_names[old_resolution as usize].slice(string_buf),
+                                        npm_ver,
+                                        string_buf,
+                                        exact_versions,
                                     )
-                                    .expect("infallible: in-memory write");
-                                } else {
-                                    write!(
-                                        &mut buf,
-                                        "{}{}",
-                                        if exact_versions { "" } else { "^" },
-                                        npm_ver.fmt(string_buf),
-                                    )
-                                    .expect("infallible: in-memory write");
-                                }
+                                )
+                                .expect("infallible: in-memory write");
 
                                 let external_version =
                                     string_builder.append::<ExternalString>(&buf);

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -716,6 +716,7 @@ impl Lockfile {
                 let old_resolutions: &[PackageID] =
                     old_resolutions_list.get(old.buffers.resolutions.as_slice());
                 let resolutions_of_yore: &[Resolution] = old.packages.items_resolution();
+                let package_names = old.packages.items_name();
                 let packages_len = old.packages.len();
 
                 for update in updates.iter() {
@@ -728,19 +729,33 @@ impl Lockfile {
                                 }
                                 let res = resolutions_of_yore[old_resolution as usize];
                                 if res.tag != ResolutionTag::Npm
-                                    || update.version.tag != dependency::Tag::DistTag
+                                    || (update.version.tag != dependency::Tag::DistTag
+                                        && !update.resolve_npm_alias)
                                 {
                                     continue;
                                 }
 
-                                // TODO(dylan-conway): this will need to handle updating dependencies (exact, ^, or ~) and aliases
+                                // TODO(dylan-conway): this will need to handle updating dependencies (exact, ^, or ~)
 
                                 let npm_ver = res.npm().version;
-                                let len = bun_core::fmt::count(format_args!(
-                                    "{}{}",
-                                    if exact_versions { "" } else { "^" },
-                                    npm_ver.fmt(string_builder.string_bytes.as_slice()),
-                                ));
+                                let string_buf = string_builder.string_bytes.as_slice();
+                                let len = if update.resolve_npm_alias {
+                                    bun_core::fmt::count(format_args!(
+                                        "npm:{}@{}{}",
+                                        bstr::BStr::new(
+                                            package_names[old_resolution as usize]
+                                                .slice(string_buf)
+                                        ),
+                                        if exact_versions { "" } else { "^" },
+                                        npm_ver.fmt(string_buf),
+                                    ))
+                                } else {
+                                    bun_core::fmt::count(format_args!(
+                                        "{}{}",
+                                        if exact_versions { "" } else { "^" },
+                                        npm_ver.fmt(string_buf),
+                                    ))
+                                };
 
                                 if len >= SemverString::MAX_INLINE_LEN {
                                     string_builder.cap += len;
@@ -759,8 +774,6 @@ impl Lockfile {
             // the only fallible call above is `allocate()`, which precedes this point).
 
             {
-                let mut temp_buf = [0u8; 513];
-
                 let root_deps: &mut [Dependency] =
                     root_deps_list.mut_(old.buffers.dependencies.as_mut_slice());
                 let old_resolutions_list_lists = old.packages.items_resolutions();
@@ -769,6 +782,7 @@ impl Lockfile {
                 let old_resolutions: &[PackageID] =
                     old_resolutions_list.get(old.buffers.resolutions.as_slice());
                 let resolutions_of_yore: &[Resolution] = old.packages.items_resolution();
+                let package_names = old.packages.items_name();
                 let packages_len = old.packages.len();
 
                 for update in updates.iter_mut() {
@@ -783,32 +797,41 @@ impl Lockfile {
                                 }
                                 let res = resolutions_of_yore[old_resolution as usize];
                                 if res.tag != ResolutionTag::Npm
-                                    || update.version.tag != dependency::Tag::DistTag
+                                    || (update.version.tag != dependency::Tag::DistTag
+                                        && !update.resolve_npm_alias)
                                 {
                                     continue;
                                 }
 
-                                // TODO(dylan-conway): this will need to handle updating dependencies (exact, ^, or ~) and aliases
+                                // TODO(dylan-conway): this will need to handle updating dependencies (exact, ^, or ~)
 
                                 let npm_ver = res.npm().version;
-                                let buf = {
-                                    let mut cursor: &mut [u8] = &mut temp_buf[..];
-                                    let start_len = cursor.len();
-                                    if write!(
-                                        cursor,
+                                let string_buf = string_builder.string_bytes.as_slice();
+                                let mut buf = Vec::new();
+                                if update.resolve_npm_alias {
+                                    write!(
+                                        &mut buf,
+                                        "npm:{}@{}{}",
+                                        bstr::BStr::new(
+                                            package_names[old_resolution as usize]
+                                                .slice(string_buf)
+                                        ),
+                                        if exact_versions { "" } else { "^" },
+                                        npm_ver.fmt(string_buf),
+                                    )
+                                    .expect("infallible: in-memory write");
+                                } else {
+                                    write!(
+                                        &mut buf,
                                         "{}{}",
                                         if exact_versions { "" } else { "^" },
-                                        npm_ver.fmt(string_builder.string_bytes.as_slice()),
+                                        npm_ver.fmt(string_buf),
                                     )
-                                    .is_err()
-                                    {
-                                        break;
-                                    }
-                                    let written = start_len - cursor.len();
-                                    &temp_buf[..written]
-                                };
+                                    .expect("infallible: in-memory write");
+                                }
 
-                                let external_version = string_builder.append::<ExternalString>(buf);
+                                let external_version =
+                                    string_builder.append::<ExternalString>(&buf);
                                 let sliced = external_version
                                     .value
                                     .sliced(string_builder.string_bytes.as_slice());

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -352,7 +352,7 @@ where
         bstr::BStr::new(package_name),
     )?;
 
-    if let Some(npm) = dependency.version.try_npm().filter(|npm| npm.is_alias) {
+    if let Some(npm) = dependency.npm_alias() {
         bun_core::write_pretty!(
             writer,
             ENABLE_ANSI_COLORS,

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -505,18 +505,33 @@ where
         let bin = bins[package_id as usize];
 
         let package_name = name.slice(string_buf);
+        let resolved_package_name = slice.items_name()[package_id as usize].slice(string_buf);
+        let resolution = resolved[package_id as usize];
+        let is_npm_alias =
+            resolution.tag == resolution::Tag::Npm && package_name != resolved_package_name;
 
         match bin.tag {
             bin::Tag::None | bin::Tag::Dir => {
                 printed_installed_update_request = true;
 
-                bun_core::write_pretty!(
-                    writer,
-                    ENABLE_ANSI_COLORS,
-                    "<r><green>installed<r> <b>{s}<r><d>@{f}<r>\n",
-                    bstr::BStr::new(package_name),
-                    resolved[package_id as usize].fmt(string_buf, PathSep::Posix),
-                )?;
+                if is_npm_alias {
+                    bun_core::write_pretty!(
+                        writer,
+                        ENABLE_ANSI_COLORS,
+                        "<r><green>installed<r> <b>{s}<r><d>@npm:<r><b>{s}<r><d>@{f}<r>\n",
+                        bstr::BStr::new(package_name),
+                        bstr::BStr::new(resolved_package_name),
+                        resolution.fmt(string_buf, PathSep::Posix),
+                    )?;
+                } else {
+                    bun_core::write_pretty!(
+                        writer,
+                        ENABLE_ANSI_COLORS,
+                        "<r><green>installed<r> <b>{s}<r><d>@{f}<r>\n",
+                        bstr::BStr::new(package_name),
+                        resolution.fmt(string_buf, PathSep::Posix),
+                    )?;
+                }
             }
             bin::Tag::Map | bin::Tag::File | bin::Tag::NamedFile => {
                 printed_installed_update_request = true;
@@ -534,13 +549,22 @@ where
                     extern_string_buf: this.lockfile.buffers.extern_strings.as_slice(),
                 };
 
-                {
+                if is_npm_alias {
+                    bun_core::write_pretty!(
+                        writer,
+                        ENABLE_ANSI_COLORS,
+                        "<r><green>installed<r> <b>{s}<r><d>@npm:<r><b>{s}<r><d>@{f}<r> with binaries:\n",
+                        bstr::BStr::new(package_name),
+                        bstr::BStr::new(resolved_package_name),
+                        resolution.fmt(string_buf, PathSep::Posix),
+                    )?;
+                } else {
                     bun_core::write_pretty!(
                         writer,
                         ENABLE_ANSI_COLORS,
                         "<r><green>installed<r> {s}<r><d>@{f}<r> with binaries:\n",
                         bstr::BStr::new(package_name),
-                        resolved[package_id as usize].fmt(string_buf, PathSep::Posix),
+                        resolution.fmt(string_buf, PathSep::Posix),
                     )?;
                 }
 

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -334,6 +334,48 @@ where
     Ok(())
 }
 
+fn print_installed_update_request<W, const ENABLE_ANSI_COLORS: bool>(
+    writer: &mut W,
+    dependency: &Dependency,
+    resolution: Resolution,
+    string_buf: &[u8],
+    has_binaries: bool,
+) -> Result<(), crate::Error>
+where
+    W: Write,
+{
+    let package_name = dependency.name.slice(string_buf);
+    bun_core::write_pretty!(
+        writer,
+        ENABLE_ANSI_COLORS,
+        "<r><green>installed<r> <b>{s}<r>",
+        bstr::BStr::new(package_name),
+    )?;
+
+    if let Some(npm) = dependency.version.try_npm().filter(|npm| npm.is_alias) {
+        bun_core::write_pretty!(
+            writer,
+            ENABLE_ANSI_COLORS,
+            "<d>@npm:<r><b>{s}<r>",
+            bstr::BStr::new(npm.name.slice(string_buf)),
+        )?;
+    }
+
+    bun_core::write_pretty!(
+        writer,
+        ENABLE_ANSI_COLORS,
+        "<d>@{f}<r>",
+        resolution.fmt(string_buf, PathSep::Posix),
+    )?;
+    writer.write_str(if has_binaries {
+        " with binaries:\n"
+    } else {
+        "\n"
+    })?;
+
+    Ok(())
+}
+
 /// - Prints an empty newline with no diffs
 /// - Prints a leading and trailing blank newline with diffs
 pub(crate) fn print<W, const ENABLE_ANSI_COLORS: bool>(
@@ -504,34 +546,18 @@ where
         let package_id = resolutions_buffer[dependency_id as usize];
         let bin = bins[package_id as usize];
 
-        let package_name = name.slice(string_buf);
-        let resolved_package_name = slice.items_name()[package_id as usize].slice(string_buf);
         let resolution = resolved[package_id as usize];
-        let is_npm_alias =
-            resolution.tag == resolution::Tag::Npm && package_name != resolved_package_name;
 
         match bin.tag {
             bin::Tag::None | bin::Tag::Dir => {
                 printed_installed_update_request = true;
-
-                if is_npm_alias {
-                    bun_core::write_pretty!(
-                        writer,
-                        ENABLE_ANSI_COLORS,
-                        "<r><green>installed<r> <b>{s}<r><d>@npm:<r><b>{s}<r><d>@{f}<r>\n",
-                        bstr::BStr::new(package_name),
-                        bstr::BStr::new(resolved_package_name),
-                        resolution.fmt(string_buf, PathSep::Posix),
-                    )?;
-                } else {
-                    bun_core::write_pretty!(
-                        writer,
-                        ENABLE_ANSI_COLORS,
-                        "<r><green>installed<r> <b>{s}<r><d>@{f}<r>\n",
-                        bstr::BStr::new(package_name),
-                        resolution.fmt(string_buf, PathSep::Posix),
-                    )?;
-                }
+                print_installed_update_request::<W, ENABLE_ANSI_COLORS>(
+                    writer,
+                    &dependencies_buffer[dependency_id as usize],
+                    resolution,
+                    string_buf,
+                    false,
+                )?;
             }
             bin::Tag::Map | bin::Tag::File | bin::Tag::NamedFile => {
                 printed_installed_update_request = true;
@@ -549,24 +575,13 @@ where
                     extern_string_buf: this.lockfile.buffers.extern_strings.as_slice(),
                 };
 
-                if is_npm_alias {
-                    bun_core::write_pretty!(
-                        writer,
-                        ENABLE_ANSI_COLORS,
-                        "<r><green>installed<r> <b>{s}<r><d>@npm:<r><b>{s}<r><d>@{f}<r> with binaries:\n",
-                        bstr::BStr::new(package_name),
-                        bstr::BStr::new(resolved_package_name),
-                        resolution.fmt(string_buf, PathSep::Posix),
-                    )?;
-                } else {
-                    bun_core::write_pretty!(
-                        writer,
-                        ENABLE_ANSI_COLORS,
-                        "<r><green>installed<r> {s}<r><d>@{f}<r> with binaries:\n",
-                        bstr::BStr::new(package_name),
-                        resolution.fmt(string_buf, PathSep::Posix),
-                    )?;
-                }
+                print_installed_update_request::<W, ENABLE_ANSI_COLORS>(
+                    writer,
+                    &dependencies_buffer[dependency_id as usize],
+                    resolution,
+                    string_buf,
+                    true,
+                )?;
 
                 {
                     if matches!(manager.track_installed_bin, TrackInstalledBin::Pending) {

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -542,6 +542,11 @@ impl Clone for Dependency {
 }
 
 impl Dependency {
+    #[inline]
+    pub fn npm_alias(&self) -> Option<&NpmInfo> {
+        self.version.try_npm().filter(|npm| npm.is_alias)
+    }
+
     /// Sorting order for dependencies is:
     /// 1. [`workspaces`, `devDependencies`, `optionalDependencies`, `dependencies`, `peerDependencies`]
     /// 2. name ASC

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,18 +1,22 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
+  createTestContext,
+  destroyTestContext,
   dummyAfterAll,
   dummyAfterEach,
   dummyBeforeAll,
   dummyBeforeEach,
   dummyRegistry,
+  dummyRegistryForContext,
   package_dir,
   requested,
   root_url,
+  setContextHandler,
   setHandler,
 } from "./dummy.registry";
 
@@ -1239,6 +1243,127 @@ it("should add aliased dependency (npm)", async () => {
     ),
   );
   await access(join(package_dir, "bun.lockb"));
+});
+
+describe("npm aliases", () => {
+  const packageJSON = {
+    name: "foo",
+    version: "0.0.1",
+  };
+  const registryVersions = {
+    "0.0.3": { bin: { "baz-run": "index.js" } },
+    "0.0.5": { bin: { "baz-run": "index.js" } },
+    latest: "0.0.3",
+  };
+  const registryDistTags = {
+    rc: "0.0.5",
+  };
+  let ctx: import("./dummy.registry").TestContext;
+  let urls: string[];
+
+  beforeEach(async () => {
+    ctx = await createTestContext({ linker: "hoisted" });
+    urls = [];
+    const registry = dummyRegistryForContext(ctx, urls, registryVersions);
+    setContextHandler(ctx, async request => {
+      const response = await registry(request);
+      if (request.url.endsWith(".tgz")) {
+        return response;
+      }
+
+      const manifest = await response.json();
+      Object.assign(manifest["dist-tags"], registryDistTags);
+      return Response.json(manifest);
+    });
+    await writeFile(join(ctx.package_dir, "package.json"), JSON.stringify(packageJSON));
+  });
+
+  afterEach(() => destroyTestContext(ctx));
+
+  test.each(
+    [
+      {
+        args: ["format@npm:baz"],
+        resolved: { name: "baz", version: "0.0.3" },
+        expected: { dependencies: { format: "npm:baz@^0.0.3" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz@latest"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz@rc"],
+        resolved: { name: "@scope/baz", version: "0.0.5" },
+        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.5" } },
+      },
+      {
+        args: ["--exact", "bar@npm:@scope/baz"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@0.0.3" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz@0.0.3"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@0.0.3" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz@^0.0.3"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz@~0.0.2"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@~0.0.2" } },
+      },
+      {
+        args: ["bar@npm:@scope/baz@>=0.0.2"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { dependencies: { bar: "npm:@scope/baz@>=0.0.2" } },
+      },
+      {
+        args: ["--dev", "bar@npm:@scope/baz"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { devDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+      },
+      {
+        args: ["--optional", "bar@npm:@scope/baz"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { optionalDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+      },
+      {
+        args: ["--peer", "bar@npm:@scope/baz"],
+        resolved: { name: "@scope/baz", version: "0.0.3" },
+        expected: { peerDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+      },
+    ].map(testCase => ({ ...testCase, command: `bun add ${testCase.args.join(" ")}` })),
+  )("$command", async ({ args, resolved, expected }) => {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "add", ...args],
+      cwd: ctx.package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    expect(await stderr.text()).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+    expect(urls.sort()).toEqual([
+      `${ctx.registry_url}${resolved.name.replace("/", "%2f")}`,
+      `${ctx.registry_url}${resolved.name}-${resolved.version}.tgz`,
+    ]);
+    expect(await file(join(ctx.package_dir, "package.json")).json()).toEqual({
+      ...packageJSON,
+      ...expected,
+    });
+  });
 });
 
 it("should add aliased dependency (GitHub)", async () => {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,3 +1,4 @@
+import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
@@ -1246,6 +1247,11 @@ it("should add aliased dependency (npm)", async () => {
 });
 
 describe("npm aliases", () => {
+  type TestCase = {
+    args: string[];
+    resolved: { name: string; version: string };
+    expected: BunLockFile["workspaces"][string];
+  };
   const packageJSON = {
     name: "foo",
     version: "0.0.1",
@@ -1262,7 +1268,7 @@ describe("npm aliases", () => {
   let urls: string[];
 
   beforeEach(async () => {
-    ctx = await createTestContext({ linker: "hoisted" });
+    ctx = await createTestContext({ linker: "hoisted", saveTextLockfile: true });
     urls = [];
     const registry = dummyRegistryForContext(ctx, urls, registryVersions);
     setContextHandler(ctx, async request => {
@@ -1280,90 +1286,118 @@ describe("npm aliases", () => {
 
   afterEach(() => destroyTestContext(ctx));
 
-  test.each(
-    [
-      {
-        args: ["format@npm:baz"],
-        resolved: { name: "baz", version: "0.0.3" },
-        expected: { dependencies: { format: "npm:baz@^0.0.3" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz@latest"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz@rc"],
-        resolved: { name: "@scope/baz", version: "0.0.5" },
-        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.5" } },
-      },
-      {
-        args: ["--exact", "bar@npm:@scope/baz"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@0.0.3" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz@0.0.3"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@0.0.3" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz@^0.0.3"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz@~0.0.2"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@~0.0.2" } },
-      },
-      {
-        args: ["bar@npm:@scope/baz@>=0.0.2"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { dependencies: { bar: "npm:@scope/baz@>=0.0.2" } },
-      },
-      {
-        args: ["--dev", "bar@npm:@scope/baz"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { devDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
-      },
-      {
-        args: ["--optional", "bar@npm:@scope/baz"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { optionalDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
-      },
-      {
-        args: ["--peer", "bar@npm:@scope/baz"],
-        resolved: { name: "@scope/baz", version: "0.0.3" },
-        expected: { peerDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
-      },
-    ].map(testCase => ({ ...testCase, command: `bun add ${testCase.args.join(" ")}` })),
-  )("$command", async ({ args, resolved, expected }) => {
-    const { stderr, exited } = spawn({
-      cmd: [bunExe(), "add", ...args],
-      cwd: ctx.package_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env,
-    });
+  const testCases: TestCase[] = [
+    {
+      args: ["format@npm:baz"],
+      resolved: { name: "baz", version: "0.0.3" },
+      expected: { dependencies: { format: "npm:baz@^0.0.3" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz@latest"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz@rc"],
+      resolved: { name: "@scope/baz", version: "0.0.5" },
+      expected: { dependencies: { bar: "npm:@scope/baz@^0.0.5" } },
+    },
+    {
+      args: ["--exact", "bar@npm:@scope/baz"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@0.0.3" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz@0.0.3"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@0.0.3" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz@^0.0.3"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz@~0.0.2"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@~0.0.2" } },
+    },
+    {
+      args: ["bar@npm:@scope/baz@>=0.0.2"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { dependencies: { bar: "npm:@scope/baz@>=0.0.2" } },
+    },
+    {
+      args: ["--dev", "bar@npm:@scope/baz"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { devDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+    },
+    {
+      args: ["--optional", "bar@npm:@scope/baz"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { optionalDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+    },
+    {
+      args: ["--peer", "bar@npm:@scope/baz"],
+      resolved: { name: "@scope/baz", version: "0.0.3" },
+      expected: { peerDependencies: { bar: "npm:@scope/baz@^0.0.3" } },
+    },
+  ];
 
-    expect(await stderr.text()).toContain("Saved lockfile");
-    expect(await exited).toBe(0);
-    expect(urls.sort()).toEqual([
-      `${ctx.registry_url}${resolved.name.replace("/", "%2f")}`,
-      `${ctx.registry_url}${resolved.name}-${resolved.version}.tgz`,
-    ]);
-    expect(await file(join(ctx.package_dir, "package.json")).json()).toEqual({
-      ...packageJSON,
-      ...expected,
-    });
-  });
+  test.each(testCases.map(testCase => ({ ...testCase, command: `bun add ${testCase.args.join(" ")}` })))(
+    "$command",
+    async ({ args, resolved, expected }) => {
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "add", ...args],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+
+      expect(await stderr.text()).toContain("Saved lockfile");
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([
+        `${ctx.registry_url}${resolved.name.replace("/", "%2f")}`,
+        `${ctx.registry_url}${resolved.name}-${resolved.version}.tgz`,
+      ]);
+      expect(await file(join(ctx.package_dir, "package.json")).json()).toEqual({
+        ...packageJSON,
+        ...expected,
+      });
+
+      const lockfilePath = join(ctx.package_dir, "bun.lock");
+      const lockfile: BunLockFile = await import(lockfilePath);
+      expect(lockfile.workspaces[""]).toEqual({ name: packageJSON.name, ...expected });
+
+      const dependencyRecord = Object.values(expected)[0];
+      if (dependencyRecord === null || typeof dependencyRecord !== "object" || Array.isArray(dependencyRecord)) {
+        throw new Error("Expected a dependency record");
+      }
+      const [alias] = Object.keys(dependencyRecord);
+      expect(lockfile.packages[alias]?.[0]).toBe(`${resolved.name}@${resolved.version}`);
+
+      const frozenInstall = spawn({
+        cmd: [bunExe(), "install", "--frozen-lockfile", "--lockfile-only"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+
+      expect(await frozenInstall.stderr.text()).toContain("Saved lockfile");
+      expect(await frozenInstall.exited).toBe(0);
+
+      const lockfileAfterFrozenInstall: BunLockFile = await import(`${lockfilePath}?after-frozen-install`);
+      expect(lockfileAfterFrozenInstall).toEqual(lockfile);
+    },
+  );
 });
 
 it("should add aliased dependency (GitHub)", async () => {

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1249,7 +1249,7 @@ it("should add aliased dependency (npm)", async () => {
 describe("npm aliases", () => {
   type TestCase = {
     args: string[];
-    resolved: { name: string; version: string };
+    resolved: { name: string; version: string; tarballVersion?: string };
     expected: BunLockFile["workspaces"][string];
   };
   const packageJSON = {
@@ -1258,11 +1258,11 @@ describe("npm aliases", () => {
   };
   const registryVersions = {
     "0.0.3": { bin: { "baz-run": "index.js" } },
-    "0.0.5": { bin: { "baz-run": "index.js" } },
+    "0.0.5-rc.123456789": { as: "0.0.5" },
     latest: "0.0.3",
   };
   const registryDistTags = {
-    rc: "0.0.5",
+    rc: "0.0.5-rc.123456789",
   };
   let ctx: import("./dummy.registry").TestContext;
   let urls: string[];
@@ -1304,8 +1304,8 @@ describe("npm aliases", () => {
     },
     {
       args: ["bar@npm:@scope/baz@rc"],
-      resolved: { name: "@scope/baz", version: "0.0.5" },
-      expected: { dependencies: { bar: "npm:@scope/baz@^0.0.5" } },
+      resolved: { name: "@scope/baz", version: "0.0.5-rc.123456789", tarballVersion: "0.0.5" },
+      expected: { dependencies: { bar: "npm:@scope/baz@^0.0.5-rc.123456789" } },
     },
     {
       args: ["--exact", "bar@npm:@scope/baz"],
@@ -1352,7 +1352,7 @@ describe("npm aliases", () => {
   test.each(testCases.map(testCase => ({ ...testCase, command: `bun add ${testCase.args.join(" ")}` })))(
     "$command",
     async ({ args, resolved, expected }) => {
-      const { stderr, exited } = spawn({
+      const { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "add", ...args],
         cwd: ctx.package_dir,
         stdout: "pipe",
@@ -1361,11 +1361,12 @@ describe("npm aliases", () => {
         env,
       });
 
+      const out = await stdout.text();
       expect(await stderr.text()).toContain("Saved lockfile");
       expect(await exited).toBe(0);
       expect(urls.sort()).toEqual([
         `${ctx.registry_url}${resolved.name.replace("/", "%2f")}`,
-        `${ctx.registry_url}${resolved.name}-${resolved.version}.tgz`,
+        `${ctx.registry_url}${resolved.name}-${resolved.tarballVersion ?? resolved.version}.tgz`,
       ]);
       expect(await file(join(ctx.package_dir, "package.json")).json()).toEqual({
         ...packageJSON,
@@ -1381,6 +1382,7 @@ describe("npm aliases", () => {
         throw new Error("Expected a dependency record");
       }
       const [alias] = Object.keys(dependencyRecord);
+      expect(out).toContain(`installed ${alias}@npm:${resolved.name}@${resolved.version}`);
       expect(lockfile.packages[alias]?.[0]).toBe(`${resolved.name}@${resolved.version}`);
 
       const frozenInstall = spawn({

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1361,9 +1361,9 @@ describe("npm aliases", () => {
         env,
       });
 
-      const out = await stdout.text();
-      expect(await stderr.text()).toContain("Saved lockfile");
-      expect(await exited).toBe(0);
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(exitCode).toBe(0);
       expect(urls.sort()).toEqual([
         `${ctx.registry_url}${resolved.name.replace("/", "%2f")}`,
         `${ctx.registry_url}${resolved.name}-${resolved.tarballVersion ?? resolved.version}.tgz`,
@@ -1374,7 +1374,7 @@ describe("npm aliases", () => {
       });
 
       const lockfilePath = join(ctx.package_dir, "bun.lock");
-      const lockfile: BunLockFile = await import(lockfilePath);
+      const lockfile = Bun.JSONC.parse(await file(lockfilePath).text()) as BunLockFile;
       expect(lockfile.workspaces[""]).toEqual({ name: packageJSON.name, ...expected });
 
       const dependencyRecord = Object.values(expected)[0];
@@ -1393,10 +1393,15 @@ describe("npm aliases", () => {
         env,
       });
 
-      expect(await frozenInstall.stderr.text()).toContain("Saved lockfile");
-      expect(await frozenInstall.exited).toBe(0);
+      const [, frozenErr, frozenExitCode] = await Promise.all([
+        frozenInstall.stdout.text(),
+        frozenInstall.stderr.text(),
+        frozenInstall.exited,
+      ]);
+      expect(frozenErr).toContain("Saved lockfile");
+      expect(frozenExitCode).toBe(0);
 
-      const lockfileAfterFrozenInstall: BunLockFile = await import(`${lockfilePath}?after-frozen-install`);
+      const lockfileAfterFrozenInstall = Bun.JSONC.parse(await file(lockfilePath).text()) as BunLockFile;
       expect(lockfileAfterFrozenInstall).toEqual(lockfile);
     },
   );

--- a/test/cli/install/dummy.registry.ts
+++ b/test/cli/install/dummy.registry.ts
@@ -108,7 +108,10 @@ function extractTestPrefix(url: string): { prefix: string; remainingPath: string
  * @param opts - Optional configuration for the test context
  * @returns A new TestContext that should be used for all test operations
  */
-export async function createTestContext(opts?: { linker: "hoisted" | "isolated" }): Promise<TestContext> {
+export async function createTestContext(opts?: {
+  linker: "hoisted" | "isolated";
+  saveTextLockfile?: boolean;
+}): Promise<TestContext> {
   const id = `test-${++testIdCounter}`;
   const pkg_dir = tmpdirSync();
 
@@ -129,7 +132,7 @@ export async function createTestContext(opts?: { linker: "hoisted" | "isolated" 
       install: {
         cache: false,
         registry: ctx.registry_url,
-        saveTextLockfile: false,
+        saveTextLockfile: opts?.saveTextLockfile ?? false,
         linker: opts?.linker,
       },
     }),


### PR DESCRIPTION
### What does this PR do?

Fixes #11901.

`bun add` previously lost the npm alias target when resolving a bare alias or dist-tag. For example:

```sh
bun add -D 'dreamcli@npm:@kjanat/dreamcli@next'
```

could save:

```json
"devDependencies": {
  "dreamcli": "^4.0.0-rc.1"
}
```

This PR preserves the alias and resolved version:

```json
"devDependencies": {
  "dreamcli": "npm:@kjanat/dreamcli@^4.0.0-rc.1"
}
```

It also:

- writes the same alias specifier to `package.json` and `bun.lock`;
- preserves explicit exact, caret, tilde, and comparator ranges;
- supports scoped and unscoped aliases across dependency sections;
- formats install output with both names, for example:
  `installed dreamcli@npm:@kjanat/dreamcli@4.0.0-rc.1`;
- centralizes npm-alias detection and resolved-specifier formatting.

<details>
<summary>Covered forms</summary>

```sh
bun add format@npm:baz
bun add bar@npm:@scope/baz
bun add bar@npm:@scope/baz@latest
bun add bar@npm:@scope/baz@rc
bun add --exact bar@npm:@scope/baz
bun add bar@npm:@scope/baz@0.0.3
bun add bar@npm:@scope/baz@^0.0.3
bun add bar@npm:@scope/baz@~0.0.2
bun add 'bar@npm:@scope/baz@>=0.0.2'
bun add --dev bar@npm:@scope/baz
bun add --optional bar@npm:@scope/baz
bun add --peer bar@npm:@scope/baz
```

</details>

### How did you verify your code works?

```sh
cargo fmt --all -- --check
cargo check -p bun_install
dprint check test/cli/install/bun-add.test.ts
bun bd test test/cli/install/bun-add.test.ts --test-name-pattern 'npm aliases'
```

The parametrized suite passes all 12 alias cases and verifies:

- `package.json` contents;
- workspace and package records in `bun.lock`;
- install output with and without package binaries;
- prerelease dist-tag resolution;
- frozen-lockfile round-trip stability.

### One thing I'm not fully set on... styling.

Specifically this part, <img width="513" height="39" alt="image" src="https://github.com/user-attachments/assets/9a22868b-574a-47c9-beef-9f1aa17d875d" /> whether only the alias, or only the package name... or what gets to have what styling.

<details><summary><a href="https://github.com/charmbracelet/vhs">vhs</a> before and after recordings of: <code>bun add -D 'dreamcli@npm:@kjanat/dreamcli@next'</code></summary>

<img width="1200" height="640" alt="before" src="https://github.com/user-attachments/assets/d3dc215d-0155-4d8f-8bf8-549acad6b741" />

<img width="1200" height="640" alt="after" src="https://github.com/user-attachments/assets/16f8690e-0d19-4d3b-82c0-792293c6c1ea" />

</details>

## Related

- Adopted by a85ddbb42bbf5106ae70b8c2bb20653f7678cb19 (oven-sh/bun#38333).
  This PR should be closed once that PR merges.