### PR TITLE
node:fs: recursive mkdir creates the parents of a//b style paths under the name a, not a/

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5743,10 +5743,26 @@ impl NodeFS {
         // iterate backwards until creating the directory works successfully
         while i > 0 {
             if bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[i as usize]) {
-                working_mem[i as usize] = 0;
-                // SAFETY: `working_mem[..i]` is initialized from `path` above and
-                // `working_mem[i]` was just set to NUL; the slice is in-bounds.
-                let parent = unsafe { OSPathSliceZ::from_raw(working_mem.as_ptr(), i as usize) };
+                // For `a//b` the parent to create is `a`: mkdir of `a/` makes macOS
+                // and FreeBSD follow a symlink at `a` and create its target (Linux
+                // reports EEXIST for both spellings). `i` stays on the run's last
+                // separator: the forward walk resumes after it, and through
+                // `first_match` the returned first-created path stays `a/`, which is
+                // what node returns as well (`MKDirpSync` splits at `find_last_of`).
+                let mut cut = i;
+                while cut > 0
+                    && bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[(cut - 1) as usize])
+                {
+                    cut -= 1;
+                }
+                if cut == 0 {
+                    // The run is the root, which exists.
+                    break;
+                }
+                working_mem[cut as usize] = 0;
+                // SAFETY: `working_mem[..cut]` is initialized from `path` above and
+                // `working_mem[cut]` was just set to NUL; the slice is in-bounds.
+                let parent = unsafe { OSPathSliceZ::from_raw(working_mem.as_ptr(), cut as usize) };
                 match mkdir_os_path(parent, mode) {
                     Err(err) => {
                         // The SEP-restore must NOT happen before the errno match:
@@ -5779,13 +5795,13 @@ impl NodeFS {
                                         }
                                     }
                                 }
-                                working_mem[i as usize] = paths::SEP as OSPathChar;
+                                working_mem[cut as usize] = paths::SEP as OSPathChar;
                                 // Handle race condition
                                 break;
                             }
                             E::ENOENT => {
-                                working_mem[i as usize] = paths::SEP as OSPathChar;
-                                i -= 1;
+                                working_mem[cut as usize] = paths::SEP as OSPathChar;
+                                i = cut - 1;
                                 continue;
                             }
                             _ => {
@@ -5813,7 +5829,7 @@ impl NodeFS {
                     Ok(_) => {
                         ctx.on_create_dir(parent);
                         // We found a parent that worked
-                        working_mem[i as usize] = paths::SEP as OSPathChar;
+                        working_mem[cut as usize] = paths::SEP as OSPathChar;
                         break;
                     }
                 }
@@ -5824,7 +5840,12 @@ impl NodeFS {
         i += 1;
         // after we find one that works, we go forward _after_ the first working directory
         while i < len {
-            if bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[i as usize]) {
+            // Only the first separator of a run ends a directory name (`a` in
+            // `a//b`); the prefixes ending at the later ones (`a/`) are the
+            // symlink-following spelling described above. `i >= 1` here.
+            if bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[i as usize])
+                && !bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[(i - 1) as usize])
+            {
                 working_mem[i as usize] = 0;
                 // SAFETY: `working_mem[..i]` is initialized from `path` and
                 // `working_mem[i]` was just set to NUL; the slice is in-bounds.

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, mkdirSync, readdirSync, statSync, symlinkSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
@@ -1224,6 +1224,31 @@ ${temp_dir}`
           .split("\n")
           .sort(),
       );
+    });
+  });
+
+  // The builtin resolves a relative operand against the cwd, which also collapses
+  // doubled separators, so only an absolute operand reaches the recursive walk with
+  // a run in it. Skipped on Windows, where the path is normalized before the walk.
+  describe.skipIf(isWindows)("mkdir -p with doubled separators", () => {
+    test("-v names each created directory without the separator run, like coreutils", async () => {
+      await using dir = tempDir("mkdir-p-doubled", {});
+      const { stdout, stderr, exitCode } = await $`mkdir -pv ${dir}/a//b//c`;
+      expect(stderr.toString()).toBe("");
+      // The first line is the name handed to mkdir(2); it used to be `${dir}/a/`.
+      expect(stdout.toString()).toBe(`${dir}/a\n${dir}/a//b\n${dir}/a//b//c\n`);
+      expect(exitCode).toBe(0);
+      expect(statSync(join(dir, "a", "b", "c")).isDirectory()).toBe(true);
+    });
+
+    test("fails below a dangling symlink and creates nothing", async () => {
+      await using dir = tempDir("mkdir-p-doubled", {});
+      symlinkSync("missing", join(dir, "dangling"));
+      const { stdout, stderr, exitCode } = await $`mkdir -pv ${dir}/dangling//out`;
+      expect(stdout.toString()).toBe("");
+      expect(stderr.toString()).toBe(`mkdir: ${dir}/dangling//out: No such file or directory\n`);
+      expect(exitCode).toBe(1);
+      expect(readdirSync(String(dir))).toEqual(["dangling"]);
     });
   });
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -384,6 +384,45 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/hello/world/b.txt", "b");
     });
 
+    // On macOS a tree of plain files and directories is copied natively, and the
+    // native copy creates the destination with the recursive mkdir walk. For this
+    // spelling that walk used to create the parent under the name `dangling/`,
+    // which macOS resolves through the link, and the tree was then copied into
+    // the link's target. Linux takes the ported implementation instead, whose own
+    // parent mkdir fails (EEXIST today, ENOENT once that mkdir reports the stat
+    // error as node does), hence the two accepted codes. Skipped on Windows, where
+    // the doubled separator is normalized away before the copy starts.
+    test.skipIf(isWindows)(
+      "directory into a dangling symlink parent spelled with a doubled separator fails",
+      async () => {
+        await using basename = tempDir("cp", {
+          "from/a.txt": "a",
+          "from/sub/b.txt": "b",
+        });
+        fs.symlinkSync("missing", basename + "/dangling");
+
+        const e = await copyShouldThrow(basename + "/from", basename + "/dangling//out", { recursive: true });
+        expect(["ENOENT", "EEXIST"]).toContain(e.code);
+
+        // Neither the link's target nor anything else was created.
+        expect(fs.readdirSync(String(basename)).sort()).toEqual(["dangling", "from"]);
+      },
+    );
+
+    test("directory into a destination spelled with doubled separators", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+        "from/sub/b.txt": "b",
+      });
+
+      await copy(basename + "/from", basename + "/out//deeper//result", { recursive: true });
+
+      assertContent(basename + "/out/deeper/result/a.txt", "a");
+      assertContent(basename + "/out/deeper/result/sub/b.txt", "b");
+      expect(fs.readdirSync(basename + "/out")).toEqual(["deeper"]);
+      expect(fs.readdirSync(basename + "/out/deeper")).toEqual(["result"]);
+    });
+
     test("relative paths for directories", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -399,3 +399,90 @@ describe("fs.promises.mkdir", () => {
     expect(result).toBeUndefined();
   });
 });
+
+// `a//b` names the same directories as `a/b`, but the parent the recursive walk
+// creates on the way must be named `a`, not `a/`: macOS and FreeBSD resolve the
+// trailing separator through a symlink at `a` and mkdir creates the link's target
+// (Linux fails with EEXIST for either name). The walk used to cut the parent at
+// the last separator of a run, so on those systems `dangling//out` created
+// `missing` and `missing/out` through the link; node on Linux reports ENOENT for
+// both spellings. Skipped on Windows, where the path is normalized (runs
+// collapsed) before the walk.
+describe.skipIf(isWindows)("fs.mkdir - recursive with doubled separators", () => {
+  let tmpdir: string;
+
+  const mkdirForms = {
+    mkdirSync: (pathname: string) => Promise.resolve().then(() => fs.mkdirSync(pathname, { recursive: true })),
+    mkdir: (pathname: string) =>
+      new Promise<string | undefined>((resolve, reject) =>
+        fs.mkdir(pathname, { recursive: true }, (err, result) => (err ? reject(err) : resolve(result))),
+      ),
+    "promises.mkdir": (pathname: string) => fs.promises.mkdir(pathname, { recursive: true }),
+  };
+  const forms = Object.keys(mkdirForms) as (keyof typeof mkdirForms)[];
+
+  beforeEach(() => {
+    tmpdir = getTmpDir();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe.each(forms)("%s", form => {
+    it("reports ENOENT below a dangling symlink and creates nothing", async () => {
+      fs.symlinkSync("missing", path.join(tmpdir, "dangling"));
+
+      const pathname = `${tmpdir}/dangling//out`;
+      await expect(mkdirForms[form](pathname)).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "mkdir",
+        path: pathname,
+      });
+      expect(fs.readdirSync(tmpdir)).toEqual(["dangling"]);
+    });
+
+    // With more components below the link, the error comes from the walk back down.
+    it("reports ENOENT below a dangling symlink with further components and creates nothing", async () => {
+      fs.symlinkSync("missing", path.join(tmpdir, "dangling"));
+
+      const pathname = `${tmpdir}/dangling//out//deeper`;
+      await expect(mkdirForms[form](pathname)).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "mkdir",
+        path: pathname,
+      });
+      expect(fs.readdirSync(tmpdir)).toEqual(["dangling"]);
+    });
+
+    // Node splits the path at its last separator, so the first path it creates
+    // for `a//b` (and returns) is spelled `a/`; the returned spelling is kept
+    // even though the directory itself is created under the name `a`.
+    it("creates the directories and returns the first one spelled as node does", async () => {
+      expect(await mkdirForms[form](`${tmpdir}/a//b`)).toBe(`${tmpdir}/a/`);
+      expect(fs.statSync(path.join(tmpdir, "a", "b")).isDirectory()).toBe(true);
+      expect(fs.readdirSync(tmpdir)).toEqual(["a"]);
+      expect(fs.readdirSync(path.join(tmpdir, "a"))).toEqual(["b"]);
+    });
+
+    it("creates every component of a path with several separator runs", async () => {
+      expect(await mkdirForms[form](`${tmpdir}/c///d//e`)).toBe(`${tmpdir}/c//`);
+      expect(fs.statSync(path.join(tmpdir, "c", "d", "e")).isDirectory()).toBe(true);
+      expect(fs.readdirSync(tmpdir)).toEqual(["c"]);
+      expect(fs.readdirSync(path.join(tmpdir, "c"))).toEqual(["d"]);
+      expect(fs.readdirSync(path.join(tmpdir, "c", "d"))).toEqual(["e"]);
+    });
+
+    it("creates the missing part below an existing directory spelled with a run", async () => {
+      fs.mkdirSync(path.join(tmpdir, "existing"));
+
+      expect(await mkdirForms[form](`${tmpdir}/existing//x//y`)).toBe(`${tmpdir}/existing//x/`);
+      expect(fs.statSync(path.join(tmpdir, "existing", "x", "y")).isDirectory()).toBe(true);
+      expect(fs.readdirSync(tmpdir)).toEqual(["existing"]);
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- Found by reading the routine while #38097 was being written, not from a user report. The macOS outcome below follows from the walk plus the kernel rule described under Background; it cannot be reproduced on Linux, and CI only runs the fixed build (the darwin 14 lane passes the new tests; FreeBSD has a build lane only, so it is asserted from its documented semantics). The Linux-visible part is reproduced in the shell builtin.
- On macOS (and FreeBSD), `fs.mkdirSync("dangling//out", { recursive: true })` with `dangling -> missing` creates `missing` and `missing/out` through the link and returns, where `fs.mkdirSync("dangling/out", ...)` fails. `fs.mkdir`, `fs.promises.mkdir` and the shell's `mkdir -p` behave the same. On Linux both spellings fail with `ENOENT` in bun and in node.
- `fs.cpSync(tree, "dangling//out", { recursive: true })` and `fs.promises.cp(...)` on macOS copy the whole tree into the link's target the same way: a tree of plain files and directories is copied natively there, and the native copy creates its destination with this routine. Node's `cpSync` and `promises.cp` fail for this spelling and create nothing (`EEXIST` / `ENOENT`, transcript below; both derive the parent with a normalizing dirname, so the platform does not matter). This is the directory-shaped counterpart of #38097, which fixes the single-file copy and leaves this spelling out.
- Cause: `NodeFS::mkdir_recursive_os_path_impl` (`src/runtime/node/node_fs.rs`) cuts the parent prefix at whatever separator it is standing on. Walking back from the end of `T/dangling//out` it meets the second separator of the run first, so the name it hands to `mkdir(2)` is `T/dangling/`. The walk forward cuts at every separator as well, so for `a//b//c` it also issues `a/`-style names. `mkdir(2)` of `name/` resolves a symlink at `name` on the BSD-derived kernels and creates its target; Linux returns `EEXIST` for `name/` and `name` alike, so on Linux the only visible trace is the shell builtin: `mkdir -pv /x/a//b//c` prints `/x/a/` for the first directory it creates (coreutils prints `/x/a`).

### Fix
- The walk back finds the start of the separator run it is standing on, NUL-terminates there (`cut`) and restores there; on `ENOENT` it continues from `cut - 1`. A run that reaches index 0 is the root, which exists, so the walk stops there instead of calling `mkdir("/")`. The walk forward only acts on the first separator of a run. The three `working_mem[i] = SEP` restores become `working_mem[cut] = SEP`; the walk's position `i` is otherwise untouched.
- Why this is correct: the name handed to `mkdir(2)` never ends in a separator, so it denotes the entry itself on every kernel, and `a//b` creates exactly what `a/b` creates. The dangling case then fails from the final `mkdir` of the full path (`ENOENT`, `syscall: "mkdir"`, `path` = the argument). Per entry point: `fs.cp`/`cpSync` now fail as node's do (before, bun on macOS was the only implementation that copied); the shell `mkdir -p` now fails as coreutils and BSD `mkdir -p` do (both try `dangling` first and stop when it is not a directory); `fs.mkdir*` now reports on macOS what it and node already report on Linux. That last one is a deliberate divergence from node on macOS, whose `MKDirpSync`/`MKDirpAsync` split at `find_last_of` and so carry the same artifact: it is confined to macOS/FreeBSD, a doubled separator, and a dangling link right before it, and no upstream test pins it (`test-fs-mkdir*.js` has no doubled-separator or symlink case). It needs a maintainer's agreement; the rest of the change cannot be had without it, since every entry point shares the walk.
- Nothing else changes: for a path without doubled separators `cut == i`, so the calls, restores and errors are the ones made before. Because `i` stays on the run's last separator, the first-created path returned by `fs.mkdir*` is the same string as before, which is also node's: `T/a/` for `T/a//b`, `T/c//` for `T/c///d//e` (checked against node v26.3.0 for all three forms, transcript below). The string a caller hands in is still created as spelled, as in node; `Bun.write("dangling//f.txt")`, whose parent `bun_core::dirname` derives as `dangling/`, therefore still goes through the link on macOS (the caller-side counterpart of #38097, reported separately). The shell's `-v` output lists the names that were created (`a`, `a//b`, `a//b//c`, as coreutils does). `Bun.write` and the test runner only look at ok/err; the `#[cfg(windows)]` copy of this routine in `src/install/PackageInstall.rs` runs where the kernel rule does not exist.
- Shape: `bun_paths::ComponentIterator` + `make_path_with` (what `bun_sys::make_path` uses) yields separator-free prefixes by construction, and porting this routine onto it would remove the class structurally. That is a separate change: `make_path_with` on main loops forever on exactly this dangling case until #36162 lands, and the port has to reproduce the returned spelling above, the Windows `EEXIST` probe (#38108, #38146) and the error attribution (#38225). This PR is the 20-line fix of the walk as it exists; its tests are the contract such a port would have to keep. #38146 and #38225 edit neighbouring arms of the same function and are independent of this change; whichever lands later has a small rebase.
- Verified with `test/js/bun/shell/bunshell.test.ts`, new block "mkdir -p with doubled separators": `mkdir -pv <dir>/a//b//c` must print `<dir>/a`, `<dir>/a//b`, `<dir>/a//b//c`. Fails with bun 1.4.0 on Linux (first line is `<dir>/a/`), passes with this branch; this is the Linux-visible proof that the walk hands `mkdir(2)` a different name. The second test (`mkdir -p <dir>/dangling//out` fails and creates nothing) only changes on macOS. Whole file: 425 pass.
- `test/js/node/fs/fs-mkdir.test.ts`, new block "fs.mkdir - recursive with doubled separators" for `mkdirSync`, `fs.mkdir` and `fs.promises.mkdir`: `dangling//out` and `dangling//out//deeper` fail with `ENOENT`/`mkdir`/argument path and create nothing (the macOS cases; on Linux they pass before and after), plus `a//b`, `c///d//e` and `existing//x//y` create every directory and return node's spelling (pass before and after, pinning the unchanged return value). Whole file: 36 pass.
- `test/js/node/fs/cp.test.ts`: a tree copied to `dangling//out` fails and creates nothing, for `cpSync` and `promises.cp` (the macOS native copy is the affected path; Linux goes through the ported implementation, whose own parent mkdir fails with `EEXIST` today and `ENOENT` after #38146, so both codes are accepted, as node itself reports one per form), and a tree copied to `out//deeper//result` still lands in the right place. Whole file: 51 pass; all 77 upstream `test-fs-cp-*` files pass.
- CI build 94876 is green; the darwin 14 aarch64 lane ran all three files (39, 56 and 510 tests) and passed. Also run locally: `fs.test.ts -t mkdir` (32 pass), upstream `test-fs-mkdir*.js` (pass), `bun-write.test.js` (45 pass; 5 subprocess tests exceed their 5 s budget on this debug/ASAN box and pass in smaller groups, except the 256 MB copy test, which times out after its mkdir assertions have passed), `cargo check -p bun_runtime --target x86_64-pc-windows-msvc`, `cargo fmt`.

### Background
- Recursive mkdir (`mkdir_recursive_os_path_impl`) first tries to create the full path. On `ENOENT` it copies the path into a scratch buffer and walks back over the separators, writing a NUL over one to make the prefix before it a C string, calling `mkdir` on that prefix and putting the separator back, until a prefix is created or exists; then it walks forward creating the remaining prefixes and finally the full path. Its position when the walk back stopped is also the length of the "first directory created" string returned to `fs.mkdir*` callers. The routine backs `fs.mkdir*({ recursive })`, the shell `mkdir -p` (which passes a `-v` callback that receives each created prefix), `Bun.write`'s parent creation and the native `fs.cp` destination.
- Pathname resolution: POSIX says a pathname with a trailing slash must resolve to a directory, and the BSD-derived kernels (XNU, FreeBSD) apply that to creating calls too, so `mkdir("link/")` follows `link` and creates whatever it points at. Linux never follows a symlink in the final component of a creating call and returns `EEXIST` with or without the trailing slash. Doubled separators inside a path (`a//b`) are otherwise equivalent to single ones on both.
- A dangling symlink is a symlink whose target does not exist: using it as an intermediate component gives `ENOENT`, creating something with its name gives `EEXIST`, and on the BSD kernels creating `name/` creates its target.

<details>
<summary>Transcripts (Linux, node v26.3.0, bun 1.4.0, this branch)</summary>

Return values; `T` is a fresh directory containing `existing/`; same result for `mkdirSync`, `fs.mkdir` and `fs.promises.mkdir`:

```
argument              node             bun 1.4.0   this branch
T/a//b                T/a/             T/a/        T/a/
T/c///d//e            T/c//            T/c//       T/c//
T/existing//x//y      T/existing//x/   (same)      (same)
```

Copy of a tree and mkdir to `dangling//out`, `dangling -> missing`, nothing created in either runtime on Linux:

```
                 node       bun 1.4.0 (Linux: ported implementation)
cpSync           EEXIST     EEXIST
promises.cp      ENOENT     EEXIST
mkdirSync        ENOENT     ENOENT
```

Shell builtin, `dangling -> missing` in `D`:

```
mkdir -pv D/a//b//c        bun 1.4.0: D/a/  D/a//b  D/a//b//c     this branch: D/a  D/a//b  D/a//b//c     (coreutils: a, a//b, a//b//c)
mkdir -p  D/dangling//out  both: exit 1, "mkdir: D/dangling//out: No such file or directory"
```

Derived for macOS with bun 1.4.0 (not observed; this is what the walk does given the kernel rule): `mkdirSync("D/dangling//out", { recursive: true })` returns `D/dangling/` and `readdirSync(D)` lists `missing`; `cpSync(tree, "D/dangling//out", { recursive: true })` copies the tree to `D/missing/out`; `mkdir -pv D/dangling//out` prints `D/dangling/` and exits 0.
</details>
