### PR TITLE
bun test: write coverage reports when --bail stops the run

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1400,15 +1400,7 @@ impl CommandLineReporter {
                 this.summary().fail += 1;
 
                 if this.summary().fail == this.jest.bail {
-                    this.print_summary();
-                    pretty_error!(
-                        "\nBailed out after {} failure{}<r>\n",
-                        this.jest.bail,
-                        if this.jest.bail == 1 { "" } else { "s" }
-                    );
-                    Output::flush();
-                    this.write_junit_report_if_needed();
-                    this.write_timings_if_needed();
+                    this.bail_out(VirtualMachine::get());
                     Global::exit(1);
                 }
             }
@@ -1456,10 +1448,28 @@ impl CommandLineReporter {
         }
     }
 
+    /// Writes every end-of-run report for a `--bail` exit; the caller exits the process.
+    pub(crate) fn bail_out(&mut self, vm: &VirtualMachine) {
+        Output::flush();
+        let mut coverage_options: CodeCoverageOptions = self.jest.test_options.coverage.clone();
+        if coverage_options.enabled {
+            self.generate_code_coverage(vm, &mut coverage_options);
+        }
+        self.print_summary();
+        pretty_error!(
+            "\nBailed out after {} failure{}<r>\n",
+            self.jest.bail,
+            if self.jest.bail == 1 { "" } else { "s" }
+        );
+        Output::flush();
+        self.write_junit_report_if_needed();
+        self.write_timings_if_needed();
+    }
+
     /// This process's coverage, one `Report` per instrumented file, sorted by
     /// path, with `coveragePathIgnorePatterns` applied.
     pub(crate) fn for_each_coverage_report(
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         opts: &CodeCoverageOptions,
         mut each: impl FnMut(CodeCoverageReport<'_>),
     ) {
@@ -1489,7 +1499,7 @@ impl CommandLineReporter {
 
     pub(crate) fn generate_code_coverage(
         &mut self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         opts: &mut CodeCoverageOptions,
     ) {
         let _trace = bun::perf::trace("TestCommand.printCodeCoverage");
@@ -2915,14 +2925,7 @@ impl TestCommand {
                     reporter.summary().fail += 1;
 
                     if reporter.jest.bail == reporter.summary().fail {
-                        reporter.print_summary();
-                        pretty_error!(
-                            "\nBailed out after {} failure{}<r>\n",
-                            reporter.jest.bail,
-                            if reporter.jest.bail == 1 { "" } else { "s" }
-                        );
-                        reporter.write_junit_report_if_needed();
-                        reporter.write_timings_if_needed();
+                        reporter.bail_out(vm);
 
                         vm.exit_handler.exit_code = 1;
                         vm.is_shutting_down = true;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1453,7 +1453,10 @@ impl CommandLineReporter {
         Output::flush();
         let mut coverage_options: CodeCoverageOptions = self.jest.test_options.coverage.clone();
         if coverage_options.enabled {
-            self.generate_code_coverage(vm, &mut coverage_options);
+            // The process exits 1 either way; the other reports must still be written.
+            if let Err(err) = self.generate_code_coverage(vm, &mut coverage_options) {
+                Output::err(err, "Failed to write lcov.info", ());
+            }
         }
         self.print_summary();
         pretty_error!(
@@ -1497,24 +1500,22 @@ impl CommandLineReporter {
         }
     }
 
+    /// Errors only from writing `lcov.info`; the caller decides whether that ends the run.
     pub(crate) fn generate_code_coverage(
         &mut self,
         vm: &VirtualMachine,
         opts: &mut CodeCoverageOptions,
-    ) {
+    ) -> bun_sys::Result<()> {
         let _trace = bun::perf::trace("TestCommand.printCodeCoverage");
         if ByteRangeMapping::map().is_none_or(|m| {
             // SAFETY: see `for_each_coverage_report`.
             unsafe { m.as_ref() }.is_empty()
         }) {
-            return;
+            return Ok(());
         }
         let mut reports: Vec<CodeCoverageReport<'static>> = Vec::new();
         Self::for_each_coverage_report(vm, opts, |report| reports.push(report.into_owned()));
-        if let Err(err) = print_coverage_reports(opts, &reports) {
-            Output::err(err, "Failed to write lcov.info", ());
-            Global::exit(1);
-        }
+        print_coverage_reports(opts, &reports)
     }
 }
 
@@ -2496,7 +2497,10 @@ impl TestCommand {
             pretty_error!("\n");
 
             if coverage_options.enabled && !ran_parallel {
-                reporter.generate_code_coverage(vm, &mut coverage_options);
+                if let Err(err) = reporter.generate_code_coverage(vm, &mut coverage_options) {
+                    Output::err(err, "Failed to write lcov.info", ());
+                    Global::exit(1);
+                }
             }
 
             // `Summary` is `Copy`; take a value snapshot so the `&mut` from

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -727,7 +727,13 @@ export function run(flag: boolean) {
         "--coverage-dir=cov",
       ],
       cwd: dir,
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // detect_leaks=0: a mid-file bail exits without tearing the VM down,
+        // so LSAN appends a leak report to stderr and aborts (#32183). This
+        // test covers what bail writes before exiting, not that exit path.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
       stdout: "ignore",
       stderr: "pipe",
     });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
@@ -696,4 +696,160 @@ test("calls second", () => {
   const record = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"));
   expect(record).toMatch(/FNF:2\nFNH:2\n/);
   expect(exitCode).toBe(0);
+});
+
+describe.concurrent("--bail", () => {
+  const files = {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = true
+`,
+    "mod.ts": `
+export function run(flag: boolean) {
+  if (flag) {
+    console.log("only reached by code");
+    console.log("that runs after the bail");
+  }
+  return 1;
+}
+`,
+  };
+
+  async function runWithBail(dir: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "test",
+        "--bail",
+        "--coverage",
+        "--coverage-reporter=text",
+        "--coverage-reporter=lcov",
+        "--coverage-dir=cov",
+      ],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr: normalizeBunSnapshot(stderr, dir), exitCode };
+  }
+
+  test("a failing test still reports coverage for what ran", async () => {
+    using dir = tempDir("cov-bail", {
+      ...files,
+      "bail.test.ts": `
+import { test, expect } from "bun:test";
+import { run } from "./mod";
+
+test("runs", () => {
+  expect(run(false)).toBe(1);
+});
+test("fails", () => {
+  throw new Error("stop here");
+});
+test("never runs", () => {
+  expect(run(true)).toBe(1);
+});
+`,
+    });
+
+    const { stderr, exitCode } = await runWithBail(String(dir));
+
+    expect(stderr).toMatchInlineSnapshot(`
+      "bail.test.ts:
+      (pass) runs
+      4 | 
+      5 | test("runs", () => {
+      6 |   expect(run(false)).toBe(1);
+      7 | });
+      8 | test("fails", () => {
+      9 |   throw new Error("stop here");
+                                       ^
+      error: stop here
+          at <anonymous> (file:NN:NN)
+      (fail) fails
+      -----------|---------|---------|-------------------
+      File       | % Funcs | % Lines | Uncovered Line #s
+      -----------|---------|---------|-------------------
+      All files  |  100.00 |   66.67 |
+       mod.ts    |  100.00 |   66.67 | 4-5
+      -----------|---------|---------|-------------------
+      Ran 2 tests across 1 file.
+      Bailed out after 1 failure"
+    `);
+    expect(readFileSync(path.join(String(dir), "cov", "lcov.info"), "utf-8")).toMatchInlineSnapshot(`
+      "TN:
+      SF:mod.ts
+      FNF:1
+      FNH:1
+      DA:2,15
+      DA:3,9
+      DA:4,0
+      DA:5,0
+      DA:6,2
+      DA:7,8
+      LF:6
+      LH:4
+      end_of_record
+      "
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a test file that throws while loading still reports coverage for what ran", async () => {
+    using dir = tempDir("cov-bail", {
+      ...files,
+      "throws.test.ts": `
+import { run } from "./mod";
+
+run(false);
+throw new Error("stop here");
+`,
+    });
+
+    const { stderr, exitCode } = await runWithBail(String(dir));
+
+    expect(stderr).toMatchInlineSnapshot(`
+      "throws.test.ts:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | 
+      2 | import { run } from "./mod";
+      3 | 
+      4 | run(false);
+      5 | throw new Error("stop here");
+                ^
+      error: stop here
+            at <dir>/throws.test.ts:5:7
+      -------------------------------
+
+      -----------|---------|---------|-------------------
+      File       | % Funcs | % Lines | Uncovered Line #s
+      -----------|---------|---------|-------------------
+      All files  |  100.00 |   66.67 |
+       mod.ts    |  100.00 |   66.67 | 4-5
+      -----------|---------|---------|-------------------
+      Ran 1 test across 1 file.
+      Bailed out after 1 failure"
+    `);
+    expect(readFileSync(path.join(String(dir), "cov", "lcov.info"), "utf-8")).toMatchInlineSnapshot(`
+      "TN:
+      SF:mod.ts
+      FNF:1
+      FNH:1
+      DA:2,15
+      DA:3,9
+      DA:4,0
+      DA:5,0
+      DA:6,2
+      DA:7,8
+      LF:6
+      LH:4
+      end_of_record
+      "
+    `);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -715,7 +715,22 @@ export function run(flag: boolean) {
 `,
   };
 
-  async function runWithBail(dir: string) {
+  const failingTest = `
+import { test, expect } from "bun:test";
+import { run } from "./mod";
+
+test("runs", () => {
+  expect(run(false)).toBe(1);
+});
+test("fails", () => {
+  throw new Error("stop here");
+});
+test("never runs", () => {
+  expect(run(true)).toBe(1);
+});
+`;
+
+  async function runWithBail(dir: string, ...extraArgs: string[]) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -725,6 +740,7 @@ export function run(flag: boolean) {
         "--coverage-reporter=text",
         "--coverage-reporter=lcov",
         "--coverage-dir=cov",
+        ...extraArgs,
       ],
       cwd: dir,
       env: {
@@ -742,23 +758,7 @@ export function run(flag: boolean) {
   }
 
   test("a failing test still reports coverage for what ran", async () => {
-    using dir = tempDir("cov-bail", {
-      ...files,
-      "bail.test.ts": `
-import { test, expect } from "bun:test";
-import { run } from "./mod";
-
-test("runs", () => {
-  expect(run(false)).toBe(1);
-});
-test("fails", () => {
-  throw new Error("stop here");
-});
-test("never runs", () => {
-  expect(run(true)).toBe(1);
-});
-`,
-    });
+    using dir = tempDir("cov-bail", { ...files, "bail.test.ts": failingTest });
 
     const { stderr, exitCode } = await runWithBail(String(dir));
 
@@ -856,6 +856,18 @@ throw new Error("stop here");
       end_of_record
       "
     `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("an lcov write failure does not stop the other reports", async () => {
+    // A plain file where --coverage-dir points makes the lcov write fail.
+    using dir = tempDir("cov-bail", { ...files, "bail.test.ts": failingTest, cov: "not a directory" });
+
+    const { stderr, exitCode } = await runWithBail(String(dir), "--reporter=junit", "--reporter-outfile=junit.xml");
+
+    expect(stderr).toContain("Failed to write lcov.info");
+    expect(stderr).toContain("Bailed out after 1 failure");
+    expect(readFileSync(path.join(String(dir), "junit.xml"), "utf-8")).toContain('<testcase name="fails"');
     expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- `bun test --bail --coverage` emits no coverage at all once bail trips: no text table, no `lcov.info`, the coverage directory is not even created. The JUnit report and `--update-timings` file for the same run are written.
- Coverage is only generated on the normal end-of-run path (`TestCommand::exec`, `src/runtime/cli/test_command.rs`, the `generate_code_coverage` call before the pass/fail counts). The two serial bail exits skip that path entirely:
  - `CommandLineReporter::handle_test_completed` (a test failure reaches `--bail`): `print_summary`, "Bailed out", JUnit, timings, `Global::exit(1)`.
  - `TestCommand::run_one_file` (a test file fails to load, e.g. a top-level throw or a syntax error): same sequence, then `global_exit()`.
- `--parallel` is not affected: `Coordinator::bail_out` only stops dispatching files, and the coordinator still merges the workers' coverage chunks after the run loop ends.
- Long-standing (same on 1.3.x); `jest --bail` writes coverage for what ran.

### Fix
- Adds `CommandLineReporter::bail_out(vm)`, which is what both serial bail sites now call: flush, coverage reporters, summary line, "Bailed out" message, JUnit, timings. Each caller still exits the way it did before (`Global::exit(1)` mid-file, VM teardown plus `global_exit()` on load failure), so the only behavioral change is the coverage output.
- `bail_out` calls the existing `generate_code_coverage(vm, opts)` on a clone of the configured `CodeCoverageOptions` when coverage is enabled. The normal end-of-run path in `exec` still calls it the same way, so its `fractions.failing` exit-code check is unchanged.
- `generate_code_coverage` now returns the `lcov.info` write error instead of exiting inside: `exec` keeps the old print-and-exit-1 behavior, while `bail_out` prints the error and still writes the summary, the "Bailed out" message, the JUnit report and timings (the process exits 1 right after either way).
- `generate_code_coverage` / `for_each_coverage_report` now take `&VirtualMachine`: they only read `vm.global()`, and the mid-file bail site has no `&mut VirtualMachine` in scope (it uses `VirtualMachine::get()`).
- The report is correct at bail time because coverage data is read from JSC's control-flow profiler and the thread-local `ByteRangeMapping` table for whatever files were loaded so far; nothing about it depends on the run having finished. The table/lcov produced on bail are byte-identical to what a non-bail run of the same executed code produces (checked on both this build and the release binary).
- Verified:
  - `test/cli/test/coverage.test.ts`, new `--bail` block: one test per bail site, plus one where `--coverage-dir` points at a plain file so the lcov write fails and the JUnit report and bail message must still appear. The first two fail on the current release (table missing from stderr, `cov/lcov.info` absent) and pass with this change. The inline lcov snapshot matches what the release binary produces for the same executed code without `--bail`.
  - The spawned child runs with `detect_leaks=0` (same pattern as other tests that spawn into a known leaky exit): the mid-file bail exits through `Global::exit` without VM teardown, so on the ASAN lane LSan appends a report to stderr and aborts. That is #32183 and happens without `--coverage` too (checked locally: `bun test --bail` alone reports the same leak set under `detect_leaks=1`); a passing `--coverage` run under `BUN_DESTRUCT_VM_ON_EXIT=1` is LSan-clean, so the coverage code itself is not leaking.
  - `bun bd test test/cli/test/coverage.test.ts test/regression/issue/26851.test.ts test/regression/issue/12250.test.ts` (26851 covers JUnit-on-bail through the refactored sites).
  - `bun bd test test/cli/test/bun-test.test.ts -t bail`, `test/js/bun/test/test-test.test.ts -t bail` (the latter exercises the load-failure bail site), `test/cli/test/parallel.test.ts -t "coverage|bail"`.
  - Serial `coverageThreshold` exit codes unchanged (text reporter exits 1, lcov-only still exits 0 as before; that gap is #32118).

### Background
- `--bail[=N]` makes `bun test` stop after N test failures. A test file that throws while being loaded counts as one failure.
- `--coverage` makes the transpiler register every loaded (non-test, by default) file in a `ByteRangeMapping` table and turns on JSC's control-flow profiler. A coverage report for a file is produced on demand by asking the profiler which basic blocks and functions of that file executed; `--coverage-reporter=text` prints the table to stderr, `--coverage-reporter=lcov` writes `<coverage-dir>/lcov.info` (via a temp file and rename).
- `CommandLineReporter` is the single object that owns run-wide state for `bun test` (counts, JUnit buffer, timings); `write_junit_report_if_needed` and `write_timings_if_needed` were already the "must also run on bail" hooks, this adds coverage to that set.
- The text reporter's "Uncovered Line #s" column drops a lone single-line range (pre-existing, unrelated, reported separately); the test fixture uses a two-line uncovered branch so its snapshot does not depend on that.

<details><summary>Notes</summary>

Rebased onto main after #39770, which turned the `generate_code_coverage` / `print_code_coverage` const generics into plain `bool` parameters. The conflict was in the helper and at the `exec` call site: `write_code_coverage_if_needed` now forwards `opts.reporters.text`, `opts.reporters.lcov` and `Output::enable_ansi_colors_stderr()` to the new signature instead of holding the old 8-way dispatch, and the `exec` block that did the same inline is replaced by the helper call as before. The `&mut VirtualMachine` to `&VirtualMachine` change and both bail sites applied unchanged. Re-ran the suites listed under Verified on the rebased build.

Rebased again after #39934, which appended a `--parallel merges line coverage across workers` test to the end of `test/cli/test/coverage.test.ts`, the same spot where the `--bail` block is added here. Kept both, main's test first. No source conflict. Re-ran the same suites.

Rebased a third time after #40678, which replaced the old `generate_code_coverage` / `print_code_coverage` / `render_lcov` trio with `for_each_coverage_report` plus a `generate_code_coverage(vm, opts)` that reads the reporter flags from `opts` and reports lcov write errors itself. That made the `write_code_coverage_if_needed` helper from earlier revisions redundant, so it is gone: `bail_out` now calls `generate_code_coverage` directly behind an `enabled` check, and the `exec` call site is left exactly as main has it. The `&mut VirtualMachine` to `&VirtualMachine` relaxation moved to the two new functions. The test file conflict was again a test appended at the end by main (#40586's `--parallel merges function coverage across workers`); kept both, main's first. Re-ran the same suites.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
bun test v1.4.1 (65362b53b)

test/cli/test/coverage.test.ts:
bun test v1.4.1 (65362b53b)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 1
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [212.00ms]
(pass) coverage crash [305.06ms]
bun test v1.4.1 (65362b53b)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [223.00ms]
(pass) lcov coverage reporter [291.87ms]
(pass) coverage excludes node_modules directory [268.41ms]
(pass) coveragePathIgnorePatterns - single pattern string [299.60ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [374.29ms]
(pass) coveragePathIgnorePatterns - array of patterns [312.20ms]
(pass) coveragePathIgnorePatterns - glob patterns [384.68ms]
(pass) coveragePathIgnorePatterns - lcov reporter [300.18ms]
(pass) co
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/cli/test/coverage.test.ts:
bun test v1.4.1-canary.1 (65362b53b)

demo.test.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [4.00ms]
(pass) coverage crash [7.80ms]
bun test v1.4.1-canary.1 (65362b53b)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [4.00ms]
(pass) lcov coverage reporter [8.04ms]
(pass) coverage excludes node_modules directory [6.81ms]
(pass) coveragePathIgnorePatterns - single pattern string [6.72ms]
184 | 
185 |   let stderr = result.stderr.toString("utf-8");
186 |   // Normalize output for cross-platform consistency
187 |   stderr = normalizeBunSnapshot(stderr, dir);
188 | 
189 |   expect(stderr).toMatchInlineSnapshot(`
                       ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "test.test.ts:
  (pass) should call only some functions
  ---------------|---------|---------|-------------------
  File           | % Funcs | % Lines | Uncovered Line #s
  ---------------|---------|---------|-------------------
  All files      |   75.00 |   83.33 |
-  include-me.ts |   50.00 |   66.67 | 6
+  include-me.ts |   50.00 |   66.67 | 
   test.test.ts  |  100.00 |  100.00 | 
  ----------
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
bun test v1.4.1 (65362b53b)

test/cli/test/coverage.test.ts:
bun test v1.4.1 (65362b53b)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 1
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [208.00ms]
(pass) coverage crash [299.56ms]
bun test v1.4.1 (65362b53b)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [296.00ms]
(pass) lcov coverage reporter [365.33ms]
(pass) coverage excludes node_modules directory [327.84ms]
(pass) coveragePathIgnorePatterns - single pattern string [295.97ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [289.95ms]
(pass) coveragePathIgnorePatterns - array of patterns [298.49ms]
(pass) coveragePathIgnorePatterns - glob patterns [455.04ms]
(pass) coveragePathIgnorePatterns - lcov reporter [366.27ms]
(pass) co
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 680ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/14] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[2/14] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[3/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[4/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[6/14] cxx obj/src/jsc/bindings/bindings.cpp.o
[7/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[8/14] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[9/14] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[10/14] gen cpp.rs (cppbind)
[10/14] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 14s
[11/14] link bun-profile
[13/14] strip bun
[13/14] bun-profile --revision
1.4.1-canary.1+a08285685
[build] done
bun test v1.4.1-canary.1 (a08285685)

test/cli
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test_command.rs |  59 ++++++++------
 test/cli/test/coverage.test.ts  | 176 +++++++++++++++++++++++++++++++++++++++-
 2 files changed, 208 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/runtime/cli/test_command.rs     22     17      0
test/cli/test/coverage.test.ts      10     10      0
```

</details>

<!-- robobun:evidence:end -->



