### PR TITLE
error printer: print the thrown Error, not the JSC::Exception cell, for errors escaping native callbacks

### DIFF
--- a/src/jsc/Exception.rs
+++ b/src/jsc/Exception.rs
@@ -18,8 +18,7 @@ impl Exception {
         JSC__Exception__getStackTrace(self, global, stack);
     }
 
-    /// The `JSC::Exception` cell itself, not the value it wraps; `JSValue::to_error`
-    /// unwraps it to the thrown value.
+    /// The `JSC::Exception` cell itself; `JSValue::to_error` unwraps it to the thrown value.
     pub fn to_js(&self) -> JSValue {
         JSValue::from_cell(self)
     }

--- a/src/jsc/Exception.rs
+++ b/src/jsc/Exception.rs
@@ -11,7 +11,6 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         stack: &mut ZigStackTrace,
     );
-    safe fn JSC__Exception__asJSValue(this: &Exception) -> JSValue;
 }
 
 impl Exception {
@@ -19,7 +18,9 @@ impl Exception {
         JSC__Exception__getStackTrace(self, global, stack);
     }
 
-    pub fn value(&self) -> JSValue {
-        JSC__Exception__asJSValue(self)
+    /// The `JSC::Exception` cell itself, not the value it wraps; `JSValue::to_error`
+    /// unwraps it to the thrown value.
+    pub fn to_js(&self) -> JSValue {
+        JSValue::from_cell(self)
     }
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4814,11 +4814,7 @@ impl VirtualMachine {
         let mut formatter = crate::console_object::Formatter::new(self.global());
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         let exception_cell = exception.to_js();
-        // A thrown Error is printed from the error itself (the stack captured
-        // when it was constructed, its own properties, its cause), exactly as
-        // when it escapes synchronously. Anything else that was thrown has no
-        // stack of its own, so the Exception cell, which records the throw
-        // site, is printed instead.
+        // An Error carries its own stack, properties and cause; anything else only has the cell's throw site.
         let value = match exception_cell.to_error() {
             Some(error) if error.is_error() => error,
             _ => exception_cell,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4814,9 +4814,7 @@ impl VirtualMachine {
         let mut formatter = crate::console_object::Formatter::new(self.global());
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         let exception_cell = exception.to_js();
-        // Only an ErrorInstance has a stack, properties and a cause of its own to print. Any other
-        // thrown value (a string, a plain object, a DOMException) has nothing but the throw-site
-        // stack the cell recorded, so it keeps printing from the cell.
+        // Print the thrown Error itself; non-Error values only have the cell's throw-site stack.
         let value = match exception_cell.to_error() {
             Some(error) if error.is_error() => error,
             _ => exception_cell,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4814,7 +4814,9 @@ impl VirtualMachine {
         let mut formatter = crate::console_object::Formatter::new(self.global());
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         let exception_cell = exception.to_js();
-        // An Error carries its own stack, properties and cause; anything else only has the cell's throw site.
+        // Only an ErrorInstance has a stack, properties and a cause of its own to print. Any other
+        // thrown value (a string, a plain object, a DOMException) has nothing but the throw-site
+        // stack the cell recorded, so it keeps printing from the cell.
         let value = match exception_cell.to_error() {
             Some(error) if error.is_error() => error,
             _ => exception_cell,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4813,8 +4813,18 @@ impl VirtualMachine {
     ) {
         let mut formatter = crate::console_object::Formatter::new(self.global());
         let colors = bun_core::Output::enable_ansi_colors_stderr();
+        let exception_cell = exception.to_js();
+        // A thrown Error is printed from the error itself (the stack captured
+        // when it was constructed, its own properties, its cause), exactly as
+        // when it escapes synchronously. Anything else that was thrown has no
+        // stack of its own, so the Exception cell, which records the throw
+        // site, is printed instead.
+        let value = match exception_cell.to_error() {
+            Some(error) if error.is_error() => error,
+            _ => exception_cell,
+        };
         self.print_errorlike_object(
-            exception.value(),
+            value,
             Some(exception),
             exception_list,
             &mut formatter,
@@ -5373,7 +5383,7 @@ impl VirtualMachine {
         exception: &Exception,
     ) -> JSValue {
         let jsc_vm = global_object.bun_vm().as_mut();
-        let _ = jsc_vm.uncaught_exception(global_object, exception.value(), false);
+        let _ = jsc_vm.uncaught_exception(global_object, exception.to_js(), false);
         JSValue::UNDEFINED
     }
 

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -478,20 +478,17 @@ static JSC::JSValue getNonObservable(JSC::VM& vm, JSC::JSGlobalObject* global, J
     return {};
 }
 
+// An Error always prints the stack it captured when it was constructed, never the stack of the
+// `throw` that delivered it: that is what `error.stack` shows and what Node prints.
 __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
-    JSC::ErrorInstance* err, const Vector<JSC::StackFrame>* stackTrace,
-    JSC::JSValue val, PopulateStackTraceFlags flags)
+    JSC::ErrorInstance* err, JSC::JSValue val, PopulateStackTraceFlags flags)
 {
     JSC::JSObject* obj = dynamicDowncast<JSC::JSObject>(val);
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     bool getFromSourceURL = false;
-    if (stackTrace != nullptr && stackTrace->size() > 0) {
-        populateStackTrace(vm, *stackTrace, except.stack, global, flags);
-        RETURN_IF_EXCEPTION(scope, );
-
-    } else if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
+    if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
         populateStackTrace(vm, *err->stackTrace(), except.stack, global, flags, FinalizerSafety::MustNotTriggerGC);
         RETURN_IF_EXCEPTION(scope, );
 
@@ -848,26 +845,21 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__toZigException(JSC::Enc
         return;
     }
 
+    // The throw-site stack a JSC::Exception records is only used for a thrown value that has no
+    // stack of its own (a string, a plain object, a DOMException).
+    JSC::Exception* jscException = nullptr;
     if (value.classInfoOrNull() == JSC::Exception::info()) {
-        auto* jscException = uncheckedDowncast<JSC::Exception>(value);
-        JSValue unwrapped = jscException->value();
-
-        if (JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(unwrapped)) {
-            fromErrorInstance(*exception, global, error, &jscException->stack(), unwrapped, PopulateStackTraceFlags::OnlyPosition);
-            return;
-        }
-
-        if (jscException->stack().size() > 0) {
-            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlyPosition);
-        }
-
-        exceptionFromString(*exception, unwrapped, global);
-        return;
+        jscException = uncheckedDowncast<JSC::Exception>(value);
+        value = jscException->value();
     }
 
     if (JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(value)) {
-        fromErrorInstance(*exception, global, error, nullptr, value, PopulateStackTraceFlags::OnlyPosition);
+        fromErrorInstance(*exception, global, error, value, PopulateStackTraceFlags::OnlyPosition);
         return;
+    }
+
+    if (jscException && jscException->stack().size() > 0) {
+        populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlyPosition);
     }
 
     exceptionFromString(*exception, value, global);
@@ -880,16 +872,12 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         return;
     }
 
+    // Same selection as JSC__JSValue__toZigException: OnlySourceLines indexes the frame vector
+    // OnlyPosition chose through jsc_stack_frame_index.
+    JSC::Exception* jscException = nullptr;
     if (value.classInfoOrNull() == JSC::Exception::info()) {
-        auto* jscException = uncheckedDowncast<JSC::Exception>(value);
-        JSValue unwrapped = jscException->value();
-
-        if (jscException->stack().size() > 0) {
-            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
-        }
-
-        exceptionFromString(*exception, unwrapped, global);
-        return;
+        jscException = uncheckedDowncast<JSC::Exception>(value);
+        value = jscException->value();
     }
 
     if (JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(value)) {
@@ -897,5 +885,13 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
             populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);
         }
         return;
+    }
+
+    if (jscException) {
+        if (jscException->stack().size() > 0) {
+            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
+        }
+
+        exceptionFromString(*exception, value, global);
     }
 }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -478,8 +478,7 @@ static JSC::JSValue getNonObservable(JSC::VM& vm, JSC::JSGlobalObject* global, J
     return {};
 }
 
-// An Error always prints the stack it captured when it was constructed, never the stack of the
-// `throw` that delivered it: that is what `error.stack` shows and what Node prints.
+// An Error prints the stack it captured at construction, matching `error.stack` and Node.
 __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
     JSC::ErrorInstance* err, JSC::JSValue val, PopulateStackTraceFlags flags)
 {
@@ -845,8 +844,7 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__toZigException(JSC::Enc
         return;
     }
 
-    // The throw-site stack a JSC::Exception records is only used for a thrown value that has no
-    // stack of its own (a string, a plain object, a DOMException).
+    // The cell's throw-site stack is used only for a thrown value with no stack of its own.
     JSC::Exception* jscException = nullptr;
     if (value.classInfoOrNull() == JSC::Exception::info()) {
         jscException = uncheckedDowncast<JSC::Exception>(value);
@@ -872,8 +870,7 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         return;
     }
 
-    // Same selection as JSC__JSValue__toZigException: OnlySourceLines indexes the frame vector
-    // OnlyPosition chose through jsc_stack_frame_index.
+    // Must pick the same frame vector as JSC__JSValue__toZigException (see jsc_stack_frame_index).
     JSC::Exception* jscException = nullptr;
     if (value.classInfoOrNull() == JSC::Exception::info()) {
         jscException = uncheckedDowncast<JSC::Exception>(value);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4875,11 +4875,6 @@ bool JSC__JSValue__stringIncludes(JSC::EncodedJSValue value, JSC::JSGlobalObject
     return stringToSearchIn.find(searchString, 0) != WTF::notFound;
 }
 
-extern "C" JSC::EncodedJSValue JSC__Exception__asJSValue(JSC::Exception* exception)
-{
-    return JSC::JSValue::encode(exception);
-}
-
 void JSC__VM__releaseWeakRefs(JSC::VM* arg0)
 {
     arg0->finalizeSynchronousJSExecution();

--- a/test/js/bun/test/dots.test.ts
+++ b/test/js/bun/test/dots.test.ts
@@ -87,7 +87,7 @@ test("dots 2", async () => {
     6 |   setTimeout(() => {
     7 |     resolve();
     8 |     throw new Error("unhandled error");
-                                             ^
+                      ^
     error: unhandled error
         at <anonymous> (file:NN:NN)
     (fail) failure

--- a/test/js/bun/test/only-failures.test.ts
+++ b/test/js/bun/test/only-failures.test.ts
@@ -39,7 +39,7 @@ test.concurrent("only-failures flag should show only failures", async () => {
     24 | 
     25 | test("another failing test", () => {
     26 |   throw new Error("This test fails");
-                                            ^
+                     ^
     error: This test fails
         at <anonymous> (file:NN:NN)
     (fail) another failing test

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -174,4 +174,200 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+describe("uncaught error printer", () => {
+  // A callback invoked from native code (timers, the microtask queue, process
+  // lifecycle events) hands an error that escapes it to the printer wrapped in
+  // a JSC::Exception. The printer must still print the Error itself: the stack
+  // captured where it was constructed, its own properties and its cause, so
+  // the output is the same as when the same error escapes synchronously.
+  const exceptionEntryPoints = ["setTimeout", "setImmediate", "queueMicrotask", "beforeExit", "exit"];
+  // nextTick callbacks run from JS, which reports the bare thrown value.
+  const entryPoints = [...exceptionEntryPoints, "nextTick"];
+
+  const fixture = `const [, , entryPoint, kind] = process.argv;
+function make(message, options) {
+  const err = new Error(message, options);
+  err.code = "E_FIXTURE";
+  return err;
+}
+function thrower() {
+  const err =
+    kind === "aggregate"
+      ? new AggregateError([make("first"), make("second")], "two errors")
+      : make("printed from the error itself", kind === "error" ? { cause: make("the cause") } : undefined);
+  if (kind === "materialized") console.log(err.stack);
+  throw err;
+}
+function throwString() {
+  throw "not an error instance";
+}
+const callback = kind === "string" ? throwString : thrower;
+switch (entryPoint) {
+  case "sync": callback(); break;
+  case "nextTick": process.nextTick(callback); break;
+  case "setTimeout": setTimeout(callback, 1); break;
+  case "setImmediate": setImmediate(callback); break;
+  case "queueMicrotask": queueMicrotask(callback); break;
+  case "beforeExit": process.on("beforeExit", callback); break;
+  case "exit": process.on("exit", callback); break;
+}
+`;
+
+  // Debug builds show builtin frames unless told otherwise.
+  const env = { BUN_JSC_showPrivateScriptsInStackTraces: "0" };
+
+  async function run(dir: string, entryPoint: string, kind: string) {
+    const { stdout, stderr, exitCode } = await bunRun([join(dir, "fixture.js"), entryPoint, kind], env);
+    const normalize = (text: string) => text.replaceAll(dir, "<dir>").replaceAll("\\", "/");
+    return { stdout: normalize(stdout), stderr: normalize(stderr), exitCode };
+  }
+
+  // Keeps exactly the part of the output that is derived from the thrown
+  // error. The entry points legitimately differ in the frames below `thrower`
+  // (the synchronous variant has a top-level frame, the others were called
+  // from native code), and the trailer names the build.
+  function errorOwnedOutput({ stderr, exitCode }: { stderr: string; exitCode: number }) {
+    const output = stderr
+      .split("\n")
+      .filter(line => !/^\s+at (?!make |thrower )/.test(line) && !line.startsWith("Bun v"))
+      .join("\n")
+      .trim();
+    return { exitCode, output };
+  }
+
+  // Columns inside the transpiled module are not the subject here; the lines
+  // (which source line the caret and the frames point at) are.
+  const withoutColumns = (output: string) =>
+    output.replace(/:(\d+):\d+(\)?)$/gm, ":$1:<col>$2").replace(/^ +\^$/gm, "^");
+
+  const frameLines = (text: string) =>
+    text
+      .split("\n")
+      .filter(line => /^\s+at /.test(line))
+      .map(line => line.trim());
+
+  async function compareWithSynchronousThrow(kind: string) {
+    using dir = tempDir("uncaught-print", { "fixture.js": fixture });
+    const [sync, ...results] = await Promise.all(
+      ["sync", ...entryPoints].map(entryPoint => run(String(dir), entryPoint, kind)),
+    );
+    const expected = errorOwnedOutput(sync);
+    expect(Object.fromEntries(entryPoints.map((entryPoint, i) => [entryPoint, errorOwnedOutput(results[i])]))).toEqual(
+      Object.fromEntries(entryPoints.map(entryPoint => [entryPoint, expected])),
+    );
+    return { ...expected, results };
+  }
+
+  test.concurrent("an Error escaping a native entry point prints like a synchronous throw", async () => {
+    const { exitCode, output } = await compareWithSynchronousThrow("error");
+    expect(withoutColumns(output)).toMatchInlineSnapshot(`
+      "1 | const [, , entryPoint, kind] = process.argv;
+      2 | function make(message, options) {
+      3 |   const err = new Error(message, options);
+      ^
+      error: printed from the error itself
+       code: "E_FIXTURE"
+
+            at make (<dir>/fixture.js:3:<col>)
+            at thrower (<dir>/fixture.js:11:<col>)
+
+      1 | const [, , entryPoint, kind] = process.argv;
+      2 | function make(message, options) {
+      3 |   const err = new Error(message, options);
+      ^
+      error: the cause
+       code: "E_FIXTURE"
+
+            at make (<dir>/fixture.js:3:<col>)
+            at thrower (<dir>/fixture.js:11:<col>)"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent(
+    "an AggregateError escaping a native entry point prints each of its errors like a synchronous throw",
+    async () => {
+      const { exitCode, output } = await compareWithSynchronousThrow("aggregate");
+      expect(output).toContain("error: first\n");
+      expect(output).toContain("error: second\n");
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  test.concurrent(
+    "an Error whose .stack was already read is printed where error.stack says it was created",
+    async () => {
+      const { exitCode, results } = await compareWithSynchronousThrow("materialized");
+      for (const { stdout, stderr } of results) {
+        const [stackTop] = frameLines(stdout);
+        expect(stackTop).toStartWith("at make (<dir>/fixture.js:3:");
+        expect(frameLines(stderr)[0]).toBe(stackTop);
+      }
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  // `bun test` reports what a test body throws through the same printer.
+  test.concurrent("bun test prints an error thrown by a test from the error itself", async () => {
+    using dir = tempDir("uncaught-print", {
+      "throws.test.js": `import { test } from "bun:test";
+function makeAndThrow() {
+  const err = new Error("outer", { cause: new Error("inner") });
+  err.code = "E_OUTER";
+  throw err;
+}
+test("throws", makeAndThrow);
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "throws.test.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, ...env },
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(frameLines(stderr)).toEqual([
+      expect.stringMatching(/^at makeAndThrow \(.*throws\.test\.js:3:\d+\)$/),
+      expect.stringMatching(/^at makeAndThrow \(.*throws\.test\.js:3:\d+\)$/),
+    ]);
+    expect(withoutColumns(normalizeBunSnapshot(stderr))).toMatchInlineSnapshot(`
+      "throws.test.js:
+      1 | import { test } from "bun:test";
+      2 | function makeAndThrow() {
+      3 |   const err = new Error("outer", { cause: new Error("inner") });
+      ^
+      error: outer
+       code: "E_OUTER"
+          at makeAndThrow (file:NN:NN)
+
+      1 | import { test } from "bun:test";
+      2 | function makeAndThrow() {
+      3 |   const err = new Error("outer", { cause: new Error("inner") });
+      ^
+      error: inner
+          at makeAndThrow (file:NN:NN)
+      (fail) throws
+
+       0 pass
+       1 fail
+      Ran 1 test across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent(
+    "a thrown value that is not an Error is still printed with the frames of the throw site",
+    async () => {
+      using dir = tempDir("uncaught-print", { "fixture.js": fixture });
+      const results = await Promise.all(exceptionEntryPoints.map(entryPoint => run(String(dir), entryPoint, "string")));
+      for (const { stderr, exitCode } of results) {
+        expect(stderr).toContain("error: not an error instance\n");
+        expect(stderr).toMatch(/^\s+at throwString \(<dir>\/fixture\.js:16:\d+\)$/m);
+        expect(exitCode).toBe(1);
+      }
+    },
+  );
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -212,6 +212,7 @@ switch (entryPoint) {
   case "queueMicrotask": queueMicrotask(callback); break;
   case "beforeExit": process.on("beforeExit", callback); break;
   case "exit": process.on("exit", callback); break;
+  case "rethrow": process.on("uncaughtException", err => { throw err; }); callback(); break;
 }
 `;
 
@@ -309,6 +310,29 @@ switch (entryPoint) {
     },
   );
 
+  // The error an uncaughtException listener rethrows is reported the same way
+  // (exit code 7 is the listener having thrown). https://github.com/oven-sh/bun/issues/30504
+  test.concurrent("an Error rethrown by an uncaughtException listener prints like a synchronous throw", async () => {
+    using dir = tempDir("uncaught-print", { "fixture.js": fixture });
+    const [sync, rethrown] = await Promise.all([
+      run(String(dir), "sync", "error"),
+      run(String(dir), "rethrow", "error"),
+    ]);
+    expect(errorOwnedOutput(rethrown)).toEqual({ ...errorOwnedOutput(sync), exitCode: 7 });
+  });
+
+  async function runBunTest(dir: string, file: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", file],
+      cwd: dir,
+      env: { ...bunEnv, ...env },
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode };
+  }
+
   // `bun test` reports what a test body throws through the same printer.
   test.concurrent("bun test prints an error thrown by a test from the error itself", async () => {
     using dir = tempDir("uncaught-print", {
@@ -321,14 +345,7 @@ function makeAndThrow() {
 test("throws", makeAndThrow);
 `,
     });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "throws.test.js"],
-      cwd: String(dir),
-      env: { ...bunEnv, ...env },
-      stdout: "ignore",
-      stderr: "pipe",
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const { stderr, exitCode } = await runBunTest(String(dir), "throws.test.js");
     expect(frameLines(stderr)).toEqual([
       expect.stringMatching(/^at makeAndThrow \(.*throws\.test\.js:3:\d+\)$/),
       expect.stringMatching(/^at makeAndThrow \(.*throws\.test\.js:3:\d+\)$/),
@@ -350,6 +367,45 @@ test("throws", makeAndThrow);
       error: inner
           at makeAndThrow (file:NN:NN)
       (fail) throws
+
+       0 pass
+       1 fail
+      Ran 1 test across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  // Printing the error itself also means a stack rewritten with
+  // Error.captureStackTrace is honored. https://github.com/oven-sh/bun/issues/21211
+  test.concurrent("bun test honors Error.captureStackTrace on a thrown error", async () => {
+    using dir = tempDir("uncaught-print", {
+      "helper.ts": `export function fail(message: string) {
+  const error = new Error(message);
+  Error.captureStackTrace(error, fail);
+  throw error;
+}
+`,
+      "helper.test.ts": `import { test } from "bun:test";
+import { fail } from "./helper";
+
+test("something", () => {
+  fail("TEST FAILURE");
+});
+`,
+    });
+    const { stderr, exitCode } = await runBunTest(String(dir), "helper.test.ts");
+    expect(frameLines(stderr)).toEqual([expect.stringMatching(/^at <anonymous> \(.*helper\.test\.ts:5:\d+\)$/)]);
+    expect(withoutColumns(normalizeBunSnapshot(stderr))).toMatchInlineSnapshot(`
+      "helper.test.ts:
+      1 | import { test } from "bun:test";
+      2 | import { fail } from "./helper";
+      3 | 
+      4 | test("something", () => {
+      5 |   fail("TEST FAILURE");
+      ^
+      error: TEST FAILURE
+          at <anonymous> (file:NN:NN)
+      (fail) something
 
        0 pass
        1 fail

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -203,7 +203,10 @@ function thrower() {
 function throwString() {
   throw "not an error instance";
 }
-const callback = kind === "string" ? throwString : thrower;
+function throwDOMException() {
+  throw new DOMException("not an error instance either", "AbortError");
+}
+const callback = kind === "string" ? throwString : kind === "domexception" ? throwDOMException : thrower;
 switch (entryPoint) {
   case "sync": callback(); break;
   case "nextTick": process.nextTick(callback); break;
@@ -414,16 +417,69 @@ test("something", () => {
     expect(exitCode).toBe(1);
   });
 
-  test.concurrent(
-    "a thrown value that is not an Error is still printed with the frames of the throw site",
-    async () => {
-      using dir = tempDir("uncaught-print", { "fixture.js": fixture });
-      const results = await Promise.all(exceptionEntryPoints.map(entryPoint => run(String(dir), entryPoint, "string")));
-      for (const { stderr, exitCode } of results) {
-        expect(stderr).toContain("error: not an error instance\n");
-        expect(stderr).toMatch(/^\s+at throwString \(<dir>\/fixture\.js:16:\d+\)$/m);
-        expect(exitCode).toBe(1);
-      }
-    },
-  );
+  // A thrown value that is not an Error has no stack of its own, so the frames
+  // of the throw that delivered it are the only location there is. When an
+  // uncaughtException listener rethrows it, that is the listener's throw.
+  const lineOf = (source: string) => fixture.split("\n").findIndex(line => line.includes(source)) + 1;
+  const frameAt = (functionName: string, line: number) =>
+    new RegExp(`^\\s+at ${functionName} \\(<dir>/fixture\\.js:${line}:\\d+\\)$`, "m");
+
+  async function expectThrowSiteFrames(kind: string, header: string, throwSite: string) {
+    using dir = tempDir("uncaught-print", { "fixture.js": fixture });
+    const [rethrown, ...results] = await Promise.all(
+      ["rethrow", ...exceptionEntryPoints].map(entryPoint => run(String(dir), entryPoint, kind)),
+    );
+    for (const { stderr, exitCode } of results) {
+      expect(stderr).toContain(header);
+      expect(stderr).toMatch(frameAt("throw\\w+", lineOf(throwSite)));
+      expect(exitCode).toBe(1);
+    }
+    expect(rethrown.stderr).toContain(header);
+    expect(rethrown.stderr).toMatch(frameAt("<anonymous>", lineOf('case "rethrow"')));
+    expect(rethrown.exitCode).toBe(7);
+  }
+
+  test.concurrent("a thrown string is still printed with the frames of the throw site", async () => {
+    await expectThrowSiteFrames("string", "error: not an error instance\n", 'throw "not an error instance"');
+  });
+
+  test.concurrent("a thrown DOMException is still printed with the frames of the throw site", async () => {
+    await expectThrowSiteFrames(
+      "domexception",
+      "AbortError: not an error instance either\n",
+      "throw new DOMException(",
+    );
+  });
+
+  // A ResolveMessage thrown through the exception has no stack of its own
+  // either, and is still printed once.
+  test.concurrent("bun test prints a synchronously thrown resolve error once", async () => {
+    using dir = tempDir("uncaught-print", {
+      "missing.test.js": `import { test } from "bun:test";
+test("sync require", () => {
+  require("./does-not-exist");
+});
+`,
+    });
+    const { stderr, exitCode } = await runBunTest(String(dir), "missing.test.js");
+    // Debug builds add an internal `require` frame, which also moves the divot.
+    const withoutStackFrames = stderr
+      .split("\n")
+      .filter(line => !/^\s*(at |\^\s*$)/.test(line))
+      .join("\n");
+    expect(normalizeBunSnapshot(withoutStackFrames, String(dir))).toMatchInlineSnapshot(`
+      "missing.test.js:
+      1 | import { test } from "bun:test";
+      2 | test("sync require", () => {
+      ResolveMessage: Cannot find module './does-not-exist'
+      Require stack:
+      - <dir>/missing.test.js
+      (fail) sync require
+
+       0 pass
+       1 fail
+      Ran 1 test across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1647,6 +1647,39 @@ describe.concurrent(() => {
     expect(await proc.stderr.text()).toContain("bar");
   });
 
+  describe.each([
+    ["rethrows", "throw err;"],
+    ["reads err.stack and then rethrows", "void err.stack; throw err;"],
+  ])("when the uncaughtException handler %s", (_, handlerBody) => {
+    it("prints the Error's own stack", async () => {
+      using dir = tempDir("rethrow-uncaught", {
+        "index.cjs": `
+          'use strict';
+          function rethrowHandler(err) {
+            ${handlerBody}
+          }
+          process.on('uncaughtException', rethrowHandler);
+          function throwUncaughtError() {
+            throw new Error('Boom');
+          }
+          throwUncaughtError();
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "index.cjs")],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(stderr).toContain("Boom");
+      expect(stderr).toContain("at throwUncaughtError (");
+      expect(stderr).not.toContain("at rethrowHandler (");
+      expect(exitCode).toBe(7);
+    });
+  });
+
   it("aborts when the uncaughtExceptionCaptureCallback throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-uncaughtExceptionCaptureCallbackAbort.js")], {
       stderr: "pipe",

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -715,6 +715,58 @@ describe("error event", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.message).toMatch(/MessagePort \[EventTarget\] \{.*\}/s);
   });
+
+  test("uncaught output shows the worker stack when there is no 'error' listener", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          const { Worker } = require("node:worker_threads");
+          new Worker(\`
+            function crashInWorkerFn() { throw new TypeError("WORKER-ORIGIN-9201"); }
+            crashInWorkerFn();
+          \`, { eval: true });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("WORKER-ORIGIN-9201");
+    expect(stderr).toContain("crashInWorkerFn");
+    expect(stderr).not.toContain("node:events");
+    expect(stderr).not.toContain("node:worker_threads");
+    expect(exitCode).toBe(1);
+  });
+
+  test("uncaught output uses a structuredClone'd error's own stack, not the rethrow site", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          const cloned = structuredClone(new TypeError("CLONED"));
+          cloned.stack = "TypeError: CLONED\\n    at workerSideFrame (fake.js:1:1)";
+          queueMicrotask(() => {
+            function rethrowIt(e) { throw e; }
+            rethrowIt(cloned);
+          });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("CLONED");
+    expect(stderr).toContain("at workerSideFrame (fake.js");
+    expect(stderr).not.toContain("rethrowIt");
+    expect(exitCode).toBe(1);
+  });
 });
 
 describe("getHeapSnapshot", () => {

--- a/test/regression/issue/12782.test.ts
+++ b/test/regression/issue/12782.test.ts
@@ -28,7 +28,7 @@ test("12782", async () => {
     4 | 
     5 | beforeAll(() => {
     6 |   if (!FOO) throw new Error("Environment variable FOO is not set");
-                                                                         ^
+                              ^
     error: Environment variable FOO is not set
         at <anonymous> (file:NN:NN)
     (fail) (unnamed)

--- a/test/regression/issue/19850/19850.test.ts
+++ b/test/regression/issue/19850/19850.test.ts
@@ -25,17 +25,17 @@ err-in-hook-and-multiple-tests.ts:
 2 | 
 3 | beforeEach(() => {
 4 |   throw new Error("beforeEach");
-                                  ^
+                ^
 error: beforeEach
-      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:31)
+      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:13)
 (fail) test 0
 1 | import { beforeEach, test } from "bun:test";
 2 | 
 3 | beforeEach(() => {
 4 |   throw new Error("beforeEach");
-                                  ^
+                ^
 error: beforeEach
-      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:31)
+      at <anonymous> (/err-in-hook-and-multiple-tests.ts:4:13)
 (fail) test 1
 
  0 pass


### PR DESCRIPTION
Fixes #30504
Fixes #21211

### Problem
- An `Error` that escapes a callback run from native code (timers, microtasks, `process` listeners, a `bun test` body, a rethrow inside an `uncaughtException` listener) prints the throw site's frames, not its own. #30504: `at <anonymous> (rethrow.cjs:4:9)` instead of `at throwUncaughtError (rethrow.cjs:8:13)`. Its properties, `cause` and `AggregateError` members are not printed at all.
- Cause: these entry points report a `JSC::Exception`, and `VirtualMachine::print_exception` (`src/jsc/VirtualMachine.rs`) printed that cell. `toZigException` read the cell's throw-site stack. `print_error_instance_body` skipped the property dump because the cell is not an `ErrorInstance`.

### Fix
- `print_exception` unwraps the cell with `JSValue::to_error()` and prints the thrown value when it is an `Error`. Other thrown values keep printing from the cell: they have no stack of their own.
- `toZigException` and `collectSourceLines` (`src/jsc/bindings/ZigException.cpp`) now unwrap the cell the same way and read the wrapper's throw-site stack only for a value that is not an `ErrorInstance`. `fromErrorInstance` loses its wrapper-stack parameter, so the rule "an Error prints its own stack" exists in one place.
- Correct because an `Error` carries what the printer needs: the stack captured at construction (what `error.stack` shows and what Node prints), its properties, `cause` and `errors`. Bun already prints that when the same Error escapes synchronously. `print_exception` is the one funnel every `JSC::Exception` report goes through.
- Verified: `test/js/bun/test/stack.test.ts` (`uncaught error printer`, 6 of 9 fail on main), `test/js/node/process/process.test.js` (rethrow variants), `test/js/node/worker_threads/worker_threads.test.ts` (worker error with no listener). Other suites in Notes.

### Background
- `JSC::Exception` is the object JavaScriptCore creates at a `throw`: the thrown value plus the stack at the throw. Native code that calls into JS receives this wrapper. A synchronous throw out of the entry module hands Bun the thrown value directly.
- An `ErrorInstance` captures its own stack at construction. It differs from the throw-site stack when an Error is created in one function and thrown in another.
- The print path is `print_errorlike_object` -> `print_error_instance_js` -> `remap_zig_exception` -> `JSC__JSValue__toZigException`.

<details><summary>Notes</summary>

**Supersedes #36437 and #37524.** Both fixed part of the same symptom at a lower layer. #36437 selected the Error's stack inside `fromErrorInstance` when both the Error and a wrapper stack are present. That restores the frames but the printed value is still the cell, so `code`, `cause` and `AggregateError` members stay missing (5 of the 7 original `uncaught error printer` tests fail on a build of #36437 rebased onto main). #37524 unwrapped the cell only for `print_error_instance_body`, so the properties print but the frames and caret stay at the throw site. This PR prints the Error's own stack, the stack `error.stack` reports and Node prints, and re-pins the four `bun test` expectations accordingly (see below). After it lands, #37524's unwrap can never see a cell. The tests of both PRs are folded in: `process.test.js` and `worker_threads.test.ts` from #36437, the `ResolveMessage` case from #37524. The `JSC__Exception__asJSValue` binding both renamed is deleted, since `JSValue::from_cell` does the same thing.

**Entry points covered.** `setTimeout`, `setImmediate`, `queueMicrotask`, `process.nextTick`, `process.on("beforeExit"|"exit")` listeners, a `bun test` test body or hook (`bun_test.rs` reports the body's exception), a worker `'error'` event with no listener (node:events rethrows the cloned Error from `emitError`), and a rethrow inside an `uncaughtException` listener (exit code 7). All of them reach `run_error_handler` with a `JSC::Exception` and go through `print_exception`. `uncaughtException` listeners already received the unwrapped value (`uncaught_exception` calls `to_error()` before `Bun__handleUncaughtException`). The printer now agrees with them. `print_error_instance_body` dumps properties and walks `cause`/`errors` only when the value it is given is itself an `ErrorInstance`, which is why the cell lost them.

**Non-Error values.** A string, a plain object, a `DOMException`, a `BuildMessage` or a `ResolveMessage` has no stack `toZigException` can read, so for those the cell's throw-site stack is the only location there is and they keep printing from the cell. `DOMException` is not an `ErrorInstance` (`is_error()` is false), so its output is unchanged. Widening the guard to `is_error_like` (#35723) or to `DOMException` (#40227) needs a fallback for a value with zero frames of its own. The three `ErrorInstance` checks inside `print_error_instance_body` are pre-existing and untouched here.

**Probes.**

```js
// frames.js
function make() { return new Error("x"); }
function thrower() { const e = make(); throw e; }
if (process.argv[2] === "sync") thrower(); else setTimeout(thrower, 1);
```

Before (`bun frames.js`): `at make (frames.js:2:14)`, `at thrower (frames.js:5:13)` (plus the top-level frame). Before (`bun frames.js timer`): only `at thrower (frames.js:5:18)`, caret at the throw. After: both modes print the same two frames.

```js
// props.js
function boom() {
  const e = new Error("outer", { cause: new Error("inner") });
  e.code = "E_CODE";
  throw e;
}
if (process.argv[2] === "sync") boom(); else setTimeout(boom, 1);
```

Before (timer): `error: outer` + `at boom (props.js:5:9)`, nothing else. After (timer): `error: outer`, `code: "E_CODE"`, `at boom (props.js:2:17)`, then the `error: inner` block with its own frame. Byte-identical to the `sync` run apart from the top-level caller frame.

The `2:26` vs `2:13` columns from the original report are the same thing seen through the runtime transpiler: it rewrites `new Error(...)` to `Error(...)`, so the construction frame maps to the `Error` token (column 13) and the `throw` statement's divot maps to the closing paren (column 26). `ErrorStackTrace.cpp` and `ErrorStackFrame.cpp` are not involved: the positions they compute are correct for the frames they are given. The wrong frames were given.

**Tests.** `stack.test.ts`, `describe("uncaught error printer")`: one fixture run through `sync`, `setTimeout`, `setImmediate`, `queueMicrotask`, `beforeExit`, `exit` and `nextTick`. The error-derived part of stderr (source excerpt, caret, message, properties, the error's frames, `cause` block) must be identical across all of them, with a snapshot of what that is, for a plain `Error` with `code` and `cause`, for an `AggregateError`, and for an error whose `.stack` had already been read (whose printed top frame must also equal the first frame of `error.stack`). A `rethrow` entry point (#30504) must produce the same output with exit code 7. Two `bun test` fixtures cover the test-runner entry point: a thrown error with `code` and `cause`, and the `Error.captureStackTrace` helper from #21211, whose printed stack must be the test-file frame only. Three tests pin the non-Error path: a thrown string and a thrown `DOMException` through the five `JSC::Exception` entry points and through a `rethrow` (the frame is the throwing function, or the listener's `throw` for the rethrow, exit code 7), and a `ResolveMessage` thrown from a test body that must print once. The folded `process.test.js` cases (handler rethrows, handler reads `err.stack` then rethrows) assert `at throwUncaughtError (` and not `at rethrowHandler (` with exit code 7. The folded `worker_threads.test.ts` cases (worker error with no `'error'` listener, cloned Error with a custom `.stack` rethrown from a microtask) assert the worker's function name and no `node:events` or `node:worker_threads` frame.

**Snapshot updates.** Four existing `bun test` output expectations (`dots.test.ts`, `only-failures.test.ts`, `12782.test.ts`, `19850.test.ts`) encoded the old throw-site caret for `throw new Error(...)` inside a test or hook. They now expect the caret under the `Error` construction, which is where `error.stack` and the existing rejection/`done(err)` expectations already pointed. #37388 (stop minifying `new Error()` into a call) moves the same columns again. Whichever of the two lands second re-pins these four expectations. They pin exact output on purpose, so they are not made column-insensitive here.

**Suites re-run on current main (731aa92) with this branch, all green:** `stack.test.ts`, `process.test.js` (the one failure, `process`, needs `$USER` and fails the same way on main in that environment), `worker_threads.test.ts`, `test-test.test.ts`, `bun_test.test.ts`, `cli/test/bun-test.test.ts`, `junit.test.js`, `cli/inspect/test-reporter.test.ts`, `test-error-code-done-callback.test.ts`, `reportError.test.ts`, `inspect-error.test.js`, `error-name-preservation.test.ts`, `console-log.test.ts`, `circular-error-stack*.test.ts`, the four snapshot files, and the node parallel tests `test-emit-after-uncaught-exception`, `test-events-uncaught-exception-stack`, `test-process-uncaught-exception-monitor`, `test-promise-unhandled-throw`, `test-promise-unhandled-throw-handler`, `test-process-exception-capture-should-abort-on-uncaught`. The repros also ran under `BUN_JSC_validateExceptionChecks=1` with no report.

**Related.** #35527 (Node-style uncaught output) unwraps the value at the rethrow-inside-handler call of `run_error_handler` as part of a larger formatting change. With this PR the funnel that call goes through already unwraps an Error, so that line becomes redundant. Two issues found on the way are tracked separately: #37388 (`return new Error()` losing the creating frame under the runtime minifier) and #24789 (non-top frames source-mapped twice after `.stack` was read). That is why the new tests compare entry points against each other and against line numbers rather than hardcoding columns. #9659 (GitHub Actions annotation for `cause`) is not claimed: its repro is a top-level `throw`, which already emits the `cause` annotation on the current release. This change does extend that annotation to errors escaping callbacks.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->