### PR TITLE
shell: only accept a real template object as the first argument of $

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -709,6 +709,7 @@ interface Map<K, V> {
 interface ObjectConstructor {
   $defineProperty: typeof Object.defineProperty;
   $defineProperties: typeof Object.defineProperties;
+  $getOwnPropertyDescriptor: typeof Object.getOwnPropertyDescriptor;
 }
 
 declare const $Object: ObjectConstructor;

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -5,9 +5,24 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     args: $ZigGeneratedClasses.ParsedShellScript,
   ) => $ZigGeneratedClasses.ShellInterpreter;
   const createParsedShellScript = createParsedShellScript_ as (
-    raw: string,
+    raw: readonly string[],
     args: string[],
   ) => $ZigGeneratedClasses.ParsedShellScript;
+
+  // `raw` runs unescaped, so it is only taken from a template object: the engine and the tsc/babel/
+  // swc/esbuild downlevel helpers all define `raw` as an own non-enumerable read-only array, while
+  // data arrives with it missing (JSON), enumerable (structuredClone, Object.assign) or inherited
+  // (polluted prototype). Not Object.isFrozen: tsc's __makeTemplateObject does not freeze.
+  function templateRawStrings(strings: any): readonly string[] {
+    if ($isArray(strings)) {
+      const descriptor = $Object.$getOwnPropertyDescriptor(strings, "raw");
+      if (descriptor !== undefined && !descriptor.enumerable && !descriptor.writable && !descriptor.configurable) {
+        const raw = descriptor.value;
+        if ($isArray(raw) && raw.length === strings.length) return raw;
+      }
+    }
+    throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
+  }
 
   function lazyBufferToHumanReadableString(this: Buffer) {
     return this.toString();
@@ -300,8 +315,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
   }
 
   var BunShell = function BunShell(first, ...rest) {
-    if (first?.raw === undefined) throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
-    const parsed_shell_script = createParsedShellScript(first.raw, rest);
+    const parsed_shell_script = createParsedShellScript(templateRawStrings(first), rest);
 
     const cwd = BunShell[cwdSymbol];
     const env = BunShell[envSymbol];
@@ -320,8 +334,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     }
 
     var Shell = function Shell(first, ...rest) {
-      if (first?.raw === undefined) throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
-      const parsed_shell_script = createParsedShellScript(first.raw, rest);
+      const parsed_shell_script = createParsedShellScript(templateRawStrings(first), rest);
 
       const cwd = Shell[cwdSymbol];
       const env = Shell[envSymbol];

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -9,10 +9,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     args: string[],
   ) => $ZigGeneratedClasses.ParsedShellScript;
 
-  // `raw` runs unescaped, so it is only taken from a template object: the engine and the tsc/babel/
-  // swc/esbuild downlevel helpers all define `raw` as an own non-enumerable read-only array, while
-  // data arrives with it missing (JSON), enumerable (structuredClone, Object.assign) or inherited
-  // (polluted prototype). Not Object.isFrozen: tsc's __makeTemplateObject does not freeze.
+  // `raw` runs unescaped; this is the shape of every template object, engine-made or downleveled (tsc's is not frozen).
   function templateRawStrings(strings: any): readonly string[] {
     if ($isArray(strings)) {
       const descriptor = $Object.$getOwnPropertyDescriptor(strings, "raw");

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -36,6 +36,74 @@ test("new $.Shell() inherits process.env and throws on non-zero exit by default"
   expect(exitCode).toBe(0);
 });
 
+// The first argument's `raw` strings are spliced into the script unescaped, so
+// only a template object may be accepted there. The default `$` and
+// `new $.Shell()` instances each make that decision.
+describe.each([
+  ["$", () => $],
+  ["new $.Shell()", () => new $.Shell()],
+])("%s only accepts a template object as its first argument", (_, makeShell) => {
+  const rejected = "threw: Please use '$' as a tagged template function: $`cmd arg1 arg2`";
+  const payload = "echo pwned";
+
+  // Not expect(() => shell(x)).toThrow(): a shell that accepts x returns a lazy ShellPromise, and
+  // toThrow() would then wait for that never-started promise instead of failing.
+  function callWith(first: unknown): string {
+    let result: unknown;
+    try {
+      result = makeShell()(first as any);
+    } catch (e) {
+      return `threw: ${(e as Error).message}`;
+    }
+    return `returned ${typeof result} without throwing`;
+  }
+
+  test.each([
+    ["a JSON object carrying a raw array", () => JSON.parse('{"raw":["echo pwned"]}')],
+    ["an array without raw", () => [payload]],
+    ["an array with raw assigned onto it", () => Object.assign([payload], { raw: [payload] })],
+    ["a structuredClone of an array with raw", () => structuredClone(Object.assign([payload], { raw: [payload] }))],
+    ["an array whose raw is a string", () => Object.defineProperty([payload], "raw", { value: payload })],
+    [
+      "an array whose raw has a different length",
+      () => Object.defineProperty([payload, ""], "raw", { value: [payload] }),
+    ],
+    ["a string", () => payload],
+    ["undefined", () => undefined],
+  ])("rejects %s", (_, makeFirstArgument) => {
+    expect(callWith(makeFirstArgument())).toBe(rejected);
+  });
+
+  test("rejects a raw inherited through a polluted prototype", () => {
+    (Object.prototype as any).raw = [payload];
+    try {
+      expect([callWith({}), callWith([]), callWith(payload)]).toEqual([rejected, rejected, rejected]);
+    } finally {
+      delete (Object.prototype as any).raw;
+    }
+  });
+
+  test("runs a template object forwarded by a wrapper", async () => {
+    const shell = makeShell();
+    const sh = (strings: TemplateStringsArray, ...values: string[]) => shell(strings, ...values);
+    expect(await sh`echo ${"forwarded"} ${"template"}`.text()).toBe("forwarded template\n");
+  });
+
+  // What tsc's __makeTemplateObject produces for target es5: raw is defined, nothing is frozen.
+  test("runs a template object built with Object.defineProperty", async () => {
+    const shell = makeShell();
+    const strings = Object.defineProperty(["echo ", ""], "raw", { value: ["echo ", ""] });
+    expect(await shell(strings as unknown as TemplateStringsArray, "downleveled").text()).toBe("downleveled\n");
+  });
+
+  // What babel, swc and esbuild produce: raw is defined and both arrays are frozen.
+  test("runs a frozen template object", async () => {
+    const shell = makeShell();
+    const strings = Object.freeze(Object.defineProperty(["echo ", ""], "raw", { value: Object.freeze(["echo ", ""]) }));
+    expect(await shell(strings as unknown as TemplateStringsArray, "frozen").text()).toBe("frozen\n");
+  });
+});
+
 test("$$", async () => {
   const $$ = new $.Shell();
   $$.env({ BUN: "bun" });


### PR DESCRIPTION
### Problem
- `$(x)` (and a `new $.Shell()` instance) accepts any `x` whose `raw` property is not `undefined` and runs `x.raw` as unescaped script text (`src/js/builtins/shell.ts`, the check was `if (first?.raw === undefined) throw ...` at both call sites).
- `x.raw` is an ordinary property read, so data satisfies it: `$(JSON.parse('{"raw":["touch PWNED"]}'))` runs `touch PWNED` on 1.4.0, as does `$(Object.assign(["x"], { raw: ["touch PWNED"] }))`.
- With `Object.prototype.raw` polluted, every non-template call does too: `$({})`, `$("echo hi")`, `$([])` all run the polluted value. Without the pollution these calls throw, so a mistaken `$()` call is only reachable as an execution primitive through the pollution.
- Interpolated values (`` $`cmd ${userInput}` ``) are not affected; they go through escaping in `shell_body.rs`. The documented `${{ raw }}` escape hatch for values is also left as is: changing it was proposed and declined in #31338, which did not touch the first-argument check this PR is about.

### Fix
- `templateRawStrings(first)` is the single predicate both `$` and `Shell` instances now go through. It accepts `first` only if it is an array whose own `raw` property is non-enumerable, non-writable and non-configurable and holds an array of the same length; anything else throws the existing "Please use '$' as a tagged template function" error.
- That is the shape of every template object: the engine's (`JSTemplateObjectDescriptor::createTemplateObject` defines `raw` as `ReadOnly | DontEnum | DontDelete`), and the ones built by the downlevel helpers of tsc (`__makeTemplateObject`, `Object.defineProperty`), babel, swc and esbuild (`defineProperty` plus `freeze`), all checked against the helpers' actual output. Data cannot take that shape: JSON produces a plain object or an array with no `raw`, `structuredClone` and `Object.assign` produce an enumerable `raw`, prototype pollution produces an inherited one.
- `Object.isFrozen` (the other obvious brand) is deliberately not used: tsc's `__makeTemplateObject` does not freeze, so it would break `target: es5` output.
- The check uses `$isArray` and `$Object.$getOwnPropertyDescriptor`, which resolve to engine intrinsics, so replacing `Array.isArray` or `Object.getOwnPropertyDescriptor` in userland does not influence it (checked by hand: with both replaced and the prototype polluted, the forgeries are still rejected and a real template still runs). `builtins.d.ts` gains the type for `$getOwnPropertyDescriptor`.
- Only behavior change for non-attack code: a hand-built strings array with a plain assigned `raw` (babel's `loose` helper, or `strings.raw = raw` in a wrapper) is now rejected; it is indistinguishable from the data case. Forwarding a real template object (`(s, ...v) => $(s, ...v)`, which is what `test/js/bun/shell/test_builder.ts` does) keeps working. The declared type of `$` was already `TemplateStringsArray` only.
- Same predicate as #38219 uses for `Bun.SQL`.
- Verified with `test/js/bun/shell/bunshell-instance.test.ts`: the new cases run against both `$` and `new $.Shell()`; 12 of them fail on 1.4.0 (the forgeries are accepted) and all 41 in the file pass with this change. The forwarded, tsc-style and frozen template cases pin what must keep working.
- `test/js/bun/shell/bunshell.test.ts` plus `lazy`, `throw`, `shelloutput`, `bunshell-default`, `exec`, `shell-sentinel-hardening`: 454 pass, 0 fail.

### Background
- A tagged template call `` $`echo ${x}` `` passes the tag a template object: a frozen array of the literal's cooked string pieces, carrying a `raw` property with the unescaped pieces, followed by the interpolated values as separate arguments. Bun's shell builds the script from `raw` and escapes only the interpolated values, so whatever is accepted as `raw` is trusted script text by construction.
- The JS wrapper in `src/js/builtins/shell.ts` is the only caller of the native `createParsedShellScript(raw, values)`, which iterates `raw` as an array-like and appends each element verbatim (`shell_cmd_from_js` in `src/runtime/shell/shell_body.rs`), so the wrapper is the only place where the decision can be made.
- In `src/js` builtins, a `$name` reference compiles to the engine's private `@name`: `$isArray` is the `IsArray` intrinsic and `$Object` is a link-time constant for the original `Object` constructor, so these calls are not affected by userland changes to the public globals.

<details>
<summary>Probe on bun 1.4.0 (before) and this branch (after)</summary>

```
$(jsonObject)             before: EXECUTED "pwned-json"       after: throws
$(forgedArray)            before: EXECUTED "pwned-forged"     after: throws
$(arrayNoRaw)             before: throws                      after: throws
polluted $({})            before: EXECUTED "pwned-proto"      after: throws
polluted $('echo hi')     before: EXECUTED "pwned-proto"      after: throws
polluted $([])            before: EXECUTED "pwned-proto"      after: throws
forward real template     before: EXECUTED "real template"    after: EXECUTED "real template"
instance $(jsonObject)    before: EXECUTED "pwned-instance"   after: throws
```

Downlevel helper output used to choose the predicate (tsc's `__makeTemplateObject`: `Object.defineProperty(cooked, "raw", { value: raw })`, no freeze; esbuild `__template`: `__freeze(__defProp(cooked, "raw", { value: __freeze(raw) }))`; swc and babel `_taggedTemplateLiteral`: `Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } }))`; babel `_taggedTemplateLiteralLoose`: `strings.raw = raw`).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.0 (7f5102abd)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [432.61ms]
69 |       () => Object.defineProperty([payload, ""], "raw", { value: [payload] }),
70 |     ],
71 |     ["a string", () => payload],
72 |     ["undefined", () => undefined],
73 |   ])("rejects %s", (_, makeFirstArgument) => {
74 |     expect(callWith(makeFirstArgument())).toBe(rejected);
                                               ^
error: expect(received).toBe(expected)

Expected: "threw: Please use '$' as a tagged template function: $`cmd arg1 arg2`"
Received: "returned object without throwing"

      at <anonymous> (/workspace/bun/test/js/bun/shell/bunshell-instance.test.ts:74:43)
(fail) $ only accepts a template object as its first argument > rejects a JSON object carrying a raw array [37.92ms]
(pass) $ only accepts a template object as its first argument > rejects an array without raw [3.52ms]
69 |       () => Object.def
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e3609dad1)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [9.25ms]
(pass) $ only accepts a template object as its first argument > rejects a JSON object carrying a raw array [0.18ms]
(pass) $ only accepts a template object as its first argument > rejects an array without raw [0.02ms]
(pass) $ only accepts a template object as its first argument > rejects an array with raw assigned onto it [0.02ms]
(pass) $ only accepts a template object as its first argument > rejects a structuredClone of an array with raw [0.04ms]
(pass) $ only accepts a template object as its first argument > rejects an array whose raw is a string [0.02ms]
(pass) $ only accepts a template object as its first argument > rejects an array whose raw has a different length [0.01ms]
(pass) $ only accepts a template object as its first argument > rejects a string
(pass) $ only accepts a template object as its first argument > rejects undefined
(pass) $ only accepts a template object as its first argument > rejects a raw inherited through a polluted prototype [0.06ms]
(pass) $ only accepts a template 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.0 (7f5102abd)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [429.85ms]
(pass) $ only accepts a template object as its first argument > rejects a JSON object carrying a raw array [12.79ms]
(pass) $ only accepts a template object as its first argument > rejects an array without raw [2.04ms]
(pass) $ only accepts a template object as its first argument > rejects an array with raw assigned onto it [2.91ms]
(pass) $ only accepts a template object as its first argument > rejects a structuredClone of an array with raw [3.43ms]
(pass) $ only accepts a template object as its first argument > rejects an array whose raw is a string [2.62ms]
(pass) $ only accepts a template object as its first argument > rejects an array whose raw has a different length [2.66ms]
(pass) $ only accepts a template object as its first argument > rejects a string [1.38ms]
(pass) $ only accepts a template object as its first argument
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/25] gen cpp.rs (cppbind)
[3/25] gen JS modules (bundle-modules)
Preprocess modules (8271ms)
Bundle modules (48ms)
Postprocesss modules (81ms)
Bundle Functions (608ms)
Generate Code (19ms)

[9.05s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins.d.ts                        |  1 +
 src/js/builtins/shell.ts                    | 20 ++++++---
 test/js/bun/shell/bunshell-instance.test.ts | 68 +++++++++++++++++++++++++++++
 3 files changed, 84 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/builtins.d.ts                             2      1      0
src/js/builtins/shell.ts                         5      9      0
test/js/bun/shell/bunshell-instance.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->
