### PR TITLE
mimalloc: fix NULL deref of the thread-locals array after a thread's teardown

### DIFF
--- a/patches/mimalloc/threadlocal-get-initval-fallback.patch
+++ b/patches/mimalloc/threadlocal-get-initval-fallback.patch
@@ -1,0 +1,41 @@
+Backport of microsoft/mimalloc 6def7be9 ("fix thread_locals_get", on dev3
+after the pinned oven-sh/mimalloc commit). Drop this patch once the pin moves
+to a revision that includes it.
+
+mimalloc keeps the per-thread theaps of every non-main heap (mi_heap_new,
+mi_heap_new_in_arena) in one per-thread slot array reached through the
+mi_thread_locals thread local. The variable starts out pointing at
+mi_thread_locals_empty, but _mi_thread_locals_thread_done (run from
+_mi_thread_done, i.e. mimalloc's pthread key destructor at thread exit) frees
+the array and stores NULL.
+
+The pthread-keys flavour of mi_define_thread_local (macOS, Android) already
+maps that NULL back to the initial value in name##_get(). The direct
+thread-local flavour, which is what Bun's glibc, musl and Windows builds
+compile, returned the raw NULL, so everything that reads the array on a thread
+after its teardown dereferenced it: mi_thread_local_get_regular (threadlocal.c
+tls->count), mi_thread_local_set_regular, and mi_thread_locals_expand.
+That happens for any non-main-heap access made on a thread after its
+_mi_thread_done: a later TLS destructor freeing a block of such a heap
+(mi_free -> mi_free_try_collect_mt -> _mi_page_associated_theap_peek), or,
+in MI_DEBUG builds, _mi_thread_done itself (mi_thread_theaps_done ->
+mi_theap_is_valid -> _mi_heap_theap_peek) when the exiting thread still has a
+theap of a non-main heap that is not the cached one, which aborts with
+  mimalloc: assertion failed: at "src/threadlocal.c":184, "tls!=NULL"
+
+With the fallback, reads after teardown see the empty array (count 0) and
+return NULL, exactly like a thread that never used a non-main heap; a write
+after teardown allocates a fresh array, which the re-registered thread-done
+frees again.
+
+--- a/src/threadlocal.c
++++ b/src/threadlocal.c
+@@ -54,7 +54,7 @@
+ #define mi_define_thread_local(tp,name,initval) \
+   static mi_decl_thread tp __##name = initval; \
+   static inline tp   name##_peek(void)    { return __##name; } \
+-  static inline tp   name##_get(void)     { return __##name; } \
++  static inline tp   name##_get(void)     { tp result = __##name; return (result!=NULL ? result : initval); } \
+   static inline bool name##_set(tp val)   { __##name = val; return true; } \
+   static inline void name##_delete(void)  {  }
+ #endif

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -24,6 +24,12 @@ export const mimalloc: Dependency = {
     commit: MIMALLOC_COMMIT,
   }),
 
+  // Backport of microsoft/mimalloc 6def7be9 (in the dev3 sync after this pin):
+  // the thread-locals array read after a thread's teardown. The matching entry
+  // in workarounds.ts fails configure once MIMALLOC_COMMIT moves, so the patch
+  // gets dropped with the bump instead of breaking the fetch (#34335).
+  patches: ["patches/mimalloc/threadlocal-get-initval-fallback.patch"],
+
   build: cfg => {
     // ─── Override behavior (global malloc replacement) ───
     //   ASAN:    OFF — ASAN interceptors must see the real malloc.

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -32,6 +32,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Config } from "./config.ts";
+import { mimalloc } from "./deps/mimalloc.ts";
 import { BuildError } from "./error.ts";
 import { satisfiesRange } from "./tools.ts";
 
@@ -225,6 +226,30 @@ export const workarounds: Workaround[] = [
       `In src/spawn_sys/posix_spawn.rs (Attr::set) and src/spawn_sys/spawn_process.rs ` +
       `(options.detached block), replace the local 0x80 with libc::POSIX_SPAWN_SETSID, ` +
       `drop the explanatory comments, and delete this entry.`,
+  },
+  {
+    id: "mimalloc-threadlocal-get-initval-fallback",
+    issue: "https://github.com/microsoft/mimalloc/commit/6def7be9458fb8a97b8323af3fb0b0ae04387065",
+    description:
+      "mimalloc's thread teardown NULLs the per-thread array holding the theaps of non-main heaps, " +
+      "and the direct-thread-local build (glibc, musl, Windows) then dereferenced that NULL on any " +
+      "later non-main-heap access from the exiting thread (MI_DEBUG builds abort in _mi_thread_done " +
+      "itself). patches/mimalloc/threadlocal-get-initval-fallback.patch backports the upstream fix.",
+    // The patch is applied to the fetched source on every target, so a pin
+    // that already contains the fix breaks the fetch everywhere (#34335).
+    applies: () => true,
+    expectedToBeFixed: cfg => {
+      // Written against this pin. Any newer oven-sh/mimalloc pin synced with
+      // upstream dev3 after 2026-08-09 (e.g. the one in #37367) carries the
+      // commit itself; a bump that somehow doesn't can re-pin this constant.
+      const PATCHED_PIN = "1803341d6241d8fa4b3f65fa68cb13a32ad92f04";
+      const source = mimalloc.source(cfg);
+      return source.kind === "github-archive" && source.commit !== PATCHED_PIN;
+    },
+    cleanup:
+      `Check that src/threadlocal.c in the new pin returns initval from the direct-thread-local ` +
+      `name##_get(), then delete patches/mimalloc/threadlocal-get-initval-fallback.patch, its ` +
+      `entry in scripts/build/deps/mimalloc.ts, and this entry.`,
   },
 ];
 

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -44,4 +44,35 @@ describe("Worker destruction", () => {
     expect(stdout.trim()).toBe("terminated 1");
     expect(exitCode).toBe(0);
   });
+
+  // Bun.TOML.parse parks a private mimalloc heap on the worker thread that outlives the worker's
+  // JS; the Transpiler call then uses (and destroys) another one. mimalloc's own thread teardown
+  // still has to look at the parked heap's thread state after it has released the thread's
+  // heap-slot array, and used to dereference the released array there (debug builds abort with
+  // `threadlocal.c: assertion "tls!=NULL"`). The parent joins the thread, so that takes down the
+  // whole process before "worker exit" is printed.
+  test.concurrent("a Worker that used several allocator heaps exits cleanly", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("worker_threads");
+        const w = new Worker(\`
+          Bun.TOML.parse("a = 1");
+          new Bun.Transpiler().transformSync("export const b = 2;");
+        \`, { eval: true });
+        w.on("error", e => { console.error(e); process.exit(2); });
+        w.on("exit", code => console.log("worker exit " + code));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("worker exit 0\n");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- On Linux (glibc and musl) and Windows, a thread that touched a non-main mimalloc heap crashes if anything touches a non-main heap on that thread again after mimalloc's own thread teardown has run. Release builds SIGSEGV in `mi_thread_local_get_regular` (`vendor/mimalloc/src/threadlocal.c:186`, reading `tls->count` through NULL); `MI_DEBUG` builds (`bun bd`) abort with:
  ```
  mimalloc: assertion failed: at "../../vendor/mimalloc/src/threadlocal.c":184, mi_thread_local_get_regular
    assertion: "tls!=NULL"
  ```
- Cause: `_mi_thread_locals_thread_done()` (`threadlocal.c:205`, run from `_mi_thread_done`, i.e. mimalloc's pthread key destructor / FLS callback) frees the thread's slot array and stores NULL into the `mi_thread_locals` thread local. The direct-thread-local flavour of `mi_define_thread_local` (`threadlocal.c:54`, what our glibc, musl and Windows builds compile) returns that NULL from `_get()`, and the three readers (`mi_thread_local_get_regular`, `mi_thread_local_set_regular`, `mi_thread_locals_expand`) dereference it. The pthreads flavour used on macOS and Android (`threadlocal.c:45`) already maps NULL back to the initial value, so those builds are not affected.
- Reached in two ways:
  - Debug builds: `_mi_thread_done` itself. It drops the array (`init.c:866`) before it abandons the thread's theaps (`init.c:888` -> `mi_theap_collect_ex` -> `mi_theap_is_valid` -> `_mi_heap_theap_peek` -> `_mi_thread_local_get`), so any thread exiting while it still has a theap of a non-main heap that is not the one in `_mi_theap_cached` aborts. In Bun that is a Worker that called `Bun.TOML.parse`/`Bun.YAML.parse` (parks a per-thread `Arena` that outlives the thread, `src/runtime/api.rs:272`) and then used any other `Arena` (deterministic, see the test), and it is the `threadlocal.c:184` abort quoted in #37480's bundler error path (10/10 on an unpatched debug build here, 0/10 with this patch; that PR's own fix is about the teardown ordering and still stands).
  - Release builds: a later TLS destructor on the exiting thread freeing a block of a non-main heap (`mi_free` -> `mi_free_try_collect_mt` `free.c:417`/`419` -> `mi_abandoned_page_try_reclaim` `free.c:355` or `_mi_arenas_page_try_reabandon_to_mapped` `arena.c:1260` -> `_mi_page_associated_theap_peek` `prim-tls.h:475`), or allocating from one (`_mi_heap_theap_get_or_init` `heap.c:101`). Bun's own TLS destructors only free main-heap memory today, so this is latent for us (JSC's structure heap and every `bun_alloc::Arena` are non-main heaps, so every JS thread has the NULLed array at exit); the C harness below exercises it directly.

### Fix
- `patches/mimalloc/threadlocal-get-initval-fallback.patch`: backport of microsoft/mimalloc@6def7be9458fb8a97b8323af3fb0b0ae04387065 ("fix thread_locals_get"), one line: the direct-thread-local `_get()` returns `initval` when the variable is NULL, which is what the pthreads flavour already does. `_peek()` is unchanged, so `_mi_thread_locals_thread_done` still sees the NULL and does not free the static empty array.
- Why this is correct: after teardown, reads now see `mi_thread_locals_empty` (count 0) and return NULL, which is the exact state of a thread that never used a non-main heap and which every caller already handles (`_mi_page_associated_theap_peek` returns NULL, the reclaim/reabandon paths bail out, `_mi_heap_theap_get_or_init` creates a theap). A write after teardown goes through `mi_thread_locals_expand`, which already treats count 0 as "allocate fresh" (`threadlocal.c:105`), and the re-initialised thread re-registers its key so the next destructor round frees that array again. `mi_slot_fast` has `initval` NULL, so its behaviour is unchanged; the pthreads branch is not touched. The fork pin #37367 moves to (oven-sh/mimalloc 49182d59) already contains this commit, so this patch is the stop-gap until that lands and gets dropped with it.
- `scripts/build/workarounds.ts` gets an entry whose `expectedToBeFixed` trips as soon as `MIMALLOC_COMMIT` is anything other than the pin this patch was written against, so a bump (#37367) fails configure with "delete the patch" instructions instead of merging cleanly and then failing `git apply` on every fresh fetch (what happened in #34335). Verified by bumping the constant locally: configure fails with that message; with the real pin it is a no-op and `build.ninja` is unchanged.
- Verified:
  - `test/js/node/worker_threads/worker_destruction.test.ts`, "a Worker that used several allocator heaps exits cleanly": 4/4 failures on a debug build of main with the assertion above in stderr, 3/3 passes (and the whole file passes) with the patch. A release build passes it both ways, since the assertion that makes `_mi_thread_done` itself read the array only exists in `MI_DEBUG` builds; the release-only paths are covered by the C harness.
  - C harness against `vendor/mimalloc/src/static.c` built with exactly the flags `mimalloc.ts` uses for a Linux release build (`-O2 -DNDEBUG -DMI_BUILD_RELEASE -DMI_MALLOC_OVERRIDE -ftls-model=initial-exec ...`): threads allocate from an `mi_heap_new` heap and exit with a pthread key destructor that runs after mimalloc's. Unpatched: 20/20 SIGSEGV at `threadlocal.c:186` for each of the three paths (free after teardown via `arena.c:1260`; `malloc` then free via `free.c:355`; `mi_heap_malloc` via `heap.c:101`). Patched: 0/20 for each. The same program and a two-heaps-then-exit variant built with `-DMI_DEBUG=3`: unpatched aborts with the `tls!=NULL` assertion, patched runs clean.
  - `bun bd` re-fetches the dep and applies the patch (`vendor/mimalloc/.ref` changes, `threadlocal.c:57` carries the new line); `heapStats-mimalloc.test.ts` and `worker-terminate-lifetime.test.ts` still pass on the patched build.

### Background
- mimalloc v3 heaps and theaps: an `mi_heap_t` (the main heap behind `malloc`, or a private one from `mi_heap_new`/`mi_heap_new_in_arena`; Bun's `bun_alloc::Arena` and JSC's structure heap are private heaps) owns no pages itself. Each thread that allocates from a heap gets its own `mi_theap_t` for it, which holds that thread's pages; allocation and most frees go through the calling thread's theap for the block's heap.
- Slot array: the main heap's theap lives in a dedicated fast thread local. The theaps of every other heap live in one per-thread array indexed by a key stored in `heap->theap`; `mi_thread_locals` is the thread local pointing at that array, `mi_thread_locals_empty` is the static zero-length array a fresh thread starts with, and `_mi_thread_local_get/_set` are the accessors `_mi_heap_theap_peek`, `_mi_page_associated_theap_peek` and `_mi_heap_theap_get_or_init` use.
- Thread teardown: mimalloc registers a pthread key (FLS callback on Windows) at process start, so `_mi_thread_done` runs among the first destructors when a thread exits. It frees the slot array, then abandons the pages of the thread's theaps (other threads can later pick them up) and frees the theaps. Destructors registered later (WTF's, libc++abi's, Rust's on musl) still run on the thread afterwards, and an allocation from one of them re-initialises the thread's main theap; neither of those restores the slot array, which is the window this patch handles.
- `_mi_theap_cached`: a one-entry per-thread cache of the last theap returned by the heap API, consulted before the slot array. A heap being destroyed clears it, which is why the repro needs a second heap after the parked one.
- `patches/<dep>/`: files listed in a dep's `patches:` are `git apply`'d over the fetched archive and hashed into the source identity (`scripts/build/source.ts`, `fetch-cli.ts`), so editing or adding one re-fetches the dep; the fork itself is not writable from here, as with #34739. `scripts/build/workarounds.ts` is the build system's registry of temporary fixes: configure evaluates each entry's `expectedToBeFixed` and fails with the entry's cleanup text once it returns true.

<details>
<summary>C harness</summary>

```c
// clang -x c++ -std=gnu++20 -O2 -DNDEBUG -DMI_BUILD_RELEASE -DMI_STATIC_LIB -DMI_SKIP_COLLECT_ON_EXIT=1
//       -DMI_NO_PROCESS_DETACH=1 -DMI_DEFAULT_ALLOW_THP=0 -DMI_MALLOC_OVERRIDE -fno-builtin-malloc
//       -ftls-model=initial-exec -fPIC -Ivendor/mimalloc/include -c vendor/mimalloc/src/static.c
// clang -O1 -g -pthread -fno-builtin -Ivendor/mimalloc/include -c late_dtor.c && clang++ -pthread late_dtor.o static.o
// ./a.out [free|reinit|alloc]
#include <mimalloc.h>
#include <pthread.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

#define NTHREADS 4
#define NBLOCKS 64
#define BLOCK_SIZE (8 * 1024)

static mi_heap_t* heap;
static pthread_key_t late_key;
static const char* mode;
typedef struct { void* blocks[NBLOCKS]; } stash_t;

static void late_dtor(void* arg) {            // runs after mimalloc's own key destructor
  stash_t* stash = (stash_t*)arg;
  if (strcmp(mode, "reinit") == 0) free(malloc(100));          // re-initialises the thread -> free.c:355
  if (strcmp(mode, "alloc") == 0) mi_free(mi_heap_malloc(heap, 64));   // heap.c:101
  else for (int i = 0; i < NBLOCKS; i++) mi_free(stash->blocks[i]);   // arena.c:1260 (pages were abandoned full)
  free(stash);
}

static void* thread_main(void* arg) {
  stash_t* stash = (stash_t*)calloc(1, sizeof(stash_t));
  for (int i = 0; i < NBLOCKS; i++) { stash->blocks[i] = mi_heap_malloc(heap, BLOCK_SIZE); memset(stash->blocks[i], 1, BLOCK_SIZE); }
  pthread_setspecific(late_key, stash);
  return NULL;
}

int main(int argc, char** argv) {
  mode = argc > 1 ? argv[1] : "free";
  free(malloc(1));                              // mimalloc's key is created before ours
  heap = mi_heap_new();
  pthread_key_create(&late_key, late_dtor);
  pthread_t t[NTHREADS];
  for (int i = 0; i < NTHREADS; i++) pthread_create(&t[i], NULL, thread_main, NULL);
  for (int i = 0; i < NTHREADS; i++) pthread_join(t[i], NULL);
  printf("ok (%s)\n", mode);
}
```

Unpatched stacks (release flags):

```
free:    mi_thread_local_get_regular threadlocal.c:186 <- _mi_page_associated_theap_peek prim-tls.h:475
         <- _mi_arenas_page_try_reabandon_to_mapped arena.c:1260 <- mi_free_try_collect_mt free.c:419 <- late_dtor
reinit:  mi_thread_local_get_regular threadlocal.c:186 <- _mi_page_associated_theap_peek prim-tls.h:475
         <- mi_abandoned_page_try_reclaim free.c:355 <- mi_free_try_collect_mt free.c:417 <- late_dtor
alloc:   mi_thread_local_get_regular threadlocal.c:186 <- _mi_heap_theap_get_or_init heap.c:101 <- mi_heap_malloc <- late_dtor
```
</details>
