### PR TITLE
sourcemap: update the remaining mentions of ParseResult::Fail

### DIFF
--- a/src/jsc/bindings/highway_sourcemap.cpp
+++ b/src/jsc/bindings/highway_sourcemap.cpp
@@ -915,7 +915,7 @@ size_t ParseMappingsImpl(const uint8_t* HWY_RESTRICT bytes, size_t len,
 
             // Accumulate and range-check. On any out-of-range value, bail at
             // this segment's start WITHOUT committing: scalar re-decodes it
-            // and reports the exact same ParseResult::Fail as before.
+            // and reports the exact same ParseFail as before.
             const int32_t n_gen_col = WrapAdd(gen_col, d_gen);
             if (HWY_UNLIKELY(n_gen_col < 0))
                 goto bail;

--- a/test/js/node/module/sourcemap-simd.test.ts
+++ b/test/js/node/module/sourcemap-simd.test.ts
@@ -444,7 +444,7 @@ describe.concurrent("SourceMap SIMD mappings decode", () => {
   test("over-long VLQ (>= 8 cont bytes): SIMD bails, scalar rejects", async () => {
     // 'g' is sextet 32 (cont bit set, payload 0). Eight in a row then
     // "AAAA," is a 12-byte segment whose first field has 9 sextets.
-    // Scalar caps at 8 bytes and returns no-progress -> ParseResult::Fail;
+    // Scalar caps at 8 bytes and returns no-progress -> Err(ParseFail);
     // SIMD must bail at this segment so scalar reports the same error.
     const head: number[][] = [];
     for (let i = 0; i < 60; i++) head.push([1, 0, 0, 1]);
@@ -459,7 +459,7 @@ describe.concurrent("SourceMap SIMD mappings decode", () => {
     expect(simd.error).toEqual(scalar.error);
   });
 
-  test("out-of-range source index: identical ParseResult::Fail", async () => {
+  test("out-of-range source index: identical ParseFail", async () => {
     const head: number[][] = [];
     for (let i = 0; i < 60; i++) head.push([1, 0, 0, 1]);
     const { mappings: headM } = build([head]);


### PR DESCRIPTION
Comments and a test name left over from #38280.