### PR TITLE
node:vm: apply negative lineOffset/columnOffset to stack frames and the error header

### DIFF
--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -173,7 +173,7 @@ impl<'a> fmt::Display for SourceURLFormatter<'a> {
 
         if self.line_column == LineColumn::Include
             && !source_slice.is_empty()
-            && (self.position.line.is_valid() || self.position.column.is_valid())
+            && self.position.line.is_valid()
         {
             if self.enable_color {
                 f.write_str(Output::pretty_fmt!("<r><d>:", true))?;

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -91,7 +91,6 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
         .column_zero_based = OrdinalNumber::fromOneBasedInt(expr.lineColumn.column).zeroBasedInt(),
         .byte_position = (int)expr.divot,
     };
-    applyNegativeSourceStart(code, pos.line_zero_based, pos.column_zero_based);
 
     auto inst = code->instructionAt(bc);
 
@@ -116,6 +115,9 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
         break;
     }
 
+    // Last, so that the walk above runs on the coordinates JSC reported (it recounts the column
+    // from the source when it crosses a line) and the first-line test sees the line it ended on.
+    applyNegativeSourceStart(code, pos.line_zero_based, pos.column_zero_based);
     return pos;
 }
 

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -14,14 +14,12 @@ void applyNegativeSourceStart(CodeBlock* code, int& lineZeroBased, int& columnZe
     if (!provider)
         return;
 
-    // Function code blocks share the provider of the program they were parsed from, so this is
-    // the whole source's start even for a frame inside a function.
+    // Nested functions share the program's provider, so this is the whole source's start.
     TextPosition start = provider->startPosition();
     int startLine = start.m_line.zeroBasedInt();
     int startColumn = start.m_column.zeroBasedInt();
 
-    // JSC only adds the start column to positions on the first physical line, which it reports
-    // as the clamped start line.
+    // JSC applies the start column to the first physical line only, reported as the clamped start line.
     if (startColumn < 0 && lineZeroBased == std::max(startLine, 0))
         columnZeroBased += startColumn;
     if (startLine < 0)
@@ -115,8 +113,7 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
         break;
     }
 
-    // Last, so that the walk above runs on the coordinates JSC reported (it recounts the column
-    // from the source when it crosses a line) and the first-line test sees the line it ended on.
+    // After the walk: it works in JSC's coordinates and may end on a different line.
     applyNegativeSourceStart(code, pos.line_zero_based, pos.column_zero_based);
     return pos;
 }

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -1,12 +1,32 @@
 #include "root.h"
+#include "ErrorStackFrame.h"
 #include "JavaScriptCore/CodeBlock.h"
-#include "headers-handwritten.h"
-#include "JavaScriptCore/BytecodeIndex.h"
+#include "JavaScriptCore/StackFrame.h"
 #include "wtf/Assertions.h"
 #include "wtf/text/OrdinalNumber.h"
 
 namespace Bun {
 using namespace JSC;
+
+void applyNegativeSourceStart(CodeBlock* code, int& lineZeroBased, int& columnZeroBased)
+{
+    auto* provider = code->source().provider();
+    if (!provider)
+        return;
+
+    // Function code blocks share the provider of the program they were parsed from, so this is
+    // the whole source's start even for a frame inside a function.
+    TextPosition start = provider->startPosition();
+    int startLine = start.m_line.zeroBasedInt();
+    int startColumn = start.m_column.zeroBasedInt();
+
+    // JSC only adds the start column to positions on the first physical line, which it reports
+    // as the clamped start line.
+    if (startColumn < 0 && lineZeroBased == std::max(startLine, 0))
+        columnZeroBased += startColumn;
+    if (startLine < 0)
+        lineZeroBased += startLine;
+}
 
 /// Adjust a `ZigStackFramePosition` by a number of bytes. This accounts for when the adjustment
 /// crosses line boundaries, and thus requires the source code in order to properly compute
@@ -71,6 +91,7 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
         .column_zero_based = OrdinalNumber::fromOneBasedInt(expr.lineColumn.column).zeroBasedInt(),
         .byte_position = (int)expr.divot,
     };
+    applyNegativeSourceStart(code, pos.line_zero_based, pos.column_zero_based);
 
     auto inst = code->instructionAt(bc);
 
@@ -95,6 +116,18 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
         break;
     }
 
+    return pos;
+}
+
+ZigStackFramePosition getLineColumnForStackFrame(const StackFrame& frame)
+{
+    auto lineColumn = frame.computeLineAndColumn();
+    ZigStackFramePosition pos {
+        .line_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.line).zeroBasedInt(),
+        .column_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.column).zeroBasedInt(),
+        .byte_position = -1,
+    };
+    applyNegativeSourceStart(frame.codeBlock(), pos.line_zero_based, pos.column_zero_based);
     return pos;
 }
 

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -13,9 +13,7 @@ namespace Bun {
 
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// Adds the negative part of the provider's start position (node:vm lineOffset / columnOffset < 0)
-/// to a position reported by JSC, which counts from the start clamped to 1:1 (JSC::SourceCode).
-/// No-op for every other source.
+/// Re-adds the part of a negative node:vm lineOffset / columnOffset that JSC::SourceCode clamps away; no-op for other sources.
 void applyNegativeSourceStart(JSC::CodeBlock* code, int& lineZeroBased, int& columnZeroBased);
 
 /// StackFrame::computeLineAndColumn() of a frame with a code block, with the above applied.

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -13,15 +13,12 @@ namespace Bun {
 
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// JSC::SourceCode counts from its start position clamped to line 1, column 1, so a source
-/// created with a negative start (node:vm lineOffset / columnOffset below 0) reports physical
-/// positions while its SourceProvider still carries the requested start. This adds back the part
-/// JSC dropped, which is the position V8 reports for the same options. No-op for sources that
-/// start at or after 1:1, i.e. everything that is not node:vm code.
+/// Adds the negative part of the provider's start position (node:vm lineOffset / columnOffset < 0)
+/// to a position reported by JSC, which counts from the start clamped to 1:1 (JSC::SourceCode).
+/// No-op for every other source.
 void applyNegativeSourceStart(JSC::CodeBlock* code, int& lineZeroBased, int& columnZeroBased);
 
-/// StackFrame::computeLineAndColumn() with applyNegativeSourceStart applied; byte_position is -1.
-/// The frame must have a code block (StackFrame::hasLineAndColumnInfo()).
+/// StackFrame::computeLineAndColumn() of a frame with a code block, with the above applied.
 ZigStackFramePosition getLineColumnForStackFrame(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -1,9 +1,27 @@
+#pragma once
+
 #include "root.h"
 #include "headers-handwritten.h"
 #include "JavaScriptCore/BytecodeIndex.h"
 
+namespace JSC {
+class CodeBlock;
+class StackFrame;
+}
+
 namespace Bun {
 
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
+
+/// JSC::SourceCode counts from its start position clamped to line 1, column 1, so a source
+/// created with a negative start (node:vm lineOffset / columnOffset below 0) reports physical
+/// positions while its SourceProvider still carries the requested start. This adds back the part
+/// JSC dropped, which is the position V8 reports for the same options. No-op for sources that
+/// start at or after 1:1, i.e. everything that is not node:vm code.
+void applyNegativeSourceStart(JSC::CodeBlock* code, int& lineZeroBased, int& columnZeroBased);
+
+/// StackFrame::computeLineAndColumn() with applyNegativeSourceStart applied; byte_position is -1.
+/// The frame must have a code block (StackFrame::hasLineAndColumnInfo()).
+ZigStackFramePosition getLineColumnForStackFrame(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -21,6 +21,7 @@
 
 #include "BunClientData.h"
 #include "CallSite.h"
+#include "ErrorStackFrame.h"
 #include "ErrorStackTrace.h"
 #include "headers-handwritten.h"
 
@@ -243,11 +244,11 @@ WTF::String formatStackTrace(
     // file's map once instead of per frame.
     WTF::Vector<ZigStackFrame, 8> remappedFrames;
     WTF::Vector<WTF::String, 8> sourceURLs;
-    WTF::Vector<LineColumn, 8> originalLineColumns;
+    WTF::Vector<ZigStackFramePosition, 8> originalPositions;
     remappedFrames.grow(framesCount);
     memset(remappedFrames.begin(), 0, sizeof(ZigStackFrame) * framesCount);
     sourceURLs.grow(framesCount);
-    originalLineColumns.grow(framesCount);
+    originalPositions.grow(framesCount);
     bool anyRemap = false;
 
     for (size_t i = 0; i < framesCount; i++) {
@@ -260,11 +261,11 @@ WTF::String formatStackTrace(
         remappedFrame.position.line_zero_based = -1;
         remappedFrame.position.column_zero_based = -1;
         remappedFrame.position.byte_position = -1;
-        originalLineColumns[i] = {};
+        originalPositions[i] = remappedFrame.position;
 
         if (!frame.hasLineAndColumnInfo()) continue;
 
-        originalLineColumns[i] = frame.computeLineAndColumn();
+        originalPositions[i] = Bun::getLineColumnForStackFrame(frame);
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
         if (auto* callee = frame.callee()) {
@@ -280,8 +281,7 @@ WTF::String formatStackTrace(
         if (isDefinitelyNotRunninginNodeVMGlobalObject || isDefaultGlobalObjectInAFinalizer) {
             // https://github.com/oven-sh/bun/issues/3595
             if (!sourceURLs[i].isEmpty()) {
-                remappedFrame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line).zeroBasedInt();
-                remappedFrame.position.column_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column).zeroBasedInt();
+                remappedFrame.position = originalPositions[i];
                 remappedFrame.source_url = Bun::toStringRef(sourceURLs[i]);
                 anyRemap = true;
             }
@@ -316,8 +316,8 @@ WTF::String formatStackTrace(
         WTF::String sourceURLForFrame = sourceURLs[i];
 
         if (frame.hasLineAndColumnInfo()) {
-            originalLine = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line);
-            originalColumn = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column);
+            originalLine = originalPositions[i].line();
+            originalColumn = originalPositions[i].column();
             displayLine = originalLine;
             displayColumn = originalColumn;
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -575,6 +575,12 @@ static JSValue computeErrorInfoToJSValue(JSC::VM& vm, Vector<StackFrame>& stackT
     return computeErrorInfoToJSValueWithoutSkipping(vm, stackTrace, line, column, sourceURL, errorInstance, bunErrorData);
 }
 
+// ErrorInstance keeps error.line / error.column unsigned; a node:vm offset can put a position at or below 0, which reads as unset (0) there.
+static unsigned toUnsignedOneBased(OrdinalNumber ordinal)
+{
+    return static_cast<unsigned>(std::max(ordinal.oneBasedInt(), 0));
+}
+
 WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, Vector<StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, String& sourceURL, void* bunErrorData)
 {
     UNUSED_PARAM(bunErrorData);
@@ -607,8 +613,8 @@ WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, Vector<StackFrame>& sta
         result = WTF::emptyString();
     }
 
-    line_in = line.oneBasedInt();
-    column_in = column.oneBasedInt();
+    line_in = toUnsignedOneBased(line);
+    column_in = toUnsignedOneBased(column);
 
     return result;
 }
@@ -644,8 +650,8 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
 
     JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorInstance, bunErrorData);
 
-    line_in = line.oneBasedInt();
-    column_in = column.oneBasedInt();
+    line_in = toUnsignedOneBased(line);
+    column_in = toUnsignedOneBased(column);
 
     // materializeErrorInfoIfNeeded putDirect()s this unconditionally; an empty JSValue
     // in property storage crashes the next read. https://github.com/oven-sh/bun/issues/34095

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -188,14 +188,15 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
 
     // The user's body starts on line 2 of the wrapped program (after the
-    // "(function () {\n" prefix). Shift the provider's start position up one
-    // line so reported positions line up with the body the way V8's
-    // CompileFunction does: body line 1 reports as lineOffset+1. JSC clamps
-    // non-positive provider start positions to zero, so once the input is
-    // already <= 0 there is nothing to gain by going further negative; clamp
-    // there to keep the value bounded for downstream arithmetic.
-    int lineZeroBased = position.m_line.zeroBasedInt();
-    TextPosition wrappedPosition(OrdinalNumber::fromZeroBasedInt(lineZeroBased > 0 ? lineZeroBased - 1 : lineZeroBased), position.m_column);
+    // "(function () {\n" prefix). Start the program one line above the
+    // requested offset so body line N reports as N + lineOffset, the way V8's
+    // CompileFunction does. For lineOffset <= 0 this start is negative; JSC
+    // counts from line 1 regardless and the stack formatters add the negative
+    // part back (Bun::applyNegativeSourceStart).
+    int startLine = position.m_line.zeroBasedInt();
+    if (startLine != std::numeric_limits<int>::min())
+        startLine--;
+    TextPosition wrappedPosition(OrdinalNumber::fromZeroBasedInt(startLine), position.m_column);
 
     SourceCode sourceCode(
         JSC::StringSourceProvider::create(code, sourceOrigin, WTF::move(options.filename), sourceTaintOrigin, wrappedPosition, SourceProviderSourceType::Program),
@@ -570,23 +571,32 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         // Node decorates vm script errors with the offending source line and a
         // caret marker (AppendExceptionLine):
         //   <url>:<line>\n<source line>\n<caret>\n\n<stack>
+        int reportedLine = static_cast<int>(line_and_column.line);
         String sourceLineText;
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                int64_t startLineZeroBased = provider->startPosition().m_line.zeroBasedInt();
-                int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - startLineZeroBased;
+                // JSC::SourceCode clamps the start position it counts from to 1:1,
+                // so line_and_column only carries the non-negative part of
+                // lineOffset/columnOffset: undo that part to index the source
+                // text, then report the physical line with the whole offset, as
+                // Node does (and as Bun::applyNegativeSourceStart does for the
+                // frames below the header).
+                TextPosition start = provider->startPosition();
+                int startLineZeroBased = start.m_line.zeroBasedInt();
+                int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - std::max(startLineZeroBased, 0);
+                reportedLine = static_cast<int>(physicalLine + startLineZeroBased);
                 sourceLineText = nthSourceLineForArrowHeader(provider->source(), physicalLine);
                 if (!sourceLineText.isNull()) {
                     caretColumn = line_and_column.column;
-                    unsigned startColumnZeroBased = static_cast<unsigned>(provider->startPosition().m_column.zeroBasedInt());
+                    unsigned startColumnZeroBased = static_cast<unsigned>(std::max(start.m_column.zeroBasedInt(), 0));
                     if (physicalLine == 1 && caretColumn > startColumnZeroBased)
                         caretColumn -= startColumnZeroBased;
                 }
             }
         }
 
-        writeArrowHeaderStack(vm, errorInstance, source_url, static_cast<int>(line_and_column.line), sourceLineText, caretColumn, stack);
+        writeArrowHeaderStack(vm, errorInstance, source_url, reportedLine, sourceLineText, caretColumn, stack);
 
         JSC::throwException(globalObject, throwScope, exception.get());
         return true;

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -187,12 +187,8 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     String code = stringifyAnonymousFunction(globalObject, args, throwScope, &startOffset);
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
 
-    // The user's body starts on line 2 of the wrapped program (after the
-    // "(function () {\n" prefix). Start the program one line above the
-    // requested offset so body line N reports as N + lineOffset, the way V8's
-    // CompileFunction does. For lineOffset <= 0 this start is negative; JSC
-    // counts from line 1 regardless and the stack formatters add the negative
-    // part back (Bun::applyNegativeSourceStart).
+    // The body is line 2 of the wrapped program, so start the program one line
+    // early; a negative start is honored by Bun::applyNegativeSourceStart.
     int startLine = position.m_line.zeroBasedInt();
     if (startLine != std::numeric_limits<int>::min())
         startLine--;
@@ -576,12 +572,8 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                // JSC::SourceCode clamps the start position it counts from to 1:1,
-                // so line_and_column only carries the non-negative part of
-                // lineOffset/columnOffset: undo that part to index the source
-                // text, then report the physical line with the whole offset, as
-                // Node does (and as Bun::applyNegativeSourceStart does for the
-                // frames below the header).
+                // line_and_column includes the start position clamped to 1:1 (see
+                // Bun::applyNegativeSourceStart); the header shows the full offset.
                 TextPosition start = provider->startPosition();
                 int startLineZeroBased = start.m_line.zeroBasedInt();
                 int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - std::max(startLineZeroBased, 0);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -187,8 +187,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     String code = stringifyAnonymousFunction(globalObject, args, throwScope, &startOffset);
     EXCEPTION_ASSERT(!!throwScope.exception() == code.isNull());
 
-    // The body is line 2 of the wrapped program, so start the program one line
-    // early; a negative start is honored by Bun::applyNegativeSourceStart.
+    // The body is line 2 of the wrapped program; a negative start is honored by Bun::applyNegativeSourceStart.
     int startLine = position.m_line.zeroBasedInt();
     if (startLine != std::numeric_limits<int>::min())
         startLine--;
@@ -572,8 +571,7 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         unsigned caretColumn = 0;
         if (JSC::CodeBlock* codeBlock = stack_frame.codeBlock()) {
             if (JSC::SourceProvider* provider = codeBlock->source().provider()) {
-                // line_and_column includes the start position clamped to 1:1 (see
-                // Bun::applyNegativeSourceStart); the header shows the full offset.
+                // line_and_column was counted from the start clamped to 1:1 (see Bun::applyNegativeSourceStart).
                 TextPosition start = provider->startPosition();
                 int startLineZeroBased = start.m_line.zeroBasedInt();
                 int64_t physicalLine = static_cast<int64_t>(line_and_column.line) - std::max(startLineZeroBased, 0);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -145,13 +145,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         return;
 
     if (!stackFrame.hasBytecodeIndex()) {
-        if (stackFrame.hasLineAndColumnInfo()) {
-            auto lineColumn = stackFrame.computeLineAndColumn();
-            position.line_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.line).zeroBasedInt();
-            position.column_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.column).zeroBasedInt();
-        }
-
-        position.byte_position = -1;
+        position = Bun::getLineColumnForStackFrame(stackFrame);
         return;
     }
 
@@ -333,7 +327,8 @@ public:
                 auto segment1 = StringView_slice(lineInner, marker1, marker2);
                 auto segment2 = StringView_slice(lineInner, marker2 + 1, marker3);
 
-                if (auto int1 = WTF::parseIntegerAllowingTrailingJunk<unsigned int>(segment2)) {
+                // Signed: a node:vm lineOffset can push positions to 0 or below.
+                if (auto int1 = WTF::parseIntegerAllowingTrailingJunk<int>(segment2)) {
                     frame.sourceURL = segment1;
                     frame.lineNumber = WTF::OrdinalNumber::fromOneBasedInt(int1.value());
                 } else {
@@ -363,8 +358,8 @@ public:
             auto segment2 = StringView_slice(lineInner, marker2 + 1, marker3);
             auto segment3 = StringView_slice(lineInner, marker3 + 1, marker4);
 
-            if (auto int1 = WTF::parseIntegerAllowingTrailingJunk<unsigned int>(segment2)) {
-                if (auto int2 = WTF::parseIntegerAllowingTrailingJunk<unsigned int>(segment3)) {
+            if (auto int1 = WTF::parseIntegerAllowingTrailingJunk<int>(segment2)) {
+                if (auto int2 = WTF::parseIntegerAllowingTrailingJunk<int>(segment3)) {
                     frame.sourceURL = segment1;
                     frame.lineNumber = WTF::OrdinalNumber::fromOneBasedInt(int1.value());
                     frame.columnNumber = WTF::OrdinalNumber::fromOneBasedInt(int2.value());
@@ -373,7 +368,7 @@ public:
                     frame.lineNumber = WTF::OrdinalNumber::fromOneBasedInt(int1.value());
                 }
             } else {
-                if (auto int2 = WTF::parseIntegerAllowingTrailingJunk<unsigned int>(segment3)) {
+                if (auto int2 = WTF::parseIntegerAllowingTrailingJunk<int>(segment3)) {
                     frame.sourceURL = StringView_slice(lineInner, marker1, marker3);
                     frame.lineNumber = WTF::OrdinalNumber::fromOneBasedInt(int2.value());
                 } else {

--- a/test/js/node/test/parallel/test-vm-basic.js
+++ b/test/js/node/test/parallel/test-vm-basic.js
@@ -278,16 +278,15 @@ const vm = require('vm');
   Error.stackTraceLimit = 1;
 
   // Bun's compileFunction stack frames differ from Node's: JSC attributes
-  // the throw to a different column (and columnOffset is not applied), the
-  // wrapper costs one line when lineOffset is 0, and the anonymous source is
-  // labeled differently.
+  // the throw to a different column (and columnOffset is not applied), and
+  // the anonymous source is labeled differently.
   assert.throws(() => {
     vm.compileFunction('throw new Error("Sample Error")')();
   }, {
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:2:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:1:16)'
   });
 
   assert.throws(() => {
@@ -313,7 +312,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:10'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:2:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:1:16)'
   });
 
   assert.strictEqual(
@@ -337,7 +336,7 @@ const vm = require('vm');
     // Bun's compileFunction stack frames differ from Node's (see above).
     stack: typeof Bun === 'undefined'
       ? 'ReferenceError: varInContext is not defined\n    at <anonymous>:1:1'
-      : 'ReferenceError: varInContext is not defined\n    at <anonymous> (file:///:2:20)'
+      : 'ReferenceError: varInContext is not defined\n    at <anonymous> (file:///:1:20)'
   });
 
   assert.notDeepStrictEqual(

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -482,15 +482,15 @@ describe("negative lineOffset and columnOffset", () => {
   // The header node:vm prepends to a thrown error (`<url>:<line>`, source line,
   // caret line, blank line) and the rest of the stack.
   function thrown(run: () => unknown) {
-    let stack: string | undefined;
+    let error: any;
     try {
       run();
-    } catch (e: any) {
-      stack = e.stack;
+    } catch (e) {
+      error = e;
     }
-    expect(typeof stack).toBe("string");
-    const lines = stack!.split("\n");
-    return { header: lines.slice(0, 4), rest: lines.slice(4).join("\n") };
+    expect(typeof error?.stack).toBe("string");
+    const lines: string[] = error.stack.split("\n");
+    return { header: lines.slice(0, 4), rest: lines.slice(4).join("\n"), error };
   }
 
   const runners: Record<string, (code: string, options: object) => unknown> = {
@@ -507,6 +507,8 @@ describe("negative lineOffset and columnOffset", () => {
       const offset = thrown(() => run(fourLines, { filename: "n.js", lineOffset: -2 }));
       expect(offset.header).toEqual(["n.js:2", "throw new Error('x')", base.header[2], ""]);
       expect(frameAt(offset.rest, "n.js")).toEqual({ ...frameAt(base.rest, "n.js"), line: 2 });
+      // JSC's own error.line property follows the top frame.
+      expect([base.error.line, offset.error.line]).toEqual([4, 2]);
     });
   }
 
@@ -550,6 +552,9 @@ describe("negative lineOffset and columnOffset", () => {
       new Script("  throw new Error('x')", { filename: "z.js", lineOffset: -1, columnOffset: -1 }).runInThisContext(),
     );
     expect(zero.header).toEqual(["z.js:0", "  throw new Error('x')", expect.stringMatching(/^ *\^$/), ""]);
+
+    // error.line is unsigned in JSC; such positions read as unset instead of wrapping around.
+    expect([far.error.line, zero.error.line]).toEqual([0, 0]);
   });
 
   const makesError = "'line 1';\nfunction f() {\n  return new Error('x');\n}\nf();";
@@ -630,9 +635,10 @@ describe("negative lineOffset and columnOffset", () => {
     // displayErrors: false leaves err.stack alone, so the error printer shows its
     // own source excerpt and frames instead of the header checked above.
     const code = "1;\n2;\nfunction f() {\n  throw new Error('x');\n}\nf();";
-    const [excerpt, belowZero] = await Promise.all([
+    const [excerpt, belowZero, belowZeroDecorated] = await Promise.all([
       run(code, { filename: "n.js", lineOffset: -2, displayErrors: false }),
-      run(fourLines, { filename: "nn.js", lineOffset: -10 }),
+      run(code, { filename: "nn.js", lineOffset: -10, displayErrors: false }),
+      run(code, { filename: "nn.js", lineOffset: -10 }),
     ]);
 
     expect(excerpt.stderr).toMatch(/^2 \| +throw new Error\('x'\);$/m);
@@ -640,9 +646,14 @@ describe("negative lineOffset and columnOffset", () => {
     expect(excerpt.stderr).toMatch(/at n\.js:4:\d+$/m);
     expect(excerpt.exitCode).toBe(1);
 
-    // Offsets that push the lines below 1 still print the error and exit normally.
-    expect(belowZero.stderr).toContain("error: x");
+    // The printer cannot show a line at or below 0, so such frames are printed
+    // without a position, whether it reads the frames directly or re-parses
+    // the `at f (nn.js:-6:9)` lines of the stack node:vm already decorated.
+    expect(belowZero.stderr).toMatch(/^\s+at f \(nn\.js\)$/m);
+    expect(belowZero.stderr).toMatch(/^\s+at nn\.js$/m);
     expect(belowZero.exitCode).toBe(1);
+    expect(belowZeroDecorated.stderr).toMatch(/^\s+at f \(nn\.js\)$/m);
+    expect(belowZeroDecorated.exitCode).toBe(1);
   });
 });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -463,6 +463,181 @@ describe("Script", () => {
   });
 });
 
+// Position of the first `<filename>:<line>:<column>` frame in a stack. The header
+// node:vm prepends to thrown errors has no column, so it never matches.
+function frameAt(stack: string, filename: string) {
+  const match = stack.match(new RegExp(`${filename.replaceAll(".", "\\.")}:(-?\\d+):(\\d+)`));
+  expect(match).not.toBeNull();
+  return { line: Number(match![1]), column: Number(match![2]) };
+}
+
+// lineOffset / columnOffset are signed in Node: a negative offset is how a caller
+// compensates for wrapper text it prepended to the source, and V8 reports the
+// resulting positions as-is. JSC clamps the position a source starts at to 1:1,
+// so the negative part has to be re-applied by Bun, both in the arrow header
+// node:vm prepends to a thrown error's stack and in every rendering of the frames.
+describe("negative lineOffset and columnOffset", () => {
+  const fourLines = "1;\n2;\n3;\nthrow new Error('x')";
+
+  // The header node:vm prepends to a thrown error (`<url>:<line>`, source line,
+  // caret line, blank line) and the rest of the stack.
+  function thrown(run: () => unknown) {
+    let stack: string | undefined;
+    try {
+      run();
+    } catch (e: any) {
+      stack = e.stack;
+    }
+    expect(typeof stack).toBe("string");
+    const lines = stack!.split("\n");
+    return { header: lines.slice(0, 4), rest: lines.slice(4).join("\n") };
+  }
+
+  const runners: Record<string, (code: string, options: object) => unknown> = {
+    "Script#runInThisContext": (code, options) => new Script(code, options).runInThisContext(),
+    "Script#runInNewContext": (code, options) => new Script(code, options).runInNewContext({}),
+    "vm.runInThisContext": (code, options) => runInThisContext(code, options),
+  };
+  for (const [name, run] of Object.entries(runners)) {
+    test(`${name}: header line and frames carry a negative lineOffset`, () => {
+      const base = thrown(() => run(fourLines, { filename: "n.js" }));
+      expect(base.header).toEqual(["n.js:4", "throw new Error('x')", expect.stringMatching(/^ *\^$/), ""]);
+      expect(frameAt(base.rest, "n.js").line).toBe(4);
+
+      const offset = thrown(() => run(fourLines, { filename: "n.js", lineOffset: -2 }));
+      expect(offset.header).toEqual(["n.js:2", "throw new Error('x')", base.header[2], ""]);
+      expect(frameAt(offset.rest, "n.js")).toEqual({ ...frameAt(base.rest, "n.js"), line: 2 });
+    });
+  }
+
+  test("the source line shown is the physical one, not the one at line + |offset|", () => {
+    // Before the offset was taken into account here the header showed the line
+    // *after* the throw (with the caret under it) whenever it was long enough.
+    const code = "1;\nthrow new Error('x');\nconsole.log('a line long enough for the caret to fit under it');";
+    const { header } = thrown(() => new Script(code, { filename: "w.js", lineOffset: -1 }).runInThisContext());
+    expect(header).toEqual(["w.js:1", "throw new Error('x');", expect.stringMatching(/^ *\^$/), ""]);
+  });
+
+  test("frames inside functions defined by the script are offset too", () => {
+    const code = "function f() {\n  throw new Error('x');\n}\nf();";
+    const { header, rest } = thrown(() => new Script(code, { filename: "nf.js", lineOffset: -1 }).runInThisContext());
+    expect(header).toEqual(["nf.js:1", "  throw new Error('x');", expect.stringMatching(/^ *\^$/), ""]);
+    expect(rest).toMatch(/^    at f \(nf\.js:1:\d+\)$/m);
+    expect(rest).toMatch(/^    at nf\.js:3:\d+$/m);
+  });
+
+  test("columnOffset shifts the first line's frame columns either way; the caret stays on the text", () => {
+    const code = "      throw new Error('x')";
+    const run = (options: object) =>
+      thrown(() => new Script(code, { filename: "c.js", ...options }).runInThisContext());
+    const base = run({});
+    expect(base.header).toEqual(["c.js:1", code, expect.stringMatching(/^ *\^$/), ""]);
+    const baseFrame = frameAt(base.rest, "c.js");
+
+    for (const columnOffset of [3, -3]) {
+      const offset = run({ columnOffset });
+      // Same caret line: the caret marks a column of the text, which did not move.
+      expect(offset.header).toEqual(base.header);
+      expect(frameAt(offset.rest, "c.js")).toEqual({ line: 1, column: baseFrame.column + columnOffset });
+    }
+  });
+
+  test("header lines at or below zero are reported like Node does", () => {
+    const far = thrown(() => new Script(fourLines, { filename: "nn.js", lineOffset: -10 }).runInThisContext());
+    expect(far.header).toEqual(["nn.js:-6", "throw new Error('x')", expect.stringMatching(/^ *\^$/), ""]);
+
+    const zero = thrown(() =>
+      new Script("  throw new Error('x')", { filename: "z.js", lineOffset: -1, columnOffset: -1 }).runInThisContext(),
+    );
+    expect(zero.header).toEqual(["z.js:0", "  throw new Error('x')", expect.stringMatching(/^ *\^$/), ""]);
+  });
+
+  const makesError = "'line 1';\nfunction f() {\n  return new Error('x');\n}\nf();";
+
+  test("Error.prepareStackTrace call sites see the offsets", () => {
+    // Positions of the call sites in `filename` as [line, column] pairs.
+    const callSites = (code: string, options: { filename: string; lineOffset?: number; columnOffset?: number }) => {
+      const previous = Error.prepareStackTrace;
+      Error.prepareStackTrace = (_, sites) =>
+        sites.filter(s => s.getFileName() === options.filename).map(s => [s.getLineNumber(), s.getColumnNumber()]);
+      try {
+        return new Script(code, options).runInThisContext().stack as [number, number][];
+      } finally {
+        Error.prepareStackTrace = previous;
+      }
+    };
+
+    const base = callSites(makesError, { filename: "cs.js" });
+    expect(base.map(([line]) => line)).toEqual([3, 5]);
+    const lines = callSites(makesError, { filename: "cs.js", lineOffset: -1 });
+    expect(lines).toEqual([
+      [2, base[0][1]],
+      [4, base[1][1]],
+    ]);
+
+    const code = "      new Error('x')";
+    const [[, baseColumn]] = callSites(code, { filename: "cc.js" });
+    expect(callSites(code, { filename: "cc.js", columnOffset: -3 })).toEqual([[1, baseColumn - 3]]);
+  });
+
+  test("Bun.inspect() prints the offset line numbers", () => {
+    const error = new Script(makesError, { filename: "insp.js", lineOffset: -1 }).runInThisContext();
+    const inspected = Bun.inspect(error);
+    expect(inspected).toMatch(/^2 \| +return new Error\('x'\);$/m);
+    expect(inspected).toMatch(/at f \(insp\.js:2:\d+\)$/m);
+    expect(inspected).toMatch(/at insp\.js:4:\d+$/m);
+  });
+
+  test("compileFunction reports body line N as N + lineOffset for every sign of the offset", () => {
+    const body = "1;\nthrow new Error('x')";
+    const lineFor = (lineOffset: number) => {
+      let stack: string | undefined;
+      try {
+        compileFunction(body, [], { filename: "cf.js", lineOffset })();
+      } catch (e: any) {
+        stack = e.stack;
+      }
+      return frameAt(stack!, "cf.js").line;
+    };
+    expect([-1, 0, 3].map(lineFor)).toEqual([1, 2, 5]);
+  });
+
+  test.concurrent("uncaught errors are printed with the offset positions", async () => {
+    const run = async (code: string, options: object) => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `require("node:vm").runInThisContext(${JSON.stringify(code)}, ${JSON.stringify(options)})`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      return { stderr, exitCode };
+    };
+
+    // displayErrors: false leaves err.stack alone, so the error printer shows its
+    // own source excerpt and frames instead of the header checked above.
+    const code = "1;\n2;\nfunction f() {\n  throw new Error('x');\n}\nf();";
+    const [excerpt, belowZero] = await Promise.all([
+      run(code, { filename: "n.js", lineOffset: -2, displayErrors: false }),
+      run(fourLines, { filename: "nn.js", lineOffset: -10 }),
+    ]);
+
+    expect(excerpt.stderr).toMatch(/^2 \| +throw new Error\('x'\);$/m);
+    expect(excerpt.stderr).toMatch(/at f \(n\.js:2:\d+\)$/m);
+    expect(excerpt.stderr).toMatch(/at n\.js:4:\d+$/m);
+    expect(excerpt.exitCode).toBe(1);
+
+    // Offsets that push the lines below 1 still print the error and exit normally.
+    expect(belowZero.stderr).toContain("error: x");
+    expect(belowZero.exitCode).toBe(1);
+  });
+});
+
 type TestRunInContextArg =
   | { fn: typeof runInContext; isIsolated: true; isNew?: boolean }
   | { fn: typeof runInThisContext; isIsolated?: false; isNew?: boolean };
@@ -671,11 +846,38 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
   test.todo("can specify filename", () => {
     //
   });
-  test.todo("can specify lineOffset", () => {
-    //
+  // Runs `code`, which evaluates to a stack string, through whichever entry
+  // point this suite exercises and returns the position of its frame in `file`.
+  const positionOf = (code: string, offsets: { lineOffset?: number; columnOffset?: number } = {}) => {
+    const options = { filename: "offsets.js", ...offsets };
+    const stack: string = isIsolated
+      ? (fn as typeof runInContext)(code, createContext({}), options)
+      : (fn as typeof runInThisContext)(code, options);
+    return frameAt(stack, options.filename);
+  };
+
+  test("can specify lineOffset", () => {
+    // `new Error()` sits on physical line 4; lineOffset is added to it in
+    // either direction (a negative offset is how callers compensate for
+    // wrapper lines they prepended to the source).
+    const code = "\n\n\n  new Error().stack;";
+    expect(positionOf(code).line).toBe(4);
+    expect(positionOf(code, { lineOffset: 10 }).line).toBe(14);
+    expect(positionOf(code, { lineOffset: -2 }).line).toBe(2);
   });
-  test.todo("can specify columnOffset", () => {
-    //
+  test("can specify columnOffset", () => {
+    // columnOffset applies to the first physical line of the source only, in
+    // either direction. The column JSC attributes to the expression is taken
+    // from an un-offset run so only the offset arithmetic is asserted here.
+    const code = "    new Error().stack;";
+    const base = positionOf(code);
+    expect(base.line).toBe(1);
+    expect(positionOf(code, { columnOffset: 10 })).toEqual({ line: 1, column: base.column + 10 });
+    expect(positionOf(code, { columnOffset: -2 })).toEqual({ line: 1, column: base.column - 2 });
+    // Still the first physical line when lineOffset moves its number.
+    expect(positionOf(code, { lineOffset: 5, columnOffset: -2 })).toEqual({ line: 6, column: base.column - 2 });
+    // Not the first physical line: the column is untouched.
+    expect(positionOf("\n" + code, { lineOffset: -1, columnOffset: -2 })).toEqual({ line: 1, column: base.column });
   });
   test.todo("can specify timeout", () => {
     //

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -578,6 +578,14 @@ describe("negative lineOffset and columnOffset", () => {
     const code = "      new Error('x')";
     const [[, baseColumn]] = callSites(code, { filename: "cc.js" });
     expect(callSites(code, { filename: "cc.js", columnOffset: -3 })).toEqual([[1, baseColumn - 3]]);
+
+    // Call sites of a `new` expression are reported at the `new` keyword. JSC's
+    // own position for this one is on line 2, so the column offset has to be
+    // applied after the position has been moved back onto the first line.
+    const wrapped = "      new\nError('x')";
+    const [[wrappedLine, wrappedColumn]] = callSites(wrapped, { filename: "nl.js" });
+    expect(wrappedLine).toBe(1);
+    expect(callSites(wrapped, { filename: "nl.js", columnOffset: -3 })).toEqual([[1, wrappedColumn - 3]]);
   });
 
   test("Bun.inspect() prints the offset line numbers", () => {


### PR DESCRIPTION
### Problem
- A negative `lineOffset` is ignored at runtime by `vm.Script`, `vm.runInThisContext` and `vm.runInContext`. `new vm.Script("1;\n2;\n3;\nthrow new Error('x')", { filename: "n.js", lineOffset: -2 }).runInThisContext()` produces a stack starting `n.js:4` / `Error: x` / `at n.js:4:16`; Node prints `n.js:2`, the source line, a caret, then `at n.js:2:7`. Positive offsets work. A negative offset is the usual way to compensate for wrapper lines a caller prepended to the source.
- The header node:vm prepends to the stack loses its source line and caret for negative offsets, and with `lineOffset: -1` it shows the line *after* the throw, caret included.
- `columnOffset < 0` is dropped from the first line's frame columns the same way, and `vm.compileFunction` reports body line N as N + 1 for every `lineOffset <= 0`.
- Cause: `JSC::SourceCode`'s constructor clamps the line and column a source starts at to 1 (`vendor/WebKit/Source/JavaScriptCore/parser/SourceCode.h`), and every position JSC reports is `clamped start + physical position`, so the negative part never reaches the frames. `handleException` (`src/jsc/bindings/NodeVM.cpp`) then subtracted the provider's *unclamped* start (`-2`) from JSC's line to locate the source line, landing two lines below the throw.

### Fix
- `Bun::applyNegativeSourceStart` (`src/jsc/bindings/ErrorStackFrame.cpp`): the `SourceProvider` still carries the requested start, so after JSC's line/column is read, `min(startLine, 0)` is added to the line and, on the first physical line, `min(startColumn, 0)` to the column. It runs as the last step of `getAdjustedPositionForBytecode` (call sites for `Error.prepareStackTrace`, `Bun.inspect`, the uncaught error printer), after the walk that moves `new X()` frames back to the `new` keyword, since that walk works in the coordinates JSC reported and can end on the first line; and in `formatStackTrace` (`error.stack`) and `populateStackFramePosition`'s fallback through the new `getLineColumnForStackFrame`.
- Correct because JSC's value is exactly `physical + max(start, 0)`: `CodeBlock::lineColumnForBytecodeIndex` adds the executable's first line, and `UnlinkedFunctionExecutable::linkedSourceCode` derives nested functions' first line and column from the clamped program values while sharing the provider. Adding `min(start, 0)` therefore gives `physical + start`, which is what V8 reports and Node prints. Every provider outside node:vm starts at 0:0 (JSC's own `makeSource` callers, eval, `new Function`, Bun's providers), so this is a no-op for them; positive offsets are unchanged.
- `handleException` removes only what JSC added (`max(start, 0)`) to find the physical line and prints `physical + start` as the header line, so the header matches Node (`n.js:2`, `nn.js:-6`, `z.js:0`) and the frames under it. The caret uses the clamped start column the same way instead of relying on an unsigned wraparound.
- `constructAnonymousFunction` shifts the wrapped program's start line by one unconditionally; its comment gave the clamp as the reason not to, which no longer applies. Body line N now reports as N + lineOffset for every offset, which also removes the off-by-one at the default `lineOffset: 0` (`INT_MIN` is left alone rather than overflowed). compileFunction's `columnOffset` on body line 1 was never applied and still is not (that line is physical line 2 of the wrapped program).
- Positions an offset pushes to line 0 or below: `error.stack` and `CallSite#toJSON` carry them as V8 would (`at f (nn.js:-6:18)`); Bun's own renderers treat a non-positive line as "no position", and three of them needed fixing for that to come out clean: the error printer's stack-string parser (`ZigException.cpp`, `V8StackTraceIterator`) read line numbers as unsigned and turned `nn.js:-6:18` into the url `nn.js:-6` with line 18; the printer (`src/jsc/ZigStackFrame.rs`) wrote the `:` separator when only the column was valid (`at f (nn.js:)`); and `error.line` / `error.column`, which `ErrorInstance` stores unsigned, wrapped to 4294967290 and now read 0. They render as `at f (nn.js)` now.
- Trade-off to be aware of: the bias lives in the start position node:vm already stores on the provider. JSC's debugger reads that value unclamped and `InspectorDebuggerAgent::resolveBreakpoint` compares it as unsigned, so breakpoints cannot be set in a source whose start is negative. That was already the case for `vm.Script` with a negative `lineOffset`; with this PR it also covers compileFunction code at the default offset, which only matters when a debugger attaches after the functions were compiled (compileFunction programs are not reported to an already attached debugger at all). Recording the bias on `NodeVMScriptFetcher` instead (keyed by source id so eval code inside the body stays unbiased, as #38240 does for its wrapper columns) would avoid that at the cost of threading it through the three creation sites; I kept the provider since it is the data JSC already keeps for exactly this purpose and eval/`new Function` get fresh providers for free.
- Verified with `test/js/node/vm/vm.test.ts`: the `can specify lineOffset` / `columnOffset` todos are implemented for all six run entry points, and a new `describe` covers the header (line, source line, caret) through `Script#runInThisContext`, `Script#runInNewContext` and `vm.runInThisContext`, the wrong-line case, frames in nested functions, `columnOffset` in both directions, lines at or below zero (header, `error.line`, and the uncaught printer with and without the decorated stack), `Error.prepareStackTrace` call sites (including a `new` whose callee is on the next line and gets walked back onto the first), `Bun.inspect`, `compileFunction` with offsets -1/0/3, and the uncaught printer in a subprocess. 23 tests fail on the released binary and on a debug build without the `src/` change; all pass with it. Columns are asserted relative to an un-offset run, so the tests do not depend on which column JSC attributes to a throw.
- Also ran `test/js/node/vm/` (`script-leak.test.ts` times out on this debug+ASAN container with and without the change), all 95 `test/js/node/test/parallel/test-vm-*.js` (the Bun-specific expectations in `test-vm-basic.js` that documented the compileFunction off-by-one now expect Node's lines, following the file's existing `typeof Bun` gating), `test/js/bun/test/stack.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/regression/issue/23022-stack-trace-iterator.test.ts`, `test/js/bun/sourcemap/`, `test/js/node/module/sourcemap.test.js`, `inspect.test.js` and `inspect-error.test.js` (its two minified-file snapshots fail on debug builds before this change as well; tracked separately). Output for non-vm errors is byte-identical to the released binary in the scripts I compared.
- Overlaps: #38240 fixes the compileFunction off-by-one by putting the body on the wrapper's own line plus a fetcher-recorded column correction. With the line bias from this PR the one-line shift already gives correct lines, so what remains distinct there is `columnOffset` on body line 1. If its layout is kept, its `constructAnonymousFunction` block has to replace this PR's shift (keeping both reports one line too high), and its column step has to run in JSC's coordinates, i.e. before `applyNegativeSourceStart`. #38228, #38236, #38239 and #38245 touch neighbouring lines of `constructAnonymousFunction`. #37396 restructures the same spots of `formatStackTrace` / `ErrorStackFrame.cpp` / `populateStackFramePosition`; on top of it, `applyNegativeSourceStart` stays the last step of both of its branches, and its rewritten walk should add the clamped (`max(start, 0)`) start column when it lands on the first line so that this step still converts JSC coordinates; the line-crossing test case here catches a double application.

### Background
- `lineOffset` / `columnOffset` tell node:vm where a snippet sits inside a larger file. They are zero-based and signed; Node adds `lineOffset` to every line and `columnOffset` to the first line's columns only, and V8 reports the sums as-is, including 0 or negative results.
- A JSC `SourceProvider` holds the source text and the `TextPosition` it was created with. A `SourceCode` is a range of a provider plus the one-based line and column JSC counts from, clamped to 1. Frames report positions relative to their code block's `SourceCode`; functions defined in a program get `SourceCode`s derived from the program's, all pointing at the same provider.
- The "arrow header" is Bun's implementation of Node's `DecorateErrorStack`: when an error escapes a vm run, `handleException` prepends `<url>:<line>`, the offending source line and a caret to `error.stack`. Compile-time SyntaxErrors get the same from `decorateParseErrorStack`, which already handled negative offsets.
- `getAdjustedPositionForBytecode` is where Bun already post-processes JSC positions (it moves `new X()` frames to the `new` keyword); `formatStackTrace` builds the `error.stack` string and used to read JSC's raw line/column directly. Positions cross to the Rust printer as `ZigStackFramePosition` (zero-based `int`s, where a negative value means "none"); once an error's `stack` string has been materialized, the printer gets its frames by re-parsing that string with `V8StackTraceIterator`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 23 failed, 50 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (e69768312)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [25.74ms]
(pass) vm > runInContext() > can return a value [19.50ms]
(pass) vm > runInContext() > can return a complex value [16.23ms]
(pass) vm > runInContext() > can return the last value [20.94ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.93ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.30ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.73ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.38ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [16.47ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [22.43ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [23.41ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [25.79ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 23 failed, 50 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.39ms]
(pass) vm > runInContext() > can return a value [0.22ms]
(pass) vm > runInContext() > can return a complex value [0.21ms]
(pass) vm > runInContext() > can return the last value [0.17ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.22ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 50 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (e69768312)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.03ms]
(pass) vm > runInContext() > can return a value [15.89ms]
(pass) vm > runInContext() > can return a complex value [16.41ms]
(pass) vm > runInContext() > can return the last value [15.28ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.66ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.41ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.08ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.13ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [16.21ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [24.33ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [21.28ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [18.61ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 50 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e69768312e
  features     baseline

22 deps, 123 codegen, 1176 objects in 904ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [21.00ms]
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1238] fetch zlib
[zlib] up to date
[7/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [18.00ms]
[8/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1238] gen .bind.ts → GeneratedBindings.cpp
[10/1238] fetch tinycc
[tinycc] up to date
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ZigStackFrame.rs                    |   5 +-
 src/jsc/bindings/ErrorStackFrame.cpp        |  36 ++++-
 src/jsc/bindings/ErrorStackFrame.h          |  13 ++
 src/jsc/bindings/FormatStackTraceForJS.cpp  |  30 ++--
 src/jsc/bindings/NodeVM.cpp                 |  26 ++--
 src/jsc/bindings/ZigException.cpp           |  17 +--
 test/js/node/test/parallel/test-vm-basic.js |  11 +-
 test/js/node/vm/vm.test.ts                  | 229 +++++++++++++++++++++++++++-
 8 files changed, 315 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/ZigStackFrame.rs                         2      1      0
src/jsc/bindings/ErrorStackFrame.cpp             5      8      0
src/jsc/bindings/ErrorStackFrame.h               2      4      0
src/jsc/bindings/FormatStackTraceForJS.cpp       5      8      0
src/jsc/bindings/NodeVM.cpp                      5      8      0
src/jsc/bindings/ZigException.cpp                5      2      0
test/js/node/test/parallel/test-vm-basic.js      2      3      0
test/js/node/vm/vm.test.ts                       8     13      0
```

</details>

<!-- robobun:evidence:end -->