### PR TITLE
js_parser: keep destructured exports when lowering top-level using

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9258,10 +9258,7 @@ impl LowerUsingDeclarationsContext {
         result
     }
 
-    /// Adds an export clause item for every identifier an exported declaration
-    /// binds, including the ones nested in destructuring patterns
-    /// (`export const { a, b: [c] } = ...` exports `a` and `c`).
-    /// Returns whether the binding declared any identifier.
+    /// Exports every identifier `binding` declares, recursing through destructuring patterns.
     fn export_binding<'a, const T: bool, const S_: bool>(
         p: &P<'a, T, S_>,
         binding: Binding,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9013,19 +9013,7 @@ impl LowerUsingDeclarationsContext {
                         // StoreRef DerefMut; hoist the kind write below.
                         let mut any_ident = false;
                         for decl in local.decls.slice() {
-                            if let js_ast::b::B::BIdentifier(identifier) = decl.binding.data {
-                                let id_ref = identifier.r#ref;
-                                exports.push(js_ast::ClauseItem {
-                                    name: LocRef {
-                                        loc: decl.binding.loc,
-                                        ref_: id_ref,
-                                    },
-                                    alias: p.symbols[id_ref.inner_index() as usize].original_name,
-                                    alias_loc: decl.binding.loc,
-                                    ..Default::default()
-                                });
-                                any_ident = true;
-                            }
+                            any_ident |= Self::export_binding(p, decl.binding, &mut exports);
                         }
                         if any_ident {
                             local.kind = js_ast::s::Kind::KVar;
@@ -9268,6 +9256,47 @@ impl LowerUsingDeclarationsContext {
         }
 
         result
+    }
+
+    /// Adds an export clause item for every identifier an exported declaration
+    /// binds, including the ones nested in destructuring patterns
+    /// (`export const { a, b: [c] } = ...` exports `a` and `c`).
+    /// Returns whether the binding declared any identifier.
+    fn export_binding<'a, const T: bool, const S_: bool>(
+        p: &P<'a, T, S_>,
+        binding: Binding,
+        exports: &mut BumpVec<'a, js_ast::ClauseItem>,
+    ) -> bool {
+        match binding.data {
+            js_ast::b::B::BMissing(_) => false,
+            js_ast::b::B::BIdentifier(identifier) => {
+                let id_ref = identifier.r#ref;
+                exports.push(js_ast::ClauseItem {
+                    name: LocRef {
+                        loc: binding.loc,
+                        ref_: id_ref,
+                    },
+                    alias: p.symbols[id_ref.inner_index() as usize].original_name,
+                    alias_loc: binding.loc,
+                    ..Default::default()
+                });
+                true
+            }
+            js_ast::b::B::BArray(array) => {
+                let mut any_ident = false;
+                for item in array.items.slice() {
+                    any_ident |= Self::export_binding(p, item.binding, exports);
+                }
+                any_ident
+            }
+            js_ast::b::B::BObject(object) => {
+                let mut any_ident = false;
+                for property in object.properties.slice() {
+                    any_ident |= Self::export_binding(p, property.value, exports);
+                }
+                any_ident
+            }
+        }
     }
 }
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2278,6 +2278,64 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("edgecase/UsingExportDestructuring", {
+    // Lowering the top-level `using` wraps the module in try/finally and has to
+    // re-export every identifier the exported patterns bind, not only the
+    // `export const x = ...` ones.
+    files: {
+      "/entry.ts": `
+        import * as ns from "./module.ts";
+        console.log(JSON.stringify(ns));
+      `,
+      "/module.ts": `
+        using res = { [Symbol.dispose]() { console.log("Disposing"); } };
+        export const { a, b: [c] } = { a: 1, b: [2] };
+        export let [d, , e = 5, ...rest] = [3, 4, undefined, 6, 7];
+        export const { x: renamed, ...others } = { x: 8, y: 9 };
+        export var plain = 10, { g } = { g: 11 };
+        export const [] = [], {} = {};
+      `,
+    },
+    run: {
+      stdout: 'Disposing\n{"a":1,"c":2,"d":3,"e":5,"g":11,"others":{"y":9},"plain":10,"renamed":8,"rest":[6,7]}',
+    },
+  });
+
+  itBundled("edgecase/UsingExportDestructuringNamedImports", {
+    files: {
+      "/entry.ts": `
+        import { a, c, rest, renamed } from "./module.ts";
+        console.log(a, c, rest, renamed);
+      `,
+      "/module.ts": `
+        using res = { [Symbol.dispose]() { console.log("Disposing"); } };
+        export const { a, b: [c] } = { a: 1, b: [2] };
+        export let [, ...rest] = [3, 4, 5];
+        export const { x: renamed } = { x: 6 };
+      `,
+    },
+    run: {
+      stdout: "Disposing\n1 2 [ 4, 5 ] 6",
+    },
+  });
+
+  itBundled("edgecase/UsingExportDestructuringBakeDev", {
+    // The dev server's module format builds its export list from the same
+    // lowered statements.
+    format: "internal_bake_dev",
+    files: {
+      "/entry.ts": `
+        using res = { [Symbol.dispose]() {} };
+        export const { a, b: [c] } = { a: 1, b: [2] };
+        export let plain = 3;
+      `,
+    },
+    onAfterBundle(api) {
+      const output = api.readFile("/out.js");
+      expect(output).toMatch(/hmr\.exports = \{\s*a,\s*c,\s*plain,?\s*\}/);
+    },
+  });
+
   itBundled("edgecase/UsingExportDefaultThrows", {
     files: {
       "/entry.ts": `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5294,6 +5294,86 @@ describe("using declarations in switch statements", () => {
   });
 });
 
+describe("lowering top-level using keeps exported destructuring declarations exported", () => {
+  const source = `
+    using res = { [Symbol.dispose]() { console.log("disposed"); } };
+    export const { a, b: [c] } = { a: 1, b: [2] };
+    export let [d, , e = 5, ...rest] = [3, 4, undefined, 6, 7];
+    export const { x: renamed, ...others } = { x: 8, y: 9 };
+    export var plain = 10, { g } = { g: 11 };
+    export const [] = [], {} = {};
+  `;
+  const expectedExports = {
+    a: 1,
+    c: 2,
+    d: 3,
+    e: 5,
+    rest: [6, 7],
+    renamed: 8,
+    others: { y: 9 },
+    plain: 10,
+    g: 11,
+  };
+  const exportClauseNames = out => {
+    const clauses = [...out.matchAll(/^export \{([^}]*)\};?$/gm)];
+    expect(clauses).toHaveLength(1);
+    return clauses[0][1]
+      .split(",")
+      .map(name => name.trim())
+      .filter(Boolean);
+  };
+
+  it.each(["browser", "node"])("target=%s exports every identifier bound by the patterns", target => {
+    const out = new Bun.Transpiler({ loader: "js", target }).transformSync(source);
+    expect(out).toContain("__using");
+    // The declarations move into the try block as plain vars and the exports
+    // are re-emitted as one export clause after it.
+    expect(out).toMatch(/var \{ a, b: \[c\] \} =/);
+    expect(out).toMatch(/var \[d, , e = 5, \.\.\.rest\] =/);
+    expect(out).toMatch(/var \{ x: renamed, \.\.\.others \} =/);
+    expect(out).toMatch(/var plain = 10, \{ g \} =/);
+    expect(out).not.toMatch(/export (const|let|var)/);
+    expect(out.indexOf("export {")).toBeGreaterThan(out.indexOf("finally"));
+    expect(exportClauseNames(out)).toEqual(Object.keys(expectedExports));
+  });
+
+  it("target=bun leaves the declarations as they were", () => {
+    const out = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(source);
+    expect(out).not.toContain("__using");
+    expect(out).toContain("export const { a, b: [c] } =");
+    expect(out).toContain("export let [d, , e = 5, ...rest] =");
+    expect(out).toContain("export const { x: renamed, ...others } =");
+    expect(out).toContain("export var plain = 10, { g } =");
+    expect(out).not.toContain("export {");
+  });
+
+  it("the lowered module exposes the same bindings when imported", async () => {
+    const lowered = new Bun.Transpiler({ loader: "js", target: "node" }).transformSync(source);
+    expect(lowered).toContain("__using");
+
+    using dir = tempDir("using-lowering-exported-destructuring", {
+      "lowered.mjs": lowered,
+      "main.mjs": `
+        import * as ns from "./lowered.mjs";
+        console.log(JSON.stringify(ns));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const [disposed, exported] = stdout.trim().split("\n");
+    expect(disposed).toBe("disposed");
+    expect(JSON.parse(exported)).toEqual(expectedExports);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("minifyWhitespace keeps the space before keyword operators", () => {
   const minifier = new Bun.Transpiler({ loader: "js", minifyWhitespace: true });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -5337,6 +5337,38 @@ describe("lowering top-level using keeps exported destructuring declarations exp
     expect(exportClauseNames(out)).toEqual(Object.keys(expectedExports));
   });
 
+  // scan() reports the exports the lowered statements end up with, so every
+  // lowering target has to report the same names as the untouched bun target.
+  const exportsFor = (target, src) => new Bun.Transpiler({ loader: "js", target }).scan(src).exports;
+  it.each([
+    ["destructured declarations", source],
+    [
+      "await using with destructured declarations",
+      `
+        await using res = { [Symbol.asyncDispose]() {} };
+        export const { a, b: [c] } = { a: 1, b: [2] };
+      `,
+    ],
+    [
+      "declarations that were already re-exported",
+      `
+        using res = { [Symbol.dispose]() {} };
+        export function f() {}
+        export class K {}
+        const x = 1;
+        export { x as y };
+        export { q } from "./q";
+        export * as ns from "./ns";
+        export default 1;
+      `,
+    ],
+  ])("scan() reports the same export set for every target: %s", (_name, src) => {
+    const unlowered = exportsFor("bun", src);
+    expect(unlowered).not.toBeEmpty();
+    expect(exportsFor("browser", src)).toEqual(unlowered);
+    expect(exportsFor("node", src)).toEqual(unlowered);
+  });
+
   it("target=bun leaves the declarations as they were", () => {
     const out = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(source);
     expect(out).not.toContain("__using");


### PR DESCRIPTION
### Problem

- In a module with a top-level `using` / `await using`, built or transpiled for a target that lowers `using` (`browser`, `node`; `--target=bun` is unaffected), an exported destructuring declaration loses its exports:
  ```js
  using h = { [Symbol.dispose]() {} };
  export const { a, b: [c] } = { a: 1, b: [2] };
  export let ex = 4;
  ```
  `bun build --target=browser` prints `export { ex };` (esbuild prints `export { a, c, ex };`), and `Bun.Transpiler({ target: "browser" })` does the same.
- Importing one of the missing names from another file fails the build: `error: No matching export in "m.mjs" for import "a"`. The dev server's module format has the same hole: `hmr.exports = { ex }`.
- Cause: `LowerUsingDeclarationsContext::finalize` (`src/js_parser/p.rs`, `SLocal` arm) clears `is_export` on every exported declaration and pushes one export clause item per decl, but only when the decl's binding is a `BIdentifier`. `BObject` / `BArray` patterns are skipped, so the identifiers they bind are never re-exported. The export table is built afterwards from the lowered statements (`ImportScanner` in `src/js_parser/scan/scan_imports.rs`), so whatever the clause lacks is gone from every output format.
- Reproduces with bun 1.4.0 and main.

### Fix

- `finalize` now walks each exported decl's binding pattern (new `export_binding`, recursing through `BObject` / `BArray` like the existing `record_exported_binding`) and pushes an export clause item for every identifier it declares, aliased by the identifier's original name. Empty patterns (`export const [] = []`) still add nothing.
- Why this is right: the export clause is the only thing that carries the exports once `is_export` has been cleared, so it has to list the same identifiers a non-lowered `export const { a, b: [c] }` would export, which is exactly what `record_exported_binding` would have collected from the untouched declaration. The identifiers are already `var`s hoisted out of the try block (`select_local_kind` turns top-level declarations into `var` whenever the module is going to be wrapped), so the clause after the block can refer to them. This matches esbuild, whose `finalize` uses `ForEachIdentifierBindingInDecls` for the same step.
- Tests:
  - `test/bundler/transpiler/transpiler.test.js` ("lowering top-level using keeps exported destructuring declarations exported"): `Bun.Transpiler` output for `browser` and `node` lists every identifier bound by object, array, renamed, defaulted and rest patterns plus a mixed `export var a = .., { g } = ..`; `scan().exports` for `browser` and `node` equals the `bun` target's for the same source (also for `await using`, and for the function / class / clause / re-export shapes that already worked); the lowered module is then imported by a child process and exposes the expected values; `target: "bun"` keeps the declarations untouched.
  - `test/bundler/bundler_edgecase.test.ts`: `UsingExportDestructuring` (namespace import of the lowered module runs and shows every export), `UsingExportDestructuringNamedImports` (named imports of destructured exports used to fail the build), `UsingExportDestructuringBakeDev` (`internal_bake_dev` export list).
  - The new tests fail with `USE_SYSTEM_BUN=1` (5 of 7 transpiler cases, the other 2 being the unchanged-shape controls; all 3 bundler cases) and pass with `bun bd test`.
  - Also ran `test/bundler/transpiler/transpiler.test.js`, `test/bundler/bundler_edgecase.test.ts`, `test/bundler/bundler_browser.test.ts` (using cases) and `test/js/bun/resolve/lower-using-bun-target.test.ts` in full: green.
- Scope: this only covers the `SLocal` arm of `finalize`. The neighbouring arms have their own PRs: `export default function` / `export default class` being dropped is #38287, `export class` being hoisted above the `try` is #38292, and relocating the lowered module's vars when it gets an ESM wrapper is #38284. Each of those merges cleanly with this one.

### Background

- Lowering `using`: for targets that may not support explicit resource management, the parser rewrites a statement list containing `using` declarations into `let __stack = []; try { ...statements... } catch (_catch) { var _err = _catch, _hasErr = 1; } finally { __callDispose(__stack, _err, _hasErr); }`. At the top level of a module the whole module body goes into the `try`.
- `export` declarations cannot appear inside a block, so `finalize` strips the `export` keyword off the declarations that move into the `try` and emits a single `export { ... }` clause after the block instead. That clause is what this PR completes for destructuring declarations.
- `record_exported_binding` is the routine that collects exports from a normal (non-lowered) `export const ...` declaration; it recurses through the same three binding shapes (identifier, array pattern, object pattern), which is the behavior the new walk mirrors.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->