### PR TITLE
js_parser: keep top-level classes module-scoped when lowering top-level using

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8975,13 +8975,6 @@ impl LowerUsingDeclarationsContext {
                     result.push(stmt);
                     continue;
                 }
-                js_ast::StmtData::SClass(c) => {
-                    if c.is_export {
-                        // can't go in try/catch; hoist out
-                        result.push(stmt);
-                        continue;
-                    }
-                }
                 js_ast::StmtData::SExportDefault(_) => {
                     continue; // this prevents re-exporting default since we already have it as an .s_export_clause
                 }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1066,7 +1066,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt));
 
         if !mark_as_dead || was_export_inside_namespace {
-            // Lower class field syntax for browsers that don't support it
+            // Class counterpart of `select_local_kind` turning top-level `let`/`const` into `var`.
+            if p.will_wrap_module_in_try_catch_for_using && p.current_scope().parent.is_none() {
+                Self::convert_class_stmt_to_var(p, lowered, data);
+            }
             stmts.extend_from_slice(lowered);
         } else {
             let ref_ = data
@@ -1116,6 +1119,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.is_control_flow_dead = original_is_dead;
         }
         Ok(())
+    }
+
+    /// Swaps the class statement in `lowered` for `var Foo = class Foo {}` (exported if it was).
+    fn convert_class_stmt_to_var(p: &mut Self, lowered: &mut [Stmt], data: &mut S::Class) {
+        let Some(slot) = lowered
+            .iter_mut()
+            .find(|s| matches!(s.data, StmtData::SClass(_)))
+        else {
+            return;
+        };
+        let loc = slot.loc;
+        let name = data
+            .class
+            .class_name
+            .expect("infallible: class statements are always named");
+        let class_expr = p.new_expr(core::mem::take(&mut data.class), loc);
+        let binding = p.b(B::Identifier { r#ref: name.ref_ }, name.loc);
+        *slot = p.s(
+            S::Local {
+                kind: S::Kind::KVar,
+                is_export: data.is_export,
+                decls: G::DeclList::from_slice(&[G::Decl {
+                    binding,
+                    value: Some(class_expr),
+                }]),
+                ..Default::default()
+            },
+            loc,
+        );
     }
 
     fn s_local(

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2348,6 +2348,177 @@ describe("bundler", () => {
     },
   });
 
+  // Lowering a top-level `using` wraps the module body in try/catch/finally.
+  // Class declarations have to stay in source order inside that block, but as
+  // module-scoped `var`s, like esbuild: exported classes used to be hoisted
+  // above the block (evaluating before the `using` value was initialized) and
+  // non-exported ones stayed block-scoped to it, so the hoisted function
+  // declarations could not see them.
+  itBundled("edgecase/UsingTopLevelClassDeclarations", {
+    files: {
+      "/entry.ts": `
+        import { Exported, Clause, viaFunction, Sub } from "./module.ts";
+        console.log(Exported.name, Exported.v);
+        console.log(Clause.name, Clause.v, Clause.self() === Clause);
+        console.log(viaFunction().name, viaFunction().v);
+        console.log(Sub.name, Sub.v, Object.getPrototypeOf(Sub) === Exported);
+      `,
+      "/module.ts": `
+        using resource = { v: 42, [Symbol.dispose]() { console.log("Disposing"); } };
+        export class Exported { static v = resource.v; }
+        class Clause { static v = resource.v; static self() { return Clause; } }
+        export { Clause };
+        class Hidden { static v = resource.v; }
+        export function viaFunction() { return Hidden; }
+        export class Sub extends Exported {}
+      `,
+    },
+    run: {
+      stdout: `
+        Disposing
+        Exported 42
+        Clause 42 true
+        Hidden 42
+        Sub 42 true
+      `,
+    },
+    onAfterBundle(api) {
+      const output = api.readFile("/out.js");
+      expect(output).not.toMatch(/^\s*class /m);
+      // Only the assignment is pinned down: when bundling, the `var` itself is
+      // relocated into a top-level declaration, and the class expression may or
+      // may not carry a name.
+      expect(output).toMatch(/\bExported = class\b/);
+      expect(output).toMatch(/\bHidden = class\b/);
+    },
+  });
+
+  // A module that is also reached through import() is evaluated inside an
+  // `__esm(...)` wrapper. The linker only hoists top-level declarations out of
+  // it, so the classes rely on the try block's `var`s being relocated into a
+  // top-level declaration (see LoweredTopLevelUsingInEsmWrapper below).
+  itBundled("edgecase/UsingTopLevelClassDeclarationsInEsmWrapper", {
+    files: {
+      "/entry.ts": `
+        import { Exported, viaFunction } from "./module.ts";
+        console.log("static", Exported.v, viaFunction().v);
+        const mod = await import("./module.ts");
+        console.log("dynamic", mod.Exported === Exported, mod.viaFunction().v);
+      `,
+      "/module.ts": `
+        using resource = { v: 42, [Symbol.dispose]() { console.log("Disposing"); } };
+        export class Exported { static v = resource.v; }
+        class Hidden { static v = resource.v; }
+        export function viaFunction() { return Hidden; }
+      `,
+    },
+    onAfterBundle(api) {
+      const output = api.readFile("/out.js");
+      expect(output).toContain("__esm(");
+      expect(output).toMatch(/^var __stack, resource, Exported, Hidden;$/m);
+    },
+    run: {
+      stdout: `
+        Disposing
+        static 42 42
+        dynamic true 42
+      `,
+    },
+  });
+
+  itBundled("edgecase/AwaitUsingTopLevelClassDeclarations", {
+    files: {
+      "/entry.ts": `
+        import { Exported, viaFunction } from "./module.ts";
+        console.log(Exported.v, viaFunction().v);
+      `,
+      "/module.ts": `
+        await using resource = { v: 42, async [Symbol.asyncDispose]() { console.log("Disposing"); } };
+        export class Exported { static v = resource.v; }
+        class Hidden { static v = resource.v; }
+        export function viaFunction() { return Hidden; }
+      `,
+    },
+    run: {
+      stdout: "Disposing\n42 42",
+    },
+  });
+
+  // `lower_class` emits extra statements around a decorated class; the class
+  // statement among them is the one that gets rewritten to a `var`.
+  itBundled("edgecase/UsingTopLevelClassStandardDecorators", {
+    files: {
+      "/entry.ts": `
+        import { Exported, viaFunction } from "./module.ts";
+        console.log(Exported.decorated, Exported.v, viaFunction().decorated, viaFunction().v);
+      `,
+      "/module.ts": `
+        using resource = { v: 42, [Symbol.dispose]() { console.log("Disposing"); } };
+        function decorate(value: any, context: ClassDecoratorContext) {
+          return class extends value { static decorated = context.name; };
+        }
+        @decorate
+        export class Exported { static v = resource.v; }
+        @decorate
+        class Hidden { static v = resource.v; }
+        export function viaFunction() { return Hidden; }
+      `,
+    },
+    run: {
+      stdout: "Disposing\nExported 42 Hidden 42",
+    },
+  });
+
+  itBundled("edgecase/UsingTopLevelClassExperimentalDecorators", {
+    files: {
+      "/entry.ts": `
+        import { Exported, viaFunction } from "./module.ts";
+        console.log(Exported.decorated, Exported.v, Exported.fields, viaFunction().decorated, viaFunction().v);
+      `,
+      "/module.ts": `
+        using resource = { v: 42, [Symbol.dispose]() { console.log("Disposing"); } };
+        function decorate(target: any) {
+          return class extends target { static decorated = target.name; };
+        }
+        function field(target: any, key: string) {
+          target.fields = key;
+        }
+        @decorate
+        export class Exported { static v = resource.v; @field static f = 1; }
+        @decorate
+        class Hidden { static v = resource.v; }
+        export function viaFunction() { return Hidden; }
+      `,
+      "/tsconfig.json": /* json */ `{ "compilerOptions": { "experimentalDecorators": true } }`,
+    },
+    run: {
+      stdout: "Disposing\nExported 42 f Hidden 42",
+    },
+  });
+
+  itBundled("edgecase/UsingTopLevelClassBakeDev", {
+    // The dev server's module format builds its export list from the same
+    // lowered statements.
+    format: "internal_bake_dev",
+    files: {
+      "/entry.ts": `
+        using resource = { [Symbol.dispose]() {} };
+        export class Exported {}
+        class Hidden {}
+        export function viaFunction() { return Hidden; }
+      `,
+    },
+    onAfterBundle(api) {
+      const output = api.readFile("/out.js");
+      expect(output).not.toMatch(/^\s*class (Exported|Hidden) /m);
+      expect(output).toMatch(/\bExported = class\b/);
+      expect(output).toMatch(/\bHidden = class\b/);
+      const [, exportList] = output.match(/hmr\.exports = \{([^}]*)\}/)!;
+      const exportNames = exportList.split(/[\s,]+/).filter(Boolean);
+      expect(exportNames.sort()).toEqual(["Exported", "viaFunction"]);
+    },
+  });
+
   itBundled("edgecase/UsingExportFails", {
     files: {
       "/entry.ts": `

--- a/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
+++ b/test/bundler/transpiler/__snapshots__/transpiler.test.js.snap
@@ -178,3 +178,37 @@ export {
 };
 "
 `;
+
+exports[`Bun.Transpiler using top level turns class declarations into vars 1`] = `
+"import { __callDispose as __callDispose, __using as __using } from "bun:wrap";
+export function f() {
+
+  class G {
+  }
+  return [new E, new G];
+}
+let __bun_temp_ref_1$ = [];
+try {
+  var a = __using(__bun_temp_ref_1$, b(), 0);
+  var C = class C {
+    static a = a;
+  };
+  var D = class D extends C {
+    static self() {
+      return D;
+    }
+  };
+  var E = class E {
+  };
+} catch (__bun_temp_ref_2$) {
+  var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;
+} finally {
+  __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);
+}
+
+export {
+  C,
+  D
+};
+"
+`;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4700,6 +4700,24 @@ console.log("boop");
       export var q = r;
     `);
   });
+
+  it("using top level turns class declarations into vars", () => {
+    // Everything but imports, exports and function declarations moves into the
+    // try block, so classes become module-scoped `var`s in source order (and
+    // exported ones move to the export clause), matching esbuild. Classes in
+    // nested scopes are left alone.
+    expectPrintedSnapshot(`
+      using a = b();
+      export class C { static a = a; }
+      class D extends C { static self() { return D; } }
+      export { D };
+      class E {}
+      export function f() {
+        class G {}
+        return [new E(), new G()];
+      }
+    `);
+  });
 });
 
 describe("await can only be used inside an async function message", () => {


### PR DESCRIPTION
Stacked on #38284 (this PR's base is its branch); see the sequencing bullet under Fix. Only the last commit is this PR.

### Problem

- In a module with a top-level `using` / `await using`, built for any target that lowers `using` (`browser`, `node`; `--target=bun` is unaffected), top-level class declarations end up in the wrong scope. Affects `bun build`, `bun build --no-bundle`, `Bun.Transpiler`, the bake client bundle and the REPL. Reproduces on 1.4.0 and main; found by inspection, no user report for this exact shape.
- An exported class is hoisted above the generated try/catch, so it runs before the `using` values it comes after are initialized: `static v = foo.v` throws `TypeError: Cannot read properties of undefined (reading 'v')`, and a field like `static v = foo?.v` is silently `undefined`. `export class Sub extends Base {}` with a non-exported `Base` throws `ReferenceError: Base is not defined`, because only `Sub` is hoisted.
- A non-exported class stays inside the try block as a block-scoped declaration, while function declarations are hoisted out of it, so an exported function that uses the class throws `ReferenceError: Bar is not defined` when called. Same for the export getters of `--format=cjs` / `iife` output.
- Cause: the `SClass` arm of `LowerUsingDeclarationsContext::finalize` (`src/js_parser/p.rs`), added in #14313 for #13734, moved `export class` out of the try block because an `export` is not allowed inside a block, and let the others fall into it unchanged. The comment above `will_wrap_module_in_try_catch_for_using` in `src/js_parser/parse/parse_entry.rs` describes the class being turned into a `var`, but nothing implemented that.

### Fix

- `s_class` (`src/js_parser/visit/visit_stmt.rs`): when the module is going to be wrapped for `using` and the class is at module scope, the class statement returned by `lower_class` is replaced with `var Foo = class Foo {}`, keeping its `export` flag (`convert_class_stmt_to_var`). It then takes the path `export const` / `export let` already take in this mode: `finalize` moves the binding into the export clause it emits after the try/catch, the export scan (which runs after visiting) picks it up from there, and when bundling #38284 relocates the `var` like every other one in the block.
- The `SClass` arm in `finalize` is removed. Module-level classes now arrive there as locals, and a class statement in a nested block is never exported, so the arm had nothing left to do. The #13734 shape it was added for (`export class` declared before the `using` that instantiates it) is still covered by the existing `edgecase/UsingExportClass`, now through the export clause.
- Why this is correct: the `var` is initialized at the same point in evaluation order as the declaration was; it is module-scoped, so the hoisted function declarations and the importing modules can reach it; and later assignments to the binding (decorator lowering emits `Foo = __decorateElement(..., Foo)` after the class) still reach the export through the clause. The class expression keeps its name, so `.name` and references to `Foo` from inside the class body behave as before. esbuild emits the same thing for this input (`var Bar = class {...}` and `var Baz = class {...}` inside the try, `export { Baz }` after it).
- Decorated classes go through the same replacement: the extra statements `lower_class` emits around a class (both decorator flavors) refer to the class by symbol, so they keep working against the `var`. Also checked by hand: TS class/namespace merging, `--minify`, `--format=cjs` / `iife`, and the REPL.
- Sequencing: when bundling, a module that is also reached through `import()` is evaluated inside an `__esm(...)` wrapper, and the linker only hoists top-level statements out of it. The `var`s inside the try block are hoisted by #38284, so this PR is based on it and has to land after it. On main alone, this change would turn an exported class that does not touch the `using` values in such a module from working (it was hoisted above the try) into a `ReferenceError` at the export getter, the state `export const` is in today. `edgecase/UsingTopLevelClassDeclarationsInEsmWrapper` pins this down: it passes on this stack, fails on #38284's branch without this change (`TypeError`, class evaluated too early) and fails on main plus this change alone (`var Exported` left inside the wrapper), so CI enforces the order.
- Tests: `test/bundler/bundler_edgecase.test.ts` (`edgecase/UsingTopLevelClassDeclarations`, `UsingTopLevelClassDeclarationsInEsmWrapper`, `AwaitUsingTopLevelClassDeclarations`, `UsingTopLevelClassStandardDecorators`, `UsingTopLevelClassExperimentalDecorators`, `UsingTopLevelClassBakeDev`) and `test/bundler/transpiler/transpiler.test.js` (`using top level turns class declarations into vars`, a snapshot of the non-bundled `Bun.Transpiler` output, which #38284 does not affect). All seven fail on the base branch without the `src/` change and pass with it. The bundler tests only assert `Foo = class` for the rewritten classes, since the `var` is relocated when bundling and the expression's name is not what they are about.
- Also passing on the stack: the rest of `bundler_edgecase` (including #38284's tests and `UsingExportClass`), `bundler_browser`, `bundler_minify`, `esbuild/{lower,ts,default}`, `transpiler/{transpiler,decorators,es-decorators,es-decorators-esbuild,decorator-metadata}`, `bundler_decorator_metadata`, `lower-using-bun-target`, `explicit-resource-management`, `bake/dev-and-prod` (`using runtime import`).
- Related PRs: #32655 adds the same class-to-var rewrite to these `s_class` lines for all bundled output (size motivation; its condition already includes the `using` mode but it has no `using` coverage and has been open since June), so the two conflict textually; if it is picked up it can widen the condition here and add its name dropping inside `convert_class_stmt_to_var`. #38287 handles `export default function/class` in this mode and removes the `finalize` arm adjacent to the one removed here, so whichever of the two lands second needs a trivial rebase. #38279 (destructured exports) touches a different part of the same function.

### Background

- Lowering `using`: for targets without native `using`, the parser rewrites `using x = v` into `var x = __using(stack, v)` and wraps the statements that follow in `try { ... } catch { ... } finally { __callDispose(stack, ...) }`. At module level the whole module body ends up inside that try block. `will_wrap_module_in_try_catch_for_using` is set before the visit pass so statements can be adjusted while they are visited; `finalize` builds the try/catch afterwards.
- Function declarations are kept outside the try block because ESM hoists them: an importer in a cycle may call them before this module's body has run. Anything such a function refers to therefore has to be visible at module scope, which is why this mode already turns top-level `let` / `const` into `var` (`select_local_kind`); a class declaration is block-scoped like `let`, so it needs the same treatment.
- `export` declarations are only valid directly at module level, so an exported binding inside the try block is exported through an `export { ... }` clause placed after it. Bun's export list (`named_exports`) is computed from the visited statements, so the clause is what makes the export exist.
- `__esm` wrapper: when bundling, a module that must be evaluated lazily (for example because it is `import()`ed) has its body wrapped in a closure, and the linker turns the module's top-level declarations into declarations outside the closure plus assignments inside it, so the export getters can reach them. Declarations nested in the try block are invisible to that pass unless the parser relocates them first, which is what #38284 adds.
- `lower_class` returns the class statement plus any statements decorator lowering adds around it; the replacement swaps out the class statement within that list.

<details>
<summary>Repro and output</summary>

```js
// cls.mjs
using foo = { v: 1, [Symbol.dispose]() {} };
class Bar { static v = foo.v; }
export function fn() { return new Bar().constructor.v; }
export class Baz { static v = foo.v; }

// entry.mjs
import { fn, Baz } from "./cls.mjs";
console.log("fn():", fn(), "Baz.v:", Baz.v);
```

```
$ node entry.mjs
fn(): 1 Baz.v: 1
$ bun build --target=browser entry.mjs --outfile=out.mjs && node out.mjs   # 1.4.0
TypeError: Cannot read properties of undefined (reading 'v')
```

`cls.mjs` section of the bundle before:

```js
function fn() { return new Bar().constructor.v; }
class Baz { static v = foo.v; }          // runs before `foo` is assigned
let __stack = [];
try {
  var foo = __using(__stack, { v: 1, [Symbol.dispose]() {} }, 0);
  class Bar { static v = foo.v; }        // scoped to the try block; fn() cannot see it
} catch (_catch) { var _err = _catch, _hasErr = 1; } finally { __callDispose(__stack, _err, _hasErr); }
```

After (on top of #38284, which is what turns the block's `var`s into assignments plus separate top-level declarations; in an `__esm` wrapper the linker merges those into one `var __stack, foo, Bar, Baz;` outside the wrapper):

```js
function fn() { return new Bar().constructor.v; }
let __stack = [];
try {
  foo = __using(__stack, { v: 1, [Symbol.dispose]() {} }, 0);
  Bar = class Bar { static v = foo.v; };
  Baz = class Baz { static v = foo.v; };
} catch (_catch) { var _err = _catch, _hasErr = 1; } finally { __callDispose(__stack, _err, _hasErr); }
var foo;
var Bar;
var Baz;
```

`bun build --no-bundle` / `Bun.Transpiler` output (no relocation outside the bundler):

```js
export function fn() { return new Bar().constructor.v; }
let __bun_temp_ref_1$ = [];
try {
  var foo = __using(__bun_temp_ref_1$, { v: 1, [Symbol.dispose]() {} }, 0);
  var Bar = class Bar { static v = foo.v; };
  var Baz = class Baz { static v = foo.v; };
} catch (__bun_temp_ref_2$) { ... } finally { ... }
export { Baz };
```

</details>
