### PR TITLE
Lower `await using` without adding microtask ticks

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -419,27 +419,9 @@ export var __require = /* @__PURE__ */ (x =>
 // Bun's WebKit also has Symbol.asyncDispose, Symbol.dispose, and
 // SuppressedError, so no polyfills are needed.
 //
-// Keep these in sync with `__using` / `__callDispose` in `src/runtime.bun.js`
-// (the copies behind `bun:wrap`, which additionally stay awaitable for files
-// transpiled by older versions of Bun) and with the statements
-// `LowerUsingDeclarationsContext::finalize` in `js_parser/p.rs` generates
-// around them.
-//
-// `__using` mirrors the spec's CreateDisposableResource: an `await using` of
-// a value that only has `Symbol.dispose` gets a wrapper whose return value is
-// ignored and whose throw turns into a rejection, like the spec's synthesized
-// async dispose method.
-//
-// `__callDispose` mirrors DisposeResources, with one difference: it cannot
-// await. Each time the spec would perform an Await it returns `next`, with
-// `next.result` set to the value the spec would await, and the generated code
-// awaits that value itself, then calls `next.fail(reason)` if it rejected and
-// `next()` to keep going. The awaits therefore run in the user's own async
-// function and take exactly as many microtask ticks as native `await using`
-// does; routing them through a promise chain inside the helper would add a
-// tick per resource. When nothing is left to await, `next()` returns
-// undefined, or throws the (possibly Suppressed) error. For plain `using` the
-// whole thing runs synchronously and the return value is ignored.
+// Keep in sync with src/runtime.bun.js and the loop `LowerUsingDeclarationsContext::finalize` emits:
+// wherever DisposeResources would await, `__callDispose` returns `next` with `next.result` to await;
+// the generated code then calls `next.fail(reason)` on rejection and `next()` to continue.
 const RUNTIME_USING_BUN: &str = "\
 export var __using = (stack, value, async) => {
   if (value != null) {

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -418,10 +418,7 @@ export var __require = /* @__PURE__ */ (x =>
 // here so the runtime module exports a consistent shape across targets.
 // Bun's WebKit also has Symbol.asyncDispose, Symbol.dispose, and
 // SuppressedError, so no polyfills are needed.
-//
-// Keep in sync with src/runtime.bun.js and the loop `LowerUsingDeclarationsContext::finalize` emits:
-// wherever DisposeResources would await, `__callDispose` returns `next` with `next.result` to await;
-// the generated code then calls `next.fail(reason)` on rejection and `next()` to continue.
+// Keep in sync with src/runtime.bun.js and with `LowerUsingDeclarationsContext::finalize`.
 const RUNTIME_USING_BUN: &str = "\
 export var __using = (stack, value, async) => {
   if (value != null) {

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -418,14 +418,40 @@ export var __require = /* @__PURE__ */ (x =>
 // here so the runtime module exports a consistent shape across targets.
 // Bun's WebKit also has Symbol.asyncDispose, Symbol.dispose, and
 // SuppressedError, so no polyfills are needed.
+//
+// Keep these in sync with `__using` / `__callDispose` in `src/runtime.bun.js`
+// (the copies behind `bun:wrap`, which additionally stay awaitable for files
+// transpiled by older versions of Bun) and with the statements
+// `LowerUsingDeclarationsContext::finalize` in `js_parser/p.rs` generates
+// around them.
+//
+// `__using` mirrors the spec's CreateDisposableResource: an `await using` of
+// a value that only has `Symbol.dispose` gets a wrapper whose return value is
+// ignored and whose throw turns into a rejection, like the spec's synthesized
+// async dispose method.
+//
+// `__callDispose` mirrors DisposeResources, with one difference: it cannot
+// await. Each time the spec would perform an Await it returns `next`, with
+// `next.result` set to the value the spec would await, and the generated code
+// awaits that value itself, then calls `next.fail(reason)` if it rejected and
+// `next()` to keep going. The awaits therefore run in the user's own async
+// function and take exactly as many microtask ticks as native `await using`
+// does; routing them through a promise chain inside the helper would add a
+// tick per resource. When nothing is left to await, `next()` returns
+// undefined, or throws the (possibly Suppressed) error. For plain `using` the
+// whole thing runs synchronously and the return value is ignored.
 const RUNTIME_USING_BUN: &str = "\
 export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== 'object' && typeof value !== 'function') throw TypeError('Object expected to be assigned to \"using\" declaration')
-    let dispose
+    let dispose, inner
     if (async) dispose = value[Symbol.asyncDispose]
-    if (dispose === void 0) dispose = value[Symbol.dispose]
+    if (dispose == null) {
+      dispose = value[Symbol.dispose]
+      if (async) inner = dispose
+    }
     if (typeof dispose !== 'function') throw TypeError('Object not disposable')
+    if (inner) dispose = function () { try { inner.call(this) } catch (e) { return Promise.reject(e) } }
     stack.push([async, dispose, value])
   } else if (async) {
     stack.push([async])
@@ -434,18 +460,38 @@ export var __using = (stack, value, async) => {
 }
 
 export var __callDispose = (stack, error, hasError) => {
-  let fail = e => error = hasError ? new SuppressedError(e, error, 'An error was suppressed during disposal') : (hasError = true, e)
-    , next = (it) => {
-      while (it = stack.pop()) {
+  let needsAwait, hasAwaited,
+    next = () => {
+      for (var it; it = stack.pop();) {
+        if (!it[0] && needsAwait && !hasAwaited) {
+          needsAwait = false
+          stack.push(it)
+          next.result = void 0
+          return next
+        }
         try {
           var result = it[1] && it[1].call(it[2])
-          if (it[0]) return Promise.resolve(result).then(next, (e) => (fail(e), next()))
         } catch (e) {
-          fail(e)
+          next.fail(e)
+          continue
         }
+        if (it[0]) {
+          if (it[1]) {
+            hasAwaited = true
+            next.result = result
+            return next
+          }
+          needsAwait = true
+        }
+      }
+      if (needsAwait && !hasAwaited) {
+        needsAwait = false
+        next.result = void 0
+        return next
       }
       if (hasError) throw error
     }
+  next.fail = e => error = hasError ? new SuppressedError(e, error, 'An error was suppressed during disposal') : (hasError = true, e)
   return next()
 }
 ";
@@ -459,10 +505,14 @@ var __asyncDispose =  Symbol.asyncDispose || /* @__PURE__ */ Symbol.for('Symbol.
 export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== 'object' && typeof value !== 'function') throw TypeError('Object expected to be assigned to \"using\" declaration')
-    var dispose
+    var dispose, inner
     if (async) dispose = value[__asyncDispose]
-    if (dispose === void 0) dispose = value[__dispose]
+    if (dispose == null) {
+      dispose = value[__dispose]
+      if (async) inner = dispose
+    }
     if (typeof dispose !== 'function') throw TypeError('Object not disposable')
+    if (inner) dispose = function () { try { inner.call(this) } catch (e) { return Promise.reject(e) } }
     stack.push([async, dispose, value])
   } else if (async) {
     stack.push([async])
@@ -473,18 +523,38 @@ export var __using = (stack, value, async) => {
 export var __callDispose = (stack, error, hasError) => {
   var E = typeof SuppressedError === 'function' ? SuppressedError :
     function (e, s, m, _) { return _ = Error(m), _.name = 'SuppressedError', _.error = e, _.suppressed = s, _ },
-    fail = e => error = hasError ? new E(e, error, 'An error was suppressed during disposal') : (hasError = true, e),
-    next = (it) => {
-      while (it = stack.pop()) {
+    needsAwait, hasAwaited,
+    next = () => {
+      for (var it; it = stack.pop();) {
+        if (!it[0] && needsAwait && !hasAwaited) {
+          needsAwait = false
+          stack.push(it)
+          next.result = void 0
+          return next
+        }
         try {
           var result = it[1] && it[1].call(it[2])
-          if (it[0]) return Promise.resolve(result).then(next, (e) => (fail(e), next()))
         } catch (e) {
-          fail(e)
+          next.fail(e)
+          continue
         }
+        if (it[0]) {
+          if (it[1]) {
+            hasAwaited = true
+            next.result = result
+            return next
+          }
+          needsAwait = true
+        }
+      }
+      if (needsAwait && !hasAwaited) {
+        needsAwait = false
+        next.result = void 0
+        return next
       }
       if (hasError) throw error
     }
+  next.fail = e => error = hasError ? new E(e, error, 'An error was suppressed during disposal') : (hasError = true, e)
   return next()
 }
 ";

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9114,7 +9114,6 @@ impl LowerUsingDeclarationsContext {
         let finally_stmts: &'a mut [Stmt] = if self.has_await_using {
             // for (var _dispose = __callDispose(stack, error, hasError); _dispose; _dispose = _dispose())
             //   try { await _dispose.result } catch (_reason) { _dispose.fail(_reason) }
-            // Awaiting here instead of inside the helper keeps the tick count identical to native code.
             let dispose_ref = p.generate_temp_ref(Some(b"_dispose"));
             let reason_ref = p.generate_temp_ref(Some(b"_reason"));
             scope.generated.append_slice(&[dispose_ref, reason_ref]);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9059,8 +9059,8 @@ impl LowerUsingDeclarationsContext {
             .append_slice(&[self.stack_ref, caught_ref, err_ref, has_err_ref]);
         p.declared_symbols
             .ensure_unused_capacity(
-                // 5 to include the _promise decl later on:
-                if self.has_await_using { 5 } else { 4 },
+                // 6 to include the _dispose and _reason decls later on:
+                if self.has_await_using { 6 } else { 4 },
             )
             .expect("oom");
         p.declared_symbols.append_assume_capacity(DeclaredSymbol {
@@ -9112,35 +9112,50 @@ impl LowerUsingDeclarationsContext {
         };
 
         let finally_stmts: &'a mut [Stmt] = if self.has_await_using {
-            let promise_ref = p.generate_temp_ref(Some(b"_promise"));
-            VecExt::append(&mut scope.generated, promise_ref);
+            // `__callDispose` (see RUNTIME_USING_OTHER in bundler/ParseTask.rs)
+            // returns a stepper each time the spec would await something, so
+            // the awaits happen here in the user's async function and the block
+            // exits on the same microtask tick as a native `await using` would:
+            //
+            //   for (var _dispose = __callDispose(stack, error, hasError); _dispose; _dispose = _dispose())
+            //     try {
+            //       await _dispose.result;
+            //     } catch (_reason) {
+            //       _dispose.fail(_reason);
+            //     }
+            //
+            // If nothing needs awaiting (e.g. an error was thrown before the
+            // `await using`), `__callDispose` returns undefined and the loop body
+            // never runs, so no await happens at all.
+            let dispose_ref = p.generate_temp_ref(Some(b"_dispose"));
+            let reason_ref = p.generate_temp_ref(Some(b"_reason"));
+            scope.generated.append_slice(&[dispose_ref, reason_ref]);
             p.declared_symbols.append_assume_capacity(DeclaredSymbol {
                 is_top_level,
-                ref_: promise_ref,
+                ref_: dispose_ref,
+            });
+            p.declared_symbols.append_assume_capacity(DeclaredSymbol {
+                is_top_level,
+                ref_: reason_ref,
             });
 
-            let promise_ref_expr = p.new_expr(
-                E::Identifier {
-                    ref_: promise_ref,
-                    ..Default::default()
-                },
-                loc,
-            );
+            let dispose_ident = |p: &mut P<'a, T, S_>| {
+                p.record_usage(dispose_ref);
+                p.new_expr(
+                    E::Identifier {
+                        ref_: dispose_ref,
+                        ..Default::default()
+                    },
+                    loc,
+                )
+            };
 
-            let await_expr = p.new_expr(
-                E::Await {
-                    value: promise_ref_expr,
-                },
-                loc,
-            );
-            p.record_usage(promise_ref);
-
-            // var promise = __callDispose(stack, error, hasError);
-            let promise_binding = p.b(B::Identifier { r#ref: promise_ref }, loc);
-            let stmt0 = p.s(
+            // var _dispose = __callDispose(stack, error, hasError)
+            let dispose_binding = p.b(B::Identifier { r#ref: dispose_ref }, loc);
+            let init = p.s(
                 S::Local {
                     decls: G::DeclList::init_one(Decl {
-                        binding: promise_binding,
+                        binding: dispose_binding,
                         value: Some(call_dispose),
                     }),
                     ..Default::default()
@@ -9148,29 +9163,111 @@ impl LowerUsingDeclarationsContext {
                 loc,
             );
 
-            // The "await" must not happen if an error was thrown before the
-            // "await using", so we conditionally await here:
-            //
-            //   var promise = __callDispose(stack, error, hasError);
-            //   promise && await promise;
-            //
-            let cond_await = p.new_expr(
-                E::Binary {
-                    op: js_ast::op::Code::BinLogicalAnd,
-                    left: promise_ref_expr,
-                    right: await_expr,
-                },
-                loc,
-            );
-            let stmt1 = p.s(
-                S::SExpr {
-                    value: cond_await,
-                    ..Default::default()
+            let test = dispose_ident(p);
+
+            // _dispose = _dispose()
+            let update = {
+                let target = dispose_ident(p);
+                let call = p.new_expr(
+                    E::Call {
+                        target,
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                let assign_target = dispose_ident(p);
+                Expr::assign(assign_target, call)
+            };
+
+            // await _dispose.result;
+            let try_body = {
+                let target = dispose_ident(p);
+                let result = p.new_expr(
+                    E::Dot {
+                        target,
+                        name: b"result".into(),
+                        name_loc: loc,
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                let await_expr = p.new_expr(E::Await { value: result }, loc);
+                let stmt = p.s(
+                    S::SExpr {
+                        value: await_expr,
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                bun_ast::StoreSlice::new_mut(p.arena.alloc_slice_copy(&[stmt]))
+            };
+
+            // catch (_reason) { _dispose.fail(_reason); }
+            let catch_binding = p.b(B::Identifier { r#ref: reason_ref }, loc);
+            let catch_body = {
+                let target = dispose_ident(p);
+                let fail = p.new_expr(
+                    E::Dot {
+                        target,
+                        name: b"fail".into(),
+                        name_loc: loc,
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                p.record_usage(reason_ref);
+                let reason = p.new_expr(
+                    E::Identifier {
+                        ref_: reason_ref,
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                let args = p.arena.alloc_slice_copy(&[reason]);
+                let call = p.new_expr(
+                    E::Call {
+                        target: fail,
+                        args: ExprNodeList::from_arena_slice(args),
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                let stmt = p.s(
+                    S::SExpr {
+                        value: call,
+                        ..Default::default()
+                    },
+                    loc,
+                );
+                bun_ast::StoreSlice::new_mut(p.arena.alloc_slice_copy(&[stmt]))
+            };
+
+            let body = p.s(
+                S::Try {
+                    body_loc: loc,
+                    body: try_body,
+                    catch: Some(js_ast::Catch {
+                        loc,
+                        binding: Some(catch_binding),
+                        body: catch_body,
+                        body_loc: loc,
+                    }),
+                    finally: None,
                 },
                 loc,
             );
 
-            p.arena.alloc_slice_copy(&[stmt0, stmt1])
+            let for_stmt = p.s(
+                S::For {
+                    init: Some(init),
+                    test: Some(test),
+                    update: Some(update),
+                    body,
+                },
+                loc,
+            );
+
+            p.arena.alloc_slice_copy(&[for_stmt])
         } else {
             let call_dispose_loc = call_dispose.loc;
             p.arena.alloc_slice_copy(&[p.s(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9112,21 +9112,9 @@ impl LowerUsingDeclarationsContext {
         };
 
         let finally_stmts: &'a mut [Stmt] = if self.has_await_using {
-            // `__callDispose` (see RUNTIME_USING_OTHER in bundler/ParseTask.rs)
-            // returns a stepper each time the spec would await something, so
-            // the awaits happen here in the user's async function and the block
-            // exits on the same microtask tick as a native `await using` would:
-            //
-            //   for (var _dispose = __callDispose(stack, error, hasError); _dispose; _dispose = _dispose())
-            //     try {
-            //       await _dispose.result;
-            //     } catch (_reason) {
-            //       _dispose.fail(_reason);
-            //     }
-            //
-            // If nothing needs awaiting (e.g. an error was thrown before the
-            // `await using`), `__callDispose` returns undefined and the loop body
-            // never runs, so no await happens at all.
+            // for (var _dispose = __callDispose(stack, error, hasError); _dispose; _dispose = _dispose())
+            //   try { await _dispose.result } catch (_reason) { _dispose.fail(_reason) }
+            // Awaiting here instead of inside the helper keeps the tick count identical to native code.
             let dispose_ref = p.generate_temp_ref(Some(b"_dispose"));
             let reason_ref = p.generate_temp_ref(Some(b"_reason"));
             scope.generated.append_slice(&[dispose_ref, reason_ref]);

--- a/src/runtime.bun.js
+++ b/src/runtime.bun.js
@@ -1,14 +1,27 @@
 export * from "./runtime";
 
-// TODO: these are duplicated from bundle_v2.js, can we ... not do that?
+// Duplicates RUNTIME_USING_BUN in src/bundler/ParseTask.rs, which documents the
+// protocol between __callDispose and the code the parser generates around it.
+// Keep the two in sync; the only intended difference is `next.then` below.
 export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== "object" && typeof value !== "function")
       throw TypeError('Object expected to be assigned to "using" declaration');
-    let dispose;
+    let dispose, inner;
     if (async) dispose = value[Symbol.asyncDispose];
-    if (dispose === void 0) dispose = value[Symbol.dispose];
+    if (dispose == null) {
+      dispose = value[Symbol.dispose];
+      if (async) inner = dispose;
+    }
     if (typeof dispose !== "function") throw TypeError("Object not disposable");
+    if (inner)
+      dispose = function () {
+        try {
+          inner.call(this);
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
     stack.push([async, dispose, value]);
   } else if (async) {
     stack.push([async]);
@@ -17,20 +30,52 @@ export var __using = (stack, value, async) => {
 };
 
 export var __callDispose = (stack, error, hasError) => {
-  let fail = e =>
-      (error = hasError
-        ? new SuppressedError(e, error, "An error was suppressed during disposal")
-        : ((hasError = true), e)),
-    next = it => {
-      while ((it = stack.pop())) {
+  let needsAwait,
+    hasAwaited,
+    next = () => {
+      for (var it; (it = stack.pop()); ) {
+        if (!it[0] && needsAwait && !hasAwaited) {
+          needsAwait = false;
+          stack.push(it);
+          next.result = void 0;
+          return next;
+        }
         try {
           var result = it[1] && it[1].call(it[2]);
-          if (it[0]) return Promise.resolve(result).then(next, e => (fail(e), next()));
         } catch (e) {
-          fail(e);
+          next.fail(e);
+          continue;
         }
+        if (it[0]) {
+          if (it[1]) {
+            hasAwaited = true;
+            next.result = result;
+            return next;
+          }
+          needsAwait = true;
+        }
+      }
+      if (needsAwait && !hasAwaited) {
+        needsAwait = false;
+        next.result = void 0;
+        return next;
       }
       if (hasError) throw error;
     };
+  next.fail = e =>
+    (error = hasError
+      ? new SuppressedError(e, error, "An error was suppressed during disposal")
+      : ((hasError = true), e));
+  // Files transpiled by older versions of Bun import this module too, and their
+  // generated code is `_promise && await _promise`, so the stepper also has to
+  // be awaitable: `then` drives the remaining steps through a promise chain.
+  // The bundler's copies don't need this; a bundle always carries the helper
+  // matching its own generated code.
+  let drive = () =>
+    Promise.resolve(next.result).then(
+      () => next() && drive(),
+      e => (next.fail(e), next()) && drive(),
+    );
+  next.then = (onFulfilled, onRejected) => drive().then(onFulfilled, onRejected);
   return next();
 };

--- a/src/runtime.bun.js
+++ b/src/runtime.bun.js
@@ -64,8 +64,7 @@ export var __callDispose = (stack, error, hasError) => {
     (error = hasError
       ? new SuppressedError(e, error, "An error was suppressed during disposal")
       : ((hasError = true), e));
-  // Files lowered by older versions of Bun do `_promise && await _promise` on the
-  // return value, so the stepper is also awaitable and `then` drives the rest itself.
+  // `then` is what files lowered by older versions of Bun hit: they `await` the return value.
   let drive = () =>
     Promise.resolve(next.result).then(
       () => next() && drive(),

--- a/src/runtime.bun.js
+++ b/src/runtime.bun.js
@@ -1,8 +1,6 @@
 export * from "./runtime";
 
-// Duplicates RUNTIME_USING_BUN in src/bundler/ParseTask.rs, which documents the
-// protocol between __callDispose and the code the parser generates around it.
-// Keep the two in sync; the only intended difference is `next.then` below.
+// Same as RUNTIME_USING_BUN in src/bundler/ParseTask.rs (keep in sync), plus `next.then` below.
 export var __using = (stack, value, async) => {
   if (value != null) {
     if (typeof value !== "object" && typeof value !== "function")
@@ -66,11 +64,8 @@ export var __callDispose = (stack, error, hasError) => {
     (error = hasError
       ? new SuppressedError(e, error, "An error was suppressed during disposal")
       : ((hasError = true), e));
-  // Files transpiled by older versions of Bun import this module too, and their
-  // generated code is `_promise && await _promise`, so the stepper also has to
-  // be awaitable: `then` drives the remaining steps through a promise chain.
-  // The bundler's copies don't need this; a bundle always carries the helper
-  // matching its own generated code.
+  // Files lowered by older versions of Bun do `_promise && await _promise` on the
+  // return value, so the stepper is also awaitable and `then` drives the rest itself.
   let drive = () =>
     Promise.resolve(next.result).then(
       () => next() && drive(),

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -151,6 +151,15 @@ devTest("using runtime import", {
         console.log("b");
       }
 
+      // __callDispose stepping through an await using block
+      (async () => {
+        {
+          await using c = { [Symbol.asyncDispose]: async () => console.log("d") };
+          console.log("c");
+        }
+        console.log("e");
+      })();
+
       // __legacyDecorateClassTS
       function undefinedDecorator(target) {
         console.log("decorator");
@@ -187,6 +196,8 @@ devTest("using runtime import", {
     await c.expectMessage(
       "b",
       "a",
+      "c",
+      "d",
       "decorator",
       ...(dev.nodeEnv === "development"
         ? [
@@ -199,6 +210,9 @@ devTest("using runtime import", {
             false,
           ]
         : []),
+      // Logged once the await on the disposal result resolves, after the rest
+      // of the module body ran.
+      "e",
     );
   },
 });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -57,9 +57,9 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5623:at"],
+          ["react.development.js:524:'getContextName'", "1:5823:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
-          ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
+          ["react.development.js:696:''Component'", '1:7885:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
           ["entry.tsx:11:'<html>'", "100:19062:void"],
           ["entry.tsx:23:'await'", "100:19161:await"],
@@ -67,7 +67,7 @@ describe("bundler", () => {
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 222000,
+      "out/entry.js": 222200,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
+++ b/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
@@ -18,8 +18,12 @@ const x = __using(__bun_temp_ref_1$, a, 1);
 } catch (__bun_temp_ref_2$) {
 var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
 } finally {
-var __bun_temp_ref_5$ = __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
-__bun_temp_ref_5$ && await __bun_temp_ref_5$;
+for (var __bun_temp_ref_5$ = __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);__bun_temp_ref_5$; __bun_temp_ref_5$ = __bun_temp_ref_5$())
+try {
+await __bun_temp_ref_5$.result;
+} catch (__bun_temp_ref_6$) {
+__bun_temp_ref_5$.fail(__bun_temp_ref_6$);
+}
 }"
 `;
 
@@ -60,8 +64,12 @@ c(a);
 } catch (__bun_temp_ref_3$) {
 var __bun_temp_ref_4$ = __bun_temp_ref_3$, __bun_temp_ref_5$ = 1;
 } finally {
-var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);
-__bun_temp_ref_6$ && await __bun_temp_ref_6$;
+for (var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);__bun_temp_ref_6$; __bun_temp_ref_6$ = __bun_temp_ref_6$())
+try {
+await __bun_temp_ref_6$.result;
+} catch (__bun_temp_ref_7$) {
+__bun_temp_ref_6$.fail(__bun_temp_ref_7$);
+}
 }
 }"
 `;
@@ -75,8 +83,12 @@ c(a);
 } catch (__bun_temp_ref_3$) {
 var __bun_temp_ref_4$ = __bun_temp_ref_3$, __bun_temp_ref_5$ = 1;
 } finally {
-var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);
-__bun_temp_ref_6$ && await __bun_temp_ref_6$;
+for (var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);__bun_temp_ref_6$; __bun_temp_ref_6$ = __bun_temp_ref_6$())
+try {
+await __bun_temp_ref_6$.result;
+} catch (__bun_temp_ref_7$) {
+__bun_temp_ref_6$.fail(__bun_temp_ref_7$);
+}
 }
 }"
 `;
@@ -121,8 +133,12 @@ a(c);
 } catch (__bun_temp_ref_3$) {
 var __bun_temp_ref_4$ = __bun_temp_ref_3$, __bun_temp_ref_5$ = 1;
 } finally {
-var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);
-__bun_temp_ref_6$ && await __bun_temp_ref_6$;
+for (var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);__bun_temp_ref_6$; __bun_temp_ref_6$ = __bun_temp_ref_6$())
+try {
+await __bun_temp_ref_6$.result;
+} catch (__bun_temp_ref_7$) {
+__bun_temp_ref_6$.fail(__bun_temp_ref_7$);
+}
 }
 }"
 `;
@@ -137,8 +153,12 @@ a(c);
 } catch (__bun_temp_ref_3$) {
 var __bun_temp_ref_4$ = __bun_temp_ref_3$, __bun_temp_ref_5$ = 1;
 } finally {
-var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);
-__bun_temp_ref_6$ && await __bun_temp_ref_6$;
+for (var __bun_temp_ref_6$ = __callDispose(__bun_temp_ref_2$, __bun_temp_ref_4$, __bun_temp_ref_5$);__bun_temp_ref_6$; __bun_temp_ref_6$ = __bun_temp_ref_6$())
+try {
+await __bun_temp_ref_6$.result;
+} catch (__bun_temp_ref_7$) {
+__bun_temp_ref_6$.fail(__bun_temp_ref_7$);
+}
 }
 }"
 `;
@@ -168,8 +188,12 @@ try {
 } catch (__bun_temp_ref_6$) {
   var __bun_temp_ref_7$ = __bun_temp_ref_6$, __bun_temp_ref_8$ = 1;
 } finally {
-  var __bun_temp_ref_9$ = __callDispose(__bun_temp_ref_5$, __bun_temp_ref_7$, __bun_temp_ref_8$);
-  __bun_temp_ref_9$ && await __bun_temp_ref_9$;
+  for (var __bun_temp_ref_9$ = __callDispose(__bun_temp_ref_5$, __bun_temp_ref_7$, __bun_temp_ref_8$);__bun_temp_ref_9$; __bun_temp_ref_9$ = __bun_temp_ref_9$())
+    try {
+      await __bun_temp_ref_9$.result;
+    } catch (__bun_temp_ref_a$) {
+      __bun_temp_ref_9$.fail(__bun_temp_ref_a$);
+    }
 }
 
 export {

--- a/test/bundler/transpiler/await-using-timing-fixture.mjs
+++ b/test/bundler/transpiler/await-using-timing-fixture.mjs
@@ -1,0 +1,245 @@
+// Prints one line per scenario describing when each dispose call, block exit,
+// and error happened, measured in microtask ticks. transpiler.test.js runs this
+// file natively and again after lowering `using` / `await using`, and expects
+// the output to be identical.
+
+let tick = 0;
+const lines = [];
+
+function describeError(e) {
+  if (e && e.name === "SuppressedError") {
+    return `Suppressed(${describeError(e.error)} over ${describeError(e.suppressed)})`;
+  }
+  // The lowered helpers use different TypeError messages than the engine does.
+  if (e instanceof TypeError) return "TypeError";
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+async function scenario(name, body) {
+  tick = 0;
+  const events = [];
+  const log = what => events.push(`${what}@${tick}`);
+  // Bumps `tick` once per microtask turn. Bounded so it cannot starve the event loop.
+  const ticker = (async () => {
+    for (let i = 0; i < 32; i++) {
+      await null;
+      tick++;
+    }
+  })();
+  let settled = false;
+  body(log).then(
+    value => {
+      settled = true;
+      log(`returned(${value})`);
+    },
+    error => {
+      settled = true;
+      log(`threw(${describeError(error)})`);
+    },
+  );
+  await ticker;
+  if (!settled) log("still pending");
+  lines.push(`${name}: ${events.join(" ")}`);
+}
+
+const asyncDisposable = (log, name) => ({
+  async [Symbol.asyncDispose]() {
+    log(`asyncDispose(${name})`);
+  },
+});
+const rejectingAsyncDisposable = (log, name) => ({
+  async [Symbol.asyncDispose]() {
+    log(`asyncDispose(${name})`);
+    throw new Error(name);
+  },
+});
+const syncDisposable = (log, name) => ({
+  [Symbol.dispose]() {
+    log(`dispose(${name})`);
+  },
+});
+
+await scenario("block exits before a sibling's second tick", async () => {
+  const order = [];
+  const block = (async () => {
+    try {
+      await using x = null;
+    } finally {
+      order.push("using-block-exited");
+    }
+  })();
+  const sibling = (async () => {
+    await null;
+    order.push("one-tick-later");
+  })();
+  await block;
+  await sibling;
+  return order.join(" < ");
+});
+
+await scenario("null resource", async log => {
+  {
+    await using a = null;
+  }
+  log("exit");
+});
+
+await scenario("one async resource", async log => {
+  {
+    await using a = asyncDisposable(log, "a");
+  }
+  log("exit");
+});
+
+await scenario("three async resources", async log => {
+  {
+    await using a = asyncDisposable(log, "a");
+    await using b = asyncDisposable(log, "b");
+    await using c = asyncDisposable(log, "c");
+  }
+  log("exit");
+});
+
+await scenario("asyncDispose returns a thenable", async log => {
+  {
+    await using a = {
+      [Symbol.asyncDispose]() {
+        log("asyncDispose(a)");
+        return {
+          then(resolve) {
+            log("then(a)");
+            resolve();
+          },
+        };
+      },
+    };
+  }
+  log("exit");
+});
+
+await scenario("await using falls back to Symbol.dispose and ignores its return value", async log => {
+  {
+    await using a = {
+      [Symbol.dispose]() {
+        log("dispose(a)");
+        return new Promise(() => {});
+      },
+    };
+  }
+  log("exit");
+});
+
+await scenario("await using falls back to Symbol.dispose when Symbol.asyncDispose is null", async log => {
+  {
+    await using a = {
+      [Symbol.asyncDispose]: null,
+      [Symbol.dispose]() {
+        log("dispose(a)");
+      },
+    };
+  }
+  log("exit");
+});
+
+await scenario("Symbol.dispose fallback that throws", async log => {
+  {
+    await using a = {
+      [Symbol.dispose]() {
+        log("dispose(a)");
+        throw new Error("a");
+      },
+    };
+    throw new Error("body");
+  }
+});
+
+await scenario("asyncDispose that throws synchronously", async log => {
+  {
+    await using a = {
+      [Symbol.asyncDispose]() {
+        log("asyncDispose(a)");
+        throw new Error("a");
+      },
+    };
+  }
+  log("unreachable");
+});
+
+await scenario("null resources around a sync resource", async log => {
+  {
+    await using a = null;
+    using b = syncDisposable(log, "b");
+    await using c = null;
+  }
+  log("exit");
+});
+
+await scenario("sync resource after an awaited resource and a null resource", async log => {
+  {
+    using a = syncDisposable(log, "a");
+    await using b = asyncDisposable(log, "b");
+    await using c = null;
+  }
+  log("exit");
+});
+
+await scenario("two null resources", async log => {
+  {
+    await using a = null;
+    await using b = null;
+  }
+  log("exit");
+});
+
+await scenario("body error plus two rejected disposals", async log => {
+  {
+    await using a = rejectingAsyncDisposable(log, "a");
+    await using b = rejectingAsyncDisposable(log, "b");
+    throw new Error("body");
+  }
+});
+
+await scenario("rejected disposal between two successful ones", async log => {
+  {
+    await using a = asyncDisposable(log, "a");
+    await using b = rejectingAsyncDisposable(log, "b");
+    await using c = asyncDisposable(log, "c");
+  }
+  log("unreachable");
+});
+
+await scenario("error thrown before the await using", async log => {
+  {
+    if (log) throw new Error("before");
+    await using a = asyncDisposable(log, "a");
+  }
+});
+
+await scenario("return value passes through", async log => {
+  {
+    await using a = asyncDisposable(log, "a");
+    await using b = null;
+    return 42;
+  }
+});
+
+await scenario("for-of with an await using binding", async log => {
+  for (await using item of [asyncDisposable(log, "x"), asyncDisposable(log, "y")]) {
+    log("body");
+  }
+  log("exit");
+});
+
+await scenario("nested blocks", async log => {
+  {
+    await using a = asyncDisposable(log, "a");
+    {
+      await using b = asyncDisposable(log, "b");
+    }
+    log("between");
+  }
+  log("exit");
+});
+
+console.log(lines.join("\n"));

--- a/test/bundler/transpiler/await-using-timing-fixture.mjs
+++ b/test/bundler/transpiler/await-using-timing-fixture.mjs
@@ -1,7 +1,6 @@
-// Prints one line per scenario describing when each dispose call, block exit,
-// and error happened, measured in microtask ticks. transpiler.test.js runs this
-// file natively and again after lowering `using` / `await using`, and expects
-// the output to be identical.
+// Prints one line per scenario saying on which microtask tick each dispose call, block
+// exit, and error happened. transpiler.test.js runs this file natively and again with
+// `using` / `await using` lowered, and expects identical output.
 
 let tick = 0;
 const lines = [];

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5342,15 +5342,12 @@ describe("await using lowering", () => {
     expect(native.split("\n").length).toBeGreaterThan(10);
 
     // Transpiled output imports the helpers from "bun:wrap"; the bundle inlines them.
+    const runs = [runScript(bunExe(), "lowered.mjs", cwd), runScript(bunExe(), "bundled.mjs", cwd)];
     const node = nodeExe();
-    const [loweredOutput, bundledOutput, bundledOutputInNode] = await Promise.all([
-      runScript(bunExe(), "lowered.mjs", cwd),
-      runScript(bunExe(), "bundled.mjs", cwd),
-      node ? runScript(node, "bundled.mjs", cwd) : native,
-    ]);
-    expect(loweredOutput).toBe(native);
-    expect(bundledOutput).toBe(native);
-    expect(bundledOutputInNode).toBe(native);
+    if (node) runs.push(runScript(node, "bundled.mjs", cwd));
+    for (const output of await Promise.all(runs)) {
+      expect(output).toBe(native);
+    }
   });
 
   it("files lowered by older versions of Bun still dispose through the current bun:wrap", async () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
+import { bunEnv, bunExe, hideFromStackTrace, nodeExe, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {
@@ -5291,6 +5291,110 @@ describe("using declarations in switch statements", () => {
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual(["case 0", "default sees a: true", "dispose b", "dispose a", "after switch"]);
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("await using lowering", () => {
+  const fixturePath = join(import.meta.dir, "await-using-timing-fixture.mjs");
+
+  async function runScript(exe, script, cwd) {
+    await using proc = Bun.spawn({
+      cmd: [exe, script],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  it("Bun.Transpiler and bun build output dispose on the same microtask ticks as the native syntax", async () => {
+    const source = await Bun.file(fixturePath).text();
+    const lowered = new Bun.Transpiler({ loader: "js", target: "node" }).transformSync(source);
+    expect(lowered).toContain("__callDispose");
+
+    using dir = tempDir("await-using-timing", {
+      "native.mjs": source,
+      "lowered.mjs": lowered,
+    });
+    const cwd = String(dir);
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=browser", "native.mjs", "--outfile=bundled.mjs"],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).toBe("");
+    expect(buildExitCode).toBe(0);
+    const bundled = await Bun.file(join(cwd, "bundled.mjs")).text();
+    expect(bundled).toContain("__callDispose");
+
+    const native = await runScript(bunExe(), "native.mjs", cwd);
+    // The scenario from the original report: the block finishes one microtask
+    // after `await using x = null`, before a sibling that awaited once.
+    expect(native).toContain("returned(using-block-exited < one-tick-later)");
+    expect(native.split("\n").length).toBeGreaterThan(10);
+
+    // Transpiled output imports the helpers from "bun:wrap"; the bundle inlines them.
+    const node = nodeExe();
+    const [loweredOutput, bundledOutput, bundledOutputInNode] = await Promise.all([
+      runScript(bunExe(), "lowered.mjs", cwd),
+      runScript(bunExe(), "bundled.mjs", cwd),
+      node ? runScript(node, "bundled.mjs", cwd) : native,
+    ]);
+    expect(loweredOutput).toBe(native);
+    expect(bundledOutput).toBe(native);
+    expect(bundledOutputInNode).toBe(native);
+  });
+
+  it("files lowered by older versions of Bun still dispose through the current bun:wrap", async () => {
+    // What Bun used to emit for:
+    //
+    //   await using a = resource("a");
+    //   await using b = resource("b");
+    //   throw new Error("body");
+    //
+    // It awaits whatever __callDispose returns instead of stepping through it.
+    using dir = tempDir("await-using-old-lowering", {
+      "old.mjs": `
+        import { __using, __callDispose } from "bun:wrap";
+        const order = [];
+        const resource = name => ({
+          async [Symbol.asyncDispose]() {
+            order.push("dispose " + name);
+            if (name === "b") throw new Error("dispose " + name);
+          },
+        });
+        async function run() {
+          let __stack = [];
+          try {
+            const a = __using(__stack, resource("a"), 1);
+            const b = __using(__stack, resource("b"), 1);
+            throw new Error("body");
+          } catch (_catch) {
+            var _err = _catch, _hasErr = 1;
+          } finally {
+            var _promise = __callDispose(__stack, _err, _hasErr);
+            _promise && await _promise;
+          }
+        }
+        try {
+          await run();
+          order.push("did not throw");
+        } catch (e) {
+          order.push(e.name + ": " + e.error.message + " suppressed " + e.suppressed.message);
+        }
+        console.log(JSON.stringify(order));
+      `,
+    });
+    const stdout = await runScript(bunExe(), "old.mjs", String(dir));
+    expect(JSON.parse(stdout)).toEqual(["dispose b", "dispose a", "SuppressedError: dispose b suppressed body"]);
   });
 });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5354,13 +5354,8 @@ describe("await using lowering", () => {
   });
 
   it("files lowered by older versions of Bun still dispose through the current bun:wrap", async () => {
-    // What Bun used to emit for:
-    //
-    //   await using a = resource("a");
-    //   await using b = resource("b");
-    //   throw new Error("body");
-    //
-    // It awaits whatever __callDispose returns instead of stepping through it.
+    // The shape older versions emitted for two `await using` declarations followed by a
+    // throw: it awaits whatever __callDispose returns instead of stepping through it.
     using dir = tempDir("await-using-old-lowering", {
       "old.mjs": `
         import { __using, __callDispose } from "bun:wrap";


### PR DESCRIPTION
### Problem

- `bun build` (any target other than `bun`) lowers `await using`, and the lowered block leaves one microtask later than the native syntax. `node r.mjs` and `bun r.mjs` print `using-block-exited < one-tick-later`; the bundle of the same file prints `one-tick-later < using-block-exited` (fuzz ledger #13431).
- With more than one resource it is worse: the helper returned a new promise from inside each `.then` callback, so every additional resource cost three ticks instead of one (three `await using` resources: block exits on tick 6, natively tick 3).
- Cause: `__callDispose` (`src/bundler/ParseTask.rs`, same copy in `src/runtime.bun.js` behind `bun:wrap`) chained `Promise.resolve(result).then(next)` per resource and the generated `finally` then awaited the chain's promise (`src/js_parser/p.rs`, `LowerUsingDeclarationsContext::finalize`), one await on top of the awaits the spec performs.
- `__using` also deviated from the spec for an `await using` whose value only has `Symbol.dispose`: the method's return value was awaited (returning a pending promise hung the block, natively it is ignored), a synchronous throw surfaced synchronously instead of after an await, and `[Symbol.asyncDispose]: null` threw `Object not disposable` instead of falling back.

### Fix

- `__callDispose` now runs the synchronous part of the spec's DisposeResources, including its `needsAwait` / `hasAwaited` rules for `null` resources, and returns a stepper function each time the spec would perform an Await, with `stepper.result` set to the value to await. The generated code became:
  ```js
  for (var _dispose = __callDispose(__stack, _err, _hasErr); _dispose; _dispose = _dispose())
    try { await _dispose.result; } catch (_reason) { _dispose.fail(_reason); }
  ```
  The awaits now happen in the user's own async function, one per Await the spec performs, so the block exits on the same tick as native code, dispose methods run on the same ticks, and rejections still get folded into a `SuppressedError` by `fail`. When nothing needs awaiting (error before the declaration, plain `using`) it returns `undefined` or throws synchronously, as before.
- `__using` wraps a `Symbol.dispose` fallback the way the spec's synthesized method does (return value dropped, throw becomes a rejection) and treats a `null` `Symbol.asyncDispose` like a missing one.
- The `bun:wrap` copy in `src/runtime.bun.js` additionally gives the stepper a `then`, so files lowered by earlier versions of Bun (`_promise && await _promise`) still dispose every resource against the new runtime. The bundler's copies do not need this since a bundle carries the helper matching its own generated code.
- Verified with `test/bundler/transpiler/transpiler.test.js`:
  - `await using lowering`: `test/bundler/transpiler/await-using-timing-fixture.mjs` records on which tick every dispose call, block exit and error happens for 18 scenarios; it is run natively, as `Bun.Transpiler` output (helpers from `bun:wrap`), and as a `bun build --target=browser` bundle under bun and node, and all four outputs must be identical. Before this change the lowered outputs differ on 16 of the 18 lines (diff below).
  - A second test runs the old generated shape against the current `bun:wrap`.
  - The `using` snapshots were updated for the new `finally` body.
- `test/bake/dev-and-prod.test.ts` `using runtime import` now also covers an `await using` block through the HMR runtime's copy of the helpers.
- Also passing locally: `test/bundler/bundler_npm.test.ts`, `test/bundler/bundler_browser.test.ts` (`AwaitUsingStatement`, `UsingStatement`), `test/js/bun/resolve/lower-using-bun-target.test.ts`, `test/regression/issue/11100.test.ts`, `test/js/web/explicit-resource-management.test.ts`.
- Minified cost: the helpers grow by 200 bytes per bundle that uses `using`, and each lowered `await using` block by about 35 bytes. `test/bundler/bundler_npm.test.ts` (`npm/ReactSSR`, whose entry uses `using`) pins two line-1 source map columns and the exact output size, so those move by 200.

### Background

- `await using x = v` registers `v` in a per-block resource stack; when the block exits, the spec's DisposeResources walks the stack in reverse and, for each resource with an async hint, calls its dispose method and performs one Await on the result. `await using x = null` registers a placeholder that only requests a single Await at the end (or before the next synchronous `using` resource), and only if no real Await happened. These Awaits are the only source of microtask ticks, so a lowering is only faithful if it performs exactly the same awaits in the same function.
- Every `await` in JavaScript costs at least one microtask tick, and resolving a promise with another promise costs two more, which is why a helper that awaits on the user's behalf and then hands back a promise cannot match native timing; the generated code itself has to await each value.
- The helpers exist in three copies: `RUNTIME_USING_OTHER` / `RUNTIME_USING_BUN` in `src/bundler/ParseTask.rs` are inlined into bundles, and `src/runtime.bun.js` is the `bun:wrap` module used by `Bun.Transpiler` / `bun build --no-bundle` output, the REPL, and the bake dev server runtime. The generated code in `p.rs` has to agree with all of them.
- Related: #33381 would add a fourth copy of these helpers (`src/ast/runtime_inline.rs`) and would need the same update if it lands.

<details>
<summary>Fixture output before this change (native on the left, lowered on the right)</summary>

```diff
-block exits before a sibling's second tick: returned(using-block-exited < one-tick-later)@4
+block exits before a sibling's second tick: returned(one-tick-later < using-block-exited)@5
-null resource: exit@1 returned(undefined)@2
+null resource: exit@2 returned(undefined)@3
-one async resource: asyncDispose(a)@0 exit@1 returned(undefined)@2
+one async resource: asyncDispose(a)@0 exit@2 returned(undefined)@3
-three async resources: asyncDispose(c)@0 asyncDispose(b)@1 asyncDispose(a)@2 exit@3 returned(undefined)@4
+three async resources: asyncDispose(c)@0 asyncDispose(b)@1 asyncDispose(a)@2 exit@6 returned(undefined)@7
-asyncDispose returns a thenable: asyncDispose(a)@0 then(a)@1 exit@2 returned(undefined)@3
+asyncDispose returns a thenable: asyncDispose(a)@0 then(a)@1 exit@3 returned(undefined)@4
-await using falls back to Symbol.dispose and ignores its return value: dispose(a)@0 exit@1 returned(undefined)@2
+await using falls back to Symbol.dispose and ignores its return value: dispose(a)@0 still pending@32
-await using falls back to Symbol.dispose when Symbol.asyncDispose is null: dispose(a)@0 exit@1 returned(undefined)@2
+await using falls back to Symbol.dispose when Symbol.asyncDispose is null: threw(TypeError)@1
-Symbol.dispose fallback that throws: dispose(a)@0 threw(Suppressed(a over body))@2
+Symbol.dispose fallback that throws: dispose(a)@0 threw(Suppressed(a over body))@1
 asyncDispose that throws synchronously: asyncDispose(a)@0 threw(a)@1
-null resources around a sync resource: dispose(b)@1 exit@2 returned(undefined)@3
+null resources around a sync resource: dispose(b)@1 exit@4 returned(undefined)@5
-sync resource after an awaited resource and a null resource: asyncDispose(b)@0 dispose(a)@1 exit@1 returned(undefined)@2
+sync resource after an awaited resource and a null resource: asyncDispose(b)@1 dispose(a)@2 exit@4 returned(undefined)@5
-two null resources: exit@1 returned(undefined)@2
+two null resources: exit@4 returned(undefined)@5
-body error plus two rejected disposals: asyncDispose(b)@0 asyncDispose(a)@1 threw(Suppressed(a over Suppressed(b over body)))@3
+body error plus two rejected disposals: asyncDispose(b)@0 asyncDispose(a)@1 threw(Suppressed(a over Suppressed(b over body)))@5
-rejected disposal between two successful ones: asyncDispose(c)@0 asyncDispose(b)@1 asyncDispose(a)@2 threw(b)@4
+rejected disposal between two successful ones: asyncDispose(c)@0 asyncDispose(b)@1 asyncDispose(a)@2 threw(b)@7
 error thrown before the await using: threw(before)@1
-return value passes through: asyncDispose(a)@0 returned(42)@2
+return value passes through: asyncDispose(a)@1 returned(42)@5
-for-of with an await using binding: body@0 asyncDispose(x)@0 body@1 asyncDispose(y)@1 exit@2 returned(undefined)@3
+for-of with an await using binding: body@0 asyncDispose(x)@0 body@2 asyncDispose(y)@2 exit@4 returned(undefined)@5
-nested blocks: asyncDispose(b)@0 between@1 asyncDispose(a)@1 exit@2 returned(undefined)@3
+nested blocks: asyncDispose(b)@0 between@2 asyncDispose(a)@2 exit@4 returned(undefined)@5
```

`@n` is the number of microtask turns that had elapsed since the scenario started. `returned` / `threw` are logged from a `.then` on the scenario's promise, one tick after the function itself finished.

</details>

<details>
<summary>Wider probe used while designing this</summary>

64 block shapes (null / sync / async / fallback mixes, synchronous throws and rejections at each position, body errors, thenables, loops, `for (await using ...)`, `break` / `continue`, nested blocks, early return) were run natively under bun and node and as lowered code against each of the three helper copies; every shape produced identical traces. The one shape that differs is `await using` placed directly in a `switch` case, which V8 and current JavaScriptCore reject as a SyntaxError while Bun's parser accepts it; that is a separate parser issue and is tracked separately, as is a pre-existing bundler bug where a lowered top-level `using` in a lazily imported module loses its exports.

</details>
