### PR TITLE
bundler: honor jsonc and sqlite_embedded in loader maps, accept every loader name in Bun.build

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5945,7 +5945,15 @@ declare module "bun" {
     | "wasm"
     | "text"
     | "css"
-    | "html";
+    | "html"
+    | "sqlite"
+    /**
+     * Like `sqlite`, but the database file is copied into the output directory
+     * (or embedded in the compiled executable) and the bundle references that
+     * copy, as `with { type: "sqlite", embed: "true" }` does. Requires
+     * `target: "bun"`.
+     */
+    | "sqlite_embedded";
 
   interface PluginConstraints {
     /**

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -1,8 +1,8 @@
 //! `Loader` + `SideEffects`.
 //!
-//! Data-only enum + pure predicates. `to_api()` / `from_api()` / `API_NAMES`
-//! live in `bun_options_types::LoaderExt` (would back-edge into the schema
-//! crate). `to_mime_type` / `from_mime_type` live in `bun_http_types` (would
+//! Data-only enum + pure predicates. `to_api()` / `from_api()` live in
+//! `bun_options_types::LoaderExt` (would back-edge into the schema crate).
+//! `to_mime_type` / `from_mime_type` live in `bun_http_types` (would
 //! back-edge into `bun_http::MimeType`).
 
 use enum_map::Enum;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -333,8 +333,6 @@ pub use bun_options_types::WindowsOptions;
 // same nominal type.
 pub(crate) use bun_ast::Loader;
 
-pub use bun_options_types::LOADER_API_NAMES;
-
 /// Bundler-only `Loader` methods. Extension trait per PORTING.md crate-tier
 /// rule — the canonical `Loader` lives in `bun_options_types` (lower tier) and
 /// cannot depend on `bun_http_types::MimeType`. Re-exported through

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -4,7 +4,7 @@
 //!
 //! `Loader` / `Target` / `SideEffects` / `Index` are now canonical in
 //! `bun_ast`; only the `schema::api`-coupled extension methods (`to_api`,
-//! `from_api`, `API_NAMES`) remain here as sealed extension traits.
+//! `from_api`) remain here as sealed extension traits.
 
 use crate::schema::api;
 use bun_ast::{Loader, Target};
@@ -160,39 +160,11 @@ impl TargetExt for Target {
 
 // ─── Loader: schema-coupled extension methods ─────────────────────────────
 
-bun_core::comptime_string_map! {
-pub static LOADER_API_NAMES: api::Loader = {
-    b"js" => api::Loader::js,
-    b"mjs" => api::Loader::js,
-    b"cjs" => api::Loader::js,
-    b"cts" => api::Loader::ts,
-    b"mts" => api::Loader::ts,
-    b"jsx" => api::Loader::jsx,
-    b"ts" => api::Loader::ts,
-    b"tsx" => api::Loader::tsx,
-    b"css" => api::Loader::css,
-    b"file" => api::Loader::file,
-    b"json" => api::Loader::json,
-    b"jsonc" => api::Loader::json,
-    b"toml" => api::Loader::toml,
-    b"yaml" => api::Loader::yaml,
-    b"json5" => api::Loader::json5,
-    b"xml" => api::Loader::xml,
-    b"wasm" => api::Loader::wasm,
-    b"node" => api::Loader::napi,
-    b"dataurl" => api::Loader::dataurl,
-    b"base64" => api::Loader::base64,
-    b"txt" => api::Loader::text,
-    b"text" => api::Loader::text,
-    b"sh" => api::Loader::file,
-    b"sqlite" => api::Loader::sqlite,
-    b"html" => api::Loader::html,
-    b"md" => api::Loader::md,
-    b"markdown" => api::Loader::md,
-};
-}
-
 /// `schema::api`-coupled methods on [`bun_ast::Loader`].
+///
+/// Loader names from `--loader`, bunfig `[loader]` and `Bun.build({ loader })`
+/// round-trip through `to_api` and then `from_api`, so an arm that merges two
+/// loaders here silently changes which loader the user's name selects.
 pub trait LoaderExt: sealed::Sealed {
     fn to_api(self) -> api::Loader;
     fn from_api(loader: api::Loader) -> Loader;
@@ -207,9 +179,11 @@ impl LoaderExt for Loader {
             Loader::Tsx => api::Loader::tsx,
             Loader::Css => api::Loader::css,
             Loader::Html => api::Loader::html,
+            // The bundler has no shell-script loader (`Bunsh` parses to an
+            // empty module), so a `"sh"` mapping copies the file instead.
             Loader::File | Loader::Bunsh => api::Loader::file,
             Loader::Json => api::Loader::json,
-            Loader::Jsonc => api::Loader::json,
+            Loader::Jsonc => api::Loader::jsonc,
             Loader::Toml => api::Loader::toml,
             Loader::Yaml => api::Loader::yaml,
             Loader::Json5 => api::Loader::json5,
@@ -219,7 +193,8 @@ impl LoaderExt for Loader {
             Loader::Base64 => api::Loader::base64,
             Loader::Dataurl => api::Loader::dataurl,
             Loader::Text => api::Loader::text,
-            Loader::SqliteEmbedded | Loader::Sqlite => api::Loader::sqlite,
+            Loader::Sqlite => api::Loader::sqlite,
+            Loader::SqliteEmbedded => api::Loader::sqlite_embedded,
             Loader::Md => api::Loader::md,
         }
     }

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -160,10 +160,7 @@ impl TargetExt for Target {
 
 // ─── Loader: schema-coupled extension methods ─────────────────────────────
 
-/// `schema::api`-coupled methods on [`bun_ast::Loader`]. User loader maps
-/// (`--loader`, bunfig `[loader]`, `Bun.build({ loader })`) round-trip through
-/// `to_api` and `from_api`, so a `to_api` arm that merges two loaders changes
-/// what the user's loader name means.
+/// `schema::api`-coupled methods on [`bun_ast::Loader`].
 pub trait LoaderExt: sealed::Sealed {
     fn to_api(self) -> api::Loader;
     fn from_api(loader: api::Loader) -> Loader;
@@ -178,8 +175,9 @@ impl LoaderExt for Loader {
             Loader::Tsx => api::Loader::tsx,
             Loader::Css => api::Loader::css,
             Loader::Html => api::Loader::html,
-            // The bundler has no shell-script loader (`Bunsh` parses to an
-            // empty module), so a `"sh"` mapping copies the file instead.
+            // Loader maps (`--loader`, bunfig, `Bun.build`) round-trip through here; this
+            // is the one arm that changes what a name means. The bundler parses `Bunsh`
+            // to an empty module, so an `"sh"` mapping copies the file instead.
             Loader::File | Loader::Bunsh => api::Loader::file,
             Loader::Json => api::Loader::json,
             Loader::Jsonc => api::Loader::jsonc,

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -160,11 +160,10 @@ impl TargetExt for Target {
 
 // ─── Loader: schema-coupled extension methods ─────────────────────────────
 
-/// `schema::api`-coupled methods on [`bun_ast::Loader`].
-///
-/// Loader names from `--loader`, bunfig `[loader]` and `Bun.build({ loader })`
-/// round-trip through `to_api` and then `from_api`, so an arm that merges two
-/// loaders here silently changes which loader the user's name selects.
+/// `schema::api`-coupled methods on [`bun_ast::Loader`]. User loader maps
+/// (`--loader`, bunfig `[loader]`, `Bun.build({ loader })`) round-trip through
+/// `to_api` and `from_api`, so a `to_api` arm that merges two loaders changes
+/// what the user's loader name means.
 pub trait LoaderExt: sealed::Sealed {
     fn to_api(self) -> api::Loader;
     fn from_api(loader: api::Loader) -> Loader;

--- a/src/options_types/lib.rs
+++ b/src/options_types/lib.rs
@@ -22,8 +22,8 @@ pub use jsx as JSX;
 // Only the `schema::api`-coupled extension traits and option-only types
 // (`Format`, `ModuleType`, …) are surfaced from this crate.
 pub use bundle_enums::{
-    BuiltInModule, BundlePackage, ForceNodeEnv, Format, LOADER_API_NAMES, LoaderExt, ModuleType,
-    TargetExt, WindowsOptions,
+    BuiltInModule, BundlePackage, ForceNodeEnv, Format, LoaderExt, ModuleType, TargetExt,
+    WindowsOptions,
 };
 
 /// Compiled-standalone-binary virtual filesystem path prefix + predicate.

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -41,8 +41,7 @@ pub mod js_bundler {
         }
     }
 
-    /// One value of the `loader` option, accepting the same names as
-    /// `--loader` and bunfig `[loader]`.
+    /// Accepts the same loader names as `--loader` and bunfig `[loader]`.
     fn loader_map_value_from_js(
         global_this: &JSGlobalObject,
         value: JSValue,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -53,11 +53,25 @@ pub mod js_bundler {
         }
         let name = value.to_slice(global_this)?;
         bun_ast::Loader::from_string(name.slice()).ok_or_else(|| {
-            global_this.throw_invalid_arguments(format_args!(
-                "loader must be one of {}",
-                bun_core::fmt::enum_tag_list::<bun_ast::Loader, true>()
-            ))
+            global_this
+                .throw_invalid_arguments(format_args!("loader must be one of {}", LoaderNamesList))
         })
+    }
+
+    /// The keys of the table `Loader::from_string` reads, as `"js", "mjs", ..., or "markdown"`.
+    struct LoaderNamesList;
+
+    impl core::fmt::Display for LoaderNamesList {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            let count = bun_ast::loader::LOADER_NAMES.len();
+            for (i, name) in bun_ast::loader::LOADER_NAMES.keys().enumerate() {
+                if i > 0 {
+                    f.write_str(if i + 1 == count { ", or " } else { ", " })?;
+                }
+                write!(f, "\"{}\"", bstr::BStr::new(name))?;
+            }
+            Ok(())
+        }
     }
 
     /// A map of file paths to their in-memory contents.

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -41,6 +41,26 @@ pub mod js_bundler {
         }
     }
 
+    /// One value of the `loader` option, accepting the same names as
+    /// `--loader` and bunfig `[loader]`.
+    fn loader_map_value_from_js(
+        global_this: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<bun_ast::Loader> {
+        if !value.is_string() {
+            return Err(
+                global_this.throw_invalid_arguments(format_args!("loader must be a string"))
+            );
+        }
+        let name = value.to_slice(global_this)?;
+        bun_ast::Loader::from_string(name.slice()).ok_or_else(|| {
+            global_this.throw_invalid_arguments(format_args!(
+                "loader must be one of {}",
+                bun_core::fmt::enum_tag_list::<bun_ast::Loader, true>()
+            ))
+        })
+    }
+
     /// A map of file paths to their in-memory contents.
     /// LAYERING: the data-only struct (`map: StringHashMap<Box<[u8]>>`) and
     /// `get`/`contains`/`resolve` live in `bun_bundler::bundle_v2` so the
@@ -1120,12 +1140,7 @@ pub mod js_bundler {
                     }
                     drop(prop_slice);
 
-                    loader_values.push(value.to_enum_from_map(
-                        global_this,
-                        "loader",
-                        &options::LOADER_API_NAMES,
-                        "\"js\", \"jsx\", \"ts\", \"tsx\", \"css\", \"file\", \"json\", \"toml\", \"wasm\", \"napi\", \"base64\", \"dataurl\", \"text\", \"html\"",
-                    )?);
+                    loader_values.push(loader_map_value_from_js(global_this, value)?.to_api());
                     loader_names.push(prop.to_owned_slice().into_boxed_slice());
                 }
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -178,6 +178,30 @@ describe("Bun.build", () => {
         sourcemap: "invalid",
       } as any),
     ).toThrow();
+    expect(() =>
+      Bun.build({
+        entrypoints: ["hello"],
+        loader: { ".cfg": 42 },
+      } as any),
+    ).toThrow("loader must be a string");
+  });
+
+  test("error for an unknown loader name lists the current loaders", () => {
+    let error: Error | undefined;
+    try {
+      Bun.build({
+        entrypoints: ["hello"],
+        loader: { ".cfg": "not-a-loader" },
+      } as any);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error?.message).toStartWith("loader must be one of ");
+    // Same names `--loader` accepts. The old hard-coded message listed none of
+    // these except "napi", which it listed but then rejected.
+    for (const name of ["jsonc", "json5", "yaml", "xml", "md", "sqlite", "sqlite_embedded", "napi"]) {
+      expect(error?.message).toContain(`"${name}"`);
+    }
   });
 
   test("returns errors properly", async () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -186,7 +186,7 @@ describe("Bun.build", () => {
     ).toThrow("loader must be a string");
   });
 
-  test("error for an unknown loader name lists the current loaders", () => {
+  test("error for an unknown loader name lists the names the loader map accepts", async () => {
     let error: Error | undefined;
     try {
       Bun.build({
@@ -197,11 +197,22 @@ describe("Bun.build", () => {
       error = e as Error;
     }
     expect(error?.message).toStartWith("loader must be one of ");
+    const listed = [...error!.message.matchAll(/"([^"]+)"/g)].map(m => m[1]);
     // Same names `--loader` accepts. The old hard-coded message listed none of
     // these except "napi", which it listed but then rejected.
-    for (const name of ["jsonc", "json5", "yaml", "xml", "md", "sqlite", "sqlite_embedded", "napi"]) {
-      expect(error?.message).toContain(`"${name}"`);
-    }
+    expect(listed).toEqual(
+      expect.arrayContaining(["jsonc", "json5", "yaml", "xml", "md", "sqlite", "sqlite_embedded", "napi", "sh"]),
+    );
+    // "sh" is the accepted spelling of the shell loader; its enum variant is "bunsh".
+    expect(listed).not.toContain("bunsh");
+
+    // Every listed name is accepted: map each one to its own extension in a single build.
+    const dir = tempDirWithFiles("bun-build-loader-names", { "entry.js": "export default 1;" });
+    const build = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      loader: Object.fromEntries(listed.map((name, i) => [`.l${i}`, name])) as any,
+    });
+    expect(build.success).toBe(true);
   });
 
   test("returns errors properly", async () => {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath, Loader } from "bun";
+import { Database } from "bun:sqlite";
 import { describe, expect } from "bun:test";
 import fs, { readdirSync } from "node:fs";
 import { join } from "path";
@@ -240,6 +241,77 @@ describe("bundler", async () => {
       "/data.jsonc": `// jsonc\n{"__proto__": {"x": 1}, "a": 2,}`,
     },
     run: { stdout: '[true,true,null,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
+  });
+
+  // `--loader .ext:name` and `Bun.build({ loader: { ".ext": name } })` must
+  // select the named loader. "jsonc" used to degrade to the strict "json"
+  // loader and "sqlite_embedded" to the non-embedding "sqlite" loader on both
+  // surfaces, and `Bun.build` rejected "napi" and "sqlite_embedded" outright.
+  describe("loader map", () => {
+    const sqliteFixture = (() => {
+      const db = new Database(":memory:");
+      db.run("CREATE TABLE t (v INTEGER)");
+      db.run("INSERT INTO t VALUES (1)");
+      return db.serialize();
+    })();
+
+    for (const backend of ["api", "cli"] as const) {
+      itBundled(`bun/loader-map-jsonc-${backend}`, {
+        backend,
+        target: "bun",
+        loader: { ".cfg": "jsonc" },
+        files: {
+          "/entry.ts": /* js */ `
+            import config from './app.cfg';
+            console.write(JSON.stringify(config));
+          `,
+          "/app.cfg": `// comment\n{"a": 1, "b": 2,}\n`,
+        },
+        run: { stdout: '{"a":1,"b":2}' },
+      });
+
+      itBundled(`bun/loader-map-sqlite-embedded-${backend}`, {
+        backend,
+        target: "bun",
+        outdir: "/out",
+        loader: { ".db": "sqlite_embedded" },
+        files: {
+          "/entry.ts": /* js */ `
+            import db from './data.db';
+            console.write(JSON.stringify(db.query("SELECT v FROM t").all()));
+          `,
+          "/data.db": sqliteFixture,
+        },
+        onAfterBundle(api) {
+          // Embedding copies the database next to the bundle and references the
+          // copy. The plain "sqlite" loader copies nothing and references the
+          // source file by absolute path.
+          const asset = readdirSync(api.outdir).find(name => /^data-\w+\.db$/.test(name));
+          expect(asset).toBeDefined();
+          api.expectFile("/out/entry.js").toContain(`"./${asset}"`);
+        },
+        run: { stdout: '[{"v":1}]' },
+      });
+
+      itBundled(`bun/loader-map-napi-${backend}`, {
+        backend,
+        target: "bun",
+        outdir: "/out",
+        loader: { ".cfg": "napi" },
+        files: {
+          "/entry.ts": /* js */ `
+            import addon from './addon.cfg';
+            export { addon };
+          `,
+          "/addon.cfg": "not really a native addon",
+        },
+        onAfterBundle(api) {
+          const asset = readdirSync(api.outdir).find(name => /^addon-\w+\.cfg$/.test(name));
+          expect(asset).toBeDefined();
+          api.expectFile("/out/entry.js").toContain(`"./${asset}"`);
+        },
+      });
+    }
   });
 
   itBundled("bun/loader-json5-proto-key-is-own-property", {

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -254,7 +254,7 @@ export interface BundlerTestInput {
   publicPath?: string;
   keepNames?: boolean;
   legalComments?: "none" | "inline" | "eof" | "linked" | "external";
-  loader?: Record<`.${string}`, Loader | "sqlite_embedded">;
+  loader?: Record<`.${string}`, Loader>;
   mangleProps?: RegExp;
   mangleQuoted?: boolean;
   mainFields?: string[];

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -254,7 +254,7 @@ export interface BundlerTestInput {
   publicPath?: string;
   keepNames?: boolean;
   legalComments?: "none" | "inline" | "eof" | "linked" | "external";
-  loader?: Record<`.${string}`, Loader>;
+  loader?: Record<`.${string}`, Loader | "sqlite_embedded">;
   mangleProps?: RegExp;
   mangleQuoted?: boolean;
   mainFields?: string[];
@@ -617,7 +617,21 @@ function expectBundled(
   }
   if (!ESBUILD && loader) {
     const loaderValues = [...new Set(Object.values(loader))];
-    const supportedLoaderTypes = ["js", "jsx", "ts", "tsx", "css", "json", "text", "file", "wtf", "toml"];
+    const supportedLoaderTypes = [
+      "js",
+      "jsx",
+      "ts",
+      "tsx",
+      "css",
+      "json",
+      "jsonc",
+      "text",
+      "file",
+      "wtf",
+      "toml",
+      "napi",
+      "sqlite_embedded",
+    ];
     const unsupportedLoaderTypes = loaderValues.filter(x => !supportedLoaderTypes.includes(x));
     if (unsupportedLoaderTypes.length > 0) {
       throw new Error(`loader '${unsupportedLoaderTypes.join("', '")}' not implemented in bun build`);

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -24,6 +24,17 @@ Bun.build({
 
 Bun.build({
   entrypoints: ["hey"],
+  target: "bun",
+  loader: {
+    ".cfg": "jsonc",
+    ".addon": "napi",
+    ".sqlite": "sqlite",
+    ".db": "sqlite_embedded",
+  },
+});
+
+Bun.build({
+  entrypoints: ["hey"],
   plugins: [
     {
       name: "my-terrible-plugin",


### PR DESCRIPTION
### Problem
- `bun build --loader .cfg:jsonc`, bunfig `[loader] ".cfg" = "jsonc"` and `Bun.build({ loader: { ".cfg": "jsonc" } })` all run the strict JSON loader: a commented file fails with `error: JSON does not support comments`. The same happens at runtime (`bun --loader .cfg:jsonc entry.mjs` throws `JSON Parse error`). The built-in `.jsonc` extension and `with { type: "jsonc" }` are unaffected, so commented-JSON extensions (`.babelrc`, `.code-workspace`, ...) cannot be mapped at all.
- `--loader .db:sqlite_embedded` is accepted but silently behaves as plain `sqlite` (no asset copied, absolute source path baked into the output).
- `Bun.build({ loader: { ".x": "napi" } })` and `"sqlite_embedded"` throw `TypeError: loader must be one of "js", ..., "napi", ..., "html"`, a list that names `napi` while rejecting it and omits `jsonc`, `yaml`, `json5`, `xml`, `md`, `sqlite`. The CLI accepts all of these.
- Cause 1: `LoaderExt::to_api` in `src/options_types/bundle_enums.rs` mapped `Loader::Jsonc` to `api::Loader::json` and `Loader::SqliteEmbedded` to `api::Loader::sqlite`, even though `api::Loader::jsonc` / `sqlite_embedded` exist and `from_api` handles them. Every loader-map surface (CLI, bunfig, `Bun.build`) goes `Loader::from_string` -> `to_api` -> `from_api`, so the name was downgraded on the way through.
- Cause 2: `Bun.build` parsed the names with a second table, `LOADER_API_NAMES` (same file), which had drifted from `bun_ast::LOADER_NAMES` (`src/ast/loader.rs`): it also had `jsonc => json` and had no `napi` / `sqlite_embedded` keys. The accompanying "must be one of" text in `src/runtime/api/JSBundler.rs` was a hard-coded string from before most of the data loaders existed.

### Fix
- `to_api` maps `Jsonc` and `SqliteEmbedded` to their own tags (the two changed arms in `bundle_enums.rs` are the fix). `Bunsh` still maps to `file` on purpose (the bundler has no shell-script loader, `ParseTask.rs` parses it to an empty module); that arm now carries a comment so it is not "fixed" the same way later.
- `packages/bun-types/bun.d.ts`: `sqlite` and `sqlite_embedded` are added to the `Loader` union, since `Bun.build({ loader })` now accepts the latter; `test/integration/bun-types/fixture/build.ts` compiles a loader map using them. `dataurl`/`base64` are deliberately not added (stubs in the bundler); `json5`/`md` are a pre-existing gap tracked separately.
- `LOADER_API_NAMES` is deleted. `Bun.build` parses each `loader` value with `bun_ast::Loader::from_string` and converts with `to_api`, exactly what `--loader` and bunfig do, so the three surfaces accept the same names. The error message lists the keys of `LOADER_NAMES`, the table `from_string` reads, so every listed name is accepted and every accepted name is listed (`"sh"` rather than the variant name `"bunsh"`), and a loader added to the table shows up without a second list to update.
- Verified: `test/bundler/bundler_loader.test.ts` (new `loader map` block: jsonc, sqlite_embedded and napi through both the API and CLI backends; 5 of the 6 cases fail on the released binary, the CLI napi case documents existing parity) and `test/bundler/bun-build-api.test.ts` (the unknown-name error lists the data/native loaders and `sh`, and one build with every listed name mapped to an extension succeeds; fails on the released binary). Both files pass in full with the debug build. `test/integration/bun-types/bun-types.test.ts` passes, and fails on the new fixture lines without the `.d.ts` change.
- Also ran `test/bundler/cli.test.ts`, `bundler_bun.test.ts`, `bundler_compile.test.ts -t sqlite`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/resolve/import-query.test.ts` (runtime plugins and `--loader` go through `to_api` too), `cargo clippy` on the touched crates, and the source lints.

### Related PRs
- #36648 contains the same `Jsonc => jsonc` change (plus an unrelated JSON error-message improvement) but not the `Bun.build` name table or `sqlite_embedded`; whichever lands first, the other rebases trivially.
- #37095 removes the whole `api::Loader` layer and fixes all of this as a side effect; it deletes the lines this PR touches, so it rebases cleanly over this either way. This PR is the small fix that can land now.
- #38283 makes the CLI's invalid `--loader` error list the same `LOADER_NAMES` keys and deletes `bun_core::fmt::enum_tag_list`. This PR no longer uses `enum_tag_list`, so the two land in either order.

### Background
- Bun has two loader enums. `bun_ast::Loader` is the one the bundler and runtime use. `api::Loader` (`src/options_types/schema.rs`) is the wire/option-bag form stored in `api::TransformOptions.loaders`, which is what the CLI, bunfig and `Bun.build` all fill in; `bundler/options.rs` converts it back with `from_api` when building the extension -> loader map. A `to_api` arm that merges two loaders therefore changes what a user-supplied name means.
- `jsonc` is the lenient JSON loader (comments, trailing commas); `json` is strict. `sqlite_embedded` is the loader selected by `with { type: "sqlite", embed: "true" }`: the database is copied into the output (or the compiled binary) and referenced by a relative path, whereas `sqlite` references the original file.
- `LOADER_NAMES` (`src/ast/loader.rs`) is the name -> `Loader` table behind `Loader::from_string`. It holds the canonical names plus extension-style aliases (`mjs`, `cts`, `node`, `txt`, `markdown`), because the same lookup is also the fallback that maps an unknown file extension to a loader.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
