### PR TITLE
js_parser: emit design:type metadata for decorated declare fields

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6917,7 +6917,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         match prop.kind {
-            PropertyKind::Normal | PropertyKind::Abstract => {
+            // typescript emits design:type for decorated `declare`/`abstract` fields just
+            // like for regular fields, even though the fields themselves are erased.
+            PropertyKind::Normal | PropertyKind::Abstract | PropertyKind::Declare => {
                 {
                     // design:type
                     let v = self
@@ -7029,8 +7031,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
             }
-            PropertyKind::Spread | PropertyKind::Declare | PropertyKind::AutoAccessor => {} // not allowed in a class (auto_accessor is standard decorators only)
-            PropertyKind::ClassStaticBlock => {} // not allowed to decorate this
+            // not allowed in a class (auto_accessor is standard decorators only)
+            PropertyKind::Spread | PropertyKind::AutoAccessor => {}
+            // not allowed to decorate this
+            PropertyKind::ClassStaticBlock => {}
         }
     }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6915,8 +6915,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         match prop.kind {
-            // typescript emits design:type for decorated `declare`/`abstract` fields just
-            // like for regular fields, even though the fields themselves are erased.
+            // typescript emits design:type for decorated `declare`/`abstract` fields too.
             PropertyKind::Normal | PropertyKind::Abstract | PropertyKind::Declare => {
                 {
                     // design:type

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6547,8 +6547,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                     }
 
-                    // TODO: prop.kind == .declare and prop.value == null
-
                     if prop.ts_decorators.len_u32() > 0 {
                         let descriptor_key = prop.key.expect("infallible: prop has key");
                         let loc = descriptor_key.loc;

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -543,4 +543,76 @@ describe("decorator metadata", () => {
     expect(Reflect.getMetadata("design:type", A.prototype, "method4")).toBe(Function);
     expect(Reflect.getMetadata("design:returntype", A.prototype, "method4")).toBeUndefined();
   });
+
+  // tsc emits design:type for a decorated `declare` field the same way it does for a
+  // regular or `abstract` field, while the field itself is still erased.
+  test("declare and abstract fields", () => {
+    const types: Record<string, unknown> = {};
+    // The design:type metadata decorator is appended after the user's decorators and
+    // decorators apply last to first, so the metadata is visible from inside d1. This
+    // is how reflect-metadata consumers (TypeORM, class-validator, ...) read it.
+    function d1(target: object, key: string) {
+      types[key] = Reflect.getMetadata("design:type", target, key);
+    }
+    class Known {}
+
+    class A {
+      @d1
+      declare prop0: string;
+      @d1
+      declare prop1: Known;
+      @d1
+      declare prop2?: number;
+      @d1
+      // @ts-ignore
+      declare prop3;
+      @d1
+      declare readonly prop4: boolean;
+      @d1
+      declare private prop5: Known[];
+      @d1
+      // @ts-ignore
+      declare ["prop" + 6]: Known;
+      @d1
+      declare static prop7: symbol;
+      // prettier-ignore
+      @d1
+      static declare prop8: bigint;
+      @d1
+      prop9: string = "";
+    }
+
+    abstract class B {
+      @d1
+      abstract abstract0: string;
+      @d1
+      abstract abstract1: Known;
+    }
+
+    expect(types).toEqual({
+      prop0: String,
+      prop1: Known,
+      prop2: Number,
+      prop3: Object,
+      prop4: Boolean,
+      prop5: Array,
+      prop6: Known,
+      prop7: Symbol,
+      prop8: BigInt,
+      prop9: String,
+      abstract0: String,
+      abstract1: Known,
+    });
+
+    // A declare field is a field, not a method: it gets design:type and nothing else.
+    expect(Reflect.getMetadataKeys(A.prototype, "prop0")).toEqual(["design:type"]);
+    expect(Reflect.getMetadataKeys(A, "prop7")).toEqual(["design:type"]);
+    expect(Reflect.getMetadataKeys(B.prototype, "abstract0")).toEqual(["design:type"]);
+
+    // The erased fields stay erased.
+    expect(Object.keys(new A())).toEqual(["prop9"]);
+    expect(Object.getOwnPropertyNames(A.prototype)).toEqual(["constructor"]);
+    expect(Object.getOwnPropertyNames(A)).not.toContain("prop7");
+    expect(Object.getOwnPropertyNames(A)).not.toContain("prop8");
+  });
 });

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -550,7 +550,7 @@ describe("decorator metadata", () => {
     const types: Record<string, unknown> = {};
     // The design:type metadata decorator is appended after the user's decorators and
     // decorators apply last to first, so the metadata is visible from inside d1. This
-    // is how reflect-metadata consumers (TypeORM, class-validator, ...) read it.
+    // is how reflect-metadata consumers (TypeORM, class-transformer, ...) read it.
     function d1(target: object, key: string) {
       types[key] = Reflect.getMetadata("design:type", target, key);
     }
@@ -575,6 +575,7 @@ describe("decorator metadata", () => {
       declare ["prop" + 6]: Known;
       @d1
       declare static prop7: symbol;
+      // The other modifier order is parsed differently; prettier would rewrite it to `declare static`.
       // prettier-ignore
       @d1
       static declare prop8: bigint;
@@ -589,7 +590,7 @@ describe("decorator metadata", () => {
       abstract abstract1: Known;
     }
 
-    expect(types).toEqual({
+    const expected = {
       prop0: String,
       prop1: Known,
       prop2: Number,
@@ -602,12 +603,17 @@ describe("decorator metadata", () => {
       prop9: String,
       abstract0: String,
       abstract1: Known,
-    });
+    };
+    expect(Object.keys(types).sort()).toEqual(Object.keys(expected).sort());
+    // Compared by identity: toEqual does not tell builtin constructors such as Array and Object apart.
+    for (const [key, type] of Object.entries(expected)) {
+      expect(types[key], key).toBe(type);
+    }
 
     // A declare field is a field, not a method: it gets design:type and nothing else.
-    expect(Reflect.getMetadataKeys(A.prototype, "prop0")).toEqual(["design:type"]);
-    expect(Reflect.getMetadataKeys(A, "prop7")).toEqual(["design:type"]);
-    expect(Reflect.getMetadataKeys(B.prototype, "abstract0")).toEqual(["design:type"]);
+    expect(Reflect.getOwnMetadataKeys(A.prototype, "prop0")).toEqual(["design:type"]);
+    expect(Reflect.getOwnMetadataKeys(A, "prop7")).toEqual(["design:type"]);
+    expect(Reflect.getOwnMetadataKeys(B.prototype, "abstract0")).toEqual(["design:type"]);
 
     // The erased fields stay erased.
     expect(Object.keys(new A())).toEqual(["prop9"]);


### PR DESCRIPTION
### Problem
- With `experimentalDecorators` + `emitDecoratorMetadata`, a decorated field with the `declare` modifier is lowered to `__legacyDecorateClassTS([dec], C.prototype, "f", undefined)` with no `__legacyMetadataTS("design:type", ...)` entry. tsc emits `__metadata("design:type", String)` for the same field. Affects `bun run`, `bun build` and `Bun.Transpiler` alike.
- Libraries that read `design:type` through reflect-metadata (TypeORM columns and relations, class-transformer nested types, NestJS property injection) see `undefined` for these fields. `@Column() declare id: number` is the usual shape of a decorated field once `useDefineForClassFields` is on.
- Cause: `emit_decorator_metadata_for_prop` in `src/js_parser/p.rs` matches `PropertyKind::Declare` in the no-op arm (commented "not allowed in a class"), while `Normal` and `Abstract` get `design:type`. The parser already records `ts_metadata` for these fields (`parse_property.rs` parses a decorated `declare` field through the regular field path and only relabels its kind), so the value was computed and then dropped.
- Regression from #16389 (bun 1.2.0): before the per-kind switch was introduced there, `design:type` was emitted for every decorated property.

### Fix
- Route `PropertyKind::Declare` through the same arm as `Normal` and `Abstract`. A `Declare` property is always a field (the parser only produces the kind for a decorated field without a value), so the method branch of that arm never applies to it and it gets exactly `design:type`, evaluated the same way as for a regular decorated field of the same type.
- Matches tsc: `visitPropertyDeclaration` in the TypeScript transform treats `declare` and `abstract` fields identically (`isAmbient`), keeps them when they carry legacy decorators, and runs `injectClassElementTypeMetadata` on them like on any other field. Bun already did this for `abstract`; this makes `declare` take the same path.
- The field itself is still erased: `lower_class` keeps dropping decorated fields that have no initializer, so no instance or static property is created. The stale `TODO: prop.kind == .declare` note above that code is removed; this was the last part of the declare case it referred to.
- Not changed: Bun applies the decorator of a `static declare` field to the constructor (like every other static member), whereas tsc 5.9/6.0 apply it to `C.prototype` because their transform strips all modifiers, `static` included, from ambient decorated members. That is separate from the metadata and left as is; the new test asserts the metadata on the target Bun decorates. Class expressions are also untouched: legacy decorators are not lowered there at all (#38095 covers the panic on that path).
- Verified with `test/bundler/transpiler/decorator-metadata.test.ts` (`declare and abstract fields`): instance, optional, unannotated, `readonly`, `private`, computed-key and both `static` orders of `declare` fields plus two `abstract` fields, read the way reflect-metadata consumers read it (from inside the decorator) and compared by identity. Fails on the current release (every `declare` entry is `undefined`), passes with this change.
  - `bun bd test` on `decorators`, `decorator-metadata`, `bundler_decorator_metadata`, `es-decorators`, `es-decorators-esbuild`, `ts-use-define-for-class-fields`, `esbuild/ts`, `transpiler.test.js`, regression 27575, `integration/nest`, `integration/typegraphql`: all pass
  - `bun build --no-bundle` output diffed against the current release for about 30 files covering modifier orders, type shapes, imported and forward-referenced types, `export default` classes, class expressions, `emitDecoratorMetadata` off and standard-decorator mode: the only difference anywhere is the added `design:type` entry on `declare` fields
  - `cargo fmt -p bun_js_parser --check`: clean

### Background
- `emitDecoratorMetadata` makes tsc (and Bun, under `experimentalDecorators`) append extra entries to each decorated member's decorator list: `design:type` for fields, plus `design:paramtypes` / `design:returntype` for methods. reflect-metadata's `Reflect.metadata(key, value)` turns each entry into a decorator that stores the value on the member; decorators run last to first, so a user decorator can read the metadata while it runs.
- A `declare x: T` field is a TypeScript-only declaration with no runtime output; `abstract x: T` is the same for abstract classes. Undecorated ones are dropped while parsing the class body. Decorated ones are kept as `PropertyKind::Declare` / `PropertyKind::Abstract` markers purely so `lower_class` can emit their `__legacyDecorateClassTS` call, after which the field is dropped.
- `__legacyDecorateClassTS` and `__legacyMetadataTS` (`src/runtime.js`) are Bun's equivalents of tsc's `__decorate` and `__metadata` helpers.
- The test compares the metadata values with `toBe` rather than one `toEqual` on the record because `toEqual` currently reports builtin constructors such as `Array` and `Object` as equal to each other (reported separately).

<details>
<summary>Output before and after for the original report</summary>

```ts
declare function dec(): any;
export class D {
  @dec() declare f: string;
  @dec() g: string = "";
}
```

Before (`bun build --no-bundle`, helper hash suffixes removed):

```js
__legacyDecorateClassTS([ dec() ], D.prototype, "f", undefined);
__legacyDecorateClassTS([ dec(), __legacyMetadataTS("design:type", String) ], D.prototype, "g", undefined);
```

After:

```js
__legacyDecorateClassTS([ dec(), __legacyMetadataTS("design:type", String) ], D.prototype, "f", undefined);
__legacyDecorateClassTS([ dec(), __legacyMetadataTS("design:type", String) ], D.prototype, "g", undefined);
```

tsc 6.0.2 with the same options:

```js
__decorate([ dec(), __metadata("design:type", String) ], D.prototype, "f", void 0);
__decorate([ dec(), __metadata("design:type", String) ], D.prototype, "g", void 0);
```

With the fix, the serialized types for `declare` fields of type `string`, a local class, `Known[]`, `symbol`, no annotation, `bigint` (computed key), `number` / `boolean` (static) come out as `String`, `Known`, `Array`, `Symbol`, `Object`, `BigInt`, `Number`, `Boolean`, the same values tsc serializes.
</details>
