### PR TITLE
js_parser: keep export default function/class when lowering top-level using

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8979,9 +8979,6 @@ impl LowerUsingDeclarationsContext {
                         continue;
                     }
                 }
-                js_ast::StmtData::SExportDefault(_) => {
-                    continue; // this prevents re-exporting default since we already have it as an .s_export_clause
-                }
                 js_ast::StmtData::SExportClause(data) => {
                     // Merge export clauses together.
                     // ClauseItem isn't `Clone` (POD-only fields, no derive);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9032,6 +9032,10 @@ impl LowerUsingDeclarationsContext {
                 _ => {}
             }
 
+            debug_assert!(
+                !matches!(stmt.data, js_ast::StmtData::SExportDefault(_)),
+                "s_export_default must split `export default` into a binding and an export clause before the module body is wrapped"
+            );
             stmts[end as usize] = stmt;
             end += 1;
         }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -362,10 +362,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// When lowered top-level `using` declarations wrap the module body in a try/catch
-    /// (`LowerUsingDeclarationsContext::finalize`), `export default` can't stay inside it,
-    /// so it becomes a binding (the function declaration itself, `var C = class C {}`, or
-    /// `var file_default = expr`) plus `export { name as default }` for `finalize` to hoist.
+    /// Once lowered `using` wraps the module body in a try/catch, `export default` has to become
+    /// a binding plus `export { name as default }`, which `finalize` keeps outside the block.
     fn append_export_default(
         p: &mut Self,
         stmts: &mut StmtList<'a>,

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -362,8 +362,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Once lowered `using` wraps the module body in a try/catch, `export default` has to become
-    /// a binding plus `export { name as default }`, which `finalize` keeps outside the block.
     fn append_export_default(
         p: &mut Self,
         stmts: &mut StmtList<'a>,

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -362,18 +362,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Appends a visited `export default` statement.
-    ///
-    /// When lowered top-level `using` declarations are about to move the module
-    /// body into a try/catch (see `LowerUsingDeclarationsContext::finalize`),
-    /// the statement can't be kept as-is: `export` is only valid at the top
-    /// level. It becomes a plain top-level binding plus `export { name as
-    /// default }`, which `finalize` merges into the export clause it emits
-    /// after the try/catch:
-    ///
-    ///   export default function f() {}   =>  function f() {}         (hoisted out of the try)
-    ///   export default class C {}        =>  var C = class C {}      (stays in the try)
-    ///   export default expr              =>  var file_default = expr (stays in the try)
+    /// When lowered top-level `using` declarations wrap the module body in a try/catch
+    /// (`LowerUsingDeclarationsContext::finalize`), `export default` can't stay inside it,
+    /// so it becomes a binding (the function declaration itself, `var C = class C {}`, or
+    /// `var file_default = expr`) plus `export { name as default }` for `finalize` to hoist.
     fn append_export_default(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
@@ -397,8 +389,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 stmts.push(func_stmt);
                 name
             }
-            // React fast refresh already declared the default binding and rewrote the
-            // value into a reference to it, so there is nothing left to declare.
+            // The default binding was already declared (react fast refresh does this).
             js_ast::StmtOrExpr::Expr(Expr {
                 data: js_ast::ExprData::EIdentifier(ident),
                 ..

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -362,6 +362,83 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
+    /// Appends a visited `export default` statement.
+    ///
+    /// When lowered top-level `using` declarations are about to move the module
+    /// body into a try/catch (see `LowerUsingDeclarationsContext::finalize`),
+    /// the statement can't be kept as-is: `export` is only valid at the top
+    /// level. It becomes a plain top-level binding plus `export { name as
+    /// default }`, which `finalize` merges into the export clause it emits
+    /// after the try/catch:
+    ///
+    ///   export default function f() {}   =>  function f() {}         (hoisted out of the try)
+    ///   export default class C {}        =>  var C = class C {}      (stays in the try)
+    ///   export default expr              =>  var file_default = expr (stays in the try)
+    fn append_export_default(
+        p: &mut Self,
+        stmts: &mut StmtList<'a>,
+        stmt: Stmt,
+        data: &mut S::ExportDefault,
+    ) {
+        if !(p.current_scope().parent.is_none() && p.will_wrap_module_in_try_catch_for_using) {
+            stmts.push(stmt);
+            return;
+        }
+
+        let default_name = data.default_name;
+        let exported: js_ast::LocRef = match data.value {
+            js_ast::StmtOrExpr::Stmt(
+                func_stmt @ Stmt {
+                    data: StmtData::SFunction(mut func),
+                    ..
+                },
+            ) => {
+                let name = *func.func.name.get_or_insert(default_name);
+                stmts.push(func_stmt);
+                name
+            }
+            // React fast refresh already declared the default binding and rewrote the
+            // value into a reference to it, so there is nothing left to declare.
+            js_ast::StmtOrExpr::Expr(Expr {
+                data: js_ast::ExprData::EIdentifier(ident),
+                ..
+            }) if ident.ref_ == default_name.ref_ => default_name,
+            value => {
+                let decls = G::DeclList::init_one(G::Decl {
+                    binding: p.b(
+                        B::Identifier {
+                            r#ref: default_name.ref_,
+                        },
+                        default_name.loc,
+                    ),
+                    value: Some(value.to_expr()),
+                });
+                stmts.push(p.s(
+                    S::Local {
+                        decls,
+                        ..Default::default()
+                    },
+                    stmt.loc,
+                ));
+                default_name
+            }
+        };
+
+        let items = core::slice::from_mut(p.arena.alloc(js_ast::ClauseItem {
+            alias: js_ast::StoreStr::new(js_ast::ClauseItem::DEFAULT_ALIAS),
+            alias_loc: exported.loc,
+            name: exported,
+            ..Default::default()
+        }));
+        stmts.push(p.s(
+            S::ExportClause {
+                items: bun_ast::StoreSlice::new_mut(items),
+                is_single_line: false,
+            },
+            stmt.loc,
+        ));
+    }
+
     fn s_export_default(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
@@ -506,45 +583,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 if p.options.features.server_components.wraps_exports() {
                     *expr = p.wrap_value_for_server_component_reference(*expr, b"default");
-                }
-
-                // If there are lowered "using" declarations, change this into a "var"
-                if p.current_scope().parent.is_none() && p.will_wrap_module_in_try_catch_for_using {
-                    stmts.reserve(2);
-
-                    let mut decls = G::DeclList::init_capacity(1);
-                    VecExt::append(
-                        &mut decls,
-                        G::Decl {
-                            binding: p.b(
-                                B::Identifier {
-                                    r#ref: data.default_name.ref_,
-                                },
-                                data.default_name.loc,
-                            ),
-                            value: Some(*expr),
-                        },
-                    );
-                    stmts.push(p.s(
-                        S::Local {
-                            decls,
-                            ..Default::default()
-                        },
-                        stmt.loc,
-                    ));
-                    let items = core::slice::from_mut(p.arena.alloc(js_ast::ClauseItem {
-                        alias: js_ast::StoreStr::new(b"default"),
-                        alias_loc: data.default_name.loc,
-                        name: data.default_name,
-                        ..Default::default()
-                    }));
-                    stmts.push(p.s(
-                        S::ExportClause {
-                            items: bun_ast::StoreSlice::new_mut(items),
-                            is_single_line: false,
-                        },
-                        stmt.loc,
-                    ));
                 }
 
                 if mark_for_replace {
@@ -701,7 +739,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                                     stmts.push(Stmt::alloc(
                                         S::Local {
-                                            kind: S::Kind::KConst,
+                                            kind: p.select_local_kind(S::Kind::KConst),
                                             decls: G::DeclList::from_slice(&[G::Decl {
                                                 binding: Binding::alloc(
                                                     p.arena,
@@ -741,7 +779,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 );
                             }
 
-                            stmts.push(*stmt);
+                            Self::append_export_default(p, stmts, *stmt, data);
                             p.emit_react_refresh_register(
                                 stmts,
                                 name,
@@ -763,7 +801,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 );
                             }
 
-                            stmts.push(*stmt);
+                            Self::append_export_default(p, stmts, *stmt, data);
                         }
 
                         p.react_refresh.hook_ctx_storage = prev;
@@ -843,22 +881,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         stmts.extend_from_slice(&class_stmts[0..class_stmt_idx]);
 
                         data.value = js_ast::StmtOrExpr::Stmt(class_stmts[class_stmt_idx]);
-                        stmts.push(*stmt);
-
-                        // Emit any suffix statements after the export default
-                        if class_stmt_idx + 1 < class_stmts.len() {
-                            stmts.extend_from_slice(&class_stmts[class_stmt_idx + 1..]);
-                        }
 
                         if p.options.features.server_components.wraps_exports() {
-                            // `data.value` is mutated *after* pushing `stmt`; the pushed
-                            // stmt still observes the write because `data` is an arena
-                            // backref shared with the pushed copy.
                             let class_expr =
                                 p.new_expr(core::mem::take(&mut class.class), stmt.loc);
                             data.value = js_ast::StmtOrExpr::Expr(
                                 p.wrap_value_for_server_component_reference(class_expr, b"default"),
                             );
+                        }
+
+                        Self::append_export_default(p, stmts, *stmt, data);
+
+                        // Emit any suffix statements after the export default
+                        if class_stmt_idx + 1 < class_stmts.len() {
+                            stmts.extend_from_slice(&class_stmts[class_stmt_idx + 1..]);
                         }
 
                         restore_dead!();
@@ -870,7 +906,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        stmts.push(*stmt);
+        Self::append_export_default(p, stmts, *stmt, data);
         restore_dead!();
         record_on_exit!();
         Ok(())

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2262,6 +2262,130 @@ describe("bundler", () => {
     },
   });
 
+  // Lowering a top-level `using` moves the module body into a try/catch, so a
+  // default-exported declaration has to be split into a binding and an export clause.
+  itBundled("edgecase/UsingExportDefaultDeclaration", {
+    files: {
+      "/entry.ts": `
+        import namedFn from "./named-fn.ts";
+        import anonymousFn from "./anonymous-fn.ts";
+        import NamedClass from "./named-class.ts";
+        import AnonymousClass from "./anonymous-class.ts";
+        console.log(namedFn(), anonymousFn(), NamedClass.describe(), AnonymousClass.tag);
+      `,
+      "/named-fn.ts": `
+        using a = { [Symbol.dispose]() { console.log("dispose named-fn"); } };
+        export default function namedFn() { return "named-fn"; }
+      `,
+      "/anonymous-fn.ts": `
+        using a = { [Symbol.dispose]() { console.log("dispose anonymous-fn"); } };
+        export default function () { return "anonymous-fn"; }
+      `,
+      "/named-class.ts": `
+        using a = { [Symbol.dispose]() { console.log("dispose named-class"); }, tag: "named-class" };
+        export default class NamedClass {
+          // Evaluated in place (after \`a\`), and the body still sees the class's own name.
+          static tag = a.tag;
+          static describe() { return NamedClass.tag; }
+        }
+      `,
+      "/anonymous-class.ts": `
+        using a = { [Symbol.dispose]() { console.log("dispose anonymous-class"); } };
+        export default class { static tag = "anonymous-class"; }
+      `,
+    },
+    run: {
+      stdout: [
+        "dispose named-fn",
+        "dispose anonymous-fn",
+        "dispose named-class",
+        "dispose anonymous-class",
+        "named-fn anonymous-fn named-class anonymous-class",
+      ].join("\n"),
+    },
+  });
+
+  itBundled("edgecase/UsingExportDefaultDecoratedClass", {
+    files: {
+      "/entry.ts": `
+        import Named from "./named.ts";
+        import Anonymous from "./anonymous.ts";
+        console.log(Named.decorated, Anonymous.decorated);
+      `,
+      "/decorate.ts": `
+        export function decorate(target: any, context: ClassDecoratorContext) {
+          console.log("decorate", String(context.name));
+          target.decorated = true;
+        }
+      `,
+      "/named.ts": `
+        import { decorate } from "./decorate.ts";
+        using a = { [Symbol.dispose]() { console.log("dispose named"); } };
+        @decorate
+        export default class Named {}
+      `,
+      "/anonymous.ts": `
+        import { decorate } from "./decorate.ts";
+        using a = { [Symbol.dispose]() { console.log("dispose anonymous"); } };
+        @decorate
+        export default class {}
+      `,
+    },
+    run: {
+      stdout: ["decorate Named", "dispose named", "decorate anonymous_default", "dispose anonymous", "true true"].join(
+        "\n",
+      ),
+    },
+  });
+
+  itBundled("edgecase/UsingExportDefaultReactFastRefresh", {
+    skipOnEsbuild: true,
+    reactFastRefresh: true,
+    files: {
+      "/entry.tsx": `
+        import "./refresh-runtime.ts";
+        import WithHooks from "./with-hooks.tsx";
+        import WithoutHooks from "./without-hooks.tsx";
+        console.log(WithHooks(), WithoutHooks(), JSON.stringify(globalThis.registered));
+      `,
+      "/refresh-runtime.ts": `
+        globalThis.registered = [];
+        globalThis.$RefreshSig$ = () => (component: any) => component;
+        globalThis.$RefreshReg$ = (component: any, id: string) => {
+          globalThis.registered.push(component.name + " as " + id.slice(id.lastIndexOf(":") + 1));
+        };
+      `,
+      "/react.ts": `
+        export function useState(initial: any) { return [initial, () => {}]; }
+      `,
+      "/with-hooks.tsx": `
+        import { useState } from "./react.ts";
+        using a = { [Symbol.dispose]() { console.log("dispose with-hooks"); } };
+        export default function WithHooks() {
+          const [value] = useState("with-hooks");
+          return value;
+        }
+      `,
+      "/without-hooks.tsx": `
+        using a = { [Symbol.dispose]() { console.log("dispose without-hooks"); } };
+        export default function WithoutHooks() { return "without-hooks"; }
+      `,
+    },
+    onAfterBundle(api) {
+      // The refresh transform declares the component itself; that binding must be
+      // function-scoped to escape the try/catch, and it is exported as-is.
+      api.expectFile("/out.js").toMatch(/var WithHooks = _s\(/);
+      api.expectFile("/out.js").not.toContain("WithHooks = WithHooks");
+    },
+    run: {
+      stdout: [
+        "dispose with-hooks",
+        "dispose without-hooks",
+        'with-hooks without-hooks ["WithHooks as default","WithoutHooks as default"]',
+      ].join("\n"),
+    },
+  });
+
   itBundled("edgecase/UsingExportClass", {
     files: {
       "/entry.ts": `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2338,6 +2338,33 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("edgecase/UsingExportDefaultBakeDev", {
+    // The dev server's module format builds each module's export object from the
+    // same lowered statements.
+    format: "internal_bake_dev",
+    files: {
+      "/entry.ts": `
+        import fn from "./fn.ts";
+        import Klass from "./klass.ts";
+        console.log(fn(), Klass.tag);
+      `,
+      "/fn.ts": `
+        using a = { [Symbol.dispose]() {} };
+        export default function fn() { return "fn"; }
+      `,
+      "/klass.ts": `
+        using a = { [Symbol.dispose]() {} };
+        export default class Klass { static tag = "klass"; }
+      `,
+    },
+    onAfterBundle(api) {
+      const output = api.readFile("/out.js");
+      expect(output).toMatch(/hmr\.exports = \{\s*default: fn\s*\}/);
+      expect(output).toMatch(/\bvar Klass = class Klass \{/);
+      expect(output).toMatch(/hmr\.exports = \{\s*default: Klass\s*\}/);
+    },
+  });
+
   itBundled("edgecase/UsingExportDefaultReactFastRefresh", {
     skipOnEsbuild: true,
     reactFastRefresh: true,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -267,6 +267,7 @@ export interface BundlerTestInput {
   serverComponents?: boolean;
   reactCompiler?: boolean;
   reactCompilerOutputMode?: "client" | "ssr";
+  reactFastRefresh?: boolean;
   treeShaking?: boolean;
   unsupportedCSSFeatures?: string[];
   unsupportedJSFeatures?: string[];
@@ -533,6 +534,7 @@ function expectBundled(
     serverComponents = false,
     reactCompiler = false,
     reactCompilerOutputMode,
+    reactFastRefresh = false,
     skipOnEsbuild,
     snapshotSourceMap,
     sourceMap,
@@ -825,6 +827,7 @@ function expectBundled(
               splitting && `--splitting`,
               serverComponents && "--server-components",
               reactCompiler && "--react-compiler",
+              reactFastRefresh && "--react-fast-refresh",
               outbase && `--root=${outbase}`,
               banner && `--banner="${banner}"`, // TODO: --banner-css=*
               footer && `--footer="${footer}"`,
@@ -1194,6 +1197,7 @@ function expectBundled(
           target,
           reactCompiler,
           reactCompilerOutputMode,
+          reactFastRefresh,
           bytecode,
           publicPath,
           emitDCEAnnotations,

--- a/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
+++ b/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
@@ -178,3 +178,417 @@ export {
 };
 "
 `;
+
+exports[`Bun.Transpiler using top level hoisting hoist-directive 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+"use wtf";
+function foo() {
+  "use wtf";
+  let __bun_temp_ref_1$ = [];
+  try {
+    const a = __using(__bun_temp_ref_1$, b, 0);
+  } catch (__bun_temp_ref_2$) {
+    var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+  } finally {
+    __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+  }
+}
+let __bun_temp_ref_5$ = [];
+try {
+  var a = __using(__bun_temp_ref_5$, b, 0);
+} catch (__bun_temp_ref_6$) {
+  var __bun_temp_ref_7$ = __bun_temp_ref_6$, __bun_temp_ref_8$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_5$, __bun_temp_ref_7$, __bun_temp_ref_8$);
+}
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-import 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+import"./foo";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-star 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+
+export * from "./foo";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-from 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+export { x, y } from "./foo";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-clause 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  a,
+  c as "c!"
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-local-indirect 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var ac1 = [a, c], { x: [x1] } = foo;
+  var a1 = a, { y: [y1] } = foo;
+  var c1 = c, { z: [z1] } = foo;
+  var ac2 = [a, c], { x: [x2] } = foo;
+  var a2 = a, { y: [y2] } = foo;
+  var c2 = c, { z: [z2] } = foo;
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  x1,
+  y1,
+  z1
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-function-direct 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+export function foo1() {
+  return [a, c];
+}
+export function bar1() {
+  return [a, c, bar1];
+}
+function foo2() {
+  return [a, c];
+}
+function bar2() {
+  return [a, c, bar2];
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-function-indirect 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+function foo1() {
+  return [a, c];
+}
+function bar1() {
+  return [a, c, bar1];
+}
+function foo2() {
+  return [a, c];
+}
+function bar2() {
+  return [a, c, bar2];
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  foo1,
+  bar1
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-class-name-unused 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var Foo = class Foo {
+    ac = [a, c];
+  };
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  Foo as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-class-name-used 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var Foo = class Foo {
+    ac = [a, c, Foo];
+  };
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  Foo as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-class-anonymous 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var input_default = class {
+    ac = [a, c];
+  };
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  input_default as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-function-name-unused 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+function foo() {
+  return [a, c];
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  foo as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-function-name-used 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+function foo() {
+  return [a, c, foo];
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  foo as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-function-anonymous 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+function input_default() {
+  return [a, c];
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  input_default as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting hoist-export-default-expr 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var input_default = [a, c];
+  var c = __using(__bun_temp_ref_1$, d, 0);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  input_default as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting await-using-export-default-class-anonymous 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 1);
+  var input_default = class {
+    ac = [a];
+  };
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  var __bun_temp_ref_5$ = __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+  __bun_temp_ref_5$ && await __bun_temp_ref_5$;
+}
+
+export {
+  input_default as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level hoisting await-using-export-default-async-generator 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+async function* input_default() {
+  yield a;
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 1);
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  var __bun_temp_ref_5$ = __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+  __bun_temp_ref_5$ && await __bun_temp_ref_5$;
+}
+
+export {
+  input_default as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level with a default export exports.replace replaces the value 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var input_default = 42;
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  input_default as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level with a default export exports.replace replaces the value 2`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var foo = 42;
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  foo as default
+};
+"
+`;
+
+exports[`Bun.Transpiler using top level with a default export exports.replace replaces the value 3`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b, 0);
+  var input_default = 42;
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  input_default as default
+};
+"
+`;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4700,6 +4700,169 @@ console.log("boop");
       export var q = r;
     `);
   });
+
+  describe("using top level with a default export", () => {
+    const lowered = code => prepareForSnapshot(parsed(code, false, false));
+
+    it("hoists an exported function declaration out of the try/catch", () => {
+      expect(lowered(`using a = b;\nexport default function foo() {}`)).toMatchInlineSnapshot(`
+        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+        function foo() {}
+        let __bun_temp_ref_1$ = [];
+        try {
+          var a = __using(__bun_temp_ref_1$, b, 0);
+        } catch (__bun_temp_ref_2$) {
+          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+        } finally {
+          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+        }
+
+        export {
+          foo as default
+        };
+        "
+      `);
+      expect(lowered(`using a = b;\nexport default function () {}`)).toMatchInlineSnapshot(`
+        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+        function input_default() {}
+        let __bun_temp_ref_1$ = [];
+        try {
+          var a = __using(__bun_temp_ref_1$, b, 0);
+        } catch (__bun_temp_ref_2$) {
+          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+        } finally {
+          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+        }
+
+        export {
+          input_default as default
+        };
+        "
+      `);
+    });
+
+    it("turns an exported class declaration into a var inside the try/catch", () => {
+      expect(lowered(`using a = b;\nexport default class Foo { static self = Foo; }`)).toMatchInlineSnapshot(`
+        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+        let __bun_temp_ref_1$ = [];
+        try {
+          var a = __using(__bun_temp_ref_1$, b, 0);
+          var Foo = class Foo {
+            static self = Foo;
+          };
+        } catch (__bun_temp_ref_2$) {
+          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+        } finally {
+          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+        }
+
+        export {
+          Foo as default
+        };
+        "
+      `);
+      expect(lowered(`using a = b;\nexport default class { static x = a; }`)).toMatchInlineSnapshot(`
+        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+        let __bun_temp_ref_1$ = [];
+        try {
+          var a = __using(__bun_temp_ref_1$, b, 0);
+          var input_default = class {
+            static x = a;
+          };
+        } catch (__bun_temp_ref_2$) {
+          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+        } finally {
+          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+        }
+
+        export {
+          input_default as default
+        };
+        "
+      `);
+    });
+
+    it("turns an exported expression into a var inside the try/catch", () => {
+      expect(lowered(`using a = b;\nexport default a.value;`)).toMatchInlineSnapshot(`
+        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+        let __bun_temp_ref_1$ = [];
+        try {
+          var a = __using(__bun_temp_ref_1$, b, 0);
+          var input_default = a.value;
+        } catch (__bun_temp_ref_2$) {
+          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+        } finally {
+          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+        }
+
+        export {
+          input_default as default
+        };
+        "
+      `);
+    });
+
+    it("scan() still reports the default export", () => {
+      const scan = code => transpiler.scan(code).exports;
+      expect(scan(`using a = b;\nexport default function foo() {}`)).toEqual(["default"]);
+      expect(scan(`using a = b;\nexport default function () {}`)).toEqual(["default"]);
+      expect(scan(`using a = b;\nexport default class Foo {}`)).toEqual(["default"]);
+      expect(scan(`await using a = b;\nexport default class {}`)).toEqual(["default"]);
+      expect(scan(`await using a = b;\nexport default async function* foo() {}`)).toEqual(["default"]);
+    });
+
+    it("exports.eliminate still drops the default export", () => {
+      const eliminate = new Bun.Transpiler({ loader: "js", target: "browser", exports: { eliminate: ["default"] } });
+      for (const code of [
+        `using a = b;\nexport default function foo() {}`,
+        `using a = b;\nexport default class Foo {}`,
+        `using a = b;\nexport default foo;`,
+      ]) {
+        const out = eliminate.transformSync(code);
+        expect(out).toContain("__using");
+        expect(out).not.toContain("export");
+        expect(out).not.toMatch(/foo/i);
+      }
+    });
+
+    it("the lowered modules export the declaration and still dispose", async () => {
+      const js = new Bun.Transpiler({ loader: "js", target: "browser" });
+      using dir = tempDir("using-export-default", {
+        "fn.mjs": js.transformSync(`
+          using a = { [Symbol.dispose]() { console.log("dispose fn"); } };
+          export default function fn() { return "fn"; }
+        `),
+        "klass.mjs": js.transformSync(`
+          using a = { [Symbol.dispose]() { console.log("dispose klass"); }, tag: "klass" };
+          export default class Klass {
+            static tag = a.tag;
+            static describe() { return Klass.tag; }
+          }
+        `),
+        "anonymous.mjs": js.transformSync(`
+          using a = { [Symbol.dispose]() { console.log("dispose anonymous"); } };
+          export default class { static tag = "anonymous"; }
+        `),
+        "main.mjs": `
+          import fn from "./fn.mjs";
+          import Klass from "./klass.mjs";
+          import Anonymous from "./anonymous.mjs";
+          console.log(fn(), Klass.describe(), Anonymous.tag);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("dispose fn\ndispose klass\ndispose anonymous\nfn klass anonymous\n");
+      expect(exitCode).toBe(0);
+    });
+  });
 });
 
 describe("await can only be used inside an async function message", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4701,114 +4701,217 @@ console.log("boop");
     `);
   });
 
+  // Port of esbuild's TestLowerUsingHoisting (internal/bundler_tests/bundler_lower_test.go):
+  // once a top-level `using` moves the module body into a try/catch, everything that has to
+  // stay at the top level (directives, imports, re-exports, function declarations and every
+  // export) must be hoisted out of it or turned into a binding plus an export clause.
+  //
+  // Each entry is [source, names reported by scan()]. Not ported yet because their output is
+  // still wrong: hoist-export-class-direct, hoist-export-class-indirect (top-level classes are
+  // left block-scoped inside the try) and hoist-export-local-direct (exported destructuring
+  // patterns lose their exports). hoist-use-strict only differs from hoist-directive by the
+  // "use strict" that Bun strips anyway.
+  describe("using top level hoisting", () => {
+    const fixtures = {
+      "hoist-directive": [
+        `
+          "use wtf"
+          using a = b
+          function foo() {
+            "use wtf"
+            using a = b
+          }
+        `,
+        [],
+      ],
+      "hoist-import": [
+        `
+          using a = b
+          import "./foo"
+          using c = d
+        `,
+        [],
+      ],
+      "hoist-export-star": [
+        `
+          using a = b
+          export * from './foo'
+          using c = d
+        `,
+        [],
+      ],
+      "hoist-export-from": [
+        `
+          using a = b
+          export {x, y} from './foo'
+          using c = d
+        `,
+        ["x", "y"],
+      ],
+      "hoist-export-clause": [
+        `
+          using a = b
+          export {a, c as 'c!'}
+          using c = d
+        `,
+        ["a", "c!"],
+      ],
+      "hoist-export-local-indirect": [
+        `
+          using a = b
+          var ac1 = [a, c], { x: [x1] } = foo
+          let a1 = a, { y: [y1] } = foo
+          const c1 = c, { z: [z1] } = foo
+          var ac2 = [a, c], { x: [x2] } = foo
+          let a2 = a, { y: [y2] } = foo
+          const c2 = c, { z: [z2] } = foo
+          using c = d
+          export {x1, y1, z1}
+        `,
+        ["x1", "y1", "z1"],
+      ],
+      "hoist-export-function-direct": [
+        `
+          using a = b
+          export function foo1() { return [a, c] }
+          export function bar1() { return [a, c, bar1] }
+          function foo2() { return [a, c] }
+          function bar2() { return [a, c, bar2] }
+          using c = d
+        `,
+        ["bar1", "foo1"],
+      ],
+      "hoist-export-function-indirect": [
+        `
+          using a = b
+          function foo1() { return [a, c] }
+          function bar1() { return [a, c, bar1] }
+          function foo2() { return [a, c] }
+          function bar2() { return [a, c, bar2] }
+          using c = d
+          export {foo1, bar1}
+        `,
+        ["bar1", "foo1"],
+      ],
+      "hoist-export-default-class-name-unused": [
+        `
+          using a = b
+          export default class Foo {
+            ac = [a, c]
+          }
+          using c = d
+        `,
+        ["default"],
+      ],
+      "hoist-export-default-class-name-used": [
+        `
+          using a = b
+          export default class Foo {
+            ac = [a, c, Foo]
+          }
+          using c = d
+        `,
+        ["default"],
+      ],
+      "hoist-export-default-class-anonymous": [
+        `
+          using a = b
+          export default class {
+            ac = [a, c]
+          }
+          using c = d
+        `,
+        ["default"],
+      ],
+      "hoist-export-default-function-name-unused": [
+        `
+          using a = b
+          export default function foo() {
+            return [a, c]
+          }
+          using c = d
+        `,
+        ["default"],
+      ],
+      "hoist-export-default-function-name-used": [
+        `
+          using a = b
+          export default function foo() {
+            return [a, c, foo]
+          }
+          using c = d
+        `,
+        ["default"],
+      ],
+      "hoist-export-default-function-anonymous": [
+        `
+          using a = b
+          export default function() {
+            return [a, c]
+          }
+          using c = d
+        `,
+        ["default"],
+      ],
+      "hoist-export-default-expr": [
+        `
+          using a = b
+          export default [a, c]
+          using c = d
+        `,
+        ["default"],
+      ],
+      // Not in esbuild's suite: `await using` takes the same path with an async finally block.
+      "await-using-export-default-class-anonymous": [
+        `
+          await using a = b
+          export default class {
+            ac = [a]
+          }
+        `,
+        ["default"],
+      ],
+      "await-using-export-default-async-generator": [
+        `
+          await using a = b
+          export default async function* () {
+            yield a
+          }
+        `,
+        ["default"],
+      ],
+    };
+
+    for (const [name, [code, exportNames]] of Object.entries(fixtures)) {
+      it(name, () => {
+        expect(prepareForSnapshot(parsed(code, false, false))).toMatchSnapshot();
+        expect(transpiler.scan(code).exports.sort()).toEqual(exportNames);
+      });
+    }
+  });
+
   describe("using top level with a default export", () => {
-    const lowered = code => prepareForSnapshot(parsed(code, false, false));
-
-    it("hoists an exported function declaration out of the try/catch", () => {
-      expect(lowered(`using a = b;\nexport default function foo() {}`)).toMatchInlineSnapshot(`
-        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
-        function foo() {}
-        let __bun_temp_ref_1$ = [];
-        try {
-          var a = __using(__bun_temp_ref_1$, b, 0);
-        } catch (__bun_temp_ref_2$) {
-          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
-        } finally {
-          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
-        }
-
-        export {
-          foo as default
-        };
-        "
-      `);
-      expect(lowered(`using a = b;\nexport default function () {}`)).toMatchInlineSnapshot(`
-        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
-        function input_default() {}
-        let __bun_temp_ref_1$ = [];
-        try {
-          var a = __using(__bun_temp_ref_1$, b, 0);
-        } catch (__bun_temp_ref_2$) {
-          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
-        } finally {
-          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
-        }
-
-        export {
-          input_default as default
-        };
-        "
-      `);
+    it("a second default export is still a duplicate", () => {
+      ts.expectParseError(
+        `using a = b;\nexport default function foo() {}\nexport { a as default };`,
+        'Multiple exports with the same name "default"',
+      );
+      ts.expectParseError(
+        `using a = b;\nexport default class Foo {}\nexport { a as default };`,
+        'Multiple exports with the same name "default"',
+      );
     });
 
-    it("turns an exported class declaration into a var inside the try/catch", () => {
-      expect(lowered(`using a = b;\nexport default class Foo { static self = Foo; }`)).toMatchInlineSnapshot(`
-        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
-        let __bun_temp_ref_1$ = [];
-        try {
-          var a = __using(__bun_temp_ref_1$, b, 0);
-          var Foo = class Foo {
-            static self = Foo;
-          };
-        } catch (__bun_temp_ref_2$) {
-          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
-        } finally {
-          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
-        }
-
-        export {
-          Foo as default
-        };
-        "
-      `);
-      expect(lowered(`using a = b;\nexport default class { static x = a; }`)).toMatchInlineSnapshot(`
-        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
-        let __bun_temp_ref_1$ = [];
-        try {
-          var a = __using(__bun_temp_ref_1$, b, 0);
-          var input_default = class {
-            static x = a;
-          };
-        } catch (__bun_temp_ref_2$) {
-          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
-        } finally {
-          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
-        }
-
-        export {
-          input_default as default
-        };
-        "
-      `);
-    });
-
-    it("turns an exported expression into a var inside the try/catch", () => {
-      expect(lowered(`using a = b;\nexport default a.value;`)).toMatchInlineSnapshot(`
-        "import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
-        let __bun_temp_ref_1$ = [];
-        try {
-          var a = __using(__bun_temp_ref_1$, b, 0);
-          var input_default = a.value;
-        } catch (__bun_temp_ref_2$) {
-          var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
-        } finally {
-          __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
-        }
-
-        export {
-          input_default as default
-        };
-        "
-      `);
-    });
-
-    it("scan() still reports the default export", () => {
-      const scan = code => transpiler.scan(code).exports;
-      expect(scan(`using a = b;\nexport default function foo() {}`)).toEqual(["default"]);
-      expect(scan(`using a = b;\nexport default function () {}`)).toEqual(["default"]);
-      expect(scan(`using a = b;\nexport default class Foo {}`)).toEqual(["default"]);
-      expect(scan(`await using a = b;\nexport default class {}`)).toEqual(["default"]);
-      expect(scan(`await using a = b;\nexport default async function* foo() {}`)).toEqual(["default"]);
+    it("exports.replace replaces the value", () => {
+      const replace = new Bun.Transpiler({ loader: "js", target: "browser", exports: { replace: { default: 42 } } });
+      // `export default class` ignores exports.replace with or without `using`; not covered here.
+      for (const code of [
+        `using a = b;\nexport default a.value;`,
+        `using a = b;\nexport default function foo() { return a; }`,
+        `using a = b;\nexport default function () { return a; }`,
+      ]) {
+        expect(prepareForSnapshot(replace.transformSync(code))).toMatchSnapshot();
+      }
     });
 
     it("exports.eliminate still drops the default export", () => {


### PR DESCRIPTION
### Problem

- A module with a top-level `using` / `await using` that is lowered (any target except `bun`) silently loses `export default function f() {}` and `export default class C {}`; anonymous forms too. `bun build --target=browser` on an importer fails with `No matching export in "a.mjs" for import "default"`, `Bun.Transpiler#transformSync` prints the try/catch with no export, and `Bun.Transpiler#scan()` reports `exports: []`. Only `export default <expr>` survived. Reproduces on 1.4.0 and main.
- `s_export_default` (`src/js_parser/visit/visit_stmt.rs`) only rewrote the expression form for this mode; the function and class branches pushed the `export default` statement unchanged.
- `LowerUsingDeclarationsContext::finalize` (`src/js_parser/p.rs`) then dropped every `S::ExportDefault` it saw. That arm existed to discard the expression form's leftover statement, but for the function and class forms it discarded the only statement carrying the export. The export scan runs after visiting, so `named_exports` never gets `default` either, which is where the link error comes from (and why a second `export { x as default }` in such a module was not reported as a duplicate).
- Same bug with react fast refresh (`Bun.build({ reactFastRefresh: true })`, bake dev): a default component was dropped, and a component without hooks left behind `$RefreshReg$(App, ...)` referencing a binding that no longer existed.

### Fix

- All four places `s_export_default` emits its statement now go through one helper, `append_export_default`. Outside the using-wrap mode it pushes the statement unchanged. In that mode it emits:
  - `export default function f() {}` -> `function f() {}` (an anonymous function gets the generated default name) + `export { f as default }`. `finalize` already hoists module-level function declarations out of the try, so this keeps ESM's cross-file function hoisting.
  - `export default class C {}` -> `var C = class C {}` inside the try + `export { C as default }`. The class is still evaluated in place (static initializers may read the `using` bindings, and a throwing class body must still dispose them), `var` is what makes the binding visible to the export clause after the block, and keeping the inner name preserves the class's own binding inside its body. Decorator prefix/suffix statements keep surrounding it. Anonymous classes become `var file_default = class {}`.
  - `export default expr` -> unchanged shape (`var file_default = expr` + clause), now emitted once instead of emitting it and also pushing the original statement for `finalize` to delete. It now runs after the `exports.replace` handling, so a replacement for `default` is what gets emitted (it used to be lost in this mode); for the function forms the replacement is emitted as `var foo = <replacement>` / `var file_default = <replacement>` + clause.
- The `S::ExportDefault` arm in `finalize` is replaced by a `debug_assert!` at the point where statements enter the wrapped body: nothing produces that statement in this mode any more, and a future miss should fail loudly instead of silently dropping the export again.
- React fast refresh: the `const App = _s(function App() {...})` it synthesizes for a default component goes through `select_local_kind` like every other top-level local, so it becomes a `var` and escapes the try block (in bundled output, where refresh is available, top-level locals are already `var`). The helper recognizes that the value is that binding itself and exports it directly instead of emitting `var App = App`.
- In the class branch, the server-components wrapping now happens before the statement is emitted rather than after (previously it relied on mutating the already-pushed statement through the arena); same output, but the helper needs the final value. This combination (server components wrapping plus a non-bun target) is not reachable from any current entry point, so it has no test.
- Output matches esbuild for all forms (esbuild drops the class name when the body does not use it; here it is always kept, which is semantically identical). As with bundled output today, an anonymous default function/class ends up with `.name` of `file_default` rather than `default` in this mode.
- Out of scope, pre-existing in every mode: `export default class` ignores `exports.replace` (the class branch overwrites the replacement when it lowers the class); #33378 covers that. Note for whichever of the two lands second: the extra push that change adds to the class branch has to go through `append_export_default` as well.
- Tests:
  - `test/bundler/transpiler/transpiler.test.js`, `using top level hoisting`: a port of esbuild's `TestLowerUsingHoisting` fixtures (transform output snapshot plus `scan()` exports for each), plus two `await using` cases. The nine default-export fixtures fail on the unfixed build; the other eight pass on both and pin the parts of `finalize` this and the sibling PRs touch. Three esbuild fixtures are left out because their output is still wrong here: `hoist-export-class-direct` / `-indirect` (#38292) and `hoist-export-local-direct` (#38279).
  - `using top level with a default export`: duplicate `default` export is still reported, `exports.replace` output for the expression and both function forms, `exports.eliminate` still removes the export, and the transformed modules are executed through bun to check exports and disposal.
  - `test/bundler/bundler_edgecase.test.ts`: `UsingExportDefaultDeclaration` (named/anonymous function and class, class static initializer reading the `using` binding and its own name, disposal order), `UsingExportDefaultDecoratedClass` (standard decorators around the converted class), `UsingExportDefaultBakeDev` (`internal_bake_dev` export objects are built from the new shapes), `UsingExportDefaultReactFastRefresh` (with and without hooks, registration still happens, binding is a `var`, no `App = App`). All fail on the unfixed build with the `No matching export` error above.
  - `test/bundler/expectBundled.ts` gains a `reactFastRefresh` option (CLI flag and API field) for the refresh test.
  - Also ran: `bundler_edgecase`, `transpiler.test.js`, `lower-using-bun-target`, `esbuild/{default,ts}`, the decorator suites, `regression/issue/25716` (reactFastRefresh), `bake/dev/{react-spa,bundle}`; all green. (`esbuild/lower.test.ts` is entirely `describe.todo` and does not cover `using`.)
- Not fixed here: a module with lowered `using` that the bundler wraps lazily (dynamic import / `__esm`) keeps its `var` declarations inside the wrapper closure, so `var C = class C {}` there hits the same `ReferenceError` that `export default 42` already hits on main; #38284 fixes that, and the tests here use static imports.

### Background

- **`using` lowering**: for targets other than `bun`, the parser rewrites `using x = v` into `__using(stack, v)` calls and, when the declaration is at module level, wraps the whole module body in `try { ... } catch { ... } finally { __callDispose(...) }` (`LowerUsingDeclarationsContext::finalize`, `will_wrap_module_in_try_catch_for_using`). Imports, `export ... from`, and module-level function declarations are kept outside the block; `export var/let/const` becomes a `var` inside the block plus an entry in one `export { ... }` clause emitted after it. `export` statements cannot appear inside a block, so every export has to be turned into that shape.
- **`default_name`**: every `S::ExportDefault` carries a `LocRef` naming the exported binding. For `export default function f` / `class C` it is `f` / `C` itself; for anonymous declarations and expressions it is a generated `<file>_default` symbol. The export clause emitted here points at it.
- **Export scanning**: `named_exports` (what the bundler links against and what `scan()` returns) is collected by `ImportScanner` in `to_ast`, i.e. from the statements left after visiting and lowering, which is why a dropped statement also loses the export record.
- **React fast refresh**: for a default-exported component using hooks, the parser rewrites the declaration into `var _s = $RefreshSig$(); <decl> App = _s(function App() {...}, "sig"); export default App; $RefreshReg$(App, "file:default")`, so by the time the export is emitted its value is a reference to a binding declared just above.
- **`exports.replace` / `exports.eliminate`**: `Bun.Transpiler` options that substitute or delete a named export while transforming; they are the only producers of `replace_exports` in the parser.
