### PR TITLE
Fix Android/FreeBSD runtime issues found by running the test suite

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -693,7 +693,10 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         msg.msg_iovlen = 1;
                         msg.msg_name = NULL;
                         msg.msg_namelen = 0;
-                        msg.msg_controllen = CMSG_LEN(sizeof(int));
+                        /* CMSG_SPACE, not CMSG_LEN: FreeBSD sets MSG_CTRUNC and
+                         * discards the descriptor when the buffer can't hold the
+                         * aligned trailing padding (20 vs 24 bytes there). */
+                        msg.msg_controllen = sizeof(cmsg_buf);
                         msg.msg_control = cmsg_buf;
 
                         length = bsd_recvmsg(us_poll_fd(&s->p), &msg, recv_flags);

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1374,10 +1374,14 @@ export const linkerFlags: Flag[] = [
     desc: "FreeBSD 13+ clang defaults to PIE; opt out (matches Linux, avoids -fPIC rebuild of WebKit/deps)",
   },
   {
+    // No `-z stack-size`: unlike Linux, FreeBSD's exec uses PT_GNU_STACK's
+    // size as the main-thread stack reservation, while libthr reports the
+    // main thread's stack as RLIMIT_STACK — so a value here smaller than the
+    // rlimit makes WTF::StackBounds overshoot and stack-overflow guards never
+    // fire (the process dies with SIGILL once the real stack is exhausted).
     flag: [
       "-Wl,-O2",
       "-Wl,--as-needed",
-      "-Wl,-z,stack-size=12800000",
       "-Wl,-z,lazy",
       "-Wl,-z,norelro",
       "-Wl,--gdb-index",
@@ -1386,7 +1390,7 @@ export const linkerFlags: Flag[] = [
       "-Wl,--build-id=sha1",
     ],
     when: c => c.freebsd,
-    desc: "FreeBSD linker tuning (same as Linux ELF)",
+    desc: "FreeBSD linker tuning (same as Linux ELF minus stack-size)",
   },
   {
     // rust-lang/llvm-project doesn't enable `LLVM_ENABLE_ZLIB` (or `_ZSTD`) for

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -21,8 +21,11 @@ import { normalize as normalizeWindows } from "node:path/win32";
 
 export const isWindows = process.platform === "win32";
 export const isMacOS = process.platform === "darwin";
-export const isLinux = process.platform === "linux";
-export const isPosix = isMacOS || isLinux;
+// Node built for Termux/bionic reports "android"; CI models that as linux + abi=android.
+export const isAndroid = process.platform === "android";
+export const isLinux = process.platform === "linux" || isAndroid;
+export const isFreeBSD = process.platform === "freebsd";
+export const isPosix = isMacOS || isLinux || isFreeBSD;
 
 export const isArm64 = process.arch === "arm64";
 export const isX64 = process.arch === "x64";
@@ -1538,14 +1541,17 @@ export function parseNumber(value) {
 
 /**
  * @param {string} string
- * @returns {"darwin" | "linux" | "windows"}
+ * @returns {"darwin" | "linux" | "windows" | "freebsd"}
  */
 export function parseOs(string) {
   if (/darwin|apple|mac/i.test(string)) {
     return "darwin";
   }
-  if (/linux/i.test(string)) {
+  if (/linux|android/i.test(string)) {
     return "linux";
+  }
+  if (/freebsd/i.test(string)) {
+    return "freebsd";
   }
   if (/win/i.test(string)) {
     return "windows";
@@ -1554,7 +1560,7 @@ export function parseOs(string) {
 }
 
 /**
- * @returns {"darwin" | "linux" | "windows"}
+ * @returns {"darwin" | "linux" | "windows" | "freebsd"}
  */
 export function getOs() {
   return parseOs(process.platform);
@@ -1604,11 +1610,15 @@ export function getKernel() {
 }
 
 /**
- * @returns {"musl" | "gnu" | undefined}
+ * @returns {"musl" | "gnu" | "android" | undefined}
  */
 export function getAbi() {
   if (!isLinux) {
     return;
+  }
+
+  if (isAndroid || existsSync("/system/bin/linker64")) {
+    return "android";
   }
 
   if (existsSync("/etc/alpine-release")) {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2413,9 +2413,23 @@ pub mod ffi {
         // (thin non-null pointer to a `#[repr(C)]` struct); the type encodes
         // the only pointer-validity precondition, so `safe fn` discharges the
         // link-time proof and the call needs no `unsafe` block.
+        #[cfg(not(target_os = "freebsd"))]
         unsafe extern "C" {
             #[link_name = "uname"]
             safe fn libc_uname(buf: &mut libc::utsname) -> core::ffi::c_int;
+        }
+        // FreeBSD's exported `uname` symbol is a compat entry that fills
+        // 32-byte fields; `struct utsname` has 256-byte fields and the
+        // header's `uname()` is an inline over `__xuname(SYS_NMLN, buf)`.
+        #[cfg(target_os = "freebsd")]
+        fn libc_uname(buf: &mut libc::utsname) -> core::ffi::c_int {
+            unsafe extern "C" {
+                safe fn __xuname(
+                    nmln: core::ffi::c_int,
+                    buf: &mut libc::utsname,
+                ) -> core::ffi::c_int;
+            }
+            __xuname(256, buf)
         }
         let mut u: libc::utsname = zeroed();
         let _ = libc_uname(&mut u);

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1637,6 +1637,17 @@ impl Poll {
             return;
         }
         let poll = pollable.poll();
+        // FreeBSD reports a changelist entry it could not apply with
+        // `flags == EV_ERROR` and the errno in `data`. ENOENT/EBADF is the
+        // `Cancel` for a oneshot knote that already fired (or an fd that was
+        // already closed): kernel state already matches, nothing to deliver.
+        #[cfg(target_os = "freebsd")]
+        if (event.flags & libc::EV_ERROR) != 0
+            && (event.data == libc::ENOENT as _ || event.data == libc::EBADF as _)
+        {
+            log!("cancel({}) already gone = {}", event.ident, event.data);
+            return;
+        }
         // CYCLEBREAK: owner (ReadFile/WriteFile) is T6; dispatch via link-time
         // `extern "Rust"` defined in `bun_runtime::dispatch`. The
         // container_of(io_poll) recovery happens there.

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -877,8 +877,8 @@ pub type OpenPtyFn = unsafe extern "C" fn(
     winp: *const Winsize,
 ) -> c_int;
 
-/// Dynamic loading of openpty on Linux (it's in libutil which may not be linked)
-#[cfg(any(target_os = "linux", target_os = "android"))]
+/// Dynamic loading of openpty on Linux/FreeBSD (it's in libutil which may not be linked)
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 mod lib_util {
     use super::*;
     use bun_core::ZStr;
@@ -898,11 +898,17 @@ mod lib_util {
         }
         LOADED.store(true, Relaxed);
 
-        // Try libutil.so first (most common), then libutil.so.1
+        // Try libutil.so first (most common), then the versioned soname
+        #[cfg(not(target_os = "freebsd"))]
         const LIB_NAMES: [&ZStr; 3] = [
             bun_core::zstr!("libutil.so"),
             bun_core::zstr!("libutil.so.1"),
             bun_core::zstr!("libc.so.6"),
+        ];
+        #[cfg(target_os = "freebsd")]
+        const LIB_NAMES: [&ZStr; 2] = [
+            bun_core::zstr!("libutil.so.9"),
+            bun_core::zstr!("libutil.so"),
         ];
         for lib_name in LIB_NAMES {
             if let Some(h) = sys::dlopen(lib_name, sys::RTLD::LAZY) {
@@ -940,14 +946,19 @@ fn get_open_pty_fn() -> Option<OpenPtyFn> {
         return Some(openpty);
     }
 
-    // On Linux, openpty is in libutil, which may not be linked
+    // On Linux/FreeBSD, openpty is in libutil, which may not be linked
     // Load it dynamically via dlopen
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     {
         return lib_util::get_open_pty();
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd"
+    )))]
     None
 }
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -442,12 +442,17 @@ mod elf {
         if vaddr == 0 {
             return None;
         }
-        // BUN_COMPILED.size holds the virtual address of the appended data.
-        // The kernel mapped it via PT_LOAD, so we can dereference directly.
+        // BUN_COMPILED.size holds the link-time virtual address of the
+        // appended data. For a PIE executable (mandatory on Android) the
+        // kernel maps every PT_LOAD at that vaddr plus a load bias, which is
+        // `dlpi_addr` of the object containing BUN_COMPILED itself; for
+        // non-PIE it is 0.
         // Format at target: [u64 payload_len][payload bytes]
         // Synthesize a `*mut u8` directly so the provenance carries write
         // permission for the in-place bytecode mutation done by JSC.
-        let target = vaddr as *mut u8;
+        let load_bias =
+            bun_sys::elf::find_loaded_module(vaddr_ptr as usize).map_or(0, |m| m.base_address);
+        let target = (vaddr as usize).wrapping_add(load_bias) as *mut u8;
         // SAFETY: target points to 8-byte little-endian length prefix.
         let payload_len =
             u64::from_le_bytes(unsafe { core::ptr::read_unaligned(target.cast::<[u8; 8]>()) });
@@ -1174,12 +1179,32 @@ impl CompileResult {
     }
 }
 
+/// The temp copy of the executable that `inject` wrote the module graph into.
+/// `temp_path` is what `inject` opened (cwd-relative or absolute); callers use
+/// it to rename into place rather than reverse-mapping `fd` to a path, which
+/// is not always possible (FreeBSD's `F_KINFO` returned an empty `kf_path` for
+/// the freshly created temp file on UFS).
+pub(crate) struct Injected {
+    pub fd: Fd,
+    #[cfg_attr(windows, allow(dead_code))]
+    pub temp_path: Box<[u8]>,
+}
+
+impl Injected {
+    fn invalid() -> Injected {
+        Injected {
+            fd: Fd::INVALID,
+            temp_path: Box::default(),
+        }
+    }
+}
+
 pub(crate) fn inject(
     bytes: &[u8],
     self_exe: &ZStr,
     inject_options: &InjectOptions,
     target: &CompileTarget,
-) -> Fd {
+) -> Injected {
     let mut buf = PathBuffer::uninit();
     // Note: `tmpname` borrows `buf` mutably for the &ZStr it returns. The
     // tmpdir-fallback retry below may need to repoint `zname` at a heap-owned
@@ -1201,7 +1226,7 @@ pub(crate) fn inject(
                 "<r><red>error<r><d>:<r> failed to get temporary file name: {}",
                 bstr::BStr::new(e.name())
             );
-            return Fd::INVALID;
+            return Injected::invalid();
         }
     };
 
@@ -1241,7 +1266,7 @@ pub(crate) fn inject(
                     e.to_system_errno()
                         .unwrap_or(bun_sys::SystemErrno::EUNKNOWN)
                 );
-                return Fd::invalid();
+                return Injected::invalid();
             }
             let out = &out_buf[..zname.len()];
             let file = match Syscall::open_file_at_windows(
@@ -1260,7 +1285,7 @@ pub(crate) fn inject(
                         "<r><red>error<r><d>:<r> failed to open temporary file to copy bun into\n{}",
                         e
                     );
-                    return Fd::invalid();
+                    return Injected::invalid();
                 }
             };
 
@@ -1363,7 +1388,7 @@ pub(crate) fn inject(
                             err
                         );
                         cleanup(zname, fd);
-                        return Fd::INVALID;
+                        return Injected::invalid();
                     }
                 }
             }
@@ -1381,7 +1406,7 @@ pub(crate) fn inject(
                     e
                 );
                 cleanup(zname, fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
 
             break 'brk fd;
@@ -1396,7 +1421,7 @@ pub(crate) fn inject(
                 Err(err) => {
                     bun_core::pretty_errorln!("Error reading standalone module graph: {}", err);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             };
             let mut macho_file = match bun_macho::MachoFile::init(&input_bytes, bytes.len()) {
@@ -1404,20 +1429,20 @@ pub(crate) fn inject(
                 Err(e) => {
                     bun_core::pretty_errorln!("Error initializing standalone module graph: {}", e);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             };
             if let Err(e) = macho_file.write_section(bytes) {
                 bun_core::pretty_errorln!("Error writing standalone module graph: {}", e);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             drop(input_bytes);
 
             if let Err(err) = Syscall::set_file_offset(cloned_executable_fd, 0) {
                 bun_core::pretty_errorln!("Error seeking to start of temporary file: {}", err);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
 
             let mut buffered_writer = std::io::BufWriter::with_capacity(
@@ -1430,19 +1455,22 @@ pub(crate) fn inject(
                     bstr::BStr::new(e.name())
                 );
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             if let Err(e) = std::io::Write::flush(&mut buffered_writer) {
                 bun_core::pretty_errorln!("Error flushing standalone module graph: {}", e);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             #[cfg(not(windows))]
             {
                 // SAFETY: libc fchmod on a valid native fd.
                 unsafe { bun_sys::c::fchmod(cloned_executable_fd.native(), 0o755) };
             }
-            return cloned_executable_fd;
+            return Injected {
+                fd: cloned_executable_fd,
+                temp_path: zname.as_bytes().into(),
+            };
         }
         CompileTargetOs::Windows => {
             let input_bytes = match bun_sys::File::borrow(&cloned_executable_fd).read_to_end() {
@@ -1450,7 +1478,7 @@ pub(crate) fn inject(
                 Err(err) => {
                     bun_core::pretty_errorln!("Error reading standalone module graph: {}", err);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             };
             let mut pe_file = match bun_pe::PEFile::init(&input_bytes) {
@@ -1458,35 +1486,35 @@ pub(crate) fn inject(
                 Err(e) => {
                     bun_core::pretty_errorln!("Error initializing PE file: {}", e);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             };
             if inject_options.hide_console {
                 if let Err(e) = pe_file.set_subsystem(bun_pe::IMAGE_SUBSYSTEM_WINDOWS_GUI) {
                     bun_core::pretty_errorln!("Error setting PE subsystem: {}", e);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             }
             // Always strip authenticode when adding .bun section for --compile
             if let Err(e) = pe_file.add_bun_section(bytes) {
                 bun_core::pretty_errorln!("Error adding Bun section to PE file: {}", e);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             drop(input_bytes);
 
             if let Err(err) = Syscall::set_file_offset(cloned_executable_fd, 0) {
                 bun_core::pretty_errorln!("Error seeking to start of temporary file: {}", err);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
 
             let mut writer = bun_sys::FileWriter(cloned_executable_fd);
             if let Err(e) = pe_file.write(&mut writer) {
                 bun_core::pretty_errorln!("Error writing PE file: {}", bstr::BStr::new(e.name()));
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             // Truncate to the in-memory PE size; Authenticode strip can make it shorter than the base.
             if let Err(err) = Syscall::ftruncate(
@@ -1495,7 +1523,7 @@ pub(crate) fn inject(
             ) {
                 bun_core::pretty_errorln!("Error truncating PE file: {}", err);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             // Set executable permissions when running on POSIX hosts, even for Windows targets
             #[cfg(not(windows))]
@@ -1503,7 +1531,10 @@ pub(crate) fn inject(
                 // SAFETY: libc fchmod on a valid native fd.
                 unsafe { bun_sys::c::fchmod(cloned_executable_fd.native(), 0o755) };
             }
-            return cloned_executable_fd;
+            return Injected {
+                fd: cloned_executable_fd,
+                temp_path: zname.as_bytes().into(),
+            };
         }
         CompileTargetOs::Linux | CompileTargetOs::Freebsd => {
             // ELF section approach: find .bun section and expand it
@@ -1512,7 +1543,7 @@ pub(crate) fn inject(
                 Err(err) => {
                     bun_core::pretty_errorln!("Error reading executable: {}", err);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             };
 
@@ -1521,7 +1552,7 @@ pub(crate) fn inject(
                 Err(e) => {
                     bun_core::pretty_errorln!("Error initializing ELF file: {}", e);
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             };
 
@@ -1530,13 +1561,13 @@ pub(crate) fn inject(
             if let Err(e) = elf_file.write_bun_section(bytes) {
                 bun_core::pretty_errorln!("Error writing .bun section to ELF: {}", e);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
 
             if let Err(err) = Syscall::set_file_offset(cloned_executable_fd, 0) {
                 bun_core::pretty_errorln!("Error seeking to start of temporary file: {}", err);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
 
             // Write the modified ELF data back to the file
@@ -1544,7 +1575,7 @@ pub(crate) fn inject(
             if let Err(err) = write_file.write_all(&elf_file.data) {
                 bun_core::pretty_errorln!("Error writing ELF file: {}", err);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
             // Truncate the file to the exact size of the modified ELF
             if let Err(err) = Syscall::ftruncate(
@@ -1553,7 +1584,7 @@ pub(crate) fn inject(
             ) {
                 bun_core::pretty_errorln!("Error truncating ELF file: {}", err);
                 cleanup(zname, cloned_executable_fd);
-                return Fd::INVALID;
+                return Injected::invalid();
             }
 
             #[cfg(not(windows))]
@@ -1561,7 +1592,10 @@ pub(crate) fn inject(
                 // SAFETY: libc fchmod on a valid native fd.
                 unsafe { bun_sys::c::fchmod(cloned_executable_fd.native(), 0o755) };
             }
-            return cloned_executable_fd;
+            return Injected {
+                fd: cloned_executable_fd,
+                temp_path: zname.as_bytes().into(),
+            };
         }
         _ => {
             let total_byte_count: usize;
@@ -1577,7 +1611,7 @@ pub(crate) fn inject(
                                 e
                             );
                             cleanup(zname, cloned_executable_fd);
-                            return Fd::invalid();
+                            return Injected::invalid();
                         }
                     };
             }
@@ -1589,7 +1623,7 @@ pub(crate) fn inject(
                         Err(err) => {
                             bun_core::pretty_errorln!("{}", err);
                             cleanup(zname, cloned_executable_fd);
-                            return Fd::INVALID;
+                            return Injected::invalid();
                         }
                     };
                     break 'brk fstat.st_size.max(0);
@@ -1613,7 +1647,7 @@ pub(crate) fn inject(
                         seek_position
                     );
                     cleanup(zname, cloned_executable_fd);
-                    return Fd::INVALID;
+                    return Injected::invalid();
                 }
             }
 
@@ -1627,7 +1661,7 @@ pub(crate) fn inject(
                             err
                         );
                         cleanup(zname, cloned_executable_fd);
-                        return Fd::INVALID;
+                        return Injected::invalid();
                     }
                 }
             }
@@ -1640,7 +1674,10 @@ pub(crate) fn inject(
                 unsafe { bun_sys::c::fchmod(cloned_executable_fd.native(), 0o755) };
             }
 
-            return cloned_executable_fd;
+            return Injected {
+                fd: cloned_executable_fd,
+                temp_path: zname.as_bytes().into(),
+            };
         }
     }
 }
@@ -1903,7 +1940,14 @@ pub fn to_executable(
         bun_core::ZBox::from_vec_with_nul(dest_z.as_bytes().to_vec())
     };
 
-    let fd = inject(&bytes, &self_exe, windows_options, target);
+    let injected = inject(&bytes, &self_exe, windows_options, target);
+    let fd = injected.fd;
+    if fd == Fd::INVALID {
+        // inject() has already printed the specific error.
+        return Ok(CompileResult::fail_fmt(format_args!(
+            "failed to write compiled executable"
+        )));
+    }
     // Note: a scopeguard closure capturing `fd` by value would not observe
     // later reassignments; capturing by `&mut` conflicts with later uses. Explicit
     // `if fd != Fd::INVALID { fd.close(); }` calls are inserted at every return below
@@ -2040,24 +2084,9 @@ pub fn to_executable(
 
     #[cfg(not(windows))]
     {
-        let mut buf2 = PathBuffer::uninit();
-        // Note: borrowck — `get_fd_path` returns `&mut [u8]` borrowing `buf2`;
-        // copy it into an owned buffer so `temp_posix_buf` can also borrow `buf2`'s
-        // sibling without overlap.
-        let temp_location: Vec<u8> = match bun_sys::get_fd_path(fd, &mut buf2) {
-            Ok(p) => p.to_vec(),
-            Err(e) => {
-                if fd != Fd::INVALID {
-                    fd.close();
-                }
-                return Ok(CompileResult::fail_fmt(format_args!(
-                    "failed to get path for fd: {}",
-                    e
-                )));
-            }
-        };
+        let temp_location: &[u8] = &injected.temp_path;
         let mut temp_posix_buf = PathBuffer::uninit();
-        let temp_posix = path::resolve_path::z(&temp_location, &mut temp_posix_buf);
+        let temp_posix = path::resolve_path::z(temp_location, &mut temp_posix_buf);
         let outfile_basename = bun_paths::basename(outfile);
         let mut outfile_posix_buf = PathBuffer::uninit();
         let outfile_posix = path::resolve_path::z(outfile_basename, &mut outfile_posix_buf);
@@ -2077,7 +2106,7 @@ pub fn to_executable(
             } else {
                 return Ok(CompileResult::fail_fmt(format_args!(
                     "failed to rename {} to {}: {}",
-                    bstr::BStr::new(&temp_location),
+                    bstr::BStr::new(temp_location),
                     bstr::BStr::new(outfile),
                     bstr::BStr::new(e.name())
                 )));

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1843,8 +1843,12 @@ export function libcPathForDlopen() {
       }
     case "darwin":
       return "libc.dylib";
+    case "android":
+      return "libc.so";
+    case "freebsd":
+      return "libc.so.7";
     default:
-      throw new Error("TODO");
+      throw new Error(`libcPathForDlopen: unsupported platform ${process.platform}`);
   }
 }
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -9,7 +9,6 @@ import {
   isBroken,
   isDebug,
   isLinux,
-  isMacOS,
   isPosix,
   isWindows,
   shellExe,
@@ -609,8 +608,10 @@ for (let [gcTick, label] of [
   });
 }
 
-// This is a test which should only be used when pidfd and EVTFILT_PROC is NOT available
-it.skipIf(Boolean(process.env.BUN_FEATURE_FLAG_FORCE_WAITER_THREAD) || !isPosix || isMacOS)(
+// The waiter thread is the Linux fallback for kernels/sandboxes without pidfd;
+// kqueue platforms (macOS, FreeBSD) always have EVFILT_PROC and its non-Linux
+// loop has no wakeup for processes appended after it starts.
+it.skipIf(Boolean(process.env.BUN_FEATURE_FLAG_FORCE_WAITER_THREAD) || !isLinux)(
   "with BUN_FEATURE_FLAG_FORCE_WAITER_THREAD",
   async () => {
     const result = spawnSync({


### PR DESCRIPTION
### What does this PR do?

Running the full test suite (via `scripts/runner.node.mjs`, as CI does) on the FreeBSD x64 and Android x64 artifacts turned up several platform-specific runtime bugs; this fixes the ones with clear root causes and teaches the runner/harness about both hosts.

- **Android `bun build --compile`**: every compiled executable segfaulted at startup. Standalone binaries are PIE on Android, so the embedded module graph's link-time vaddr now gets the load bias (found via `dl_iterate_phdr`) added before it is dereferenced.
- **FreeBSD `--compile` on UFS**: `inject()` now returns the temp path it created instead of the caller reverse-mapping fd→path (`F_KINFO` returned an empty path there, so the final rename failed with ENOENT).
- **FreeBSD stack overflow → SIGILL**: dropped `-z stack-size` from the FreeBSD link. FreeBSD's exec uses `PT_GNU_STACK` as the main-thread stack reservation while libthr reports `RLIMIT_STACK`, so overflow guards never fired and deep recursion (TOML/YAML/JSONC/transpiler tests) killed the process instead of throwing `RangeError`.
- **FreeBSD `uname`**: the exported `uname` symbol fills 32-byte fields; call `__xuname(256, …)` so `utsname.release` isn't empty (crash reports printed `FreeBSD Kernel v`).
- **FreeBSD kqueue**: ignore `EV_ERROR`/ENOENT|EBADF receipts from cancelling an already-fired oneshot knote; they were surfacing as read errors for FIFOs/pipes via `Bun.file()`.
- **FreeBSD PTY**: load `openpty` from `libutil` so `Bun.Terminal` works.
- `scripts/utils.mjs` / `test/harness.ts`: recognize `freebsd` and `android`.

### How did you verify your code works?

Linux: `bun bd build --compile` (plain, `--bytecode`, nested `--outfile`) produces working binaries; `test/bundler/bun-build-compile.test.ts` unchanged vs main. `cargo check` passes for `x86_64-unknown-freebsd` and `x86_64-linux-android`. The FreeBSD/Android behavior changes were diagnosed on a FreeBSD 14.3 VM and an API 35 x86_64 emulator against the current artifacts; re-verification on-target is pending this PR's CI artifacts.