### PR TITLE
ci: bring the darwin x64 test lane back (main only for now)

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -192,8 +192,7 @@ const testPlatforms = [
   // every PR push.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
-  // x64 is off until enough Intel test agents are back on the queue.
-  // { os: "darwin", arch: "x64", release: "14", tier: "latest" },
+  { os: "darwin", arch: "x64", release: "14", tier: "latest" },
   { os: "linux", arch: "aarch64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", profile: "asan", distro: "debian", release: "13", tier: "latest" },


### PR DESCRIPTION
Four Intel test agents are back on `test-darwin`. This un-comments the `darwin x64` test platform; because it is `tier: "latest"`, the gate from #37980 keeps it to main, manual builds, and `[macos tests]` commits, which is what four boxes can serve. PR builds are unchanged.

`--dry-run`:
```
PR:   ['darwin-aarch64-14-test-bun']
main: ['darwin-aarch64-26-test-bun', 'darwin-aarch64-14-test-bun', 'darwin-x64-14-test-bun']
```