### PR TITLE
resolver: read devDependencies/optionalDependencies by their package.json keys

### DIFF
--- a/docs/pm/filter.mdx
+++ b/docs/pm/filter.mdx
@@ -122,4 +122,4 @@ Use `--if-present` with `--workspaces` to skip packages that don't have the requ
 
 ### Dependency Order
 
-Bun respects package dependency order when running scripts. Say you have a package `foo` that depends on another package `bar` in your workspace, and both have a `build` script. When you run `bun --filter '*' build`, `foo` only starts once `bar` is done.
+Bun respects package dependency order when running scripts. Say you have a package `foo` that depends on another package `bar` in your workspace, and both have a `build` script. When you run `bun --filter '*' build`, `foo` only starts once `bar` is done. A package counts as depending on another when it lists it in `dependencies`, `devDependencies`, or `optionalDependencies`.

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1344,7 +1344,10 @@ impl WakeHandler {
 
 #[derive(Clone, Copy)]
 pub struct DependencyGroup {
+    /// The package.json key, e.g. `"devDependencies"`. Use this for JSON lookups.
     pub prop: &'static [u8],
+    /// The snake_case manifest field name, e.g. `"dev_dependencies"`, as
+    /// accepted by `PackageVersion::dep_group`. Never a package.json key.
     pub field: &'static [u8],
     pub behavior: Behavior,
 }

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -865,7 +865,7 @@ impl PackageJSON {
 
                 let mut total_dependency_count: usize = 0;
                 for group in dependency_groups {
-                    if let Some(group_json) = json.get(group.field) {
+                    if let Some(group_json) = json.get(group.prop) {
                         total_dependency_count += group_json.property_count();
                     }
                 }
@@ -885,7 +885,7 @@ impl PackageJSON {
                         .expect("unreachable");
 
                     for group in dependency_groups {
-                        if let Some(group_json) = json.get(group.field) {
+                        if let Some(group_json) = json.get(group.prop) {
                             if let js_ast::ExprData::EObjectJSON(group_obj) = &group_json.data {
                                 for prop in group_obj.get().properties() {
                                     let name_str = prop.key.slice();

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -310,6 +310,42 @@ describe("bun", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/10323
+  test.each(["devDependencies", "optionalDependencies"])("respect dependency order declared in %s", group => {
+    using dir = tempDir("testworkspace", {
+      dep0: {
+        // dep0 stays alive past dep1's startup so that, if dep1 were wrongly
+        // started in parallel, dep1 reads out.txt before dep0 has written it.
+        "index.js": ["await Bun.sleep(100)", "await Bun.write('out.txt', 'success')"].join(";"),
+        "package.json": JSON.stringify({
+          name: "dep0",
+          scripts: {
+            script: `${bunExe()} run index.js`,
+          },
+        }),
+      },
+      dep1: {
+        "index.js": 'console.log(await Bun.file("../dep0/out.txt").text())',
+        "package.json": JSON.stringify({
+          name: "dep1",
+          [group]: {
+            dep0: "*",
+          },
+          scripts: {
+            script: `${bunExe()} run index.js`,
+          },
+        }),
+      },
+    });
+    runInCwdSuccess({
+      cwd: dir,
+      pattern: "*",
+      target_pattern: [/dep0 script: Exited with code 0[\s\S]*dep1 script: success/],
+      antipattern: [/ENOENT/],
+      command: ["script"],
+    });
+  });
+
   test("respect dependency order when dependency name is larger than 8 characters", () => {
     const largeNamePkgName = "larger-than-8-char";
     const fileContent = `${largeNamePkgName} - ${new Date().getTime()}`;


### PR DESCRIPTION
### Problem

- `bun run --filter '*' <script>` (and `--workspaces`) starts a package in parallel with a workspace member it depends on when the dependency is declared in `devDependencies` or `optionalDependencies`. Only `dependencies` is honored. Reported in #10323; docs/pm/filter.mdx ("Dependency Order") documents the ordering without restricting it to one section.
- Cause: `PackageJSON::parse` (src/resolver/package_json.rs:868 and :888) looks the sections up with `json.get(group.field)`. `DependencyGroup.field` is the snake_case manifest field name (`dev_dependencies`, `optional_dependencies`, src/install_types/resolver_hooks.rs:1346); the package.json key is `group.prop` (`devDependencies`, `optionalDependencies`). Only `dependencies` spells both the same, so the `DEV` and `OPTIONAL` entries in the group list have never matched anything. Every other reader of these sections in src/install already uses `group.prop`; `field` is only meant for `PackageVersion::dep_group`.
- Not a port regression: the same lookup was in package_json.zig. #27331 made the same change there and was closed unmerged by its author two days before the Rust rewrite landed; this re-applies it to the port (credited in the commit).

### Fix

- Look the sections up with `group.prop` at both sites (the count pass and the fill pass). The group lists themselves are unchanged: `dependencies` + `optionalDependencies` for `IncludeDependencies::Local`, plus `devDependencies` for `IncludeDependencies::Main`.
- Correct because `prop` is the key as it appears in package.json, which is what `json.get` takes; `field` names a struct field of the manifest cache and is not a JSON key anywhere. Doc comments on the two struct fields now say which is which.
- Consumers that change behaviour:
  - `bun run --filter` / `--workspaces` (src/runtime/cli/filter_run.rs, parses with `Main` and reads the map keys): a package now waits for workspace members listed in any of the three sections. Cycles already drop the ordering (existing "ignore dependency order on cycle" tests), so this cannot deadlock. `--parallel` / `--sequential` (multi_run.rs) also parse with `Main` but never read the map.
  - Runtime auto-install (src/resolver/resolver.rs, parses with `Local`): entries from `optionalDependencies` now land in the dependency map with `Behavior::OPTIONAL`, which is what `enqueue_dependency_to_resolve` already asks for (`Features { optional_dependencies: true }`). On main this is not observable yet because the versions in this map are not used (#38198 fixes that separately; the two diffs touch disjoint hunks). Once both land, an import declared only in `optionalDependencies` resolves to the declared range, and a range nothing satisfies is tolerated the same way `bun install` tolerates a failed optional dependency (the import then fails with the usual `Cannot find package`). Probed the registry-404 case on both builds: identical output.
- Docs: one sentence in docs/pm/filter.mdx naming the three sections that count.
- Verified with test/cli/run/filter-workspace.test.ts: new `test.each` over `devDependencies` / `optionalDependencies`, same fixture shape as the existing `dependencies` test, asserting that dep0's exit line precedes dep1's output. Both cases fail on `USE_SYSTEM_BUN=1` and on an unfixed debug build (6/6 runs, dep1 hits `ENOENT` on dep0's output file), and pass with the fix; the whole file passes (60 tests).
- Also run with the debug build: test/cli/run/{multi-run,workspaces,run-autoinstall,autoinstall-cached-manifest,run-autoinstall-abs-path}.test.ts and test/js/bun/resolve/{resolve,resolve-autoinstall-invalid-name,resolve-autoinstall-log-dangling}.test.ts.

### Background

- `DependencyGroup` (src/install_types/resolver_hooks.rs): one constant per package.json dependency section, carrying the JSON key (`prop`), the snake_case name of the matching field in the npm manifest cache's `PackageVersion` (`field`, consumed by `dep_group`), and the `Behavior` bit (prod / dev / optional / peer) stamped on dependencies read from that section.
- Resolver `PackageJSON`: the resolver's own lightweight parse of a package.json (separate from the package manager's `Lockfile::Package`). `IncludeDependencies` selects whether, and which, dependency sections are read into `PackageJSON.dependencies`: `None` for ordinary resolution, `Local` when auto-install is on, `Main` for `bun run --filter`.
- `bun run --filter` ordering: filter_run.rs builds one `ScriptConfig` per matched package whose `deps` are the names in that map; a script is only started once every matched package named in `deps` has finished, unless a cycle is detected, in which case ordering is dropped for all of them.

Fixes #10323
