### PR TITLE
bake: exit a successful bun build --app through the build VM

### DIFF
--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -112,11 +112,13 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // SAFETY: `init_bake` returns a freshly-allocated VM owned by this thread;
     // unique access for the rest of this function.
     let vm = unsafe { &mut *vm_ptr };
-    // defer vm.deinit() — handled by `vm.destroy()` on the unwind path below.
+    // Runs only on the `Err` return below (a bundler or I/O failure). Every
+    // other way out of this function exits the process, and the normal one,
+    // `global_exit()` at the end, tears the VM down itself.
     // Note: pass `vm_ptr` by value into the guard so the drop closure does
     // not borrow the local (`defer!` would capture `&vm_ptr`, which under
     // edition-2024 disjoint-capture rules collides with the `&mut *vm_ptr`
-    // re-borrows on the JSError path).
+    // re-borrows below).
     let _vm_guard = scopeguard::guard(vm_ptr, |p| {
         // SAFETY: p is the unique live VM on this thread; its loop is alive, so
         // queued work is released here rather than by a thread teardown.
@@ -211,28 +213,32 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // LIFO order — under the API lock, before the VM is destroyed.
     let mut pt = PerThread::placeholder(vm_ptr);
 
-    match build_with_vm(ctx, &cwd, &mut pt) {
+    let result = build_with_vm(ctx, &cwd, &mut pt);
+    // SAFETY: the reborrows `build_with_vm` made through `pt.vm` died when it
+    // returned, so this frame has exclusive access again; the VM stays
+    // allocated until `global_exit` (or `_vm_guard`) destroys it.
+    let vm = unsafe { &mut *vm_ptr };
+    match result {
         Ok(()) => {}
         Err(crate::Error::JSError) => {
-            // SAFETY: vm.global is live for VM lifetime.
-            let global = unsafe { &*(*vm_ptr).global };
-            let err_value = global.take_exception(jsc::JsError::Thrown);
-            // SAFETY: see above.
-            unsafe {
-                (*vm_ptr)
-                    .print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value))
-            };
-            // SAFETY: see above.
-            let vm = unsafe { &mut *vm_ptr };
+            let err_value = vm.global().take_exception(jsc::JsError::Thrown);
+            vm.print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value));
             if vm.exit_handler.exit_code == 0 {
                 vm.exit_handler.exit_code = 1;
             }
-            vm.on_exit();
-            vm.global_exit();
         }
         Err(e) => return Err(e),
     }
-    Ok(())
+
+    // A rendered build exits the same way a failed one does: `on_exit` runs the
+    // `process.on("exit")` handlers the config and prerender registered, and
+    // `global_exit` exits with `process.exitCode`, tearing the VM down first
+    // under BUN_DESTRUCT_VM_ON_EXIT. Returning `Ok` instead would free only the
+    // Rust side of the VM (`_vm_guard`); the JSC heap would never be destroyed,
+    // so the natives still owned by the prerender's JS objects (timers, blobs,
+    // decoders, ...) would never be freed.
+    vm.on_exit();
+    vm.global_exit()
 }
 
 /// Ported inline from `bun.bun_js.failWithBuildError` to avoid the

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -112,9 +112,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // SAFETY: `init_bake` returns a freshly-allocated VM owned by this thread;
     // unique access for the rest of this function.
     let vm = unsafe { &mut *vm_ptr };
-    // Runs only on the `Err` return below (a bundler or I/O failure). Every
-    // other way out of this function exits the process, and the normal one,
-    // `global_exit()` at the end, tears the VM down itself.
+    // Only the `Err` return below reaches this; the other exits are process exits.
     // Note: pass `vm_ptr` by value into the guard so the drop closure does
     // not borrow the local (`defer!` would capture `&vm_ptr`, which under
     // edition-2024 disjoint-capture rules collides with the `&mut *vm_ptr`
@@ -214,9 +212,8 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     let mut pt = PerThread::placeholder(vm_ptr);
 
     let result = build_with_vm(ctx, &cwd, &mut pt);
-    // SAFETY: the reborrows `build_with_vm` made through `pt.vm` died when it
-    // returned, so this frame has exclusive access again; the VM stays
-    // allocated until `global_exit` (or `_vm_guard`) destroys it.
+    // SAFETY: `build_with_vm` has returned, so its reborrows through `pt.vm` are
+    // dead; the VM is live until `global_exit` (or `_vm_guard`) destroys it.
     let vm = unsafe { &mut *vm_ptr };
     match result {
         Ok(()) => {}
@@ -230,13 +227,9 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         Err(e) => return Err(e),
     }
 
-    // A rendered build exits the same way a failed one does: `on_exit` runs the
-    // `process.on("exit")` handlers the config and prerender registered, and
-    // `global_exit` exits with `process.exitCode`, tearing the VM down first
-    // under BUN_DESTRUCT_VM_ON_EXIT. Returning `Ok` instead would free only the
-    // Rust side of the VM (`_vm_guard`); the JSC heap would never be destroyed,
-    // so the natives still owned by the prerender's JS objects (timers, blobs,
-    // decoders, ...) would never be freed.
+    // Success exits through the VM as well: this runs the 'exit' handlers, applies
+    // process.exitCode and, under BUN_DESTRUCT_VM_ON_EXIT, destroys the JSC heap
+    // that owns the prerender's timers, blobs, ...; `_vm_guard` frees only the Rust side.
     vm.on_exit();
     vm.global_exit()
 }

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -227,9 +227,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         Err(e) => return Err(e),
     }
 
-    // Success exits through the VM as well: this runs the 'exit' handlers, applies
-    // process.exitCode and, under BUN_DESTRUCT_VM_ON_EXIT, destroys the JSC heap
-    // that owns the prerender's timers, blobs, ...; `_vm_guard` frees only the Rust side.
+    // Success must exit through the VM too: 'exit' handlers, process.exitCode, VM teardown.
     vm.on_exit();
     vm.global_exit()
 }

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import path from "path";
-import { tempDirWithBakeDeps } from "../bake-harness";
+import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
 
 const normalizePath = (path: string) => (process.platform === "win32" ? path.replaceAll("\\", "/") : path);
 const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", "\\") : path);
@@ -594,4 +594,99 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  // A build that succeeds has to leave through the build VM's exit sequence
+  // (`on_exit` + `global_exit`), like a build that throws already does: that is
+  // what runs the 'exit' handlers, applies process.exitCode and, under
+  // BUN_DESTRUCT_VM_ON_EXIT, destroys the JSC heap. Before, it returned and
+  // exited the process directly, skipping all three.
+  const onExitConfig = `
+    process.on("exit", code => console.log("exit event: " + code));
+    export default { app: { framework: "react" } };
+  `;
+
+  test.concurrent(
+    "rendered build runs 'exit' handlers and exits with process.exitCode",
+    async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-exit-rendered", {
+        "app.ts": onExitConfig,
+        "pages/index.tsx": `
+          process.exitCode = 3;
+          export default function IndexPage() {
+            return <div>Hello World</div>;
+          }
+        `,
+      });
+
+      const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
+        .cwd(dir)
+        .env(bunEnv)
+        .quiet()
+        .throws(false);
+
+      expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
+      expect(stdout.toString()).toBe("done\nexit event: 3\n");
+      expect(exitCode).toBe(3);
+    },
+    30_000 * WAIT_MULTIPLIER,
+  );
+
+  test.concurrent(
+    "build with nothing to render runs 'exit' handlers",
+    async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-exit-no-routes", {
+        "app.ts": onExitConfig,
+      });
+
+      const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
+        .cwd(dir)
+        .env(bunEnv)
+        .quiet()
+        .throws(false);
+
+      expect(stdout.toString()).toBe("done\nexit event: 0\n");
+      expect(exitCode).toBe(0);
+    },
+    30_000 * WAIT_MULTIPLIER,
+  );
+
+  // The natives behind these wrappers are freed by the wrappers' finalizers, so
+  // they stay allocated until the VM is destroyed; LSan sees them as leaked when
+  // the build exits without destroying it. This checks the report's contents
+  // rather than requiring it to be empty because the build's own transpilers
+  // are still leaked (separate fix), which keeps this file in
+  // test/no-validate-leaksan.txt for now.
+  test.concurrent.skipIf(!isASAN)(
+    "rendered build destroys its VM under BUN_DESTRUCT_VM_ON_EXIT",
+    async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-exit-teardown", {
+        "app.ts": `export default { app: { framework: "react" } };`,
+        "pages/index.tsx": `
+          globalThis.keepUntilExit = [new TextDecoder(), new Blob(["prerender"]), setImmediate(() => {})];
+          export default function IndexPage() {
+            return <div>Hello World</div>;
+          }
+        `,
+      });
+
+      const { stdout, stderr } = await Bun.$`${bunExe()} build --app ./app.ts`
+        .cwd(dir)
+        .env({
+          ...bunEnv,
+          BUN_DESTRUCT_VM_ON_EXIT: "1",
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../leaksan.supp")}`,
+        })
+        .quiet()
+        .throws(false);
+
+      expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
+      expect(stdout.toString()).toBe("done\n");
+      const leaked = ["TextDecoder", "Blob", "ImmediateObject"].filter(type => stderr.toString().includes(type));
+      expect(leaked).toEqual([]);
+    },
+    // LSan symbolizes every reported stack through llvm-symbolizer, which is
+    // slow against a debug binary.
+    60_000 * WAIT_MULTIPLIER,
+  );
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -601,6 +601,12 @@ export default function IndexPage() {
   // BUN_DESTRUCT_VM_ON_EXIT, destroys the JSC heap. Before, it returned and
   // exited the process directly, skipping all three.
   describe.concurrent("exits through the build VM", () => {
+    // With BUN_DESTRUCT_VM_ON_EXIT set, global_exit tears the VM down before the
+    // process exits, so the exit codes asserted below also show that a build
+    // VM's teardown completes on every platform, not only on the ASAN lane that
+    // looks at what it frees.
+    const env = { ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" };
+
     const onExitConfig = `
       process.on("exit", code => console.log("exit event: " + code));
       export default { app: { framework: "react" } };
@@ -626,7 +632,7 @@ export default function IndexPage() {
 
         const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
           .cwd(dir)
-          .env(bunEnv)
+          .env(env)
           .quiet()
           .throws(false);
 
@@ -646,7 +652,7 @@ export default function IndexPage() {
 
         const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
           .cwd(dir)
-          .env(bunEnv)
+          .env(env)
           .quiet()
           .throws(false);
 
@@ -656,20 +662,28 @@ export default function IndexPage() {
       timeout,
     );
 
-    // The natives behind these wrappers are freed by the wrappers' finalizers,
-    // so they stay allocated until the VM is destroyed, and LSan reports them
-    // when the build exits without destroying it. This checks the report's
-    // contents instead of requiring an empty report because the build's own
-    // transpilers are still leaked (#38233), which is also what keeps this file
-    // in test/no-validate-leaksan.txt.
+    // The natives behind these objects are released by their wrappers'
+    // finalizers, so a build that exits without destroying its VM leaves all of
+    // them for LeakSanitizer to report. The page creates them while it renders:
+    // bun-framework-react's own prerender creates the first three kinds the same
+    // way (that is how the bug was found), and leaksan.supp would hide the same
+    // objects if they were created while the module is evaluated. The report
+    // cannot be required to be empty yet because the build's transpilers still
+    // leak (#38233), which is also what keeps this file in
+    // test/no-validate-leaksan.txt.
     test.skipIf(!isASAN)(
-      "a rendered build destroys its VM under BUN_DESTRUCT_VM_ON_EXIT",
+      "a rendered build frees the natives its JS objects own",
       async () => {
         const dir = await tempDirWithBakeDeps("bake-production-exit-teardown", {
           "app.ts": `export default { app: { framework: "react" } };`,
           "pages/index.tsx": `
-            globalThis.keepUntilExit = [new TextDecoder(), new Blob(["prerender"]), setImmediate(() => {})];
             export default function IndexPage() {
+              globalThis.keepUntilExit = [
+                new TextDecoder(),
+                new Blob(["prerender"]),
+                setImmediate(() => {}),
+                new Bun.CryptoHasher("sha256"),
+              ];
               return <div>Hello World</div>;
             }
           `,
@@ -678,8 +692,7 @@ export default function IndexPage() {
         const { stdout, stderr } = await Bun.$`${bunExe()} build --app ./app.ts`
           .cwd(dir)
           .env({
-            ...bunEnv,
-            BUN_DESTRUCT_VM_ON_EXIT: "1",
+            ...env,
             ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
             LSAN_OPTIONS: [
               bunEnv.LSAN_OPTIONS,
@@ -693,7 +706,9 @@ export default function IndexPage() {
 
         expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
         expect(stdout.toString()).toBe("done\n");
-        const leaked = ["TextDecoder", "Blob", "ImmediateObject"].filter(type => stderr.toString().includes(type));
+        const leaked = ["TextDecoder", "Blob", "ImmediateObject", "CryptoHasher"].filter(type =>
+          stderr.toString().includes(type),
+        );
         expect(leaked).toEqual([]);
       },
       timeout,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -681,7 +681,12 @@ export default function IndexPage() {
             ...bunEnv,
             BUN_DESTRUCT_VM_ON_EXIT: "1",
             ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-            LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../leaksan.supp")}`,
+            LSAN_OPTIONS: [
+              bunEnv.LSAN_OPTIONS,
+              `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../leaksan.supp")}`,
+            ]
+              .filter(Boolean)
+              .join(":"),
           })
           .quiet()
           .throws(false);

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -600,93 +600,98 @@ export default function IndexPage() {
   // what runs the 'exit' handlers, applies process.exitCode and, under
   // BUN_DESTRUCT_VM_ON_EXIT, destroys the JSC heap. Before, it returned and
   // exited the process directly, skipping all three.
-  const onExitConfig = `
-    process.on("exit", code => console.log("exit event: " + code));
-    export default { app: { framework: "react" } };
-  `;
+  describe.concurrent("exits through the build VM", () => {
+    const onExitConfig = `
+      process.on("exit", code => console.log("exit event: " + code));
+      export default { app: { framework: "react" } };
+    `;
 
-  test.concurrent(
-    "rendered build runs 'exit' handlers and exits with process.exitCode",
-    async () => {
-      const dir = await tempDirWithBakeDeps("bake-production-exit-rendered", {
-        "app.ts": onExitConfig,
-        "pages/index.tsx": `
-          process.exitCode = 3;
-          export default function IndexPage() {
-            return <div>Hello World</div>;
-          }
-        `,
-      });
+    // Each case is a full react build on a debug (and ASAN) binary, and the
+    // LSan case also symbolizes its report, which the default timeout does not
+    // cover; WAIT_MULTIPLIER is how the bake harness budgets production builds.
+    const timeout = 30_000 * WAIT_MULTIPLIER;
 
-      const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
-        .cwd(dir)
-        .env(bunEnv)
-        .quiet()
-        .throws(false);
+    test(
+      "a rendered build runs 'exit' handlers and exits with process.exitCode",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-exit-rendered", {
+          "app.ts": onExitConfig,
+          "pages/index.tsx": `
+            process.exitCode = 3;
+            export default function IndexPage() {
+              return <div>Hello World</div>;
+            }
+          `,
+        });
 
-      expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
-      expect(stdout.toString()).toBe("done\nexit event: 3\n");
-      expect(exitCode).toBe(3);
-    },
-    30_000 * WAIT_MULTIPLIER,
-  );
+        const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
+          .cwd(dir)
+          .env(bunEnv)
+          .quiet()
+          .throws(false);
 
-  test.concurrent(
-    "build with nothing to render runs 'exit' handlers",
-    async () => {
-      const dir = await tempDirWithBakeDeps("bake-production-exit-no-routes", {
-        "app.ts": onExitConfig,
-      });
+        expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
+        expect(stdout.toString()).toBe("done\nexit event: 3\n");
+        expect(exitCode).toBe(3);
+      },
+      timeout,
+    );
 
-      const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
-        .cwd(dir)
-        .env(bunEnv)
-        .quiet()
-        .throws(false);
+    test(
+      "a build with nothing to render runs 'exit' handlers",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-exit-no-routes", {
+          "app.ts": onExitConfig,
+        });
 
-      expect(stdout.toString()).toBe("done\nexit event: 0\n");
-      expect(exitCode).toBe(0);
-    },
-    30_000 * WAIT_MULTIPLIER,
-  );
+        const { stdout, exitCode } = await Bun.$`${bunExe()} build --app ./app.ts`
+          .cwd(dir)
+          .env(bunEnv)
+          .quiet()
+          .throws(false);
 
-  // The natives behind these wrappers are freed by the wrappers' finalizers, so
-  // they stay allocated until the VM is destroyed; LSan sees them as leaked when
-  // the build exits without destroying it. This checks the report's contents
-  // rather than requiring it to be empty because the build's own transpilers
-  // are still leaked (separate fix), which keeps this file in
-  // test/no-validate-leaksan.txt for now.
-  test.concurrent.skipIf(!isASAN)(
-    "rendered build destroys its VM under BUN_DESTRUCT_VM_ON_EXIT",
-    async () => {
-      const dir = await tempDirWithBakeDeps("bake-production-exit-teardown", {
-        "app.ts": `export default { app: { framework: "react" } };`,
-        "pages/index.tsx": `
-          globalThis.keepUntilExit = [new TextDecoder(), new Blob(["prerender"]), setImmediate(() => {})];
-          export default function IndexPage() {
-            return <div>Hello World</div>;
-          }
-        `,
-      });
+        expect(stdout.toString()).toBe("done\nexit event: 0\n");
+        expect(exitCode).toBe(0);
+      },
+      timeout,
+    );
 
-      const { stdout, stderr } = await Bun.$`${bunExe()} build --app ./app.ts`
-        .cwd(dir)
-        .env({
-          ...bunEnv,
-          BUN_DESTRUCT_VM_ON_EXIT: "1",
-          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-          LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../leaksan.supp")}`,
-        })
-        .quiet()
-        .throws(false);
+    // The natives behind these wrappers are freed by the wrappers' finalizers,
+    // so they stay allocated until the VM is destroyed, and LSan reports them
+    // when the build exits without destroying it. This checks the report's
+    // contents instead of requiring an empty report because the build's own
+    // transpilers are still leaked (#38233), which is also what keeps this file
+    // in test/no-validate-leaksan.txt.
+    test.skipIf(!isASAN)(
+      "a rendered build destroys its VM under BUN_DESTRUCT_VM_ON_EXIT",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-exit-teardown", {
+          "app.ts": `export default { app: { framework: "react" } };`,
+          "pages/index.tsx": `
+            globalThis.keepUntilExit = [new TextDecoder(), new Blob(["prerender"]), setImmediate(() => {})];
+            export default function IndexPage() {
+              return <div>Hello World</div>;
+            }
+          `,
+        });
 
-      expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
-      expect(stdout.toString()).toBe("done\n");
-      const leaked = ["TextDecoder", "Blob", "ImmediateObject"].filter(type => stderr.toString().includes(type));
-      expect(leaked).toEqual([]);
-    },
-    // LSan symbolizes every reported stack through llvm-symbolizer, which is
-    // slow against a debug binary.
-    60_000 * WAIT_MULTIPLIER,
-  );
+        const { stdout, stderr } = await Bun.$`${bunExe()} build --app ./app.ts`
+          .cwd(dir)
+          .env({
+            ...bunEnv,
+            BUN_DESTRUCT_VM_ON_EXIT: "1",
+            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+            LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../leaksan.supp")}`,
+          })
+          .quiet()
+          .throws(false);
+
+        expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("Hello World");
+        expect(stdout.toString()).toBe("done\n");
+        const leaked = ["TextDecoder", "Blob", "ImmediateObject"].filter(type => stderr.toString().includes(type));
+        expect(leaked).toEqual([]);
+      },
+      timeout,
+    );
+  });
 });

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -337,7 +337,10 @@ test/napi/node-napi-tests/test/js-native-api/6_object_wrap/do.test.ts
 # LSAN per-spawn adds no coverage and slows the file significantly.
 test/napi/uv_stub.test.ts
 
+# `bun build --app` still leaks its transpilers (#38233) and, with "use client"
+# components, a ServerComponentParseTask (#38004); remove once both have landed.
 test/bake/dev/production.test.ts
+
 test/js/third_party/pg-gateway/pglite.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
 


### PR DESCRIPTION
### Problem
- A `bun build --app` that renders successfully exits without going through its build VM's exit sequence. Three things are skipped as a result:
  - `process.on("exit")` handlers registered by the app config or by the prerendered modules never run.
  - `process.exitCode` set during prerendering is ignored; the process always exits 0.
  - Under `BUN_DESTRUCT_VM_ON_EXIT=1` (what the ASAN CI lane runs tests with), the JSC VM is never destroyed, so every native object still owned by a JS wrapper created during prerendering is never freed. For a react app with one page, LeakSanitizer reports 10 allocations: 2x `ImmediateObject` (`bun_runtime::timer::All::set_immediate`, react's scheduler), 2x `Blob` (`bun_jsc::webcore_types::Blob::new`) and 2x `TextDecoder` (`TextDecoder::new`), plus their indirect buffers.
- Cause: `build_command` in `src/runtime/bake/production.rs` only called `vm.on_exit()` and `vm.global_exit()` in the `Err(JSError)` arm of the `build_with_vm` match. The `Ok` arm returned, the scopeguard created at the top of the function ran `release_queued_work()` + `destroy()` (the Rust side of the VM only), and `main` then called `Global::exit(0)`. A build whose page throws takes the other arm and is clean under LeakSanitizer with the same environment; only the two success returns (a rendered build, and the early return when there is nothing to bundle) were affected. bake's production build is the only main-thread VM in bun that exited this way.

### Fix
- `build_command` runs `vm.on_exit()` + `vm.global_exit()` after the match, for both the `Ok` and the `JSError` arm. The `JSError` arm now only prints the exception and sets the exit code to 1 if nothing set one.
- The `Err(e)` return (a `BuildFailed` from the bundler or an I/O error) is deliberately left as it was: it still returns through the scopeguard, because `Cli::start` is what prints the accumulated bundler log for it before exiting. It is now the scopeguard's only user.
- Why this is the right exit: `on_exit` + `global_exit` is the exit sequence every other main thread VM in bun uses (`bun run`, `bun test`, the repl), and the one the failing arm of this very function already used. `global_exit` exits with `exit_handler.exit_code`, which is where `process.exitCode` is stored, and under `BUN_DESTRUCT_VM_ON_EXIT` runs `VirtualMachine::teardown`, the only sequence that destroys the JSC heap and so runs the wrapper finalizers that own these natives. Nothing in the build needs the VM after `build_with_vm` returns: its last step is `wait_for_tasks()`, so the event loop is already drained when the exit handlers run.
- Without `BUN_DESTRUCT_VM_ON_EXIT` the VM is now left allocated at exit instead of `destroy()`ed, exactly as `bun run` leaves its VM. It stays reachable from the thread local and the stack, so LeakSanitizer does not report it: after this change the no-pages build reports the same 2870 allocations with and without the variable, all of them the transpiler allocations that #38233 fixes.
- Cost on a normal build: the exit event dispatch and the sqlite close that `global_exit` does; from the `done` line to process exit takes about 50ms on a debug build, and that interval includes the process exit itself.
- Verified with `test/bake/dev/production.test.ts`, three new cases in one `describe`, all run with `BUN_DESTRUCT_VM_ON_EXIT=1` so the exit codes also show that a build VM's teardown completes on every platform CI runs this file on:
  - a rendered build whose config registers an `exit` handler and whose page sets `process.exitCode = 3` prints `exit event: 3` and exits 3 (before: no event, exit 0);
  - a build with no pages directory (the early return) prints `exit event: 0` and exits 0 (before: no event);
  - ASAN only: the page component creates a `TextDecoder`, a `Blob`, a `setImmediate` handle and a `Bun.CryptoHasher` while it renders and parks them on `globalThis`; the build runs with `detect_leaks=1` and the LeakSanitizer output must not name any of the four types. Before the fix it names all four (`CryptoHasher` is there to show the planted objects are what is measured, since the framework never creates one; the other three are the kinds the framework itself leaked). They are created during render rather than at module scope because `test/leaksan.supp` suppresses anything allocated while a module is being evaluated. The test checks the report's contents rather than requiring an empty report because the build's transpilers still leak at this commit (#38233).
  - Verified in both directions on a debug ASAN build: with `src/runtime/bake/production.rs` at main's version all three fail as described; with it at this branch all three pass, and so does the rest of the file, including the throwing-component case that exercises the restructured `JSError` arm.
  - With #38233 merged in locally, the rendered build, the no-pages build and the throwing build are all completely clean under LeakSanitizer with `BUN_DESTRUCT_VM_ON_EXIT=1`. The only report left in this test file's scenarios is the `ServerComponentParseTask` allocation from builds with `"use client"` components, which #38004 fixes. `test/no-validate-leaksan.txt` now says so next to this file's entry; whichever of the three PRs lands last can remove the entry.
  - `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.
- Overlaps textually with #38233 only in `production.test.ts` (both append tests to the same file); the `production.rs` changes merge cleanly.

### Background
- `bun build --app` (bake's static production build, `src/runtime/bake/production.rs`) creates a dedicated `VirtualMachine` (`init_bake`) to evaluate the app config and to prerender the routes in; `build_command` owns that VM and `build_with_vm` does the work.
- `VirtualMachine::on_exit` emits `process`'s `exit` event and runs the VM's cleanup hooks; `global_exit` then terminates the process with `exit_handler.exit_code` (the field behind `process.exitCode`). When `BUN_DESTRUCT_VM_ON_EXIT=1` is set, `global_exit` first runs `VirtualMachine::teardown`, the ordered shutdown that cancels timers, destroys the JSC VM (running every remaining wrapper finalizer) and finally calls `destroy()`. Without the variable the main thread skips the teardown and lets the OS reclaim memory; CI's ASAN lane sets it so that LeakSanitizer can tell real leaks from objects that were simply alive at exit.
- `VirtualMachine::destroy()` frees only the Rust-owned parts of a VM (event loops, RareData, runtime state). Natives created through JS constructors (`new Blob()`, `new TextDecoder()`, `setImmediate()`, `new Bun.CryptoHasher()`) are owned by their JSC wrapper cells and are released by the cells' finalizers, so they are freed only when the JSC heap is destroyed.
- LeakSanitizer reports allocations that are unreachable at process exit. Memory still referenced from a live stack frame or a thread local is not reported; memory referenced only from JSC heap cells is, because the JSC heap is not malloc memory that LeakSanitizer scans. `test/leaksan.supp` additionally hides any leak whose stack contains one of the listed frames, which is why the test's objects have to be created during render and not during module evaluation.
