### PR TITLE
test: run compile-outfile-subdirs.test.ts cases concurrently and assert their outputs

### DIFF
--- a/test/regression/issue/compile-outfile-subdirs.test.ts
+++ b/test/regression/issue/compile-outfile-subdirs.test.ts
@@ -1,146 +1,109 @@
 import { describe, expect, test } from "bun:test";
-import { execSync } from "child_process";
-import { existsSync } from "fs";
+import { readdirSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
-describe.if(isWindows)("compile --outfile with subdirectories", () => {
-  test("places executable in subdirectory with forward slash", async () => {
-    using dir = tempDir("compile-subdir-forward", {
-      "app.js": `console.log("Hello from subdirectory!");`,
+// https://github.com/oven-sh/bun/pull/22365: `--outfile` / `compile.outfile`
+// with directory components on Windows, including the PE metadata pass, which
+// used to fail on relative paths. The `.`/`..` case is also what the Windows
+// mkdir_recursive_at_mode in src/sys/lib.rs is written against.
+
+async function spawn(cmd: string[], cwd?: string) {
+  await using proc = Bun.spawn({ cmd, cwd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// Runs `bun build --compile` from `cwd`, which is what a relative --outfile
+// resolves against. The summary on stdout is returned with the per-run
+// timings ("   [12ms]", "[1.05s]") stripped so it can be compared exactly.
+async function compile(cwd: string, entrypoint: string, outfile: string, ...flags: string[]) {
+  const { stdout, stderr, exitCode } = await spawn(
+    [bunExe(), "build", "--compile", entrypoint, "--outfile", outfile, ...flags],
+    cwd,
+  );
+  return { stdout: stdout.replace(/^\s*\[[\d.]+m?s\]\s*/gm, ""), stderr, exitCode };
+}
+
+function run(exe: string) {
+  return spawn([exe]);
+}
+
+// Reads every requested VersionInfo field with a single PowerShell invocation;
+// each PowerShell start costs a good fraction of a second.
+async function readVersionInfo(exe: string, fields: string[]): Promise<Record<string, string | null>> {
+  const { stdout, stderr, exitCode } = await spawn([
+    "powershell",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ` +
+      `(Get-Item -LiteralPath '${exe.replaceAll("'", "''")}').VersionInfo | ` +
+      `Select-Object ${fields.join(",")} | ConvertTo-Json -Compress`,
+  ]);
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  return JSON.parse(stdout);
+}
+
+// Every successful compile below copies the whole bun executable, so the CLI
+// cases run concurrently, each in its own temp dir.
+describe.skipIf(!isWindows).concurrent("compile --outfile with subdirectories", () => {
+  test.each([
+    { outfile: "subdir/nested/app.exe", expected: ["subdir", "nested", "app.exe"] },
+    { outfile: "subdir\\nested\\app.exe", expected: ["subdir", "nested", "app.exe"] },
+    { outfile: "a/b/c/d/e/app.exe", expected: ["a", "b", "c", "d", "e", "app.exe"] },
+    { outfile: "./output/../output/./app.exe", expected: ["output", "app.exe"] },
+  ])("--outfile $outfile creates the directories and places the executable there", async ({ outfile, expected }) => {
+    using dir = tempDir("compile-outfile-subdir", {
+      // The executable prints the --outfile it was compiled with, so running it
+      // proves the file at the expected path is the one this case built.
+      "src/app.js": `console.log(${JSON.stringify(outfile)});`,
     });
 
-    // Use forward slash in outfile
-    const outfile = "subdir/nested/app.exe";
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", join(String(dir), "app.js"), "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
+    expect(await compile(String(dir), join(String(dir), "src", "app.js"), outfile)).toEqual({
+      stdout: `bundle  1 modules\ncompile  ${outfile}\n`,
+      stderr: "",
+      exitCode: 0,
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(exitCode).toBe(0);
-    expect(stderr).toBe("");
-
-    // Check that the file exists in the subdirectory
-    const expectedPath = join(String(dir), "subdir", "nested", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
-
-    // Run the executable to verify it works
-    await using exe = Bun.spawn({
-      cmd: [expectedPath],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-
-    const exeOutput = await exe.stdout.text();
-    expect(exeOutput.trim()).toBe("Hello from subdirectory!");
+    // Only the requested top-level directory appeared next to src/: nothing
+    // else (such as the temporary copy of the executable) was left in the cwd.
+    expect(readdirSync(String(dir)).sort()).toEqual([expected[0], "src"].sort());
+    expect(await run(join(String(dir), ...expected))).toEqual({ stdout: `${outfile}\n`, stderr: "", exitCode: 0 });
   });
 
-  test("places executable in subdirectory with backslash", async () => {
-    using dir = tempDir("compile-subdir-backslash", {
-      "app.js": `console.log("Hello with backslash!");`,
-    });
-
-    // Use backslash in outfile
-    const outfile = "subdir\\nested\\app.exe";
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", join(String(dir), "app.js"), "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(exitCode).toBe(0);
-    expect(stderr).toBe("");
-
-    // Check that the file exists in the subdirectory
-    const expectedPath = join(String(dir), "subdir", "nested", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
-  });
-
-  test("creates parent directories if they don't exist", async () => {
-    using dir = tempDir("compile-create-dirs", {
-      "app.js": `console.log("Created directories!");`,
-    });
-
-    // Use a deep nested path that doesn't exist yet
-    const outfile = "a/b/c/d/e/app.exe";
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", join(String(dir), "app.js"), "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const exitCode = await proc.exited;
-    expect(exitCode).toBe(0);
-
-    // Check that the file and all directories were created
-    const expectedPath = join(String(dir), "a", "b", "c", "d", "e", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
-  });
-
-  test.if(isWindows)("Windows metadata works with subdirectories", async () => {
+  test("Windows metadata works with subdirectories", async () => {
     using dir = tempDir("compile-metadata-subdir", {
       "app.js": `console.log("App with metadata!");`,
     });
 
-    const outfile = "output/bin/app.exe";
-
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "build",
-        "--compile",
+    expect(
+      await compile(
+        String(dir),
         join(String(dir), "app.js"),
-        "--outfile",
-        outfile,
+        "output/bin/app.exe",
         "--windows-title",
         "Subdirectory App",
         "--windows-version",
         "1.2.3.4",
         "--windows-description",
         "App in a subdirectory",
-      ],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
+      ),
+    ).toEqual({
+      stdout: "bundle  1 modules\ncompile  output/bin/app.exe\n",
+      stderr: "",
+      exitCode: 0,
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(exitCode).toBe(0);
-    expect(stderr).toBe("");
-
-    const expectedPath = join(String(dir), "output", "bin", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
-
-    // Verify metadata was set correctly
-    const getMetadata = (field: string) => {
-      try {
-        return execSync(`powershell -Command "(Get-ItemProperty '${expectedPath}').VersionInfo.${field}"`, {
-          encoding: "utf8",
-        }).trim();
-      } catch {
-        return "";
-      }
-    };
-
-    expect(getMetadata("ProductName")).toBe("Subdirectory App");
-    expect(getMetadata("FileDescription")).toBe("App in a subdirectory");
-    expect(getMetadata("ProductVersion")).toBe("1.2.3.4");
+    // The metadata is written into the executable after it has been moved to
+    // the relative outfile, so check both that it landed and that it still runs.
+    const exe = join(String(dir), "output", "bin", "app.exe");
+    expect(await run(exe)).toEqual({ stdout: "App with metadata!\n", stderr: "", exitCode: 0 });
+    expect(await readVersionInfo(exe, ["ProductName", "FileDescription", "ProductVersion"])).toEqual({
+      ProductName: "Subdirectory App",
+      FileDescription: "App in a subdirectory",
+      ProductVersion: "1.2.3.4",
+    });
   });
 
   test("fails gracefully when parent is a file", async () => {
@@ -149,82 +112,47 @@ describe.if(isWindows)("compile --outfile with subdirectories", () => {
       "blocked": "This is a file, not a directory",
     });
 
-    // Try to use blocked/app.exe where blocked is a file
-    const outfile = "blocked/app.exe";
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", join(String(dir), "app.js"), "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
+    expect(await compile(String(dir), join(String(dir), "app.js"), "blocked/app.exe")).toEqual({
+      stdout: "",
+      stderr: 'ENOTDIR: Not a directory: could not open output directory "blocked" (open)\n',
+      exitCode: 1,
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(exitCode).not.toBe(0);
-    // Should get an error about the path
-    expect(stderr.toLowerCase()).toContain("notdir");
-  });
-
-  test("works with . and .. in paths", async () => {
-    using dir = tempDir("compile-relative-paths", {
-      "src/app.js": `console.log("Relative paths work!");`,
-    });
-
-    // Use relative path with . and ..
-    const outfile = "./output/../output/./app.exe";
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", join(String(dir), "src", "app.js"), "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const exitCode = await proc.exited;
-    expect(exitCode).toBe(0);
-
-    // Should normalize to output/app.exe
-    const expectedPath = join(String(dir), "output", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
+    // The build fails before the executable is copied, so nothing was written.
+    expect(readdirSync(String(dir)).sort()).toEqual(["app.js", "blocked"]);
   });
 });
 
-describe("Bun.build() compile with subdirectories", () => {
-  test.if(isWindows)("places executable in subdirectory via API", async () => {
+// Bun.build() does the compile step synchronously on this thread. Run inside
+// the concurrent group above, each of these multi-second blocks would count
+// against every other test's timeout, so these two stay serial.
+describe.skipIf(!isWindows).serial("Bun.build() compile with subdirectories", () => {
+  test("places executable in subdirectory via API", async () => {
     using dir = tempDir("api-compile-subdir", {
       "app.js": `console.log("API subdirectory test!");`,
     });
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
+      outdir: String(dir),
       compile: {
         outfile: "dist/bin/app.exe",
       },
-      outdir: String(dir),
     });
 
+    const exe = join(String(dir), "dist", "bin", "app.exe");
     expect(result.success).toBe(true);
-    expect(result.outputs.length).toBe(1);
-
-    // The output path should include the subdirectories
-    expect(result.outputs[0].path).toContain("dist");
-    expect(result.outputs[0].path).toContain("bin");
-
-    // File should exist at the expected location
-    const expectedPath = join(String(dir), "dist", "bin", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
+    expect(result.outputs.map(output => output.path)).toEqual([exe]);
+    expect(await run(exe)).toEqual({ stdout: "API subdirectory test!\n", stderr: "", exitCode: 0 });
   });
 
-  test.if(isWindows)("API with Windows metadata and subdirectories", async () => {
+  test("API with Windows metadata and subdirectories", async () => {
     using dir = tempDir("api-metadata-subdir", {
       "app.js": `console.log("API with metadata!");`,
     });
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
+      outdir: String(dir),
       compile: {
         outfile: "build/release/app.exe",
         windows: {
@@ -233,27 +161,16 @@ describe("Bun.build() compile with subdirectories", () => {
           publisher: "Test Publisher",
         },
       },
-      outdir: String(dir),
     });
 
+    const exe = join(String(dir), "build", "release", "app.exe");
     expect(result.success).toBe(true);
-
-    const expectedPath = join(String(dir), "build", "release", "app.exe");
-    expect(existsSync(expectedPath)).toBe(true);
-
-    // Verify metadata
-    const getMetadata = (field: string) => {
-      try {
-        return execSync(`powershell -Command "(Get-ItemProperty '${expectedPath}').VersionInfo.${field}"`, {
-          encoding: "utf8",
-        }).trim();
-      } catch {
-        return "";
-      }
-    };
-
-    expect(getMetadata("ProductName")).toBe("API Subdirectory App");
-    expect(getMetadata("CompanyName")).toBe("Test Publisher");
-    expect(getMetadata("ProductVersion")).toBe("2.0.0.0");
+    expect(result.outputs.map(output => output.path)).toEqual([exe]);
+    expect(await run(exe)).toEqual({ stdout: "API with metadata!\n", stderr: "", exitCode: 0 });
+    expect(await readVersionInfo(exe, ["ProductName", "CompanyName", "ProductVersion"])).toEqual({
+      ProductName: "API Subdirectory App",
+      CompanyName: "Test Publisher",
+      ProductVersion: "2.0.0.0",
+    });
   });
 });


### PR DESCRIPTION
### Problem
- `test/regression/issue/compile-outfile-subdirs.test.ts` is one of the slower Windows-only files: 8s on the Windows Server 2019 x64 lane (2.5s on Windows 11 aarch64). It runs seven full `--compile` builds strictly one after another (5 CLI, 2 `Bun.build()`), and each one copies the whole bun executable, so the file is seven serial copies of bun.exe.
- The two metadata tests each spawned PowerShell three times (`execSync`, one per VersionInfo field) inside a `try {} catch { return "" }`, so a failed read surfaced as a confusing `""` mismatch, and the three blocking spawns came on top of the compile.
- Most assertions were weak: two of the five successful CLI cases checked only the exit code, three never looked at stdout, only one of the seven executables was ever run, the `Bun.build()` cases checked `path` with `toContain("dist")` / `toContain("bin")` (or not at all) plus `existsSync`, and the failure case checked `exitCode != 0` and `toContain("notdir")`.

### Fix
- The four near-identical CLI path cases (`/`, `\`, deep missing parents, `.`/`..` segments) become one `test.each` table inside `describe.concurrent`, together with the metadata and failure cases, so the five CLI compiles overlap. Each case still gets its own `tempDir` and a distinct executable; no case was removed or made lighter.
- The two `Bun.build()` cases stay serial (`describe.serial`, with a comment saying why): `Bun.build()` performs the compile step synchronously on the test thread, and inside the concurrent group each of those blocks would be charged against every other test's clock (that is what makes every test in `compile-windows-metadata.test.ts` report ~11s under a debug build locally).
- VersionInfo is read with one PowerShell spawn per executable (same approach as `compile-windows-metadata.test.ts`); the spawn itself must exit 0 with empty stderr, and the fields are compared with `toEqual`.
- Assertions now made, per path:
  - every CLI compile: `{ stdout, stderr, exitCode }` compared as one object, where stdout must be exactly `bundle  1 modules` / `compile  <outfile as passed>` (timings stripped) and stderr must be empty;
  - every produced executable (5 CLI, 2 API) is run and its `{ stdout, stderr, exitCode }` compared exactly. Each table case's fixture prints the `--outfile` it was compiled with, so the file found at the expected path is provably the one that case built;
  - table cases also assert the cwd listing is exactly `[<requested top-level dir>, "src"]`: nothing else was created and the temporary copy of the executable did not stay behind;
  - metadata CLI case additionally runs the binary after the metadata pass (the relative-path metadata rewrite is the bug #22365 fixed);
  - failure case: stdout `""`, stderr exactly `ENOTDIR: Not a directory: could not open output directory "blocked" (open)`, exit code 1, and the directory still contains only `app.js` and `blocked`;
  - `Bun.build()` cases: `outputs.map(o => o.path)` must equal `[<dir>/dist/bin/app.exe]` (resp. `build/release/app.exe`), then the binary is run; the metadata variant also reads back `ProductName` / `CompanyName` / `ProductVersion`.
- Why this is the right shape: the CLI cases are independent processes writing to separate temp dirs, so overlapping them loses nothing; the stronger assertions only pin down behaviour the tests already relied on implicitly (the binary landing at that path, being runnable, the summary naming the outfile), and every one of them was checked to be live (details below).
- Verified on a Windows Server 2019 x64 machine (16 vCPU) with a debug build, `bun bd test test/regression/issue/compile-outfile-subdirs.test.ts --timeout=90000` (the per-test budget CI's runner passes; under a debug build the file needs it on main as well, where the metadata test alone exceeds the 5s default). Time is the runner's own `Ran 8 tests` figure:

  | | run 1 | run 2 | run 3 | run 4 | run 5 |
  | --- | --- | --- | --- | --- | --- |
  | before (main) | 26.47s | 25.91s | 24.38s | | |
  | after | 12.61s | 13.20s | 12.22s | 12.27s | 13.23s |

  After the change the concurrent CLI group takes ~5-6s of that (five copies of a ~194MB debug bun.exe are bound by write bandwidth: writing 200MB takes ~0.35s alone and 1.6-2.5s per process when five processes do it at once on this machine), the two serial `Bun.build()` tests ~3.5s + ~2.2s. 8/8 pass in every run; on Linux all 8 still skip.
- Liveness: temporarily breaking each expected value in a scratch copy of the file made exactly the corresponding tests fail (summary line: the four table cases; VersionInfo `ProductName` / `CompanyName`: the two metadata cases; ENOTDIR text and the readdir lists: the failure case and a table case; executable stdout: a table case and the first API case). The scratch copy was deleted afterwards; the committed file is unmodified by this.

### Notes for review
- `src/sys/lib.rs` (Windows `mkdir_recursive_at_mode`) has a comment pointing at this file's `.`/`..` case by its old title, "works with . and .. in paths". The case and its outfile string (`./output/../output/./app.exe`) are unchanged; only the test title is now generated from the table. This PR does not touch `src/`, so that comment's quoted title is slightly out of date; the new header comment in the test file links back the other way.
- Two adjacent problems turned up while measuring and are deliberately not covered here because they reproduce on main (they are being handled separately): with a regular file as a grandparent component (`--outfile blocked/sub/app.exe`) `bun build` on Windows spins forever at 100% CPU in the mkdir walk, and a `Bun.build()` compile whose final move fails leaves the ~200MB temporary copy of bun.exe in the cwd. The failure case here keeps the one-level `blocked/app.exe` shape, which errors out before anything is copied.

### Background
- `bun build --compile` bundles the entry point, copies the running bun executable to a temporary file in the cwd, appends the bundle to it, and then moves it to `--outfile`; on Windows, `--windows-title` and friends are written into the moved file afterwards as PE VersionInfo resources. The parent directories of a CLI `--outfile` are created by `build_command.rs` before any of that happens, which is why the parent-is-a-file case fails fast with ENOTDIR and copies nothing.
- `bun:test` runs consecutive `concurrent` tests as one group; a test's timeout clock runs from its start, so synchronous work done by one test in the group (here, `Bun.build()`'s compile step) also counts against every other test in the group. Serial tests form their own groups. CI's test runner passes `--timeout=90000` per test; the default used by a bare `bun test` is 5s.
- `(Get-Item x).VersionInfo` is how PowerShell exposes a PE file's version resources (`ProductName`, `CompanyName`, `ProductVersion`, ...); `ConvertTo-Json` makes one spawn return all requested fields at once.
