### PR TITLE
bundler: define __require for ESM-imported .node files

### DIFF
--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -373,6 +373,14 @@ pub(crate) fn generate_code_for_lazy_export(
         loc: stmt.loc,
     };
 
+    // The napi loader's lazy export is `require(<unique key>)`. Every output
+    // format except cjs prints that call target as the runtime's `__require`
+    // symbol, so the part that ends up holding `expr` has to import it from the
+    // runtime or the symbol is never declared in the bundle.
+    let calls_runtime_require = matches!(expr.data, ExprData::ECall(ref c)
+        if matches!(c.target.data, ExprData::ERequireCallTarget))
+        && this.options.output_format != crate::options::OutputFormat::Cjs;
+
     match exports_kind {
         bun_ast::ExportsKind::Cjs => {
             part.stmts.slice_mut()[0] = Stmt::assign(
@@ -395,12 +403,7 @@ pub(crate) fn generate_code_for_lazy_export(
                 Index::init(source_index),
             )?;
 
-            // If this is a .napi addon and it's not node, we need to generate a require() call to the runtime
-            if matches!(expr.data, ExprData::ECall(ref c)
-                if matches!(c.target.data, ExprData::ERequireCallTarget))
-                // if it's commonjs, use require()
-                && this.options.output_format != crate::options::OutputFormat::Cjs
-            {
+            if calls_runtime_require {
                 this.graph.generate_runtime_symbol_import_and_use(
                     source_index,
                     Index::part(1u32),
@@ -510,6 +513,15 @@ pub(crate) fn generate_code_for_lazy_export(
                     )));
                 let parts = this.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice();
                 parts[generated.1 as usize].stmts = bun_ast::StoreSlice::new_mut(new_stmts);
+
+                if calls_runtime_require {
+                    this.graph.generate_runtime_symbol_import_and_use(
+                        source_index,
+                        Index::part(generated.1),
+                        b"__require",
+                        1,
+                    )?;
+                }
             }
         }
     }

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -859,6 +859,27 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  // An ESM-imported .node file is embedded and loaded through the runtime's
+  // `__require`, which the bundle has to define (it used to throw
+  // `ReferenceError: __require is not defined`). The addon is a fake, so the
+  // load itself fails with ERR_DLOPEN_FAILED once `__require` resolves.
+  itBundled("compile/EmbeddedNapiAddonEsmImport", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import addon from "./addon.node";
+        console.log(addon);
+      `,
+      "/addon.node": "not a real addon",
+    },
+    run: {
+      exitCode: 1,
+      validate({ stderr }) {
+        expect(stderr).toContain("ERR_DLOPEN_FAILED");
+        expect(stderr).not.toContain("__require is not defined");
+      },
+    },
+  });
   itBundled("compile/sqlite-file", {
     compile: true,
     files: {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -454,6 +454,97 @@ describe("bundler", async () => {
     }
   });
 
+  // The napi loader turns a .node file into `require(<copied asset>)`. In every
+  // output format except cjs that call is printed through the runtime's
+  // `__require`, which has to be pulled into the bundle no matter whether the
+  // addon was require()d or ESM-imported. The addon here is a fake, so loading
+  // it fails with ERR_DLOPEN_FAILED; the unfixed output never got that far and
+  // threw `ReferenceError: __require is not defined` instead.
+  describe("napi loader", () => {
+    for (const target of ["bun", "node"] as const) {
+      itBundled(`${target}/loader-napi-esm-import-defines-require`, {
+        target,
+        outdir: "/out",
+        files: {
+          "/entry.js": /* js */ `
+            import addon from "./addon.node";
+            console.log(addon);
+          `,
+          "/addon.node": "not a real addon",
+          "/run.js": /* js */ `
+            try {
+              await import("./out/entry.js");
+              console.log("loaded");
+            } catch (e) {
+              console.log(e.name, e.code);
+            }
+          `,
+        },
+        onAfterBundle(api) {
+          const output = api.readFile("/out/entry.js");
+          expect(output).toMatch(/var addon_default = __require\("\.\/addon-[a-z0-9]+\.node"\);/);
+          expect(output).toContain("var __require = ");
+        },
+        run: { file: "/run.js", stdout: "Error ERR_DLOPEN_FAILED" },
+      });
+    }
+
+    // With code splitting the addon lands in its own chunk, so `__require`
+    // additionally has to be imported from the chunk that defines it.
+    itBundled("bun/loader-napi-dynamic-import-splitting-imports-require", {
+      target: "bun",
+      splitting: true,
+      outdir: "/out",
+      files: {
+        "/entry.js": /* js */ `
+          try {
+            await import("./addon.node");
+            console.log("loaded");
+          } catch (e) {
+            console.log(e.name, e.code);
+          }
+        `,
+        "/addon.node": "not a real addon",
+      },
+      onAfterBundle(api) {
+        const addonChunk = readdirSync(api.outdir).find(x => x.startsWith("addon-") && x.endsWith(".js"))!;
+        const output = api.readFile(join("/out", addonChunk));
+        expect(output).toMatch(/var addon_default = __require\("\.\/addon-[a-z0-9]+\.node"\);/);
+        expect(output).toMatch(/import\s*\{\s*__require\s*\}\s*from/);
+      },
+      run: { stdout: "Error ERR_DLOPEN_FAILED" },
+    });
+
+    // cjs output calls the wrapper's own `require`, so nothing is imported
+    // from the runtime.
+    itBundled("bun/loader-napi-esm-import-cjs-output-uses-require", {
+      target: "bun",
+      format: "cjs",
+      outdir: "/out",
+      files: {
+        "/entry.js": /* js */ `
+          import addon from "./addon.node";
+          console.log(addon);
+        `,
+        "/addon.node": "not a real addon",
+        "/run.js": /* js */ `
+          try {
+            await import("./out/entry.js");
+            console.log("loaded");
+          } catch (e) {
+            console.log(e.name, e.code);
+          }
+        `,
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out/entry.js");
+        expect(output).toMatch(/var addon_default = require\("\.\/addon-[a-z0-9]+\.node"\);/);
+        expect(output).not.toContain("__require");
+      },
+      run: { file: "/run.js", stdout: "Error ERR_DLOPEN_FAILED" },
+    });
+  });
+
   // Lazy-export modules (JSON, TOML, CSS modules, ...) used to crash the
   // printer when bundled with the dev server's module format.
   // https://github.com/oven-sh/bun/issues/31943


### PR DESCRIPTION
### Problem
- `bun build` of a file that ESM-imports a native addon (`import addon from "./addon.node"`) produces output that throws `ReferenceError: __require is not defined` as soon as it is loaded. Same for `--target=bun` and `--target=node`, for a code-split `import("./addon.node")`, and for `--compile` (`var addon_default = __require("/$bunfs/root/addon-xxxx.node")`). Reproduces on 1.4.0 and on main.
- `const addon = require("./addon.node")` works (the output starts with `var __require = import.meta.require;`), and so does `--format=cjs` (plain `require(...)` is printed).
- The napi loader turns the `.node` file into the lazy export `require(<asset key>)` with an `ERequireCallTarget` target (`src/bundler/ParseTask.rs:1104`). The printer prints that target as the runtime's `__require` symbol for every output format except cjs (`src/js_printer/lib.rs:3292`, `require_ref` set in `src/bundler/LinkerContext.rs:2215`).
- The runtime part defining `__require` only ends up in the bundle when some part records a use of it. For lazy exports that happened in `src/bundler/linker_context/generateCodeForLazyExport.rs` inside the `ExportsKind::Cjs` arm only, which is the arm taken when the file is `require()`d. An ESM import (or a code-split `import()`) takes the other arm, which moves the expression into a generated `export default` part and recorded nothing, so `__require` was printed but its definition was tree-shaken away.

### Fix
- `generateCodeForLazyExport.rs`: the "is this `require(...)` that will be printed as `__require`" check is computed once, before the match, and the ESM arm now records the `__require` use on the generated default-export part, exactly like the cjs arm does on its part. No change for any other loader (the check only matches a call whose target is `ERequireCallTarget`, which only the napi loader produces) and none for cjs output.
- Recording the use on the part that holds the expression is what makes it correct in every case: the dependency is only pulled in if that part survives tree shaking, it is imported cross-chunk when the addon lands in its own chunk with `--splitting`, and the printed code becomes identical to what the already-working `require()` path emits (`var __require = import.meta.require;` for bun, `createRequire(import.meta.url)` for node).
- Tests (`test/bundler/bundler_loader.test.ts` "napi loader", `test/bundler/bundler_compile.test.ts` `compile/EmbeddedNapiAddonEsmImport`) use a fake `.node` file: loading it fails with `ERR_DLOPEN_FAILED`, which the unfixed output never reached (it threw the `ReferenceError` first). Covered: static import for bun and node targets, `--splitting` + `import()` (asserts the addon chunk imports `__require` from the shared chunk), `--compile`, plus a cjs-output control that still prints plain `require()` and imports nothing. 4 of the 5 new tests fail on the unfixed build.
- Also checked locally with a real prebuilt addon (msgpackr-extract's linux-x64 binary): ESM import bundled for bun and for node (run under bun and under node), `--splitting`, and `--compile` all load the addon and expose its exports; 1.4.0 throws the `ReferenceError` on the same input.
- `test/bundler/bundler_loader.test.ts`, `bundler_bun.test.ts`, `bundler_splitting.test.ts`, `esbuild/loader.test.ts` and the compile tests around the new one pass on a debug build; `cargo clippy -p bun_bundler` is clean.

### Background
- Lazy export: loaders such as json, toml, sqlite and napi do not parse anything; they hand the linker a single expression, and `generate_code_for_lazy_export` turns it into either `module.exports = <expr>` (when the importer uses `require()`, so the file is treated as CommonJS) or `var x_default = <expr>; export default x_default` (ESM import), the latter living in a part created on the spot.
- Part: the unit of tree shaking. A part's `symbol_uses`/dependencies decide which other parts get included; `generate_runtime_symbol_import_and_use` adds a dependency from a part onto the runtime part that declares a helper, and also registers the import so that the symbol is bound (and imported across chunks) when printing.
- `__require`: the bundler's runtime has a per-target definition of `require` for non-cjs output (`import.meta.require` for bun, `createRequire(import.meta.url)` for node, a throwing shim for browsers, `src/bundler/ParseTask.rs:385`). The printer always prints unbundled `require` call targets as this symbol in esm/iife output; it is up to the parser (for parsed files) or the linker (for lazy exports) to make sure the defining part is referenced.

<details>
<summary>Repro on 1.4.0</summary>

```sh
printf 'fake' > addon.node
printf 'import addon from "./addon.node";\nconsole.log(addon);\n' > entry.js
bun build entry.js --target=bun --outdir=out && bun out/entry.js
```

```
// @bun
// addon.node
var addon_default = __require("./addon-9v8ks3ze.node");

// entry.js
console.log(addon_default);
```

```
ReferenceError: __require is not defined
      at out/entry.js:3:30
```

With this change the output starts with `var __require = import.meta.require;` and the run gets to `error: .../addon-9v8ks3ze.node: file too short  code: "ERR_DLOPEN_FAILED"`, i.e. the same point a `require("./addon.node")` bundle reaches.
</details>
