### PR TITLE
js_parser: hoist the declarations of a lowered top-level `using` out of the ESM wrapper and the REPL IIFE

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -5,7 +5,7 @@ use bun_core::feature_flags as FeatureFlags;
 use crate::p::P;
 use crate::parser::{self as js_parser, IdentifierOpts, RelocateVars, RelocateVarsMode};
 use bun_ast::ast_result::CommonJSNamedExport;
-use bun_ast::{self as js_ast, Binding, E, Expr, Flags, G, LocRef, S};
+use bun_ast::{self as js_ast, Binding, E, Expr, Flags, G, LocRef, S, Stmt};
 
 // ── local EString shims ────────────────────────────────────────────────────
 // E.rs currently carries two `impl EString` blocks (live + round-C draft) with
@@ -79,6 +79,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
         }
 
+        RelocateVars {
+            stmt: p.relocate_vars_to_top_level(decls, mode),
+            ok: true,
+        }
+    }
+
+    /// Declares the identifiers bound by these `var` decls at the top level of
+    /// the current part instead (`append_part` emits the declarations) and
+    /// returns what replaces the original declaration: the initializers turned
+    /// into assignments, or `None` if there is nothing left to evaluate.
+    pub(crate) fn relocate_vars_to_top_level(
+        &mut self,
+        decls: &[G::Decl],
+        mode: RelocateVarsMode,
+    ) -> Option<Stmt> {
+        let p = self;
         let mut value: Expr = Expr::EMPTY;
         for decl in decls {
             // Derive `*mut P` from the live `&mut Self` so the trampoline's
@@ -94,22 +110,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         if matches!(value.data, js_ast::ExprData::EMissing(_)) {
-            return RelocateVars {
-                ok: true,
-                ..Default::default()
-            };
+            return None;
         }
 
-        RelocateVars {
-            stmt: Some(p.s(
-                S::SExpr {
-                    value,
-                    does_not_affect_tree_shaking: false,
-                },
-                value.loc,
-            )),
-            ok: true,
-        }
+        Some(p.s(
+            S::SExpr {
+                value,
+                does_not_affect_tree_shaking: false,
+            },
+            value.loc,
+        ))
     }
 
     // EDot nodes represent a property access. This function may return an

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -85,8 +85,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Re-declares these `var`s at the top level of the part (`append_part` emits
-    /// them) and returns the assignments that replace the declaration, if any.
+    /// Declares these `var`s at the part's top level; returns the assignments that replace them.
     pub(crate) fn relocate_vars_to_top_level(
         &mut self,
         decls: &[G::Decl],

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -85,10 +85,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Declares the identifiers bound by these `var` decls at the top level of
-    /// the current part instead (`append_part` emits the declarations) and
-    /// returns what replaces the original declaration: the initializers turned
-    /// into assignments, or `None` if there is nothing left to evaluate.
+    /// Re-declares these `var`s at the top level of the part (`append_part` emits
+    /// them) and returns the assignments that replace the declaration, if any.
     pub(crate) fn relocate_vars_to_top_level(
         &mut self,
         decls: &[G::Decl],

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8961,13 +8961,9 @@ impl LowerUsingDeclarationsContext {
     ) -> ListManaged<'a, Stmt> {
         let mut result = BumpVec::new_in(p.arena);
         let mut exports = BumpVec::<js_ast::ClauseItem>::new_in(p.arena);
-        // When the linker wraps a module in an `__esm` closure, it hoists the
-        // module's declarations out of the closure (where the export getters and
-        // the importing modules reference them) by looking at the module's
-        // top-level statements only; `var`s nested in other statements were
-        // already relocated up there while visiting. The module body's `var`s
-        // are about to be moved into the try block, so relocate them the same
-        // way and keep only their assignments in the try block.
+        // The linker hoists a wrapped module's declarations out of its `__esm`
+        // closure by scanning the top-level statements only, so the `var`s that
+        // move into the try block below must stay declared at the top level.
         let relocate_vars = p.options.bundle && p.current_scope == p.module_scope;
         let mut end: u32 = 0;
         for i in 0..stmts.len() {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -24,9 +24,10 @@ use crate::{
     FindLabelSymbolResult, FnOnlyDataVisit, FnOrArrowDataParse, FnOrArrowDataVisit, FunctionKind,
     IdentifierOpts, ImportItemForNamespaceMap, InvalidLoc, JSXImport, JSXTransformType, Jest,
     LOC_MODULE_SCOPE as loc_module_scope, LocList, MacroState, ParseStatementOptions, ParsedPath,
-    PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RuntimeImports, ScopeOrder,
-    ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef, ThenCatchChain,
-    TransposeState, WrapMode, fs, is_eval_or_arguments, options, statement_cares_about_scope,
+    PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RelocateVarsMode, RuntimeImports,
+    ScopeOrder, ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef,
+    ThenCatchChain, TransposeState, WrapMode, fs, is_eval_or_arguments, options,
+    statement_cares_about_scope,
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
@@ -8960,9 +8961,17 @@ impl LowerUsingDeclarationsContext {
     ) -> ListManaged<'a, Stmt> {
         let mut result = BumpVec::new_in(p.arena);
         let mut exports = BumpVec::<js_ast::ClauseItem>::new_in(p.arena);
+        // When the linker wraps a module in an `__esm` closure, it hoists the
+        // module's declarations out of the closure (where the export getters and
+        // the importing modules reference them) by looking at the module's
+        // top-level statements only; `var`s nested in other statements were
+        // already relocated up there while visiting. The module body's `var`s
+        // are about to be moved into the try block, so relocate them the same
+        // way and keep only their assignments in the try block.
+        let relocate_vars = p.options.bundle && p.current_scope == p.module_scope;
         let mut end: u32 = 0;
         for i in 0..stmts.len() {
-            let stmt = stmts[i];
+            let mut stmt = stmts[i];
             match stmt.data {
                 js_ast::StmtData::SDirective(_)
                 | js_ast::StmtData::SImport(_)
@@ -9029,6 +9038,16 @@ impl LowerUsingDeclarationsContext {
                         }
                         if any_ident {
                             local.kind = js_ast::s::Kind::KVar;
+                        }
+                    }
+
+                    if relocate_vars && local.kind == js_ast::s::Kind::KVar {
+                        match p.relocate_vars_to_top_level(
+                            local.decls.slice(),
+                            RelocateVarsMode::Normal,
+                        ) {
+                            Some(assignments) => stmt = assignments,
+                            None => continue,
                         }
                     }
                 }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8961,8 +8961,8 @@ impl LowerUsingDeclarationsContext {
     ) -> ListManaged<'a, Stmt> {
         let mut result = BumpVec::new_in(p.arena);
         let mut exports = BumpVec::<js_ast::ClauseItem>::new_in(p.arena);
-        // The linker's `__esm` wrapper hoists declarations by scanning top-level statements only.
-        let relocate_vars = p.options.bundle && p.current_scope == p.module_scope;
+        // The linker's `__esm` wrapper and the REPL transform hoist only top-level declarations.
+        let relocate_module_vars = p.current_scope == p.module_scope;
         let mut end: u32 = 0;
         for i in 0..stmts.len() {
             let mut stmt = stmts[i];
@@ -9035,7 +9035,7 @@ impl LowerUsingDeclarationsContext {
                         }
                     }
 
-                    if relocate_vars && local.kind == js_ast::s::Kind::KVar {
+                    if relocate_module_vars && local.kind == js_ast::s::Kind::KVar {
                         match p.relocate_vars_to_top_level(
                             local.decls.slice(),
                             RelocateVarsMode::Normal,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8961,9 +8961,7 @@ impl LowerUsingDeclarationsContext {
     ) -> ListManaged<'a, Stmt> {
         let mut result = BumpVec::new_in(p.arena);
         let mut exports = BumpVec::<js_ast::ClauseItem>::new_in(p.arena);
-        // The linker hoists a wrapped module's declarations out of its `__esm`
-        // closure by scanning the top-level statements only, so the `var`s that
-        // move into the try block below must stay declared at the top level.
+        // The linker's `__esm` wrapper hoists declarations by scanning top-level statements only.
         let relocate_vars = p.options.bundle && p.current_scope == p.module_scope;
         let mut end: u32 = 0;
         for i in 0..stmts.len() {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2374,7 +2374,10 @@ describe("bundler", () => {
   // reached through import() gets wrapped in `__esm(() => { ... })`, and the
   // linker hoists the module's top-level declarations out of that closure so
   // the export getters and the static importers can reach them. The ones that
-  // were moved into the try block have to end up hoisted as well.
+  // were moved into the try block have to end up hoisted as well. The fixture
+  // covers each way a declaration ends up in there: exported and local
+  // let/const, the `using` itself, a destructuring pattern, a declaration
+  // without an initializer, and the variable `export default <expr>` becomes.
   const loweredTopLevelUsing = {
     Using: `using handle = { val: 42, [Symbol.dispose]() { state.disposed = true; } };`,
     AwaitUsing: `await using handle = { val: 42, async [Symbol.asyncDispose]() { state.disposed = true; } };`,
@@ -2389,6 +2392,7 @@ describe("bundler", () => {
     export function internals() {
       return [val, assignedLater];
     }
+    export default { tag: "default", val };
   `;
   const loweredTopLevelUsingInEsmWrapper = (
     kind: keyof typeof loweredTopLevelUsing,
@@ -2397,10 +2401,10 @@ describe("bundler", () => {
     target,
     files: {
       "/entry.js": /* js */ `
-        import { result, state, internals } from "./lazy.js";
-        console.log(JSON.stringify(["static", result, state.disposed, internals()]));
+        import def, { result, state, internals } from "./lazy.js";
+        console.log(JSON.stringify(["static", result, state.disposed, internals(), def]));
         const mod = await import("./lazy.js");
-        console.log(JSON.stringify(["dynamic", mod.result, mod.state.disposed, mod.internals()]));
+        console.log(JSON.stringify(["dynamic", mod.result, mod.state.disposed, mod.internals(), mod.default]));
       `,
       "/lazy.js": loweredTopLevelUsingModule(kind),
     },
@@ -2410,12 +2414,12 @@ describe("bundler", () => {
       expect(out).toContain("__callDispose(");
       // Everything the module declares at its top level is hoisted out of the
       // wrapper in one declaration; the try block only keeps the assignments.
-      expect(out).toMatch(/^var __stack, state, handle, result, val, assignedLater;$/m);
+      expect(out).toMatch(/^var __stack, state, handle, result, val, assignedLater, lazy_default;$/m);
     },
     run: {
       stdout: `
-        ["static",42,true,[42,43]]
-        ["dynamic",42,true,[42,43]]
+        ["static",42,true,[42,43],{"tag":"default","val":42}]
+        ["dynamic",42,true,[42,43],{"tag":"default","val":42}]
       `,
     },
   });
@@ -2435,8 +2439,8 @@ describe("bundler", () => {
   const loweredTopLevelUsingInlined = (kind: keyof typeof loweredTopLevelUsing): BundlerTestInput => ({
     files: {
       "/entry.js": /* js */ `
-        import { result, state, internals } from "./lazy.js";
-        console.log(JSON.stringify([result, state.disposed, internals()]));
+        import def, { result, state, internals } from "./lazy.js";
+        console.log(JSON.stringify([result, state.disposed, internals(), def]));
       `,
       "/lazy.js": loweredTopLevelUsingModule(kind),
     },
@@ -2445,7 +2449,7 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("__callDispose(");
     },
     run: {
-      stdout: "[42,true,[42,43]]",
+      stdout: '[42,true,[42,43],{"tag":"default","val":42}]',
     },
   });
   itBundled("edgecase/LoweredTopLevelUsingInlined", loweredTopLevelUsingInlined("Using"));

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isBroken, isWindows, tempDir } from "harness";
 import { readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
+import { BundlerTestInput, decodeSourceMappingsLine, itBundled } from "./expectBundled";
 
 // A public path composes with the referenced file's path relative to the output
 // directory, never relative to the importing chunk (esbuild's semantics).
@@ -2368,6 +2368,88 @@ describe("bundler", () => {
       stdout: "Disposing\ntrue",
     },
   });
+
+  // Lowering a top-level `using` moves the rest of the module's top-level
+  // declarations into a generated try/catch/finally. A module that is also
+  // reached through import() gets wrapped in `__esm(() => { ... })`, and the
+  // linker hoists the module's top-level declarations out of that closure so
+  // the export getters and the static importers can reach them. The ones that
+  // were moved into the try block have to end up hoisted as well.
+  const loweredTopLevelUsing = {
+    Using: `using handle = { val: 42, [Symbol.dispose]() { state.disposed = true; } };`,
+    AwaitUsing: `await using handle = { val: 42, async [Symbol.asyncDispose]() { state.disposed = true; } };`,
+  };
+  const loweredTopLevelUsingModule = (kind: keyof typeof loweredTopLevelUsing) => /* js */ `
+    export const state = { disposed: false };
+    ${loweredTopLevelUsing[kind]}
+    export const result = handle.val;
+    const { val } = handle;
+    let assignedLater;
+    assignedLater = val + 1;
+    export function internals() {
+      return [val, assignedLater];
+    }
+  `;
+  const loweredTopLevelUsingInEsmWrapper = (
+    kind: keyof typeof loweredTopLevelUsing,
+    target: "browser" | "node",
+  ): BundlerTestInput => ({
+    target,
+    files: {
+      "/entry.js": /* js */ `
+        import { result, state, internals } from "./lazy.js";
+        console.log(JSON.stringify(["static", result, state.disposed, internals()]));
+        const mod = await import("./lazy.js");
+        console.log(JSON.stringify(["dynamic", mod.result, mod.state.disposed, mod.internals()]));
+      `,
+      "/lazy.js": loweredTopLevelUsingModule(kind),
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("__esm(");
+      expect(out).toContain("__callDispose(");
+      // Everything the module declares at its top level is hoisted out of the
+      // wrapper in one declaration; the try block only keeps the assignments.
+      expect(out).toMatch(/^var __stack, state, handle, result, val, assignedLater;$/m);
+    },
+    run: {
+      stdout: `
+        ["static",42,true,[42,43]]
+        ["dynamic",42,true,[42,43]]
+      `,
+    },
+  });
+  itBundled("edgecase/LoweredTopLevelUsingInEsmWrapper", loweredTopLevelUsingInEsmWrapper("Using", "browser"));
+  itBundled(
+    "edgecase/LoweredTopLevelAwaitUsingInEsmWrapper",
+    loweredTopLevelUsingInEsmWrapper("AwaitUsing", "browser"),
+  );
+  itBundled("edgecase/LoweredTopLevelUsingInEsmWrapperNodeTarget", loweredTopLevelUsingInEsmWrapper("Using", "node"));
+  itBundled(
+    "edgecase/LoweredTopLevelAwaitUsingInEsmWrapperNodeTarget",
+    loweredTopLevelUsingInEsmWrapper("AwaitUsing", "node"),
+  );
+
+  // Without the import() the module is inlined into the entry point instead of
+  // being wrapped; the relocated declarations have to keep working there too.
+  const loweredTopLevelUsingInlined = (kind: keyof typeof loweredTopLevelUsing): BundlerTestInput => ({
+    files: {
+      "/entry.js": /* js */ `
+        import { result, state, internals } from "./lazy.js";
+        console.log(JSON.stringify([result, state.disposed, internals()]));
+      `,
+      "/lazy.js": loweredTopLevelUsingModule(kind),
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__esm(");
+      api.expectFile("/out.js").toContain("__callDispose(");
+    },
+    run: {
+      stdout: "[42,true,[42,43]]",
+    },
+  });
+  itBundled("edgecase/LoweredTopLevelUsingInlined", loweredTopLevelUsingInlined("Using"));
+  itBundled("edgecase/LoweredTopLevelAwaitUsingInlined", loweredTopLevelUsingInlined("AwaitUsing"));
 
   itBundled("edgecase/NoOutWithTwoFiles", {
     files: {

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -60,14 +60,14 @@ describe("bundler", () => {
           ["react.development.js:524:'getContextName'", "1:5623:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19062:void"],
-          ["entry.tsx:23:'await'", "100:19161:await"],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18804:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19054:void"],
+          ["entry.tsx:23:'await'", "100:19145:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 222000,
+      "out/entry.js": 221999,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
+++ b/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
@@ -159,12 +159,12 @@ export function c(e) {
 import { using } from "n";
 let __bun_temp_ref_5$ = [];
 try {
-  var a = __using(__bun_temp_ref_5$, b, 0);
-  var j = __using(__bun_temp_ref_5$, c(i), 1);
-  var k = __using(__bun_temp_ref_5$, l(m), 0);
-  var o = __using(__bun_temp_ref_5$, using, 0);
-  var p = __using(__bun_temp_ref_5$, await using, 1);
-  var q = r;
+  a = __using(__bun_temp_ref_5$, b, 0);
+  j = __using(__bun_temp_ref_5$, c(i), 1);
+  k = __using(__bun_temp_ref_5$, l(m), 0);
+  o = __using(__bun_temp_ref_5$, using, 0);
+  p = __using(__bun_temp_ref_5$, await using, 1);
+  q = r;
 } catch (__bun_temp_ref_6$) {
   var __bun_temp_ref_7$ = __bun_temp_ref_6$, __bun_temp_ref_8$ = 1;
 } finally {
@@ -176,5 +176,11 @@ export {
   k,
   q
 };
+var a;
+var j;
+var k;
+var o;
+var p;
+var q;
 "
 `;

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -672,6 +672,18 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(stdout)).toContain("deep");
       expect(exitCode).toBe(0);
     });
+
+    test("declarations on a line with a top-level using persist", async () => {
+      // `using` is lowered into a try/finally before the REPL hoists the line's
+      // declarations, so the declarations must not stay trapped inside of it.
+      const { stdout, exitCode } = await runRepl([
+        "var disposed = false; using handle = { [Symbol.dispose]() { disposed = true; } }; const a = 6000; let b = 70; var c = 8",
+        "disposed && a + b + c",
+        ".exit",
+      ]);
+      expect(stripAnsi(stdout)).toContain("6078");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("multiline input", () => {

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -72,6 +72,18 @@ describe("Bun.Transpiler replMode", () => {
       expect(result).toContain("console.log(this)");
       expect(result).not.toContain("console.log(exports)");
     });
+
+    test("declarations next to a top-level using are hoisted out of the lowered try block", () => {
+      const result = transpiler.transformSync("using handle = open(); const a = 1; let b = 2; var c = 3;");
+      // The lowering's try/finally survives inside the IIFE...
+      expect(result).toContain("__callDispose");
+      // ...while every declaration is hoisted next to it, at the top level.
+      expect(result).toMatch(/^var handle;$/m);
+      expect(result).toMatch(/^var a;$/m);
+      expect(result).toMatch(/^var b;$/m);
+      expect(result).toMatch(/^var c;$/m);
+      expect(result).not.toMatch(/^\s+(var|let|const) (handle|a|b|c)\b/m);
+    });
   });
 
   describe("REPL session with node:vm", () => {


### PR DESCRIPTION
### Problem

- `bun build` for a target that lowers `using` (anything but `--target=bun`) produces a broken bundle when a module containing a top-level `using` / `await using` is reached through `import()`: reading any of its exports throws `ReferenceError: result is not defined` from the export getter (`result: () => result` in the generated `__export(...)` call). A static import of the same module fails the same way once the module is wrapped. Reproduces with released 1.4.0; esbuild 0.25.12 has the same bug.
- Repro (`bun build --target=browser entry.mjs --outfile=out.mjs && node out.mjs`):
  ```js
  // entry.mjs
  const mod = await import("./lazy.mjs");
  console.log(mod.result);
  // lazy.mjs
  await using handle = { val: 42, async [Symbol.asyncDispose]() {} };
  export const result = handle.val;
  ```
- The REPL has the same bug in a different costume: `bun repl` lowers `using` on purpose (see the comment in `src/runtime/cli/repl.rs`), so after `using h = ...; const y = 1` on one line, `y` on the next line throws `ReferenceError: y is not defined`. Same with `new Bun.Transpiler({ replMode: true })`.
- Cause: `LowerUsingDeclarationsContext::finalize` (`src/js_parser/p.rs`) runs after the module body has been visited and moves the module's top-level `var`s into the try block it generates. `var`s nested inside other statements get relocated to the top level while they are visited (`maybe_relocate_vars_to_top_level`), but these were top-level statements at that point, so nothing relocated them. Both consumers that hoist a module's declarations, the linker's ESM wrapper (`src/bundler/linker_context/generateCodeForFileInChunkJS.rs`, `WrapKind::Esm`) and the REPL transform (`src/js_parser/repl_transforms.rs`), only look at the module's top-level statements, so the `var`s stayed inside `__esm(() => { try { var result = ... } ... })` (or the REPL's IIFE) while `__export` and the importers (or the next REPL line) reference them outside of it.

### Fix

- `finalize` now relocates the module body's `var`s through the same mechanism as nested `var`s (`relocated_top_level_vars`, emitted by `append_part`): the declarations become top-level `var` statements and the try block keeps only the assignments. The conversion is split out of `maybe_relocate_vars_to_top_level` (`src/js_parser/fold.rs`) into `relocate_vars_to_top_level`, since the existing function deliberately does nothing at module scope.
- This restores the invariant both hoisters rely on (every top-level binding of a module is declared by a top-level statement), so the existing wrapper hoist produces `var __stack, state, handle, result;` before `var init_lazy = __esm(...)`, and the REPL transform hoists `var y;` next to its IIFE, with no changes to either. Static imports, export getters, hoisted functions reading non-exported module variables and later REPL lines all see the same bindings. Disposal is unchanged: the try/catch/finally still runs where it did, and the `var`s were module-scoped before, so making the declarations explicit does not change what unwrapped output does.
- It applies whenever `finalize` handles the module body itself (`current_scope == module_scope`), regardless of mode, like the nested-`var` relocation it reuses; the other `finalize` call sites (for-of bodies, switch statements) run in nested scopes, where the visit pass already relocated everything. Non-bundled output for a module with a top-level `using` therefore changes shape too (`x = ...` in the try plus trailing `var x;` statements, the shape nested `var`s already get), which is what the updated `using top level` snapshot in `test/bundler/transpiler/__snapshots__/transpiler.test.js.snap` shows; that output still runs and exports correctly.
- Symbol bookkeeping is the same as for a relocated nested `var`: `wrap_identifier_hoisting` records one use per relocated binding for the assignment that now references it, and `append_part` re-declares it as a top-level symbol of the same part. Tree shaking is not affected either: a module with a lowered top-level `using` is always emitted as a single part (`parse_entry.rs` disables per-statement parts for it, since everything lives in one try block), that part is never removable because of the try statement, and the relocated declarations are added to that same part, so the recorded uses only point at the part they are in. The lowering's own temporaries are not affected: `__stack` is declared by the `let` that `finalize` emits outside the try block, and `_catch` / `_err` / `_hasErr` / `_promise` live in the catch and finally blocks, so none of them go through the relocation.
- Verified with:
  - `test/bundler/bundler_edgecase.test.ts` (`edgecase/LoweredTopLevel*`): a module with a top-level `using` or `await using` that is imported both statically and with `import()`, built for `browser` and `node`. The fixture has every kind of declaration the lowering moves into the try block: exported and local `const`, the `using` itself, a destructuring pattern, a `let` without initializer, a function reading the local ones, and `export default <expr>` (which `visit_stmt.rs` turns into its own `var` when a top-level `using` is present). Plus the same module imported only statically (inlined, not wrapped). The four wrapped cases fail before this change with the ReferenceError above.
  - `test/js/bun/repl/repl.test.ts` (`declarations on a line with a top-level using persist`) and `test/js/bun/transpiler/repl-transform.test.ts` (`declarations next to a top-level using are hoisted ...`): both fail before this change.
  - `test/bundler/bundler_npm.test.ts` (`npm/ReactSSR`) pins the exact size and three source map positions of a minified entry point that has a top-level `using`; its five `var x=...` statements inside the try block become `x=...` plus one trailing `var` list, so the output is 1 byte smaller and the pinned positions move by the removed `var ` prefixes (4, 8 and 16 bytes). The pinned values are updated accordingly.
  - Also passing locally: the rest of `test/bundler/bundler_edgecase.test.ts`, `test/bundler/transpiler/transpiler.test.js`, the rest of `repl.test.ts` / `repl-transform.test.ts`, `test/js/bun/resolve/lower-using-bun-target.test.ts`, `test/regression/issue/11100.test.ts`, `test/js/web/explicit-resource-management.test.ts`, `test/bundler/bundler_browser.test.ts`, `test/bundler/esbuild/dce.test.ts`, `test/bundler/esbuild/default.test.ts`. Manually checked `--minify`, `--format=cjs` / `iife`, `--splitting`, `require()` of the module from a CommonJS file, a CommonJS file with a top-level `using`, `--format=internal_bake_dev` output, and running `Bun.Transpiler` (non-bundled) output of a module with exports under bun.

### Background

- Lowering `using`: for targets without native support, a top-level `using x = v` makes the parser rewrite the whole module body into `let __stack = []; try { var x = __using(__stack, v); ...rest of the module as var declarations... } catch (e) { ... } finally { __callDispose(__stack, ...) }`, with imports and function declarations kept outside the try and exports collected into a trailing `export { ... }` clause.
- ESM wrapper: when a module is needed lazily (`import()`, `require()` of ESM), the linker emits its body as `var init_x = __esm(() => { ... })` and an `exports_x` object whose getters read the module's bindings. For that to work the module's top-level declarations are moved out of the closure as `var a, b;` with the initializers left inside as assignments.
- REPL transform: each REPL input is turned into hoisted `var` declarations plus an IIFE containing the rest, so the variables become properties of the REPL's context and survive to the next input. It finds the declarations the same way, by walking the input's top-level statements.
- Relocating vars: while visiting, the parser already turns a module-level `var` that sits inside a block (`if (c) { var x = 1 }`) into a top-level `var x;` plus an assignment in place, which is what lets those two passes look at top-level statements only. This change applies that same transformation to the declarations the `using` lowering moves into its try block.
- Neighbouring, independent bugs in the same lowering (exported destructuring declarations losing their exports: #38279; `export default function`/`class` being dropped; class declarations staying inside the try block) are tracked separately and are not changed here.
