### PR TITLE
valkey: count idle time from connect and restart it on incoming data

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -382,7 +382,10 @@ const client = new RedisClient("redis://localhost:6379", {
   // Connection timeout in milliseconds (default: 10000)
   connectionTimeout: 5000,
 
-  // Idle timeout in milliseconds (default: 0 = no timeout)
+  // Idle timeout in milliseconds (default: 0 = no timeout). Bun counts it
+  // from the last data the server sent. Sending does not reset it. When it
+  // fires, Bun closes the connection and runs onclose. Bun does not reconnect
+  // on its own, even with autoReconnect: true. Call connect() to reconnect.
   idleTimeout: 30000,
 
   // Whether to automatically reconnect on disconnection (default: true)

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -7,7 +7,10 @@ declare module "bun" {
     connectionTimeout?: number;
 
     /**
-     * Idle timeout in milliseconds
+     * Idle timeout in milliseconds. Bun counts it from the last data the
+     * server sent. Sending does not reset it. When it fires, Bun closes the
+     * connection and runs `onclose`. Bun does not reconnect on its own, even
+     * with `autoReconnect: true`. Call `connect()` to reconnect.
      * @default 0 (no timeout)
      */
     idleTimeout?: number;

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -22,8 +22,9 @@ declare module "bun" {
     autoReconnect?: boolean;
 
     /**
-     * Maximum number of reconnection attempts
-     * @default 10
+     * Maximum number of reconnection attempts before the client gives up and
+     * runs `onclose`.
+     * @default 20
      */
     maxRetries?: number;
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1224,6 +1224,8 @@ impl JSValkeyClient {
         debug_assert!(self.client.get().status == valkey::Status::Connected);
         // we should always have a strong reference to the object here
         debug_assert!(self.this_value.get().is_strong());
+        // Now counting idle time, not connect time.
+        self.reset_connection_timeout();
 
         let self_ptr = self.as_ctx_ptr();
         let _defer = scopeguard::guard(self_ptr, |p| {
@@ -1927,6 +1929,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
 
         let _guard = this.ref_scope();
         let result = this.client_mut().on_data(data);
+        if this.client.get().status == valkey::Status::Connected {
+            this.reset_connection_timeout();
+        }
         this.update_poll_ref();
         result
     }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -597,6 +597,66 @@ describe("Valkey: Recovering After fail()", () => {
       fake.server.close();
     }
   });
+
+  test("a connection that stays silent after the handshake is closed by its idle timeout", async () => {
+    const fake = helloServer();
+    const port = await fake.listen();
+    // The timer is armed with connectionTimeout when the socket is dialed, and
+    // accepting HELLO is what switches it to idleTimeout. With connectionTimeout
+    // off, the idle timeout is the only thing that can close this connection.
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, {
+      connectionTimeout: 0,
+      idleTimeout: 50,
+      autoReconnect: false,
+    });
+    try {
+      // Once for a first connection, once for the one connect() dials after it.
+      for (const connection of [1, 2]) {
+        const closed = Promise.withResolvers<Error>();
+        client.onclose = err => closed.resolve(err);
+        await client.connect();
+        expect(client.connected).toBe(true);
+        expect(await closed.promise).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+        expect(client.connected).toBe(false);
+        expect(fake.connections).toBe(connection);
+      }
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("data from the server restarts the idle timeout", async () => {
+    let pushes = 0;
+    const fake = helloServer({
+      // PING is answered with 30 pushes 20ms apart, at least 600ms of traffic,
+      // and never with PONG. A client that is not subscribed discards them, so
+      // restarting its idle timer is all they can do.
+      PING: (_, socket) => {
+        const timer = setInterval(() => {
+          socket.write(">2\r\n$7\r\nmessage\r\n$2\r\nhi\r\n");
+          if (++pushes === 30) clearInterval(timer);
+        }, 20);
+        socket.on("close", () => clearInterval(timer));
+        return null;
+      },
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { idleTimeout: 400, autoReconnect: false });
+    try {
+      await client.connect();
+      // Every push restarts the 400ms idle timer armed by the handshake, so it
+      // runs out, rejecting PING, 400ms after the last push, not in the middle
+      // of them.
+      await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_IDLE_TIMEOUT" });
+      expect(pushes).toBe(30);
+      expect(client.connected).toBe(false);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
   test("connected reads false inside onclose when the server drops an established connection", async () => {
     // Connection 1 is dropped by the server right after it answers PING.
     const fake = helloServer({
@@ -692,59 +752,6 @@ describe("Valkey: Recovering After fail()", () => {
       client.close();
       fake.sockets[0]?.destroy();
       fake.server.close();
-    }
-  });
-
-  test("an idle connection is closed after idleTimeout, and connect() reconnects", async () => {
-    const closed = Promise.withResolvers<Error>();
-    const fake = helloServer();
-    const port = await fake.listen();
-    const client = new RedisClient(`redis://127.0.0.1:${port}`, { idleTimeout: 50 });
-    try {
-      client.onclose = err => closed.resolve(err);
-      await client.connect();
-      expect(client.connected).toBe(true);
-      // Nothing is sent, so only the idle timer can end this; connectionTimeout
-      // is still at its 10s default, well past the test's own timeout.
-      expect(await closed.promise).toBeInstanceOf(Error);
-      expect(client.connected).toBe(false);
-      await client.connect();
-      expect(await client.ping()).toBe("PONG");
-      expect(fake.connections).toBe(2);
-    } finally {
-      client.close();
-      await fake.close();
-    }
-  });
-
-  test("data from the server restarts the idle timer", async () => {
-    let pushes = 0;
-    const server = net.createServer(socket => {
-      socket.on("data", chunk => {
-        if (!chunk.toString("latin1").includes("HELLO")) return;
-        socket.write("+OK\r\n");
-        // Unsolicited pushes 25ms apart, each well inside the 100ms idle window;
-        // together they outlast it twice over.
-        const timer = setInterval(() => {
-          socket.write(">2\r\n$7\r\nmessage\r\n$2\r\nhi\r\n");
-          if (++pushes === 8) clearInterval(timer);
-        }, 25);
-        socket.on("close", () => clearInterval(timer));
-      });
-      socket.on("error", () => {});
-    });
-    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
-    const port = (server.address() as net.AddressInfo).port;
-    const closed = Promise.withResolvers<void>();
-    const client = new RedisClient(`redis://127.0.0.1:${port}`, { idleTimeout: 100, autoReconnect: false });
-    try {
-      client.onclose = () => closed.resolve();
-      await client.connect();
-      await closed.promise;
-      expect(pushes).toBe(8);
-    } finally {
-      client.close();
-      server.close();
     }
   });
 

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -695,6 +695,59 @@ describe("Valkey: Recovering After fail()", () => {
     }
   });
 
+  test("an idle connection is closed after idleTimeout, and connect() reconnects", async () => {
+    const closed = Promise.withResolvers<Error>();
+    const fake = helloServer();
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { idleTimeout: 50 });
+    try {
+      client.onclose = err => closed.resolve(err);
+      await client.connect();
+      expect(client.connected).toBe(true);
+      // Nothing is sent, so only the idle timer can end this; connectionTimeout
+      // is still at its 10s default, well past the test's own timeout.
+      expect(await closed.promise).toBeInstanceOf(Error);
+      expect(client.connected).toBe(false);
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
+    } finally {
+      client.close();
+      await fake.close();
+    }
+  });
+
+  test("data from the server restarts the idle timer", async () => {
+    let pushes = 0;
+    const server = net.createServer(socket => {
+      socket.on("data", chunk => {
+        if (!chunk.toString("latin1").includes("HELLO")) return;
+        socket.write("+OK\r\n");
+        // Unsolicited pushes 25ms apart, each well inside the 100ms idle window;
+        // together they outlast it twice over.
+        const timer = setInterval(() => {
+          socket.write(">2\r\n$7\r\nmessage\r\n$2\r\nhi\r\n");
+          if (++pushes === 8) clearInterval(timer);
+        }, 25);
+        socket.on("close", () => clearInterval(timer));
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    const closed = Promise.withResolvers<void>();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { idleTimeout: 100, autoReconnect: false });
+    try {
+      client.onclose = () => closed.resolve();
+      await client.connect();
+      await closed.promise;
+      expect(pushes).toBe(8);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
   test("a connect() issued from onclose after a refused connection rejects instead of hanging", async () => {
     // Nothing listens on the port a just-closed listener used.
     const fake = helloServer();


### PR DESCRIPTION
Stacked on #37993, which makes an idle timeout actually close the socket. Will retarget to main once that lands.

The one timer is armed with connectionTimeout when the socket is opened and only re-armed by send(). So a connection that just sits there, or only receives (a subscriber), has its idleTimeout fire when connectionTimeout runs out, 10s by default, whatever idleTimeout was set to.

Re-arm it when the handshake completes, which switches it to the idle interval (or disarms it when idleTimeout is 0), and again on every incoming packet. This is what the postgres client already does in set_status and on_data.

With idleTimeout 100ms a silent server now gets closed at about 100ms, and a server pushing messages keeps the client alive until it stops. Release closes neither within 15s. Two tests in connection-failures.test.ts, no container needed.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts test/cli/hot/watch-many-dirs.test.ts test/cli/install/bun-install.test.ts test/cli/install/bun-pm-diff.test.ts test/cli/install/isolated-install.test.ts test/internal/build-debug-info-flags.test.ts test/internal/build-post-link-ordering.test.ts test/internal/macos-cro…

<!-- robobun:evidence:end -->

Fixes #18895 (together with #39511 and #39513, which land before this).
