### PR TITLE
node:vm: accept a hashbang line at the start of a compileFunction body

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -385,11 +385,9 @@ struct EmbeddedFunctionBody {
     StringView rest;
 };
 
-// A hashbang comment is only valid at offset 0 of a source text, but the body
-// lands after the "(function (...) {\n" prefix. V8's CompileFunction accepts it
-// (Node's CommonJS loader relies on that), and it ends where a "//" comment
-// would, so embed it as one. Swapping those two characters in place keeps every
-// offset into the body unchanged. The view borrows from `body`.
+// "#!" is only a comment at offset 0 of a source text, and the body is embedded
+// after the "(function (...) {\n" prefix, so emit it as the equivalent "//"
+// comment. Swapped in place, so body offsets are unchanged.
 static EmbeddedFunctionBody embedFunctionBody(const String& body)
 {
     if (body.startsWith("#!"_s))

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -388,9 +388,13 @@ struct EmbeddedFunctionBody {
 // JSC only lexes "#!" as a comment at offset 0 of the source, and the body is embedded after the "(function (...) {\n" prefix.
 static EmbeddedFunctionBody embedFunctionBody(const String& body)
 {
-    if (body.startsWith("#!"_s))
-        return { "//"_s, StringView(body).substring(2) };
-    return { ""_s, body };
+    if (!body.startsWith("#!"_s))
+        return { ""_s, body };
+    StringView rest = StringView(body).substring(2);
+    // Unlike a hashbang, a "//" comment honors "# sourceURL=" and "@ sourceURL=" directives; blank the marker so it cannot become one.
+    if (rest.startsWith('#') || rest.startsWith('@'))
+        return { "// "_s, rest.substring(1) };
+    return { "//"_s, rest };
 }
 
 // Helper function to create an anonymous function expression with parameters

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -380,6 +380,23 @@ static JSPromise* importModuleInner(JSGlobalObject* globalObject, JSString* modu
     RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, thenResult));
 }
 
+struct EmbeddedFunctionBody {
+    ASCIILiteral prefix;
+    StringView rest;
+};
+
+// A hashbang comment is only valid at offset 0 of a source text, but the body
+// lands after the "(function (...) {\n" prefix. V8's CompileFunction accepts it
+// (Node's CommonJS loader relies on that), and it ends where a "//" comment
+// would, so embed it as one. Swapping those two characters in place keeps every
+// offset into the body unchanged. The view borrows from `body`.
+static EmbeddedFunctionBody embedFunctionBody(const String& body)
+{
+    if (body.startsWith("#!"_s))
+        return { "//"_s, StringView(body).substring(2) };
+    return { ""_s, body };
+}
+
 // Helper function to create an anonymous function expression with parameters
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset)
 {
@@ -393,7 +410,8 @@ String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& a
         auto body = args.at(0).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        program = tryMakeString("(function () {\n"_s, body, "\n})"_s);
+        auto [bodyPrefix, bodyRest] = embedFunctionBody(body);
+        program = tryMakeString("(function () {\n"_s, bodyPrefix, bodyRest, "\n})"_s);
         *outOffset = "(function () {\n"_s.length();
 
         if (!program) [[unlikely]] {
@@ -419,7 +437,8 @@ String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& a
         auto body = args.at(parameterCount).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
 
-        program = tryMakeString("(function ("_s, paramString.toString(), ") {\n"_s, body, "\n})"_s);
+        auto [bodyPrefix, bodyRest] = embedFunctionBody(body);
+        program = tryMakeString("(function ("_s, paramString.toString(), ") {\n"_s, bodyPrefix, bodyRest, "\n})"_s);
         *outOffset = "(function ("_s.length() + paramString.length() + ") {\n"_s.length();
 
         if (!program) [[unlikely]] {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -385,9 +385,7 @@ struct EmbeddedFunctionBody {
     StringView rest;
 };
 
-// "#!" is only a comment at offset 0 of a source text, and the body is embedded
-// after the "(function (...) {\n" prefix, so emit it as the equivalent "//"
-// comment. Swapped in place, so body offsets are unchanged.
+// JSC only lexes "#!" as a comment at offset 0 of the source, and the body is embedded after the "(function (...) {\n" prefix.
 static EmbeddedFunctionBody embedFunctionBody(const String& body)
 {
     if (body.startsWith("#!"_s))

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -360,13 +360,31 @@ describe("vm", () => {
       });
 
       test("only a hashbang at offset 0 of the body is a comment", () => {
-        // Same inputs node rejects: V8 does not strip a BOM or whitespace here
-        // either (node's CommonJS loader strips the BOM before compiling).
-        expect(() => compileFunction(" #!/usr/bin/env node\nreturn 1")).toThrow(SyntaxError);
-        expect(() => compileFunction("\n#!/usr/bin/env node\nreturn 1")).toThrow(SyntaxError);
-        expect(() => compileFunction("\uFEFF#!/usr/bin/env node\nreturn 1")).toThrow(SyntaxError);
-        expect(() => compileFunction("#\nreturn 1")).toThrow(SyntaxError);
-        expect(() => compileFunction("return 1", ["#!p"])).toThrow();
+        const compileError = (code: string, params: string[] = []) => {
+          try {
+            compileFunction(code, params);
+          } catch (e: any) {
+            return `${e.name}: ${e.message}`;
+          }
+          return "compiled";
+        };
+        // Node rejects the body variants too: V8 does not skip whitespace or a
+        // BOM before the hashbang (node's CommonJS loader strips the BOM itself).
+        // A hashbang in a parameter only fails once the wrapper is compiled,
+        // hence the generic error; node aborts on that input.
+        expect([
+          compileError(" #!/usr/bin/env node\nreturn 1"),
+          compileError("\n#!/usr/bin/env node\nreturn 1"),
+          compileError("\uFEFF#!/usr/bin/env node\nreturn 1"),
+          compileError("#\nreturn 1"),
+          compileError("return 1", ["#!p"]),
+        ]).toEqual([
+          "SyntaxError: Invalid character: '#'",
+          "SyntaxError: Invalid character: '#'",
+          "SyntaxError: Invalid character: '#'",
+          "SyntaxError: Invalid character: '#'",
+          "Error: Failed to compile function",
+        ]);
       });
     });
   });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -278,8 +278,14 @@ describe("vm", () => {
         expect(compileFunction("#!/usr/bin/env node\nreturn 1", [])()).toBe(1);
         expect(compileFunction("#!/usr/bin/env node\nreturn 2")()).toBe(2);
         expect(compileFunction("#!/usr/bin/env node\nreturn a + b", ["a", "b"])(1, 2)).toBe(3);
-        expect(compileFunction("#!/usr/bin/env node", [])()).toBeUndefined();
-        expect(compileFunction("#!", [])()).toBeUndefined();
+        // Non-Latin1 body, so the 16-bit string path is exercised too.
+        expect(compileFunction("#!@ sourceURL=evil.js\u2028return a + '\u2192'", ["a"])("x")).toBe("x\u2192");
+        expect(["#!/usr/bin/env node", "#!", "#!#", "#!@"].map(body => compileFunction(body, [])())).toEqual([
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+        ]);
       });
 
       test("CommonJS loader style", () => {
@@ -303,7 +309,7 @@ describe("vm", () => {
 
       test("a 'use strict' directive on the next line still applies", () => {
         expect(compileFunction("#!/usr/bin/env node\n'use strict';\nreturn this", [])()).toBeUndefined();
-        expect(typeof compileFunction("#!/usr/bin/env node\nreturn this", [])()).toBe("object");
+        expect(compileFunction("#!/usr/bin/env node\nreturn this", [])()).toBe(globalThis);
       });
 
       test("parsingContext and contextExtensions", () => {
@@ -316,18 +322,23 @@ describe("vm", () => {
         ).toBe("extension");
       });
 
-      test("the hashbang line still counts as a line of the body", () => {
-        // The two bodies differ only in how line 1 is commented out; node
-        // reports frame.js:13 for both.
-        const frame = (firstLine: string) =>
-          compileFunction(`${firstLine}\n\nreturn new Error("x")`, [], {
-            filename: "frame.js",
-            lineOffset: 10,
-          })().stack.split("\n")[1];
-        const hashbangFrame = frame("#!/usr/bin/env node");
-        expect(hashbangFrame).toContain("frame.js:13:");
-        expect(hashbangFrame).toBe(frame("// /usr/bin/env node"));
+      // First stack frame of an Error created on the last line of a body whose
+      // first line is `firstLine`. Only the line number is compared against
+      // node below: the column bun reports for compileFunction bodies differs
+      // from node's for every body (tracked separately), so the exact frame is
+      // instead compared with that of an ordinary comment line.
+      const frameAfter = (firstLine: string, filename: string, lineOffset = 0) =>
+        compileFunction(`${firstLine}\n\nreturn new Error("x")`, [], { filename, lineOffset })().stack.split("\n")[1];
 
+      test("the hashbang line still counts as a line of the body", () => {
+        // node reports frame.js:13 for both bodies.
+        const hashbangFrame = frameAfter("#!/usr/bin/env node", "frame.js", 10);
+        expect(hashbangFrame).toMatch(/\bframe\.js:13:\d+\b/);
+        expect(hashbangFrame).toBe(frameAfter("// /usr/bin/env node", "frame.js", 10));
+
+        // Compile errors on a later line: node reports bad.js:13 as well. (The
+        // body is also parsed on its own, where the hashbang is at offset 0, so
+        // this holds with or without the rewrite.)
         let err: any;
         try {
           compileFunction("#!/usr/bin/env node\nvar a = 1;\nvar = ;", [], { filename: "bad.js", lineOffset: 10 });
@@ -338,12 +349,32 @@ describe("vm", () => {
         expect(err.stack.split("\n").slice(0, 4)).toEqual(["bad.js:13", "var = ;", "    ^", ""]);
       });
 
-      test("Function.prototype.toString keeps the line", () => {
+      test("a hashbang line is not a sourceURL directive", () => {
+        // A "//" comment starting with "# " or "@ " is a sourceURL directive; a
+        // hashbang line never is (node reports real.js for both of these), so
+        // the rewrite blanks that character out.
+        const reference = frameAfter("//  sourceURL=evil.js", "real.js");
+        expect(reference).toMatch(/\breal\.js:\d+:\d+\b/);
+        expect(reference).not.toContain("evil.js");
+        expect([
+          frameAfter("#!# sourceURL=evil.js", "real.js"),
+          frameAfter("#!@ sourceURL=evil.js", "real.js"),
+        ]).toEqual([reference, reference]);
+      });
+
+      test("Function.prototype.toString shows the hashbang line as a comment of the same length", () => {
         // JSC only lexes "#!" at offset 0 of a source, so inside the function
         // the line is stored as a "//" comment; node returns it as "#!...".
-        expect(compileFunction("#!/usr/bin/env node\nreturn a + b", ["a", "b"]).toString()).toBe(
+        const source = (body: string, params: string[] = []) => compileFunction(body, params).toString();
+        expect([
+          source("#!/usr/bin/env node\nreturn a + b", ["a", "b"]),
+          source("#!# sourceURL=evil.js\nreturn 1"),
+          source("#!@ sourceURL=evil.js\nreturn 1", ["a"]),
+        ]).toEqual([
           "function (a, b) {\n///usr/bin/env node\nreturn a + b\n}",
-        );
+          "function () {\n//  sourceURL=evil.js\nreturn 1\n}",
+          "function (a) {\n//  sourceURL=evil.js\nreturn 1\n}",
+        ]);
       });
 
       test("cachedData round-trips", () => {
@@ -370,8 +401,10 @@ describe("vm", () => {
         };
         // Node rejects the body variants too: V8 does not skip whitespace or a
         // BOM before the hashbang (node's CommonJS loader strips the BOM itself).
-        // A hashbang in a parameter only fails once the wrapper is compiled,
-        // hence the generic error; node aborts on that input.
+        // These are guards rather than fixes: the body is parsed on its own
+        // before being wrapped, which already rejected them. A hashbang in a
+        // parameter only fails once the wrapper is compiled, hence the generic
+        // error; node aborts on that input.
         expect([
           compileError(" #!/usr/bin/env node\nreturn 1"),
           compileError("\n#!/usr/bin/env node\nreturn 1"),

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -269,6 +269,106 @@ describe("vm", () => {
         expect(e).toBeTruthy();
       }
     });
+
+    // Node (V8's CompileFunction) treats the body like a script source, so a
+    // hashbang line at the very start of it is a comment. Node's own CommonJS
+    // loader compiles "#!" files this way.
+    describe("body starting with a hashbang", () => {
+      test("compiles with and without params", () => {
+        expect(compileFunction("#!/usr/bin/env node\nreturn 1", [])()).toBe(1);
+        expect(compileFunction("#!/usr/bin/env node\nreturn 2")()).toBe(2);
+        expect(compileFunction("#!/usr/bin/env node\nreturn a + b", ["a", "b"])(1, 2)).toBe(3);
+        expect(compileFunction("#!/usr/bin/env node", [])()).toBeUndefined();
+        expect(compileFunction("#!", [])()).toBeUndefined();
+      });
+
+      test("CommonJS loader style", () => {
+        const mod = { exports: {} as any };
+        compileFunction("#!/usr/bin/env node\nmodule.exports = { answer: 42, filename: __filename };", [
+          "exports",
+          "require",
+          "module",
+          "__filename",
+          "__dirname",
+        ])(mod.exports, () => {}, mod, "/app/cli.js", "/app");
+        expect(mod.exports).toEqual({ answer: 42, filename: "/app/cli.js" });
+      });
+
+      test("the hashbang ends at any line terminator", () => {
+        const results = ["\n", "\r\n", "\r", "\u2028", "\u2029"].map(terminator =>
+          compileFunction(`#!/usr/bin/env node${terminator}return "ok"`, [])(),
+        );
+        expect(results).toEqual(["ok", "ok", "ok", "ok", "ok"]);
+      });
+
+      test("a 'use strict' directive on the next line still applies", () => {
+        expect(compileFunction("#!/usr/bin/env node\n'use strict';\nreturn this", [])()).toBeUndefined();
+        expect(typeof compileFunction("#!/usr/bin/env node\nreturn this", [])()).toBe("object");
+      });
+
+      test("parsingContext and contextExtensions", () => {
+        const parsingContext = createContext({ fromContext: "context" });
+        expect(compileFunction("#!/usr/bin/env node\nreturn fromContext", [], { parsingContext })()).toBe("context");
+        expect(
+          compileFunction("#!/usr/bin/env node\nreturn fromExtension", [], {
+            contextExtensions: [{ fromExtension: "extension" }],
+          })(),
+        ).toBe("extension");
+      });
+
+      test("the hashbang line still counts as a line of the body", () => {
+        // The two bodies differ only in how line 1 is commented out; node
+        // reports frame.js:13 for both.
+        const frame = (firstLine: string) =>
+          compileFunction(`${firstLine}\n\nreturn new Error("x")`, [], {
+            filename: "frame.js",
+            lineOffset: 10,
+          })().stack.split("\n")[1];
+        const hashbangFrame = frame("#!/usr/bin/env node");
+        expect(hashbangFrame).toContain("frame.js:13:");
+        expect(hashbangFrame).toBe(frame("// /usr/bin/env node"));
+
+        let err: any;
+        try {
+          compileFunction("#!/usr/bin/env node\nvar a = 1;\nvar = ;", [], { filename: "bad.js", lineOffset: 10 });
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeInstanceOf(SyntaxError);
+        expect(err.stack.split("\n").slice(0, 4)).toEqual(["bad.js:13", "var = ;", "    ^", ""]);
+      });
+
+      test("Function.prototype.toString keeps the line", () => {
+        // JSC only lexes "#!" at offset 0 of a source, so inside the function
+        // the line is stored as a "//" comment; node returns it as "#!...".
+        expect(compileFunction("#!/usr/bin/env node\nreturn a + b", ["a", "b"]).toString()).toBe(
+          "function (a, b) {\n///usr/bin/env node\nreturn a + b\n}",
+        );
+      });
+
+      test("cachedData round-trips", () => {
+        const body = "#!/usr/bin/env node\nreturn 7";
+        const producer = compileFunction(body, [], { produceCachedData: true }) as any;
+        const consumer = compileFunction(body, [], { cachedData: producer.cachedData }) as any;
+        const otherBody = compileFunction("return 7", [], { cachedData: producer.cachedData }) as any;
+        expect({
+          produced: producer.cachedDataProduced,
+          rejected: consumer.cachedDataRejected,
+          result: consumer(),
+          rejectedForOtherBody: otherBody.cachedDataRejected,
+        }).toEqual({ produced: true, rejected: false, result: 7, rejectedForOtherBody: true });
+      });
+
+      test("only a hashbang at offset 0 of the body is a comment", () => {
+        // Same inputs node rejects: V8 does not strip a BOM or whitespace here
+        // either (node's CommonJS loader strips the BOM before compiling).
+        expect(() => compileFunction(" #!/usr/bin/env node\nreturn 1")).toThrow(SyntaxError);
+        expect(() => compileFunction("\n#!/usr/bin/env node\nreturn 1")).toThrow(SyntaxError);
+        expect(() => compileFunction("\uFEFF#!/usr/bin/env node\nreturn 1")).toThrow(SyntaxError);
+        expect(() => compileFunction("#\nreturn 1")).toThrow(SyntaxError);
+        expect(() => compileFunction("return 1", ["#!p"])).toThrow();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `vm.compileFunction("#!/usr/bin/env node\nreturn 1", [])` throws `Error: Failed to compile function`. Node returns a function.
- Same for the CommonJS shape, `vm.compileFunction("#!...\nmodule.exports = 1", ["exports", "require", "module", ...])`, which is how loaders built on `compileFunction` compile files that start with a shebang.
- Cause: `stringifyAnonymousFunction` (`src/jsc/bindings/NodeVM.cpp`) compiles the body as the program `(function (<params>) {\n<body>\n})`. Inside that wrapper the `#!` is not at offset 0 of the source, and JSC's lexer only accepts a hashbang there (`parser/Lexer.cpp`, `case '#'`: `next == '!' && !currentOffset()`), so the program fails to parse.
- `vm.Script`, `runIn*Context` and `SourceTextModule` are not affected: they give JSC the user's text unwrapped, so the hashbang is at offset 0. `vmModuleCompileFunction` is the only caller of this code.

### Fix
- When the body starts with `#!`, `stringifyAnonymousFunction` embeds it as `//` plus the rest of the body (`embedFunctionBody`). Nothing else about the wrapper changes.
- A hashbang comment and a `//` comment both run to the next line terminator (JSC lexes both through the same single-line-comment path), so JSC now compiles the function V8 compiles for the same body.
- The one place the two differ: JSC reads `# sourceURL=` / `@ sourceURL=` (and `sourceMappingURL`) directives out of a `//` comment but never out of a hashbang line. So when the character after `#!` is `#` or `@`, it is blanked as well (`#!# x` becomes `//  x`), which keeps the line from turning into a directive.
- Both rewrites keep the length of the line, so no offset, line or column of the body moves: `lineOffset`, SyntaxError positions on later lines and stack frames come out the same as for a body whose first line is an ordinary comment.
- #38325 fixes the same problem for the native `Module.prototype._compile` and puts this exact helper in a shared `src/jsc/bindings/EmbedFunctionBody.h`; the two PRs do not touch the same files, and whichever lands second drops its local copy and includes the header.
- Only offset 0 of the body is rewritten. A hashbang after whitespace or a BOM, on line 2, or in a parameter is still rejected, which is what Node does too.
- Residual difference: `Function.prototype.toString()` shows the first line as `///usr/bin/env node`, Node shows `#!/usr/bin/env node`. `toString` returns the text JSC parsed and JSC cannot parse `#!` inside a function, so any wrapper-based implementation has this; the test pins it.
- Verified: `test/js/node/vm/vm.test.ts`, `describe("body starting with a hashbang")`. 9 of the 10 tests fail on the released bun with `Failed to compile function` and pass with this change; the tenth pins the rejections above and passes both ways (the body is also parsed on its own before wrapping, which already rejected them).
- Also run on the debug build: the full `vm.test.ts`, `vm-script-fetcher-leak.test.ts`, `test/regression/issue/isArray-proxy-crash.test.ts`, and Node's `test-vm-basic.js`, `test-vm-cached-data.js`, `test-vm-module-basic.js`, `test-vm-no-dynamic-import-callback.js`.

### Background
- Hashbang comment: ECMAScript treats `#!` plus the rest of the line as a comment, but only as the first characters of a Script or Module source text. Anywhere else, `#` outside a private name is a syntax error.
- `vm.compileFunction(code, params)`: compiles `code` as the body of a function with parameters `params`, so callers do not have to build a wrapper string themselves. In Node this is V8's `ScriptCompiler::CompileFunction`, which scans the body like a script source, so a hashbang at its start is skipped; Node's own CommonJS loader depends on that for shebang files. JSC has no such entry point, so Bun builds a wrapper program and lifts the function expression out of it.
- Comment directives: `//# sourceURL=name` and `//@ sourceURL=name` inside a source set the name stack traces and debuggers show for it (`sourceMappingURL` works the same way). JSC checks for them when it skips a `//` comment (`Lexer.cpp`, `inSingleLineCommentCheckForDirectives`); its hashbang path jumps past that check, and V8 does not apply them to hashbang lines either.
- `produceCachedData` / `cachedData`: the bytecode cache is keyed on the program text JSC compiled, i.e. the wrapper. Producing and consuming both go through `stringifyAnonymousFunction`, so the cache round-trips for a hashbang body (covered by a test).

<details>
<summary>Node v26.3.0 vs bun with this change, on the probe inputs</summary>

Accepted by both: `#!...\nreturn 1` with and without a params array, `#!...\nmodule.exports = 1` with `["module"]`, a body that is only `#!...`, `#!`, `#!#` or `#!@`, hashbang lines ended by `\n`, `\r\n`, `\r`, U+2028 and U+2029, and non-Latin1 bodies.

Rejected by both: `" #!..."`, `"\n#!..."`, `"\uFEFF#!..."`, `"#\n..."`.

`#!# sourceURL=evil.js` / `#!@ sourceURL=evil.js` as the first line: stack frames name the real filename in both (before the second rewrite, bun named `evil.js`).

`#!...\nvar a = 1;\nvar = ;` with `lineOffset: 10` reports `bad.js:13` in both. An Error created on body line 3 with `lineOffset: 10` reports line 13 in both. (The column differs from Node for every `compileFunction` body, not only hashbang ones, and line numbers are off by one when `lineOffset` is 0; both are pre-existing and tracked separately, so the tests compare the hashbang frame with that of an ordinary comment line instead of pinning those.)

Found while reviewing: Bun's native `Module.prototype._compile` wraps its source the same way and rejects `#!` sources that Node accepts; that is #38325.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (1a993e526)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.43ms]
(pass) vm > runInContext() > can return a value [14.87ms]
(pass) vm > runInContext() > can return a complex value [15.67ms]
(pass) vm > runInContext() > can return the last value [15.23ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.16ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.60ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.32ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.43ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.44ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.47ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.37ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.94ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 9 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.36ms]
(pass) vm > runInContext() > can return a value [0.21ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (1a993e526)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.28ms]
(pass) vm > runInContext() > can return a value [15.37ms]
(pass) vm > runInContext() > can return a complex value [16.15ms]
(pass) vm > runInContext() > can return the last value [14.82ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.42ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.62ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.59ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.67ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.94ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.51ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.92ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.93ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1a993e526d
  features     baseline

22 deps, 123 codegen, 1176 objects in 678ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch tinycc
[tinycc] up to date
[4/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1237] fetch zlib
[zlib] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[10/1237] subst deps/zlib/zconf.h
[11/1237] subst deps/zlib/zlib.h
[12/1188] install /workspace/bun
bun install v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp |  23 ++++++-
 test/js/node/vm/vm.test.ts  | 151 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 172 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      8      6      0
test/js/node/vm/vm.test.ts       7     10      0
```

</details>

**root cause** · written by the author bot

vm.compileFunction builds the program by wrapping the body in "(function (<params>) {\n<body>\n})", so a body that begins with a #! hashbang has that line at a nonzero source offset, where JSC's lexer only recognizes hashbang comments at offset 0 and therefore rejects the body that Node accepts. The fix adds embedFunctionBody, which rewrites a leading "#!" to "//" (and "#!#" or "#!@" to "// " so the line cannot become a sourceURL or sourceMappingURL directive) before both wrapper-building paths embed the body. Because the substitution preserves the body's length, every offset, line and colu…

<!-- robobun:evidence:end -->
