### PR TITLE
bake: give AstBuilder modules the exports_ref and wrapper_ref every AST has

### DIFF
--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -287,11 +287,10 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             ..Default::default()
         });
 
-        // Same as the `exports` symbol js_parser gives every file: the linker
-        // declares it in the namespace export part and binds `import * as ns`
-        // to it. Created after `symbol_uses` above so the code part does not
-        // depend on the namespace export part and keep it from being tree shaken.
+        // Declared by the linker's namespace export part, like js_parser's `exports` symbol.
         let exports_ref = self.push_symbol(SymbolKind::Other, b"exports");
+        // The code part must not use it, or the namespace object could never be tree shaken.
+        debug_assert!(!parts[1].symbol_uses.contains(&exports_ref));
 
         let mut top_level_symbols_to_parts = TopLevelSymbolToParts::default();
         // SAFETY: module_scope is a live arena allocation (set in init, scopes stack is empty)

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -550,7 +550,8 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             module_scope: module_scope_value,
             symbols: bun_alloc::vec_from_iter_in(core::mem::take(&mut self.symbols), self.bump),
             exports_ref,
-            wrapper_ref: Ref::NONE,
+            // Doubles as the HMR API binding, as in js_parser's `to_ast`.
+            wrapper_ref: self.hmr_api_ref,
             module_ref: self.module_ref,
             import_records: bun_alloc::vec_from_iter_in(
                 core::mem::take(&mut self.import_records),

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -112,14 +112,20 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         unsafe { &mut *self.current_scope }
     }
 
-    pub(crate) fn new_symbol(&mut self, kind: SymbolKind, identifier: &[u8]) -> Result<Ref, OOM> {
+    /// Adds a symbol without declaring it in the current scope or in the
+    /// generated part.
+    fn push_symbol(&mut self, kind: SymbolKind, identifier: &[u8]) -> Ref {
         let inner_index: RefInt = RefInt::try_from(self.symbols.len()).unwrap();
         self.symbols.push(Symbol {
             kind,
             original_name: bun_ast::StoreStr::new(identifier),
             ..Default::default()
         });
-        let ref_ = Ref::new(inner_index, self.source_index, RefTag::Symbol);
+        Ref::new(inner_index, self.source_index, RefTag::Symbol)
+    }
+
+    pub(crate) fn new_symbol(&mut self, kind: SymbolKind, identifier: &[u8]) -> Result<Ref, OOM> {
+        let ref_ = self.push_symbol(kind, identifier);
         self.current_scope_mut().generated.push(ref_);
         self.declared_symbols.append(DeclaredSymbol {
             ref_,
@@ -283,11 +289,19 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             ..Default::default()
         });
 
+        // The linker binds `import * as ns`, `export * as ns`, `require()` and
+        // `import()` of this module to `exports_ref` and declares it in the
+        // namespace export part (`create_exports_for_file`), the same as the
+        // `exports` symbol js_parser gives every file. It is created after the
+        // `symbol_uses` above so the code part does not depend on the namespace
+        // export part, which keeps the namespace object tree-shakeable.
+        let exports_ref = self.push_symbol(SymbolKind::Other, b"exports");
+
         let mut top_level_symbols_to_parts = TopLevelSymbolToParts::default();
         // SAFETY: module_scope is a live arena allocation (set in init, scopes stack is empty)
         let module_scope_ref = unsafe { &*module_scope };
         let generated_len = module_scope_ref.generated.len();
-        top_level_symbols_to_parts.ensure_total_capacity(generated_len)?;
+        top_level_symbols_to_parts.ensure_total_capacity(generated_len + 1)?;
         // `ArrayHashMap` keeps keys/values in private `Vec`s and rebuilds
         // hashes on every `put_assume_capacity`, so a plain pre-reserved
         // insert loop suffices (and `re_index` is a no-op here). `Vec` is
@@ -296,6 +310,11 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             top_level_symbols_to_parts
                 .put_assume_capacity(ref_, bun_alloc::AstAlloc::vec_from_slice(&[1]));
         }
+        // Pulling in the exports of this module always pulls in the export part
+        top_level_symbols_to_parts.put_assume_capacity(
+            exports_ref,
+            bun_alloc::AstAlloc::vec_from_slice(&[bun_ast::NAMESPACE_EXPORT_PART_INDEX]),
+        );
         top_level_symbols_to_parts.re_index()?;
 
         // For more details on this section, look at js_parser.toAST
@@ -535,7 +554,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             parts,
             module_scope: module_scope_value,
             symbols: bun_alloc::vec_from_iter_in(core::mem::take(&mut self.symbols), self.bump),
-            exports_ref: Ref::NONE,
+            exports_ref,
             wrapper_ref: Ref::NONE,
             module_ref: self.module_ref,
             import_records: bun_alloc::vec_from_iter_in(

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -112,8 +112,6 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         unsafe { &mut *self.current_scope }
     }
 
-    /// Adds a symbol without declaring it in the current scope or in the
-    /// generated part.
     fn push_symbol(&mut self, kind: SymbolKind, identifier: &[u8]) -> Ref {
         let inner_index: RefInt = RefInt::try_from(self.symbols.len()).unwrap();
         self.symbols.push(Symbol {
@@ -289,12 +287,10 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             ..Default::default()
         });
 
-        // The linker binds `import * as ns`, `export * as ns`, `require()` and
-        // `import()` of this module to `exports_ref` and declares it in the
-        // namespace export part (`create_exports_for_file`), the same as the
-        // `exports` symbol js_parser gives every file. It is created after the
-        // `symbol_uses` above so the code part does not depend on the namespace
-        // export part, which keeps the namespace object tree-shakeable.
+        // Same as the `exports` symbol js_parser gives every file: the linker
+        // declares it in the namespace export part and binds `import * as ns`
+        // to it. Created after `symbol_uses` above so the code part does not
+        // depend on the namespace export part and keep it from being tree shaken.
         let exports_ref = self.push_symbol(SymbolKind::Other, b"exports");
 
         let mut top_level_symbols_to_parts = TopLevelSymbolToParts::default();

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -187,11 +187,7 @@ fn task_callback(
         // Client-side,
         Data::ClientEntryWrapper(_) => Target::Browser,
     };
-    let hmr_api_ref = ab.hmr_api_ref;
-    let mut bundled_ast: JSAst = ab.to_bundled_ast(target)?;
-
-    // `wrapper_ref` is used to hold the HMR api ref.
-    bundled_ast.wrapper_ref = hmr_api_ref;
+    let bundled_ast: JSAst = ab.to_bundled_ast(target)?;
 
     Ok(Success {
         ast: bundled_ast,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -376,8 +376,9 @@ export default function Client() {
 
   test("namespace import, export * as and require() of a client component", async () => {
     // The server sees a "use client" module through a generated client
-    // reference proxy. Named and default imports bind to its exports directly;
-    // these three forms all need the proxy's module namespace object.
+    // reference proxy, and "bun:bake/server" is generated the same way. Named
+    // and default imports bind to their exports directly; these forms all need
+    // the generated module's namespace object.
     const dir = await tempDirWithBakeDeps("bake-production-client-namespace", {
       "src/index.tsx": `export default { app: { framework: "react" } };`,
       "components/Client.tsx": `"use client";
@@ -407,6 +408,11 @@ export default function ReexportPage() {
   const C = require("../components/Client");
   return <i>{Object.keys(C).sort().join(",")}</i>;
 }`,
+      "pages/manifest.tsx": `import * as bake from "bun:bake/server";
+
+export default function ManifestPage() {
+  return <i>{Object.keys(bake).sort().join(",")}</i>;
+}`,
       "package.json": JSON.stringify({
         "name": "test-app",
         "version": "1.0.0",
@@ -432,6 +438,9 @@ export default function ReexportPage() {
 
     const requireHtml = await Bun.file(path.join(dir, "dist", "require", "index.html")).text();
     expect(requireHtml).toContain("<i>Client,value</i>");
+
+    const manifestHtml = await Bun.file(path.join(dir, "dist", "manifest", "index.html")).text();
+    expect(manifestHtml).toContain("<i>serverManifest,ssrManifest</i>");
   });
 
   test("importing useState server-side", async () => {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -377,8 +377,8 @@ export default function Client() {
   test("namespace import, export * as and require() of a client component", async () => {
     // The server sees a "use client" module through a generated client
     // reference proxy, and "bun:bake/server" is generated the same way. Named
-    // and default imports bind to their exports directly; these forms all need
-    // the generated module's namespace object.
+    // and default imports bind to their exports directly; these forms need the
+    // generated module's namespace object, and require() also needs its wrapper.
     const dir = await tempDirWithBakeDeps("bake-production-client-namespace", {
       "src/index.tsx": `export default { app: { framework: "react" } };`,
       "components/Client.tsx": `"use client";
@@ -406,12 +406,16 @@ export default function ReexportPage() {
 }`,
       "pages/require.tsx": `export default function RequirePage() {
   const C = require("../components/Client");
-  return <i>{Object.keys(C).sort().join(",")}</i>;
+  return <i>{Object.keys(C).sort().join(",") + " " + typeof C.Client}</i>;
 }`,
       "pages/manifest.tsx": `import * as bake from "bun:bake/server";
 
 export default function ManifestPage() {
   return <i>{Object.keys(bake).sort().join(",")}</i>;
+}`,
+      "pages/manifest-require.tsx": `export default function ManifestRequirePage() {
+  const bake = require("bun:bake/server");
+  return <i>{Object.keys(bake).sort().join(",") + " " + typeof bake.serverManifest}</i>;
 }`,
       "package.json": JSON.stringify({
         "name": "test-app",
@@ -431,16 +435,24 @@ export default function ManifestPage() {
 
     const namespaceHtml = await Bun.file(path.join(dir, "dist", "index.html")).text();
     expect(namespaceHtml).toContain("<b>client</b>");
-    expect(namespaceHtml).toContain("<i>Client,value</i>");
 
-    const reexportHtml = await Bun.file(path.join(dir, "dist", "reexport", "index.html")).text();
-    expect(reexportHtml).toContain("<i>Client,value</i>");
-
-    const requireHtml = await Bun.file(path.join(dir, "dist", "require", "index.html")).text();
-    expect(requireHtml).toContain("<i>Client,value</i>");
-
-    const manifestHtml = await Bun.file(path.join(dir, "dist", "manifest", "index.html")).text();
-    expect(manifestHtml).toContain("<i>serverManifest,ssrManifest</i>");
+    const rendered = async (page: string) => {
+      const html = await Bun.file(path.join(dir, "dist", page, "index.html")).text();
+      return html.match(/<i>(.*?)<\/i>/)?.[1];
+    };
+    expect({
+      namespace: await rendered("."),
+      reexport: await rendered("reexport"),
+      require: await rendered("require"),
+      manifest: await rendered("manifest"),
+      manifestRequire: await rendered("manifest-require"),
+    }).toEqual({
+      namespace: "Client,value",
+      reexport: "Client,value",
+      require: "Client,value function",
+      manifest: "serverManifest,ssrManifest",
+      manifestRequire: "serverManifest,ssrManifest object",
+    });
   });
 
   test("importing useState server-side", async () => {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -374,6 +374,66 @@ export default function Client() {
     expect(htmlContent).toContain("Hello World");
   });
 
+  test("namespace import, export * as and require() of a client component", async () => {
+    // The server sees a "use client" module through a generated client
+    // reference proxy. Named and default imports bind to its exports directly;
+    // these three forms all need the proxy's module namespace object.
+    const dir = await tempDirWithBakeDeps("bake-production-client-namespace", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "components/Client.tsx": `"use client";
+
+export function Client() {
+  return <b>client</b>;
+}
+
+export const value = 1;`,
+      "lib/reexport.ts": `export * as ns from "../components/Client";`,
+      "pages/index.tsx": `import * as C from "../components/Client";
+
+export default function NamespacePage() {
+  return (
+    <div>
+      <C.Client />
+      <i>{Object.keys(C).sort().join(",")}</i>
+    </div>
+  );
+}`,
+      "pages/reexport.tsx": `import { ns } from "../lib/reexport";
+
+export default function ReexportPage() {
+  return <i>{Object.keys(ns).sort().join(",")}</i>;
+}`,
+      "pages/require.tsx": `export default function RequirePage() {
+  const C = require("../components/Client");
+  return <i>{Object.keys(C).sort().join(",")}</i>;
+}`,
+      "package.json": JSON.stringify({
+        "name": "test-app",
+        "version": "1.0.0",
+        "devDependencies": {
+          "react": "^18.0.0",
+          "react-dom": "^18.0.0",
+        },
+      }),
+    });
+
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(exitCode, stderr.toString()).toBe(0);
+
+    const namespaceHtml = await Bun.file(path.join(dir, "dist", "index.html")).text();
+    expect(namespaceHtml).toContain("<b>client</b>");
+    expect(namespaceHtml).toContain("<i>Client,value</i>");
+
+    const reexportHtml = await Bun.file(path.join(dir, "dist", "reexport", "index.html")).text();
+    expect(reexportHtml).toContain("<i>Client,value</i>");
+
+    const requireHtml = await Bun.file(path.join(dir, "dist", "require", "index.html")).text();
+    expect(requireHtml).toContain("<i>Client,value</i>");
+  });
+
   test("importing useState server-side", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-react-import", {
       "src/index.tsx": `export default { app: { framework: "react" } };`,


### PR DESCRIPTION
### Problem
- In a production bake build (`bun build --app` with the built-in `react` framework), a server module that does `import * as C from "./Client"` where `Client.tsx` is a `"use client"` module fails to bundle:
  ```
  error: No matching export in "components/Client.tsx" for import ""
  ```
- `export * as ns from "./Client"` of the same module panics in the linker: `panic: infallible: alias present` (`LinkerContext.rs`, `advance_import_tracker`).
- `require("./Client")` of the same module trips `assertion failed: !ref_.is_empty()` in `LinkerGraph.rs` (`generate_symbol_import_and_use`) on debug builds; release builds emit `init_Client()` without the namespace object, so the page gets `undefined`.
- `import * as bake from "bun:bake/server"` fails the same way, and `require("bun:bake/server")` produces a server chunk containing `const bake = ;` plus an `__INVALID__REF__` import (`SyntaxError` at prerender time); on debug builds it trips `assertion failed: !ast.wrapper_ref.is_empty()` in `generateCodeForFileInChunkJS.rs`.
- Cause: these modules are built by `AstBuilder` (the client reference proxy in `ServerComponentParseTask.rs`, the `bun:bake/server` and `bun:bake/client` modules in `bundle_v2.rs`), and `AstBuilder::to_bundled_ast` returned them with `exports_ref: Ref::NONE` and `wrapper_ref: Ref::NONE` (`src/bundler/AstBuilder.rs`, previously lines 538-539). The linker resolves every form above through `exports_ref` (`resolved_export_star` for the star imports, `require_or_import_meta_for_source` and the `WrapKind::Esm` branch of step 6 for `require()`), and wrapping a file for `require()` needs `wrapper_ref`. `ServerComponentParseTask` patched `wrapper_ref` onto the proxy after the fact, which is why only `require()` of the proxy got as far as the `exports_ref` assertion; the `bun:bake/*` modules had neither symbol.
- Named and default imports touch neither symbol, which is why they worked. The dev server also worked because it does not run import matching (exports are looked up at runtime by the HMR runtime), and `bun:bake/*` imports are external there.

### Fix
- `to_bundled_ast` now creates an `exports` symbol, stores it as `exports_ref`, and maps it to the namespace export part in `top_level_symbols_to_parts`, which is what `js_parser::to_ast` does for every parsed file. This is correct because the linker's step 5 (`create_exports_for_file`) already builds that part for these files (`var exports_Client = {}; __export(exports_Client, {...})`); it just declared it under `Ref::NONE`. With a real symbol every consumer binds to that part and pulls it in through the `top_level_symbols_to_parts` entry, exactly like a parsed ESM file.
- The symbol is created after the generated code part's `symbol_uses` map is filled (that part pretends to use every symbol that exists at that point), so the code part does not depend on the namespace part and the namespace object is still tree shaken when only named imports are used; a `debug_assert!` pins that down. Verified: with `import { Client }` the server chunk has no `exports_Client`; with `import * as C` it has the usual `var exports_Client = {}; __export(...)` block and `C.Client` is rewritten to the `Client` binding. `new_symbol` is split into `push_symbol` plus the existing scope/declared-symbol bookkeeping because the namespace part, not the code part, declares this symbol.
- `to_bundled_ast` also sets `wrapper_ref` to the builder's HMR API symbol for every module it builds, and the after-the-fact assignment in `ServerComponentParseTask` is removed. This is the value the proxy already had (so its output is unchanged) and what `js_parser::to_ast` does under HMR; the dev server reads the HMR binding from `wrapper_ref`, and when the linker wraps the file for `require()` it renames the symbol to `init_<file>`. An unwrapped file never prints it: every production-mode reader of a file's `wrapper_ref` is behind a `wrap` check (`scanImportsAndExports.rs` steps 6 naming and wrapper binding, `LinkerContext.rs` `WrapKind::Esm` import rewriting and `create_wrapper_for_file`, `convertStmtsForChunk.rs`, `generateCodeForFileInChunkJS.rs`, `postProcessJSChunk.rs`, `renameSymbolsInChunk.rs`, `computeCrossChunkDependencies.rs`), and the only unconditional reader is the dev server's HMR binding, which never sees the `bun:bake/*` modules because those imports are external in dev (`bundle_v2.rs`, import record resolution).
- Test: `test/bake/dev/production.test.ts` ("namespace import, export * as and require() of a client component") builds one app whose pages use `import *`, `export * as` and `require()` against the same `"use client"` module plus `import *` and `require()` of `bun:bake/server`, and checks the prerendered HTML of each page. The `require()` pages also render `typeof` an export, which is only right if the wrapper actually ran. Because three pages share the proxy it is placed in a shared server chunk, so the test also covers the namespace object being exported from one chunk and imported by the page chunks (`require()` becomes `(init_Client(), __toCommonJS(exports_Client))` there). Fails on the current release build with the error above, passes with this change; the `bun:bake/server` `require()` page was also checked to fail against a build with only the `exports_ref` half applied (the `wrapper_ref` assertion).
- Also ran: the rest of `test/bake/dev/production.test.ts`, the `"use client"` dev server test in `test/bake/dev/bundle.test.ts` (namespace import of a `"use client"` module with `separateSSRGraph`, exercising the proxy and its HMR binding in dev mode), the svelte component islands dev test in `test/bake/dev/ecosystem.test.ts` (client reference proxy with a custom framework, including a hot reload), `test/bake/dev/response-to-bake-response.test.ts`, `cargo check -p bun_bundler`.
- Not fixed here: `import()` of a `"use client"` module from the server still produces a call to an undeclared wrapper. That is a different problem (dynamic import entry points are registered before the import records are redirected to the proxy) and is tracked separately.

### Background
- Client reference proxy: when bake's server graph imports a `"use client"` file (and the framework uses a separate SSR graph), the server does not get the real module. `ServerComponentParseTask` uses `AstBuilder` to generate a replacement module with the same export names, each exporting `registerClientReference(...)`. This generated module is what the server-side importer is linked against. `AstBuilder` is also used to generate the `bun:bake/server` module (the manifests) and the `bun:bake/client` module in production builds.
- `exports_ref`: every JS AST carries a symbol that stands for the module's namespace object. The linker binds `import * as ns`, `export * as ns`, and the value returned by `require()` / inline `import()` of the module to this symbol, and emits its definition (`var x_exports = {}; __export(x_exports, {...})`) in a dedicated part of the file.
- Namespace export part: part index 0 of every file is reserved for that definition. The linker fills it in during linking (step 5) and only keeps it if something depends on it. `top_level_symbols_to_parts` is the per-file map from a top-level symbol to the parts that declare it; it is how a use of a symbol pulls in the code that declares it, so `exports_ref` has to map to part 0.
- `wrapper_ref`: when a module has to be evaluated lazily (it is `require()`d, or `import()`ed without code splitting), the linker wraps its body in `var init_x = __esm(() => { ... })` and replaces each `require()` with `(init_x(), __toCommonJS(x_exports))`; `wrapper_ref` is the `init_x` symbol. In the dev server the same slot holds the binding through which each module receives the HMR API, which is why both js_parser (under HMR) and `AstBuilder` put the HMR symbol there.