### PR TITLE
sourcemap: make ParseResult a Result alias (fixes clippy on main)

### DIFF
--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -682,11 +682,11 @@ impl SourceMapStore {
             0, // unused
             Default::default(),
         ) {
-            source_map::ParseResult::Fail(fail) => {
+            Err(fail) => {
                 bun_core::debug_warn!("Failed to re-parse source map: {}", fail.err.message());
                 None
             }
-            source_map::ParseResult::Success(mut psm) => Some(GetResult {
+            Ok(mut psm) => Some(GetResult {
                 mappings: core::mem::take(&mut psm.mappings),
                 file_paths: &entry.paths,
                 entry_files: &entry.files,

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -460,7 +460,7 @@ pub fn parse(
 
     if let Some(count) = estimated_mapping_count {
         if mapping.ensure_total_capacity(count).is_err() {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::Alloc(bun_alloc::AllocError),
                 loc: Loc::default(),
             });
@@ -508,7 +508,7 @@ pub fn parse(
                 );
             }
             SimdResult::OutOfMemory => {
-                return ParseResult::Fail(ParseResultFail {
+                return Err(ParseResultFail {
                     err: crate::Error::Alloc(bun_alloc::AllocError),
                     loc: Loc::default(),
                 });
@@ -539,7 +539,7 @@ pub fn parse(
         let generated_column_delta = decode_vlq(remain, 0);
 
         if generated_column_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::MissingGeneratedColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -554,7 +554,7 @@ pub fn parse(
             .zero_based()
             .wrapping_add(generated_column_delta.value);
         if generated_column < 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::InvalidGeneratedColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -587,7 +587,7 @@ pub fn parse(
         // Read the original source
         let source_index_delta = decode_vlq(remain, 0);
         if source_index_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::InvalidSourceIndexDelta,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -597,7 +597,7 @@ pub fn parse(
         source_index = source_index.wrapping_add(source_index_delta.value);
 
         if source_index < 0 || source_index >= sources_count {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::InvalidSourceIndexValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -609,7 +609,7 @@ pub fn parse(
         // Read the original line
         let original_line_delta = decode_vlq(remain, 0);
         if original_line_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::MissingOriginalLine,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -622,7 +622,7 @@ pub fn parse(
             .zero_based()
             .wrapping_add(original_line_delta.value);
         if original_line < 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::InvalidOriginalLineValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -635,7 +635,7 @@ pub fn parse(
         // Read the original column
         let original_column_delta = decode_vlq(remain, 0);
         if original_column_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::MissingOriginalColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -648,7 +648,7 @@ pub fn parse(
             .zero_based()
             .wrapping_add(original_column_delta.value);
         if original_column < 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseResultFail {
                 err: crate::Error::InvalidOriginalColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -672,7 +672,7 @@ pub fn parse(
                     // Read the name index
                     let name_index_delta = decode_vlq(remain, 0);
                     if name_index_delta.start == 0 {
-                        return ParseResult::Fail(ParseResultFail {
+                        return Err(ParseResultFail {
                             err: crate::Error::InvalidNameIndexDelta,
                             loc: Loc {
                                 start: i32::try_from(bytes.len() - remain.len())
@@ -686,7 +686,7 @@ pub fn parse(
                         name_index = name_index.wrapping_add(name_index_delta.value);
                         if !has_names {
                             if mapping.ensure_with_names().is_err() {
-                                return ParseResult::Fail(ParseResultFail {
+                                return Err(ParseResultFail {
                                     err: crate::Error::Alloc(bun_alloc::AllocError),
                                     loc: Loc {
                                         start: i32::try_from(bytes.len() - remain.len())
@@ -737,7 +737,7 @@ pub fn parse(
     let mut psm = ParsedSourceMap::default();
     psm.mappings = mapping;
     psm.input_line_count = input_line_count;
-    ParseResult::Success(psm)
+    Ok(psm)
 }
 
 enum SimdResult {

--- a/src/sourcemap/error.rs
+++ b/src/sourcemap/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
 }
 
 impl Error {
-    /// What `ParseResult::Fail` reports to the user.
+    /// What `ParseResultFail` reports to the user.
     pub fn message(self) -> &'static str {
         match self {
             Self::MissingGeneratedColumnValue => "Missing generated column value",

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -105,10 +105,7 @@ pub struct ParseUrl {
     pub source_contents: Option<Box<[u8]>>,
 }
 
-pub enum ParseResult {
-    Fail(ParseResultFail),
-    Success(ParsedSourceMap),
-}
+pub type ParseResult = Result<ParsedSourceMap, ParseResultFail>;
 
 pub struct ParseResultFail {
     pub loc: bun_ast::Loc,
@@ -953,7 +950,7 @@ pub(crate) fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Resu
     };
 
     let map: Option<Arc<ParsedSourceMap>> = if !source_only {
-        let mut map_data = match mapping::parse(
+        let mut map_data = mapping::parse(
             mappings_vlq,
             None,
             i32::MAX,
@@ -968,10 +965,8 @@ pub(crate) fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Resu
                 ),
                 sort: true,
             },
-        ) {
-            ParseResult::Success(x) => x,
-            ParseResult::Fail(fail) => return Err(fail.err),
-        };
+        )
+        .map_err(|fail| fail.err)?;
 
         if let ParseUrlResultHint::All {
             include_names: true,

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -7,7 +7,7 @@ use bstr::BStr;
 
 use bun_core::{self as bstring, strings};
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, bun_string_jsc};
-use bun_sourcemap::{Mapping, Ordinal, ParseResult, ParsedSourceMap, mapping};
+use bun_sourcemap::{Mapping, Ordinal, ParsedSourceMap, mapping};
 
 // generate-classes.ts does not emit Rust accessors yet, so the
 // `to_js`/cached-setter helpers below forward to the codegen-emitted C++
@@ -157,8 +157,8 @@ impl JSSourceMap {
         );
 
         let mapping_list = match parse_result {
-            ParseResult::Success(parsed) => parsed,
-            ParseResult::Fail(fail) => {
+            Ok(parsed) => parsed,
+            Err(fail) => {
                 if let Some(loc) = fail.loc.to_nullable() {
                     return Err(global.throw_value(global.create_syntax_error_instance(
                         format_args!("{} at {}", fail.err.message(), loc.start),


### PR DESCRIPTION
### What does this PR do?

`cargo clippy` has been red on main since #38263: that change shrank `ParseResultFail` to 8 bytes, so `bun_sourcemap::ParseResult { Fail(ParseResultFail), Success(ParsedSourceMap) }` (152-byte `Success`) now trips `clippy::large_enum_variant`, which the clippy workflow denies. Every PR checked against current main inherits the failure.

`ParseResult` was only ever built and immediately matched like a `Result`, so this defines it as `pub type ParseResult = Result<ParsedSourceMap, ParseResultFail>;` and switches the four call sites (`mapping::parse`, `parse_json`, the `node:module` `SourceMap` constructor, and the dev server's `SourceMapStore`) to `Ok`/`Err`. No boxing or `#[allow]`; `parse_json` gets to use `?`. No behavior change intended.

### How did you verify your code works?

- `bun run rust:clippy` (the CI command, with `build/debug/codegen` generated) → 0 warnings, 0 errors across the workspace.
- Debug build: `new (require("node:module").SourceMap)(...)` with valid mappings (`findEntry` result) and with malformed mappings (`SyntaxError: Invalid source index delta at 1`), plus an error thrown from a `bun build --sourcemap=inline` output file — all three produce output identical to bun 1.4.0.