### PR TITLE
cli: list the names --loader accepts in the invalid loader error

### DIFF
--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -173,8 +173,7 @@ impl Loader {
         })
     }
 
-    /// Every name `from_string` accepts, one `-  name` line each, for
-    /// "expected one of:" errors.
+    /// Formats every name `from_string` accepts as `\n-  name` lines.
     pub fn accepted_names_list() -> impl core::fmt::Display {
         AcceptedNamesList
     }

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -173,6 +173,12 @@ impl Loader {
         })
     }
 
+    /// Every name `from_string` accepts, one `-  name` line each, for
+    /// "expected one of:" errors.
+    pub fn accepted_names_list() -> impl core::fmt::Display {
+        AcceptedNamesList
+    }
+
     #[inline]
     pub fn is_jsx(self) -> bool {
         self == Loader::Jsx || self == Loader::Tsx
@@ -234,6 +240,17 @@ impl Loader {
             | Loader::Md => SideEffects::NoSideEffectsPureData,
             _ => SideEffects::HasSideEffects,
         }
+    }
+}
+
+struct AcceptedNamesList;
+
+impl core::fmt::Display for AcceptedNamesList {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for name in Loader::NAMES.keys() {
+            write!(f, "\n-  {}", bstr::BStr::new(name))?;
+        }
+        Ok(())
     }
 }
 

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -12,18 +12,7 @@ use enum_map::Enum;
 /// - bun-native-bundler-plugin-api/bundler_plugin.h
 /// - src/jsc/bindings/headers-handwritten.h
 #[repr(u8)]
-#[derive(
-    Copy,
-    Clone,
-    Default,
-    Eq,
-    PartialEq,
-    Debug,
-    Hash,
-    Enum,
-    strum::IntoStaticStr,
-    strum::VariantNames,
-)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug, Hash, Enum, strum::IntoStaticStr)]
 // The lower_snake names are exposed to JS (HTMLImportManifest
 // `"loader":`, BuildArtifact.loader) so the strum serialization must match exactly.
 #[strum(serialize_all = "snake_case")]

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2281,45 +2281,6 @@ pub fn quote(self_: &[u8]) -> QuotedFormatter<'_> {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// EnumTagListFormatter
-// ───────────────────────────────────────────────────────────────────────────
-
-// ConstParamTy is nightly, so use a runtime value instead.
-pub const SEP_DASH: bool = false;
-
-pub struct EnumTagListFormatter<E: strum::VariantNames, const LIST: bool> {
-    _marker: core::marker::PhantomData<E>,
-}
-
-impl<E: strum::VariantNames, const LIST: bool> Display for EnumTagListFormatter<E, LIST> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        // PERF: could be precomputed as a single &'static str.
-        let names = E::VARIANTS;
-        for (i, name) in names.iter().enumerate() {
-            if LIST {
-                if i > 0 {
-                    if i + 1 == names.len() {
-                        f.write_str(", or ")?;
-                    } else {
-                        f.write_str(", ")?;
-                    }
-                }
-                write!(f, "\"{}\"", name)?;
-            } else {
-                write!(f, "\n-  {}", name)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-pub fn enum_tag_list<E: strum::VariantNames, const LIST: bool>() -> EnumTagListFormatter<E, LIST> {
-    EnumTagListFormatter {
-        _marker: core::marker::PhantomData,
-    }
-}
-
-// ───────────────────────────────────────────────────────────────────────────
 // formatIp
 // ───────────────────────────────────────────────────────────────────────────
 

--- a/src/runtime/cli/colon_list_type.rs
+++ b/src/runtime/cli/colon_list_type.rs
@@ -1,4 +1,5 @@
 use crate::Error;
+use bstr::BStr;
 use bun_core::fmt as bun_fmt;
 use bun_core::strings;
 use bun_core::{Global, pretty_errorln};
@@ -19,6 +20,19 @@ pub(crate) struct ColonListType<T: ColonListValue> {
     // in practice — that is what makes the `&'static` typing sound.
     pub keys: Vec<&'static [u8]>,
     pub values: Vec<T>,
+}
+
+/// The names `Loader::from_string` accepts, one per line, read from its lookup
+/// table so the error cannot list a name the flag then rejects.
+struct AcceptedLoaderNames;
+
+impl core::fmt::Display for AcceptedLoaderNames {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for name in bun_ast::loader::LOADER_NAMES.keys() {
+            write!(f, "\n-  {}", BStr::new(name))?;
+        }
+        Ok(())
+    }
 }
 
 impl<T: ColonListValue> ColonListType<T> {
@@ -72,7 +86,7 @@ impl<T: ColonListValue> ColonListType<T> {
                         pretty_errorln!(
                             "<r><red>error<r><d>:<r> <b>invalid loader {}<r>, expected one of:{}",
                             bun_fmt::quote(&str[midpoint + 1..str.len()]),
-                            bun_fmt::enum_tag_list::<bun_ast::Loader, { bun_fmt::SEP_DASH }>(),
+                            AcceptedLoaderNames,
                         );
                         Global::exit(1);
                     }

--- a/src/runtime/cli/colon_list_type.rs
+++ b/src/runtime/cli/colon_list_type.rs
@@ -1,5 +1,4 @@
 use crate::Error;
-use bstr::BStr;
 use bun_core::fmt as bun_fmt;
 use bun_core::strings;
 use bun_core::{Global, pretty_errorln};
@@ -20,19 +19,6 @@ pub(crate) struct ColonListType<T: ColonListValue> {
     // in practice — that is what makes the `&'static` typing sound.
     pub keys: Vec<&'static [u8]>,
     pub values: Vec<T>,
-}
-
-/// The names `Loader::from_string` accepts, one per line, read from its lookup
-/// table so the error cannot list a name the flag then rejects.
-struct AcceptedLoaderNames;
-
-impl core::fmt::Display for AcceptedLoaderNames {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        for name in bun_ast::loader::LOADER_NAMES.keys() {
-            write!(f, "\n-  {}", BStr::new(name))?;
-        }
-        Ok(())
-    }
 }
 
 impl<T: ColonListValue> ColonListType<T> {
@@ -86,7 +72,7 @@ impl<T: ColonListValue> ColonListType<T> {
                         pretty_errorln!(
                             "<r><red>error<r><d>:<r> <b>invalid loader {}<r>, expected one of:{}",
                             bun_fmt::quote(&str[midpoint + 1..str.len()]),
-                            AcceptedLoaderNames,
+                            bun_ast::Loader::accepted_names_list(),
                         );
                         Global::exit(1);
                     }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -501,6 +501,47 @@ describe("CLI argument error messages", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("--loader with an unknown loader lists the names the flag accepts", async () => {
+    using dir = tempDir("build-loader-unknown", { "in.js": "console.log(1)" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--loader", ".cool:wtf", "in.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain('invalid loader "wtf", expected one of:');
+    expect(exitCode).toBe(1);
+
+    const listed = stderr
+      .split("\n")
+      .filter(line => line.startsWith("-  "))
+      .map(line => line.slice("-  ".length).trim());
+    // "sh" is the spelling the flag accepts for the shell loader; the list used
+    // to print the enum variant name "bunsh" instead, which the flag rejects.
+    expect(listed).toContain("sh");
+    expect(listed).toContain("mjs");
+    expect(listed).toContain("js");
+
+    // Every name in the list must be accepted. The flag is parsed the same way
+    // by every command, so map one made-up extension to each name in a single run.
+    await using accepted = Bun.spawn({
+      cmd: [bunExe(), ...listed.flatMap((name, i) => ["--loader", `.l${i}:${name}`]), "-e", "console.log('ok')"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [acceptedStdout, acceptedStderr, acceptedExitCode] = await Promise.all([
+      accepted.stdout.text(),
+      accepted.stderr.text(),
+      accepted.exited,
+    ]);
+    expect({ stdout: acceptedStdout, stderr: acceptedStderr }).toEqual({ stdout: "ok\n", stderr: "" });
+    expect(acceptedExitCode).toBe(0);
+  });
+
   test("--define without a separator names the flag and shows an example", async () => {
     using dir = tempDir("build-define-err", { "in.js": "console.log(FOO)" });
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- `bun --loader .x:bogus -e 1` (same for `bun run`, `bun build`, `bun test`, which share the flag parser) prints `error: invalid loader "bogus", expected one of:` followed by a list that includes `bunsh`. `bun --loader .x:bunsh -e 1` fails with the same error, while `--loader .x:sh` works and `sh` is not in the list. Reproduces on the released 1.4.0. Found by inspection while working on the neighbouring loader-name lists (#38266); there is no user report.
- The list was `bun_fmt::enum_tag_list::<bun_ast::Loader>()` (`src/runtime/cli/colon_list_type.rs:75`): the snake_case variant names of the `Loader` enum. The value itself is resolved by `Loader::from_string` (`src/runtime/cli/Arguments.rs:39`), which looks the name up in the `LOADER_NAMES` table in `src/ast/loader.rs`. The two sets differ: the table has no `bunsh` key (the variant `Bunsh` is spelled `sh`), and it has spellings the enum does not (`mjs`, `cjs`, `cts`, `mts`, `node`, `txt`, `markdown`).

### Fix
- `Loader::accepted_names_list()` (`src/ast/loader.rs`, next to the table) formats the keys of `LOADER_NAMES` as the same `-  name` lines, and the CLI error prints that after its unchanged `expected one of:` header. `from_string` consults exactly this table, so every listed name is accepted and every accepted name is listed, and a loader added to the table shows up without a second list to update. Same approach as the `OUTPUT_COLOR_FORMAT_MAP` error in `src/css_jsc/color_js.rs`.
- Deleted code this makes dead: `enum_tag_list`, `EnumTagListFormatter` and `SEP_DASH` in `src/bun_core/fmt.rs` (this was their only caller), and the `strum::VariantNames` derive on `Loader` (only read by that formatter; `IntoStaticStr`, which `BuildArtifact.loader` and the HTML manifest use, stays). rustfmt collapses the remaining derive list onto one line.
- The list names what the flag accepts, not what every name is worth using: `sh` is accepted and currently maps to the `file` loader, and `jsonc` / `sqlite_embedded` are currently downgraded to `json` / `sqlite` by `to_api()` (#38247 fixes the latter two). Filtering those out here would mean a second hand-maintained list, which is what drifted in the first place; the docs and help text (#38266, #38270) are where the recommended subset lives.
- Related open PRs, so the merge order is visible: #38247 adds a new `enum_tag_list` call for the `Bun.build({ loader })` error, which this PR deletes. The two merge cleanly but whichever lands second needs that one call changed (rendering from `LOADER_NAMES` there too would fix the same `bunsh` drift on that surface); noted on #38247. #37095 adds a `bunsh` key to `LOADER_NAMES`, which this list would then simply include, and touches the same derive block (trivial conflict). The stale `Valid loaders:` literal in the `--loader` help text is #38270.
- Test: `test/bundler/cli.test.ts`, `--loader with an unknown loader lists the names the flag accepts`. It runs `bun build --loader .cool:wtf`, parses the `-  name` lines, checks `sh`, `mjs` and `js` are present, then starts `bun -e` once with every listed name mapped to its own made-up extension and requires exit 0 with empty stderr. On 1.4.0 it fails (`sh` missing; the acceptance run would also fail on `bunsh`); it passes with the debug build.
- Also run: the existing `edgecase/InvalidLoaderSegfault` case in `test/bundler/bundler_edgecase.test.ts`, which asserts the unchanged header; `test/internal/source-lints/`; `cargo fmt --check` on the three crates.

### Background
- A loader is the parser Bun applies to a file (`json`, `text`, `file`, ...). `--loader .ext:name` maps an extension to one, for the runtime and for `bun build`; `ColonListType` in `colon_list_type.rs` parses the `.ext:name` pairs for `--loader` and `--define`.
- `LOADER_NAMES` is a `comptime_string_map!`, a static string to value table with a length-dispatched lookup; `keys()` yields the keys in declaration order, so the printed order is the order of the table in `loader.rs`. Several keys map to the same loader (`mjs` and `cjs` to `Js`, `node` to `Napi`), which is why the list is longer than the enum.
- `to_api()` (`src/options_types/bundle_enums.rs`) converts the resolved `Loader` into the option-bag enum the loader map stores; it is where `sh` becomes `file`.
- `strum::VariantNames` generates `Loader::VARIANTS`, the array of variant names the old formatter printed. `strum::IntoStaticStr` is the separate derive that converts one value to its name.

<details>
<summary>Before / after</summary>

Before (1.4.0):

```
error: invalid loader "bogus", expected one of:
-  jsx
-  js
-  ts
-  tsx
-  css
-  file
-  json
-  jsonc
-  toml
-  wasm
-  napi
-  base64
-  dataurl
-  text
-  bunsh
-  sqlite
-  sqlite_embedded
-  html
-  yaml
-  json5
-  md
-  xml
```

After:

```
error: invalid loader "bogus", expected one of:
-  js
-  mjs
-  cjs
-  cts
-  mts
-  jsx
-  ts
-  tsx
-  css
-  file
-  json
-  jsonc
-  toml
-  yaml
-  json5
-  xml
-  wasm
-  napi
-  node
-  dataurl
-  base64
-  txt
-  text
-  sh
-  sqlite
-  sqlite_embedded
-  html
-  md
-  markdown
```

All 29 names were also checked by hand against 1.4.0 with one `bun -e` run and one `bun build` run carrying all of them as `--loader` flags; both exit 0.
</details>

<details>
<summary>Changes after self-review</summary>

- The first revision kept the formatter as a private struct in `colon_list_type.rs`; it now lives next to `LOADER_NAMES` as `Loader::accepted_names_list()`, so the other surfaces that resolve through the same table have something to call.
- The relationship to #38247 / #37095 / #38270 above was added for the same reason.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->