### PR TITLE
sourcemap: derive the parse failure message from the error instead of storing both

### DIFF
--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -683,10 +683,7 @@ impl SourceMapStore {
             Default::default(),
         ) {
             source_map::ParseResult::Fail(fail) => {
-                bun_core::debug_warn!(
-                    "Failed to re-parse source map: {}",
-                    bstr::BStr::new(fail.msg)
-                );
+                bun_core::debug_warn!("Failed to re-parse source map: {}", fail.err.message());
                 None
             }
             source_map::ParseResult::Success(mut psm) => Some(GetResult {

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -461,10 +461,8 @@ pub fn parse(
     if let Some(count) = estimated_mapping_count {
         if mapping.ensure_total_capacity(count).is_err() {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Out of memory",
                 err: crate::Error::Alloc(bun_alloc::AllocError),
                 loc: Loc::default(),
-                ..Default::default()
             });
         }
     }
@@ -511,10 +509,8 @@ pub fn parse(
             }
             SimdResult::OutOfMemory => {
                 return ParseResult::Fail(ParseResultFail {
-                    msg: b"Out of memory",
                     err: crate::Error::Alloc(bun_alloc::AllocError),
                     loc: Loc::default(),
-                    ..Default::default()
                 });
             }
         }
@@ -544,7 +540,6 @@ pub fn parse(
 
         if generated_column_delta.start == 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Missing generated column value",
                 err: crate::Error::MissingGeneratedColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -560,7 +555,6 @@ pub fn parse(
             .wrapping_add(generated_column_delta.value);
         if generated_column < 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Invalid generated column value",
                 err: crate::Error::InvalidGeneratedColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -594,19 +588,16 @@ pub fn parse(
         let source_index_delta = decode_vlq(remain, 0);
         if source_index_delta.start == 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Invalid source index delta",
                 err: crate::Error::InvalidSourceIndexDelta,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
                 },
-                ..Default::default()
             });
         }
         source_index = source_index.wrapping_add(source_index_delta.value);
 
         if source_index < 0 || source_index >= sources_count {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Invalid source index value",
                 err: crate::Error::InvalidSourceIndexValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -619,12 +610,10 @@ pub fn parse(
         let original_line_delta = decode_vlq(remain, 0);
         if original_line_delta.start == 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Missing original line",
                 err: crate::Error::MissingOriginalLine,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
                 },
-                ..Default::default()
             });
         }
 
@@ -634,7 +623,6 @@ pub fn parse(
             .wrapping_add(original_line_delta.value);
         if original_line < 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Invalid original line value",
                 err: crate::Error::InvalidOriginalLineValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -648,7 +636,6 @@ pub fn parse(
         let original_column_delta = decode_vlq(remain, 0);
         if original_column_delta.start == 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Missing original column value",
                 err: crate::Error::MissingOriginalColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -662,7 +649,6 @@ pub fn parse(
             .wrapping_add(original_column_delta.value);
         if original_column < 0 {
             return ParseResult::Fail(ParseResultFail {
-                msg: b"Invalid original column value",
                 err: crate::Error::InvalidOriginalColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -687,7 +673,6 @@ pub fn parse(
                     let name_index_delta = decode_vlq(remain, 0);
                     if name_index_delta.start == 0 {
                         return ParseResult::Fail(ParseResultFail {
-                            msg: b"Invalid name index delta",
                             err: crate::Error::InvalidNameIndexDelta,
                             loc: Loc {
                                 start: i32::try_from(bytes.len() - remain.len())
@@ -702,13 +687,11 @@ pub fn parse(
                         if !has_names {
                             if mapping.ensure_with_names().is_err() {
                                 return ParseResult::Fail(ParseResultFail {
-                                    msg: b"Out of memory",
                                     err: crate::Error::Alloc(bun_alloc::AllocError),
                                     loc: Loc {
                                         start: i32::try_from(bytes.len() - remain.len())
                                             .unwrap_or(i32::MAX),
                                     },
-                                    ..Default::default()
                                 });
                             }
                         }

--- a/src/sourcemap/error.rs
+++ b/src/sourcemap/error.rs
@@ -37,6 +37,29 @@ pub enum Error {
 }
 
 impl Error {
+    /// What `ParseResult::Fail` reports to the user.
+    pub fn message(self) -> &'static str {
+        match self {
+            Self::MissingGeneratedColumnValue => "Missing generated column value",
+            Self::InvalidGeneratedColumnValue => "Invalid generated column value",
+            Self::InvalidSourceIndexDelta => "Invalid source index delta",
+            Self::InvalidSourceIndexValue => "Invalid source index value",
+            Self::MissingOriginalLine => "Missing original line",
+            Self::InvalidOriginalLineValue => "Invalid original line value",
+            Self::MissingOriginalColumnValue => "Missing original column value",
+            Self::InvalidOriginalColumnValue => "Invalid original column value",
+            Self::InvalidNameIndexDelta => "Invalid name index delta",
+            Self::Unknown => "Invalid source map",
+            Self::InvalidBase64 => "Invalid base64",
+            Self::UnsupportedFormat => "Unsupported source map format",
+            Self::InvalidJSON => "Invalid source map JSON",
+            Self::UnsupportedVersion => "Unsupported source map version",
+            Self::InvalidSourceMap => "Invalid source map",
+            Self::Alloc(_) => "Out of memory",
+            Self::Core(e) => e.name(),
+        }
+    }
+
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -112,18 +112,7 @@ pub enum ParseResult {
 
 pub struct ParseResultFail {
     pub loc: bun_ast::Loc,
-    pub(crate) err: crate::Error,
-    pub msg: &'static [u8],
-}
-
-impl Default for ParseResultFail {
-    fn default() -> Self {
-        Self {
-            loc: bun_ast::Loc::default(),
-            err: crate::Error::Unknown,
-            msg: b"",
-        }
-    }
+    pub err: crate::Error,
 }
 
 /// The sourcemap spec says line and column offsets are zero-based.

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -161,11 +161,11 @@ impl JSSourceMap {
             ParseResult::Fail(fail) => {
                 if let Some(loc) = fail.loc.to_nullable() {
                     return Err(global.throw_value(global.create_syntax_error_instance(
-                        format_args!("{} at {}", BStr::new(fail.msg), loc.start),
+                        format_args!("{} at {}", fail.err.message(), loc.start),
                     )));
                 }
                 return Err(global.throw_value(
-                    global.create_syntax_error_instance(format_args!("{}", BStr::new(fail.msg))),
+                    global.create_syntax_error_instance(format_args!("{}", fail.err.message())),
                 ));
             }
         };


### PR DESCRIPTION
ParseResultFail carried err and msg, and all 12 places that build one set msg to the fixed string for that err. The string now comes from Error::message(), so a mismatched pair cannot be written. Also drops the Default impl, which only existed for ..Default::default() spreads that were setting nothing.

Same strings and offsets as before, checked against the released binary. sourcemap-simd.test.ts pins two of them and passes.