### PR TITLE
GitHub Actions annotations: percent-encode % and a lone CR in the body

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1291,68 +1291,28 @@ impl Display for FormatValidIdentifier<'_> {
 // GitHub Actions formatting
 // ───────────────────────────────────────────────────────────────────────────
 
-/// Formats a string to be safe to output in a Github action.
-/// - Encodes "\n" as "%0A" to support multi-line strings.
-///   https://github.com/actions/toolkit/issues/193#issuecomment-605394935
-/// - Strips ANSI output as it will appear malformed.
+/// Escapes a string for the data part of a GitHub Actions workflow command (the
+/// text after the `::` in `::error ...::<data>`), as actions/toolkit's
+/// `escapeData` does: `%`->`%25`, `\r`->`%0D`, `\n`->`%0A`. The runner decodes
+/// exactly those three sequences, so a literal `%` has to be encoded too or text
+/// like `%0A` comes back out as a newline. A CRLF pair is written as one `%0A`.
+/// ANSI colour sequences are dropped as they would otherwise be rendered verbatim.
 pub(crate) fn github_action_writer(writer: &mut impl fmt::Write, self_: &[u8]) -> fmt::Result {
-    let mut offset: usize = 0;
-    let end = self_.len() as u32;
-    while (offset as u32) < end {
-        if let Some(i) = crate::strings::index_of_newline_or_non_ascii_or_ansi(self_, offset as u32)
-        {
-            let i = i as usize;
-            let byte = self_[i];
-            if byte > 0x7F {
-                let seq_len = strings::wtf8_byte_sequence_length(byte) as usize;
-                if i + seq_len > end as usize {
-                    // Truncated trailing sequence; emit the pending ASCII and stop
-                    // rather than hand an invalid slice to from_utf8_unchecked.
-                    write_bytes(writer, &self_[offset..i])?;
-                    break;
-                }
-                write_bytes(writer, &self_[offset..i + seq_len])?;
-                offset = i + seq_len;
-                continue;
-            }
-            if i > 0 {
-                write_bytes(writer, &self_[offset..i])?;
-            }
-            let mut n: usize = 1;
-            if byte == b'\n' {
-                writer.write_str("%0A")?;
-            } else if (i + 1) < end as usize {
-                let next = self_[i + 1];
-                if byte == b'\r' && next == b'\n' {
-                    n += 1;
-                    writer.write_str("%0A")?;
-                } else if byte == 0x1b && next == b'[' {
-                    n += 1;
-                    if (i + 2) < end as usize {
-                        let upper = (i + 5).min(end as usize);
-                        let remain = &self_[(i + 2)..upper];
-                        if let Some(j) = crate::strings::index_of_char_usize(remain, b'm') {
-                            n += j + 1;
-                        }
-                    }
-                }
-            }
-            offset = i + n;
-        } else {
-            write_bytes(writer, &self_[offset..end as usize])?;
-            break;
-        }
-    }
-    Ok(())
+    github_action_escape_writer::<false>(writer, self_)
 }
 
-/// Formats a string to be safe to use as a Github Actions workflow-command
-/// *property* value (e.g. the `title=` in `::error title=...::`). Unlike
-/// [`github_action`] (which only escapes the message-class metacharacters), this
-/// escapes the property-class metacharacters per the actions/toolkit spec:
-/// `%`->`%25`, `\r`->`%0D`, `\n`->`%0A`, `:`->`%3A`, `,`->`%2C`.
-/// ANSI colour sequences are dropped, matching [`github_action`].
+/// Escapes a string for a workflow-command *property* value (e.g. the `title=`
+/// in `::error title=...::`), as actions/toolkit's `escapeProperty` does: the
+/// [`github_action_writer`] set plus `:`->`%3A` and `,`->`%2C`, which would
+/// otherwise terminate the value.
 pub(crate) fn github_action_property_writer(
+    writer: &mut impl fmt::Write,
+    self_: &[u8],
+) -> fmt::Result {
+    github_action_escape_writer::<true>(writer, self_)
+}
+
+fn github_action_escape_writer<const PROPERTY: bool>(
     writer: &mut impl fmt::Write,
     self_: &[u8],
 ) -> fmt::Result {
@@ -1363,10 +1323,14 @@ pub(crate) fn github_action_property_writer(
         let mut skip: usize = 1;
         let replacement: &str = match byte {
             b'%' => "%25",
+            b'\r' if self_.get(i + 1) == Some(&b'\n') => {
+                skip = 2;
+                "%0A"
+            }
             b'\r' => "%0D",
             b'\n' => "%0A",
-            b':' => "%3A",
-            b',' => "%2C",
+            b':' if PROPERTY => "%3A",
+            b',' if PROPERTY => "%2C",
             0x1b if self_.get(i + 1) == Some(&b'[') => {
                 skip = 2;
                 if i + 2 < self_.len() {

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1291,15 +1291,12 @@ impl Display for FormatValidIdentifier<'_> {
 // GitHub Actions formatting
 // ───────────────────────────────────────────────────────────────────────────
 
-/// actions/toolkit `escapeData`, for the text after the `::` of a workflow command:
-/// `%`, `\r`, `\n` -> `%25`, `%0D`, `%0A` (the runner decodes all three, so `%` has
-/// to be encoded too). A CRLF pair becomes one `%0A`; ANSI colour sequences are dropped.
+/// actions/toolkit `escapeData`: `%`/CR/LF -> `%25`/`%0D`/`%0A`; CRLF is one `%0A`; SGR is dropped.
 pub(crate) fn github_action_writer(writer: &mut impl fmt::Write, self_: &[u8]) -> fmt::Result {
     github_action_escape_writer::<false>(writer, self_)
 }
 
-/// actions/toolkit `escapeProperty`, for a property value such as `title=`:
-/// the [`github_action_writer`] set plus `:` -> `%3A` and `,` -> `%2C`.
+/// actions/toolkit `escapeProperty`: [`github_action_writer`] plus `:` -> `%3A` and `,` -> `%2C`.
 pub(crate) fn github_action_property_writer(
     writer: &mut impl fmt::Write,
     self_: &[u8],

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1291,20 +1291,15 @@ impl Display for FormatValidIdentifier<'_> {
 // GitHub Actions formatting
 // ───────────────────────────────────────────────────────────────────────────
 
-/// Escapes a string for the data part of a GitHub Actions workflow command (the
-/// text after the `::` in `::error ...::<data>`), as actions/toolkit's
-/// `escapeData` does: `%`->`%25`, `\r`->`%0D`, `\n`->`%0A`. The runner decodes
-/// exactly those three sequences, so a literal `%` has to be encoded too or text
-/// like `%0A` comes back out as a newline. A CRLF pair is written as one `%0A`.
-/// ANSI colour sequences are dropped as they would otherwise be rendered verbatim.
+/// actions/toolkit `escapeData`, for the text after the `::` of a workflow command:
+/// `%`, `\r`, `\n` -> `%25`, `%0D`, `%0A` (the runner decodes all three, so `%` has
+/// to be encoded too). A CRLF pair becomes one `%0A`; ANSI colour sequences are dropped.
 pub(crate) fn github_action_writer(writer: &mut impl fmt::Write, self_: &[u8]) -> fmt::Result {
     github_action_escape_writer::<false>(writer, self_)
 }
 
-/// Escapes a string for a workflow-command *property* value (e.g. the `title=`
-/// in `::error title=...::`), as actions/toolkit's `escapeProperty` does: the
-/// [`github_action_writer`] set plus `:`->`%3A` and `,`->`%2C`, which would
-/// otherwise terminate the value.
+/// actions/toolkit `escapeProperty`, for a property value such as `title=`:
+/// the [`github_action_writer`] set plus `:` -> `%3A` and `,` -> `%2C`.
 pub(crate) fn github_action_property_writer(
     writer: &mut impl fmt::Write,
     self_: &[u8],

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1387,8 +1387,6 @@ pub fn str_utf8(bytes: &[u8]) -> Option<&str> {
     }
 }
 
-pub use index_of_newline_or_non_ascii as index_of_newline_or_non_ascii_or_ansi;
-
 /// Checks if slice[offset..] has any < 0x20 or > 127 characters
 // PERF: `#[inline]` — this is the predicate of the source-map column-tracking
 // fast path (`Chunk.rs::update_generated_line_and_column`) and the per-rune

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1428,8 +1428,9 @@ impl ZigString {
     // encoder bodies live in `bun_runtime`.
 
     /// `ZigString.githubAction` — returns a `Display`
-    /// formatter that escapes the string for GitHub Actions annotation output
-    /// (`%0A` for newlines, ANSI stripped). Encoding-aware via `to_slice`.
+    /// formatter that escapes the string for the data part of a GitHub Actions
+    /// annotation (see `crate::fmt::github_action_writer`). Encoding-aware via
+    /// `to_slice`.
     #[inline]
     pub fn github_action(self) -> ZigStringGithubActionFormatter {
         ZigStringGithubActionFormatter { text: self }

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1427,10 +1427,8 @@ impl ZigString {
     // `bun_runtime::webcore::encoding::ZigStringEncode` (extension trait); the
     // encoder bodies live in `bun_runtime`.
 
-    /// `ZigString.githubAction` — returns a `Display`
-    /// formatter that escapes the string for the data part of a GitHub Actions
-    /// annotation (see `crate::fmt::github_action_writer`). Encoding-aware via
-    /// `to_slice`.
+    /// `ZigString.githubAction` — `Display` formatter over
+    /// `crate::fmt::github_action_writer`; encoding-aware via `to_slice`.
     #[inline]
     pub fn github_action(self) -> ZigStringGithubActionFormatter {
         ZigStringGithubActionFormatter { text: self }

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1427,8 +1427,7 @@ impl ZigString {
     // `bun_runtime::webcore::encoding::ZigStringEncode` (extension trait); the
     // encoder bodies live in `bun_runtime`.
 
-    /// `ZigString.githubAction` — `Display` formatter over
-    /// `crate::fmt::github_action_writer`; encoding-aware via `to_slice`.
+    /// `ZigString.githubAction` — encoding-aware `Display` via `fmt::github_action_writer`.
     #[inline]
     pub fn github_action(self) -> ZigStringGithubActionFormatter {
         ZigStringGithubActionFormatter { text: self }

--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -800,9 +800,6 @@ size_t IndexOfNewlineOrNonASCIIImpl(const uint8_t* HWY_RESTRICT start_ptr, size_
     const auto vec_max_ascii = hn::Set(d, uint8_t { 127 });
     const auto vec_min_ascii = hn::Set(d, uint8_t { 0x20 });
 
-    // FUTURE TODO: normalize tabs
-    // Some tests involving githubactions depend on tabs not being normalized right now.
-
     size_t i = 0;
     const size_t simd_text_len = search_len - (search_len % N);
     // Process full vectors

--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -800,6 +800,8 @@ size_t IndexOfNewlineOrNonASCIIImpl(const uint8_t* HWY_RESTRICT start_ptr, size_
     const auto vec_max_ascii = hn::Set(d, uint8_t { 127 });
     const auto vec_min_ascii = hn::Set(d, uint8_t { 0x20 });
 
+    // FUTURE TODO: normalize tabs
+
     size_t i = 0;
     const size_t simd_text_len = search_len - (search_len % N);
     // Process full vectors

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -683,6 +683,76 @@ describe("bun test", () => {
         /^::error file=.*,line=\d+,col=\d+,title=Odd%3AName%2CWith%25Chars: alpha%3A one%2C two 100%25::beta: three, four%0A {6}at /,
       );
     });
+    test.each([
+      {
+        label: "a percent sign in the body",
+        message: "header\n\nprogress: 50%, %0A stays text",
+        expected: "error: header::progress: 50%25, %250A stays text",
+      },
+      {
+        label: "a lone carriage return in the body",
+        message: "header\n\nleft\rright",
+        expected: "error: header::left%0Dright",
+      },
+      {
+        label: "a tab in the body",
+        message: "header\n\nleft\tright",
+        expected: "error: header::left\tright",
+      },
+      {
+        label: "CRLF line endings in the body",
+        message: "header\n\nline one\r\nline two",
+        expected: "error: header::line one%0Aline two",
+      },
+      {
+        label: "CRLF in the title",
+        name: "Odd\r\nName",
+        message: "header\n\nbody",
+        expected: "Odd%0AName: header::body",
+      },
+    ])("should percent-encode an annotation with $label", ({ name, message, expected }) => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("fail", () => {
+            const err = new Error(${JSON.stringify(message)});
+            ${name === undefined ? "" : `err.name = ${JSON.stringify(name)};`}
+            throw err;
+          });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"))!;
+      expect(annotation).toMatch(/^::error file=.*,line=\d+,col=\d+,title=/);
+      expect(annotation.slice(annotation.indexOf(",title=") + ",title=".length)).toStartWith(`${expected}%0A      at `);
+    });
+    test("should percent-encode the stack frames in the annotation body", () => {
+      const stderr = runTest({
+        input: [
+          {
+            filename: "odd%name.test.ts",
+            contents: `
+              import { test } from "bun:test";
+              function inner() {
+                throw new Error("boom");
+              }
+              Object.defineProperty(inner, "name", { value: "50%done" });
+              test("fail", () => {
+                inner();
+              });
+            `,
+          },
+        ],
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toMatch(/^::error file=(.*[\\/])?odd%25name\.test\.ts,line=\d+,col=\d+,title=error: boom::/);
+      expect(annotation).toMatch(/%0A {6}at 50%25done \((.*[\\/])?odd%25name\.test\.ts:\d+:\d+\)/);
+    });
     test("should keep a function name containing a newline on the annotation line", () => {
       const stderr = runTest({
         input: `


### PR DESCRIPTION
### Problem
- Under `GITHUB_ACTIONS=true`, the `::error ...::<body>` line printed for a failing test or uncaught error does not encode `%` in the body (message lines after the first, plus the stack frames). The runner decodes `%25`, `%0D` and `%0A` in the body, so a message containing the text `%0A` is rendered as a line break and `%25` as `%`. The title property already gets this right.
- A lone `\r` in the body is dropped, and so is a tab or any other control byte: `"left\tright"` is annotated as `leftright`.
- Cause: `github_action_writer` (`src/bun_core/fmt.rs`) scanned with `index_of_newline_or_non_ascii`, which stops at every byte below 0x20, but only had arms for `\n`, `\r\n` and `ESC[`; any other byte it stopped at was skipped without being written, and `%` was never a stop byte at all. Reproduces on bun 1.4.0.
- Cosmetic only: `\n` was already encoded, so a body could not start a new workflow command.

### Fix
- `github_action_writer` (body) and `github_action_property_writer` (`file=`, `title=`) now share one byte table, `github_action_escape_writer<PROPERTY>`: `%` -> `%25`, lone `\r` -> `%0D`, `\n` -> `%0A`, and for properties also `:` -> `%3A`, `,` -> `%2C`. `ESC[...m` is still dropped. Every other byte is written as is.
- This is the escape set of actions/toolkit's `escapeData` / `escapeProperty`, which is what the runner's decoder is the inverse of, so the rendered annotation is the original text again. The one deliberate difference is kept from the old body writer: a CRLF pair is written as a single `%0A` (the runner turns either form into a line break; this keeps stray CRs out of the annotation). It now applies to property values too, where it previously came out as `%0D%0A`.
- Writing the remaining bytes through unchanged is safe for the non-ASCII handling the old writer did by hand: the runs are only ever split at ASCII bytes, and the inputs are UTF-8 already (the message via `to_utf8()`, the frame strings are Rust `String`s).
- Removes the now unused `index_of_newline_or_non_ascii_or_ansi` alias, and the sentence in `IndexOfNewlineOrNonASCIIImpl` (`highway_strings.cpp`) saying the GitHub Actions output depends on that scanner; the kernel's own tab TODO stays.
- Not changed here: the two `::group::<path>` headers `bun test` prints per file (`CurrentFile::print` in `src/runtime/test_runner/jest.rs`, and `ensure_header` in `src/runtime/cli/test/parallel/Coordinator.rs` for `--parallel`) write the path raw. They do not go through either writer, and the runner only alters such a header if the path itself contains a literal `%25`, `%0A` or `%0D`, so they are left for a separate change.
- Tests: `test/cli/test/bun-test.test.ts`, "support for Github Actions": 5 `test.each` rows (`%` in the body with `:`/`,` left alone, lone CR, tab, CRLF in the body, CRLF in a title) and one test for `%` in a frame's function name and file path.
  - `USE_SYSTEM_BUN=1 bun test test/cli/test/bun-test.test.ts -t percent-encode`: 5 of the 6 new tests fail on 1.4.0 (the CRLF-in-body row pins unchanged behavior).
  - `bun bd test test/cli/test/bun-test.test.ts`: 87 pass, 6 todo, 0 fail (includes the existing ANSI-stripping and title/file encoding tests).
- #38256 fixes a different bug in the same output (line 2 of the message being dropped, in `VirtualMachine.rs`); the two changes do not overlap.

### Background
- A GitHub Actions workflow command is a line of the form `::error file=a,line=1,title=<title>::<body>` on stdout/stderr. The part before the second `::` is a comma separated property list (so property values must encode `,` and `:`), the part after it is the body, which has to fit on one line, so line breaks are sent as `%0A`/`%0D`. Because the runner decodes those sequences, `%` itself has to be sent as `%25`; actions/toolkit calls these two escape sets `escapeProperty` and `escapeData`.
- Bun prints one of these per failing test (and per uncaught error) from `VirtualMachine::print_github_annotation`: error name and first message line go into `title=` through the property encoder, the rest of the message and each `at ...` frame go into the body through `github_action_writer`.

<details>
<summary>Before / after</summary>

```js
import { test } from "bun:test";
test("pct", () => { throw new Error("title 100%\n\nbody 50% done %0A not-a-newline"); });
test("cr",  () => { throw new Error("t\n\nbody\rafter"); });
test("tab", () => { throw new Error("t\n\nbody\tafter"); });
```

`GITHUB_ACTIONS=true bun test ./p.test.js 2>&1 | grep '^::error'`

Before (bun 1.4.0):

```
::error file=p.test.js,line=2,col=84,title=error: title 100%25::body 50% done %0A not-a-newline%0A      at <anonymous> (/tmp/gha/p.test.js:2:84)
::error file=p.test.js,line=3,col=54,title=error: t::bodyafter%0A      at <anonymous> (/tmp/gha/p.test.js:3:54)
::error file=p.test.js,line=4,col=55,title=error: t::bodyafter%0A      at <anonymous> (/tmp/gha/p.test.js:4:55)
```

After:

```
::error file=p.test.js,line=2,col=84,title=error: title 100%25::body 50%25 done %250A not-a-newline%0A      at <anonymous> (/tmp/gha/p.test.js:2:84)
::error file=p.test.js,line=3,col=54,title=error: t::body%0Dafter%0A      at <anonymous> (/tmp/gha/p.test.js:3:54)
::error file=p.test.js,line=4,col=55,title=error: t::body<TAB>after%0A      at <anonymous> (/tmp/gha/p.test.js:4:55)
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->