### PR TITLE
bundler: fail the build for `with { type: "sqlite" }` imports when the target is not bun

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6084,8 +6084,10 @@ pub mod bv2_impl {
                     }
                 }
 
-                // By default, we treat .sqlite files as external.
-                if import_record.loader == Some(Loader::Sqlite) {
+                // By default, we treat .sqlite files as external; the Bun runtime opens
+                // them. For other targets the record falls through to the parse task,
+                // which reports that the sqlite loader requires target "bun".
+                if import_record.loader == Some(Loader::Sqlite) && ctx.target.is_bun() {
                     import_record
                         .flags
                         .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6084,9 +6084,8 @@ pub mod bv2_impl {
                     }
                 }
 
-                // By default, we treat .sqlite files as external; the Bun runtime opens
-                // them. For other targets the record falls through to the parse task,
-                // which reports that the sqlite loader requires target "bun".
+                // External for target bun, where the runtime opens the database. Other
+                // targets fall through to the parse task, which reports the target error.
                 if import_record.loader == Some(Loader::Sqlite) && ctx.target.is_bun() {
                     import_record
                         .flags

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6084,8 +6084,7 @@ pub mod bv2_impl {
                     }
                 }
 
-                // External for target bun, where the runtime opens the database. Other
-                // targets fall through to the parse task, which reports the target error.
+                // Left external for target bun; other targets get the parse task's target error.
                 if import_record.loader == Some(Loader::Sqlite) && ctx.target.is_bun() {
                     import_record
                         .flags

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -38,6 +38,57 @@ describe("bundler", () => {
     },
     run: { stdout: "RedisClient\nRedisClient\nRedisClient\n" },
   });
+  // Only the Bun runtime can open a database the bundle leaves external, so
+  // every way of selecting the sqlite loader has to fail the build for the
+  // other targets. The `with { type: "sqlite" }` form used to be externalized
+  // before that check ran: the build succeeded and the output imported the
+  // database as a plain module, with the attribute dropped.
+  describe("sqlite loader requires target bun", () => {
+    const database = (() => {
+      const db = new Database(":memory:");
+      db.exec("create table messages (message text)");
+      db.exec("insert into messages values ('Hello, world!')");
+      return db.serialize();
+    })();
+    const targetError = {
+      "/db.sqlite": ['To use the "sqlite" loader, set target to "bun"'],
+    };
+    for (const target of ["node", "browser"] as const) {
+      itBundled(`bun/sqlite-file-target-${target}`, {
+        target,
+        files: {
+          "/entry.ts": /* js */ `
+            import db from './db.sqlite' with {type: "sqlite"};
+            console.log(db);
+          `,
+          "/db.sqlite": database,
+        },
+        bundleErrors: targetError,
+      });
+      itBundled(`bun/sqlite-file-dynamic-import-target-${target}`, {
+        target,
+        files: {
+          "/entry.ts": /* js */ `
+            const { default: db } = await import('./db.sqlite', {with: {type: "sqlite"}});
+            console.log(db);
+          `,
+          "/db.sqlite": database,
+        },
+        bundleErrors: targetError,
+      });
+      itBundled(`bun/embedded-sqlite-file-target-${target}`, {
+        target,
+        files: {
+          "/entry.ts": /* js */ `
+            import db from './db.sqlite' with {type: "sqlite", embed: "true"};
+            console.log(db);
+          `,
+          "/db.sqlite": database,
+        },
+        bundleErrors: targetError,
+      });
+    }
+  });
   itBundled("bun/embedded-sqlite-file", {
     target: "bun",
     outfile: "",

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -38,12 +38,16 @@ describe("bundler", () => {
     },
     run: { stdout: "RedisClient\nRedisClient\nRedisClient\n" },
   });
-  // Only the Bun runtime can open a database the bundle leaves external, so
-  // every way of selecting the sqlite loader has to fail the build for the
-  // other targets. The `with { type: "sqlite" }` form used to be externalized
-  // before that check ran: the build succeeded and the output imported the
-  // database as a plain module, with the attribute dropped.
-  describe("sqlite loader requires target bun", () => {
+  // Only the Bun runtime can open a database the bundle leaves external, so a
+  // sqlite import attribute has to fail the build for the other targets, the
+  // way `embed: "true"` and `--loader .db:sqlite` already did. The plain
+  // `with { type: "sqlite" }` form used to be externalized before that check
+  // ran: the build succeeded and the output imported the database as a plain
+  // module, with the attribute dropped.
+  //
+  // The fixture is `app.db` on purpose: `.sqlite` selects the loader by
+  // extension alone, while a `.db` file only gets it from the attribute.
+  describe("sqlite import attribute requires target bun", () => {
     const database = (() => {
       const db = new Database(":memory:");
       db.exec("create table messages (message text)");
@@ -51,41 +55,56 @@ describe("bundler", () => {
       return db.serialize();
     })();
     const targetError = {
-      "/db.sqlite": ['To use the "sqlite" loader, set target to "bun"'],
+      "/app.db": ['To use the "sqlite" loader, set target to "bun"'],
     };
     for (const target of ["node", "browser"] as const) {
-      itBundled(`bun/sqlite-file-target-${target}`, {
+      itBundled(`bun/sqlite-attribute-target-${target}`, {
         target,
         files: {
           "/entry.ts": /* js */ `
-            import db from './db.sqlite' with {type: "sqlite"};
+            import db from './app.db' with {type: "sqlite"};
             console.log(db);
           `,
-          "/db.sqlite": database,
+          "/app.db": database,
         },
         bundleErrors: targetError,
       });
-      itBundled(`bun/sqlite-file-dynamic-import-target-${target}`, {
+      itBundled(`bun/sqlite-attribute-dynamic-import-target-${target}`, {
         target,
         files: {
           "/entry.ts": /* js */ `
-            const { default: db } = await import('./db.sqlite', {with: {type: "sqlite"}});
+            const { default: db } = await import('./app.db', {with: {type: "sqlite"}});
             console.log(db);
           `,
-          "/db.sqlite": database,
+          "/app.db": database,
         },
         bundleErrors: targetError,
       });
-      itBundled(`bun/embedded-sqlite-file-target-${target}`, {
+      itBundled(`bun/sqlite-attribute-embed-target-${target}`, {
         target,
         files: {
           "/entry.ts": /* js */ `
-            import db from './db.sqlite' with {type: "sqlite", embed: "true"};
+            import db from './app.db' with {type: "sqlite", embed: "true"};
             console.log(db);
           `,
-          "/db.sqlite": database,
+          "/app.db": database,
         },
         bundleErrors: targetError,
+      });
+      // For these targets the import is resolved like any other, so a database
+      // that is not there is a resolution error (target bun never looks for it:
+      // see bun/sqlite-file below, which only creates the file at run time).
+      itBundled(`bun/sqlite-attribute-missing-file-target-${target}`, {
+        target,
+        files: {
+          "/entry.ts": /* js */ `
+            import db from './app.db' with {type: "sqlite"};
+            console.log(db);
+          `,
+        },
+        bundleErrors: {
+          "/entry.ts": ['Could not resolve: "./app.db"'],
+        },
       });
     }
   });


### PR DESCRIPTION
### Problem
- `bun build --target node` (or `browser`) of `import db from "./app.db" with { type: "sqlite" }` exits 0 and emits `import db from "./app.db";`: the attribute is gone and the database is imported as a plain module, which fails at runtime on the target the bundle was built for. `await import("./app.db", { with: { type: "sqlite" } })` does the same.
- The neighbouring forms already fail the build with `error: To use the "sqlite" loader, set target to "bun"`: `with { type: "sqlite", embed: "true" }`, and `--loader .db:sqlite` (or a `.sqlite` extension) without an attribute. The docs for the loader say it is only supported for target `bun`.
- Cause: `resolve_import_records` in `src/bundler/bundle_v2.rs` (the `By default, we treat .sqlite files as external` check) flags a record whose attribute selected `Loader::Sqlite` as external and skips it for every target, before the file is resolved. The target check lives in the `Loader::SqliteEmbedded | Loader::Sqlite` arm of `get_ast` in `src/bundler/ParseTask.rs`, which an external record never reaches. The printer only re-emits `with { type }` for the bun platform, so the attribute disappears from the output. This has been the case since the loader was added (#8178).

### Fix
- The early externalization now also requires `ctx.target.is_bun()`. For other targets the record is resolved like any other import and gets a parse task with the sqlite loader, which reports the existing error. Output for target `bun` is unchanged (the record is externalized exactly as before), and the `embed: "true"` path is untouched (it already fell through to the parse task).
- Why this is right: leaving the import external only means something when the Bun runtime will open the database from the emitted import; no other target can, so the record has to go through the same loader check as the embed and loader-map forms. The error is the one the docs describe, and it is the same policy #38275 applies to the externalization it adds after resolution, so the two sites agree.
- User-visible change: `bun build --target node|browser` of a project using this attribute now fails instead of exiting 0 with a bundle that cannot run on that target. A database that does not exist on disk reports `Could not resolve` on those targets (the import is now an ordinary import there; the target error is reported once the file resolves). For target `bun` a missing file still builds, since it is only opened at runtime.
- Verified with `test/bundler/bundler_bun.test.ts`, new `sqlite import attribute requires target bun` block, for each of `node` and `browser`: static import, dynamic import and `embed: "true"` must fail with the error above, and a missing database must fail with `Could not resolve`. The fixture is `app.db` (the docs example), which only gets the sqlite loader from the attribute; a `.db` import without the attribute builds on these targets through the file loader (checked by hand), so the error in the tests can only come from the attribute. 6 of the 8 cases fail on the released binary (the build succeeds, so the expected error never appears); the two `embed` cases pass before and after and pin the form this change must not disturb. The whole file passes with the debug build, including the existing target bun tests `bun/sqlite-file` and `bun/embedded-sqlite-file`.
- Also run with the debug build: `bundler_compile.test.ts` (`compile/sqlite-file`, `compile/EmbeddedSqlite`), `bundler_loader.test.ts`, `test/js/bun/import-attributes`.
- Not covered here, found while checking the neighbouring forms and tracked separately: a 0-byte database (a valid empty SQLite file) skips the loader arm entirely through the parse task's empty-file shortcut, so it bundles as `{}` and also skips this error; and a `type` attribute on `export ... from` is ignored by the parser for every loader, so that form never selects the sqlite loader on any target.

### Related
- #38275 (open) externalizes the records whose sqlite loader comes from the extension or loader map, at a second site after resolution, and gates that on the same `is_bun()` condition. It leaves the pre-resolution attribute block fixed here unchanged, so the attribute form still builds successfully on non-bun targets with it applied. The two hunks do not overlap.

### Background
- Import record: the bundler's per-import entry. The parser stores the loader an import attribute selected in `import_record.loader`; `resolve_import_records` turns each record into either a bundled module (a parse task) or an external import that is printed back out as written. `IS_EXTERNAL_WITHOUT_SIDE_EFFECTS` is the external flavor that tree shaking may drop when the binding is unused.
- `sqlite` loader: makes `import db from "./x"` evaluate to a `bun:sqlite` `Database`. Without `embed`, the bundler leaves the import in the output and the Bun runtime opens the file when the bundle runs, which is why the record is externalized for target `bun`. With `embed: "true"` the file is copied into the output and bundled as a module. The loader is selected by the attribute, by the `--loader` / bunfig / `Bun.build({ loader })` map, or by a `.sqlite` extension.
- Parse task: the per-file step that produces a module's AST. For non-JS loaders it synthesizes the module body; the sqlite arm is where the `set target to "bun"` error is reported, so any record that should get that error has to become a parse task.

<details>
<summary>CLI output before and after (Linux, the handoff's reproduction)</summary>

```
$ printf 'x' > app.db
$ printf 'import db from "./app.db" with { type: "sqlite" }; console.log(db);\n' > entry.mjs

# released 1.4.0
$ bun build ./entry.mjs --target node --outdir out; echo exit=$?
Bundled 1 module in 4ms
  entry.js  57 bytes  (entry point)
exit=0
$ cat out/entry.js
// entry.mjs
import db from "./app.db";
console.log(db);

# this branch
$ bun build ./entry.mjs --target node --outdir out; echo exit=$?
error: To use the "sqlite" loader, set target to "bun"
    at /tmp/sqlrepro/app.db
exit=1
$ bun build ./entry.mjs --target bun --outdir out && cat out/entry.js
// @bun
// entry.mjs
import db from "./app.db" with { type: "sqlite" };
console.log(db);
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_bun.test.ts
bun test v1.4.0 (c6b1765f6)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/import-bun-format-cjs [958.54ms]
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
1369 |         } else if (expectedErrors && expectedErrors.length > 0) {
1370 |           throw new Error("Errors were expected while bundling:\n" + expectedErrors.map(formatError).join("\n"));
                           ^
error: Errors were expected while bundling:
/app.db: To use the "sqlite" loader, set target to "bun"
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1370:21)
(fail) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-target-node [179.23ms]
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
1369 |         } else if (expectedErrors && expectedEr
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/import-bun-format-cjs [22.96ms]
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
1369 |         } else if (expectedErrors && expectedErrors.length > 0) {
1370 |           throw new Error("Errors were expected while bundling:\n" + expectedErrors.map(formatError).join("\n"));
                           ^
error: Errors were expected while bundling:
/app.db: To use the "sqlite" loader, set target to "bun"
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1370:21)
(fail) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-target-node [4.86ms]
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
1369 |         } else if (expectedErrors && expectedErrors.length > 0) {
1370 |           throw new Error("Errors were expected while bundling:\n" + expectedErrors.map(formatError).join("\n"));
                    
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_bun.test.ts
bun test v1.4.0 (c6b1765f6)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/import-bun-format-cjs [946.80ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-target-node [112.99ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-dynamic-import-target-node [100.64ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-embed-target-node [100.06ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-missing-file-target-node [99.63ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-target-browser [75.46ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-dynamic-import-target-browser [92.24ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-embed-target-browser [102.62ms]
(pass) bundler > sqlite import attribute requires target bun > bun/sqlite-attribute-missing
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c6b1765f66
  features     baseline

22 deps, 123 codegen, 1176 objects in 629ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [10.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1238] gen bindgenv2
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch zlib
[zlib] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] gen .bind.ts → GeneratedBindings.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs         |  4 +--
 test/bundler/bundler_bun.test.ts | 70 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 72 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/bundler/bundle_v2.rs              3      4      0
test/bundler/bundler_bun.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->