### PR TITLE
bundler: pull the runtime into chunks that print a CSS file's namespace object

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -926,7 +926,6 @@ impl<'a> LinkerContext<'a> {
                 parts,
                 import_records,
                 file_entry_bits,
-                css_reprs,
                 queue: std::collections::VecDeque::new(),
             };
 
@@ -2597,7 +2596,6 @@ pub(crate) struct CodeSplitCtx<'a, 'r> {
     pub(crate) parts: &'r [bun_ast::PartList<'a>],
     pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) file_entry_bits: &'r mut [AutoBitSet],
-    pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
     pub(crate) queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
 }
 
@@ -2650,11 +2648,10 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // CSS files only follow their import records.
-            if ctx.css_reprs[source_index as usize].is_some() {
-                continue;
-            }
-
+            // CSS files are not skipped here: unlike esbuild, the JS side of a
+            // CSS file (namespace object, default export, require() wrapper)
+            // lives in this same source index, and its parts depend on runtime
+            // helpers such as `__export` that the chunk has to pull in.
             for part in ctx.parts[source_index as usize].as_slice() {
                 for dependency in part.dependencies.iter() {
                     let dep = dependency.source_index.get();

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2653,11 +2653,8 @@ impl<'a> LinkerContext<'a> {
             // Of the JS parts a stylesheet also carries, only the live ones get printed.
             let live_parts_only = ctx.css_reprs[source_index as usize].is_some();
             let parts_live = &self.graph.parts_live[source_index as usize];
-            for (part_index, part) in ctx.parts[source_index as usize]
-                .as_slice()
-                .iter()
-                .enumerate()
-            {
+            let parts = ctx.parts[source_index as usize].as_slice();
+            for (part_index, part) in parts.iter().enumerate() {
                 if live_parts_only && !parts_live.is_set(part_index) {
                     continue;
                 }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2648,10 +2648,7 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // CSS files are not skipped here: unlike esbuild, the JS side of a
-            // CSS file (namespace object, default export, require() wrapper)
-            // lives in this same source index, and its parts depend on runtime
-            // helpers such as `__export` that the chunk has to pull in.
+            // CSS files too: the JS printed for a stylesheet lives in the same source index.
             for part in ctx.parts[source_index as usize].as_slice() {
                 for dependency in part.dependencies.iter() {
                     let dep = dependency.source_index.get();

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -926,6 +926,7 @@ impl<'a> LinkerContext<'a> {
                 parts,
                 import_records,
                 file_entry_bits,
+                css_reprs,
                 queue: std::collections::VecDeque::new(),
             };
 
@@ -2596,6 +2597,7 @@ pub(crate) struct CodeSplitCtx<'a, 'r> {
     pub(crate) parts: &'r [bun_ast::PartList<'a>],
     pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) file_entry_bits: &'r mut [AutoBitSet],
+    pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
     pub(crate) queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
 }
 
@@ -2648,8 +2650,17 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // CSS files too: the JS printed for a stylesheet lives in the same source index.
-            for part in ctx.parts[source_index as usize].as_slice() {
+            // Of the JS parts a stylesheet also carries, only the live ones get printed.
+            let live_parts_only = ctx.css_reprs[source_index as usize].is_some();
+            let parts_live = &self.graph.parts_live[source_index as usize];
+            for (part_index, part) in ctx.parts[source_index as usize]
+                .as_slice()
+                .iter()
+                .enumerate()
+            {
+                if live_parts_only && !parts_live.is_set(part_index) {
+                    continue;
+                }
                 for dependency in part.dependencies.iter() {
                     let dep = dependency.source_index.get();
                     if dep != source_index

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -145,8 +145,7 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
             return;
         };
 
-        // `compute_chunks` gives CSS files no chunk of their own; `find_imported_parts_in_js_order`
-        // copies their live JS parts into every chunk importing them instead.
+        // CSS files get no chunk; their live JS parts are copied into each chunk that imports them.
         let css_asts = deps.css_asts;
         let copied_css_files = js
             .files_in_chunk_order

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -145,13 +145,7 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
             return;
         };
 
-        // CSS files are never members of a JS chunk (`compute_chunks` leaves
-        // them out of `files_with_parts_in_chunk`); instead
-        // `find_imported_parts_in_js_order` prints a copy of their live JS
-        // parts (namespace object, default export, wrapper) into every chunk
-        // that imports them. Those copies use runtime helpers such as
-        // `__export` that may live in another chunk, so their uses are imports
-        // of this chunk, while their declarations belong to no single chunk.
+        // CSS files belong to no chunk; their live JS parts are copied into every importing chunk.
         let css_asts = deps.css_asts;
         let copied_css_files = js
             .files_in_chunk_order

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -145,7 +145,8 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
             return;
         };
 
-        // CSS files belong to no chunk; their live JS parts are copied into every importing chunk.
+        // `compute_chunks` gives CSS files no chunk of their own; `find_imported_parts_in_js_order`
+        // copies their live JS parts into every chunk importing them instead.
         let css_asts = deps.css_asts;
         let copied_css_files = js
             .files_in_chunk_order

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -63,6 +63,7 @@ pub(crate) fn compute_cross_chunk_dependencies(
             chunks: bun_ptr::BackRef::new(&*chunks),
             chunk_meta: &mut chunk_metas,
             parts: ast.parts,
+            css_asts: ast.css,
             import_records: ast.import_records,
             flags: meta.flags,
             entry_point_chunk_indices: files.entry_point_chunk_index,
@@ -91,6 +92,7 @@ struct CrossChunkDependencies<'a, 'bump> {
     // (caller stack frame).
     chunks: bun_ptr::BackRef<[Chunk]>,
     parts: &'a [bun_ast::PartList<'bump>],
+    css_asts: &'a [crate::bundled_ast::CssCol],
     import_records: &'a mut [bun_ast::import_record::List<'bump>],
     flags: &'a [js_meta::Flags],
     entry_point_chunk_indices: &'a [IndexInt],
@@ -139,15 +141,33 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
         // Go through `chunk_meta.imports` / `chunk_meta.dynamic_imports`.
         let entry_point_chunk_indices = deps.entry_point_chunk_indices;
 
+        let chunk::Content::Javascript(js) = &chunk.content else {
+            return;
+        };
+
+        // CSS files are never members of a JS chunk (`compute_chunks` leaves
+        // them out of `files_with_parts_in_chunk`); instead
+        // `find_imported_parts_in_js_order` prints a copy of their live JS
+        // parts (namespace object, default export, wrapper) into every chunk
+        // that imports them. Those copies use runtime helpers such as
+        // `__export` that may live in another chunk, so their uses are imports
+        // of this chunk, while their declarations belong to no single chunk.
+        let css_asts = deps.css_asts;
+        let copied_css_files = js
+            .files_in_chunk_order
+            .iter()
+            .copied()
+            .filter(|&source_index| css_asts[source_index as usize].is_some());
+
         // Go over each file in this chunk
-        for &source_index in chunk.files_with_parts_in_chunk.keys() {
-            // TODO: make this switch
-            if matches!(chunk.content, chunk::Content::Css(_)) {
-                continue;
-            }
-            if !matches!(chunk.content, chunk::Content::Javascript(_)) {
-                continue;
-            }
+        for source_index in chunk
+            .files_with_parts_in_chunk
+            .keys()
+            .iter()
+            .copied()
+            .chain(copied_css_files)
+        {
+            let is_css_copy = css_asts[source_index as usize].is_some();
 
             // Go over each part in this file that's marked for inclusion in this chunk
             let parts = deps.parts[source_index as usize].as_slice();
@@ -191,7 +211,9 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                 // the same name should already be marked as all being in a single
                 // chunk. In that case this will overwrite the same value below which
                 // is fine.
-                symbols.assign_chunk_index(&part.declared_symbols, chunk_index as u32);
+                if !is_css_copy {
+                    symbols.assign_chunk_index(&part.declared_symbols, chunk_index as u32);
+                }
 
                 let used_refs = part.symbol_uses.keys();
 
@@ -255,66 +277,63 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
         }
 
         // Include the exports if this is an entry point chunk
-        if matches!(chunk.content, chunk::Content::Javascript(_)) {
-            if chunk.entry_point.is_entry_point() {
-                let flags = deps.flags[chunk.entry_point.source_index() as usize];
-                if flags.wrap != WrapKind::Cjs {
-                    let resolved_exports =
-                        &deps.resolved_exports[chunk.entry_point.source_index() as usize];
-                    let sorted_and_filtered_export_aliases = &deps
-                        .sorted_and_filtered_export_aliases
-                        [chunk.entry_point.source_index() as usize];
-                    for alias in sorted_and_filtered_export_aliases.iter() {
-                        let export_ = resolved_exports.get(alias).unwrap();
-                        let mut target_ref = export_.data.import_ref;
+        if chunk.entry_point.is_entry_point() {
+            let flags = deps.flags[chunk.entry_point.source_index() as usize];
+            if flags.wrap != WrapKind::Cjs {
+                let resolved_exports =
+                    &deps.resolved_exports[chunk.entry_point.source_index() as usize];
+                let sorted_and_filtered_export_aliases = &deps.sorted_and_filtered_export_aliases
+                    [chunk.entry_point.source_index() as usize];
+                for alias in sorted_and_filtered_export_aliases.iter() {
+                    let export_ = resolved_exports.get(alias).unwrap();
+                    let mut target_ref = export_.data.import_ref;
 
-                        // If this is an import, then target what the import points to
-                        if let Some(import_data) = deps.imports_to_bind
-                            [export_.data.source_index.get() as usize]
-                            .get(&target_ref)
-                        {
-                            target_ref = import_data.data.import_ref;
-                        }
-
-                        // If this is an ES6 import from a CommonJS file, it will become a
-                        // property access off the namespace symbol instead of a bare
-                        // identifier. In that case we want to pull in the namespace symbol
-                        // instead. The namespace symbol stores the result of "require()".
-                        if let Some(namespace_alias) =
-                            &symbols.get_const(target_ref).unwrap().namespace_alias
-                        {
-                            target_ref = namespace_alias.namespace_ref;
-                        }
-
-                        if cfg!(debug_assertions) {
-                            // SAFETY: arena slice valid for the link pass.
-                            let name = symbols.get_const(target_ref).unwrap().original_name.slice();
-                            debug!("Cross-chunk export: {}", bstr::BStr::new(name),);
-                        }
-
-                        let _ = chunk_meta.imports.put(target_ref, ()); // OOM-only Result
+                    // If this is an import, then target what the import points to
+                    if let Some(import_data) = deps.imports_to_bind
+                        [export_.data.source_index.get() as usize]
+                        .get(&target_ref)
+                    {
+                        target_ref = import_data.data.import_ref;
                     }
-                }
 
-                // Ensure "exports" is included if the current output format needs it
-                // https://github.com/evanw/esbuild/blob/v0.27.2/internal/linker/linker.go#L1049-L1051
-                if flags.force_include_exports_for_entry_point {
-                    // result intentionally discarded
-                    let _ = chunk_meta.imports.put(
-                        deps.exports_refs[chunk.entry_point.source_index() as usize],
-                        (),
-                    );
-                }
+                    // If this is an ES6 import from a CommonJS file, it will become a
+                    // property access off the namespace symbol instead of a bare
+                    // identifier. In that case we want to pull in the namespace symbol
+                    // instead. The namespace symbol stores the result of "require()".
+                    if let Some(namespace_alias) =
+                        &symbols.get_const(target_ref).unwrap().namespace_alias
+                    {
+                        target_ref = namespace_alias.namespace_ref;
+                    }
 
-                // Include the wrapper if present
-                // https://github.com/evanw/esbuild/blob/v0.27.2/internal/linker/linker.go#L1053-L1056
-                if flags.wrap != WrapKind::None {
-                    // result intentionally discarded
-                    let _ = chunk_meta.imports.put(
-                        deps.wrapper_refs[chunk.entry_point.source_index() as usize],
-                        (),
-                    );
+                    if cfg!(debug_assertions) {
+                        // SAFETY: arena slice valid for the link pass.
+                        let name = symbols.get_const(target_ref).unwrap().original_name.slice();
+                        debug!("Cross-chunk export: {}", bstr::BStr::new(name),);
+                    }
+
+                    let _ = chunk_meta.imports.put(target_ref, ()); // OOM-only Result
                 }
+            }
+
+            // Ensure "exports" is included if the current output format needs it
+            // https://github.com/evanw/esbuild/blob/v0.27.2/internal/linker/linker.go#L1049-L1051
+            if flags.force_include_exports_for_entry_point {
+                // result intentionally discarded
+                let _ = chunk_meta.imports.put(
+                    deps.exports_refs[chunk.entry_point.source_index() as usize],
+                    (),
+                );
+            }
+
+            // Include the wrapper if present
+            // https://github.com/evanw/esbuild/blob/v0.27.2/internal/linker/linker.go#L1053-L1056
+            if flags.wrap != WrapKind::None {
+                // result intentionally discarded
+                let _ = chunk_meta.imports.put(
+                    deps.wrapper_refs[chunk.entry_point.source_index() as usize],
+                    (),
+                );
             }
         }
     }

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -322,6 +322,33 @@ describe("bundler", async () => {
     run: { stdout: "[true,true,true]" },
   });
 
+  // The namespace object of a CSS file is built with the runtime's `__export`
+  // helper. No other module in this bundle uses the runtime, so the CSS file's
+  // JS side is the only thing pulling it into the output.
+  for (const target of ["bun", "browser"] as const) {
+    itBundled(`bun/loader-css-namespace-import-${target}`, {
+      target,
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `
+          import * as plain from "./plain.css";
+          import * as styles from "./styles.module.css";
+          console.log(
+            JSON.stringify([
+              Object.keys(plain),
+              plain.default,
+              Object.keys(styles).sort(),
+              styles.foo === styles.default.foo && typeof styles.foo === "string",
+            ]),
+          );
+        `,
+        "/plain.css": `.plain { color: red; }`,
+        "/styles.module.css": `.foo { color: blue; }`,
+      },
+      run: { stdout: '[["default"],{},["default","foo"],true]' },
+    });
+  }
+
   itBundled("bun/wasm-is-copied-to-outdir", {
     target: "bun",
     outdir: "/out",

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -349,6 +349,84 @@ describe("bundler", async () => {
     });
   }
 
+  // Every CSS file has a namespace export part that uses `__export`, but it is
+  // only printed when something namespace-imports the file. A stylesheet that
+  // is merely imported must not pull the (here live, because of util.js)
+  // runtime into its entry point.
+  itBundled("bun/loader-css-plain-import-does-not-pull-in-runtime", {
+    outdir: "/out",
+    entryPoints: ["/a.js", "/b.js"],
+    files: {
+      "/a.js": /* js */ `
+        import * as util from "./util.js";
+        console.log(JSON.stringify(Object.keys(util)));
+      `,
+      "/util.js": `export const util = 1;`,
+      "/b.js": /* js */ `
+        import "./side-effect.css";
+        import styles from "./styles.module.css";
+        console.log(JSON.stringify(Object.keys(styles)));
+      `,
+      "/side-effect.css": `.side { color: red; }`,
+      "/styles.module.css": `.foo { color: blue; }`,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out/a.js")).toContain("__export(");
+      api.expectFile("/out/b.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          foo: "foo_-MSaAA"
+        };
+
+        // b.js
+        console.log(JSON.stringify(Object.keys(styles_module_default)));
+        "
+      `);
+    },
+    run: [
+      { file: "/out/a.js", stdout: '["util"]' },
+      { file: "/out/b.js", stdout: '["foo"]' },
+    ],
+  });
+
+  // Which entry points print a stylesheet's namespace object is decided by the
+  // entry bits of the stylesheet, however it was reached: here b.js reaches
+  // x.css through its own stylesheet's @import, and the import record of a
+  // tree-shaken package is what makes the printer visit x.css, so b.js prints
+  // the namespace object that a.js made live and needs the runtime as well.
+  itBundled("bun/loader-css-namespace-object-printed-for-another-entry", {
+    outdir: "/out",
+    entryPoints: ["/a.js", "/b.js"],
+    files: {
+      "/a.js": /* js */ `
+        import * as ns from "./x.css";
+        console.log("a", JSON.stringify(Object.keys(ns)));
+      `,
+      "/b.js": /* js */ `
+        import { unused } from "pkg";
+        import "./b.css";
+        console.log("b");
+      `,
+      "/x.css": `.x { color: red; }`,
+      "/b.css": /* css */ `
+        @import "./x.css";
+        .b { color: blue; }
+      `,
+      "/node_modules/pkg/package.json": `{ "name": "pkg", "main": "index.js", "sideEffects": false }`,
+      "/node_modules/pkg/index.js": /* js */ `
+        import "../../x.css";
+        export const unused = 1;
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out/b.js")).toContain("__export(exports_x,");
+    },
+    run: [
+      { file: "/out/a.js", stdout: 'a ["default"]' },
+      { file: "/out/b.js", stdout: "b" },
+    ],
+  });
+
   itBundled("bun/wasm-is-copied-to-outdir", {
     target: "bun",
     outdir: "/out",

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -274,58 +274,60 @@ describe("bundler", () => {
   // with the runtime's `__export` helper, into each chunk that imports it. The
   // runtime is used by nothing else here, so the CSS file alone decides where
   // the helper ends up: in the entry's own chunk with one entry point...
-  itBundled("splitting/NamespaceImportOfCSS", {
-    files: {
-      "/entry.js": `
-        import * as ns from './styles.css'
-        console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns.default))
-      `,
-      "/styles.css": `.styles { color: blue; }`,
-    },
-    entryPoints: ["/entry.js"],
-    splitting: true,
-    outdir: "/out",
-    target: "browser",
-    format: "esm",
-    onAfterBundle(api) {
-      expect(readdirSync(api.outdir).sort()).toEqual(["entry.css", "entry.js"]);
-    },
-    run: {
-      file: "/out/entry.js",
-      stdout: '["default"] {}',
-    },
-  });
+  for (const target of ["bun", "browser"] as const) {
+    itBundled(`splitting/NamespaceImportOfCSS-${target}`, {
+      files: {
+        "/entry.js": `
+          import * as ns from './styles.css'
+          console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns.default))
+        `,
+        "/styles.css": `.styles { color: blue; }`,
+      },
+      entryPoints: ["/entry.js"],
+      splitting: true,
+      outdir: "/out",
+      target,
+      format: "esm",
+      onAfterBundle(api) {
+        expect(readdirSync(api.outdir).sort()).toEqual(["entry.css", "entry.js"]);
+      },
+      run: {
+        file: "/out/entry.js",
+        stdout: '["default"] {}',
+      },
+    });
 
-  // ...and in a chunk shared by both entry points when two of them import the
-  // stylesheet, which each entry chunk then has to import the helper from.
-  itBundled("splitting/MultipleEntryPointsWithNamespaceImportOfSharedCSS", {
-    files: {
-      "/entry1.js": `
-        import * as ns from './shared.module.css'
-        console.log('entry1', JSON.stringify(Object.keys(ns).sort()), ns.shared === ns.default.shared)
-      `,
-      "/entry2.js": `
-        import * as ns from './shared.module.css'
-        console.log('entry2', JSON.stringify(Object.keys(ns).sort()), ns.shared === ns.default.shared)
-      `,
-      "/shared.module.css": `.shared { font-size: 16px; }`,
-    },
-    entryPoints: ["/entry1.js", "/entry2.js"],
-    splitting: true,
-    outdir: "/out",
-    target: "browser",
-    format: "esm",
-    run: [
-      {
-        file: "/out/entry1.js",
-        stdout: 'entry1 ["default","shared"] true',
+    // ...and in a chunk shared by both entry points when two of them import the
+    // stylesheet, which each entry chunk then has to import the helper from.
+    itBundled(`splitting/MultipleEntryPointsWithNamespaceImportOfSharedCSS-${target}`, {
+      files: {
+        "/entry1.js": `
+          import * as ns from './shared.module.css'
+          console.log('entry1', JSON.stringify(Object.keys(ns).sort()), ns.shared === ns.default.shared)
+        `,
+        "/entry2.js": `
+          import * as ns from './shared.module.css'
+          console.log('entry2', JSON.stringify(Object.keys(ns).sort()), ns.shared === ns.default.shared)
+        `,
+        "/shared.module.css": `.shared { font-size: 16px; }`,
       },
-      {
-        file: "/out/entry2.js",
-        stdout: 'entry2 ["default","shared"] true',
-      },
-    ],
-  });
+      entryPoints: ["/entry1.js", "/entry2.js"],
+      splitting: true,
+      outdir: "/out",
+      target,
+      format: "esm",
+      run: [
+        {
+          file: "/out/entry1.js",
+          stdout: 'entry1 ["default","shared"] true',
+        },
+        {
+          file: "/out/entry2.js",
+          stdout: 'entry2 ["default","shared"] true',
+        },
+      ],
+    });
+  }
 
   itBundled("splitting/DynamicImportWithOnlyCSSNoJS", {
     files: {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -329,6 +329,79 @@ describe("bundler", () => {
     });
   }
 
+  // The usual shape: the entry points also share a JS module, so the runtime
+  // already lands in the shared chunk. Each entry chunk prints its own copy of
+  // the stylesheet's namespace object and has to import `__export` from there.
+  itBundled("splitting/NamespaceImportOfCSSNextToSharedModule", {
+    files: {
+      "/entry1.js": `
+        import * as ns from './styles.css'
+        import { shared } from './shared.js'
+        console.log('entry1', JSON.stringify(Object.keys(ns)), shared)
+      `,
+      "/entry2.js": `
+        import * as ns from './styles.css'
+        import { shared } from './shared.js'
+        console.log('entry2', JSON.stringify(Object.keys(ns)), shared)
+      `,
+      "/shared.js": `export const shared = 'shared'`,
+      "/styles.css": `.styles { color: blue; }`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      const [chunk] = readdirSync(api.outdir).filter(name => /^entry1-.*\.js$/.test(name));
+      expect(chunk).toBeDefined();
+      expect(api.readFile(`/out/${chunk}`)).toContain("export { __export, shared }");
+      for (const entry of ["entry1", "entry2"]) {
+        const js = api.readFile(`/out/${entry}.js`);
+        expect(js).toMatch(new RegExp(String.raw`^import \{\s*__export,\s*shared\s*\} from "\./${chunk}";`));
+        expect(js).toContain("__export(exports_styles,");
+      }
+    },
+    run: [
+      { file: "/out/entry1.js", stdout: 'entry1 ["default"] shared' },
+      { file: "/out/entry2.js", stdout: 'entry2 ["default"] shared' },
+    ],
+  });
+
+  // The stylesheet's namespace export part exists whether or not anything
+  // namespace-imports it. An entry point that merely imports the stylesheet
+  // must not be given a dependency on the runtime (live here because of
+  // entry1), which would show up as a shared chunk that both entries import.
+  itBundled("splitting/PlainImportOfCSSDoesNotShareTheRuntime", {
+    files: {
+      "/entry1.js": `
+        import * as util from './util.js'
+        console.log('entry1', JSON.stringify(Object.keys(util)))
+      `,
+      "/util.js": `export const util = 1`,
+      "/entry2.js": `
+        import './styles.css'
+        console.log('entry2')
+      `,
+      "/styles.css": `.styles { color: blue; }`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["entry1.js", "entry2.css", "entry2.js"]);
+      api.expectFile("/out/entry2.js").toMatchInlineSnapshot(`
+        "// entry2.js
+        console.log("entry2");
+        "
+      `);
+    },
+    run: [
+      { file: "/out/entry1.js", stdout: 'entry1 ["util"]' },
+      { file: "/out/entry2.js", stdout: "entry2" },
+    ],
+  });
+
   itBundled("splitting/DynamicImportWithOnlyCSSNoJS", {
     files: {
       "/entry.js": `

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -270,6 +270,63 @@ describe("bundler", () => {
     ],
   });
 
+  // `import * as ns` of a CSS file prints the file's namespace object, built
+  // with the runtime's `__export` helper, into each chunk that imports it. The
+  // runtime is used by nothing else here, so the CSS file alone decides where
+  // the helper ends up: in the entry's own chunk with one entry point...
+  itBundled("splitting/NamespaceImportOfCSS", {
+    files: {
+      "/entry.js": `
+        import * as ns from './styles.css'
+        console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns.default))
+      `,
+      "/styles.css": `.styles { color: blue; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["entry.css", "entry.js"]);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: '["default"] {}',
+    },
+  });
+
+  // ...and in a chunk shared by both entry points when two of them import the
+  // stylesheet, which each entry chunk then has to import the helper from.
+  itBundled("splitting/MultipleEntryPointsWithNamespaceImportOfSharedCSS", {
+    files: {
+      "/entry1.js": `
+        import * as ns from './shared.module.css'
+        console.log('entry1', JSON.stringify(Object.keys(ns).sort()), ns.shared === ns.default.shared)
+      `,
+      "/entry2.js": `
+        import * as ns from './shared.module.css'
+        console.log('entry2', JSON.stringify(Object.keys(ns).sort()), ns.shared === ns.default.shared)
+      `,
+      "/shared.module.css": `.shared { font-size: 16px; }`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    format: "esm",
+    run: [
+      {
+        file: "/out/entry1.js",
+        stdout: 'entry1 ["default","shared"] true',
+      },
+      {
+        file: "/out/entry2.js",
+        stdout: 'entry2 ["default","shared"] true',
+      },
+    ],
+  });
+
   itBundled("splitting/DynamicImportWithOnlyCSSNoJS", {
     files: {
       "/entry.js": `


### PR DESCRIPTION
### Problem
- `import * as ns from "./style.css"` bundles to a file that throws at load: `ReferenceError: __export is not defined`. The CSS file's namespace object (`__export(exports_style, { default: () => style_default })`) is printed, but the runtime that defines `__export` is not. Same for `.module.css`, for `--target bun` and `browser`, with and without `--splitting`. `import style from "./style.css"` is fine.
- Without `--splitting` it only works today when some JS module in the same bundle happens to need the runtime too (any file with an `export` does), so cause 1 below shows up in small bundles. With `--splitting` and more than one entry point it fails even then (cause 2), because the runtime sits in a shared chunk that the entry chunks do not import from; that is the shape real apps hit.
- Cause 1, `src/bundler/LinkerContext.rs` (`mark_file_reachable_for_code_splitting`): CSS files `continue`d before the loop over their parts' dependencies. The CSS file's namespace export part depends on the runtime's `__export` part, so the runtime never received the entry point's bit and `find_imported_parts_in_js_order` left it out of the chunk. With `--splitting` the live runtime parts ended up in a chunk with no entry bits at all, which nothing imported (the stray `entry-<hash>.js` in the new splitting test's fail-before output).
- Cause 2, `src/bundler/linker_context/computeCrossChunkDependencies.rs`: the walk that records which symbols a chunk uses only visits `chunk.files_with_parts_in_chunk`, and `compute_chunks` never puts CSS files in there. So with `--splitting` and more than one entry point, even once the runtime lands in a shared chunk, the entry chunks that print a copy of the namespace object do not `import { __export }` from it.

### Fix
- `mark_file_reachable_for_code_splitting` now also follows the part dependencies of CSS files, but only those of their live parts. Correct because, unlike esbuild (whose CSS files have no JS parts, which is where the skip came from), a CSS file in bun carries its JS side in the same source index, and its live parts are printed into the chunk, so whatever they depend on has to be reachable from the same entry points. Dead parts are not printed, and following them is harmful: every stylesheet has a (usually dead) namespace export part depending on the runtime, so the first version of this PR marked the runtime reachable from every entry point with a stylesheet, which printed the server's live `__jsonParse` helper into the browser chunk of an HTML import (`test/bundler/html-import-manifest.test.ts` caught it, see details). JS files keep following every part as before (esbuild parity, and changing it would move chunks around in existing builds).
- What this changes for bundles that already worked: nothing, unless some entry point namespace-imports (or, with #38307, `require()`s) a stylesheet, because otherwise no stylesheet has a live part with a runtime dependency. Checked by diffing such builds (HTML import, side-effect and default imports next to an entry that does use the runtime, with and without `--splitting`) against the release build: byte-identical, and pinned by the two `...DoesNot...` tests below.
- When a stylesheet's namespace object is live, every entry point whose bit the stylesheet carries now also reaches the runtime, including entries that only reach it through a CSS `@import`. That is deliberate: the printer (`find_imported_parts_in_js_order`) prints the live namespace object into any chunk whose bit the stylesheet carries once it reaches the file through any import record, including one of a tree-shaken module, so the entry bits of the file itself are the only thing that is guaranteed to cover every chunk printing it. `bun/loader-css-namespace-object-printed-for-another-entry` is exactly that case (entry B reaches the stylesheet through `@import`, the printer through a `sideEffects: false` package) and currently throws the `ReferenceError` in B's output; propagating only along JS import edges would leave it broken. The cost is the `__export` prelude (or, with `--splitting`, an import of the chunk holding it) in an entry that reaches such a stylesheet via `@import` but never prints the object; an entry point containing any module with an `export` already gets every live helper printed into it today for the same reason, so this only affects entries without one.
- `compute_cross_chunk_dependencies` also walks the CSS files in the chunk's `files_in_chunk_order`, i.e. exactly the CSS files whose JS parts the chunk prints. Their symbol uses become imports of the chunk like everyone else's; their declarations are not assigned a chunk index, since every importing chunk prints its own copy of them (the existing behavior, see `css-module/BundleTwoFilesWithCodeSplitting`) and `assign_chunk_index` asserts a symbol lives in one chunk. Uses of those per-chunk copies by JS in the same chunk resolve to the local copy as before, because a symbol without a chunk index is ignored when cross-chunk imports are generated. Unchanged and out of scope here: the copies are still not members of `files_with_parts_in_chunk`, so their bytes are not attributed to any input in the metafile, and each chunk has its own copy of the objects (a default import from two chunks yields two objects), as on main.
- The redundant `chunk.content` checks in that walk became an early return (the entry-point block below it is only re-indented, `git diff -w` shows it unchanged).
- Intentionally not touched: `mark_file_live_step` has the same esbuild-shaped early return for CSS files. It causes a different bug (`require("./x.module.css")` bundles to an empty wrapper), fixed in #38307. That PR needs the same reachability hunk as this one; both carry it with identical text (see the comment there), so they merge in either order, and the rest of the two diffs does not overlap.
- Tests failing on the release build with the `ReferenceError` above and passing with this change: in `test/bundler/bundler_loader.test.ts`, `bun/loader-css-namespace-import-{bun,browser}` (plain and module CSS, no other runtime user in the bundle) and `bun/loader-css-namespace-object-printed-for-another-entry` (the `@import` case described above); in `test/bundler/bundler_splitting.test.ts`, `splitting/NamespaceImportOfCSS-{bun,browser}` (single entry: runtime joins the entry chunk, exact output file list), `splitting/MultipleEntryPointsWithNamespaceImportOfSharedCSS-{bun,browser}` (runtime alone in a shared chunk, needs both changes) and `splitting/NamespaceImportOfCSSNextToSharedModule` (the usual shape: a shared JS module, asserts the entry chunks `import { __export, shared }` from the shared chunk and that it exports them).
- Tests pinning what must stay unchanged (they pass on the release build, and failed on the first version of this PR): `bun/loader-css-plain-import-does-not-pull-in-runtime` (side-effect and default imports next to an entry with a live `__export`, inline snapshot of the untouched entry) and `splitting/PlainImportOfCSSDoesNotShareTheRuntime` (same with `--splitting`: exact output file list, no shared chunk, snapshot of the untouched entry), plus the existing `html-import-manifest.test.ts` content hashes.
- Also run with this change, all passing: `test/bundler/{bundler_loader,bundler_splitting,html-import-manifest,bundler_regressions,bundler_html,bundler_html_server,bun-build-api,bundler_defer,bundler_compile_splitting,metafile}.test.ts`, `test/bundler/css/css-modules.test.ts`, `test/bundler/esbuild/{css,splitting,metafile,loader,default}.test.ts`, `test/js/bun/http/bun-serve-html{,-manifest}.test.ts`, `test/bake/dev-and-prod.test.ts`; `bun run rust:clippy` and `cargo fmt --all --check` are clean.

### Background
- Runtime: a generated JS source (`Index::RUNTIME`) holding helpers such as `__export`, `__commonJS`, `__toESM`. Its parts are printed at the top of whichever chunk they belong to; nothing imports it through import records, it is only reached through part dependencies.
- Part: the linker's unit of tree shaking, a group of top-level statements with the symbols it declares and uses and a list of `(source, part)` dependencies. Step 5 of the linker gives every file a "namespace export part" that builds the `import * as` object with `__export`, and makes it depend on the runtime's `__export` part.
- JS side of a CSS file: bun parses a CSS file imported from JS into both a CSS AST and a small lazy-export JS AST in the same source index (namespace export part, `var x_default = {...}` or the CSS module class map, a `__commonJS` wrapper if `require()`d). esbuild instead gives that JS a separate source index, which is why its CSS-only branches in these passes were wrong to port as-is.
- Entry bits: after tree shaking, `mark_file_reachable_for_code_splitting` marks every file each entry point can reach (via import records and part dependencies) with that entry's bit. `compute_chunks` groups files by their bits into chunks, and `find_imported_parts_in_js_order` prints a file's live parts into a chunk only if its bits match the chunk's. CSS files are excluded from chunk membership and are instead printed into every chunk whose bits intersect theirs.
- Cross-chunk dependencies (`--splitting` only): for each chunk, the symbols used by the parts it prints are collected; any of them declared in another chunk becomes an `import { x } from "./other-chunk.js"` plus an `export { x }` there. A symbol not declared by any chunk member is assumed local and skipped.

<details>
<summary>Repro and output before / after</summary>

```sh
printf 'body { color: red }\n' > style.css
printf 'import * as mod from "./style.css";\nconsole.log(Object.keys(mod), mod.default);\n' > entry.ts
bun build entry.ts --outdir out --target bun && bun out/entry.js
```

Before:

```
// style.css
var exports_style = {};
__export(exports_style, {
  default: () => style_default
});
var style_default = {};

// entry.ts
console.log(Object.keys(exports_style), style_default);
```

```
ReferenceError: __export is not defined
      at out/entry.js:4:9
```

After: the `var __defProp = ...; var __export = ...` prelude is emitted first and the script prints `[ "default" ] {}`.

With `--splitting` and two entries `a.ts` / `b.ts` both importing `* as` the stylesheet, before: `a-<hash>.js` contains the runtime but neither `a.js` nor `b.js` imports it. After:

```js
// a.js
import { __export } from "./a-nb39b5ae.js";
// style.css
var exports_style = {};
__export(exports_style, { default: () => style_default });
...
```

and `a-nb39b5ae.js` ends with `export { __export };`.

Why only live parts (superseded first version of this PR, 9a7b1d0, followed every part of a CSS file): with

```js
// server.js
import home from "./home.html";   // home.html links home.css and home.js
```

the server entry uses the runtime's `__jsonParse` (the HTML manifest), so that part is live. `home.css` has a dead namespace export part depending on the runtime, and following it gave the runtime the `home.html` entry's bit, so the browser chunk became

```js
var __jsonParse = (a) => JSON.parse(a);

// home.js
console.log("Home page");
```

instead of just the `home.js` line, changing its content hash (`test/bundler/html-import-manifest.test.ts`, `html-import/multiple-manifests`). With the live-parts rule (20868a0, reshaped in 3127bcc) the browser chunk is byte-identical to the release build again. The same rule also means a multi-entry `--splitting` build whose entries only side-effect-import or default-import stylesheets keeps its chunk layout.
</details>
