### PR TITLE
node:fs: name the requested path when recursive mkdir fails on a parent directory

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5751,8 +5751,8 @@ impl NodeFS {
                     Err(err) => {
                         // The SEP-restore must NOT happen before the errno match:
                         // `OSPathSliceZ` (`WStr`/`ZStr`) carries a hard
-                        // `ptr[len] == 0` invariant, and the EEXIST/`_` arms below still
-                        // read `parent`. Defer the SEP-restore into each arm so `parent`
+                        // `ptr[len] == 0` invariant, and the EEXIST arm below still
+                        // reads `parent`. Defer the SEP-restore into each arm so `parent`
                         // is never observed with its terminator clobbered.
                         match err.get_errno() {
                             E::EEXIST => {
@@ -5788,25 +5788,16 @@ impl NodeFS {
                                 i -= 1;
                                 continue;
                             }
+                            // Report the requested path, as the other error arms here and
+                            // node's mkdirSync do, not the prefix that failed.
                             _ => {
-                                #[cfg(windows)]
-                                let p = {
-                                    // `parent` aliases `working_mem` (== sync_error_buf). Copy it
-                                    // out to a temp before re-deriving `&mut PathBuffer` so we
-                                    // never hold `&mut buf` and `&buf[..]` simultaneously.
-                                    let stripped = without_nt_prefix(&parent[..]);
-                                    let n = stripped.len();
-                                    let mut tmp = paths::os_path_buffer_pool::get();
-                                    tmp[..n].copy_from_slice(stripped);
-                                    // SAFETY: `working_mem`/`parent` are not used after this return.
-                                    Self::os_path_into_buf(
-                                        unsafe { &mut *sync_error_buf_ptr },
-                                        &tmp[..n],
-                                    )
-                                };
-                                #[cfg(not(windows))]
-                                let p = without_nt_prefix(&parent[..]);
-                                return Err(err.with_path(p));
+                                // SAFETY: `working_mem` (and `parent`, which points into it) is
+                                // not used after this return; the re-derived &mut PathBuffer is
+                                // scoped to the call.
+                                return Err(err.with_path(Self::os_path_into_buf(
+                                    unsafe { &mut *sync_error_buf_ptr },
+                                    without_nt_prefix(&path[..]),
+                                )));
                             }
                         }
                     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5749,11 +5749,8 @@ impl NodeFS {
                 let parent = unsafe { OSPathSliceZ::from_raw(working_mem.as_ptr(), i as usize) };
                 match mkdir_os_path(parent, mode) {
                     Err(err) => {
-                        // The SEP-restore must NOT happen before the errno match:
-                        // `OSPathSliceZ` (`WStr`/`ZStr`) carries a hard
-                        // `ptr[len] == 0` invariant, and the EEXIST arm below still
-                        // reads `parent`. Defer the SEP-restore into each arm so `parent`
-                        // is never observed with its terminator clobbered.
+                        // The SEP is restored inside the arms, not before the match: the
+                        // EEXIST arm still reads `parent`, which is terminated by that NUL.
                         match err.get_errno() {
                             E::EEXIST => {
                                 // On Windows, this may happen if trying to mkdir replacing a file
@@ -5788,12 +5785,11 @@ impl NodeFS {
                                 i -= 1;
                                 continue;
                             }
-                            // Report the requested path, as the other error arms here and
-                            // node's mkdirSync do, not the prefix that failed.
+                            // Names the requested path, like the other error arms.
                             _ => {
-                                // SAFETY: `working_mem` (and `parent`, which points into it) is
-                                // not used after this return; the re-derived &mut PathBuffer is
-                                // scoped to the call.
+                                // SAFETY: neither `working_mem` nor `parent` (which points into
+                                // it) is used after this return; the re-derived &mut PathBuffer
+                                // is scoped to the call.
                                 return Err(err.with_path(Self::os_path_into_buf(
                                     unsafe { &mut *sync_error_buf_ptr },
                                     without_nt_prefix(&path[..]),

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5749,7 +5749,7 @@ impl NodeFS {
                 let parent = unsafe { OSPathSliceZ::from_raw(working_mem.as_ptr(), i as usize) };
                 match mkdir_os_path(parent, mode) {
                     Err(err) => {
-                        // Each arm restores the SEP itself; the EEXIST arm still reads `parent`.
+                        // The SEP is restored per arm: the EEXIST arm still reads `parent` first.
                         match err.get_errno() {
                             E::EEXIST => {
                                 // On Windows, this may happen if trying to mkdir replacing a file
@@ -5784,7 +5784,7 @@ impl NodeFS {
                                 i -= 1;
                                 continue;
                             }
-                            // Names the requested path, like the other error arms.
+                            // Names the requested path, like the other arms and node's mkdirSync.
                             _ => {
                                 // SAFETY: neither `working_mem` nor `parent` (which points into
                                 // it) is used after this return; the re-derived &mut PathBuffer

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5749,8 +5749,7 @@ impl NodeFS {
                 let parent = unsafe { OSPathSliceZ::from_raw(working_mem.as_ptr(), i as usize) };
                 match mkdir_os_path(parent, mode) {
                     Err(err) => {
-                        // The SEP is restored inside the arms, not before the match: the
-                        // EEXIST arm still reads `parent`, which is terminated by that NUL.
+                        // Each arm restores the SEP itself; the EEXIST arm still reads `parent`.
                         match err.get_errno() {
                             E::EEXIST => {
                                 // On Windows, this may happen if trying to mkdir replacing a file

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { isLinux, isWindows, tmpdirSync } from "harness";
+import { isLinux, isPosix, isWindows, tmpdirSync } from "harness";
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+
+const isRoot = process.getuid?.() === 0;
 
 let dirc = 0;
 function nextdir() {
@@ -397,5 +399,120 @@ describe("fs.promises.mkdir", () => {
     expect(fs.existsSync(pathname)).toBe(true);
     expect(fs.statSync(pathname).isDirectory()).toBe(true);
     expect(result).toBeUndefined();
+  });
+});
+
+// Each target below is `<refusing dir>/missing/b`: mkdir of the target itself fails with
+// ENOENT, so the recursive walk moves up to `missing`, and that is the mkdir the refusing
+// directory rejects. The error must still name the requested target, as node's mkdirSync and
+// every other failure of the walk do; it used to name `<refusing dir>/missing`.
+describe("fs.mkdir - recursive error names the requested path", () => {
+  let tmpdir: string;
+
+  beforeEach(() => {
+    tmpdir = getTmpDir();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  function describeError(err: any) {
+    return err === undefined
+      ? undefined
+      : { code: err.code, syscall: err.syscall, path: err.path, message: err.message };
+  }
+
+  async function recursiveMkdirErrors(target: string) {
+    let sync: unknown;
+    try {
+      fs.mkdirSync(target, { recursive: true });
+    } catch (err) {
+      sync = err;
+    }
+
+    const { promise: callbackDone, resolve } = Promise.withResolvers<unknown>();
+    fs.mkdir(target, { recursive: true }, err => resolve(err ?? undefined));
+    const callback = await callbackDone;
+
+    const promises = await fs.promises.mkdir(target, { recursive: true }).then(
+      () => undefined,
+      err => err,
+    );
+
+    return { sync: describeError(sync), callback: describeError(callback), promises: describeError(promises) };
+  }
+
+  it.skipIf(!isPosix || isRoot)("when a parent cannot be created in an unwritable directory", async () => {
+    const unwritable = path.join(tmpdir, nextdir());
+    fs.mkdirSync(unwritable);
+    fs.chmodSync(unwritable, 0o555);
+    try {
+      const target = path.join(unwritable, "missing", "b");
+      const expected = {
+        code: "EACCES",
+        syscall: "mkdir",
+        path: target,
+        message: `EACCES: permission denied, mkdir '${target}'`,
+      };
+
+      expect(await recursiveMkdirErrors(target)).toEqual({ sync: expected, callback: expected, promises: expected });
+    } finally {
+      fs.chmodSync(unwritable, 0o755);
+    }
+  });
+
+  // sysfs refuses every mkdir, root's included (EROFS when it is mounted read-only, as in
+  // containers; otherwise EPERM for root and EACCES for anyone else), so unlike the chmod
+  // fixture above this one also exercises the walk when the tests run as root.
+  function sysMountIsSysfs() {
+    const SYSFS_MAGIC = 0x62656572;
+    try {
+      return isLinux && fs.statfsSync("/sys").type === SYSFS_MAGIC;
+    } catch {
+      return false;
+    }
+  }
+  it.skipIf(!sysMountIsSysfs())("when a parent cannot be created on sysfs", async () => {
+    const target = "/sys/bun-fs-mkdir-test-missing/b";
+
+    const errors = await recursiveMkdirErrors(target);
+    const code = errors.sync?.code;
+    expect(["EROFS", "EPERM", "EACCES"]).toContain(code);
+    const expected = {
+      code,
+      syscall: "mkdir",
+      path: target,
+      message: expect.stringContaining(`, mkdir '${target}'`),
+    };
+    expect(errors).toEqual({ sync: expected, callback: expected, promises: expected });
+  });
+
+  // Deny "add subdirectory" / "add file" to Everyone (S-1-1-0); deny entries also bind
+  // administrators, and the entry is removed again before the directory is deleted.
+  it.skipIf(!isWindows)("when a parent cannot be created in a directory whose ACL denies it", async () => {
+    const denied = path.join(tmpdir, nextdir());
+    fs.mkdirSync(denied);
+    execSync(`icacls "${denied}" /deny "*S-1-1-0:(AD,WD)"`);
+    try {
+      const target = path.join(denied, "missing", "b");
+
+      const errors = await recursiveMkdirErrors(target);
+      const code = errors.sync?.code;
+      expect(["EPERM", "EACCES"]).toContain(code);
+      const expected = {
+        code,
+        syscall: "mkdir",
+        path: target,
+        message: expect.stringContaining(`, mkdir '${target}'`),
+      };
+      expect(errors).toEqual({ sync: expected, callback: expected, promises: expected });
+    } finally {
+      execSync(`icacls "${denied}" /remove:d "*S-1-1-0"`);
+    }
   });
 });

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { isLinux, isPosix, isWindows, tmpdirSync } from "harness";
 import { execSync } from "node:child_process";
 import fs from "node:fs";
@@ -492,27 +492,41 @@ describe("fs.mkdir - recursive error names the requested path", () => {
     expect(errors).toEqual({ sync: expected, callback: expected, promises: expected });
   });
 
-  // Deny "add subdirectory" / "add file" to Everyone (S-1-1-0); deny entries also bind
-  // administrators, and the entry is removed again before the directory is deleted.
-  it.skipIf(!isWindows)("when a parent cannot be created in a directory whose ACL denies it", async () => {
-    const denied = path.join(tmpdir, nextdir());
-    fs.mkdirSync(denied);
-    execSync(`icacls "${denied}" /deny "*S-1-1-0:(AD,WD)"`);
+  // Windows: a directory whose ACL denies Everyone (S-1-1-0) "add subdirectory" and "add
+  // file". A token with the backup/restore privileges enabled (some elevated agents) is not
+  // bound by that, so enforcement is probed up front and the test skips visibly in that case.
+  let deniedRoot = "";
+  let denied = "";
+  if (isWindows) {
     try {
-      const target = path.join(denied, "missing", "b");
+      deniedRoot = getTmpDir();
+      const dir = path.join(deniedRoot, "denied");
+      fs.mkdirSync(dir);
+      execSync(`icacls "${dir}" /deny "*S-1-1-0:(AD,WD)"`);
+      try {
+        fs.mkdirSync(path.join(dir, "probe"));
+      } catch {
+        denied = dir;
+      }
+    } catch {}
+  }
+  afterAll(() => {
+    if (!deniedRoot) return;
+    try {
+      execSync(`icacls "${path.join(deniedRoot, "denied")}" /remove:d "*S-1-1-0"`);
+    } catch {}
+    fs.rmSync(deniedRoot, { recursive: true, force: true });
+  });
 
-      const errors = await recursiveMkdirErrors(target);
-      const code = errors.sync?.code;
-      expect(["EPERM", "EACCES"]).toContain(code);
-      const expected = {
-        code,
-        syscall: "mkdir",
-        path: target,
-        message: expect.stringContaining(`, mkdir '${target}'`),
-      };
-      expect(errors).toEqual({ sync: expected, callback: expected, promises: expected });
-    } finally {
-      execSync(`icacls "${denied}" /remove:d "*S-1-1-0"`);
-    }
+  it.skipIf(!denied)("when a parent cannot be created in a directory whose ACL denies it", async () => {
+    const target = path.join(denied, "missing", "b");
+    const expected = {
+      code: "EPERM",
+      syscall: "mkdir",
+      path: target,
+      message: `EPERM: operation not permitted, mkdir '${target}'`,
+    };
+
+    expect(await recursiveMkdirErrors(target)).toEqual({ sync: expected, callback: expected, promises: expected });
   });
 });

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -515,7 +515,11 @@ describe("fs.mkdir - recursive error names the requested path", () => {
     try {
       execSync(`icacls "${path.join(deniedRoot, "denied")}" /remove:d "*S-1-1-0"`);
     } catch {}
-    fs.rmSync(deniedRoot, { recursive: true, force: true });
+    try {
+      fs.rmSync(deniedRoot, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
   });
 
   it.skipIf(!denied)("when a parent cannot be created in a directory whose ACL denies it", async () => {


### PR DESCRIPTION
### Problem
- `fs.mkdirSync("/ro/a/b", { recursive: true })`, where `/ro` exists but is not writable, throws `EACCES: permission denied, mkdir '/ro/a'` with `err.path === "/ro/a"`: the parent the walk was trying to create, not the argument. `fs.mkdir` and `fs.promises.mkdir` report the same. Node's `mkdirSync` throws `EACCES: permission denied, mkdir '/ro/a/b'` with `err.path === "/ro/a/b"` (node v26.3.0 vs bun 1.4.0 on Linux, output below; main has the same code).
- Which path bun names depends on how much of the path is missing: `mkdirSync("/ro/a", { recursive: true })` names `/ro/a`, the argument, because the first attempt fails directly. Only a failure during the walk up names a prefix.
- Cause: the walk up in `NodeFS::mkdir_recursive_os_path_impl` (`src/runtime/node/node_fs.rs`) has three error arms. `ENOENT` keeps walking, `EEXIST` stops, and the catch-all arm returned `err.with_path(parent)`, `parent` being the prefix it had just cut out of the path. The first attempt, the walk back down and the final mkdir of the same routine all report the full path.

### Fix
- The catch-all arm of the walk up reports the full path, through the same `os_path_into_buf(.., without_nt_prefix(&path[..]))` expression the walk down uses. The arm no longer reads `parent`, so its Windows-only copy of `parent` into a scratch buffer (needed because `parent` lives in the buffer the error path is written into) is gone too.
- Why the argument is the right path: node's `MKDirpSync` returns only the errno of the walk and `mkdirSync` builds the exception from the argument (`ThrowUVException(err, "mkdir", nullptr, *path)`), so this is what node users get; and it is what every other failure of this routine already reports, so `err.path` no longer depends on how deep the missing part starts. Node's callback and promise forms report whatever prefix libuv tried last (`req->path` of the last `uv_fs_mkdir`), and node's own test for this case (`test-fs-mkdir-recursive-eaccess.js`) only asserts that `err.path` is set; bun's three forms share this one routine, so they all follow the sync form.
- Other callers of the routine, checked: the shell's `mkdir -p` (`src/runtime/shell/builtin/mkdir.rs`) and `Bun.write` on POSIX (`src/runtime/webcore/Blob.rs`) replace the path with their own operand, so nothing changes for them. The native copy (`cp_sync_inner`, `cp_async_directory`, `cp_open_dest_with_mkdir`, reached from the `fs.cp`/`fs.cpSync` fast paths and the shell's Windows `cp`) and `Bun.write` on Windows (`AsyncMkdirp`) pass the error through; their errors now name the directory they asked the routine for, which is what the routine's other failures already gave them. For the single-file copy that is the destination's parent directory, as in node (spelled `dir/` with a trailing separator today; #38097 changes that to `dir` independently of this). The directory copy (native only on macOS) asks for the destination itself, so its error names the destination where node's names the parent; that is how that caller already reported its other failures and is not changed here.
- Independent of #38146 (the `EEXIST` arm of the same walk) and #38222 (which separator the prefix is cut at); both keep this arm's `with_path(parent)`.
- Test: `test/js/node/fs/fs-mkdir.test.ts`, describe block `fs.mkdir - recursive error names the requested path`. Each test checks `code`, `syscall`, `path` and `message` of the sync, callback and promise forms against the requested path. Fixtures: a `chmod 555` directory (POSIX, EACCES; skipped as root), sysfs (Linux; it refuses mkdir for root as well, so the case is also covered where tests run as root) and a directory with an ACL deny entry (Windows, EPERM, which is also what node's `test-fs-mkdir-recursive-eaccess.js` expects there). A token with the backup/restore privileges enabled is not bound by the deny entry, so that fixture probes itself once and skips visibly when it is not enforced (same approach as `test/js/bun/glob/scan.test.ts`).
- Fails on bun 1.4.0 and passes with this change: the chmod fixture as an unprivileged user on Linux, the sysfs fixture as root and unprivileged, and the ACL fixture on Windows Server 2019 under a basic-user token (under the elevated token of that machine it skips). All three forms named `.../missing` before.
- Also ran `test/js/node/fs/fs.test.ts`, `test/js/node/fs/cp.test.ts` and `test/js/bun/io/bun-write.test.js` with the change: unchanged results.

### Background
- Recursive mkdir in bun is one routine with three phases: mkdir the full path; on `ENOENT`, walk up the path, NUL-terminating it at each separator and calling mkdir on the shortened prefix until one is created or already exists; then walk back down creating the remaining components and finally the full path. An error other than `ENOENT`/`EEXIST` can happen in any phase; phases 1 and 3 already reported the full path, phase 2 did not.
- `sync_error_buf` is a per-`NodeFS` scratch buffer that error paths are copied into right before `with_path` boxes them. This routine also uses it as the working copy of the path it NUL-terminates, which is why each error arm re-derives a `&mut` to the buffer only at the point of returning, and why the removed Windows code first had to copy `parent` (a pointer into that same buffer) elsewhere.
- Bun builds the fs error message as `CODE: description, syscall 'path'` from the `path` the error carries, so `err.message` changes together with `err.path`.

<details>
<summary>Repro (Linux, run as an unprivileged user so that EACCES fires)</summary>

```sh
mkdir -p /tmp/roprobe/ro && chmod 755 /tmp/roprobe && chmod 555 /tmp/roprobe/ro
```

```js
// probe.mjs: runs the three forms against process.argv[2] and prints code, path, message
```

```
$ node probe.mjs /tmp/roprobe/ro/a/b            # v26.3.0
sync:      EACCES  /tmp/roprobe/ro/a/b  "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a/b'"
callback:  EACCES  /tmp/roprobe/ro/a    "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a'"
promises:  EACCES  /tmp/roprobe/ro/a    "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a'"

$ bun probe.mjs /tmp/roprobe/ro/a/b             # 1.4.0, main is the same
sync:      EACCES  /tmp/roprobe/ro/a    "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a'"
callback:  EACCES  /tmp/roprobe/ro/a    "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a'"
promises:  EACCES  /tmp/roprobe/ro/a    "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a'"

$ bun-debug probe.mjs /tmp/roprobe/ro/a/b       # this branch
sync:      EACCES  /tmp/roprobe/ro/a/b  "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a/b'"
callback:  EACCES  /tmp/roprobe/ro/a/b  "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a/b'"
promises:  EACCES  /tmp/roprobe/ro/a/b  "EACCES: permission denied, mkdir '/tmp/roprobe/ro/a/b'"
```

`/tmp/roprobe/ro/a` (nothing missing in between) names `/tmp/roprobe/ro/a` before and after, since that is the first attempt failing.
</details>

<details>
<summary>Callers that pass the error through, before and after (same fixture, unprivileged user)</summary>

```
                                   1.4.0                   this branch
fs.cpSync(file, ro/a/b/f.txt)      mkdir 'ro/a'            mkdir 'ro/a/b/'   (trailing separator: #38097)
fs.promises.cp(file, ro/a/b/f.txt) mkdir 'ro/a'            mkdir 'ro/a/b/'   (same)
fs.cpSync(dir, ro/a/b/c)           mkdir 'ro/a'            mkdir 'ro/a/b'    (JS port: mkdirSync(dirname), node says 'ro/a/b' too)
shell mkdir -p ro/a/b              mkdir: ro/a/b: Permission denied   (unchanged)
Bun.write(ro/a/b/x, "data")        ENOENT open 'ro/a/b/x'  (unchanged, error is rebuilt from the file path)
Bun.write(ro/a/b/x, "")            EACCES mkdir 'ro/a/b/x' (unchanged, same reason)
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-mkdir.test.ts

<!-- robobun:evidence:end -->