### PR TITLE
bun test --reporter=junit: drop U+FFFE and U+FFFF from the report

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -172,13 +172,14 @@ pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate:
                 }
                 last = i + 1;
             }
-            0xef if matches!(str_[i..], [_, 0xbf, 0xbe | 0xbf, ..]) => {
-                // UTF-8 for U+FFFE / U+FFFF, which XML 1.0 excludes from Char like the
-                // controls above (no escaped form exists), so the sequence is dropped.
+            0xef if str_[i..].starts_with("\u{FFFE}".as_bytes())
+                || str_[i..].starts_with("\u{FFFF}".as_bytes()) =>
+            {
+                // XML 1.0 excludes these two code points from Char as well.
                 if i > last {
                     writer.write_all(&str_[last..i])?;
                 }
-                i += 3;
+                i += "\u{FFFE}".len();
                 last = i;
                 continue;
             }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -172,6 +172,17 @@ pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate:
                 }
                 last = i + 1;
             }
+            0xef if matches!(str_[i..], [_, 0xbf, 0xbe | 0xbf, ..]) => {
+                // U+FFFE and U+FFFF are the only UTF-8-encodable code points outside
+                // the C0 range that XML 1.0 excludes from Char. Like the controls
+                // above they have no escaped form either, so drop the 3-byte sequence.
+                if i > last {
+                    writer.write_all(&str_[last..i])?;
+                }
+                i += 3;
+                last = i;
+                continue;
+            }
             _ => {}
         }
         i += 1;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -173,9 +173,8 @@ pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate:
                 last = i + 1;
             }
             0xef if matches!(str_[i..], [_, 0xbf, 0xbe | 0xbf, ..]) => {
-                // U+FFFE and U+FFFF are the only UTF-8-encodable code points outside
-                // the C0 range that XML 1.0 excludes from Char. Like the controls
-                // above they have no escaped form either, so drop the 3-byte sequence.
+                // UTF-8 for U+FFFE / U+FFFF, which XML 1.0 excludes from Char like the
+                // controls above (no escaped form exists), so the sequence is dropped.
                 if i > last {
                     writer.write_all(&str_[last..i])?;
                 }

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -447,7 +447,11 @@ describe("junit reporter", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Checked before reading the report so a child that died early shows its
+    // stderr here rather than as a missing junit.xml below.
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 1 fail");
 
     const xmlContent = await file(junitPath).text();
     // XML 1.0 Char excludes U+FFFE and U+FFFF outright, so neither the literal

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -429,6 +429,43 @@ describe("junit reporter", () => {
     expect(exitCode).toBe(1);
   });
 
+  it("produces well-formed XML when test names or errors contain U+FFFE / U+FFFF", async () => {
+    await using tmpDir = tempDir("junit-nonchar", {
+      "package.json": "{}",
+      "nonchar.test.js":
+        'import { test } from "bun:test";\n' +
+        // U+FFFD next to U+FFFE: the first is a valid XML Char and must survive,
+        // the other two are the only BMP code points XML 1.0 excludes from Char.
+        'test("bom \\uFFFD\\uFFFE swapped \\uFFFF end", () => {});\n' +
+        'test("throws", () => { throw new Error("bad \\uFFFE byte \\uFFFF order"); });\n',
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    // XML 1.0 Char excludes U+FFFE and U+FFFF outright, so neither the literal
+    // code point nor a numeric reference to it may appear anywhere in the report.
+    expect(xmlContent).not.toContain("\uFFFE");
+    expect(xmlContent).not.toContain("\uFFFF");
+    expect(xmlContent).not.toMatch(/&#(6553[45]|x0*fff[ef]);/i);
+
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const [passing, failing] = result.testsuites.testsuite[0].testcase;
+    expect(passing.$.name).toBe("bom \uFFFD swapped  end");
+    expect(failing.failure[0].$.message).toBe("bad  byte  order");
+    expect(failing.failure[0]._).toContain("Error: bad  byte  order");
+    expect(exitCode).toBe(1);
+  });
+
   it("escapes the classname attribute exactly once", async () => {
     await using tmpDir = tempDir("junit-escape", {
       "package.json": "{}",


### PR DESCRIPTION
### Problem
- `bun test --reporter=junit` writes a report that XML parsers reject when a test name or error message contains U+FFFE or U+FFFF: `xmllint` reports `Char 0xFFFE out of allowed range`, Python's ElementTree reports `not well-formed (invalid token)`. One such test makes the whole file unreadable for JUnit consumers, not just that testcase.
- `escape_xml` in `src/runtime/cli/test_command.rs` escapes `& < > " '`, emits TAB/LF/CR as numeric references and drops the other C0 controls, but has no arm for these two code points, so their UTF-8 bytes (`EF BF BE` / `EF BF BF`) are copied into the report verbatim.

### Fix
- Add an arm to `escape_xml` that drops the 3-byte UTF-8 sequences for U+FFFE and U+FFFF, the same treatment the C0 controls already get.
- Dropping is the only option: XML 1.0 excludes these code points from `Char` entirely, so a numeric reference (`&#xFFFE;`) is just as ill-formed as the literal. U+FFFE and U+FFFF are the only UTF-8-encodable code points outside the C0 range that `Char` excludes (surrogates cannot reach this function, the UTF-16 to UTF-8 conversion already turns lone surrogates into U+FFFD), so the existing arms plus this one cover the whole production. Matching the full 3-byte sequence means neighbours such as U+FFFD (`EF BF BD`) still pass through.
- Both `escape_xml` callers are covered: the single-process reporter and the `--parallel` aggregator in `src/runtime/cli/test/parallel/aggregate.rs`.
- Verified by the new case in `test/js/junit-reporter/junit.test.js`, which puts the two code points in a test name and in a thrown error message and asserts they appear nowhere in the report while U+FFFD survives. It fails on the current release build and passes with this change; the rest of the file still passes.
- Also checked the issue's repro by hand with both the default and `--parallel=2` reporters: ElementTree parses the output.

### Background
- The JUnit reporter builds the XML by hand. Every user-controlled string (test names, describe names, file paths, failure type/message/body, CI properties) is written through `escape_xml`, which is the only place character-level policy for the report lives.
- XML 1.0 defines which characters may appear in a document at all (`Char`, section 2.2): TAB, LF, CR, U+0020 to U+D7FF, U+E000 to U+FFFD and U+10000 to U+10FFFF. Anything outside that set is rejected by conforming parsers wherever it appears, escaped or not, which is why the only way to keep the report well-formed is to leave those characters out.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (6f34308c5)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [960.62ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [473.75ms]
[String: "/tmp/junit-comprehensive_qfBSRM"]
(pass) junit reporter > more scenarios [962.99ms]
(pass) junit reporter > should report only the final result for a retried test [351.09ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [401.70ms]
454 |     expect(stderr).toContain(" 1 fail");
455 | 
456 |     const xmlContent = await file(junitPath).text();
457 |     // XML 1.0 Char excludes U+FFFE and U+FFFF outright, so neither the literal
458 |     // code point nor a numeric reference to it may appear anywhere in the report.
459 |     expect(xmlContent).not.toContain("\uFFFE");
                                 ^
error: expect(received).not.toContain(expected)

Expected to not contain: "￾"
Received: "<?xml version=\"
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [19.87ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [12.76ms]
[String: "/tmp/junit-comprehensive_PzGJKQ"]
(pass) junit reporter > more scenarios [21.73ms]
(pass) junit reporter > should report only the final result for a retried test [19.66ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [10.82ms]
454 |     expect(stderr).toContain(" 1 fail");
455 | 
456 |     const xmlContent = await file(junitPath).text();
457 |     // XML 1.0 Char excludes U+FFFE and U+FFFF outright, so neither the literal
458 |     // code point nor a numeric reference to it may appear anywhere in the report.
459 |     expect(xmlContent).not.toContain("\uFFFE");
                                 ^
error: expect(received).not.toContain(expected)

Expected to not contain: "￾"
Received: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites name=\"bun test\" tests=\"2\" assertions=\"0\" failures=\"1\" skipped=\"0\" time=\"0.004981854\">\n  <testsuite name=\"nonchar
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (6f34308c5)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [837.29ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [586.02ms]
[String: "/tmp/junit-comprehensive_e33uBp"]
(pass) junit reporter > more scenarios [1326.60ms]
(pass) junit reporter > should report only the final result for a retried test [740.36ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [491.62ms]
(pass) junit reporter > produces well-formed XML when test names or errors contain U+FFFE / U+FFFF [752.24ms]
(pass) junit reporter > escapes the classname attribute exactly once [473.27ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [377.34ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [427.35ms]

 9 pass
 0 fail
 2 snapshots, 144 expect() calls
Ran 9 tests across 1 file. [10.66s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 872ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test_command.rs      | 11 ++++++++++
 test/js/junit-reporter/junit.test.js | 41 ++++++++++++++++++++++++++++++++++++
 2 files changed, 52 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/runtime/cli/test_command.rs           5      4      0
test/js/junit-reporter/junit.test.js      3      3      0
```

</details>

<!-- robobun:evidence:end -->