### PR TITLE
node:net: make resetAndDestroy() throw ERR_INVALID_HANDLE_TYPE on TLS and pipe sockets

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -145,6 +145,11 @@ const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kupgraded = Symbol("kupgraded");
 const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
+// Node gives a unix-socket / named-pipe connection a Pipe handle and a TCP
+// connection a TCP handle; resetAndDestroy() only accepts the latter. Bun's
+// native handle is the same class for both, so the distinction is recorded
+// where the connection is made (connect() and the server accept paths).
+const kIsPipe = Symbol("kIsPipe");
 const ksocket = Symbol("ksocket");
 const khandlers = Symbol("khandlers");
 const kclosed = Symbol("closed");
@@ -1141,6 +1146,10 @@ function onconnection(err, clientHandle) {
     highWaterMark: self.highWaterMark,
   }) as NetSocket | TLSSocket;
   _socket.isServer = true;
+  // The listener knows the path it was bound to, except in a cluster worker
+  // accepting on the primary's shared fd, which recorded it on the server
+  // instead (the same two sources Server.prototype.address() reads).
+  _socket[kIsPipe] = !!(handle.unix || self[kClusterUnixPath]);
   // Use the server's normalized fields so the per-socket flag agrees with the
   // native listener: node's tlsConnectionListener passes `this.requestCert`
   // (`=== true`-normalized), not the raw option.
@@ -1584,6 +1593,7 @@ function Socket(options?) {
   this._pendingEncoding = undefined; // for compatibility
   this._hadError = false;
   this.isServer = false;
+  this[kIsPipe] = false;
   this._handle = options?.handle || null;
   this[ksocket] = undefined;
   this.server = undefined;
@@ -2108,6 +2118,7 @@ Socket.prototype.connect = function connect(...args) {
   const { path } = options;
   const pipe = !!path;
   $debug("pipe", pipe, path);
+  this[kIsPipe] = pipe;
 
   if (!this._handle) {
     this._handle = newDetachedSocket(typeof this[bunTlsSymbol] === "function");
@@ -2569,6 +2580,13 @@ function fdSyncWritev(data, callback) {
 
 Socket.prototype.resetAndDestroy = function resetAndDestroy() {
   if (this._handle) {
+    // Node: `if (!(this._handle instanceof TCP)) throw new ERR_INVALID_HANDLE_TYPE()`.
+    // A TLSSocket's handle is a TLS wrap there, and a pipe connection's handle
+    // is a Pipe; neither can be reset, connecting or not.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L801-L815
+    if (typeof this[bunTlsSymbol] === "function" || this[kIsPipe]) {
+      throw $ERR_INVALID_HANDLE_TYPE();
+    }
     if (this.connecting) {
       this.once("connect", () => this._reset());
     } else {
@@ -4197,6 +4215,8 @@ function onClusterConnection(err, clientHandle) {
     socket[kSetKeepAliveInitialDelay] = self.keepAliveInitialDelay;
   }
   socket.connect({ fd: clientHandle.fd, fdIsRawSocket: true, pauseOnConnect: self.pauseOnConnect });
+  // kClusterFauxListen records the listen path on the handle (see address()).
+  socket[kIsPipe] = !!this.unix;
   const blockList = self.blockList;
   if (blockList) {
     const remote = socket.remoteAddress;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -145,10 +145,8 @@ const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kupgraded = Symbol("kupgraded");
 const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
-// Node gives a unix-socket / named-pipe connection a Pipe handle and a TCP
-// connection a TCP handle; resetAndDestroy() only accepts the latter. Bun's
-// native handle is the same class for both, so the distinction is recorded
-// where the connection is made (connect() and the server accept paths).
+// Node's Pipe-vs-TCP handle class; bun's native handle is the same class for
+// both, so connect() and the accept paths record it (read by resetAndDestroy).
 const kIsPipe = Symbol("kIsPipe");
 const ksocket = Symbol("ksocket");
 const khandlers = Symbol("khandlers");
@@ -1146,9 +1144,7 @@ function onconnection(err, clientHandle) {
     highWaterMark: self.highWaterMark,
   }) as NetSocket | TLSSocket;
   _socket.isServer = true;
-  // The listener knows the path it was bound to, except in a cluster worker
-  // accepting on the primary's shared fd, which recorded it on the server
-  // instead (the same two sources Server.prototype.address() reads).
+  // The same two sources Server.prototype.address() reads.
   _socket[kIsPipe] = !!(handle.unix || self[kClusterUnixPath]);
   // Use the server's normalized fields so the per-socket flag agrees with the
   // native listener: node's tlsConnectionListener passes `this.requestCert`
@@ -1894,8 +1890,7 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd != null) {
-      // The descriptor's address family is not inspected; callers that know it
-      // is a pipe (onClusterConnection) set kIsPipe after this returns.
+      // An adopted descriptor's address family is not inspected.
       this[kIsPipe] = false;
       doConnect(this._handle, {
         data: this,
@@ -2583,9 +2578,7 @@ function fdSyncWritev(data, callback) {
 
 Socket.prototype.resetAndDestroy = function resetAndDestroy() {
   if (this._handle) {
-    // Node: `if (!(this._handle instanceof TCP)) throw new ERR_INVALID_HANDLE_TYPE()`.
-    // A TLSSocket's handle is a TLS wrap there, and a pipe connection's handle
-    // is a Pipe; neither can be reset, connecting or not.
+    // Node's `this._handle instanceof TCP` check: a TLS wrap or a Pipe throws.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L801-L815
     if (typeof this[bunTlsSymbol] === "function" || this[kIsPipe]) {
       throw $ERR_INVALID_HANDLE_TYPE();
@@ -4218,8 +4211,7 @@ function onClusterConnection(err, clientHandle) {
     socket[kSetKeepAliveInitialDelay] = self.keepAliveInitialDelay;
   }
   socket.connect({ fd: clientHandle.fd, fdIsRawSocket: true, pauseOnConnect: self.pauseOnConnect });
-  // After connect({ fd }), which clears it. kClusterFauxListen records the
-  // listen path on the handle (see address()).
+  // After connect({ fd }), which cleared it.
   socket[kIsPipe] = !!this.unix;
   const blockList = self.blockList;
   if (blockList) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1894,6 +1894,9 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd != null) {
+      // The descriptor's address family is not inspected; callers that know it
+      // is a pipe (onClusterConnection) set kIsPipe after this returns.
+      this[kIsPipe] = false;
       doConnect(this._handle, {
         data: this,
         fd: fd,
@@ -4215,7 +4218,8 @@ function onClusterConnection(err, clientHandle) {
     socket[kSetKeepAliveInitialDelay] = self.keepAliveInitialDelay;
   }
   socket.connect({ fd: clientHandle.fd, fdIsRawSocket: true, pauseOnConnect: self.pauseOnConnect });
-  // kClusterFauxListen records the listen path on the handle (see address()).
+  // After connect({ fd }), which clears it. kClusterFauxListen records the
+  // listen path on the handle (see address()).
   socket[kIsPipe] = !!this.unix;
   const blockList = self.blockList;
   if (blockList) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -145,8 +145,7 @@ const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kupgraded = Symbol("kupgraded");
 const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
-// Node's Pipe-vs-TCP handle class; bun's native handle is the same class for
-// both, so connect() and the accept paths record it (read by resetAndDestroy).
+// Pipe vs TCP is not visible on bun's native handle, so the connect and accept paths record it here.
 const kIsPipe = Symbol("kIsPipe");
 const ksocket = Symbol("ksocket");
 const khandlers = Symbol("khandlers");
@@ -2578,8 +2577,7 @@ function fdSyncWritev(data, callback) {
 
 Socket.prototype.resetAndDestroy = function resetAndDestroy() {
   if (this._handle) {
-    // Node's `this._handle instanceof TCP` check: a TLS wrap or a Pipe throws.
-    // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L801-L815
+    // Only a TCP handle can be reset: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L801-L815
     if (typeof this[bunTlsSymbol] === "function" || this[kIsPipe]) {
       throw $ERR_INVALID_HANDLE_TYPE();
     }

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -523,6 +523,61 @@ if (cluster.isPrimary) {
   expect(exitCode).toBe(0);
 });
 
+// A worker accepts through a different path per scheduling policy (a faux
+// handle fed by the primary under SCHED_RR, the primary's shared fd under
+// SCHED_NONE); both must still tell a unix-path server's connections apart from
+// a TCP server's: node's resetAndDestroy() throws ERR_INVALID_HANDLE_TYPE for
+// the former (a Pipe handle) and resets the latter.
+test.skipIf(isWindows).each(["SCHED_RR", "SCHED_NONE"])(
+  "%s: resetAndDestroy() on a worker's accepted sockets rejects unix-path connections and resets TCP ones",
+  async policy => {
+    using dir = tempDir("cluster-reset-handle-type", {
+      "main.ts": `
+const cluster = require("node:cluster");
+const net = require("node:net");
+const path = require("node:path");
+cluster.schedulingPolicy = cluster[process.env.POLICY];
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  cluster.on("listening", (_worker, address) => {
+    const client = address.addressType === -1 ? net.connect(address.address) : net.connect(address.port, address.address);
+    client.on("error", () => {});
+  });
+  worker.on("message", result => {
+    console.log(JSON.stringify(result));
+    worker.kill();
+    process.exit(0);
+  });
+} else {
+  const result = {};
+  function report(kind) {
+    return socket => {
+      try {
+        socket.resetAndDestroy();
+        result[kind] = { threw: null, destroyed: socket.destroyed };
+      } catch (err) {
+        result[kind] = { threw: err.code, destroyed: socket.destroyed };
+        socket.destroy();
+      }
+      if ("unix" in result && "tcp" in result) process.send(result);
+    };
+  }
+  net.createServer(report("unix")).listen(path.join(__dirname, "worker.sock"));
+  net.createServer(report("tcp")).listen(0, "127.0.0.1");
+}
+`,
+    });
+    const { stdout, stderr, exitCode } = await bunRun(joinP(String(dir), "main.ts"), { POLICY: policy });
+    expect({ exitCode, result: exitCode === 0 ? JSON.parse(stdout) : stderr }).toEqual({
+      exitCode: 0,
+      result: {
+        unix: { threw: "ERR_INVALID_HANDLE_TYPE", destroyed: false },
+        tcp: { threw: null, destroyed: true },
+      },
+    });
+  },
+);
+
 test.skipIf(!isLinux)("SCHED_NONE: an abstract-namespace listen is reachable by clients", async () => {
   using dir = tempDir("cluster-shared-abstract", {
     "main.ts": `

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -531,7 +531,9 @@ if (cluster.isPrimary) {
 test.skipIf(isWindows).each(["SCHED_RR", "SCHED_NONE"])(
   "%s: resetAndDestroy() on a worker's accepted sockets rejects unix-path connections and resets TCP ones",
   async policy => {
-    using dir = tempDir("cluster-reset-handle-type", {
+    // Short names: the primary connects to the absolute path, which has to fit
+    // in sun_path (104 bytes on macOS) together with the default TMPDIR.
+    using dir = tempDir("cl-reset", {
       "main.ts": `
 const cluster = require("node:cluster");
 const net = require("node:net");
@@ -562,7 +564,7 @@ if (cluster.isPrimary) {
       if ("unix" in result && "tcp" in result) process.send(result);
     };
   }
-  net.createServer(report("unix")).listen(path.join(__dirname, "worker.sock"));
+  net.createServer(report("unix")).listen(path.join(__dirname, "w.sock"));
   net.createServer(report("tcp")).listen(0, "127.0.0.1");
 }
 `,

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -2078,3 +2078,128 @@ describe("net.Server.listen({ fd })", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Node can only reset a TCP handle. A socket whose handle is anything else (a
+// unix socket / named pipe is a Pipe handle there) throws
+// ERR_INVALID_HANDLE_TYPE synchronously, before the connecting/connected
+// distinction is even looked at. Verified against node v26.3.0.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L801-L815
+describe("net.Socket.resetAndDestroy() handle type", () => {
+  function tryReset(socket: Socket) {
+    let threw: string | null = null;
+    try {
+      socket.resetAndDestroy();
+    } catch (e: any) {
+      threw = `${e.name} ${e.code}: ${e.message}`;
+    }
+    return { threw, destroyed: socket.destroyed };
+  }
+  const rejected = { threw: "TypeError ERR_INVALID_HANDLE_TYPE: This handle type cannot be sent", destroyed: false };
+  const reset = { threw: null, destroyed: true };
+  // A TCP socket that has not connected yet is reset once it does.
+  const resetDeferred = { threw: null, destroyed: false };
+
+  async function serve(kind: "pipe" | "tcp") {
+    const accepted = Promise.withResolvers<Socket>();
+    const connections: Socket[] = [];
+    const server = createServer(c => {
+      c.on("error", () => {});
+      connections.push(c);
+      accepted.resolve(c);
+    });
+    if (kind === "pipe") {
+      server.listen(
+        isWindows
+          ? `\\\\.\\pipe\\bun-reset-handle-type-${process.pid}-${randomUUID()}`
+          : join(socket_domain, `reset-${randomUUID().slice(0, 8)}.sock`),
+      );
+    } else {
+      server.listen(0, "127.0.0.1");
+    }
+    await once(server, "listening");
+    const address = server.address();
+    return {
+      target: typeof address === "string" ? { path: address } : { port: address!.port, host: "127.0.0.1" },
+      accepted: accepted.promise,
+      stop() {
+        for (const c of connections) c.destroy();
+        server.close();
+      },
+    };
+  }
+
+  it("a unix socket / named pipe connection throws while connecting, once connected, and on the accepting side", async () => {
+    const pipe = await serve("pipe");
+    try {
+      const client = connect(pipe.target);
+      client.on("error", () => {});
+      const whileConnecting = tryReset(client);
+      await once(client, "connect");
+      const acceptedSocket = await pipe.accepted;
+      const connected = tryReset(client);
+      const serverSide = tryReset(acceptedSocket);
+      expect({ whileConnecting, connected, serverSide }).toEqual({
+        whileConnecting: rejected,
+        connected: rejected,
+        serverSide: rejected,
+      });
+
+      // The rejected calls left the connection intact.
+      client.destroy();
+      const [hadError] = await once(client, "close");
+      expect(hadError).toBe(false);
+    } finally {
+      pipe.stop();
+    }
+  });
+
+  it("a TCP connection is still reset while connecting, once connected, and on the accepting side", async () => {
+    const tcp = await serve("tcp");
+    const tcpForEarlyReset = await serve("tcp");
+    try {
+      const early = connect(tcpForEarlyReset.target);
+      early.on("error", () => {});
+      const whileConnecting = tryReset(early);
+      await once(early, "close");
+
+      const client = connect(tcp.target);
+      client.on("error", () => {});
+      await once(client, "connect");
+      const acceptedSocket = await tcp.accepted;
+      const connected = tryReset(client);
+      const serverSide = tryReset(acceptedSocket);
+      expect({ whileConnecting, earlyDestroyed: early.destroyed, connected, serverSide }).toEqual({
+        whileConnecting: resetDeferred,
+        earlyDestroyed: true,
+        connected: reset,
+        serverSide: reset,
+      });
+    } finally {
+      tcp.stop();
+      tcpForEarlyReset.stop();
+    }
+  });
+
+  it("is decided per connect(): a socket reused for TCP after a unix socket / named pipe can be reset", async () => {
+    const pipe = await serve("pipe");
+    const tcp = await serve("tcp");
+    try {
+      const socket = new Socket();
+      socket.on("error", () => {});
+
+      socket.connect(pipe.target);
+      await once(socket, "connect");
+      const overPipe = tryReset(socket);
+      socket.destroy();
+      await once(socket, "close");
+
+      socket.connect(tcp.target);
+      await once(socket, "connect");
+      const overTcp = tryReset(socket);
+      expect({ overPipe, overTcp }).toEqual({ overPipe: rejected, overTcp: reset });
+    } finally {
+      pipe.stop();
+      tcp.stop();
+    }
+  });
+});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1426,3 +1426,91 @@ describe("throwing 'secureConnect' listener", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Node's resetAndDestroy() only resets a TCP handle. A TLSSocket's handle is
+// the TLS wrap, whatever transport sits underneath it, so it throws
+// ERR_INVALID_HANDLE_TYPE synchronously (before and after the handshake, on
+// both ends); only the plain net.Socket underneath a tls.connect({ socket })
+// wrapper is still a TCP socket. Verified against node v26.3.0.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L801-L815
+describe("TLSSocket.resetAndDestroy()", () => {
+  function tryReset(socket: net.Socket) {
+    let threw: string | null = null;
+    try {
+      socket.resetAndDestroy();
+    } catch (e: any) {
+      threw = `${e.name} ${e.code}: ${e.message}`;
+    }
+    return { threw, destroyed: socket.destroyed };
+  }
+  const rejected = { threw: "TypeError ERR_INVALID_HANDLE_TYPE: This handle type cannot be sent", destroyed: false };
+
+  it("throws for a tls.connect() socket before and after the handshake, and for the server's socket", async () => {
+    const accepted = Promise.withResolvers<TLSSocket>();
+    const server = tls.createServer(COMMON_CERT_, socket => {
+      socket.on("error", () => {});
+      accepted.resolve(socket);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const client = tls.connect({
+      port: (server.address() as AddressInfo).port,
+      host: "127.0.0.1",
+      rejectUnauthorized: false,
+    });
+    client.on("error", () => {});
+    try {
+      // Asserted on its own: a reset that is accepted here tears the connection
+      // down as soon as it connects, and 'secureConnect' below never arrives.
+      expect(tryReset(client)).toEqual(rejected);
+      await once(client, "secureConnect");
+      const serverSocket = await accepted.promise;
+      const afterHandshake = tryReset(client);
+      const serverSide = tryReset(serverSocket);
+      expect({ afterHandshake, serverSide }).toEqual({ afterHandshake: rejected, serverSide: rejected });
+
+      // The rejected calls left the connection intact.
+      client.destroy();
+      const [hadError] = await once(client, "close");
+      expect(hadError).toBe(false);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
+
+  it("throws for a tls.connect({ socket }) wrapper over a net.Socket or a Duplex; the wrapped net.Socket is still resettable", async () => {
+    const server = net.createServer(socket => socket.on("error", () => {}));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+    raw.on("error", () => {});
+    await once(raw, "connect");
+    const overNetSocket = tls.connect({ socket: raw, rejectUnauthorized: false });
+    overNetSocket.on("error", () => {});
+    const transport = new Duplex({
+      read() {},
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    const overDuplex = tls.connect({ socket: transport, rejectUnauthorized: false });
+    overDuplex.on("error", () => {});
+    try {
+      expect({
+        overNetSocket: tryReset(overNetSocket),
+        overDuplex: tryReset(overDuplex),
+        wrappedNetSocket: tryReset(raw),
+      }).toEqual({
+        overNetSocket: rejected,
+        overDuplex: rejected,
+        wrappedNetSocket: { threw: null, destroyed: true },
+      });
+      await once(raw, "close");
+    } finally {
+      overNetSocket.destroy();
+      overDuplex.destroy();
+      server.close();
+    }
+  });
+});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1513,4 +1513,14 @@ describe("TLSSocket.resetAndDestroy()", () => {
       server.close();
     }
   });
+
+  it("throws for a new TLSSocket(stream) that has not started its handshake", () => {
+    // Until connect() attaches a native handle, the wrapped stream itself sits
+    // in _handle. Before this was rejected, the reset went through and failed
+    // inside _destroy ("this._handle.terminate is not a function") instead.
+    // Like the _requestCert test above, the never-started wrap is not torn down.
+    const wrap = new TLSSocket(new stream.PassThrough());
+    wrap.on("error", () => {});
+    expect(tryReset(wrap)).toEqual(rejected);
+  });
 });


### PR DESCRIPTION
### Problem
- `socket.resetAndDestroy()` on a `tls.TLSSocket` or on a unix socket / named pipe connection resets and destroys the socket. Node throws `TypeError [ERR_INVALID_HANDLE_TYPE]: This handle type cannot be sent` synchronously for both (client or server side, connected or still connecting) and only resets plain TCP sockets.
- On a `new tls.TLSSocket(socket)` that has not started yet, the call went even further off: the reset ran and failed inside `_destroy` with `this._handle.terminate is not a function`, delivered as the socket's `'error'`.
- Cause: `Socket.prototype.resetAndDestroy` in `src/js/node/net.ts` has no equivalent of node's `if (!(this._handle instanceof TCP)) throw new ERR_INVALID_HANDLE_TYPE()` (lib/net.js, v26.3.0 L801-L815). Bun cannot use the handle's class for this: the native handle is the same `TCPSocket` class for a TCP and for a unix / named-pipe connection.

### Fix
- `resetAndDestroy()` throws `$ERR_INVALID_HANDLE_TYPE()` when the socket has a handle and is either a `tls.TLSSocket` (recognized by its class, the same check `Ipc.ts` uses to refuse sending a TLS socket) or a pipe connection. The check sits before the `connecting` branch, like node's.
- Pipe connections are recorded in a per-socket flag (`kIsPipe`) at the points where net.ts decides the transport, which is where node would construct a `Pipe` instead of a `TCP` handle:
  - `Socket.prototype.connect()`: the `path` option; the fd branch sets it to false. Every `connect()` call decides it, so a reused socket follows its current connection;
  - `onconnection`: the listener's bound path (`handle.unix`), or `kClusterUnixPath` for a cluster worker accepting on the primary's shared fd (the two sources `Server.prototype.address()` already reads);
  - `onClusterConnection` (round-robin cluster worker): the path `kClusterFauxListen` stores on the faux handle, set after the `connect({ fd })` that cleared it.
- Why this is correct: it matches node. Every `TLSSocket` with a handle has a TLS wrap there, so the class is the exact predicate; for pipes, node's handle type is itself derived from the same `path` / listen-path decisions, so recording that decision reproduces it. The plain `net.Socket` underneath `tls.connect({ socket })` keeps a TCP handle in node and stays resettable here too.
- Not covered, on purpose: connections adopted from a bare descriptor (`connect({ fd })`, `listen({ fd })`, IPC-received sockets) count as TCP, where node inspects the descriptor type; and a `TLSSocket` that has no handle at all yet (bare `new tls.TLSSocket()`, `tls.connect({ socket })` over a still-connecting socket, or a server-side `new tls.TLSSocket(socket, { isServer: true })` in the tick before its upgrade attaches) takes the existing no-handle branch (`destroy(ERR_SOCKET_CLOSED)`) where node, which wraps eagerly, throws. Both follow from how bun attaches handles, not from this check, and nothing in the repo calls `resetAndDestroy()` on either.
- Verified (every new test fails on the released build and passes with this branch):
  - `test/js/node/net/node-net.test.ts`, "resetAndDestroy() handle type": unix socket / named pipe while connecting, connected, and on the accepting side throw; TCP still resets in all three states; a socket reused for TCP after a pipe connection resets again.
  - `test/js/node/tls/node-tls-connect.test.ts`, "TLSSocket.resetAndDestroy()": `tls.connect()` before and after the handshake, the server's socket, `tls.connect({ socket })` over a `net.Socket` and over a `Duplex`, and a not-yet-started `new TLSSocket(stream)` all throw; the wrapped `net.Socket` still resets.
  - `test/js/node/cluster.test.ts`: SCHED_RR and SCHED_NONE workers; the unix-path server's accepted socket throws, the TCP server's resets.
  - Full `node-net.test.ts`: the same 11 failures as without the change in this container (`connect(port)` localhost resolution and unref tests), nothing new. `node-tls-connect.test.ts`, `cluster.test.ts`, `child_process_ipc_handle.test.ts`, and the proxy tests whose fixtures call `resetAndDestroy()` on a TLS server socket inside a try/catch (`proxy-stress-lifecycle.test.ts`, `proxy-stress-adversarial.test.ts`, the handshake-reset cases in `proxy.test.ts`; on the TLS legs they now take their `destroy()` fallback, since bun does not expose a `_parent` to reset instead): all pass.
  - Vendored `test/js/node/test/parallel/test-net-*reset*.js` (8 files) pass; the full `test-net-*` / `test-tls-*` set has no failures attributable to the change.

### Background
- `resetAndDestroy()` (added in node 18.3) closes a TCP connection with an RST instead of a FIN; in node it calls `TCP.prototype.reset`, which only TCP handles have, hence the handle-type guard. Bun implements the RST with the native `terminate()`, which exists on every native handle, so nothing stopped the call from going through.
- Node handle types: a `net.Socket` wraps a `TCP` handle (TCP connection), a `Pipe` handle (unix domain socket, or named pipe on Windows), or for `tls.TLSSocket` a `TLSWrap` around one of those. `this._handle instanceof TCP` is how node tells them apart; bun's native handle is a `TCPSocket` or `TLSSocket` object regardless of the address family underneath.
- `Symbol.for("::buntls::")` (`bunTlsSymbol`): a method defined on `tls.TLSSocket.prototype` (and on `tls.Server`) that net.ts uses throughout to detect TLS sockets; `new tls.TLSSocket`, `tls.connect()` and server-accepted TLS sockets are all instances of that class.
- Cluster workers accept connections in two ways: under `SCHED_RR` the primary accepts and hands each connection's fd to a worker, which wraps it via a faux listen handle (`onClusterConnection`); under `SCHED_NONE` the worker listens on the primary's shared fd, so the native listener has no path and the server records it in `kClusterUnixPath`.

<details>
<summary>Probe output (node v26.3.0 vs bun 1.4.0 vs this branch)</summary>

```
case                                          node 26.3.0                 bun 1.4.0 (release)                          this branch
tcp connecting                                no throw, destroyed=false   no throw, destroyed=false                    no throw, destroyed=false
tcp connected                                 no throw, destroyed=true    no throw, destroyed=true                     no throw, destroyed=true
unix client connecting                        ERR_INVALID_HANDLE_TYPE     no throw, destroyed=false                    ERR_INVALID_HANDLE_TYPE
unix client connected                         ERR_INVALID_HANDLE_TYPE     no throw, destroyed=true                     ERR_INVALID_HANDLE_TYPE
unix server-side accepted                     ERR_INVALID_HANDLE_TYPE     no throw, destroyed=true                     ERR_INVALID_HANDLE_TYPE
tls.connect() connecting                      ERR_INVALID_HANDLE_TYPE     no throw, destroyed=false                    ERR_INVALID_HANDLE_TYPE
tls.connect() after secureConnect             ERR_INVALID_HANDLE_TYPE     no throw, destroyed=true                     ERR_INVALID_HANDLE_TYPE
tls server-side accepted                      ERR_INVALID_HANDLE_TYPE     no throw, destroyed=true                     ERR_INVALID_HANDLE_TYPE
tls.connect({ socket }) wrapper               ERR_INVALID_HANDLE_TYPE     no throw, destroyed=true                     ERR_INVALID_HANDLE_TYPE
new tls.TLSSocket(connectedSocket), unstarted ERR_INVALID_HANDLE_TYPE     'error' "_handle.terminate is not a function" ERR_INVALID_HANDLE_TYPE
net.Socket wrapped by tls.connect({ socket }) no throw, destroyed=true    no throw, destroyed=true                     no throw, destroyed=true
new net.Socket() (no handle)                  'error' ERR_SOCKET_CLOSED   'error' ERR_SOCKET_CLOSED                    'error' ERR_SOCKET_CLOSED
new tls.TLSSocket() (no socket, no handle)    ERR_INVALID_HANDLE_TYPE     'error' ERR_SOCKET_CLOSED                    'error' ERR_SOCKET_CLOSED (see "not covered")
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/cluster.test.ts test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->