### PR TITLE
error printer: fix the code frame lines above errors thrown from vm/eval sources

### DIFF
--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -161,22 +161,36 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         return;
 
     if (source_lines_count > 1 && source_lines != nullptr && sourceString.is8Bit()) {
-        // Search for the beginning of the line
-        unsigned int lineStart = location.byte_position;
-        while (lineStart > 0 && sourceString[lineStart] != '\n') {
-            lineStart--;
-        }
+        const std::span<const Latin1Character> bytes = sourceString.span8();
+        const unsigned length = sourceString.length();
 
-        // Search for the end of the line
-        unsigned int lineEnd = location.byte_position;
-        unsigned int maxSearch = sourceString.length();
-        while (lineEnd < maxSearch && sourceString[lineEnd] != '\n') {
+        // The divot of an expression may be its end offset: one past its last character, which
+        // for the last expression in the source is `length`, and otherwise is often the '\n'
+        // terminating its line. Both belong to the line the expression is on.
+        const unsigned divot = std::min(static_cast<unsigned>(std::max(location.byte_position, 0)), length);
+
+        // Offset of the first character of the line whose terminating '\n' (or end of source) is at `end`.
+        auto startOfLineEndingAt = [&](unsigned end) -> unsigned {
+            unsigned start = end;
+            while (start > 0 && bytes[start - 1] != '\n') {
+                start--;
+            }
+            return start;
+        };
+
+        // The line's text without its terminator ("\r\n" included).
+        auto lineText = [&](unsigned start, unsigned end) -> BunString {
+            if (end > start && bytes[end - 1] == '\r') {
+                end--;
+            }
+            return Bun::toStringView(sourceString.substring(start, end - start));
+        };
+
+        unsigned lineEnd = divot;
+        while (lineEnd < length && bytes[lineEnd] != '\n') {
             lineEnd++;
         }
-
-        const unsigned char* bytes = sourceString.span8().data();
-
-        // Most of the time, when you look at a stack trace, you want a couple lines above.
+        unsigned lineStart = startOfLineEndingAt(lineEnd);
 
         // It is key to not clone this data because source code strings are large.
         // Usage of toStringView (non-owning) is safe as we ref the provider.
@@ -185,41 +199,18 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
             (*referenced_source_provider)->deref();
         }
         *referenced_source_provider = provider;
-        source_lines[0] = Bun::toStringView(sourceString.substring(lineStart, lineEnd - lineStart));
+        source_lines[0] = lineText(lineStart, lineEnd);
         source_line_numbers[0] = location.line();
 
-        if (lineStart > 0) {
-            auto byte_offset_in_source_string = lineStart - 1;
-            uint8_t source_line_i = 1;
-            auto remaining_lines_to_grab = source_lines_count - 1;
-
-            {
-                // This should probably be code points instead of newlines
-                while (byte_offset_in_source_string > 0 && bytes[byte_offset_in_source_string] != '\n') {
-                    byte_offset_in_source_string--;
-                }
-
-                byte_offset_in_source_string -= byte_offset_in_source_string > 0;
-            }
-
-            while (byte_offset_in_source_string > 0 && remaining_lines_to_grab > 0) {
-                unsigned int end_of_line_offset = byte_offset_in_source_string;
-
-                // This should probably be code points instead of newlines
-                while (byte_offset_in_source_string > 0 && bytes[byte_offset_in_source_string] != '\n') {
-                    byte_offset_in_source_string--;
-                }
-
-                // We are at the beginning of the line
-                source_lines[source_line_i] = Bun::toStringView(sourceString.substring(byte_offset_in_source_string, end_of_line_offset - byte_offset_in_source_string + 1));
-
-                source_line_numbers[source_line_i] = location.line().fromZeroBasedInt(location.line().zeroBasedInt() - source_line_i);
-                source_line_i++;
-
-                remaining_lines_to_grab--;
-
-                byte_offset_in_source_string -= byte_offset_in_source_string > 0;
-            }
+        // Most of the time, when you look at a stack trace, you want a couple lines above.
+        // While `lineStart` is not the start of the source, `bytes[lineStart - 1]` is the '\n'
+        // terminating the line above the one most recently collected.
+        for (uint8_t i = 1; i < source_lines_count && lineStart > 0; i++) {
+            const unsigned aboveEnd = lineStart - 1;
+            const unsigned aboveStart = startOfLineEndingAt(aboveEnd);
+            source_lines[i] = lineText(aboveStart, aboveEnd);
+            source_line_numbers[i] = OrdinalNumber::fromZeroBasedInt(location.line_zero_based - i);
+            lineStart = aboveStart;
         }
     }
 }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -164,12 +164,10 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         const std::span<const Latin1Character> bytes = sourceString.span8();
         const unsigned length = sourceString.length();
 
-        // The divot of an expression may be its end offset: one past its last character, which
-        // for the last expression in the source is `length`, and otherwise is often the '\n'
-        // terminating its line. Both belong to the line the expression is on.
+        // JSC may position an expression one past its end: on the '\n' ending its line, or at `length`.
         const unsigned divot = std::min(static_cast<unsigned>(std::max(location.byte_position, 0)), length);
 
-        // Offset of the first character of the line whose terminating '\n' (or end of source) is at `end`.
+        // `end` is the offset of a line's terminating '\n', or `length` for the last line.
         auto startOfLineEndingAt = [&](unsigned end) -> unsigned {
             unsigned start = end;
             while (start > 0 && bytes[start - 1] != '\n') {
@@ -202,9 +200,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         source_lines[0] = lineText(lineStart, lineEnd);
         source_line_numbers[0] = location.line();
 
-        // Most of the time, when you look at a stack trace, you want a couple lines above.
-        // While `lineStart` is not the start of the source, `bytes[lineStart - 1]` is the '\n'
-        // terminating the line above the one most recently collected.
+        // Lines above: `bytes[lineStart - 1]` is the '\n' ending the line above the one just collected.
         for (uint8_t i = 1; i < source_lines_count && lineStart > 0; i++) {
             const unsigned aboveEnd = lineStart - 1;
             const unsigned aboveStart = startOfLineEndingAt(aboveEnd);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -181,7 +181,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
             if (end > start && bytes[end - 1] == '\r') {
                 end--;
             }
-            return Bun::toStringView(sourceString.substring(start, end - start));
+            return Bun::toStringView(StringView_slice(sourceString, start, end));
         };
 
         unsigned lineEnd = divot;

--- a/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
+++ b/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
@@ -12,7 +12,10 @@ Error: hello
 `;
 
 exports[`can get sourceURL inside node:vm 1`] = `
-"4 |     return Bun.inspect(new Error("hello"));
+"1 | 
+2 | 
+3 | function hello() {
+4 |     return Bun.inspect(new Error("hello"));
                            ^
 error: hello
       at hello (hellohello.js:4:24)
@@ -22,7 +25,10 @@ error: hello
 `;
 
 exports[`eval sourceURL is correct 1`] = `
-"4 |     return Bun.inspect(new Error("hello"));
+"1 | 
+2 | 
+3 | function hello() {
+4 |     return Bun.inspect(new Error("hello"));
                            ^
 error: hello
       at hello (hellohello.js:4:24)

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import {
   compileFunction,
   constants,
@@ -1483,4 +1483,96 @@ test("node:vm Object.defineProperty on the context global when the sandbox is an
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe(JSON.stringify({ result: 1, sandboxArray: 1 }));
   expect(exitCode).toBe(0);
+});
+
+// A vm script has no source map, so the code frame bun prints above an error
+// thrown from it is cut out of the script text itself (the same path serves
+// eval and new Function). Bun.inspect renders the same frame as the
+// uncaught-error printer.
+describe("code frame of an error thrown from a vm script", () => {
+  function codeFrame(source: string, options: { lineOffset?: number } = {}): string[] {
+    let error: unknown;
+    try {
+      // With displayErrors, node:vm replaces err.stack with node's own header.
+      runInThisContext(source, { filename: "frame.js", displayErrors: false, ...options });
+    } catch (e) {
+      error = e;
+    }
+    return Bun.inspect(error).split("\n");
+  }
+
+  const throwLine = "throw new Error('x');";
+  const numbered = (count: number) => Array.from({ length: count }, (_, i) => `'L${i + 1}';`);
+  // JSC positions a ReferenceError one past the end of the identifier.
+  const fooFrame = ["1 | 'L1';", "2 | foo", "       ^", "ReferenceError: foo is not defined"];
+  const fooAtEndOfSource = "'L1';\nfoo";
+
+  test.each([
+    [
+      "every line above the error, numbered",
+      [...numbered(4), throwLine].join("\n"),
+      ["1 | 'L1';", "2 | 'L2';", "3 | 'L3';", "4 | 'L4';", `5 | ${throwLine}`, "          ^", "error: x"],
+    ],
+    ["error on line 2", ["'L1';", throwLine].join("\n"), ["1 | 'L1';", `2 | ${throwLine}`, "          ^", "error: x"]],
+    [
+      "at most five lines above the error",
+      [...numbered(9), throwLine].join("\n"),
+      [
+        " 5 | 'L5';",
+        " 6 | 'L6';",
+        " 7 | 'L7';",
+        " 8 | 'L8';",
+        " 9 | 'L9';",
+        `10 | ${throwLine}`,
+        "           ^",
+        "error: x",
+      ],
+    ],
+    [
+      "blank lines, including a blank first line",
+      ["", "'L2';", "", throwLine].join("\n"),
+      ["1 | ", "2 | 'L2';", "3 | ", `4 | ${throwLine}`, "          ^", "error: x"],
+    ],
+    [
+      "CRLF line endings",
+      ["'L1';", "'L2';", throwLine, "'L4';", ""].join("\r\n"),
+      ["1 | 'L1';", "2 | 'L2';", `3 | ${throwLine}`, "          ^", "error: x"],
+    ],
+    ["error positioned on the newline ending its line", "'L1';\nfoo\n'L3';", fooFrame],
+    ["error positioned at the end of the source", fooAtEndOfSource, fooFrame],
+  ])("%s", (_, source, expected) => {
+    expect(codeFrame(source).slice(0, expected.length)).toEqual(expected);
+  });
+
+  test("line numbers include lineOffset", () => {
+    const expected = ["11 | 'L1';", "12 | 'L2';", `13 | ${throwLine}`, "           ^", "error: x"];
+    expect(codeFrame([...numbered(2), throwLine].join("\n"), { lineOffset: 10 }).slice(0, expected.length)).toEqual(
+      expected,
+    );
+  });
+
+  test("uncaught error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("node:vm").runInThisContext(${JSON.stringify(fooAtEndOfSource)}, { filename: "frame.js", displayErrors: false })`,
+      ],
+      env: {
+        ...bunEnv,
+        // Malloc=1 routes JSC's allocations through the system allocator so ASAN
+        // sees a read past the end of the source string; detect_leaks=0 because
+        // that also exposes JSC's never-freed startup allocations to LSAN.
+        ...(isWindows ? {} : { Malloc: "1" }),
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr.split("\n").slice(0, fooFrame.length)).toEqual(fooFrame);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1513,6 +1513,7 @@ describe("code frame of an error thrown from a vm script", () => {
       [...numbered(4), throwLine].join("\n"),
       ["1 | 'L1';", "2 | 'L2';", "3 | 'L3';", "4 | 'L4';", `5 | ${throwLine}`, "          ^", "error: x"],
     ],
+    ["error on line 1", [throwLine, "'L2';"].join("\n"), [`1 | ${throwLine}`, "          ^", "error: x"]],
     ["error on line 2", ["'L1';", throwLine].join("\n"), ["1 | 'L1';", `2 | ${throwLine}`, "          ^", "error: x"]],
     [
       "at most five lines above the error",
@@ -1534,9 +1535,9 @@ describe("code frame of an error thrown from a vm script", () => {
       ["1 | ", "2 | 'L2';", "3 | ", `4 | ${throwLine}`, "          ^", "error: x"],
     ],
     [
-      "CRLF line endings",
-      ["'L1';", "'L2';", throwLine, "'L4';", ""].join("\r\n"),
-      ["1 | 'L1';", "2 | 'L2';", `3 | ${throwLine}`, "          ^", "error: x"],
+      "CRLF line endings, including a blank line",
+      ["'L1';", "'L2';", "", throwLine, "'L5';", ""].join("\r\n"),
+      ["1 | 'L1';", "2 | 'L2';", "3 | ", `4 | ${throwLine}`, "          ^", "error: x"],
     ],
     ["error positioned on the newline ending its line", "'L1';\nfoo\n'L3';", fooFrame],
     ["error positioned at the end of the source", fooAtEndOfSource, fooFrame],
@@ -1561,8 +1562,10 @@ describe("code frame of an error thrown from a vm script", () => {
       env: {
         ...bunEnv,
         // Malloc=1 routes JSC's allocations through the system allocator so ASAN
-        // sees a read past the end of the source string; detect_leaks=0 because
-        // that also exposes JSC's never-freed startup allocations to LSAN.
+        // sees a read past the end of the source string (bmalloc's system heap
+        // is unimplemented on Windows, which has no ASAN lane anyway);
+        // detect_leaks=0 because it also exposes JSC's never-freed startup
+        // allocations to LSAN.
         ...(isWindows ? {} : { Malloc: "1" }),
         ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
       },
@@ -1572,8 +1575,10 @@ describe("code frame of an error thrown from a vm script", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toBe("");
-    expect(stderr.split("\n").slice(0, fooFrame.length)).toEqual(fooFrame);
-    expect(exitCode).toBe(1);
+    expect({ stdout, frame: stderr.split("\n").slice(0, fooFrame.length), exitCode }).toEqual({
+      stdout: "",
+      frame: fooFrame,
+      exitCode: 1,
+    });
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1570,8 +1570,9 @@ describe("code frame of an error thrown from a vm script", () => {
       stderr: "pipe",
     });
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    expect(stdout).toBe("");
     expect(stderr.split("\n").slice(0, fooFrame.length)).toEqual(fooFrame);
     expect(exitCode).toBe(1);
   });


### PR DESCRIPTION
### Problem
- The code frame printed above an error thrown from a source bun did not transpile (`vm.Script` / `runInThisContext`, `eval`, `new Function`, `module._compile`) is wrong: the line directly above the error is missing and the remaining context lines are numbered one too high. Affects both the uncaught-error output and `Bun.inspect(err)` / `console.error(err)`.
- Same cause, other shapes: an error on line 2 or 3 gets no context lines at all; a ReferenceError for an identifier that ends its line (JSC positions it on the terminating `\n`) prints the line above but not the error line or the caret; an identifier at the very end of the source makes the scan read one byte past the source string (ASAN `heap-buffer-overflow` in `populateStackFramePosition`, `ZigException.cpp:166`, reproducible with `Malloc=1`).
- Cause: `populateStackFramePosition` in `src/jsc/bindings/ZigException.cpp`. #11581 changed the line-start scan to stop *on* the `\n` that terminates the previous line (`sourceString[lineStart] != '\n'`), but the block collecting the lines above (previously lines 191-223) still assumed `lineStart` was the first character of the error line: it stepped back over one more whole line before the collection loop started, so the loop's first line was two lines up while labelled one line up. The loop also stopped at offset 0, so line 1 was never collected. The scan started by reading `sourceString[byte_position]` itself, which is out of range when the position is the source length, and when that byte is a `\n` it was taken as the start of the error line, yielding an empty error line.
- Transpiled files are not affected: their frame is rebuilt from the original file in `remap_zig_exception` (`VirtualMachine.rs`). That producer has its own, separate line-splitting bugs (no trailing newline: #36683; it also keeps the `\r` on line 1 of CRLF files, handed off separately); neither is touched here.

### Fix
- Rewrite the collection in terms of line ends: scan forward from the position to the error line's `\n` (or the end of the source), derive each line's start by scanning back from its end (`bytes[start - 1]`), and for each line above use `lineStart - 1`, which is by construction the `\n` terminating it. Line 1 is collected like any other line; the loop ends when a line starts at offset 0.
- This is what removes the out-of-bounds read: the new scan never reads the byte at the position itself, only `bytes[i]` for `i < length` going forward and `bytes[i - 1]` for `i > 0` going back. The `std::min`/`std::max` on the position is a bounds guard on top of that, so a position outside the provider's text can never index it.
- A position sitting on a `\n` or at `length` is treated as belonging to the line it ends, which is the line JSC reports for it (`frame.js:2:4` for `foo` on line 2 in the tests), so the frame and the caret agree.
- Lines are stored without their terminator; a trailing `\r` is dropped too, so CRLF sources print the same as LF ones (previously every collected line of a CRLF source carried a `\r` into the output and into `Bun.inspect` strings). The only consumer that does not trim these strings before use is the inspector's `LifecycleReporter.error` `sourceLines` payload, which for these sources now carries bare lines instead of `\n`-wrapped ones; every printer and the dev error page go through `trimmed_text()` and are unaffected by the shape change.
- The contract with the Rust side is otherwise unchanged: `source_lines[0]` is the error line, up to `source_lines_to_collect - 1` lines above it follow, numbered the same way, and the provider ref/deref is untouched, so no Rust changes. The 8-bit-only guard is unchanged (non-Latin1 vm/eval sources got no frame before and still do not; separate limitation).
- Verified: `test/js/node/vm/vm.test.ts`, "code frame of an error thrown from a vm script": context count and numbering, error on line 1 (nothing above it) and on line 2, the five-line window with number padding, blank lines including a blank line 1, CRLF including a blank CRLF line, position on a terminating `\n`, position at end of source, `lineOffset`, plus the uncaught printer run with `Malloc=1` for the end-of-source case. 9 of the 10 fail on the released binary (the line-1 case is the negative contract and passes on both); all pass with the fix; under ASAN the spawned case additionally crashes without the fix.
- Two existing snapshots in `test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap` (one via `vm`, one via `eval`) had captured the broken output (only line 4 of a script whose lines 1-3 exist); they now show lines 1-4, matching the fixture text and what the transpiled-file path prints for the same source.

### Background
- Code frame: the numbered source lines, caret and `name: message` bun prints above a stack trace. `remap_zig_exception` fills them from the original file when the top frame has a source map; otherwise it calls `ZigException__collectSourceLines`, which is the path fixed here. Both write into the same `source_lines` / `source_line_numbers` arrays (6 slots, pre-filled with `-1`) that `print_error_instance_body` renders from the highest populated index down to the error line at index 0.
- Position / divot: JSC records for each bytecode a character offset into the source provider's text marking the expression. It is not always inside the expression's line: for an identifier it is one past the identifier's last character, which can be the `\n` ending the line or, for the last token of the source, the source length.
- Source provider: the object holding a script's full source text. The code frame strings are non-owning views into it; the provider is ref'd here and released with the exception, unchanged by this PR.

<details>
<summary>Before / after for the repro</summary>

```js
new (require("node:vm").Script)("'L1';\n'L2';\n'L3';\n'L4';\nthrow new Error('x');", { filename: "ex.js" })
  .runInThisContext({ displayErrors: false });
```

Before:

```
2 | 'L1';
3 | 'L2';
4 | 'L3';
5 | throw new Error('x');
          ^
error: x
      at ex.js:5:7
```

After:

```
1 | 'L1';
2 | 'L2';
3 | 'L3';
4 | 'L4';
5 | throw new Error('x');
          ^
error: x
      at ex.js:5:7
```

Identifier ending a line (`"'L1';\nfoo\n'L3';"`), before:

```
1 | 'L1';
ReferenceError: foo is not defined
      at ex.js:2:4
```

After:

```
1 | 'L1';
2 | foo
       ^
ReferenceError: foo is not defined
      at ex.js:2:4
```

`displayErrors: false` only keeps node:vm from replacing `err.stack` with node's own header (with the default, bun currently prints no frame at all for these errors, which is a different code path); `eval("...")` of the same text shows the same frames through the same function.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->