### PR TITLE
transpiler: don't fold typeof require when the output does not bind require

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1606,6 +1606,7 @@ impl<'a> Transpiler<'a> {
                 // JavaScriptCore implements `using` / `await using` natively, so
                 // when targeting Bun there is no need to lower them.
                 opts.features.lower_using = !target.is_bun();
+                opts.features.typeof_require_is_function = target.is_bun();
 
                 opts.features.inject_jest_globals = this_parse.inject_jest_globals;
                 opts.features.minify_syntax = self.options.minify_syntax;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5628,10 +5628,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // checks are not yet handled correctly by bun or esbuild, so this possibility is
                 // currently ignored.
                 js_ast::op::Code::UnTypeof => {
-                    if matches!(ex.value.data, js_ast::ExprData::EIdentifier(_))
-                        && ex
-                            .flags
-                            .contains(E::UnaryFlags::WAS_ORIGINALLY_TYPEOF_IDENTIFIER)
+                    // `ERequireCallTarget` is the substituted `require` identifier.
+                    if matches!(
+                        ex.value.data,
+                        js_ast::ExprData::EIdentifier(_) | js_ast::ExprData::ERequireCallTarget
+                    ) && ex
+                        .flags
+                        .contains(E::UnaryFlags::WAS_ORIGINALLY_TYPEOF_IDENTIFIER)
                     {
                         return true;
                     }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -190,6 +190,7 @@ impl<'a> Options<'a> {
                 set_breakpoint_on_first_line: f.set_breakpoint_on_first_line,
                 trim_unused_imports: f.trim_unused_imports,
                 auto_polyfill_require: f.auto_polyfill_require,
+                typeof_require_is_function: f.typeof_require_is_function,
                 replace_exports: Default::default(),
                 dont_bundle_twice: f.dont_bundle_twice,
                 unwrap_commonjs_packages: f.unwrap_commonjs_packages,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -219,11 +219,9 @@ pub mod Runtime {
         /// Allow runtime usage of require(), converting `require` into `__require`
         pub auto_polyfill_require: bool,
 
-        /// Whether `typeof require` may be constant-folded to `"function"`
-        /// without bundling. Only sound when the emitted output is known to
-        /// bind `require` (target bun: the printer binds it from
-        /// `import.meta`). When bundling, `Options.bundle` covers this
-        /// instead (the bundler substitutes its own `require` wrapper).
+        /// Fold `typeof require` to `"function"` without bundling. Only sound
+        /// when the output binds `require` (target bun binds it from
+        /// `import.meta`); bundling is covered by `Options.bundle`.
         pub typeof_require_is_function: bool,
 
         pub replace_exports: ReplaceableExportMap,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -219,6 +219,13 @@ pub mod Runtime {
         /// Allow runtime usage of require(), converting `require` into `__require`
         pub auto_polyfill_require: bool,
 
+        /// Whether `typeof require` may be constant-folded to `"function"`
+        /// without bundling. Only sound when the emitted output is known to
+        /// bind `require` (target bun: the printer binds it from
+        /// `import.meta`). When bundling, `Options.bundle` covers this
+        /// instead (the bundler substitutes its own `require` wrapper).
+        pub typeof_require_is_function: bool,
+
         pub replace_exports: ReplaceableExportMap,
 
         /// Scan for '// @bun' at the top of this file, halting a parse if it is
@@ -300,6 +307,7 @@ pub mod Runtime {
                 set_breakpoint_on_first_line: false,
                 trim_unused_imports: false,
                 auto_polyfill_require: false,
+                typeof_require_is_function: false,
                 replace_exports: ReplaceableExportMap::default(),
                 dont_bundle_twice: false,
                 unwrap_commonjs_packages: &[],
@@ -362,7 +370,7 @@ pub mod Runtime {
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -380,6 +388,7 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
+                self.typeof_require_is_function,
                 // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
             ];
 

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -206,10 +206,13 @@ impl SideEffects {
                         // "typeof x" must not be transformed into if "x" since doing so could
                         // cause an exception to be thrown. Instead we can just remove it since
                         // "typeof x" is special-cased in the standard to never throw.
-                        if matches!(un.value.data, ExprData::EIdentifier(_))
-                            && un
-                                .flags
-                                .contains(E::UnaryFlags::WAS_ORIGINALLY_TYPEOF_IDENTIFIER)
+                        // `ERequireCallTarget` is the substituted `require` identifier.
+                        if matches!(
+                            un.value.data,
+                            ExprData::EIdentifier(_) | ExprData::ERequireCallTarget
+                        ) && un
+                            .flags
+                            .contains(E::UnaryFlags::WAS_ORIGINALLY_TYPEOF_IDENTIFIER)
                         {
                             return None;
                         }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1200,7 +1200,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .join_with_comma(e_.value);
                 }
 
-                if matches!(e_.value.data, Data::ERequireCallTarget) {
+                // `typeof require` folds to "function" only when the output is
+                // known to bind `require`: bundling substitutes a wrapper, and
+                // target bun binds it from `import.meta`. Otherwise (e.g.
+                // Bun.Transpiler with target browser/node) leave the expression
+                // intact so `typeof require !== "undefined"` guards survive.
+                if matches!(e_.value.data, Data::ERequireCallTarget)
+                    && (p.options.bundle || p.options.features.typeof_require_is_function)
+                {
                     p.ignore_usage_of_runtime_require();
                     *e = p.new_expr(
                         E::String {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1200,11 +1200,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .join_with_comma(e_.value);
                 }
 
-                // `typeof require` folds to "function" only when the output is
-                // known to bind `require`: bundling substitutes a wrapper, and
-                // target bun binds it from `import.meta`. Otherwise (e.g.
-                // Bun.Transpiler with target browser/node) leave the expression
-                // intact so `typeof require !== "undefined"` guards survive.
+                // Fold only when the output will bind `require`, so that
+                // `typeof require !== "undefined"` guards survive when it
+                // won't (e.g. Bun.Transpiler with target browser).
                 if matches!(e_.value.data, Data::ERequireCallTarget)
                     && (p.options.bundle || p.options.features.typeof_require_is_function)
                 {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2544,8 +2544,7 @@ console.log(<div {...obj} key="after" />);`),
     }
     // target bun binds `require` from import.meta, so the fold stays.
     const bunOut = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(input);
-    expect(bunOut).not.toContain("typeof require");
-    expect(bunOut).toContain("import.meta");
+    expect(bunOut).toBe(`var {require}=import.meta;export const hasRequire = !0;\n`);
   });
 
   it("CommonJS", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2545,6 +2545,12 @@ console.log(<div {...obj} key="after" />);`),
     // target bun binds `require` from import.meta, so the fold stays.
     const bunOut = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(input);
     expect(bunOut).toBe(`var {require}=import.meta;export const hasRequire = !0;\n`);
+
+    // An unused `typeof require` statement never throws, so dead-code
+    // elimination drops it entirely; it must not leave a bare `require`.
+    const browser = new Bun.Transpiler({ loader: "js", target: "browser" });
+    expect(browser.transformSync(`typeof require;`)).toBe("");
+    expect(browser.transformSync(`typeof require !== "undefined";`)).toBe("");
   });
 
   it("CommonJS", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2535,6 +2535,19 @@ console.log(<div {...obj} key="after" />);`),
     expect(nodeTranspiler.transformSync("require('hi' + bar)")).toBe('require("hi" + bar);\n');
   });
 
+  // https://github.com/oven-sh/bun/issues/38202
+  it("typeof require is not folded when the output does not bind require", () => {
+    const input = `export const hasRequire = typeof require !== "undefined";`;
+    for (const target of ["browser", "node"]) {
+      const out = new Bun.Transpiler({ loader: "js", target }).transformSync(input);
+      expect(out).toBe(`export const hasRequire = typeof require !== "undefined";\n`);
+    }
+    // target bun binds `require` from import.meta, so the fold stays.
+    const bunOut = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(input);
+    expect(bunOut).not.toContain("typeof require");
+    expect(bunOut).toContain("import.meta");
+  });
+
   it("CommonJS", () => {
     var nodeTranspiler = new Bun.Transpiler({ platform: "node", minify: { syntax: false } });
 


### PR DESCRIPTION
Fixes #38202

### Problem

- `Bun.Transpiler({ target: "browser" }).transformSync(...)` constant-folds `typeof require !== "undefined"` to `true` (and `typeof require` to `"function"`) for every target, including browser and node.
- This destroys guarded interop code, including the `__require` shim Bun's own bundler emits: the safe branches are dead-code-eliminated, leaving a bare `require` reference that throws `ReferenceError: require is not defined` the moment the module evaluates in a browser.
- Cause: the visitor replaces any uncalled module-scope `require` identifier with `ERequireCallTarget` (src/js_parser/visit/visit_expr.rs:307), and `typeof <ERequireCallTarget>` was folded to the string `"function"` unconditionally (src/js_parser/visit/visit_expr.rs:1203). The fold is only sound when the emitted output actually binds `require`, which the standalone transpiler does not do for browser/node targets.

### Fix

- Gate the `typeof require` fold on the output binding `require`: it still fires when bundling (`Options.bundle`, where the bundler substitutes its own require wrapper/polyfill) and for the standalone transpiler with target bun (a new `typeof_require_is_function` parser feature, set from `target.is_bun()` in src/bundler/transpiler.rs), and is skipped otherwise, leaving the `typeof require` guard intact.
- This matches esbuild, whose transform API also leaves `typeof require` alone.
- Companion fix in dead-code elimination: the unused-expression checks only recognized `typeof <identifier>` as removable, so with the fold gated, an unused `typeof require` statement had its `typeof` stripped, leaving a bare `require;`. Both sites (`simplify_unused_expr` and `expr_can_be_removed_if_unused_without_dce_check`) now also match the substituted `ERequireCallTarget` operand (`typeof` never throws), so the unused statement is dropped entirely, same as before this PR.
- Output after the fix:
  - browser/node: `export const hasRequire = typeof require !== "undefined";` (unchanged input, and the bundler's `__require` shim survives verbatim)
  - bun: `var {require}=import.meta;export const hasRequire = !0;` (unchanged from before)
  - `bun build` output: unchanged for all formats/targets
- Verified with `bun bd test`:
  - test/bundler/transpiler/transpiler.test.js (includes the new test; fails on the released build, passes with the fix)
  - test/bundler/bundler_minify.test.ts `-t TypeOfRequire`, test/bundler/esbuild/extra.test.ts `-t TypeofRequire`, test/bundler/esbuild/default.test.ts `-t RequireShimSubstitution` (bundler folding behavior preserved)
  - test/bundler/transpiler/react-compiler.test.ts, test/bundler/transpiler/function-tostring-require.test.ts, test/js/bun/repl/repl.test.ts `-t require`, test/cli/run/run-eval.test.ts

### Background

- The parser never prints `require` literally: uncalled references become the `ERequireCallTarget` AST node, which the printer resolves to a symbol (`require_ref`). When bundling, that symbol is the bundler's `__require` polyfill or CJS wrapper, so `typeof require` really is `"function"`. With the standalone transpiler targeting bun, the printer prepends `var {require} = import.meta;` so `require` is also bound. With target browser or node, nothing binds it, so the folded guard lies about the runtime environment.
- The new feature flag is included in the runtime transpiler cache hash alongside the other output-affecting feature bools.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (349ee7574)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.53ms]
(pass) Bun.Transpiler > normalizes \r\n [7.20ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.55ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.30ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.45ms]
(pass) Bun.Transpiler > property access inlining > works [2.53ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.55ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [44.99ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [20.44ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [348.38ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 22 skipped
bun test v1.4.0-canary.1 (6e8905b16)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.09ms]
(pass) Bun.Transpiler > normalizes \r\n [0.13ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.30ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.29ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [10.17ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.40ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.08ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly whe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (349ee7574)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.53ms]
(pass) Bun.Transpiler > normalizes \r\n [7.30ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.35ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [7.78ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.58ms]
(pass) Bun.Transpiler > property access inlining > works [2.76ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.84ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [46.64ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [21.28ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [318.21ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 675ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs                  |  1 +
 src/js_parser/p.rs                         | 11 +++++++----
 src/js_parser/parse/parse_entry.rs         |  1 +
 src/js_parser/parser.rs                    |  9 ++++++++-
 src/js_parser/scan/scan_side_effects.rs    | 11 +++++++----
 src/js_parser/visit/visit_expr.rs          |  7 ++++++-
 test/bundler/transpiler/transpiler.test.js | 18 ++++++++++++++++++
 7 files changed, 48 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bundler/transpiler.rs                       1      1      0
src/js_parser/p.rs                              2      1      0
src/js_parser/parse/parse_entry.rs              1      1      0
src/js_parser/parser.rs                         3      6      0
src/js_parser/scan/scan_side_effects.rs         1      1      0
src/js_parser/visit/visit_expr.rs               2      3      0
test/bundler/transpiler/transpiler.test.js      2      3      0
```

</details>

**root cause** · written by the author bot

The root cause was that the parser unconditionally treated `require` as a defined global when folding `typeof` expressions, so `typeof require !== "undefined"` collapsed to `true` even for browser targets where no `require` binding exists, breaking the guarded `__require` interop shim. The fix introduces a `typeof_require_is_function` parser feature that is only enabled for Bun targets or bundled output where a `require` binding is actually guaranteed, and gates the folding in the expression visitor and related dead code elimination sites on that flag. With the flag off, `typeof require` is…

<!-- robobun:evidence:end -->