### PR TITLE
node:http: enforce blockList on https servers and on server.blockList assignments

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1,6 +1,7 @@
 // Hardcoded module "node:_http_server"
 const EventEmitter: typeof import("node:events").EventEmitter = require("node:events");
 const { Stream } = require("node:stream");
+const { isIP } = require("internal/net/isIP");
 const {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   chunkExpression,
@@ -100,6 +101,12 @@ const MathFloor = Math.floor;
 const DateNow = Date.now;
 
 let cluster;
+
+let BlockList;
+function isBlockList(value) {
+  BlockList ??= $rust("node_net_binding.rs", "BlockList");
+  return BlockList.isBlockList(value);
+}
 
 function emitCloseServer(self: Server) {
   callCloseCallback(self);
@@ -363,6 +370,15 @@ function Server(options, callback): void {
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       });
+
+      // TLS-only like Node, where tls.Server passes its options through to net.Server and http.Server does not.
+      const blockList = options.blockList;
+      if (blockList) {
+        if (!isBlockList(blockList)) {
+          throw $ERR_INVALID_ARG_TYPE("options.blockList", "net.BlockList", blockList);
+        }
+        this.blockList = blockList;
+      }
     } else {
       this[tlsSymbol] = null;
     }
@@ -1151,6 +1167,18 @@ function onServerConnection(this: Server, socketHandle) {
     socket.destroy();
     this.emit("drop", data);
     return;
+  }
+
+  // Node's onconnection checks server.blockList next and closes a blocked peer silently: no 'drop', no 'connection'.
+  const blockList = this.blockList;
+  if (blockList) {
+    const remoteAddress = socket.remoteAddress;
+    const addressType = isIP(remoteAddress);
+    if (addressType && blockList.check(remoteAddress, `ipv${addressType}`)) {
+      tracked?.delete(socket);
+      socket.destroy();
+      return;
+    }
   }
 
   // Node's connectionListener attaches the HTTPParser (socket.parser) before

--- a/test/js/node/http/node-http-server-blocklist.test.ts
+++ b/test/js/node/http/node-http-server-blocklist.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir, tls } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import { BlockList } from "node:net";
+import { join } from "node:path";
+
+// Node stores the list as a plain property on the server (net.Server constructor).
+type ServerWithBlockList = http.Server & { blockList?: BlockList };
+
+type Outcome = { statusCode: number | undefined; body: string } | { error: string | undefined };
+
+// Every client in this file connects from 127.0.0.1.
+function blockListCoveringLocalhost() {
+  const blockList = new BlockList();
+  blockList.addAddress("127.0.0.1");
+  return blockList;
+}
+
+function blockListNotCoveringLocalhost() {
+  const blockList = new BlockList();
+  blockList.addSubnet("10.0.0.0", 8);
+  return blockList;
+}
+
+async function listen(server: http.Server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return (server.address() as AddressInfo).port;
+}
+
+function request(mod: typeof http | typeof https, port: number): Promise<Outcome> {
+  return new Promise(resolve => {
+    mod
+      .get({ host: "127.0.0.1", port, agent: false, rejectUnauthorized: false }, res => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", chunk => (body += chunk));
+        res.on("end", () => resolve({ statusCode: res.statusCode, body }));
+      })
+      .on("error", (error: NodeJS.ErrnoException) => resolve({ error: error.code }));
+  });
+}
+
+describe("https server blockList option", () => {
+  const constructors: [string, (options: https.ServerOptions, listener: http.RequestListener) => https.Server][] = [
+    ["https.createServer()", (options, listener) => https.createServer(options, listener)],
+    ["new https.Server()", (options, listener) => new https.Server(options, listener)],
+  ];
+
+  test.each(constructors)(
+    "%s: a blocked peer is closed before 'connection' and never reaches the request handler",
+    async (_name, construct) => {
+      const blockList = blockListCoveringLocalhost();
+      const events: string[] = [];
+      const server = construct({ ...tls, blockList }, (_req, res) => {
+        events.push("request");
+        res.end("served");
+      }) as ServerWithBlockList;
+      server.on("connection", () => events.push("connection"));
+      server.on("secureConnection", () => events.push("secureConnection"));
+      // Node only emits 'drop' for maxConnections; a blocked peer is closed silently.
+      server.on("drop", () => events.push("drop"));
+      try {
+        const port = await listen(server);
+        expect(await request(https, port)).toEqual({ error: "ECONNRESET" });
+        expect(events).toEqual([]);
+        expect(server.blockList).toBe(blockList);
+      } finally {
+        server.close();
+      }
+    },
+  );
+
+  test("a peer outside the list is served", async () => {
+    const server = https.createServer({ ...tls, blockList: blockListNotCoveringLocalhost() }, (_req, res) => {
+      res.end("served");
+    });
+    try {
+      const port = await listen(server);
+      expect(await request(https, port)).toEqual({ statusCode: 200, body: "served" });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("a value that is not a net.BlockList is rejected", () => {
+    const notABlockList = { check: () => true } as any;
+    expect(() => https.createServer({ ...tls, blockList: notABlockList })).toThrowWithCode(
+      TypeError,
+      "ERR_INVALID_ARG_TYPE",
+    );
+  });
+});
+
+describe("http.Server blockList", () => {
+  test("server.blockList assigned after listen() applies to the next connection", async () => {
+    let requests = 0;
+    const server = http.createServer((_req, res) => {
+      requests++;
+      res.end("served");
+    }) as ServerWithBlockList;
+    try {
+      const port = await listen(server);
+      expect(await request(http, port)).toEqual({ statusCode: 200, body: "served" });
+
+      server.blockList = blockListCoveringLocalhost();
+      expect(await request(http, port)).toEqual({ error: "ECONNRESET" });
+      expect(requests).toBe(1);
+
+      server.blockList = undefined;
+      expect(await request(http, port)).toEqual({ statusCode: 200, body: "served" });
+      expect(requests).toBe(2);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("a unix socket peer has no IP address to check and is served", async () => {
+    using dir = tempDir("http-blocklist", {});
+    const socketPath = join(String(dir), "server.sock");
+    const server = http.createServer((_req, res) => {
+      res.end("served");
+    }) as ServerWithBlockList;
+    server.blockList = blockListCoveringLocalhost();
+    try {
+      server.listen(socketPath);
+      await once(server, "listening");
+      const response = await fetch("http://localhost/", { unix: socketPath, headers: { connection: "close" } });
+      expect({ statusCode: response.status, body: await response.text() }).toEqual({ statusCode: 200, body: "served" });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("the constructor option is ignored on a plain http server, like Node's http.Server", async () => {
+    const options = { blockList: blockListCoveringLocalhost() } as any;
+    const server = http.createServer(options, (_req, res) => {
+      res.end("served");
+    }) as ServerWithBlockList;
+    try {
+      expect(server.blockList).toBeUndefined();
+      const port = await listen(server);
+      expect(await request(http, port)).toEqual({ statusCode: 200, body: "served" });
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- `https.createServer({ key, cert, blockList })` accepts the option and then serves peers that are on the list. Node v26.3.0 closes them at accept time; `server.blockList` is `undefined` in Bun, the request handler runs, and the client gets a 200.
- `server.blockList = list` assigned on an `http.Server` is ignored the same way (Node enforces it).
- Cause: the `node:http` `Server` constructor (`src/js/node/_http_server.ts`, which also backs `https.Server`) never reads `options.blockList`, and the accept callback `onServerConnection` only checks `maxConnections`.

### Fix
- Constructor: for TLS-backed servers, validate `options.blockList` with the native `BlockList` class's `isBlockList` (loaded on first use, as `node:dgram` does; `ERR_INVALID_ARG_TYPE` otherwise, as in `net.Server`) and store it on `server.blockList`. Plain `http.createServer({ blockList })` stays ignored: in Node, `tls.Server` passes its options through to `net.Server` and `http.Server` does not, so that is what Node does too.
- `onServerConnection`: after the existing `maxConnections` gate, read `server.blockList`, and if `blockList.check(remoteAddress, ipv4|ipv6)` matches, destroy the connection and return. Nothing is emitted (Node's `onconnection` closes silently; `'drop'` is for `maxConnections` only). The property is read per connection, so a list assigned after construction or after `listen()` applies too. Peers without an IP (unix sockets) are not checked, like Node.
- Known difference: for https, Bun's native listener reports the connection once the TLS handshake has completed (the same point `maxConnections` is enforced at), so a blocked peer completes the handshake before it is closed; Node closes at TCP accept. The handler still never runs, no `'connection'`/`'secureConnection'` is emitted, and the client sees `ECONNRESET` in both runtimes. Closing before the handshake would need a hook in the uws/Rust accept path and is left out of this change.
- Not covered on purpose: sockets handed to the server via `server.emit('connection', socket)` bypass the list in Node as well.
- Test: `test/js/node/http/node-http-server-blocklist.test.ts`. `https.createServer()` and `new https.Server()` with a blocked peer (no handler, no `'connection'`/`'secureConnection'`/`'drop'`, client `ECONNRESET`), a non-matching list being served, invalid option rejected, `http.Server` list assigned after `listen()` (blocked, then served again once cleared), unix socket peer served, plain `http.createServer({ blockList })` still ignored.
- `USE_SYSTEM_BUN=1 bun test` on the file: 4 of 7 fail (the served-vs-closed cases and the validation case); `bun bd test`: 7 pass, 8 repeated runs stable.
- `bun bd test test/js/node/http/node-http.test.ts`: unchanged from main (143 pass; the one failure, the `localhost` proxy test, fails identically with the released binary in this container because `localhost` binds `::1` there).
- `test-net-server-blocklist.js`, `test-net-blocklist.js`, `test-http-server-drop-connections-in-cluster.js`, `node-http-server-timeouts.test.ts`, `node-http-server-abort-events.test.ts`: pass.

### Background
- `net.BlockList` is Node's IP deny list object (`addAddress`/`addSubnet`/`addRange`, `check(address, 'ipv4' | 'ipv6')`). Node's `net.Server` stores the `blockList` option on the server and its accept handler (`onconnection` in `lib/net.js`) checks `maxConnections` first, then `server.blockList`, and closes a matching peer before creating a `Socket`. `tls.Server` (and so `https.Server`) inherits this because it forwards its whole options object to `net.Server`; `http.Server` forwards only a fixed subset, which is why the option is TLS-only.
- Bun's `node:http` and `node:https` servers are the same `Server` class in `_http_server.ts`, backed by `Bun.serve`, so Bun's `net.Server` code never sees these connections. The accept-time hook for this class is `onServerConnection`, a callback the native listener (a uws connection filter) invokes for every connection before any request bytes are parsed: at TCP accept for http, and when the handshake completes for https. Closing the socket there is already what the `maxConnections` gate does, and the TLS layer checks for a closed socket after that callback before decrypting any application data, so a request arriving in the same flight as the client's Finished is never dispatched.
- `remoteAddress` comes from `getpeername()` without normalization in both runtimes, so a v4 peer on a `::` listener is checked as `::ffff:a.b.c.d` with `'ipv6'` in Bun exactly as in Node.

<details>
<summary>Repro output (Node v26.3.0 vs Bun 1.4.0 vs this branch)</summary>

Script: `https.createServer({ key, cert, blockList })` with a list covering `127.0.0.0/8`, one `https.get` from `127.0.0.1`; then the same with `server.blockList` assigned on an `http.Server`; then `http.createServer({ blockList })`.

```
node v26.3.0
[https invalid blockList] threw ERR_INVALID_ARG_TYPE
[http invalid blockList] no throw
[https] server.blockList set: true | handler ran: 0 | connection events: 0 | secureConnection events: 0 | client error ECONNRESET
[http assigned] handler ran: 0 | client error ECONNRESET
[http ctor] server.blockList set: false | handler ran: 1 | RESPONSE 200

bun 1.4.0
[https invalid blockList] no throw
[http invalid blockList] no throw
[https] server.blockList set: false | handler ran: 1 | connection events: 1 | secureConnection events: 1 | RESPONSE 200
[http assigned] handler ran: 1 | RESPONSE 200
[http ctor] server.blockList set: false | handler ran: 1 | RESPONSE 200

this branch (debug build)
[https invalid blockList] threw ERR_INVALID_ARG_TYPE
[http invalid blockList] no throw
[https] server.blockList set: true | handler ran: 0 | connection events: 0 | secureConnection events: 0 | client error ECONNRESET
[http assigned] handler ran: 0 | client error ECONNRESET
[http ctor] server.blockList set: false | handler ran: 1 | RESPONSE 200
```

The `isIP` guard in the accept path was checked by removing it: the unix socket test then fails with `TypeError: The "address" property must be of type string, got undefined` from `onServerConnection`.

Rebase note: #39628 removed the module-level `require("node:net")` from `_http_server.ts` so that `require("http")` no longer loads `node:net`. The first version of this PR added `BlockList` and `isIP` to that import. The rebased version keeps the deferral: `isIP` comes from `internal/net/isIP` (already loaded by `internal/http`), and the `BlockList` class is fetched from the native binding on first use (`$rust("node_net_binding.rs", "BlockList")`, the same helper shape `node:dgram` uses), which also keeps the validation independent of the user-assignable `net.BlockList` property. The accept-path code is unchanged. On the rebased tree the test file still fails 4 of 7 on the released binary and passes with the branch.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-blocklist.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-blocklist.test.ts:
63 |       server.on("secureConnection", () => events.push("secureConnection"));
64 |       // Node only emits 'drop' for maxConnections; a blocked peer is closed silently.
65 |       server.on("drop", () => events.push("drop"));
66 |       try {
67 |         const port = await listen(server);
68 |         expect(await request(https, port)).toEqual({ error: "ECONNRESET" });
                                                ^
error: expect(received).toEqual(expected)

  {
-   "error": "ECONNRESET",
+   "body": "served",
+   "statusCode": 200,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-server-blocklist.test.ts:68:44)
(fail) https server blockList option > https.createServer(): a blocked peer is closed before 'connection' and never reaches the request handler [1179.52ms]
63 |       server.on("secureConnection", () => events.push("secureConnection")
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/node/http/node-http-server-blocklist.test.ts:
63 |       server.on("secureConnection", () => events.push("secureConnection"));
64 |       // Node only emits 'drop' for maxConnections; a blocked peer is closed silently.
65 |       server.on("drop", () => events.push("drop"));
66 |       try {
67 |         const port = await listen(server);
68 |         expect(await request(https, port)).toEqual({ error: "ECONNRESET" });
                                                ^
error: expect(received).toEqual(expected)

  {
-   "error": "ECONNRESET",
+   "body": "served",
+   "statusCode": 200,
  }

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-server-blocklist.test.ts:68:44)
(fail) https server blockList option > https.createServer(): a blocked peer is closed before 'connection' and never reaches the request handler [27.76ms]
63 |       server.on("secureConnection", () => events.push("secureConnection"));
64 |       // Node only emits 'drop' for maxConnections; a blocked peer is closed silently.
65 |       server.on("drop", () => events.push("drop"));
66 |       try {
67 |      
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-blocklist.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-blocklist.test.ts:
(pass) https server blockList option > https.createServer(): a blocked peer is closed before 'connection' and never reaches the request handler [899.02ms]
(pass) https server blockList option > new https.Server(): a blocked peer is closed before 'connection' and never reaches the request handler [152.89ms]
(pass) https server blockList option > a peer outside the list is served [313.37ms]
(pass) https server blockList option > a value that is not a net.BlockList is rejected [10.79ms]
(pass) http.Server blockList > server.blockList assigned after listen() applies to the next connection [235.93ms]
(pass) http.Server blockList > a unix socket peer has no IP address to check and is served [121.96ms]
(pass) http.Server blockList > the constructor option is ignored on a plain http server, like Node's http.Server [84.95ms]

 7 pass
 0 fail
 16 expect() calls
Ran 7 tests across 1 file. [4.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 664ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (7624ms)
Bundle modules (58ms)
Postprocesss modules (270ms)
Bundle Functions (868ms)
Generate Code (28ms)

[8.87s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  28 ++++
 .../node/http/node-http-server-blocklist.test.ts   | 151 +++++++++++++++++++++
 2 files changed, 179 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/js/node/_http_server.ts                              12      8      0
test/js/node/http/node-http-server-blocklist.test.ts      2      7      0
```

</details>

<!-- robobun:evidence:end -->
