### PR TITLE
bake: drop the production build's transpilers and framework projection

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -649,7 +649,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     // `Framework.initTranspiler(..., &dev.X_transpiler, ...)`.
     //
     // SAFETY: `init_transpiler` writes the slot via `MaybeUninit::write` (see
-    // `bake_body.rs`), so the previous (uninitialized) bytes are never dropped.
+    // `bake/mod.rs`), so the previous (uninitialized) bytes are never dropped.
     // `framework`/`log`/`bundler_options` were written above; reborrowing each
     // individually via `addr_of_mut!` is sound because no `&mut DevServer` exists.
     // Note: `Transpiler<'static>` erases the arena lifetime — `options.arena`

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1136,8 +1136,6 @@ impl Framework {
         )
     }
 
-    /// On `Err`, a transpiler that was already constructed stays in `out`,
-    /// which drops it.
     pub(crate) fn init_transpiler_with_options<'a, 'slot>(
         &self,
         arena: &'a Arena,
@@ -1289,9 +1287,7 @@ impl Framework {
     }
 }
 
-/// Owns a `Transpiler` built in place (a configured one points into its own
-/// fields, see `configure_linker`, so it cannot be returned by value) and
-/// drops it.
+/// Owns a `Transpiler` built in place: a configured one points into its own fields (`configure_linker`).
 pub(crate) struct TranspilerSlot<'a> {
     transpiler: MaybeUninit<bun_bundler::Transpiler<'a>>,
     initialized: bool,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -5,6 +5,7 @@
 #![allow(unexpected_cfgs)] // `bun_codegen_embed` is set via RUSTFLAGS (scripts/build/rust.ts) for release/CI builds.
 
 use bun_alloc::ArenaVecExt as _;
+use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 
 use bun_alloc::Arena; // = bumpalo::Bump
@@ -1135,27 +1136,30 @@ impl Framework {
         )
     }
 
-    pub fn init_transpiler_with_options<'a>(
-        &mut self,
+    /// Builds the transpiler for one graph of a production build into `out`
+    /// and returns it. `framework_view` is the projection of `self` the
+    /// transpiler (and the workers cloned from it) read while bundling; it
+    /// must outlive `out`. On `Err` after the transpiler was constructed, the
+    /// partially configured transpiler stays in `out` and is released with it.
+    pub(crate) fn init_transpiler_with_options<'a, 'slot>(
+        &self,
         arena: &'a Arena,
         log: &mut bun_ast::Log,
         mode: Mode,
         renderer: Graph,
-        out: &mut core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
+        out: &'slot mut TranspilerSlot<'a>,
+        framework_view: &'a bun_bundler::bake_types::Framework,
         bundler_options: &BuildConfigSubset,
         source_map: bun_bundler::options::SourceMapOption,
         minify_whitespace: Option<bool>,
         minify_syntax: Option<bool>,
         minify_identifiers: Option<bool>,
-    ) -> crate::Result<()> {
+    ) -> crate::Result<&'slot mut bun_bundler::Transpiler<'a>> {
         // `ASTMemoryAllocator::enter` returns an RAII `Scope` whose `Drop`
         // runs `exit()` at end-of-fn.
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
-        // The caller (`DevServer::init`) hands us an uninitialized slot, so
-        // use `MaybeUninit::write` (no drop of prior bytes) then reborrow as
-        // `&mut Transpiler` for the field assignments below.
         let out: &mut bun_bundler::Transpiler = out.write(bun_bundler::Transpiler::init(
             arena,
             log,
@@ -1217,13 +1221,7 @@ impl Framework {
         out.options.minify_identifiers = minify_identifiers.unwrap_or(mode != Mode::Development);
         out.options.minify_whitespace = minify_whitespace.unwrap_or(mode != Mode::Development);
         out.options.css_chunking = true;
-        // The bundler crate (lower tier) carries a TYPE_ONLY projection
-        // (`bake_types::Framework`); construct it here and give it arena
-        // lifetime so `BundleOptions<'a>` can borrow it for the bundle pass.
-        // NOTE: interior `Box<[u8]>` in the projection are not dropped by
-        // bumpalo — bounded per-session, revisit when `bake_types::BuiltInModule`
-        // is reshaped to `&'a [u8]`.
-        out.options.framework = Some(&*arena.alloc(self.as_bundler_view()));
+        out.options.framework = Some(framework_view);
         out.options.inline_entrypoint_import_meta_main = true;
         if let Some(ignore) = bundler_options.ignore_dce_annotations {
             out.options.ignore_dce_annotations = ignore;
@@ -1290,7 +1288,46 @@ impl Framework {
         // Re-sync after define/naming mutations so the resolver sees the
         // final option set.
         out.sync_resolver_opts();
-        Ok(())
+        Ok(out)
+    }
+}
+
+/// Stack home of one production-build transpiler. A configured `Transpiler`
+/// points back into its own fields (`configure_linker`), so
+/// [`Framework::init_transpiler_with_options`] builds it in place here instead
+/// of returning it by value, and the slot must stay where it is afterwards.
+/// The transpiler built into the slot is dropped with it.
+pub(crate) struct TranspilerSlot<'a> {
+    transpiler: MaybeUninit<bun_bundler::Transpiler<'a>>,
+    initialized: bool,
+}
+
+impl<'a> TranspilerSlot<'a> {
+    pub(crate) fn uninit() -> Self {
+        Self {
+            transpiler: MaybeUninit::uninit(),
+            initialized: false,
+        }
+    }
+
+    fn write(
+        &mut self,
+        transpiler: bun_bundler::Transpiler<'a>,
+    ) -> &mut bun_bundler::Transpiler<'a> {
+        debug_assert!(!self.initialized, "TranspilerSlot is written once");
+        let transpiler = self.transpiler.write(transpiler);
+        self.initialized = true;
+        transpiler
+    }
+}
+
+impl Drop for TranspilerSlot<'_> {
+    fn drop(&mut self) {
+        if self.initialized {
+            // SAFETY: `initialized` is only set by `write`, after it stored a
+            // transpiler here, and the slot itself is dropped exactly once.
+            unsafe { self.transpiler.assume_init_drop() };
+        }
     }
 }
 

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1136,11 +1136,8 @@ impl Framework {
         )
     }
 
-    /// Builds the transpiler for one graph of a production build into `out`
-    /// and returns it. `framework_view` is the projection of `self` the
-    /// transpiler (and the workers cloned from it) read while bundling; it
-    /// must outlive `out`. On `Err` after the transpiler was constructed, the
-    /// partially configured transpiler stays in `out` and is released with it.
+    /// On `Err`, a transpiler that was already constructed stays in `out`,
+    /// which drops it.
     pub(crate) fn init_transpiler_with_options<'a, 'slot>(
         &self,
         arena: &'a Arena,
@@ -1292,11 +1289,9 @@ impl Framework {
     }
 }
 
-/// Stack home of one production-build transpiler. A configured `Transpiler`
-/// points back into its own fields (`configure_linker`), so
-/// [`Framework::init_transpiler_with_options`] builds it in place here instead
-/// of returning it by value, and the slot must stay where it is afterwards.
-/// The transpiler built into the slot is dropped with it.
+/// Owns a `Transpiler` built in place (a configured one points into its own
+/// fields, see `configure_linker`, so it cannot be returned by value) and
+/// drops it.
 pub(crate) struct TranspilerSlot<'a> {
     transpiler: MaybeUninit<bun_bundler::Transpiler<'a>>,
     initialized: bool,

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -586,8 +586,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         framework_router::InsertionContext::wrap(&mut entry_points),
     )?;
 
-    // `framework_view` predates `resolve()` (which ran on the transpilers it
-    // configured), so the bundle gets a fresh projection with the resolved paths.
+    // Projected again so the bundle sees the paths `resolve()` filled in.
     let bundler_framework = framework.as_bundler_view();
 
     let bundled_outputs_list: Vec<OutputFile> = {

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -2,7 +2,6 @@
 
 use bun_paths::strings;
 use core::cell::UnsafeCell;
-use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use std::io::Write as _;
 use std::sync::OnceLock;
@@ -419,66 +418,65 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     loader.map.put(b"NODE_ENV", b"production")?;
     dotenv::set_instance(std::ptr::from_mut::<dotenv::Loader>(loader));
 
-    // In-place init via `MaybeUninit` (`init_transpiler_with_options`
-    // keeps the out-param shape shared with the dev-server path).
-    let mut client_transpiler = MaybeUninit::<Transpiler>::uninit();
-    let mut server_transpiler = MaybeUninit::<Transpiler>::uninit();
-    let mut ssr_transpiler = MaybeUninit::<Transpiler>::uninit();
+    // The transpilers borrow `framework_view` and `options.arena` until their
+    // slots drop at the end of this function (on every exit path), so both
+    // have to be declared before the slots.
+    let framework_view = framework.as_bundler_view();
+    let mut server_slot = bake_body::TranspilerSlot::uninit();
+    let mut client_slot = bake_body::TranspilerSlot::uninit();
+    let mut ssr_slot = bake_body::TranspilerSlot::uninit();
     // `vm.log` is set from `ctx.log` (non-null, process-lifetime);
     // `log_mut()` is the safe accessor encapsulating the NonNull deref.
     let vm_log = vm.log_mut().unwrap();
-    framework.init_transpiler_with_options(
+    let server_transpiler = framework.init_transpiler_with_options(
         &options.arena,
         vm_log,
         bake_body::Mode::ProductionStatic,
         bake_body::Graph::Server,
-        &mut server_transpiler,
+        &mut server_slot,
+        &framework_view,
         &options.bundler_options.server,
         SourceMapOption::from_api(Some(options.bundler_options.server.source_map)),
         options.bundler_options.server.minify_whitespace,
         options.bundler_options.server.minify_syntax,
         options.bundler_options.server.minify_identifiers,
     )?;
-    framework.init_transpiler_with_options(
+    let client_transpiler = framework.init_transpiler_with_options(
         &options.arena,
         vm_log,
         bake_body::Mode::ProductionStatic,
         bake_body::Graph::Client,
-        &mut client_transpiler,
+        &mut client_slot,
+        &framework_view,
         &options.bundler_options.client,
         SourceMapOption::from_api(Some(options.bundler_options.client.source_map)),
         options.bundler_options.client.minify_whitespace,
         options.bundler_options.client.minify_syntax,
         options.bundler_options.client.minify_identifiers,
     )?;
-    if separate_ssr_graph {
-        framework.init_transpiler_with_options(
+    let mut ssr_transpiler = if separate_ssr_graph {
+        Some(framework.init_transpiler_with_options(
             &options.arena,
             vm_log,
             bake_body::Mode::ProductionStatic,
             bake_body::Graph::Ssr,
-            &mut ssr_transpiler,
+            &mut ssr_slot,
+            &framework_view,
             &options.bundler_options.ssr,
             SourceMapOption::from_api(Some(options.bundler_options.ssr.source_map)),
             options.bundler_options.ssr.minify_whitespace,
             options.bundler_options.ssr.minify_syntax,
             options.bundler_options.ssr.minify_identifiers,
-        )?;
-    }
-    // SAFETY: written above by init_transpiler_with_options.
-    let server_transpiler = unsafe { server_transpiler.assume_init_mut() };
-    // SAFETY: written above by init_transpiler_with_options.
-    let client_transpiler = unsafe { client_transpiler.assume_init_mut() };
-    // `ssr_transpiler` stays `MaybeUninit` and is only `assume_init_mut()`'d
-    // inside `if separate_ssr_graph` blocks below — Rust forbids forming
-    // `&mut T` to uninitialized memory regardless of later use.
+        )?)
+    } else {
+        None
+    };
 
     if ctx.bundler_options.bake_debug_disable_minify {
         let mut targets: Vec<&mut Transpiler> =
             vec![&mut *client_transpiler, &mut *server_transpiler];
-        if separate_ssr_graph {
-            // SAFETY: written above by init_transpiler_with_options when separate_ssr_graph.
-            targets.push(unsafe { ssr_transpiler.assume_init_mut() });
+        if let Some(ssr_transpiler) = ssr_transpiler.as_deref_mut() {
+            targets.push(ssr_transpiler);
         }
         for transpiler in targets {
             transpiler.options.minify_syntax = false;
@@ -593,8 +591,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // `bake_body::Framework` is the runtime-side superset; the bundler reads only
     // `built_in_modules` / `server_components` / `react_fast_refresh` /
     // `is_built_in_react` via its lower-tier `bake_types::Framework` view.
-    // Project once here via the shared helper so the field-shape (e.g.
-    // `BuiltInModule` `&'static [u8]` → `Box<[u8]>`) stays in one place.
+    // Unlike `framework_view` (projected before `resolve()` because the
+    // transpilers it configures are what `resolve()` runs on), this projection
+    // carries the resolved paths; `BundleV2` takes ownership of it.
     // (The two Framework types could only merge if `FileSystemRouterType` /
     // `framework_router::Style` moved down to bun_bundler.)
     let bundler_framework = framework.as_bundler_view();
@@ -602,15 +601,13 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     let bundled_outputs_list: Vec<OutputFile> = {
         // Transpiler pointers — reborrow via raw to sidestep the
         // `&'a mut Transpiler<'a>` invariant lifetime on the bundler API.
-        // SAFETY: the three transpilers live in this stack frame and outlive
+        // SAFETY: the transpilers live in this frame's slots, which outlive
         // the bundle call; `BundleV2` does not retain them past return.
         let server_ptr: *mut Transpiler = &raw mut *server_transpiler;
         let client_ptr: *mut Transpiler = &raw mut *client_transpiler;
-        let ssr_ptr: *mut Transpiler = if separate_ssr_graph {
-            // SAFETY: written above by init_transpiler_with_options when separate_ssr_graph.
-            core::ptr::from_mut(unsafe { ssr_transpiler.assume_init_mut() })
-        } else {
-            server_ptr
+        let ssr_ptr: *mut Transpiler = match ssr_transpiler {
+            Some(ssr_transpiler) => &raw mut *ssr_transpiler,
+            None => server_ptr,
         };
 
         // Construct the `AnyEventLoop` enum

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -418,9 +418,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     loader.map.put(b"NODE_ENV", b"production")?;
     dotenv::set_instance(std::ptr::from_mut::<dotenv::Loader>(loader));
 
-    // The transpilers borrow `framework_view` and `options.arena` until their
-    // slots drop at the end of this function (on every exit path), so both
-    // have to be declared before the slots.
+    // Borrowed by the transpilers until their slots drop, so it is declared first.
     let framework_view = framework.as_bundler_view();
     let mut server_slot = bake_body::TranspilerSlot::uninit();
     let mut client_slot = bake_body::TranspilerSlot::uninit();
@@ -588,14 +586,8 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         framework_router::InsertionContext::wrap(&mut entry_points),
     )?;
 
-    // `bake_body::Framework` is the runtime-side superset; the bundler reads only
-    // `built_in_modules` / `server_components` / `react_fast_refresh` /
-    // `is_built_in_react` via its lower-tier `bake_types::Framework` view.
-    // Unlike `framework_view` (projected before `resolve()` because the
-    // transpilers it configures are what `resolve()` runs on), this projection
-    // carries the resolved paths; `BundleV2` takes ownership of it.
-    // (The two Framework types could only merge if `FileSystemRouterType` /
-    // `framework_router::Style` moved down to bun_bundler.)
+    // `framework_view` predates `resolve()` (which ran on the transpilers it
+    // configured), so the bundle gets a fresh projection with the resolved paths.
     let bundler_framework = framework.as_bundler_view();
 
     let bundled_outputs_list: Vec<OutputFile> = {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -593,5 +593,72 @@ export default function IndexPage() {
 
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
+  });
+
+  // `bun build --app` sets up one transpiler per graph of the framework and
+  // used to exit without freeing them, so LeakSanitizer reported their
+  // options, define tables and resolver state after every build. An app
+  // without a pages directory finishes right after bundling, which is the
+  // earliest point the transpilers are done with; a leak report makes the
+  // process exit non-zero and shows up in stderr.
+  describe.concurrent.skipIf(!isASAN)("frees its transpilers before exiting", () => {
+    async function buildApp(cwd: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--app", "./app.ts"],
+        cwd,
+        env: {
+          ...bunEnv,
+          // Silences the "Bun Bake is highly experimental" banner.
+          BUN_DEV_SERVER_TEST_RUNNER: "1",
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dir, "../../leaksan.supp")}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    const cleanBuild = {
+      stdout: "done\n",
+      stderr: "Loading configuration\nBundling routes\n",
+      exitCode: 0,
+    };
+
+    // LSan symbolizes its report against the debug binary when it does find
+    // something, which takes well over the default timeout.
+    const timeout = 30_000;
+
+    test(
+      "react framework: server, client and ssr graphs",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-transpiler-leak-react", {
+          "app.ts": `export default { app: { framework: "react" } };`,
+        });
+
+        expect(await buildApp(dir)).toEqual(cleanBuild);
+      },
+      timeout,
+    );
+
+    test(
+      "framework without server components: server and client graphs only",
+      async () => {
+        using dir = tempDir("bake-production-transpiler-leak-two-graphs", {
+          "app.ts": `export default {
+            app: {
+              framework: {
+                fileSystemRouterTypes: [{ root: "pages", serverEntryPoint: "./server.ts", style: "nextjs-pages" }],
+              },
+            },
+          };`,
+          "server.ts": `export function prerender() {}`,
+        });
+
+        expect(await buildApp(String(dir))).toEqual(cleanBuild);
+      },
+      timeout,
+    );
   });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -597,10 +597,11 @@ export default function IndexPage() {
 
   // `bun build --app` sets up one transpiler per graph of the framework and
   // used to exit without freeing them, so LeakSanitizer reported their
-  // options, define tables and resolver state after every build. An app
-  // without a pages directory finishes right after bundling, which is the
-  // earliest point the transpilers are done with; a leak report makes the
-  // process exit non-zero and shows up in stderr.
+  // options, define tables and resolver state after every build, whether it
+  // succeeded or not. The builds below stop as soon as bundling is over (no
+  // pages directory, or a bundle error), which is the earliest point the
+  // transpilers are done with; a leak report shows up in stderr and makes a
+  // successful build exit non-zero.
   describe.concurrent.skipIf(!isASAN)("frees its transpilers before exiting", () => {
     async function buildApp(cwd: string) {
       await using proc = Bun.spawn({
@@ -626,8 +627,9 @@ export default function IndexPage() {
       exitCode: 0,
     };
 
-    // LSan symbolizes its report against the debug binary when it does find
-    // something, which takes well over the default timeout.
+    // LeakSanitizer's exit-time check symbolizes against the debug binary,
+    // which takes a few seconds even when it finds nothing and longer when it
+    // has a report to print.
     const timeout = 30_000;
 
     test(
@@ -657,6 +659,38 @@ export default function IndexPage() {
         });
 
         expect(await buildApp(String(dir))).toEqual(cleanBuild);
+      },
+      timeout,
+    );
+
+    test(
+      "build that fails while bundling",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-transpiler-leak-bundle-error", {
+          "app.ts": `export default { app: { framework: "react" } };`,
+          "pages/index.tsx": `import { useState } from "react";
+export default function IndexPage() {
+  useState(0);
+}
+`,
+        });
+
+        const { stdout, stderr, exitCode } = await buildApp(dir);
+        expect({ stdout, stderr: normalizeBunSnapshot(stderr, dir), exitCode }).toMatchInlineSnapshot(`
+          {
+            "exitCode": 1,
+            "stderr": 
+          "Loading configuration
+          Bundling routes
+          3 |   useState(0);
+                ^
+          error: "useState" is not available in a server component. If you need interactivity, consider converting part of this to a Client Component (by adding \`"use client";\` to the top of the file).
+              at <dir>/pages/index.tsx:3:3
+          error: 'main' returned error.BuildFailed"
+          ,
+            "stdout": "",
+          }
+        `);
       },
       timeout,
     );


### PR DESCRIPTION
### Problem
- Every `bun build --app` leaks its bundler setup. LeakSanitizer on a react-framework build with one page reports ~330KB in ~2900 allocations at exit, nearly all of them under this stack:
  ```
  <bun_bundler::options_impl::BundleOptions>::from_api              src/bundler/options.rs
  <bun_bundler::transpiler::Transpiler>::init_in_place              src/bundler/transpiler.rs
  <bun_runtime::bake::bake_body::Framework>::init_transpiler_with_options   src/runtime/bake/bake_body.rs
  bun_runtime::bake::production_body::build_with_vm                 src/runtime/bake/production.rs
  ```
  (plus the define tables, resolver options and `as_bundler_view` copies each transpiler owns), once per graph: server, client and, with `separateSSRGraph`, ssr.
- Cause 1: `build_with_vm` (src/runtime/bake/production.rs) built the three transpilers into `MaybeUninit<Transpiler>` stack slots and only ever called `assume_init_mut()` on them; nothing dropped them after the bundle and the prerender finished.
- Cause 2: `Framework::init_transpiler_with_options` (src/runtime/bake/bake_body.rs) stored the `bake_types::Framework` projection each transpiler borrows in the `UserOptions` bump arena. The arena frees the struct's bytes but never runs its `Drop`, so its `built_in_modules` map (for the react framework, copies of the built-in module sources) and strings leaked once per transpiler. The comment at that line acknowledged this.
- The process exits right after, so this is exit-time only; the cost is that `test/bake/dev/production.test.ts` has to sit in `test/no-validate-leaksan.txt`, which leaves the whole production bundling path without leak coverage.

### Fix
- `TranspilerSlot` (bake_body.rs) is the stack home `init_transpiler_with_options` builds a transpiler into; it drops the transpiler when the slot goes out of scope. `build_with_vm` declares one slot per graph, so the transpilers are released on every exit of the function: the normal return, the early return when there is nothing to bundle, and the `?` returns for JS and build errors. The function returns the `&mut Transpiler` it built, which also removes the `assume_init_mut()` calls and the `separate_ssr_graph` checks that guarded the ssr slot (it is now an `Option`).
- `init_transpiler_with_options` takes the framework projection as a parameter instead of making an arena copy per transpiler. `build_with_vm` owns one projection that all its transpilers borrow; it is an ordinary local, dropped after the slots. The projection it builds after `resolve()` and hands to `BundleV2` was already owned and dropped by the bundle (LSan never reported it), so that part is unchanged.
- Why dropping the transpilers here is correct: nothing uses them after the bundle. `generate_from_bake_production_cli` waits for its parse tasks and, since this path passes no shared pool, shuts down and joins the thread pool it created (`deinit_without_freeing_arena`) before returning, so no worker that cloned them is alive; the prerender that follows only reads the bundle's output files. The transpilers' raw-pointer fields (`log`, `fs`, `env`) point at process-lifetime singletons and have no drop glue, and everything else they own (`BundleOptions`, resolver options and caches, linker state) is theirs alone; the same full drop is what `BundleThread` does for its per-build transpiler and what `DevServer`'s `Drop` does for its three. Declaration order is checked by the compiler: `BundleOptions` has a `Drop` impl, so a slot cannot outlive the projection or the arena it borrows.
- Intentionally not touched: the dev server's `Framework::init_transpiler` (bake/mod.rs) keeps its own arena projections because `DevServer` already tracks and drops them (`bundler_framework_views`); only the production path leaked. Only a comment in DevServer.rs changes, since it pointed at the signature this PR replaces.
- Verified:
  - `test/bake/dev/production.test.ts`, three new cases gated on `isASAN`, each run with `detect_leaks=1`: a react app with no pages (server, client and ssr graphs; exits 0 after bundling), a custom framework without server components (server and client graphs only; same exit), and a react app whose page fails to bundle (the `?` exit with `BuildFailed`). The first two assert the exact build output and exit 0; the third snapshots the exact build error and exit 1. Without the src changes all three fail with the LeakSanitizer report above appended to stderr; with them all three pass. The rest of the file (prerendering, `"use client"` components, the throwing-component exit) passes on the same ASAN build, which covers the paths that actually use the transpilers before they are dropped.
  - Running the one-page react build by hand under LSan: 329,510 bytes in 2,879 allocations before, 3,265 bytes in 10 allocations after. The remaining 10 are `Blob`, `TextDecoder` and `setImmediate` objects created by the prerender JS, which the build VM never finalizes because the success path of `build_command` exits without tearing down its JSC VM; the throwing-component and build-error exits are clean. That is a separate bug, fixed in #38241. `production.test.ts` stays on the exclusion list until that and #38004 land, so the new tests enable leak checking themselves and stop before anything is prerendered.
  - `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.

### Background
- `bun build --app` (src/runtime/bake/production.rs) is bake's static production build: it evaluates the app config in a dedicated VM, creates one bundler `Transpiler` per graph the framework uses (server, client, and ssr when the framework bundles server components with a separate SSR graph), runs `BundleV2` over the routes with those transpilers, and prerenders the routes in the same VM.
- A `Transpiler` is configured in place: `configure_linker` stores raw pointers to the transpiler's own fields inside it, so a configured transpiler cannot be moved or returned by value. That is why these functions take an out-slot, and why the slot type exists instead of returning the transpiler.
- `bake_types::Framework` is the bundler-side projection of bake's `Framework` (the bundler crate cannot see bake's type). `BundleOptions` holds it by reference, so someone outside the transpiler has to own it for as long as the transpiler lives; this PR makes that owner a local in `build_with_vm`.
- `UserOptions.arena` is a bumpalo arena (`bun_alloc::Arena`) used for config-lifetime allocations. Values placed in it are freed in bulk without running `Drop`, so anything put there that owns heap memory leaks that memory (see the "Arena gotcha" in src/CLAUDE.md).
- LeakSanitizer reports allocations that are unreachable when the process exits. CI runs the ASAN lane with `detect_leaks=1` for every test file not listed in `test/no-validate-leaksan.txt`; the new tests set it themselves because this file is still listed.
