### PR TITLE
websocket: fire close on terminate() of a wss:// socket with a dead peer

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -217,12 +217,8 @@ impl<const SSL: bool> WebSocket<SSL> {
         let had_tunnel = this.proxy_tunnel.get().is_some();
         this.clear_data();
 
-        if SSL {
-            // we still want to send pending SSL buffer + close_notify
-            this.tcp.get().close(uws::CloseKind::Normal);
-        } else {
-            this.tcp.get().close(uws::CloseKind::Failure);
-        }
+        // Failure still sends close_notify best-effort but never waits for the peer's reply.
+        this.tcp.get().close(uws::CloseKind::Failure);
 
         // In tunnel mode tcp is .detached so close() above is a no-op and
         // handle_close() never fires. Mirror what handle_close() does for
@@ -1741,12 +1737,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
 
         if !this.tcp.get().is_closed() {
-            // no need to be .failure we still wanna to send pending SSL buffer + close_notify
-            if SSL {
-                this.tcp.get().close(uws::CloseKind::Normal);
-            } else {
-                this.tcp.get().close(uws::CloseKind::Failure);
-            }
+            this.tcp.get().close(uws::CloseKind::Failure);
         }
     }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -651,12 +651,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             // `connect_group`; single-threaded (JS thread), no other `&mut`
             // to it is live.
             .is_some_and(|ext| unsafe { (*ext).take().is_some() });
-        // no need to be .failure we still wanna to send pending SSL buffer + close_notify
-        if SSL {
-            tcp.close(uws::CloseCode::Normal);
-        } else {
-            tcp.close(uws::CloseCode::Failure);
-        }
+        tcp.close(uws::CloseCode::Failure);
         if had_socket_ref {
             // SAFETY: short-lived `&mut` for the field detach.
             unsafe { (*this.as_ptr()).tcp.detach() };

--- a/test/js/web/websocket/websocket-frozen-server-fixture.ts
+++ b/test/js/web/websocket/websocket-frozen-server-fixture.ts
@@ -1,0 +1,22 @@
+// Worker hosting a wss:// server that freezes its event loop on the first message: TCP still ACKs, but close_notify is never answered.
+import { tls } from "harness";
+
+declare const self: Worker;
+
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  tls,
+  fetch(req, server) {
+    if (server.upgrade(req)) return;
+    return new Response("expected websocket", { status: 400 });
+  },
+  websocket: {
+    message() {
+      self.postMessage("frozen");
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+    },
+  },
+});
+
+self.postMessage(server.port);

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -1154,13 +1154,15 @@ describe("WebSocket message handler re-entrancy during a multi-frame read", () =
 it("terminate() on a wss:// socket whose peer never answers close_notify still fires close", async () => {
   const worker = new Worker(join(import.meta.dir, "websocket-frozen-server-fixture.ts"));
   try {
-    const port = await new Promise(resolve => (worker.onmessage = e => resolve(e.data)));
+    const workerFailed = new Promise((_, reject) => (worker.onerror = e => reject(e.error ?? new Error(e.message))));
+    const port = await Promise.race([workerFailed, new Promise(resolve => (worker.onmessage = e => resolve(e.data)))]);
     const frozen = new Promise(resolve => (worker.onmessage = e => resolve(e.data)));
-    const ws = new WebSocket(`wss://localhost:${port}`, { tls: { rejectUnauthorized: false } });
+    const ws = new WebSocket(`wss://127.0.0.1:${port}`, { tls: { rejectUnauthorized: false } });
+    const errored = new Promise((_, reject) => (ws.onerror = e => reject(e.error ?? new Error(e.message))));
     const closed = new Promise(resolve => (ws.onclose = e => resolve(e.code)));
-    await new Promise(resolve => (ws.onopen = resolve));
+    await Promise.race([errored, new Promise(resolve => (ws.onopen = resolve))]);
     ws.send("freeze");
-    expect(await frozen).toBe("frozen");
+    expect(await Promise.race([workerFailed, frozen])).toBe("frozen");
 
     ws.terminate();
     expect(ws.readyState).toBe(WebSocket.CLOSING);

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -1149,3 +1149,24 @@ describe("WebSocket message handler re-entrancy during a multi-frame read", () =
     expect(close).toEqual({ code: 1006, wasClean: false });
   });
 });
+
+// https://github.com/oven-sh/bun/issues/38188
+it("terminate() on a wss:// socket whose peer never answers close_notify still fires close", async () => {
+  const worker = new Worker(join(import.meta.dir, "websocket-frozen-server-fixture.ts"));
+  try {
+    const port = await new Promise(resolve => (worker.onmessage = e => resolve(e.data)));
+    const frozen = new Promise(resolve => (worker.onmessage = e => resolve(e.data)));
+    const ws = new WebSocket(`wss://localhost:${port}`, { tls: { rejectUnauthorized: false } });
+    const closed = new Promise(resolve => (ws.onclose = e => resolve(e.code)));
+    await new Promise(resolve => (ws.onopen = resolve));
+    ws.send("freeze");
+    expect(await frozen).toBe("frozen");
+
+    ws.terminate();
+    expect(ws.readyState).toBe(WebSocket.CLOSING);
+    expect(await closed).toBe(1006);
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+  } finally {
+    worker.terminate();
+  }
+});


### PR DESCRIPTION
### What does this PR do?

`ws.terminate()` on a `wss://` connection whose peer has stopped responding (black-holed network path) left the socket in `CLOSING` forever and never fired `close`; plain `ws://` closed immediately. The TLS branch of the client's `cancel()`/`finalize()` closed the socket with the graceful close code, which uSockets implements as "send close_notify and defer the fd close until the peer's close_notify arrives" — on a dead path that reply never comes. These are abortive paths (`terminate()`, protocol failure, GC), and `clear_data()` has already discarded the send buffers before the close, so there is nothing to wait for; they now use the abortive close code on TLS too, matching the plain-TCP path. The same change is applied to the upgrade client's `cancel()` (close during CONNECTING), where JS already got its close event but the fd lingered.

The graceful `ws.close()` path is unchanged: it still drains the Close frame via `close_dispatch_pending` before tearing down.

Fixes #38188

### How did you verify your code works?

Added a test: a `wss://` server in a Worker blocks its event loop after the first message (TCP still ACKs, nothing answers close_notify), then the client calls `terminate()` and the test awaits `close` (1006). Times out on the current release/canary, passes in ~0.7s with this change (`bun bd test test/js/web/websocket/websocket.test.js -t close_notify`). Also reproduced the original report locally with a standalone script against system Bun before the fix.