### PR TITLE
cli: list every working loader name in the --loader help text

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -134,7 +134,7 @@ const TRANSPILER_PARAMS_: &[ParamType] = &[
         "--feature <STR>...               Enable a feature flag for dead-code elimination, e.g. --feature=SUPER_SECRET"
     ),
     parse_param!(
-        "-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi"
+        "-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file"
     ),
     parse_param!(
         "--no-macros                       Disable macros from being executed in the bundler, transpiler and runtime"

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -176,6 +176,132 @@ describe("bun", () => {
     });
   });
 
+  describe("--loader help text", () => {
+    // The names the -l/--loader help text in src/runtime/cli/Arguments.rs advertises. The same
+    // list is repeated in docs/snippets/cli/run.mdx, docs/runtime/bunfig.mdx and completions/bun.{zsh,bash}.
+    const advertisedLoaders = [
+      "js",
+      "jsx",
+      "ts",
+      "tsx",
+      "json",
+      "toml",
+      "yaml",
+      "json5",
+      "xml",
+      "text",
+      "md",
+      "css",
+      "html",
+      "wasm",
+      "napi",
+      "sqlite",
+      "file",
+    ];
+
+    test.concurrent.each([
+      ["bun --help", ["--help"]],
+      ["bun run --help", ["run", "--help"]],
+    ])("%s lists the loaders --loader accepts", async (_, args) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const loaderLine = stdout.split(/\r?\n/).find(line => line.includes("--loader"));
+      expect(loaderLine).toBeDefined();
+      const [, listed] = loaderLine!.split("Valid loaders:");
+      expect(listed?.split(",").map(name => name.trim())).toEqual(advertisedLoaders);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent(
+      "every advertised loader name is accepted by --loader and applied to the mapped extension",
+      async () => {
+        using dir = tempDir("loader-help-names", {
+          "m.l_js": `export default "js";`,
+          "m.l_jsx": `export default "jsx";`,
+          "m.l_ts": `export default "ts" as string;`,
+          "m.l_tsx": `export default "tsx" as string;`,
+          "m.l_json": `{ "kind": "json" }`,
+          "m.l_toml": `kind = "toml"`,
+          "m.l_yaml": `kind: yaml`,
+          "m.l_json5": `{ kind: "json5", /* json5 allows this */ }`,
+          "m.l_xml": `<kind>xml</kind>`,
+          "m.l_text": `plain text`,
+          "m.l_md": `# md`,
+          "m.l_css": `a { color: red }`,
+          "m.l_html": `<!doctype html><p>html</p>`,
+          "m.l_sqlite": "",
+          "m.l_file": `not a module`,
+          "main.ts": `
+          import { Database } from "bun:sqlite";
+          import { basename } from "node:path";
+          import js from "./m.l_js";
+          import jsx from "./m.l_jsx";
+          import ts from "./m.l_ts";
+          import tsx from "./m.l_tsx";
+          import json from "./m.l_json";
+          import toml from "./m.l_toml";
+          import yaml from "./m.l_yaml";
+          import json5 from "./m.l_json5";
+          import xml from "./m.l_xml";
+          import text from "./m.l_text";
+          import md from "./m.l_md";
+          import css from "./m.l_css";
+          import html from "./m.l_html";
+          import db from "./m.l_sqlite";
+          import file from "./m.l_file";
+          console.log(
+            JSON.stringify({
+              js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md,
+              css: typeof css,
+              html: Object.prototype.toString.call(html),
+              sqlite: db instanceof Database,
+              file: basename(file),
+            }),
+          );
+        `,
+        });
+
+        await using proc = Bun.spawn({
+          // Without these flags every fixture falls back to the file loader and imports as a path.
+          // wasm and napi have no fixture: an unknown name fails argument parsing, so mapping
+          // them is what the test checks for those two.
+          cmd: [bunExe(), ...advertisedLoaders.flatMap(name => ["--loader", `.l_${name}:${name}`]), "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual({
+          js: "js",
+          jsx: "jsx",
+          ts: "ts",
+          tsx: "tsx",
+          json: { kind: "json" },
+          toml: { kind: "toml" },
+          yaml: { kind: "yaml" },
+          json5: { kind: "json5" },
+          xml: { kind: "xml" },
+          text: "plain text",
+          md: "<h1>md</h1>\n",
+          css: "object",
+          html: "[object HTMLBundle]",
+          sqlite: true,
+          file: "m.l_file",
+        });
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
   describe("test command line arguments", () => {
     test("test --config, issue #4128", () => {
       const path = `${tmpdir()}/bunfig-${Date.now()}.toml`;


### PR DESCRIPTION
### Problem
- `bun --help`, `bun run --help` and `bun repl --help` describe `-l, --loader` as: `Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi`.
- That list predates the `css`, `html`, `yaml`, `json5`, `xml`, `md` and `sqlite` loaders. The flag resolves its value through `loader_resolver()` (`src/runtime/cli/Arguments.rs:38`), which is `bun_ast::Loader::from_string` over `LOADER_NAMES` (`src/ast/loader.rs:73`), so all seven are accepted and applied today; the help text is the only in-binary place they are missing.
- The string lives in `TRANSPILER_PARAMS_` at `src/runtime/cli/Arguments.rs:137`.

### Fix
- Update the help string to `js, jsx, ts, tsx, json, toml, yaml, json5, xml, text, md, css, html, wasm, napi, sqlite, file`, the same list (same order) that #38266 puts in the `--loader` docs and shell completions. No behavior change.
- Every added name is accepted by the flag and does what its name says when mapped to an extension: mapping a made-up extension to each one and importing a fixture gives a parsed object for `yaml`/`json5`/`xml`, rendered HTML for `md`, an `HTMLBundle` for `html`, a `Database` for `sqlite`, and the same module shape as a real `.css` file for `css`. Without the mapping each fixture imports as a path (the `file` loader), so the flag is what makes them work.
- The list is deliberately the names that work as named, not everything `from_string` accepts: `jsonc` and `sqlite_embedded` collapse to `json` and `sqlite` in `to_api()` (`src/options_types/bundle_enums.rs`, being fixed in #38247, after which both belong in this list), `base64` and `dataurl` are unimplemented stubs (#36327, #36334), `sh` maps to `file`, and the aliases (`mjs`, `cjs`, `mts`, `cts`, `node`, `txt`, `markdown`) stay unlisted as before. The full accepted set is what the `invalid loader` error prints (#38283); the help line is the recommended subset.
- Tests, in `test/cli/bun.test.ts`:
  - `bun --help` and `bun run --help`: the `--loader` line's `Valid loaders:` list equals the 17 names above. Fails on the current release (the eight missing names), passes with this change.
  - One `bun` run that maps a distinct extension to every advertised name and imports a fixture for each of the 15 that are observable at runtime, asserting the loader-specific result; `wasm` and `napi` are only mapped (an unknown name fails argument parsing). This ties the advertised list to what the flag accepts.
- `bun bd test test/cli/bun.test.ts`: 24 pass.

### Related
- The same list is hand-copied in `docs/snippets/cli/run.mdx`, `docs/runtime/bunfig.mdx`, `completions/bun.zsh` and `completions/bun.bash`; #38266 updates those copies to this list. This PR carries the binary half because a `src/` change needs the help-output test. The `Loader` type in `bun-types` is updated separately in #38267.
- Once #38266 and this land, a source lint (`test/internal/source-lints/`) asserting the copies equal `LOADER_NAMES` minus an explicit exclusion list would stop the next drift; it can only pass once both are in one tree, so it is a follow-up rather than part of either PR.
- #36904 edits this same help line (adds an extensionless example) and will need a one-line rebase.

### Background
- A loader is the parser Bun applies to a file based on its extension (`json` parses to an object, `text` returns the contents, `file` returns the path, and so on). `--loader .ext:name` overrides the extension to loader mapping for the runtime and the bundler.
- `LOADER_NAMES` is the table of spellings `--loader` (and bunfig `[loader]`) accept; `to_api()` then converts the chosen loader into the API enum the bundler and runtime consume, which is where a few accepted names currently degrade into another loader.
