### PR TITLE
bake: honor fileSystemRouterTypes[n].ignoreDirs

### DIFF
--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1039,24 +1039,24 @@ impl Framework {
                     ]
                 };
 
-                let ignore_dirs: &'static [&'static [u8]] = if let Some(exts_js) =
+                let ignore_dirs: &'static [&'static [u8]] = if let Some(dirs_js) =
                     fsr_opts.get(global, "ignoreDirs")?
                 {
-                    'exts: {
-                        if exts_js.is_array() {
-                            let mut it_2 = array.array_iterator(global)?;
+                    'dirs: {
+                        if dirs_js.is_array() {
+                            let mut it_2 = dirs_js.array_iterator(global)?;
                             let mut dirs = bun_alloc::ArenaVec::<&'static [u8]>::with_capacity_in(
-                                len as usize,
+                                dirs_js.get_length(global)? as usize,
                                 arena,
                             );
                             while let Some(array_item) = it_2.next()? {
                                 dirs.push(refs.track(array_item.to_slice(global)?));
                             }
-                            break 'exts arena_erase(dirs.into_bump_slice());
+                            break 'dirs arena_erase(dirs.into_bump_slice());
                         }
 
                         return Err(global.throw_invalid_arguments(format_args!(
-                            "'ignoreDirs' must be an array of strings or \"*\" for all extensions"
+                            "'ignoreDirs' must be an array of strings"
                         )));
                     }
                 } else {

--- a/test/bake/dev/file-system-router-types.test.ts
+++ b/test/bake/dev/file-system-router-types.test.ts
@@ -1,0 +1,87 @@
+// Tests for the `fileSystemRouterTypes[n]` options of a custom framework
+// (`Bun.serve({ app: { framework } })`).
+import { Bake } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { devTest, minimalFramework } from "../bake-harness";
+
+function frameworkWithRouterOptions(options: Partial<Bake.FrameworkFileSystemRouterType>): Bake.Framework {
+  return {
+    ...minimalFramework,
+    fileSystemRouterTypes: [{ ...minimalFramework.fileSystemRouterTypes[0], ...options }],
+  };
+}
+
+const page = (text: string) => `export default () => new Response(${JSON.stringify(text)});`;
+
+devTest("ignoreDirs skips directories whose name is listed", {
+  framework: frameworkWithRouterOptions({ ignoreDirs: ["hidden", "also-hidden"] }),
+  files: {
+    "routes/index.ts": page("index"),
+    "routes/hidden/index.ts": page("hidden"),
+    "routes/also-hidden/index.ts": page("also-hidden"),
+    "routes/visible/index.ts": page("visible"),
+    "routes/visible/hidden/index.ts": page("visible/hidden"),
+    "routes/hidden-suffix/index.ts": page("hidden-suffix"),
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("index");
+    await dev.fetch("/visible").equals("visible");
+    await dev.fetch("/hidden").expect404();
+    await dev.fetch("/also-hidden").expect404();
+    // Matched at any depth, not only directly under the root.
+    await dev.fetch("/visible/hidden").expect404();
+    // Compared against the whole directory name, not as a prefix.
+    await dev.fetch("/hidden-suffix").equals("hidden-suffix");
+  },
+});
+
+devTest("ignoreDirs defaults to node_modules and .git", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": page("index"),
+    "routes/other/index.ts": page("other"),
+    "routes/node_modules/index.ts": page("node_modules"),
+    "routes/.git/index.ts": page(".git"),
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("index");
+    await dev.fetch("/other").equals("other");
+    await dev.fetch("/node_modules").expect404();
+    await dev.fetch("/.git").expect404();
+  },
+});
+
+test("ignoreDirs must be an array", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        try {
+          Bun.serve({
+            port: 0,
+            development: true,
+            app: {
+              framework: {
+                fileSystemRouterTypes: [
+                  { root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts", ignoreDirs: "hidden" },
+                ],
+              },
+            },
+          });
+          console.log("did not throw");
+        } catch (e) {
+          console.log(e.message);
+        }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("'ignoreDirs' must be an array of strings\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/bake/dev/file-system-router-types.test.ts
+++ b/test/bake/dev/file-system-router-types.test.ts
@@ -5,17 +5,19 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { devTest, minimalFramework } from "../bake-harness";
 
-function frameworkWithRouterOptions(options: Partial<Bake.FrameworkFileSystemRouterType>): Bake.Framework {
+/** `minimalFramework` with one router type per entry, each overriding the minimal router type's options. */
+function frameworkWithRouterTypes(...types: Partial<Bake.FrameworkFileSystemRouterType>[]): Bake.Framework {
+  const [minimalType] = minimalFramework.fileSystemRouterTypes!;
   return {
     ...minimalFramework,
-    fileSystemRouterTypes: [{ ...minimalFramework.fileSystemRouterTypes[0], ...options }],
+    fileSystemRouterTypes: types.map(options => ({ ...minimalType, ...options })),
   };
 }
 
 const page = (text: string) => `export default () => new Response(${JSON.stringify(text)});`;
 
 devTest("ignoreDirs skips directories whose name is listed", {
-  framework: frameworkWithRouterOptions({ ignoreDirs: ["hidden", "also-hidden"] }),
+  framework: frameworkWithRouterTypes({ ignoreDirs: ["hidden", "also-hidden"] }),
   files: {
     "routes/index.ts": page("index"),
     "routes/hidden/index.ts": page("hidden"),
@@ -23,6 +25,7 @@ devTest("ignoreDirs skips directories whose name is listed", {
     "routes/visible/index.ts": page("visible"),
     "routes/visible/hidden/index.ts": page("visible/hidden"),
     "routes/hidden-suffix/index.ts": page("hidden-suffix"),
+    "routes/node_modules/index.ts": page("node_modules"),
   },
   async test(dev) {
     await dev.fetch("/").equals("index");
@@ -33,6 +36,27 @@ devTest("ignoreDirs skips directories whose name is listed", {
     await dev.fetch("/visible/hidden").expect404();
     // Compared against the whole directory name, not as a prefix.
     await dev.fetch("/hidden-suffix").equals("hidden-suffix");
+    // Like `extensions`, a configured list replaces the default one instead of extending it.
+    await dev.fetch("/node_modules").equals("node_modules");
+  },
+});
+
+devTest("ignoreDirs is read from each router type", {
+  framework: frameworkWithRouterTypes(
+    { root: "routes-a", ignoreDirs: ["skip-a"] },
+    { root: "routes-b", ignoreDirs: ["skip-b"] },
+  ),
+  files: {
+    "routes-a/skip-a/one.ts": page("a: skip-a/one"),
+    "routes-a/skip-b/two.ts": page("a: skip-b/two"),
+    "routes-b/skip-a/three.ts": page("b: skip-a/three"),
+    "routes-b/skip-b/four.ts": page("b: skip-b/four"),
+  },
+  async test(dev) {
+    await dev.fetch("/skip-a/one").expect404();
+    await dev.fetch("/skip-b/two").equals("a: skip-b/two");
+    await dev.fetch("/skip-a/three").equals("b: skip-a/three");
+    await dev.fetch("/skip-b/four").expect404();
   },
 });
 


### PR DESCRIPTION
### Problem
- A custom framework's `fileSystemRouterTypes[n].ignoreDirs` is never honored: with `ignoreDirs: ["hidden"]`, `routes/hidden/index.ts` is still scanned and `fetch("/hidden")` on the dev server returns 200 instead of 404.
- `Framework::from_js` (`src/runtime/bake/bake_body.rs`, `ignoreDirs` block) checks that the `ignoreDirs` value is an array, then builds the list by iterating `array` (the enclosing `fileSystemRouterTypes` array) and sizing it with that array's `len`, instead of iterating the `ignoreDirs` value it just validated.
- The parsed list therefore holds `to_slice()` of each router type object (`"[object Object]"`), so no real directory name ever matches. The behavior dates back to the original Zig implementation, so this is not a regression.
- The error for a non-array value ended in `or "*" for all extensions`, copied from the `extensions` block; `ignoreDirs` does not accept `"*"`.

### Fix
- Iterate the `ignoreDirs` value and size the list from its own length, the same shape as the `extensions` block directly above it.
- Error message for a non-array value is now `'ignoreDirs' must be an array of strings`.
- Correct because the consumers already use the parsed list as a list of directory names: `FrameworkRouter.rs` `scan_inner` compares each directory's basename against `ignore_dirs` while walking the route root, and both `DevServer.rs` and `production.rs` copy `ignore_dirs` from the parsed router type into the router. Only the parse step was wrong. The default when the option is omitted (`.git`, `node_modules`) is unchanged, and a configured list replaces the default rather than extending it, as `extensions` does and as the `@default` doc on the option describes.
- Verified with `test/bake/dev/file-system-router-types.test.ts`:
  - listed directories 404 at the root and nested, a directory whose name merely starts with a listed name is still routed, and a configured list replaces the default (`routes/node_modules/` becomes routable);
  - with two router types, each type skips only the names in its own list;
  - the defaults still apply when the option is omitted;
  - a non-array value throws the new message.
- Without the `src/` change the first two dev server tests fail (`404` expected, `200` received) and the message test fails; with it all four pass. The defaults test passes either way and is there as a guard.
- `test/bake/framework-router.test.ts` and `test/bake/dev/bundle.test.ts` still pass.
- The same parsed value feeds `bun build --app` (`production.rs`), but production builds of any custom framework currently panic before reaching the router (#32142, fix in #32143), so the tests here cover the dev server.

### Background
- Bake is bun's full-stack framework layer (`Bun.serve({ app })` for the dev server, `bun build --app` for static builds). A framework describes its routes with `fileSystemRouterTypes`: each entry names a `root` directory to scan, a routing `style` (for example `nextjs-pages`), the server entry that renders matched routes, and options that filter the scan, including `ignoreDirs`, the directory names the scan must not descend into (documented default: `node_modules` and `.git`).
- `Framework::from_js` is the one place the JS framework object is turned into the Rust `Framework` struct; the dev server and the production build both start from its output.
