### PR TITLE
test: speed up the AbortSignal.timeout + util.aborted leak test and assert its numbers

### DIFF
--- a/test/regression/issue/28756.test.ts
+++ b/test/regression/issue/28756.test.ts
@@ -1,73 +1,113 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 // https://github.com/oven-sh/bun/issues/28756
-// AbortSignal.timeout() + util.aborted() causes unbounded memory growth
-// because the extra ref() taken in timeout() is never released when all
-// listeners are removed before the timer fires.
+// AbortSignal.timeout() + util.aborted(): once the listener aborted() added is
+// gone nothing observes the signal any more, and the signal and its timer have
+// to become garbage. The bug kept every such signal alive until the timer
+// fired (here: never).
+//
+// The child churns batches of signals after a warmup batch and reports
+//   - how many AbortSignal wrappers outlive a full GC: 0 when fixed, every
+//     signal when something keeps the signal observed or referenced,
+//   - RSS growth since the warmup batch, which also covers the original shape
+//     of the bug, where the wrapper died but the native signal and timer did not.
+//
+// RSS of the fixed build still moves by a few MB of JIT code and allocator
+// slack that do not scale with the signal count, so the release build churns
+// enough signals for a leak to stand clear of that floor. Measured on linux
+// x64, fixed build vs. leak simulated by keeping every signal alive:
+//   release,    80 x 500 signals:  2-4 MB vs. 23-34 MB (0.6-0.9 KB per signal)
+//   debug+ASAN,  4 x 250 signals:  0-3 MB vs.   0-3 MB (hidden in the slack)
+// Slow builds churn few signals to keep the file fast, so there only the
+// wrapper count tells the two apart and the RSS bound is a coarse backstop.
+const slow = isASAN || isDebug;
+const batchSize = slow ? 250 : 500;
+const batches = slow ? 4 : 80;
+const signals = batchSize * batches;
+const maxRssGrowthMB = 12;
+
 test("AbortSignal.timeout + util.aborted does not leak memory", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `
+      /* js */ `
       const { aborted } = require("util");
+      const { heapStats } = require("bun:jsc");
       const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const liveSignals = () => heapStats().objectTypeCounts.AbortSignal ?? 0;
 
-      // 10 batches * 8000 = 80k signals.
-      // Without fix: leaks ~0.8 KB/signal => ~60 MB growth.
-      // With fix: stays flat.
-      // Completes in <2s on release, ~120s on ASAN.
-      const iterations = 10;
-      const batchSize = 8000;
-
-      // Warm up so baseline memory is established.
-      for (let i = 0; i < 200; i++) {
-        const sig = AbortSignal.timeout(1_000_000_000);
-        sig.addEventListener("abort", () => {});
-        aborted(sig, {});
-      }
-      await new Promise(r => setTimeout(r, 0));
-      Bun.gc(true);
-      await new Promise(r => setTimeout(r, 50));
-      Bun.gc(true);
-      const baselineRSS = rss();
-
-      for (let iter = 0; iter < iterations; iter++) {
-        for (let i = 0; i < batchSize; i++) {
-          function lis() {}
-          const sig = AbortSignal.timeout(1_000_000_000);
-          sig.addEventListener("abort", lis);
-          aborted(sig, {});
-          sig.removeEventListener("abort", lis);
+      function churn() {
+        for (let i = 0; i < ${batchSize}; i++) {
+          const listener = () => {};
+          const signal = AbortSignal.timeout(1_000_000_000);
+          signal.addEventListener("abort", listener);
+          aborted(signal, {});
+          signal.removeEventListener("abort", listener);
         }
-        await new Promise(r => setTimeout(r, 0));
+      }
+
+      // A churned signal dies in two collections: the first collects the {}
+      // passed to aborted(), whose FinalizationRegistry callback removes the
+      // listener aborted() registered (callbacks run as a task, hence the event
+      // loop turn), the second collects the now unobserved signal and its timer.
+      async function settle() {
+        Bun.gc(true);
+        await new Promise(resolve => setImmediate(resolve));
         Bun.gc(true);
       }
 
-      await new Promise(r => setTimeout(r, 100));
-      Bun.gc(true);
-      await new Promise(r => setTimeout(r, 100));
-      Bun.gc(true);
+      churn();
+      await settle();
+      const baselineRss = rss();
+      const baselineSignals = liveSignals();
 
-      const finalRSS = rss();
-      const growth = finalRSS - baselineRSS;
-      const growthMB = (growth / 1024 / 1024).toFixed(1);
-      console.log(JSON.stringify({ baselineMB: (baselineRSS/1024/1024).toFixed(1), finalMB: (finalRSS/1024/1024).toFixed(1), growthMB }));
-      // Without the fix, 80k signals leak ~60 MB.  With the fix, <50 MB.
-      // ASAN's quarantine retains freed allocations so widen the threshold there.
-      process.exit(growth < ${isASAN ? 256 : 50} * 1024 * 1024 ? 0 : 1);
+      const rssGrowthPerBatch = [];
+      for (let i = 0; i < ${batches}; i++) {
+        churn();
+        await settle();
+        rssGrowthPerBatch.push(rss() - baselineRss);
+      }
+
+      console.log(JSON.stringify({
+        leakedSignals: liveSignals() - baselineSignals,
+        rssGrowth: rssGrowthPerBatch.at(-1),
+        rssGrowthPerBatch,
+      }));
       `,
     ],
-    env: bunEnv,
+    env: {
+      ...bunEnv,
+      // ASAN parks freed allocations in its quarantine (default 256 MB) instead
+      // of reusing them, so RSS grows by everything the child allocates whether
+      // or not it leaks (measured: the fixed build grew more than the leaking
+      // one). Disable it for the measuring process; non-ASAN builds ignore it.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+    },
     stdout: "pipe",
     stderr: "pipe",
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
 
-  if (exitCode !== 0) {
-    expect().fail(`Memory grew too much. stdout: ${stdout} stderr: ${stderr}`);
-  }
+  const { leakedSignals, rssGrowth, rssGrowthPerBatch } = JSON.parse(stdout);
+  expect(rssGrowthPerBatch).toHaveLength(batches);
+
+  // With the leak every signal survives. Conservative stack scanning can keep
+  // a couple of them alive on a fixed build, never a whole batch.
+  expect(leakedSignals, `${leakedSignals} of ${signals} AbortSignal wrappers survived GC`).toBeLessThan(batchSize);
+
+  const toMB = (bytes: number) => (bytes / 1024 / 1024).toFixed(1) + " MB";
+  const every = Math.ceil(batches / 8);
+  const trend = rssGrowthPerBatch.flatMap((bytes: number, i: number) =>
+    (i + 1) % every === 0 ? [`${i + 1}: ${toMB(bytes)}`] : [],
+  );
+  expect(
+    rssGrowth / 1024 / 1024,
+    `RSS grew ${toMB(rssGrowth)} over ${signals} signals (after batch ${trend.join(", ")})`,
+  ).toBeLessThan(maxRssGrowthMB);
+
   expect(exitCode).toBe(0);
-}, 300_000);
+});


### PR DESCRIPTION
### Problem
- `test/regression/issue/28756.test.ts` (leak test for #28756, fixed in #28761) takes 13s on the x64 ASAN lane and 95s under a local `bun bd` (debug+ASAN), versus 0.6-1.7s on the release lanes. The child churns 10 x 8000 signals and sleeps 50-100ms between GCs.
- The parent only looks at the child's exit code; the child decides pass/fail itself and its `baselineMB`/`finalMB`/`growthMB` line is ignored.
- On ASAN builds the test cannot fail: the bound is 256 MB while the leak is ~60 MB. With ASAN's quarantine on, RSS also stops measuring retention at all: at 4 x 1000 signals the fixed build grew 9.1 MB and a simulated leak grew 7.0 MB (freed memory stays resident in the quarantine, leaked memory is never freed).
- Under ASAN the RSS of the fixed build and of a leaking build only separate after several thousand signals, and a debug+ASAN build spends ~0.3ms per signal plus ~0.5s just loading `node:util`, so on those builds a signal count that fits in the default test timeout is too small for an RSS bound to tell the two apart.

### Fix
- The child churns batches of signals (listener added, `aborted()` called, listener removed) after one warmup batch, settles with `gc, one event loop turn, gc`, and prints JSON with the number of `AbortSignal` wrappers that survived relative to the post-warmup count (`bun:jsc` `heapStats()`) and the RSS growth after every batch.
- The parent asserts `stderr === ""`, that every batch reported, `leakedSignals < batchSize` (a leak keeps every signal alive, the fixed build keeps 0), RSS growth below 12 MB with the per-batch trend in the failure message, and the exit code last.
- Release builds churn 80 x 500 signals; ASAN or debug builds churn 4 x 250. The RSS floor of the fixed build (JIT code, allocator slack) is a few MB and does not grow with the count, so the release count leaves the leak well clear of it; on slow builds the wrapper count is the assertion that detects the leak and the RSS bound is a backstop. The comment in the file records the measurements.
- The child runs with `ASAN_OPTIONS=...:quarantine_size_mb=0`, the same thing the other RSS based leak tests do, so freed memory is reused and RSS growth means retention on ASAN builds too.
- The remaining event loop turn (`setImmediate`) is required, not a delay: the `{}` passed to `aborted()` dies on the first GC, its `FinalizationRegistry` callback (a task) removes the listener `aborted()` registered, and only the second GC can collect the signal. Verified by counting wrappers: `gc, microtask, gc` leaves all 1000 alive, `gc, setImmediate, gc` leaves 0. The 50/100ms sleeps and the 300s per test timeout are gone.
- Why this is the right measurement: a signal that leaks the way #28756 did, or any other way, either keeps its wrapper alive (counted directly) or only its native object and timer alive (shows in RSS at the release count, 0.6-0.9 KB per signal, 23-34 MB at 40k signals against the 12 MB bound).

### Verification
- `bun bd test test/regression/issue/28756.test.ts` (debug+ASAN): 94.8s before, 2.5-2.8s after (20 runs: RSS growth 0-3.1 MB, `leakedSignals` 0 every time, slowest run 3.6s).
- `USE_SYSTEM_BUN=1 bun test ...` (release 1.4.0): 1.1s before, ~0.3s after (30 runs: RSS growth 2.0-3.1 MB, `leakedSignals` 0 every time).
- Leak still detected, by temporarily simulating it in the child and reverting:
  - listener never removed (signal stays observed): release `40000 of 40000 AbortSignal wrappers survived GC`, debug+ASAN `1000 of 1000 ...`.
  - every signal pushed into an array: same two failures.
  - same two simulations with the wrapper assertion deleted, to exercise the RSS bound alone: release fails with `RSS grew 32.0-34.0 MB` and `RSS grew 23.0 MB over 40000 signals (after batch 10: 3.0 MB, 20: 8.0 MB, ... 80: 23.0 MB)` against the 12 MB bound; on debug+ASAN at 1000 signals both grow 0-3 MB and pass, which is the documented reason the wrapper count carries those builds.
- The x64 ASAN lane churns 1250 signals instead of 80k and no longer sleeps; its time should come down to process startup.

### Background
- `util.aborted(signal, resource)` registers an abort listener and a `FinalizationRegistry` entry keyed on `resource`; when `resource` is collected the callback removes the listener again. `FinalizationRegistry` callbacks run as event loop tasks after the GC that found the dead target, so a microtask checkpoint is not enough to run them.
- A timeout signal's wrapper is kept alive by the GC only while something observes it (`JSAbortSignalOwner::isReachableFromOpaqueRoots`); once the last listener is gone the wrapper is collectible and its destructor frees the native signal and its timer (#35849, #37666). #28756 was the older variant of this: the wrapper died but the timer held a reference on the native signal.
- `heapStats().objectTypeCounts.AbortSignal` from `bun:jsc` is the number of live `AbortSignal` wrappers in the JS heap after the last collection.
- ASAN's allocator keeps freed allocations in a quarantine (256 MB by default) to detect use after free, so under ASAN RSS tracks the volume allocated rather than the volume retained unless the quarantine is disabled.
