### PR TITLE
node:vm: validate lineOffset/columnOffset by value like Node's validateInt32

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1964,9 +1964,6 @@ bool BaseVMOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
             this->filename = "evalmachine.<anonymous>"_s;
         }
 
-        // Node validateInt32()s both offsets. Checking the value (not
-        // isInt32()/isAnyInt(), which test how JSC boxed it) is what lets
-        // -0 and integral doubles such as 1.5 + 1.5 through, as in Node.
         auto lineOffsetOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "lineOffset"_s));
         RETURN_IF_EXCEPTION(scope, false);
         if (lineOffsetOpt && !lineOffsetOpt.isUndefined()) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1964,44 +1964,27 @@ bool BaseVMOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
             this->filename = "evalmachine.<anonymous>"_s;
         }
 
+        // Node validateInt32()s both offsets. Checking the value (not
+        // isInt32()/isAnyInt(), which test how JSC boxed it) is what lets
+        // -0 and integral doubles such as 1.5 + 1.5 through, as in Node.
         auto lineOffsetOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "lineOffset"_s));
         RETURN_IF_EXCEPTION(scope, false);
-        if (lineOffsetOpt) {
-            if (lineOffsetOpt.isAnyInt()) {
-                if (!lineOffsetOpt.isInt32()) {
-                    ERR::OUT_OF_RANGE(scope, globalObject, "options.lineOffset"_s, std::numeric_limits<int32_t>().min(), std::numeric_limits<int32_t>().max(), lineOffsetOpt);
-                    return false;
-                }
-                this->lineOffset = OrdinalNumber::fromZeroBasedInt(lineOffsetOpt.asInt32());
-                any = true;
-            } else if (lineOffsetOpt.isNumber()) {
-                ERR::OUT_OF_RANGE(scope, globalObject, "options.lineOffset"_s, "an integer"_s, lineOffsetOpt);
-                return false;
-            } else if (!lineOffsetOpt.isUndefined()) {
-                ERR::INVALID_ARG_TYPE(scope, globalObject, "options.lineOffset"_s, "number"_s, lineOffsetOpt);
-                return false;
-            }
+        if (lineOffsetOpt && !lineOffsetOpt.isUndefined()) {
+            int32_t lineOffsetValue = 0;
+            V::validateInt32(scope, globalObject, lineOffsetOpt, "options.lineOffset"_s, jsUndefined(), jsUndefined(), &lineOffsetValue);
+            RETURN_IF_EXCEPTION(scope, false);
+            this->lineOffset = OrdinalNumber::fromZeroBasedInt(lineOffsetValue);
+            any = true;
         }
 
         auto columnOffsetOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "columnOffset"_s));
         RETURN_IF_EXCEPTION(scope, false);
-        if (columnOffsetOpt) {
-            if (columnOffsetOpt.isAnyInt()) {
-                if (!columnOffsetOpt.isInt32()) {
-                    ERR::OUT_OF_RANGE(scope, globalObject, "options.columnOffset"_s, std::numeric_limits<int32_t>().min(), std::numeric_limits<int32_t>().max(), columnOffsetOpt);
-                    return false;
-                }
-                int columnOffsetValue = columnOffsetOpt.asInt32();
-
-                this->columnOffset = OrdinalNumber::fromZeroBasedInt(columnOffsetValue);
-                any = true;
-            } else if (columnOffsetOpt.isNumber()) {
-                ERR::OUT_OF_RANGE(scope, globalObject, "options.columnOffset"_s, "an integer"_s, columnOffsetOpt);
-                return false;
-            } else if (!columnOffsetOpt.isUndefined()) {
-                ERR::INVALID_ARG_TYPE(scope, globalObject, "options.columnOffset"_s, "number"_s, columnOffsetOpt);
-                return false;
-            }
+        if (columnOffsetOpt && !columnOffsetOpt.isUndefined()) {
+            int32_t columnOffsetValue = 0;
+            V::validateInt32(scope, globalObject, columnOffsetOpt, "options.columnOffset"_s, jsUndefined(), jsUndefined(), &columnOffsetValue);
+            RETURN_IF_EXCEPTION(scope, false);
+            this->columnOffset = OrdinalNumber::fromZeroBasedInt(columnOffsetValue);
+            any = true;
         }
     }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -473,7 +473,11 @@ describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
   const fourAsDouble = new Float64Array([4])[0];
 
   const source = "new Error().stack";
-  const location = (stack: unknown) => String(stack).match(/offsets\.js:\d+:\d+/)?.[0];
+  const location = (stack: unknown) => {
+    const match = String(stack).match(/offsets\.js:\d+:\d+/);
+    if (!match) throw new Error(`no offsets.js frame in:\n${stack}`);
+    return match[0];
+  };
   const entryPoints: Record<string, (options: Record<string, unknown>) => unknown> = {
     "new Script(code, options).runInThisContext()": options => new Script(source, options).runInThisContext(),
     "new Script(code, options).runInContext(context, options)": options =>
@@ -481,6 +485,8 @@ describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
     "vm.runInThisContext": options => runInThisContext(source, options),
     "vm.runInContext": options => runInContext(source, createContext(), options),
     "vm.runInNewContext": options => runInNewContext(source, {}, options),
+    // compileFunction does not apply columnOffset to runtime frames yet, so
+    // for this entry only the line half of the comparisons is discriminating.
     "vm.compileFunction": options => compileFunction(`return ${source}`, [], options)(),
   };
 
@@ -489,9 +495,22 @@ describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
       location(entryPoints[name]({ filename: "offsets.js", ...options }));
 
     expect(run({ lineOffset: -0, columnOffset: -0 })).toBe(run({ lineOffset: 0, columnOffset: 0 }));
-    expect(run({ lineOffset: threeAsDouble, columnOffset: fourAsDouble })).toBe(
-      run({ lineOffset: 3, columnOffset: 4 }),
-    );
+    const shifted = run({ lineOffset: threeAsDouble, columnOffset: fourAsDouble });
+    expect(shifted).toBe(run({ lineOffset: 3, columnOffset: 4 }));
+    expect(shifted).toMatch(/^offsets\.js:4:\d+$/);
+  });
+
+  // Both int32 bounds are accepted whichever way they are boxed. Compiling at
+  // INT32_MAX overflows JSC's line counter (#38228), and the run-side options
+  // are validated without compiling anything, so the bounds are checked there.
+  test.each(["lineOffset", "columnOffset"])("%s accepts INT32_MIN and INT32_MAX as int32 or double", option => {
+    const script = new Script("1");
+    const bounds = [-2147483648, 2147483647];
+    const boundsAsDoubles = new Float64Array(bounds);
+    for (let i = 0; i < bounds.length; i++) {
+      expect(script.runInThisContext({ [option]: bounds[i] })).toBe(1);
+      expect(script.runInThisContext({ [option]: boundsAsDoubles[i] })).toBe(1);
+    }
   });
 
   test("-0 and integral doubles position errors like the integers they equal", () => {
@@ -511,16 +530,16 @@ describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
   const int32Range = ">= -2147483648 && <= 2147483647";
   const ok = () => "ok";
   const outOfRange = (must: string, received: string) => (name: string) =>
-    `ERR_OUT_OF_RANGE: The value of "${name}" is out of range. It must be ${must}. Received ${received}`;
+    `RangeError ERR_OUT_OF_RANGE: The value of "${name}" is out of range. It must be ${must}. Received ${received}`;
   const invalidType = (received: string) => (name: string) =>
-    `ERR_INVALID_ARG_TYPE: The "${name}" property must be of type number. Received ${received}`;
+    `TypeError ERR_INVALID_ARG_TYPE: The "${name}" property must be of type number. Received ${received}`;
   const cases: [label: string, value: unknown, expected: (name: string) => string][] = [
     ["-0", -0, ok],
     ["integral double", threeAsDouble, ok],
     ["Float64Array element", fourAsDouble, ok],
-    // INT32_MAX is accepted too, but compiling at that offset overflows JSC's
-    // line counter (#38228), so only the lower bound is compiled here.
+    // Only the lower bound is compiled at; see the INT32_MAX test above.
     ["INT32_MIN", -2147483648, ok],
+    ["INT32_MIN as a double", new Float64Array([-2147483648])[0], ok],
     ["undefined", undefined, ok],
     ["INT32_MAX + 1", 2147483648, outOfRange(int32Range, "2147483648")],
     ["INT32_MIN - 1", -2147483649, outOfRange(int32Range, "-2147483649")],
@@ -542,7 +561,7 @@ describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
       fn();
       return "ok";
     } catch (e: any) {
-      return `${e.code}: ${e.message}`;
+      return `${e.name} ${e.code}: ${e.message}`;
     }
   };
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -463,6 +463,104 @@ describe("Script", () => {
   });
 });
 
+describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
+  // JSC boxes these as doubles even though they are integers: -0 is what
+  // `lineOffset: -n` produces when n is 0, and double arithmetic / Float64Array
+  // reads produce integral doubles. Derived at runtime so nothing folds them
+  // back into int32 literals. Validation must look at the value, like Node.
+  const half = Number("1.5");
+  const threeAsDouble = half + half;
+  const fourAsDouble = new Float64Array([4])[0];
+
+  const source = "new Error().stack";
+  const location = (stack: unknown) => String(stack).match(/offsets\.js:\d+:\d+/)?.[0];
+  const entryPoints: Record<string, (options: Record<string, unknown>) => unknown> = {
+    "new Script(code, options).runInThisContext()": options => new Script(source, options).runInThisContext(),
+    "new Script(code, options).runInContext(context, options)": options =>
+      new Script(source, options).runInContext(createContext(), options),
+    "vm.runInThisContext": options => runInThisContext(source, options),
+    "vm.runInContext": options => runInContext(source, createContext(), options),
+    "vm.runInNewContext": options => runInNewContext(source, {}, options),
+    "vm.compileFunction": options => compileFunction(`return ${source}`, [], options)(),
+  };
+
+  test.each(Object.keys(entryPoints))("%s accepts -0 and integral doubles and applies them as the integer", name => {
+    const run = (options: Record<string, unknown>) =>
+      location(entryPoints[name]({ filename: "offsets.js", ...options }));
+
+    expect(run({ lineOffset: -0, columnOffset: -0 })).toBe(run({ lineOffset: 0, columnOffset: 0 }));
+    expect(run({ lineOffset: threeAsDouble, columnOffset: fourAsDouble })).toBe(
+      run({ lineOffset: 3, columnOffset: 4 }),
+    );
+  });
+
+  test("-0 and integral doubles position errors like the integers they equal", () => {
+    const header = (options: Record<string, unknown>) => {
+      try {
+        new Script("%%", { filename: "offsets.js", ...options });
+      } catch (e: any) {
+        return e.stack.split("\n", 1)[0];
+      }
+      throw new Error("expected a SyntaxError");
+    };
+    expect(header({ lineOffset: -0, columnOffset: -0 })).toBe("offsets.js:1");
+    expect(header({ lineOffset: threeAsDouble, columnOffset: fourAsDouble })).toBe("offsets.js:4");
+  });
+
+  // Expected outcomes are what Node v26 reports for the same values.
+  const int32Range = ">= -2147483648 && <= 2147483647";
+  const ok = () => "ok";
+  const outOfRange = (must: string, received: string) => (name: string) =>
+    `ERR_OUT_OF_RANGE: The value of "${name}" is out of range. It must be ${must}. Received ${received}`;
+  const invalidType = (received: string) => (name: string) =>
+    `ERR_INVALID_ARG_TYPE: The "${name}" property must be of type number. Received ${received}`;
+  const cases: [label: string, value: unknown, expected: (name: string) => string][] = [
+    ["-0", -0, ok],
+    ["integral double", threeAsDouble, ok],
+    ["Float64Array element", fourAsDouble, ok],
+    ["INT32_MAX", 2147483647, ok],
+    ["INT32_MIN", -2147483648, ok],
+    ["undefined", undefined, ok],
+    ["INT32_MAX + 1", 2147483648, outOfRange(int32Range, "2147483648")],
+    ["INT32_MIN - 1", -2147483649, outOfRange(int32Range, "-2147483649")],
+    ["2 ** 32", 2 ** 32, outOfRange(int32Range, "4294967296")],
+    // Past JSC's int52 range, but an integer to Node, so it gets the range
+    // message rather than "an integer".
+    ["MAX_SAFE_INTEGER", Number.MAX_SAFE_INTEGER, outOfRange(int32Range, "9_007_199_254_740_991")],
+    ["0.1", 0.1, outOfRange("an integer", "0.1")],
+    ["NaN", NaN, outOfRange("an integer", "NaN")],
+    ["Infinity", Infinity, outOfRange("an integer", "Infinity")],
+    ["null", null, invalidType("null")],
+    ["string", "1", invalidType("type string ('1')")],
+    ["bigint", 1n, invalidType("type bigint (1n)")],
+    ["array", [1], invalidType("an instance of Array")],
+  ];
+
+  const outcome = (fn: () => unknown) => {
+    try {
+      fn();
+      return "ok";
+    } catch (e: any) {
+      return `${e.code}: ${e.message}`;
+    }
+  };
+
+  const compilers: Record<string, (options: Record<string, unknown>) => unknown> = {
+    "new Script": options => new Script("1", options),
+    "vm.compileFunction": options => compileFunction("return 1", [], options),
+  };
+
+  test.each(
+    Object.keys(compilers).flatMap(compiler =>
+      ["lineOffset", "columnOffset"].map(option => [compiler, option] as const),
+    ),
+  )("%s validates %s like Node", (compiler, option) => {
+    const expected = cases.map(([label, , expectedFor]) => [label, expectedFor(`options.${option}`)]);
+    const actual = cases.map(([label, value]) => [label, outcome(() => compilers[compiler]({ [option]: value }))]);
+    expect(actual).toEqual(expected);
+  });
+});
+
 type TestRunInContextArg =
   | { fn: typeof runInContext; isIsolated: true; isNew?: boolean }
   | { fn: typeof runInThisContext; isIsolated?: false; isNew?: boolean };

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -518,7 +518,8 @@ describe("lineOffset/columnOffset validation (Node's validateInt32)", () => {
     ["-0", -0, ok],
     ["integral double", threeAsDouble, ok],
     ["Float64Array element", fourAsDouble, ok],
-    ["INT32_MAX", 2147483647, ok],
+    // INT32_MAX is accepted too, but compiling at that offset overflows JSC's
+    // line counter (#38228), so only the lower bound is compiled here.
     ["INT32_MIN", -2147483648, ok],
     ["undefined", undefined, ok],
     ["INT32_MAX + 1", 2147483648, outOfRange(int32Range, "2147483648")],


### PR DESCRIPTION
### Problem
- `new vm.Script("1", { lineOffset: -0 })` throws `RangeError [ERR_OUT_OF_RANGE]: The value of "options.lineOffset" is out of range. It must be an integer. Received 0`. Same for `columnOffset`, and for `vm.compileFunction` and the `runInThisContext` / `runInContext` / `runInNewContext` wrappers, which all build a `Script`. Node accepts `-0` (it is an integer to `Number.isInteger`). `lineOffset: -n` with `n === 0` is how user code produces it.
- An in-range integer that JSC holds as a double is rejected too: `{ lineOffset: a + b }` with `a = b = 1.5`, or an element read out of a `Float64Array`, throws `... It must be >= -2147483648 and <= 2147483647. Received 3`.
- Integers past JSC's int52 range (`Number.MAX_SAFE_INTEGER`) are reported as `It must be an integer`; Node reports the int32 range. The range message itself says `and` where Node's says `&&`.
- Cause: `BaseVMOptions::fromJS` (`src/jsc/bindings/NodeVM.cpp:1970` and `:1989` on main) gates each offset on `JSValue::isAnyInt()` and then `isInt32()`. Both describe how the number is boxed, not its value: `tryConvertToInt52` excludes `-0` and anything beyond 2^51 (`JSCJSValue.h:892-897`), and `isInt32()` is false for any double-boxed value. The range error was also built with the `ERR::OUT_OF_RANGE(name, lower, upper, ...)` overload, which renders `and` (`ErrorCode.cpp:900`).

### Fix
- Both offsets now go through `V::validateInt32` (`src/jsc/bindings/NodeValidator.cpp:429`), the existing native port of Node's `validateInt32`, and the resulting `int32_t` is what gets stored. `undefined` keeps meaning "not provided", as before.
- Correct because this is what Node runs on these options (`lib/vm.js` calls `validateInt32(lineOffset, 'options.lineOffset')` and the same for `columnOffset`), and the helper already implements its three checks with Node's messages: non-number is `ERR_INVALID_ARG_TYPE`, non-integral (`0.1`, `NaN`, `Infinity`) is `It must be an integer`, and anything outside int32 is `>= -2147483648 && <= 2147483647`. `-0` and double-boxed integers pass the value check and become `0` / the integer. This covers every path that reads these options: `vm.Script` (`ScriptOptions`), `vm.compileFunction` (`CompileFunctionOptions`) and the running-script options (`RunningScriptOptions`), all of which share `BaseVMOptions::fromJS`. Internal callers (`repl`) pass literal `0`, so nothing else observes the change.
- Verified with `test/js/node/vm/vm.test.ts` (`describe("lineOffset/columnOffset validation (Node's validateInt32)")`, 13 tests): for each of the six entry points, `-0` and double-boxed `3` / `4` produce the same stack positions as `0` / `3` / `4` (and the shifted position is asserted to be on line 4, so a missing frame cannot pass the comparison); both int32 bounds are accepted as int32 and as doubles; the compile-time SyntaxError header reports `offsets.js:1` and `offsets.js:4` for them; and a 17-value table (accepted values, out-of-range, non-integral, wrong type) is compared against the exact error class, code and message Node v26.3.0 produces, for both `new Script` and `compileFunction` and both option names. The same expectations were run as a plain script under Node 26.3.0 and all hold there. All 13 fail on the unfixed build (the table diff shows the `-0`, double-boxed, `MAX_SAFE_INTEGER` and `and`/`&&` differences; the bounds tests fail on the double-boxed bounds); all pass with the fix.
- The bounds are checked through `script.runInThisContext(options)`: the run-side options go through the same `BaseVMOptions::fromJS` but nothing is compiled at the offset. Compiling at `INT32_MAX` overflows JSC's line counter and aborts assertion builds with `ASSERTION FAILED: line >= 0` (the bug #38228 fixes), which is what happened on the x64-asan lane when an `INT32_MAX` row was in the compiled table; the table itself therefore only compiles at `INT32_MIN` (as an int32 and as a double).
- Also ran the rest of `vm.test.ts` (227 pass), `vm-sourceUrl.test.ts`, and the upstream `test-vm-options-validation.js`, `test-vm-api-handles-getter-errors.js`, `test-vm-basic.js`, `test-vm-context.js`, `test-vm-syntax-error-message.js`, `test-vm-syntax-error-stderr.js` against the debug build: all pass.

### Background
- `lineOffset` / `columnOffset` tell `node:vm` where a snippet sits inside a larger file so that error positions and stack frames line up with that file. They are zero-based, may be negative, and Node validates them as int32.
- JSC stores a JS number either as a boxed int32 or as a boxed double. Which one a given value gets depends on how it was produced, not on its value: `3` written as a literal is an int32, but `1.5 + 1.5` and a `Float64Array` read yield a double holding `3.0`, and `-0` can only be a double. `JSValue::isInt32()` asks about the boxing; `isAnyInt()` additionally accepts doubles that are integers within +-2^51, except `-0`.
- `V::validateInt32` (`NodeValidator.cpp`) is the C++ counterpart of `validateInt32` in Node's `lib/internal/validators.js`, used by the `node:crypto` bindings for the same purpose; it checks type, integrality (`fmod(value, 1) == 0`, which `-0` satisfies) and range, and writes the value out as an `int32_t`.

<details>
<summary>Related behaviour seen while testing, left unchanged here</summary>

- `vm.SourceTextModule` validates these options on the JS side (`src/js/node/vm.ts`) with Node's validator, but the native argument check in `NodeVMSourceTextModule.cpp:52` / `:58` uses `isUInt32AsAnyInt()`, so `-0` (and any negative offset) is still rejected there. #38235 replaces that check (and covers `-0` in its tests), so it is not touched here. Neither #38235 nor #38228 edits the lines this PR changes, and the test blocks land in different parts of `vm.test.ts`, so the three merge independently.
- `vm.compileFunction` runtime stack frames report line 2 for `lineOffset` 0 or 1 and do not apply `columnOffset` at all (`constructAnonymousFunction` shifts the wrapper's start line and the body sits on wrapper line 2). Compile-time SyntaxErrors are positioned correctly. The new tests compare the double-boxed inputs against their integer equivalents, so they hold regardless of how that is resolved.
- `script.runInThisContext(options)` and friends still validate `lineOffset` / `columnOffset` if present, while Node ignores them on the run side. Pre-existing and unchanged; `-0` now passes there as well.

Before / after for the values in the test table, `new vm.Script("1", { lineOffset: v })`:

```
v                    before                                              after (= Node 26)
-0                   OUT_OF_RANGE "an integer"                           ok
1.5 + 1.5            OUT_OF_RANGE ">= ... and <= ...". Received 3        ok
Float64Array [4][0]  OUT_OF_RANGE ">= ... and <= ...". Received 4        ok
2147483648           "... >= -2147483648 and <= 2147483647"              "... >= -2147483648 && <= 2147483647"
MAX_SAFE_INTEGER     OUT_OF_RANGE "an integer"                           "... >= -2147483648 && <= 2147483647"
0.1 / NaN / Infinity OUT_OF_RANGE "an integer"                           unchanged
null / "1" / 1n / [] INVALID_ARG_TYPE                                    unchanged
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (5bdb4f7fd)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [37.57ms]
(pass) vm > runInContext() > can return a value [27.55ms]
(pass) vm > runInContext() > can return a complex value [28.70ms]
(pass) vm > runInContext() > can return the last value [26.34ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [29.80ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [25.39ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [27.47ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [27.57ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [27.19ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [28.61ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [27.29ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [26.27ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 13 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.54ms]
(pass) vm > runInContext() > can return a value [0.29ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.25ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (5bdb4f7fd)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.49ms]
(pass) vm > runInContext() > can return a value [16.02ms]
(pass) vm > runInContext() > can return a complex value [16.33ms]
(pass) vm > runInContext() > can return the last value [15.47ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.96ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.33ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.21ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [18.24ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [17.28ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [17.25ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [16.14ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [16.01ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 670ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/28] gen cpp.rs (cppbind)
[3/28] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/28] gen JS modules (bundle-modules)
Preprocess modules (9394ms)
Bundle modules (42ms)
Postprocesss modules (156ms)
Bundle Functions (697ms)
Generate Code (32ms)

[10.35s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/14] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp |  44 +++++------------
 test/js/node/vm/vm.test.ts  | 118 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 130 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      4      3      0
test/js/node/vm/vm.test.ts       7      8      0
```

</details>

**root cause** · written by the author bot

BaseVMOptions::fromJS validated lineOffset and columnOffset with JSValue::isAnyInt() and isInt32(), which describe how JSC boxes a number rather than its value, so -0 and any integral value stored as a double were rejected with ERR_OUT_OF_RANGE even though Node's validateInt32 accepts them. The fix replaces those checks with the existing V::validateInt32 helper, which tests the numeric value itself against integrality and int32 bounds and writes the truncated result, so -0 and double-boxed integers are accepted while invalid types and out of range values still produce Node's error codes and…

<!-- robobun:evidence:end -->