### PR TITLE
worker_threads: don't drop stdout/stderr on synchronous worker exit; honor exitCode set in 'exit' listeners

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -460,25 +460,23 @@ function makePortWritable(port) {
   return stream;
 }
 
+// The parent always sends stdout and stderr ports; stdin only for { stdin: true }.
 function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
-  let stdoutStream, stderrStream;
-  if (stdout) {
-    Object.defineProperty(process, "stdout", {
-      value: (stdoutStream = makePortWritable(stdout)),
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
-  }
-  if (stderr) {
-    Object.defineProperty(process, "stderr", {
-      value: (stderrStream = makePortWritable(stderr)),
-      writable: true,
-      configurable: true,
-      enumerable: true,
-    });
-  }
+  const stdoutStream = makePortWritable(stdout);
+  const stderrStream = makePortWritable(stderr);
+  Object.defineProperty(process, "stdout", {
+    value: stdoutStream,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+  Object.defineProperty(process, "stderr", {
+    value: stderrStream,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
   // node always replaces a worker's process.stdin: port-backed when { stdin: true },
   // otherwise an immediately-EOF'd stream — never the process-wide fd 0, which
   // would race the main thread (and hang on a TTY).
@@ -495,15 +493,13 @@ function setupWorkerStdio(stdio) {
     enumerable: true,
   });
   // node routes console.log through process.stdout/stderr; Bun's global console
-  // writes the fd directly, so rebind it to the captured streams when present.
-  if (stdoutStream || stderrStream) {
-    const { Console } = require("node:console");
-    globalThis.console = new Console(process.stdout, process.stderr);
-    process.on("exit", () => {
-      stdoutStream?.[kFlushSync]();
-      stderrStream?.[kFlushSync]();
-    });
-  }
+  // writes the fd directly, so rebind it to the port-backed streams.
+  const { Console } = require("node:console");
+  globalThis.console = new Console(stdoutStream, stderrStream);
+  process.on("exit", () => {
+    stdoutStream[kFlushSync]();
+    stderrStream[kFlushSync]();
+  });
 }
 
 // Emulation of Node's JSTransferable protocol (kTransfer/kTransferList/kDeserialize) for

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -381,13 +381,8 @@ function makePortReadable(port, incrementsPortRef) {
       port.unref();
     }
   });
-  // Lets the parent end worker.stdout/stderr when the worker exits, delivering
-  // anything still queued on the port first (node's kOnExit drains before EOF).
+  // Lets the parent end worker.stdout/stderr when the worker exits abruptly.
   stream.endFromOwner = function () {
-    let entry;
-    while (ended === false && (entry = _receiveMessageOnPort(port)) !== undefined) {
-      onMessage(entry.message);
-    }
     if (ended === false) {
       ended = true;
       stream.push(null);

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -335,6 +335,8 @@ const BUN_WORKER_PARENT_PORT_KEY = "@@bunWorkerThreadsParentPort";
 // each stream has its own port (node multiplexes one env port), the payload is
 // the bare chunk array, EOF is null, and any other message is the ack.
 
+const kFlushSync = Symbol("kFlushSync");
+
 // Readable fed by a control MessagePort (worker.stdout/stderr on the parent,
 // process.stdin in the worker). The peer posts arrays of Buffers; null signals EOF.
 function makePortReadable(port, incrementsPortRef) {
@@ -379,8 +381,13 @@ function makePortReadable(port, incrementsPortRef) {
       port.unref();
     }
   });
-  // Lets the parent end worker.stdout/stderr when the worker exits abruptly.
+  // Lets the parent end worker.stdout/stderr when the worker exits, delivering
+  // anything still queued on the port first (node's kOnExit drains before EOF).
   stream.endFromOwner = function () {
+    let entry;
+    while (ended === false && (entry = _receiveMessageOnPort(port)) !== undefined) {
+      onMessage(entry.message);
+    }
     if (ended === false) {
       ended = true;
       stream.push(null);
@@ -408,7 +415,7 @@ function makePortWritable(port) {
   }
   port.on("message", onAck);
   port.unref();
-  return new Writable({
+  const stream = new Writable({
     decodeStrings: false,
     writev(chunks, cb) {
       const payload = new Array(chunks.length);
@@ -446,13 +453,19 @@ function makePortWritable(port) {
       cb(err);
     },
   });
+  // On a synchronous exit no ack can arrive; completing the parked writev lets
+  // the Writable clear its buffer through writev, which now completes
+  // synchronously because process._exiting is set (node's flushSync).
+  stream[kFlushSync] = onAck;
+  return stream;
 }
 
 function setupWorkerStdio(stdio) {
   const { stdin, stdout, stderr } = stdio;
+  let stdoutStream, stderrStream;
   if (stdout) {
     Object.defineProperty(process, "stdout", {
-      value: makePortWritable(stdout),
+      value: (stdoutStream = makePortWritable(stdout)),
       writable: true,
       configurable: true,
       enumerable: true,
@@ -460,7 +473,7 @@ function setupWorkerStdio(stdio) {
   }
   if (stderr) {
     Object.defineProperty(process, "stderr", {
-      value: makePortWritable(stderr),
+      value: (stderrStream = makePortWritable(stderr)),
       writable: true,
       configurable: true,
       enumerable: true,
@@ -483,9 +496,13 @@ function setupWorkerStdio(stdio) {
   });
   // node routes console.log through process.stdout/stderr; Bun's global console
   // writes the fd directly, so rebind it to the captured streams when present.
-  if (stdout || stderr) {
+  if (stdoutStream || stderrStream) {
     const { Console } = require("node:console");
     globalThis.console = new Console(process.stdout, process.stderr);
+    process.on("exit", () => {
+      stdoutStream?.[kFlushSync]();
+      stderrStream?.[kFlushSync]();
+    });
   }
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -905,14 +905,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionExit, (JSC::JSGlobalObject * globalObje
     setProcessExitCodeInner(globalObject, process, code);
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    auto exitCode = Bun__getExitCode(bunVM(zigGlobal));
-    Process__dispatchOnExit(zigGlobal, exitCode);
+    Process__dispatchOnExit(zigGlobal, Bun__getExitCode(bunVM(zigGlobal)));
 
-    // process.reallyExit(exitCode);
+    // process.reallyExit(process.exitCode) — re-read: an 'exit' listener may have set it.
     auto reallyExitVal = process->get(globalObject, Identifier::fromString(vm, "reallyExit"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     MarkedArgumentBuffer args;
-    args.append(jsNumber(exitCode));
+    args.append(jsNumber(Bun__getExitCode(bunVM(zigGlobal))));
     JSC::call(globalObject, reallyExitVal, args, ""_s);
     RETURN_IF_EXCEPTION(throwScope, {});
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -302,11 +302,11 @@ static void dispatchExitInternal(JSC::JSGlobalObject* globalObject, Process* pro
     if (vm.hasTerminationRequest() || vm.hasExceptionsAfterHandlingTraps())
         return;
 
+    process->putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(true), 0);
     auto event = Identifier::fromString(vm, "exit"_s);
     if (!emitter.hasEventListeners(event)) {
         return;
     }
-    process->putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(true), 0);
 
     MarkedArgumentBuffer arguments;
     arguments.append(jsNumber(exitCode));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1856,43 +1856,63 @@ it("process._exiting", () => {
   expect(process._exiting).toBe(false);
 });
 
-// node sets process._exiting before emitting 'exit' regardless of whether anyone
-// listens (lib/internal/process/per_thread.js). reallyExit is looked up after the
-// 'exit' dispatch, so an override observes the post-dispatch state without adding
-// an 'exit' listener itself.
-describe.concurrent("process._exiting is set by process.exit() with no 'exit' listeners", () => {
+// node's process.exit() (lib/internal/process/per_thread.js): _exiting is set before
+// 'exit' is emitted whether or not anyone listens, and reallyExit — looked up after
+// the dispatch — receives process.exitCode as the listeners left it. Overriding
+// reallyExit observes both without adding an 'exit' listener of its own.
+describe.concurrent("process.exit()", () => {
   const probe = `const { writeSync } = require("node:fs");
     const reallyExit = process.reallyExit;
     process.reallyExit = function (code) {
-      writeSync(1, "listeners=" + process.listenerCount("exit") + " _exiting=" + process._exiting + "\\n");
+      writeSync(1, "_exiting=" + process._exiting + " code=" + code + "\\n");
       return reallyExit.call(process, code);
-    };
-    process.exit(0);`;
+    };`;
 
-  it("main thread", async () => {
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", probe], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  it("sets _exiting with no 'exit' listeners (main thread)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", probe + "process.exit(0);"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "listeners=0 _exiting=true\n", stderr: "", exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "_exiting=true code=0\n", stderr: "", exitCode: 0 });
   });
 
-  it("worker thread", async () => {
+  it("sets _exiting with no user 'exit' listeners (worker thread)", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `const { Worker } = require("node:worker_threads");
-         new Worker(${JSON.stringify(probe)}, { eval: true }).on("exit", c => console.log("exit " + c));`,
+         new Worker(${JSON.stringify(probe + "process.exit(0);")}, { eval: true }).on("exit", c => console.log("exit " + c));`,
       ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // The worker's stdio bootstrap owns one 'exit' listener (node's flushSync).
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "_exiting=true code=0\nexit 0\n", stderr: "", exitCode: 0 });
+  });
+
+  it("exits with the exitCode an 'exit' listener assigns", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        probe +
+          `process.on("exit", code => { writeSync(1, "listener code=" + code + "\\n"); process.exitCode = 42; });
+           process.exit(7);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "listeners=1 _exiting=true\nexit 0\n",
+      stdout: "listener code=7\n_exiting=true code=42\n",
       stderr: "",
-      exitCode: 0,
+      exitCode: 42,
     });
   });
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1856,6 +1856,47 @@ it("process._exiting", () => {
   expect(process._exiting).toBe(false);
 });
 
+// node sets process._exiting before emitting 'exit' regardless of whether anyone
+// listens (lib/internal/process/per_thread.js). reallyExit is looked up after the
+// 'exit' dispatch, so an override observes the post-dispatch state without adding
+// an 'exit' listener itself.
+describe.concurrent("process._exiting is set by process.exit() with no 'exit' listeners", () => {
+  const probe = `const { writeSync } = require("node:fs");
+    const reallyExit = process.reallyExit;
+    process.reallyExit = function (code) {
+      writeSync(1, "listeners=" + process.listenerCount("exit") + " _exiting=" + process._exiting + "\\n");
+      return reallyExit.call(process, code);
+    };
+    process.exit(0);`;
+
+  it("main thread", async () => {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", probe], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "listeners=0 _exiting=true\n", stderr: "", exitCode: 0 });
+  });
+
+  it("worker thread", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         new Worker(${JSON.stringify(probe)}, { eval: true }).on("exit", c => console.log("exit " + c));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The worker's stdio bootstrap owns one 'exit' listener (node's flushSync).
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "listeners=1 _exiting=true\nexit 0\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 it("process.memoryUsage.arrayBuffers", () => {
   const initial = process.memoryUsage().arrayBuffers;
   const array = new ArrayBuffer(1024 * 1024 * 16);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -479,8 +479,7 @@ describe("captured stdio backpressure", () => {
 
 // A synchronous worker exit leaves no loop turns for the reader's ack to release
 // the parked writev, so everything buffered behind it must be flushed from the
-// worker's process 'exit' (node's flushSync) and drained by the parent before it
-// ends worker.stdout/stderr.
+// worker's process 'exit' (node's flushSync).
 describe("stdio is flushed when the worker exits synchronously", () => {
   const N = 300;
 
@@ -542,6 +541,38 @@ describe("stdio is flushed when the worker exits synchronously", () => {
     expect(lines.length).toBe(LINES + 1);
     expect(lines).toEqual([...Array.from({ length: LINES }, (_, i) => "L" + i), ""]);
     expect(code).toBe(0);
+  });
+
+  // The stdio bootstrap's own 'exit' listener must not disturb the user's: on an
+  // uncaught exception the user's handler still sees code 1 with _exiting set, its
+  // buffered + exit-time output arrives, and the exitCode it assigns wins (as in node).
+  // Spawned so the test runner's unhandled-error hook doesn't intercept the
+  // worker's uncaught exception.
+  test("user 'exit' handler on uncaught exception: output flushed and exitCode honored", async () => {
+    const workerSrc = `process.on("exit", code => {
+        process.stdout.write("exit handler " + code + " " + process._exiting + "\\n");
+        process.exitCode = 42;
+      });
+      console.log("hello");
+      throw new Error("boom");`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true, stdout: true });
+         let out = "";
+         w.stdout.setEncoding("utf8").on("data", d => (out += d));
+         w.on("error", e => console.log("error " + e.message));
+         w.on("exit", c => console.log(JSON.stringify({ code: c, out })));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(`error boom\n${JSON.stringify({ code: 42, out: "hello\nexit handler 1 true\n" })}\n`);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -519,36 +519,39 @@ describe("stdio is flushed when the worker exits synchronously", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe(Array.from({ length: N }, (_, i) => "W" + i + "\n").join(""));
-    expect(stderr).toContain(`[exit ${expectedWorkerCode}]`);
+    expect(stderr).toBe(`[exit ${expectedWorkerCode}]\n`);
     expect(exitCode).toBe(0);
   });
 
-  // Every write from an 'exit' handler is its own message (process._exiting makes
-  // writev complete synchronously); all of them must be delivered, in order,
-  // before the parent ends worker.stdout and emits 'exit'.
-  test("worker 'exit' handler output all arrives, in order, before the parent's 'exit'", async () => {
-    const LINES = 5000;
+  // Output buffered behind the parked batch is flushed first, then each write
+  // from the user's 'exit' handler goes through synchronously; all of it arrives,
+  // in order, before the parent's 'exit', and the exitCode the handler sets wins.
+  test("buffered output, then 'exit' handler output, arrive in order; handler exitCode wins", async () => {
+    const M = 200;
     const worker = new Worker(
-      `process.on("exit", () => {
-         for (let i = 0; i < ${LINES}; i++) process.stdout.write("L" + i + "\\n");
-       });`,
+      `process.on("exit", code => {
+         for (let i = 0; i < ${M}; i++) process.stdout.write("L" + i + " " + code + " " + process._exiting + "\\n");
+         process.exitCode = 42;
+       });
+       for (let i = 0; i < ${N}; i++) console.log("W" + i);
+       process.exit(7);`,
       { eval: true, stdout: true },
     );
     let out = "";
     worker.stdout.setEncoding("utf8").on("data", d => (out += d));
     const [code] = await once(worker, "exit");
-    const lines = out.split("\n");
-    expect(lines.length).toBe(LINES + 1);
-    expect(lines).toEqual([...Array.from({ length: LINES }, (_, i) => "L" + i), ""]);
-    expect(code).toBe(0);
+    expect(out).toBe(
+      Array.from({ length: N }, (_, i) => "W" + i + "\n").join("") +
+        Array.from({ length: M }, (_, i) => "L" + i + " 7 true\n").join(""),
+    );
+    expect(code).toBe(42);
   });
 
-  // The stdio bootstrap's own 'exit' listener must not disturb the user's: on an
-  // uncaught exception the user's handler still sees code 1 with _exiting set, its
-  // buffered + exit-time output arrives, and the exitCode it assigns wins (as in node).
+  // Same on an uncaught exception: the user's handler sees code 1 with _exiting
+  // set, buffered + exit-time output arrives, and its exitCode wins (as in node).
   // Spawned so the test runner's unhandled-error hook doesn't intercept the
   // worker's uncaught exception.
-  test("user 'exit' handler on uncaught exception: output flushed and exitCode honored", async () => {
+  test.concurrent("user 'exit' handler on uncaught exception: output flushed and exitCode honored", async () => {
     const workerSrc = `process.on("exit", code => {
         process.stdout.write("exit handler " + code + " " + process._exiting + "\\n");
         process.exitCode = 42;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -500,7 +500,7 @@ describe("stdio is flushed when the worker exits synchronously", () => {
     expect(code).toBe(0);
   });
 
-  test.each([
+  test.concurrent.each([
     ["process.exit", "process.exit(0);", 0],
     ["uncaught exception", 'throw new Error("boom");', 1],
     ["unhandled rejection", 'Promise.reject(new Error("boom"));', 1],

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -477,6 +477,74 @@ describe("captured stdio backpressure", () => {
   });
 });
 
+// A synchronous worker exit leaves no loop turns for the reader's ack to release
+// the parked writev, so everything buffered behind it must be flushed from the
+// worker's process 'exit' (node's flushSync) and drained by the parent before it
+// ends worker.stdout/stderr.
+describe("stdio is flushed when the worker exits synchronously", () => {
+  const N = 300;
+
+  test.each(["stdout", "stderr"] as const)("captured %s: console + raw write, then process.exit(0)", async name => {
+    const method = name === "stdout" ? "log" : "error";
+    const worker = new Worker(
+      `for (let i = 0; i < ${N}; i++) {
+         if (i % 2) console.${method}("W" + i); else process.${name}.write("W" + i + "\\n");
+       }
+       process.exit(0);`,
+      { eval: true, stdout: true, stderr: true },
+    );
+    let out = "";
+    worker[name].setEncoding("utf8").on("data", d => (out += d));
+    const [code] = await once(worker, "exit");
+    expect(out).toBe(Array.from({ length: N }, (_, i) => "W" + i + "\n").join(""));
+    expect(code).toBe(0);
+  });
+
+  test.each([
+    ["process.exit", "process.exit(0);", 0],
+    ["uncaught exception", 'throw new Error("boom");', 1],
+    ["unhandled rejection", 'Promise.reject(new Error("boom"));', 1],
+  ])("auto-piped stdout survives %s", async (_label, exit, expectedWorkerCode) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(`for (let i = 0; i < ${N}; i++) console.log("W" + i);\n${exit}`)}, { eval: true });
+         w.on("error", () => {});
+         w.on("exit", c => console.error("[exit " + c + "]"));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(Array.from({ length: N }, (_, i) => "W" + i + "\n").join(""));
+    expect(stderr).toContain(`[exit ${expectedWorkerCode}]`);
+    expect(exitCode).toBe(0);
+  });
+
+  // Every write from an 'exit' handler is its own message (process._exiting makes
+  // writev complete synchronously); all of them must be delivered, in order,
+  // before the parent ends worker.stdout and emits 'exit'.
+  test("worker 'exit' handler output all arrives, in order, before the parent's 'exit'", async () => {
+    const LINES = 5000;
+    const worker = new Worker(
+      `process.on("exit", () => {
+         for (let i = 0; i < ${LINES}; i++) process.stdout.write("L" + i + "\\n");
+       });`,
+      { eval: true, stdout: true },
+    );
+    let out = "";
+    worker.stdout.setEncoding("utf8").on("data", d => (out += d));
+    const [code] = await once(worker, "exit");
+    const lines = out.split("\n");
+    expect(lines.length).toBe(LINES + 1);
+    expect(lines).toEqual([...Array.from({ length: LINES }, (_, i) => "L" + i), ""]);
+    expect(code).toBe(0);
+  });
+});
+
 describe("worker event", () => {
   test("is emitted on the next tick with the right value", () => {
     const { promise, resolve } = Promise.withResolvers();


### PR DESCRIPTION
### What does this PR do?

A `node:worker_threads` worker that writes to `process.stdout`/`process.stderr` and then exits synchronously — `process.exit()`, an uncaught exception, or an unhandled rejection — lost everything after the first write. Node delivers all of it.

```js
const w = new Worker('for (let i=0;i<300;i++) console.log(i); process.exit(0)', { eval: true, stdout: true });
let out = ""; w.stdout.setEncoding("utf8").on("data", d => out += d);
w.on("exit", () => console.log(out.split("\n").length));   // node: 301, bun before: 2
```

Worker stdio is a port-backed Writable whose `writev` parks its callback until the parent acks the batch. On a synchronous exit there are no more loop turns, so the ack never arrives and the buffered writes behind the parked batch are dropped. `writev` already completes synchronously when `process._exiting` is set, but nothing ever released the parked batch to get there.

- The worker's stdio bootstrap registers a process `'exit'` listener that completes the parked `writev` for stdout/stderr (Node's `flushSync` in `is_not_main_thread.js`), letting the Writable clear its buffer through the now-synchronous `writev`. `setupWorkerStdio` no longer guards on stdout/stderr being present — the parent always sends both ports (only stdin is optional).
- `process._exiting` is set before the "any `'exit'` listeners?" early return in `dispatchExitInternal`, as Node sets it unconditionally. This applies to the main thread too: `_exiting` is now `true` after `'exit'` dispatch even when nobody listens.
- `process.exit()` re-reads `process.exitCode` after emitting `'exit'` before calling `reallyExit`, so an exit code assigned inside an `'exit'` listener is the one the process (or worker) exits with, as in Node. Previously the pre-dispatch value was used and the assignment was ignored on both the main thread and in workers.

`worker.terminate()` still does not flush, same as Node. The parent side needed no change: the worker closes its stdio ports during teardown before posting its close task, so `MessagePort::peerClosed` has already flushed the port before `Worker#onClose` ends the streams.

### How did you verify your code works?

New tests, each failing on current main and passing here:
- `worker_threads.test.ts`: captured stdout/stderr (console + raw writes) with `process.exit(0)`; auto-piped stdout across `process.exit`, uncaught exception, and unhandled rejection; buffered output followed by an `'exit'` handler's writes all arrive in order and the handler's `exitCode` wins after `process.exit(7)`; the same on an uncaught exception (handler sees code 1 with `_exiting` set).
- `process.test.js`: with a `reallyExit` override, `process.exit()` shows `_exiting === true` with no `'exit'` listeners on the main thread and in a worker, and `process.exit(7)` with a listener assigning `exitCode = 42` exits 42.

The full `worker_threads.test.ts` (129 tests) and the Node parallel `test-process-exit*`, `test-process-really-exit`, `test-process-beforeexit-throw-exit`, `test-worker-*exit*`, `test-worker-stdio*`, and `test-next-tick-when-exiting` tests pass on a debug build; each exit mode was compared against Node by hand. No additional Node parallel tests change state with this diff.