### PR TITLE
node:vm: report compileFunction body errors as SyntaxErrors and reject bodies that close the function

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -125,14 +125,11 @@ bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedD
     return false;
 }
 
-// vm.compileFunction compiles "(function (<params>) {\n<body>\n})" as a program
-// and lifts the function expression out of it (constructAnonymousFunction).
+// compileFunction compiles "(function (<params>) {\n" + body + this as a program.
 static constexpr ASCIILiteral anonymousFunctionSuffix = "\n})"_s;
 
-// A token found where only the end of the source may follow (a stray "}",
-// "case" or "default" at the top level) ends the parse without a message, which
-// Parser::parseInner reports as a bare "Parser error"; Node names the token
-// ("Unexpected token '}'", asserted by test/parallel/test-vm-basic.js).
+// "Parser error" is JSC's placeholder for a token where only EOF may follow (a
+// stray "}", "case", "default"); Node names the token (test-vm-basic.js asserts it).
 static String parseErrorMessage(const ParserError& error, StringView source)
 {
     if (error.message() != "Parser error"_s)
@@ -144,11 +141,9 @@ static String parseErrorMessage(const ParserError& error, StringView source)
     return makeString("Unexpected token '"_s, source.substring(start, end - start), '\'');
 }
 
-// What a function body may contain that a standalone parse of it (as a
-// program) rejects, by the messages Parser.cpp gives those rejections. Only
-// consulted once the wrapped program has already been rejected, so a message
-// missing here costs a less precise diagnostic, never the acceptance or
-// rejection of an input.
+// Program-parse rejections (Parser.cpp wording) of things a function body may
+// contain. Consulted only for input the wrapped compile already rejected, so an
+// omission here can only worsen a message.
 static bool isFunctionBodyOnlyConstruct(const ParserError& error)
 {
     if (error.type() != ParserError::SyntaxError)
@@ -159,10 +154,8 @@ static bool isFunctionBodyOnlyConstruct(const ParserError& error)
         || message == "new.target is not valid inside arrow functions in global code."_s;
 }
 
-// A SyntaxError at `offset` into `body`, shaped like the ones the parser
-// produces for `bodySource`: line() counts up from the source's first line
-// (which carries lineOffset, clamped the way JSC clamps it), and the token's
-// column() is the physical column, which is what decorateParseErrorStack reads.
+// Positioned the way the parser positions its own errors in bodySource: line()
+// counts from the source's first line, the token's column() is physical.
 static ParserError syntaxErrorAtBodyOffset(const SourceCode& bodySource, StringView body, unsigned offset, const String& message)
 {
     int line = bodySource.firstLine().oneBasedInt();
@@ -183,32 +176,23 @@ static void throwParseError(JSGlobalObject* globalObject, ThrowScope& throwScope
 {
     VM& vm = globalObject->vm();
     JSObject* exception = error.toErrorObject(globalObject, source);
-    // Building the error materializes its stack, running a user
-    // Error.prepareStackTrace that may throw; Node throws the SyntaxError
-    // anyway. Terminations survive tryClearException.
+    // Materializing the stack may run a throwing Error.prepareStackTrace; Node
+    // throws the SyntaxError regardless. Terminations survive tryClearException.
     (void)throwScope.tryClearException();
     RETURN_IF_EXCEPTION(throwScope, void());
-    // Node always attaches the arrow header to compile-time SyntaxErrors
-    // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
-    // A parse that ran out of stack or memory has no position to point at.
+    // Node's arrow header (node_contextify.cc DecorateErrorStack) goes on every
+    // compile-time SyntaxError; a stack overflow or OOM has no position.
     if (error.type() == ParserError::SyntaxError)
         decorateParseErrorStack(globalObject, vm, exception, sourceString, url, error, lineOffset);
     throwException(globalObject, throwScope, exception);
 }
 
-// The wrapped program was rejected, either by the parser (`wrapperMessage` at
-// `wrapperOffset` into `wrapper`) or because its function expression ended
-// before the wrapper's own closing brace, meaning a parameter or the body
-// closed it early (`wrapperOffset` is the brace that did). Throws the
-// SyntaxError Node reports for the body.
-//
-// Parsing the body on its own locates the error in the body directly and names
-// the token Node names, both when the wrapper only choked on its own "\n})"
-// suffix (an unterminated body) and when it parsed on past an escaping "}". It
-// cannot tell `return` or `new.target` from an error, though, so when one of
-// those is the first thing it trips over, the wrapper's verdict is reported
-// instead, moved onto the body: an offset in the parameter prefix lands on the
-// start of the body, one in the suffix on its end.
+// The wrapped program was rejected: by the parser (`wrapperMessage` at
+// `wrapperOffset`), or because its function ended early at the brace at
+// `wrapperOffset`. Parsing the body alone yields the error in body coordinates
+// and Node's token for unterminated or escaping bodies, but is blind to
+// `return` and `new.target`; behind one of those the wrapper's verdict is
+// reported, clamped into the body (prefix offsets to its start, suffix to its end).
 static void throwCompileFunctionSyntaxError(JSGlobalObject* globalObject, ThrowScope& throwScope, const String& wrapper, unsigned bodyOffset, const String& wrapperMessage, unsigned wrapperOffset, const SourceOrigin& sourceOrigin, const CompileFunctionOptions& options, SourceTaintedOrigin sourceTaintOrigin)
 {
     VM& vm = globalObject->vm();
@@ -239,9 +223,8 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     TextPosition position(options.lineOffset, options.columnOffset);
     LexicallyScopedFeatures lexicallyScopedFeatures = globalObject->globalScopeExtension() ? TaintedByWithScopeLexicallyScopedFeature : NoLexicallyScopedFeatures;
 
-    // Wrap the parameters and body in an anonymous function expression.
-    // Compiling that program is what validates them; the body is only parsed
-    // on its own to report an error (throwCompileFunctionSyntaxError).
+    // Compiling the wrapped program is the only validation; the body is parsed
+    // on its own solely to report an error.
     int bodyOffset = 0;
     String code = stringifyAnonymousFunction(globalObject, args, throwScope, &bodyOffset);
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
@@ -315,14 +298,10 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
         return nullptr;
     }
 
-    // The program parsed, but it is only the function the caller asked for if
-    // it consists of one function expression reaching the "}" of the trailing
-    // "\n})", so that everything in between is inside it. A body such as
-    // "}); (function () {" (or a parameter doing the same) also parses, as a
-    // program whose first function ends at the injected brace. Everything
-    // before that brace was accepted as function body, so it is the token Node
-    // (which parses the body as nothing but a function body) rejects.
-    // functionEnd() is the offset of the function's closing brace in `code`.
+    // Only a program made of one function expression ending at the suffix's "}"
+    // is the requested function. A body (or parameter) like "}); (function () {"
+    // parses too, with the first function ending at the injected brace, which is
+    // the token Node rejects; functionEnd() is that brace's offset into `code`.
     unsigned wrapperClosingBrace = code.length() - anonymousFunctionSuffix.length() + 1;
     if (programCodeBlock->numberOfFunctionExprs() != 1 || functionExecutable->functionEnd() != wrapperClosingBrace) {
         throwCompileFunctionSyntaxError(globalObject, throwScope, code, bodyOffset, "Unexpected token '}'"_s, functionExecutable->functionEnd(), sourceOrigin, options, sourceTaintOrigin);
@@ -463,9 +442,8 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
-// Helper function to create an anonymous function expression with parameters.
-// The body (args' last entry) is copied in verbatim: it starts at *outOffset
-// and runs up to the anonymousFunctionSuffix that ends the program.
+// Builds the program compileFunction compiles: the body (args' last entry) sits
+// verbatim at *outOffset, followed by anonymousFunctionSuffix.
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
     // How we stringify functions is important for creating anonymous function expressions

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -125,6 +125,110 @@ bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedD
     return false;
 }
 
+// vm.compileFunction compiles "(function (<params>) {\n<body>\n})" as a program
+// and lifts the function expression out of it (constructAnonymousFunction).
+static constexpr ASCIILiteral anonymousFunctionSuffix = "\n})"_s;
+
+// A token found where only the end of the source may follow (a stray "}",
+// "case" or "default" at the top level) ends the parse without a message, which
+// Parser::parseInner reports as a bare "Parser error"; Node names the token
+// ("Unexpected token '}'", asserted by test/parallel/test-vm-basic.js).
+static String parseErrorMessage(const ParserError& error, StringView source)
+{
+    if (error.message() != "Parser error"_s)
+        return error.message();
+    int start = error.token().m_startPosition.offset;
+    int end = error.token().m_endPosition.offset;
+    if (start < 0 || start >= end)
+        return error.message();
+    return makeString("Unexpected token '"_s, source.substring(start, end - start), '\'');
+}
+
+// What a function body may contain that a standalone parse of it (as a
+// program) rejects, by the messages Parser.cpp gives those rejections. Only
+// consulted once the wrapped program has already been rejected, so a message
+// missing here costs a less precise diagnostic, never the acceptance or
+// rejection of an input.
+static bool isFunctionBodyOnlyConstruct(const ParserError& error)
+{
+    if (error.type() != ParserError::SyntaxError)
+        return false;
+    const String& message = error.message();
+    return message == "Return statements are only valid inside functions."_s
+        || message == "new.target is only valid inside functions or static blocks."_s
+        || message == "new.target is not valid inside arrow functions in global code."_s;
+}
+
+// A SyntaxError at `offset` into `body`, shaped like the ones the parser
+// produces for `bodySource`: line() counts up from the source's first line
+// (which carries lineOffset, clamped the way JSC clamps it), and the token's
+// column() is the physical column, which is what decorateParseErrorStack reads.
+static ParserError syntaxErrorAtBodyOffset(const SourceCode& bodySource, StringView body, unsigned offset, const String& message)
+{
+    int line = bodySource.firstLine().oneBasedInt();
+    unsigned lineStart = 0;
+    for (unsigned i = 0; i < offset; i++) {
+        if (body[i] == '\n') {
+            line++;
+            lineStart = i + 1;
+        }
+    }
+    JSToken token;
+    token.m_startPosition = JSTextPosition(line, offset, lineStart);
+    token.m_endPosition = token.m_startPosition;
+    return ParserError(ParserError::SyntaxError, ParserError::SyntaxErrorIrrecoverable, token, message, line);
+}
+
+static void throwParseError(JSGlobalObject* globalObject, ThrowScope& throwScope, ParserError& error, const SourceCode& source, StringView sourceString, const String& url, OrdinalNumber lineOffset)
+{
+    VM& vm = globalObject->vm();
+    JSObject* exception = error.toErrorObject(globalObject, source);
+    // Building the error materializes its stack, running a user
+    // Error.prepareStackTrace that may throw; Node throws the SyntaxError
+    // anyway. Terminations survive tryClearException.
+    (void)throwScope.tryClearException();
+    RETURN_IF_EXCEPTION(throwScope, void());
+    // Node always attaches the arrow header to compile-time SyntaxErrors
+    // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
+    // A parse that ran out of stack or memory has no position to point at.
+    if (error.type() == ParserError::SyntaxError)
+        decorateParseErrorStack(globalObject, vm, exception, sourceString, url, error, lineOffset);
+    throwException(globalObject, throwScope, exception);
+}
+
+// The wrapped program was rejected, either by the parser (`wrapperMessage` at
+// `wrapperOffset` into `wrapper`) or because its function expression ended
+// before the wrapper's own closing brace, meaning a parameter or the body
+// closed it early (`wrapperOffset` is the brace that did). Throws the
+// SyntaxError Node reports for the body.
+//
+// Parsing the body on its own locates the error in the body directly and names
+// the token Node names, both when the wrapper only choked on its own "\n})"
+// suffix (an unterminated body) and when it parsed on past an escaping "}". It
+// cannot tell `return` or `new.target` from an error, though, so when one of
+// those is the first thing it trips over, the wrapper's verdict is reported
+// instead, moved onto the body: an offset in the parameter prefix lands on the
+// start of the body, one in the suffix on its end.
+static void throwCompileFunctionSyntaxError(JSGlobalObject* globalObject, ThrowScope& throwScope, const String& wrapper, unsigned bodyOffset, const String& wrapperMessage, unsigned wrapperOffset, const SourceOrigin& sourceOrigin, const CompileFunctionOptions& options, SourceTaintedOrigin sourceTaintOrigin)
+{
+    VM& vm = globalObject->vm();
+    String body = wrapper.substring(bodyOffset, wrapper.length() - bodyOffset - anonymousFunctionSuffix.length());
+    TextPosition position(options.lineOffset, options.columnOffset);
+    SourceCode bodySource(
+        JSC::StringSourceProvider::create(body, sourceOrigin, options.filename, sourceTaintOrigin, position, SourceProviderSourceType::Program),
+        position.m_line.oneBasedInt(), position.m_column.oneBasedInt());
+
+    ParserError error;
+    if (checkSyntax(vm, bodySource, error) || isFunctionBodyOnlyConstruct(error)) {
+        unsigned offset = wrapperOffset < bodyOffset ? 0 : std::min<unsigned>(wrapperOffset - bodyOffset, body.length());
+        error = syntaxErrorAtBodyOffset(bodySource, body, offset, wrapperMessage);
+    } else if (error.type() == ParserError::SyntaxError) {
+        error = ParserError(ParserError::SyntaxError, error.syntaxErrorType(), error.token(), parseErrorMessage(error, body), error.line());
+    }
+
+    throwParseError(globalObject, throwScope, error, bodySource, body, options.filename, options.lineOffset);
+}
+
 JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, const ArgList& args, const SourceOrigin& sourceOrigin, CompileFunctionOptions&& options, JSC::SourceTaintedOrigin sourceTaintOrigin, JSC::JSScope* scope)
 {
     ASSERT(scope);
@@ -135,57 +239,13 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     TextPosition position(options.lineOffset, options.columnOffset);
     LexicallyScopedFeatures lexicallyScopedFeatures = globalObject->globalScopeExtension() ? TaintedByWithScopeLexicallyScopedFeature : NoLexicallyScopedFeatures;
 
-    // First try parsing the code as is without wrapping it in an anonymous function expression.
-    // This is to reject cases where the user passes in a string like "});(function() {".
-    if (!args.isEmpty() && args.at(0).isString()) {
-        ParserError error;
-        String code = args.at(0).toWTFString(globalObject);
-
-        SourceCode sourceCode(
-            JSC::StringSourceProvider::create(code, sourceOrigin, options.filename, sourceTaintOrigin, position, SourceProviderSourceType::Program),
-            position.m_line.oneBasedInt(), position.m_column.oneBasedInt());
-
-        if (!checkSyntax(vm, sourceCode, error)) {
-            ASSERT(error.isValid());
-
-            bool actuallyValid = true;
-
-            if (error.type() == ParserError::ErrorType::SyntaxError && error.syntaxErrorType() == ParserError::SyntaxErrorIrrecoverable) {
-                String message = error.message();
-                if (message == "Return statements are only valid inside functions.") {
-                    actuallyValid = false;
-                } else {
-                    const JSToken& token = error.token();
-                    int start = token.m_startPosition.offset;
-                    int end = token.m_endPosition.offset;
-                    if (start >= 0 && start < end) {
-                        StringView tokenView = sourceCode.view().substring(start, end - start);
-                        error = ParserError(ParserError::SyntaxError, ParserError::SyntaxErrorIrrecoverable, token, makeString("Unexpected token '"_s, tokenView, '\''), error.line());
-                    }
-                }
-            }
-
-            if (actuallyValid) {
-                auto exception = error.toErrorObject(globalObject, sourceCode, -1);
-                // Building the error materializes its stack, running a user
-                // Error.prepareStackTrace that may throw; Node throws the
-                // SyntaxError anyway. Terminations survive tryClearException.
-                if (exception)
-                    (void)throwScope.tryClearException();
-                RETURN_IF_EXCEPTION(throwScope, nullptr);
-                // Node always attaches the arrow header to compile-time SyntaxErrors
-                // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
-                decorateParseErrorStack(globalObject, vm, exception, code, options.filename, error, options.lineOffset);
-                throwException(globalObject, throwScope, exception);
-                return nullptr;
-            }
-        }
-    }
-
-    // wrap the arguments in an anonymous function expression
-    int startOffset = 0;
-    String code = stringifyAnonymousFunction(globalObject, args, throwScope, &startOffset);
+    // Wrap the parameters and body in an anonymous function expression.
+    // Compiling that program is what validates them; the body is only parsed
+    // on its own to report an error (throwCompileFunctionSyntaxError).
+    int bodyOffset = 0;
+    String code = stringifyAnonymousFunction(globalObject, args, throwScope, &bodyOffset);
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
 
     // The user's body starts on line 2 of the wrapped program (after the
     // "(function () {\n" prefix). Shift the provider's start position up one
@@ -198,7 +258,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     TextPosition wrappedPosition(OrdinalNumber::fromZeroBasedInt(lineZeroBased > 0 ? lineZeroBased - 1 : lineZeroBased), position.m_column);
 
     SourceCode sourceCode(
-        JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program),
+        JSC::StringSourceProvider::create(code, sourceOrigin, options.filename, sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program),
         wrappedPosition.m_line.oneBasedInt(), wrappedPosition.m_column.oneBasedInt());
 
     CodeCache* cache = vm.codeCache();
@@ -226,7 +286,16 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
         unlinkedProgramCodeBlock = cache->getUnlinkedProgramCodeBlock(vm, programExecutable, sourceCode, {}, error);
     }
 
-    if (!unlinkedProgramCodeBlock || error.isValid()) {
+    if (error.isValid()) {
+        if (error.type() != ParserError::SyntaxError) {
+            throwParseError(globalObject, throwScope, error, sourceCode, code, options.filename, options.lineOffset);
+            return nullptr;
+        }
+        throwCompileFunctionSyntaxError(globalObject, throwScope, code, bodyOffset, parseErrorMessage(error, code), std::max(error.token().m_startPosition.offset, 0), sourceOrigin, options, sourceTaintOrigin);
+        return nullptr;
+    }
+
+    if (!unlinkedProgramCodeBlock) {
         return nullptr;
     }
 
@@ -243,6 +312,20 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
 
     FunctionExecutable* functionExecutable = programCodeBlock->functionExpr(0);
     if (!functionExecutable) {
+        return nullptr;
+    }
+
+    // The program parsed, but it is only the function the caller asked for if
+    // it consists of one function expression reaching the "}" of the trailing
+    // "\n})", so that everything in between is inside it. A body such as
+    // "}); (function () {" (or a parameter doing the same) also parses, as a
+    // program whose first function ends at the injected brace. Everything
+    // before that brace was accepted as function body, so it is the token Node
+    // (which parses the body as nothing but a function body) rejects.
+    // functionEnd() is the offset of the function's closing brace in `code`.
+    unsigned wrapperClosingBrace = code.length() - anonymousFunctionSuffix.length() + 1;
+    if (programCodeBlock->numberOfFunctionExprs() != 1 || functionExecutable->functionEnd() != wrapperClosingBrace) {
+        throwCompileFunctionSyntaxError(globalObject, throwScope, code, bodyOffset, "Unexpected token '}'"_s, functionExecutable->functionEnd(), sourceOrigin, options, sourceTaintOrigin);
         return nullptr;
     }
 
@@ -380,20 +463,23 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
-// Helper function to create an anonymous function expression with parameters
+// Helper function to create an anonymous function expression with parameters.
+// The body (args' last entry) is copied in verbatim: it starts at *outOffset
+// and runs up to the anonymousFunctionSuffix that ends the program.
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
     // How we stringify functions is important for creating anonymous function expressions
     String program;
     if (args.isEmpty()) {
         // No arguments, just an empty function body
-        program = "(function () {\n\n})"_s;
+        program = makeString("(function () {\n"_s, anonymousFunctionSuffix);
+        *outOffset = "(function () {\n"_s.length();
     } else if (args.size() == 1) {
         // Just the function body
         auto body = args.at(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        program = tryMakeString("(function () {\n"_s, body, "\n})"_s);
+        program = tryMakeString("(function () {\n"_s, body, anonymousFunctionSuffix);
         *outOffset = "(function () {\n"_s.length();
 
         if (!program) [[unlikely]] {
@@ -419,7 +505,7 @@ String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& a
         auto body = args.at(parameterCount).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        program = tryMakeString("(function ("_s, paramString.toString(), ") {\n"_s, body, "\n})"_s);
+        program = tryMakeString("(function ("_s, paramString.toString(), ") {\n"_s, body, anonymousFunctionSuffix);
         *outOffset = "(function ("_s.length() + paramString.length() + ") {\n"_s.length();
 
         if (!program) [[unlikely]] {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -298,10 +298,11 @@ describe("vm", () => {
         ["}); (function () {", ["a"], "Unexpected token '}'"],
         ["return 1 }); (function () {", [], "Unexpected token '}'"],
         ["return 1 }); (function () {", ["a"], "Unexpected token '}'"],
-        ["return 1 }); globalThis.escaped = true; ({", [], "Unexpected token '}'"],
+        // Escapes without opening a second function: the program still holds
+        // exactly one function expression, it just ends before the wrapper does.
+        ["return 1 }); x = 1; ({", [], "Unexpected token '}'"],
       ])("compileFunction(%j, %j) throws %j", (body, params, message) => {
         expect(() => compileFunction(body, params)).toThrow({ name: "SyntaxError", message });
-        expect(globalThis.escaped).toBeUndefined();
       });
 
       test("errors keep JSC's own message instead of being rewritten to 'Unexpected token'", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -343,6 +343,15 @@ describe("vm", () => {
         expect(compileFunction("return rest.length", ["...rest"])(1, 2, 3)).toBe(3);
       });
 
+      test("a body too deeply nested to parse throws the parser's RangeError, without an arrow header", () => {
+        const body = "return " + Buffer.alloc(100_000, "(").toString();
+        for (const params of [[], ["a"]]) {
+          const err = thrownBy(() => compileFunction(body, params));
+          expect(err).toBeInstanceOf(RangeError);
+          expect(err.stack.startsWith("RangeError")).toBe(true);
+        }
+      });
+
       test("the arrow header and line point into the body", () => {
         const header = (err: any) => {
           expect(err).toBeInstanceOf(SyntaxError);
@@ -362,6 +371,13 @@ describe("vm", () => {
         expect(header(moved)).toEqual(["f.js:7", "  %%", "  ^", ""]);
         expect(header(thrownBy(() => compileFunction("return 1;\n%%", [], { lineOffset: -5 })))).toEqual([
           ":-3",
+          "%%",
+          "^",
+          "",
+        ]);
+        // Params spanning lines do not shift the reported position.
+        expect(header(thrownBy(() => compileFunction("return 1;\n%%", ["a,\nb"], { filename: "f.js" })))).toEqual([
+          "f.js:2",
           "%%",
           "^",
           "",

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -269,6 +269,128 @@ describe("vm", () => {
         expect(e).toBeTruthy();
       }
     });
+
+    describe("syntax errors in the body", () => {
+      const thrownBy = (fn: () => unknown): any => {
+        try {
+          fn();
+        } catch (e) {
+          return e;
+        }
+        throw new Error("expected a throw");
+      };
+      // What JSC says about the same text when it is compiled any other way.
+      const scriptMessage = (code: string) => thrownBy(() => new Script(code)).message;
+
+      // Node reports the body's first bad token as a SyntaxError whether or not
+      // params are given, and whether or not a `return` precedes it.
+      test.each([
+        ["%%", [], "Unexpected token '%'"],
+        ["%%", ["a"], "Unexpected token '%'"],
+        ["return 1;\n%%", [], "Unexpected token '%'"],
+        ["return 1;\n%%", ["a"], "Unexpected token '%'"],
+        ["}", [], "Unexpected token '}'"],
+        ["}", ["a"], "Unexpected token '}'"],
+        ["case 1:", ["a"], "Unexpected token 'case'"],
+        // A body that closes the function it is compiled into and opens another
+        // one parses fine as a program; it must still be rejected at the brace.
+        ["}); (function () {", [], "Unexpected token '}'"],
+        ["}); (function () {", ["a"], "Unexpected token '}'"],
+        ["return 1 }); (function () {", [], "Unexpected token '}'"],
+        ["return 1 }); (function () {", ["a"], "Unexpected token '}'"],
+        ["return 1 }); globalThis.escaped = true; ({", [], "Unexpected token '}'"],
+      ])("compileFunction(%j, %j) throws %j", (body, params, message) => {
+        expect(() => compileFunction(body, params)).toThrow({ name: "SyntaxError", message });
+        expect(globalThis.escaped).toBeUndefined();
+      });
+
+      test("errors keep JSC's own message instead of being rewritten to 'Unexpected token'", () => {
+        for (const body of ["let x = 1; let x = 2;", "await 1", "'use strict'; with ({}) {}", "if (x) {"]) {
+          expect(thrownBy(() => compileFunction(body, ["a"]))).toBeInstanceOf(SyntaxError);
+          expect(thrownBy(() => compileFunction(body)).message).toBe(scriptMessage(body));
+          expect(thrownBy(() => compileFunction(body, ["a"])).message).toBe(scriptMessage(body));
+        }
+      });
+
+      test("errors only visible with the params in scope are SyntaxErrors too", () => {
+        const err = thrownBy(() => compileFunction("let a = 1;", ["a"]));
+        expect(err).toBeInstanceOf(SyntaxError);
+        expect(err.message).toBe(scriptMessage("(function (a) {\nlet a = 1;\n})"));
+      });
+
+      test("invalid params are SyntaxErrors", () => {
+        expect(thrownBy(() => compileFunction("return 1", ["a b"]))).toBeInstanceOf(SyntaxError);
+        expect(thrownBy(() => compileFunction("return 1", ["a) { return 2 } ); (function (b"]))).toBeInstanceOf(
+          SyntaxError,
+        );
+      });
+
+      test("constructs that are only valid inside a function body compile", () => {
+        expect(compileFunction("if (0) new.target; return 1")()).toBe(1);
+        expect(compileFunction("const f = () => new.target; return f()")()).toBeUndefined();
+        expect(compileFunction("return new.target", ["a"])()).toBeUndefined();
+      });
+
+      test("bodies and params that merely look like an escape compile", () => {
+        expect(compileFunction('return "}); (function () {"', ["a"])()).toBe("}); (function () {");
+        expect(compileFunction("return 1 // })")()).toBe(1);
+        expect(compileFunction("return a()", ["a = function () { return 7 }"])()).toBe(7);
+        expect(compileFunction("return a + b", ["a,\nb"])(1, 2)).toBe(3);
+      });
+
+      test("params are validated as parameters, not as programs", () => {
+        expect(compileFunction("return rest.length", ["...rest"])(1, 2, 3)).toBe(3);
+      });
+
+      test("the arrow header and line point into the body", () => {
+        const header = (err: any) => {
+          expect(err).toBeInstanceOf(SyntaxError);
+          return err.stack.split("\n").slice(0, 4);
+        };
+        // Located by parsing the body on its own.
+        expect(header(thrownBy(() => compileFunction("1;\n%%", ["a"], { filename: "f.js", lineOffset: 5 })))).toEqual([
+          "f.js:7",
+          "%%",
+          "^",
+          "",
+        ]);
+        // Located by the wrapped compile (the `return` hides it from the
+        // standalone parse) and moved onto the body.
+        const moved = thrownBy(() => compileFunction("return 1;\n  %%", ["a"], { filename: "f.js", lineOffset: 5 }));
+        expect(moved.message).toBe("Unexpected token '%'");
+        expect(header(moved)).toEqual(["f.js:7", "  %%", "  ^", ""]);
+        expect(header(thrownBy(() => compileFunction("return 1;\n%%", [], { lineOffset: -5 })))).toEqual([
+          ":-3",
+          "%%",
+          "^",
+          "",
+        ]);
+        // Both routes record the same position on the error object itself.
+        const located = thrownBy(() => compileFunction("1;\n%%", [], { filename: "f.js", lineOffset: 5 }));
+        expect([located.line, located.sourceURL]).toEqual([7, "f.js"]);
+        expect([moved.line, moved.sourceURL]).toEqual([7, "f.js"]);
+        // The brace that closed the function early.
+        const escaped = thrownBy(() =>
+          compileFunction("return 1;\nx = 1 }); (function () {", [], { filename: "f.js" }),
+        );
+        expect(escaped.message).toBe("Unexpected token '}'");
+        expect(header(escaped)).toEqual(["f.js:2", "x = 1 }); (function () {", "      ^", ""]);
+        // An unterminated body is reported at its end, not inside the wrapper.
+        expect(header(thrownBy(() => compileFunction("return (", [], { filename: "f.js" })))).toEqual([
+          "f.js:1",
+          "return (",
+          "        ^",
+          "",
+        ]);
+        // A bad param is reported against the start of the body.
+        expect(header(thrownBy(() => compileFunction("return 1", ["a b"], { filename: "f.js" })))).toEqual([
+          "f.js:1",
+          "return 1",
+          "^",
+          "",
+        ]);
+      });
+    });
   });
 });
 
@@ -447,16 +569,23 @@ describe("Script", () => {
       expect(err.message).toBe("Unexpected token '%'");
       expect(err.stack.split("\n").slice(0, 4)).toEqual(["evalmachine.<anonymous>:1", "%%", "^", ""]);
 
-      // Same eager-materialization path via vm.compileFunction.
-      let fnErr: any;
-      try {
-        compileFunction("%%");
-      } catch (e) {
-        fnErr = e;
+      // Same eager-materialization path via vm.compileFunction, with the error
+      // found by the standalone parse of the body and by the wrapped compile.
+      for (const [body, params, caret] of [
+        ["%%", [], "^"],
+        ["%%", ["a"], "^"],
+        ["return;%%", ["a"], "       ^"],
+      ] as [string, string[], string][]) {
+        let fnErr: any;
+        try {
+          compileFunction(body, params);
+        } catch (e) {
+          fnErr = e;
+        }
+        expect(fnErr).toBeInstanceOf(SyntaxError);
+        expect(fnErr.message).toBe("Unexpected token '%'");
+        expect(fnErr.stack.split("\n").slice(0, 4)).toEqual([":1", body, caret, ""]);
       }
-      expect(fnErr).toBeInstanceOf(SyntaxError);
-      expect(fnErr.message).toBe("Unexpected token '%'");
-      expect(fnErr.stack.split("\n").slice(0, 4)).toEqual([":1", "%%", "^", ""]);
     } finally {
       Error.prepareStackTrace = prev;
     }


### PR DESCRIPTION
### Problem
- `vm.compileFunction(body, params)` reports a syntax error in `body` as `Error: Failed to compile function` whenever `params` is non-empty; Node throws a `SyntaxError` with the parser's message (`vm.compileFunction("%%", ["a"])` is `SyntaxError: Unexpected token '%'` in Node v26.3.0).
- A body that closes the function and opens another one compiles if it starts with a top-level `return`: `vm.compileFunction("return 1 }); (function () {")` returns `function () {\nreturn 1 }`, with or without params. Node throws `SyntaxError: Unexpected token '}'`.
- Valid bodies using `new.target` are rejected: `vm.compileFunction("if (0) new.target; return 1")` throws `SyntaxError: Unexpected token 'target'`; Node compiles it.
- Messages that do get through are rewritten: `let x = 1; let x = 2;` reports `Unexpected token '='` instead of the parser's own message (which `new vm.Script` and `new Function` give for the same text).
- Cause, `src/jsc/bindings/NodeVM.cpp` `constructAnonymousFunction`: the body was pre-parsed on its own as a program to catch errors and escapes, but it parsed `args.at(0)`, which with params is the first parameter name, not the body (the caller builds `[param..., body]`). The pre-parse also returned "valid" for any body whose first complaint was `Return statements are only valid inside functions.`, so nothing after a top-level `return` was checked, and it treated every other program-only complaint (`new.target`) as an error. A failure of the real, wrapped compile below it returned `nullptr`, which `vmModuleCompileFunction` turns into the generic error.

### Fix
- The wrapped program `(function (<params>) {\n<body>\n})` is now the only thing that decides whether the input compiles, so nothing valid inside a function body can be rejected and params are no longer parsed as programs (`["...rest"]` works; it used to throw).
- A parse error from that compile is thrown as a `SyntaxError` instead of returning `nullptr` (the line that fixes the first two symptoms is the `error.isValid()` branch after `getUnlinkedProgramCodeBlock`).
- A program that does parse must consist of exactly one function expression whose closing brace is the wrapper's own (`FunctionExecutable::functionEnd()` against the brace in the trailing `\n})`). Anything else means a parameter or the body closed the function early; since everything before that brace was accepted as function body, the brace is exactly the token Node, which parses the body as nothing but a function body, rejects, so it is reported as `Unexpected token '}'` at that position. This replaces the pre-parse as the escape check and is not bypassed by `return`.
- Error reporting (`throwCompileFunctionSyntaxError`): once the input is known to be invalid, the body is parsed on its own to get the message and position in body coordinates, which is what Node reports (first bad token of the body, JSC's wording; the placeholder `Parser error` JSC uses for a stray `}`/`case`/`default` becomes `Unexpected token '<token>'`, the wording `test/parallel/test-vm-basic.js` asserts). When that parse stops at `return`/`new.target` instead, the wrapped compile's own error is reported and its offset is moved onto the body (prefix positions clamp to the body start, suffix positions to its end); in that fallback the message is JSC's wording for the wrapped context, e.g. `return 1; }` gets `Unexpected token '}'. Expected ')' to end a compound expression.` at the end of the body. Both routes feed the existing `decorateParseErrorStack`, so the arrow header, `lineOffset` handling and `err.line`/`err.sourceURL` match the existing no-params behavior; stack overflow / OOM parser failures are thrown as-is.
- Side effects on the happy path: the body is no longer parsed twice; a `filename` copy replaces a move so the error path can still use it. The generic `Failed to compile function` remains only as the fallback for a compile that fails without a parser error.
- Verified with `test/js/node/vm/vm.test.ts` (`compileFunction() > syntax errors in the body`, plus a params case in the `Error.prepareStackTrace` test): 16 tests fail on the unfixed build (`USE_SYSTEM_BUN=1`), 234 pass with the fix. Also run: `test/js/node/test/parallel/test-vm-basic.js`, `test-vm-cached-data.js`, `test-vm-createcacheddata.js`, `test-vm-syntax-error-message.js`, `test-vm-syntax-error-stderr.js`, `test-vm-module-basic.js`, `test-vm-no-dynamic-import-callback.js` (all exit 0), the rest of `test/js/node/vm/` (only `script-leak.test.ts` fails locally, by timing out at 21s on the debug build; it does not involve compileFunction), and the new tests under `BUN_JSC_validateExceptionChecks=1`.
- Out of scope, unchanged by this PR and tracked separately: with `parsingContext`, Node creates the compile-time error in that context's realm while Bun (before and after) creates it in the caller's; and a body starting with a `#!` line compiles in Node but not in Bun (it now gets a SyntaxError instead of the generic error).
- Node v26.3.0 itself only has `test-vm-basic.js` for this area (already vendored, still passes); nothing further to port. Upstream Node aborts on non-identifier params, so their exact messages have no reference to match; they are plain `SyntaxError`s here.

### Background
- `vm.compileFunction` in Bun is implemented by building the program text `(function (a, b) {\n<body>\n})`, compiling it as a program through JSC's `CodeCache`, linking it and returning the first function expression of the resulting code block; the program itself is never run. Node/V8 instead compiles the body directly as a function body with the params declared separately, which is why its errors are always in body coordinates and why a body cannot "escape" there.
- `ParserError` is what JSC's parser hands back on failure: a type (syntax error, stack overflow, OOM), a message, the offending token (whose offsets are into the text that was parsed) and a line number that counts up from the `SourceCode`'s first line. `toErrorObject` turns it into the JS error; `decorateParseErrorStack` (existing) prepends Node's `<file>:<line>\n<source line>\n<caret>` header from the same fields. The fix synthesizes a `ParserError` in those terms for errors it has to relocate, so the rest of the pipeline is shared.
- `FunctionExecutable::functionEnd()` is the offset of a function's closing brace within the source it was parsed from (it is what `Function.prototype.toString` uses to cut the text), which is why comparing it against the wrapper's brace tells whether the body stayed inside the function.

<details>
<summary>Repro under Bun 1.4.0, this branch, and Node v26.3.0</summary>

```js
const vm = require("node:vm");
vm.compileFunction("%%", ["a"]);
//   before: Error "Failed to compile function"
//   after:  SyntaxError "Unexpected token '%'"
//   node:   SyntaxError "Unexpected token '%'"
vm.compileFunction("return 1 }); (function(){", []);       // and with ["a"]
//   before: returns function () {\nreturn 1 }
//   after:  SyntaxError "Unexpected token '}'"
//   node:   SyntaxError "Unexpected token '}'"
vm.compileFunction("let a = 1", ["a"]);
//   before: Error "Failed to compile function"
//   after:  SyntaxError "Cannot declare a let variable twice: 'a'."
//   node:   SyntaxError "Identifier 'a' has already been declared"
vm.compileFunction("if (0) new.target");
//   before: SyntaxError "Unexpected token 'target'"
//   after:  ok
//   node:   ok
vm.compileFunction("let x = 1; let x = 2;");
//   before: SyntaxError "Unexpected token '='"
//   after:  SyntaxError "Cannot declare a let variable twice: 'x'."   (same as new vm.Script / new Function)
//   node:   SyntaxError "Identifier 'x' has already been declared"
vm.compileFunction("return 1;\n  %%", ["a"], { filename: "f.js", lineOffset: 5 }).stack
//   after:  f.js:7 / "  %%" / "  ^"   (error found by the wrapped compile, relocated onto the body)
```

</details>

