### PR TITLE
bun test: report a test file or preload the loader cannot resolve instead of exiting; keep the JUnit report valid UTF-8

### DIFF
--- a/src/jsc/JSModuleLoader.rs
+++ b/src/jsc/JSModuleLoader.rs
@@ -1,3 +1,5 @@
+use core::ptr::NonNull;
+
 use crate::{JSGlobalObject, JSInternalPromise, JsError, JsResult};
 use bun_core::String as BunString;
 
@@ -28,33 +30,60 @@ impl JSModuleLoader {
     /// Raw-pointer variant of `load_and_evaluate_module`. Returns the FFI
     /// `*mut JSInternalPromise` directly so callers that need to store or pass
     /// a mutable cell pointer don't launder provenance through `&T -> *mut T`.
+    ///
+    /// Every load failure comes back as a rejected promise (see
+    /// [`Self::reject_with_thrown_exception`]); `None` only while the VM is
+    /// being terminated, with the termination exception left pending.
     pub fn load_and_evaluate_module_ptr(
         global_object: *mut JSGlobalObject,
         module_name: Option<&BunString>,
-    ) -> Option<core::ptr::NonNull<JSInternalPromise>> {
+    ) -> Option<NonNull<JSInternalPromise>> {
         // `JSGlobalObject` is an opaque ZST handle; `opaque_ref` is the
         // centralised zero-byte deref proof (panics on null).
-        core::ptr::NonNull::new(JSC__JSModuleLoader__loadAndEvaluateModule(
-            JSGlobalObject::opaque_ref(global_object),
+        let global = JSGlobalObject::opaque_ref(global_object);
+        NonNull::new(JSC__JSModuleLoader__loadAndEvaluateModule(
+            global,
             module_name,
         ))
+        .or_else(|| Self::reject_with_thrown_exception(global))
     }
 
     /// Raw-pointer variant of `Self::import`. Returns the FFI
     /// `*mut JSInternalPromise` directly so callers that need to store or pass
     /// a mutable cell pointer (e.g. `VirtualMachine::pending_internal_promise`)
     /// don't launder provenance through `&T -> *mut T`. Mirrors
-    /// [`Self::load_and_evaluate_module_ptr`].
+    /// [`Self::load_and_evaluate_module_ptr`], including how failures are
+    /// reported: `Err` only while the VM is being terminated.
     pub fn import_ptr(
         global_object: *mut JSGlobalObject,
         module_name: &BunString,
-    ) -> JsResult<core::ptr::NonNull<JSInternalPromise>> {
+    ) -> JsResult<NonNull<JSInternalPromise>> {
         // `JSGlobalObject` is an opaque ZST handle; `opaque_ref` is the
         // centralised zero-byte deref proof (panics on null).
-        core::ptr::NonNull::new(JSModuleLoader__import(
-            JSGlobalObject::opaque_ref(global_object),
-            module_name,
-        ))
-        .ok_or(JsError::Thrown)
+        let global = JSGlobalObject::opaque_ref(global_object);
+        NonNull::new(JSModuleLoader__import(global, module_name))
+            .or_else(|| Self::reject_with_thrown_exception(global))
+            .ok_or(JsError::Thrown)
+    }
+
+    /// JSC resolves the specifier before it has a promise to reject
+    /// (Completion.cpp `loadAndEvaluateModule`, JSModuleLoader.cpp
+    /// `requestImportModule`), so an unresolvable one is thrown and the binding
+    /// returns null. One way to get there is a path whose bytes are not valid
+    /// UTF-8: once it is a JS string it no longer names the file. The callers
+    /// report load failures from the promise, so deliver the error that way,
+    /// marked handled like the loader's own promises so the unhandled
+    /// rejection tracker does not report it a second time.
+    fn reject_with_thrown_exception(global: &JSGlobalObject) -> Option<NonNull<JSInternalPromise>> {
+        let exception = global.try_take_exception()?;
+        // `try_take_exception` leaves a termination exception pending; so do we.
+        if exception.is_termination_exception() {
+            return None;
+        }
+        let promise = JSInternalPromise::create(global);
+        promise
+            .reject_as_handled(global, exception.to_error().unwrap_or(exception))
+            .ok()?;
+        Some(NonNull::from(promise))
     }
 }

--- a/src/jsc/JSModuleLoader.rs
+++ b/src/jsc/JSModuleLoader.rs
@@ -30,10 +30,7 @@ impl JSModuleLoader {
     /// Raw-pointer variant of `load_and_evaluate_module`. Returns the FFI
     /// `*mut JSInternalPromise` directly so callers that need to store or pass
     /// a mutable cell pointer don't launder provenance through `&T -> *mut T`.
-    ///
-    /// Every load failure comes back as a rejected promise (see
-    /// [`Self::reject_with_thrown_exception`]); `None` only while the VM is
-    /// being terminated, with the termination exception left pending.
+    /// A failed load is a rejected promise; `None` only on VM termination.
     pub fn load_and_evaluate_module_ptr(
         global_object: *mut JSGlobalObject,
         module_name: Option<&BunString>,
@@ -52,8 +49,7 @@ impl JSModuleLoader {
     /// `*mut JSInternalPromise` directly so callers that need to store or pass
     /// a mutable cell pointer (e.g. `VirtualMachine::pending_internal_promise`)
     /// don't launder provenance through `&T -> *mut T`. Mirrors
-    /// [`Self::load_and_evaluate_module_ptr`], including how failures are
-    /// reported: `Err` only while the VM is being terminated.
+    /// [`Self::load_and_evaluate_module_ptr`]; `Err` only on VM termination.
     pub fn import_ptr(
         global_object: *mut JSGlobalObject,
         module_name: &BunString,
@@ -66,17 +62,14 @@ impl JSModuleLoader {
             .ok_or(JsError::Thrown)
     }
 
-    /// JSC resolves the specifier before it has a promise to reject
-    /// (Completion.cpp `loadAndEvaluateModule`, JSModuleLoader.cpp
-    /// `requestImportModule`), so an unresolvable one is thrown and the binding
-    /// returns null. One way to get there is a path whose bytes are not valid
-    /// UTF-8: once it is a JS string it no longer names the file. The callers
-    /// report load failures from the promise, so deliver the error that way,
-    /// marked handled like the loader's own promises so the unhandled
-    /// rejection tracker does not report it a second time.
+    /// JSC resolves the specifier before it has a promise to reject (Completion.cpp
+    /// `loadAndEvaluateModule`, JSModuleLoader.cpp `requestImportModule`), so that
+    /// failure alone is thrown, and the binding returns null. Callers report load
+    /// failures from the promise. Handled, like the loader's own promises: the
+    /// caller reports it, not the rejection tracker.
     fn reject_with_thrown_exception(global: &JSGlobalObject) -> Option<NonNull<JSInternalPromise>> {
         let exception = global.try_take_exception()?;
-        // `try_take_exception` leaves a termination exception pending; so do we.
+        // Still pending (`try_take_exception` does not clear it); leave it to the caller.
         if exception.is_termination_exception() {
             return None;
         }

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -186,22 +186,18 @@ impl ResolveMessage {
                     let _ = write!(&mut out, "Module not found '{}'", BStr::new(specifier));
                     return out;
                 }
-                if bun_resolver::is_package_path(specifier)
+                let what = if bun_resolver::is_package_path(specifier)
                     && !strings::contains_char(specifier, b'/')
                 {
-                    let _ = write!(
-                        &mut out,
-                        "Cannot find package '{}' from '{}'",
-                        BStr::new(specifier),
-                        BStr::new(referrer),
-                    );
+                    "package"
                 } else {
-                    let _ = write!(
-                        &mut out,
-                        "Cannot find module '{}' from '{}'",
-                        BStr::new(specifier),
-                        BStr::new(referrer),
-                    );
+                    "module"
+                };
+                let _ = write!(&mut out, "Cannot find {what} '{}'", BStr::new(specifier));
+                // Entry points and preloads are loaded directly, not imported
+                // from anywhere; Node words those the same way.
+                if !referrer.is_empty() {
+                    let _ = write!(&mut out, " from '{}'", BStr::new(referrer));
                 }
                 return out;
             }

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -194,8 +194,7 @@ impl ResolveMessage {
                     "module"
                 };
                 let _ = write!(&mut out, "Cannot find {what} '{}'", BStr::new(specifier));
-                // Entry points and preloads are loaded directly, not imported
-                // from anywhere; Node words those the same way.
+                // Empty for an entry point or preload; Node omits it there too.
                 if !referrer.is_empty() {
                     let _ = write!(&mut out, " from '{}'", BStr::new(referrer));
                 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3682,9 +3682,7 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         return result;
     } else {
         auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-        // The resolver leaves `res` untouched when it threw (a plugin's onResolve
-        // throwing, for instance); that exception is the one to keep. Same shape
-        // as moduleLoaderImportModule below.
+        // `res` is not written when the resolver threw (e.g. a plugin's onResolve); keep that exception.
         if (!scope.exception())
             throwException(scope, res.result.err, globalObject);
         return globalObject->vm().propertyNames->emptyIdentifier;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3609,7 +3609,7 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
 
     ErrorableString res;
-    res.success = false;
+    memset(&res, 0, sizeof(res));
 
     BunString keyZ;
     if (key.isString()) {
@@ -3682,7 +3682,11 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         return result;
     } else {
         auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-        throwException(scope, res.result.err, globalObject);
+        // The resolver leaves `res` untouched when it threw (a plugin's onResolve
+        // throwing, for instance); that exception is the one to keep. Same shape
+        // as moduleLoaderImportModule below.
+        if (!scope.exception())
+            throwException(scope, res.result.err, globalObject);
         return globalObject->vm().propertyNames->emptyIdentifier;
     }
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -141,9 +141,8 @@ mod bun_test {
     }
 }
 
-/// The report declares `encoding="UTF-8"`, but file paths, the hostname and the
-/// CI env vars are raw OS bytes: ill-formed sequences become U+FFFD, as the
-/// console already prints them (`bstr::BStr`).
+/// Paths, the hostname and CI env vars are raw OS bytes; the report is declared
+/// UTF-8, so ill-formed sequences become U+FFFD as on the console (`bstr::BStr`).
 pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate::Result<()> {
     if strings::is_valid_utf8(str_) {
         return escape_xml_utf8(str_, writer);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -141,7 +141,23 @@ mod bun_test {
     }
 }
 
+/// The report declares `encoding="UTF-8"`, but file paths, the hostname and the
+/// CI env vars are raw OS bytes: ill-formed sequences become U+FFFD, as the
+/// console already prints them (`bstr::BStr`).
 pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate::Result<()> {
+    if strings::is_valid_utf8(str_) {
+        return escape_xml_utf8(str_, writer);
+    }
+    for chunk in str_.utf8_chunks() {
+        escape_xml_utf8(chunk.valid().as_bytes(), writer)?;
+        if !chunk.invalid().is_empty() {
+            writer.write_all("\u{FFFD}".as_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+fn escape_xml_utf8(str_: &[u8], writer: &mut impl bun_io::Write) -> crate::Result<()> {
     let mut last: usize = 0;
     let mut i: usize = 0;
     let len = str_.len();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -712,10 +712,8 @@ fn generate_entry_point(_vm: &VirtualMachine, watch: bool, entry_path: &[u8]) ->
 /// preload promise if any, else null.
 ///
 /// Error mapping: resolver `Failure` returns the resolver error,
-/// `Pending`/`NotFound` returns `error.ModuleNotFound`. A preload the module
-/// loader cannot load comes back as a rejected promise like any other failing
-/// preload; `JSModuleLoader.import` only fails (`error.JSError`) when the VM is
-/// being terminated.
+/// `Pending`/`NotFound` returns `error.ModuleNotFound`, a load the module loader
+/// refuses is a rejected promise, `error.JSError` means VM termination.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -712,8 +712,10 @@ fn generate_entry_point(_vm: &VirtualMachine, watch: bool, entry_path: &[u8]) ->
 /// preload promise if any, else null.
 ///
 /// Error mapping: resolver `Failure` returns the resolver error,
-/// `Pending`/`NotFound` returns `error.ModuleNotFound`,
-/// `JSModuleLoader.import` throwing returns `error.JSError`.
+/// `Pending`/`NotFound` returns `error.ModuleNotFound`. A preload the module
+/// loader cannot load comes back as a rejected promise like any other failing
+/// preload; `JSModuleLoader.import` only fails (`error.JSError`) when the VM is
+/// being terminated.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM.

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, realpathSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, canCreateNonUtf8FileNames, tempDir } from "harness";
+import { mkdirSync, realpathSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 const preloadModule = `
@@ -211,30 +211,54 @@ plugin({
     }
   });
 
-  test.skipIf(!canCreateNonUtf8FileNames())(
-    "throws an error when the preloaded module's path is not valid UTF-8",
-    async () => {
-      // The resolver finds the file, but its path does not survive becoming a
-      // module specifier, so loading it fails; that failure has to be reported.
-      using dir = tempDir("bun-preload-non-utf8", { "main.js": `console.log("RAN main");` });
-      writeFileSync(
-        Buffer.concat([Buffer.from(`${dir}/p`), Buffer.from([0xff]), Buffer.from(".js")]),
-        `console.log("RAN preload");`,
-      );
+  async function run(dir, ...args) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+      env: bunEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
 
-      await using proc = Bun.spawn({
-        // A JS string cannot carry the raw byte into argv; the shell can.
-        cmd: ["sh", "-c", `exec "$0" --preload "./$(printf 'p\\377.js')" main.js`, bunExe()],
-        cwd: String(dir),
-        stderr: "pipe",
-        stdout: "pipe",
-        env: bunEnv,
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // A preload is handed to the module loader as the specifier itself; node:
+  // names skip the file resolver, so this is the loader's own refusal, which
+  // used to be reported as nothing more than "Error occurred loading entry point: JSError".
+  test("reports a preloaded node: module that does not exist", async () => {
+    using dir = tempDir("bun-preload-missing-builtin", { "main.js": `console.log("RAN main");` });
+    const result = await run(dir, "--preload", "node:does_not_exist", "main.js");
 
-      expect(stdout).toBe("");
-      expect(stderr).toMatch(/error: Cannot find module '[^']*\/p\uFFFD\.js'\n/);
-      expect(exitCode).toBe(1);
-    },
-  );
+    expect(result).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("error: No such built-in module: node:does_not_exist\n"),
+      exitCode: 1,
+    });
+  });
+
+  // Resolving the entry point runs the plugin; its exception used to be
+  // replaced by an uninitialized one, which crashed the process.
+  test("reports the error thrown by a preloaded plugin's onResolve for the entry point", async () => {
+    using dir = tempDir("bun-preload-plugin-throws", {
+      "plugin.js": `
+        Bun.plugin({
+          name: "refuse",
+          setup(build) {
+            build.onResolve({ filter: /main\\.js$/ }, () => {
+              throw new Error("refused by onResolve");
+            });
+          },
+        });
+      `,
+      "main.js": `console.log("RAN main");`,
+    });
+    const result = await run(dir, "--preload", "./plugin.js", "./main.js");
+
+    expect(result).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("error: refused by onResolve\n"),
+      exitCode: 1,
+    });
+  });
 });

--- a/test/cli/run/preload-test.test.js
+++ b/test/cli/run/preload-test.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, realpathSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { mkdirSync, realpathSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, canCreateNonUtf8FileNames, tempDir } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 const preloadModule = `
@@ -210,4 +210,31 @@ plugin({
       expect(exitCode).toBe(1);
     }
   });
+
+  test.skipIf(!canCreateNonUtf8FileNames())(
+    "throws an error when the preloaded module's path is not valid UTF-8",
+    async () => {
+      // The resolver finds the file, but its path does not survive becoming a
+      // module specifier, so loading it fails; that failure has to be reported.
+      using dir = tempDir("bun-preload-non-utf8", { "main.js": `console.log("RAN main");` });
+      writeFileSync(
+        Buffer.concat([Buffer.from(`${dir}/p`), Buffer.from([0xff]), Buffer.from(".js")]),
+        `console.log("RAN preload");`,
+      );
+
+      await using proc = Bun.spawn({
+        // A JS string cannot carry the raw byte into argv; the shell can.
+        cmd: ["sh", "-c", `exec "$0" --preload "./$(printf 'p\\377.js')" main.js`, bunExe()],
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+        env: bunEnv,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toBe("");
+      expect(stderr).toMatch(/error: Cannot find module '[^']*\/p\uFFFD\.js'\n/);
+      expect(exitCode).toBe(1);
+    },
+  );
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, canCreateNonUtf8FileNames, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, canCreateNonUtf8FileNames, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1750,40 +1750,97 @@ describe.concurrent("test file discovery (scanner)", () => {
   });
 });
 
-// Such a path does not survive becoming a module specifier, so the file cannot
-// be loaded (Node cannot load it either); what is tested here is that this is
-// reported as a failed file and the rest of the run still happens. The names
-// need Buffer paths, so they cannot be part of the tempDir tree.
-describe.concurrent.skipIf(!canCreateNonUtf8FileNames())("files whose path is not valid UTF-8", () => {
-  const invalidByte = Buffer.from([0xff]);
+// A scanned file, and each --preload, is handed to the module loader as the
+// specifier itself. When that specifier does not resolve, the failure used to
+// end the whole run: the file's header, then exit 1 with nothing else printed.
+// Each case below is one way to make such a specifier; what is asserted is that
+// the failure is reported under the file and the other files still run.
+describe.concurrent("test files and preloads the module loader cannot resolve", () => {
+  const passing = (name: string) =>
+    `import { test } from "bun:test"; test("t", () => { console.log("RAN ${name}"); });`;
 
-  test("a scanned test file that cannot be loaded fails without stopping the run", async () => {
-    using dir = tempDir("scanner-non-utf8-path", {
-      "a_first.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a_first"); });`,
-      "z_last.test.ts": `import { test } from "bun:test"; test("z", () => { console.log("RAN z_last"); });`,
-    });
-    const source = `import { test } from "bun:test"; test("t", () => { console.log("RAN unloadable"); });`;
-    const root = Buffer.from(String(dir) + "/");
-    // Once in the file name itself, once in a directory on the way to the file.
-    writeFileSync(Buffer.concat([root, Buffer.from("b"), invalidByte, Buffer.from(".test.ts")]), source);
-    const subdir = Buffer.concat([root, Buffer.from("dir"), invalidByte]);
-    mkdirSync(subdir);
-    writeFileSync(Buffer.concat([subdir, Buffer.from("/inner.test.ts")]), source);
-
+  async function runBunTest(dir: string, ...args: string[]) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test"],
+      cmd: [bunExe(), "test", ...args],
       env: bunEnv,
-      cwd: String(dir),
+      cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("a preload plugin whose onResolve throws for a file fails that file with the thrown error", async () => {
+    using dir = tempDir("unresolvable-plugin-throw", {
+      "plugin.ts": `
+        Bun.plugin({
+          name: "refuse",
+          setup(build) {
+            build.onResolve({ filter: /refused\\.test\\.ts$/ }, () => {
+              throw new Error("refused by onResolve");
+            });
+          },
+        });
+      `,
+      "a_first.test.ts": passing("a_first"),
+      "refused.test.ts": passing("refused"),
+      "z_last.test.ts": passing("z_last"),
+    });
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir), "--preload", "./plugin.ts");
+
+    expect(stdout).toContain("RAN a_first");
+    expect(stdout).toContain("RAN z_last");
+    expect(stdout).not.toContain("RAN refused");
+    expect(stderr).toContain("\nrefused.test.ts:\n");
+    expect(stderr).toContain("error: refused by onResolve\n");
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(stderr).toMatch(/\bacross 3 files\./);
+    expect(exitCode).toBe(1);
+  });
+
+  // '?' is not a legal file name character on Windows. Elsewhere the loader
+  // reads it as the start of a query string, so the file itself is not found.
+  test.skipIf(isWindows)("a file whose name contains '?' fails without stopping the run", async () => {
+    using dir = tempDir("unresolvable-question-mark", {
+      "a_first.test.ts": passing("a_first"),
+      "what?.test.ts": passing("what"),
+      "z_last.test.ts": passing("z_last"),
+    });
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
+
+    expect(stdout).toContain("RAN a_first");
+    expect(stdout).toContain("RAN z_last");
+    expect(stdout).not.toContain("RAN what");
+    expect(stderr).toContain("\nwhat?.test.ts:\n");
+    // Named as the entry point it was loaded as: no "from", nothing imported it.
+    expect(stderr).toMatch(/error: Cannot find module '[^']*\/what\?\.test\.ts'\n/);
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(stderr).toMatch(/\bacross 3 files\./);
+    expect(exitCode).toBe(1);
+  });
+
+  // Such a name only survives as raw bytes; as a specifier it holds U+FFFD and
+  // no longer names the file (Node cannot load it either). Buffer paths are the
+  // only way to create one, so these files cannot be part of the tempDir tree.
+  test.skipIf(!canCreateNonUtf8FileNames())("file and directory names that are not valid UTF-8", async () => {
+    using dir = tempDir("unresolvable-non-utf8", {
+      "a_first.test.ts": passing("a_first"),
+      "z_last.test.ts": passing("z_last"),
+    });
+    const invalidByte = Buffer.from([0xff]);
+    const root = Buffer.from(String(dir) + "/");
+    writeFileSync(Buffer.concat([root, Buffer.from("b"), invalidByte, Buffer.from(".test.ts")]), passing("unloadable"));
+    const subdir = Buffer.concat([root, Buffer.from("dir"), invalidByte]);
+    mkdirSync(subdir);
+    writeFileSync(Buffer.concat([subdir, Buffer.from("/inner.test.ts")]), passing("unloadable"));
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir));
 
     expect(stdout).toContain("RAN a_first");
     expect(stdout).toContain("RAN z_last");
     expect(stdout).not.toContain("RAN unloadable");
-    // Each unloadable file gets its header and a load error naming it (the
-    // invalid byte prints as U+FFFD), with no "from" since nothing imported it.
     expect(stderr).toContain("\nb\uFFFD.test.ts:\n");
     expect(stderr).toMatch(/error: Cannot find module '[^']*\/b\uFFFD\.test\.ts'\n/);
     expect(stderr).toContain("\ndir\uFFFD/inner.test.ts:\n");
@@ -1794,28 +1851,15 @@ describe.concurrent.skipIf(!canCreateNonUtf8FileNames())("files whose path is no
     expect(exitCode).toBe(1);
   });
 
-  test("--preload naming a file that cannot be loaded reports the error", async () => {
-    using dir = tempDir("preload-non-utf8-path", {
-      "a.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a"); });`,
-    });
-    writeFileSync(
-      Buffer.concat([Buffer.from(String(dir) + "/p"), invalidByte, Buffer.from(".ts")]),
-      `console.log("RAN preload");`,
-    );
+  // node: specifiers skip the file resolver, so the module loader is the first
+  // thing that rejects this one.
+  test("--preload of a node: module that does not exist reports it", async () => {
+    using dir = tempDir("unresolvable-node-preload", { "a.test.ts": passing("a") });
+    const { stdout, stderr, exitCode } = await runBunTest(String(dir), "--preload", "node:does_not_exist");
 
-    await using proc = Bun.spawn({
-      // A JS string cannot carry the raw byte into argv; the shell can.
-      cmd: ["sh", "-c", `exec "$0" test --preload "./$(printf 'p\\377.ts')"`, bunExe()],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stdout).not.toContain("RAN preload");
     expect(stdout).not.toContain("RAN a");
-    expect(stderr).toMatch(/error: Cannot find module '[^']*\/p\uFFFD\.ts'\n/);
+    expect(stderr).toContain("\na.test.ts:\n");
+    expect(stderr).toContain("error: No such built-in module: node:does_not_exist\n");
     expect(stderr).toContain(" 0 pass");
     expect(stderr).toContain(" 1 fail");
     expect(exitCode).toBe(1);

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, canCreateNonUtf8FileNames, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1747,5 +1747,77 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stdout).not.toContain("RAN other");
     expect(stderr).toContain(" 1 pass");
     expect(exitCode).toBe(0);
+  });
+});
+
+// Such a path does not survive becoming a module specifier, so the file cannot
+// be loaded (Node cannot load it either); what is tested here is that this is
+// reported as a failed file and the rest of the run still happens. The names
+// need Buffer paths, so they cannot be part of the tempDir tree.
+describe.concurrent.skipIf(!canCreateNonUtf8FileNames())("files whose path is not valid UTF-8", () => {
+  const invalidByte = Buffer.from([0xff]);
+
+  test("a scanned test file that cannot be loaded fails without stopping the run", async () => {
+    using dir = tempDir("scanner-non-utf8-path", {
+      "a_first.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a_first"); });`,
+      "z_last.test.ts": `import { test } from "bun:test"; test("z", () => { console.log("RAN z_last"); });`,
+    });
+    const source = `import { test } from "bun:test"; test("t", () => { console.log("RAN unloadable"); });`;
+    const root = Buffer.from(String(dir) + "/");
+    // Once in the file name itself, once in a directory on the way to the file.
+    writeFileSync(Buffer.concat([root, Buffer.from("b"), invalidByte, Buffer.from(".test.ts")]), source);
+    const subdir = Buffer.concat([root, Buffer.from("dir"), invalidByte]);
+    mkdirSync(subdir);
+    writeFileSync(Buffer.concat([subdir, Buffer.from("/inner.test.ts")]), source);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RAN a_first");
+    expect(stdout).toContain("RAN z_last");
+    expect(stdout).not.toContain("RAN unloadable");
+    // Each unloadable file gets its header and a load error naming it (the
+    // invalid byte prints as U+FFFD), with no "from" since nothing imported it.
+    expect(stderr).toContain("\nb\uFFFD.test.ts:\n");
+    expect(stderr).toMatch(/error: Cannot find module '[^']*\/b\uFFFD\.test\.ts'\n/);
+    expect(stderr).toContain("\ndir\uFFFD/inner.test.ts:\n");
+    expect(stderr).toMatch(/error: Cannot find module '[^']*\/dir\uFFFD\/inner\.test\.ts'\n/);
+    expect(stderr).toContain(" 2 pass");
+    expect(stderr).toContain(" 2 fail");
+    expect(stderr).toContain("Ran 4 tests across 4 files.");
+    expect(exitCode).toBe(1);
+  });
+
+  test("--preload naming a file that cannot be loaded reports the error", async () => {
+    using dir = tempDir("preload-non-utf8-path", {
+      "a.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a"); });`,
+    });
+    writeFileSync(
+      Buffer.concat([Buffer.from(String(dir) + "/p"), invalidByte, Buffer.from(".ts")]),
+      `console.log("RAN preload");`,
+    );
+
+    await using proc = Bun.spawn({
+      // A JS string cannot carry the raw byte into argv; the shell can.
+      cmd: ["sh", "-c", `exec "$0" test --preload "./$(printf 'p\\377.ts')"`, bunExe()],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).not.toContain("RAN preload");
+    expect(stdout).not.toContain("RAN a");
+    expect(stderr).toMatch(/error: Cannot find module '[^']*\/p\uFFFD\.ts'\n/);
+    expect(stderr).toContain(" 0 pass");
+    expect(stderr).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1790,7 +1790,7 @@ describe.concurrent.skipIf(!canCreateNonUtf8FileNames())("files whose path is no
     expect(stderr).toMatch(/error: Cannot find module '[^']*\/dir\uFFFD\/inner\.test\.ts'\n/);
     expect(stderr).toContain(" 2 pass");
     expect(stderr).toContain(" 2 fail");
-    expect(stderr).toContain("Ran 4 tests across 4 files.");
+    expect(stderr).toMatch(/\bacross 4 files\./);
     expect(exitCode).toBe(1);
   });
 

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,16 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  canCreateNonUtf8FileNames,
+  isASAN,
+  isDebug,
+  isWindows,
+  normalizeBunSnapshot,
+  tempDir,
+  tls,
+} from "harness";
+import { writeFileSync } from "node:fs";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -1133,6 +1144,50 @@ test("--parallel --reporter=junit emits a synthetic suite for crashed files", as
   const innerFail = [...xml.matchAll(/<testsuite [^>]*\bfailures="(\d+)"/g)].reduce((a, m) => a + Number(m[1]), 0);
   expect({ innerTests, innerFail }).toEqual({ innerTests: outerTests, innerFail: outerFail });
 });
+
+test.skipIf(!canCreateNonUtf8FileNames())(
+  "--parallel --reporter=junit writes a crashed file's non-UTF-8 path as U+FFFD",
+  async () => {
+    using dir = tempDir("parallel-junit-non-utf8-path", {
+      // Every worker exits while setting up its first file, so both files end
+      // up in the synthetic crashed suite, the one place the coordinator writes
+      // a path itself. (A file with such a path cannot be loaded at all, so it
+      // never gets a regular suite.)
+      "exit-preload.js": `process.exit(7);`,
+      "ok.test.js": `import {test} from "bun:test"; test("ok", () => {});`,
+    });
+    writeFileSync(
+      Buffer.concat([Buffer.from(String(dir) + "/b"), Buffer.from([0xff]), Buffer.from(".test.js")]),
+      `import {test} from "bun:test"; test("t", () => {});`,
+    );
+    const out = String(dir) + "/out.xml";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "test",
+        "--parallel=2",
+        "--preload",
+        "./exit-preload.js",
+        "--reporter=junit",
+        `--reporter-outfile=${out}`,
+      ],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("b\uFFFD.test.js (worker crashed: exit code 7)");
+
+    // The report declares encoding="UTF-8"; decoding it strictly is the first
+    // thing any XML parser does with it.
+    const xml = new TextDecoder("utf-8", { fatal: true }).decode(await Bun.file(out).bytes());
+    expect(xml).toContain('<testsuite name="b\uFFFD.test.js" file="b\uFFFD.test.js"');
+    expect(xml).toContain('<testcase name="(worker crashed)" classname="b\uFFFD.test.js">');
+    expect(xml).toContain('<testsuite name="ok.test.js"');
+    expect(exitCode).toBe(1);
+  },
+);
 
 test("--parallel: SIGTERM on coordinator kills workers and their grandchildren", async () => {
   const grandchild = `

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -289,7 +289,7 @@ export function canCreateNonUtf8FileNames(): boolean {
     if (isWindows) {
       canCreateNonUtf8FileNamesCached = false;
     } else {
-      const dir = fs.mkdtempSync(join(os.tmpdir(), "bun-non-utf8-name-probe-"));
+      const dir = tmpdirSync("bun-non-utf8-name-probe-");
       try {
         fs.writeFileSync(Buffer.concat([Buffer.from(dir + "/"), Buffer.from([0xff])]), "");
         canCreateNonUtf8FileNamesCached = fs.readdirSync(dir, { encoding: "buffer" }).some(name => name.includes(0xff));

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -276,6 +276,33 @@ export function canBuildNodeAddons(): boolean {
   return canBuildNodeAddonsCached;
 }
 
+let canCreateNonUtf8FileNamesCached: boolean | undefined;
+
+/**
+ * Whether the temp filesystem stores file names that are not valid UTF-8 byte
+ * for byte. Linux filesystems do, macOS's do not, and Windows names are UTF-16,
+ * so the situation does not exist there. Such a name can only be created by
+ * passing the path as a Buffer.
+ */
+export function canCreateNonUtf8FileNames(): boolean {
+  if (canCreateNonUtf8FileNamesCached === undefined) {
+    if (isWindows) {
+      canCreateNonUtf8FileNamesCached = false;
+    } else {
+      const dir = fs.mkdtempSync(join(os.tmpdir(), "bun-non-utf8-name-probe-"));
+      try {
+        fs.writeFileSync(Buffer.concat([Buffer.from(dir + "/"), Buffer.from([0xff])]), "");
+        canCreateNonUtf8FileNamesCached = fs.readdirSync(dir, { encoding: "buffer" }).some(name => name.includes(0xff));
+      } catch {
+        canCreateNonUtf8FileNamesCached = false;
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  }
+  return canCreateNonUtf8FileNamesCached;
+}
+
 export function shellExe(): string {
   return isWindows ? "pwsh" : "bash";
 }

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
 const xml2js = require("xml2js");
@@ -387,6 +387,46 @@ describe("junit reporter", () => {
     expect(suite.$.failures).toBe("1");
 
     expect(proc.exitCode).toBe(1);
+  });
+
+  it.skipIf(isWindows)("produces well-formed XML when a value taken from the OS is not valid UTF-8", async () => {
+    await using tmpDir = tempDir("junit-non-utf8", {
+      "package.json": "{}",
+      "ok.test.js": 'import { test } from "bun:test";\ntest("ok", () => {});\n',
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    // The commit property is copied from the environment as raw bytes, like
+    // file paths and the hostname are. A JS string cannot hold such a byte, so
+    // the shell puts it into the variable (on Windows the environment is
+    // UTF-16, so the situation does not exist there).
+    await using proc = spawn(
+      [
+        "sh",
+        "-c",
+        `GITHUB_SHA="$(printf 'abc\\377')" exec "$0" test --reporter=junit --reporter-outfile "$1"`,
+        bunExe(),
+        junitPath,
+      ],
+      {
+        cwd: tmpDir,
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(" 1 pass");
+
+    // The report declares encoding="UTF-8", so it has to decode as such; the
+    // invalid byte is written as U+FFFD, as the console already prints it.
+    const xmlContent = new TextDecoder("utf-8", { fatal: true }).decode(await file(junitPath).bytes());
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const properties = result.testsuites.testsuite[0].properties[0].property;
+    expect(properties.find(p => p.$.name === "commit").$.value).toBe("abc\uFFFD");
+    expect(exitCode).toBe(0);
   });
 
   it("produces well-formed XML when test names contain control characters", async () => {


### PR DESCRIPTION
### Problem

- `bun test` stops dead on a scanned test file whose specifier the module loader cannot resolve: the file's header is printed, then exit 1 with no error, no summary, no `--reporter-outfile`, and the remaining files never run. Ways to get such a file: a name or directory name with bytes that are not valid UTF-8, a `?` in the file name, or a preload plugin whose `onResolve` throws for it. `bun test --preload` with a specifier the loader refuses (`node:does_not_exist`, a non-UTF-8 path) does the same; `bun --preload node:does_not_exist main.js` prints only `Error occurred loading entry point: JSError`. Debug builds add `debug warn: Unhandled error: JSError`.
- Cause: the test runner and `--preload` hand the specifier to the module loader directly (`JSC__JSModuleLoader__loadAndEvaluateModule`, `JSModuleLoader__import`), and JSC resolves a direct load's specifier before it has a promise to reject (`vendor/WebKit/.../runtime/Completion.cpp:195`, `JSModuleLoader.cpp:445`), so that one failure is a thrown exception and the bindings return null. `reload_entry_point_for_test_runner` (`src/jsc/VirtualMachine.rs:4828`) and `load_preloads` (`src/runtime/jsc_hooks.rs:835`) turn null into a bare `CrateError::JSError`, and its handlers (`handle_top_level_test_error_before_javascript_start`, `src/runtime/cli/test_command.rs:3409`; `entry_point_load_failed`, `src/runtime/cli/run_command.rs:1652`) exit without printing the pending exception. Every later load failure (syntax error, missing import) arrives as a rejected promise and is reported.
- `moduleLoaderResolve` (`src/jsc/bindings/ZigGlobalObject.cpp:3611`) declares `ErrorableString res` with only `success` initialised. When the resolver returns because it already threw (a plugin's `onResolve` throwing is the reachable case) nothing writes `res`, and line 3685 threw an `Exception` built from the uninitialised `res.result.err`. For an entry point that is `panic(main thread): Segmentation fault at address 0x0` on current `bun --preload ./plugin.js ./main.js` (the second repro of #33408); for a test file it was hidden by the silent exit, and the first fix below would have turned it into the same crash.
- `bun test --parallel --reporter=junit` writes the synthetic crashed-file suite with the raw path bytes (`src/runtime/cli/test/parallel/aggregate.rs:68`), because `escape_xml` (`src/runtime/cli/test_command.rs:144`) works byte-wise; the hostname and the CI env vars written as `<property>` values are raw OS bytes too. The report declares `encoding="UTF-8"` but is not UTF-8, so parsers reject it (Python: `not well-formed (invalid token)`).

### Fix

- `JSModuleLoader::load_and_evaluate_module_ptr` / `import_ptr` (`src/jsc/JSModuleLoader.rs`): when the binding returns null, take the thrown exception and return a promise rejected with it, marked handled like the loader's own promises. `None` / `Err` are left for a pending termination exception, which is what they meant before in practice. This is the fixing change: `bun test` prints the error under the file's header, counts the file as failed, honours `--bail` and goes on to the next file (the same path a file with a missing import takes today); `bun run` prints the error and exits 1.
- Correct because failing to resolve is the same event as failing to fetch, link or evaluate, which JSC already delivers through the promise; only the first step leaks out as a throw. Converting it in the one place every direct load goes through covers the class instead of teaching each exit handler to print a pending exception. Marking the promise handled matters: the callers report the rejection themselves; unmarked, the rejection tracker would report it again.
- The two wrappers have six call sites and each already had a rejected-promise path: the test runner entry (`VirtualMachine.rs:4828`) and `load_preloads` (`jsc_hooks.rs:835`) are the cases above; `reload_entry_point` (`VirtualMachine.rs:2730`, and `:2753` under `BUN_DISABLE_TRANSPILER=1`) feeds `run_command`'s and the worker's rejected-entry reporting; the macro loader (`VirtualMachine.rs:5097`) reports through `unhandled_rejection` in `Macro.rs`; `bake/production.rs:339` re-throws the rejection and returns the same `JSError` it returned for a null, so it is unchanged in effect.
- `moduleLoaderResolve`: zero the struct and only throw `res.result.err` when no exception is pending, the shape `moduleLoaderImportModule` (the dynamic `import()` hook, `ZigGlobalObject.cpp:3750`) already has. The plugin's own error is what gets reported. #33408 carries the same two lines plus a separate `BunPlugin.cpp` fix for `onResolve` returning a rejected promise; it is needed here for the first change to be safe, and whichever lands second drops the duplicate hunk.
- `ResolveMessage::fmt`: with no referrer (entry points, preloads) the message is `Cannot find module 'x'` rather than `Cannot find module 'x' from ''`, which is Node's wording for an entry point. The only other way to reach the empty-referrer wording is `Bun.resolveSync(specifier, "")`, which drops the `from ''` as well; a real referrer takes the `imported from <path>` wording, untouched. Nothing in the suite asserts the `from ''` form.
- `escape_xml`: validate (simdutf) and, only for invalid input, write each ill-formed sequence as U+FFFD, which is how the console already prints these names (`bstr::BStr`). It is the one function every string in the report passes through, serial reporter and coordinator alike. #38249 edits the inside of the same loop (dropping U+FFFE/U+FFFF); the two hunks are independent. Test names and error text are already valid UTF-8 when they get here (lone surrogates are replaced earlier), so OS-sourced bytes are the only input this changes.
- Tests. Each fails on the unfixed build for the reason given and passes with this branch:
  - `test/cli/test/bun-test.test.ts`, "test files and preloads the module loader cannot resolve": a plugin whose `onResolve` throws for one of three files (the thrown message is reported, the other two run, 2 pass / 1 fail, exit 1; without the C++ change this case crashes), a `what?.test.ts` among two good files (skipped on Windows, where `?` is not a legal name), non-UTF-8 file and directory names (gated on the probe below), and `--preload node:does_not_exist` (`No such built-in module`, the file counted as failed). Before: the run aborted at the file, or exited with only the header.
  - `test/cli/run/preload-test.test.js`: `bun --preload node:does_not_exist main.js` prints the loader's error (before: `Error occurred loading entry point: JSError`); a preload plugin throwing for the entry point prints the plugin's error and exits 1 (before: segfault).
  - `test/cli/test/parallel.test.ts`: a preload that exits makes each worker die on its first file, so the coordinator writes the crashed suite for a non-UTF-8 path; the report must decode as strict UTF-8 and name the file with U+FFFD (before: a raw `0xFF` byte). A file with such a path can never produce a regular suite, so this is the one deterministic way to get the path into a report.
  - `test/js/junit-reporter/junit.test.js`: `GITHUB_SHA` holding a `0xFF` byte (set through `sh`; a JS string cannot hold one) comes out as `abc\uFFFD` in the `commit` property and the report parses (before: strict decode fails). Covers the serial reporter.
  - `test/harness.ts`: `canCreateNonUtf8FileNames()` probes whether the temp filesystem stores such a name byte for byte (Linux does, macOS does not, Windows names are UTF-16); the two tests that need one skip elsewhere. The plugin, `?` and `node:` cases run on every platform.
- Also run: the four touched test files in full, `test/cli/test/isolation.test.ts`, `test/js/bun/resolve/{resolve,resolve-error,import-meta-resolve,resolve-bad-parent,bun-main-entry-point,non-english-import}`, `test/js/web/workers/worker.test.ts`, `cargo clippy -p bun_jsc -p bun_runtime`, and the repros under `BUN_JSC_validateExceptionChecks=1`. The handful of timing tests that failed locally in `worker.test.ts` and `parallel.test.ts` fail the same way on a main build in the same container.
- #38258 fixes the test-runner entry case of the first bug at its call site in `VirtualMachine.rs`; this PR's wrapper-level change covers that site along with the others, so the two should not both land.

### Background

- Direct loads: `bun run` evaluates a generated entry module that imports the real file, so a bad entry path comes back as a rejected import and is printed. The test runner, `--preload`, macros and bake's config loader instead hand the specifier itself to the loader; all of those go through the two wrappers in `src/jsc/JSModuleLoader.rs`, and that is where JSC's synchronous resolve throw shows up.
- `moduleLoaderResolve` is the hook JSC calls to resolve a specifier for static imports and direct loads; it calls Bun's resolver, which runs `onResolve` plugins and, when one throws, leaves that exception pending and returns without filling in its out-parameter.
- Handled rejected promise: JSC tells the embedder about a promise rejected with no handler attached, and Bun reports those as unhandled rejections. The module loader marks the promises it hands back as handled because whoever asked for the load reports the outcome; the promise created here follows the same rule.
- `escape_xml` is the JUnit reporter's single output function for attribute values and text; under `--parallel` the coordinator concatenates the workers' reports and writes paths itself only for files whose worker died.

<details>
<summary>Before / after</summary>

Setup (Linux):

```sh
mkdir t && cd t && echo '{}' > package.json
printf 'import {test} from "bun:test"; test("ok", () => {});\n' > a.test.js
cp a.test.js "$(printf 'b\xff.test.js')"
cp a.test.js z.test.js
```

Before:

```
$ bun test
bun test v1.4.0-canary.1 (da3851e57)

a.test.js:
(pass) ok

b�.test.js:
$ echo $?
1
```

After:

```
$ bun test
a.test.js:
(pass) ok [1.78ms]

b�.test.js:

# Unhandled error between tests
-------------------------------
error: Cannot find module '/tmp/t/b�.test.js'
-------------------------------

z.test.js:
(pass) ok [1.22ms]

 2 pass
 1 fail
 1 error
Ran 3 tests across 3 files.
$ echo $?
1
```

Node 26 in the same directory (`node --test`, files written with `node:test`) reports the file the same way, runs the rest and exits 1:

```
✔ ok
Error: Cannot find module '/tmp/t/n�.test.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1519:15)
    ...
✖ n�.test.js
ℹ tests 2
ℹ pass 1
ℹ fail 1
```

Plugin whose `onResolve` throws for `*.test.js`, `bun test --preload ./plugin.js`. Before: `a.test.js:` then exit 1. After:

```
a.test.js:

# Unhandled error between tests
-------------------------------
5 |       throw new Error("onResolve refused this file");
                    ^
error: onResolve refused this file
      at <anonymous> (/tmp/t/plugin.js:5:17)
-------------------------------
...
 0 pass
 2 fail
```

Same plugin for the entry point, `bun --preload ./plugin.js ./main.js`. Before: `panic(main thread): Segmentation fault at address 0x0`, exit 139. After: `error: onResolve refused main.js`, exit 1.

`bun --preload node:nope a.js`. Before: `Error occurred loading entry point: JSError`. After: `error: No such built-in module: node:nope`.

`--parallel=2 --reporter=junit` with the non-UTF-8 file, before (`cat -v`; `M-^?` is the raw `0xFF` byte):

```
<testsuite name="bM-^?.test.js" file="bM-^?.test.js" tests="1" ...>
  <testcase name="(worker crashed)" classname="bM-^?.test.js">
```

After, the file is reported as a load error like in the serial run and the report parses; when a worker does die on such a file (the preload-exits case the test uses) the suite is written as `name="b\uFFFD.test.js"`.

</details>
