### PR TITLE
node:fs: make cp/cpSync replace an existing destination file like node

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -301,11 +301,14 @@ function tryNativeFastPathSync(src, dest, opts) {
       checked,
     };
   }
-  // The single-file native copy is only node-equivalent for regular-file ->
-  // regular-file (or missing dest). Symlinks (node resolves relative link
-  // targets) and special files (node-specific error codes) must go through
-  // the ported implementation.
-  return { ok: srcStat.isFile() && (!destStat || destStat.isFile()), checked };
+  // The single-file native copy is only node-equivalent for a regular file
+  // copied to a path that does not exist yet. Symlinks (node resolves
+  // relative link targets) and special files (node-specific error codes) must
+  // go through the ported implementation. So must an existing dest: node
+  // unlinks it and creates a fresh file (see mayCopyFile), whereas the native
+  // copy opens and rewrites the existing inode, which writes through every
+  // other hard link to it and fails on a read-only dest.
+  return { ok: srcStat.isFile() && !destStat, checked };
 }
 
 function cpSyncFn(src, dest, opts, checked?) {

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -173,11 +173,14 @@ async function tryNativeFastPath(src, dest, opts) {
       checked,
     };
   }
-  // The single-file native copy is only node-equivalent for regular-file ->
-  // regular-file (or missing dest). Symlinks (node resolves relative link
-  // targets) and special files (node-specific error codes) must go through
-  // the ported implementation.
-  return { ok: srcStat.isFile() && (!destStat || destStat.isFile()), checked };
+  // The single-file native copy is only node-equivalent for a regular file
+  // copied to a path that does not exist yet. Symlinks (node resolves
+  // relative link targets) and special files (node-specific error codes) must
+  // go through the ported implementation. So must an existing dest: node
+  // unlinks it and creates a fresh file (see mayCopyFile), whereas the native
+  // copy opens and rewrites the existing inode, which writes through every
+  // other hard link to it and fails on a read-only dest.
+  return { ok: srcStat.isFile() && !destStat, checked };
 }
 
 async function cpFn(src, dest, opts, checked?) {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -129,6 +129,50 @@ for (const [name, copy] of impls) {
       assertContent(basename + "/result/a.txt", "win");
     });
 
+    test("overwriting a hard-linked file replaces the link instead of writing through it", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "new",
+        "store/a.txt": "original",
+        "result": {},
+      });
+      // result/a.txt shares its inode with store/a.txt, the way a package
+      // manager hard-links node_modules files out of its cache. node unlinks
+      // the destination and creates a fresh file, so the store copy is untouched.
+      fs.linkSync(basename + "/store/a.txt", basename + "/result/a.txt");
+
+      await copy(basename + "/from/a.txt", basename + "/result/a.txt");
+
+      expect({
+        result: fs.readFileSync(basename + "/result/a.txt", "utf8"),
+        store: fs.readFileSync(basename + "/store/a.txt", "utf8"),
+        storeLinks: fs.statSync(basename + "/store/a.txt").nlink,
+      }).toEqual({
+        result: "new",
+        store: "original",
+        storeLinks: 1,
+      });
+    });
+
+    // As root, open() ignores the file mode, so the in-place overwrite this
+    // guards against succeeds either way.
+    test.skipIf(isWindows || process.getuid?.() === 0)("overwriting a read-only file replaces it", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "new",
+        "result/a.txt": "original",
+      });
+      fs.chmodSync(basename + "/result/a.txt", 0o444);
+
+      await copy(basename + "/from/a.txt", basename + "/result/a.txt");
+
+      expect({
+        content: fs.readFileSync(basename + "/result/a.txt", "utf8"),
+        mode: fs.statSync(basename + "/result/a.txt").mode & 0o777,
+      }).toEqual({
+        content: "new",
+        mode: fs.statSync(basename + "/from/a.txt").mode & 0o777,
+      });
+    });
+
     test("'force: false' + 'errorOnExist: true' can throw", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "lose",
@@ -428,6 +472,29 @@ test("cp with missing callback throws", () => {
     // @ts-expect-error
     fs.cp("a", "b" as any);
   }).toThrow(/"cb"/);
+});
+
+test("callback fs.cp overwriting a hard-linked file replaces the link instead of writing through it", async () => {
+  await using basename = tempDir("cp", {
+    "from/a.txt": "new",
+    "store/a.txt": "original",
+    "result": {},
+  });
+  fs.linkSync(join(basename, "store", "a.txt"), join(basename, "result", "a.txt"));
+
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  fs.cp(join(basename, "from", "a.txt"), join(basename, "result", "a.txt"), err => (err ? reject(err) : resolve()));
+  await promise;
+
+  expect({
+    result: fs.readFileSync(join(basename, "result", "a.txt"), "utf8"),
+    store: fs.readFileSync(join(basename, "store", "a.txt"), "utf8"),
+    storeLinks: fs.statSync(join(basename, "store", "a.txt")).nlink,
+  }).toEqual({
+    result: "new",
+    store: "original",
+    storeLinks: 1,
+  });
 });
 
 // On Windows, _copySingleFileSync's reparse-point branch opens a handle to the


### PR DESCRIPTION
### Problem
- `fs.cpSync(file, dest)`, `fs.cp(file, dest, cb)` and `fs.promises.cp(file, dest)` onto a `dest` that already exists as a regular file write the new contents into the existing inode. If `dest` is a hard link (bun install's Linux backend and pnpm both hard-link `node_modules` files out of their store), every other link to that inode now has the new contents too. node leaves the other links untouched; so does bun's own recursive `cp(dir, dir)` for the same file one level down.
- Same cause, second symptom: onto a `dest` with mode `0444`, all three forms fail with `EACCES: permission denied, open '.../dest'` when not running as root. node succeeds.
- Cause: `tryNativeFastPathSync` (`src/js/internal/fs/cp-sync.ts:308`) and `tryNativeFastPath` (`src/js/internal/fs/cp.ts:180`) hand the copy to the native binding when `src` is a regular file and `dest` is missing *or a regular file*. The native copy (`copy_single_file_sync`, `src/runtime/node/node_fs.rs:8551`) opens `dest` with `O_WRONLY | O_CREAT` and clones / `copy_file_range`s into whatever inode is there. node's `mayCopyFile` (and the ported walker's, `cp-sync.ts:375`) does `unlink(dest)` then `copyFile`, creating a new inode.

### Fix
- Take the native single-file copy only when `dest` does not exist, which is the condition the recursive fast path in the same functions already uses. An existing `dest` falls through to the ported walker, which unlinks it, copies and chmods exactly as node does. The stats collected by the gate are passed along, so the walker does not re-stat.
- Correct because "dest exists" is precisely the case where rewriting in place is observable (other hard links, read-only mode, open file descriptors keep the old inode), and the walker is the node algorithm. The fast path still covers the copy-to-new-path case.
- Verified:
  - `test/js/node/fs/cp.test.ts`: new hard-link tests for `cpSync`, `promises.cp` and callback `cp`, and read-only-dest tests for `cpSync` and `promises.cp` (skipped as root, where the mode is not enforced, and on Windows). Before the fix the hard-link tests fail with `store: "new"`, `nlink: 2`; as a non-root user the read-only tests fail with `EACCES`. With the fix the file passes (50 pass, 7 skip on Linux), and all 5 new tests pass as a non-root user.
  - The 77 upstream `test/js/node/test/parallel/test-fs-cp-*` tests pass with the debug build.
  - The original repro below now prints the same results node v26.3.0 prints for the three single-file forms.

### Background
- `fs.cp` family dispatch (`src/js/node/fs.ts` `cpSync`, `src/js/node/fs.promises.ts` `cp`): when no option other than the default `force: true` is set, the JS side first runs node's validation (`checkPaths`, `checkParentPaths`) and then decides between the native binding and the JS port of node's `lib/internal/fs/cp/` walker. The `tryNativeFastPath*` functions are that decision; they only say yes when the native result is indistinguishable from the walker's.
- A hard link is a second directory entry for the same inode. Writing into the file through either name changes what both names show; unlinking one name and creating a new file under it leaves the other name pointing at the old, unchanged data. `copyFileSync` writes through in both node and bun; only `cp` has the unlink-first semantics.

<details>
<summary>Repro</summary>

```js
import fs from "node:fs";
const d = fs.mkdtempSync("cp-hl-");
fs.writeFileSync(`${d}/store.txt`, "ORIGINAL\n");
fs.writeFileSync(`${d}/src.txt`, "NEW\n");
fs.linkSync(`${d}/store.txt`, `${d}/dst.txt`);
fs.cpSync(`${d}/src.txt`, `${d}/dst.txt`);
console.log(fs.readFileSync(`${d}/store.txt`, "utf8")); // bun 1.4.0: "NEW", node: "ORIGINAL"
```

Before (bun 1.4.0), the fuller script covering all forms:

```
cpSync(file, hardlinkedDest)           other-link=OVERWRITTEN
promises.cp(file, hardlinkedDest)      other-link=OVERWRITTEN
cp(file, hardlinkedDest, cb)           other-link=OVERWRITTEN
cpSync(dir,dir) td/x hardlinked        other-link=intact
promises.cp(dir,dir) td/x hardlinked   other-link=intact
```

After (this branch), and node v26.3.0 for the single-file forms:

```
cpSync(file, hardlinkedDest)           other-link=intact
promises.cp(file, hardlinkedDest)      other-link=intact
cp(file, hardlinkedDest, cb)           other-link=intact
cpSync(dir,dir) td/x hardlinked        other-link=intact
promises.cp(dir,dir) td/x hardlinked   other-link=intact
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->