### PR TITLE
install: keep npm: alias targets when bun update rewrites versions

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -647,7 +647,6 @@ impl WorkspaceFilter {
 #[derive(Default)]
 pub struct PackageUpdateInfo {
     pub(crate) original_version_literal: Box<[u8]>,
-    pub(crate) is_alias: bool,
     pub(crate) original_version_string_buf: Box<[u8]>,
     pub(crate) original_version: Option<Semver::Version>,
 }
@@ -657,7 +656,6 @@ pub struct CatalogUpdateInfo {
     pub catalog_name: Box<[u8]>,
     pub dep_name: Box<[u8]>,
     pub original_version_literal: Box<[u8]>,
-    pub is_alias: bool,
 }
 
 pub struct UpdateTargetWorkspace {

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1328,10 +1328,9 @@ pub(crate) fn edit(
                                 manager.updating_packages.fetch_swap_remove(request.name)
                             {
                                 let original: &[u8] = &entry.value.original_version_literal;
-                                // `<name>@npm:<other>` retargeted the entry; keep its pin style.
-                                // Plain literals may come from `preprocess_update_requests`.
                                 let installed =
                                     request.version.literal.slice(request.version_buf());
+                                // None: `preprocess_update_requests` may have rewritten plain ones.
                                 let original = match split_npm_alias(installed) {
                                     Some(_) => with_alias_of(
                                         arena,

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1327,8 +1327,22 @@ pub(crate) fn edit(
                             if let Some(entry) =
                                 manager.updating_packages.fetch_swap_remove(request.name)
                             {
+                                let original: &[u8] = &entry.value.original_version_literal;
+                                // `<name>@npm:<other>` retargeted the entry; keep its pin style.
+                                // Plain literals may come from `preprocess_update_requests`.
+                                let installed =
+                                    request.version.literal.slice(request.version_buf());
+                                let original = match split_npm_alias(installed) {
+                                    Some(_) => with_alias_of(
+                                        arena,
+                                        installed,
+                                        split_npm_alias(original)
+                                            .map_or(original, |(_, version)| version),
+                                    ),
+                                    None => original,
+                                };
                                 let new_version = updated_version_literal(
-                                    &entry.value.original_version_literal,
+                                    original,
                                     resolutions[request.package_id as usize].npm().version,
                                     manager.lockfile.buffers.string_bytes.as_slice(),
                                     options.exact_versions,

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -39,10 +39,7 @@ fn arena_dup<'a>(arena: &'a bun_alloc::Arena, bytes: &[u8]) -> &'a [u8] {
     arena.alloc_slice_copy(bytes)
 }
 
-/// Splits an `npm:` alias into the `npm:<name>` part `bun update` keeps and the version
-/// (or dist-tag) after it, which is empty for `npm:<name>` alone. The separator is the
-/// first `@` after the name, as in `Dependency::parse`, so a scoped name's leading `@`
-/// is not mistaken for it: `npm:@foo/bar@~1.2.3` -> (`npm:@foo/bar`, `~1.2.3`).
+/// `npm:@foo/bar@~1.2.3` -> (`npm:@foo/bar`, `~1.2.3`); `npm:foo` -> (`npm:foo`, `""`).
 fn split_npm_alias(literal: &[u8]) -> Option<(&[u8], &[u8])> {
     let literal = strings::trim(literal, &strings::WHITESPACE_CHARS);
     let name = literal.strip_prefix(b"npm:")?;
@@ -59,9 +56,7 @@ fn split_npm_alias(literal: &[u8]) -> Option<(&[u8], &[u8])> {
     }
 }
 
-/// The version `--latest` resolves in place of `version_literal`: `latest`, or
-/// `npm:<name>@latest` so an alias still resolves the aliased package rather than
-/// a package named after the alias.
+/// What `--latest` resolves instead of `version_literal`: `latest`, or `npm:<name>@latest`.
 fn latest_version_literal<'a>(arena: &'a bun_alloc::Arena, version_literal: &[u8]) -> &'a [u8] {
     match split_npm_alias(version_literal) {
         Some((alias, _)) => {
@@ -74,9 +69,7 @@ fn latest_version_literal<'a>(arena: &'a bun_alloc::Arena, version_literal: &[u8
     }
 }
 
-/// The version `bun update` writes back once `original_version_literal` resolved to
-/// `resolved`: the original pin style (`1.2.3`, `~1.2.3` or `^1.2.3`) unless
-/// `exact_versions`, behind the original `npm:<name>@` prefix if it was an alias.
+/// `resolved` in the pin style of `original_version_literal`, behind its `npm:<name>@` if any.
 fn updated_version_literal(
     original_version_literal: &[u8],
     resolved: semver::Version,
@@ -365,7 +358,6 @@ pub(crate) fn edit_update_no_args_in(
                         let version_literal = value
                             .as_utf8_string_literal()
                             .unwrap_or_else(|| bun_core::out_of_memory());
-                        // `Tag::infer` classifies an `npm:` alias by the version after its name.
                         let tag = dependency::Tag::infer(version_literal);
 
                         // npm versions only (and dist-tags with --latest); `catalog:` is handled by edit_catalogs_*.
@@ -547,8 +539,7 @@ fn for_each_catalog_object(
 }
 
 /// Records the original version of every catalog entry and, with `--latest`,
-/// rewrites each to `latest` (`npm:<name>@latest` for aliases) in memory so the
-/// resolver fetches it.
+/// rewrites each to `latest` in memory so the resolver fetches it.
 pub(crate) fn edit_catalogs_before_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
@@ -831,8 +822,6 @@ pub(crate) fn edit(
                                                 else {
                                                     break 'add_packages_to_update;
                                                 };
-                                                // `Tag::infer` classifies an `npm:` alias by
-                                                // the version after its name.
                                                 let tag = dependency::Tag::infer(version_literal);
 
                                                 if tag != dependency::Tag::Npm
@@ -1295,8 +1284,7 @@ pub(crate) fn edit(
             if request.package_id as usize >= resolutions.len()
                 || resolutions[request.package_id as usize].tag == resolution::Tag::Uninitialized
             {
-                // `bun update <name>` re-resolves what package.json already has; everything
-                // else resolves the request itself.
+                // `bun update <name>` re-resolves the existing entry; anything else, the request.
                 let version_literal: bun_ast::StoreStr = if manager.subcommand != Subcommand::Update
                     || !options.before_install
                     || e_string.is_blank()
@@ -1314,7 +1302,6 @@ pub(crate) fn edit(
                 e_string.data = if manager.subcommand == Subcommand::Update
                     && manager.options.do_.contains(Do::UPDATE_TO_LATEST)
                 {
-                    // Keeps an alias pointed at its target: `npm:<name>@latest`, not `latest`.
                     latest_version_literal(arena, version_literal.slice()).into()
                 } else {
                     version_literal

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -56,16 +56,25 @@ fn split_npm_alias(literal: &[u8]) -> Option<(&[u8], &[u8])> {
     }
 }
 
-/// What `--latest` resolves instead of `version_literal`: `latest`, or `npm:<name>@latest`.
-fn latest_version_literal<'a>(arena: &'a bun_alloc::Arena, version_literal: &[u8]) -> &'a [u8] {
-    match split_npm_alias(version_literal) {
-        Some((alias, _)) => {
+/// `version_literal` behind `from`'s `npm:<name>@` (if any), unless it already names a target.
+fn with_alias_of<'a>(
+    arena: &'a bun_alloc::Arena,
+    from: &[u8],
+    version_literal: &'a [u8],
+) -> &'a [u8] {
+    match split_npm_alias(from) {
+        Some((alias, _)) if split_npm_alias(version_literal).is_none() => {
             let mut v = Vec::new();
-            write!(&mut v, "{}@latest", bstr::BStr::new(alias))
-                .expect("infallible: in-memory write");
+            write!(
+                &mut v,
+                "{}@{}",
+                bstr::BStr::new(alias),
+                bstr::BStr::new(version_literal)
+            )
+            .expect("infallible: in-memory write");
             arena_str(arena, &v)
         }
-        None => b"latest",
+        _ => version_literal,
     }
 }
 
@@ -387,7 +396,7 @@ pub(crate) fn edit_update_no_args_in(
                         };
 
                         if update_to_latest {
-                            let temp_version = latest_version_literal(arena, version_literal);
+                            let temp_version = with_alias_of(arena, version_literal, b"latest");
                             dep.value = Some(Expr::allocate(
                                 arena,
                                 E::EString::init(temp_version),
@@ -596,7 +605,7 @@ pub(crate) fn edit_catalogs_before_update(
             });
 
             if update_to_latest {
-                let temp_version = latest_version_literal(arena, version_literal);
+                let temp_version = with_alias_of(arena, version_literal, b"latest");
                 dep.value = Some(Expr::allocate(
                     arena,
                     E::EString::init(temp_version),
@@ -1284,28 +1293,27 @@ pub(crate) fn edit(
             if request.package_id as usize >= resolutions.len()
                 || resolutions[request.package_id as usize].tag == resolution::Tag::Uninitialized
             {
-                // `bun update <name>` re-resolves the existing entry; anything else, the request.
-                let version_literal: bun_ast::StoreStr = if manager.subcommand != Subcommand::Update
-                    || !options.before_install
-                    || e_string.is_blank()
-                    || request.version.tag == dependency::Tag::Npm
-                {
-                    match request.version.tag {
-                        dependency::Tag::Uninitialized => b"latest".into(),
-                        _ => arena_dup(arena, request.version.literal.slice(request.version_buf()))
-                            .into(),
-                    }
-                } else {
-                    e_string.data
+                // The entry `bun update` is updating keeps its alias target whatever gets resolved.
+                let existing: Option<&[u8]> = (manager.subcommand == Subcommand::Update
+                    && options.before_install
+                    && !e_string.is_blank())
+                .then(|| e_string.data.slice());
+                let mut version_literal: &[u8] = match existing {
+                    Some(existing) if request.version.tag != dependency::Tag::Npm => existing,
+                    _ => match request.version.tag {
+                        dependency::Tag::Uninitialized => b"latest",
+                        _ => request.version.literal.slice(request.version_buf()),
+                    },
                 };
-
-                e_string.data = if manager.subcommand == Subcommand::Update
+                if let Some(existing) = existing {
+                    version_literal = with_alias_of(arena, existing, version_literal);
+                }
+                if manager.subcommand == Subcommand::Update
                     && manager.options.do_.contains(Do::UPDATE_TO_LATEST)
                 {
-                    latest_version_literal(arena, version_literal.slice()).into()
-                } else {
-                    version_literal
-                };
+                    version_literal = with_alias_of(arena, version_literal, b"latest");
+                }
+                e_string.data = arena_dup(arena, version_literal).into();
 
                 continue;
             }
@@ -1350,26 +1358,18 @@ pub(crate) fn edit(
                                 v
                             };
 
+                            let new_version = arena_str(arena, &new_version);
                             if request.version.tag == dependency::Tag::Npm
                                 && request.version.npm().is_alias
                             {
-                                let dep_literal =
-                                    request.version.literal.slice(request.version_buf());
-                                if let Some(at_index) = strings::index_of_char(dep_literal, b'@') {
-                                    let at_index = at_index as usize;
-                                    let mut v = Vec::new();
-                                    write!(
-                                        &mut v,
-                                        "{}@{}",
-                                        bstr::BStr::new(&dep_literal[0..at_index]),
-                                        bstr::BStr::new(&new_version)
-                                    )
-                                    .unwrap();
-                                    break 'npm arena_str(arena, &v);
-                                }
+                                break 'npm with_alias_of(
+                                    arena,
+                                    request.version.literal.slice(request.version_buf()),
+                                    new_version,
+                                );
                             }
 
-                            break 'npm arena_str(arena, &new_version);
+                            break 'npm new_version;
                         }
 
                         arena_dup(arena, request.version.literal.slice(request.version_buf()))

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -39,6 +39,73 @@ fn arena_dup<'a>(arena: &'a bun_alloc::Arena, bytes: &[u8]) -> &'a [u8] {
     arena.alloc_slice_copy(bytes)
 }
 
+/// Splits an `npm:` alias into the `npm:<name>` part `bun update` keeps and the version
+/// (or dist-tag) after it, which is empty for `npm:<name>` alone. The separator is the
+/// first `@` after the name, as in `Dependency::parse`, so a scoped name's leading `@`
+/// is not mistaken for it: `npm:@foo/bar@~1.2.3` -> (`npm:@foo/bar`, `~1.2.3`).
+fn split_npm_alias(literal: &[u8]) -> Option<(&[u8], &[u8])> {
+    let literal = strings::trim(literal, &strings::WHITESPACE_CHARS);
+    let name = literal.strip_prefix(b"npm:")?;
+    let scope_len = usize::from(name.starts_with(b"@"));
+    if name.len() == scope_len {
+        return None;
+    }
+    match strings::index_of_char_usize(&name[scope_len..], b'@') {
+        Some(i) => {
+            let (alias, version) = literal.split_at(b"npm:".len() + scope_len + i);
+            Some((alias, &version[1..]))
+        }
+        None => Some((literal, b"")),
+    }
+}
+
+/// The version `--latest` resolves in place of `version_literal`: `latest`, or
+/// `npm:<name>@latest` so an alias still resolves the aliased package rather than
+/// a package named after the alias.
+fn latest_version_literal<'a>(arena: &'a bun_alloc::Arena, version_literal: &[u8]) -> &'a [u8] {
+    match split_npm_alias(version_literal) {
+        Some((alias, _)) => {
+            let mut v = Vec::new();
+            write!(&mut v, "{}@latest", bstr::BStr::new(alias))
+                .expect("infallible: in-memory write");
+            arena_str(arena, &v)
+        }
+        None => b"latest",
+    }
+}
+
+/// The version `bun update` writes back once `original_version_literal` resolved to
+/// `resolved`: the original pin style (`1.2.3`, `~1.2.3` or `^1.2.3`) unless
+/// `exact_versions`, behind the original `npm:<name>@` prefix if it was an alias.
+fn updated_version_literal(
+    original_version_literal: &[u8],
+    resolved: semver::Version,
+    resolved_buf: &[u8],
+    exact_versions: bool,
+) -> Vec<u8> {
+    let mut v = Vec::new();
+    let version_literal = match split_npm_alias(original_version_literal) {
+        Some((alias, version_literal)) => {
+            write!(&mut v, "{}@", bstr::BStr::new(alias)).expect("infallible: in-memory write");
+            version_literal
+        }
+        None => original_version_literal,
+    };
+
+    let range_prefix = if exact_versions {
+        ""
+    } else {
+        match semver::Version::which_version_is_pinned(version_literal) {
+            semver::PinnedVersion::Patch => "",
+            semver::PinnedVersion::Minor => "~",
+            semver::PinnedVersion::Major => "^",
+        }
+    };
+    write!(&mut v, "{}{}", range_prefix, resolved.fmt(resolved_buf))
+        .expect("infallible: in-memory write");
+    v
+}
+
 /// Shallow-copy a `G::Property` for the JSON-editing path. Only `key`/`value`
 /// (both `Option<Expr>`, `Copy`) are populated by the JSON parser; the rest
 /// (`ts_decorators`, `class_static_block`, …) are always default for parsed
@@ -298,32 +365,14 @@ pub(crate) fn edit_update_no_args_in(
                         let version_literal = value
                             .as_utf8_string_literal()
                             .unwrap_or_else(|| bun_core::out_of_memory());
-                        let mut tag = dependency::Tag::infer(version_literal);
+                        // `Tag::infer` classifies an `npm:` alias by the version after its name.
+                        let tag = dependency::Tag::infer(version_literal);
 
                         // npm versions only (and dist-tags with --latest); `catalog:` is handled by edit_catalogs_*.
                         if tag != dependency::Tag::Npm
                             && (tag != dependency::Tag::DistTag || !update_to_latest)
                         {
                             continue;
-                        }
-
-                        let mut alias_at_index: Option<usize> = None;
-                        if strings::trim(version_literal, &strings::WHITESPACE_CHARS)
-                            .starts_with(b"npm:")
-                        {
-                            // negative because the real package might have a scope
-                            // e.g. "dep": "npm:@foo/bar@1.2.3"
-                            if let Some(at_index) =
-                                strings::last_index_of_char(version_literal, b'@')
-                            {
-                                tag = dependency::Tag::infer(&version_literal[at_index + 1..]);
-                                if tag != dependency::Tag::Npm
-                                    && (tag != dependency::Tag::DistTag || !update_to_latest)
-                                {
-                                    continue;
-                                }
-                                alias_at_index = Some(at_index);
-                            }
                         }
 
                         let key_str = key.as_utf8_string_literal().expect("unreachable");
@@ -341,26 +390,12 @@ pub(crate) fn edit_update_no_args_in(
 
                         *entry.value_ptr = PackageUpdateInfo {
                             original_version_literal: version_literal_owned,
-                            is_alias: alias_at_index.is_some(),
                             original_version_string_buf: Box::default(),
                             original_version: None,
                         };
 
                         if update_to_latest {
-                            // is it an aliased package
-                            let temp_version: &[u8] = if let Some(at_index) = alias_at_index {
-                                let mut v = Vec::new();
-                                write!(
-                                    &mut v,
-                                    "{}@latest",
-                                    bstr::BStr::new(&version_literal[0..at_index])
-                                )
-                                .unwrap();
-                                arena_str(arena, &v)
-                            } else {
-                                b"latest"
-                            };
-
+                            let temp_version = latest_version_literal(arena, version_literal);
                             dep.value = Some(Expr::allocate(
                                 arena,
                                 E::EString::init(temp_version),
@@ -415,7 +450,6 @@ pub(crate) fn edit_update_no_args_in(
                             // fetchSwapRemove because we want to update the first dependency with a matching
                             // name, or none at all
                             if let Some(entry) = updating_packages.fetch_swap_remove(key_str) {
-                                let is_alias = entry.value.is_alias;
                                 let dep_name = &*entry.key;
                                 debug_assert_eq!(
                                     workspace_deps.len(),
@@ -449,83 +483,13 @@ pub(crate) fn edit_update_no_args_in(
                                         }
                                     }
 
-                                    let new_version: Vec<u8> = 'new_version: {
+                                    let new_version = updated_version_literal(
+                                        &entry.value.original_version_literal,
                                         // `resolution.tag == Npm` checked above.
-                                        let version_fmt = resolution.npm().version.fmt(string_buf);
-                                        if options.exact_versions {
-                                            let mut v = Vec::new();
-                                            write!(&mut v, "{}", version_fmt)
-                                                .expect("infallible: in-memory write");
-                                            break 'new_version v;
-                                        }
-
-                                        let version_literal: &[u8] = 'version_literal: {
-                                            if !is_alias {
-                                                break 'version_literal &entry
-                                                    .value
-                                                    .original_version_literal;
-                                            }
-                                            if let Some(at_index) = strings::last_index_of_char(
-                                                &entry.value.original_version_literal,
-                                                b'@',
-                                            ) {
-                                                break 'version_literal &entry
-                                                    .value
-                                                    .original_version_literal[at_index + 1..];
-                                            }
-                                            &entry.value.original_version_literal
-                                        };
-
-                                        let pinned_version =
-                                            semver::Version::which_version_is_pinned(
-                                                version_literal,
-                                            );
-                                        let mut v = Vec::new();
-                                        match pinned_version {
-                                            semver::PinnedVersion::Patch => {
-                                                write!(&mut v, "{}", version_fmt)
-                                                    .expect("infallible: in-memory write")
-                                            }
-                                            semver::PinnedVersion::Minor => {
-                                                write!(&mut v, "~{}", version_fmt)
-                                                    .expect("infallible: in-memory write")
-                                            }
-                                            semver::PinnedVersion::Major => {
-                                                write!(&mut v, "^{}", version_fmt)
-                                                    .expect("infallible: in-memory write")
-                                            }
-                                        }
-                                        v
-                                    };
-
-                                    if is_alias {
-                                        let dep_literal =
-                                            workspace_dep.version.literal.slice(string_buf);
-
-                                        // negative because the real package might have a scope
-                                        // e.g. "dep": "npm:@foo/bar@1.2.3"
-                                        if let Some(at_index) =
-                                            strings::last_index_of_char(dep_literal, b'@')
-                                        {
-                                            let mut v = Vec::new();
-                                            write!(
-                                                &mut v,
-                                                "{}@{}",
-                                                bstr::BStr::new(&dep_literal[0..at_index]),
-                                                bstr::BStr::new(&new_version)
-                                            )
-                                            .unwrap();
-                                            dep.value = Some(Expr::allocate(
-                                                arena,
-                                                E::EString::init(arena_str(arena, &v)),
-                                                bun_ast::Loc::EMPTY,
-                                            ));
-                                            break 'updated;
-                                        }
-
-                                        // fallthrough and replace entire version.
-                                    }
-
+                                        resolution.npm().version,
+                                        string_buf,
+                                        options.exact_versions,
+                                    );
                                     dep.value = Some(Expr::allocate(
                                         arena,
                                         E::EString::init(arena_str(arena, &new_version)),
@@ -583,7 +547,8 @@ fn for_each_catalog_object(
 }
 
 /// Records the original version of every catalog entry and, with `--latest`,
-/// rewrites each to `latest` in memory so the resolver fetches it.
+/// rewrites each to `latest` (`npm:<name>@latest` for aliases) in memory so the
+/// resolver fetches it.
 pub(crate) fn edit_catalogs_before_update(
     manager: &mut PackageManager,
     root_package_json: &Expr,
@@ -621,16 +586,7 @@ pub(crate) fn edit_catalogs_before_update(
             let version_literal = value
                 .as_utf8_string_literal()
                 .unwrap_or_else(|| bun_core::out_of_memory());
-            let mut tag = dependency::Tag::infer(version_literal);
-
-            let mut alias_at_index: Option<usize> = None;
-            if strings::trim(version_literal, &strings::WHITESPACE_CHARS).starts_with(b"npm:") {
-                // last '@' handles scoped aliases like "npm:@foo/bar@1.2.3"
-                if let Some(at_index) = strings::last_index_of_char(version_literal, b'@') {
-                    tag = dependency::Tag::infer(&version_literal[at_index + 1..]);
-                    alias_at_index = Some(at_index);
-                }
-            }
+            let tag = dependency::Tag::infer(version_literal);
 
             // same tag rule as direct dependencies
             if tag != dependency::Tag::Npm && (tag != dependency::Tag::DistTag || !update_to_latest)
@@ -646,23 +602,10 @@ pub(crate) fn edit_catalogs_before_update(
                 catalog_name: Box::from(catalog_name),
                 dep_name: Box::from(key_str),
                 original_version_literal: Box::from(version_literal),
-                is_alias: alias_at_index.is_some(),
             });
 
             if update_to_latest {
-                let temp_version: &[u8] = if let Some(at_index) = alias_at_index {
-                    let mut v = Vec::new();
-                    write!(
-                        &mut v,
-                        "{}@latest",
-                        bstr::BStr::new(&version_literal[0..at_index])
-                    )
-                    .expect("infallible: in-memory write");
-                    arena_str(arena, &v)
-                } else {
-                    b"latest"
-                };
-
+                let temp_version = latest_version_literal(arena, version_literal);
                 dep.value = Some(Expr::allocate(
                     arena,
                     E::EString::init(temp_version),
@@ -743,61 +686,12 @@ pub(crate) fn edit_catalogs_after_update(
             }
         }
 
-        let info = &infos[index];
-        let version_fmt = resolution.npm().version.fmt(string_buf);
-        let new_version: Vec<u8> = 'new_version: {
-            if options.exact_versions {
-                let mut v = Vec::new();
-                write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write");
-                break 'new_version v;
-            }
-
-            let version_literal: &[u8] = 'version_literal: {
-                if !info.is_alias {
-                    break 'version_literal &info.original_version_literal;
-                }
-                if let Some(at_index) =
-                    strings::last_index_of_char(&info.original_version_literal, b'@')
-                {
-                    break 'version_literal &info.original_version_literal[at_index + 1..];
-                }
-                &info.original_version_literal
-            };
-
-            let pinned_version = semver::Version::which_version_is_pinned(version_literal);
-            let mut v = Vec::new();
-            match pinned_version {
-                semver::PinnedVersion::Patch => {
-                    write!(&mut v, "{}", version_fmt).expect("infallible: in-memory write")
-                }
-                semver::PinnedVersion::Minor => {
-                    write!(&mut v, "~{}", version_fmt).expect("infallible: in-memory write")
-                }
-                semver::PinnedVersion::Major => {
-                    write!(&mut v, "^{}", version_fmt).expect("infallible: in-memory write")
-                }
-            }
-            v
-        };
-
-        new_literals[index] = Some(if info.is_alias {
-            let dep_literal = &info.original_version_literal;
-            if let Some(at_index) = strings::last_index_of_char(dep_literal, b'@') {
-                let mut v = Vec::new();
-                write!(
-                    &mut v,
-                    "{}@{}",
-                    bstr::BStr::new(&dep_literal[0..at_index]),
-                    bstr::BStr::new(&new_version)
-                )
-                .expect("infallible: in-memory write");
-                v
-            } else {
-                new_version
-            }
-        } else {
-            new_version
-        });
+        new_literals[index] = Some(updated_version_literal(
+            &infos[index].original_version_literal,
+            resolution.npm().version,
+            string_buf,
+            options.exact_versions,
+        ));
     }
 
     let mut changed = false;
@@ -937,8 +831,9 @@ pub(crate) fn edit(
                                                 else {
                                                     break 'add_packages_to_update;
                                                 };
-                                                let mut tag =
-                                                    dependency::Tag::infer(version_literal);
+                                                // `Tag::infer` classifies an `npm:` alias by
+                                                // the version after its name.
+                                                let tag = dependency::Tag::infer(version_literal);
 
                                                 if tag != dependency::Tag::Npm
                                                     && tag != dependency::Tag::DistTag
@@ -959,38 +854,8 @@ pub(crate) fn edit(
                                                     break 'add_packages_to_update;
                                                 }
 
-                                                // `get_or_put` default-initializes the slot,
-                                                // so the `npm:`-alias bailout path below
-                                                // (later read by `fetchSwapRemove`) is
-                                                // well-defined.
-                                                let mut is_alias = false;
-                                                if strings::trim(
-                                                    &version_literal_owned,
-                                                    &strings::WHITESPACE_CHARS,
-                                                )
-                                                .starts_with(b"npm:")
-                                                {
-                                                    if let Some(at_index) =
-                                                        strings::last_index_of_char(
-                                                            &version_literal_owned,
-                                                            b'@',
-                                                        )
-                                                    {
-                                                        tag = dependency::Tag::infer(
-                                                            &version_literal_owned[at_index + 1..],
-                                                        );
-                                                        if tag != dependency::Tag::Npm
-                                                            && tag != dependency::Tag::DistTag
-                                                        {
-                                                            break 'add_packages_to_update;
-                                                        }
-                                                        is_alias = true;
-                                                    }
-                                                }
-
                                                 *entry.value_ptr = PackageUpdateInfo {
                                                     original_version_literal: version_literal_owned,
-                                                    is_alias,
                                                     original_version_string_buf: Box::default(),
                                                     original_version: None,
                                                 };
@@ -1430,29 +1295,29 @@ pub(crate) fn edit(
             if request.package_id as usize >= resolutions.len()
                 || resolutions[request.package_id as usize].tag == resolution::Tag::Uninitialized
             {
-                e_string.data = 'uninitialized: {
-                    if manager.subcommand == Subcommand::Update
-                        && manager.options.do_.contains(Do::UPDATE_TO_LATEST)
-                    {
-                        break 'uninitialized b"latest".into();
-                    }
-
-                    if manager.subcommand != Subcommand::Update
-                        || !options.before_install
-                        || e_string.is_blank()
-                        || request.version.tag == dependency::Tag::Npm
-                    {
-                        break 'uninitialized match request.version.tag {
-                            dependency::Tag::Uninitialized => b"latest".into(),
-                            _ => arena_dup(
-                                arena,
-                                request.version.literal.slice(request.version_buf()),
-                            )
+                // `bun update <name>` re-resolves what package.json already has; everything
+                // else resolves the request itself.
+                let version_literal: bun_ast::StoreStr = if manager.subcommand != Subcommand::Update
+                    || !options.before_install
+                    || e_string.is_blank()
+                    || request.version.tag == dependency::Tag::Npm
+                {
+                    match request.version.tag {
+                        dependency::Tag::Uninitialized => b"latest".into(),
+                        _ => arena_dup(arena, request.version.literal.slice(request.version_buf()))
                             .into(),
-                        };
-                    } else {
-                        break 'uninitialized e_string.data;
                     }
+                } else {
+                    e_string.data
+                };
+
+                e_string.data = if manager.subcommand == Subcommand::Update
+                    && manager.options.do_.contains(Do::UPDATE_TO_LATEST)
+                {
+                    // Keeps an alias pointed at its target: `npm:<name>@latest`, not `latest`.
+                    latest_version_literal(arena, version_literal.slice()).into()
+                } else {
+                    version_literal
                 };
 
                 continue;
@@ -1467,74 +1332,12 @@ pub(crate) fn edit(
                             if let Some(entry) =
                                 manager.updating_packages.fetch_swap_remove(request.name)
                             {
-                                let new_version: Vec<u8> = 'new_version: {
-                                    let version_fmt = resolutions[request.package_id as usize]
-                                        .npm()
-                                        .version
-                                        .fmt(manager.lockfile.buffers.string_bytes.as_slice());
-                                    if options.exact_versions {
-                                        let mut v = Vec::new();
-                                        write!(&mut v, "{}", version_fmt)
-                                            .expect("infallible: in-memory write");
-                                        break 'new_version v;
-                                    }
-
-                                    let version_literal: &[u8] = 'version_literal: {
-                                        if !entry.value.is_alias {
-                                            break 'version_literal &entry
-                                                .value
-                                                .original_version_literal;
-                                        }
-                                        if let Some(at_index) = strings::last_index_of_char(
-                                            &entry.value.original_version_literal,
-                                            b'@',
-                                        ) {
-                                            break 'version_literal &entry
-                                                .value
-                                                .original_version_literal[at_index + 1..];
-                                        }
-
-                                        &entry.value.original_version_literal
-                                    };
-
-                                    let pinned_version =
-                                        semver::Version::which_version_is_pinned(version_literal);
-                                    let mut v = Vec::new();
-                                    match pinned_version {
-                                        semver::PinnedVersion::Patch => {
-                                            write!(&mut v, "{}", version_fmt)
-                                                .expect("infallible: in-memory write")
-                                        }
-                                        semver::PinnedVersion::Minor => {
-                                            write!(&mut v, "~{}", version_fmt)
-                                                .expect("infallible: in-memory write")
-                                        }
-                                        semver::PinnedVersion::Major => {
-                                            write!(&mut v, "^{}", version_fmt)
-                                                .expect("infallible: in-memory write")
-                                        }
-                                    }
-                                    v
-                                };
-
-                                if entry.value.is_alias {
-                                    let dep_literal = &entry.value.original_version_literal;
-
-                                    if let Some(at_index) =
-                                        strings::last_index_of_char(dep_literal, b'@')
-                                    {
-                                        let mut v = Vec::new();
-                                        write!(
-                                            &mut v,
-                                            "{}@{}",
-                                            bstr::BStr::new(&dep_literal[0..at_index]),
-                                            bstr::BStr::new(&new_version)
-                                        )
-                                        .unwrap();
-                                        break 'npm arena_str(arena, &v);
-                                    }
-                                }
-
+                                let new_version = updated_version_literal(
+                                    &entry.value.original_version_literal,
+                                    resolutions[request.package_id as usize].npm().version,
+                                    manager.lockfile.buffers.string_bytes.as_slice(),
+                                    options.exact_versions,
+                                );
                                 break 'npm arena_str(arena, &new_version);
                             }
                         }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5370,6 +5370,8 @@ describe("update", () => {
       args: string[];
       after: string;
       realName?: string;
+      /** `[install] exact = true` in bunfig.toml */
+      exact?: boolean;
     }[] = [
       // --latest with a package name used to request `latest` of `aliased-dep` itself (404)
       {
@@ -5418,6 +5420,15 @@ describe("update", () => {
         args: ["aliased-dep@npm:no-deps", "--latest"],
         after: "npm:no-deps@~2.0.0",
       },
+      // `exact` replaces the range but not the alias target
+      {
+        before: "npm:no-deps@~1.0.0",
+        installed: "1.0.1",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:no-deps@2.0.0",
+        exact: true,
+      },
+      { before: "npm:no-deps@~1.0.0", installed: "1.0.1", args: ["--latest"], after: "npm:no-deps@2.0.0", exact: true },
       // without a version after the alias target, the `npm:<name>@` prefix used to be dropped
       // (`"aliased-dep": "^2.0.0"`, which the next install resolves as a different package)
       { before: "npm:no-deps", installed: "2.0.0", args: ["aliased-dep"], after: "npm:no-deps@^2.0.0" },
@@ -5440,7 +5451,7 @@ describe("update", () => {
     ];
     test.each(aliasUpdateCases)(
       `"aliased-dep": "$before" + bun update $args -> "$after"`,
-      async ({ before, installed, args, after, realName = "no-deps" }) => {
+      async ({ before, installed, args, after, realName = "no-deps", exact = false }) => {
         await write(
           packageJson,
           JSON.stringify({
@@ -5450,6 +5461,11 @@ describe("update", () => {
             },
           }),
         );
+        if (exact) {
+          // the bunfig written by the registry helper only has an `[install]` table
+          const bunfig = join(packageDir, "bunfig.toml");
+          await write(bunfig, (await file(bunfig).text()) + "exact = true\n");
+        }
 
         await runBunInstall(env, packageDir);
         expect(await file(join(packageDir, "node_modules", "aliased-dep", "package.json")).json()).toMatchObject({

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5366,9 +5366,12 @@ describe("update", () => {
     // the alias name itself (`aliased-dep`) does not exist in the registry.
     const aliasUpdateCases: {
       before: string;
+      /** version installed by `bun install` of `before` */
       installed: string;
       args: string[];
       after: string;
+      /** version installed after the update, 2.0.0 unless the request asks for less */
+      installedAfter?: string;
       realName?: string;
       /** `[install] exact = true` in bunfig.toml */
       exact?: boolean;
@@ -5420,6 +5423,29 @@ describe("update", () => {
         args: ["aliased-dep@npm:no-deps", "--latest"],
         after: "npm:no-deps@~2.0.0",
       },
+      // a request naming a plain version applies it to the alias target (as `bun update no-deps@^1.0.0`
+      // does to a plain dependency) instead of resolving `aliased-dep@<version>` from the registry
+      {
+        before: "npm:no-deps@~1.0.0",
+        installed: "1.0.1",
+        args: ["aliased-dep@^1.0.0"],
+        after: "npm:no-deps@~1.1.0",
+        installedAfter: "1.1.0",
+      },
+      { before: "npm:no-deps@~1.0.0", installed: "1.0.1", args: ["aliased-dep@2.0.0"], after: "npm:no-deps@~2.0.0" },
+      {
+        before: "npm:no-deps@~1.0.0",
+        installed: "1.0.1",
+        args: ["aliased-dep@1.0.0", "--latest"],
+        after: "npm:no-deps@~2.0.0",
+      },
+      {
+        before: "npm:@types/no-deps@1.0.0",
+        installed: "1.0.0",
+        args: ["aliased-dep@^2.0.0"],
+        after: "npm:@types/no-deps@2.0.0",
+        realName: "@types/no-deps",
+      },
       // `exact` replaces the range but not the alias target
       {
         before: "npm:no-deps@~1.0.0",
@@ -5451,7 +5477,7 @@ describe("update", () => {
     ];
     test.each(aliasUpdateCases)(
       `"aliased-dep": "$before" + bun update $args -> "$after"`,
-      async ({ before, installed, args, after, realName = "no-deps", exact = false }) => {
+      async ({ before, installed, args, after, installedAfter = "2.0.0", realName = "no-deps", exact = false }) => {
         await write(
           packageJson,
           JSON.stringify({
@@ -5484,13 +5510,50 @@ describe("update", () => {
         });
         expect(await file(join(packageDir, "node_modules", "aliased-dep", "package.json")).json()).toMatchObject({
           name: realName,
-          version: "2.0.0",
+          version: installedAfter,
         });
 
         // the rewritten literal still installs (it must not name `aliased-dep` itself)
         await runBunInstall(env, packageDir, { savesLockfile: false });
       },
     );
+    // `bun update <new-name>@npm:<target>` adds the dependency; the written value used to be cut at
+    // the first `@`, which for a scoped target is the scope (`"npm:@^1.0.0"`), and a target without a
+    // version lost its `npm:` prefix entirely.
+    test.each([
+      [
+        "new-alias@npm:@types/no-deps@^1.0.0",
+        "npm:@types/no-deps@^1.0.0",
+        { name: "@types/no-deps", version: "1.0.0" },
+      ],
+      ["new-alias@npm:@types/no-deps", "npm:@types/no-deps@^2.0.0", { name: "@types/no-deps", version: "2.0.0" }],
+      ["new-alias@npm:no-deps", "npm:no-deps@^2.0.0", { name: "no-deps", version: "2.0.0" }],
+      ["new-alias@npm:no-deps@^1.0.0", "npm:no-deps@^1.1.0", { name: "no-deps", version: "1.1.0" }],
+    ])("bun update %s adds %s", async (request, written, installed) => {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: {
+            "a-dep": "1.0.1",
+          },
+        }),
+      );
+
+      await runBunUpdate(env, packageDir, [request]);
+      assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        dependencies: {
+          "a-dep": "1.0.1",
+          "new-alias": written,
+        },
+      });
+      expect(await file(join(packageDir, "node_modules", "new-alias", "package.json")).json()).toEqual(installed);
+
+      await runBunInstall(env, packageDir, { savesLockfile: false });
+    });
     test("update specific aliased package with --latest alongside a regular package", async () => {
       await write(
         packageJson,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5361,6 +5361,163 @@ describe("update", () => {
         version: "1.1.0",
       });
     });
+    // `no-deps` and `@types/no-deps` both have 1.x releases and `latest` = 2.0.0.
+    // Every `npm:` form `bun update` rewrites must keep pointing at the aliased package:
+    // the alias name itself (`aliased-dep`) does not exist in the registry.
+    const aliasUpdateCases: {
+      before: string;
+      installed: string;
+      args: string[];
+      after: string;
+      realName?: string;
+    }[] = [
+      // --latest with a package name used to request `latest` of `aliased-dep` itself (404)
+      {
+        before: "npm:no-deps@^1.0.0",
+        installed: "1.1.0",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:no-deps@^2.0.0",
+      },
+      {
+        before: "npm:no-deps@~1.0.0",
+        installed: "1.0.1",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:no-deps@~2.0.0",
+      },
+      {
+        before: "npm:no-deps@1.0.0",
+        installed: "1.0.0",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:no-deps@2.0.0",
+      },
+      {
+        before: "npm:no-deps@latest",
+        installed: "2.0.0",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:no-deps@^2.0.0",
+      },
+      { before: "npm:no-deps", installed: "2.0.0", args: ["aliased-dep", "--latest"], after: "npm:no-deps@^2.0.0" },
+      {
+        before: "npm:@types/no-deps@~1.0.0",
+        installed: "1.0.0",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:@types/no-deps@~2.0.0",
+        realName: "@types/no-deps",
+      },
+      {
+        before: "npm:@types/no-deps",
+        installed: "2.0.0",
+        args: ["aliased-dep", "--latest"],
+        after: "npm:@types/no-deps@^2.0.0",
+        realName: "@types/no-deps",
+      },
+      // a request spelling out the alias target is still resolved against that target
+      {
+        before: "npm:no-deps@~1.0.0",
+        installed: "1.0.1",
+        args: ["aliased-dep@npm:no-deps", "--latest"],
+        after: "npm:no-deps@~2.0.0",
+      },
+      // without a version after the alias target, the `npm:<name>@` prefix used to be dropped
+      // (`"aliased-dep": "^2.0.0"`, which the next install resolves as a different package)
+      { before: "npm:no-deps", installed: "2.0.0", args: ["aliased-dep"], after: "npm:no-deps@^2.0.0" },
+      { before: "npm:no-deps", installed: "2.0.0", args: [], after: "npm:no-deps@^2.0.0" },
+      { before: "npm:no-deps", installed: "2.0.0", args: ["--latest"], after: "npm:no-deps@^2.0.0" },
+      {
+        before: "npm:@types/no-deps",
+        installed: "2.0.0",
+        args: ["aliased-dep"],
+        after: "npm:@types/no-deps@^2.0.0",
+        realName: "@types/no-deps",
+      },
+      {
+        before: "npm:@types/no-deps",
+        installed: "2.0.0",
+        args: ["--latest"],
+        after: "npm:@types/no-deps@^2.0.0",
+        realName: "@types/no-deps",
+      },
+    ];
+    test.each(aliasUpdateCases)(
+      `"aliased-dep": "$before" + bun update $args -> "$after"`,
+      async ({ before, installed, args, after, realName = "no-deps" }) => {
+        await write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies: {
+              "aliased-dep": before,
+            },
+          }),
+        );
+
+        await runBunInstall(env, packageDir);
+        expect(await file(join(packageDir, "node_modules", "aliased-dep", "package.json")).json()).toMatchObject({
+          name: realName,
+          version: installed,
+        });
+
+        await runBunUpdate(env, packageDir, args);
+        assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+        expect(await file(packageJson).json()).toEqual({
+          name: "foo",
+          dependencies: {
+            "aliased-dep": after,
+          },
+        });
+        expect(await file(join(packageDir, "node_modules", "aliased-dep", "package.json")).json()).toMatchObject({
+          name: realName,
+          version: "2.0.0",
+        });
+
+        // the rewritten literal still installs (it must not name `aliased-dep` itself)
+        await runBunInstall(env, packageDir, { savesLockfile: false });
+      },
+    );
+    test("update specific aliased package with --latest alongside a regular package", async () => {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          devDependencies: {
+            "aliased-dep": "npm:no-deps@^1.0.0",
+          },
+          dependencies: {
+            "a-dep": "1.0.1",
+            "no-deps": "~1.0.0",
+          },
+        }),
+      );
+
+      await runBunInstall(env, packageDir);
+
+      await runBunUpdate(env, packageDir, ["aliased-dep", "no-deps", "--latest"]);
+      assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        devDependencies: {
+          "aliased-dep": "npm:no-deps@^2.0.0",
+        },
+        dependencies: {
+          "a-dep": "1.0.1",
+          "no-deps": "~2.0.0",
+        },
+      });
+      expect(await file(join(packageDir, "node_modules", "aliased-dep", "package.json")).json()).toMatchObject({
+        name: "no-deps",
+        version: "2.0.0",
+      });
+      expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+        name: "no-deps",
+        version: "2.0.0",
+      });
+      expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).toMatchObject({
+        name: "a-dep",
+        version: "1.0.1",
+      });
+    });
     test("with pre and build tags", async () => {
       await write(
         packageJson,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5554,6 +5554,58 @@ describe("update", () => {
 
       await runBunInstall(env, packageDir, { savesLockfile: false });
     });
+    // `bun update <name>@npm:<other>` installs the other package, so package.json has to be pointed at
+    // it as well (keeping only the entry's pin style). It used to keep the old target (or a plain range
+    // of it) next to the new package's version. a-dep's latest is 1.0.10.
+    test.each([
+      {
+        key: "aliased-dep",
+        before: "npm:no-deps@~1.0.0",
+        args: ["aliased-dep@npm:a-dep@^1.0.0"],
+        after: "npm:a-dep@~1.0.10",
+      },
+      { key: "aliased-dep", before: "npm:no-deps@~1.0.0", args: ["aliased-dep@npm:a-dep"], after: "npm:a-dep@~1.0.10" },
+      {
+        key: "aliased-dep",
+        before: "npm:no-deps@~1.0.0",
+        args: ["aliased-dep@npm:a-dep", "--latest"],
+        after: "npm:a-dep@~1.0.10",
+      },
+      { key: "aliased-dep", before: "npm:no-deps", args: ["aliased-dep@npm:a-dep"], after: "npm:a-dep@^1.0.10" },
+      { key: "no-deps", before: "~1.0.0", args: ["no-deps@npm:a-dep"], after: "npm:a-dep@~1.0.10" },
+      { key: "no-deps", before: "1.0.0", args: ["no-deps@npm:a-dep@^1.0.0"], after: "npm:a-dep@1.0.10" },
+    ])(`"$key": "$before" + bun update $args retargets it to "$after"`, async ({ key, before, args, after }) => {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: {
+            [key]: before,
+          },
+        }),
+      );
+
+      await runBunInstall(env, packageDir);
+      expect((await file(join(packageDir, "node_modules", key, "package.json")).json()).name).toBe("no-deps");
+
+      await runBunUpdate(env, packageDir, args);
+      assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        dependencies: {
+          [key]: after,
+        },
+      });
+      expect(await file(join(packageDir, "node_modules", key, "package.json")).json()).toMatchObject({
+        name: "a-dep",
+        version: "1.0.10",
+      });
+
+      // package.json now names the package that is installed, so reinstalling keeps it
+      await runBunInstall(env, packageDir, { savesLockfile: false });
+      expect((await file(join(packageDir, "node_modules", key, "package.json")).json()).name).toBe("a-dep");
+    });
     test("update specific aliased package with --latest alongside a regular package", async () => {
       await write(
         packageJson,

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -497,6 +497,80 @@ describe("update", () => {
     expect(exitCode).toBe(0);
   });
 
+  // Catalog entries written as `npm:` aliases have to keep naming the aliased package when they
+  // are rewritten: the alias keys themselves do not exist in the registry.
+  test.each([
+    {
+      args: [] as string[],
+      expectedCatalog: {
+        "aliased-range": "npm:no-deps@~1.0.1",
+        "aliased-bare": "npm:no-deps@^2.0.0",
+        "aliased-scoped-bare": "npm:@types/no-deps@^2.0.0",
+      },
+      expectedRangeVersion: "1.0.1",
+    },
+    {
+      args: ["--latest"],
+      expectedCatalog: {
+        "aliased-range": "npm:no-deps@~2.0.0",
+        "aliased-bare": "npm:no-deps@^2.0.0",
+        "aliased-scoped-bare": "npm:@types/no-deps@^2.0.0",
+      },
+      expectedRangeVersion: "2.0.0",
+    },
+  ])(
+    "update $args keeps the alias target of npm: aliases in catalogs",
+    async ({ args, expectedCatalog, expectedRangeVersion }) => {
+      const { packageDir } = await registry.createTestDir();
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "catalog-update-aliases",
+            workspaces: {
+              packages: ["packages/*"],
+              catalog: {
+                "aliased-range": "npm:no-deps@~1.0.0",
+                "aliased-bare": "npm:no-deps",
+                "aliased-scoped-bare": "npm:@types/no-deps",
+              },
+            },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg1", "package.json"),
+          JSON.stringify({
+            name: "pkg1",
+            dependencies: {
+              "aliased-range": "catalog:",
+              "aliased-bare": "catalog:",
+              "aliased-scoped-bare": "catalog:",
+            },
+          }),
+        ),
+      ]);
+      await runBunInstall(bunEnv, packageDir);
+
+      const { err, exitCode } = await runUpdate(packageDir, ...args);
+      expect(err).not.toContain("error:");
+
+      expect((await file(join(packageDir, "package.json")).json()).workspaces.catalog).toEqual(expectedCatalog);
+      expect(await file(join(packageDir, "node_modules", "aliased-range", "package.json")).json()).toEqual({
+        name: "no-deps",
+        version: expectedRangeVersion,
+      });
+      expect(await file(join(packageDir, "node_modules", "aliased-bare", "package.json")).json()).toEqual({
+        name: "no-deps",
+        version: "2.0.0",
+      });
+      expect(await file(join(packageDir, "node_modules", "aliased-scoped-bare", "package.json")).json()).toEqual({
+        name: "@types/no-deps",
+        version: "2.0.0",
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test("update <pkg> --latest keeps the catalog reference", async () => {
     const { packageDir } = await registry.createTestDir();
     await createUpdateMonorepo(packageDir, "catalog-update-targeted");


### PR DESCRIPTION
### Problem
- With `"aliased-dep": "npm:no-deps@~1.0.0"` in package.json, `bun update aliased-dep --latest` fails with `error: GET http://<registry>/aliased-dep - 404`. Plain `bun update aliased-dep` and a bare `bun update --latest` work.
- Cause: before the install, `PackageJSONEditor::edit` rewrites the entry in the in-memory package.json so the resolver fetches the new version. Under `--latest` it wrote a bare `latest` (`src/install/PackageManager/PackageJSONEditor.rs`, the branch for requests that have no resolution yet), which is a dist-tag of the package named `aliased-dep`. The bare-`bun update` pass already wrote `npm:no-deps@latest` here; the named pass did not handle aliases at all. The same branch writes a requested version as-is, so `bun update aliased-dep@2.0.0` also resolved `aliased-dep` from the registry (404), and `aliased-dep@^1.0.0` only "worked" because the resolver redirected it back to the old `~1.0.0` spec, ignoring the requested range.
- Same class, same file: every other place that rewrites an alias (bare `bun update`, catalogs, and the post-install write-back that all three paths use) found the alias target by splitting the literal on its last `@`. An alias written without a version (`"x": "npm:no-deps"`, meaning any version of `no-deps`) has no such `@`, so it was treated as a plain range and rewritten to `"x": "^2.0.0"`: the alias is gone and the next `bun install` 404s on `x`. With `--latest` it 404ed immediately. The scoped form `npm:@types/no-deps` split on the scope's `@` and was silently skipped. This applied to `bun update`, `bun update <name>`, and catalog entries alike.
- Retargeting an existing entry, `bun update aliased-dep@npm:a-dep` (or `no-deps@npm:a-dep` on a plain entry), installed `a-dep` but wrote the entry back as `npm:no-deps@~<a-dep's version>` (or a plain `~<a-dep's version>`): the post-install write-back took the target from the literal recorded before the install, so package.json and node_modules disagreed until the next `bun install` swapped the package back.
- The write-back for a request that spells out an alias for a new entry (`bun update x@npm:@types/no-deps@^1.0.0`) cut the request at its first `@`, which for a scoped target is the scope, and wrote `"x": "npm:@^1.0.0"`; `x@npm:no-deps` (no version) wrote `"x": "^2.0.0"`.

### Fix
- One helper, `split_npm_alias`, splits a literal into `npm:<name>` and the version after it using the grammar `Dependency::parse` and `Tag::infer` already use (skip a leading `@` of a scoped name, then split at the next `@`; no `@` means an empty version).
- Two formatters built on it replace every inline copy: `with_alias_of` puts a version behind another literal's `npm:<name>@` (used for the `--latest` placeholder, `with_alias_of(entry, "latest")`, in the bare, named and catalog paths; for re-attaching the existing entry's target to a version named on the command line; and for the request-spelled write-back), and `updated_version_literal` writes the resolved version back in the original pin style, or exact, behind the original prefix (bare, named and catalog write-backs).
- The pre-install branch for `bun update` now starts from the same literal it used before (the package.json entry, or the request's own version when one was given) and then keeps the entry's alias target and, under `--latest`, swaps in `latest`. For a plain dependency every input still produces exactly what it did before (`latest`, the entry, or the requested version).
- The post-install write-back for a named update takes the target from the literal that was actually installed when that literal is an `npm:` alias (after the install, `request.version` is the root dependency that got resolved, so this covers `x@npm:other`, with or without a version, and `x@npm:other --latest`, whose installed literal is a dist-tag), and keeps only the entry's pin style. A plain installed literal is not used: `Lockfile::preprocess_update_requests` rewrites it to a bare `^<version>` for plain-name requests (the `TODO` about aliases there), so those keep formatting from the recorded original literal exactly as before.
- `PackageUpdateInfo.is_alias` and `CatalogUpdateInfo.is_alias` were only ever the result of the last-`@` split on the stored literal; the write-back now derives that from the literal, so the fields are removed.
- Why this is the right shape: for any alias that carries a version, the first `@` after the name and the last `@` are the same byte (versions and dist-tags cannot contain `@`), so every previously working rewrite produces the same bytes as before; the only outputs that change are the broken ones above. The tag re-inference the old code did on the part after the `@` was redundant with `Tag::infer`, which already classifies an `npm:` literal by the version after its name. A version-less alias now becomes `npm:no-deps@^2.0.0`, matching what `bun update` already does to a plain `"no-deps": "*"`; a version named on the command line is applied to the alias target and written back in the entry's pin style, matching what `bun update no-deps@^1.0.0` does to a plain `"no-deps": "~1.0.0"` (`~1.1.0`).
- Overlap with #38190 (issue #11901, `bun add x@npm:y@<dist-tag>` losing the alias): that PR rewrites the request-spelled write-back block to format from the resolved package name. This PR only fixes how the existing block extracts the prefix from the request and leaves the dist-tag case to it. Whichever lands second has a small conflict in that block; the `update <new-name>@npm:...` tests added here describe what the block has to keep producing (reading #38190's current formatter, it attaches the target only for version-less and dist-tag requests, so the versioned rows here would flag that at rebase time).
- Tests, all in existing files: `test/cli/install/bun-install-registry.test.ts` (`update > alises`): a 19 case matrix over `^`, `~`, exact pin, dist-tag, version-less and scoped aliases and `exact = true` in bunfig, crossed with `update <name> --latest`, `update <name>@npm:<target> --latest`, `update <name>@<version>` with and without `--latest`, `update <name>`, `update`, `update --latest`; a multi-target run that checks the `~` sibling and an untouched dependency; four `update <new-name>@npm:<target>...` additions; six retargets (`<name>@npm:a-dep...` on alias and plain entries, with and without a version, with `--latest`); `test/cli/install/catalogs.test.ts` (`update`): catalog entries in the three alias forms under `bun update` and `bun update --latest`. 30 of the 32 new cases fail on the current release (404, a wrong literal, or an unchanged one) and pass with this change; the other two (bare `update --latest` on a versioned alias with `exact = true`, and adding an unscoped versioned alias) already passed and pin the paths the shared formatters replaced.
- Also run with the debug build: all of `bun-install-registry.test.ts` (260 pass, 5 pre-existing todo), `catalogs.test.ts`, `bun-update.test.ts`, `bun-add.test.ts`, `regression/issue/24131`, `26657`; `cargo clippy -p bun_install` and `cargo fmt --check` are clean.

### Background
- npm alias: a dependency whose package.json value is `npm:<real-name>@<range>` (or just `npm:<real-name>`, any version). The key is a local name that need not exist in the registry; the manifest fetched is `<real-name>`'s. Scoped real names start with `@`, so the literal can contain two `@`s.
- How `bun update` edits package.json: it runs in two passes. Before the install it rewrites the targeted entries of an in-memory copy to what should be resolved (the existing literal, a version given on the command line, or a `latest` placeholder under `--latest`), records each original literal, and installs from that copy. After the install it writes the resolved version back in the original's pin style. Three entry points share this: `edit` for `bun update <names>` (also used by `bun add`), `edit_update_no_args` for a bare `bun update`, and `edit_catalogs_*` for workspace catalog entries. The on-disk package.json is only written after a successful install, which is why the 404 left it untouched.
- `Tag::infer` is the dependency-literal classifier; for an `npm:` literal it already looks at the part after the name's `@` and returns `Npm` when there is none, which is the behavior the removed re-inference duplicated.
- `known_npm_aliases` (PackageManagerEnqueue.rs): when a plain dependency has the same name as an alias recorded from the lockfile and its range overlaps, the resolver resolves the recorded alias spec instead. This is what made `bun update aliased-dep@^1.0.0` appear to work while ignoring the requested range; writing `npm:no-deps@^1.0.0` bypasses it, so the request is honored.

<details>
<summary>Behavior on the current release vs this branch (local registry; no-deps and @types/no-deps have latest = 2.0.0)</summary>

| package.json value | command | before | after |
| --- | --- | --- | --- |
| `npm:no-deps@~1.0.0` | `update aliased --latest` | `GET /aliased - 404` | `npm:no-deps@~2.0.0` |
| `npm:no-deps@latest` | `update aliased --latest` | 404 | `npm:no-deps@^2.0.0` |
| `npm:no-deps` | `update aliased --latest` | 404 | `npm:no-deps@^2.0.0` |
| `npm:no-deps@~1.0.0` | `update aliased@npm:no-deps --latest` | 404 | `npm:no-deps@~2.0.0` |
| `npm:no-deps@~1.0.0` | `update aliased@^1.0.0` | `npm:no-deps@~1.0.1` (requested range ignored) | `npm:no-deps@~1.1.0` |
| `npm:no-deps@~1.0.0` | `update aliased@2.0.0` | 404 | `npm:no-deps@~2.0.0` |
| `npm:no-deps@~1.0.0` | `update aliased@1.0.0 --latest` | 404 | `npm:no-deps@~2.0.0` |
| `npm:no-deps` | `update aliased` | `^2.0.0` (alias lost) | `npm:no-deps@^2.0.0` |
| `npm:no-deps` | `update` | `^2.0.0` (alias lost) | `npm:no-deps@^2.0.0` |
| `npm:no-deps` | `update --latest` | 404 | `npm:no-deps@^2.0.0` |
| `npm:@types/no-deps` | `update --latest` | unchanged, skipped | `npm:@types/no-deps@^2.0.0` |
| catalog `npm:no-deps` | `update` | `^2.0.0` (alias lost) | `npm:no-deps@^2.0.0` |
| catalog `npm:no-deps` | `update --latest` | 404 | `npm:no-deps@^2.0.0` |
| `npm:no-deps@~1.0.0` | `update aliased@npm:a-dep` | `npm:no-deps@~1.0.10` with a-dep installed | `npm:a-dep@~1.0.10` |
| `"no-deps": "~1.0.0"` | `update no-deps@npm:a-dep` | `~1.0.10` with a-dep installed | `npm:a-dep@~1.0.10` |
| (absent) | `update x@npm:@types/no-deps@^1.0.0` | `npm:@^1.0.0` | `npm:@types/no-deps@^1.0.0` |
| (absent) | `update x@npm:no-deps` | `^2.0.0` (alias lost) | `npm:no-deps@^2.0.0` |
| `npm:no-deps@^1.0.0` | `update`, `update aliased` | `npm:no-deps@^1.1.0` (already correct) | same |
| `npm:no-deps@^1.0.0` | `update --latest` | `npm:no-deps@^2.0.0` (already correct) | same |
| `"no-deps": "*"` | `update` | `^2.0.0` | same (precedent for the version-less alias result) |
| `"no-deps": "~1.0.0"` | `update no-deps@^1.0.0` | `~1.1.0` | same (precedent for the explicit-version alias result) |

Also probed values with surrounding whitespace (`" npm:no-deps@^1.0.0"`, `"npm:no-deps@^1.0.0 "`) under `update`, `update <name>` and `update --latest`: identical output on the release and on this branch (the helper trims the same way the old `starts_with("npm:")` check did). The leading-whitespace form is mishandled the same way before and after because the tag classification runs on the untrimmed value; that is separate from this change and tracked on its own.

</details>
