### PR TITLE
Bump WebKit (oven-sh/WebKit#422 preview): +x on operands of * / % - keeps its evaluation order and BigInt TypeError

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-422-937021ee";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/unary-plus-operand-evaluation-order.js
+++ b/test/js/bun/jsc-stress/fixtures/unary-plus-operand-evaluation-order.js
@@ -1,0 +1,121 @@
+// The parser used to drop the unary plus from the operands of `*`, `/`, `%` and `-` because those
+// operators convert their operands anyway. That changed observable behavior: `+x` converts x while
+// the operand is evaluated, before the other operand runs, and it throws for BigInts, whereas the
+// operators convert both operands only after evaluating both, and accept BigInts.
+// https://bugs.webkit.org/show_bug.cgi?id=159968
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected ${String(expected)}`);
+}
+
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`${func} should have thrown a ${errorType.name}, got ${String(error)}`);
+    return error;
+}
+
+// The shape from the original report, without any parentheses.
+{
+    const log = [];
+    const left = { valueOf() { log.push("left.valueOf"); return 2; } };
+    function right() { log.push("right()"); return 3; }
+    shouldBe(+left * right(), 6);
+    shouldBe(log.join(), "left.valueOf,right()");
+}
+
+// `**` never dropped the unary plus (see pow-evaluation-order.js); it is included to pin the shared code path.
+for (const op of ["*", "/", "%", "-", "**"]) {
+    const expected = eval(`6 ${op} 3`);
+
+    // `+left op right()`: left is converted before right() is called.
+    {
+        const log = [];
+        const left = { valueOf() { log.push("left.valueOf"); return 6; } };
+        const right = () => { log.push("right()"); return 3; };
+        shouldBe(new Function("left", "right", `return (+left) ${op} right();`)(left, right), expected);
+        shouldBe(log.join(), "left.valueOf,right()");
+    }
+
+    // `left op +right`: the unary plus converts right before the operator converts left.
+    {
+        const log = [];
+        const left = { valueOf() { log.push("left.valueOf"); return 6; } };
+        const right = { valueOf() { log.push("right.valueOf"); return 3; } };
+        shouldBe(new Function("left", "right", `return left ${op} (+right);`)(left, right), expected);
+        shouldBe(log.join(), "right.valueOf,left.valueOf");
+    }
+
+    // When both operands would throw, the unary plus's conversion throws first and right() never runs.
+    {
+        let rightCalled = false;
+        const left = { valueOf() { throw new RangeError("left"); } };
+        const right = () => { rightCalled = true; throw new Error("right"); };
+        const error = shouldThrow(() => new Function("left", "right", `return (+left) ${op} right();`)(left, right), RangeError);
+        shouldBe(error.message, "left");
+        shouldBe(rightCalled, false);
+    }
+
+    // Unary plus throws for BigInts even though the operator itself accepts them.
+    shouldBe(new Function(`return 6n ${op} 3n;`)(), BigInt(expected));
+    shouldThrow(() => new Function("a", "b", `return (+a) ${op} b;`)(6n, 3n), TypeError);
+    shouldThrow(() => new Function("a", "b", `return a ${op} (+b);`)(6n, 3n), TypeError);
+    shouldThrow(() => new Function("a", "b", `return (+a) ${op} (+b);`)(6n, 3n), TypeError);
+    shouldThrow(new Function(`return (+6n) ${op} 3n;`), TypeError);
+    shouldThrow(new Function(`return 6n ${op} (+3n);`), TypeError);
+    shouldThrow(() => new Function("a", `return (+a) ${op} 3;`)({ valueOf() { return 6n; } }), TypeError);
+
+    // A unary plus on a number literal is a no-op, so the literal operands still fold to the same value.
+    shouldBe(new Function(`return (+6) ${op} 3;`)(), expected);
+    shouldBe(new Function(`return 6 ${op} (+3);`)(), expected);
+    shouldBe(new Function(`return (+6) ${op} (+3);`)(), expected);
+    shouldBe(new Function(`return (+6.0) ${op} (+3.0);`)(), expected);
+    shouldBe(new Function("a", "b", `return (+a) ${op} (+b);`)("6", "3"), expected);
+    shouldBe(new Function("a", "b", `return (+a) ${op} b;`)("6", "3"), expected);
+}
+
+// `x * 1` and `1 * x` become a plain ToNumber(x); a unary plus already on x must not make it convert twice or change the result.
+{
+    let conversions = 0;
+    const x = { valueOf() { ++conversions; return 7; } };
+    shouldBe(new Function("x", "return (+x) * 1;")(x), 7);
+    shouldBe(new Function("x", "return 1 * (+x);")(x), 7);
+    shouldBe(new Function("x", "return x * 1;")(x), 7);
+    shouldBe(new Function("x", "return 1 * x;")(x), 7);
+    shouldBe(conversions, 4);
+    shouldThrow(() => new Function("x", "return (+x) * 1;")(7n), TypeError);
+    shouldThrow(() => new Function("x", "return 1 * (+x);")(7n), TypeError);
+    shouldBe(new Function("return (+7) * 1;")(), 7);
+    shouldBe(new Function("return 1 * (+7);")(), 7);
+}
+
+// The order must survive the optimizing tiers.
+{
+    const log = [];
+    const left = { valueOf() { log.push("left.valueOf"); return 6; } };
+    const right = () => { log.push("right()"); return 3; };
+
+    function multiply(left, right) { return +left * right(); }
+    noInline(multiply);
+    function divide(left, right) { return +left / right(); }
+    noInline(divide);
+    function remainder(left, right) { return +left % right(); }
+    noInline(remainder);
+    function subtract(left, right) { return +left - right(); }
+    noInline(subtract);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        log.length = 0;
+        shouldBe(multiply(left, right), 18);
+        shouldBe(divide(left, right), 2);
+        shouldBe(remainder(left, right), 0);
+        shouldBe(subtract(left, right), 3);
+        shouldBe(log.join(), "left.valueOf,right(),left.valueOf,right(),left.valueOf,right(),left.valueOf,right()");
+    }
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Parser
+  "unary-plus-operand-evaluation-order.js",
 ];
 
 const wasmFixtures = [


### PR DESCRIPTION
### Problem
- `+left * right()` calls `right()` before `left.valueOf()`; Node (V8), SpiderMonkey and the spec convert `left` first. Same for `/`, `%` and `-`, and mirrored on the right operand (`left * +right` converts `left` before `right`, spec says `right` first). When both sides throw, the wrong exception surfaces.
- `+1n * 2n` returns `2n` (also `+a - b`, `a % +b` with BigInt variables). Unary plus must throw a `TypeError` on a BigInt; only the bare operators accept BigInts.
- Not a transpiler issue: `bun build` prints the expression unchanged, and the same text misbehaves through indirect `eval` / `new Function`. The cause is in JavaScriptCore's parser: `ASTBuilder::makeMultNode` / `makeDivNode` / `makeModNode` / `makeSubNode` strip the `UnaryPlusNode` off both operands unconditionally (upstream FIXME since 2016, https://bugs.webkit.org/show_bug.cgi?id=159968), so the operand's `to_number` is never emitted and the conversion is left to the operator, which runs after both operands have been evaluated and has different BigInt semantics.
- Reported by the transpiler/minifier semantic-equivalence fuzzer (runtime lane, bun vs node on unbuilt programs).

### Fix
- oven-sh/WebKit#422: the four operators now use the rule `makePowNode` already had, only dropping the unary plus when the node under it is a number literal (the one case where `+x` is a no-op). `+2 * x` and `+6 / +3` still constant fold; every other operand keeps its `to_number` in operand position, and `+x * 1` still compiles to a single `to_number`.
- This PR points `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-422-937021ee`, which is the current pin `f0f60fd2` plus that one commit) so CI runs against it. Before landing, oven-sh/WebKit#422 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha (the build prints that exact instruction if the preview release disappears).
- Test: `test/js/bun/jsc-stress/fixtures/unary-plus-operand-evaluation-order.js`, the same file the WebKit PR adds to `JSTests/stress`, registered in `jsc-stress.test.ts`. It covers `* / % - **` with the plus on either operand, exception order, BigInt literals and variables, the `x * 1` rewrite, and a `testLoopCount` loop so the DFG/FTL see the same order. Under the current `f0f60fd2` WebKit it fails at the first block (`bad value: right(),left.valueOf, expected left.valueOf,right()`); with the preview it passes.
- Other verification is on the WebKit PR: the existing `pow-*`, `big-int-*`, `to-number-*` and `op_{mul,div,mod,sub}-*` stress suites pass on the patched `jsc`, across `--useJIT=false` / `--useDFGJIT=false` / `--useFTLJIT=false` / eager compilation.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit; `scripts/build/deps/webkit.ts` pins which build. A fix in the engine lands as a WebKit PR plus a bump here, and `autobuild-preview-pr-*` tags are how a bump PR runs Bun's suite against a WebKit PR before it merges.
- `test/js/bun/jsc-stress/` runs files copied verbatim from WebKit's `JSTests/stress` under `bun` (its preload supplies `noInline` and `testLoopCount`), which is why the engine test can be shared with the WebKit PR as is.
- Spec-wise, unary `+` performs ToNumber as part of evaluating its own operand, so in `+a OP b` it happens before `b` is evaluated at all, and it rejects BigInts. The arithmetic operators evaluate both operands first and only then apply ToNumeric to each, and accept BigInts. Removing the node therefore changes both when the conversion happens and what it accepts; `**` was unaffected because its builder already kept the node.

<details>
<summary>Repro</summary>

```js
const order = [];
const left = { valueOf() { order.push("left.valueOf"); return 2; } };
function right() { order.push("right()"); return 3; }
console.log(+left * right(), order.join(" -> "));
try { console.log(+2n * 3n); } catch (e) { console.log(e.constructor.name); }
```

```
bun 1.4.0 (WebKit caad865e,
  same on f0f60fd2):           6 right() -> left.valueOf
                               6n
node v26:                      6 left.valueOf -> right()
                               TypeError
this PR:                       6 left.valueOf -> right()
                               TypeError
```

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts
bun test v1.4.0 (d07abcdc3)

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [359.06ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [344.21ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [343.93ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [364.38ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [359.53ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [355.21ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [364.95ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [350.83ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [406.76ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [471.91ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [340.57ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [361.49ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [411.03ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [483.70ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined-and-not-inlined.js [435.00ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception.js [379.06ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-varargs-exception.js [352.90ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception-no-catch.js [439.84ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-try-catch-arith-sub-exception.js [437.23ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DF
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../unary-plus-operand-evaluation-order.js         | 121 +++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |   2 +
 3 files changed, 124 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      1      0
…-stress/fixtures/unary-plus-operand-evaluation-order.js      0      0      0
test/js/bun/jsc-stress/jsc-stress.test.ts                     1      1      0
```

</details>

<!-- robobun:evidence:end -->
