### PR TITLE
node:http: release a request whose body fin was buffered while paused once the response ends

### DIFF
--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -680,15 +680,23 @@ impl NodeHTTPResponse {
             return false;
         }
 
+        // The body keeps the request pending only while uws still owes it
+        // chunks. A fin that arrived while the request was paused leaves
+        // `body_read_state` at `Pending` so JS can still drain the buffered
+        // tail (`drainRequestBody`), but uws will not deliver anything further,
+        // so for this accounting that body is complete as well.
+        let body_pending = self.body_read_state.get() == BodyReadState::Pending
+            && !flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST);
+
         // A raw 'upgrade'/'connect' tunnel handoff ends the HTTP exchange the
         // same way, except an Upgrade carrying a body keeps parsing as HTTP
         // until the body's fin chunk (the actual tunnel start).
         if flags.contains(Flags::TUNNELED) {
-            return self.body_read_state.get() == BodyReadState::Pending;
+            return body_pending;
         }
 
         if flags.contains(Flags::ENDED) {
-            return self.body_read_state.get() == BodyReadState::Pending;
+            return body_pending;
         }
 
         true
@@ -743,8 +751,18 @@ impl NodeHTTPResponse {
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
         self.upgrade_context.with_mut(|c| c.reset());
 
-        self.buffered_request_body_data_during_pause
-            .with_mut(|b| b.clear_and_free());
+        // A body whose fin was buffered during a pause is still owed to the
+        // IncomingMessage, which drains it through `drainRequestBody` when it
+        // next reads (possibly only after the response has ended). Keep it while
+        // JS can still get at it; `set_on_data` frees it once the reader lets go.
+        let flags = self.flags.get();
+        let tail_still_readable = flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+            && !flags.contains(Flags::SOCKET_CLOSED)
+            && !flags.contains(Flags::UPGRADED);
+        if !tail_still_readable {
+            self.buffered_request_body_data_during_pause
+                .with_mut(|b| b.clear_and_free());
+        }
         let mut server = self.server;
         self.poll_ref.with_mut(|r| r.unref(vm));
         self.unregister_auto_flush();
@@ -1283,9 +1301,8 @@ impl NodeHTTPResponse {
                 // The socket is gone — no further uws callback will arrive to
                 // balance the IS_REQUEST_PENDING ref. `on_request_complete()`
                 // can set REQUEST_HAS_COMPLETED while `body_read_state` is
-                // still `.pending` (e.g. the request body's last chunk was
-                // buffered during pause before `res.end()` — the
-                // `Expect: 100-continue` path), in which case
+                // still `.pending` (a custom `ondata` reader keeps the body
+                // pending across `res.end()`, see `write_or_end`), in which case
                 // `mark_request_as_done()` never ran there and both that ref
                 // and the server's pending-request counter are stranded. The
                 // synchronous `set_closed()` from `JSNodeHTTPServerSocket::
@@ -2337,6 +2354,11 @@ impl NodeHTTPResponse {
                 self.body_read_ref
                     .with_mut(|r| r.unref(bun_vm_mut(global_object)));
             }
+            // The reader is letting go of the body (_dump / _destroy, or it has
+            // already drained what was buffered), so nothing will drain a tail
+            // that `mark_request_as_done` left in place for it.
+            self.buffered_request_body_data_during_pause
+                .with_mut(|b| b.clear_and_free());
             return;
         }
 

--- a/test/js/node/http/node-http-req-socket-pause.test.ts
+++ b/test/js/node/http/node-http-req-socket-pause.test.ts
@@ -1,10 +1,11 @@
 /**
  * All tests in this file should also run in Node.js.
  */
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { once } from "node:events";
-import { Agent, createServer, request } from "node:http";
-import type { AddressInfo } from "node:net";
+import { Agent, createServer, request, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { connect } from "node:net";
 
 it("req.socket emits 'pause' once an unread request body fills the IncomingMessage buffer", async () => {
   // Node's test-http-no-read-no-dump: a handler that never reads the body sees
@@ -110,5 +111,186 @@ it("req.socket emits 'pause' on every body-bearing keep-alive request, not just 
   } finally {
     server.closeAllConnections();
     server.close();
+  }
+});
+
+// A chunked body whose first chunk alone overflows a 1 KiB highWaterMark: the
+// first push() pauses the connection while the parser is still inside this
+// segment, so the chunk after it and the terminating chunk are received while
+// the request is paused. The whole request is written at once so that it is
+// parsed in one go.
+const BODY_HEAD = Buffer.alloc(2048, "x").toString();
+const BODY_TAIL = "tail";
+function chunkedPost(path: string, extraHeaders = "") {
+  return (
+    `POST ${path} HTTP/1.1\r\nHost: a\r\n${extraHeaders}Transfer-Encoding: chunked\r\n\r\n` +
+    `${BODY_HEAD.length.toString(16)}\r\n${BODY_HEAD}\r\n` +
+    `${BODY_TAIL.length.toString(16)}\r\n${BODY_TAIL}\r\n` +
+    "0\r\n\r\n"
+  );
+}
+
+async function connectTo(server: Server) {
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const socket = connect((server.address() as AddressInfo).port, "127.0.0.1");
+  socket.setNoDelay(true);
+  let received = "";
+  const waiting: Array<{ marker: string; resolve: () => void }> = [];
+  socket.on("data", chunk => {
+    received += chunk;
+    for (let i = 0; i < waiting.length; ) {
+      if (received.includes(waiting[i].marker)) waiting.splice(i, 1)[0].resolve();
+      else i++;
+    }
+  });
+  await once(socket, "connect");
+  return {
+    socket,
+    /** Resolves once the response bytes received so far contain `marker`. */
+    receive(marker: string) {
+      if (received.includes(marker)) return Promise.resolve();
+      const { promise, resolve } = Promise.withResolvers<void>();
+      waiting.push({ marker, resolve });
+      return promise;
+    },
+  };
+}
+
+async function disconnectAndClose(socket: Socket, server: Server) {
+  socket.destroy();
+  await once(socket, "close");
+  // The server's 'close' event waits for every request the server still
+  // counts as in flight, so a request that is never released keeps it from
+  // ever firing.
+  server.close();
+  await once(server, "close");
+}
+
+describe("request whose whole body arrived while it was paused, answered later on a keep-alive connection", () => {
+  // In each test the connection goes on to serve a second request before it is
+  // closed, so closing it does not tear down the first request as a side
+  // effect: the first request has to be released by its own response ending.
+  it("is released once the response ends even though the body is never read", async () => {
+    const paused: string[] = [];
+    const server = createServer({ highWaterMark: 1024 }, (req, res) => {
+      req.socket.once("pause", () => paused.push(req.url!));
+      if (req.url === "/unread") {
+        // Respond once the segment that carried this request has been parsed
+        // to the end of its body (setImmediate runs after the read callback
+        // that dispatched it), without ever reading the body.
+        setImmediate(() => res.end("alpha"));
+      } else {
+        res.end("bravo");
+      }
+    });
+    try {
+      const client = await connectTo(server);
+      client.socket.write(chunkedPost("/unread"));
+      await client.receive("alpha");
+      client.socket.write("GET /next HTTP/1.1\r\nHost: a\r\n\r\n");
+      await client.receive("bravo");
+      expect(paused).toEqual(["/unread"]);
+      await disconnectAndClose(client.socket, server);
+    } finally {
+      server.closeAllConnections();
+      if (server.listening) server.close();
+    }
+  });
+
+  it("still hands the rest of the body to a reader that starts reading as the response ends", async () => {
+    const paused: string[] = [];
+    const { promise: body, resolve: gotBody } = Promise.withResolvers<string>();
+    const server = createServer({ highWaterMark: 1024 }, (req, res) => {
+      req.socket.once("pause", () => paused.push(req.url!));
+      if (req.url !== "/read") {
+        res.end("bravo");
+        return;
+      }
+      let received = "";
+      req.on("end", () => gotBody(received));
+      setImmediate(() => {
+        // The whole body has been received by now, but only its first chunk
+        // fit into the request's buffer. Reading starts on the next tick, so
+        // the response ends before the rest of the body has been handed over.
+        req.on("data", chunk => (received += chunk));
+        res.end("alpha");
+      });
+    });
+    try {
+      const client = await connectTo(server);
+      client.socket.write(chunkedPost("/read"));
+      await client.receive("alpha");
+      expect(await body).toBe(BODY_HEAD + BODY_TAIL);
+      client.socket.write("GET /next HTTP/1.1\r\nHost: a\r\n\r\n");
+      await client.receive("bravo");
+      expect(paused).toEqual(["/read"]);
+      await disconnectAndClose(client.socket, server);
+    } finally {
+      server.closeAllConnections();
+      if (server.listening) server.close();
+    }
+  });
+
+  it("is released once the response ends when the next request was pipelined behind it", async () => {
+    const paused: string[] = [];
+    const { promise: pipelinedBody, resolve: gotPipelinedBody } = Promise.withResolvers<string>();
+    const server = createServer({ highWaterMark: 1024 }, (req, res) => {
+      req.socket.once("pause", () => paused.push(req.url!));
+      if (req.url === "/unread") {
+        setImmediate(() => res.end("alpha"));
+        return;
+      }
+      let received = "";
+      req.on("data", chunk => (received += chunk));
+      req.on("end", () => {
+        gotPipelinedBody(received);
+        res.end("bravo");
+      });
+    });
+    try {
+      const client = await connectTo(server);
+      // The second request (and its body) is in the same segment as the first
+      // one, so it is dispatched, and its response queued, while the first
+      // response is still pending.
+      client.socket.write(
+        chunkedPost("/unread") + "POST /pipelined HTTP/1.1\r\nHost: a\r\nContent-Length: 3\r\n\r\nabc",
+      );
+      await client.receive("alpha");
+      await client.receive("bravo");
+      expect(await pipelinedBody).toBe("abc");
+      expect(paused).toEqual(["/unread"]);
+      await disconnectAndClose(client.socket, server);
+    } finally {
+      server.closeAllConnections();
+      if (server.listening) server.close();
+    }
+  });
+});
+
+it("upgrade request whose whole body arrived while it was paused still hands the whole body to a reader attached later", async () => {
+  const { promise: body, resolve: gotBody } = Promise.withResolvers<string>();
+  const server = createServer({ highWaterMark: 1024 });
+  server.on("upgrade", (req, socket) => {
+    socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n");
+    let received = "";
+    req.on("end", () => {
+      gotBody(received);
+      socket.destroy();
+    });
+    // As above: the whole body has been received by the time this runs, but
+    // only its first chunk fit into the request's buffer.
+    setImmediate(() => req.on("data", chunk => (received += chunk)));
+  });
+  try {
+    const client = await connectTo(server);
+    client.socket.write(chunkedPost("/upgrade", "Upgrade: test\r\nConnection: Upgrade\r\n"));
+    await client.receive("101 Switching Protocols");
+    expect(await body).toBe(BODY_HEAD + BODY_TAIL);
+    await once(client.socket, "close");
+    server.close();
+    await once(server, "close");
+  } finally {
+    server.closeAllConnections();
+    if (server.listening) server.close();
   }
 });


### PR DESCRIPTION
### Problem

- A `node:http` server request stays counted as in flight forever when the last chunk of its body arrived while the `IncomingMessage` was paused and the response was ended afterwards. `server.close()` never calls back (the server's `'close'` event needs the in-flight count to reach zero), the process it keeps alive never exits, and the native response object leaks (`IS_REQUEST_PENDING` is a self-reference). Node v26 closes cleanly; reproduces on bun 1.4.0 and main.
- Easy to hit without an explicit `pause()`: a body chunk larger than the `IncomingMessage` `highWaterMark` that nobody reads pauses the connection mid-segment (Node's `readStop` semantics), so the rest of the same segment (remaining chunks + terminating chunk) is buffered natively while paused.
- Cause, `src/runtime/server/NodeHTTPResponse.rs`:
  - `on_buffer_request_body_while_paused(last = true)` sets `IS_DATA_BUFFERED_DURING_PAUSE_LAST`, releases `body_read_ref`, and deliberately leaves `body_read_state == Pending` so JS can still drain the buffered tail (`drainRequestBody`).
  - `should_request_be_pending()` read that `Pending` as "body still arriving", so `res.end()` -> `on_request_complete()` kept `IS_REQUEST_PENDING`. `write_or_end`'s dump-equivalent does not apply either, because it keys on `body_read_ref` still being held.
  - Nothing re-evaluates later: uws delivers nothing further for that body (it nulls its handler at the fin and again at `end()`), and the later `ondata = undefined` from `_dump()`/`_destroy()` only flips the state to `Done`.
  - The socket-close fallback in `handle_abort_or_timeout` only reaches the connection's *current* response, so as soon as the keep-alive connection serves one more request the strand is permanent.

### Fix

- `should_request_be_pending()` treats a body whose fin was buffered while paused as complete (`Pending` and not `IS_DATA_BUFFERED_DURING_PAUSE_LAST` is the only "still arriving" state). The request is then released where every other body state is released: at `res.end()` via `on_request_complete()`, or for an upgrade tunnel with a body at the fin itself (the existing `mark_request_as_done_if_necessary()` call in `on_buffer_request_body_while_paused`, matching what the unbuffered fin already does in `on_data_or_aborted`).
- `mark_request_as_done()` no longer frees `buffered_request_body_data_during_pause` in that state while the connection is still open: the `IncomingMessage` still owns that tail and drains it on its next `_read()` (possibly after the response ended). It is freed when drained, when the reader lets go (`set_on_data`'s clear branch, reached from `_dump()` / `_destroy()` / a re-arm attempt that follows `_read()`'s drain), or with the box. Closed/upgraded connections free it immediately as before.
- Why this is correct: once the fin has been seen there is nothing left for the accounting to wait for. Every other consumer of the flag already treats it as "body complete" (`hasBody` reports done, `pause()`/`resume()`/`ondata` refuse to re-arm), and the accounting release at `res.end()` is what Node does too (`resOnFinish` drops the request from the server's queue regardless of whether its body was consumed). Releasing the accounting does not affect JS's ability to read the tail because the wrapper holds its own reference to the box; only the buffer's lifetime had to be decoupled.
- The `clear_on_data()` reached from `mark_request_as_done()` on this new path is a no-op: uws already nulled the connection's handler when it delivered the fin (and again in `end()`), and `ondata` is cleared on this request's own wrapper (`armed_this_value`).
- Tests: `test/js/node/http/node-http-req-socket-pause.test.ts`, four new tests, each also checked against Node v26 (all pass there):
  - unread body, response ended later, second keep-alive request, server `'close'` fires: times out on main.
  - reader that starts reading as the response ends still gets the buffered tail, then server `'close'` fires: times out on main, and fails (tail missing) if the tail is freed at release.
  - same with the next request pipelined in the same segment (covers the variant where the tail was drained before `res.end()`): times out on main.
  - upgrade request with such a body, reader attached later gets the whole body: passes on main by design, fails (tail missing) if the tail is freed at the fin-time release; covers the tunnel arm.
- Also run on this build: the handoff repro exits with `server closed`; `node-http.test.ts`, `node-http-backpressure*.test.ts`, `node-http-transfer-encoding`, `node-http-server-abort-events`, `node-http-connect`, `node-http-with-ws`, `node-http-ondata-reregister-leak`, `node-http-server-socket-end-drain`, `node-http-uaf`, `node-http-server-timeouts`, and 42 vendored `test-http-{pause,no-read-no-dump,expect-continue,keep-alive,pipeline,upgrade-server-with-body,...}` tests. The only failures are identical without this diff (the proxy test's `localhost` resolution in this container and a few subprocess tests exceeding 5 s on the ASAN build). `cargo clippy -p bun_runtime` is clean.
- Related: #38196 (keep receiving the body after the response ended) names this same predicate `body_still_arriving()` and leaves this strand to a separate fix; in its model a paused reader can also get the fin buffered after `res.end()`, and this change is what releases that request. #34761 (pipelined successor's handler slot) is independent.

### Background

- Request body delivery: uws keeps one `HttpResponseData` per connection with a single body-data handler slot. `NodeHTTPResponse` arms it with `on_data_shim` (deliver to JS `ondata`) or, while the `IncomingMessage` is paused, `on_buffer_paused_shim`, which appends chunks to `buffered_request_body_data_during_pause`; JS later fetches that buffer with `drainRequestBody()` from `IncomingMessage._read()`. uws clears the slot itself after the chunk flagged as the fin.
- `body_read_state` is `None` (no body), `Pending` (uws may still call back, or a buffered tail is still readable) or `Done`; `IS_DATA_BUFFERED_DURING_PAUSE_LAST` records that the fin was among the buffered chunks. `body_read_ref` is the event-loop keep-alive held while chunks are still expected.
- `IS_REQUEST_PENDING` is a self-reference on the response box plus one unit of the server's in-flight request count; `mark_request_as_done()` drops both, and `should_request_be_pending()` decides whether an ended/tunneled response may drop them yet. `server.close()` in `node:http` completes through the native server's all-requests-done promise, which is gated on that count.

<details>
<summary>Repro from the report (hangs on bun 1.4.0, exits with "server closed" on Node and with this change)</summary>

```js
import { once } from "node:events";
import { createServer } from "node:http";
import { connect } from "node:net";
let n = 0;
const server = createServer((req, res) => { const i = ++n; if (i === 1) setTimeout(() => res.end("ok1"), 100); else res.end("ok2"); });
server.listen(0, "127.0.0.1"); await once(server, "listening");
const client = connect(server.address().port, "127.0.0.1");
let data = ""; client.on("data", d => (data += d)); await once(client, "connect");
const big = Buffer.alloc(70000, "x").toString();
client.write("POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n" + big.length.toString(16) + "\r\n" + big + "\r\n3\r\nend\r\n0\r\n\r\n");
while (!data.includes("ok1")) await new Promise(r => setTimeout(r, 5));
client.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
while (!data.includes("ok2")) await new Promise(r => setTimeout(r, 5));
client.destroy(); server.close(() => console.log("server closed"));
```

`BUN_DEBUG_NodeHTTPResponse=1` before: `onData(70000)` -> `doPause` -> `onBufferRequestBodyWhilePaused(3, false)` -> `onBufferRequestBodyWhilePaused(0, true)` -> `end('ok1')` -> `onRequestComplete`, and no `markRequestAsDone()` for the first request. After: `markRequestAsDone()` follows `onRequestComplete` directly, and the later `drainBufferedRequestBodyFromPause 3` shows the tail still being handed to JS.

</details>
