### PR TITLE
node:vm: report compileFunction body lines relative to lineOffset when it is 0

### DIFF
--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "JavaScriptCore/CodeBlock.h"
 #include "headers-handwritten.h"
+#include "NodeVMScriptFetcher.h"
 #include "JavaScriptCore/BytecodeIndex.h"
 #include "wtf/Assertions.h"
 #include "wtf/text/OrdinalNumber.h"
@@ -93,6 +94,11 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
 
     default:
         break;
+    }
+
+    if (auto* provider = code->source().provider()) {
+        if (unsigned wrapperColumns = NodeVMScriptFetcher::wrapperColumnsOnLine(*provider, pos.line_zero_based))
+            pos.column_zero_based = static_cast<int32_t>(std::max<int64_t>(static_cast<int64_t>(pos.column_zero_based) - wrapperColumns, 0));
     }
 
     return pos;

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -22,6 +22,7 @@
 #include "BunClientData.h"
 #include "CallSite.h"
 #include "ErrorStackTrace.h"
+#include "NodeVMScriptFetcher.h"
 #include "headers-handwritten.h"
 
 #include <wtf/Scope.h>
@@ -265,6 +266,13 @@ WTF::String formatStackTrace(
         if (!frame.hasLineAndColumnInfo()) continue;
 
         originalLineColumns[i] = frame.computeLineAndColumn();
+        if (auto* codeBlock = frame.codeBlock()) {
+            if (auto* provider = codeBlock->source().provider()) {
+                LineColumn& lineColumn = originalLineColumns[i];
+                if (unsigned wrapperColumns = NodeVMScriptFetcher::wrapperColumnsOnLine(*provider, static_cast<int>(lineColumn.line) - 1))
+                    lineColumn.column = lineColumn.column > wrapperColumns ? lineColumn.column - wrapperColumns : 1;
+            }
+        }
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
         if (auto* callee = frame.callee()) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -198,14 +198,14 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     int columnOffset = position.m_column.zeroBasedInt();
     TextPosition wrappedPosition(position.m_line, OrdinalNumber::fromZeroBasedInt(columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0));
 
+    Ref<JSC::SourceProvider> provider = JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program);
+
     // Lets handleException map a frame on the first line back to the user's
     // source when decorating a runtime error with the offending line.
     if (auto* fetcher = sourceOrigin.fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
-        static_cast<NodeVMScriptFetcher*>(fetcher)->setWrapperPrefixLength(static_cast<unsigned>(wrapperPrefixLength));
+        static_cast<NodeVMScriptFetcher*>(fetcher)->setWrapper(provider.get(), static_cast<unsigned>(wrapperPrefixLength));
 
-    SourceCode sourceCode(
-        JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program),
-        wrappedPosition.m_line.oneBasedInt(), wrappedPosition.m_column.oneBasedInt());
+    SourceCode sourceCode(WTF::move(provider), wrappedPosition.m_line.oneBasedInt(), wrappedPosition.m_column.oneBasedInt());
 
     CodeCache* cache = vm.codeCache();
     ProgramExecutable* programExecutable = ProgramExecutable::create(globalObject, sourceCode);
@@ -505,7 +505,9 @@ JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::So
 // AppendExceptionLine helpers shared by the runtime (handleException) and
 // compile-time (decorateParseErrorStack) paths — a single implementation of
 // Node's arrow-header format so the two call sites cannot drift.
-static String nthSourceLineForArrowHeader(StringView source, int64_t physicalLine1Based)
+// firstLineSkip is the length of compileFunction's wrapper, which shares the
+// first line with the user's source and is not part of it.
+static String nthSourceLineForArrowHeader(StringView source, int64_t physicalLine1Based, unsigned firstLineSkip = 0)
 {
     if (physicalLine1Based < 1 || physicalLine1Based > static_cast<int64_t>(source.length()) + 1)
         return {};
@@ -520,6 +522,8 @@ static String nthSourceLineForArrowHeader(StringView source, int64_t physicalLin
     if (lineEnd == WTF::notFound)
         lineEnd = source.length();
     StringView lineView = source.substring(lineStart, lineEnd - lineStart);
+    if (physicalLine1Based == 1)
+        lineView = lineView.substring(firstLineSkip);
     if (lineView.endsWith('\r'))
         lineView = lineView.left(lineView.length() - 1);
     // Like Node, skip the decoration for excessively long lines.
@@ -589,17 +593,17 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                // The user's source starts after compileFunction's wrapper prefix
-                // (if any), which shares the first line with it; JSC's columns on
-                // that line count the prefix too.
+                // In a compileFunction program the user's first line starts after
+                // the wrapper prefix, and JSC's columns on that line count the
+                // prefix too. Zero for every other provider, including eval() code
+                // from inside such a function, which shares the fetcher.
                 unsigned wrapperPrefixLength = 0;
                 if (auto* fetcher = provider->sourceOrigin().fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
-                    wrapperPrefixLength = static_cast<NodeVMScriptFetcher*>(fetcher)->wrapperPrefixLength();
-                StringView userSource = provider->source().substring(wrapperPrefixLength);
+                    wrapperPrefixLength = static_cast<NodeVMScriptFetcher*>(fetcher)->wrapperPrefixLength(*provider);
 
                 int64_t startLineZeroBased = provider->startPosition().m_line.zeroBasedInt();
                 int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - startLineZeroBased;
-                sourceLineText = nthSourceLineForArrowHeader(userSource, physicalLine);
+                sourceLineText = nthSourceLineForArrowHeader(provider->source(), physicalLine, wrapperPrefixLength);
                 if (!sourceLineText.isNull()) {
                     caretColumn = line_and_column.column;
                     if (physicalLine == 1) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -188,14 +188,17 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
     RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    // Line 1's columns already include the wrapper, so only the excess of columnOffset over it is applied.
+    // JSC counts the wrapper in line 1's columns and cannot start a source at a negative column: the part of
+    // columnOffset beyond the wrapper is applied here, the rest is taken off again when positions are reported.
     int columnOffset = position.m_column.zeroBasedInt();
-    TextPosition wrappedPosition(position.m_line, OrdinalNumber::fromZeroBasedInt(columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0));
+    int appliedColumnOffset = columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0;
+    unsigned wrapperColumns = static_cast<unsigned>(static_cast<int64_t>(wrapperPrefixLength) + appliedColumnOffset - columnOffset);
+    TextPosition wrappedPosition(position.m_line, OrdinalNumber::fromZeroBasedInt(appliedColumnOffset));
 
     Ref<JSC::SourceProvider> provider = JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program);
 
     if (auto* fetcher = sourceOrigin.fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
-        static_cast<NodeVMScriptFetcher*>(fetcher)->setWrapper(provider.get(), static_cast<unsigned>(wrapperPrefixLength));
+        static_cast<NodeVMScriptFetcher*>(fetcher)->setWrapper(provider.get(), static_cast<unsigned>(wrapperPrefixLength), wrapperColumns);
 
     SourceCode sourceCode(WTF::move(provider), wrappedPosition.m_line.oneBasedInt(), wrappedPosition.m_column.oneBasedInt());
 
@@ -576,9 +579,7 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                unsigned wrapperPrefixLength = 0;
-                if (auto* fetcher = provider->sourceOrigin().fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
-                    wrapperPrefixLength = static_cast<NodeVMScriptFetcher*>(fetcher)->wrapperPrefixLength(*provider);
+                unsigned wrapperPrefixLength = NodeVMScriptFetcher::wrapperTextLength(*provider);
 
                 int64_t startLineZeroBased = provider->startPosition().m_line.zeroBasedInt();
                 int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - startLineZeroBased;

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -378,9 +378,7 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
-// Builds `(function (<params>) {<body>\n})`; *outOffset is the body's offset. The body shares the
-// wrapper's line on purpose: JSC clamps a source's first line to 1, so a wrapper line cannot be
-// compensated for when lineOffset is 0.
+// The body deliberately shares the wrapper's line: JSC clamps a source's first line to 1, so a wrapper line could not be compensated for at lineOffset 0.
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
     // How we stringify functions is important for creating anonymous function expressions

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -188,9 +188,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
     RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    // The body starts on the program's first line (see stringifyAnonymousFunction),
-    // so that line's columns already include the wrapper: only the part of
-    // columnOffset beyond it is applied, as a source cannot start at a negative column.
+    // Line 1's columns already include the wrapper, so only the excess of columnOffset over it is applied.
     int columnOffset = position.m_column.zeroBasedInt();
     TextPosition wrappedPosition(position.m_line, OrdinalNumber::fromZeroBasedInt(columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0));
 
@@ -380,10 +378,9 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
-// Builds `(function (<params>) {<body>\n})`; *outOffset is the body's offset.
-// The body must start on the wrapper's own line: JSC clamps a SourceCode's first
-// line to 1, so a wrapper line could not be compensated for at lineOffset 0 and
-// every body line would be reported one too high.
+// Builds `(function (<params>) {<body>\n})`; *outOffset is the body's offset. The body shares the
+// wrapper's line on purpose: JSC clamps a source's first line to 1, so a wrapper line cannot be
+// compensated for when lineOffset is 0.
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
     // How we stringify functions is important for creating anonymous function expressions
@@ -581,8 +578,6 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                // Non-zero only for a compileFunction program, whose first line
-                // (text and columns) starts with the wrapper.
                 unsigned wrapperPrefixLength = 0;
                 if (auto* fetcher = provider->sourceOrigin().fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
                     wrapperPrefixLength = static_cast<NodeVMScriptFetcher*>(fetcher)->wrapperPrefixLength(*provider);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -188,20 +188,14 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
     RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    // The body starts on the wrapped program's first line (see
-    // stringifyAnonymousFunction), so the program starts at lineOffset itself
-    // and body line N is reported as lineOffset + N. Columns on body line 1 are
-    // physical columns of the wrapped line, so they already include the
-    // wrapper prefix; Node reports columnOffset + column there, so apply only
-    // the part of columnOffset that exceeds the prefix (a SourceCode cannot
-    // start at a negative column).
+    // The body starts on the program's first line (see stringifyAnonymousFunction),
+    // so that line's columns already include the wrapper: only the part of
+    // columnOffset beyond it is applied, as a source cannot start at a negative column.
     int columnOffset = position.m_column.zeroBasedInt();
     TextPosition wrappedPosition(position.m_line, OrdinalNumber::fromZeroBasedInt(columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0));
 
     Ref<JSC::SourceProvider> provider = JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program);
 
-    // Lets handleException map a frame on the first line back to the user's
-    // source when decorating a runtime error with the offending line.
     if (auto* fetcher = sourceOrigin.fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
         static_cast<NodeVMScriptFetcher*>(fetcher)->setWrapper(provider.get(), static_cast<unsigned>(wrapperPrefixLength));
 
@@ -386,15 +380,10 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
-// Helper function to create an anonymous function expression with parameters.
-//
-// The body follows `{` on the same line rather than on a line of its own: JSC
-// clamps a SourceCode's first line to 1, so a wrapper line cannot be
-// compensated for when lineOffset is 0 (the default) and every body line would
-// be reported one too high. This way body line N is physical line N of the
-// program. The price is that columns on body line 1 include the wrapper text;
-// *outOffset receives its length. The "\n" before `})` keeps a trailing `//`
-// comment in the body from swallowing the closing of the wrapper.
+// Builds `(function (<params>) {<body>\n})`; *outOffset is the body's offset.
+// The body must start on the wrapper's own line: JSC clamps a SourceCode's first
+// line to 1, so a wrapper line could not be compensated for at lineOffset 0 and
+// every body line would be reported one too high.
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
     // How we stringify functions is important for creating anonymous function expressions
@@ -505,8 +494,7 @@ JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::So
 // AppendExceptionLine helpers shared by the runtime (handleException) and
 // compile-time (decorateParseErrorStack) paths — a single implementation of
 // Node's arrow-header format so the two call sites cannot drift.
-// firstLineSkip is the length of compileFunction's wrapper, which shares the
-// first line with the user's source and is not part of it.
+// firstLineSkip: compileFunction's wrapper text in front of the user's first line.
 static String nthSourceLineForArrowHeader(StringView source, int64_t physicalLine1Based, unsigned firstLineSkip = 0)
 {
     if (physicalLine1Based < 1 || physicalLine1Based > static_cast<int64_t>(source.length()) + 1)
@@ -593,10 +581,8 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                // In a compileFunction program the user's first line starts after
-                // the wrapper prefix, and JSC's columns on that line count the
-                // prefix too. Zero for every other provider, including eval() code
-                // from inside such a function, which shares the fetcher.
+                // Non-zero only for a compileFunction program, whose first line
+                // (text and columns) starts with the wrapper.
                 unsigned wrapperPrefixLength = 0;
                 if (auto* fetcher = provider->sourceOrigin().fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
                     wrapperPrefixLength = static_cast<NodeVMScriptFetcher*>(fetcher)->wrapperPrefixLength(*provider);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -188,8 +188,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
     RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    // JSC counts the wrapper in line 1's columns and cannot start a source at a negative column: the part of
-    // columnOffset beyond the wrapper is applied here, the rest is taken off again when positions are reported.
+    // JSC counts the wrapper in line 1's columns and cannot start a source at a negative column: apply what exceeds the wrapper here, take the rest off when positions are reported.
     int columnOffset = position.m_column.zeroBasedInt();
     int appliedColumnOffset = columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0;
     unsigned wrapperColumns = static_cast<unsigned>(static_cast<int64_t>(wrapperPrefixLength) + appliedColumnOffset - columnOffset);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -183,19 +183,25 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     }
 
     // wrap the arguments in an anonymous function expression
-    int startOffset = 0;
-    String code = stringifyAnonymousFunction(globalObject, args, throwScope, &startOffset);
+    int wrapperPrefixLength = 0;
+    String code = stringifyAnonymousFunction(globalObject, args, throwScope, &wrapperPrefixLength);
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    // The user's body starts on line 2 of the wrapped program (after the
-    // "(function () {\n" prefix). Shift the provider's start position up one
-    // line so reported positions line up with the body the way V8's
-    // CompileFunction does: body line 1 reports as lineOffset+1. JSC clamps
-    // non-positive provider start positions to zero, so once the input is
-    // already <= 0 there is nothing to gain by going further negative; clamp
-    // there to keep the value bounded for downstream arithmetic.
-    int lineZeroBased = position.m_line.zeroBasedInt();
-    TextPosition wrappedPosition(OrdinalNumber::fromZeroBasedInt(lineZeroBased > 0 ? lineZeroBased - 1 : lineZeroBased), position.m_column);
+    // The body starts on the wrapped program's first line (see
+    // stringifyAnonymousFunction), so the program starts at lineOffset itself
+    // and body line N is reported as lineOffset + N. Columns on body line 1 are
+    // physical columns of the wrapped line, so they already include the
+    // wrapper prefix; Node reports columnOffset + column there, so apply only
+    // the part of columnOffset that exceeds the prefix (a SourceCode cannot
+    // start at a negative column).
+    int columnOffset = position.m_column.zeroBasedInt();
+    TextPosition wrappedPosition(position.m_line, OrdinalNumber::fromZeroBasedInt(columnOffset > wrapperPrefixLength ? columnOffset - wrapperPrefixLength : 0));
+
+    // Lets handleException map a frame on the first line back to the user's
+    // source when decorating a runtime error with the offending line.
+    if (auto* fetcher = sourceOrigin.fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
+        static_cast<NodeVMScriptFetcher*>(fetcher)->setWrapperPrefixLength(static_cast<unsigned>(wrapperPrefixLength));
 
     SourceCode sourceCode(
         JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program),
@@ -380,21 +386,30 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
-// Helper function to create an anonymous function expression with parameters
+// Helper function to create an anonymous function expression with parameters.
+//
+// The body follows `{` on the same line rather than on a line of its own: JSC
+// clamps a SourceCode's first line to 1, so a wrapper line cannot be
+// compensated for when lineOffset is 0 (the default) and every body line would
+// be reported one too high. This way body line N is physical line N of the
+// program. The price is that columns on body line 1 include the wrapper text;
+// *outOffset receives its length. The "\n" before `})` keeps a trailing `//`
+// comment in the body from swallowing the closing of the wrapper.
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
     // How we stringify functions is important for creating anonymous function expressions
     String program;
     if (args.isEmpty()) {
         // No arguments, just an empty function body
-        program = "(function () {\n\n})"_s;
+        program = "(function () {\n})"_s;
+        *outOffset = "(function () {"_s.length();
     } else if (args.size() == 1) {
         // Just the function body
         auto body = args.at(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        program = tryMakeString("(function () {\n"_s, body, "\n})"_s);
-        *outOffset = "(function () {\n"_s.length();
+        program = tryMakeString("(function () {"_s, body, "\n})"_s);
+        *outOffset = "(function () {"_s.length();
 
         if (!program) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
@@ -419,8 +434,8 @@ String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& a
         auto body = args.at(parameterCount).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        program = tryMakeString("(function ("_s, paramString.toString(), ") {\n"_s, body, "\n})"_s);
-        *outOffset = "(function ("_s.length() + paramString.length() + ") {\n"_s.length();
+        program = tryMakeString("(function ("_s, paramString.toString(), ") {"_s, body, "\n})"_s);
+        *outOffset = "(function ("_s.length() + paramString.length() + ") {"_s.length();
 
         if (!program) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
@@ -574,14 +589,25 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
+                // The user's source starts after compileFunction's wrapper prefix
+                // (if any), which shares the first line with it; JSC's columns on
+                // that line count the prefix too.
+                unsigned wrapperPrefixLength = 0;
+                if (auto* fetcher = provider->sourceOrigin().fetcher(); fetcher && fetcher->fetcherType() == ScriptFetcher::Type::NodeVM)
+                    wrapperPrefixLength = static_cast<NodeVMScriptFetcher*>(fetcher)->wrapperPrefixLength();
+                StringView userSource = provider->source().substring(wrapperPrefixLength);
+
                 int64_t startLineZeroBased = provider->startPosition().m_line.zeroBasedInt();
                 int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - startLineZeroBased;
-                sourceLineText = nthSourceLineForArrowHeader(provider->source(), physicalLine);
+                sourceLineText = nthSourceLineForArrowHeader(userSource, physicalLine);
                 if (!sourceLineText.isNull()) {
                     caretColumn = line_and_column.column;
-                    unsigned startColumnZeroBased = static_cast<unsigned>(provider->startPosition().m_column.zeroBasedInt());
-                    if (physicalLine == 1 && caretColumn > startColumnZeroBased)
-                        caretColumn -= startColumnZeroBased;
+                    if (physicalLine == 1) {
+                        // SourceCode clamps a negative start column to 0, so that is what the frame's column includes.
+                        unsigned startColumnZeroBased = static_cast<unsigned>(std::max(0, provider->startPosition().m_column.zeroBasedInt()));
+                        unsigned firstLineShift = startColumnZeroBased + wrapperPrefixLength;
+                        caretColumn = caretColumn > firstLineShift ? caretColumn - firstLineShift : 0;
+                    }
                 }
             }
         }

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -42,18 +42,47 @@ public:
         });
     }
 
-    // Keyed by provider because eval() and new Function() code inherits this fetcher without the wrapper.
-    void setWrapper(JSC::SourceProvider& provider, unsigned prefixLength)
+    // compileFunction's program has its `(function (<params>) {` wrapper on the body's first line (see
+    // stringifyAnonymousFunction): `textLength` is that text, `columns` is what JSC's columns on that line
+    // exceed Node's by (the wrapper net of columnOffset). Keyed by provider because eval() and
+    // new Function() code inherits this fetcher without the wrapper.
+    void setWrapper(JSC::SourceProvider& program, unsigned textLength, unsigned columns)
     {
-        m_wrapperSourceID = provider.asID();
-        m_wrapperPrefixLength = prefixLength;
+        m_wrapperSourceID = program.asID();
+        m_wrapperTextLength = textLength;
+        m_wrapperColumns = columns;
     }
-    unsigned wrapperPrefixLength(JSC::SourceProvider& provider) const
+
+    // 0 unless `provider` is a compileFunction program.
+    static unsigned wrapperTextLength(JSC::SourceProvider& provider)
     {
-        return m_wrapperPrefixLength && provider.asID() == m_wrapperSourceID ? m_wrapperPrefixLength : 0;
+        auto* fetcher = wrapperFetcherFor(provider);
+        return fetcher ? fetcher->m_wrapperTextLength : 0;
+    }
+
+    // 0 unless `lineZeroBased` is the first line of a compileFunction program.
+    static unsigned wrapperColumnsOnLine(JSC::SourceProvider& provider, int lineZeroBased)
+    {
+        auto* fetcher = wrapperFetcherFor(provider);
+        if (!fetcher)
+            return 0;
+        // SourceCode clamps the start line to the first line, so JSC reports the first physical line as max(lineOffset, 0).
+        int firstLine = std::max(0, provider.startPosition().m_line.zeroBasedInt());
+        return lineZeroBased == firstLine ? fetcher->m_wrapperColumns : 0;
     }
 
 private:
+    static NodeVMScriptFetcher* wrapperFetcherFor(JSC::SourceProvider& provider)
+    {
+        auto* fetcher = provider.sourceOrigin().fetcher();
+        if (!fetcher || fetcher->fetcherType() != Type::NodeVM)
+            return nullptr;
+        auto* vmFetcher = static_cast<NodeVMScriptFetcher*>(fetcher);
+        if (!vmFetcher->m_wrapperTextLength || provider.asID() != vmFetcher->m_wrapperSourceID)
+            return nullptr;
+        return vmFetcher;
+    }
+
     JSC::Strong<JSC::Unknown> m_dynamicImportCallback;
     // m_owner is the NodeVMScript / JSFunction / module wrapper that holds this
     // fetcher via m_source -> SourceProvider -> SourceOrigin -> RefPtr<fetcher>.
@@ -63,7 +92,8 @@ private:
     // SourceCode chain drops the last RefPtr to this fetcher.
     JSC::Weak<JSC::JSCell> m_owner;
     JSC::SourceID m_wrapperSourceID = 0;
-    unsigned m_wrapperPrefixLength = 0;
+    unsigned m_wrapperTextLength = 0;
+    unsigned m_wrapperColumns = 0;
     bool m_isUsingDefaultLoader = false;
 
     NodeVMScriptFetcher(JSC::VM& vm, JSC::JSValue dynamicImportCallback, JSC::JSValue owner)

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -42,25 +42,22 @@ public:
         });
     }
 
-    // compileFunction's program has its `(function (<params>) {` wrapper on the body's first line (see
-    // stringifyAnonymousFunction): `textLength` is that text, `columns` is what JSC's columns on that line
-    // exceed Node's by (the wrapper net of columnOffset). Keyed by provider because eval() and
-    // new Function() code inherits this fetcher without the wrapper.
-    void setWrapper(JSC::SourceProvider& program, unsigned textLength, unsigned columns)
+    // The compileFunction wrapper (see stringifyAnonymousFunction) shares the program's first line with the body.
+    void setWrapper(JSC::SourceProvider& program, unsigned textLength, unsigned columnsBeyondNode)
     {
         m_wrapperSourceID = program.asID();
         m_wrapperTextLength = textLength;
-        m_wrapperColumns = columns;
+        m_wrapperColumns = columnsBeyondNode;
     }
 
-    // 0 unless `provider` is a compileFunction program.
+    // Wrapper text starting the first line; 0 unless `provider` is a compileFunction program.
     static unsigned wrapperTextLength(JSC::SourceProvider& provider)
     {
         auto* fetcher = wrapperFetcherFor(provider);
         return fetcher ? fetcher->m_wrapperTextLength : 0;
     }
 
-    // 0 unless `lineZeroBased` is the first line of a compileFunction program.
+    // By how much JSC's columns exceed Node's on this line; 0 unless it is a compileFunction program's first line.
     static unsigned wrapperColumnsOnLine(JSC::SourceProvider& provider, int lineZeroBased)
     {
         auto* fetcher = wrapperFetcherFor(provider);
@@ -72,6 +69,7 @@ public:
     }
 
 private:
+    // Matched by provider: eval() and new Function() code inside the body inherits this fetcher without the wrapper.
     static NodeVMScriptFetcher* wrapperFetcherFor(JSC::SourceProvider& provider)
     {
         auto* fetcher = provider.sourceOrigin().fetcher();

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -42,13 +42,9 @@ public:
         });
     }
 
-    // vm.compileFunction compiles `(function (<params>) {<body>` with the body
-    // starting on the same line as the wrapper so that body line N is reported
-    // as line lineOffset + N. Records the provider holding that program and the
-    // length of the wrapper text preceding the user's source on its first line.
-    // Keyed by provider because eval() and new Function() inside the body create
-    // providers that inherit this fetcher through the SourceOrigin but contain
-    // no wrapper; for those, and for vm.Script sources, this returns 0.
+    // The compileFunction program whose first line starts with the `(function (...) {`
+    // wrapper, and the wrapper's length. Keyed by provider: eval() and new Function()
+    // inside the body inherit this fetcher through the SourceOrigin but have no wrapper.
     void setWrapper(JSC::SourceProvider& provider, unsigned prefixLength)
     {
         m_wrapperSourceID = provider.asID();

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -41,6 +41,14 @@ public:
         });
     }
 
+    // vm.compileFunction compiles `(function (<params>) {<body>` with the body
+    // starting on the same line as the wrapper so that body line N is reported
+    // as line lineOffset + N. This is the length of that wrapper text, which
+    // precedes the user's source on the provider's first line; 0 for sources
+    // that are compiled as written (vm.Script, modules).
+    unsigned wrapperPrefixLength() const { return m_wrapperPrefixLength; }
+    void setWrapperPrefixLength(unsigned length) { m_wrapperPrefixLength = length; }
+
 private:
     JSC::Strong<JSC::Unknown> m_dynamicImportCallback;
     // m_owner is the NodeVMScript / JSFunction / module wrapper that holds this
@@ -50,6 +58,7 @@ private:
     // as a GC root). Use Weak instead: when the owner is collected its
     // SourceCode chain drops the last RefPtr to this fetcher.
     JSC::Weak<JSC::JSCell> m_owner;
+    unsigned m_wrapperPrefixLength = 0;
     bool m_isUsingDefaultLoader = false;
 
     NodeVMScriptFetcher(JSC::VM& vm, JSC::JSValue dynamicImportCallback, JSC::JSValue owner)

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -42,8 +42,7 @@ public:
         });
     }
 
-    // compileFunction's program and the length of the `(function (...) {` wrapper on its first line.
-    // Keyed by provider: eval() and new Function() code inherits this fetcher but has no wrapper.
+    // Keyed by provider because eval() and new Function() code inherits this fetcher without the wrapper.
     void setWrapper(JSC::SourceProvider& provider, unsigned prefixLength)
     {
         m_wrapperSourceID = provider.asID();

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -3,6 +3,7 @@
 #include "root.h"
 
 #include <JavaScriptCore/ScriptFetcher.h>
+#include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/Scope.h>
@@ -43,11 +44,20 @@ public:
 
     // vm.compileFunction compiles `(function (<params>) {<body>` with the body
     // starting on the same line as the wrapper so that body line N is reported
-    // as line lineOffset + N. This is the length of that wrapper text, which
-    // precedes the user's source on the provider's first line; 0 for sources
-    // that are compiled as written (vm.Script, modules).
-    unsigned wrapperPrefixLength() const { return m_wrapperPrefixLength; }
-    void setWrapperPrefixLength(unsigned length) { m_wrapperPrefixLength = length; }
+    // as line lineOffset + N. Records the provider holding that program and the
+    // length of the wrapper text preceding the user's source on its first line.
+    // Keyed by provider because eval() and new Function() inside the body create
+    // providers that inherit this fetcher through the SourceOrigin but contain
+    // no wrapper; for those, and for vm.Script sources, this returns 0.
+    void setWrapper(JSC::SourceProvider& provider, unsigned prefixLength)
+    {
+        m_wrapperSourceID = provider.asID();
+        m_wrapperPrefixLength = prefixLength;
+    }
+    unsigned wrapperPrefixLength(JSC::SourceProvider& provider) const
+    {
+        return m_wrapperPrefixLength && provider.asID() == m_wrapperSourceID ? m_wrapperPrefixLength : 0;
+    }
 
 private:
     JSC::Strong<JSC::Unknown> m_dynamicImportCallback;
@@ -58,6 +68,7 @@ private:
     // as a GC root). Use Weak instead: when the owner is collected its
     // SourceCode chain drops the last RefPtr to this fetcher.
     JSC::Weak<JSC::JSCell> m_owner;
+    JSC::SourceID m_wrapperSourceID = 0;
     unsigned m_wrapperPrefixLength = 0;
     bool m_isUsingDefaultLoader = false;
 

--- a/src/jsc/bindings/NodeVMScriptFetcher.h
+++ b/src/jsc/bindings/NodeVMScriptFetcher.h
@@ -42,9 +42,8 @@ public:
         });
     }
 
-    // The compileFunction program whose first line starts with the `(function (...) {`
-    // wrapper, and the wrapper's length. Keyed by provider: eval() and new Function()
-    // inside the body inherit this fetcher through the SourceOrigin but have no wrapper.
+    // compileFunction's program and the length of the `(function (...) {` wrapper on its first line.
+    // Keyed by provider: eval() and new Function() code inherits this fetcher but has no wrapper.
     void setWrapper(JSC::SourceProvider& provider, unsigned prefixLength)
     {
         m_wrapperSourceID = provider.asID();

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -43,6 +43,7 @@
 
 #include "ErrorStackFrame.h"
 #include "ErrorStackTrace.h"
+#include "NodeVMScriptFetcher.h"
 #include "ObjectBindings.h"
 
 #include <JavaScriptCore/VMInlines.h>
@@ -161,6 +162,9 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         return;
 
     if (source_lines_count > 1 && source_lines != nullptr && sourceString.is8Bit()) {
+        // vm.compileFunction's wrapper starts the first line; it is not part of the user's source.
+        unsigned wrapperTextLength = Bun::NodeVMScriptFetcher::wrapperTextLength(*provider);
+
         // Search for the beginning of the line
         unsigned int lineStart = location.byte_position;
         while (lineStart > 0 && sourceString[lineStart] != '\n') {
@@ -185,7 +189,8 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
             (*referenced_source_provider)->deref();
         }
         *referenced_source_provider = provider;
-        source_lines[0] = Bun::toStringView(sourceString.substring(lineStart, lineEnd - lineStart));
+        unsigned int textStart = lineStart == 0 ? std::min(wrapperTextLength, lineEnd) : lineStart;
+        source_lines[0] = Bun::toStringView(sourceString.substring(textStart, lineEnd - textStart));
         source_line_numbers[0] = location.line();
 
         if (lineStart > 0) {
@@ -211,7 +216,8 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
                 }
 
                 // We are at the beginning of the line
-                source_lines[source_line_i] = Bun::toStringView(sourceString.substring(byte_offset_in_source_string, end_of_line_offset - byte_offset_in_source_string + 1));
+                unsigned int contextStart = byte_offset_in_source_string == 0 ? std::min(wrapperTextLength, end_of_line_offset + 1) : byte_offset_in_source_string;
+                source_lines[source_line_i] = Bun::toStringView(sourceString.substring(contextStart, end_of_line_offset + 1 - contextStart));
 
                 source_line_numbers[source_line_i] = location.line().fromZeroBasedInt(location.line().zeroBasedInt() - source_line_i);
                 source_line_i++;

--- a/test/js/node/test/parallel/test-vm-basic.js
+++ b/test/js/node/test/parallel/test-vm-basic.js
@@ -131,9 +131,9 @@ const vm = require('vm');
 
 // vm.compileFunction
 {
-  // Bun compiles the body on the same line as the wrapper so that stack
-  // frames report body line N as lineOffset + N (the engine cannot start a
-  // source at line 0), which is what toString() reflects.
+  // Bun compiles the body on the same line as the wrapper (the engine cannot
+  // start a source at line 0, so a wrapper line would shift every body line),
+  // and toString() returns the text as compiled.
   assert.strictEqual(
     vm.compileFunction('console.log("Hello, World!")').toString(),
     typeof Bun === 'undefined'
@@ -282,18 +282,17 @@ const vm = require('vm');
   // Setting value to run the last three tests
   Error.stackTraceLimit = 1;
 
-  // Bun's compileFunction stack frames differ from Node's in their columns:
-  // JSC attributes the throw to a different column than V8, and columns on
-  // body line 1 also count the `(function () {` wrapper the body shares its
-  // line with (so a columnOffset shorter than the wrapper has no effect).
-  // The anonymous source is labeled differently too. Lines match Node.
+  // Bun's compileFunction stack frames differ from Node's in two ways: JSC
+  // attributes the throw to the call's `(` where V8 uses the `new` keyword
+  // (hence column 16 where Node has 7), and the anonymous source is labeled
+  // differently. Lines and offsets match Node.
   assert.throws(() => {
     vm.compileFunction('throw new Error("Sample Error")')();
   }, {
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:1:30)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:1:16)'
   });
 
   assert.throws(() => {
@@ -306,7 +305,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:4:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:4:30)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:4:16)'
   });
 
   assert.throws(() => {
@@ -319,7 +318,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:10'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:1:30)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:1:19)'
   });
 
   assert.strictEqual(
@@ -343,7 +342,7 @@ const vm = require('vm');
     // Bun's compileFunction stack frames differ from Node's (see above).
     stack: typeof Bun === 'undefined'
       ? 'ReferenceError: varInContext is not defined\n    at <anonymous>:1:1'
-      : 'ReferenceError: varInContext is not defined\n    at <anonymous> (file:///:1:34)'
+      : 'ReferenceError: varInContext is not defined\n    at <anonymous> (file:///:1:20)'
   });
 
   assert.notDeepStrictEqual(

--- a/test/js/node/test/parallel/test-vm-basic.js
+++ b/test/js/node/test/parallel/test-vm-basic.js
@@ -131,9 +131,14 @@ const vm = require('vm');
 
 // vm.compileFunction
 {
+  // Bun compiles the body on the same line as the wrapper so that stack
+  // frames report body line N as lineOffset + N (the engine cannot start a
+  // source at line 0), which is what toString() reflects.
   assert.strictEqual(
     vm.compileFunction('console.log("Hello, World!")').toString(),
-    'function () {\nconsole.log("Hello, World!")\n}'
+    typeof Bun === 'undefined'
+      ? 'function () {\nconsole.log("Hello, World!")\n}'
+      : 'function () {console.log("Hello, World!")\n}'
   );
 
   assert.strictEqual(
@@ -277,17 +282,18 @@ const vm = require('vm');
   // Setting value to run the last three tests
   Error.stackTraceLimit = 1;
 
-  // Bun's compileFunction stack frames differ from Node's: JSC attributes
-  // the throw to a different column (and columnOffset is not applied), the
-  // wrapper costs one line when lineOffset is 0, and the anonymous source is
-  // labeled differently.
+  // Bun's compileFunction stack frames differ from Node's in their columns:
+  // JSC attributes the throw to a different column than V8, and columns on
+  // body line 1 also count the `(function () {` wrapper the body shares its
+  // line with (so a columnOffset shorter than the wrapper has no effect).
+  // The anonymous source is labeled differently too. Lines match Node.
   assert.throws(() => {
     vm.compileFunction('throw new Error("Sample Error")')();
   }, {
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:2:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:1:30)'
   });
 
   assert.throws(() => {
@@ -300,7 +306,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:4:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:4:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:4:30)'
   });
 
   assert.throws(() => {
@@ -313,7 +319,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:10'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:2:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:1:30)'
   });
 
   assert.strictEqual(
@@ -337,7 +343,7 @@ const vm = require('vm');
     // Bun's compileFunction stack frames differ from Node's (see above).
     stack: typeof Bun === 'undefined'
       ? 'ReferenceError: varInContext is not defined\n    at <anonymous>:1:1'
-      : 'ReferenceError: varInContext is not defined\n    at <anonymous> (file:///:2:20)'
+      : 'ReferenceError: varInContext is not defined\n    at <anonymous> (file:///:1:34)'
   });
 
   assert.notDeepStrictEqual(

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -417,6 +417,20 @@ describe("vm", () => {
         scriptCaret,
         "",
       ]);
+
+      // Code eval'd from inside the body gets its own source, which has no
+      // wrapper, even though it inherits the function's origin.
+      for (const evalCall of ["eval", "(0, eval)"]) {
+        const [headerLine, sourceLine, caret] = header(
+          callFromScript(compileFunction(`${evalCall}(${JSON.stringify(line1)})`, [], { filename: "cf-header.js" })),
+        );
+        expect({ evalCall, headerLine: headerLine.replace(/^.*:/, ":"), sourceLine, caret }).toEqual({
+          evalCall,
+          headerLine: ":1",
+          sourceLine: line1,
+          caret: scriptCaret,
+        });
+      }
     });
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -340,29 +340,92 @@ describe("vm", () => {
       }
     });
 
-    test("columnOffset shifts body line 1 only", () => {
+    test("body line 1 reports the body's own columns, plus columnOffset", () => {
       const filename = "cf-columns.js";
       const statement = 'throw new Error("column")';
       // The column JSC assigns to this statement when it starts a line that no
-      // offset applies to.
+      // wrapper or offset touches.
       const { column } = thrownPosition(filename, compileFunction("\n" + statement, [], { filename }));
-      // Body line 1 shares its line with the `(function () {` wrapper, so its
-      // columns include that text; a columnOffset at least that long is
-      // applied exactly, as in Node.
-      expect(thrownPosition(filename, compileFunction(statement, [], { filename, columnOffset: 100 }))).toEqual({
-        line: 1,
-        column: column + 100,
+      const results = {
+        line1: thrownPosition(filename, compileFunction(statement, [], { filename })),
+        line1WithParams: thrownPosition(filename, () => compileFunction(statement, ["a", "b"], { filename })()),
+        // Node adds columnOffset on the first line only, whatever its size.
+        line1Offset3: thrownPosition(filename, compileFunction(statement, [], { filename, columnOffset: 3 })),
+        line1Offset100: thrownPosition(filename, compileFunction(statement, [], { filename, columnOffset: 100 })),
+        line1WithParamsOffset100: thrownPosition(filename, () =>
+          compileFunction(statement, ["a", "b"], { filename, columnOffset: 100 })(),
+        ),
+        line2Offset100: thrownPosition(
+          filename,
+          compileFunction("\n" + statement, [], { filename, columnOffset: 100 }),
+        ),
+        nestedArrowOnLine1: thrownPosition(
+          filename,
+          compileFunction(`return () => { ${statement} };`, [], { filename })(),
+        ),
+        nestedArrowOnLine2: thrownPosition(
+          filename,
+          compileFunction(`\nreturn () => { ${statement} };`, [], { filename })(),
+        ),
+      };
+      expect(results).toEqual({
+        line1: { line: 1, column },
+        line1WithParams: { line: 1, column },
+        line1Offset3: { line: 1, column: column + 3 },
+        line1Offset100: { line: 1, column: column + 100 },
+        line1WithParamsOffset100: { line: 1, column: column + 100 },
+        line2Offset100: { line: 2, column },
+        nestedArrowOnLine1: { line: 1, column: results.nestedArrowOnLine2.column },
+        nestedArrowOnLine2: { line: 2, column: results.nestedArrowOnLine2.column },
       });
-      expect(
-        thrownPosition(filename, () => compileFunction(statement, ["a", "b"], { filename, columnOffset: 100 })()),
-      ).toEqual({ line: 1, column: column + 100 });
-      // Later lines are never shifted.
-      expect(thrownPosition(filename, compileFunction("\n" + statement, [], { filename, columnOffset: 100 }))).toEqual({
-        line: 2,
-        column,
-      });
-      // Without a columnOffset, line 1 still reports line 1.
-      expect(thrownPosition(filename, compileFunction(statement, [], { filename })).line).toBe(1);
+    });
+
+    test("Error.prepareStackTrace call sites report the same columns on body line 1", () => {
+      const previous = Error.prepareStackTrace;
+      Error.prepareStackTrace = (_, callSites) => callSites.map(site => [site.getLineNumber(), site.getColumnNumber()]);
+      try {
+        const body = "return new Error('x').stack[0];";
+        const [, column] = compileFunction("\n" + body, [], { filename: "cf-callsite-columns.js" })();
+        expect({
+          line1: compileFunction(body, [], { filename: "cf-callsite-columns.js" })(),
+          line1WithParams: compileFunction(body, ["a"], { filename: "cf-callsite-columns.js" })(),
+          line1Offset5: compileFunction(body, [], { filename: "cf-callsite-columns.js", columnOffset: 5 })(),
+        }).toEqual({
+          line1: [1, column],
+          line1WithParams: [1, column],
+          line1Offset5: [1, column + 5],
+        });
+      } finally {
+        Error.prepareStackTrace = previous;
+      }
+    });
+
+    test.concurrent("uncaught error output shows the body line without the wrapper", async () => {
+      const run = async (code: string) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", code],
+          env: bunEnv,
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(exitCode).toBe(1);
+        // The source excerpt: line-numbered source lines followed by the caret line.
+        return stderr.split("\n").filter(line => /^\s*\d+ \| /.test(line) || /^\s*\^$/.test(line));
+      };
+      const body = JSON.stringify('let ok = 1; throw new Error("boom")');
+      const [fromScript, fromFunction, fromOffsetFunction] = await Promise.all([
+        // Reference: the same text run as a script, which has no wrapper.
+        run(
+          `new (require("node:vm").Script)(${body}, { filename: "/virtual/ref.js" }).runInThisContext({ displayErrors: false })`,
+        ),
+        run(`require("node:vm").compileFunction(${body}, ["exports", "require"], { filename: "/virtual/cf.js" })()`),
+        run(`require("node:vm").compileFunction(${body}, [], { filename: "/virtual/cf.js", lineOffset: 10 })()`),
+      ]);
+      expect(fromScript).toEqual([`1 | ${JSON.parse(body)}`, expect.stringMatching(/^ +\^$/)]);
+      expect(fromFunction).toEqual(fromScript);
+      // A wider line number indents the caret one more column.
+      expect(fromOffsetFunction).toEqual([`11 | ${JSON.parse(body)}`, " " + fromScript[1]]);
     });
 
     test("runtime arrow header shows the body line when called from a vm script", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -269,6 +269,155 @@ describe("vm", () => {
         expect(e).toBeTruthy();
       }
     });
+
+    // Positions of runtime errors thrown by the compiled function. Node
+    // reports body line N as lineOffset + N; the body is line 1, not the
+    // line after a wrapper.
+    function thrownPosition(filename: string, fn: () => unknown) {
+      let stack: string = "";
+      try {
+        fn();
+      } catch (e: any) {
+        stack = e.stack;
+      }
+      const match = stack.match(new RegExp(`${filename.replaceAll(".", "\\.")}:(\\d+):(\\d+)`));
+      if (!match) throw new Error(`no ${filename} frame in:\n${stack}`);
+      return { line: Number(match[1]), column: Number(match[2]) };
+    }
+
+    test("runtime errors report body line N as lineOffset + N", () => {
+      const filename = "cf-lines.js";
+      const results: unknown[] = [];
+      const expected: unknown[] = [];
+      for (const lineOffset of [undefined, 0, 1, 7]) {
+        const options = lineOffset === undefined ? { filename } : { filename, lineOffset };
+        const base = lineOffset ?? 0;
+        results.push({
+          lineOffset,
+          line1: thrownPosition(filename, compileFunction('throw new Error("line 1")', [], options)).line,
+          line3: thrownPosition(filename, compileFunction('1;\n2;\nthrow new Error("line 3")', [], options)).line,
+          line1WithParams: thrownPosition(filename, () =>
+            compileFunction("throw new Error(String(a + b))", ["a", "b"], options)(1, 2),
+          ).line,
+          // Functions nested in the body are positioned relative to the same origin.
+          nestedArrowOnLine1: thrownPosition(
+            filename,
+            compileFunction('return () => { throw new Error("arrow") };', [], options)(),
+          ).line,
+          nestedFunctionOnLine2: thrownPosition(
+            filename,
+            compileFunction('return function inner() {\n  throw new Error("inner");\n};', [], options)(),
+          ).line,
+        });
+        expected.push({
+          lineOffset,
+          line1: base + 1,
+          line3: base + 3,
+          line1WithParams: base + 1,
+          nestedArrowOnLine1: base + 1,
+          nestedFunctionOnLine2: base + 2,
+        });
+      }
+      expect(results).toEqual(expected);
+    });
+
+    test("Error.prepareStackTrace call sites see the same body lines", () => {
+      const previous = Error.prepareStackTrace;
+      Error.prepareStackTrace = (_, callSites) =>
+        callSites.map(site => `${site.getFileName()}:${site.getLineNumber()}`);
+      try {
+        const fn = compileFunction("return [new Error('a').stack[0], (() => new Error('b').stack[0])()];", [], {
+          filename: "cf-callsites.js",
+        });
+        expect(fn()).toEqual(["cf-callsites.js:1", "cf-callsites.js:1"]);
+        const offsetFn = compileFunction("\nreturn new Error('c').stack[0];", [], {
+          filename: "cf-callsites.js",
+          lineOffset: 10,
+        });
+        expect(offsetFn()).toBe("cf-callsites.js:12");
+      } finally {
+        Error.prepareStackTrace = previous;
+      }
+    });
+
+    test("columnOffset shifts body line 1 only", () => {
+      const filename = "cf-columns.js";
+      const statement = 'throw new Error("column")';
+      // The column JSC assigns to this statement when it starts a line that no
+      // offset applies to.
+      const { column } = thrownPosition(filename, compileFunction("\n" + statement, [], { filename }));
+      // Body line 1 shares its line with the `(function () {` wrapper, so its
+      // columns include that text; a columnOffset at least that long is
+      // applied exactly, as in Node.
+      expect(thrownPosition(filename, compileFunction(statement, [], { filename, columnOffset: 100 }))).toEqual({
+        line: 1,
+        column: column + 100,
+      });
+      expect(
+        thrownPosition(filename, () => compileFunction(statement, ["a", "b"], { filename, columnOffset: 100 })()),
+      ).toEqual({ line: 1, column: column + 100 });
+      // Later lines are never shifted.
+      expect(thrownPosition(filename, compileFunction("\n" + statement, [], { filename, columnOffset: 100 }))).toEqual({
+        line: 2,
+        column,
+      });
+      // Without a columnOffset, line 1 still reports line 1.
+      expect(thrownPosition(filename, compileFunction(statement, [], { filename })).line).toBe(1);
+    });
+
+    test("runtime arrow header shows the body line when called from a vm script", () => {
+      // Node decorates an error escaping a vm run with `<url>:<line>`, the
+      // offending source line and a caret. For a function from compileFunction
+      // the line and source text are those of the body, not of the wrapper.
+      const header = (fn: () => unknown) => {
+        let stack: string = "";
+        try {
+          fn();
+        } catch (e: any) {
+          stack = e.stack;
+        }
+        return stack.split("\n").slice(0, 4);
+      };
+      const line1 = 'throw new Error("line 1")';
+      const line2 = '0;\n  throw new Error("line 2")';
+
+      // Reference: the same statements compiled as a script, where no wrapper exists.
+      const [, , scriptCaret] = header(() => new Script(line1, { filename: "ref.js" }).runInThisContext());
+      expect(scriptCaret).toMatch(/^ *\^$/);
+      const [, , scriptCaret2] = header(() => new Script(line2, { filename: "ref.js" }).runInThisContext());
+      expect(scriptCaret2).toMatch(/^ +\^$/);
+
+      const callFromScript = (fn: Function) => () =>
+        new Script("fn()", { filename: "outer.js" }).runInNewContext({ fn });
+
+      expect(header(callFromScript(compileFunction(line1, [], { filename: "cf-header.js" })))).toEqual([
+        "cf-header.js:1",
+        line1,
+        scriptCaret,
+        "",
+      ]);
+      expect(header(callFromScript(compileFunction(line1, ["a", "b"], { filename: "cf-header.js" })))).toEqual([
+        "cf-header.js:1",
+        line1,
+        scriptCaret,
+        "",
+      ]);
+      expect(
+        header(callFromScript(compileFunction(line1, [], { filename: "cf-header.js", columnOffset: 100 }))),
+      ).toEqual(["cf-header.js:1", line1, scriptCaret, ""]);
+      expect(header(callFromScript(compileFunction(line2, [], { filename: "cf-header.js" })))).toEqual([
+        "cf-header.js:2",
+        '  throw new Error("line 2")',
+        scriptCaret2,
+        "",
+      ]);
+      expect(header(callFromScript(compileFunction(line1, [], { filename: "cf-header.js", lineOffset: 4 })))).toEqual([
+        "cf-header.js:5",
+        line1,
+        scriptCaret,
+        "",
+      ]);
+    });
   });
 });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -408,10 +408,13 @@ describe("vm", () => {
           stderr: "pipe",
           stdout: "pipe",
         });
-        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-        expect(exitCode).toBe(1);
-        // The source excerpt: line-numbered source lines followed by the caret line.
-        return stderr.split("\n").filter(line => /^\s*\d+ \| /.test(line) || /^\s*\^$/.test(line));
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return {
+          // The source excerpt: line-numbered source lines followed by the caret line.
+          excerpt: stderr.split("\n").filter(line => /^\s*\d+ \| /.test(line) || /^\s*\^$/.test(line)),
+          stdout,
+          exitCode,
+        };
       };
       const body = JSON.stringify('let ok = 1; throw new Error("boom")');
       const [fromScript, fromFunction, fromOffsetFunction] = await Promise.all([
@@ -422,10 +425,18 @@ describe("vm", () => {
         run(`require("node:vm").compileFunction(${body}, ["exports", "require"], { filename: "/virtual/cf.js" })()`),
         run(`require("node:vm").compileFunction(${body}, [], { filename: "/virtual/cf.js", lineOffset: 10 })()`),
       ]);
-      expect(fromScript).toEqual([`1 | ${JSON.parse(body)}`, expect.stringMatching(/^ +\^$/)]);
+      expect(fromScript).toEqual({
+        excerpt: [`1 | ${JSON.parse(body)}`, expect.stringMatching(/^ +\^$/)],
+        stdout: "",
+        exitCode: 1,
+      });
       expect(fromFunction).toEqual(fromScript);
       // A wider line number indents the caret one more column.
-      expect(fromOffsetFunction).toEqual([`11 | ${JSON.parse(body)}`, " " + fromScript[1]]);
+      expect(fromOffsetFunction).toEqual({
+        excerpt: [`11 | ${JSON.parse(body)}`, " " + fromScript.excerpt[1]],
+        stdout: "",
+        exitCode: 1,
+      });
     });
 
     test("runtime arrow header shows the body line when called from a vm script", () => {


### PR DESCRIPTION
### Problem
- Runtime positions inside a `vm.compileFunction()` function are one line too high unless `lineOffset` is at least 1. `vm.compileFunction('throw new Error("x")', [], { filename: "cf.js" })()` reports `cf.js:2`, Node reports `cf.js:1`. `lineOffset: 0` is the default, so this affects every caller that does not pass an offset. With `lineOffset: 5` both report line 6.
- Everything derived from those positions is off: `error.stack` frames, `Error.prepareStackTrace` call sites, frames of functions nested in the body, the source excerpt Bun prints for an uncaught error, and the `<file>:<line>` header node:vm prepends when such a function throws inside a vm script. Compile-time SyntaxErrors were already right (they come from a separate parse of the bare body).
- `columnOffset` was ignored entirely: it landed on the wrapper's line instead of the body's first line.
- Cause: `constructAnonymousFunction` (`src/jsc/bindings/NodeVM.cpp`) compiles `(function () {\n<body>\n})`, so the body is line 2 of what JSC parses, and compensates by starting the program one line early (`lineOffset - 1`). `JSC::SourceCode` clamps its first line to 1 (`vendor/WebKit/Source/JavaScriptCore/parser/SourceCode.h`, `std::max(firstLine, 1)`), so for `lineOffset <= 0` the compensation is discarded and the wrapper line is reported as part of the body.

### Fix
- `stringifyAnonymousFunction` now emits `(function (<params>) {<body>\n})`: the body starts on the wrapper's own line, so body line N is physical line N of the program and is reported as `lineOffset + N` for every `lineOffset`, with nothing to compensate. This is the only layout JSC can report correctly: a position is always `first line of the executable (>= 1) + line terminators before it`, so a body preceded by a newline can never report as line 1, and JSC has no line bias (`overrideLineNumber` pins one constant line for a whole function).
- The first line now contains wrapper text, which JSC counts in that line's columns and which Bun's source excerpts would otherwise show. `constructAnonymousFunction` records on the function's `NodeVMScriptFetcher`, keyed by the wrapper program's `SourceID`, the wrapper's length and the amount by which JSC's columns on that line exceed Node's (`columnOffset` is split: the part beyond the wrapper is given to JSC as the program's start column, since a start column cannot be negative; the recorded amount covers the rest). Keying by `SourceID` matters because `eval()` / `new Function()` inside the body inherit the fetcher through the `SourceOrigin` but contain no wrapper; for them, and for `vm.Script` sources, every query below returns 0 and nothing changes.
- The amount is subtracted in the two places Bun derives frame positions from JSC: `formatStackTrace` (the default `error.stack` text) and `getAdjustedPositionForBytecode` (call sites and the uncaught-error printer). The printer (`ZigException.cpp`) additionally skips the wrapper text when it excerpts the first line, and node:vm's own `handleException` header does the same, so the excerpt, the caret and the frame agree. Net effect: a statement on body line 1 reports exactly the column it reports on any other line, plus `columnOffset`, which is Node's rule; only JSC's usual choice of column within a statement still differs from V8's (the `(` of a call rather than `new`), as it does everywhere else in Bun.
- For every provider that is not a compileFunction program the new code is a null fetcher check per frame; ordinary modules are created with a fetcher-less `SourceOrigin`.
- Behavior changes that follow from the layout: `fn.toString()` is now `function () {<body>\n}` (was `function () {\n<body>\n}`, the text V8 synthesizes), and a body whose first line is an Annex B `-->` comment no longer compiles, since that comment form is only recognized at the start of a line. `cachedData` from earlier versions is rejected as with any change to the compiled text; produce/consume within one version still round-trips, including across different offsets.
- Not changed by this PR (raised in review): a body starting with `#!` was already rejected (any wrapper puts it past offset 0; #38245 fixes that separately), and negative `lineOffset` values are still clamped by JSC for runtime frames exactly as for `vm.Script` (compileFunction used to report N + 1 there and now reports N).
- The vendored `test/js/node/test/parallel/test-vm-basic.js` already carried Bun-gated expectations for these four frames (pinning the off-by-one line and the wrapper-free columns of the old layout); they are updated to the Node lines with the same columns as before, and the `toString()` assertion gets a gated expectation. The Node branches are untouched and the file still passes under Node v26.
- Verified with `test/js/node/vm/vm.test.ts`, six new `compileFunction()` tests: lines for `lineOffset` unset/0/1/7 with params and nested functions; call-site lines; first-line columns against the same statement on line 2 (plain, params, `columnOffset` 3 and 100, nested arrow); call-site columns; the uncaught-error excerpt compared with the excerpt `vm.Script` prints for the same text (spawned, also with `lineOffset`); and the vm header for line 1, params, `columnOffset`, line 2, `lineOffset`, and direct/indirect `eval` in the body, compared with the header `vm.Script` produces. All six fail on the released binary (line 2 instead of 1, offset dropped, excerpt and header labeled `:2`) and pass with the fix.
- Also ran on the debug build: the rest of `test/js/node/vm/`, all 95 `test/js/node/test/parallel/test-vm-*.js` plus the 3 sequential ones, the error-related `test-repl-*` tests, the stack-trace and error-printing suites touched by the generic changes (`inspect-error`, `reportError`, `bun/test/stack`, `v8/capture-stack-trace`, the stack-trace regression tests; the two `inspect-error` minified-file failures reproduce without this diff), and the compileFunction tests under `BUN_JSC_validateExceptionChecks=1`.
- Overlaps textually with #38228 (offset overflow clamp, which moves the `stringifyAnonymousFunction` call), #38245 (hashbang rewrite inside it), #38239 (body syntax errors; replaces the pre-parse above this diff and works in body offsets, using the same stringify out-param this PR uses as the wrapper length) and #38244 (rewrites the excerpt loop in `ZigException.cpp`; the wrapper skip becomes one clamp of the line start inside its `lineText`). All compose with this change; whichever lands later re-applies a few lines.

### Background
- `vm.compileFunction(body, params, options)` returns a function whose source is `body`; V8 compiles the body directly, so its positions are exact. Bun has no such JSC entry point and compiles a program containing one function expression that wraps the body, then returns that function. `lineOffset` / `columnOffset` say where the body sits in a larger file; Node adds `lineOffset` to every line and `columnOffset` to the first line's columns only.
- `JSC::SourceCode` is a range of a `SourceProvider` (the text) plus the one-based line and column the range starts at. A reported position is that line plus the line terminators before the position; on the first line the start column is added too. Nested functions derive their `SourceCode` from the enclosing one, so the layout fix is picked up by every consumer, while anything about the first line's columns has to be applied where positions are read out.
- Bun reads positions out of JSC in two places: `formatStackTrace` (`FormatStackTraceForJS.cpp`) builds the default `error.stack` text from `StackFrame::computeLineAndColumn()`, and `getAdjustedPositionForBytecode` (`ErrorStackFrame.cpp`) builds the `ZigStackFramePosition` used by `prepareStackTrace` call sites and by the uncaught-error printer, which also uses its byte offset to excerpt the source line (`ZigException.cpp`).
- `NodeVMScriptFetcher` is the per-compilation object node:vm attaches to a source's `SourceOrigin` (it already carries the dynamic import callback); every frame of the compiled program reaches it through its code block's provider. JSC copies the caller's `SourceOrigin` onto the sources it creates for `eval()` and `new Function()`, which is why the fetcher has to check the provider's `SourceID` (JSC's process-unique id per provider) before answering.
- node:vm's `handleException` implements Node's `DecorateErrorStack`: when an error escapes `runInContext` and friends it prepends `<url>:<line>`, the top frame's source line and a caret; the top frame can be a compileFunction function called by the script.

<details>
<summary>Before/after (node v26 for comparison)</summary>

```
body 'throw new Error("x")' on line 1, and on line 3 of a 3-line body; filename cf.js

                 before              after               node
lineOffset unset 2:16   line3 4:16   1:16   line3 3:16   1:7   line3 3:7
lineOffset 0     2:16   line3 4:16   1:16   line3 3:16   1:7   line3 3:7
lineOffset 1     2:16   line3 4:16   2:16   line3 4:16   2:7   line3 4:7
lineOffset 5     6:16   line3 8:16   6:16   line3 8:16   6:7   line3 8:7
params [a, b]    2:16                1:16                1:7
columnOffset 10, line 1   2:16       1:26                1:17
columnOffset 10, line 2   3:16       2:16                2:7

uncaught error, body line 1, default options:
  before:  2 | throw new Error("x")          (right text, wrong line)
  after:   1 | throw new Error("x")          (identical to the excerpt for a vm.Script of the same text)

vm header when called from a vm script, body line 1:
  before: cf.js:2 / throw new Error("x") / caret      after and node: cf.js:1 / throw new Error("x") / caret

16 vs 7 is JSC reporting the call's `(` where V8 reports `new`; it is the same on every line.
```

An earlier revision of this PR left the first line's columns including the wrapper text (reporting 1:30 above) and only corrected node:vm's own header; review of the printer output showed the wrapper text leaking into uncaught-error excerpts, which is what led to recording the column amount and applying it where positions are read out.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (5d4c0f54f)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [23.00ms]
(pass) vm > runInContext() > can return a value [16.06ms]
(pass) vm > runInContext() > can return a complex value [17.15ms]
(pass) vm > runInContext() > can return the last value [16.68ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.52ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.82ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.67ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.38ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [16.75ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [16.55ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [16.24ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [16.27ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 6 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.44ms]
(pass) vm > runInContext() > can return a value [0.25ms]
(pass) vm > runInContext() > can return a complex value [0.26ms]
(pass) vm > runInContext() > can return the last value [0.18ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.30ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (5d4c0f54f)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.61ms]
(pass) vm > runInContext() > can return a value [16.34ms]
(pass) vm > runInContext() > can return a complex value [17.83ms]
(pass) vm > runInContext() > can return the last value [15.54ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [18.00ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.96ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.57ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.43ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.90ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [19.80ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [24.07ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [24.28ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5d4c0f54f5
  features     baseline

22 deps, 123 codegen, 1176 objects in 753ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [4.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [8.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch zlib
[zlib] up to date
[6/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[7/1238] gen .bind.ts → GeneratedBindings.cpp
[8/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1238] fetch tinycc
[tinycc] up to date
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorStackFrame.cpp        |   6 +
 src/jsc/bindings/FormatStackTraceForJS.cpp  |   8 +
 src/jsc/bindings/NodeVM.cpp                 |  59 ++++---
 src/jsc/bindings/NodeVMScriptFetcher.h      |  42 +++++
 src/jsc/bindings/ZigException.cpp           |  10 +-
 test/js/node/test/parallel/test-vm-basic.js |  21 ++-
 test/js/node/vm/vm.test.ts                  | 237 ++++++++++++++++++++++++++++
 7 files changed, 348 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/ErrorStackFrame.cpp             1      3      0
src/jsc/bindings/FormatStackTraceForJS.cpp       1      4      0
src/jsc/bindings/NodeVM.cpp                     20     25      0
src/jsc/bindings/NodeVMScriptFetcher.h           5     15      0
src/jsc/bindings/ZigException.cpp                2      3      0
test/js/node/test/parallel/test-vm-basic.js      3      6      0
test/js/node/vm/vm.test.ts                       6      6      0
```

</details>

<!-- robobun:evidence:end -->