### PR TITLE
node:http2: destroy the socket on session.destroy() without close(), emit the session 'close' once the socket has closed

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5034,10 +5034,11 @@ function destroySessionSocketDelayedNT(socket, error) {
 // Node's finishSessionClose. Either way end() goes first, so the final GOAWAY
 // leaves behind a FIN instead of an abortive close.
 //
-// `graceful` is a session that was close()d: it has announced the shutdown and
-// waits for the peer to hang up, only resume()ing "so we can detect the peer
-// closing" (unread inbound bytes, e.g. the peer's own GOAWAY, would otherwise
-// turn our eventual close into an RST the peer reads as ECONNRESET).
+// `graceful` is a session that was close()d (and is not dying with an error on
+// top of that): it has announced the shutdown and waits for the peer to hang
+// up, only resume()ing "so we can detect the peer closing" (unread inbound
+// bytes, e.g. the peer's own GOAWAY, would otherwise turn our eventual close
+// into an RST the peer reads as ECONNRESET).
 //
 // Everything else is a destroy(), and node hard-destroys the socket once the
 // FIN is out (a tick later, "to try to avoid ECONNRESET on Windows"). That

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -451,12 +451,29 @@ function emitEventNT(self: any, event: string, ...args: any[]) {
     self.emit(event, ...args);
   }
 }
-// The frame is passed in: destroy() clears it off the session before emitting
-// 'error', so a throwing listener on either event cannot leave a retained
-// session pinning the store.
-function emitSessionCloseNT(self: Http2Session, frame) {
+// Node's emitClose. The frame is passed in: destroy() clears it off the session
+// before scheduling this, so a throwing listener on either event cannot leave a
+// retained session pinning the store.
+function emitSessionCloseNT(self: Http2Session, error: Error | undefined, frame) {
+  if (error) {
+    runInFrame(frame, self.emit, self, "error", error);
+  }
   if (self.listenerCount("close") > 0) {
     runInFrame(frame, self.emit, self, "close");
+  }
+}
+// Node's finishSessionClose emits the session's 'error'/'close' from the socket's
+// own 'close' listener, so by the time a session reports itself closed its
+// connection is gone (a server's getConnections() no longer counts it). Only a
+// session whose socket is already down (or that never had one) emits on the next
+// tick; even then it is asynchronous, so a listener attached right after
+// close()/destroy() returns still observes it.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1188
+function emitSessionCloseAfterSocket(self: Http2Session, socket, error: Error | undefined, frame) {
+  if (socket && !socket.destroyed) {
+    socket.once("close", () => emitSessionCloseNT(self, error, frame));
+  } else {
+    process.nextTick(emitSessionCloseNT, self, error, frame);
   }
 }
 function emitErrorNT(self: any, error: any, destroy: boolean) {
@@ -4903,7 +4920,8 @@ class ServerHttp2Session extends Http2Session {
       return;
     }
     this.#destroying = true;
-    emitHttp2SessionPerf(this, this.#parser, this[bunHTTP2Socket]);
+    const socket = this[bunHTTP2Socket];
+    emitHttp2SessionPerf(this, this.#parser, socket);
     try {
       const server = this[kServer];
       if (server) {
@@ -4927,7 +4945,6 @@ class ServerHttp2Session extends Http2Session {
         this[kSessionDestroyError] = error;
       }
 
-      const socket = this[bunHTTP2Socket];
       if (!this.#connected) return;
       this.#closed = true;
       this.#connected = false;
@@ -4938,24 +4955,7 @@ class ServerHttp2Session extends Http2Session {
           // a destroy(err) after close() must still put the error GOAWAY on the wire.
           this.goaway(code || constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(0));
         }
-        if (error) {
-          // node's finishSessionClose destroys the socket when the session dies
-          // with an error (a misbehaving peer must observe the connection going
-          // away) - but it still ends first and destroys a tick later, so the
-          // final GOAWAY flushes behind a FIN instead of an abortive close (see
-          // endThenDestroySessionSocket).
-          endThenDestroySessionSocket(socket, error);
-        } else {
-          // Node's finishSessionClose: "If we're gracefully closing the socket,
-          // call resume() so we can detect the peer closing in case
-          // binding.Http2Session is already gone." Without a reader, unread
-          // inbound bytes (a late GOAWAY from the peer) turn the close into an
-          // RST, which the peer surfaces as read ECONNRESET (routine on Windows
-          // loopback - the same reason Node delays the error-path destroy).
-          // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1188
-          socket.resume();
-          socket.end();
-        }
+        closeSessionSocket(socket, this.#closeCalled && !error, error);
       }
       const parser = this.#parser;
       if (parser) {
@@ -4981,16 +4981,9 @@ class ServerHttp2Session extends Http2Session {
     }
     this[bunHTTP2Socket] = null;
 
-    // Read-and-clear the frame first: emitting 'error' with no listener throws,
-    // which would skip the clear and leave a retained session pinning the store.
     const asyncFrame = this[bunHTTP2AsyncContextFrame];
     this[bunHTTP2AsyncContextFrame] = undefined;
-    if (error) {
-      runInFrame(asyncFrame, this.emit, this, "error", error);
-    }
-    // node emits the session 'close' event asynchronously (a listener attached right after
-    // close()/destroy() returns must still observe it).
-    process.nextTick(emitSessionCloseNT, this, asyncFrame);
+    emitSessionCloseAfterSocket(this, socket, error, asyncFrame);
   }
 }
 function emitTimeout(session: ClientHttp2Session) {
@@ -5033,19 +5026,34 @@ function setSessionTimeout(this: Http2Session, msecs, callback) {
   return this;
 }
 
-// Node's finishSessionClose error path: socket.end() flushes and sends the FIN
-// first, and the hard destroy runs a tick later - "If session.destroy() was
-// called, destroy the underlying socket. Delay it a bit to try to avoid
-// ECONNRESET on Windows" - so the peer reads our final frames off a FIN'd
-// socket instead of observing an abortive close.
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1188
 function destroySessionSocketDelayedNT(socket, error) {
   if (!socket.destroyed) {
     socket.destroy(error);
   }
 }
-function endThenDestroySessionSocket(socket, error) {
-  socket.end(() => setImmediate(destroySessionSocketDelayedNT, socket, error));
+// Node's finishSessionClose. Either way end() goes first, so the final GOAWAY
+// leaves behind a FIN instead of an abortive close.
+//
+// `graceful` is a session that was close()d: it has announced the shutdown and
+// waits for the peer to hang up, only resume()ing "so we can detect the peer
+// closing" (unread inbound bytes, e.g. the peer's own GOAWAY, would otherwise
+// turn our eventual close into an RST the peer reads as ECONNRESET).
+//
+// Everything else is a destroy(), and node hard-destroys the socket once the
+// FIN is out (a tick later, "to try to avoid ECONNRESET on Windows"). That
+// destroy is what releases the connection: destroy() is what timeouts and error
+// handling use against a peer that has stopped responding, and such a peer
+// does not answer the FIN either, so end() alone would keep the socket (and a
+// server's connection count) alive for as long as the peer cares to linger.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1188
+function closeSessionSocket(socket, graceful: boolean, error: Error | undefined) {
+  if (socket.destroyed) return;
+  if (graceful) {
+    socket.resume();
+    socket.end();
+  } else {
+    socket.end(() => setImmediate(destroySessionSocketDelayedNT, socket, error));
+  }
 }
 // node callTimeout (lib/internal/http2/core.js): when the timer expires while writes are still in
 // flight and bytes have reached the wire since the previous expiry, the session is not idle —
@@ -6029,18 +6037,7 @@ class ClientHttp2Session extends Http2Session {
           // a destroy(err) after close() must still put the error GOAWAY on the wire.
           this.goaway(code || constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(0));
         }
-        if (error) {
-          // See the client session: end first, destroy a tick later (node's
-          // finishSessionClose Windows-ECONNRESET avoidance).
-          endThenDestroySessionSocket(socket, error);
-        } else {
-          // See the client session's destroy: Node's finishSessionClose resumes
-          // the socket on a graceful close so unread inbound bytes cannot turn
-          // the FIN teardown into an RST.
-          // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1188
-          socket.resume();
-          socket.end();
-        }
+        closeSessionSocket(socket, this.#closeCalled && !error, error);
       }
       const parser = this.#parser;
       if (parser) {
@@ -6070,16 +6067,9 @@ class ClientHttp2Session extends Http2Session {
     this.#parser = null;
     this[bunHTTP2Socket] = null;
 
-    // Read-and-clear the frame first: emitting 'error' with no listener throws,
-    // which would skip the clear and leave a retained session pinning the store.
     const asyncFrame = this[bunHTTP2AsyncContextFrame];
     this[bunHTTP2AsyncContextFrame] = undefined;
-    if (error) {
-      runInFrame(asyncFrame, this.emit, this, "error", error);
-    }
-    // node emits the session 'close' event asynchronously (a listener attached right after
-    // close()/destroy() returns must still observe it).
-    process.nextTick(emitSessionCloseNT, this, asyncFrame);
+    emitSessionCloseAfterSocket(this, socket, error, asyncFrame);
   }
 
   request(headers: any, options?: any) {

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1005,9 +1005,11 @@ describe("async context passes through", () => {
     expect(stderr).not.toContain("AssertionError");
   });
 
-  // destroy(err) with no 'error' listener throws out of the emit, which must
-  // not skip the frame clear (the 'close' tick after it never runs).
-  test("http2 clears the session frame when destroy(err) throws past the emit", async () => {
+  // Like node, destroy(err) emits 'error' later (once the socket has closed), so
+  // with no listener it surfaces as an uncaught exception rather than a throw out
+  // of destroy(); the frame must already be clear when destroy() returns, not
+  // only once the deferred emit has run.
+  test("http2 clears the session frame when destroy(err) has no 'error' listener", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -1021,13 +1023,18 @@ describe("async context passes through", () => {
            als.run({ marker: true }, () => {
              client = http2.connect("http://127.0.0.1:" + server.address().port);
            });
+           // The throw IS the condition: the unlistened 'error' can only come from
+           // the deferred emit, which runs strictly after the read-and-clear.
+           process.on("uncaughtException", err => {
+             console.log("UNCAUGHT " + err.message);
+             // Drain rather than process.exit(), like the siblings.
+             server.close();
+           });
            client.on("connect", () => {
-             try { client.destroy(new Error("boom")); } catch {}
+             client.destroy(new Error("boom"));
              const sym = Object.getOwnPropertySymbols(client)
                .find(x => x.description === "::bunhttp2asynccontextframe::");
              console.log(sym === undefined ? "SYMBOL-MISSING" : client[sym] === undefined ? "CLEARED" : "PINNED");
-             // Drain rather than process.exit(), like the siblings.
-             server.close();
            });
          });`,
       ],
@@ -1036,7 +1043,7 @@ describe("async context passes through", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "CLEARED", exitCode: 0 });
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "CLEARED\nUNCAUGHT boom", exitCode: 0 });
     expect(stderr).not.toContain("AssertionError");
   });
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4396,6 +4396,228 @@ it("close() completes when the peer never ACKs an outstanding SETTINGS", async (
   server.close();
 });
 
+// Node's finishSessionClose: destroy() ends the socket and then hard-destroys it, so the
+// connection is released even when the peer never closes its own side (the peer a timeout or
+// an error handler is typically destroying). close() only ends it and waits for the peer. In
+// both cases the session's 'error'/'close' are emitted once the socket itself has closed.
+describe.concurrent("session teardown when the peer never closes its side of the connection", () => {
+  // allowHalfOpen keeps the peer's side open after our FIN arrives: from the server's point of
+  // view this is a peer that stays connected for as long as it likes, and `peer.end()` is the
+  // peer finally hanging up.
+  async function lingeringPeer(server) {
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+    const peer = net.connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+    peer.on("error", () => {});
+    const sawFin = new Promise(resolve => peer.once("end", resolve));
+    peer.resume(); // 'end' only fires on a socket that is reading
+    return { peer, sawFin };
+  }
+  async function acceptH2c(server) {
+    const session = new Promise(resolve => server.once("session", resolve));
+    // The server's own 'connection' listener (which creates the session) is registered first,
+    // so this resolves with the socket behind the session above.
+    const socket = new Promise(resolve => server.once("connection", resolve));
+    const { peer, sawFin } = await lingeringPeer(server);
+    return { session: await session, socket: await socket, peer, sawFin };
+  }
+  function connectionCount(server) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    server.getConnections((err, count) => (err ? reject(err) : resolve(count)));
+    return promise;
+  }
+  // Records the session's terminal events, each tagged with whether its socket was already
+  // destroyed when the event fired; `closed` resolves with the list once 'close' has fired.
+  function recordTeardown(session, socket) {
+    const events = [];
+    const { promise: closed, resolve } = Promise.withResolvers();
+    session.on("error", err => events.push(["error", err.message, socket.destroyed]));
+    session.on("close", () => {
+      events.push(["close", socket.destroyed]);
+      resolve(events);
+    });
+    return { events, closed };
+  }
+  // A server that accepts and then says and does nothing, and whose side of each connection
+  // stays open after the client's FIN (allowHalfOpen): the client-side shape of the same peer.
+  async function silentServer() {
+    const accepted = [];
+    const server = net.createServer({ allowHalfOpen: true }, socket => {
+      accepted.push(socket);
+      socket.resume(); // 'end' only fires on a socket that is reading
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+    return {
+      port,
+      firstConnectionEnded: new Promise(resolve => server.once("connection", socket => socket.once("end", resolve))),
+      [Symbol.dispose]() {
+        for (const socket of accepted) socket.destroy();
+        server.close();
+      },
+    };
+  }
+  function connectOverOwnSocket(port) {
+    let socket;
+    const client = http2.connect(`http://127.0.0.1:${port}`, {
+      createConnection: () => (socket = net.connect({ port, host: "127.0.0.1" })),
+    });
+    return { client, socket };
+  }
+
+  it("server session.destroy() destroys the socket and releases the server connection", async () => {
+    const server = http2.createServer();
+    const { session, socket, peer, sawFin } = await acceptH2c(server);
+    try {
+      const { closed } = recordTeardown(session, socket);
+      session.destroy();
+      expect(session.destroyed).toBeTrue();
+      await sawFin; // the FIN still goes out first: the peer is told we are done before the hard close
+      expect(await closed).toEqual([["close", true]]);
+      expect(await connectionCount(server)).toBe(0);
+      await new Promise(resolve => server.close(resolve));
+    } finally {
+      peer.destroy();
+      server.close();
+    }
+  });
+
+  it("server session.destroy(err) emits 'error' and 'close' only once the socket is gone", async () => {
+    const server = http2.createServer();
+    const { session, socket, peer } = await acceptH2c(server);
+    try {
+      const { closed } = recordTeardown(session, socket);
+      session.destroy(new Error("boom"));
+      expect(await closed).toEqual([
+        ["error", "boom", true],
+        ["close", true],
+      ]);
+      expect(await connectionCount(server)).toBe(0);
+    } finally {
+      peer.destroy();
+      server.close();
+    }
+  });
+
+  it("server.setTimeout() reaping an idle session releases its connection", async () => {
+    const server = http2.createServer();
+    server.setTimeout(1); // armed on every accepted session; an unhandled 'timeout' destroys it
+    const { session, socket, peer } = await acceptH2c(server);
+    try {
+      const { closed } = recordTeardown(session, socket);
+      expect(await closed).toEqual([["close", true]]);
+      expect(await connectionCount(server)).toBe(0);
+    } finally {
+      peer.destroy();
+      server.close();
+    }
+  });
+
+  it("server session.close() leaves the socket to the peer and reports 'close' once it hangs up", async () => {
+    const server = http2.createServer();
+    const { session, socket, peer, sawFin } = await acceptH2c(server);
+    try {
+      const { events, closed } = recordTeardown(session, socket);
+      session.close();
+      await sawFin; // our GOAWAY + FIN are out and the peer has not answered either
+      expect({ events, socketDestroyed: socket.destroyed, connections: await connectionCount(server) }).toEqual({
+        events: [],
+        socketDestroyed: false,
+        connections: 1,
+      });
+      peer.end(); // the peer hangs up: now the socket closes, and the session reports it
+      expect(await closed).toEqual([["close", true]]);
+      expect(await connectionCount(server)).toBe(0);
+    } finally {
+      peer.destroy();
+      server.close();
+    }
+  });
+
+  it("secure server session.destroy() destroys the TLS socket and releases the server connection", async () => {
+    const server = http2.createSecureServer(TLS_CERT);
+    const session = new Promise(resolve => server.once("session", resolve));
+    const socket = new Promise(resolve => server.once("secureConnection", resolve));
+    const { peer, sawFin } = await lingeringPeer(server);
+    // The peer's TLS layer talks through a carrier Duplex that stops delivering inbound bytes
+    // once the handshake is done, so it never sees the server's close_notify and never answers
+    // it (a TLS peer that answered would close the connection itself and mask the bug).
+    let handshakeDone = false;
+    const carrier = new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        peer.write(chunk, callback);
+      },
+    });
+    peer.on("data", chunk => {
+      if (!handshakeDone) carrier.push(chunk);
+    });
+    await new Promise(resolve => peer.once("connect", resolve));
+    const peerTls = tls.connect({ socket: carrier, ALPNProtocols: ["h2"], ...TLS_OPTIONS, servername: "localhost" });
+    peerTls.on("error", () => {});
+    await new Promise(resolve => peerTls.once("secureConnect", resolve));
+    handshakeDone = true;
+    const serverSession = await session;
+    const serverSocket = await socket;
+    try {
+      const { closed } = recordTeardown(serverSession, serverSocket);
+      serverSession.destroy();
+      await sawFin;
+      expect(await closed).toEqual([["close", true]]);
+      expect(await connectionCount(server)).toBe(0);
+      await new Promise(resolve => server.close(resolve));
+    } finally {
+      peerTls.destroy();
+      peer.destroy();
+      server.close();
+    }
+  });
+
+  it("client session.destroy() destroys the socket even though the server never closes", async () => {
+    using server = await silentServer();
+    const { client, socket } = connectOverOwnSocket(server.port);
+    try {
+      await new Promise(resolve => client.once("connect", resolve));
+      const { closed } = recordTeardown(client, socket);
+      client.destroy();
+      expect(client.destroyed).toBeTrue();
+      await server.firstConnectionEnded; // the FIN still goes out first
+      expect(await closed).toEqual([["close", true]]);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  it("client session.destroy(err) emits 'error' and 'close' only once the socket is gone", async () => {
+    using server = await silentServer();
+    const { client, socket } = connectOverOwnSocket(server.port);
+    try {
+      await new Promise(resolve => client.once("connect", resolve));
+      const { closed } = recordTeardown(client, socket);
+      client.destroy(new Error("boom"));
+      expect(await closed).toEqual([
+        ["error", "boom", true],
+        ["close", true],
+      ]);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  it("a session whose socket the peer already closed still reports 'close'", async () => {
+    const server = http2.createServer();
+    const { session, socket, peer } = await acceptH2c(server);
+    try {
+      const { closed } = recordTeardown(session, socket);
+      peer.destroy();
+      expect(await closed).toEqual([["close", true]]);
+      expect(await connectionCount(server)).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+});
+
 // A pull-mode consumer (pause() then on('readable')/read()) must reopen the receive
 // window via _read(): the 'resume' event never fires on that path, so without _read()
 // clearing the paused gate the peer stalls at the initial ~64KB stream window.


### PR DESCRIPTION
### Problem
- `session.destroy()` without an error only `end()`s the session's socket. Against a peer that does not close its own side the socket then stays open for as long as the peer likes: a server's `getConnections()` keeps counting it and `server.close(cb)` never calls back. Node destroys the socket. Same on bun 1.4.0 and main, on a plain listening `http2.createServer()` / `createSecureServer()` and on client sessions.
- A peer that does not hang up is exactly the peer `destroy()` gets used against (idle-timeout reaping, `server.setTimeout()`, error handling). A well-behaved peer hides the bug by closing when it reads our GOAWAY + FIN.
- The session's `'error'` / `'close'` fire synchronously / on the next tick while the socket is still open. In node both fire from the socket's own `'close'`, so a session that has reported `'close'` has already released its connection.
- Cause: `ServerHttp2Session#destroy()` and `ClientHttp2Session#destroy()` in `src/js/node/http2.ts` (main L4941 and L6032) choose end-then-destroy only `if (error)` and a bare `end()` otherwise. Node's `finishSessionClose` (lib/internal/http2/core.js L1188, v26.3.0) keys this on whether `close()` was called (`session.closed`), not on whether there was an error; `destroy()` on a session that was not `close()`d always destroys the socket.

### Fix
- `closeSessionSocket()` replaces the two inline branches in both `destroy()`s: `end()` only when `close()` was called (bun already tracks this as `#closeCalled`) and there is no error, otherwise `end()` followed by `socket.destroy(error)` one `setImmediate` after the FIN is out. That is node's condition, plus the existing bun behaviour that an error after `close()` still hard-closes; the error path itself is unchanged. A socket that is already destroyed is left alone, as in node.
- `emitSessionCloseAfterSocket()` replaces the synchronous `'error'` emit plus `nextTick` `'close'`: when the socket is still up, the session's `'error'` and `'close'` are emitted from the socket's `'close'` (node's `emitClose`); when it is already gone (socket `'close'` / `'error'` driven teardown) or there never was one, they are emitted on the next tick, as node does. The events still run in the session's captured async-context frame, which `destroy()` still clears before scheduling them.
- Why this is right: it matches node. The `end()` before the destroy still puts GOAWAY + FIN on the wire before the hard close (node's Windows ECONNRESET avoidance, already used on the error path), the graceful `close()` path is unchanged apart from when `'close'` fires, and the only other observable difference is also node's: `destroy(err)` with no `'error'` listener now surfaces the error as an uncaught exception instead of throwing out of `destroy()`.
- Verified with `bun bd test test/js/node/http2/node-http2.test.js` (new `describe` "session teardown when the peer never closes its side of the connection": server `destroy()`, `destroy(err)`, `server.setTimeout()` reaping, `close()` parity, `createSecureServer` over TLS, client `destroy()` / `destroy(err)`, and the peer-closes-first path; 7 of the 8 fail on main, the last one guards the next-tick path) and `test/js/node/async_hooks/AsyncLocalStorage.test.ts` (the `destroy(err)` frame-clearing test now asserts the node-shaped unlistened-error behaviour; fails on main).
- node's vendored http2 suites (`test/js/node/test/{parallel,sequential}/test-http2-*`, 282 files) give the same result before and after (281 pass; `test-http2-forget-closed-streams` times out under the debug build either way). `node-http2.test.js`, `h2-conformance`, the staged h2 tests, `node-http2-upgrade`, grpc-js `test-server` / `test-metadata`, the ping-flood test and `AsyncLocalStorage.test.ts` pass.
- Related, not overlapping: #38154 releases the raw socket behind an injected (`server.emit('connection', raw)`) connection at the TLS proxy layer and is what surfaced this; #38158 reorders the same `destroy()` bodies so handle-less sockets get their GOAWAY and will need a trivial rebase against this (or vice versa).

### Background
- `Http2Session#close()` is the graceful shutdown: it sends GOAWAY, lets in-flight streams finish and then calls `destroy()` itself. `destroy()` is the immediate teardown, used directly by timeouts and error handling. Node records `close()` in `session.closed`; bun's equivalent flag is `#closeCalled` (`#closed` is also set by `destroy()`).
- Node's `finishSessionClose` is the last step of both: it registers the session's `'error'`/`'close'` emission on the socket's `'close'`, calls `socket.end()`, and, unless `session.closed`, destroys the socket once `end()` has flushed. `socket.end()` only half-closes (sends a FIN); the socket is not released, and the server's connection count not decremented, until it is destroyed, which without `socket.destroy()` only happens once the peer sends its own FIN.
- The tests build an unresponsive peer out of a `net` socket with `allowHalfOpen: true` (it receives our FIN and keeps its side open) and, for the TLS case, a client whose carrier `Duplex` stops delivering inbound bytes after the handshake, so it never answers the server's close_notify.

<details>
<summary>Probe: h2c server, peer never closes its side, `server.getConnections()` read after the session reported `'close'` (or after 2s)</summary>

```
                node v26.3.0                                     bun 1.4.0 / main                                         this branch
destroy()       socket destroyed, connections=0                  socket never destroyed, connections=1                    as node
destroy(err)    socket destroyed, 'error'/'close' fire with      socket destroyed, but 'error'/'close' fire with          as node
                socket.destroyed === true                        socket.destroyed === false
close()         waits for the peer: no 'close', connections=1    'close' fires at once, connections=1                     as node
```

`createSecureServer` behaves the same. Whether a user's own socket `'close'` listener runs before or after the session's `'close'` depends only on listener registration order (it differs between node's h2c and TLS runs as well), so the tests assert `socket.destroyed` from inside the session's handlers rather than that order.
</details>
