### PR TITLE
test(sql): assert resolution order in "reserve connection" instead of a wall-clock delta

### DIFF
--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -3997,7 +3997,6 @@ CREATE TABLE ${table_name} (
     });
     test("reserve connection", async () => {
       await using sql = postgres({ ...options, max: 1 });
-      const reserved = await sql.reserve();
 
       const resolved: number[] = [];
       const track = (query: Promise<{ x: number }[]>) =>
@@ -4005,19 +4004,23 @@ CREATE TABLE ${table_name} (
           resolved.push(x);
         });
 
-      const first = track(reserved`select 1 as x`);
-      // max is 1 and that one connection is reserved, so the pool cannot run this until release()
-      const pooled = track(sql`select 2 as x`);
-      const third = track(reserved`select 3 as x`);
+      let pooled: Promise<void>;
+      let beforeRelease: number[];
+      {
+        // released however this block exits: closing the pool above waits for outstanding
+        // reservations, so a leaked one would report any failure in here as a timeout
+        await using reserved = await sql.reserve();
 
-      await Promise.all([first, third]);
-      const beforeRelease = [...resolved];
+        const first = track(reserved`select 1 as x`);
+        // max is 1 and that connection is reserved, so this cannot run until the block releases it
+        pooled = track(sql`select 2 as x`);
+        const third = track(reserved`select 3 as x`);
 
-      // release before asserting: closing the pool waits for the reservation, so a failed
-      // expect here would otherwise hang the `await using` disposal until the test times out
-      await reserved.release();
+        await Promise.all([first, third]);
+        beforeRelease = [...resolved];
+      }
+
       await pooled;
-
       expect(beforeRelease).toEqual([1, 3]);
       expect(resolved).toEqual([1, 3, 2]);
     });

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -3996,20 +3996,26 @@ CREATE TABLE ${table_name} (
       }
     });
     test("reserve connection", async () => {
-      const sql = postgres({ ...options, max: 1 });
+      await using sql = postgres({ ...options, max: 1 });
       const reserved = await sql.reserve();
 
-      setTimeout(() => reserved.release(), 510);
+      const resolved: number[] = [];
+      const track = (query: Promise<{ x: number }[]>) =>
+        query.then(([{ x }]) => {
+          resolved.push(x);
+        });
 
-      const xs = await Promise.all([
-        reserved`select 1 as x`.then(([{ x }]) => ({ time: Date.now(), x })),
-        sql`select 2 as x`.then(([{ x }]) => ({ time: Date.now(), x })),
-        reserved`select 3 as x`.then(([{ x }]) => ({ time: Date.now(), x })),
-      ]);
+      const first = track(reserved`select 1 as x`);
+      // max is 1 and that one connection is reserved, so the pool cannot run this until release()
+      const pooled = track(sql`select 2 as x`);
+      const third = track(reserved`select 3 as x`);
 
-      if (xs[1].time - xs[2].time < 500) throw new Error("Wrong time");
+      await Promise.all([first, third]);
+      expect(resolved).toEqual([1, 3]);
 
-      expect(xs.map(x => x.x).join("")).toBe("123");
+      await reserved.release();
+      await pooled;
+      expect(resolved).toEqual([1, 3, 2]);
     });
 
     test("keeps process alive when it should", async () => {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -4011,10 +4011,14 @@ CREATE TABLE ${table_name} (
       const third = track(reserved`select 3 as x`);
 
       await Promise.all([first, third]);
-      expect(resolved).toEqual([1, 3]);
+      const beforeRelease = [...resolved];
 
+      // release before asserting: closing the pool waits for the reservation, so a failed
+      // expect here would otherwise hang the `await using` disposal until the test times out
       await reserved.release();
       await pooled;
+
+      expect(beforeRelease).toEqual([1, 3]);
       expect(resolved).toEqual([1, 3, 2]);
     });
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -4005,7 +4005,6 @@ CREATE TABLE ${table_name} (
         });
 
       let pooled: Promise<void>;
-      let beforeRelease: number[];
       {
         // released however this block exits: closing the pool above waits for outstanding
         // reservations, so a leaked one would report any failure in here as a timeout
@@ -4015,14 +4014,16 @@ CREATE TABLE ${table_name} (
         // max is 1 and that connection is reserved, so this cannot run until the block releases it
         pooled = track(sql`select 2 as x`);
         const third = track(reserved`select 3 as x`);
-
         await Promise.all([first, third]);
-        beforeRelease = [...resolved];
+
+        // one more round trip: a connection handed back to the pool when 1 or 3 finished would
+        // have run the pooled query by now, and 2 would show up here ahead of 4
+        await track(reserved`select 4 as x`);
+        expect(resolved).toEqual([1, 3, 4]);
       }
 
       await pooled;
-      expect(beforeRelease).toEqual([1, 3]);
-      expect(resolved).toEqual([1, 3, 2]);
+      expect(resolved).toEqual([1, 3, 4, 2]);
     });
 
     test("keeps process alive when it should", async () => {


### PR DESCRIPTION
### Problem
- `PostgreSQL tests > reserve connection` in `test/js/sql/sql.test.ts` fails with `error: Wrong time` (sql.test.ts:4010) on every run when executed in isolation against a debug/ASAN build, and occasionally inside a full-file run.
- The test releases the reserved connection from a `setTimeout(..., 510)` and then requires the pooled query to have resolved at least 500ms after the second reserved query (`xs[1].time - xs[2].time >= 500`).
- That leaves 10ms for the two reserved queries to complete after the timer is armed. On a debug build the first queries on a fresh connection take around 80ms, so the measured delta comes out around 458ms and the test throws even though the pool behaved correctly (measured: reserved queries resolved 77ms and 82ms after arming, `release()` ran at 512ms, pooled query resolved at 542ms).
- The remaining assertion, `xs.map(x => x.x).join("") === "123"`, cannot fail: `Promise.all` returns results in input order regardless of when each promise settled. The wall-clock delta was the only live check, so it cannot simply be dropped.

### Fix
- Rewrite the test to assert the order in which queries resolve. With `max: 1` and the only connection reserved: queries 1 and 3 are run on the reservation, query 2 on the pool, then one more query (4) on the reservation. While the reservation is still held the order must be `[1, 3, 4]`; after it is released the pooled query resolves and the order must be `[1, 3, 4, 2]`. No timer is involved.
- This is the property the test exists to check (a pool whose only connection is reserved cannot service a pool query until the reservation is released); the 500ms delta was only an indirect way of observing it. The pass path is deterministic: query 2 is not written to the socket until the release, and queries on one connection are answered in FIFO order.
- Query 4 is what makes the order a sufficient oracle. If the pool got the connection back when query 1 or 3 finished (the regression the old 500ms delta would have caught), query 2 would be queued on the connection before query 4 is issued and resolve ahead of it, so the first assertion sees `[1, 3, 2, 4]`. Without query 4, that regression still produces `[1, 3, 2]`. Confirmed by temporarily making reserved queries release the connection on completion in `src/js/bun/sql.ts` (not part of this PR): the version without query 4 kept passing, this version fails.
- Other simulated regressions also fail it: `max: 2` (pooled query runs on a second connection) gives `[1, 2, 3, 4]`; a release that does not flush the waiting queue hangs on `await pooled`, which is the only honest failure mode for that case.
- The reservation is held in an `await using` block and the pool itself is closed with `await using` (it was left open before). `sql.close()` waits for outstanding reservations, so a failure while the reservation was still held (a failed expectation, or a reserved query rejecting) would otherwise hang disposal and be reported as a 5s timeout; with this shape the `max: 2` variant reports the order diff and a rejecting reserved query (`select no_such_column`) reports the `PostgresError`, both in well under 100ms (probes under `bun test` on the debug build).
- Verified with `bun bd test test/js/sql/sql.test.ts -t "reserve connection"` (the file is gated on docker, so locally the gate was temporarily pointed at the `BUN_TEST_SERVICE_postgres_plain` instance; that edit is not part of this PR):
  - before: fails 5/5 runs in isolation on the debug build (`error: Wrong time`, ~630ms each)
  - after: passes 10/10 runs in isolation (~250ms each), and the earlier revision passed inside a full `sql.test.ts` run (the other failures in that local run are environment-specific: missing md5/scram roles, prepared transactions disabled, SQL_ASCII encoding)

### Background
- `sql.reserve()` takes one connection out of the pool and returns a handle that runs queries on that connection only. While it is held, the connection is not in the pool's ready set; with `max: 1` there is no other connection, so queries issued on the pool itself are parked in the pool's waiting queue.
- Releasing the reservation (`reserved.release()`, which is also what the handle's `Symbol.asyncDispose` calls) marks the connection ready again and flushes the waiting queue, which is when the parked query is first written to the socket.
- Queries sent on one postgres connection are answered strictly in the order they were written, so on a single connection resolution order equals dispatch order. That is what lets query 4 act as a barrier: anything dispatched to the connection before query 4 resolves before it.
- `sql.close()` without a timeout (what `await using` on the pool calls) resolves only once every outstanding query and reservation has been released.

<details>
<summary>Earlier revisions of this PR</summary>

- fa9b6668bc asserted `[1, 3]` before releasing; a failing expectation there would have hung pool disposal.
- 2ad63b3415 released explicitly before asserting; a reserved query rejecting would still have skipped the release.
- e1d6e5fd21 scoped the reservation with `await using`, but asserted only `[1, 3]` / `[1, 3, 2]`, which a release-on-query-completion regression also produces. 6951225ef4 (current) adds query 4.
</details>
