### PR TITLE
docs, completions: update the loader name lists for bunfig [loader] and --loader

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -132,7 +132,11 @@ _bun_completions() {
         -l|--loader)
             [[ "${cur_word}" =~ (:) ]] && {
                 local cut_colon_forward="${cur_word%%:*}"
-                COMPREPLY=( $(compgen -W "${cut_colon_forward}:jsx ${cut_colon_forward}:js ${cut_colon_forward}:json ${cut_colon_forward}:tsx ${cut_colon_forward}:ts ${cut_colon_forward}:css" -- "${cut_colon_forward}:${cur_word##*:}") );
+                local loader loaders="";
+                for loader in js jsx ts tsx json toml yaml json5 xml text md css html wasm napi sqlite file; do
+                    loaders+=" ${cut_colon_forward}:${loader}";
+                done
+                COMPREPLY=( $(compgen -W "${loaders}" -- "${cut_colon_forward}:${cur_word##*:}") );
             }
             return;;
     esac

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -132,11 +132,7 @@ _bun_completions() {
         -l|--loader)
             [[ "${cur_word}" =~ (:) ]] && {
                 local cut_colon_forward="${cur_word%%:*}"
-                local loader loaders="";
-                for loader in js jsx ts tsx json toml yaml json5 xml text md css html wasm napi sqlite file; do
-                    loaders+=" ${cut_colon_forward}:${loader}";
-                done
-                COMPREPLY=( $(compgen -W "${loaders}" -- "${cut_colon_forward}:${cur_word##*:}") );
+                COMPREPLY=( $(compgen -W "${cut_colon_forward}:jsx ${cut_colon_forward}:js ${cut_colon_forward}:json ${cut_colon_forward}:tsx ${cut_colon_forward}:ts ${cut_colon_forward}:css" -- "${cut_colon_forward}:${cur_word##*:}") );
             }
             return;;
     esac

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -462,9 +462,9 @@ _bun_run_completion() {
         '-d[Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:"development". Values are parsed as JSON.]:define' \
         '--external[Exclude module from transpilation (can use * wildcards). ex: -e react]:external' \
         '-e[Exclude module from transpilation (can use * wildcards). ex: -e react]:external' \
-        '--loader[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi]:loader' \
+        '--loader[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file]:loader' \
         '--packages[Exclude dependencies from bundle, e.g. --packages external. Valid options: bundle, external]:packages' \
-        '-l[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi]:loader' \
+        '-l[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file]:loader' \
         '--origin[Rewrite import URLs to start with --origin. Default: ""]:origin' \
         '-u[Rewrite import URLs to start with --origin. Default: ""]:origin' \
         '--port[Port to serve bun'"'"'s dev server on. Default: '"'"'3000'"'"']:port' \
@@ -674,8 +674,8 @@ _bun_test_completion() {
         '-d[Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:"development". Values are parsed as JSON.]:define' \
         '--external[Exclude module from transpilation (can use * wildcards). ex: -e react]:external' \
         '-e[Exclude module from transpilation (can use * wildcards). ex: -e react]:external' \
-        '--loader[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi]:loader' \
-        '-l[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi]:loader' \
+        '--loader[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file]:loader' \
+        '-l[Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file]:loader' \
         '--origin[Rewrite import URLs to start with --origin. Default: ""]:origin' \
         '-u[Rewrite import URLs to start with --origin. Default: ""]:origin' \
         '--port[Port to serve bun'"'"'s dev server on. Default: '"'"'3000'"'"']:port' \

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -89,7 +89,7 @@ Configure how Bun maps file extensions to [loaders](/bundler/loaders). Use this 
 ".bagel" = "tsx"
 ```
 
-Each value must be one of the following loader names:
+The available loaders are:
 
 - `js`
 - `jsx`

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -89,21 +89,25 @@ Configure how Bun maps file extensions to [loaders](/bundler/loaders). Use this 
 ".bagel" = "tsx"
 ```
 
-Bun supports the following loaders:
+Each value must be one of the following loader names:
 
-- `jsx`
 - `js`
+- `jsx`
 - `ts`
 - `tsx`
-- `css`
-- `file`
 - `json`
 - `toml`
+- `yaml`
+- `json5`
+- `xml`
+- `text`
+- `md`
+- `css`
+- `html`
 - `wasm`
 - `napi`
-- `base64`
-- `dataurl`
-- `text`
+- `sqlite`
+- `file`
 
 ### `telemetry`
 

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -210,8 +210,9 @@ bun run <file or script>
 
 <ParamField path="--loader" type="string">
   Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. Valid loaders: <code>js</code>,{" "}
-  <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>, <code>text</code>,{" "}
-  <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
+  <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>, <code>yaml</code>,{" "}
+  <code>json5</code>, <code>xml</code>, <code>text</code>, <code>md</code>, <code>css</code>, <code>html</code>,{" "}
+  <code>wasm</code>, <code>napi</code>, <code>sqlite</code>, <code>file</code>. Alias: <code>-l</code>
 </ParamField>
 
 <ParamField path="--no-macros" type="boolean">


### PR DESCRIPTION
### Problem
- `docs/runtime/bunfig.mdx`, section `loader`, lists the loader names a `[loader]` entry accepts as `jsx, js, ts, tsx, css, file, json, toml, wasm, napi, base64, dataurl, text`. `docs/snippets/cli/run.mdx` repeats the list (minus css) for `--loader`, and `completions/bun.zsh` carries the same `--loader` sentence four times (these scripts are embedded in the binary and printed by `bun completions`).
- These lists predate the `yaml`, `json5`, `xml`, `md`, `html` and `sqlite` loaders. Mapping an extension to any of them from bunfig or `--loader` works today (checked on the current build, table below), but none of them is documented as a valid value.
- `base64` and `dataurl` are listed but not implemented: the name is accepted, then the bundler emits a module whose default export is `""` and the runtime falls back to the `file` loader (returns the path). `docs/bundler/esbuild.mdx` already describes them as not implemented.

### Fix
- Replace the list in both docs pages and in the four zsh descriptions with the loaders that work when mapped from bunfig or `--loader`: `js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file`. Same names, same order, in every copy.
- This is correct because bunfig `[loader]` and `--loader` (`bun run`, `bun build`, `bun test`) resolve the value through the same code, `bun_ast::Loader::from_string` followed by `to_api()` (`src/bunfig/bunfig.rs`, `loader_resolver` in `src/runtime/cli/Arguments.rs`), and each of the 17 names maps to a loader that does what the name says on both the runtime and `bun build` paths (table below). The bunfig page now says "The available loaders are" rather than claiming these are the only accepted spellings: aliases such as `mjs`, `node` or `txt` are accepted too, they are just not listed, as before.
- Left out on purpose:
  - `jsonc` and `sqlite_embedded`: accepted, but `to_api()` collapses them into `json` and `sqlite` (`src/options_types/bundle_enums.rs`), so a jsonc file with comments fails to parse. #38247 fixes that; when it lands, both names should be added to every copy of this list in one go.
  - `base64`, `dataurl`: stubs as described above. #36327 (bundler) and #36334 (runtime) implement them; add them back with those.
  - `sh`: mapped to `file`; the loader docs already say it is not available in the runtime or bundler.
- Sibling copies of the same list that this PR deliberately does not touch:
  - `src/runtime/cli/Arguments.rs:137`, the `--help` text: #38270 changes it to this exact list and adds a test that `--help` prints it and that every listed name works via `--loader`. That test's array is the natural place to also assert the docs and zsh copies match, so the cross-check lives in one file once both PRs are in; this PR stays free of source changes.
  - `completions/bun.bash`: its `--loader` branch only runs when `:` has been removed from `COMP_WORDBREAKS` (bash splits `.ext:name` at the colon by default, so `prev` is `:` and the branch is skipped; checked by driving `_bun_completions` directly), and #35443 turns the file into generated output of `misctools/generate-shell-completions.ts`. The longer list belongs in that generator. An earlier revision of this PR changed the file; reverted.
  - The `dataurl` example under `loader` in `docs/bundler/index.mdx` is being replaced separately.
- Verified by mapping a made-up extension to every name in `LOADER_NAMES` (`src/ast/loader.rs`) from a `bunfig.toml`, importing one fixture per extension at runtime and bundling one entry per extension with `bun build --target bun`, then repeating the runtime run with `--loader` flags under `bun run` and `bun test`. Without any mapping every fixture imports as a path, so the results are attributable to the mapping. `prettier --check` passes on both docs pages.

### Background
- A loader is the parser Bun picks for a file based on its extension (`json` parses JSON into an object, `text` returns the contents as a string, `file` returns the path, and so on). `[loader]` in bunfig.toml and `bun --loader .ext:name` override the extension to loader mapping, for the runtime and for `bun build`.
- `LOADER_NAMES` in `src/ast/loader.rs` is the table of spellings these settings accept (29 entries, including aliases). The chosen loader is converted with `to_api()` into the enum the bundler consumes, which is where `jsonc`, `sqlite_embedded` and `sh` currently collapse into `json`, `sqlite` and `file`. The documented list is the subset of that table that behaves as named.

<details>
<summary>Per-name results on the current build (each row is a fixture mapped to that loader name from bunfig.toml)</summary>

`import()` at runtime:

```
js               ok      string "ok-js"
jsx              ok      Object {"type":"div",...}
ts               ok      string "ok-ts"
tsx              ok      Object {"type":"span",...}
css              ok      Object {}                       (same as importing a real .css file)
file             ok      string "/.../fixture.l_file"
json             ok      Object {"kind":"json"}
jsonc            throws  SyntaxError: JSON Parse error: Unrecognized token '/'
toml             ok      Object {"kind":"toml"}
yaml             ok      Object {"kind":"yaml"}
json5            ok      Object {"kind":"json5"}
xml              ok      Object {"root":{"kind":"xml"}}
wasm             ok      string "/.../fixture.l_wasm"     (same as importing a real .wasm file)
napi             throws  TypeError: To load Node-API modules, use require() or process.dlopen instead of import.
base64           ok      string "/.../fixture.l_base64"   (file loader fallback)
dataurl          ok      string "/.../fixture.l_dataurl"  (file loader fallback)
text             ok      string "hello text"
sh               ok      string "/.../fixture.l_sh"       (file loader)
sqlite           ok      Database {"filename":"/.../fixture.l_sqlite"}
sqlite_embedded  ok      Database {"filename":"/.../fixture.l_sqlite_embedded"}
html             ok      [object HTMLBundle]             (same as importing a real .html file)
md               ok      string "<h1>Title</h1>\n<p>some <em>md</em></p>\n"
```

`bun build --target bun`, then running the output:

```
base64           built    string ""                       (bundle contains: var fixture_default = "";)
dataurl          built    string ""                       (same)
css              built    emits entry.css
file             built    string "./fixture-qpmg3she.l_file"
html             built    Object {"index":"./fixture.html","files":[...]}
json / json5 / toml / yaml / xml      built, parsed object
jsonc            BUILD FAILS  error: JSON does not support comments
md               built    string "<h1>Title</h1>..."
napi             built    copied as a file (documented behavior for the bundler)
sh               built    string "./fixture-z278whqb.l_sh" (file loader)
sqlite / sqlite_embedded              built, Database instance
text             built    string "hello text"
wasm             built    string "./fixture-4swqeqke.l_wasm" (copied, same as a real .wasm)
```

The same runtime import with `--loader .l_<name>:<name>` flags instead of the bunfig gives the same results for every name, under both `bun run` and `bun test`.
</details>

<details>
<summary>Earlier revision</summary>

The first revision also expanded the candidate list in `completions/bun.bash` from six names to the same seventeen. Reverted for the two reasons given above (the branch is unreachable with the default `COMP_WORDBREAKS`, and #35443 regenerates the file from a template that still carries the six-name list).
</details>
