### PR TITLE
hot/watch: keep driving timers and surviving errors after an unhandled error

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1455,6 +1455,17 @@ impl VirtualMachine {
         !self.bun_watcher.is_null()
     }
 
+    /// Whether an error nothing in script handled ends the run. Under
+    /// `--hot`/`--watch` it does not: the error is printed and the process keeps
+    /// running what it has (servers, timers) until the watcher reloads it.
+    /// Counting it in `unhandled_error_counter` there would keep
+    /// `is_event_loop_alive()` false for the rest of the process, leaving the
+    /// watcher run loop in `tick_possibly_forever()`, which polls I/O but never
+    /// drains the timer heap.
+    fn unhandled_errors_are_fatal(&self) -> bool {
+        !self.is_watcher_enabled()
+    }
+
     /// Thin setter so callers don't need `.with` plumbing on the thread-local.
     #[inline]
     pub fn set_is_main_thread_vm(value: bool) {
@@ -1527,7 +1538,12 @@ impl VirtualMachine {
             // and exit, like node's fatal-exception path. Main thread only:
             // process_exit() RETURNS on a worker, so the panic would fire; a
             // worker falls through and exits 1 below (e.g. a beforeExit throw).
-            if self.exit_on_uncaught_exception && self.is_main_thread() {
+            // A watcher's run loop dispatches `beforeExit` whenever it drains
+            // and keeps turning afterwards, so there the error is only printed.
+            if self.exit_on_uncaught_exception
+                && self.is_main_thread()
+                && self.unhandled_errors_are_fatal()
+            {
                 self.run_error_handler(err, None);
                 // `process_exit` emits `exit`, re-entering here if a listener
                 // throws. No handler is running, so drop the recursion guard or
@@ -1538,7 +1554,9 @@ impl VirtualMachine {
                 panic!("made it past process.exit()");
             }
             // TODO maybe we want a separate code path for uncaught exceptions
-            self.unhandled_error_counter += 1;
+            if self.unhandled_errors_are_fatal() {
+                self.unhandled_error_counter += 1;
+            }
             self.exit_handler.exit_code = 1;
             (self.on_unhandled_rejection)(self, global_object, err);
         }
@@ -3568,7 +3586,8 @@ impl VirtualMachine {
         }
     }
 
-    /// Routes an unhandled promise rejection to the configured handler, bumping the unhandled-error counter.
+    /// Routes an unhandled promise rejection to the configured handler and, where
+    /// [`Self::unhandled_errors_are_fatal`], bumps the unhandled-error counter.
     pub fn unhandled_rejection(
         &mut self,
         global_object: &JSGlobalObject,
@@ -3668,7 +3687,9 @@ impl VirtualMachine {
                 }
             }
         }
-        self.unhandled_error_counter += 1;
+        if self.unhandled_errors_are_fatal() {
+            self.unhandled_error_counter += 1;
+        }
         (self.on_unhandled_rejection)(self, global_object, reason);
     }
 

--- a/test/cli/hot/hot-error-server-fixture.js
+++ b/test/cli/hot/hot-error-server-fixture.js
@@ -1,0 +1,42 @@
+// Spawned by hot.test.ts under --hot / --watch. Nothing edits files while it
+// runs: the flag alone puts the process in watcher mode, where an unhandled
+// error is supposed to be printed and otherwise change nothing. The routes let
+// the test raise such errors and then check that the run loop still drives
+// timers and still survives the next error.
+const server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    switch (new URL(req.url).pathname) {
+      case "/timer":
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return new Response("timer fired");
+      case "/throw":
+        queueMicrotask(() => {
+          throw new Error("uncaught exception from /throw");
+        });
+        return new Response("alive");
+      case "/reject":
+        Promise.reject(new Error("unhandled rejection from /reject"));
+        return new Response("alive");
+      default:
+        return new Response("alive");
+    }
+  },
+});
+
+switch (process.env.HOT_ERROR_FIXTURE) {
+  case "entry-rejects":
+    console.log(server.port);
+    await 0;
+    throw new Error("rejected by the entry point");
+  case "idle":
+    // With the server unref'd nothing keeps the loop alive once this module
+    // finishes, so the run loop drains and dispatches beforeExit, then parks.
+    // The unref'd server still answers while it is parked.
+    server.unref();
+    process.on("beforeExit", () => console.log("beforeExit"));
+    console.log(server.port);
+    break;
+  default:
+    console.log(server.port);
+}

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
-import { spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
+import { spawn, type Subprocess } from "bun";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, forEachLine, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -776,3 +776,94 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
   },
   longTimeout,
 );
+// An error nothing handled must not wind the process down in watcher mode: the
+// watcher keeps the process alive, so what it is running has to keep running.
+// Before the fix the first such error stopped the run loop from draining the
+// timer heap (sockets were still serviced, timers never fired again) and armed
+// the hard exit taken by the next uncaught exception, which then ended the
+// process. Kept sequential on purpose: when this regresses the fixture hangs
+// instead of exiting, and bun test only kills a timed-out test's leftover
+// processes for sequential tests.
+describe.each(["--hot", "--watch"])("%s after an unhandled error", flag => {
+  function startFixture(mode: "entry-rejects" | "runtime-errors" | "idle") {
+    return spawn({
+      cmd: [bunExe(), flag, "hot-error-server-fixture.js"],
+      env: { ...bunEnv, HOT_ERROR_FIXTURE: mode },
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+  }
+
+  async function nextLine(lines: AsyncGenerator<string>) {
+    const { value, done } = await lines.next();
+    if (done) throw new Error("the fixture exited before printing the expected line");
+    return value;
+  }
+
+  async function ready(proc: Subprocess<"ignore", "pipe", "pipe">) {
+    const stderr = proc.stderr.text();
+    const stdoutLines = forEachLine(proc.stdout);
+    const port = await nextLine(stdoutLines);
+    return {
+      stdoutLines,
+      async get(path: string) {
+        const response = await fetch(`http://127.0.0.1:${port}${path}`);
+        return response.text();
+      },
+      // Kills the fixture and returns the errors it reported. Each message also
+      // appears in the source excerpt bun prints above the report, so only the
+      // report lines are collected.
+      async reportedErrors() {
+        proc.kill();
+        await proc.exited;
+        return (await stderr).match(/^error: [^\r\n]*/gm);
+      },
+    };
+  }
+
+  it("still fires timers after the entry point's promise rejected", async () => {
+    await using proc = startFixture("entry-rejects");
+    const { get, reportedErrors } = await ready(proc);
+
+    expect(await get("/timer")).toBe("timer fired");
+    expect(await get("/throw")).toBe("alive");
+    expect(await get("/")).toBe("alive");
+    expect(await get("/timer")).toBe("timer fired");
+
+    expect(await reportedErrors()).toEqual([
+      "error: rejected by the entry point",
+      "error: uncaught exception from /throw",
+    ]);
+  });
+
+  it("keeps running, timers included, through an uncaught exception and an unhandled rejection", async () => {
+    await using proc = startFixture("runtime-errors");
+    const { get, reportedErrors } = await ready(proc);
+
+    expect(await get("/throw")).toBe("alive");
+    expect(await get("/reject")).toBe("alive");
+    expect(await get("/throw")).toBe("alive");
+    expect(await get("/")).toBe("alive");
+    expect(await get("/timer")).toBe("timer fired");
+
+    expect(await reportedErrors()).toEqual([
+      "error: uncaught exception from /throw",
+      "error: unhandled rejection from /reject",
+      "error: uncaught exception from /throw",
+    ]);
+  });
+
+  it("survives an uncaught exception raised after beforeExit was dispatched", async () => {
+    await using proc = startFixture("idle");
+    const { stdoutLines, get, reportedErrors } = await ready(proc);
+    expect(await nextLine(stdoutLines)).toBe("beforeExit");
+
+    expect(await get("/throw")).toBe("alive");
+    expect(await get("/")).toBe("alive");
+    expect(await get("/timer")).toBe("timer fired");
+
+    expect(await reportedErrors()).toEqual(["error: uncaught exception from /throw"]);
+  });
+});


### PR DESCRIPTION
### Problem
- Under `bun --hot` or `bun --watch`, once any error goes unhandled (the entry point's promise rejecting, an uncaught exception in a callback, an unhandled rejection), no `setTimeout`/`setInterval` callback runs again for the rest of the process, while sockets keep being serviced: a `Bun.serve` started before the error still answers. Smallest form: `setTimeout(() => process.exit(0), 10); await 0; throw new Error("x")` never exits under `--hot`.
- Same state, second symptom: the next uncaught exception after that first error exits the `--hot` process with code 1. The exit also happens with no prior error when the loop drained once (`beforeExit` was dispatched) and a later generation throws from a callback.
- Cause: the `!handled` tail of `VirtualMachine::uncaught_exception` and the tail of `VirtualMachine::unhandled_rejection` (src/jsc/VirtualMachine.rs) do `unhandled_error_counter += 1`. `is_event_loop_alive()` is false while that counter is nonzero, so the watcher arm of the run loop in `Run::start` (src/runtime/cli/run_command.rs) never re-enters its `while vm.is_event_loop_alive()` body and only repeats `on_before_exit()` + `tick_possibly_forever()`. `tick_possibly_forever` (src/jsc/event_loop.rs) polls sockets and runs tasks but never calls `timer::All::get_timeout`/`drain_timers`; on epoll/kqueue those only run from `auto_tick_active`, which is inside the skipped body. (On Windows libuv drives the heap, so only the exit symptom reproduces there.)
- `on_before_exit()` with the counter nonzero sets `exit_on_uncaught_exception`, and `Process__dispatchOnBeforeExit` sets it on every drain; with it set, `uncaught_exception` calls `process.exit(1)` for the next unhandled throw.
- Not a regression: `tick_possibly_forever` never drained JS timers, before or after #33359.

### Fix
- Add `VirtualMachine::unhandled_errors_are_fatal()` (`!is_watcher_enabled()`) and gate the two counter bumps and the `exit_on_uncaught_exception` hard exit on it. Printing and `exit_code = 1` are unchanged.
- Why this is the right place: the counter and the flag both mean "the process is exiting because of this error". With a watcher installed the process must not exit on errors (the watcher arm is an infinite loop; only `process.exit()` or a signal ends it), so recording exit state there is the bug. Once the state is not entered, the run loop, `on_before_exit`, and `tick_possibly_forever` (still used for the genuinely idle case) already do the right thing; the alternative of teaching the parked loop to also drive timers would add a second timer path and still leave the hard exit armed.
- The sockets half of the process was already kept alive after errors in both modes; this makes timers consistent with it. After a reported error the loop now behaves like a generation that did not fail, including dispatching `beforeExit` when it drains.
- Scope: `bun test` is unaffected (its `isBunTest` branches return before these lines), workers have no watcher, plain `bun run` is unchanged.
- Open PRs nearby: #34657 resets the same two fields in `reload()`, which only takes effect once a fixing reload happens; with the state never entered, that scenario works as well (checked by hand: an interval kept ticking through a saved syntax error and after the fix was saved). #34627 stops the non-watcher `load_entry_point` wait on the counter and leaves the watcher arm alone, which this change is consistent with.
- Tests: `test/cli/hot/hot.test.ts`, `describe.each(["--hot", "--watch"])`, three tests per flag against `test/cli/hot/hot-error-server-fixture.js` (no files are edited; the flag alone puts the run loop in watcher mode): timers after a rejected entry point; an uncaught exception, an unhandled rejection and a second uncaught exception at runtime, then a timer; an uncaught exception after `beforeExit` was dispatched. Each also checks the exact `error:` lines reported.
- `USE_SYSTEM_BUN=1 bun test`: 6 fail (entry-point ones time out waiting on the timer-backed response, the others get `ConnectionRefused`/`ECONNRESET` because the fixture exited 1). `bun bd test`: 6 pass.
- Also pass with the change: the rest of `hot.test.ts` (error-reload tests included), `test/cli/hot/watch.test.ts`, `test/cli/watch/watch.test.ts`, `test/cli/test/test-changed.test.ts` (`bun test --watch`), `test/cli/run/run-eval.test.ts`, `test/js/node/process/process.test.js` (two failures there are container-specific: `process.env.USER` unset, and a worker test that takes 4.6s on this debug build with no errors involved).

### Background
- `unhandled_error_counter`: VM field bumped when an error reaches the top with no `uncaughtException`/`unhandledRejection` listener. `is_event_loop_alive()` is false while it is nonzero; that is how plain `bun run` exits 1 after such an error, since its run loop is `while vm.is_event_loop_alive() { tick(); auto_tick_active(); }`. `bun test` bumps it on separate branches and uses it as a tally.
- `exit_on_uncaught_exception`: VM flag meaning "past `beforeExit`"; set by `Process__dispatchOnBeforeExit` and by `on_before_exit()` when an error was counted. With it set, an unhandled throw calls `process.exit(1)` directly because outside watch mode there is no loop turn left to unwind through.
- Watcher mode: `--hot` re-evaluates the entry point in-process on file changes, `--watch` re-execs the process. Both install `vm.bun_watcher` (`is_watcher_enabled()`) and share the watcher arm of the run loop, which never returns: drive the loop while something is alive, dispatch `beforeExit` when it drains, park in `tick_possibly_forever()` until the watcher thread wakes it.
- JS timers on POSIX live in Bun's own heap (`timer::All`) and fire only from `auto_tick`/`auto_tick_active`, which compute the poll timeout from the heap and drain it after the poll. `tick_possibly_forever` is a fixed one-second park that does neither.

<details>
<summary>Probes on the released build (1.4.0, linux x64)</summary>

```
$ cat tla.mjs
setTimeout(() => { console.log("timer fired"); process.exit(0); }, 300);
await 0;
throw new Error("tla boom");
$ timeout 5 bun --hot tla.mjs      # error printed, killed by timeout (124)
$ timeout 5 bun --watch tla.mjs    # same
$ timeout 5 bun tla.mjs            # error, exit 1 (expected without a watcher)

$ cat later-throw.mjs
setTimeout(() => { throw new Error("later boom"); }, 100);
setTimeout(() => console.log("timer fired"), 600);
$ timeout 5 bun --hot later-throw.mjs   # error only, 124
# An unhandled rejection raised inside a timer callback lets one more batch of
# due timers fire, because auto_tick_active runs once more in the iteration
# that counts it; after that the loop is parked the same way.

# Server whose entry point completed normally, under --hot:
#   GET /throw      -> "alive", error printed, GET / still answers
#   GET /timer      -> the 50ms timer it arms never fires
#   GET /throw again -> empty reply, process exited 1

# No prior error: entry touches `process`, loop drains (beforeExit), file is
# rewritten so a setTimeout callback throws -> process exits 1 instead of
# printing and waiting for the next save.

# With this branch (debug build): an interval armed by generation 1 produced 20
# ticks between a saved syntax error being reported and the fix being saved,
# then kept ticking after the fix.
```
</details>
