### PR TITLE
bake: make import() of a "use client" module work in production builds

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -98,8 +98,7 @@ bitflags::bitflags! {
         const IS_EXECUTABLE = 1 << 0;
         const HAS_HTML_CHUNK = 1 << 1;
         const IS_BROWSER_CHUNK_FROM_SERVER_BUILD = 1 << 2;
-        /// Set on bake server entry point chunks whose entry point transitively
-        /// imports a `"use client"` boundary. See `static_route_visitor`.
+        /// The entry point transitively imports a `"use client"` file. Set by `static_route_visitor`.
         const HAS_TRANSITIVE_USE_CLIENT = 1 << 3;
         // _padding: u4 = 0
     }

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -98,7 +98,10 @@ bitflags::bitflags! {
         const IS_EXECUTABLE = 1 << 0;
         const HAS_HTML_CHUNK = 1 << 1;
         const IS_BROWSER_CHUNK_FROM_SERVER_BUILD = 1 << 2;
-        // _padding: u5 = 0
+        /// Set on bake server entry point chunks whose entry point transitively
+        /// imports a `"use client"` boundary. See `static_route_visitor`.
+        const HAS_TRANSITIVE_USE_CLIENT = 1 << 3;
+        // _padding: u4 = 0
     }
 }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -804,8 +804,7 @@ impl<'a> LinkerContext<'a> {
             self.check_for_memory_corruption();
         }
 
-        // Before `compute_cross_chunk_dependencies`, which clears the source index
-        // of every `import()` record that targets another chunk.
+        // Must run before `compute_cross_chunk_dependencies` clears the `import()` records it walks.
         StaticRouteVisitor::mark_chunks_with_transitive_use_client(self, &mut chunks)?;
 
         compute_cross_chunk_dependencies(self, &mut chunks)?;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -804,6 +804,10 @@ impl<'a> LinkerContext<'a> {
             self.check_for_memory_corruption();
         }
 
+        // Before `compute_cross_chunk_dependencies`, which clears the source index
+        // of every `import()` record that targets another chunk.
+        StaticRouteVisitor::mark_chunks_with_transitive_use_client(self, &mut chunks)?;
+
         compute_cross_chunk_dependencies(self, &mut chunks)?;
 
         if FeatureFlags::HELP_CATCH_MEMORY_ISSUES {

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -210,6 +210,7 @@ pub struct LinkerGraph<'a> {
     /// Index from `.parse_graph.input_files` to index in `.files`
     pub(crate) stable_source_indices: Vec<u32>,
 
+    /// The original file of every `"use client"` boundary. See `load`.
     pub(crate) is_scb_bitset: BitSet,
 
     /// This is for cross-module inlining of detected inlinable constants
@@ -754,7 +755,6 @@ impl<'a> LinkerGraph<'a> {
                                 .is_scb_bitset
                                 .is_set(import_record.source_index.get() as usize)
                         {
-                            // Only rewrite if this is an original SCB file, not a reference file
                             if let Some(ref_index) =
                                 scb.get_reference_source_index(import_record.source_index.get())
                             {
@@ -762,7 +762,6 @@ impl<'a> LinkerGraph<'a> {
                                 debug_assert!(import_record.source_index.is_valid());
                                 // did not generate
                             }
-                            // If it's already a reference file, leave it as-is
                         }
                     }
                 }
@@ -988,9 +987,10 @@ pub struct File {
     /// If "entry_point_kind" is not ".none", this is the index of the
     /// corresponding entry point chunk.
     ///
-    /// This is also initialized for files that are a SCB's generated
-    /// reference, pointing to its destination. This forms a lookup map from
-    /// a Source.Index to its output path inb reakOutputIntoPieces
+    /// For the original file of a SCB, `find_all_imported_parts_in_js_order`
+    /// overwrites this with the chunk the file's code was placed in; the SCB
+    /// unique keys (`QueryKind::Scb`) are resolved through it when the output
+    /// is broken into pieces.
     pub entry_point_chunk_index: u32,
 
     pub line_offset_table: bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc>,

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -682,6 +682,12 @@ impl<'a> LinkerGraph<'a> {
             for &id in dynamic_import_entry_points {
                 debug_assert!(self.code_splitting); // this should never be a thing without code splitting
 
+                // This list was collected from the import records before the rewrite
+                // below, so an `import()` of a "use client" file names the original
+                // file here. The record ends up pointing at the reference proxy, so
+                // that is the file that has to become the entry point.
+                let id = scb.get_reference_source_index(id).unwrap_or(id);
+
                 if entry_point_kinds[id as usize] != entry_point::Kind::None {
                     // You could dynamic import a file that is already an entry point
                     continue;
@@ -708,28 +714,26 @@ impl<'a> LinkerGraph<'a> {
             if scb.list.len() > 0 {
                 self.is_scb_bitset = BitSet::init_empty(self.files.len()).expect("unreachable");
 
-                // Index all SCBs into the bitset. This is needed so chunking
-                // can track the chunks that SCBs belong to.
+                // Index the original file of every SCB into the bitset. Chunking uses
+                // it to record which chunk each boundary's code lands in, which is
+                // what the SCB unique keys resolve to. The reference proxies are left
+                // out: no SCB key refers to them, and a proxy that is `import()`ed is
+                // a dynamic import entry point whose `entry_point_chunk_index` has to
+                // keep pointing at its own chunk.
                 debug_assert_eq!(
                     scb.list.items_use_directive().len(),
                     scb.list.items_source_index().len()
                 );
-                debug_assert_eq!(
-                    scb.list.items_use_directive().len(),
-                    scb.list.items_reference_source_index().len()
-                );
-                for ((use_, original_id), ref_id) in scb
+                for (use_, original_id) in scb
                     .list
                     .items_use_directive()
                     .iter()
                     .zip(scb.list.items_source_index().iter())
-                    .zip(scb.list.items_reference_source_index().iter())
                 {
                     match use_ {
                         UseDirective::None => {}
                         UseDirective::Client => {
                             self.is_scb_bitset.set(*original_id as usize);
-                            self.is_scb_bitset.set(*ref_id as usize);
                         }
                         UseDirective::Server => {
                             bun_core::todo_panic!("um");

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -210,7 +210,7 @@ pub struct LinkerGraph<'a> {
     /// Index from `.parse_graph.input_files` to index in `.files`
     pub(crate) stable_source_indices: Vec<u32>,
 
-    /// The original file of every `"use client"` boundary. See `load`.
+    /// The original file of every `"use client"` boundary; chunking records their chunks for the SCB keys.
     pub(crate) is_scb_bitset: BitSet,
 
     /// This is for cross-module inlining of detected inlinable constants
@@ -683,10 +683,7 @@ impl<'a> LinkerGraph<'a> {
             for &id in dynamic_import_entry_points {
                 debug_assert!(self.code_splitting); // this should never be a thing without code splitting
 
-                // This list was collected from the import records before the rewrite
-                // below, so an `import()` of a "use client" file names the original
-                // file here. The record ends up pointing at the reference proxy, so
-                // that is the file that has to become the entry point.
+                // The rewrite below points `import()`s of a "use client" file at its reference proxy.
                 let id = scb.get_reference_source_index(id).unwrap_or(id);
 
                 if entry_point_kinds[id as usize] != entry_point::Kind::None {
@@ -715,12 +712,7 @@ impl<'a> LinkerGraph<'a> {
             if scb.list.len() > 0 {
                 self.is_scb_bitset = BitSet::init_empty(self.files.len()).expect("unreachable");
 
-                // Index the original file of every SCB into the bitset. Chunking uses
-                // it to record which chunk each boundary's code lands in, which is
-                // what the SCB unique keys resolve to. The reference proxies are left
-                // out: no SCB key refers to them, and a proxy that is `import()`ed is
-                // a dynamic import entry point whose `entry_point_chunk_index` has to
-                // keep pointing at its own chunk.
+                // Not the proxies: an `import()`ed proxy is an entry point that must keep its own chunk index.
                 debug_assert_eq!(
                     scb.list.items_use_directive().len(),
                     scb.list.items_source_index().len()
@@ -987,10 +979,7 @@ pub struct File {
     /// If "entry_point_kind" is not ".none", this is the index of the
     /// corresponding entry point chunk.
     ///
-    /// For the original file of a SCB, `find_all_imported_parts_in_js_order`
-    /// overwrites this with the chunk the file's code was placed in; the SCB
-    /// unique keys (`QueryKind::Scb`) are resolved through it when the output
-    /// is broken into pieces.
+    /// For SCB originals this is the chunk holding the file's code instead, which the `QueryKind::Scb` keys resolve to.
     pub entry_point_chunk_index: u32,
 
     pub line_offset_table: bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc>,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3951,7 +3951,7 @@ pub mod bv2_impl {
                     // both are `crate::Index` (= `bun_ast::Index`), so no cast is needed.
                     let ep = (*bundle_ptr).graph.entry_points.as_slice();
                     // `this.graph.server_component_boundaries` must stay intact for
-                    // `StaticRouteVisitor` (generateChunksInParallel) to read via
+                    // `StaticRouteVisitor` (run by `link`) to read via
                     // `parse_graph`. Borrow — do NOT `take`, which would empty the
                     // graph slot and drop the moved-out `MultiArrayList` heap inside
                     // `load()` (ASAN use-after-poison / wrong `fully_static`).

--- a/src/bundler/linker_context/StaticRouteVisitor.rs
+++ b/src/bundler/linker_context/StaticRouteVisitor.rs
@@ -1,12 +1,4 @@
-//! Decides which bake server entry points (routes) transitively import a file
-//! with `"use client"`. A route that imports none is prerendered without any
-//! client-side JavaScript (`BakeRouteKind::FullyStaticRoute`).
-//!
-//! `mark_chunks_with_transitive_use_client` has to run before
-//! `compute_cross_chunk_dependencies`: that pass rewrites every `import()` of
-//! another chunk into an import of the chunk's path and clears the record's
-//! `source_index`, which would hide the client components a route only
-//! reaches through `import()`.
+//! Marks the bake routes (server entry point chunks) that transitively import a `"use client"` file.
 //!
 //! TODO: Could we move this into the ReachableFileVisitor inside `bundle_v2.rs`?
 
@@ -24,8 +16,7 @@ pub(crate) fn mark_chunks_with_transitive_use_client(
     c: &LinkerContext,
     chunks: &mut [Chunk],
 ) -> Result<(), AllocError> {
-    // Only the built-in React framework prerenders routes differently based on
-    // this; `generate_chunks_in_parallel` reads the flag under the same condition.
+    // Same condition under which `generate_chunks_in_parallel` reads the flag.
     if !c
         .framework
         .is_some_and(|framework| framework.is_built_in_react)
@@ -82,8 +73,7 @@ pub(crate) fn mark_chunks_with_transitive_use_client(
 
 struct StaticRouteVisitor<'a, 'ir> {
     all_import_records: &'a [import_record::List<'ir>],
-    /// The generated reference proxies of every server component boundary,
-    /// parallel to `use_directives`.
+    /// The reference proxy of every server component boundary, parallel to `use_directives`.
     referenced_source_indices: &'a [u32],
     use_directives: &'a [UseDirective],
     cache: ArrayHashMap</* Index::Int */ u32, bool>,
@@ -91,10 +81,6 @@ struct StaticRouteVisitor<'a, 'ir> {
 }
 
 impl StaticRouteVisitor<'_, '_> {
-    /// This the quickest, simplest, dumbest way I can think of doing this.
-    /// Investigate performance. It can have false negatives (it doesn't properly
-    /// handle cycles), but that's okay as it's just used an optimization
-    ///
     /// 1. Get AST for `source_index`
     /// 2. Recursively traverse its imports in import records
     /// 3. If any of the imports match any item in

--- a/src/bundler/linker_context/StaticRouteVisitor.rs
+++ b/src/bundler/linker_context/StaticRouteVisitor.rs
@@ -1,70 +1,106 @@
-//! The `is_fully_static(source_index)` function returns whether or not
-//! `source_index` imports a file with `"use client"`.
+//! Decides which bake server entry points (routes) transitively import a file
+//! with `"use client"`. A route that imports none is prerendered without any
+//! client-side JavaScript (`BakeRouteKind::FullyStaticRoute`).
+//!
+//! `mark_chunks_with_transitive_use_client` has to run before
+//! `compute_cross_chunk_dependencies`: that pass rewrites every `import()` of
+//! another chunk into an import of the chunk's path and clears the record's
+//! `source_index`, which would hide the client components a route only
+//! reaches through `import()`.
 //!
 //! TODO: Could we move this into the ReachableFileVisitor inside `bundle_v2.rs`?
 
 use crate::mal_prelude::*;
+use bun_alloc::AllocError;
 use bun_collections::{ArrayHashMap, AutoBitSet};
 use bun_core::env_var;
 
+use crate::chunk::{self, Chunk};
 use crate::import_record;
+use crate::options::{OutputKind, Target};
 use crate::{Index, LinkerContext, UseDirective};
 
-pub(crate) struct StaticRouteVisitor<'a> {
-    pub(crate) c: &'a LinkerContext<'a>,
-    pub(crate) cache: ArrayHashMap</* Index::Int */ u32, bool>,
-    pub(crate) visited: AutoBitSet,
+pub(crate) fn mark_chunks_with_transitive_use_client(
+    c: &LinkerContext,
+    chunks: &mut [Chunk],
+) -> Result<(), AllocError> {
+    // Only the built-in React framework prerenders routes differently based on
+    // this; `generate_chunks_in_parallel` reads the flag under the same condition.
+    if !c
+        .framework
+        .is_some_and(|framework| framework.is_built_in_react)
+    {
+        return Ok(());
+    }
+
+    if cfg!(debug_assertions)
+        && env_var::BUN_SSG_DISABLE_STATIC_ROUTE_VISITOR
+            .get()
+            .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let parse_graph = c.parse_graph();
+    let mut visitor = StaticRouteVisitor {
+        all_import_records: parse_graph.ast.items_import_records(),
+        referenced_source_indices: parse_graph
+            .server_component_boundaries
+            .list
+            .items_reference_source_index(),
+        use_directives: parse_graph
+            .server_component_boundaries
+            .list
+            .items_use_directive(),
+        cache: ArrayHashMap::default(),
+        visited: AutoBitSet::init_empty(c.graph.files.len())?,
+    };
+    let entry_point_kinds = c.graph.files.items_entry_point_kind();
+    let targets = c.graph.ast.items_target();
+
+    for chunk in chunks {
+        if !matches!(chunk.content, chunk::Content::Javascript(_))
+            || !chunk.entry_point.is_entry_point()
+        {
+            continue;
+        }
+        let source_index = chunk.entry_point.source_index();
+        // Routes are the user specified entry points of the server graph.
+        if entry_point_kinds[source_index as usize].output_kind() != OutputKind::EntryPoint
+            || targets[source_index as usize] == Target::Browser
+        {
+            continue;
+        }
+        if visitor.has_transitive_use_client(Index::init(source_index)) {
+            chunk.flags.insert(chunk::Flags::HAS_TRANSITIVE_USE_CLIENT);
+        }
+    }
+
+    Ok(())
 }
 
-impl<'a> StaticRouteVisitor<'a> {
+struct StaticRouteVisitor<'a, 'ir> {
+    all_import_records: &'a [import_record::List<'ir>],
+    /// The generated reference proxies of every server component boundary,
+    /// parallel to `use_directives`.
+    referenced_source_indices: &'a [u32],
+    use_directives: &'a [UseDirective],
+    cache: ArrayHashMap</* Index::Int */ u32, bool>,
+    visited: AutoBitSet,
+}
+
+impl StaticRouteVisitor<'_, '_> {
     /// This the quickest, simplest, dumbest way I can think of doing this.
     /// Investigate performance. It can have false negatives (it doesn't properly
     /// handle cycles), but that's okay as it's just used an optimization
-    pub(crate) fn has_transitive_use_client(&mut self, entry_point_source_index: u32) -> bool {
-        if cfg!(debug_assertions)
-            && env_var::BUN_SSG_DISABLE_STATIC_ROUTE_VISITOR
-                .get()
-                .unwrap_or(false)
-        {
-            return false;
-        }
-
-        // `self.c` is `&'a LinkerContext` (Copy), so these slice
-        // borrows are tied to `'a`, not to `&self`, and do not conflict with
-        // the `&mut self` call below. `parse_graph()` is the safe backref
-        // accessor (one centralized `unsafe`, see `LinkerContext::parse_graph`).
-        let parse_graph = self.c.parse_graph();
-        let all_import_records: &[import_record::List<'_>] = parse_graph.ast.items_import_records();
-        let referenced_source_indices: &[u32] = parse_graph
-            .server_component_boundaries
-            .list
-            .items_reference_source_index();
-        let use_directives: &[UseDirective] = parse_graph
-            .server_component_boundaries
-            .list
-            .items_use_directive();
-
-        self.has_transitive_use_client_impl(
-            all_import_records,
-            referenced_source_indices,
-            use_directives,
-            Index::init(entry_point_source_index),
-        )
-    }
-
+    ///
     /// 1. Get AST for `source_index`
     /// 2. Recursively traverse its imports in import records
     /// 3. If any of the imports match any item in
     ///    `referenced_source_indices` which has `use_directive ==
     ///    .client`, then we know `source_index` is NOT fully
     ///    static.
-    fn has_transitive_use_client_impl(
-        &mut self,
-        all_import_records: &[import_record::List<'_>],
-        referenced_source_indices: &[u32],
-        use_directives: &[UseDirective],
-        source_index: Index,
-    ) -> bool {
+    fn has_transitive_use_client(&mut self, source_index: Index) -> bool {
         if let Some(result) = self.cache.get(&source_index.get()) {
             return *result;
         }
@@ -73,7 +109,7 @@ impl<'a> StaticRouteVisitor<'a> {
         }
         self.visited.set(source_index.get() as usize);
 
-        let import_records = &all_import_records[source_index.get() as usize];
+        let import_records = &self.all_import_records[source_index.get() as usize];
 
         let result = 'result: {
             for import_record in import_records.as_slice() {
@@ -82,9 +118,14 @@ impl<'a> StaticRouteVisitor<'a> {
                 }
 
                 // check if this import is a client boundary
-                debug_assert_eq!(referenced_source_indices.len(), use_directives.len());
-                for (referenced_source_index, use_directive) in
-                    referenced_source_indices.iter().zip(use_directives)
+                debug_assert_eq!(
+                    self.referenced_source_indices.len(),
+                    self.use_directives.len()
+                );
+                for (referenced_source_index, use_directive) in self
+                    .referenced_source_indices
+                    .iter()
+                    .zip(self.use_directives)
                 {
                     if *use_directive != UseDirective::Client {
                         continue;
@@ -96,12 +137,7 @@ impl<'a> StaticRouteVisitor<'a> {
                 }
 
                 // otherwise check its children
-                if self.has_transitive_use_client_impl(
-                    all_import_records,
-                    referenced_source_indices,
-                    use_directives,
-                    import_record.source_index,
-                ) {
+                if self.has_transitive_use_client(import_record.source_index) {
                     break 'result true;
                 }
             }

--- a/src/bundler/linker_context/StaticRouteVisitor.rs
+++ b/src/bundler/linker_context/StaticRouteVisitor.rs
@@ -43,7 +43,8 @@ pub(crate) fn mark_chunks_with_transitive_use_client(
 
     let parse_graph = c.parse_graph();
     let mut visitor = StaticRouteVisitor {
-        all_import_records: parse_graph.ast.items_import_records(),
+        // The linker's copy is the one `LinkerGraph::load` pointed at the proxies.
+        all_import_records: c.graph.ast.items_import_records(),
         referenced_source_indices: parse_graph
             .server_component_boundaries
             .list

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -29,7 +29,6 @@ use crate::linker_context::output_file_list_builder::OutputFileList as OutputFil
 use crate::linker_context::prepare_css_asts_for_chunk::{
     PrepareCssAstTask, prepare_css_asts_for_chunk,
 };
-use crate::linker_context::static_route_visitor::StaticRouteVisitor;
 use crate::linker_context::write_output_files_to_disk::write_output_files_to_disk;
 use crate::linker_context_mod::{GenerateChunkCtx, PendingPartRange};
 
@@ -623,15 +622,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     // SAFETY: c points to LinkerContext which is the `linker` field of BundleV2.
     let bundler: &mut BundleV2 =
         unsafe { &mut *LinkerContext::bundle_v2_ptr(std::ptr::from_mut::<LinkerContext>(c)) };
-    let mut static_route_visitor = StaticRouteVisitor {
-        // SAFETY: launder via raw ptr so this long-lived
-        // shared borrow doesn't conflict with `c.log_disjoint()` inside
-        // the chunk loop below. `c` outlives `static_route_visitor`.
-        c: unsafe { bun_ptr::detach_lifetime_ref::<LinkerContext>(c) },
-        cache: bun_collections::ArrayHashMap::default(),
-        visited: AutoBitSet::init_empty(c.graph.files.len()).expect("oom"),
-    };
-    // defer static_route_visitor.deinit() — handled by Drop
 
     // For standalone mode, resolve JS/CSS chunks so we can inline their content into HTML.
     // Closing tag escaping (</script → <\\/script, </style → <\\/style) is handled during
@@ -1128,10 +1118,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         } else {
                             // an error
                             // logger OOM-only
-                            // Split-borrow — `static_route_visitor.c` holds a
-                            // detached `&LinkerContext`; `log_disjoint` returns the
-                            // disjoint `Transpiler.log` backref so no `&mut c` is
-                            // materialized.
                             let _ = c.log_disjoint().add_error_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
@@ -1287,8 +1273,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         if output_kind == options::OutputKind::EntryPoint
                             && side == options::Side::Server
                         {
-                            extra.route = if static_route_visitor
-                                .has_transitive_use_client(chunk.entry_point.source_index())
+                            extra.route = if chunk
+                                .flags
+                                .contains(crate::chunk::Flags::HAS_TRANSITIVE_USE_CLIENT)
                             {
                                 BakeRouteKind::Route
                             } else {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -597,6 +597,8 @@ export default function IndexPage() {
 
   // The <script> that hydrates a prerendered route. Routes without client components don't get one.
   const clientEntryScript = /<script type="module" src="\/_bun\/[^"]+\.js"/;
+  // The row of the inlined RSC payload that refers to the `Client` export as a client reference.
+  const clientReferenceRow = /:I\["[^"]+",\[\],"Client"\]/;
 
   const clientComponentFiles = {
     "src/index.tsx": `export default { app: { framework: "react" } };`,
@@ -634,8 +636,9 @@ export const value = 1;`,
     </div>
   );
 }`,
-      // The same module imported statically by another route, so its code is shared by
-      // both routes and the import() above has to resolve to the module's own chunk.
+      // The same module imported statically by another route. Its code then lands in a chunk
+      // shared with this route, and the import() above has to resolve to the module's own chunk
+      // rather than the shared one, whose exports have minified names (the keys above catch that).
       "pages/static-import.tsx": `import { Client } from "../components/Client";
 
 export default function StaticImportPage() {
@@ -647,12 +650,13 @@ export default function StaticImportPage() {
 
     const index = await html("");
     expect(index).toContain("<span>Client,value</span><b>client</b>");
+    expect(index).toMatch(clientReferenceRow);
     expect(index).toMatch(clientEntryScript);
 
     const staticImport = await html("static-import");
     expect(staticImport).toContain("<div><b>client</b></div>");
     expect(staticImport).toMatch(clientEntryScript);
-  }, 30_000);
+  });
 
   test("a route that only reaches a client component through import() is not fully static", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-dynamic-import-static-route", {
@@ -677,11 +681,12 @@ export function renderClient() {
 
     const index = await html("");
     expect(index).toContain("<div><b>client</b></div>");
+    expect(index).toMatch(clientReferenceRow);
     expect(index).toMatch(clientEntryScript);
 
     // import() of a module without client components keeps the route fully static.
     const plain = await html("plain");
     expect(plain).toContain("<div>no client components here</div>");
     expect(plain).not.toMatch(clientEntryScript);
-  }, 30_000);
+  });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -594,4 +594,94 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  // The <script> that hydrates a prerendered route. Routes without client components don't get one.
+  const clientEntryScript = /<script type="module" src="\/_bun\/[^"]+\.js"/;
+
+  const clientComponentFiles = {
+    "src/index.tsx": `export default { app: { framework: "react" } };`,
+    "components/Client.tsx": `"use client";
+
+export function Client() {
+  return <b>client</b>;
+}
+
+export const value = 1;`,
+    "package.json": JSON.stringify({ "name": "test-app", "version": "1.0.0" }),
+  };
+
+  async function buildApp(dir: string) {
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(stderr.toString()).not.toContain("error");
+    expect(exitCode).toBe(0);
+    return (route: string) => Bun.file(path.join(dir, "dist", route, "index.html")).text();
+  }
+
+  test("import() of a client component from the server", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-dynamic-import-client", {
+      ...clientComponentFiles,
+      // The server side of a "use client" module is a generated module with one client
+      // reference per export, so the namespace has to contain every export of Client.tsx.
+      "pages/index.tsx": `export default async function IndexPage() {
+  const mod = await import("../components/Client");
+  return (
+    <div>
+      <span>{Object.keys(mod).sort().join(",")}</span>
+      <mod.Client />
+    </div>
+  );
+}`,
+      // The same module imported statically by another route, so its code is shared by
+      // both routes and the import() above has to resolve to the module's own chunk.
+      "pages/static-import.tsx": `import { Client } from "../components/Client";
+
+export default function StaticImportPage() {
+  return <div><Client /></div>;
+}`,
+    });
+
+    const html = await buildApp(dir);
+
+    const index = await html("");
+    expect(index).toContain("<span>Client,value</span><b>client</b>");
+    expect(index).toMatch(clientEntryScript);
+
+    const staticImport = await html("static-import");
+    expect(staticImport).toContain("<div><b>client</b></div>");
+    expect(staticImport).toMatch(clientEntryScript);
+  }, 30_000);
+
+  test("a route that only reaches a client component through import() is not fully static", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-dynamic-import-static-route", {
+      ...clientComponentFiles,
+      "components/render-client.tsx": `import { Client } from "./Client";
+
+export function renderClient() {
+  return <Client />;
+}`,
+      "components/plain.ts": `export const text = "no client components here";`,
+      "pages/index.tsx": `export default async function IndexPage() {
+  const { renderClient } = await import("../components/render-client");
+  return <div>{renderClient()}</div>;
+}`,
+      "pages/plain.tsx": `export default async function PlainPage() {
+  const { text } = await import("../components/plain");
+  return <div>{text}</div>;
+}`,
+    });
+
+    const html = await buildApp(dir);
+
+    const index = await html("");
+    expect(index).toContain("<div><b>client</b></div>");
+    expect(index).toMatch(clientEntryScript);
+
+    // import() of a module without client components keeps the route fully static.
+    const plain = await html("plain");
+    expect(plain).toContain("<div>no client components here</div>");
+    expect(plain).not.toMatch(clientEntryScript);
+  }, 30_000);
 });


### PR DESCRIPTION
### Problem
- In a production bake build (`bun build --app`, built-in `react` framework), a server module that does `await import("../components/Client")` where `Client.tsx` is a `"use client"` module bundles, but prerendering fails with `ReferenceError: hmr is not defined` followed by `error: Route "pages/index.tsx" cannot be pre-rendered to a static page.` The server chunk contains `const C = await Promise.resolve().then(() => hmr());` and the client reference proxy for `Client.tsx` is not emitted at all.
- Cause: with code splitting, an internal `import()` is printed as a real `import("<chunk>")` only when its target is an entry point (`LinkerContext::is_external_dynamic_import`); otherwise the linker must have wrapped the target, which step 1 of `scan_imports_and_exports` never does for `import()` when splitting is on. The dynamic import entry points are collected in `find_reachable_files` while the server's import record still points at the original `Client.tsx` (which is already an entry point of the client graph), and `LinkerGraph::load` (`src/bundler/LinkerGraph.rs:682` and the rewrite loop below it) redirects the record to the reference proxy only afterwards. The proxy therefore never becomes an entry point, the `import()` takes the inline path, and the printer emits a call to the proxy's `wrapper_ref`, which `ServerComponentParseTask` sets to the HMR api symbol (`src/bundler/ServerComponentParseTask.rs:194`), a symbol nothing declares outside the dev server.
- Two more things on the same path, found while fixing it:
  - `is_scb_bitset` also contained the proxies, and `find_all_imported_parts_in_js_order` (`findAllImportedPartsInJSOrder.rs:238`) repoints `entry_point_chunk_index` of every file in that bitset at the chunk its code lands in. Once the proxy is an entry point, that breaks the case where another route imports the same module statically: the proxy's code moves to a shared chunk, the `import()` is resolved against `entry_point_chunk_index`, and the page gets the shared chunk's minified cross-chunk exports instead of the module's namespace (`Element type is invalid: ... got: undefined` during prerender).
  - Routes were classified as fully static in `generate_chunks_in_parallel`, after `compute_cross_chunk_dependencies` had rewritten every `import()` of another chunk to the chunk's path and cleared the record's `source_index`. A route whose only path to a client component goes through an `import()` was therefore flagged `FullyStaticRoute` and prerendered without its client entry `<script>`. This reproduces on the current release without the bug above (a page that `import()`s a plain server module which renders a client component gets no script), and a route fixed by the change above hits it too unless it also imports some client component statically.

### Fix
- `LinkerGraph::load`: map each collected dynamic import target through `scb.get_reference_source_index` before registering it, so the proxy becomes the `DynamicImport` entry point. Correct because this is exactly the mapping the rewrite loop applies to the records a few lines later: the entry point set follows the records, and the restored invariant is the one the printer and step 1 rely on (with splitting, every internal `import()` target is an entry point). The original file needs nothing; it is already a user specified entry point of the client graph.
- `is_scb_bitset` now only holds the original files. Nothing resolves a proxy through an SCB unique key (the proxy's own `registerClientReference` path and the manifest both key on the original and SSR indices), so the proxy bit had no effect besides the `entry_point_chunk_index` overwrite (the other reader, the rewrite loop's prefilter, never matched a proxy anyway), and that index now has to stay at the proxy's own chunk like for every other dynamic import entry point. Originals keep the existing behavior.
- Route classification moved into `link()`, between `compute_chunks` and `compute_cross_chunk_dependencies`, where the import records are still intact; the result is stored as `chunk::Flags::HAS_TRANSITIVE_USE_CLIENT` and `generate_chunks_in_parallel` reads the flag under the same conditions it used before. The visitor's algorithm is unchanged; it now takes its slices up front and walks the linker graph's import records (the copy `LinkerGraph::load` redirected to the proxies) instead of relying on the parse graph's records aliasing the same buffers, which is equivalent today. The set of entry points it is asked about (JS, user specified, non-browser, built-in React framework only) is the same as before, so non-bake builds and the dev server are not affected. Its old doc note saying false negatives are harmless is dropped: a misclassified route loses its client entry script (see the last bullet below).
- Tests, in `test/bake/dev/production.test.ts`:
  - "import() of a client component from the server": one build with a route that `import()`s the `"use client"` module (checks the namespace keys, renders a reference through it and checks the RSC payload contains that reference) and a route that imports it statically. Release build: fails with the `hmr is not defined` output above. With only the `is_scb_bitset` hunk reverted: fails with `Element type is invalid ... got: undefined`. Passes with the PR.
  - "a route that only reaches a client component through import() is not fully static": a route that `import()`s a server module rendering a client component must get the client entry script, a route whose `import()` leads to no client component must not. Release build: fails on the missing script. Passes with the PR.
- Also ran: the rest of `test/bake/dev/production.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bake/dev/bundle.test.ts`, `test/bake/dev/response-to-bake-response.test.ts`, `test/bundler/bundler_splitting.test.ts`, `test/bundler/esbuild/splitting.test.ts`, `test/bundler/bundler_html.test.ts`, `test/bundler/bundler_html_server.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `cargo clippy -p bun_bundler`.
- Not in this PR: a `"use client"` module that statically imports another `"use client"` module gets the server proxy in its client chunk. Different mechanism (the record rewrite and the path map put in `on_parse_task_complete` do not look at the importer's graph), reported separately. #38227 fixes the static `import * as` / `export * as` / `require()` forms of this module, and #38336 makes routes with layouts prerender and takes the layouts' classification into account; both are independent of this change (#38336 consumes the per entry point classification this PR computes, through the unchanged `BakeExtra.route`). The classifier's pre-existing imprecision on import cycles (a file inside a cycle can be cached as static) is also unchanged here and reported separately.

### Background
- Server component boundary (SCB): a `"use client"` file in a bake build. It is bundled as the original file (browser build), an SSR copy, and a generated "client reference proxy" for the server graph, a module with the same export names where each export is `registerClientReference(...)`. Server-side import records that resolve to the original are redirected to the proxy in `LinkerGraph::load`.
- Dynamic import entry point: with code splitting, every file that is the target of an `import()` becomes an entry point with its own chunk, and the `import()` is printed as an import of that chunk's path. Without splitting, the target is instead wrapped in a function (`wrapper_ref` names it) and `import()` becomes `Promise.resolve().then(() => wrapper())`.
- `entry_point_chunk_index`: per file, the chunk that represents it as an entry point. `compute_cross_chunk_dependencies` uses it to turn an `import()` record into the target chunk's path; SCB unique keys (the module ids handed to React) use it to find the chunk of a client component. For SCB originals the linker overwrites it with the chunk that actually holds the file's code.
- Fully static route: bake prerenders each server entry point ("route"); routes that do not transitively import any client boundary are emitted without a client entry script. The classification walks import records looking for records that point at a reference proxy.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->