### PR TITLE
test: size the text-loader reload stress fixture for debug builds

### DIFF
--- a/test/js/bun/util/text-loader-fixture-dynamic-import-stress.ts
+++ b/test/js/bun/util/text-loader-fixture-dynamic-import-stress.ts
@@ -1,6 +1,8 @@
-const count = process.platform === "win32" ? 1000 : 10_000;
+// Reloads the same file under a fresh specifier each time: https://github.com/oven-sh/bun/issues/9521
+// text-loader.test.ts passes the count.
+const count = Number(process.argv[2] ?? 5_000);
 for (let i = 0; i < count; i++) {
-  await import("./text-loader-fixture-text-file.txt?" + i++);
+  await import("./text-loader-fixture-text-file.txt?" + i);
 }
 Bun.gc(true);
 

--- a/test/js/bun/util/text-loader.test.ts
+++ b/test/js/bun/util/text-loader.test.ts
@@ -1,21 +1,23 @@
 import { spawnSync } from "bun";
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows } from "harness";
 import { join } from "path";
 
 describe("text-loader", () => {
+  // A reload costs ~2.5ms on debug builds; 5,000 of them would blow the default 5s test timeout.
+  const reloads = isWindows || isDebug ? 500 : 5_000;
   const fixtures = [
-    ["dynamic-import reloaded 10000 times", "text-loader-fixture-dynamic-import-stress.ts"],
+    [`dynamic-import reloaded ${reloads} times`, "text-loader-fixture-dynamic-import-stress.ts", String(reloads)],
     ["dynamic-import", "text-loader-fixture-dynamic-import.ts"],
     ["import", "text-loader-fixture-import.ts"],
     ["require", "text-loader-fixture-require.ts"],
   ] as const;
-  for (let [kind, path] of fixtures) {
+  for (let [kind, path, ...args] of fixtures) {
     describe("should load text", () => {
       it(`using ${kind}`, () => {
         const result = spawnSync({
-          cmd: [bunExe(), join(import.meta.dir, path)],
+          cmd: [bunExe(), join(import.meta.dir, path), ...args],
           env: bunEnv,
           stdout: "pipe",
           stderr: "inherit",


### PR DESCRIPTION
### Problem
- `bun bd test test/js/bun/util/text-loader.test.ts` always fails on a debug build, on a clean checkout of main:
  ```
  (fail) text-loader > should load text > using dynamic-import reloaded 10000 times [5082.59ms]
    ^ this test timed out after 5000ms.
  ```
  (`expect(received).toBe(expected)`, received `""`, because the fixture is still running when the test is killed).
- Cause: `test/js/bun/util/text-loader-fixture-dynamic-import-stress.ts:1-4` reloads the text file 5,000 times (`count` is 10,000 but the loop increments `i` twice) on every build type. A reload costs about 2.5ms on a debug+ASAN build, so the fixture takes about 13s there (0.17s on a release build), past bun test's default 5s per-test timeout.
- CI does not see this because `scripts/runner.node.mjs` passes its own `--timeout` (90s, tripled under ASAN). It breaks every local `bun bd test` run of the file, and with it any PR that wants to add a test to this file and have the file pass under `bun bd test` (#32999 ran into the same failure and had to explain it away).

### Fix
- `text-loader.test.ts` now picks the reload count and passes it to the fixture as `argv[2]`: 500 on debug builds and on Windows, 5,000 otherwise. The fixture loops `count` times (the old double increment is gone) and keeps the `Bun.gc(true)` plus final import.
- The test name reports the real count (`reloaded 500 times` / `reloaded 5000 times`) instead of the previous `10000`, which no configuration ever ran.
- Why this keeps the coverage the fixture exists for: the fixture guards the specifier over-deref from #9521 (a string freed while still referenced, hit by importing the same file under many query strings and then collecting). Debug builds are the only configuration whose count changes, and `bun bd` builds them with ASAN on, which reports that bug class on the first access to the freed string, so the count does not decide whether it is detected there. Release builds (including the release ASAN lanes in CI), where a plain release binary only crashes once enough churn has reused the freed memory, keep 5,000 reloads. Windows already ran 500 (the old `1000` with the double increment), so its coverage is unchanged.
- Why 500: on the debug+ASAN build here, startup is 0.32s and 250 / 500 / 1000 reloads take 0.94s / 1.56s / 2.83s, so 500 leaves room for slower machines under the 5s budget, and it matches the count Windows has used since #9540.
- No per-test timeout is added (test/CLAUDE.md).
- Verified:
  - `bun bd test test/js/bun/util/text-loader.test.ts` (debug+ASAN): 7 pass, the stress case in 1.58s. Same command with the test changes stashed: the stress case times out at 5s as quoted above, the other 6 pass.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/util/text-loader.test.ts` (release): 7 pass, `reloaded 5000 times` in 171ms, the same work as before the change.
  - Test-only change, so there is nothing under `src/` to stash for a fail-before run; the before/after above is the test file itself.

### Background
- The stress fixture comes from #9530 (fix for #9521, a segfault after importing a file with a query string). It was already cut from 50,000 to 5,000 reloads and given the `Bun.gc(true)` in #9540; this PR continues that sizing for debug builds.
- `isDebug` (`test/harness.ts`) is true when the bun running the tests is a debug build, which is what `bun bd` builds and what the fixture is spawned with through `bunExe()`. Release ASAN builds are not debug builds and keep the full count.
- Scope: this PR only touches this file. Other test files with release-sized loops that also miss the 5s default under `bun bd test` have their own PRs (#36929 load-same-js-file-a-lot, #37835 heap-snapshot, #37488 highway-strings, #32031 inspect-error-leak); error-gc-test.test.js and svelte.test.ts are in the same state and are being picked up separately.
