### PR TITLE
resolver: make auto-install use the version range from the project's package.json

### DIFF
--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -170,9 +170,10 @@ impl hooks::AutoInstaller for PackageManager {
         &self,
         name: &[u8],
         version: &hooks::DependencyVersion,
+        version_buf: &[u8],
     ) -> Option<PackageID> {
         self.lockfile
-            .resolve_package_from_name_and_version(name, version)
+            .resolve_package_from_name_and_version(name, version, version_buf)
     }
 
     fn lockfile_legacy_package_to_dependency_id(
@@ -432,6 +433,31 @@ impl hooks::AutoInstaller for PackageManager {
     fn infer_dependency_tag(&self, dep: &[u8]) -> hooks::DependencyVersionTag {
         <dependency::Tag as dependency::TagExt>::infer(dep)
     }
+}
+
+// ─── Dependency parsing without a manager (resolver → install link-time hook) ──
+//
+// `bun_resolver::PackageJSON::parse` reads the project's package.json before the
+// first bare import creates the `PackageManager` (see `Resolver::parse_dependency`).
+// `parse` only uses the manager to record `npm:` aliases, and
+// `lockfile_append_from_package_json` records them when these dependencies are
+// cloned into the lockfile, so nothing is lost by parsing without one.
+#[unsafe(no_mangle)]
+fn __bun_resolver_parse_dependency(
+    name: SemverString,
+    name_hash: hooks::PackageNameHash,
+    version: &[u8],
+    sliced: &SlicedString,
+    log: Option<&mut bun_ast::Log>,
+) -> Option<hooks::DependencyVersion> {
+    dependency::parse(
+        name,
+        name_hash,
+        version,
+        sliced,
+        log,
+        None::<&mut PackageManager>,
+    )
 }
 
 // ─── Lazy factory (resolver → install link-time hook) ─────────────────────

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3052,10 +3052,15 @@ impl Lockfile {
         Ok(digest)
     }
 
+    /// `version_buf` is the buffer `version`'s strings (prerelease/build tags)
+    /// were parsed against. The auto-install resolver passes versions parsed
+    /// from a project's package.json here, so it is not always this lockfile's
+    /// string buffer.
     pub(crate) fn resolve_package_from_name_and_version(
         &self,
         package_name: &[u8],
         version: &DependencyVersion,
+        version_buf: &[u8],
     ) -> Option<PackageID> {
         let name_hash = SemverStringBuilder::string_hash(package_name);
         let entry = self.package_index.get(&name_hash)?;
@@ -3071,7 +3076,7 @@ impl Lockfile {
                 // folder/symlink deps share the name index with other variants.
                 let satisfies = |resolution: &Resolution| -> bool {
                     resolution.tag == ResolutionTag::Npm
-                        && npm_group.satisfies(resolution.npm().version, buf, buf)
+                        && npm_group.satisfies(resolution.npm().version, version_buf, buf)
                 };
                 match entry {
                     PackageIndexEntry::Id(id) => {

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1446,7 +1446,15 @@ pub trait AutoInstaller {
     fn lockfile_dependencies_buf(&self) -> &[Dependency];
     fn lockfile_resolutions_buf(&self) -> &[PackageID];
     fn lockfile_string_bytes(&self) -> &[u8];
-    fn lockfile_resolve(&self, name: &[u8], version: &DependencyVersion) -> Option<PackageID>;
+    /// `version_buf` holds the strings `version` was parsed against (a
+    /// package.json's bytes, the lockfile's string buffer, or the import
+    /// specifier itself).
+    fn lockfile_resolve(
+        &self,
+        name: &[u8],
+        version: &DependencyVersion,
+        version_buf: &[u8],
+    ) -> Option<PackageID>;
     fn lockfile_legacy_package_to_dependency_id(
         &self,
         package_id: PackageID,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -98,6 +98,13 @@ pub struct InitOptions {
     /// `transpiler.resolver.store_fd` BEFORE `configure_linker()` reads
     /// `top_level_dir`, so it threads through `init_runtime_state`.
     pub store_fd: bool,
+    /// Auto-install mode (`--install=...`). Like `store_fd`, it must be on the
+    /// resolver BEFORE `configure_linker()` reads `top_level_dir`: that read
+    /// caches the project's package.json, and its dependency ranges are only
+    /// recorded (for auto-install to resolve against) when the resolver has
+    /// auto-install enabled at the time it is cached. Defaults to `disable`,
+    /// matching `BundleOptions::from_api`.
+    pub global_cache: bun_options_types::global_cache::GlobalCache,
     pub smol: bool,
     pub eval_mode: bool,
     pub is_main_thread: bool,
@@ -123,6 +130,7 @@ impl Default for InitOptions {
             env_loader: None,
             graph: None,
             store_fd: false,
+            global_cache: bun_options_types::global_cache::GlobalCache::disable,
             smol: false,
             eval_mode: false,
             is_main_thread: false,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -811,9 +811,11 @@ impl PackageJSON {
                                 Some(&mut *r_log),
                             ) {
                                 if dependency_version.is_exact_npm() {
-                                    if let Some(resolved) =
-                                        pm.lockfile_resolve(&package_json.name, &dependency_version)
-                                    {
+                                    if let Some(resolved) = pm.lockfile_resolve(
+                                        &package_json.name,
+                                        &dependency_version,
+                                        &package_json.version,
+                                    ) {
                                         package_json.package_manager_package_id = resolved;
                                         if resolved > 0 {
                                             break 'update_dependencies;
@@ -904,25 +906,30 @@ impl PackageJSON {
                                     let Some(version_str) = prop.value.as_str() else {
                                         continue;
                                     };
-                                    let sliced_str =
-                                        Semver::SlicedString::init(version_str, version_str);
+                                    // Like the key above: a value with JSON escapes is
+                                    // decoded outside the source buffer and cannot be
+                                    // stored as an offset into it.
+                                    if !bun_alloc::is_slice_in_buffer(
+                                        version_str,
+                                        package_json.dependencies.source_buf,
+                                    ) {
+                                        continue;
+                                    }
+                                    // The strings inside the parsed version are offsets
+                                    // into this buffer; every reader of the map slices
+                                    // them with `dependencies.source_buf`.
+                                    let sliced_str = Semver::SlicedString::init(
+                                        package_json.dependencies.source_buf,
+                                        version_str,
+                                    );
 
-                                    // The parser body lives in install-tier so route through
-                                    // the AutoInstaller vtable when one is wired. When it
-                                    // isn't, still record the dependency name (with an
-                                    // uninitialized-tag version) — `bun run --filter` reads
-                                    // only the map keys to compute workspace ordering.
-                                    let dependency_version = match r.auto_installer() {
-                                        Some(pm) => pm.parse_dependency(
-                                            name,
-                                            Some(name_hash),
-                                            version_str,
-                                            &sliced_str,
-                                            Some(&mut *r_log),
-                                        ),
-                                        None => Some(DependencyVersion::default()),
-                                    };
-                                    if let Some(dependency_version) = dependency_version {
+                                    if let Some(dependency_version) = r.parse_dependency(
+                                        name,
+                                        name_hash,
+                                        version_str,
+                                        &sliced_str,
+                                        Some(&mut *r_log),
+                                    ) {
                                         let dependency = Dependency {
                                             name,
                                             version: dependency_version,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -20,8 +20,8 @@ use ::bun_install_types::resolver_hooks as Install;
 use ::bun_install_types::resolver_hooks::{AutoInstaller, Resolution};
 use ::bun_semver as Semver;
 
-// LAYERING: `PackageManager.initWithRuntime` lives in
-// `bun_install`, which depends on this crate. The lazy-init body is defined
+// LAYERING: `PackageManager.initWithRuntime` and `Dependency.parse` live in
+// `bun_install`, which depends on this crate. Both bodies are defined
 // `#[no_mangle]` in `bun_install::auto_installer` and resolved at link time
 // (same pattern as `__bun_regex_*` / `__BUN_RUNTIME_HOOKS`). `install` is the
 // `?*Api.BunInstall` (`self.opts.install`); `env` is the `*DotEnv.Loader`.
@@ -37,6 +37,16 @@ unsafe extern "Rust" {
         install: Option<NonNull<bun_options_types::schema::api::BunInstall>>,
         env: NonNull<bun_dotenv::Loader>,
     ) -> core::result::Result<NonNull<dyn AutoInstaller>, bun_errno::SystemErrno>;
+
+    /// `Dependency.parse` with no `PackageManager` (it only uses one to record
+    /// `npm:` aliases). See [`Resolver::parse_dependency`].
+    safe fn __bun_resolver_parse_dependency(
+        name: Semver::String,
+        name_hash: Install::PackageNameHash,
+        version: &[u8],
+        sliced: &Semver::SlicedString,
+        log: Option<&mut bun_ast::Log>,
+    ) -> Option<Dependency::Version>;
 }
 use crate::cache::Set as CacheSet;
 use ::bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
@@ -860,6 +870,26 @@ impl<'a> Resolver<'a> {
         // singleton, live for the resolver's lifetime once installed; `&mut
         // self` ⇒ exclusive access to the only Rust handle.
         self.package_manager.map(|mut pm| unsafe { pm.as_mut() })
+    }
+
+    /// Parses one package.json dependency value (`"^1.0.0"`, `"npm:foo@1"`,
+    /// `"file:../foo"`, ...). Goes through the package manager when it already
+    /// exists so `npm:` aliases get recorded; otherwise parses standalone. The
+    /// package manager is created lazily by the first bare import, so the
+    /// project's own package.json normally takes the second path, and the
+    /// versions recorded there are what auto-install resolves against.
+    pub(crate) fn parse_dependency(
+        &mut self,
+        name: Semver::String,
+        name_hash: Install::PackageNameHash,
+        version: &[u8],
+        sliced: &Semver::SlicedString,
+        log: Option<&mut bun_ast::Log>,
+    ) -> Option<Dependency::Version> {
+        match self.auto_installer() {
+            Some(pm) => pm.parse_dependency(name, Some(name_hash), version, sliced, log),
+            None => __bun_resolver_parse_dependency(name, name_hash, version, sliced, log),
+        }
     }
 
     /// Safe read-only accessor for the optional `DotEnv::Loader` back-reference.
@@ -3065,7 +3095,8 @@ impl<'a> Resolver<'a> {
                             };
                         }
 
-                        if let Some(id) = manager!().lockfile_resolve(esm.name, &dependency_version)
+                        if let Some(id) =
+                            manager!().lockfile_resolve(esm.name, &dependency_version, string_buf)
                         {
                             resolved_package_id = id;
                         }
@@ -3591,7 +3622,11 @@ impl<'a> Resolver<'a> {
             };
         }
         // we should never be trying to resolve a dependency that is already resolved
-        debug_assert!(pm!().lockfile_resolve(esm.name, &version).is_none());
+        debug_assert!(
+            pm!()
+                .lockfile_resolve(esm.name, &version, version_buf)
+                .is_none()
+        );
 
         // Add the containing package to the lockfile
 

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -78,6 +78,7 @@ impl ReplCommand {
             transform_options: core::mem::take(&mut ctx.args),
             debugger: core::mem::take(&mut ctx.runtime_options.debugger),
             log: core::ptr::NonNull::new(ctx.log),
+            global_cache: ctx.debug.global_cache,
             smol: ctx.runtime_options.smol,
             eval_mode: true,
             is_main_thread: true,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -610,6 +610,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         this_transpiler.resolver.care_about_bin_folder = true;
         this_transpiler.resolver.care_about_scripts = true;
         this_transpiler.resolver.store_fd = store_root_fd;
+        // The directories read below are cached process-wide and reused by the
+        // VM that `bun run file.js` boots afterwards, and a package.json's
+        // dependency ranges (what auto-install resolves against) are only
+        // recorded when the resolver caching it has auto-install enabled. So
+        // this resolver needs the VM's setting (see `InitOptions::global_cache`).
+        this_transpiler.options.global_cache = ctx.debug.global_cache;
+        this_transpiler.resolver.opts.global_cache = ctx.debug.global_cache;
 
         // Bundler-linker + JSX-runtime config: only callers that actually
         // transpile through this `Transpiler` need it. `configure_linker`'s
@@ -951,6 +958,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             transform_options: ctx.args.clone(),
             log: ::core::ptr::NonNull::new(ctx.log),
             debugger: ::core::mem::take(&mut ctx.runtime_options.debugger),
+            global_cache: ctx.debug.global_cache,
             smol: ctx.runtime_options.smol,
             mini_mode: ctx.runtime_options.smol,
             eval_mode: ctx.runtime_options.eval.eval_and_print,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -465,6 +465,8 @@ unsafe fn init_runtime_state(
                     let t = &mut (*vm).transpiler;
                     t.options.emit_dce_annotations = false;
                     t.resolver.store_fd = opts.store_fd;
+                    t.options.global_cache = opts.global_cache;
+                    t.resolver.opts.global_cache = opts.global_cache;
                     t.resolver.prefer_module_field = false;
                     // Propagate `--preserve-symlinks`
                     // from CLI args to the resolver so symlinked node_modules

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -85,6 +85,184 @@ test("auto-install in a project whose package.json has a name and version", asyn
   expect(exitCode).toBe(1);
 });
 
+// Serves the `no-deps` fixture (versions 1.0.0, 1.0.1, 1.1.0 and 2.0.0, with
+// `latest` pointing at 2.0.0) and records every request path, so a test can
+// tell which version auto-install decided to download.
+function noDepsRegistry() {
+  const fixtures = join(import.meta.dir, "..", "install", "registry", "packages", "no-deps");
+  const requests: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const pathname = new URL(req.url).pathname;
+      requests.push(pathname);
+      if (pathname === "/no-deps") {
+        const manifest = await Bun.file(join(fixtures, "package.json")).text();
+        return Response.json(
+          JSON.parse(manifest.replaceAll("http://localhost:4873", `http://127.0.0.1:${server.port}`)),
+        );
+      }
+      const tgz = pathname.match(/^\/no-deps\/-\/(no-deps-[\d.]+\.tgz)$/);
+      if (tgz) return new Response(Bun.file(join(fixtures, tgz[1])));
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return {
+    requests,
+    bunfig: `[install]\nregistry = "http://127.0.0.1:${server.port}/"\n`,
+    tarballs: () => requests.filter(p => p.endsWith(".tgz")),
+    [Symbol.dispose]() {
+      server.stop(true);
+    },
+  };
+}
+
+async function runAutoInstall(cwd: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd,
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+const printNoDepsVersion = `console.log(require("no-deps").version);\n`;
+
+// docs/runtime/auto-install.mdx: a bare import resolves to the version range the
+// nearest package.json declares for it, and only falls back to `latest` when no
+// package.json lists the package.
+describe.concurrent("auto-install uses the version range from package.json", () => {
+  test("bun <file> run from the project directory", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": "^1.0.0" } }),
+      "index.js": printNoDepsVersion,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "index.js");
+    expect(stdout).toBe("1.1.0\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.tarballs()).toEqual(["/no-deps/-/no-deps-1.1.0.tgz"]);
+  });
+
+  // `bun run <file>` reads the project directory while looking for a
+  // package.json script before it boots the runtime; the cached result must
+  // still carry the dependency ranges.
+  test("bun run <file> run from the project directory", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-run", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": "^1.0.0" } }),
+      "index.js": printNoDepsVersion,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "run", "index.js");
+    expect(stdout).toBe("1.1.0\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.tarballs()).toEqual(["/no-deps/-/no-deps-1.1.0.tgz"]);
+  });
+
+  test("project package.json in a directory below the cwd", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-nested", {
+      "bunfig.toml": registry.bunfig,
+      "app/package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": "^1.0.0" } }),
+      "app/index.js": printNoDepsVersion,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "app/index.js");
+    expect(stdout).toBe("1.1.0\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.tarballs()).toEqual(["/no-deps/-/no-deps-1.1.0.tgz"]);
+  });
+
+  test("package.json without a name field", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-nameless", {
+      "package.json": JSON.stringify({ dependencies: { "no-deps": "~1.0.0" } }),
+      "index.js": printNoDepsVersion,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "index.js");
+    expect(stdout).toBe("1.0.1\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.tarballs()).toEqual(["/no-deps/-/no-deps-1.0.1.tgz"]);
+  });
+
+  // Ranges longer than 8 bytes are stored as offsets into the package.json
+  // source rather than inline, so this also checks they are read back from the
+  // right buffer.
+  test("range longer than an inline semver string", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-long", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": ">=1.0.0 <1.1.0" } }),
+      "index.js": printNoDepsVersion,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "index.js");
+    expect(stdout).toBe("1.0.1\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.tarballs()).toEqual(["/no-deps/-/no-deps-1.0.1.tgz"]);
+  });
+
+  test("a range nothing in the registry satisfies is an error, not latest", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-unsatisfiable", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "no-deps": "^3.0.0" } }),
+      "index.js": printNoDepsVersion,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "index.js");
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Cannot find package 'no-deps'");
+    expect(exitCode).toBe(1);
+    expect(registry.requests).toContain("/no-deps");
+    expect(registry.tarballs()).toEqual([]);
+  });
+
+  test("npm: alias installs the aliased package", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-alias", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "my-alias": "npm:no-deps@^1.0.0" } }),
+      "index.js": `console.log(require("my-alias").version);\n`,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "index.js");
+    expect(stdout).toBe("1.1.0\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.requests).toEqual(["/no-deps", "/no-deps/-/no-deps-1.1.0.tgz"]);
+  });
+
+  test("a package the package.json does not list still resolves to latest", async () => {
+    using registry = noDepsRegistry();
+    using dir = tempDir("autoinstall-range-unlisted", {
+      "package.json": JSON.stringify({ name: "app", dependencies: { "something-else": "^1.0.0" } }),
+      "index.js": printNoDepsVersion,
+      "bunfig.toml": registry.bunfig,
+    });
+
+    const { stdout, stderr, exitCode } = await runAutoInstall(String(dir), "index.js");
+    expect(stdout).toBe("2.0.0\n");
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    expect(registry.tarballs()).toEqual(["/no-deps/-/no-deps-2.0.0.tgz"]);
+  });
+});
+
 test("--install=fallback to install missing packages", async () => {
   const dir = tmpdirSync();
   mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
### Problem

- Runtime auto-install (`bun index.js` with no `node_modules`) installs the `latest` dist-tag of a bare import even when the project's `package.json` declares a range for it. With `"no-deps": "^1.0.0"` and a registry whose `latest` is `2.0.0`, `require("no-deps")` loads `2.0.0`; a range nothing satisfies silently installs `latest` too. docs/runtime/auto-install.mdx ("Version resolution", step 2) documents the range being used.
- Two separate causes:
  - `src/resolver/package_json.rs:915` (before this change): dependency versions were only parsed through the `AutoInstaller` vtable. The project's `package.json` is parsed while the entry point is resolved, before the first bare import creates the package manager, so every entry was stored with an `Uninitialized` version. `load_node_modules` (`src/resolver/resolver.rs:3041`) treats that as "no range declared" and re-parses the specifier as `latest`. This is a regression from the Rust port (bun 1.3.14 parsed the versions here without a package manager); it is what the second cause left visible.
  - The cwd's `DirInfo` is created before the runtime's `--install` setting is applied: by the VM transpiler's `configure_linker()` inside `VirtualMachine::init` (`src/runtime/jsc_hooks.rs:512`, before `boot` calls `wire_transpiler_from_ctx`), and for `bun run <file>` earlier still by the `configure_env_for_run` transpiler. Both have auto-install disabled (`BundleOptions::from_api` default), and `dir_info_uncached` (`src/resolver/resolver.rs:6431`) only parses dependencies when the resolver creating the entry has it enabled, so the project's `package.json` was cached with no dependencies at all and reused from the process-wide cache by the runtime resolver. This part predates the port: bun 1.3.14 only honored the range when the `package.json` was in a directory below the cwd.
- Two smaller bugs in the same path that become observable once ranges are actually used:
  - `package_json.rs` built the `SlicedString` over the version string itself, so any specifier longer than the 8-byte inline form (`>=1.0.0 <1.1.0`, `npm:foo@^1.0.0`, prerelease tags) was stored as an offset relative to the wrong base; every reader slices the map with `dependencies.source_buf`.
  - `Lockfile::resolve_package_from_name_and_version` compared the query against the lockfile's string buffer even when the query was parsed from a `package.json`, so prerelease tags in a range would be read from the wrong buffer.

### Fix

- `PackageJSON::parse` parses versions through `Resolver::parse_dependency`, which uses the package manager when it exists and otherwise a new link-time hook `__bun_resolver_parse_dependency` (`bun_install::auto_installer`, same mechanism as `__bun_resolver_init_package_manager`) that calls `dependency::parse` with no manager. Correct because the manager's only role in `parse` is recording `npm:` aliases, and `lockfile_append_from_package_json` records those anyway when the map is cloned into the lockfile; this restores what the pre-port code did.
- `VirtualMachine::InitOptions` gains `global_cache` (default `disable`, the previous value), applied in `init_runtime_state` before `configure_linker()`, the same way `store_fd` already is; `boot` and the REPL pass `ctx.debug.global_cache`. `configure_env_for_run_impl` applies the same setting before it reads the directory. Correct because the setting only changes whether a `package.json`'s dependencies are recorded when its directory is cached; these resolvers never auto-install themselves (`Resolver::resolve` passes `GlobalCache::disable` per call), and `wire_transpiler_from_ctx` sets the same value afterwards. Workers, `bun test`, compiled executables and `Bun.build` keep the default.
- The `SlicedString` for a version is built over `dependencies.source_buf`, with the same in-buffer guard the key already has (a value with JSON escapes is decoded outside the buffer and is skipped, as escaped keys are).
- `AutoInstaller::lockfile_resolve` and `resolve_package_from_name_and_version` take the buffer the version was parsed against; the resolver already tracks it (`string_buf`).
- Behaviour note: a declared non-registry specifier (`workspace:`, `link:`, `file:`, git) now fails with `Cannot find package` instead of auto-installing whatever the registry has under that name. This only arises with no `node_modules` anywhere above the file; the old behaviour was the same as for an unsatisfiable range, i.e. a different package than the one declared.
- Verified with `test/cli/run/run-autoinstall.test.ts` (new `describe` block, local registry serving the `no-deps` fixture): `bun <file>` and `bun run <file>` from the project directory, a project directory below the cwd, a nameless `package.json`, a range longer than the inline form, an unsatisfiable range, an `npm:` alias, and a package the `package.json` does not list (still `latest`). All but the last fail on the unfixed build (every one installs `2.0.0`); 20/20 pass with the debug build.
- Also run with the debug build: `test/cli/run/filter-workspace.test.ts` (the other consumer of this dependency map), `test/js/bun/resolve/`, `test/js/bun/repl/repl.test.ts`, `autoinstall-cached-manifest`, `run-autoinstall-abs-path`, `run_command`, `workspaces`, `multi-run`, `self-reference`, `env`.
- Not changed here: `devDependencies`/`optionalDependencies` are still not read by this parser (it looks the sections up by the wrong key); that is a separate pre-existing bug affecting `--filter` ordering as well and is tracked separately.

### Background

- Auto-install: when a bare import cannot be found in any `node_modules`, the runtime resolver (`load_node_modules`) lazily creates a `PackageManager` and installs the package into the global cache. To pick a version it looks at `dir_info.package_json_for_dependencies`, the nearest cached `package.json` whose dependency map is non-empty; if the import is listed there, that entry's parsed version is what gets resolved, otherwise the specifier is parsed as the `latest` dist-tag.
- `DirInfo` cache: every resolver in the process shares one cache of directory entries (`DirInfo`), each holding the interned parse of that directory's `package.json`. Whichever resolver touches a directory first decides what the cached entry contains; `bun run` creates several transpilers (and so several resolvers) before the runtime one.
- `GlobalCache` / `global_cache`: the auto-install mode from `--install` (`auto` by default, `disable` for bundlers and tests). `Resolver::use_package_manager()` reads it to decide whether to record a `package.json`'s dependencies at all; the per-call argument to `resolve_and_auto_install` decides whether a given resolution may install.
- `bun_resolver` / `bun_install` layering: `bun_install` depends on the resolver crate, so the resolver reaches install-tier code either through the `AutoInstaller` trait object it is handed once a manager exists, or through `extern "Rust"` functions defined with `#[no_mangle]` in `bun_install` and resolved at link time.
- `SemverString` / `SlicedString`: dependency names and versions are stored as 8 bytes, either the string inline (up to 8 bytes) or an offset+length into a buffer supplied when the string was created; reading one back requires the same buffer. `SlicedString` pairs that buffer with the sub-slice being parsed.
