### PR TITLE
bundler: keep sqlite imports external when the loader comes from the extension or loader map

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -17,12 +17,9 @@ pub struct ImportRecord {
     pub path: Path<'static>,
     pub kind: ImportKind,
     pub tag: Tag,
-    /// Set by the parser from a `type` import attribute, and by the bundler when it
-    /// leaves an import to the runtime with a loader of its choosing. Resolution
-    /// reads it to pick the imported file's loader; the printer puts it back as a
-    /// `type` attribute on any import it prints. The loader resolution picks for a
-    /// bundled file is kept with the input file, not here, so a record the linker
-    /// later prints as an external import does not carry a stale one.
+    /// The loader a `type` import attribute asked for, or one the bundler wants the
+    /// runtime to apply to an import it left external; the printer re-emits it as
+    /// the attribute. A bundled file's loader lives on its input file, not here.
     pub loader: Option<Loader>,
 
     pub source_index: Index,

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -17,9 +17,8 @@ pub struct ImportRecord {
     pub path: Path<'static>,
     pub kind: ImportKind,
     pub tag: Tag,
-    /// The loader a `type` import attribute asked for, or one the bundler wants the
-    /// runtime to apply to an import it left external; the printer re-emits it as
-    /// the attribute. A bundled file's loader lives on its input file, not here.
+    /// Printed back as a `type` attribute: set by that attribute or for an import the
+    /// bundler leaves to the runtime, never to the loader of a bundled file.
     pub loader: Option<Loader>,
 
     pub source_index: Index,

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -17,6 +17,12 @@ pub struct ImportRecord {
     pub path: Path<'static>,
     pub kind: ImportKind,
     pub tag: Tag,
+    /// Set by the parser from a `type` import attribute, and by the bundler when it
+    /// leaves an import to the runtime with a loader of its choosing. Resolution
+    /// reads it to pick the imported file's loader; the printer puts it back as a
+    /// `type` attribute on any import it prints. The loader resolution picks for a
+    /// bundled file is kept with the input file, not here, so a record the linker
+    /// later prints as an external import does not carry a stale one.
     pub loader: Option<Loader>,
 
     pub source_index: Index,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6545,6 +6545,25 @@ pub mod bv2_impl {
                 };
                 import_record.loader = Some(import_record_loader);
 
+                // Same as the `with { type: "sqlite" }` case above, for databases the
+                // loader map (or a `.sqlite` extension) selects: the import stays as
+                // written and the printer re-attaches the type. Bundling the file would
+                // bake the build machine's absolute path into the output. Other targets
+                // still reach the parse task, which reports that sqlite needs target bun.
+                if import_record_loader == Loader::Sqlite
+                    && target.is_bun()
+                    && self.dev_server.is_none()
+                    && matches!(
+                        import_record.kind,
+                        ImportKind::Stmt | ImportKind::Require | ImportKind::Dynamic
+                    )
+                {
+                    import_record
+                        .flags
+                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                    continue;
+                }
+
                 let is_html_entrypoint = import_record_loader == Loader::Html
                     && target.is_server_side()
                     && self.dev_server.is_none();

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -716,6 +716,12 @@ pub mod bv2_impl {
                     path: &mut BunString,
                     is_on_load: bool,
                 ) -> bool;
+                #[link_name = "JSBundlerPlugin__anyOnBeforeParseMatches"]
+                safe fn JSBundlerPlugin__anyOnBeforeParseMatches(
+                    this: &Plugin,
+                    namespace: &mut BunString,
+                    path: &mut BunString,
+                ) -> bool;
                 // `context` is an opaque cookie C++ round-trips back to a Rust
                 // callback without dereferencing, so the only pointer validity
                 // obligations are on `this`/`BunString` — discharged by `&`.
@@ -803,18 +809,36 @@ pub mod bv2_impl {
                     path: &crate::bun_fs::Path,
                     is_on_load: bool,
                 ) -> bool {
-                    let mut namespace_string = if path.is_file() {
-                        BunString::empty()
-                    } else {
-                        BunString::clone_utf8(path.namespace)
-                    };
-                    let mut path_string = BunString::clone_utf8(path.text);
+                    let (mut namespace_string, mut path_string) = Self::filter_input(path);
                     JSBundlerPlugin__anyMatches(
                         self,
                         &mut namespace_string,
                         &mut path_string,
                         is_on_load,
                     )
+                }
+
+                /// Whether a native `onBeforeParse` plugin would run on the file.
+                pub(crate) fn has_any_on_before_parse_matches(
+                    &self,
+                    path: &crate::bun_fs::Path,
+                ) -> bool {
+                    let (mut namespace_string, mut path_string) = Self::filter_input(path);
+                    JSBundlerPlugin__anyOnBeforeParseMatches(
+                        self,
+                        &mut namespace_string,
+                        &mut path_string,
+                    )
+                }
+
+                /// The C++ side takes ownership of both strings.
+                fn filter_input(path: &crate::bun_fs::Path) -> (BunString, BunString) {
+                    let namespace_string = if path.is_file() {
+                        BunString::empty()
+                    } else {
+                        BunString::clone_utf8(path.namespace)
+                    };
+                    (namespace_string, BunString::clone_utf8(path.text))
                 }
 
                 pub(crate) fn match_on_load(
@@ -5955,7 +5979,7 @@ pub mod bv2_impl {
 
     impl BundleV2<'_> {
         /// The sqlite loader opens the database at runtime; bundling the file could only
-        /// print the build machine's path. An onLoad plugin for the file takes precedence.
+        /// print the build machine's path. A plugin that loads the file takes precedence.
         fn leaves_sqlite_import_to_runtime(
             &self,
             loader: Loader,
@@ -5970,9 +5994,10 @@ pub mod bv2_impl {
                     kind,
                     ImportKind::Stmt | ImportKind::Require | ImportKind::Dynamic
                 )
-                && !self
-                    .plugins_ref()
-                    .is_some_and(|plugins| plugins.has_any_matches(path, true))
+                && !self.plugins_ref().is_some_and(|plugins| {
+                    plugins.has_any_matches(path, true)
+                        || plugins.has_any_on_before_parse_matches(path)
+                })
         }
     }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2255,24 +2255,30 @@ pub mod bv2_impl {
                 ) {
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
-                    let has_dev_server = self.dev_server.is_some();
-                    let loader: Loader = {
-                        let record: &mut ImportRecord =
+                    let attribute_loader = self.graph.ast.items_import_records()
+                        [import_record.importer_source_index as usize]
+                        .as_slice()[import_record.import_record_index as usize]
+                        .loader;
+                    let loader: Loader = attribute_loader.unwrap_or_else(|| {
+                        // SAFETY: see `transpiler` note above.
+                        Fs::Path::init(path_primary.text)
+                            .loader(unsafe { &(*transpiler).options.loaders })
+                            .unwrap_or(Loader::File)
+                    });
+                    if self.leaves_sqlite_import_to_runtime(
+                        loader,
+                        &path_primary,
+                        import_record.kind,
+                        target,
+                    ) {
+                        mark_sqlite_import_external(
                             &mut self.graph.ast.items_import_records_mut()
                                 [import_record.importer_source_index as usize]
                                 .as_mut_slice()
-                                [import_record.import_record_index as usize];
-                        let loader = record.loader.unwrap_or_else(|| {
-                            // SAFETY: see `transpiler` note above.
-                            Fs::Path::init(path_primary.text)
-                                .loader(unsafe { &(*transpiler).options.loaders })
-                                .unwrap_or(Loader::File)
-                        });
-                        if keep_sqlite_import_external(record, loader, target, has_dev_server) {
-                            return;
-                        }
-                        loader
-                    };
+                                [import_record.import_record_index as usize],
+                        );
+                        return;
+                    }
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
                     // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
@@ -2491,21 +2497,23 @@ pub mod bv2_impl {
                 return;
             }
 
-            let has_dev_server = self.dev_server.is_some();
-            let loader: Loader = {
-                let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
-                    [import_record.importer_source_index as usize]
-                    .as_mut_slice()[import_record.import_record_index as usize];
-                let loader = record.loader.unwrap_or_else(|| {
-                    // SAFETY: see `transpiler` note above.
-                    path.loader(unsafe { &(*transpiler).options.loaders })
-                        .unwrap_or(Loader::File)
-                });
-                if keep_sqlite_import_external(record, loader, target, has_dev_server) {
-                    return;
-                }
-                loader
-            };
+            let attribute_loader = self.graph.ast.items_import_records()
+                [import_record.importer_source_index as usize]
+                .as_slice()[import_record.import_record_index as usize]
+                .loader;
+            let loader: Loader = attribute_loader.unwrap_or_else(|| {
+                // SAFETY: see `transpiler` note above.
+                path.loader(unsafe { &(*transpiler).options.loaders })
+                    .unwrap_or(Loader::File)
+            });
+            if self.leaves_sqlite_import_to_runtime(loader, &path, import_record.kind, target) {
+                mark_sqlite_import_external(
+                    &mut self.graph.ast.items_import_records_mut()
+                        [import_record.importer_source_index as usize]
+                        .as_mut_slice()[import_record.import_record_index as usize],
+                );
+                return;
+            }
 
             if path.pretty.as_ptr() == path.text.as_ptr() {
                 // TODO: outbase
@@ -5937,29 +5945,37 @@ pub mod bv2_impl {
         }
     }
 
-    /// Same output as `with { type: "sqlite" }`: the database is opened at runtime, and
-    /// bundling it would print the build machine's path. Other targets get the parse task's error.
-    fn keep_sqlite_import_external(
-        import_record: &mut ImportRecord,
-        loader: Loader,
-        target: options::Target,
-        has_dev_server: bool,
-    ) -> bool {
-        if loader != Loader::Sqlite
-            || !target.is_bun()
-            || has_dev_server
-            || !matches!(
-                import_record.kind,
-                ImportKind::Stmt | ImportKind::Require | ImportKind::Dynamic
-            )
-        {
-            return false;
-        }
+    /// The record `leaves_sqlite_import_to_runtime` approved prints as the import as
+    /// written plus `type: "sqlite"`, which is also what `with { type: "sqlite" }` produces.
+    fn mark_sqlite_import_external(import_record: &mut ImportRecord) {
         import_record.loader = Some(Loader::Sqlite);
         import_record
             .flags
             .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
-        true
+    }
+
+    impl BundleV2<'_> {
+        /// The sqlite loader opens the database at runtime, and bundling the file would
+        /// print the build machine's path. An onLoad plugin for the file still gets it,
+        /// and other targets still get the parse task's error.
+        fn leaves_sqlite_import_to_runtime(
+            &self,
+            loader: Loader,
+            path: &Fs::Path,
+            kind: ImportKind,
+            target: options::Target,
+        ) -> bool {
+            loader == Loader::Sqlite
+                && target.is_bun()
+                && self.dev_server.is_none()
+                && matches!(
+                    kind,
+                    ImportKind::Stmt | ImportKind::Require | ImportKind::Dynamic
+                )
+                && !self
+                    .plugins_ref()
+                    .is_some_and(|plugins| plugins.has_any_matches(path, true))
+        }
     }
 
     pub(crate) struct ResolveImportRecordCtx<'a> {
@@ -6207,12 +6223,13 @@ pub mod bv2_impl {
                                 .unwrap_or(Loader::File)
                         });
 
-                        if keep_sqlite_import_external(
-                            import_record,
+                        if self.leaves_sqlite_import_to_runtime(
                             import_record_loader,
+                            &path_primary,
+                            import_record.kind,
                             target,
-                            self.dev_server.is_some(),
                         ) {
+                            mark_sqlite_import_external(import_record);
                             continue;
                         }
 
@@ -6584,12 +6601,13 @@ pub mod bv2_impl {
                     break 'brk resolved_loader;
                 };
 
-                if keep_sqlite_import_external(
-                    import_record,
+                if self.leaves_sqlite_import_to_runtime(
                     import_record_loader,
+                    path,
+                    import_record.kind,
                     target,
-                    self.dev_server.is_some(),
                 ) {
+                    mark_sqlite_import_external(import_record);
                     continue;
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5937,14 +5937,10 @@ pub mod bv2_impl {
         }
     }
 
-    /// An import whose file the loader map (or a `.sqlite` extension) assigns the
-    /// sqlite loader is left to the runtime, like one written with
-    /// `with { type: "sqlite" }`: the loader opens the database at runtime, and
-    /// bundling the file would bake the build machine's absolute path into the
-    /// output. The record keeps the specifier as written, and `loader` makes the
-    /// printer add the type attribute back. Other targets go on to the parse
-    /// task, which reports that the loader needs target bun; the dev server
-    /// resolves imports itself and is left alone.
+    /// A database the loader map assigns the sqlite loader is opened at runtime, so
+    /// the import is left as written with the type attribute re-added, the same as
+    /// `with { type: "sqlite" }`; bundling it would print the build machine's path.
+    /// Other targets fall through to the parse task's "set target to bun" error.
     fn keep_sqlite_import_external(
         import_record: &mut ImportRecord,
         loader: Loader,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5937,10 +5937,8 @@ pub mod bv2_impl {
         }
     }
 
-    /// A database the loader map assigns the sqlite loader is opened at runtime, so
-    /// the import is left as written with the type attribute re-added, the same as
-    /// `with { type: "sqlite" }`; bundling it would print the build machine's path.
-    /// Other targets fall through to the parse task's "set target to bun" error.
+    /// Same output as `with { type: "sqlite" }`: the database is opened at runtime, and
+    /// bundling it would print the build machine's path. Other targets get the parse task's error.
     fn keep_sqlite_import_external(
         import_record: &mut ImportRecord,
         loader: Loader,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2255,6 +2255,24 @@ pub mod bv2_impl {
                 ) {
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
+                    let has_dev_server = self.dev_server.is_some();
+                    let loader: Loader = {
+                        let record: &mut ImportRecord =
+                            &mut self.graph.ast.items_import_records_mut()
+                                [import_record.importer_source_index as usize]
+                                .as_mut_slice()
+                                [import_record.import_record_index as usize];
+                        let loader = record.loader.unwrap_or_else(|| {
+                            // SAFETY: see `transpiler` note above.
+                            Fs::Path::init(path_primary.text)
+                                .loader(unsafe { &(*transpiler).options.loaders })
+                                .unwrap_or(Loader::File)
+                        });
+                        if keep_sqlite_import_external(record, loader, target, has_dev_server) {
+                            return;
+                        }
+                        loader
+                    };
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
                     // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
@@ -2270,20 +2288,6 @@ pub mod bv2_impl {
                         )
                     };
                     if !found_existing {
-                        let loader: Loader = 'brk: {
-                            let record: &mut ImportRecord =
-                                &mut self.graph.ast.items_import_records_mut()
-                                    [import_record.importer_source_index as usize]
-                                    .as_mut_slice()
-                                    [import_record.import_record_index as usize];
-                            if let Some(out_loader) = record.loader {
-                                break 'brk out_loader;
-                            }
-                            // SAFETY: see `transpiler` note above.
-                            break 'brk Fs::Path::init(path_primary.text)
-                                .loader(unsafe { &(*transpiler).options.loaders })
-                                .unwrap_or(Loader::File);
-                        };
                         // For virtual files, use the path text as-is (no relative path computation needed).
                         path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
                         let mut tmp_source = bun_ast::Source {
@@ -2487,6 +2491,22 @@ pub mod bv2_impl {
                 return;
             }
 
+            let has_dev_server = self.dev_server.is_some();
+            let loader: Loader = {
+                let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                    [import_record.importer_source_index as usize]
+                    .as_mut_slice()[import_record.import_record_index as usize];
+                let loader = record.loader.unwrap_or_else(|| {
+                    // SAFETY: see `transpiler` note above.
+                    path.loader(unsafe { &(*transpiler).options.loaders })
+                        .unwrap_or(Loader::File)
+                });
+                if keep_sqlite_import_external(record, loader, target, has_dev_server) {
+                    return;
+                }
+                loader
+            };
+
             if path.pretty.as_ptr() == path.text.as_ptr() {
                 // TODO: outbase
                 let rel = bun_paths::resolve_path::relative_platform::<
@@ -2518,19 +2538,6 @@ pub mod bv2_impl {
                 if let Some(p) = resolve_result.path() {
                     *p = path;
                 }
-                let loader: Loader = 'brk: {
-                    let record: &ImportRecord = &self.graph.ast.items_import_records()
-                        [import_record.importer_source_index as usize]
-                        .as_slice()[import_record.import_record_index as usize];
-                    if let Some(out_loader) = record.loader {
-                        break 'brk out_loader;
-                    }
-                    // SAFETY: see `transpiler` note above.
-                    break 'brk path
-                        .loader(unsafe { &(*transpiler).options.loaders })
-                        .unwrap_or(Loader::File);
-                    // HTML is only allowed at the entry point.
-                };
                 let mut tmp_source = bun_ast::Source {
                     path: path_as_static(&path.dupe_alloc(self.arena()).expect("oom")),
                     contents: std::borrow::Cow::Borrowed(&b""[..]),
@@ -5930,6 +5937,37 @@ pub mod bv2_impl {
         }
     }
 
+    /// An import whose file the loader map (or a `.sqlite` extension) assigns the
+    /// sqlite loader is left to the runtime, like one written with
+    /// `with { type: "sqlite" }`: the loader opens the database at runtime, and
+    /// bundling the file would bake the build machine's absolute path into the
+    /// output. The record keeps the specifier as written, and `loader` makes the
+    /// printer add the type attribute back. Other targets go on to the parse
+    /// task, which reports that the loader needs target bun; the dev server
+    /// resolves imports itself and is left alone.
+    fn keep_sqlite_import_external(
+        import_record: &mut ImportRecord,
+        loader: Loader,
+        target: options::Target,
+        has_dev_server: bool,
+    ) -> bool {
+        if loader != Loader::Sqlite
+            || !target.is_bun()
+            || has_dev_server
+            || !matches!(
+                import_record.kind,
+                ImportKind::Stmt | ImportKind::Require | ImportKind::Dynamic
+            )
+        {
+            return false;
+        }
+        import_record.loader = Some(Loader::Sqlite);
+        import_record
+            .flags
+            .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+        true
+    }
+
     pub(crate) struct ResolveImportRecordCtx<'a> {
         pub(crate) import_records: &'a mut [ImportRecord],
         pub(crate) source: &'a bun_ast::Source,
@@ -6174,7 +6212,15 @@ pub mod bv2_impl {
                                 .loader(&transpiler.options.loaders)
                                 .unwrap_or(Loader::File)
                         });
-                        import_record.loader = Some(import_record_loader);
+
+                        if keep_sqlite_import_external(
+                            import_record,
+                            import_record_loader,
+                            target,
+                            self.dev_server.is_some(),
+                        ) {
+                            continue;
+                        }
 
                         if let Some(id) =
                             self.path_to_source_index_map(target).get(path_primary.text)
@@ -6543,24 +6589,13 @@ pub mod bv2_impl {
                     }
                     break 'brk resolved_loader;
                 };
-                import_record.loader = Some(import_record_loader);
 
-                // Same as the `with { type: "sqlite" }` case above, for databases the
-                // loader map (or a `.sqlite` extension) selects: the import stays as
-                // written and the printer re-attaches the type. Bundling the file would
-                // bake the build machine's absolute path into the output. Other targets
-                // still reach the parse task, which reports that sqlite needs target bun.
-                if import_record_loader == Loader::Sqlite
-                    && target.is_bun()
-                    && self.dev_server.is_none()
-                    && matches!(
-                        import_record.kind,
-                        ImportKind::Stmt | ImportKind::Require | ImportKind::Dynamic
-                    )
-                {
-                    import_record
-                        .flags
-                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                if keep_sqlite_import_external(
+                    import_record,
+                    import_record_loader,
+                    target,
+                    self.dev_server.is_some(),
+                ) {
                     continue;
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5945,8 +5945,7 @@ pub mod bv2_impl {
         }
     }
 
-    /// The record `leaves_sqlite_import_to_runtime` approved prints as the import as
-    /// written plus `type: "sqlite"`, which is also what `with { type: "sqlite" }` produces.
+    /// Prints like `with { type: "sqlite" }` does.
     fn mark_sqlite_import_external(import_record: &mut ImportRecord) {
         import_record.loader = Some(Loader::Sqlite);
         import_record
@@ -5955,9 +5954,8 @@ pub mod bv2_impl {
     }
 
     impl BundleV2<'_> {
-        /// The sqlite loader opens the database at runtime, and bundling the file would
-        /// print the build machine's path. An onLoad plugin for the file still gets it,
-        /// and other targets still get the parse task's error.
+        /// The sqlite loader opens the database at runtime; bundling the file could only
+        /// print the build machine's path. An onLoad plugin for the file takes precedence.
         fn leaves_sqlite_import_to_runtime(
             &self,
             loader: Loader,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1358,6 +1358,35 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
     }
 }
 
+/// `loader` as the value of a `type` import attribute; the runtime maps it back
+/// with `Loader::from_string` when it loads an import the printed code left to it.
+fn import_attribute_type(loader: bun_ast::Loader) -> &'static [u8] {
+    use bun_ast::Loader;
+    match loader {
+        Loader::Jsx => b"jsx",
+        Loader::Js => b"js",
+        Loader::Ts => b"ts",
+        Loader::Tsx => b"tsx",
+        Loader::Css => b"css",
+        Loader::File => b"file",
+        Loader::Json => b"json",
+        Loader::Jsonc => b"jsonc",
+        Loader::Toml => b"toml",
+        Loader::Yaml => b"yaml",
+        Loader::Json5 => b"json5",
+        Loader::Xml => b"xml",
+        Loader::Wasm => b"wasm",
+        Loader::Napi => b"napi",
+        Loader::Base64 => b"base64",
+        Loader::Dataurl => b"dataurl",
+        Loader::Text => b"text",
+        Loader::Bunsh => b"sh",
+        Loader::Sqlite | Loader::SqliteEmbedded => b"sqlite",
+        Loader::Html => b"html",
+        Loader::Md => b"md",
+    }
+}
+
 pub enum PrintResult {
     Result(PrintResultSuccess),
     Err(crate::Error),
@@ -2681,6 +2710,13 @@ pub(crate) mod __gated_printer {
 
                 self.print(b"(");
                 self.print_import_record_path(record);
+                if IS_BUN_PLATFORM {
+                    if let Some(loader) = record.loader {
+                        self.print_whitespacer(ws!(b", { type: \""));
+                        self.print(import_attribute_type(loader));
+                        self.print_whitespacer(ws!(b"\" }"));
+                    }
+                }
                 self.print(b")");
 
                 if wrap_with_to_esm {
@@ -2714,6 +2750,12 @@ pub(crate) mod __gated_printer {
             if !import_options.is_missing() {
                 self.print_whitespacer(ws!(b", "));
                 self.print_expr(import_options, Level::Comma, ExprFlagSet::empty());
+            } else if IS_BUN_PLATFORM && module_type != bundle_opts::Format::InternalBakeDev {
+                if let Some(loader) = record.loader {
+                    self.print_whitespacer(ws!(b", { with: { type: \""));
+                    self.print(import_attribute_type(loader));
+                    self.print_whitespacer(ws!(b"\" } }"));
+                }
             }
 
             self.print(b")");
@@ -5859,72 +5901,9 @@ pub(crate) mod __gated_printer {
                     // backwards compatibility: previously, we always stripped type
                     if IS_BUN_PLATFORM {
                         if let Some(loader) = record.loader {
-                            use bun_ast::Loader;
-                            match loader {
-                                Loader::Jsx => {
-                                    self.print_whitespacer(ws!(b" with { type: \"jsx\" }"))
-                                }
-                                Loader::Js => {
-                                    self.print_whitespacer(ws!(b" with { type: \"js\" }"))
-                                }
-                                Loader::Ts => {
-                                    self.print_whitespacer(ws!(b" with { type: \"ts\" }"))
-                                }
-                                Loader::Tsx => {
-                                    self.print_whitespacer(ws!(b" with { type: \"tsx\" }"))
-                                }
-                                Loader::Css => {
-                                    self.print_whitespacer(ws!(b" with { type: \"css\" }"))
-                                }
-                                Loader::File => {
-                                    self.print_whitespacer(ws!(b" with { type: \"file\" }"))
-                                }
-                                Loader::Json => {
-                                    self.print_whitespacer(ws!(b" with { type: \"json\" }"))
-                                }
-                                Loader::Jsonc => {
-                                    self.print_whitespacer(ws!(b" with { type: \"jsonc\" }"))
-                                }
-                                Loader::Toml => {
-                                    self.print_whitespacer(ws!(b" with { type: \"toml\" }"))
-                                }
-                                Loader::Yaml => {
-                                    self.print_whitespacer(ws!(b" with { type: \"yaml\" }"))
-                                }
-                                Loader::Json5 => {
-                                    self.print_whitespacer(ws!(b" with { type: \"json5\" }"))
-                                }
-                                Loader::Xml => {
-                                    self.print_whitespacer(ws!(b" with { type: \"xml\" }"))
-                                }
-                                Loader::Wasm => {
-                                    self.print_whitespacer(ws!(b" with { type: \"wasm\" }"))
-                                }
-                                Loader::Napi => {
-                                    self.print_whitespacer(ws!(b" with { type: \"napi\" }"))
-                                }
-                                Loader::Base64 => {
-                                    self.print_whitespacer(ws!(b" with { type: \"base64\" }"))
-                                }
-                                Loader::Dataurl => {
-                                    self.print_whitespacer(ws!(b" with { type: \"dataurl\" }"))
-                                }
-                                Loader::Text => {
-                                    self.print_whitespacer(ws!(b" with { type: \"text\" }"))
-                                }
-                                Loader::Bunsh => {
-                                    self.print_whitespacer(ws!(b" with { type: \"sh\" }"))
-                                }
-                                Loader::Sqlite | Loader::SqliteEmbedded => {
-                                    self.print_whitespacer(ws!(b" with { type: \"sqlite\" }"))
-                                }
-                                Loader::Html => {
-                                    self.print_whitespacer(ws!(b" with { type: \"html\" }"))
-                                }
-                                Loader::Md => {
-                                    self.print_whitespacer(ws!(b" with { type: \"md\" }"))
-                                }
-                            }
+                            self.print_whitespacer(ws!(b" with { type: \""));
+                            self.print(import_attribute_type(loader));
+                            self.print_whitespacer(ws!(b"\" }"));
                         }
                     }
                     self.print_semicolon_after_statement();
@@ -5939,35 +5918,12 @@ pub(crate) mod __gated_printer {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let irp_id = mi.str(import_record_path);
                             let fetch_parameters: FP = if IS_BUN_PLATFORM {
-                                if let Some(loader) = record.loader {
-                                    use bun_ast::Loader;
-                                    match loader {
-                                        Loader::Json => FP::Json,
-                                        Loader::Jsx => FP::host_defined(mi.str(b"jsx")),
-                                        Loader::Js => FP::host_defined(mi.str(b"js")),
-                                        Loader::Ts => FP::host_defined(mi.str(b"ts")),
-                                        Loader::Tsx => FP::host_defined(mi.str(b"tsx")),
-                                        Loader::Css => FP::host_defined(mi.str(b"css")),
-                                        Loader::File => FP::host_defined(mi.str(b"file")),
-                                        Loader::Jsonc => FP::host_defined(mi.str(b"jsonc")),
-                                        Loader::Toml => FP::host_defined(mi.str(b"toml")),
-                                        Loader::Yaml => FP::host_defined(mi.str(b"yaml")),
-                                        Loader::Wasm => FP::host_defined(mi.str(b"wasm")),
-                                        Loader::Napi => FP::host_defined(mi.str(b"napi")),
-                                        Loader::Base64 => FP::host_defined(mi.str(b"base64")),
-                                        Loader::Dataurl => FP::host_defined(mi.str(b"dataurl")),
-                                        Loader::Text => FP::host_defined(mi.str(b"text")),
-                                        Loader::Bunsh => FP::host_defined(mi.str(b"sh")),
-                                        Loader::Sqlite | Loader::SqliteEmbedded => {
-                                            FP::host_defined(mi.str(b"sqlite"))
-                                        }
-                                        Loader::Html => FP::host_defined(mi.str(b"html")),
-                                        Loader::Json5 => FP::host_defined(mi.str(b"json5")),
-                                        Loader::Xml => FP::host_defined(mi.str(b"xml")),
-                                        Loader::Md => FP::host_defined(mi.str(b"md")),
+                                match record.loader {
+                                    None => FP::None,
+                                    Some(bun_ast::Loader::Json) => FP::Json,
+                                    Some(loader) => {
+                                        FP::host_defined(mi.str(import_attribute_type(loader)))
                                     }
-                                } else {
-                                    FP::None
                                 }
                             } else {
                                 FP::None

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1358,8 +1358,8 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
     }
 }
 
-/// `loader` as the value of a `type` import attribute; the runtime maps it back
-/// with `Loader::from_string` when it loads an import the printed code left to it.
+/// `ImportRecord::loader` as the value of a `type` import attribute; the runtime
+/// maps it back with `Loader::from_string` when it loads the printed import.
 fn import_attribute_type(loader: bun_ast::Loader) -> &'static [u8] {
     use bun_ast::Loader;
     match loader {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1358,8 +1358,7 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
     }
 }
 
-/// `ImportRecord::loader` as the value of a `type` import attribute; the runtime
-/// maps it back with `Loader::from_string` when it loads the printed import.
+/// The `type` import attribute value `Loader::from_string` maps back to `loader`.
 fn import_attribute_type(loader: bun_ast::Loader) -> &'static [u8] {
     use bun_ast::Loader;
     match loader {

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -77,7 +77,9 @@ void BundlerPlugin::NamespaceList::append(JSC::VM& vm, JSC::RegExp* filter, Stri
     nsGroup->append(WTF::move(filter_regexp));
 }
 
-static bool anyMatchesForNamespace(JSC::VM& vm, BundlerPlugin::NamespaceList& list, BunString* namespaceStr, BunString* path)
+// `List` is `NamespaceList` (onLoad / onResolve) or `NativePluginList` (onBeforeParse).
+template<typename List>
+static bool anyMatchesForNamespace(JSC::VM& vm, List& list, BunString* namespaceStr, BunString* path)
 {
     auto namespaceString = namespaceStr ? namespaceStr->transferToWTFString() : String();
     auto pathString = path->transferToWTFString();
@@ -522,6 +524,11 @@ void JSBundlerPlugin::finishCreation(JSC::VM& vm)
 extern "C" bool JSBundlerPlugin__anyMatches(Bun::JSBundlerPlugin* pluginObject, BunString* namespaceString, BunString* path, bool isOnLoad)
 {
     return pluginObject->plugin.anyMatchesCrossThread(pluginObject->vm(), namespaceString, path, isOnLoad);
+}
+
+extern "C" bool JSBundlerPlugin__anyOnBeforeParseMatches(Bun::JSBundlerPlugin* pluginObject, BunString* namespaceString, BunString* path)
+{
+    return anyMatchesForNamespace(pluginObject->vm(), pluginObject->plugin.onBeforeParse, namespaceString, path);
 }
 
 extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, BunString* namespaceString, BunString* path, void* context, uint8_t defaultLoaderId, bool isServerSide)

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -1,5 +1,7 @@
 import { Database } from "bun:sqlite";
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -183,4 +185,177 @@ error: Hello World`,
       });
     }
   }
+
+  // The sqlite loader is also selected without an import attribute: by a `.sqlite`
+  // extension, `--loader .db:sqlite`, bunfig `[loader]` or `Bun.build({ loader })`.
+  // The database is never part of the bundle, so the import has to stay as
+  // written (it is resolved next to the bundle at runtime) and carry the type,
+  // the same as `with { type: "sqlite" }`. It used to be bundled as a module
+  // holding the absolute path of the file on the build machine.
+  describe("sqlite loader selected by extension or loader map", () => {
+    function database(message: string): Buffer {
+      const db = new Database(":memory:");
+      db.run("create table messages (message text)");
+      db.run("insert into messages values (?)", [message]);
+      return db.serialize();
+    }
+    // The file that exists while bundling and the one next to the bundle hold
+    // different rows, so the program's output tells which file the bundle opens.
+    const buildTimeCopy = database("build-time copy");
+    const runtimeCopy = database("copy next to the bundle");
+    const entry = (load: string) => /* js */ `
+      ${load}
+      console.log(db.query("select message from messages").get().message);
+    `;
+
+    itBundled("bun/sqlite-extension-import", {
+      target: "bun",
+      files: {
+        "/src/entry.ts": entry(`import db from './db.sqlite';`),
+        "/src/db.sqlite": buildTimeCopy,
+      },
+      runtimeFiles: { "/db.sqlite": runtimeCopy },
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toMatch(/^import \w+ from "\.\/db\.sqlite" with \{ type: "sqlite" \};$/m);
+        expect(out).not.toContain("import.meta.require");
+      },
+      run: { stdout: "copy next to the bundle" },
+    });
+
+    itBundled("bun/sqlite-extension-import-cjs", {
+      target: "bun",
+      format: "cjs",
+      files: {
+        "/src/entry.ts": entry(`import db from './db.sqlite';`),
+        "/src/db.sqlite": buildTimeCopy,
+      },
+      runtimeFiles: { "/db.sqlite": runtimeCopy },
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toContain('require("./db.sqlite", { type: "sqlite" })');
+        expect(out).not.toContain("import.meta");
+      },
+      run: { stdout: "copy next to the bundle" },
+    });
+
+    itBundled("bun/sqlite-extension-require", {
+      target: "bun",
+      minifyWhitespace: true,
+      files: {
+        "/src/entry.ts": entry(`const { db } = require('./db.sqlite');`),
+        "/src/db.sqlite": buildTimeCopy,
+      },
+      runtimeFiles: { "/db.sqlite": runtimeCopy },
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toContain('require("./db.sqlite",{type:"sqlite"})');
+      },
+      run: { stdout: "copy next to the bundle" },
+    });
+
+    itBundled("bun/sqlite-extension-dynamic-import", {
+      target: "bun",
+      files: {
+        "/src/entry.ts": entry(`const { default: db } = await import('./db.sqlite');`),
+        "/src/db.sqlite": buildTimeCopy,
+      },
+      runtimeFiles: { "/db.sqlite": runtimeCopy },
+      onAfterBundle(api) {
+        api.expectFile("/out.js").toContain('import("./db.sqlite", { with: { type: "sqlite" } })');
+      },
+      run: { stdout: "copy next to the bundle" },
+    });
+
+    // External without side effects, like the attribute form: an unused import
+    // does not make the bundle open the database.
+    itBundled("bun/sqlite-extension-unused-import", {
+      target: "bun",
+      files: {
+        "/src/entry.ts": /* js */ `
+          import db from './db.sqlite';
+          console.log("unused");
+        `,
+        "/src/db.sqlite": buildTimeCopy,
+      },
+      onAfterBundle(api) {
+        api.expectFile("/out.js").not.toContain("db.sqlite");
+      },
+      run: { stdout: "unused" },
+    });
+
+    // `.db` is not a sqlite extension by itself; these map it through each of
+    // the loader-map surfaces.
+    const loaderMapProject = {
+      "src/entry.ts": entry(`import db from "./app.db";`),
+      "src/app.db": buildTimeCopy,
+      "out/app.db": runtimeCopy,
+    };
+
+    async function bunBuild(dir: string, ...args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "./src/entry.ts", "--outfile", "./out/entry.js", ...args],
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stderr, exitCode };
+    }
+
+    async function expectExternalSqliteImport(dir: string, bundle: string) {
+      expect(bundle).toMatch(/^import \w+ from "\.\/app\.db" with \{ type: "sqlite" \};$/m);
+      expect(bundle).not.toContain("import.meta.require");
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(dir, "out/entry.js")],
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("copy next to the bundle\n");
+      expect(exitCode).toBe(0);
+    }
+
+    test.concurrent("--loader .db:sqlite", async () => {
+      using dir = tempDir("sqlite-loader-flag", loaderMapProject);
+      const { stderr, exitCode } = await bunBuild(String(dir), "--target", "bun", "--loader", ".db:sqlite");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      await expectExternalSqliteImport(String(dir), await Bun.file(join(String(dir), "out/entry.js")).text());
+    });
+
+    test.concurrent("bunfig [loader]", async () => {
+      using dir = tempDir("sqlite-loader-bunfig", {
+        ...loaderMapProject,
+        "bunfig.toml": `[loader]\n".db" = "sqlite"\n`,
+      });
+      const { stderr, exitCode } = await bunBuild(String(dir), "--target", "bun");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      await expectExternalSqliteImport(String(dir), await Bun.file(join(String(dir), "out/entry.js")).text());
+    });
+
+    test.concurrent("Bun.build({ loader })", async () => {
+      using dir = tempDir("sqlite-loader-api", loaderMapProject);
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "src/entry.ts")],
+        outdir: join(String(dir), "out"),
+        target: "bun",
+        loader: { ".db": "sqlite" as any },
+      });
+      expect(result.outputs.map(output => output.path)).toEqual([join(String(dir), "out/entry.js")]);
+      await expectExternalSqliteImport(String(dir), await result.outputs[0].text());
+    });
+
+    test.concurrent("still requires target bun", async () => {
+      using dir = tempDir("sqlite-loader-node-target", loaderMapProject);
+      const { stderr, exitCode } = await bunBuild(String(dir), "--target", "node", "--loader", ".db:sqlite");
+      expect(stderr).toContain('To use the "sqlite" loader, set target to "bun"');
+      expect(exitCode).toBe(1);
+    });
+  });
 });

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -1,3 +1,4 @@
+import type { BunPlugin } from "bun";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
@@ -339,23 +340,108 @@ error: Hello World`,
       await expectExternalSqliteImport(String(dir), await Bun.file(join(String(dir), "out/entry.js")).text());
     });
 
-    test.concurrent("Bun.build({ loader })", async () => {
-      using dir = tempDir("sqlite-loader-api", loaderMapProject);
-      const result = await Bun.build({
-        entrypoints: [join(String(dir), "src/entry.ts")],
-        outdir: join(String(dir), "out"),
-        target: "bun",
-        loader: { ".db": "sqlite" as any },
+    // The bundler resolves imports on three paths: directly, after an onResolve
+    // plugin matched but returned nothing, and against `files` (in memory); each
+    // path picks the loader itself.
+    const passthroughPlugin: BunPlugin = {
+      name: "passthrough",
+      setup(build) {
+        build.onResolve({ filter: /.*/ }, () => undefined);
+      },
+    };
+    const variants: [string, { plugins?: BunPlugin[]; inMemoryDatabase?: boolean }][] = [
+      ["Bun.build({ loader })", {}],
+      ["Bun.build({ loader, plugins })", { plugins: [passthroughPlugin] }],
+      ["Bun.build({ loader, files })", { inMemoryDatabase: true }],
+      ["Bun.build({ loader, files, plugins })", { inMemoryDatabase: true, plugins: [passthroughPlugin] }],
+    ];
+    for (const [name, { plugins, inMemoryDatabase }] of variants) {
+      test.concurrent(name, async () => {
+        const { "src/app.db": _, ...withoutDatabaseOnDisk } = loaderMapProject;
+        using dir = tempDir("sqlite-loader-api", inMemoryDatabase ? withoutDatabaseOnDisk : loaderMapProject);
+        const result = await Bun.build({
+          entrypoints: [join(String(dir), "src/entry.ts")],
+          outdir: join(String(dir), "out"),
+          target: "bun",
+          loader: { ".db": "sqlite" as any },
+          ...(plugins && { plugins }),
+          ...(inMemoryDatabase && { files: { [join(String(dir), "src/app.db")]: buildTimeCopy } }),
+        });
+        expect(result.outputs.map(output => output.path)).toEqual([join(String(dir), "out/entry.js")]);
+        await expectExternalSqliteImport(String(dir), await result.outputs[0].text());
       });
-      expect(result.outputs.map(output => output.path)).toEqual([join(String(dir), "out/entry.js")]);
-      await expectExternalSqliteImport(String(dir), await result.outputs[0].text());
-    });
+    }
 
     test.concurrent("still requires target bun", async () => {
       using dir = tempDir("sqlite-loader-node-target", loaderMapProject);
       const { stderr, exitCode } = await bunBuild(String(dir), "--target", "node", "--loader", ".db:sqlite");
       expect(stderr).toContain('To use the "sqlite" loader, set target to "bun"');
       expect(exitCode).toBe(1);
+    });
+  });
+
+  // For target bun the printer puts an import record's loader back on the import
+  // as `with { type }` (and `require(path, { type })` / `import(path, { with })`).
+  // Only a loader that came from an import attribute, or from the bundler leaving
+  // the import to the runtime on purpose, may be printed: the loader the bundler
+  // resolved for a file it bundled must not leak onto imports the linker later
+  // turns external, where the runtime would apply it to a different file.
+  describe("type attributes on imports the linker makes external", () => {
+    // `--splitting` rewrites a dynamic import of a bundled file into an import of
+    // the chunk that holds it, which is JavaScript whatever the file was.
+    itBundled("bun/splitting-dynamic-import-does-not-carry-the-loader", {
+      target: "bun",
+      splitting: true,
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `
+          const { default: data } = await import("./data.json");
+          const { page } = await import("./page.ts");
+          console.log(data.answer, page);
+        `,
+        "/data.json": `{ "answer": 42 }`,
+        "/page.ts": `export const page: string = "page";`,
+      },
+      onAfterBundle(api) {
+        const imports = api.readFile("/out/entry.js").match(/\bimport\(.*\)/g);
+        expect(imports).toHaveLength(2);
+        for (const call of imports!) {
+          expect(call).toMatch(/^import\("\.\/(data|page)-\w+\.js"\)$/);
+        }
+      },
+      run: { file: "/out/entry.js", stdout: "42 page" },
+    });
+
+    // A file consisting of `module.exports = require(x)` is collapsed: imports of
+    // it are redirected to x. When x is external, they are printed as imports of
+    // x and must not carry the loader of the collapsed file. At runtime the
+    // external resolves to a TypeScript file here, which `type: "js"` would
+    // fail to parse.
+    itBundled("bun/redirect-to-external-does-not-carry-the-loader", {
+      target: "bun",
+      external: ["some-ext"],
+      files: {
+        "/entry.ts": /* js */ `
+          import * as viaImport from "./shim.cjs";
+          const viaRequire = require("./shim.cjs");
+          const viaDynamicImport = await import("./shim.cjs");
+          console.log(viaImport.value, viaRequire.value, viaDynamicImport.value);
+        `,
+        "/shim.cjs": `module.exports = require("some-ext");`,
+      },
+      runtimeFiles: {
+        "/node_modules/some-ext/package.json": `{ "name": "some-ext", "main": "index.ts" }`,
+        "/node_modules/some-ext/index.ts": `export const value: string = "from some-ext";`,
+      },
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out.match(/^.*"some-ext".*$/gm)).toEqual([
+          'import * as viaImport from "some-ext";',
+          'var viaRequire = __require("some-ext");',
+          'var viaDynamicImport = await import("some-ext");',
+        ]);
+      },
+      run: { stdout: "from some-ext from some-ext from some-ext" },
     });
   });
 });

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -372,6 +372,33 @@ error: Hello World`,
       });
     }
 
+    // An onLoad plugin for the file takes precedence over the loader, as it
+    // does for every other loader.
+    test.concurrent("an onLoad plugin still receives the file", async () => {
+      using dir = tempDir("sqlite-loader-onload", {
+        "src/entry.ts": `import db from "./app.sqlite";\nconsole.log(db);\n`,
+        "src/app.sqlite": buildTimeCopy,
+      });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "src/entry.ts")],
+        target: "bun",
+        plugins: [
+          {
+            name: "schema",
+            setup(build) {
+              build.onLoad({ filter: /\.sqlite$/ }, () => ({
+                contents: `export default "generated from the database";`,
+                loader: "js",
+              }));
+            },
+          },
+        ],
+      });
+      const bundle = await result.outputs[0].text();
+      expect(bundle).toContain("generated from the database");
+      expect(bundle).not.toContain('from "./app.sqlite"');
+    });
+
     test.concurrent("still requires target bun", async () => {
       using dir = tempDir("sqlite-loader-node-target", loaderMapProject);
       const { stderr, exitCode } = await bunBuild(String(dir), "--target", "node", "--loader", ".db:sqlite");

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -815,4 +815,49 @@ console.log(JSON.stringify(json))
       expect(result.success).toBeTrue();
     });
   }
+
+  // For target bun, an import of a file with the sqlite loader is normally left
+  // external (the database is opened at runtime) unless a plugin loads the file.
+  describe("sqlite loader", () => {
+    const project = {
+      "index.ts": /* ts */ `import db from "./app.sqlite";\nconsole.log(typeof db);`,
+      // Not a real database: the sqlite loader never reads the contents, but the
+      // plugin counts the "foo"s in whatever it receives.
+      "app.sqlite": "foo foo foo",
+    };
+
+    const addon = () => require(path.join(tempdir, "build/Release/xXx123_foo_counter_321xXx.node"));
+
+    async function buildWithFilter(filter: RegExp) {
+      const napiModule = addon();
+      const external = napiModule.createExternal();
+      const dir = tempDirWithFiles("native-plugin-sqlite", project);
+      const result = await Bun.build({
+        target: "bun",
+        entrypoints: [path.join(dir, "index.ts")],
+        plugins: [
+          {
+            name: "xXx123_foo_counter_321xXx",
+            setup(build) {
+              build.onBeforeParse({ filter }, { napiModule, symbol: "plugin_impl", external });
+            },
+          },
+        ],
+      });
+      expect(result.success).toBeTrue();
+      return { fooCount: napiModule.getFooCount(external), bundle: await result.outputs[0].text() };
+    }
+
+    it("a native plugin whose filter matches the file still receives it", async () => {
+      const { fooCount, bundle } = await buildWithFilter(/\.sqlite$/);
+      expect(fooCount).toBe(3);
+      expect(bundle).not.toContain('from "./app.sqlite"');
+    });
+
+    it("a native plugin for other files leaves the import external", async () => {
+      const { fooCount, bundle } = await buildWithFilter(/\.ts$/);
+      expect(fooCount).toBe(0);
+      expect(bundle).toContain('from "./app.sqlite" with { type: "sqlite" }');
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `bun build --target bun` with the sqlite loader selected by extension or loader map (`--loader .db:sqlite`, bunfig `[loader] ".db" = "sqlite"`, `Bun.build({ loader: { ".db": "sqlite" } })`, or importing a `.sqlite` file without an attribute) emits the build machine's absolute path:
  ```js
  var app_default = import.meta.require("/home/me/project/app.db", { type: "sqlite" }).db;
  ```
  The bundle (or `--compile` executable) opens that path wherever it runs, so it breaks once moved. The same import written as `import db from "./app.db" with { type: "sqlite" }` is emitted unchanged and left external.
- Cause: `resolve_import_records` (`src/bundler/bundle_v2.rs`) only externalizes a record whose loader an attribute set, in a check that runs before resolution. A loader that comes from the file's extension is only known after resolution, so the database becomes a module in the graph and the `Loader::Sqlite` arm of `src/bundler/ParseTask.rs` builds the module from `source.path.text`, which is absolute. The plugin fallback resolver (`run_resolver`, used when an `onResolve` plugin matched but returned nothing) and the in-memory `files` path pick the loader separately and had the same gap.
- Two printer gaps made externalizing alone insufficient or unsafe:
  - `print_require_or_import_expr` (`src/js_printer/lib.rs`) printed external `require()` and `import()` without the record's loader; only import statements got `with { type }` back. The cjs output format turns every import into `require()`, so even the attribute form printed `__toESM(require("./app.db"))` there, which loads a `.db` file as JavaScript.
  - `resolve_import_records` stored the loader it resolved for every bundled file on the import record. Where the linker later turns such a record external, that loader was printed on an import of something else: an import redirected through a `module.exports = require(x)` shim to an external `x` printed `import * as y from "x" with { type: "js" }` (on main and 1.4.0; `x` resolving to a `.ts` file at runtime then fails to parse), and with the require()/import() printing added here, `--splitting` would have printed `import("./data-HASH.js", { with: { type: "json" } })` on every cross-chunk dynamic import (found in review; a JS chunk then fails to parse as JSON).

### Fix
- `ImportRecord::loader` now means one thing: a loader the runtime must apply to the import as printed. It is set by the parser from a `type` attribute (unchanged) and by the bundler when it leaves a sqlite import to the runtime; `resolve_import_records` no longer stores the loader it resolves for a bundled file there. Nothing else read that value: the linker, metafile, HTML output and dev server all take a bundled file's loader from the input file, and builds that go through `onResolve` plugins already ran with it unset. This fixes the shim redirect leak and makes the `--splitting` chunk rewrite inert, without touching the linker.
- `leaves_sqlite_import_to_runtime` / `mark_sqlite_import_external` (`bundle_v2.rs`): after the resolved loader is known, a `Loader::Sqlite` record from an `import` statement, `require()` or `import()` is flagged `IS_EXTERNAL_WITHOUT_SIDE_EFFECTS`, given `loader = Sqlite`, and skipped, exactly like the attribute case. It runs on all four resolution paths (disk and `files`, directly and via the plugin fallback). The record still holds the specifier as written, so the output reads `./app.db` relative to the bundle. Not applied when an `onLoad` or native `onBeforeParse` plugin filter matches the resolved file (the plugin keeps receiving it, as for any other loader; `src/jsc/bindings/JSBundlerPlugin.cpp` gains `JSBundlerPlugin__anyOnBeforeParseMatches`, the existing filter matcher applied to the native plugin list, because the `onLoad` matcher does not see those filters), for targets other than bun (the parse task still reports `To use the "sqlite" loader, set target to "bun"`), or in the dev server, which resolves imports itself and is unchanged.
- Printer: an external `require()` gets `, { type: "x" }` and an external `import()` without user options gets `, { with: { type: "x" } }` when the record carries a loader, for the bun platform only (the only consumer of these forms; `import.meta.require` and `import()` in Bun accept them, and the code this replaces already emitted the `require` form). Import statements already did this; the three sites now share one `import_attribute_type` table, replacing two copies with byte-identical output.
- Why this is the right behavior: the docs for the loader say the database "stays external to the bundle", which is what the attribute form has always done. A module in the graph cannot be made portable, since the non-embedded loader deliberately does not copy the file, so the only path the parse task could print is the source path. Leaving the import to the runtime with the type re-attached makes the loader-map output identical to the attribute output in every output format, including extensions the runtime would not recognize on its own (`.db`). `sqlite_embedded` is untouched; unused imports are still dropped (the record is external without side effects, matching the `NoSideEffectsPureData` the bundled module used to get).
- Visible side effect: an external import that carries an attribute keeps its type in cjs output (`__toESM(require("./db.sqlite", { type: "sqlite" }))`), and a shim redirected to an external no longer prints the shim's loader. Output for records without an attribute is otherwise unchanged.
- Not changed: an entry point that is itself a database, or a database a plugin's `onResolve` returned a path for, still goes through the parse task and prints the absolute path; there is no import specifier to keep in those cases.
- Verified with `test/bundler/bundler_bun.test.ts`. The `sqlite loader selected by extension or loader map` block keeps a different database at build time and next to the bundle, so the program's output says which file the bundle opened: `import` (esm and cjs), `require()` (minified), `import()`, an unused import being dropped, `--loader`, bunfig `[loader]`, `Bun.build({ loader })` alone and combined with a passthrough `onResolve` plugin and/or `files`, an `onLoad` plugin taking precedence, plus the `--target node` error. `test/bundler/native-plugin.test.ts` gets two cases: a native plugin filtering `.sqlite` still receives the file (its counter sees the contents), and one filtering `.ts` leaves the import external (fails on the released build with the absolute path). The `type attributes on imports the linker makes external` block pins the shim redirect (import statement, `require()`, `import()`, run against a TypeScript external) and `--splitting` cross-chunk `import()` of `.json` and `.ts` files. 11 of the 15 new tests fail on the released binary (the sqlite ones with the absolute path, the redirect one with `with { type: "js" }`); the file passes with the debug build.
- Also run with the debug build: `bundler_edgecase`, `bundler_plugin`, `bundler_plugin_chain`, `native-plugin`, `bundler_files`, `bundler_barrel`, `bundler_splitting`, `bundler_compile_splitting`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_loader`, `bun-build-api`, `metafile`, `bundler_html`, `html-import-manifest`, `esbuild/{loader,default,importstar,splitting}`, `bundler_compile -t sqlite`, `transpiler/transpiler.test.js`, `bake/dev/{bundle,plugins}`, `test/js/bun/import-attributes`; `native-plugin` (full file); `cargo clippy` on `bun_ast`, `bun_js_printer`, `bun_bundler`; clang-format on the C++ file. Manually confirmed a `--compile` build with `--loader .db:sqlite` opens the database next to the executable.

### Related
- #35692 fixes the shim redirect symptom for import statements by copying the loader at the redirect; this PR removes the stale loader at its source, which covers that case and the `--splitting` one, and the two are compatible.
- Pre-existing and not changed here: under `--splitting`, a dynamic import the user wrote with an attribute (`import("./x.json", { with: { type: "json" } })`) keeps that attribute on the rewritten chunk import; that is the user's options object, a separate channel, and is tracked separately.
- #38173 changes the `import.meta.require` call the parse task synthesizes for the embedded loader; this PR does not touch that arm.
- #38247 makes `sqlite_embedded` selectable from the loader map; independent of this change.

### Background
- Loader map: the extension to loader table built from `--loader`, bunfig `[loader]` and `Bun.build({ loader })`. `Path::loader()` (`src/resolver/lib.rs`) consults it and then falls back to `Loader::from_string(extension)`, which is why a `.sqlite` extension selects the sqlite loader with no configuration and `.db` does not.
- `sqlite` vs `sqlite_embedded` loaders: both make `import db from "./x"` evaluate to a `bun:sqlite` `Database`. `sqlite` opens the file at runtime and does not copy it; `sqlite_embedded` (`with { type: "sqlite", embed: "true" }`) copies it into the output directory or the compiled executable and references the copy.
- Import record: the bundler's entry for one import. `source_index` points at the bundled module once one exists; a record without one is printed back out as an import of its `path`. `IS_EXTERNAL_WITHOUT_SIDE_EFFECTS` additionally lets tree shaking drop it when nothing uses the binding. The linker repurposes records in two places: a cross-chunk dynamic import under `--splitting` is pointed at the chunk file, and an import of a one-line `module.exports = require(x)` shim is redirected to `x`.
- Re-attached attributes: for `--target bun` the printer adds `with { type: "x" }` to import statements from `record.loader`, so the runtime uses the loader the build decided on. The runtime accepts the same information on `require(id, { type })` and `import(id, { with: { type } })`.
- Resolution paths: `resolve_import_records` handles imports the bundler resolves itself; when an `onResolve` plugin's filter matches but the callback returns nothing, `run_resolver` does the same work after the round trip to the JS thread; both check `Bun.build({ files })` (in-memory files) before the disk resolver.

<details>
<summary>Earlier version of this PR</summary>

The first push only added the externalization in `resolve_import_records` and keyed the new `require()`/`import()` printing on `record.loader` while resolution still stored every resolved loader there. Review found that `--splitting` output for target bun then carried `{ with: { type: "json" } }` on cross-chunk dynamic imports and failed at runtime, and that shim redirects leaked the shim's loader (already the case for import statements on main). The second commit changes what the field holds instead, moves the sqlite check into a helper that also covers the plugin fallback and `files` paths, and adds the redirect and splitting tests. Later commits make a matching `onLoad` plugin, and then a matching native `onBeforeParse` plugin, take precedence over the externalization, which the first version skipped.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/native-plugin.test.ts

<!-- robobun:evidence:end -->