### PR TITLE
parser: match engines on where `using` declarations may appear (switch clauses, for heads)

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -828,7 +828,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             p.lexer.next()?;
 
-            if p.lexer.token == T::TIdentifier && !p.lexer.has_newline_before {
+            if p.lexer.token == T::TIdentifier
+                && !p.lexer.has_newline_before
+                && !(opts.is_for_loop_init && p.is_using_for_of_variable())
+            {
                 if opts.lexical_decl != LexicalDecl::AllowAll {
                     p.forbid_lexical_decl(token_range.loc);
                 }
@@ -888,12 +891,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next()?;
 
             let raw2 = p.lexer.raw();
-            let mut value = if p.lexer.token == T::TIdentifier && raw2 == b"using" {
+            let mut value = if p.lexer.token == T::TIdentifier
+                && raw2 == b"using"
+                && !p.lexer.has_newline_before
+            {
                 'value: {
                     // const using_loc = p.saveExprCommentsHere();
                     let using_range = p.lexer.range();
                     p.lexer.next()?;
-                    if p.lexer.token == T::TIdentifier && !p.lexer.has_newline_before {
+                    if p.lexer.token == T::TIdentifier
+                        && !p.lexer.has_newline_before
+                        && !(opts.is_for_loop_init && p.is_using_for_of_variable())
+                    {
                         // It's an "await using" declaration if we get here
                         if opts.lexical_decl != LexicalDecl::AllowAll {
                             p.forbid_lexical_decl(using_range.loc);
@@ -1572,6 +1581,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     #[inline]
     fn check_for_arrow_after_the_current_token(&mut self) -> bool {
         self.next_token_matches(|p| p.lexer.token == T::TEqualsGreaterThan)
+    }
+
+    /// With the lexer on the token after `using` in a for-loop head: `for (using of y)`
+    /// loops over a variable named `using`, while `for (using of = x;;)` declares `of`.
+    fn is_using_for_of_variable(&mut self) -> bool {
+        self.lexer.is_contextual_keyword(b"of")
+            && !self.next_token_matches(|p| p.lexer.token == T::TEquals)
     }
 
     /// This parses an expression. This assumes we've already parsed the "async"

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1583,8 +1583,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.next_token_matches(|p| p.lexer.token == T::TEqualsGreaterThan)
     }
 
-    /// With the lexer on the token after `using` in a for-loop head: `for (using of y)`
-    /// loops over a variable named `using`, while `for (using of = x;;)` declares `of`.
+    /// `for (using of y)` loops over the variable `using`; `for (using of = x;;)` declares `of`.
     fn is_using_for_of_variable(&mut self) -> bool {
         self.lexer.is_contextual_keyword(b"of")
             && !self.next_token_matches(|p| p.lexer.token == T::TEquals)

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -832,6 +832,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if opts.lexical_decl != LexicalDecl::AllowAll {
                     p.forbid_lexical_decl(token_range.loc);
                 }
+                if opts.is_switch_case_body {
+                    p.log().add_range_error(
+                        Some(p.source),
+                        token_range,
+                        b"\"using\" declarations are not allowed in \"case\" or \"default\" clauses unless wrapped in a block",
+                    );
+                }
                 // p.markSyntaxFeature(.using, token_range.loc);
                 opts.is_using_statement = true;
                 let decls = p.parse_and_declare_decls(js_ast::symbol::Kind::Constant, opts)?;
@@ -890,6 +897,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // It's an "await using" declaration if we get here
                         if opts.lexical_decl != LexicalDecl::AllowAll {
                             p.forbid_lexical_decl(using_range.loc);
+                        }
+                        if opts.is_switch_case_body {
+                            p.log().add_range_error(
+                                Some(p.source),
+                                bun_ast::Range {
+                                    loc: token_range.loc,
+                                    len: using_range.end().start - token_range.loc.start,
+                                },
+                                b"\"await using\" declarations are not allowed in \"case\" or \"default\" clauses unless wrapped in a block",
+                            );
                         }
                         // p.markSyntaxFeature(.using, using_range.loc);
                         opts.is_using_statement = true;
@@ -1448,6 +1465,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut return_without_semicolon_start: i32 = -1;
         opts.lexical_decl = LexicalDecl::AllowAll;
+        opts.is_switch_case_body = false;
         let mut is_directive_prologue = true;
 
         loop {

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1583,10 +1583,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.next_token_matches(|p| p.lexer.token == T::TEqualsGreaterThan)
     }
 
-    /// `for (using of y)` loops over the variable `using`; `for (using of = x;;)` declares `of`.
+    /// `for (using of y)` loops over `using`; `for (using of = x;;)` or a TS `of: T` declares `of`.
     fn is_using_for_of_variable(&mut self) -> bool {
         self.lexer.is_contextual_keyword(b"of")
-            && !self.next_token_matches(|p| p.lexer.token == T::TEquals)
+            && !self.next_token_matches(|p| {
+                p.lexer.token == T::TEquals
+                    || (Self::IS_TYPESCRIPT_ENABLED && p.lexer.token == T::TColon)
+            })
     }
 
     /// This parses an expression. This assumes we've already parsed the "async"

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -377,6 +377,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         _ => {
                             let mut stmt_opts = ParseStatementOptions {
                                 lexical_decl: LexicalDecl::AllowAll,
+                                is_switch_case_body: true,
                                 ..Default::default()
                             };
                             body.push(p.parse_stmt(&mut stmt_opts)?);

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -672,6 +672,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // Detect for-in loops
             if p.lexer.token == T::TIn {
+                if let Some(init_stmt) = &init_ {
+                    if let js_ast::StmtData::SLocal(local) = &init_stmt.data {
+                        match local.kind {
+                            js_ast::s::Kind::KUsing => p.log().add_error(
+                                Some(p.source),
+                                init_loc,
+                                b"Cannot use a \"using\" declaration in a for-in loop",
+                            ),
+                            js_ast::s::Kind::KAwaitUsing => p.log().add_error(
+                                Some(p.source),
+                                init_loc,
+                                b"Cannot use an \"await using\" declaration in a for-in loop",
+                            ),
+                            _ => {}
+                        }
+                    }
+                }
                 p.forbid_initializers(decls_ptr.slice(), "in", is_var)?;
                 p.lexer.next()?;
                 let value = p.parse_expr(Level::Lowest)?;
@@ -688,12 +705,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ));
             }
 
-            // Only require "const" statement initializers when we know we're a normal for loop
+            // Only require "const" and "using" statement initializers when we know we're a
+            // normal for loop
             if let Some(init_stmt) = &init_ {
                 match &init_stmt.data {
                     js_ast::StmtData::SLocal(local) => {
-                        if local.kind == js_ast::s::Kind::KConst {
-                            p.require_initializers(js_ast::s::Kind::KConst, decls_ptr.slice())?;
+                        if local.kind == js_ast::s::Kind::KConst || local.kind.is_using() {
+                            p.require_initializers(local.kind, decls_ptr.slice())?;
                         }
                     }
                     _ => {}

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -705,8 +705,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ));
             }
 
-            // Only require "const" and "using" statement initializers when we know we're a
-            // normal for loop
+            // Only require "const"/"using" initializers once we know this is a normal for loop
             if let Some(init_stmt) = &init_ {
                 match &init_stmt.data {
                     js_ast::StmtData::SLocal(local) => {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1028,7 +1028,6 @@ pub enum StmtsKind {
     #[default]
     None,
     LoopBody,
-    SwitchStmt,
     FnBody,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1497,8 +1497,7 @@ pub struct ParseStatementOptions<'a> {
     pub(crate) is_name_optional: bool,
     pub(crate) is_typescript_declare: bool,
     pub(crate) is_for_loop_init: bool,
-    /// The statement is a direct child of a `case`/`default` clause, where a
-    /// `using`/`await using` declaration is a syntax error unless wrapped in a block.
+    /// Directly inside a `case`/`default` clause, not in a block nested within one.
     pub(crate) is_switch_case_body: bool,
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1498,6 +1498,9 @@ pub struct ParseStatementOptions<'a> {
     pub(crate) is_name_optional: bool,
     pub(crate) is_typescript_declare: bool,
     pub(crate) is_for_loop_init: bool,
+    /// The statement is a direct child of a `case`/`default` clause, where a
+    /// `using`/`await using` declaration is a syntax error unless wrapped in a block.
+    pub(crate) is_switch_case_body: bool,
 }
 
 impl<'a> ParseStatementOptions<'a> {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1542,7 +1542,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // Lower using declarations
-        if kind != StmtsKind::SwitchStmt && p.should_lower_using_declarations(stmts.as_slice()) {
+        if p.should_lower_using_declarations(stmts.as_slice()) {
             let mut ctx = LowerUsingDeclarationsContext::init(p)?;
             ctx.scan_stmts(p, stmts.as_mut_slice());
             // `finalize` stores a sub-slice of the old buffer as the lowered

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2087,7 +2087,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::Switch,
     ) -> Result<(), Error> {
         p.visit_expr(&mut data.test);
-        let mut lowered_using = false;
         {
             p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, data.body_loc)
                 .expect("unreachable");
@@ -2107,29 +2106,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 cases[i].body = list_to_stmts(_stmts);
             }
             p.fn_or_arrow_data_visit.is_inside_switch = old_is_inside_switch;
-
-            for i in 0..cases.len() {
-                if p.should_lower_using_declarations(cases[i].body.slice()) {
-                    lowered_using = true;
-                    break;
-                }
-            }
-            if lowered_using {
-                let mut ctx = crate::p::LowerUsingDeclarationsContext::init(p)?;
-                for i in 0..cases.len() {
-                    ctx.scan_stmts(p, cases[i].body.slice_mut());
-                }
-                let switch_stmt = p.arena.alloc_slice_copy(&[*stmt]);
-                stmts.extend_from_slice(&ctx.finalize(p, switch_stmt, false));
-            }
-
             p.pop_scope();
         }
         // TODO: duplicate case checker
 
-        if !lowered_using {
-            stmts.push(*stmt);
-        }
+        stmts.push(*stmt);
         Ok(())
     }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2101,7 +2101,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     //                 p.warnAboutTypeofAndString(s.Test, *c.Value)
                 }
                 let mut _stmts = stmts_to_list(p.arena, cases[i].body);
-                p.visit_stmts(&mut _stmts, StmtsKind::SwitchStmt)
+                p.visit_stmts(&mut _stmts, StmtsKind::None)
                     .expect("unreachable");
                 cases[i].body = list_to_stmts(_stmts);
             }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: `using` / `await using` directly in a switch case clause is a
+/// parse error; entries written by the parser that accepted it must not be reused.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `using` directly in a switch case clause is now a parse error.
+/// Version 26: `using` declarations in switch clauses and for-in / uninitialized for
+/// heads are parse errors; `for (using of y)` parses as a loop over `using`.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,8 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `using` declarations in switch clauses and for-in / uninitialized for
-/// heads are parse errors; `for (using of y)` parses as a loop over `using`.
+/// Version 26: `using` is rejected in switch clauses, for-in heads and uninitialized for heads.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,8 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `using` / `await using` directly in a switch case clause is a
-/// parse error; entries written by the parser that accepted it must not be reused.
+/// Version 26: `using` directly in a switch case clause is now a parse error.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5198,10 +5198,12 @@ describe("export of a block-scoped function declaration", () => {
   });
 });
 
-// A `using` / `await using` declaration placed directly in a `case` / `default`
-// clause is a SyntaxError (V8, JSC and tsc all reject it); it has to be wrapped
-// in a block. The parser reports it the same way for every loader and target.
-describe("using declarations in switch statements", () => {
+// Where `using` / `await using` declarations may appear. Every verdict below matches
+// node 26 and JSC: directly in a `case` / `default` clause (must be wrapped in a block),
+// as the head of a for-in loop, without an initializer in a C-style for loop, and with
+// a newline between `await` and `using` are all SyntaxErrors, while `for (using of y)`
+// loops over a variable named `using`.
+describe("using declaration placement", () => {
   const usingError = {
     message: '"using" declarations are not allowed in "case" or "default" clauses unless wrapped in a block',
     length: "using".length,
@@ -5224,7 +5226,86 @@ describe("using declarations in switch statements", () => {
     return [];
   }
 
+  // The printed output when `code` is accepted, otherwise the first error reported.
+  // target "bun" keeps `using` as written, so the output shows how the input was parsed.
+  function verdict(code, loader) {
+    try {
+      return new Bun.Transpiler({ loader, target: "bun" }).transformSync(code);
+    } catch (e) {
+      return (e instanceof AggregateError ? e.errors[0] : e).message;
+    }
+  }
+
   describe.each(["js", "ts"])("loader %s", loader => {
+    it("for loop heads", () => {
+      const verdicts = {};
+      for (const code of [
+        "for (using x in y);",
+        "for (await using x in y);",
+        "for (using x;;);",
+        "for (await using x;;);",
+        "for (using of of y);",
+        "for (await using of y);",
+        "for (using\nx of y);",
+        "for (using x = y;;);",
+        "for (await using x = y;;);",
+        "for (using of = x;;);",
+        "for (await using of = x;;);",
+        "for (using of y);",
+        "for await (using of y);",
+        "for (using x of y);",
+        "for (await using x of y);",
+        "for await (using x of y);",
+        "for await (await using x of y);",
+      ]) {
+        verdicts[code] = verdict(code, loader);
+      }
+      expect(verdicts).toEqual({
+        "for (using x in y);": 'Cannot use a "using" declaration in a for-in loop',
+        "for (await using x in y);": 'Cannot use an "await using" declaration in a for-in loop',
+        "for (using x;;);": 'The declaration "x" must be initialized',
+        "for (await using x;;);": 'The declaration "x" must be initialized',
+        "for (using of of y);": 'Expected ")" but found "y"',
+        "for (await using of y);": "Invalid assignment target",
+        "for (using\nx of y);": 'Expected ";" but found "x"',
+        "for (using x = y;;);": "for (using x = y;; )\n  ;\n",
+        "for (await using x = y;;);": "for (await using x = y;; )\n  ;\n",
+        "for (using of = x;;);": "for (using of = x;; )\n  ;\n",
+        "for (await using of = x;;);": "for (await using of = x;; )\n  ;\n",
+        "for (using of y);": "for (using of y)\n  ;\n",
+        "for await (using of y);": "for await (using of y)\n  ;\n",
+        "for (using x of y);": "for (using x of y)\n  ;\n",
+        "for (await using x of y);": "for (await using x of y)\n  ;\n",
+        "for await (using x of y);": "for await (using x of y)\n  ;\n",
+        "for await (await using x of y);": "for await (await using x of y)\n  ;\n",
+      });
+    });
+
+    it("`using` as a binding name is only special in a for-of head", () => {
+      expect(verdict("using of = x;", loader)).toBe("using of = x;\n");
+      expect(verdict("await using of = x;", loader)).toBe("await using of = x;\n");
+    });
+
+    it("a newline between `await` and `using` makes it an await expression", () => {
+      const verdicts = {};
+      for (const code of [
+        "await\nusing a = b;",
+        "async function f() { await\nusing a = b; }",
+        "for (await\nusing a of b);",
+        "await\nusing;",
+        "await\nusing\na = b;",
+      ]) {
+        verdicts[code] = verdict(code, loader);
+      }
+      expect(verdicts).toEqual({
+        "await\nusing a = b;": 'Expected ";" but found "a"',
+        "async function f() { await\nusing a = b; }": 'Expected ";" but found "a"',
+        "for (await\nusing a of b);": 'Expected ";" but found "a"',
+        "await\nusing;": "await using;\n",
+        "await\nusing\na = b;": "await using;\na = b;\n",
+      });
+    });
+
     it("rejects `using` directly in a case or default clause", () => {
       expect(parseErrors("switch (x) { case 0: using a = b; }", { loader })).toEqual([usingError]);
       expect(parseErrors("switch (x) { default: using a = b; }", { loader })).toEqual([usingError]);
@@ -5302,7 +5383,33 @@ describe("using declarations in switch statements", () => {
     expect(new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(code)).toContain("using a = b;");
   });
 
-  it.concurrent("is reported as a syntax error when running the file", async () => {
+  it("lowering sibling blocks in one scope generates distinct temporaries", () => {
+    // The lowering hoists its error temporaries to the enclosing scope as `var`, so the
+    // two blocks must not reuse names. The method bodies in the initializers matter: the
+    // temporary counter used to be reset whenever a function body was visited.
+    const out = new Bun.Transpiler({ loader: "js", target: "browser" }).transformSync(
+      "switch (v()) {\n case 0: { using x = { [s]() {} }; }\n default: { using y = { [t]() {} }; }\n }",
+    );
+    const [first, second] = out.split("default:").map(part => new Set(part.match(/__bun_temp_ref_\d+\$/g)));
+    expect(first.size).toBeGreaterThan(0);
+    expect(second.size).toBe(first.size);
+    expect(first.isDisjointFrom(second)).toBe(true);
+  });
+
+  it.concurrent("`for (using of y)` loops over the variable named using", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "let using; for (using of [1, 2]) console.log(using);"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1\n2\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("a declaration in a clause is reported as a syntax error when running the file", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "switch (1) {\n  case 1:\n    using a = null;\n}\nconsole.log('ran');"],
       env: bunEnv,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5198,98 +5198,155 @@ describe("export of a block-scoped function declaration", () => {
   });
 });
 
+// A `using` / `await using` declaration placed directly in a `case` / `default`
+// clause is a SyntaxError (V8, JSC and tsc all reject it); it has to be wrapped
+// in a block. The parser reports it the same way for every loader and target.
 describe("using declarations in switch statements", () => {
-  const reparse = out => new Bun.Transpiler({ loader: "js" }).transformSync(out);
+  const usingError = {
+    message: '"using" declarations are not allowed in "case" or "default" clauses unless wrapped in a block',
+    length: "using".length,
+  };
+  const awaitUsingError = {
+    message: '"await using" declarations are not allowed in "case" or "default" clauses unless wrapped in a block',
+    length: "await using".length,
+  };
 
-  it("lowers by wrapping the entire switch in a single try/finally", () => {
-    const input =
-      "switch (dom()) {\n case 0:\n using d23 = { [Se]() {} };\n default:\n using d24 = { [ose]() {} };\n }";
-
-    for (const minifyWhitespace of [false, true]) {
-      const out = new Bun.Transpiler({ loader: "jsx", target: "node", minifyWhitespace }).transformSync(input);
-      expect(() => reparse(out)).not.toThrow();
-      expect(out).toMatch(/try\s*\{\s*switch\s*\(dom\(\)\)/);
-      expect(out.match(/finally/g)).toHaveLength(1);
+  // One entry per reported error ("length" is the underlined source range), [] when the code transpiles.
+  function parseErrors(code, options) {
+    try {
+      new Bun.Transpiler(options).transformSync(code);
+    } catch (e) {
+      return (e instanceof AggregateError ? e.errors : [e]).map(err => ({
+        message: err.message,
+        length: err.position.length,
+      }));
     }
-  });
+    return [];
+  }
 
-  it("lowers `await using` in switch cases the same way", () => {
-    const input = `async function f(x) {
-      switch (x()) {
-        case 0:
-          await using a = y();
-        default:
-          await using b = z();
+  describe.each(["js", "ts"])("loader %s", loader => {
+    it("rejects `using` directly in a case or default clause", () => {
+      expect(parseErrors("switch (x) { case 0: using a = b; }", { loader })).toEqual([usingError]);
+      expect(parseErrors("switch (x) { default: using a = b; }", { loader })).toEqual([usingError]);
+      expect(parseErrors("switch (x) { case 0: f(); using a = b; g(); }", { loader })).toEqual([usingError]);
+      expect(parseErrors("switch (x) {\n case 0:\n using a = b;\n default:\n using c = d;\n }", { loader })).toEqual([
+        usingError,
+        usingError,
+      ]);
+    });
+
+    it("rejects `await using` directly in a case or default clause", () => {
+      expect(parseErrors("async function f() { switch (x) { case 0: await using a = b; } }", { loader })).toEqual([
+        awaitUsingError,
+      ]);
+      expect(parseErrors("async function f() { switch (x) { default: await using a = b; } }", { loader })).toEqual([
+        awaitUsingError,
+      ]);
+      // Top-level await form of the declaration.
+      expect(parseErrors("switch (x) { case 0: await using a = b; }", { loader })).toEqual([awaitUsingError]);
+    });
+
+    it("rejects them for every target, including bun where using is not lowered", () => {
+      for (const target of ["browser", "node", "bun"]) {
+        expect(parseErrors("switch (x) { case 0: using a = b; }", { loader, target })).toEqual([usingError]);
+        expect(parseErrors("switch (x) { case 0: await using a = b; }", { loader, target })).toEqual([awaitUsingError]);
       }
-    }`;
-    const out = new Bun.Transpiler({ loader: "js", target: "node" }).transformSync(input);
-    expect(() => reparse(out)).not.toThrow();
-    expect(out).toMatch(/try\s*\{\s*switch\s*\(x\(\)\)/);
-    expect(out.match(/finally/g)).toHaveLength(1);
-  });
+    });
 
-  it("keeps generated temp refs unique across sibling switches in the same scope", () => {
-    const input = `
-      switch (a()) { case 0: using x = { [s]() {} }; }
-      switch (b()) { case 1: using y = { [t]() {} }; }
-    `;
-    const out = new Bun.Transpiler({ loader: "js", target: "node", minifyWhitespace: true }).transformSync(input);
-    expect(() => reparse(out)).not.toThrow();
-    expect(out.match(/finally/g)).toHaveLength(2);
-  });
-
-  it("keeps case bindings const when combined with top-level using declarations", () => {
-    const input = `
-      using top = r();
-      switch (a()) {
-        case 0:
-          using x = { [s]() {} };
-        default:
-          using y = { [t]() {} };
+    it("still accepts using declarations nested anywhere inside a clause", () => {
+      const accepted = [
+        "switch (x) { case 0: { using a = b; } }",
+        "switch (x) { default: { await using a = b; } }",
+        "switch (x) { case 0: if (y) { using a = b; } }",
+        "switch (x) { case 0: try { await using a = b; } finally {} }",
+        "switch (x) { case 0: for (using a of b) c(a); }",
+        "switch (x) { case 0: for (await using a of b) c(a); }",
+        "switch (x) { case 0: for await (using a of b) c(a); }",
+        "switch (x) { case 0: function f() { using a = b; } }",
+        "switch (x) { case 0: (async () => { await using a = b; })(); }",
+        "switch (x) { case 0: class C { static { using a = b; } } }",
+        "switch (x) { case 0: { switch (y) { default: { using a = b; } } } }",
+      ];
+      for (const code of accepted) {
+        for (const target of ["browser", "bun"]) {
+          expect(parseErrors(code, { loader, target })).toEqual([]);
+        }
       }
-    `;
-    const out = new Bun.Transpiler({ loader: "js", target: "node", minifyWhitespace: true }).transformSync(input);
-    expect(() => reparse(out)).not.toThrow();
-    expect(out).toMatch(/const x\s*=\s*__using/);
-    expect(out).toMatch(/const y\s*=\s*__using/);
-    expect(out).not.toMatch(/var [xy]\b/);
+    });
+
+    it("still accepts `using` as an identifier in a clause", () => {
+      expect(
+        parseErrors(
+          "switch (x) { case 0: using; case 1: using(a); case 2: using = a; case 3: using.a = b; default: using\n a = b; }",
+          { loader },
+        ),
+      ).toEqual([]);
+      expect(
+        parseErrors(
+          "async function f() { switch (x) { case 0: await using; case 1: await using.a; default: await using\n a = b; } }",
+          { loader },
+        ),
+      ).toEqual([]);
+    });
   });
 
-  it("disposes at switch exit in reverse order and keeps bindings visible across cases", async () => {
+  it("a newline after `using` in a clause is an identifier statement, not a declaration", () => {
+    expect(new Bun.Transpiler({ loader: "js" }).transformSync("switch (x) {\n default:\n using\n a = b;\n }")).toBe(
+      "switch (x) {\n  default:\n    using;\n    a = b;\n}\n",
+    );
+  });
+
+  it("lowers a block-wrapped using in a clause for other targets and keeps it for bun", () => {
+    const code = "switch (x) { case 0: { using a = b; } }";
+    expect(new Bun.Transpiler({ loader: "js", target: "browser" }).transformSync(code)).toContain("__using");
+    expect(new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(code)).toContain("using a = b;");
+  });
+
+  it.concurrent("is reported as a syntax error when running the file", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "switch (1) {\n  case 1:\n    using a = null;\n}\nconsole.log('ran');"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(usingError.message);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  it.concurrent("block-wrapped declarations are disposed when their block exits", async () => {
     const source = `
       const order = [];
       function resource(name) {
         return { [Symbol.dispose]() { order.push("dispose " + name); } };
       }
-      function run(value) {
-        switch (value) {
-          case 0:
-            using a = resource("a");
-            order.push("case 0");
-          default:
-            using b = resource("b");
-            order.push("default sees a: " + (a !== undefined));
+      switch (0) {
+        case 0: {
+          using a = resource("a");
+          order.push("case 0");
         }
-        order.push("after switch");
+        default: {
+          using b = resource("b");
+          order.push("default");
+        }
       }
-      run(0);
+      order.push("after switch");
       console.log(JSON.stringify(order));
     `;
 
-    const lowered = new Bun.Transpiler({ loader: "js", target: "node" }).transformSync(source);
+    const lowered = new Bun.Transpiler({ loader: "js", target: "browser" }).transformSync(source);
     expect(lowered).toContain("__using");
 
-    using dir = tempDir("using-switch-lowering", { "lowered.mjs": lowered });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "lowered.mjs"],
+      cmd: [bunExe(), "-e", lowered],
       env: bunEnv,
-      cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual(["case 0", "default sees a: true", "dispose b", "dispose a", "after switch"]);
+    expect(JSON.parse(stdout)).toEqual(["case 0", "dispose a", "default", "dispose b", "after switch"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5371,6 +5371,12 @@ describe("using declaration placement", () => {
     });
   });
 
+  it("a type annotation after `using of` in a for head also declares `of` (tsc does the same)", () => {
+    expect(verdict("for (using of: T = x;;);", "ts")).toBe("for (using of = x;; )\n  ;\n");
+    expect(verdict("for (await using of: T = x;;);", "ts")).toBe("for (await using of = x;; )\n  ;\n");
+    expect(verdict("for (using of: T = x;;);", "js")).toBe("Unexpected :");
+  });
+
   it("a newline after `using` in a clause is an identifier statement, not a declaration", () => {
     expect(new Bun.Transpiler({ loader: "js" }).transformSync("switch (x) {\n default:\n using\n a = b;\n }")).toBe(
       "switch (x) {\n  default:\n    using;\n    a = b;\n}\n",
@@ -5390,7 +5396,8 @@ describe("using declaration placement", () => {
     const out = new Bun.Transpiler({ loader: "js", target: "browser" }).transformSync(
       "switch (v()) {\n case 0: { using x = { [s]() {} }; }\n default: { using y = { [t]() {} }; }\n }",
     );
-    const [first, second] = out.split("default:").map(part => new Set(part.match(/__bun_temp_ref_\d+\$/g)));
+    // The counter is printed in hex.
+    const [first, second] = out.split("default:").map(part => new Set(part.match(/__bun_temp_ref_[0-9a-f]+\$/g)));
     expect(first.size).toBeGreaterThan(0);
     expect(second.size).toBe(first.size);
     expect(first.isDisjointFrom(second)).toBe(true);


### PR DESCRIPTION
### Problem
- The parser accepts a `using` / `await using` declaration written directly in a `case:` / `default:` clause, e.g. `switch (x) { case 0: using a = b; }`. V8 (node 26: `SyntaxError: Unexpected identifier 'a'`), JSC (`'using' declaration is not allowed directly in a switch case or default clause`) and tsc (TS1547 / TS1548) all reject it; the declaration has to be wrapped in a block.
- `bun build --target=bun` and `Bun.Transpiler` therefore emit the invalid syntax unchanged, other targets lower it as if it were valid, and `bun run` fails with JSC's error against the transpiled output instead of a parse error pointing at the source.
- Cause: `t_switch` (`src/js_parser/parse/parse_stmt.rs`) parses clause statements with plain `lexical_decl: AllowAll` options, so the `using` branches of `parse_expr_or_let_stmt` (`src/js_parser/parse/mod.rs`) cannot tell they are directly inside a clause.
- The same two functions have four sibling mismatches with node and JSC, found while checking the surrounding code: `for (using x in y)` and `for (await using x in y)` are accepted (a `using` declaration cannot head a for-in loop); `for (using x;;)` is accepted without an initializer; `for (using of y)`, a for-of over a variable named `using`, is rejected while `for (using of of y)` is accepted; and `await` + newline + `using a = b` is parsed as an `await using` declaration instead of an await expression followed by a stray identifier.

### Fix
- Adds `ParseStatementOptions::is_switch_case_body`, set by `t_switch` for each statement parsed directly in a clause. The `using` and `await using` branches of `parse_expr_or_let_stmt` report `"using" declarations are not allowed in "case" or "default" clauses unless wrapped in a block` (and the `"await using"` variant) when it is set, underlining the keyword(s), and keep parsing so the remaining errors in the file are still reported. `parse_stmts_up_to` clears the flag next to its existing `lexical_decl` reset, so nothing past a brace is affected: blocks, function bodies, static blocks, `if`/`try` bodies and `for (using x of ...)` inside a clause stay accepted, as does `using` used as an identifier.
- For-in heads with a `using` / `await using` declaration report `Cannot use a "using" declaration in a for-in loop` (`t_for`), and the C-style for head requires initializers for `using` kinds the way it already did for `const` (`The declaration "x" must be initialized`, reusing `require_initializers`).
- In a for head, `using of` / `await using of` only starts a declaration when the next token is `=` (`for (using of = x;;)`, which V8 and JSC accept) or, in TypeScript, a `:` type annotation (the same rule tsc applies); otherwise `using` is the loop variable, so `for (using of y)` now parses and `for (using of of y)` fails like it does everywhere else. Outside for heads `using of = x;` is unchanged. `await using` requires `using` on the same line as `await`, matching the existing requirement between `using` and its binding.
- Removes the whole-switch `using` lowering from `s_switch` (`src/js_parser/visit/visit_stmt.rs`, added in #31262), `StmtsKind::SwitchStmt` and the `kind != SwitchStmt` operand of the lowering guard in `visit_stmts`: the only declarations they handled are now rejected before the visit pass. Block-wrapped declarations in clauses are lowered by the generic statement-list lowering, as before, and the temporary-counter fix from #31262 stays and gets its own test again.
- Bumps the runtime transpiler cache `EXPECTED_VERSION` to 26 (`src/jsc/RuntimeTranspilerCache.rs`), as the parser.rs header requires for parser fixes: the on-disk cache is consulted before parsing, so entries written by the old parser for files containing the now-rejected forms would otherwise still be served.
- Correct because every verdict matches node 26 and the JSC bun currently pins (checked both directly; the table is in the tests), and the error now points at the source instead of at transpiled output. The only code this turns from accepted into an error is code both runtimes reject; `for (using of y)` is the one form that goes the other way, and both runtimes accept it. Not changed: `for (using x = y;;)` and `for (await using x = y;;)` stay accepted (spec, V8 and JSC accept them; esbuild rejects the latter).
- Verified with `test/bundler/transpiler/transpiler.test.js` (`using declaration placement`): 13 of its 23 tests fail on the unfixed build (switch clauses, for heads and the newline case for both loaders, the TypeScript `using of: T` row, plus `bun -e` runs of a clause declaration and of `for (using of y)`), all 23 pass with the fix; the other 10 pin the forms that must keep working.
- Also run with the fix: the full `transpiler.test.js`, `test/js/bun/resolve/lower-using-bun-target.test.ts`, `test/js/web/explicit-resource-management.test.ts`, `test/regression/issue/11100.test.ts`, `test/cli/run/transpiler-cache.test.ts`, `test/bundler/esbuild/{lower,default,ts}.test.ts`, `test/bundler/transpiler/es-decorators.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/internal/source-lints/`; all green. Transpiling every JS/TS file under `test/`, `src/js/`, `packages/`, `scripts/` and `bench/` (10,820 files) with this build and with the released build fails the same 703 intentionally invalid fixtures and nothing else, so no existing code changes verdict.

### Background
- `using` / `await using` declarations (Explicit Resource Management): block-scoped bindings whose value is disposed (`Symbol.dispose` / `Symbol.asyncDispose`) when the enclosing block exits. They may appear as statements, in C-style for heads (with initializers) and as for-of heads; not in for-in heads, and, since the proposal stopped scoping them to a whole switch block, not directly in a `case` clause. `using` is still an ordinary identifier everywhere it does not start a declaration, which is why `for (using of y)` is valid.
- `ParseStatementOptions`: a small `Copy` struct the parser hands to `parse_stmt` describing the position of the statement about to be parsed (`is_for_loop_init`, `is_typescript_declare`, `lexical_decl`, which says whether declarations are allowed at all in this position). Every nested statement list (`parse_stmts_up_to`) starts from fresh or normalized options, which is why a per-position flag is the natural way to express "directly in a clause".
- Lowering: for targets other than `bun`, the visit pass rewrites `using` declarations into `const` plus a `try`/`finally` that disposes the values, naming its temporaries `__bun_temp_ref_N$` from a per-file counter; the error temporaries are hoisted to the enclosing scope as `var`, so sibling lowerings in one scope must not share names. Targeting `bun` passes the syntax through unchanged and JSC executes it natively.
- Runtime transpiler cache: `bun run` stores transpiled output on disk keyed by source hash, options and `EXPECTED_VERSION`, and checks it before parsing, so a parser behavior change has to bump the version to take effect for already-cached files.
