### PR TITLE
sourcemap: make mapping::parse return a Result instead of a hand-rolled two-variant enum

### DIFF
--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -682,11 +682,11 @@ impl SourceMapStore {
             0, // unused
             Default::default(),
         ) {
-            source_map::ParseResult::Fail(fail) => {
+            Err(fail) => {
                 bun_core::debug_warn!("Failed to re-parse source map: {}", fail.err.message());
                 None
             }
-            source_map::ParseResult::Success(mut psm) => Some(GetResult {
+            Ok(mut psm) => Some(GetResult {
                 mappings: core::mem::take(&mut psm.mappings),
                 file_paths: &entry.paths,
                 entry_files: &entry.files,

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -8,7 +8,7 @@ use bun_core::{declare_scope, scoped_log};
 use bun_semver::String as SemverString;
 
 use crate::vlq::decode as decode_vlq;
-use crate::{LineColumnOffset, Ordinal, ParseResult, ParseResultFail, ParsedSourceMap};
+use crate::{LineColumnOffset, Ordinal, ParseFail, ParseResult, ParsedSourceMap};
 
 declare_scope!(SourceMap, visible);
 
@@ -460,7 +460,7 @@ pub fn parse(
 
     if let Some(count) = estimated_mapping_count {
         if mapping.ensure_total_capacity(count).is_err() {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::Alloc(bun_alloc::AllocError),
                 loc: Loc::default(),
             });
@@ -508,7 +508,7 @@ pub fn parse(
                 );
             }
             SimdResult::OutOfMemory => {
-                return ParseResult::Fail(ParseResultFail {
+                return Err(ParseFail {
                     err: crate::Error::Alloc(bun_alloc::AllocError),
                     loc: Loc::default(),
                 });
@@ -539,7 +539,7 @@ pub fn parse(
         let generated_column_delta = decode_vlq(remain, 0);
 
         if generated_column_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::MissingGeneratedColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -554,7 +554,7 @@ pub fn parse(
             .zero_based()
             .wrapping_add(generated_column_delta.value);
         if generated_column < 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::InvalidGeneratedColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -587,7 +587,7 @@ pub fn parse(
         // Read the original source
         let source_index_delta = decode_vlq(remain, 0);
         if source_index_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::InvalidSourceIndexDelta,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -597,7 +597,7 @@ pub fn parse(
         source_index = source_index.wrapping_add(source_index_delta.value);
 
         if source_index < 0 || source_index >= sources_count {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::InvalidSourceIndexValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -609,7 +609,7 @@ pub fn parse(
         // Read the original line
         let original_line_delta = decode_vlq(remain, 0);
         if original_line_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::MissingOriginalLine,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -622,7 +622,7 @@ pub fn parse(
             .zero_based()
             .wrapping_add(original_line_delta.value);
         if original_line < 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::InvalidOriginalLineValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -635,7 +635,7 @@ pub fn parse(
         // Read the original column
         let original_column_delta = decode_vlq(remain, 0);
         if original_column_delta.start == 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::MissingOriginalColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -648,7 +648,7 @@ pub fn parse(
             .zero_based()
             .wrapping_add(original_column_delta.value);
         if original_column < 0 {
-            return ParseResult::Fail(ParseResultFail {
+            return Err(ParseFail {
                 err: crate::Error::InvalidOriginalColumnValue,
                 loc: Loc {
                     start: i32::try_from(bytes.len() - remain.len()).unwrap_or(i32::MAX),
@@ -672,7 +672,7 @@ pub fn parse(
                     // Read the name index
                     let name_index_delta = decode_vlq(remain, 0);
                     if name_index_delta.start == 0 {
-                        return ParseResult::Fail(ParseResultFail {
+                        return Err(ParseFail {
                             err: crate::Error::InvalidNameIndexDelta,
                             loc: Loc {
                                 start: i32::try_from(bytes.len() - remain.len())
@@ -686,7 +686,7 @@ pub fn parse(
                         name_index = name_index.wrapping_add(name_index_delta.value);
                         if !has_names {
                             if mapping.ensure_with_names().is_err() {
-                                return ParseResult::Fail(ParseResultFail {
+                                return Err(ParseFail {
                                     err: crate::Error::Alloc(bun_alloc::AllocError),
                                     loc: Loc {
                                         start: i32::try_from(bytes.len() - remain.len())
@@ -737,7 +737,7 @@ pub fn parse(
     let mut psm = ParsedSourceMap::default();
     psm.mappings = mapping;
     psm.input_line_count = input_line_count;
-    ParseResult::Success(psm)
+    Ok(psm)
 }
 
 enum SimdResult {

--- a/src/sourcemap/error.rs
+++ b/src/sourcemap/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
 }
 
 impl Error {
-    /// What `ParseResult::Fail` reports to the user.
+    /// What a `ParseFail` reports to the user.
     pub fn message(self) -> &'static str {
         match self {
             Self::MissingGeneratedColumnValue => "Missing generated column value",

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -105,12 +105,9 @@ pub struct ParseUrl {
     pub source_contents: Option<Box<[u8]>>,
 }
 
-pub enum ParseResult {
-    Fail(ParseResultFail),
-    Success(ParsedSourceMap),
-}
+pub type ParseResult = core::result::Result<ParsedSourceMap, ParseFail>;
 
-pub struct ParseResultFail {
+pub struct ParseFail {
     pub loc: bun_ast::Loc,
     pub err: crate::Error,
 }
@@ -969,8 +966,8 @@ pub(crate) fn parse_json(source: &[u8], hint: ParseUrlResultHint) -> crate::Resu
                 sort: true,
             },
         ) {
-            ParseResult::Success(x) => x,
-            ParseResult::Fail(fail) => return Err(fail.err),
+            Ok(x) => x,
+            Err(fail) => return Err(fail.err),
         };
 
         if let ParseUrlResultHint::All {

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -7,7 +7,7 @@ use bstr::BStr;
 
 use bun_core::{self as bstring, strings};
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, bun_string_jsc};
-use bun_sourcemap::{Mapping, Ordinal, ParseResult, ParsedSourceMap, mapping};
+use bun_sourcemap::{Mapping, Ordinal, ParsedSourceMap, mapping};
 
 // generate-classes.ts does not emit Rust accessors yet, so the
 // `to_js`/cached-setter helpers below forward to the codegen-emitted C++
@@ -157,8 +157,8 @@ impl JSSourceMap {
         );
 
         let mapping_list = match parse_result {
-            ParseResult::Success(parsed) => parsed,
-            ParseResult::Fail(fail) => {
+            Ok(parsed) => parsed,
+            Err(fail) => {
                 if let Some(loc) = fail.loc.to_nullable() {
                     return Err(global.throw_value(global.create_syntax_error_instance(
                         format_args!("{} at {}", fail.err.message(), loc.start),


### PR DESCRIPTION
Fixes clippy on main. #38263 shrank the failure side of ParseResult to 8 bytes, and clippy now flags the enum for the size gap between its two variants.

ParseResult was Result spelled by hand, so it is now a type alias for Result<ParsedSourceMap, ParseFail>. Callers match Ok/Err. Same values, same layout of the payloads.

sourcemap-simd.test.ts passes on the debug build and the parse error output is identical to the release binary.