### PR TITLE
bundler: advance the resolver generation once per build instead of once per queue drain

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2331,8 +2331,12 @@ impl StackCheck {
 // Small helpers that downstream crates need.
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Bumped each rebuild/rescan to invalidate stale cache entries.
-pub type Generation = u16;
+/// Invalidation counter for cached directory listings: a listing read at an
+/// older generation than the resolver's is re-read. The bundle thread advances
+/// it once per build for the life of the process and saturates rather than
+/// wrapping (a wrapped counter would stop invalidating anything), so it is
+/// sized to keep saturation out of reach.
+pub type Generation = u32;
 
 // ── Ordinal ───────────────────────────────────────────────────────────────
 // ABI-equivalent of WTF::OrdinalNumber:

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -49,6 +49,12 @@ pub(crate) struct BundleThread<C: Node> {
     // `bun.UnboundedQueue(CompletionStruct, .next)` — intrusive over `C.next`;
     // the field offset is encoded via the `Node` supertrait on `CompletionStruct`.
     pub(crate) queue: UnboundedQueue<C>,
+    /// Resolver generation of the current build. Advanced before every build
+    /// (not once per queue drain) so that each build re-reads the directory
+    /// listings cached by the builds before it, even while other `Bun.build`
+    /// calls keep the queue from ever draining. Builds start at 1: generation
+    /// 0 is the runtime resolver's, and it alone trusts cached "directory does
+    /// not exist" entries.
     pub(crate) generation: bun_core::Generation,
 }
 
@@ -234,7 +240,11 @@ impl<C: CompletionStruct> BundleThread<C> {
                 // SAFETY: as above; started ⇒ the owner waits for us.
                 let completion = unsafe { &mut *completion };
                 // SAFETY: `generation` is only read/written on this (bundle) thread.
-                let generation = unsafe { (*instance).generation };
+                let generation = unsafe {
+                    let g = core::ptr::addr_of_mut!((*instance).generation);
+                    *g = (*g).saturating_add(1);
+                    *g
+                };
                 // `panic = "abort"` → a Rust panic on this thread enters the
                 // crash-handler hook and aborts the whole process.
                 // No `catch_unwind` — there is nothing to catch.
@@ -246,11 +256,6 @@ impl<C: CompletionStruct> BundleThread<C> {
                     }
                 }
                 has_bundled = true;
-            }
-            // SAFETY: `generation` is only read/written on this (bundle) thread.
-            unsafe {
-                let g = core::ptr::addr_of_mut!((*instance).generation);
-                *g = (*g).saturating_add(1);
             }
 
             if has_bundled {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -494,6 +494,91 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
+  // The bundle thread hands every build a resolver generation, and a build
+  // re-reads the directory listings cached by builds of an older generation. The
+  // generation used to advance only when the thread found its queue empty, so as
+  // long as other Bun.build() calls kept the queue non-empty, every build reused
+  // the listings read by the first one and never saw files created or removed
+  // since. The driver keeps the queue non-empty deterministically: behind every
+  // app build it queues a build that parks the thread in an async onLoad until
+  // the next app build has been queued.
+  test.concurrent("rebuilding sees directory changes while other builds keep the bundle thread busy", async () => {
+    using dir = tempDir("rebuild-while-bundle-thread-busy", {
+      "package.json": `{}`,
+      "driver.ts": `
+        const parkedBuilds: ReturnType<typeof Bun.build>[] = [];
+        let releaseParkedBuild = () => {};
+
+        // Queues a build whose onLoad does not return until the next call
+        // (or the final release below), then lets the previously parked build
+        // finish. Everything queued in between therefore sits behind a build the
+        // thread cannot finish yet, and the thread never sees an empty queue.
+        function parkBundleThread() {
+          const gate = Promise.withResolvers<void>();
+          parkedBuilds.push(
+            Bun.build({
+              entrypoints: ["./parked/entry.js"],
+              throw: false,
+              plugins: [
+                {
+                  name: "park",
+                  setup(build) {
+                    build.onResolve({ filter: /^parked:/ }, args => ({ path: args.path, namespace: "parked" }));
+                    build.onLoad({ filter: /.*/, namespace: "parked" }, async () => {
+                      await gate.promise;
+                      return { contents: "export default 1;", loader: "js" };
+                    });
+                  },
+                },
+              ],
+            }),
+          );
+          const releasePrevious = releaseParkedBuild;
+          releaseParkedBuild = gate.resolve;
+          releasePrevious();
+        }
+
+        async function buildApp() {
+          const build = Bun.build({ entrypoints: ["./app/entry.js"], throw: false });
+          parkBundleThread();
+          const result = await build;
+          return { success: result.success, messages: result.logs.map(log => log.message) };
+        }
+
+        parkBundleThread();
+        const before = await buildApp();
+        await Bun.write("app/mod.js", "export const value = 1;\\n");
+        const afterAdd = await buildApp();
+        await Bun.file("app/mod.js").delete();
+        const afterRemove = await buildApp();
+        releaseParkedBuild();
+        const parked = (await Promise.all(parkedBuilds)).map(result => result.success);
+        console.log(JSON.stringify({ before, afterAdd, afterRemove, parked }));
+      `,
+      "app/entry.js": `import { value } from "./mod.js";\nconsole.log(value);\n`,
+      "parked/entry.js": `import "parked:mod";\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "driver.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      before: { success: false, messages: ['Could not resolve: "./mod.js"'] },
+      afterAdd: { success: true, messages: [] },
+      // A listing still holding the removed file would fail later, while
+      // reading it ("File not found"), rather than here in the resolver.
+      afterRemove: { success: false, messages: ['Could not resolve: "./mod.js"'] },
+      parked: [true, true, true, true],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // https://github.com/oven-sh/bun/issues/33099
   // A package reached through a symlinked node_modules entry caches its file
   // descriptor in the resolver. A second in-process Bun.build() used to reuse a


### PR DESCRIPTION
### Problem

- While two or more callers keep `Bun.build()` busy in one process, no build ever sees a file that was created, removed or renamed in a directory an earlier build already listed. A rebuild queued right after the change resolves against the old listing (`Could not resolve: "./mod.js"` for a file that now exists, `File not found` for one that was removed). The same caller building sequentially sees the change on its next build.
- `src/bundler/BundleThread.rs` (`thread_main`) handed every dequeued build the current `generation` and only incremented it after the dequeue loop found the queue empty. Each build posts its result to JS before the thread looks at the queue again, so with two callers re-enqueueing as soon as their previous build finishes the queue is never observed empty and the generation never moves. Even a single caller has a small window where its next build is enqueued before the increment lands (PR #36874's test works around it with a retry loop).
- The resolver only re-reads a cached listing when `DirEntry.generation < resolver.generation` (`src/resolver/lib.rs` `read_directory_with_iterator` and `entries_at_locked`, `src/resolver/resolver.rs` `dir_info_for_resolution`), so a build that runs at the generation of an earlier build reuses everything that build listed.

### Fix

- `thread_main` now increments `generation` immediately before each build and hands the build the new value; the per-drain increment is gone.
- Correct because a build's generation is now greater than that of every build that ran before it, so the first build dequeued after a filesystem change re-reads any listing cached by earlier builds. The change happened before `Bun.build()` was called, and the queue push/pop orders it before the re-read.
- Sequential callers are unchanged: their builds already got generations 1, 2, 3, ... because each build drained the queue, and the thread's initial empty drain had already moved the counter to 1 before the first build was enqueued. Builds still start at 1 rather than 0; 0 is the runtime resolver's generation, and it is the only one for which `read_directory_with_iterator` trusts a cached "directory does not exist" entry, which a build must re-check.
- The only cost is for builds that are queued at the same time (`Promise.all` of several `Bun.build()` calls): each now re-reads the directories it touches once, which is what every sequential build already did, and is small next to re-reading and re-parsing the files themselves, which every build does anyway.
- `bun_core::Generation` goes from `u16` to `u32`. The counter saturates instead of wrapping (a wrapped counter would never invalidate anything again), and with one increment per build a long-lived process reached the `u16` ceiling after 65535 builds, after which listings were never refreshed again. Every use goes through the alias and compares or assigns, so nothing else changes; `DirEntry` holds one per directory.
- Test: `test/bundler/bun-build-api.test.ts`, "rebuilding sees directory changes while other builds keep the bundle thread busy". A driver process queues, behind every app build, a build that parks the bundle thread in an async `onLoad` until the next app build has been queued, so the thread never finds its queue empty, independent of timing. It then checks that the build queued after creating `app/mod.js` resolves it and the build queued after deleting it fails in the resolver again. Fails on every run without the fix (10/10 with the released binary, 8/8 with a debug build of main; the add step still reports `Could not resolve`) and passes with this change.
- `test/bundler/bun-build-api.test.ts`, `test/bundler/bundler_plugin.test.ts`, `test/js/bun/resolve/resolve.test.ts` and `test/js/bun/http/bun-serve-html.test.ts` pass on a debug build, except that the pre-existing 400-build stress test in bun-build-api hits its 180s timeout on this machine with or without the change (each of its builds takes about 0.5s here).
- `cargo clippy -p bun_core -p bun_resolver -p bun_bundler` and `cargo fmt --check` are clean.

### Background

- Bundle thread: `Bun.build()` does not bundle on the JS thread. It pushes a completion task onto a queue consumed by one process-wide thread (`BundleThread`), which runs the queued builds one at a time and posts each result back to the JS event loop.
- Directory listing cache: the resolver keeps one process-wide cache of directory listings (`DirEntry`, the names in a directory) that survives across builds. Each `DirEntry` records the generation at which it was read. A resolver carries its own generation; when it meets a `DirEntry` with an older one it re-reads the directory in place, otherwise it uses the cached names. Within one build every worker shares the build's generation, so a directory is re-read at most once per build.
- Generation 0 is the runtime's resolver (the one that loads the script itself); it invalidates through file watchers instead of the counter, so it is also allowed to trust cached negative entries. Builds have no watcher and rely entirely on the counter.
