### PR TITLE
worker_threads test: make the stop-ordering fixture's log termination-safe

### DIFF
--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2520,7 +2520,11 @@ describe("worker stop ordering as seen by the worker's own handlers", () => {
   const workerSource = (door: "terminate" | "exit") => `
     const { workerData, parentPort } = require("node:worker_threads");
     const log = workerData.log;
-    const put = tag => { const i = Atomics.add(log, 0, 1) + 1; if (i < log.length) Atomics.store(log, i, tag); };
+    // The worker is the log's only writer. The tag is stored before the count that exposes it:
+    // terminate() can land between the two Atomics calls (the TerminationException is thrown
+    // inside whichever host call runs next), and a put() cut off there must leave nothing behind
+    // rather than a count that points at an unwritten (0) slot.
+    const put = tag => { const i = Atomics.load(log, 0) + 1; if (i < log.length) Atomics.store(log, i, tag); Atomics.store(log, 0, i); };
     process.on("exit", () => put(${TAG.exitHandler}));
     process.on("beforeExit", () => put(${TAG.beforeExit}));
     const net = require("node:net"), dgram = require("node:dgram"), fs = require("node:fs"), os = require("node:os");


### PR DESCRIPTION
Test-only. Fixes a rare flake in `test/js/node/worker_threads/worker_threads.test.ts`, describe "worker stop ordering as seen by the worker's own handlers", test "terminate(): nothing of the worker's runs after the request".

### Problem
- Seen once on a release CI lane: `expect(tags).toEqual([TAG.ready])` failed with `Expected [12]`, `Received [12, 0]`. No tag is 0.
- The fixture's logger was two steps on a SharedArrayBuffer: `const i = Atomics.add(log, 0, 1) + 1; if (i < log.length) Atomics.store(log, i, tag);` (`workerSource` in the describe block). A 0 entry means the count was bumped and the tag store never ran.
- Cause: `worker.terminate()` can stop the worker between those two steps. JSC's `RETURN_IF_EXCEPTION` also services pending VM traps (`vendor/WebKit/Source/JavaScriptCore/runtime/ExceptionScope.h`, `hasExceptionsAfterHandlingTraps`), and `Atomics.store` runs several of them before it writes (`runtime/AtomicsObject.cpp`, `atomicStore` / `atomicStoreCase`), as does the `log.length` getter call. A termination requested after `Atomics.add` returned is thrown from inside the next host call, and the half-written `put()` is what the parent reads. The `[12, 0]` shape matches: `ready` was logged, then the first interval tick's `put()` was cut in half.
- The other candidate, the parent observing 'exit' while the worker was still running, does not apply: `shutdown()` in `src/jsc/web_worker.rs` reports `workerGlobalScopeDestroyed` only after `VirtualMachine::teardown` has destroyed the JSC VM, and the Worker 'close' event (which `node:worker_threads` turns into 'exit' and the `terminate()` result) is dispatched only from that task (`workerGlobalScopeDestroyedInternal` in `src/jsc/bindings/webcore/WorkerMessagingProxy.cpp`). The probe below agrees: every 0 it observed was still 0 after the thread had been joined.

### Fix
- `put()` now stores the tag into its slot first and publishes the count last (`Atomics.load` + two `Atomics.store`). A `put()` that termination cuts off anywhere leaves the count untouched, so it records nothing instead of a 0; the parent's read (`Math.min(count, log.length - 1)` slots, interval ticks filtered) and both tests' assertions are unchanged.
- Correct because the worker thread is the log's only writer (its handlers, including the process 'exit' handler, all run on that thread; the parent reads only after 'exit'), so a load/store pair needs no atomic read-modify-write, and because a slot store that precedes the count store is visible to whoever sees the count.
- What the tests check is unaffected: a handler that runs to completion after the stop request is still recorded and still fails the test. Only a `put()` already in flight when the request landed changes from "0 entry" to "nothing", and such a put is not something that ran after the request.
- Verified: `bun bd test test/js/node/worker_threads/worker_threads.test.ts -t "worker stop ordering"` passes (debug/ASAN); the describe block passed 40/40 loops on the release build; probe results below.
- This is not provable with a fail-before run of the test itself: the old fixture fails at roughly one run in ten thousand (0 of 300 here, 1 CI hit), so the evidence is the probe.

### Background
- VM traps: JSC's mechanism for interrupting a running VM from another thread (`VM::notifyNeedTermination`, used by `WebWorker::request_termination`). It sets a flag; the worker thread throws the uncatchable `TerminationException` the next time it checks the flag. Checks happen at JS function entry and loop back-edges, and, in current JSC, in every `RETURN_IF_EXCEPTION` inside runtime (host) functions, so a termination can land between two consecutive host calls in straight-line JS.
- The fixture: the worker appends a tag per handler into an `Int32Array` over a `SharedArrayBuffer` (slot 0 is the count); the parent reads the log after the worker's 'exit' to check which handlers ran and in what order.

<details>
<summary>Probe: widen the window between the two steps with straight-line host calls, terminate 500 workers per variant</summary>

The window between the two steps is widened by inserting N `Atomics.load(log, 0);` statements (no loops or function calls, so a termination landing in the window lands inside a host call, as in the unmodified fixture). After 'exit' the parent reads the log; if it saw a 0 it re-reads after `terminate()` resolved (thread joined) plus 50ms. For the publish-last variant, a tag sitting in slot `count + 1` means the window was hit and nothing was recorded.

Release build, N = 3000:

```
{"logger":"count-first", "runs":500,"zeroAfterExit":2,"zeroStillThereLater":2,"unpublishedTail":0,"badTags":2}
{"logger":"publish-last","runs":500,"zeroAfterExit":0,"zeroStillThereLater":0,"unpublishedTail":5,"badTags":0}
```

N = 10000: count-first 4/500 permanent 0 entries, publish-last 0/500. N = 0 (the fixture as it was): 0/300, matching how rare the CI hit is.

```ts
import { Worker } from "node:worker_threads";
import { once } from "node:events";

const [loggerKind, widenStr, itersStr] = process.argv.slice(2);
const filler = "Atomics.load(log, 0);".repeat(Number(widenStr));
const put =
  loggerKind === "count-first"
    ? `const put = tag => { const i = Atomics.add(log, 0, 1) + 1; ${filler} if (i < log.length) Atomics.store(log, i, tag); };`
    : `const put = tag => { const i = Atomics.load(log, 0) + 1; if (i < log.length) Atomics.store(log, i, tag); ${filler} Atomics.store(log, 0, i); };`;
const source = `
  const { workerData, parentPort } = require("node:worker_threads");
  const log = workerData.log;
  ${put}
  setInterval(() => put(7), 1).unref();
  parentPort.on("message", () => {});
  put(12);
  parentPort.postMessage("ready");
`;
const read = (log: Int32Array) => Array.from(log.slice(1, 1 + Math.min(Atomics.load(log, 0), log.length - 1)));
let zeroAfterExit = 0, zeroStillThereLater = 0, unpublishedTail = 0, badTags = 0;
for (let i = 0; i < Number(itersStr); i++) {
  const log = new Int32Array(new SharedArrayBuffer(4 * 4096));
  const w = new Worker(source, { eval: true, workerData: { log } });
  const exited = once(w, "exit");
  await once(w, "message");
  await Bun.sleep(Math.random() * 3);
  const t = w.terminate();
  await exited;
  const first = read(log);
  await t;
  const count = Atomics.load(log, 0);
  if (first.includes(0)) {
    zeroAfterExit++;
    await Bun.sleep(50);
    if (read(log).includes(0)) zeroStillThereLater++;
  }
  if (log[count + 1] !== 0) unpublishedTail++;
  const tags = first.filter(t => t !== 7);
  if (tags.length !== 1 || tags[0] !== 12) badTags++;
}
console.log(JSON.stringify({ logger: loggerKind, zeroAfterExit, zeroStillThereLater, unpublishedTail, badTags }));
```

</details>
