### PR TITLE
bake: link client-side imports of a "use client" file to its client build

### DIFF
--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -960,9 +960,9 @@ pub struct File {
     /// If "entry_point_kind" is not ".none", this is the index of the
     /// corresponding entry point chunk.
     ///
-    /// This is also initialized for files that are a SCB's generated
-    /// reference, pointing to its destination. This forms a lookup map from
-    /// a Source.Index to its output path inb reakOutputIntoPieces
+    /// The `Scb` unique keys resolve through this as well: a server component
+    /// boundary and its SSR copy are always entry points, and their keys
+    /// print the path of their entry point chunk.
     pub entry_point_chunk_index: u32,
 
     pub line_offset_table: bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc>,

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -210,8 +210,6 @@ pub struct LinkerGraph<'a> {
     /// Index from `.parse_graph.input_files` to index in `.files`
     pub(crate) stable_source_indices: Vec<u32>,
 
-    pub(crate) is_scb_bitset: BitSet,
-
     /// This is for cross-module inlining of detected inlinable constants
     // const_values: bun_ast::Ast::ConstValuesMap,
     /// This is for cross-module inlining of TypeScript enum constants
@@ -225,9 +223,9 @@ pub struct LinkerGraph<'a> {
 // - `bump: *const Arena` is a backref into `BundleV2`; the arena is frozen
 //   (no new allocations) for the duration of any worker-pool fan-out that
 //   holds `&LinkerGraph`.
-// - `files_live` / `parts_live` / `is_scb_bitset` / `reachable_files` /
-//   `stable_source_indices` / `code_splitting` / `ts_enums` are populated
-//   before fan-out and only read by workers.
+// - `files_live` / `parts_live` / `reachable_files` / `stable_source_indices` /
+//   `code_splitting` / `ts_enums` are populated before fan-out and only read
+//   by workers.
 // - `ast` / `meta` / `files` columns that workers mutate are split out via
 //   `split_mut()` into disjoint `&mut [_]` *before* the pool runs (see
 //   `compute_cross_chunk_dependencies`); workers never reach those columns
@@ -274,7 +272,6 @@ impl Default for LinkerGraph<'_> {
             meta: MultiArrayList::default(),
             reachable_files: Vec::new(),
             stable_source_indices: Vec::new(),
-            is_scb_bitset: BitSet::default(),
             ts_enums: bun_ast::ast_result::TsEnumsMap::default(),
         }
     }
@@ -706,64 +703,43 @@ impl<'a> LinkerGraph<'a> {
             }
 
             if scb.list.len() > 0 {
-                self.is_scb_bitset = BitSet::init_empty(self.files.len()).expect("unreachable");
-
-                // Index all SCBs into the bitset. This is needed so chunking
-                // can track the chunks that SCBs belong to.
-                debug_assert_eq!(
-                    scb.list.items_use_directive().len(),
-                    scb.list.items_source_index().len()
-                );
-                debug_assert_eq!(
-                    scb.list.items_use_directive().len(),
-                    scb.list.items_reference_source_index().len()
-                );
-                for ((use_, original_id), ref_id) in scb
+                if scb
                     .list
                     .items_use_directive()
-                    .iter()
-                    .zip(scb.list.items_source_index().iter())
-                    .zip(scb.list.items_reference_source_index().iter())
+                    .contains(&UseDirective::Server)
                 {
-                    match use_ {
-                        UseDirective::None => {}
-                        UseDirective::Client => {
-                            self.is_scb_bitset.set(*original_id as usize);
-                            self.is_scb_bitset.set(*ref_id as usize);
-                        }
-                        UseDirective::Server => {
-                            bun_core::todo_panic!("um");
-                        }
-                    }
+                    bun_core::todo_panic!("um");
                 }
+                let is_boundary: BitSet = scb.bit_set(self.files.len())?;
 
-                // For client components, the import record index currently points to the original source index, instead of the reference source index.
-                let import_records_list: &mut [import_record::List<'_>] =
-                    self.ast.items_import_records_mut();
+                // Import records still point at the boundary file itself. The
+                // generated reference file stands in for the boundary on the
+                // other side of it, so only importers built for a different
+                // target than the boundary are redirected to it. Importers on
+                // the same side (a "use client" file importing another one)
+                // keep importing the boundary file.
+                let ast_cols = self.ast.split_mut();
+                let import_records_list: &mut [import_record::List<'_>] = ast_cols.import_records;
+                let targets: &[bun_ast::Target] = ast_cols.target;
                 for source_id in self.reachable_files.slice() {
+                    let importer_target = targets[source_id.get() as usize];
                     for import_record in import_records_list[source_id.get() as usize]
                         .as_mut_slice()
                         .iter_mut()
                     {
-                        if import_record.source_index.is_valid()
-                            && self
-                                .is_scb_bitset
-                                .is_set(import_record.source_index.get() as usize)
+                        let imported = import_record.source_index;
+                        if !imported.is_valid()
+                            || !is_boundary.is_set(imported.get() as usize)
+                            || targets[imported.get() as usize] == importer_target
                         {
-                            // Only rewrite if this is an original SCB file, not a reference file
-                            if let Some(ref_index) =
-                                scb.get_reference_source_index(import_record.source_index.get())
-                            {
-                                import_record.source_index = Index::init(ref_index);
-                                debug_assert!(import_record.source_index.is_valid());
-                                // did not generate
-                            }
-                            // If it's already a reference file, leave it as-is
+                            continue;
                         }
+                        let reference = scb
+                            .get_reference_source_index(imported.get())
+                            .expect("is_boundary was built from the same boundary list");
+                        import_record.source_index = Index::init(reference);
                     }
                 }
-            } else {
-                self.is_scb_bitset = BitSet::default();
             }
         }
 

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -712,12 +712,9 @@ impl<'a> LinkerGraph<'a> {
                 }
                 let is_boundary: BitSet = scb.bit_set(self.files.len())?;
 
-                // Import records still point at the boundary file itself. The
-                // generated reference file stands in for the boundary on the
-                // other side of it, so only importers built for a different
-                // target than the boundary are redirected to it. Importers on
-                // the same side (a "use client" file importing another one)
-                // keep importing the boundary file.
+                // The reference replaces the boundary only for importers built for
+                // another target; a "use client" file importing another one keeps
+                // importing the boundary file itself.
                 let ast_cols = self.ast.split_mut();
                 let import_records_list: &mut [import_record::List<'_>] = ast_cols.import_records;
                 let targets: &[bun_ast::Target] = ast_cols.target;
@@ -958,11 +955,8 @@ pub struct File {
     pub entry_point_kind: EntryPoint::Kind,
 
     /// If "entry_point_kind" is not ".none", this is the index of the
-    /// corresponding entry point chunk.
-    ///
-    /// The `Scb` unique keys resolve through this as well: a server component
-    /// boundary and its SSR copy are always entry points, and their keys
-    /// print the path of their entry point chunk.
+    /// corresponding entry point chunk. The `Scb` unique keys are resolved
+    /// through this as well.
     pub entry_point_chunk_index: u32,
 
     pub line_offset_table: bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc>,

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -712,9 +712,7 @@ impl<'a> LinkerGraph<'a> {
                 }
                 let is_boundary: BitSet = scb.bit_set(self.files.len())?;
 
-                // The reference replaces the boundary only for importers built for
-                // another target; a "use client" file importing another one keeps
-                // importing the boundary file itself.
+                // Only importers built for a target other than the boundary's get the reference.
                 let ast_cols = self.ast.split_mut();
                 let import_records_list: &mut [import_record::List<'_>] = ast_cols.import_records;
                 let targets: &[bun_ast::Target] = ast_cols.target;
@@ -955,8 +953,7 @@ pub struct File {
     pub entry_point_kind: EntryPoint::Kind,
 
     /// If "entry_point_kind" is not ".none", this is the index of the
-    /// corresponding entry point chunk. The `Scb` unique keys are resolved
-    /// through this as well.
+    /// corresponding entry point chunk.
     pub entry_point_chunk_index: u32,
 
     pub line_offset_table: bun_sourcemap::line_offset_table::List<bun_alloc::AstAlloc>,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7306,11 +7306,10 @@ pub mod bv2_impl {
                             (server_index, Index::INVALID.get())
                         };
 
-                        this.graph
-                            .path_to_source_index_map(result_ast_target)
-                            .put(source_path_text, reference_source_index)
-                            .expect("oom");
-
+                        // The generated files are not registered in the path maps:
+                        // every graph keeps resolving this path to the file it
+                        // parsed itself, and `LinkerGraph::load` redirects the
+                        // import records that cross the boundary to the reference.
                         this.graph
                             .server_component_boundaries
                             .put(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7306,8 +7306,6 @@ pub mod bv2_impl {
                             (server_index, Index::INVALID.get())
                         };
 
-                        // The path maps keep pointing at the parsed file; `LinkerGraph::load`
-                        // redirects the import records that cross the boundary.
                         this.graph
                             .server_component_boundaries
                             .put(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7306,10 +7306,8 @@ pub mod bv2_impl {
                             (server_index, Index::INVALID.get())
                         };
 
-                        // The generated files are not registered in the path maps:
-                        // every graph keeps resolving this path to the file it
-                        // parsed itself, and `LinkerGraph::load` redirects the
-                        // import records that cross the boundary to the reference.
+                        // The path maps keep pointing at the parsed file; `LinkerGraph::load`
+                        // redirects the import records that cross the boundary.
                         this.graph
                             .server_component_boundaries
                             .put(

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -20,7 +20,7 @@ pub(crate) fn find_all_imported_parts_in_js_order(
     // PERF: these scratch lists could become
     // `bun_alloc::ArenaVec<'bump, PartRange>` with a threaded `&'bump Bump`
     // (introduces lifetimes on this fn + visitor). Profile if hot.
-    for (index, chunk) in chunks.iter_mut().enumerate() {
+    for chunk in chunks.iter_mut() {
         match &chunk.content {
             chunk::Content::Javascript(_) => {
                 find_imported_parts_in_js_order(
@@ -28,7 +28,6 @@ pub(crate) fn find_all_imported_parts_in_js_order(
                     chunk,
                     &mut part_ranges_shared,
                     &mut parts_prefix_shared,
-                    u32::try_from(index).expect("int cast"),
                 )?;
             }
             chunk::Content::Css(_) => {} // handled in `find_imported_css_files_in_js_order`
@@ -43,7 +42,6 @@ pub(crate) fn find_imported_parts_in_js_order(
     chunk: &mut Chunk,
     part_ranges_shared: &mut Vec<PartRange>,
     parts_prefix_shared: &mut Vec<PartRange>,
-    chunk_index: u32,
 ) -> Result<(), crate::Error> {
     let mut chunk_order_array: Vec<Order> =
         Vec::with_capacity(chunk.files_with_parts_in_chunk.count());
@@ -64,19 +62,7 @@ pub(crate) fn find_imported_parts_in_js_order(
     part_ranges_shared.clear();
     parts_prefix_shared.clear();
 
-    // Capture before constructing the visitor (borrowck).
     let with_code_splitting = this.graph.code_splitting;
-    let with_scb = this.graph.is_scb_bitset.bit_length > 0;
-
-    // The visitor holds a LinkerContext alongside SoA column slices
-    // borrowed from it, and mutates one column (`entry_point_chunk_index`).
-    // Borrowck forbids the latter through a shared `&LinkerContext`, so cache that
-    // single mutable column as a raw `*mut [u32]` (provenance via the
-    // `MultiArrayList.bytes: *mut u8` raw-pointer field — see
-    // `scanImportsAndExports.rs` for the same pattern). All other `c.*` accesses
-    // are read-only.
-    let entry_point_chunk_indices: *mut [u32] =
-        this.graph.files.slice().split_raw().entry_point_chunk_index;
 
     let (files_in_chunk_order, parts_in_chunk_order) = {
         let mut visitor = FindImportedPartsVisitor {
@@ -89,16 +75,13 @@ pub(crate) fn find_imported_parts_in_js_order(
             import_records: this.graph.ast.items_import_records(),
             entry_bits: chunk.entry_bits(),
             c: &*this,
-            chunk_index,
-            entry_point_chunk_indices,
             stack: Vec::new(),
         };
 
-        match (with_code_splitting, with_scb) {
-            (true, true) => run_visits::<true, true>(&mut visitor, &chunk_order_array),
-            (true, false) => run_visits::<true, false>(&mut visitor, &chunk_order_array),
-            (false, true) => run_visits::<false, true>(&mut visitor, &chunk_order_array),
-            (false, false) => run_visits::<false, false>(&mut visitor, &chunk_order_array),
+        if with_code_splitting {
+            run_visits::<true>(&mut visitor, &chunk_order_array);
+        } else {
+            run_visits::<false>(&mut visitor, &chunk_order_array);
         }
 
         let mut parts_in_chunk_order: Vec<PartRange> =
@@ -128,13 +111,13 @@ pub(crate) fn find_imported_parts_in_js_order(
 }
 
 #[inline]
-fn run_visits<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
+fn run_visits<const WITH_CODE_SPLITTING: bool>(
     visitor: &mut FindImportedPartsVisitor<'_, '_>,
     chunk_order_array: &[Order],
 ) {
-    visitor.visit::<WITH_CODE_SPLITTING, WITH_SCB>(Index::RUNTIME.value());
+    visitor.visit::<WITH_CODE_SPLITTING>(Index::RUNTIME.value());
     for order in chunk_order_array {
-        visitor.visit::<WITH_CODE_SPLITTING, WITH_SCB>(order.source_index);
+        visitor.visit::<WITH_CODE_SPLITTING>(order.source_index);
     }
 }
 
@@ -148,10 +131,6 @@ pub(crate) struct FindImportedPartsVisitor<'a, 'ctx> {
     pub(crate) visited: HashMap<IndexInt, ()>,
     pub(crate) parts_prefix: Vec<PartRange>,
     pub(crate) c: &'a LinkerContext<'ctx>,
-    pub(crate) chunk_index: u32,
-    /// Raw column pointer into `c.graph.files` for the single mutable write in
-    /// `visit` (see the raw-pointer note above).
-    entry_point_chunk_indices: *mut [u32],
     stack: Vec<PartsFrame>,
 }
 
@@ -201,10 +180,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
     // queuing its imports interleaved with per-part `Part` markers and a
     // trailing `File` marker, then reverses the tail so LIFO pop reproduces
     // the original recursion order exactly.
-    pub(crate) fn visit<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
-        &mut self,
-        source_index: IndexInt,
-    ) {
+    pub(crate) fn visit<const WITH_CODE_SPLITTING: bool>(&mut self, source_index: IndexInt) {
         debug_assert!(self.stack.is_empty());
         self.stack.push(PartsFrame::Enter(source_index));
 
@@ -235,18 +211,6 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                     can_be_split,
                 } => {
                     if is_file_in_chunk {
-                        if WITH_SCB && self.c.graph.is_scb_bitset.is_set(source_index as usize) {
-                            // SAFETY: `entry_point_chunk_indices` is the raw column pointer
-                            // for `entry_point_chunk_index` (distinct from every
-                            // column read through `self.c` / `self.flags` / `self.parts`),
-                            // valid for `graph.files.len()` writes for the duration of the
-                            // link step. No `&` to this column is live here.
-                            unsafe {
-                                (*self.entry_point_chunk_indices)[source_index as usize] =
-                                    self.chunk_index;
-                            }
-                        }
-
                         self.files.push(source_index);
 
                         // CommonJS files are all-or-nothing so all parts must be contiguous

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,11 +1,8 @@
-import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
-import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
-
-// Every test here runs a full production build, which takes several seconds on a debug build.
-setDefaultTimeout(10_000 * WAIT_MULTIPLIER);
+import { tempDirWithBakeDeps } from "../bake-harness";
 
 const normalizePath = (path: string) => (process.platform === "win32" ? path.replaceAll("\\", "/") : path);
 const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", "\\") : path);
@@ -503,6 +500,7 @@ export default function Counter() {
     expect(foundCounterBundle).toBe(true);
   });
 
+  // The production build plus the render below take longer than the default test timeout on a debug build.
   test("client component importing another client component gets its client code", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-client-imports-client", {
       "src/index.tsx": `export default { app: { framework: "react" } };`,
@@ -576,7 +574,7 @@ console.log(
       dynamicImportIsSameModule: true,
     });
     expect(exitCode).toBe(0);
-  });
+  }, 60_000);
 
   test("inline flight data is escaped as a single unit across stream chunks", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-flight-escaping", {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { existsSync } from "fs";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
-import { tempDirWithBakeDeps } from "../bake-harness";
+import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
+
+// Every test here runs a full production build, which takes several seconds on a debug build.
+setDefaultTimeout(10_000 * WAIT_MULTIPLIER);
 
 const normalizePath = (path: string) => (process.platform === "win32" ? path.replaceAll("\\", "/") : path);
 const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", "\\") : path);
@@ -498,6 +501,81 @@ export default function Counter() {
     }
 
     expect(foundCounterBundle).toBe(true);
+  });
+
+  test("client component importing another client component gets its client code", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-client-imports-client", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/index.tsx": `import { Outer } from "../components/Outer";
+
+export default function IndexPage() {
+  return <div><Outer /></div>;
+}`,
+      "components/Outer.tsx": `"use client";
+import { Inner, innerLater } from "./Inner";
+
+export { Inner, innerLater };
+
+export const loadInner = () => import("./Inner").then(mod => mod.Inner);
+
+export function Outer() {
+  return <i>outer:<Inner /></i>;
+}`,
+      "components/Inner.tsx": `"use client";
+export { innerLater } from "./inner-later";
+
+export function Inner() {
+  return <b>inner</b>;
+}`,
+      // Only reachable through Inner.tsx, so it is resolved after Inner.tsx has already been
+      // turned into a client component boundary.
+      "components/inner-later.ts": `import { Inner } from "./Inner";
+
+export const innerLater = () => Inner;`,
+      // Loads the client chunk the RSC payload points at for Outer, like the browser would,
+      // and renders it with the react-dom installed next to the app.
+      "render-client-chunk.mjs": `import { readFileSync } from "node:fs";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const rsc = readFileSync("dist/index.rsc", "utf8");
+const [, outerChunk] = rsc.match(/I\\["\\.\\/([^"]+)",\\[\\],"Outer"\\]/);
+const mod = await import("./dist/_bun/" + outerChunk);
+const loaded = await mod.loadInner();
+console.log(
+  JSON.stringify({
+    outer: renderToStaticMarkup(createElement(mod.Outer)),
+    loaded: typeof loaded === "function" ? renderToStaticMarkup(createElement(loaded)) : typeof loaded,
+    laterImportIsSameModule: mod.innerLater() === mod.Inner,
+    dynamicImportIsSameModule: loaded === mod.Inner,
+  }),
+);`,
+      "package.json": JSON.stringify({ "name": "test-app", "version": "1.0.0" }),
+    });
+
+    const build = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).env(bunEnv).throws(false);
+    expect(build.stderr.toString()).not.toContain("error");
+    expect(build.exitCode).toBe(0);
+
+    // Prerendering goes through the SSR copies of the components, not through the client chunks.
+    expect(await Bun.file(path.join(dir, "dist", "index.html")).text()).toContain("<i>outer:<b>inner</b></i>");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "render-client-chunk.mjs"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      outer: "<i>outer:<b>inner</b></i>",
+      loaded: "<b>inner</b>",
+      laterImportIsSameModule: true,
+      dynamicImportIsSameModule: true,
+    });
+    expect(exitCode).toBe(0);
   });
 
   test("inline flight data is escaped as a single unit across stream chunks", async () => {


### PR DESCRIPTION
### Problem
- In a production bake build (`bun build --app`, built-in `react` framework), a `"use client"` component that statically imports another `"use client"` component (`A.tsx` imports `B.tsx`) gets the wrong `B` in the browser: A's client chunk contains B's client reference proxy (`$registerClientReference(() => { throw new Error("Attempted to call B() from the server ...") }, "./B.<hash>.js", "B")`) instead of B's code, and imports `$registerClientReference` from the react-server runtime chunk. That chunk is a server-side output file, so it is never written to `dist/`; loading A's chunk in the browser fails with a 404 on it (`Cannot find module './edth6k75.js' from 'dist/_bun/hkr9re8z.js'` when the chunk is loaded with bun), so the page never hydrates. Prerendered HTML is correct, because SSR uses the SSR copies, which is why nothing noticed.
- Two places bind client-side importers to the proxy:
  - `LinkerGraph::load` (`src/bundler/LinkerGraph.rs`, the loop after the boundary bitset) redirected every reachable file's import records that point at a boundary file to that boundary's proxy, without looking at which side the importer is on. With `separateSSRGraph` the boundary file itself is the browser build (`ParseTask.rs` switches `"use client"` files to the browser transpiler), so A's record to B was redirected too.
  - `on_parse_task_complete` (`src/bundler/bundle_v2.rs`, the boundary block) did `path_to_source_index_map(result.ast.target).put(path, reference_source_index)`. `result.ast.target` is `browser` for these files, so the browser graph's map for `B.tsx` pointed at the server proxy and any client file that resolved `B.tsx` after that was bound to the proxy directly, before the linker ran. Until #20265 this put went to the server graph's map.
- With the first fix in place a third thing shows: `find_imported_parts_in_js_order` (`findAllImportedPartsInJSOrder.rs`) overwrote `entry_point_chunk_index` of every boundary file with the index of the chunk its code lands in. As long as nothing on the client could import a boundary, that was always the boundary's own entry chunk. Once A imports B, B's code moves to a chunk shared by A's entry and B's entry, and both the SCB unique keys (the module ids in `registerClientReference` calls and in the `bun:bake/server` manifests) and an `import("./B")` from client code resolved to that shared chunk, whose exports are the minified cross-chunk aliases (`export{b as e}`), not `B`.

### Fix
- `LinkerGraph::load` only redirects an import record to the proxy when the importer's AST target differs from the boundary file's target. The proxy is the boundary as seen from the other side (`ServerComponentBoundary.reference_source_index` is documented as "the file imported on the opposite platform"), so a same-side importer has to keep importing the boundary file. Server files still have a different target than the browser-built boundary and are redirected exactly as before; the same rule also holds for `separateSSRGraph: false`, where the boundary is the server build and the reference is the browser copy (dev server only; production builds do not support that mode, `process_server_component_manifest_files` panics on it).
- The path map put is removed instead of moved to the server map. Every importer that resolves a boundary file gets the file its own graph parsed, and the linker rule above handles the server side no matter when the record was resolved. Registering the boundary's files in the other graphs' maps at boundary creation time (proxy into the server map, client build into the browser map, SSR copy into the SSR map) was tried first: whether an importer then binds to the registered file depends on whether the boundary's parse finished before that importer's imports were processed. With that variant even the basic repro produced two different sets of output files across runs; a server-map-only put has the same property for server importers that are resolved after the boundary. Without the put the output is stable (8/8 identical runs of the repro).
- The `entry_point_chunk_index` overwrite is removed. `compute_chunks` already sets `entry_point_chunk_index` for every entry point, and boundary files and their SSR copies are always entry points (`add_server_component_boundaries_as_extra_entry_points`), so the overwrite was a no-op whenever the code stayed in the entry chunk and wrong whenever it did not. The entry chunk is the one that exports the component under its real names (`import{e as a}from"./13dtm2kk.js";export{a as B}` in the repro). This removes the only consumer of `LinkerGraph.is_scb_bitset` outside `load`, so the bitset is now a local there, built with the existing `server_component_boundary::Slice::bit_set` (boundary files only, like `find_reachable_files`); the paragraph in the `File::entry_point_chunk_index` doc that described the overwrite is dropped with it.
- Test: `test/bake/dev/production.test.ts`, "client component importing another client component gets its client code". It builds `page -> Outer ("use client") -> Inner ("use client")`, where Outer also `import()`s Inner and Inner pulls in `inner-later.ts`, a file that imports Inner back and is therefore resolved only after Inner has become a boundary. It then loads the client chunk named in `dist/index.rsc` with bun and react-dom, the way the browser would, and checks that Outer renders `<i>outer:<b>inner</b></i>` and that the static import, the late import and the dynamic import of Inner are the same function. Each part is covered:
  - release build (`USE_SYSTEM_BUN=1`): fails, the chunk imports the missing server chunk
  - only the `LinkerGraph::load` change: fails the same way through `inner-later.ts` (3/3 runs), i.e. the path map put
  - `LinkerGraph::load` change + put removed: fails with `loaded: "undefined"`, `dynamicImportIsSameModule: false`, i.e. the `entry_point_chunk_index` overwrite
  - all three: passes
- The new test carries a 60 second timeout of its own: the production build plus the render subprocess take 7 to 9 seconds on a debug build, past the 5 second default of a plain `bun test` run (CI passes its own, larger `--timeout`, which this stays below). The other tests in the file are untouched.
- Also ran: the rest of `test/bake/dev/production.test.ts`, `test/bake/dev/bundle.test.ts` (dev server, both `separateSSRGraph` modes), `test/bake/dev/response-to-bake-response.test.ts`, `test/bake/dev/ecosystem.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bundler/bundler_splitting.test.ts`, `test/bundler/esbuild/splitting.test.ts`, `test/bundler/bundler_compile_splitting.test.ts`, `test/bundler/bundler_html.test.ts`, `test/bundler/bundler_html_server.test.ts`, `test/bundler/html-import-manifest.test.ts`, `cargo clippy -p bun_bundler`.
- Dev server: it runs `LinkerGraph::load` too, and the linker's AST rows share the import record storage of the parse graph, so the changed redirect is visible to it for the records that do carry source indices in dev (barrel un-deferral and plugin-resolved imports; ordinary JS records carry none). Those records now point at the boundary file of the importer's own side instead of at the file generated for the other side; `IncrementalGraph::process_edge_attachment` already fell back to a path lookup for the latter, so the edges end up on the same files either way. Checked by hand with a `sideEffects: false` barrel of `"use client"` files imported by a route, in both `separateSSRGraph` modes: the route still receives the client reference wrappers. The dev server does not use `find_imported_parts_in_js_order`. The removed put also used to mark a boundary discovered through the server graph as present in the browser graph's map, so a client file importing it within the same bundle now parses it for the browser side as well; that already happened before whenever that client file's imports were processed first, so it is a path the dev server handles (`test/bake/dev/bundle.test.ts` exercises boundaries in both modes).
- Not changed here: a `"use client"` file that is reached from both the server graph and the client graph (a page rendering `Inner` directly and also `Outer`, which imports `Inner`) is parsed once per graph and gets two boundaries, and since both copies are emitted as entry points the build fails with `Multiple files share the same output path`. The release build fails the same way (4/4 runs of that shape); in the ordering where it did not, it produced the broken chunk described above instead. With this change the shape fails consistently; deduplicating the boundaries per path is a separate, already reported problem. #38238 (server-side `import()` of a `"use client"` file) edits the same block of `LinkerGraph::load` and independently drops the proxies from the bitset; whichever lands second needs a small rebase, and after this change its dynamic import mapping only matters for records this loop actually redirects.

### Background
- Server component boundary (SCB): a `"use client"` file in a bake build. With `separateSSRGraph` the file itself is parsed as a browser build, and `on_parse_task_complete` additionally generates a client reference proxy for the server graph (a module with the same export names whose exports are `registerClientReference(...)` calls, see `ServerComponentParseTask.rs`) and parses an SSR copy. The browser build and the SSR copy are added as extra entry points so each gets an output chunk.
- Path maps (`Graph.build_graphs`): one `path -> source index` map per target. The server graph, the browser graph and the SSR graph each resolve and parse JS files independently, so the same path can have a different source index per graph.
- `entry_point_chunk_index`: per file, the chunk that represents it as an entry point. `compute_cross_chunk_dependencies` uses it to print an `import()` of an entry point as an import of that chunk, and the `Scb` unique keys (placeholders written into the proxies and into the `bun:bake/server` manifests, replaced with output paths when chunks are written) are resolved through it.
- Shared chunks: with code splitting, a file reachable from several entry points is emitted in a chunk of its own, and entry chunks re-export from it under generated (minified) alias names. Only the entry chunk exports a module under its own export names.

<details>
<summary>Repro output before and after</summary>

Files: `pages/index.tsx` imports `components/A.tsx` (`"use client"`, imports and renders `B`), `components/B.tsx` (`"use client"`).

Before, A's client chunk (`dist/_bun/hkr9re8z.js`, referenced from `dist/index.rsc`):

```
import{f as o}from"./edth6k75.js";import{g as n,h as r}from"./hw6sppfr.js";import"./mrxbzrmw.js";const i=o(()=>{throw new Error("Attempted to call B() from the server but B is on the client. ...
```

`edth6k75.js` is the server-side chunk containing the react-server runtime and is not in `dist/`.

After (`dist/_bun/y926bx34.js`), with B's code in the shared chunk `13dtm2kk.js` and B's entry chunk re-exporting it:

```
import{e as n}from"./13dtm2kk.js";import{f as i,g as o}from"./xf5fcnfz.js";import"./5p9spn2z.js";function t(){return o("i",{children:["A",i(n,{})]})}export{t as A};
// 13dtm2kk.js: import{f as n}from"./xf5fcnfz.js";function b(){return n("b",{children:"B"})} export{b as e};
// 4yvgscpv.js: import{e as a}from"./13dtm2kk.js";import"./xf5fcnfz.js";import"./5p9spn2z.js";export{a as B};
```

With `--debug-dump-server-files`, the server manifest now maps B to its entry chunk (`id: "../components/B.gtg8pn3b.js"`, `specifier: "../components/B.v6wc7ms3.js"` for SSR), and B's proxy is no longer part of any output file; A's proxy is still inlined into the page's server chunk as before.
</details>
