### PR TITLE
Bump WebKit: allow using declarations in a function nested in a switch case clause

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "caad865eb1a6e5ca4427f5ea1f066140b11953e7";
+export const WEBKIT_VERSION = "autobuild-preview-pr-423-23e89c28";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/using-declaration-in-function-inside-switch-case.js
+++ b/test/js/bun/jsc-stress/fixtures/using-declaration-in-function-inside-switch-case.js
@@ -1,0 +1,149 @@
+// @bun
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+// `using` / `await using` declarations are not allowed directly in a switch case or default clause,
+// but a function nested in such a clause is a fresh statement list, so they are allowed at the top
+// level of its body. The check happens while the enclosing code is parsed (the nested body is
+// syntax-checked as part of it), so every case below goes through eval to exercise that parse.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+function shouldThrowSyntaxError(code) {
+    let threw = false;
+    try {
+        (0, eval)(code);
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof SyntaxError))
+            throw new Error(`Expected SyntaxError but got ${e.constructor.name}: ${e.message}: ${code}`);
+    }
+    if (!threw)
+        throw new Error(`Expected SyntaxError for: ${code}`);
+}
+
+function shouldNotThrowSyntaxError(code) {
+    try {
+        (0, eval)(code);
+    } catch (e) {
+        if (e instanceof SyntaxError)
+            throw new Error(`Unexpected SyntaxError: ${e.message}: ${code}`);
+        throw e;
+    }
+}
+
+const bodies = [
+    // Every kind of function body that parseFunctionBody() handles, each containing a `using`.
+    `function f() { using x = null; }`,
+    `(function () { using x = null; });`,
+    `() => { using x = null; };`,
+    `() => (() => { using x = null; })();`,
+    `function* g() { using x = null; }`,
+    `async function f() { using x = null; }`,
+    `({ m() { using x = null; } });`,
+    `({ get g() { using x = null; } });`,
+    `({ set s(v) { using x = null; } });`,
+    `class C { constructor() { using x = null; } }`,
+    `class C { m() { using x = null; } }`,
+    `class C { static m() { using x = null; } }`,
+    `class C { #m() { using x = null; } }`,
+    `class C { field = () => { using x = null; }; }`,
+    `class C { static field = function () { using x = null; }; }`,
+    `function f(a = () => { using x = null; }) { }`,
+    // The await form, in every kind of async body.
+    `async function f() { await using x = null; }`,
+    `(async function () { await using x = null; });`,
+    `async () => { await using x = null; };`,
+    `async () => (async () => { await using x = null; })();`,
+    `async function* g() { await using x = null; }`,
+    `({ async m() { await using x = null; } });`,
+    `class C { async m() { await using x = null; } }`,
+    `class C { static async m() { await using x = null; } }`,
+    `class C { field = async () => { await using x = null; }; }`,
+];
+
+for (const body of bodies) {
+    shouldNotThrowSyntaxError(`switch (0) { case 0: ${body} }`);
+    shouldNotThrowSyntaxError(`switch (0) { default: ${body} }`);
+    shouldNotThrowSyntaxError(`switch (0) { case 1: break; case 0: ${body} }`);
+    shouldNotThrowSyntaxError(`function outer() { switch (0) { case 0: ${body} } }`);
+    shouldNotThrowSyntaxError(`async function outer() { switch (0) { case 0: ${body} } }`);
+    shouldNotThrowSyntaxError(`(function () { "use strict"; switch (0) { default: ${body} } })`);
+}
+
+// Still an error directly in a clause, including right after a nested function has been parsed,
+// and in a switch that is itself inside a function nested in a clause.
+shouldThrowSyntaxError(`switch (0) { case 0: using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { default: using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { case 0: function f() { using y = null; } using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { case 0: (() => { using y = null; })(); using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { case 0: ({ m() { using y = null; } }); using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { case 0: class C { m() { using y = null; } } using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { case 0: function f() { } case 1: using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { case 0: function f() { } default: using x = null; }`);
+shouldThrowSyntaxError(`switch (0) { default: function f() { } case 1: using x = null; }`);
+shouldThrowSyntaxError(`function f() { switch (0) { case 0: using x = null; } }`);
+shouldThrowSyntaxError(`switch (0) { case 0: function f() { switch (1) { case 1: using x = null; } } }`);
+shouldThrowSyntaxError(`switch (0) { case 0: (() => { switch (1) { default: using x = null; } })(); }`);
+shouldThrowSyntaxError(`switch (0) { case 0: { function f() { } } using x = null; }`);
+shouldThrowSyntaxError(`async function f() { switch (0) { case 0: await using x = null; } }`);
+shouldThrowSyntaxError(`async function f() { switch (0) { default: await using x = null; } }`);
+shouldThrowSyntaxError(`async function f() { switch (0) { case 0: async function g() { await using y = null; } await using x = null; } }`);
+shouldThrowSyntaxError(`async function f() { switch (0) { case 0: (async () => { await using y = null; })(); await using x = null; } }`);
+shouldThrowSyntaxError(`async function f() { switch (0) { case 0: async function g() { } case 1: await using x = null; } }`);
+shouldThrowSyntaxError(`async function f() { switch (0) { case 0: async function g() { switch (1) { case 1: await using x = null; } } } }`);
+
+// The declarations in the nested functions are real `using` declarations: the resources are disposed.
+{
+    const order = (0, eval)(`
+        const order = [];
+        switch (0) {
+            case 0:
+                function f() {
+                    using a = { [Symbol.dispose]() { order.push("dispose-a"); } };
+                    order.push("body-f");
+                }
+                const g = () => {
+                    using b = { [Symbol.dispose]() { order.push("dispose-b"); } };
+                    order.push("body-g");
+                };
+                f();
+                g();
+                order.push("after");
+        }
+        order;
+    `);
+    shouldBe(order.join(","), "body-f,dispose-a,body-g,dispose-b,after");
+}
+
+{
+    let result;
+    let error;
+    (0, eval)(`
+        const order = [];
+        async function outer() {
+            switch (0) {
+                default:
+                    async function f() {
+                        await using a = { [Symbol.asyncDispose]() { order.push("dispose-a"); } };
+                        order.push("body-f");
+                    }
+                    const g = async () => {
+                        await using b = { [Symbol.asyncDispose]() { order.push("dispose-b"); } };
+                        order.push("body-g");
+                    };
+                    await f();
+                    await g();
+                    order.push("after");
+            }
+            return order.join(",");
+        }
+        outer();
+    `).then(value => { result = value; }, e => { error = e; });
+    drainMicrotasks();
+    if (error)
+        throw error;
+    shouldBe(result, "body-f,dispose-a,body-g,dispose-b,after");
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Parser
+  "using-declaration-in-function-inside-switch-case.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc-stress/preload.js
+++ b/test/js/bun/jsc-stress/preload.js
@@ -32,3 +32,6 @@ globalThis.fullGC = jsc.fullGC;
 globalThis.edenGC = jsc.edenGC;
 globalThis.numberOfDFGCompiles = jsc.numberOfDFGCompiles;
 globalThis.noDFG = jsc.noFTL;
+
+// drainMicrotasks: the jsc shell's way of settling promises synchronously.
+globalThis.drainMicrotasks = jsc.drainMicrotasks;

--- a/test/js/web/explicit-resource-management.test.ts
+++ b/test/js/web/explicit-resource-management.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
 // tbh, we should have more tests for this
 test("Symbol.dispose exists", () => {
   expect(Symbol.dispose).toBeDefined();
@@ -143,4 +146,95 @@ test("await using syntax works and doesnt collide with user symbols", async () =
       var _hasErr = 1;
     }
   }
+});
+
+// `using` / `await using` may not appear directly in a switch case or default clause, but a
+// function nested in such a clause is a fresh statement list. JSC used to reject these at load
+// time with "'using' declaration is not allowed directly in a switch case or default clause".
+// The sync cases need a real resource: bun's transpiler folds `using a = null` into `let a = null`,
+// and JSC would never see the declaration.
+describe("using declarations in a function nested in a switch case clause", () => {
+  const cases: [name: string, program: string][] = [
+    [
+      "await using in an async arrow called from a case clause",
+      `const r = { [Symbol.asyncDispose]() { console.log("disposed"); } };
+async function g() {
+  switch (1) {
+    case 1:
+      await (async () => {
+        await using a = r;
+        console.log("body");
+      })();
+      console.log("after");
+  }
+}
+await g();`,
+    ],
+    [
+      "await using in an async function declared in a default clause",
+      `const r = { [Symbol.asyncDispose]() { console.log("disposed"); } };
+async function j() {
+  switch (1) {
+    default:
+      async function inner() {
+        await using a = r;
+        console.log("body");
+      }
+      await inner();
+      console.log("after");
+  }
+}
+await j();`,
+    ],
+    [
+      "using in an arrow called from a case clause",
+      `const r = { [Symbol.dispose]() { console.log("disposed"); } };
+switch (1) {
+  case 1:
+    (() => {
+      using a = r;
+      console.log("body");
+    })();
+    console.log("after");
+}`,
+    ],
+    [
+      "using in a function declared in a default clause",
+      `const r = { [Symbol.dispose]() { console.log("disposed"); } };
+switch (1) {
+  default:
+    function inner() {
+      using a = r;
+      console.log("body");
+    }
+    inner();
+    console.log("after");
+}`,
+    ],
+    [
+      "using in a method of an object literal in a case clause",
+      `const r = { [Symbol.dispose]() { console.log("disposed"); } };
+switch (1) {
+  case 1:
+    ({
+      m() {
+        using a = r;
+        console.log("body");
+      },
+    }).m();
+    console.log("after");
+}`,
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_name, program) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", program],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "body\ndisposed\nafter\n", stderr: "", exitCode: 0 });
+  });
 });


### PR DESCRIPTION
### Problem

- A `using` or `await using` declaration at the top level of a function that is lexically inside a `case:` / `default:` clause fails to load:
  ```
  SyntaxError: 'await using' declaration is not allowed directly in a switch case or default clause.
  SyntaxError: 'using' declaration is not allowed directly in a switch case or default clause.
  ```
  ```js
  switch (1) { case 1: await (async () => { await using a = r; })(); }   // rejected by bun, runs in node
  switch (1) { case 1: (() => { using a = r; })(); }                      // same
  ```
- The declaration is not directly in the clause, so the code is valid and node runs it. Every kind of nested body is affected: function declarations and expressions, arrows, methods, getters/setters, generators, async functions, class methods, the functions in class field initializers and parameter defaults. Only a declaration directly in the clause's own statement list is supposed to be rejected.
- Cause: JSC's parser sets `m_insideSwitchCaseBody` while it parses a clause's statements and only clears it in `parseBlockStatement()`. `parseFunctionBody()` (`Source/JavaScriptCore/parser/Parser.cpp:2379`, the path every nested function body takes while the enclosing code is parsed) goes straight to `parseSourceElements()` with the flag still set, so the checks in `parseStatementListItem()` (`Parser.cpp:810`, `:845`) fire for the nested body. Upstream WebKit has the same code.
- The sync form is easy to miss: bun's transpiler folds `using a = null` into `let a = null` before JSC sees it, so probes with a `null` initializer only show the `await using` form. With a real resource both forms fail.

### Fix

- oven-sh/WebKit#423: `parseFunctionBody()` clears `m_insideSwitchCaseBody` with a `SetForScope` for the duration of the body, next to the `m_statementDepth` reset that exists for the same reason. This PR pins that PR's preview build, `autobuild-preview-pr-423-23e89c28`; WebKit main is otherwise identical to the current pin (`caad865e`), so the bump carries only this change.
- Why this is right: the early error is defined on the CaseClause's own StatementList, and a function body is a new statement list whatever it is nested in, which is exactly the exemption `parseBlockStatement()` already implements for blocks. The flag is restored when the body ends, so `case 1: function f() {} using x = r;` is still rejected. Node/V8 agrees on every shape the new test encodes (150 accepted, 19 rejected).
- Before this PR can merge, oven-sh/WebKit#423 has to land and `WEBKIT_VERSION` has to move to its merge commit's `autobuild-<sha>` (GitHub deletes the preview release when the WebKit PR merges).
- Two sibling leaks of other parser flags into nested function bodies (`allowAwait` for functions in an async function's parameter defaults, `allowsIn` for block-bodied arrows in a for-init) reproduce independently of this one and are tracked separately; see "Related, not fixed here" in oven-sh/WebKit#423.
- #38260 pins oven-sh/WebKit#422's preview and touches the same two lines (`WEBKIT_VERSION`, the fixture list). Whichever lands second re-pins to a WebKit main sha that contains both engine changes; both fixture sets stay.
- Tests:
  - `test/js/bun/jsc-stress/fixtures/using-declaration-in-function-inside-switch-case.js`: the stress test from the WebKit PR, verbatim. 25 kinds of nested body containing `using` / `await using`, each in case and default clauses in 6 enclosing contexts, must parse; 19 shapes with the declaration directly in a clause (including right after a nested function, and in a switch nested inside such a function) must still be rejected; the declarations in the nested functions must actually dispose. `preload.js` gains `drainMicrotasks`, the jsc shell builtin the test uses.
  - `test/js/web/explicit-resource-management.test.ts`: the user-facing shapes as whole programs run by bun (transpiler included): `await using` in an async arrow and in an async function declaration, `using` in an arrow, a function declaration and an object literal method, in case and default clauses.
- Verified:
  - `bun bd test` on both files against the current pin: the fixture fails on its first shape with the message above, the 5 new runtime tests fail with it, the 4 pre-existing tests pass. `USE_SYSTEM_BUN=1` gives the same 5 failures.
  - `bun bd test` on both files against the preview build: all pass. `jsc-stress.test.ts` as a whole is 116/116; `lower-using-bun-target.test.ts`, `mock-disposable.test.ts`, `bun-jsc.test.ts` and `node/vm/vm.test.ts` also pass.
  - The new stress test against the prebuilts' `jsc` shells: fails on the current pin, passes on the preview; the 41 existing `using` / `await using` / DisposableStack stress tests in `JSTests/stress` pass on the preview (the two syntax-error ones keep the direct-in-clause rejection covered).

### Background

- bun does not build JavaScriptCore from source: `scripts/build/deps/webkit.ts` pins a release of the oven-sh/WebKit fork and the build downloads its prebuilt libraries. Engine fixes land in the fork and reach bun by moving that pin, which is why this PR has no `src/` change.
- A PR against oven-sh/WebKit gets a prerelease tagged `autobuild-preview-pr-<n>-<sha8>` that bun CI can build against; a merge to the fork's main produces the permanent `autobuild-<sha>` release.
- JSC parses a nested function's body while it parses the enclosing code (to report syntax errors eagerly; the body is parsed again on first call), so any parser state that is not reset at the function boundary leaks from the enclosing code into the nested body. `m_insideSwitchCaseBody` is such state; `m_statementDepth` (which the "no `using` at the top level of a script" check uses) already gets reset at the same spot.
- `test/js/bun/jsc-stress/` runs WebKit `JSTests/stress`-style files through bun with a preload that supplies the jsc shell globals they use. The `// @bun` header makes bun hand the file to JSC without transpiling it, which is what a parser test wants.

