### PR TITLE
node:module: accept an empty mappings string in the SourceMap constructor

### DIFF
--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -114,11 +114,14 @@ impl JSSourceMap {
 
         // Parse the payload to create a proper sourcemap
 
-        // Extract mappings string from payload
-        let Some(mappings_value) = payload_arg.get_stringish(global, b"mappings")? else {
-            return Err(
-                global.throw_invalid_arguments(format_args!("payload 'mappings' must be a string"))
-            );
+        // Extract mappings string from payload. Not `get_stringish`: it drops ""
+        // and `"mappings": ""` is a valid map with no segments.
+        let mappings_value = match payload_arg.get(global, b"mappings")? {
+            Some(value) if !value.is_undefined_or_null() => value.to_bun_string(global)?,
+            _ => {
+                return Err(global
+                    .throw_invalid_arguments(format_args!("payload 'mappings' must be a string")));
+            }
         };
         let mappings_value = bstring::OwnedString::new(mappings_value);
 

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -114,8 +114,7 @@ impl JSSourceMap {
 
         // Parse the payload to create a proper sourcemap
 
-        // Extract mappings string from payload. Not `get_stringish`: it drops ""
-        // and `"mappings": ""` is a valid map with no segments.
+        // Extract mappings string from payload
         let mappings_value = match payload_arg.get(global, b"mappings")? {
             Some(value) if !value.is_undefined_or_null() => value.to_bun_string(global)?,
             _ => {

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -22,6 +22,39 @@ test("SourceMap payload must be an object", () => {
   );
 });
 
+test("SourceMap accepts an empty mappings string", () => {
+  // esbuild and tsc emit `"mappings": ""` for modules that produce no code,
+  // such as re-export-only or side-effect-only modules.
+  const payload = { version: 3, sources: ["empty.js"], names: [], mappings: "" };
+  const sourceMap = new SourceMap(payload);
+
+  expect(sourceMap).toBeInstanceOf(SourceMap);
+  expect(sourceMap.payload).toEqual(payload);
+  expect(sourceMap.findEntry(0, 0)).toEqual({});
+  expect(sourceMap.findOrigin(1, 1)).toEqual({});
+});
+
+test("SourceMap accepts mappings made only of line separators", () => {
+  const sourceMap = new SourceMap({ version: 3, sources: ["a.js"], names: [], mappings: ";;;" });
+
+  expect(sourceMap.findEntry(0, 0)).toEqual({});
+  expect(sourceMap.findEntry(3, 0)).toEqual({});
+});
+
+test.each([
+  ["missing", { version: 3, sources: ["a.js"], names: [] }],
+  ["undefined", { version: 3, sources: ["a.js"], names: [], mappings: undefined }],
+  ["null", { version: 3, sources: ["a.js"], names: [], mappings: null }],
+])("SourceMap constructor rejects %s mappings", (_, payload) => {
+  expect(() => new SourceMap(payload)).toThrow(
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: "payload 'mappings' must be a string",
+    }),
+  );
+});
+
 test("SourceMap instance has expected methods", () => {
   const sourceMap = new SourceMap({
     version: 3,


### PR DESCRIPTION
### Problem
- `new SourceMap({ version: 3, sources: ["a.js"], names: [], mappings: "" })` from `node:module` throws `TypeError: payload 'mappings' must be a string` (`ERR_INVALID_ARG_TYPE`). Node accepts it and `findEntry` returns `{}`.
- `"mappings": ""` is what esbuild and tsc emit for modules that generate no code (re-export-only or side-effect-only modules), so a tool that walks a build's maps with `new SourceMap(json)` fails on the first such module.
- Cause: the constructor reads the property with `get_stringish` (`src/sourcemap_jsc/JSSourceMap.rs:118`), and `get_stringish` maps an empty string to `None` (`src/jsc/JSValue.rs:1199`). That helper is meant for options like `Bun.serve`'s `hostname`, where `""` means "not set". For `mappings`, `""` is a real value. The Zig implementation used the same helper, so this is not a port regression.

### Fix
- Read `mappings` with a plain property get, reject only `undefined` and `null` with the existing error, and convert everything else to a string as before. The VLQ parser already returns an empty mapping list for an empty input, so `findEntry`/`findOrigin` on such a map return `{}` like Node.
- Behavior for values other than `""` is unchanged except that `false` now goes through string conversion like every other non-string value (it fails to parse with a `SyntaxError` instead of being reported as missing) and a symbol now throws the engine's "Cannot convert a symbol to a string" `TypeError`, which is what Node throws too.
- Verified with `test/js/node/module/sourcemap.test.js`: the new "accepts an empty mappings string" test fails on the released build with the error above and passes with this change. Also added tests pinning the `;;;` case and the `undefined`/`null`/missing rejections, which pass before and after.
- `test/js/node/module/module-sourcemap.test.js`, `sourcemap-simd.test.ts`, `node-module-module.test.js` and `test/js/bun/sourcemap/negative-vlq-mapping.test.ts` still pass.
- The 0-based `findOrigin` divergence from Node in the same class is a separate issue handled by #35123 and is not touched here.

### Background
- `module.SourceMap` is Node's API for querying a source map v3 payload: the constructor takes the parsed JSON object and `findEntry(line, column)` returns the mapping segment covering a generated position, or `{}` when there is none.
- `mappings` is the VLQ-encoded segment list of a source map. Segments are separated by `,`, generated lines by `;`, and a map for a file with no generated code has an empty string here.
- `get_stringish` is a `JSValue` helper in `src/jsc/JSValue.rs` that reads a property, coerces it to a string, and returns `None` for missing, `null`, `false`, and empty-string values so callers can treat all of those as "option not provided".
