### PR TITLE
mimalloc: register fork handlers once per process (fixes macOS abort in astro/vite builds); build: --local-deps

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -459,6 +459,7 @@ function parseArgs(argv: string[]): CliArgs {
     "buildType",
     "mode",
     "webkit",
+    "localDeps",
     "buildDir",
     "cacheDir",
     "nodejsVersion",
@@ -588,6 +589,8 @@ Options:
                           on/off/true/false/yes/no/1/0.
                           Fields: asan, lto, assertions, logs, baseline,
                                   canary, valgrind, webkit (prebuilt|local),
+                                  local-deps (name=path[,name=path] — build a
+                                  vendored dep from a local checkout),
                                   buildDir, mode (full|cpp-only|link-only),
                                   unifiedSources, timeTrace, os, arch, abi,
                                   winsysroot (Windows cross-compile SDK root)
@@ -605,6 +608,7 @@ Examples:
   bun scripts/build.ts --profile=release --lto=off
   bun scripts/build.ts test foo.test.ts
   bun scripts/build.ts --profile=debug-local run script.ts
+  bun scripts/build.ts --local-deps=mimalloc=~/code/mimalloc test foo.test.ts
   bun scripts/build.ts --target=bun-rust
   bun scripts/build.ts --configure-only
 `;

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -123,7 +123,7 @@ Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local 
 
 **Bump a dependency** — edit the `commit` in `scripts/build/deps/<name>.ts`. See `deps/README.md` for adding/removing deps.
 
-**Iterate on a dependency from a local checkout** — `bun bd --local-deps=mimalloc=~/code/mimalloc …` builds that dep from the clone instead of the pinned tarball (no fetch, no patches; edits rebuild incrementally). Any `github-archive` dep; details in `deps/README.md`.
+**Iterate on a dependency from a local checkout** — `bun bd --local-deps=mimalloc=~/code/mimalloc …` builds that dep from the clone instead of the pinned tarball (no fetch, no patches; edits rebuild incrementally). Any `github-archive` dep the graph compiles (not lolhtml — cargo reads that via `Cargo.toml`); details in `deps/README.md`.
 
 **Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header).
 

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -123,6 +123,8 @@ Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local 
 
 **Bump a dependency** — edit the `commit` in `scripts/build/deps/<name>.ts`. See `deps/README.md` for adding/removing deps.
 
+**Iterate on a dependency from a local checkout** — `bun bd --local-deps=mimalloc=~/code/mimalloc …` builds that dep from the clone instead of the pinned tarball (no fetch, no patches; edits rebuild incrementally). Any `github-archive` dep; details in `deps/README.md`.
+
 **Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header).
 
 **Add a Config field** — add to `Config` interface and `PartialConfig` in `config.ts`, resolve in `resolveConfig()`. If it needs a CLI flag, `build.ts`'s arg parser already handles `--anyfield=value` generically.

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -1168,5 +1168,16 @@ export function validateBunConfig(cfg: Config): void {
       `--local-deps: ${name} is disabled for ${cfg.os}-${cfg.arch}${cfg.abi ? `-${cfg.abi}` : ""} in this configuration, so the checkout at ${path} would never be built`,
       { hint: `Drop ${name} from --local-deps, or build a target/config where its \`enabled\` predicate holds` },
     );
+    // A dep the graph fetches but never reads (no build step, no sources, no
+    // includes — lolhtml, which cargo consumes through the workspace
+    // Cargo.toml's `path = "vendor/lolhtml"`) can't be redirected from here.
+    const provides = dep.provides(cfg);
+    assert(
+      dep.build(cfg).kind !== "none" || (provides.sources ?? []).length > 0 || provides.includes.length > 0,
+      `--local-deps: ${name} is only fetched by the build graph, never compiled or included by it, so redirecting it to ${path} would change nothing`,
+      {
+        hint: `Point ${name}'s real consumer at the checkout instead (for a cargo path dependency: the workspace Cargo.toml)`,
+      },
+    );
   }
 }

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -1158,14 +1158,15 @@ export function validateBunConfig(cfg: Config): void {
   // --local-deps names must match a dep — a typo would otherwise silently
   // build the pinned tarball while the banner claims `local:<typo>`.
   const depsByName = new Map(allDeps.map(d => [d.name, d]));
-  for (const name of Object.keys(cfg.localDeps)) {
+  for (const [name, path] of Object.entries(cfg.localDeps)) {
     const dep = depsByName.get(name);
     assert(dep !== undefined, `--local-deps: unknown dep '${name}'`, {
       hint: `Known deps: ${[...depsByName.keys()].sort().join(", ")}`,
     });
     assert(
       !dep.enabled || dep.enabled(cfg),
-      `--local-deps: ${name} is not built for this target/config, so a local checkout would be ignored`,
+      `--local-deps: ${name} is disabled for ${cfg.os}-${cfg.arch}${cfg.abi ? `-${cfg.abi}` : ""} in this configuration, so the checkout at ${path} would never be built`,
+      { hint: `Drop ${name} from --local-deps, or build a target/config where its \`enabled\` predicate holds` },
     );
   }
 }

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -1154,4 +1154,18 @@ export function validateBunConfig(cfg: Config): void {
       );
     }
   }
+
+  // --local-deps names must match a dep — a typo would otherwise silently
+  // build the pinned tarball while the banner claims `local:<typo>`.
+  const depsByName = new Map(allDeps.map(d => [d.name, d]));
+  for (const name of Object.keys(cfg.localDeps)) {
+    const dep = depsByName.get(name);
+    assert(dep !== undefined, `--local-deps: unknown dep '${name}'`, {
+      hint: `Known deps: ${[...depsByName.keys()].sort().join(", ")}`,
+    });
+    assert(
+      !dep.enabled || dep.enabled(cfg),
+      `--local-deps: ${name} is not built for this target/config, so a local checkout would be ignored`,
+    );
+  }
 }

--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -8,7 +8,7 @@
 
 import { mkdirSync } from "node:fs";
 import { availableParallelism } from "node:os";
-import { basename, dirname, extname, relative, resolve } from "node:path";
+import { basename, dirname, extname, relative, resolve, sep } from "node:path";
 import type { Config } from "./config.ts";
 import { assert } from "./error.ts";
 import { writeIfChanged } from "./fs.ts";
@@ -528,7 +528,16 @@ function objectPath(cfg: Config, src: string): string {
     relSrc = relative(cfg.buildDir, absSrc);
   } else {
     relSrc = relative(cfg.cwd, absSrc);
+    // --local-deps checkouts may live outside the repo; map them onto the
+    // vendor/<name>/ path the pinned source would have so obj/ stays a tree.
+    for (const [name, dir] of Object.entries(cfg.localDeps)) {
+      if (absSrc.startsWith(dir + sep)) {
+        relSrc = relative(cfg.cwd, resolve(cfg.vendorDir, name, relative(dir, absSrc)));
+        break;
+      }
+    }
   }
+  assert(!relSrc.startsWith(".."), `object path for ${absSrc} escapes the build dir (obj/${relSrc})`);
 
   return resolve(cfg.buildDir, "obj", relSrc + cfg.objSuffix);
 }

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -175,6 +175,14 @@ export interface Config {
 
   // ─── Dependency modes ───
   webkit: WebKitMode;
+  /**
+   * Deps built from a local checkout instead of the pinned tarball, keyed by
+   * dep name → absolute source dir. Set via `--local-deps=name=path[,...]`.
+   * The checkout is used as-is: no fetch, no `.ref` stamp, and the dep's
+   * `patches` are NOT applied (they target the pinned tarball; a fork
+   * checkout is expected to carry whatever you're iterating on).
+   */
+  localDeps: Record<string, string>;
 
   // ─── Paths (all absolute) ───
   /** Repository root. */
@@ -356,6 +364,12 @@ export interface PartialConfig {
   ci?: boolean;
   buildkite?: boolean;
   webkit?: WebKitMode;
+  /**
+   * `name=path[,name=path...]` — build these deps from a local checkout
+   * (e.g. `mimalloc=~/code/mimalloc`). `~` expands to $HOME; relative paths
+   * resolve against the repo root. See `Config.localDeps`.
+   */
+  localDeps?: string;
   buildDir?: string;
   cacheDir?: string;
   /** Override NDK location (default: $ANDROID_NDK_ROOT etc). Only used when abi=android. */
@@ -1210,6 +1224,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     ci,
     buildkite,
     webkit: partial.webkit ?? "prebuilt",
+    localDeps: parseLocalDeps(partial.localDeps, cwd),
     cwd,
     buildDir,
     codegenDir,
@@ -1418,6 +1433,29 @@ export function findRepoRoot(): string {
 }
 
 /**
+ * Parse `--local-deps=name=path[,name=path...]` into name → absolute path.
+ * Names are checked against `allDeps` later (bun.ts) where the dep list is
+ * in scope; here we only validate shape and resolve paths.
+ */
+function parseLocalDeps(spec: string | undefined, cwd: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (spec === undefined || spec === "") return out;
+  for (const entry of spec.split(",")) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0 || eq === entry.length - 1) {
+      throw new BuildError(`--local-deps: expected name=path, got '${entry}'`, {
+        hint: "Example: --local-deps=mimalloc=~/code/mimalloc",
+      });
+    }
+    const name = entry.slice(0, eq);
+    let path = entry.slice(eq + 1);
+    if (path === "~" || path.startsWith("~/")) path = join(homedir(), path.slice(1));
+    out[name] = resolve(cwd, path);
+  }
+  return out;
+}
+
+/**
  * Get the current git revision (HEAD sha).
  *
  * Uses `git rev-parse` rather than reading .git/HEAD directly — the sha
@@ -1543,6 +1581,7 @@ export function formatConfig(cfg: Config, exe: string): string {
   if (!cfg.canary) features.push("canary:off");
   // Non-default modes — show so you notice when a build is unusual.
   if (cfg.webkit !== "prebuilt") features.push(`webkit:${cfg.webkit}`);
+  for (const name of Object.keys(cfg.localDeps)) features.push(`local:${name}`);
   if (cfg.mode !== "full") features.push(`mode:${cfg.mode}`);
   // Version pin overrides — show an identifying value so you catch "forgot
   // to revert my WebKit test branch" before the build goes weird. Strip the

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -1438,7 +1438,9 @@ export function findRepoRoot(): string {
  * in scope; here we only validate shape and resolve paths.
  */
 function parseLocalDeps(spec: string | undefined, cwd: string): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Null prototype: any name (even `__proto__`) is stored as a plain entry and
+  // reaches the unknown-dep check in validateBunConfig.
+  const out = Object.create(null) as Record<string, string>;
   if (spec === undefined || spec === "") return out;
   for (const entry of spec.split(",")) {
     const eq = entry.indexOf("=");

--- a/scripts/build/deps/README.md
+++ b/scripts/build/deps/README.md
@@ -58,18 +58,21 @@ git clone https://github.com/oven-sh/mimalloc ~/code/mimalloc
 bun bd --local-deps=mimalloc=~/code/mimalloc test foo.test.ts
 ```
 
-Any `github-archive` dep can be redirected; several at once with
-`name=path,name=path`. The checkout is compiled as-is — no fetch, no `.ref`
-stamp, and the dep's `patches` are **not** applied (they target the pinned
-tarball), so start the clone from the pinned commit if you want an identical
-baseline. Switching a dep between pinned and local moves its `-I` path, so
-the first build after the switch recompiles every TU that sees the dep's
-headers; after that, edits are picked up incrementally: `direct` deps
-through the compiler depfiles, `nested-cmake`/`cargo` deps by re-invoking
-their inner build every run. The build banner shows `local:<name>` while
-this is on.
-Don't edit `vendor/<name>/` in place instead — it is wiped whenever the pin
-or patches change. WebKit has its own switch (`--webkit=local`).
+Any `github-archive` dep the graph compiles or includes can be redirected
+(so not lolhtml, which cargo reads from `vendor/lolhtml` via the workspace
+`Cargo.toml` — point that path at your checkout instead); several at once
+with `name=path,name=path`. Cross-dep references (`depSourceDir()`, e.g.
+lsquic's `-I` into boringssl) follow the redirect. The checkout is compiled
+as-is — no fetch, no `.ref` stamp, and the dep's `patches` are **not**
+applied (they target the pinned tarball), so start the clone from the pinned
+commit if you want an identical baseline. Switching a dep between pinned and
+local moves its `-I` path, so the first build after the switch recompiles
+every TU that sees the dep's headers; after that, edits are picked up
+incrementally: `direct` deps through the compiler depfiles,
+`nested-cmake`/`cargo` deps by re-invoking their inner build every run. The
+build banner shows `local:<name>` while this is on. Don't edit
+`vendor/<name>/` in place instead — it is wiped whenever the pin or patches
+change. WebKit has its own switch (`--webkit=local`).
 
 ## Common fields
 

--- a/scripts/build/deps/README.md
+++ b/scripts/build/deps/README.md
@@ -47,6 +47,30 @@ catches a missed addition (link error on the unresolved symbol); a
 removed file fails at compile. Either way the auto-bump PR goes red,
 which is the cue to diff the upstream `CMakeLists.txt`.
 
+## Iterating on a dep from a local checkout
+
+To hack on a vendored dep (e.g. chase a bug in the mimalloc or libuv fork)
+without cutting a commit and bumping the pin each round, point the build at
+a git clone:
+
+```sh
+git clone https://github.com/oven-sh/mimalloc ~/code/mimalloc
+bun bd --local-deps=mimalloc=~/code/mimalloc test foo.test.ts
+```
+
+Any `github-archive` dep can be redirected; several at once with
+`name=path,name=path`. The checkout is compiled as-is — no fetch, no `.ref`
+stamp, and the dep's `patches` are **not** applied (they target the pinned
+tarball), so start the clone from the pinned commit if you want an identical
+baseline. Switching a dep between pinned and local moves its `-I` path, so
+the first build after the switch recompiles every TU that sees the dep's
+headers; after that, edits are picked up incrementally: `direct` deps
+through the compiler depfiles, `nested-cmake`/`cargo` deps by re-invoking
+their inner build every run. The build banner shows `local:<name>` while
+this is on.
+Don't edit `vendor/<name>/` in place instead — it is wiped whenever the pin
+or patches change. WebKit has its own switch (`--webkit=local`).
+
 ## Common fields
 
 ```ts
@@ -57,8 +81,9 @@ export const mydep: Dependency = {
   // just the files at `commit`). Most deps use this.
   //
   // Other kinds: `prebuilt` (download pre-compiled .a, e.g. WebKit default),
-  // `local` (user manages vendor/<name>/ manually — only WebKit uses this
-  // because its clone is too slow to automate), `in-tree` (source in src/).
+  // `local` (user-managed checkout — WebKit declares it because its clone is
+  // too slow to automate; any github-archive dep becomes one via
+  // `--local-deps`, see below), `in-tree` (source in src/).
   source: () => ({ kind: "github-archive", repo: "owner/repo", commit: "..." }),
 
   // Optional: macro name for bun_dependency_versions.h (process.versions).

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "be7eb3ff1384713508610b92e56966cc94fb24bd";
+const MIMALLOC_COMMIT = "6e891cbe4790982ca9f3f9a60319a72e61b5d725";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -687,6 +687,28 @@ export function depBuildDir(cfg: Config, name: string): string {
 }
 
 /**
+ * The dep's source, with `--local-deps` applied: a dep named there is
+ * redirected from its pinned github-archive tarball to the local checkout.
+ * Only github-archive sources can be redirected — prebuilt/in-tree deps
+ * have their own switches (e.g. `--webkit=local`).
+ */
+export function depSource(cfg: Config, dep: Dependency): Source {
+  const source = dep.source(cfg);
+  const localPath = cfg.localDeps[dep.name];
+  if (localPath === undefined) return source;
+  assert(
+    source.kind === "github-archive",
+    `--local-deps: ${dep.name} has a ${source.kind} source; only github-archive deps can be redirected`,
+    dep.name === "WebKit" ? { hint: "Use --webkit=local (and $BUN_WEBKIT_PATH) for WebKit" } : {},
+  );
+  return {
+    kind: "local",
+    path: localPath,
+    hint: `--local-deps points ${dep.name} at ${localPath} — clone ${source.repo} there`,
+  };
+}
+
+/**
  * Resolve a dependency: emit ninja rules for fetch → configure → build,
  * return absolute paths for linking.
  *
@@ -703,7 +725,7 @@ export function resolveDep(
     return null;
   }
 
-  const source = dep.source(cfg);
+  const source = depSource(cfg, dep);
   const buildSpec = dep.build(cfg);
   const provides = dep.provides(cfg);
 
@@ -760,7 +782,7 @@ export function resolveDep(
   // For github-archive: this runs fetchCli which downloads/extracts/patches.
   // For local/in-tree: source is already on disk; we use a sentinel file
   //   (CMakeLists.txt) as the stamp. Editing it → reconfigure.
-  let sourceStamp: string;
+  let sourceStamp: string | undefined;
   if (source.kind === "github-archive") {
     sourceStamp = emitFetch(n, cfg, dep.name, source, patches, [...resolvedSources, ...directSources]);
   } else {
@@ -768,7 +790,9 @@ export function resolveDep(
     // as the stamp — touching it triggers reconfigure/rebuild.
     //   cmake deps → CMakeLists.txt (in sourceSubdir if set, e.g. zstd)
     //   cargo deps → Cargo.toml (in manifestDir)
-    //   header-only → source dir itself (no build = no manifest needed)
+    //   direct/header-only → none: the sources are on disk before ninja
+    //     starts, so the compiler depfiles see edits directly. (Stamping the
+    //     directory would rebuild the PCH whenever a top-level entry moved.)
     let stampDir: string;
     let stampFile: string;
     if (buildSpec.kind === "nested-cmake") {
@@ -781,10 +805,10 @@ export function resolveDep(
       stampDir = srcDir;
       stampFile = "";
     }
-    sourceStamp = stampFile ? resolve(stampDir, stampFile) : stampDir;
+    sourceStamp = stampFile ? resolve(stampDir, stampFile) : undefined;
 
     const modeName = source.kind === "in-tree" ? "in-tree" : "local";
-    assert(existsSync(sourceStamp), `${modeName} dep "${dep.name}" source not found at ${stampDir}`, {
+    assert(existsSync(sourceStamp ?? stampDir), `${modeName} dep "${dep.name}" source not found at ${stampDir}`, {
       hint:
         source.kind === "in-tree"
           ? `Expected ${stampFile || "source"} at ${source.path}/ — check deps/${dep.name}.ts`
@@ -819,7 +843,7 @@ export function resolveDep(
   if (buildSpec.kind === "nested-cmake") {
     const result = emitNestedCmake(n, cfg, dep.name, buildSpec, {
       srcDir,
-      sourceStamp,
+      sourceStamp: sourceStamp!, // .ref or CMakeLists.txt — always set for cmake deps
       provides,
       fetchDepStamps,
       // Local-mode deps: always re-invoke inner build. We can't track
@@ -830,7 +854,7 @@ export function resolveDep(
     libs = result.libs;
     outputs = result.libs;
   } else if (buildSpec.kind === "cargo") {
-    const result = emitCargo(n, cfg, dep.name, buildSpec, { srcDir, sourceStamp });
+    const result = emitCargo(n, cfg, dep.name, buildSpec, { srcDir, sourceStamp: sourceStamp! }); // .ref or Cargo.toml
     libs = result.libs;
     outputs = result.libs;
   } else if (buildSpec.kind === "direct") {
@@ -842,11 +866,11 @@ export function resolveDep(
     // are link inputs, not include-order dependencies).
     outputs = result.headerOutputs;
   } else {
-    // No build step. Source stamp is the only output. For deps with
-    // provides.sources (picohttpparser), emitBun adds a phony pointing at
-    // the compiled .o files so `--target <name>` actually compiles them.
+    // No build step. The fetch stamp (if any) is the only output. For deps
+    // with provides.sources (picohttpparser), emitBun adds a phony pointing
+    // at the compiled .o files so `--target <name>` actually compiles them.
     libs = [];
-    outputs = [sourceStamp];
+    outputs = sourceStamp === undefined ? [] : [sourceStamp];
   }
 
   // ─── Resolve include paths ───
@@ -1450,7 +1474,8 @@ function emitCargo(n: Ninja, cfg: Config, name: string, spec: CargoBuild, input:
 
 interface EmitDirectInput {
   srcDir: string;
-  sourceStamp: string;
+  /** Fetch `.ref` stamp; undefined for local/in-tree sources (already on disk). */
+  sourceStamp: string | undefined;
   fetchDepStamps: string[];
 }
 
@@ -1506,7 +1531,7 @@ function emitDirect(
   // Sources must exist before compile attempts. sourceStamp (or the fetch
   // .ref) is order-only: we don't want every .o recompiling when the stamp
   // mtime bumps but the .c files are unchanged — the depfile knows better.
-  const orderOnly = [sourceStamp, ...fetchDepStamps];
+  const orderOnly = [...(sourceStamp === undefined ? [] : [sourceStamp]), ...fetchDepStamps];
 
   // ─── Generated headers (optional) ───
   // Literal-string headers are written at configure time via writeIfChanged
@@ -1628,8 +1653,8 @@ function emitDirect(
   n.phony(name, objects);
   // headerOutputs: what downstream needs to wait on for HEADERS to be
   // ready. For no-archive direct deps that's the generated header set
-  // (subst/literal/codegen) plus the source stamp — not the .o files.
-  return { libs: [], objects, headerOutputs: [...generated, sourceStamp] };
+  // (subst/literal/codegen) plus the fetch stamp — not the .o files.
+  return { libs: [], objects, headerOutputs: sourceStamp === undefined ? generated : [...generated, sourceStamp] };
 }
 
 /**

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -669,13 +669,14 @@ export function registerDepRules(n: Ninja, cfg: Config): void {
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Path to a dep's source tree. Does NOT handle in-tree sources — use
- * the per-dep `srcDir` computed in resolveDep() for that.
- * Both "github-archive" and "local" sources live here — the difference is
- * whether WE manage it (fetch + .ref stamp) or the USER manages it.
+ * Path to a dep's source tree: its `--local-deps` checkout if redirected,
+ * else vendor/<name>/. Cross-dep references (lsquic's -I into boringssl,
+ * boringssl's nasm -I) go through here so they follow a redirect too. Does
+ * NOT handle in-tree sources or WebKit's $BUN_WEBKIT_PATH — use the per-dep
+ * `srcDir` computed in resolveDep() for those.
  */
 export function depSourceDir(cfg: Config, name: string): string {
-  return resolve(cfg.vendorDir, name);
+  return cfg.localDeps[name] ?? resolve(cfg.vendorDir, name);
 }
 
 /**

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { checkPrime, checkPrimeSync, randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
-import { bunEnv, bunExe, isLinux, isMusl, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isMusl, tempDir } from "harness";
 import { join } from "path";
 
 describe("randomInt args validation", () => {
@@ -57,6 +57,36 @@ describe("randomBytes", () => {
     });
 
     await promise;
+  });
+
+  // BoringSSL's RNG registers a pthread_atfork handler on first use and abort()s if that
+  // fails. macOS caps a process's atfork table (~680 entries on arm64); mimalloc once
+  // registered its fork handlers on every mi_heap_new (one per transpiled module) instead
+  // of once per process, so a program that imported ~700 modules and then asked for random
+  // bytes died with SIGABRT. Other libcs grow the table dynamically, so only Darwin bites.
+  it.skipIf(!isMacOS)("still works after transpiling hundreds of modules (atfork table not exhausted)", async () => {
+    const files: Record<string, string> = {};
+    let entry = "";
+    for (let i = 0; i < 800; i++) {
+      files[`m/m${i}.ts`] = `export const v${i}: number = ${i};\n`;
+      entry += `import "./m/m${i}.ts";\n`;
+    }
+    entry += `import { randomBytes } from "node:crypto";\nconsole.log("randomBytes", randomBytes(4).length);\n`;
+    files["entry.ts"] = entry;
+    using dir = tempDir("crypto-random-atfork", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      cwd: String(dir),
+      // Each fresh transpile creates a mimalloc heap; a cache hit would skip that.
+      env: { ...bunEnv, BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0" },
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("randomBytes 4\n");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -576,7 +576,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "1a41b9025c2c0a37edd07ff10f6944f03e028522",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "be7eb3ff1384713508610b92e56966cc94fb24bd",
+    mimalloc: "6e891cbe4790982ca9f3f9a60319a72e61b5d725",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",


### PR DESCRIPTION
### What was crashing

`test/js/third_party/astro/astro-post.test.js` and `test/integration/vite-build/vite-build.test.ts` SIGABRT on the darwin lanes since #37367 ([build 95095](https://buildkite.com/bun/bun/builds/95095)). Stack:

```
abort
init_pthread_fork_detection()      ← BoringSSL aborts when pthread_atfork() != 0
pthread_once
RAND_bytes
bun_runtime::node::crypto::random::__jsc_host_random_bytes
```

The mimalloc dev3 sync left `pthread_atfork(...)` in `mi_process_init()` *after* its `mi_atomic_do_once` block instead of inside `mi_process_init_once()`. `mi_process_init()` is reached from every `mi_heap_new()`, so each transpile job / arena reset registered another handler triple (~1050 registrations by the time astro's build reaches its first `randomBytes`). macOS caps a process's atfork table at one page (~680 entries on arm64); once full, every other `pthread_atfork` in the process gets `ENOMEM`, and BoringSSL aborts on that. glibc's list is unbounded, so Linux only leaked entries.

Minimal repro: 700 trivial `.ts` imports followed by `crypto.randomBytes(4)` → `abort()`; 600 is fine.

### Fix

Bump `oven-sh/mimalloc` to `6e891cbe` — the `bun-dev3-v2` merge of https://github.com/oven-sh/mimalloc/pull/19 — which moves the call back under the once-guard and adds a regression case to the fork's `test-fork-user-heap` (fails with `ENOMEM` on macOS before, passes after). `process.versions.mimalloc` expectation updated.

Verified locally with `build:release` on macOS arm64, same build config both ways:

| mimalloc source | 700-import + `randomBytes` | `astro-post.test.js` |
|---|---|---|
| `be7eb3f` (current pin) | abort | abort |
| `6e891cbe` (tree-identical to the tested `f201f52a`) | ok | 4/4 pass ×2 |

### Also: `--local-deps=name=path`

Added while chasing this so a vendored dep can be built from a local checkout instead of the pinned tarball:

```sh
bun bd --local-deps=mimalloc=~/code/mimalloc test foo.test.ts
```

Works for any `github-archive` dep (`name=path[,name=path]`); no fetch / `.ref` / patches, banner shows `local:<name>`, unknown or disabled names fail at configure, and an out-of-repo checkout's objects map onto `obj/vendor/<name>/`. Editing the checkout rebuilds incrementally (for mimalloc: just `static.c.o` + link). Local/in-tree `direct` deps also stop stamping their source *directory* as a PCH dependency (depfiles already track edits). Default-config `build.ninja` is byte-identical apart from the pin. Docs in `scripts/build/deps/README.md`.

