### PR TITLE
error printer: remap frames when the original source is unavailable, and not twice after error.stack

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5705,6 +5705,9 @@ impl VirtualMachine {
                     break 'code bun_core::ZigStringSlice::EMPTY;
                 }
                 let mut log = bun_ast::Log::default();
+                // The source may be gone (deleted after it was loaded, or named by
+                // a source map that carries no `sourcesContent`). That only costs
+                // the code frame; the frames below still have to be remapped.
                 let Ok(original_source) = Self::fetch_without_on_load_plugins(
                     self,
                     global,
@@ -5715,7 +5718,7 @@ impl VirtualMachine {
                     &mut log,
                     FetchFlags::PrintSource,
                 ) else {
-                    return;
+                    break 'code bun_core::ZigStringSlice::EMPTY;
                 };
                 *must_reset_parser_arena_later = true;
                 // Note: the transpile path `clone_utf8`s the source for
@@ -5789,7 +5792,10 @@ impl VirtualMachine {
 
         if frames.len() > 1 {
             for i in 0..frames.len() {
-                if i == top || frames[i].position.is_invalid() {
+                // Frames parsed back out of an already formatted `error.stack`
+                // arrive with `remapped` set; their positions are original
+                // positions and must not be run through the source map again.
+                if i == top || frames[i].remapped || frames[i].position.is_invalid() {
                     continue;
                 }
                 let source_url = frames[i].source_url.to_utf8();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5705,9 +5705,6 @@ impl VirtualMachine {
                     break 'code bun_core::ZigStringSlice::EMPTY;
                 }
                 let mut log = bun_ast::Log::default();
-                // The source may be gone (deleted after it was loaded, or named by
-                // a source map that carries no `sourcesContent`). That only costs
-                // the code frame; the frames below still have to be remapped.
                 let Ok(original_source) = Self::fetch_without_on_load_plugins(
                     self,
                     global,
@@ -5718,6 +5715,7 @@ impl VirtualMachine {
                     &mut log,
                     FetchFlags::PrintSource,
                 ) else {
+                    // Source is gone; the frames still get remapped below.
                     break 'code bun_core::ZigStringSlice::EMPTY;
                 };
                 *must_reset_parser_arena_later = true;
@@ -5792,9 +5790,7 @@ impl VirtualMachine {
 
         if frames.len() > 1 {
             for i in 0..frames.len() {
-                // Frames parsed back out of an already formatted `error.stack`
-                // arrive with `remapped` set; their positions are original
-                // positions and must not be run through the source map again.
+                // `remapped`: frames parsed back out of a formatted `error.stack`.
                 if i == top || frames[i].remapped || frames[i].position.is_invalid() {
                     continue;
                 }

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -184,14 +184,16 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
 });
 
 describe("source map remapping of the printed stack", () => {
-  // The "at ..." lines that mention one of `files`, with the directory part of
-  // the path removed so the expectations are independent of the temp dir.
-  function frames(text, files) {
+  // The "at ..." lines that mention one of `files`, with the temp dir removed
+  // from the paths.
+  function frames(text, dir, files) {
+    const prefix = dir.replaceAll("\\", "/") + "/";
     return text
+      .replaceAll("\\", "/")
       .split("\n")
       .map(line => line.trim())
       .filter(line => line.startsWith("at ") && files.some(file => line.includes(file)))
-      .map(line => line.replace(/[^\s(]*[\\/](?=[\w.-]+:\d+:\d+)/g, ""));
+      .map(line => line.replaceAll(prefix, ""));
   }
 
   async function run(files) {
@@ -204,7 +206,7 @@ describe("source map remapping of the printed stack", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { out: JSON.parse(stdout), stderr, exitCode };
+    return { dir: String(dir), out: JSON.parse(stdout), stderr, exitCode };
   }
 
   // A prebuilt file whose map names a source that is neither on disk nor in
@@ -233,16 +235,16 @@ describe("source map remapping of the printed stack", () => {
       names: [],
       mappings: ";AAUI;;AAUA;AAUA;;AAUA",
     };
-    const { out, stderr, exitCode } = await run({
+    const { dir, out, stderr, exitCode } = await run({
       "main.js": main.join("\n") + "\n//# sourceMappingURL=main.js.map\n",
       "main.js.map": JSON.stringify(map),
     });
 
     const files = ["orig.ts", "main.js"];
     expect({
-      stack: frames(out.stack, files),
-      inspect: frames(out.inspect, files),
-      uncaught: frames(stderr, files),
+      stack: frames(out.stack, dir, files),
+      inspect: frames(out.inspect, dir, files),
+      uncaught: frames(stderr, dir, files),
     }).toEqual({
       stack: ["at thrower (orig.ts:11:5)", "at orig.ts:31:5"],
       inspect: ["at thrower (orig.ts:11:5)", "at orig.ts:21:5"],
@@ -275,7 +277,7 @@ describe("source map remapping of the printed stack", () => {
         "}",
         "",
       ].join("\n");
-    const { out, stderr, exitCode } = await run({
+    const { dir, out, stderr, exitCode } = await run({
       "present.ts": module("present"),
       "deleted.ts": module("deleted"),
       "main.js": [
@@ -299,7 +301,7 @@ describe("source map remapping of the printed stack", () => {
     });
 
     const files = ["present.ts", "deleted.ts"];
-    const positions = text => frames(text, files);
+    const positions = text => frames(text, dir, files);
     // The throw is on line 5 and the call to thrower() on line 9 of the
     // original module; after type stripping they are on lines 2 and 6.
     const expected = file => [

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -9,21 +10,23 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
-5 |   const err2 = new Error("error 2", { cause: err });
+2 | import { bunEnv, bunExe, tempDir } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
+6 |   const err2 = new Error("error 2", { cause: err });
                        ^
 error: error 2
-      at <anonymous> ([dir]/inspect-error.test.js:5:20)
+      at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
+2 | import { bunEnv, bunExe, tempDir } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
                       ^
 error: error 1
-      at <anonymous> ([dir]/inspect-error.test.js:4:19)
+      at <anonymous> ([dir]/inspect-error.test.js:5:19)
 "
 `);
 });
@@ -35,15 +38,15 @@ test("Error", () => {
       .replaceAll("\\", "/")
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
-"27 | "
-28 | \`);
-29 | });
-30 | 
-31 | test("Error", () => {
-32 |   const err = new Error("my message");
+"30 | "
+31 | \`);
+32 | });
+33 | 
+34 | test("Error", () => {
+35 |   const err = new Error("my message");
                        ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:32:19)
+      at <anonymous> ([dir]/inspect-error.test.js:35:19)
 "
 `);
 });
@@ -71,22 +74,13 @@ note: "duplicateConstDecl" was originally declared here
   }
 });
 
-const normalizeError = str => {
-  // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
-    const splits = str.split("\n");
-    for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
-        splits.splice(i, 1);
-        i--;
-      }
-    }
-    return splits.join("\n");
-  }
-
-  return str;
-};
+const normalizeError = str =>
+  // remove debug-only stack trace frames of bun's own builtins, which have a
+  // position but no file, like "at require (51:24)"
+  str
+    .split("\n")
+    .filter(line => !/^\s*at \S+ \(:?\d+:\d+\)$/.test(line))
+    .join("\n");
 
 test("Error inside minified file (no color) ", () => {
   try {
@@ -111,7 +105,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:86:7)"
     `);
   }
 });
@@ -140,7 +134,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:114:7)"
     `);
   }
 });
@@ -154,7 +148,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:143:19)"
 `);
 });
 
@@ -187,4 +181,147 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
   expect(() => {
     throw err;
   }).toThrow();
+});
+
+describe("source map remapping of the printed stack", () => {
+  // The "at ..." lines that mention one of `files`, with the directory part of
+  // the path removed so the expectations are independent of the temp dir.
+  function frames(text, files) {
+    return text
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at ") && files.some(file => line.includes(file)))
+      .map(line => line.replace(/[^\s(]*[\\/](?=[\w.-]+:\d+:\d+)/g, ""));
+  }
+
+  async function run(files) {
+    using dir = tempDir("inspect-error-sourcemap", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out: JSON.parse(stdout), stderr, exitCode };
+  }
+
+  // A prebuilt file whose map names a source that is neither on disk nor in
+  // `sourcesContent` (the shape of a deployed `bun build --target=bun
+  // --sourcemap` artifact with the sources stripped). The original source can't
+  // be shown, but the frames still have to be remapped, exactly like
+  // error.stack is.
+  test.concurrent("external map whose original source is unavailable", async () => {
+    const main = [
+      "// @bun",
+      'function thrower() { throw new Error("HOSTILE"); }',
+      "const out = {};",
+      "try { thrower(); } catch (e) { out.inspect = Bun.inspect(e); }",
+      "try { thrower(); } catch (e) { out.stack = e.stack; }",
+      "console.log(JSON.stringify(out));",
+      "thrower();",
+    ];
+    // One segment at column 0 of each generated line below, so every position on
+    // a line maps to the same original position: line 1 -> orig.ts:11:5, line 3
+    // -> 21:5, line 4 -> 31:5, line 6 -> 41:5. (Column 5 rather than 1 because
+    // error.stack prints no column at all for column 1.)
+    const map = {
+      version: 3,
+      sources: ["orig.ts"],
+      sourcesContent: [null],
+      names: [],
+      mappings: ";AAUI;;AAUA;AAUA;;AAUA",
+    };
+    const { out, stderr, exitCode } = await run({
+      "main.js": main.join("\n") + "\n//# sourceMappingURL=main.js.map\n",
+      "main.js.map": JSON.stringify(map),
+    });
+
+    const files = ["orig.ts", "main.js"];
+    expect({
+      stack: frames(out.stack, files),
+      inspect: frames(out.inspect, files),
+      uncaught: frames(stderr, files),
+    }).toEqual({
+      stack: ["at thrower (orig.ts:11:5)", "at orig.ts:31:5"],
+      inspect: ["at thrower (orig.ts:11:5)", "at orig.ts:21:5"],
+      uncaught: ["at thrower (orig.ts:11:5)", "at orig.ts:41:5"],
+    });
+    expect(exitCode).toBe(1);
+  });
+
+  // Modules bun transpiled itself. `present.ts` stays on disk; `deleted.ts` is
+  // removed after it was loaded, so the code frame can no longer be read back.
+  // Reading error.stack first makes the printer start from the already
+  // remapped frames of that string instead of the raw JSC frames; those must
+  // not be remapped a second time.
+  test.concurrent("transpiled modules: source deleted, and frames already remapped by error.stack", async () => {
+    const module = message =>
+      [
+        "type Padding1 = { a: number };",
+        "type Padding2 = { b: string };",
+        "type Padding3 = { c: boolean };",
+        "export function thrower(): never {",
+        `  throw new Error(${JSON.stringify(message)});`,
+        "}",
+        "export function caller(onError: (e: Error) => string): string {",
+        "  try {",
+        "    thrower();",
+        "  } catch (e) {",
+        "    return onError(e as Error);",
+        "  }",
+        "  return 'unreachable';",
+        "}",
+        "",
+      ].join("\n");
+    const { out, stderr, exitCode } = await run({
+      "present.ts": module("present"),
+      "deleted.ts": module("deleted"),
+      "main.js": [
+        'import { unlinkSync } from "node:fs";',
+        'import { join } from "node:path";',
+        'import * as present from "./present.ts";',
+        'import * as deleted from "./deleted.ts";',
+        'unlinkSync(join(import.meta.dir, "deleted.ts"));',
+        "const out = {",
+        "  presentStack: present.caller(e => e.stack),",
+        "  presentInspect: present.caller(e => Bun.inspect(e)),",
+        "  presentStackThenInspect: present.caller(e => (e.stack, Bun.inspect(e))),",
+        "  deletedStack: deleted.caller(e => e.stack),",
+        "  deletedInspect: deleted.caller(e => Bun.inspect(e)),",
+        "  deletedStackThenInspect: deleted.caller(e => (e.stack, Bun.inspect(e))),",
+        "};",
+        "console.log(JSON.stringify(out));",
+        "present.caller(e => { e.stack; throw e; });",
+        "",
+      ].join("\n"),
+    });
+
+    const files = ["present.ts", "deleted.ts"];
+    const positions = text => frames(text, files);
+    // The throw is on line 5 and the call to thrower() on line 9 of the
+    // original module; after type stripping they are on lines 2 and 6.
+    const expected = file => [
+      expect.stringMatching(new RegExp(`^at thrower \\(${file}:5:\\d+\\)$`)),
+      expect.stringMatching(new RegExp(`^at caller \\(${file}:9:\\d+\\)$`)),
+    ];
+    expect(positions(out.presentStack)).toEqual(expected("present.ts"));
+    expect(positions(out.deletedStack)).toEqual(expected("deleted.ts"));
+
+    expect({
+      presentInspect: positions(out.presentInspect),
+      presentStackThenInspect: positions(out.presentStackThenInspect),
+      deletedInspect: positions(out.deletedInspect),
+      deletedStackThenInspect: positions(out.deletedStackThenInspect),
+      uncaughtAfterStack: positions(stderr),
+    }).toEqual({
+      presentInspect: positions(out.presentStack),
+      presentStackThenInspect: positions(out.presentStack),
+      deletedInspect: positions(out.deletedStack),
+      deletedStackThenInspect: positions(out.deletedStack),
+      uncaughtAfterStack: positions(out.presentStack),
+    });
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -257,7 +257,7 @@ describe("source map remapping of the printed stack", () => {
   // removed after it was loaded, so the code frame can no longer be read back.
   // Reading error.stack first makes the printer start from the already
   // remapped frames of that string instead of the raw JSC frames; those must
-  // not be remapped a second time.
+  // not be remapped a second time (https://github.com/oven-sh/bun/issues/15859).
   test.concurrent("transpiled modules: source deleted, and frames already remapped by error.stack", async () => {
     const module = message =>
       [


### PR DESCRIPTION
### Problem
- `Bun.inspect(err)`, `console.error(err)` and the uncaught exception output print the mapped file name with the generated line:column when the mapped source cannot be read: `at thrower (orig.ts:2:27)` where `err.stack` says `at thrower (orig.ts:4:9)`. The frames below it are not remapped at all (`at host.js:5:8`).
- Triggers: a `.map` whose `sourcesContent` entry is `null` (or missing) and whose source is not on disk (a deployed `bun build --target=bun --sourcemap` artifact with the sources stripped), or any module bun transpiled itself that was deleted or moved after it was loaded.
- Cause: `remap_zig_exception` (`src/jsc/VirtualMachine.rs:5704` on main) `return`ed when `fetch_without_on_load_plugins` for the code frame failed. At that point the top frame's `source_url` had already been replaced by the mapped name (line 5679) but `position` was still the generated one (set at 5731, after the return), and the loop remapping the other frames (5778) never ran. Same `catch return` existed in the Zig version.
- Second bug in the same function: once `err.stack` has been read, `toZigException` rebuilds the frames by parsing that string and marks them `remapped` (`ZigException.cpp:615`). The top frame honors that, but the loop at 5778 pushed the other frames through the source map a second time, so `err.stack; console.error(err)` printed `at outer (m.js:1:39)` / `at top (m.js:1:39)` for frames whose real positions are `2:20` and `3:18`. Any error reporter that touches `.stack` before the error is logged or goes uncaught hits this.
- Both reproduce on 1.3.14 and on main. The second one is #15859 (`let x = error.stack; throw error` printing `f1` at the wrong line: `13:5` before, `8:5` with this change) and the `.stack`-access half of #1352; the AggregateError and assigned-`.stack` parts of #1352 are not touched here.
- Not fixed here: once `.stack` has been read, the stack-string parser still stops at the first frame without parentheses (the global-code frame, usually last), so that frame stays missing from the printed output. That is a separate bug in `V8StackTraceIterator` (`ZigException.cpp`) and is tracked separately.

### Fix
- On a failed code-frame fetch, `break` out of the `code` block with an empty slice instead of returning. The rest of the function then behaves as for every other case with no original text (same fallback the plugin virtual module case already uses): the generated line is shown as the code frame, the top frame gets the mapped position, and the other frames are remapped. That code frame therefore carries generated line numbers under a mapped frame line; dropping the excerpt or the caret in that situation would be a separate change that also affects the virtual module output, so it is not part of this fix.
- Skip frames with `remapped` set in the per-frame loop, which is what `remap_stack_frame_positions` already does. Without this the first change would also regress the "`.stack` read first, source missing" case, which today is only correct because the early return skipped the loop.
- Output for eval, stdin, `data:`/`blob:` modules, `new Function`, plugin virtual modules, `bun test` failures and `--compile` binaries is unchanged (compared against the release build); those all fetch their source fine.
- Tests: `test/js/bun/util/inspect-error.test.js`, `source map remapping of the printed stack`. An external map with `sourcesContent: [null]` and no source on disk checks `Bun.inspect`, `err.stack` and the uncaught output against fixed expected positions; a second test covers a transpiled module deleted after import, and `Bun.inspect` / uncaught output after `err.stack` was read, for a present and a deleted module, all compared against `err.stack`. Both fail on the release build and on main's `src/` (the deleted-module test also fails with only the first change applied), pass with the fix.
- Also in that file: `normalizeError` stripped debug-only builtin frames by looking for ` (:`, but that frame now prints as `at require (51:24)`, so the two minified-file tests failed on debug builds; it now matches on the missing file name. The other inline snapshots only moved because of the added import.
- Also ran `test/js/bun/sourcemap/`, `test/js/node/module/sourcemap.test.js`, `test/regression/issue/23022-stack-trace-iterator.test.ts`, the compile sourcemap tests and the console/reportError tests: green.

### Background
- Two code paths remap stack traces. `err.stack` is formatted in C++ (`FormatStackTraceForJS.cpp`), which calls `remap_stack_frame_positions` for all frames at once. The error printer (`Bun.inspect`, `console.error`, uncaught exceptions) instead builds a `ZigException` and calls `remap_zig_exception`, which remaps the top frame, fetches its original source to print the code frame, then remaps the remaining frames. The bug is only in the second path, which is why `err.stack` was right while the printed output was wrong.
- `Lookup::display_source_url_if_needed` returns the original file name when the map is external (a `.map` file or a `--compile` binary); for bun's own runtime transpilation the file name does not change, only line:column do. That is why the external case showed a wrong file/position mix and the deleted-module case showed generated positions under the right name.
- `ZigStackFrame.remapped` means the frame's position is already an original position. It is set by the remap paths and by the `error.stack` string parser, since that string was itself produced by the remapping formatter.
- JSC drops the structured stack frames of an `ErrorInstance` once `err.stack` has been materialized, which is why reading `.stack` changes which input the printer works from.

<details>
<summary>Repro output, before and after</summary>

`host.js` (`// @bun` pragma, sidecar map with `sourcesContent: [null]`, `orig.ts` not on disk):

```
# before
Bun.inspect:      at thrower (/tmp/x/orig.ts:2:27)
err.stack  :    at thrower (/tmp/x/orig.ts:4:9)
error: HOSTILE
      at thrower (/tmp/x/orig.ts:2:27)
      at /tmp/x/host.js:5:8

# after
Bun.inspect:      at thrower (/tmp/x/orig.ts:4:9)
err.stack  :    at thrower (/tmp/x/orig.ts:4:9)
error: HOSTILE
      at thrower (/tmp/x/orig.ts:4:9)
      at /tmp/x/orig.ts:6:17
```

`m.js`, `.stack` read before the error is printed:

```js
function inner() { throw new Error("X"); }
function outer() { inner(); }
function main() { try { outer(); } catch (e) { e.stack; throw e; } }
main();
```

```
# before
      at inner (/tmp/y/m.js:1:30)
      at outer (/tmp/y/m.js:1:39)
      at main (/tmp/y/m.js:1:39)

# after
      at inner (/tmp/y/m.js:1:30)
      at outer (/tmp/y/m.js:2:20)
      at main (/tmp/y/m.js:3:25)
```
</details>

Fixes #15859

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (18936795e)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [9.98ms]
(pass) Error [5.69ms]
(pass) BuildMessage [16.31ms]
(pass) Error inside minified file (no color)  [133.07ms]
(pass) Error inside minified file (color)  [80.34ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [211.03ms]
(pass) observable properties > sourceURL is observable [9.36ms]
(pass) observable properties > line is observable [4.51ms]
(pass) observable properties > column is observable [3.26ms]
(pass) error.stack throwing an error doesn't lead to a crash [6.33ms]
243 |     const files = ["orig.ts", "main.js"];
244 |     expect({
245 |       stack: frames(out.stack, dir, files),
246 |       inspect: frames(out.inspect, dir, files),
247 |       uncaught: frames(stderr, dir, files),
248 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
    "inspect": [
-     "at thrower (orig.ts:11:5)",
-     "at orig.ts:21:5",
+     "at thrower (ori
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [0.41ms]
(pass) Error [0.13ms]
(pass) BuildMessage [0.43ms]
(pass) Error inside minified file (no color)  [1.57ms]
(pass) Error inside minified file (color)  [0.51ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [3.66ms]
(pass) observable properties > sourceURL is observable [0.26ms]
(pass) observable properties > line is observable [0.09ms]
(pass) observable properties > column is observable [0.09ms]
(pass) error.stack throwing an error doesn't lead to a crash [0.11ms]
243 |     const files = ["orig.ts", "main.js"];
244 |     expect({
245 |       stack: frames(out.stack, dir, files),
246 |       inspect: frames(out.inspect, dir, files),
247 |       uncaught: frames(stderr, dir, files),
248 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
    "inspect": [
-     "at thrower (orig.ts:11:5)",
-     "at orig.ts:21:5",
+     "at thrower (orig.ts:2:28)",
+     "at main.js:4:14",
    ],
    "stack": [
      "at thrower (orig.ts:11:5)",
      "at orig.ts:31:5",
    ],
    "uncaught": [
-     "at thrower (orig.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (18936795e)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [8.90ms]
(pass) Error [6.22ms]
(pass) BuildMessage [19.94ms]
(pass) Error inside minified file (no color)  [138.56ms]
(pass) Error inside minified file (color)  [77.24ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [160.63ms]
(pass) observable properties > sourceURL is observable [6.49ms]
(pass) observable properties > line is observable [3.00ms]
(pass) observable properties > column is observable [2.11ms]
(pass) error.stack throwing an error doesn't lead to a crash [4.53ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [392.03ms]
(pass) source map remapping of the printed stack > transpiled modules: source deleted, and frames already remapped by error.stack [1180.02ms]

 12 pass
 0 fail
 6 snapshots, 19 expect() calls
Ran 12 tests across 1 file. [5.01s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 909ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs              |   6 +-
 test/js/bun/util/inspect-error.test.js | 209 +++++++++++++++++++++++++++------
 2 files changed, 178 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/VirtualMachine.rs                   3      7      0
test/js/bun/util/inspect-error.test.js      6     14      0
```

</details>

<!-- robobun:evidence:end -->