### PR TITLE
sql: only treat real template objects as tagged template calls

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -12,6 +12,26 @@ const { SQLHelper, parseOptions } = require("internal/sql/shared");
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
 
 const defineProperties = Object.defineProperties;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+/**
+ * Template objects (GetTemplateObject, and the ES5 downlevel helpers of tsc/babel/swc/esbuild)
+ * define `raw` as an own, non-enumerable, read-only, non-configurable array of the same length.
+ * Data can only ever reach `sql()` with an enumerable `raw` (structuredClone, Object.assign, a
+ * deep-merged request body) or an inherited one (polluted Array.prototype.raw); such arrays must
+ * take the helper path, otherwise their elements would be spliced into the query as SQL text.
+ */
+function isTemplateStringsArray(strings: readonly unknown[]): boolean {
+  const raw = getOwnPropertyDescriptor(strings, "raw");
+  return (
+    raw !== undefined &&
+    !raw.enumerable &&
+    !raw.writable &&
+    !raw.configurable &&
+    $isArray(raw.value) &&
+    raw.value.length === strings.length
+  );
+}
 
 type TransactionCallback = (sql: (strings: string, ...values: any[]) => Query<any, any>) => Promise<any>;
 
@@ -266,8 +286,7 @@ const SQL: typeof Bun.SQL = function SQL(
         return Promise.$reject(pool.connectionClosedError());
       }
       if ($isArray(strings)) {
-        // detect if is tagged template
-        if (!$isArray(strings.raw)) {
+        if (!isTemplateStringsArray(strings)) {
           return new SQLHelper(strings, values);
         }
       } else if (typeof strings === "object" && !(strings instanceof Query) && !(strings instanceof SQLHelper)) {
@@ -568,8 +587,7 @@ const SQL: typeof Bun.SQL = function SQL(
         return Promise.$reject(pool.connectionClosedError());
       }
       if ($isArray(strings)) {
-        // detect if is tagged template
-        if (!$isArray((strings as unknown as TemplateStringsArray).raw)) {
+        if (!isTemplateStringsArray(strings)) {
           return new SQLHelper(strings, values);
         }
       } else if (typeof strings === "object" && !(strings instanceof Query) && !(strings instanceof SQLHelper)) {
@@ -796,8 +814,7 @@ const SQL: typeof Bun.SQL = function SQL(
     ...values: any[]
   ) {
     if ($isArray(strings)) {
-      // detect if is tagged template
-      if (!$isArray((strings as unknown as TemplateStringsArray).raw)) {
+      if (!isTemplateStringsArray(strings)) {
         return new SQLHelper(strings, values);
       }
     } else if (typeof strings === "object" && !(strings instanceof Query) && !(strings instanceof SQLHelper)) {

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -7,6 +7,11 @@
 // mysql rows need no live server: their URLs point at a closed port that is
 // never actually dialed. The sqlite row uses an in-memory database.
 // https://github.com/oven-sh/bun/issues/32155
+//
+// The same matrix also covers how sql(x) tells a tagged-template call apart
+// from the sql(array) helper: that decision is made synchronously, before any
+// connection, and a wrong answer splices the array's elements into the query
+// as SQL text (demonstrated end to end against sqlite at the bottom).
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
 
@@ -174,5 +179,156 @@ describe("sqlite helper behavior preserved", () => {
     expect(await sql`SELECT 1 as num WHERE 1 IN ${sql([{ id: null }, { id: 1 }], "id")}`).toEqual([{ num: 1 }]);
     // a null item without a column binds NULL
     expect(await sql`SELECT 1 as num WHERE 1 IN ${sql([null, 1])}`).toEqual([{ num: 1 }]);
+  });
+});
+
+const payload = "(0) UNION SELECT id, s FROM secrets";
+
+// Data arrays that nevertheless carry a `raw` array. JSON.parse cannot produce
+// these, but structuredClone/postMessage, Object.assign and deep-merge style
+// body parsers all preserve or add arbitrary enumerable properties.
+const arraysWithRaw: [string, () => string[]][] = [
+  [
+    "an array with an own raw of the same length",
+    () => {
+      const items: any = [payload];
+      items.raw = [payload];
+      return items;
+    },
+  ],
+  [
+    "an array with an own empty raw",
+    () => {
+      const items: any = [payload];
+      items.raw = [];
+      return items;
+    },
+  ],
+  [
+    "a structuredClone of an array with raw",
+    () => {
+      const items: any = [payload];
+      items.raw = [payload];
+      return structuredClone(items);
+    },
+  ],
+  ["an array with raw merged in by Object.assign", () => Object.assign([], { 0: payload, raw: [payload] })],
+];
+
+// Runs fn while every array inherits a `raw` array, as after a prototype
+// pollution bug in the application. Only synchronous work happens inside.
+function withPollutedArrayPrototype<T>(fn: () => T): T {
+  (Array.prototype as any).raw = [];
+  try {
+    return fn();
+  } finally {
+    delete (Array.prototype as any).raw;
+  }
+}
+
+// Template objects as created by the engine and by downlevel compilers. All of
+// them define `raw` as an own, non-enumerable, read-only, non-configurable array.
+const templateObjects: [string, () => TemplateStringsArray][] = [
+  ["an engine template object", () => ((strings: TemplateStringsArray) => strings)`SELECT 1 AS one`],
+  [
+    "a tsc __makeTemplateObject template (target es5)",
+    () => {
+      const cooked: any = ["SELECT 1 AS one"];
+      Object.defineProperty(cooked, "raw", { value: ["SELECT 1 AS one"] });
+      return cooked;
+    },
+  ],
+  [
+    "a babel/swc/esbuild taggedTemplateLiteral template",
+    () => {
+      const strings: any = ["SELECT 1 AS one"];
+      return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(strings.slice(0)) } }));
+    },
+  ],
+];
+
+describe.each(adapters)("%s template detection", (_adapter, makeSql) => {
+  test.each(arraysWithRaw)("%s is a helper, not a query", async (_shape, makeItems) => {
+    await using sql = makeSql();
+    const items = makeItems();
+    const helper = sql(items) as unknown as SQL.Helper<string>;
+    expect(helper).not.toBeInstanceOf(Promise);
+    expect(helper.value).toBe(items);
+    expect(helper.columns).toEqual([]);
+  });
+
+  test("a polluted Array.prototype.raw does not turn arrays into queries", async () => {
+    await using sql = makeSql();
+    const items = [payload];
+    const rows = [{ id: 2, name: "bob" }];
+    const [inHelper, insertHelper] = withPollutedArrayPrototype(
+      () =>
+        [
+          sql(items) as unknown as SQL.Helper<string>,
+          sql(rows) as unknown as SQL.Helper<(typeof rows)[number]>,
+        ] as const,
+    );
+    expect(inHelper).not.toBeInstanceOf(Promise);
+    expect(inHelper.value).toBe(items);
+    expect(inHelper.columns).toEqual([]);
+    expect(insertHelper).not.toBeInstanceOf(Promise);
+    expect(insertHelper.value).toBe(rows);
+    expect(insertHelper.columns).toEqual(["id", "name"]);
+  });
+
+  test.each(templateObjects)("%s passed programmatically is still a query", async (_shape, makeTemplate) => {
+    await using sql = makeSql();
+    // Queries only connect once awaited, so this never dials the closed port.
+    expect(sql(makeTemplate())).toBeInstanceOf(Promise);
+  });
+});
+
+// What the decision above protects: spliced into the query as text, `payload`
+// reads the secrets table; bound as a parameter it matches nothing.
+describe("sqlite binds arrays carrying a raw property as parameters", () => {
+  async function makeDatabase() {
+    const sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE users (id INTEGER, name TEXT)`;
+    await sql`INSERT INTO users VALUES (1, 'alice')`;
+    await sql`CREATE TABLE secrets (id INTEGER, s TEXT)`;
+    await sql`INSERT INTO secrets VALUES (7, 'TOPSECRET')`;
+    return sql;
+  }
+
+  test.each(arraysWithRaw)("WHERE IN given %s", async (_shape, makeItems) => {
+    await using sql = await makeDatabase();
+    expect(await sql`SELECT * FROM users WHERE id IN ${sql(makeItems())}`).toEqual([]);
+  });
+
+  test("every element of such an array is bound", async () => {
+    await using sql = await makeDatabase();
+    const names: any = ["alice", payload];
+    names.raw = ["alice", payload];
+    expect(await sql`SELECT * FROM users WHERE name IN ${sql(names)}`).toEqual([{ id: 1, name: "alice" }]);
+  });
+
+  test("WHERE IN inside a transaction", async () => {
+    await using sql = await makeDatabase();
+    const items: any = [payload];
+    items.raw = [payload];
+    expect(await sql.begin(tx => tx`SELECT * FROM users WHERE id IN ${tx(items)}`)).toEqual([]);
+  });
+
+  test("helpers created while Array.prototype.raw is polluted", async () => {
+    await using sql = await makeDatabase();
+    const [inHelper, insertHelper] = withPollutedArrayPrototype(
+      () => [sql([payload] as any), sql([{ id: 2, name: "bob" }] as any)] as const,
+    );
+    expect(await sql`SELECT * FROM users WHERE id IN ${inHelper}`).toEqual([]);
+    await sql`INSERT INTO users ${insertHelper}`;
+    expect(await sql`SELECT * FROM users ORDER BY id`).toEqual([
+      { id: 1, name: "alice" },
+      { id: 2, name: "bob" },
+    ]);
+  });
+
+  test.each(templateObjects)("%s passed programmatically executes", async (_shape, makeTemplate) => {
+    await using sql = await makeDatabase();
+    expect(await sql(makeTemplate())).toEqual([{ one: 1 }]);
   });
 });


### PR DESCRIPTION
### Problem
- `sql(x)` decides between "tagged template call" and "`sql(array)` helper" with `$isArray(x.raw)` (`src/js/bun/sql.ts`, three copies: `sql`, `reserved_sql`, `transaction_sql`).
- Any data array carrying an array-valued `raw` property is therefore executed as a template: `normalizeQuery` concatenates its elements into the query text instead of binding them. Same on all three adapters, the decision happens before the adapter is involved.
- Data ends up with such a property without any code meaning it: `structuredClone`/`postMessage` of an array that had one, `Object.assign` or deep-merge onto an array, or a prototype pollution bug setting `Array.prototype.raw`. With the last one every `sql(array)` IN-list in the app executes its strings as SQL, and every `sql([row, ...])` bulk insert rejects with `Invalid query: SQL Fragment cannot be executed or was misused`.
- Repro on 1.4.0 (sqlite); without the `raw` line it returns `[]`:

```ts
const ids = ["(0) union select id, s from secrets"];
ids.raw = [];
await sql`select * from users where id in ${sql(ids)}`; // [{ id: 7, name: "TOPSECRET" }]
```

### Fix
- One shared `isTemplateStringsArray` replaces the three inline checks. An array counts as a template only if its `raw` is an own, non-enumerable, non-writable, non-configurable property holding an array of the same length. Everything else takes the existing `SQLHelper` path, so its elements are bound.
- That is the shape every template object has: the engine's (`JSTemplateObjectDescriptor::createTemplateObject` defines `raw` as `ReadOnly | DontEnum | DontDelete`) and the ones built by the ES5 downlevel helpers of tsc (`__makeTemplateObject`, which does not freeze), babel, swc and esbuild (`defineProperty`, then freeze). Data can only arrive with an enumerable `raw` (clone, assign, merge) or an inherited one (pollution), so none of it passes.
- The non-enumerable bit is why this is checked instead of `Object.isFrozen`: freezing a cloned forgery leaves `raw` enumerable, so it is still rejected, while requiring frozen-ness would break tsc `target: es5` output. Babel's `loose` helper assigns `raw` with `=`, is indistinguishable from data, and takes the helper path too.
- Verified with `test/js/sql/sql-helpers-validation.test.ts`: the 22 new cases fail on 1.4.0 and all 62 pass with this change (three-adapter matrix for the classification, sqlite end to end for the actual injection, `begin()` included).
- `test/js/sql/sqlite-sql.test.ts`: 239 pass.
- Ad hoc script against a local postgres: pool, `reserve()` and `begin()` functions all bind a forged array and still run real templates.

### Background
- A tag call `` sql`... ${v} ...` `` receives a template object: an array of the literal's string pieces with a `raw` property holding the unescaped pieces. Bun's `sql` is also the helper constructor (`sql(values)` for `IN (...)`, `sql(rows)` for bulk insert), so it has to tell the two apart from the first argument alone.
- `normalizeQuery` (`src/js/internal/sql/shared.ts`) appends each template string piece verbatim and binds each interpolated value, so whatever is classified as a template is trusted SQL text by construction; a `SQLHelper` is expanded into placeholders with its items pushed onto the bound values.
- postgres.js uses the same `Array.isArray(strings.raw)` test, so this is hardening rather than a regression fix. The only behavior change is for hand-built template arrays that were neither frozen nor defined with `defineProperty`: they now behave like any other array (`sql.unsafe(text, params)` is the supported way to run dynamic text).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 22 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-helpers-validation.test.ts
bun test v1.4.0 (5c35711c7)

test/js/sql/sql-helpers-validation.test.ts:
(pass) sqlite helper validation > null items in WHERE IN helper with a column are rejected [190.25ms]
(pass) sqlite helper validation > null and undefined items in INSERT helper are rejected [27.99ms]
(pass) sqlite helper validation > null and undefined items in UPDATE helper are rejected [21.59ms]
(pass) sqlite helper validation > empty update helper throws regardless of SET casing [31.69ms]
(pass) sqlite helper validation > empty update helper throws even alongside a literal assignment [26.17ms]
(pass) postgres helper validation > null items in WHERE IN helper with a column are rejected [46.69ms]
(pass) postgres helper validation > null and undefined items in INSERT helper are rejected [11.97ms]
(pass) postgres helper validation > null and undefined items in UPDATE helper are rejected [9.10ms]
(pass) postgres helper validation > empty update helper throws regardless of SET casing [15.71ms]
(pass) postgres helper validat
... (truncated)

release without fix: 22 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/sql/sql-helpers-validation.test.ts:
(pass) sqlite helper validation > null items in WHERE IN helper with a column are rejected [3.25ms]
(pass) sqlite helper validation > null and undefined items in INSERT helper are rejected [0.44ms]
(pass) sqlite helper validation > null and undefined items in UPDATE helper are rejected [0.30ms]
(pass) sqlite helper validation > empty update helper throws regardless of SET casing [0.39ms]
(pass) sqlite helper validation > empty update helper throws even alongside a literal assignment [0.33ms]
(pass) postgres helper validation > null items in WHERE IN helper with a column are rejected [0.92ms]
(pass) postgres helper validation > null and undefined items in INSERT helper are rejected [0.13ms]
(pass) postgres helper validation > null and undefined items in UPDATE helper are rejected [0.09ms]
(pass) postgres helper validation > empty update helper throws regardless of SET casing [0.19ms]
(pass) postgres helper validation > empty update helper throws even alongside a literal assignment [0.08ms]
(pass) mysql helper validation > null items in WHERE IN helper with a column are rejected [0.87ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-helpers-validation.test.ts
bun test v1.4.0 (5c35711c7)

test/js/sql/sql-helpers-validation.test.ts:
(pass) sqlite helper validation > null items in WHERE IN helper with a column are rejected [186.46ms]
(pass) sqlite helper validation > null and undefined items in INSERT helper are rejected [26.56ms]
(pass) sqlite helper validation > null and undefined items in UPDATE helper are rejected [19.87ms]
(pass) sqlite helper validation > empty update helper throws regardless of SET casing [30.11ms]
(pass) sqlite helper validation > empty update helper throws even alongside a literal assignment [24.89ms]
(pass) postgres helper validation > null items in WHERE IN helper with a column are rejected [43.21ms]
(pass) postgres helper validation > null and undefined items in INSERT helper are rejected [11.26ms]
(pass) postgres helper validation > null and undefined items in UPDATE helper are rejected [8.58ms]
(pass) postgres helper validation > empty update helper throws regardless of SET casing [14.60ms]
(pass) postgres helper validat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 650ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (8979ms)
Bundle modules (53ms)
Postprocesss modules (250ms)
Bundle Functions (636ms)
Generate Code (18ms)

[9.95s] Bundled "src/js" for production
  2627 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/bun/sql.ts                          |  29 ++++--
 test/js/sql/sql-helpers-validation.test.ts | 156 +++++++++++++++++++++++++++++
 2 files changed, 179 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/bun/sql.ts                               5      5      0
test/js/sql/sql-helpers-validation.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->