### PR TITLE
error printer: don't leave a trailing comma on the last own property line

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6392,9 +6392,8 @@ impl VirtualMachine {
             }
 
             if !is_first_property {
-                // Separators are written before each property after the first,
-                // so the last line (a regular property or `code`) ends without a
-                // comma; the second newline is the blank line before the stack.
+                // Ends the last property line; the second newline separates the
+                // properties from the stack trace.
                 pretty_write!(writer, "<r>\n\n")?;
             }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6345,6 +6345,9 @@ impl VirtualMachine {
                     let formatter = &mut *restore.f;
 
                     let pad_left = longest_name.saturating_sub(field.length());
+                    if !is_first_property {
+                        pretty_write!(writer, "<r><d>,<r>\n")?;
+                    }
                     is_first_property = false;
                     splat_space(writer, pad_left as u64)?;
                     pretty_write!(writer, " {}<r><d>:<r> ", field)?;
@@ -6371,24 +6374,28 @@ impl VirtualMachine {
                     } else if global_ref.has_exception() || formatter.failed {
                         return Ok(());
                     }
-
-                    pretty_write!(writer, "<r><d>,<r>\n")?;
                 }
             }
 
             if let Some(code_str) = code {
                 let pad_left = longest_name.saturating_sub(b"code".len());
+                if !is_first_property {
+                    pretty_write!(writer, "<r><d>,<r>\n")?;
+                }
                 is_first_property = false;
                 splat_space(writer, pad_left as u64)?;
                 pretty_write!(
                     writer,
-                    " code<r><d>:<r> <green>{}<r>\n",
+                    " code<r><d>:<r> <green>{}",
                     bun_core::fmt::quote(code_str)
                 )?;
             }
 
             if !is_first_property {
-                writer.write_all(b"\n")?;
+                // Separators are written before each property after the first,
+                // so the last line (a regular property or `code`) ends without a
+                // comma; the second newline is the blank line before the stack.
+                pretty_write!(writer, "<r>\n\n")?;
             }
 
             // "cause" is not enumerable, so the above loop won't see it.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6392,9 +6392,8 @@ impl VirtualMachine {
             }
 
             if !is_first_property {
-                // Ends the last property line; the second newline separates the
-                // properties from the stack trace.
-                pretty_write!(writer, "<r>\n\n")?;
+                pretty_write!(writer, "<r>\n")?;
+                writer.write_all(b"\n")?;
             }
 
             // "cause" is not enumerable, so the above loop won't see it.

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -134,6 +134,13 @@ describe("own properties of a printed error are comma-separated, with no comma a
     return lines.slice(message + 1, firstFrame);
   }
 
+  function expectPropertyLines(err: Error, expected: string[]) {
+    expect(linesBetweenMessageAndStack(Bun.inspect(err), "error: own properties")).toEqual(expected);
+    expect(
+      linesBetweenMessageAndStack(Bun.stripANSI(Bun.inspect(err, { colors: true })), "error: own properties"),
+    ).toEqual(expected);
+  }
+
   test.each([
     ["one property", { rethrow: true }, [" rethrow: true", ""]],
     ["two properties", { extra: 42, rethrow: true }, ["   extra: 42,", " rethrow: true", ""]],
@@ -145,12 +152,21 @@ describe("own properties of a printed error are comma-separated, with no comma a
     ["only a string code", { code: "E_X" }, [' code: "E_X"', ""]],
     ["a non-string code", { code: 42 }, [" code: 42", ""]],
     ["no properties", {}, []],
+    // Error-valued properties are not part of the list: they are printed in full after the stack trace.
+    [
+      "a property followed by an Error-valued property",
+      { status: 500, cause: new Error("inner") },
+      [" status: 500", ""],
+    ],
+    ["only an Error-valued property", { cause: new Error("inner") }, []],
   ])("%s", (_, properties, expected) => {
-    const err = Object.assign(new Error("own properties"), properties);
-    expect(linesBetweenMessageAndStack(Bun.inspect(err), "error: own properties")).toEqual(expected);
-    expect(
-      linesBetweenMessageAndStack(Bun.stripANSI(Bun.inspect(err, { colors: true })), "error: own properties"),
-    ).toEqual(expected);
+    expectPropertyLines(Object.assign(new Error("own properties"), properties), expected);
+  });
+
+  test("a property followed by an enumerable accessor (accessors are not printed)", () => {
+    const err = Object.assign(new Error("own properties"), { a: 1 });
+    Object.defineProperty(err, "b", { get: () => "not printed", enumerable: true });
+    expectPropertyLines(err, [" a: 1", ""]);
   });
 
   test("uncaught error", async () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -160,10 +160,10 @@ describe("own properties of a printed error are comma-separated, with no comma a
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(linesBetweenMessageAndStack(stderr, "error: uncaught")).toEqual(["   extra: 42,", " rethrow: true", ""]);
-    expect(exitCode).toBe(1);
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 1 });
   });
 });
 

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
 import { join } from "node:path";
 
@@ -119,6 +119,52 @@ test("throwing inside an error suppresses the error and continues printing prope
     code: "ENOENT"
 `);
   expect(exitCode).toBe(1);
+});
+
+describe("own properties of a printed error are comma-separated, with no comma after the last one", () => {
+  // An error prints as: message line, one line per own property, a blank line,
+  // then the stack frames. Returns the lines between the message line and the
+  // first stack frame.
+  function linesBetweenMessageAndStack(output: string, messageLine: string): string[] {
+    const lines = output.split("\n");
+    const message = lines.indexOf(messageLine);
+    if (message === -1) throw new Error(`${JSON.stringify(messageLine)} not found in:\n${output}`);
+    const firstFrame = lines.findIndex((line, i) => i > message && line.trimStart().startsWith("at "));
+    if (firstFrame === -1) throw new Error(`no stack frame after ${JSON.stringify(messageLine)} in:\n${output}`);
+    return lines.slice(message + 1, firstFrame);
+  }
+
+  test.each([
+    ["one property", { rethrow: true }, [" rethrow: true", ""]],
+    ["two properties", { extra: 42, rethrow: true }, ["   extra: 42,", " rethrow: true", ""]],
+    [
+      "a property and a string code (code is always printed last)",
+      { code: "E_X", extra: 42 },
+      [" extra: 42,", '  code: "E_X"', ""],
+    ],
+    ["only a string code", { code: "E_X" }, [' code: "E_X"', ""]],
+    ["a non-string code", { code: 42 }, [" code: 42", ""]],
+    ["no properties", {}, []],
+  ])("%s", (_, properties, expected) => {
+    const err = Object.assign(new Error("own properties"), properties);
+    expect(linesBetweenMessageAndStack(Bun.inspect(err), "error: own properties")).toEqual(expected);
+    expect(
+      linesBetweenMessageAndStack(Bun.stripANSI(Bun.inspect(err, { colors: true })), "error: own properties"),
+    ).toEqual(expected);
+  });
+
+  test("uncaught error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const err = new Error("uncaught"); err.extra = 42; err.rethrow = true; throw err;`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(linesBetweenMessageAndStack(stderr, "error: uncaught")).toEqual(["   extra: 42,", " rethrow: true", ""]);
+    expect(exitCode).toBe(1);
+  });
 });
 
 test("Async functions frame should be included in stack trace", async () => {


### PR DESCRIPTION
### Problem

- When an uncaught error (or one passed to `console.error` / `Bun.inspect`) has own properties but no string `code`, the last property line of the dump ends with a comma:
  ```
  $ bun -e 'const err = new Error("boom"); err.rethrow = true; throw err;'
  error: boom
   rethrow: true,

        at [eval]:1:17
  ```
  With a `code` the same dump ends cleanly (`extra: 42,` then `code: "X"`), so the output is inconsistent between the two cases.
- Cause: the property loop in `VirtualMachine::print_error_instance_body` (`src/jsc/VirtualMachine.rs`) writes `,\n` after every property and relies on the `code` line, which is printed after the loop without a comma, to terminate the list. When `code` is `None` nothing terminates it. The Zig version behaved the same way, so this is long-standing rather than a port regression.

### Fix

- Write the `,\n` separator before each property line after the first (both in the loop and before the `code` line). Property lines no longer end themselves; once the block is done, one `<r>\n` ends the last line, followed by the existing blank line before the stack trace.
- Correct because the separator is only ever emitted when a second line is actually about to be written. That also covers the properties the loop visits without printing (Error-valued properties, which are printed after the stack trace instead, and accessors, which are skipped): when one of those comes last, the line before it is the last line and gets no comma. Deciding after each line whether more properties remain would not handle those.
- For errors that do have a string `code`, the bytes written are identical to before (including the ANSI sequences); only the no-`code` case loses its dangling `,`. Errors with nothing to print still print no property block at all.
- No test in `test/` encoded the trailing comma (the closest, the ENOENT dump in `stack.test.ts`, has `code` last and is unaffected).
- Verified with `test/js/bun/test/stack.test.ts`: `Bun.inspect` with and without colors across one property / two properties / property + `code` / `code` only / non-string `code` / no properties / property followed by an Error-valued property / only an Error-valued property / property followed by an enumerable accessor, plus an uncaught `throw` in a child process. 6 of the new cases fail on the released binary (`USE_SYSTEM_BUN=1`), all pass with `bun bd test`.
- Also ran `test/js/bun/util/{inspect-error,inspect,reportError}.test` locally; the only failures are the pre-existing debug-build-only `at require (51:24)` frame in the two minified-file snapshots, which this change does not touch.

### Background

- `print_error_instance_body` is the native error printer behind uncaught exceptions, unhandled rejections, `console.error(err)` and `Bun.inspect(err)`. Given the error object it prints the source preview, the `name: message` line, one right-aligned line per own enumerable data property, a blank line, then the stack frames and any Error-valued properties / `cause`. (`bun test` failure output goes through the same function without the error object, so it never prints the property block and is unaffected either way.)
- `code` is special-cased: a string `code` (looked up as a data property, own or inherited) is printed as the final line of the block, and the loop skips the own `code` entry so it is not printed twice. That is why the `code` case already looked right. A non-string `code` is printed by the loop like any other property.
- `pretty_write!` / `<r>` / `<d>`: Bun's format-string markup for ANSI reset and dim; it expands to escape sequences when colors are on and to nothing when they are off.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts
bun test v1.4.0 (7050092dd)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [6.57ms]
(pass) name property is used for function calls in Bun.inspect [11.83ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [308.02ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-debug+7050092dd (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [308.93ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-debug+7050092dd (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [788.20ms]
133 |     if (firstFrame === -1) throw new Error(`no stack frame after
... (truncated)

release without fix: 6 failed, 1 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [0.13ms]
(pass) name property is used for function calls in Bun.inspect [0.34ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [9.90ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-canary.1+b7a043103 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [9.52ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-canary.1+b7a043103 (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [18.11ms]
133 |     if (firstFrame === -1) throw new Error(`no stack frame after ${JSON.stringify(messageLine)} in:\n${output}`);
134 |     return lines.slice(message + 1, firstFrame);
135 |   }
136 | 
137 |   function expectPropertyLi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts
bun test v1.4.0 (7050092dd)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [6.92ms]
(pass) name property is used for function calls in Bun.inspect [11.16ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [311.07ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-debug+7050092dd (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [318.41ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-debug+7050092dd (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [772.17ms]
(pass) own properties of a printed error are comma-separated, with no 
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7050092dd8
  features     baseline

22 deps, 123 codegen, 1176 objects in 706ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [4.00ms]
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1238] gen .bind.ts → GeneratedBindings.cpp
[6/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[7/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1238] fetch zlib
[zlib] up to date
[9/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1238] fetch tinycc
[tinycc] up to date
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs      | 11 ++++++--
 test/js/bun/test/stack.test.ts | 64 +++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 71 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/jsc/VirtualMachine.rs           5      5      0
test/js/bun/test/stack.test.ts      7      7      0
```

</details>

**root cause** · written by the author bot

The own-property loop in print_error_instance_body wrote a comma and newline after every property it printed, relying on the separately printed code line to supply the unterminated final line, so whenever an error had no string code property the last regular property was left with a trailing comma. The fix moves the separator so it is written before each printed property after the first, tracked by a flag that is only set in the branch that actually prints a value, and emits a single newline once the block is finished. As a result the final line never ends with a comma whether or not code i…

<!-- robobun:evidence:end -->