### PR TITLE
node:vm: apply SourceTextModule lineOffset/columnOffset like Node and name frames after the identifier

### DIFF
--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -179,7 +179,14 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         parserError);
 
     if (parserError.isValid()) {
-        throwException(globalObject, scope, parserError.toErrorObject(globalObject, m_sourceCode));
+        JSObject* exception = parserError.toErrorObject(globalObject, m_sourceCode);
+        // Building the error materializes its stack, which runs a user
+        // Error.prepareStackTrace that may throw; Node throws the SyntaxError
+        // anyway. tryClearException leaves a termination for the check below.
+        if (exception)
+            (void)scope.tryClearException();
+        RETURN_IF_EXCEPTION(scope, {});
+        throwException(globalObject, scope, exception);
         return {};
     }
 

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -48,8 +48,7 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         return nullptr;
     }
 
-    // vm.ts already ran validateInt32 on the offsets; like Node's ModuleWrap this
-    // only checks the type. Negative offsets are valid, and -0 fails isAnyInt().
+    // Type check only: vm.ts validated the int32 range, and -0 (valid there) is not an isAnyInt().
     JSValue lineOffsetValue = args.at(3);
     if (!lineOffsetValue.isNumber()) {
         throwArgumentTypeError(*globalObject, scope, 3, "lineOffset"_s, "Module"_s, "Module"_s, "number"_s);
@@ -103,9 +102,7 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
     WTF::String identifier = identifierValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    // Built the same way vm.Script builds its source: the identifier is the URL
-    // stack frames report, and makeSource converts the zero-based offsets to the
-    // one-based first line/column that SourceCode counts positions from.
+    // As for vm.Script: makeSource turns the zero-based offsets into SourceCode's one-based start position.
     SourceCode sourceCode = makeSource(sourceText, sourceOrigin, SourceTaintedOrigin::Untainted, identifier, startPosition, SourceProviderSourceType::Module);
 
     auto* zigGlobalObject = defaultGlobalObject(globalObject);

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -180,9 +180,7 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
 
     if (parserError.isValid()) {
         JSObject* exception = parserError.toErrorObject(globalObject, m_sourceCode);
-        // Building the error materializes its stack, which runs a user
-        // Error.prepareStackTrace that may throw; Node throws the SyntaxError
-        // anyway. tryClearException leaves a termination for the check below.
+        // toErrorObject materialized the stack, which can run a throwing user Error.prepareStackTrace; like Node, the SyntaxError still wins.
         if (exception)
             (void)scope.tryClearException();
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -48,14 +48,16 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         return nullptr;
     }
 
+    // vm.ts already ran validateInt32 on the offsets; like Node's ModuleWrap this
+    // only checks the type. Negative offsets are valid, and -0 fails isAnyInt().
     JSValue lineOffsetValue = args.at(3);
-    if (!lineOffsetValue.isUInt32AsAnyInt()) {
+    if (!lineOffsetValue.isNumber()) {
         throwArgumentTypeError(*globalObject, scope, 3, "lineOffset"_s, "Module"_s, "Module"_s, "number"_s);
         return nullptr;
     }
 
     JSValue columnOffsetValue = args.at(4);
-    if (!columnOffsetValue.isUInt32AsAnyInt()) {
+    if (!columnOffsetValue.isNumber()) {
         throwArgumentTypeError(*globalObject, scope, 4, "columnOffset"_s, "Module"_s, "Module"_s, "number"_s);
         return nullptr;
     }
@@ -85,10 +87,11 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
         return nullptr;
     }
 
-    uint32_t lineOffset = lineOffsetValue.toUInt32(globalObject);
+    int32_t lineOffset = lineOffsetValue.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    uint32_t columnOffset = columnOffsetValue.toUInt32(globalObject);
+    int32_t columnOffset = columnOffsetValue.toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
+    TextPosition startPosition { OrdinalNumber::fromZeroBasedInt(lineOffset), OrdinalNumber::fromZeroBasedInt(columnOffset) };
 
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, dynamicImportCallback, moduleWrapper));
     RETURN_IF_EXCEPTION(scope, nullptr);
@@ -97,15 +100,15 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
 
     WTF::String sourceText = sourceTextValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
-
-    Ref<StringSourceProvider> sourceProvider = StringSourceProvider::create(WTF::move(sourceText), sourceOrigin, String {}, SourceTaintedOrigin::Untainted,
-        TextPosition { OrdinalNumber::fromZeroBasedInt(lineOffset), OrdinalNumber::fromZeroBasedInt(columnOffset) }, SourceProviderSourceType::Module);
-
-    SourceCode sourceCode(WTF::move(sourceProvider), lineOffset, columnOffset);
-
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
     WTF::String identifier = identifierValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
+
+    // Built the same way vm.Script builds its source: the identifier is the URL
+    // stack frames report, and makeSource converts the zero-based offsets to the
+    // one-based first line/column that SourceCode counts positions from.
+    SourceCode sourceCode = makeSource(sourceText, sourceOrigin, SourceTaintedOrigin::Untainted, identifier, startPosition, SourceProviderSourceType::Module);
+
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
     NodeVMSourceTextModule* ptr = new (NotNull, allocateCell<NodeVMSourceTextModule>(vm)) NodeVMSourceTextModule(
         vm, zigGlobalObject->NodeVMSourceTextModuleStructure(), WTF::move(identifier), contextValue,
         WTF::move(sourceCode), moduleWrapper, initializeImportMeta);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1600,17 +1600,17 @@ describe("node:vm SourceTextModule identifier and lineOffset/columnOffset", () =
       expect(topFrame(thrownBy(() => m.namespace.onLine1())).url).toBe("negative.mjs");
     }
 
-    // The native binding relies on vm.ts validating the range and integrality.
-    for (const value of [1.5, 2 ** 31, -(2 ** 31) - 1]) {
-      expect(() => new SourceTextModule(source, { lineOffset: value })).toThrow(
-        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
-      );
-      expect(() => new SourceTextModule(source, { columnOffset: value })).toThrow(
-        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    // The native binding reads the offsets with ToInt32 and relies on vm.ts
+    // having rejected everything that is not an int32 (Node's validateInt32).
+    for (const option of ["lineOffset", "columnOffset"] as const) {
+      for (const value of [1.5, NaN, Infinity, -Infinity, 2 ** 31, -(2 ** 31) - 1]) {
+        expect(() => new SourceTextModule(source, { [option]: value })).toThrow(
+          expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+        );
+      }
+      expect(() => new SourceTextModule(source, { [option]: "1" as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
       );
     }
-    expect(() => new SourceTextModule(source, { lineOffset: "1" as any })).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-    );
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1569,6 +1569,23 @@ describe("node:vm SourceTextModule identifier and lineOffset/columnOffset", () =
     expect(error.stack).toContain("broken.mjs:7");
   });
 
+  test("a throwing Error.prepareStackTrace does not escape the constructor's SyntaxError", () => {
+    // Building the SyntaxError materializes its stack, which runs the user's
+    // prepareStackTrace; the SyntaxError must still be what comes out, as with
+    // new Script() (and Node).
+    const previous = Error.prepareStackTrace;
+    Error.prepareStackTrace = () => {
+      throw new Error("boom-from-prepareStackTrace");
+    };
+    try {
+      const error = thrownBy(() => new SourceTextModule("%%", { identifier: "broken.mjs" })) as Error;
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error.message).toBe("Unexpected token '%'");
+    } finally {
+      Error.prepareStackTrace = previous;
+    }
+  });
+
   test("cachedData is accepted regardless of identifier and offsets, which then apply to the consumer", async () => {
     const plain = await evaluated(source, { identifier: "plain.mjs" });
     const { column } = topFrame(thrownBy(() => plain.namespace.onLine1()));

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -8,6 +8,7 @@ import {
   runInNewContext,
   runInThisContext,
   Script,
+  SourceTextModule,
 } from "node:vm";
 
 function capture(_: any, _1?: any) {}
@@ -1483,4 +1484,133 @@ test("node:vm Object.defineProperty on the context global when the sandbox is an
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe(JSON.stringify({ result: 1, sandboxArray: 1 }));
   expect(exitCode).toBe(0);
+});
+
+describe("node:vm SourceTextModule identifier and lineOffset/columnOffset", () => {
+  // Node compiles the source under the identifier and adds the zero-based
+  // offsets to every reported position: physical line L reports as
+  // L + lineOffset, and columnOffset shifts the first line only.
+  const source = [
+    "export function onLine1() { throw new Error('line 1'); }",
+    "export function onLine2() { throw new Error('line 2'); }",
+  ].join("\n");
+
+  async function evaluated(sourceText: string, options?: ConstructorParameters<typeof SourceTextModule>[1]) {
+    const m = new SourceTextModule(sourceText, options);
+    await m.link(() => {
+      throw new Error("unexpected import");
+    });
+    await m.evaluate();
+    return m;
+  }
+
+  function topFrame(error: unknown) {
+    const frame = String((error as Error).stack)
+      .split("\n")
+      .find(line => /^\s+at /.test(line));
+    const match = /^\s+at (?:.* \()?(.+?):(\d+):(\d+)\)?$/.exec(frame ?? "");
+    if (!match) throw new Error(`no frame in ${(error as Error).stack}`);
+    return { url: match[1], line: Number(match[2]), column: Number(match[3]) };
+  }
+
+  function thrownBy(fn: () => unknown) {
+    try {
+      fn();
+    } catch (e) {
+      return e;
+    }
+    throw new Error("expected fn to throw");
+  }
+
+  test("frames report the identifier and the offset positions", async () => {
+    const plain = await evaluated(source, { identifier: "plain.mjs" });
+    const line1 = topFrame(thrownBy(() => plain.namespace.onLine1()));
+    const line2 = topFrame(thrownBy(() => plain.namespace.onLine2()));
+    expect(line1).toEqual({ url: "plain.mjs", line: 1, column: expect.any(Number) });
+    // Both lines hold the same text, so the throw sits at the same column on each.
+    expect(line2).toEqual({ url: "plain.mjs", line: 2, column: line1.column });
+
+    const offset = await evaluated(source, { identifier: "offset.mjs", lineOffset: 10, columnOffset: 7 });
+    expect(topFrame(thrownBy(() => offset.namespace.onLine1()))).toEqual({
+      url: "offset.mjs",
+      line: 11,
+      column: line1.column + 7,
+    });
+    expect(topFrame(thrownBy(() => offset.namespace.onLine2()))).toEqual({
+      url: "offset.mjs",
+      line: 12,
+      column: line1.column,
+    });
+  });
+
+  test("the generated identifier is used when none is given", async () => {
+    const m = await evaluated(source);
+    expect(m.identifier).toMatch(/^vm:module\(\d+\)$/);
+    expect(topFrame(thrownBy(() => m.namespace.onLine1()))).toMatchObject({ url: m.identifier, line: 1 });
+  });
+
+  test("errors thrown while evaluating the module body", async () => {
+    const m = new SourceTextModule("1;\n2;\nthrow new Error('top level');", {
+      identifier: "body.mjs",
+      lineOffset: 100,
+    });
+    await m.link(() => {
+      throw new Error("unexpected import");
+    });
+    let error: unknown;
+    await m.evaluate().catch(e => (error = e));
+    expect(m.error).toBe(error);
+    expect(topFrame(error)).toMatchObject({ url: "body.mjs", line: 103 });
+  });
+
+  test("SyntaxError thrown by the constructor points at the identifier and offset line", () => {
+    const error = thrownBy(() => new SourceTextModule("1;\n%%", { identifier: "broken.mjs", lineOffset: 5 })) as Error;
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error.stack).toContain("broken.mjs:7");
+  });
+
+  test("cachedData is accepted regardless of identifier and offsets, which then apply to the consumer", async () => {
+    const plain = await evaluated(source, { identifier: "plain.mjs" });
+    const { column } = topFrame(thrownBy(() => plain.namespace.onLine1()));
+
+    const cachedData = new SourceTextModule(source).createCachedData();
+    const consumer = await evaluated(source, {
+      identifier: "consumer.mjs",
+      lineOffset: 20,
+      columnOffset: 3,
+      cachedData,
+    });
+    expect(topFrame(thrownBy(() => consumer.namespace.onLine1()))).toEqual({
+      url: "consumer.mjs",
+      line: 21,
+      column: column + 3,
+    });
+  });
+
+  test("any int32 offset is accepted, as in Node", async () => {
+    // JSC cannot count positions from below line 1 / column 1, so a negative
+    // offset compiles the module and reports physical positions, like vm.Script.
+    for (const options of [
+      { lineOffset: -1 },
+      { columnOffset: -1 },
+      { lineOffset: -0, columnOffset: -0 },
+      { lineOffset: -2147483648, columnOffset: -2147483648 },
+    ]) {
+      const m = await evaluated(source, { identifier: "negative.mjs", ...options });
+      expect(topFrame(thrownBy(() => m.namespace.onLine1())).url).toBe("negative.mjs");
+    }
+
+    // The native binding relies on vm.ts validating the range and integrality.
+    for (const value of [1.5, 2 ** 31, -(2 ** 31) - 1]) {
+      expect(() => new SourceTextModule(source, { lineOffset: value })).toThrow(
+        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+      );
+      expect(() => new SourceTextModule(source, { columnOffset: value })).toThrow(
+        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+      );
+    }
+    expect(() => new SourceTextModule(source, { lineOffset: "1" as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
 });


### PR DESCRIPTION
### Problem
- Positions reported from code compiled by `vm.SourceTextModule` are one line short of Node's, and one column short on the first line: `new vm.SourceTextModule('1;\nthrow new Error("x")', { identifier: "m.mjs", lineOffset: 5 })` reports `at unknown:6:16`, Node reports line 7 (physical line 2 + 5). `columnOffset: 10` on a first-line throw adds 9. `lineOffset: 0` happens to be right only because JSC clamps the value to 1.
- Negative offsets are rejected: `new vm.SourceTextModule("1", { lineOffset: -1 })` throws `TypeError: Argument 4 ('lineOffset') to Module.Module must be an instance of number`. Node accepts any int32 here (`validateInt32`), and so does `src/js/node/vm.ts`; only the native binding refuses.
- Every frame from module code, and the module's own SyntaxErrors, name the source `unknown` instead of the identifier (`at f (unknown:1:37)`; Node: `at f (myid.mjs:1:28)`, `vm:module(0)` when no identifier was given).
- Separately, any module with a syntax error (`new vm.SourceTextModule("%%")`) aborts under `BUN_JSC_validateExceptionChecks=1` (the x64-asan lane) with `unchecked exception at createModuleRecord @ NodeVMSourceTextModule.cpp:169 (thrown from FormatStackTraceForJS.cpp:536)`: `createModuleRecord` passes `parserError.toErrorObject(...)` straight into `throwException`, and building the error materializes its stack, which can run a user `Error.prepareStackTrace`. Pre-existing on main (reproduced with main's copy of the file); the new constructor SyntaxError test is the first one in CI to reach it.
- Cause, `src/jsc/bindings/NodeVMSourceTextModule.cpp` `NodeVMSourceTextModule::create`:
  - `SourceCode sourceCode(provider, lineOffset, columnOffset)` passes the zero-based option values into `SourceCode`'s one-based `firstLine` / `startColumn` parameters (`SourceCode.h:52`), and those are what the lexer starts counting at (`Lexer::setCode`) and what `CodeBlock::lineColumnForBytecodeIndex` adds to every reported position.
  - The offsets were checked with `isUInt32AsAnyInt()` and read with `toUInt32()`.
  - `StringSourceProvider::create(..., String {}, ...)` gave the provider no source URL; the identifier was only stored on the module object.

### Fix
- Build the module's `SourceCode` with `JSC::makeSource(sourceText, origin, Untainted, identifier, startPosition, SourceProviderSourceType::Module)`, which is exactly how `vm.Script` builds its source in `NodeVMScript.cpp`: `makeSource` converts the `TextPosition` to one-based `firstLine` / `startColumn` (`SourceCode.h:91`), and the identifier becomes the provider's source URL, the same role `filename` plays for `vm.Script`.
- Correct because physical line `L` is now reported as `L + lineOffset` and first-line columns as `column + columnOffset`, with later lines unshifted, which is Node's (V8 `ScriptOrigin`) definition of the two options; the module path now produces the same positions as `vm.Script` does for the same source and options (verified side by side, see the details block).
- Type-check the offsets with `isNumber()` and read them with `toInt32()`. `vm.ts` has already run `validateInt32` on them, so this is the same contract as Node's `ModuleWrap` binding (`IsNumber()` check, read as `Int32`); `isInt32AsAnyInt()` would still have rejected `-0`, which `validateInt32` and Node accept. Negative offsets compile and report physical positions because `SourceCode` clamps the start to line 1 / column 1; that is the existing `vm.Script` behaviour for negative offsets as well (tracked separately).
- Nothing else keys off these values: `SourceCodeKey` (used to validate `cachedData`) hashes the source text and flags, not the provider URL or the first line, so cached data still round-trips between modules with different identifiers or offsets (covered by a test). The provider's start position was already being set; the debugger is its only consumer.
- `SourceOrigin` stays empty on purpose (as before). `vm.Script` also sets a file URL there, but nothing consumes it for a module (`import.meta` is built from the module key and dynamic `import()` is intercepted by the fetcher first), and `SourceCodeKey` compares the origin's host, so filling it in would make `cachedData` acceptance depend on the identifier.
- Knock-on effects of frames now carrying a URL, all of them identical to what `vm.Script` already does with `filename`: the `cachedData` bytes embed the identifier (acceptance across identifiers/offsets is unaffected, see the test); an identifier that happens to equal a file the host process itself loaded makes Bun's stack remapper run the frame through that file's source map, which is a pre-existing remapper bug reproducible with `vm.Script` today and tracked separately; the uncaught-error printer now shows the module's source line (with the pre-existing context-line numbering bug that `vm.Script` previews have, also tracked separately).
- Supersedes #33564, which fixed the line half and the identifier but not `columnOffset` or negative offsets, and no longer applied cleanly; it is closed in favour of this PR.
- Offsets within a few lines of `INT32_MAX` are out of scope here and stay as broken as they are for `vm.Script` today: JSC keeps positions in `int`, so `makeSource`'s one-based conversion and the lexer's per-line increment overflow up there (positions come out wrapped or clamped; assertion builds abort). This PR moves the module's boundary onto `vm.Script`'s exactly (checked on the debug build: `lineOffset: INT32_MAX` now compiles and reports from line 1, `INT32_MAX - 1` with a two-line source asserts, both identical to `vm.Script` with the same input). #38228 clamps the offsets against the source length for all three APIs and touches these same lines; whichever lands second routes the clamped `TextPosition` into this `makeSource` call.
- `createModuleRecord` now builds the error, clears a non-termination exception left by stack materialization and returns on a termination (`tryClearException` + `RETURN_IF_EXCEPTION`), then throws the SyntaxError, which is the shape `NodeVMScript.cpp` and `NodeVM.cpp` already use for their `toErrorObject` calls. The SyntaxError still wins over a throwing `prepareStackTrace`, as in Node (checked against node v26).
- Verified with `test/js/node/vm/vm.test.ts`, `describe("node:vm SourceTextModule identifier and lineOffset/columnOffset")`: 7 tests covering identifier and generated identifier in frames, `lineOffset` / `columnOffset` on line 1 and line 2 for exported-function frames, module-body evaluation errors, the constructor's SyntaxError (including with a throwing `Error.prepareStackTrace` installed), `cachedData` across differing identifiers/offsets, and negative / `-0` / `INT32_MIN` offsets plus the `vm.ts` validation the binding relies on (`1.5`, `NaN`, `+/-Infinity`, both out-of-range values and a wrong type, through both options). 6 of the 7 fail on main (frames named `unknown`, positions off by one, `TypeError` for negative offsets); the prepareStackTrace one documents behaviour that only the exception validator could tell apart. All 7 pass with the change, and the whole file (221 tests) passes under `BUN_JSC_validateExceptionChecks=1`.
- Review pass over the edges (probed on this build against Node 26 and against `vm.Script` given the same inputs): identifiers that are empty, huge, contain newlines / colons / parens / non-ASCII, or look like URLs and paths; modules in a separate context and the generated `vm:module(N)` names; `import.meta` and dynamic `import()`; CRLF / U+2028 / template-literal line breaks, nested functions, classes, async functions and TLA under both offsets; `error.line` / `error.column` / `error.sourceURL`; `cachedData` in both directions; `Error.stackTraceLimit = 0` and throwing or string-returning `prepareStackTrace`; the `INT32_MIN` / `INT32_MAX` corners. Everything matched `vm.Script` byte for byte, and Node line for line; the only differences found are the two pre-existing ones listed above.
- Also ran the rest of `vm.test.ts` (220 pass), the other `test/js/node/vm/*.test.ts` files, and all 97 `test/js/node/test/parallel/test-vm-*` files on the debug build.

### Background
- `lineOffset` / `columnOffset` (`vm.Script`, `vm.compileFunction`, `vm.SourceTextModule`) say where a snippet sits inside a larger file so that reported positions line up with that file. They are zero-based: physical line 1 with `lineOffset: 5` is reported as line 6. `columnOffset` only affects the first line, since later lines start at column 1 of the snippet anyway. Node validates both as int32, so negative values are legal.
- `identifier` is the module's name. Node uses it as the script's resource name, so it is what stack frames print (`vm:module(N)` is the generated default). A module has no file behind it, so this is the only name a frame can carry.
- JSC `SourceProvider` holds the source text, its URL (what stack frames and `error.sourceURL` print) and a zero-based `startPosition` used by the debugger. `SourceCode` wraps a provider plus a one-based `firstLine` / `startColumn` (clamped to at least 1); the lexer starts numbering there and `CodeBlock` adds them to every position it reports. `makeSource` builds both from one `TextPosition`, doing the zero-to-one-based conversion.
- `isAnyInt()` in JSC is false for `-0`, so integer checks built on it (`isInt32AsAnyInt`, `isUInt32AsAnyInt`) reject a value Node's validators accept.

<details>
<summary>Before / after on the handoff's probe (main debug build; Node v26 with --experimental-vm-modules for reference)</summary>

```
                                          before (main)        after                node
module lineOffset=5, physical line 2      at unknown:6:16      at m.mjs:7:16        at m.mjs:7:7
module columnOffset=10, line 1            at unknown:1:25      at c.mjs:1:26        at c.mjs:1:17
module no offset, line 1                  at unknown:1:16      at c0.mjs:1:16       at c0.mjs:1:7
module columnOffset=10, line 2            at unknown:2:16      at c2.mjs:2:16       at c2.mjs:2:7
exported fn, lineOffset 10 columnOffset 3 at f (unknown:10:39) at f (off.mjs:11:40) at Module.f (off.mjs:11:31)
no identifier                             at f (unknown:1:37)  at f (vm:module(1):1:37)  at Module.f (vm:module(1):1:28)
constructor SyntaxError, lineOffset 5     at <parse> (:6)      at <parse> (syn.mjs:7)    header "syn.mjs:7"
{ lineOffset: -1 }                        TypeError            accepted             accepted
{ lineOffset: -0 }                        TypeError            accepted             accepted
{ columnOffset: -2147483648 }             TypeError            accepted             accepted
vm.Script lineOffset=5, physical line 2   at s.js:7:16         at s.js:7:16         at s.js:7:7
vm.Script columnOffset=10, line 1         at sc.js:1:26        at sc.js:1:26        at sc.js:1:17
```

The remaining column difference against Node is the engines' choice of position within the throw expression (JSC reports the call's `(`, V8 the start of `new`) and is unrelated to the offsets; the offsets themselves now add the same amounts.

</details>



