### PR TITLE
sys: stop truncating Node-style error messages at 4096 bytes when path/dest are long

### DIFF
--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -349,7 +349,7 @@ impl Error {
     /// Shared scaffolding for [`to_shell_system_error`] and [`to_system_error`].
     /// Fills `errno`/`syscall`/`code`/`path`/`dest`/`fd`, leaves `message` empty,
     /// and returns the looked-up `(code, label)` so each caller can build its own
-    /// `message` (shell: static label; node: formatted stack buffer).
+    /// `message` (shell: static label; node: formatted with path/dest).
     fn fill_system_error_common(
         &self,
         map: &enum_map::EnumMap<SystemErrno, &'static str>,
@@ -418,59 +418,33 @@ impl Error {
 
         // format taken from Node.js 'exceptions.cc'
         // search keyword: `Local<Value> UVException(Isolate* isolate,`
-        let mut message_buf = [0u8; 4096];
-        let pos = {
-            use std::io::Write as _;
-            let mut cursor = std::io::Cursor::new(&mut message_buf[..]);
-            'brk: {
-                if let Some((code, _)) = looked_up {
-                    if cursor.write_all(code.as_bytes()).is_err() {
-                        break 'brk;
-                    }
-                    if cursor.write_all(b": ").is_err() {
-                        break 'brk;
-                    }
-                }
-                let label = looked_up.map(|(_, l)| l).unwrap_or("Unknown Error");
-                if cursor.write_all(label.as_bytes()).is_err() {
-                    break 'brk;
-                }
-                if cursor.write_all(b", ").is_err() {
-                    break 'brk;
-                }
-                if cursor
-                    .write_all(<&'static str>::from(self.syscall).as_bytes())
-                    .is_err()
-                {
-                    break 'brk;
-                }
-                if !self.path.is_empty() {
-                    if cursor.write_all(b" '").is_err() {
-                        break 'brk;
-                    }
-                    if cursor.write_all(&self.path).is_err() {
-                        break 'brk;
-                    }
-                    if cursor.write_all(b"'").is_err() {
-                        break 'brk;
-                    }
+        // Node concatenates, so the message has no size limit: `path` and `dest`
+        // appear in full however long they are.
+        let label = looked_up.map_or("Unknown Error", |(_, label)| label);
+        let syscall = <&'static str>::from(self.syscall);
+        // 64 covers the code and the punctuation around every piece.
+        let mut message = Vec::with_capacity(
+            64 + label.len() + syscall.len() + self.path.len() + self.dest.len(),
+        );
+        if let Some((code, _)) = looked_up {
+            message.extend_from_slice(code.as_bytes());
+            message.extend_from_slice(b": ");
+        }
+        message.extend_from_slice(label.as_bytes());
+        message.extend_from_slice(b", ");
+        message.extend_from_slice(syscall.as_bytes());
+        if !self.path.is_empty() {
+            message.extend_from_slice(b" '");
+            message.extend_from_slice(&self.path);
+            message.extend_from_slice(b"'");
 
-                    if !self.dest.is_empty() {
-                        if cursor.write_all(b" -> '").is_err() {
-                            break 'brk;
-                        }
-                        if cursor.write_all(&self.dest).is_err() {
-                            break 'brk;
-                        }
-                        if cursor.write_all(b"'").is_err() {
-                            break 'brk;
-                        }
-                    }
-                }
+            if !self.dest.is_empty() {
+                message.extend_from_slice(b" -> '");
+                message.extend_from_slice(&self.dest);
+                message.extend_from_slice(b"'");
             }
-            usize::try_from(cursor.position()).expect("int cast")
-        };
-        err.message = BunString::clone_utf8(&message_buf[..pos]).into();
+        }
+        err.message = BunString::clone_utf8(&message).into();
 
         err
     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5313,6 +5313,80 @@ describe("error.syscall is node's operation name, not the raw kernel syscall", (
   });
 });
 
+// The message used to be formatted into a fixed 4096 byte buffer and stopped
+// mid-path (no closing quote, no dest) when it did not fit. Linux only: with
+// PATH_MAX = 4096 these operands reach the syscall while the message is longer
+// than that buffer was; macOS caps a path at 1024 bytes.
+describe.skipIf(!isLinux)("error.message includes long path and dest operands in full", () => {
+  // Nothing is ever created below `root`, so every operation fails with ENOENT.
+  const root = tmpdirSync();
+
+  // A path of exactly `length` bytes below `root`. No component is longer than
+  // 201 bytes, so only the total length is unusual.
+  function pathOfLength(length: number, fill: string): string {
+    let p = root;
+    while (length - p.length > 202) p += "/" + Buffer.alloc(200, fill).toString();
+    return p + "/" + Buffer.alloc(length - p.length - 1, fill).toString();
+  }
+
+  const src = pathOfLength(3000, "a");
+  const dest = pathOfLength(3000, "b");
+
+  function expectedShape(syscall: string) {
+    return {
+      code: "ENOENT",
+      syscall,
+      path: src,
+      dest,
+      message: `ENOENT: no such file or directory, ${syscall} '${src}' -> '${dest}'`,
+    };
+  }
+
+  function shapeOf(err: any) {
+    const { code, syscall, path, dest, message } = err;
+    return { code, syscall, path, dest, message };
+  }
+
+  function thrownBy(fn: () => unknown) {
+    try {
+      fn();
+    } catch (err) {
+      return shapeOf(err);
+    }
+    throw new Error("expected to throw");
+  }
+
+  it.each([
+    ["renameSync", "rename", renameSync],
+    ["linkSync", "link", fs.linkSync],
+    ["copyFileSync", "copyfile", copyFileSync],
+    ["symlinkSync", "symlink", symlinkSync],
+  ] as const)("%s", (_name, syscall, op) => {
+    expect(thrownBy(() => op(src, dest))).toEqual(expectedShape(syscall));
+  });
+
+  it("promises.rename", async () => {
+    const err = await promises.rename(src, dest).catch(err => err);
+    expect(shapeOf(err)).toEqual(expectedShape("rename"));
+  });
+
+  it("rename with a callback", async () => {
+    const err = await new Promise(resolve => fs.rename(src, dest, resolve));
+    expect(shapeOf(err)).toEqual(expectedShape("rename"));
+  });
+
+  it("a single path just below PATH_MAX", () => {
+    const file = pathOfLength(4090, "c");
+    expect(thrownBy(() => openSync(file, "r"))).toEqual({
+      code: "ENOENT",
+      syscall: "open",
+      path: file,
+      dest: undefined,
+      message: `ENOENT: no such file or directory, open '${file}'`,
+    });
+  });
+});
+
 it.if(isWindows)("writing to windows hidden file is possible", () => {
   const temp = tmpdir();
   writeFileSync(join(temp, "file.txt"), "FAIL");


### PR DESCRIPTION
### Problem
- A `node:fs` error whose operands are long has a `message` that is exactly 4096 characters and stops mid-path: no closing quote, and for two-path operations no `-> '<dest>'` at all. `err.path` and `err.dest` are complete, only `message` is cut.
- Reachable with ordinary arguments: `renameSync(a, b)` with two ~3 KB paths (each well under PATH_MAX, components under NAME_MAX) gives a 4096-char message; Node gives the full 6088-char one. Same for `link`, `copyFile`, `symlink` (sync, promises and callback forms), and for a single path of 4055..4095 bytes (`open`, etc.).
- Cause: `bun_sys::Error::to_system_error` (src/sys/Error.rs:421) formats `<code>: <label>, <syscall> '<path>' -> '<dest>'` into a fixed `[u8; 4096]` through a `std::io::Cursor`, and the first `write_all` that does not fit breaks out of the block, so whatever was written so far becomes the message. The Zig version had the same buffer; this is not a regression.

### Fix
- `to_system_error` appends the pieces to a `Vec<u8>` sized from their lengths and passes that to `BunString::clone_utf8`, so the message always carries `path` and `dest` in full.
- Correct because it matches Node: both `UVException` (src/node_errors.cc) and `uvException` (lib/internal/errors.js) build this message by concatenation with no length limit, and the wording is unchanged for every message that fit before (the pieces and their order are the same; only the cap is gone).
- The one extra allocation is on an error path that already allocates the message, path and dest strings. `to_shell_system_error` (static label, no formatting) is untouched.
- Verified with `test/js/node/fs/fs.test.ts` ("error.message includes long path and dest operands in full", 7 cases: the four sync two-path operations, `promises.rename`, callback `rename`, and a 4090-byte single path): all 7 fail on the released binary, pass with this change.
- Whole `fs.test.ts` (518 pass) and the upstream `test-fs-error-messages.js`, `test-fs-copyfile.js`, `test-fs-promises.js` still pass with the change.
- The test is Linux-only: with PATH_MAX = 4096 these operands reach the syscall while the message exceeds the old buffer; on macOS a path is capped at 1024 bytes so the operands cannot get there. The formatter itself is platform-independent.

### Background
- `bun_sys::Error` is the errno + syscall tag + path/dest value every syscall wrapper returns. `to_system_error` turns it into a `SystemError` (the struct `ErrorJsc::to_js` hands to C++ to create the JS error object), including the Node-format `message`; every `bun_sys::Error` that reaches JavaScript (node:fs, `Bun.file`, ...) goes through it.
- A path of 4096 bytes or more never reaches this function: the PathLike conversion rejects it earlier with a bare `ENAMETOOLONG` (no `syscall`/`path`). That separate gap is tracked in #36324 and is not changed here.

<details>
<summary>Probe: single path length vs message, released bun 1.4.0 / this branch / node</summary>

`openSync` on a missing path of N bytes (`full` = message equals `` `ENOENT: no such file or directory, open '${p}'` ``):

```
released bun
len=4054: ENOENT msg.len=4096 full=true
len=4055: ENOENT msg.len=4096 full=false
len=4095: ENOENT msg.len=4096 full=false
len=4096: ENAMETOOLONG syscall=undefined path=undefined msg.len=33   (PathLike check, #36324)

this branch
len=4054: ENOENT msg.len=4096 full=true
len=4055: ENOENT msg.len=4097 full=true
len=4095: ENOENT msg.len=4137 full=true
len=4096: ENAMETOOLONG syscall=undefined path=undefined msg.len=33   (unchanged, #36324)

node v26.3.0
len=4054: ENOENT msg.len=4096 full=true
len=4055: ENOENT msg.len=4097 full=true
len=4095: ENOENT msg.len=4137 full=true
len=4096: ENAMETOOLONG syscall=open path.len=4096 msg.len=4132 full=true
```

Two ~3 KB paths through `renameSync`: released bun `message.length` 4096, not ending in `'`, does not contain `err.dest`; this branch and node both 6088 and identical to `` `ENOENT: no such file or directory, rename '${src}' -> '${dest}'` ``.
</details>
