### PR TITLE
fs.writeFile, Bun.write: skip the ftruncate when the file did not shrink

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7439,7 +7439,8 @@ impl NodeFS {
             }
             #[cfg(not(windows))]
             {
-                let _ = Syscall::ftruncate(fd, (written as u64 & ((1u64 << 63) - 1)) as i64);
+                let _ =
+                    Syscall::ftruncate_if_longer(fd, (written as u64 & ((1u64 << 63) - 1)) as i64);
             }
         }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5363,7 +5363,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
     // if it's a file descriptor, we assume they want manual control over that behavior
     scopeguard::defer! {
         if truncate.get() {
-            let _ = bun_sys::ftruncate(fd, i64::try_from(written.get()).expect("int cast"));
+            let _ = bun_sys::ftruncate_if_longer(fd, i64::try_from(written.get()).expect("int cast"));
         }
     }
 
@@ -5480,7 +5480,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
             bun_sys::windows::kernel32::SetEndOfFile(fd.native())
         };
         #[cfg(not(windows))]
-        let _ = bun_sys::ftruncate(fd, i64::try_from(written).expect("int cast"));
+        let _ = bun_sys::ftruncate_if_longer(fd, i64::try_from(written).expect("int cast"));
     }
 
     JSPromise::resolved_promise_value(global_this, JSValue::js_number(written as f64))

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2646,6 +2646,21 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
+    /// `ftruncate` for callers that rewrote a file from offset 0 without
+    /// `O_TRUNC` and now want whatever the previous contents left past `len`
+    /// gone. Skipped when the file is already `len` bytes or shorter (new
+    /// files, same-size rewrites, grows): besides being a no-op there, the
+    /// call is expensive on XFS, which writes the just-dirtied pages back
+    /// synchronously when it is asked to set the size of a file whose size
+    /// grew since the last writeback (about 1ms per file on NVMe).
+    pub fn ftruncate_if_longer(fd: Fd, len: i64) -> Maybe<()> {
+        if let Ok(st) = fstat(fd) {
+            if st.st_size <= len {
+                return Ok(());
+            }
+        }
+        ftruncate(fd, len)
+    }
     pub fn getcwd(buf: &mut [u8]) -> Maybe<usize> {
         // SAFETY: `buf` is a valid exclusive slice; `getcwd` writes at most
         // `buf.len()` bytes (including the NUL).

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2646,13 +2646,9 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
-    /// `ftruncate` for callers that rewrote a file from offset 0 without
-    /// `O_TRUNC` and now want whatever the previous contents left past `len`
-    /// gone. Skipped when the file is already `len` bytes or shorter (new
-    /// files, same-size rewrites, grows): besides being a no-op there, the
-    /// call is expensive on XFS, which writes the just-dirtied pages back
-    /// synchronously when it is asked to set the size of a file whose size
-    /// grew since the last writeback (about 1ms per file on NVMe).
+    /// `ftruncate`, skipped when the file is already `len` bytes or shorter.
+    /// On XFS, setting the size of a file that just grew (every new file)
+    /// writes its dirty pages back synchronously, about 1ms per file.
     pub fn ftruncate_if_longer(fd: Fd, len: i64) -> Maybe<()> {
         if let Ok(st) = fstat(fd) {
             if st.st_size <= len {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2646,9 +2646,7 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
-    /// `ftruncate`, skipped when the file is already `len` bytes or shorter.
-    /// On XFS, setting the size of a file that just grew (every new file)
-    /// writes its dirty pages back synchronously, about 1ms per file.
+    /// On XFS, resizing a file that just grew flushes it synchronously, so skip the no-op case.
     pub fn ftruncate_if_longer(fd: Fd, len: i64) -> Maybe<()> {
         if let Ok(st) = fstat(fd) {
             if st.st_size <= len {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -7,6 +7,7 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isGlibc,
   isWindows,
   tempDir,
   withoutAggressiveGC,
@@ -718,6 +719,99 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
           stdout: "",
         });
         expect(fs.readFileSync(join(String(dir), "dst.bin"))).toEqual(Buffer.alloc(128 * 1024, 0x41));
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    // The string and TypedArray fast paths open without O_TRUNC and cut the
+    // previous contents off with ftruncate(2) after writing. On XFS, truncating
+    // a file whose size just grew (every new file) synchronously writes the
+    // data back, about 1ms per file, so the ftruncate must only be issued when
+    // there is an old tail to cut. The LD_PRELOAD shim logs every ftruncate(2)
+    // with the file's name (glibc-only: relies on ELF symbol interposition).
+    it.skipIf(!isGlibc || !(Bun.which("cc") || Bun.which("gcc") || Bun.which("clang")))(
+      "only calls ftruncate when the file shrinks",
+      async () => {
+        const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+        using dir = tempDir("bun-write-ftruncate", {
+          "shim.c": `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static void log_ftruncate(int fd, long long len) {
+  char link[64], target[4096], line[4200];
+  snprintf(link, sizeof link, "/proc/self/fd/%d", fd);
+  ssize_t n = readlink(link, target, sizeof target - 1);
+  target[n < 0 ? 0 : n] = 0;
+  const char *name = strrchr(target, '/');
+  int m = snprintf(line, sizeof line, "ftruncate %s %lld\\n", name ? name + 1 : target, len);
+  write(2, line, m);
+}
+
+int ftruncate(int fd, off_t len) {
+  static int (*real)(int, off_t);
+  if (!real) real = dlsym(RTLD_NEXT, "ftruncate");
+  log_ftruncate(fd, len);
+  return real(fd, len);
+}
+
+int ftruncate64(int fd, off_t len) {
+  static int (*real)(int, off_t);
+  if (!real) real = dlsym(RTLD_NEXT, "ftruncate64");
+  log_ftruncate(fd, len);
+  return real(fd, len);
+}
+`,
+          "string-grow.txt": "x",
+          "string-shrink.txt": "xyz",
+          "bytes-grow.txt": "x",
+          "bytes-shrink.txt": "xyz",
+          "fixture.mjs": `
+            import fs from "node:fs";
+            await Bun.write("string-new.txt", "x");
+            await Bun.write("string-grow.txt", "yy");
+            await Bun.write("string-shrink.txt", "y");
+            await Bun.write("bytes-new.txt", new TextEncoder().encode("x"));
+            await Bun.write("bytes-grow.txt", new TextEncoder().encode("yy"));
+            await Bun.write("bytes-shrink.txt", new Uint8Array(0));
+            const names = fs.readdirSync(".").filter(name => name.endsWith(".txt")).sort();
+            console.log(JSON.stringify(Object.fromEntries(names.map(name => [name, fs.readFileSync(name, "utf8")]))));
+          `,
+        });
+
+        const shim = join(String(dir), "shim.so");
+        await using ccProc = Bun.spawn({
+          cmd: [cc, "-shared", "-fPIC", "-o", shim, join(String(dir), "shim.c"), "-ldl"],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+        const [ccErr, ccExit] = await Promise.all([ccProc.stderr.text(), ccProc.exited]);
+        if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
+
+        const existing = bunEnv.LD_PRELOAD;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "fixture.mjs"],
+          env: { ...bunEnv, LD_PRELOAD: existing ? `${shim}:${existing}` : shim },
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect({ contents: JSON.parse(stdout), ftruncates: stderr.trim().split("\n") }).toEqual({
+          contents: {
+            "string-new.txt": "x",
+            "string-grow.txt": "yy",
+            "string-shrink.txt": "y",
+            "bytes-new.txt": "x",
+            "bytes-grow.txt": "yy",
+            "bytes-shrink.txt": "",
+          },
+          ftruncates: ["ftruncate string-shrink.txt 1", "ftruncate bytes-shrink.txt 0"],
+        });
         expect(exitCode).toBe(0);
       },
     );

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5871,6 +5871,98 @@ const outcome = async fn => {
   expect(exitCode).toBe(0);
 });
 
+// writeFile opens without O_TRUNC and cuts the previous contents off with
+// ftruncate(2) after writing. On XFS, truncating a file whose size just grew
+// (every new file) synchronously writes the data back, about 1ms per file, so
+// the ftruncate must only be issued when there is an old tail to cut. The
+// LD_PRELOAD shim logs every ftruncate(2) with the file's name (glibc-only:
+// relies on ELF symbol interposition).
+it.skipIf(!isGlibc || !cc)("writeFile only calls ftruncate when the file shrinks", async () => {
+  using dir = tempDir("writefile-ftruncate", {
+    "shim.c": `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static void log_ftruncate(int fd, long long len) {
+  char link[64], target[4096], line[4200];
+  snprintf(link, sizeof link, "/proc/self/fd/%d", fd);
+  ssize_t n = readlink(link, target, sizeof target - 1);
+  target[n < 0 ? 0 : n] = 0;
+  const char *name = strrchr(target, '/');
+  int m = snprintf(line, sizeof line, "ftruncate %s %lld\\n", name ? name + 1 : target, len);
+  write(2, line, m);
+}
+
+int ftruncate(int fd, off_t len) {
+  static int (*real)(int, off_t);
+  if (!real) real = dlsym(RTLD_NEXT, "ftruncate");
+  log_ftruncate(fd, len);
+  return real(fd, len);
+}
+
+int ftruncate64(int fd, off_t len) {
+  static int (*real)(int, off_t);
+  if (!real) real = dlsym(RTLD_NEXT, "ftruncate64");
+  log_ftruncate(fd, len);
+  return real(fd, len);
+}
+`,
+    "same.txt": "x",
+    "grow.txt": "x",
+    "shrink.txt": "xyz",
+    "promises-grow.txt": "x",
+    "promises-shrink.txt": "xyz",
+    "fixture.mjs": `
+      import fs from "node:fs";
+      fs.writeFileSync("new.txt", "x");
+      fs.writeFileSync("same.txt", "y");
+      fs.writeFileSync("grow.txt", "yy");
+      fs.writeFileSync("shrink.txt", "y");
+      await fs.promises.writeFile("promises-new.txt", "x");
+      await fs.promises.writeFile("promises-grow.txt", "yy");
+      await fs.promises.writeFile("promises-shrink.txt", "");
+      const names = fs.readdirSync(".").filter(name => name.endsWith(".txt")).sort();
+      console.log(JSON.stringify(Object.fromEntries(names.map(name => [name, fs.readFileSync(name, "utf8")]))));
+    `,
+  });
+
+  const soPath = path.join(String(dir), "shim.so");
+  const compile = Bun.spawnSync({
+    cmd: [cc!, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+  });
+  if (compile.exitCode !== 0) {
+    throw new Error(`Failed to build ftruncate shim:\n${compile.stderr.toString()}`);
+  }
+
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.mjs"],
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${soPath}:${existing}` : soPath },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ contents: JSON.parse(stdout), ftruncates: stderr.trim().split("\n") }).toEqual({
+    contents: {
+      "new.txt": "x",
+      "same.txt": "y",
+      "grow.txt": "yy",
+      "shrink.txt": "y",
+      "promises-new.txt": "x",
+      "promises-grow.txt": "yy",
+      "promises-shrink.txt": "",
+    },
+    ftruncates: ["ftruncate shrink.txt 1", "ftruncate promises-shrink.txt 0"],
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("fs.Stat constructor", () => {
   expect(new Stats()).toMatchObject({
     "atimeMs": undefined,


### PR DESCRIPTION
### Problem
- `fs.writeFileSync`, `fs.writeFile`, `fs.promises.writeFile` and `Bun.write(path, stringOrBytes)` cost about 1ms per newly created (or growing) file on XFS, the default root filesystem on RHEL, Rocky, Alma and Amazon Linux. Node takes about 0.02ms for the same write. Same-size rewrites and shrinks are not affected.
- All of these paths open the destination without `O_TRUNC` (so a rewrite reuses the file's blocks), write, then unconditionally `ftruncate(fd, written)` to drop whatever the previous contents left past the new end: `src/runtime/node/node_fs.rs` (`write_file_with_path_buffer`) and the `write_string_to_file_fast` / `write_bytes_to_file_fast` fast paths in `src/runtime/webcore/Blob.rs`.
- For a new file or a growing rewrite the `ftruncate` changes nothing about the size, but XFS (`xfs_setattr_size`) writes the just-dirtied pages back synchronously whenever the size being set is past the on-disk size and the file's size changed since its last writeback, which is exactly the state a fresh write leaves behind. The reporter confirmed the shape with raw syscalls in the same directory: open+write+ftruncate is 1.00ms per file, open+write (or `O_TRUNC`, or ftruncate before the write) is 0.02ms.

### Fix
- Adds `bun_sys::ftruncate_if_longer(fd, len)`: `fstat` the descriptor and only call `ftruncate` when the file is longer than `len` (falls back to the plain `ftruncate` if `fstat` fails). `fstat` is a few hundred nanoseconds; the `ftruncate` it replaces is a journaled inode update on every filesystem and a synchronous writeback on XFS.
- None of these paths stat the destination beforehand (`Bun.file(path)` is lazy and the fast paths never build a Blob), so this `fstat` is the only one. Per small write, today: `openat, write, ftruncate, close`. After: `openat, write, fstat, close` for new files, same-size rewrites and grows (same syscall count), and `openat, write, fstat, ftruncate, close` for shrinks, the one case that gains a syscall.
- The three write paths call it instead of `ftruncate`. Shrinking rewrites still truncate, so the resulting file contents are unchanged in every case; new files, same-size rewrites and growing rewrites no longer issue the syscall. The no-`O_TRUNC` block reuse is kept as is (on this box a 256MB rewrite is 61ms vs 367ms for a fresh file in a debug build).
- Large writes (2MB and up on Linux) `fallocate` the full length first, so they end up exactly `written` bytes long and now also skip the truncate; the fallocated range is fully covered by the data that was written.
- `fs.writeFileSync(fd, ...)`, `flag: "a"` / `"r+"` and the Windows `SetEndOfFile` path are untouched: they never took the `ftruncate` branch or have no XFS equivalent.
- Verified with `test/js/node/fs/fs.test.ts` ("writeFile only calls ftruncate when the file shrinks") and `test/js/bun/io/bun-write.test.js` ("only calls ftruncate when the file shrinks"). Each compiles a small `LD_PRELOAD` shim that logs every `ftruncate(2)` with the file name, then runs new / same-size / grow / shrink writes through each API: before this change every step logs a truncate (7 of 7 and 6 of 6), after it only the shrinks do (2 each), and the file contents are asserted for every step. The shim needs glibc symbol interposition and a C compiler, so the tests skip elsewhere, like the existing `statfs` and `posix_fadvise` shim tests next to them.
- Also ran the full `fs.test.ts` (512 pass), `bun-write.test.js`, `fs/promises.test.js`, node's `test-fs-write-file*` / `test-fs-promises-writefile*` suites, and `cargo check -p bun_sys` for the darwin, freebsd, android and musl targets. This container has no XFS mount, so the 1ms number itself is the reporter's measurement; what the tests pin down is that the syscall is gone from the new and growing cases.

### Background
- `O_TRUNC` makes `open(2)` empty the file before anything is written; a filesystem then has to free the file's blocks and allocate new ones for the data. Bun deliberately skips it for `writeFile` so a rewrite of a large file overwrites in place, and instead trims the file to the written length afterwards with `ftruncate(2)`, which sets a file's size to an exact byte count (cutting data off or extending with zeros).
- The `fs.copyFile` / `fs.cp` implementations use the same open-without-`O_TRUNC` then `ftruncate` pattern and are left alone here; they can move to the same helper separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts, test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->
