### PR TITLE
lexer: decode ill-formed UTF-8 in JS source as U+FFFD

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -11,8 +11,8 @@ use bun_simdutf_sys::simdutf;
 
 pub use self::unicode::{
     CodepointIterator, Cursor, NewCodePointIterator, UnsignedCodepointIterator,
-    contains_non_bmp_code_point_or_is_invalid_identifier, decode_wtf8_rune_t,
-    decode_wtf8_rune_t_multibyte, wtf8_byte_sequence_length,
+    contains_non_bmp_code_point_or_is_invalid_identifier, decode_wtf8_non_ascii,
+    decode_wtf8_rune_t, decode_wtf8_rune_t_multibyte, wtf8_byte_sequence_length,
     wtf8_byte_sequence_length_with_invalid,
 };
 pub use unicode_draft::CodePointZero;
@@ -96,12 +96,73 @@ pub mod unicode {
         pub c: CodePoint,
     }
 
+    /// Decodes the sequence led by the non-ASCII byte `tail[0]`, returning the code
+    /// point and the number of bytes it spans (always `1..=4` and never more than
+    /// `tail.len()`).
+    ///
+    /// Well-formed WTF-8 (UTF-8 plus encoded surrogates) decodes as-is. Anything else
+    /// becomes U+FFFD spanning the ill-formed sequence's maximal subpart, which is how
+    /// the WHATWG UTF-8 decoder (V8, `TextDecoder`, `Bun.file().text()`) replaces
+    /// ill-formed input: a byte that cannot lead a sequence is replaced on its own, and
+    /// a sequence cut short is replaced as a unit (`E2 82 41` is U+FFFD followed by
+    /// `A`). A replacement never spans an ASCII byte, so callers scanning for ASCII
+    /// syntax (quotes, newlines, braces) never skip any.
+    #[inline(never)]
+    pub fn decode_wtf8_non_ascii(tail: &[u8]) -> (CodePoint, u8) {
+        let first = tail[0];
+        debug_assert!(first >= 0x80);
+        let len = wtf8_byte_sequence_length(first);
+        if len == 1 {
+            // Continuation byte or 0xF8..=0xFF: cannot lead a sequence.
+            return (super::UNICODE_REPLACEMENT as CodePoint, 1);
+        }
+        let take = (len as usize).min(tail.len());
+        let mut quad = [0u8; 4];
+        quad[..take].copy_from_slice(&tail[..take]);
+        let cp = decode_wtf8_rune_t_multibyte::<CodePoint>(quad, len, -1);
+        if cp == -1 {
+            return (
+                super::UNICODE_REPLACEMENT as CodePoint,
+                ill_formed_sequence_width(quad, len),
+            );
+        }
+        (cp, len)
+    }
+
+    /// Byte count of the maximal subpart of the ill-formed sequence in `quad` (whose
+    /// lead byte declares `len` bytes): the lead byte plus each following byte that is
+    /// still valid for its position per the UTF-8 table (Unicode §3.9, table 3-7; the
+    /// surrogates WTF-8 additionally allows only matter for complete sequences, which
+    /// decode successfully and never get here). `quad` is zero-padded past the end of
+    /// the input and 0x00 is never a valid continuation byte, so the result never
+    /// exceeds the bytes actually present.
+    #[cold]
+    fn ill_formed_sequence_width(quad: [u8; 4], len: u8) -> u8 {
+        let second_ok = match quad[0] {
+            0xE0 => matches!(quad[1], 0xA0..=0xBF),
+            0xED => matches!(quad[1], 0x80..=0x9F),
+            0xF0 => matches!(quad[1], 0x90..=0xBF),
+            0xF4 => matches!(quad[1], 0x80..=0x8F),
+            0xC2..=0xDF | 0xE1..=0xEF | 0xF1..=0xF3 => matches!(quad[1], 0x80..=0xBF),
+            // 0xC0, 0xC1 and 0xF5..=0xF7 only encode overlong forms or code points
+            // above U+10FFFF, so they cannot lead a sequence at all.
+            _ => false,
+        };
+        if !second_ok {
+            1
+        } else if len == 4 && matches!(quad[2], 0x80..=0xBF) {
+            3
+        } else {
+            2
+        }
+    }
+
     impl<'a> NewCodePointIterator<'a> {
         /// Cursor advance. Returns `false` at end.
         // PERF: `#[inline]` alone is hint-only; LLVM declined to inline
-        // this cross-crate into `bun_js_printer::print_identifier_ascii_only`
-        // (the multibyte slow path makes the body look heavy). Called per-byte
-        // of every printed identifier under `ASCII_ONLY=true`. Force it.
+        // this cross-crate into `bun_js_printer::print_identifier_ascii_only`.
+        // Called per-byte of every printed identifier under `ASCII_ONLY=true`.
+        // Force it; the multibyte path stays out of line in `decode_wtf8_non_ascii`.
         #[inline(always)]
         pub fn next(&self, cursor: &mut Cursor) -> bool {
             let bytes = self.bytes;
@@ -121,19 +182,7 @@ pub mod unicode {
                 cursor.width = 1;
                 return true;
             }
-            let len = wtf8_byte_sequence_length(first);
-            // `take ∈ 1..=4` clamped to the remaining length.
-            let take = (len as usize).min(tail.len());
-            let mut buf = [0u8; 4];
-            buf[..take].copy_from_slice(&tail[..take]);
-            let cp = decode_wtf8_rune_t::<CodePoint>(buf, len, -1);
-            if cp == -1 {
-                cursor.c = super::UNICODE_REPLACEMENT as CodePoint;
-                cursor.width = 1;
-            } else {
-                cursor.c = cp;
-                cursor.width = len;
-            }
+            (cursor.c, cursor.width) = decode_wtf8_non_ascii(tail);
             true
         }
     }
@@ -184,68 +233,30 @@ pub fn peek_n_codepoints_wtf8(bytes: &[u8], at: usize, n: usize) -> &[u8] {
     &bytes[at..end]
 }
 
-/// WTF-8 codepoint stepper shared by the JS and JSON lexers.
-///
-/// The JS and JSON lexers call the same
-/// `wtf8_byte_sequence_length_with_invalid` / `decode_wtf8_rune_t_multibyte`
-/// pair defined alongside this module, so the stepper belongs here.
-///
-/// NOT the same algorithm as [`CodepointIterator::next_codepoint`] — that one
-/// uses `utf8ByteSequenceLength` + `next_width` lookahead, has no `end`
-/// cursor, and does not advance-by-1 on U+FFFD.
+/// Non-ASCII tail of the JS lexer's `step()`. Decodes exactly like
+/// `CodepointIterator::next` (both go through [`decode_wtf8_non_ascii`]), so
+/// the code points the lexer scans over are the ones the string-literal, JSX
+/// and template decoders later produce from the same bytes.
 pub mod lexer_step {
-    use super::{
-        CodePoint, UNICODE_REPLACEMENT, decode_wtf8_rune_t_multibyte,
-        wtf8_byte_sequence_length_with_invalid,
-    };
+    use super::{CodePoint, decode_wtf8_non_ascii};
 
-    /// Non-ASCII tail of [`next_codepoint`]. Kept out-of-line so the hot
-    /// ASCII path stays small enough to inline into every `step()` site.
+    /// Decodes the non-ASCII sequence at `contents[*current]` (the caller has
+    /// already handled EOF and ASCII) and advances `*current` past it. Ill-formed
+    /// bytes yield U+FFFD, never the lexer's `-1` EOF sentinel, so the main lex
+    /// loop reports them as a syntax error instead of ending the file early.
     ///
-    /// `#[cold]` is required: with fat LTO + `codegen-units = 1`, LLVM's
-    /// single-caller heuristic merges an `#[inline(never)]`-only callee back
-    /// into its sole caller, which then makes `next_codepoint` too large to
-    /// inline into `next()` (perf showed it as a separate ~2.6% symbol with
-    /// the multibyte decode folded in). `cold` parks this in `.text.unlikely`
-    /// and survives LTO's IPO inliner.
+    /// Kept out-of-line so the hot ASCII path stays small enough to inline into
+    /// every `step()` site. `#[cold]` is required: with fat LTO +
+    /// `codegen-units = 1`, LLVM's single-caller heuristic merges an
+    /// `#[inline(never)]`-only callee back into its sole caller, which then makes
+    /// `next_codepoint` too large to inline into `next()` (perf showed it as a
+    /// separate ~2.6% symbol with the multibyte decode folded in). `cold` parks
+    /// this in `.text.unlikely` and survives LTO's IPO inliner.
     #[cold]
     #[inline(never)]
-    pub fn next_codepoint_multibyte(contents: &[u8], current: &mut usize, first: u8) -> CodePoint {
-        let len = contents.len();
-        let cp_len = wtf8_byte_sequence_length_with_invalid(first) as usize;
-        let avail = len - *current;
-
-        // The ASCII fast path above handled `first < 0x80`; here `first >= 0x80` but `cp_len`
-        // may still be 1 for invalid lead bytes (0x80-0xBF, 0xF8-0xFF) — those must yield the
-        // raw byte, NOT the EOF sentinel, so the main lex loop falls through to its syntax-error
-        // arm instead of silently emitting TEndOfFile mid-stream.
-        let code_point: CodePoint = if cp_len == 1 {
-            first as CodePoint
-        } else if avail < cp_len {
-            // truncated multibyte at EOF
-            -1
-        } else {
-            let mut quad = [0u8; 4];
-            // SAFETY: `*current < len` (checked by caller), `cp_len ∈ 2..=4`, and
-            // `avail >= cp_len`, so `contents[current..current + cp_len]` is in-bounds.
-            // `decode_wtf8_rune_t_multibyte` only dereferences `p[0..len]`; pad bytes are
-            // never read.
-            unsafe {
-                core::ptr::copy_nonoverlapping(
-                    contents.as_ptr().add(*current),
-                    quad.as_mut_ptr(),
-                    cp_len,
-                );
-            }
-            decode_wtf8_rune_t_multibyte(quad, cp_len as u8, UNICODE_REPLACEMENT as CodePoint)
-        };
-
-        *current += if code_point != UNICODE_REPLACEMENT as CodePoint {
-            cp_len
-        } else {
-            1
-        };
-
+    pub fn next_codepoint_multibyte(contents: &[u8], current: &mut usize) -> CodePoint {
+        let (code_point, width) = decode_wtf8_non_ascii(&contents[*current..]);
+        *current += width as usize;
         code_point
     }
 }
@@ -2753,5 +2764,73 @@ mod tests {
         assert_eq!(out, &[0xD800][..]);
         let out = super::convert_utf8_to_utf16_in_buffer(&mut buf, b"\xC3\xA9\xF0\x9F\x98\x80");
         assert_eq!(out, &[0x00E9, 0xD83D, 0xDE00][..]);
+    }
+
+    /// Every (code point, width) the iterator yields for `bytes`; the lexer's
+    /// `step()` goes through the same `decode_wtf8_non_ascii`, so this is what
+    /// both see.
+    fn code_points(bytes: &[u8]) -> Vec<(i32, u8)> {
+        let iter = super::CodepointIterator::init(bytes);
+        let mut cursor = super::Cursor::default();
+        let mut out = Vec::new();
+        while iter.next(&mut cursor) {
+            out.push((cursor.c, cursor.width));
+        }
+        out
+    }
+
+    #[test]
+    fn codepoint_iterator_decodes_well_formed_wtf8() {
+        assert_eq!(
+            code_points(b"a\xC3\xA9\xE2\x82\xAC\xF0\x9F\x98\x80\xEF\xBF\xBD"),
+            [(0x61, 1), (0xE9, 2), (0x20AC, 3), (0x1F600, 4), (0xFFFD, 3)]
+        );
+        // WTF-8: an encoded surrogate is passed through, not replaced.
+        assert_eq!(code_points(b"\xED\xA0\x80"), [(0xD800, 3)]);
+    }
+
+    #[test]
+    fn codepoint_iterator_replaces_bytes_that_cannot_lead_a_sequence() {
+        for byte in (0x80..=0xC1).chain(0xF5..=0xFF) {
+            assert_eq!(
+                code_points(&[b'a', byte, b'b']),
+                [(0x61, 1), (0xFFFD, 1), (0x62, 1)],
+                "byte {byte:#04X}"
+            );
+        }
+        // Continuation bytes after a byte that cannot lead a sequence are each
+        // replaced on their own, as are the ones after an overlong or
+        // out-of-range lead.
+        assert_eq!(code_points(b"\xF5\x80\x80\x80"), [(0xFFFD, 1); 4]);
+        assert_eq!(code_points(b"\xC0\x80"), [(0xFFFD, 1); 2]);
+        assert_eq!(code_points(b"\xE0\x80\x80"), [(0xFFFD, 1); 3]);
+        assert_eq!(code_points(b"\xF0\x80\x80\x80"), [(0xFFFD, 1); 4]);
+        assert_eq!(code_points(b"\xF4\x90\x80\x80"), [(0xFFFD, 1); 4]);
+    }
+
+    #[test]
+    fn codepoint_iterator_replaces_a_truncated_sequence_as_one_unit() {
+        // Interrupted by ASCII: the replacement spans the valid prefix only.
+        assert_eq!(code_points(b"\xC2A"), [(0xFFFD, 1), (0x41, 1)]);
+        assert_eq!(code_points(b"\xE2A"), [(0xFFFD, 1), (0x41, 1)]);
+        assert_eq!(code_points(b"\xE2\x82A"), [(0xFFFD, 2), (0x41, 1)]);
+        assert_eq!(code_points(b"\xF0\x9FA"), [(0xFFFD, 2), (0x41, 1)]);
+        assert_eq!(code_points(b"\xF0\x9F\x98A"), [(0xFFFD, 3), (0x41, 1)]);
+        // Interrupted by the end of the input.
+        assert_eq!(code_points(b"\xE2"), [(0xFFFD, 1)]);
+        assert_eq!(code_points(b"\xE2\x82"), [(0xFFFD, 2)]);
+        assert_eq!(code_points(b"\xF0\x9F\x98"), [(0xFFFD, 3)]);
+        // Interrupted by another lead byte: that byte starts its own sequence.
+        assert_eq!(code_points(b"\xE2\x82\xC3\xA9"), [(0xFFFD, 2), (0xE9, 2)]);
+        // A second byte outside the lead's narrower range does not belong to the
+        // sequence (E0: A0..BF, ED: 80..9F, F0: 90..BF, F4: 80..8F).
+        assert_eq!(code_points(b"\xE0\x9F\x80"), [(0xFFFD, 1); 3]);
+        assert_eq!(
+            code_points(b"\xED\xA0A"),
+            [(0xFFFD, 1), (0xFFFD, 1), (0x41, 1)]
+        );
+        assert_eq!(code_points(b"\xED\x9FA"), [(0xFFFD, 2), (0x41, 1)]);
+        assert_eq!(code_points(b"\xF0\x8F\x80"), [(0xFFFD, 1); 3]);
+        assert_eq!(code_points(b"\xF4\x8FA"), [(0xFFFD, 2), (0x41, 1)]);
     }
 }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -96,24 +96,13 @@ pub mod unicode {
         pub c: CodePoint,
     }
 
-    /// Decodes the sequence led by the non-ASCII byte `tail[0]`, returning the code
-    /// point and the number of bytes it spans (always `1..=4` and never more than
-    /// `tail.len()`).
-    ///
-    /// Well-formed WTF-8 (UTF-8 plus encoded surrogates) decodes as-is. Anything else
-    /// becomes U+FFFD spanning the ill-formed sequence's maximal subpart, which is how
-    /// the WHATWG UTF-8 decoder (V8, `TextDecoder`, `Bun.file().text()`) replaces
-    /// ill-formed input: a byte that cannot lead a sequence is replaced on its own, and
-    /// a sequence cut short is replaced as a unit (`E2 82 41` is U+FFFD followed by
-    /// `A`). A replacement never spans an ASCII byte, so callers scanning for ASCII
-    /// syntax (quotes, newlines, braces) never skip any.
+    /// Decodes the sequence at `tail[0]`; ill-formed input is one U+FFFD per maximal subpart.
     #[inline(never)]
     pub fn decode_wtf8_non_ascii(tail: &[u8]) -> (CodePoint, u8) {
         let first = tail[0];
         debug_assert!(first >= 0x80);
         let len = wtf8_byte_sequence_length(first);
         if len == 1 {
-            // Continuation byte or 0xF8..=0xFF: cannot lead a sequence.
             return (super::UNICODE_REPLACEMENT as CodePoint, 1);
         }
         let take = (len as usize).min(tail.len());
@@ -129,13 +118,7 @@ pub mod unicode {
         (cp, len)
     }
 
-    /// Byte count of the maximal subpart of the ill-formed sequence in `quad` (whose
-    /// lead byte declares `len` bytes): the lead byte plus each following byte that is
-    /// still valid for its position per the UTF-8 table (Unicode §3.9, table 3-7; the
-    /// surrogates WTF-8 additionally allows only matter for complete sequences, which
-    /// decode successfully and never get here). `quad` is zero-padded past the end of
-    /// the input and 0x00 is never a valid continuation byte, so the result never
-    /// exceeds the bytes actually present.
+    /// Length of the ill-formed sequence's maximal subpart (Unicode 3.9, Table 3-7).
     #[cold]
     fn ill_formed_sequence_width(quad: [u8; 4], len: u8) -> u8 {
         let second_ok = match quad[0] {
@@ -144,8 +127,7 @@ pub mod unicode {
             0xF0 => matches!(quad[1], 0x90..=0xBF),
             0xF4 => matches!(quad[1], 0x80..=0x8F),
             0xC2..=0xDF | 0xE1..=0xEF | 0xF1..=0xF3 => matches!(quad[1], 0x80..=0xBF),
-            // 0xC0, 0xC1 and 0xF5..=0xF7 only encode overlong forms or code points
-            // above U+10FFFF, so they cannot lead a sequence at all.
+            // C0, C1 and F5..=F7 can only start overlong or out-of-range sequences.
             _ => false,
         };
         if !second_ok {
@@ -160,9 +142,9 @@ pub mod unicode {
     impl<'a> NewCodePointIterator<'a> {
         /// Cursor advance. Returns `false` at end.
         // PERF: `#[inline]` alone is hint-only; LLVM declined to inline
-        // this cross-crate into `bun_js_printer::print_identifier_ascii_only`.
-        // Called per-byte of every printed identifier under `ASCII_ONLY=true`.
-        // Force it; the multibyte path stays out of line in `decode_wtf8_non_ascii`.
+        // this cross-crate into `bun_js_printer::print_identifier_ascii_only`
+        // (the multibyte slow path makes the body look heavy). Called per-byte
+        // of every printed identifier under `ASCII_ONLY=true`. Force it.
         #[inline(always)]
         pub fn next(&self, cursor: &mut Cursor) -> bool {
             let bytes = self.bytes;
@@ -233,25 +215,19 @@ pub fn peek_n_codepoints_wtf8(bytes: &[u8], at: usize, n: usize) -> &[u8] {
     &bytes[at..end]
 }
 
-/// Non-ASCII tail of the JS lexer's `step()`. Decodes exactly like
-/// `CodepointIterator::next` (both go through [`decode_wtf8_non_ascii`]), so
-/// the code points the lexer scans over are the ones the string-literal, JSX
-/// and template decoders later produce from the same bytes.
+/// Non-ASCII tail of the JS lexer's `step()`; decodes exactly like `CodepointIterator::next`.
 pub mod lexer_step {
     use super::{CodePoint, decode_wtf8_non_ascii};
 
-    /// Decodes the non-ASCII sequence at `contents[*current]` (the caller has
-    /// already handled EOF and ASCII) and advances `*current` past it. Ill-formed
-    /// bytes yield U+FFFD, never the lexer's `-1` EOF sentinel, so the main lex
-    /// loop reports them as a syntax error instead of ending the file early.
+    /// Non-ASCII tail of [`next_codepoint`]. Kept out-of-line so the hot
+    /// ASCII path stays small enough to inline into every `step()` site.
     ///
-    /// Kept out-of-line so the hot ASCII path stays small enough to inline into
-    /// every `step()` site. `#[cold]` is required: with fat LTO +
-    /// `codegen-units = 1`, LLVM's single-caller heuristic merges an
-    /// `#[inline(never)]`-only callee back into its sole caller, which then makes
-    /// `next_codepoint` too large to inline into `next()` (perf showed it as a
-    /// separate ~2.6% symbol with the multibyte decode folded in). `cold` parks
-    /// this in `.text.unlikely` and survives LTO's IPO inliner.
+    /// `#[cold]` is required: with fat LTO + `codegen-units = 1`, LLVM's
+    /// single-caller heuristic merges an `#[inline(never)]`-only callee back
+    /// into its sole caller, which then makes `next_codepoint` too large to
+    /// inline into `next()` (perf showed it as a separate ~2.6% symbol with
+    /// the multibyte decode folded in). `cold` parks this in `.text.unlikely`
+    /// and survives LTO's IPO inliner.
     #[cold]
     #[inline(never)]
     pub fn next_codepoint_multibyte(contents: &[u8], current: &mut usize) -> CodePoint {
@@ -2766,9 +2742,6 @@ mod tests {
         assert_eq!(out, &[0x00E9, 0xD83D, 0xDE00][..]);
     }
 
-    /// Every (code point, width) the iterator yields for `bytes`; the lexer's
-    /// `step()` goes through the same `decode_wtf8_non_ascii`, so this is what
-    /// both see.
     fn code_points(bytes: &[u8]) -> Vec<(i32, u8)> {
         let iter = super::CodepointIterator::init(bytes);
         let mut cursor = super::Cursor::default();
@@ -2798,9 +2771,7 @@ mod tests {
                 "byte {byte:#04X}"
             );
         }
-        // Continuation bytes after a byte that cannot lead a sequence are each
-        // replaced on their own, as are the ones after an overlong or
-        // out-of-range lead.
+        // The continuation bytes that follow are each replaced on their own.
         assert_eq!(code_points(b"\xF5\x80\x80\x80"), [(0xFFFD, 1); 4]);
         assert_eq!(code_points(b"\xC0\x80"), [(0xFFFD, 1); 2]);
         assert_eq!(code_points(b"\xE0\x80\x80"), [(0xFFFD, 1); 3]);
@@ -2822,8 +2793,7 @@ mod tests {
         assert_eq!(code_points(b"\xF0\x9F\x98"), [(0xFFFD, 3)]);
         // Interrupted by another lead byte: that byte starts its own sequence.
         assert_eq!(code_points(b"\xE2\x82\xC3\xA9"), [(0xFFFD, 2), (0xE9, 2)]);
-        // A second byte outside the lead's narrower range does not belong to the
-        // sequence (E0: A0..BF, ED: 80..9F, F0: 90..BF, F4: 80..8F).
+        // E0, ED, F0 and F4 accept a narrower second byte (A0..BF, 80..9F, 90..BF, 80..8F).
         assert_eq!(code_points(b"\xE0\x9F\x80"), [(0xFFFD, 1); 3]);
         assert_eq!(
             code_points(b"\xED\xA0A"),

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -1109,7 +1109,7 @@ lexer_impl_header! {
             return first as CodePoint;
         }
 
-        strings::lexer_step::next_codepoint_multibyte(contents, &mut self.current, first)
+        strings::lexer_step::next_codepoint_multibyte(contents, &mut self.current)
     }
 
     /// PERF: `contents` threaded by value — see [`Self::next_codepoint_with`].

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -55,13 +55,8 @@ function codePoints(s: string): string {
   return Array.from(s, c => c.codePointAt(0)!.toString(16)).join(" ");
 }
 
-// node decodes a source file with the WHATWG UTF-8 decoder, so every ill-formed
-// sequence becomes U+FFFD: a byte that cannot start a sequence is replaced on its
-// own and a truncated sequence is replaced as a unit. Every expectation in this
-// block is what node prints for the same bytes. Bun used to hand bytes that
-// cannot start a sequence (0x80-0xBF, 0xF8-0xFF) through as Latin-1 code points
-// instead, so `"\xFF"` in a file read as "ÿ" and a raw 0xA0 byte counted as
-// whitespace.
+// Every expectation below is what node prints for the same bytes: one U+FFFD per
+// maximal subpart of an ill-formed sequence (WHATWG UTF-8 decode).
 describe("ill-formed UTF-8 in JS source decodes to U+FFFD", () => {
   const transpiler = new Bun.Transpiler({
     loader: "jsx",

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -124,13 +124,23 @@ describe("ill-formed UTF-8 in JS source decodes to U+FFFD", () => {
   });
 
   describe("is a syntax error outside of literals", () => {
-    test.each<[string, (string | number[])[]]>([
-      ["0xFF where an identifier is expected", ["var ", [0xff], " = 1;"]],
-      ["0xA0 where whitespace is expected", ["var", [0xa0], "x = 1;"]],
-      ["0xBA after an identifier", ["var x", [0xba], " = 1;"]],
-      ["truncated sequence at the end of the file", ["var x = 1;", [0xe2]]],
-    ])("%s", (_name, parts) => {
-      expect(() => transpiler.transformSync(source(...parts))).toThrow();
+    /** The first parse error reported for the bytes, or null when they parse. */
+    function firstParseError(...parts: (string | number[])[]): string | null {
+      try {
+        transpiler.transformSync(source(...parts));
+        return null;
+      } catch (error) {
+        return (error instanceof AggregateError ? error.errors[0] : error).message;
+      }
+    }
+
+    test.each<[string, (string | number[])[], string]>([
+      ["0xFF where an identifier is expected", ["var ", [0xff], " = 1;"], 'Expected identifier but found "\uFFFD"'],
+      ["0xA0 where whitespace is expected", ["var", [0xa0], "x = 1;"], 'Expected identifier but found "\uFFFD"'],
+      ["0xBA after an identifier", ["var x", [0xba], " = 1;"], 'Expected ";" but found "\uFFFD"'],
+      ["truncated sequence at the end of the file", ["var x = 1;", [0xe2]], "Unexpected \uFFFD"],
+    ])("%s", (_name, parts, message) => {
+      expect(firstParseError(...parts)).toBe(message);
     });
   });
 
@@ -187,7 +197,7 @@ describe("ill-formed UTF-8 in JS source decodes to U+FFFD", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("");
-    expect(stderr).toContain("error: Expected identifier");
+    expect(stderr).toContain('error: Expected identifier but found "\uFFFD"');
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen, tempDir } from "harness";
 import path from "node:path";
 
 // The fixture uses mmap/mprotect via bun:ffi to place source bytes immediately
@@ -42,5 +42,152 @@ describe.skipIf(!(isLinux || isMacOS))("Bun.Transpiler.transformSync with trunca
       exitCode: 0,
       signalCode: null,
     });
+  });
+});
+
+/** Source bytes: strings are UTF-8 encoded, number arrays are spliced in as-is. */
+function source(...parts: (string | number[])[]): Uint8Array {
+  return Uint8Array.from(parts.flatMap(part => (typeof part === "string" ? [...Buffer.from(part)] : part)));
+}
+
+/** `"a\uFFFDb"` -> `"61 fffd 62"` */
+function codePoints(s: string): string {
+  return Array.from(s, c => c.codePointAt(0)!.toString(16)).join(" ");
+}
+
+// node decodes a source file with the WHATWG UTF-8 decoder, so every ill-formed
+// sequence becomes U+FFFD: a byte that cannot start a sequence is replaced on its
+// own and a truncated sequence is replaced as a unit. Every expectation in this
+// block is what node prints for the same bytes. Bun used to hand bytes that
+// cannot start a sequence (0x80-0xBF, 0xF8-0xFF) through as Latin-1 code points
+// instead, so `"\xFF"` in a file read as "ÿ" and a raw 0xA0 byte counted as
+// whitespace.
+describe("ill-formed UTF-8 in JS source decodes to U+FFFD", () => {
+  const transpiler = new Bun.Transpiler({
+    loader: "jsx",
+    tsconfig: { compilerOptions: { jsx: "react", jsxFactory: "h" } },
+  });
+
+  /** Transpiles the bytes of `var x = ...;` built from `parts` and returns `x`. */
+  function evaluate(...parts: (string | number[])[]): any {
+    const output = transpiler.transformSync(source(...parts));
+    const h = (tag: string, props: unknown, ...children: unknown[]) => ({ tag, props, children });
+    return new Function("h", `${output}\nreturn x;`)(h);
+  }
+
+  describe("inside a string literal", () => {
+    test.each<[string, number[], string]>([
+      ["lone continuation byte", [0x80], "61 fffd 62"],
+      ["last continuation byte", [0xbf], "61 fffd 62"],
+      ["0xF8", [0xf8], "61 fffd 62"],
+      ["0xFF", [0xff], "61 fffd 62"],
+      ["overlong 2-byte sequence", [0xc0, 0x80], "61 fffd fffd 62"],
+      ["lead byte above U+10FFFF", [0xf5, 0x80, 0x80, 0x80], "61 fffd fffd fffd fffd 62"],
+      ["3-byte lead cut off before any continuation", [0xe2], "61 fffd 62"],
+      ["3-byte lead cut off after one continuation", [0xe2, 0x82], "61 fffd 62"],
+      ["4-byte lead cut off after two continuations", [0xf0, 0x9f, 0x98], "61 fffd 62"],
+      ["truncated sequence followed by a well-formed one", [0xe2, 0x82, 0xc3, 0xa9], "61 fffd e9 62"],
+      ["second byte outside the lead's range (ED A0)", [0xed, 0xa0], "61 fffd fffd 62"],
+      ["second byte outside the lead's range (E0 9F)", [0xe0, 0x9f], "61 fffd fffd 62"],
+      ["mixed with ASCII", [0xff, 0x41, 0xe2, 0x41, 0x80], "61 fffd 41 fffd 41 fffd 62"],
+      // Well-formed input is untouched, including an actual U+FFFD.
+      ["encoded U+FFFD", [0xef, 0xbf, 0xbd], "61 fffd 62"],
+      ["encoded U+00FF", [0xc3, 0xbf], "61 ff 62"],
+      ["encoded U+1F600", [0xf0, 0x9f, 0x98, 0x80], "61 1f600 62"],
+    ])("%s", (_name, bytes, expected) => {
+      expect(codePoints(evaluate('var x = "a', bytes, 'b";'))).toBe(expected);
+    });
+  });
+
+  test("template literal", () => {
+    expect(codePoints(evaluate("var x = `a", [0xff], "b`;"))).toBe("61 fffd 62");
+  });
+
+  test("tagged template literal", () => {
+    expect(codePoints(evaluate("var x = (s => s[0])`a", [0x80], "b`;"))).toBe("61 fffd 62");
+  });
+
+  test("object key", () => {
+    expect(codePoints(evaluate('var x = Object.keys({ "a', [0xff], 'b": 1 })[0];'))).toBe("61 fffd 62");
+  });
+
+  test("JSX text", () => {
+    expect(codePoints(evaluate("var x = (<a>p", [0xff], "q</a>).children[0];"))).toBe("70 fffd 71");
+  });
+
+  test("JSX attribute", () => {
+    expect(codePoints(evaluate('var x = (<a b="p', [0xe2, 0x82], 'q" />).props.b;'))).toBe("70 fffd 71");
+  });
+
+  test("a raw 0xA0 byte is not JSX whitespace", () => {
+    expect(evaluate("var x = (<a>", [0xa0], "</a>).children;")).toEqual(["\uFFFD"]);
+  });
+
+  describe("is a syntax error outside of literals", () => {
+    test.each<[string, (string | number[])[]]>([
+      ["0xFF where an identifier is expected", ["var ", [0xff], " = 1;"]],
+      ["0xA0 where whitespace is expected", ["var", [0xa0], "x = 1;"]],
+      ["0xBA after an identifier", ["var x", [0xba], " = 1;"]],
+      ["truncated sequence at the end of the file", ["var x = 1;", [0xe2]]],
+    ])("%s", (_name, parts) => {
+      expect(() => transpiler.transformSync(source(...parts))).toThrow();
+    });
+  });
+
+  test.concurrent("when running a file", async () => {
+    using dir = tempDir("ill-formed-utf8", {
+      "main.js": Buffer.from(
+        source(
+          'const codePoints = s => Array.from(s, c => c.codePointAt(0).toString(16)).join(" ");\n',
+          'console.log(codePoints("a',
+          [0xff],
+          "b",
+          [0xe2, 0x82],
+          'c"));\n',
+          "console.log(codePoints(`a",
+          [0x80],
+          "b`));\n",
+          "console.log(codePoints(((s) => s[0])`a",
+          [0xff],
+          "b`));\n",
+          "console.log(/^a",
+          [0xff],
+          'b$/.test("a\\uFFFDb"), /^a',
+          [0xff],
+          'b$/.test("a\\u00FFb"));\n',
+          'console.log(codePoints(Object.keys({ "',
+          [0xf8],
+          '": 1 })[0]));\n',
+        ),
+      ),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("61 fffd 62 fffd 63\n61 fffd 62\n61 fffd 62\ntrue false\nfffd\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("when running a file that uses 0xFF as an identifier", async () => {
+    using dir = tempDir("ill-formed-utf8-identifier", {
+      "main.js": Buffer.from(source("var ", [0xff], ' = 1;\nconsole.log("ran");\n')),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error: Expected identifier");
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem

- A JS/TS source file containing a byte that cannot start a UTF-8 sequence (a stray continuation byte `80..BF`, or `F8..FF`) evaluates differently in bun and node: `const s = "a<FF>b"` gives `s.codePointAt(1) === 0xFF` in bun and `0xFFFD` in node. The same applies to template literals, tagged template cooked strings, object keys, regex literals (`/a<FF>b/` matches `"a\u00FFb"` in bun, `"a\uFFFDb"` in node) and JSX text/attributes.
- Outside of literals the Latin-1 reading changes what parses: a raw `A0` byte is accepted as whitespace (`let<A0>x = 1` runs), and `BA`/`F8..FF` are accepted as identifier characters (`var <FF> = 1` runs, and `bun build` copies the raw byte into the output as an identifier). node rejects all of these with a SyntaxError.
- Truncated sequences were only half right: `E2 82 41` lexed as `U+FFFD U+0082 A` (node: `U+FFFD A`), and a sequence truncated by the end of the file made the lexer report EOF, so `1;<E2>` was accepted (node: SyntaxError).
- Cause: `CodepointIterator::next` (src/bun_core/string/immutable.rs, used to build string literal, template and JSX values) and `lexer_step::next_codepoint_multibyte` (same file, the non-ASCII tail of the lexer's `step()`) both special-cased a width-1 lead byte as "the byte is the code point", which is only true for ASCII. `lexer_step` also returned the `-1` EOF sentinel for a sequence truncated by EOF. Both quirks are inherited from the original `js_lexer.zig`; this never worked.
- This is the source-file half of the handoff that #38253 covers for `text`/`md` imports. The printer's UTF-8 string path is not involved for JS source: every non-ASCII literal goes through these decoders into UTF-16 first. Not related despite the similar symptom: #37161 (`// @bun` pragma files are handed to JSC as Latin-1 without going through the lexer at all; #37162 is the fix for that path).

### Fix

- Add `strings::decode_wtf8_non_ascii(tail) -> (code point, width)` and make both `CodepointIterator::next` and `lexer_step` use it, so the code points the lexer scans are the same ones the literal decoders later produce from the same bytes (previously the two copies could only agree by accident).
- Well-formed input decodes exactly as before, including WTF-8 encoded surrogates, which `Bun.Transpiler` string input relies on (#35920). Only ill-formed input changes: it becomes U+FFFD whose width is the sequence's maximal subpart (`ill_formed_sequence_width`, a direct transcription of Unicode Table 3-7): a byte that cannot lead a sequence is replaced on its own, a truncated sequence is replaced as one unit. `F5..F7` and `C0`/`C1` already decoded to U+FFFD and still do.
- Why this is the right behavior: node (V8), `TextDecoder`, `Bun.file().text()` and `fs.readFileSync(f, "utf8")` all decode with that same rule, so a file with ill-formed bytes now evaluates to the same strings under `bun file.js`, `node file.js`, and `node` running a `bun build` bundle of it. The per-byte Latin-1 reading had no decoder agreeing with it, and it made Latin-1 encoded files decode inconsistently (`«` survived, `é` did not).
- A replacement width never covers an ASCII byte (only `80..BF` can extend a subpart), so none of the ~40 `CodepointIterator` callers that scan for quotes, backslashes, newlines or braces can skip one. The callers that do something with the code point all move in the same direction: `ensure_valid_identifier`/`FormatValidIdentifier` now emit `_` instead of copying the stray byte into a generated identifier, `is_identifier` stops accepting it, and the JSON loader's exotic-whitespace check stops accepting a raw `A0` byte in a `.json` file at bundle time (the runtime `require` of the same file already rejected it).
- `lexer_step` never returns `-1` now, so the lexer's syntax-error arm reports a truncated trailing sequence like any other unexpected character. The old `unsafe` copy is gone with it.
- Code shape on the hot paths is unchanged: both ASCII fast paths are untouched, and `decode_wtf8_non_ascii` is `#[inline(never)]`, so `CodepointIterator::next` (force-inlined into ~40 sites) now inlines less than before, while the lexer's non-ASCII step was already an out-of-line `#[cold]` call and keeps its attributes; the only addition is one direct call inside that cold function per non-ASCII code point. The ill-formed branch is a separate `#[cold]` function, so well-formed non-ASCII does the same work as before.
- `decode_wtf8_rune_t` itself is left alone: its other callers (`js_printer`, sourcemap column tables, glob) pass their own sentinel and are not part of this bug.
- Verified:
  - `bun bd test test/js/bun/transpiler/transpiler-truncated-utf8.test.ts`: new `ill-formed UTF-8 in JS source decodes to U+FFFD` block. 16 byte sequences in a string literal, plus template, tagged template, object key, JSX text, JSX attribute, JSX whitespace, 4 syntax-error positions, and two `bun main.js` runs. Every expectation was checked against `node` v26 on the same bytes (they match in all cases); 23 of the 29 tests fail on main, the rest are well-formed regression guards.
  - `bun run rust:miri -p bun_core --lib -- codepoint_iterator`: three new unit tests on the iterator covering the width table (`E0`/`ED`/`F0`/`F4` second-byte ranges, truncation by ASCII, by EOF and by another lead byte, surrogate passthrough).
  - `bun bd test` on `test/bundler/transpiler/transpiler.test.js`, `bundler_string`, `bundler_jsx`, `bundler_loader`, `bundler_naming`, `bundler_edgecase`, `bundler_regressions`, `bundler_minify`, `test/js/bun/jsonc` (JSON test suite + differential fuzz), `test/js/bun/transpiler`, `test/js/bun/shell/{brace,lex,parse}.test.ts`, `test/js/bun/sourcemap`, `test/js/bun/util/text-loader.test.ts`, `test/internal/source-lints`: no new failures (`text-loader`'s 10000x stress test times out identically on a main debug build in this container).
  - `cargo clippy`/`cargo fmt --check` clean for `bun_core` and `bun_js_parser`.
- Not changed, on purpose: the printer still copies the raw bytes of tagged template raw strings and of regex literals for non-bun targets, so a `bun build` of those still contains the original bytes (consumers decoding the bundle as UTF-8, now including bun itself, read U+FFFD there, matching what they read from the source). Same for the existing escaping of `String.raw` contents in the ASCII-only printer; both are independent of which code point the bytes decode to.

### Background

- WTF-8: UTF-8 extended to also encode the surrogate code points `U+D800..DFFF` (as `ED A0 80..ED BF BF`), so that a JS string containing a lone surrogate can round-trip through bytes. The lexer reads source as WTF-8 because sources can come from JS strings, not only files; that is why this change keeps complete surrogate triples and only touches sequences that fail to decode.
- Maximal subpart (Unicode 3.9, WHATWG "UTF-8 decode"): when decoding hits an ill-formed sequence, the lead byte plus every following byte that was still valid for its position is replaced by a single U+FFFD, and decoding resumes at the first offending byte. So `E2 82 41` is one U+FFFD then `A`, while `FF` or `E0 80` each yield one U+FFFD per byte, because `80` is not a valid second byte after `E0`. Valid second bytes are narrower than `80..BF` for `E0`, `ED`, `F0` and `F4` (that is what rules out overlong forms, surrogates and code points above U+10FFFF); those four rows are the `match` in `ill_formed_sequence_width`.
- `CodepointIterator` is bun_core's byte-slice code point cursor (`next()` fills `Cursor { i, width, c }`); the lexer uses it to decode the contents of string/template literals and JSX text after scanning them, and the printer, shell parser, JSON parsers and identifier sanitizers use it too. `lexer_step` is the out-of-line non-ASCII tail of the lexer's `step()`, kept separate so the ASCII path inlines into every call site (see the perf note on it).

<details>
<summary>Probes, bun 1.4.0 vs node v26 vs this branch</summary>

```
$ printf 'const s = "a\xffb\xe2AB\x80c";\nconsole.log(Array.from(s, c => c.codePointAt(0).toString(16)).join(" "));\n' > lex.js
$ bun lex.js            # 1.4.0
61 ff 62 fffd 41 42 80 63
$ node lex.js
61 fffd 62 fffd 41 42 fffd 63
$ bun-debug lex.js      # this branch
61 fffd 62 fffd 41 42 fffd 63

$ printf 'const s = "a\xe2\x82Ab\xf5\x80\x80\x80c\xc0\x80d"; ...' > multi.js
$ bun multi.js          # 1.4.0
61 fffd 82 41 62 fffd 80 80 80 63 fffd 80 64
$ node multi.js
61 fffd 41 62 fffd fffd fffd fffd 63 fffd fffd 64
$ bun-debug multi.js    # this branch
61 fffd 41 62 fffd fffd fffd fffd 63 fffd fffd 64

$ printf 'var \xff = 1; console.log("ident ok", \xff);\n' > ident.js
$ bun ident.js          # 1.4.0
ident ok 1
$ node ident.js
SyntaxError: Invalid or unexpected token
$ bun-debug ident.js    # this branch
error: Expected identifier but found "�"

$ printf 'let\xa0x = 1; console.log("nbsp ok", x);\n' > nbsp.js
$ bun nbsp.js           # 1.4.0
nbsp ok 1
$ node nbsp.js
SyntaxError: Invalid or unexpected token
$ bun-debug nbsp.js     # this branch
error: Expected ";" but found "�"

$ printf 'console.log(/a\xffb/.test("a\\uFFFDb"), /a\xffb/.test("a\\u00FFb"));\n' > regex.js
$ bun regex.js          # 1.4.0
false true
$ node regex.js
true false
$ bun-debug regex.js    # this branch
true false

$ bun build lex.js | grep 'var s'    # 1.4.0: the Latin-1 reading is baked into the bundle
var s = "a\303\277b\357\277\275AB\302\200c";
$ bun-debug build lex.js | grep 'var s'
var s = "a\357\277\275b\357\277\275AB\357\277\275c";
```

</details>
