### PR TITLE
bun:test: stop leaking the name of every bound test/describe function

### DIFF
--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -810,7 +810,11 @@ fn bind(value: JSValue, global: &JSGlobalObject, name: BunString) -> JsResult<JS
     // `#[bun_jsc::host_fn]` on `call_as_function` emits the C-ABI thunk
     // `__jsc_host_call_as_function`; `JSFunction::create` wants the raw
     // `JSHostFn` shape, not the safe Rust signature.
-    let call_fn = bun_jsc::JSFunction::create(global, name.clone(), __jsc_host_call_as_function, 1, Default::default());
+    //
+    // `name` is a `Copy` handle that both callees below only borrow. Do not
+    // `name.clone()` it: that is `bun.String.clone`, a +1 WTF copy nobody here
+    // releases.
+    let call_fn = bun_jsc::JSFunction::create(global, name, __jsc_host_call_as_function, 1, Default::default());
     let bound = JSValueTestExt::bind(call_fn, global, value, &name, 1.0, &[])?;
     set_prototype_direct(bound, value.get_prototype(global), global)?;
     Ok(bound)

--- a/test/js/bun/test/bun-test.test.ts
+++ b/test/js/bun/test/bun-test.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
+import { join } from "path";
 
 test("Bun.version", () => {
   expect(process.versions.bun).toBe(Bun.version);
@@ -41,3 +42,85 @@ console.log("OK");`,
   expect(stdout).toBe("OK\n");
   expect(exitCode).toBe(0);
 });
+
+// Every test/describe function handed to user code (the four created with the
+// bun:test module object plus one per modifier call) is a ScopeFunctions bound
+// through ScopeFunctions.rs `bind`, which used to leak a WTF copy of the
+// function's name each time. LSan only sees WTF allocations when Malloc=1
+// routes bmalloc through the system allocator.
+test.skipIf(!isASAN || isWindows)(
+  "test/describe modifiers do not leak the bound function name",
+  async () => {
+    using dir = tempDir("scope-functions-name-leak", {
+      "modifiers.test.ts": `
+        import { describe, expect, test, xdescribe, xtest } from "bun:test";
+
+        const fails = () => {
+          throw new Error("expected failure");
+        };
+
+        test("test", () => {});
+        xtest("xtest", () => {});
+        test.skip("test.skip", () => {});
+        test.todo("test.todo");
+        test.failing("test.failing", fails);
+        test.concurrent("test.concurrent", () => {});
+        test.serial("test.serial", () => {});
+        test.if(true)("test.if(true)", () => {});
+        test.if(false)("test.if(false)", () => {});
+        test.skipIf(true)("test.skipIf(true)", () => {});
+        test.skipIf(false)("test.skipIf(false)", () => {});
+        test.todoIf(true)("test.todoIf(true)", () => {});
+        test.todoIf(false)("test.todoIf(false)", () => {});
+        test.failingIf(true)("test.failingIf(true)", fails);
+        test.failingIf(false)("test.failingIf(false)", () => {});
+        test.concurrentIf(true)("test.concurrentIf(true)", () => {});
+        test.concurrentIf(false)("test.concurrentIf(false)", () => {});
+        test.serialIf(true)("test.serialIf(true)", () => {});
+        test.serialIf(false)("test.serialIf(false)", () => {});
+        test.each([1, 2])("test.each %i", i => expect(i).toBeNumber());
+        test.skip.each([1])("test.skip.each %i", () => {});
+        test.each([1]).skipIf(false)("test.each().skipIf(false) %i", () => {});
+
+        describe("describe", () => test("inner", () => {}));
+        xdescribe("xdescribe", () => test("inner", () => {}));
+        describe.skip("describe.skip", () => test("inner", () => {}));
+        describe.todo("describe.todo", () => test("inner", () => {}));
+        describe.concurrent("describe.concurrent", () => test("inner", () => {}));
+        describe.serial("describe.serial", () => test("inner", () => {}));
+        describe.if(true)("describe.if(true)", () => test("inner", () => {}));
+        describe.skipIf(true)("describe.skipIf(true)", () => test("inner", () => {}));
+        describe.skipIf(false)("describe.skipIf(false)", () => test("inner", () => {}));
+        describe.todoIf(false)("describe.todoIf(false)", () => test("inner", () => {}));
+        describe.concurrentIf(true)("describe.concurrentIf(true)", () => test("inner", () => {}));
+        describe.serialIf(true)("describe.serialIf(true)", () => test("inner", () => {}));
+        describe.each([1, 2])("describe.each %i", i => test("inner", () => expect(i).toBeNumber()));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "modifiers.test.ts"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        Malloc: "1",
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The result counts prove every modifier above registered; a leak report
+    // adds LeakSanitizer lines after them and fails the exit code.
+    const report = stderr
+      .split("\n")
+      .filter(line => /^ \d+ (pass|skip|todo|fail)$/.test(line) || /Sanitizer|leak of /.test(line));
+    expect({ report, exitCode }).toEqual({ report: [" 26 pass", " 8 skip", " 3 todo", " 0 fail"], exitCode: 0 });
+  },
+  // LSan symbolizes stacks against the debug binary: about 5s even for a clean
+  // run (the suppressed leaks still get symbolized), much longer on failure.
+  90_000,
+);


### PR DESCRIPTION
### Problem
- Every bound test/describe function `bun test` creates leaks one `WTF::StringImpl` holding the function's name. LSan (debug ASAN build, `Malloc=1`) on a file that only calls `test()` reports four leaks of 24/25/28/29 bytes (`test`, `xtest`, `describe`, `xdescribe`), all allocated from `BunString__fromLatin1 <- bun_core::String::clone <- scope_functions::bind` (`src/runtime/test_runner/ScopeFunctions.rs:813`) `<- create_bound <- Jest::create_test_module`.
- Each modifier call in a test file adds one more: `test.skipIf(..)` leaks `"skipIf"`, `test.each(..)` leaks `"each"`, and so on for `.skip`, `.todo`, `.concurrent`, `describe.each`, etc. The test fixture in this PR (37 registrations) leaks 36 allocations / 949 bytes on main. The count grows with the size of the suite, and with `--isolate` the four module-object leaks repeat per file.
- Cause: `bind` passed `name.clone()` to `JSFunction::create`. `bun_core::String` has an inherent `clone()` that is `bun.String.clone`, not `Clone::clone`: for the static names used here it allocates a fresh refcount-1 `WTF::StringImpl`. `JSFunction__createFromZig` (`src/jsc/bindings/bindings.cpp`) only borrows its `BunString` argument (`fn_name.toWTFString()` takes its own ref), and `bun_core::String` is `Copy` with no `Drop`, so the +1 was dropped on the floor. The Zig version of this function passed `name` straight through; the `.clone()` arrived with the Rust port.

### Fix
- `bind` passes `name` itself to `JSFunction::create`, the same way it already passed `&name` to `bind` on the next line. `BunString` is `Copy`, so nothing else changes.
- Correct because both callees borrow: `JSFunction__createFromZig` and `Bun__JSValue__bind` each build their own `WTF::String` from the argument and never take ownership of it, and every caller of `create_bound` (`create_test_module`, `fn_each`, `generic_if`, `generic_extend`) hands in a `BunString::static_str(..)` that has nothing to release.
- Test: `test/js/bun/test/bun-test.test.ts`, "test/describe modifiers do not leak the bound function name". It runs a fixture covering every `create_bound` entry point (module object, `.each`, every `*If` method in both branches, every getter except `.only`, and the describe variants) under LSan with `Malloc=1`, and asserts on the result counts plus exit code so a leak report shows up as extra `Direct leak of ...` / `SUMMARY` lines in the failure message. Gated on `isASAN`.
- Fails on main with 36 leaked allocations (949 bytes) and exit code 1; passes with the fix, 10/10 consecutive clean runs locally (about 5 to 6.5s each, almost all of it LSan symbolizing the suppressed stacks against the debug binary, hence the explicit timeout).

### Background
- `ScopeFunctions` is the native object behind `test`, `describe` and their modifiers. Each `test.x` access or `.xIf(..)` / `.each(..)` call creates a new one through `create_bound`, which wraps it in a host `JSFunction` and a `JSBoundFunction` named after the modifier; `bind` is the function that names them.
- `bun_core::String` (`BunString`) is the 24-byte tagged string handle shared with C++. It can point at a `'static` byte slice (no refcount) or at a `WTF::StringImpl`, in which case the holder owns one ref and has to `deref()` it; the type is `Copy` and has no `Drop`. Its inherent `clone()` follows Zig's `bun.String.clone`: it returns an owned WTF-backed copy (a new ref, or a fresh allocation for static input), which the caller must release or transfer.
- LSan cannot normally see WTF allocations because they come from bmalloc's own pages; `Malloc=1` makes bmalloc forward to the system allocator, and `BUN_DESTRUCT_VM_ON_EXIT=1` tears the main VM down at exit so anything still unreachable afterwards is a real leak. This is the same setup the other LSan tests in the tree use.

<details>
<summary>LSan report on main for the fixture (headers only)</summary>

```
 26 pass
 8 skip
 3 todo
 0 fail
==8273==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 96 byte(s) in 4 object(s) allocated from:
Direct leak of 78 byte(s) in 3 object(s) allocated from:
... (22 groups, every stack goes through scope_functions::bind ScopeFunctions.rs:813)
SUMMARY: AddressSanitizer: 949 byte(s) leaked in 36 allocation(s).
```

Representative stack:

```
#18 BunString__fromLatin1 src/jsc/bindings/BunString.cpp:459
#19 BunString__fromBytes src/jsc/bindings/BunString.cpp:500
#20 <bun_core::string::String>::clone_utf8 src/bun_core/string/mod.rs:221
#21 <bun_core::string::String>::clone src/bun_core/string/mod.rs:802
#22 bun_runtime::test_runner::scope_functions::bind src/runtime/test_runner/ScopeFunctions.rs:813
#23 bun_runtime::test_runner::scope_functions::create_bound src/runtime/test_runner/ScopeFunctions.rs:839
#24 bun_runtime::test_runner::jest::Jest::create_test_module src/runtime/test_runner/jest.rs:333
```
</details>
