### PR TITLE
node:vm: compile compileFunction sources in the parsingContext realm

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1619,9 +1619,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
         }
     }
 
-    // Node compiles inside parsingContext (node_contextify.cc enters it before
-    // ScriptCompiler::CompileFunction), so the function and any compile error
-    // belong to that realm rather than to the caller's.
+    // Like Node, the function and any compile error are created in parsingContext's realm.
     JSGlobalObject* parsingContext = options.parsingContext;
     parsingContext->setGlobalScopeExtension(functionScope);
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1619,21 +1619,20 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
         }
     }
 
-    options.parsingContext->setGlobalScopeExtension(functionScope);
+    // Node compiles inside parsingContext (node_contextify.cc enters it before
+    // ScriptCompiler::CompileFunction), so the function and any compile error
+    // belong to that realm rather than to the caller's.
+    JSGlobalObject* parsingContext = options.parsingContext;
+    parsingContext->setGlobalScopeExtension(functionScope);
 
-    // Create the function using constructAnonymousFunction with the appropriate scope chain
-    JSFunction* function = constructAnonymousFunction(globalObject, ArgList(constructFunctionArgs), sourceOrigin, WTF::move(options), JSC::SourceTaintedOrigin::Untainted, functionScope);
+    JSFunction* function = constructAnonymousFunction(parsingContext, ArgList(constructFunctionArgs), sourceOrigin, WTF::move(options), JSC::SourceTaintedOrigin::Untainted, functionScope);
     RETURN_IF_EXCEPTION(scope, {});
 
     if (!function) {
-        return throwVMError(globalObject, scope, "Failed to compile function"_s);
+        return throwVMError(parsingContext, scope, "Failed to compile function"_s);
     }
 
     fetcher->owner(vm, function);
-
-    if (!function) {
-        return throwVMError(globalObject, scope, "Failed to compile function"_s);
-    }
 
     return JSValue::encode(function);
 }

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -37,6 +37,7 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
 NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSValue contextValue, bool canThrow);
 JSC::EncodedJSValue INVALID_ARG_VALUE_VM_VARIATION(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, JSC::JSValue value);
 // For vm.compileFunction we need to return an anonymous function expression. This code is adapted from/inspired by JSC::constructFunction, which is used for function declarations.
+// `globalObject` is the realm the source is compiled in (options.parsingContext): the returned function and any compile error are created there.
 JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, const ArgList& args, const SourceOrigin& sourceOrigin, CompileFunctionOptions&& options, JSC::SourceTaintedOrigin sourceTaintOrigin, JSC::JSScope* scope);
 JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin);
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -160,6 +160,16 @@ describe("vm", () => {
         expect(fn(1)).toBe("context:1");
       });
 
+      test("the body cannot reach the caller's realm through its own function object", () => {
+        // With a caller-realm prototype, arguments.callee.constructor was the
+        // caller's Function, whose functions see the caller's globals.
+        const parsingContext = createContext({});
+        const fn = compileFunction("return new (arguments.callee.constructor)('return globalThis')()", [], {
+          parsingContext,
+        });
+        expect(fn()).toBe(runInContext("globalThis", parsingContext));
+      });
+
       test("without parsingContext the caller's realm is used", () => {
         expect(Object.getPrototypeOf(compileFunction("return 1"))).toBe(Function.prototype);
         expect(thrownBy(() => compileFunction("%%"))).toBeInstanceOf(SyntaxError);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -102,6 +102,123 @@ describe("vm", () => {
       expect(result).toBe(2);
     });
 
+    describe("parsingContext", () => {
+      // Node compiles the source inside parsingContext, so whatever the compile
+      // produces (the function, or the error it throws) belongs to that
+      // context's realm rather than to the caller's.
+      const thrownBy = (fn: () => unknown): any => {
+        try {
+          fn();
+        } catch (e) {
+          return e;
+        }
+        throw new Error("expected a throw");
+      };
+      const realmOf = (context: object) => ({
+        Error: runInContext("Error", context),
+        SyntaxError: runInContext("SyntaxError", context),
+        Function: runInContext("Function", context),
+      });
+
+      test("a body that does not parse throws the context's SyntaxError", () => {
+        const parsingContext = createContext({});
+        const context = realmOf(parsingContext);
+        for (const body of ["%%", "}); (function () {"]) {
+          const err = thrownBy(() => compileFunction(body, [], { parsingContext }));
+          expect(err).toBeInstanceOf(context.SyntaxError);
+          expect(err).not.toBeInstanceOf(Error);
+          expect(err.message).toMatch(/^Unexpected token '[%}]'$/);
+        }
+      });
+
+      test("errors reported by the other compile paths come from the context too", () => {
+        const parsingContext = createContext({});
+        const context = realmOf(parsingContext);
+        const cases: [body: string, params: string[]][] = [
+          // Only rejected once the body is wrapped in its function.
+          ["%%", ["a"]],
+          ["return 1;\n%%", []],
+          ["return 1;\n%%", ["a"]],
+          // Too deeply nested for the parser: a RangeError rather than a SyntaxError.
+          ["return " + Buffer.alloc(100_000, "(").toString(), []],
+        ];
+        // Which Error subclass each path reports is covered elsewhere; what
+        // every path has in common is the realm the error is created in.
+        for (const [body, params] of cases) {
+          const err = thrownBy(() => compileFunction(body, params, { parsingContext }));
+          expect(err).toBeInstanceOf(context.Error);
+          expect(err).not.toBeInstanceOf(Error);
+        }
+      });
+
+      test("the compiled function is a function of the context", () => {
+        const parsingContext = createContext({ fromContext: "context" });
+        const context = realmOf(parsingContext);
+        const fn = compileFunction("return fromContext + ':' + a", ["a"], { parsingContext });
+        expect(Object.getPrototypeOf(fn)).toBe(context.Function.prototype);
+        expect(fn).not.toBeInstanceOf(Function);
+        expect(fn(1)).toBe("context:1");
+      });
+
+      test("without parsingContext the caller's realm is used", () => {
+        expect(Object.getPrototypeOf(compileFunction("return 1"))).toBe(Function.prototype);
+        expect(thrownBy(() => compileFunction("%%"))).toBeInstanceOf(SyntaxError);
+        expect(thrownBy(() => compileFunction("%%", ["a"]))).toBeInstanceOf(Error);
+      });
+
+      test("cachedData is a Buffer of the caller's realm, accepted by a compile in another context", () => {
+        const fn = compileFunction("return 1", [], { parsingContext: createContext({}), produceCachedData: true });
+        expect(fn.cachedDataProduced).toBe(true);
+        expect(fn.cachedData).toBeInstanceOf(Buffer);
+        const reused = compileFunction("return 1", [], {
+          parsingContext: createContext({}),
+          cachedData: fn.cachedData,
+        });
+        expect(reused.cachedDataRejected).toBe(false);
+        expect(reused()).toBe(1);
+      });
+
+      test("the context's Error.prepareStackTrace formats the compile error, under the arrow header", () => {
+        const calls: string[] = [];
+        const parsingContext = createContext({ calls });
+        runInContext(
+          `Error.prepareStackTrace = err => {
+            calls.push("context:" + err.constructor.name);
+            return "formatted by the context";
+          };`,
+          parsingContext,
+        );
+        const prev = Error.prepareStackTrace;
+        Error.prepareStackTrace = err => {
+          calls.push("caller:" + err.constructor.name);
+          return "formatted by the caller";
+        };
+        let err: any;
+        try {
+          err = thrownBy(() => compileFunction("%%", [], { parsingContext, filename: "f.js" }));
+        } finally {
+          Error.prepareStackTrace = prev;
+        }
+        expect(calls).toEqual(["context:SyntaxError"]);
+        expect(err.stack).toBe("f.js:1\n%%\n^\n\nformatted by the context");
+      });
+
+      test("a throwing Error.prepareStackTrace in the context does not escape the compile error", () => {
+        const parsingContext = createContext({});
+        const context = realmOf(parsingContext);
+        runInContext(
+          `Error.prepareStackTrace = () => {
+            throw new Error("boom-from-prepareStackTrace");
+          };`,
+          parsingContext,
+        );
+        const err = thrownBy(() => compileFunction("%%", [], { parsingContext }));
+        expect(err).toBeInstanceOf(context.SyntaxError);
+        expect(err.message).toBe("Unexpected token '%'");
+        expect(err.stack.split("\n").slice(0, 4)).toEqual([":1", "%%", "^", ""]);
+      });
+    });
+
     // Security tests
     test("Template literal attack should not break out of sandbox", () => {
       const before = globalThis.hacked;


### PR DESCRIPTION
### Problem
- `vm.compileFunction(code, params, { parsingContext })` throws a compile error from the caller's realm: `err instanceof SyntaxError` is `true` and `err instanceof vm.runInContext("SyntaxError", parsingContext)` is `false`. Node (v26.3.0) gives `false` / `true`. Same for the parser's `RangeError` on a body too deep to parse and for the `Failed to compile function` fallback.
- On success the returned function is a caller-realm function as well: `Object.getPrototypeOf(fn)` is the caller's `Function.prototype`; in Node it is the context's. Because of that, the body could get out of the context through its own function object: `compileFunction("return new (arguments.callee.constructor)('return globalThis')()", [], { parsingContext })()` returns the caller's `globalThis` (with `process` on it) on bun 1.4.0; Node returns the context's.
- The compile error is formatted by the caller's `Error.prepareStackTrace`; Node runs the context's.
- Cause: `vmModuleCompileFunction` (`src/jsc/bindings/NodeVM.cpp`, the `constructAnonymousFunction` call near line 1625) passes its own `globalObject`, the realm `vm.compileFunction` itself lives in, as the realm to compile in; `options.parsingContext` only reaches the call as the scope chain.
- Inside `constructAnonymousFunction` that realm argument is what `ParserError::toErrorObject` creates the error from and what `JSFunction::selectStructureForNewFuncExp` takes the function's structure from, so both come out in the wrong realm. The fallback `throwVMError` used the same global.
- Found by comparing against Node while working in this file; there is no issue for it.

### Fix
- Pass `options.parsingContext` as the realm argument of `constructAnonymousFunction` and throw the fallback from it too. It is always set (`CompileFunctionOptions::fromJS` defaults it to the caller's global), so without the option the two globals are the same object and nothing changes.
- Matches Node: `node_contextify.cc` enters the parsing context before `ScriptCompiler::CompileFunction`, so the error and the function are created in it. It is also what JSC does on its own: the parse error of a lazily compiled function is created in the realm of the scope it is linked against (`ScriptExecutable::newCodeBlockFor`), and a function's structure realm normally equals the realm of its scope chain, which this restores.
- Nothing else in `constructAnonymousFunction` moves realm: `ProgramExecutable::create` only takes the VM from the argument, `ProgramCodeBlock::create` and `JSFunction::create` already received the parsing context's scope, `decorateParseErrorStack` ignores it, and `createBuffer` always builds `cachedData` from the default global, so it stays a Buffer of the caller's realm like Node's `Buffer::Copy(env, ...)`. The `cachedData` key and `getBytecode` still read one and the same global on the produce and consume sides.
- The context's `Error.prepareStackTrace` runs with no further change because `computeErrorInfo` (`FormatStackTraceForJS.cpp`) dispatches on the error object's own realm; a throwing one is still swallowed by the existing `tryClearException`, as in the caller-realm case.
- Removed the unreachable second `if (!function)` after `fetcher->owner(...)`.
- Independent of #38239, which reworks how the error is built inside `constructAnonymousFunction`: it creates the error in whatever realm it is handed, and this PR only changes what is handed in.
- Scope: `node:vm` has three compile entry points that create their compile error from the caller's global instead of the target context's. This PR is the `compileFunction` one (`NodeVM.cpp`), the only one of the three where the compiled code object itself is mis-realmed too. `runInContext` / `runInNewContext` (`NodeVMScript.cpp`, Node's `kParsingContext`) is #38317, and `new SourceTextModule(code, { context })` (`NodeVMSourceTextModule.cpp`, `createModuleRecord`) is left for a separate change; each derives its target realm from a different option and lives in a different constructor, so they are kept as separate changes. #29998 covers the related `prepareStackTrace` call-site allocations.
- Not changed here: the `setGlobalScopeExtension(functionScope)` call in the diff is the pre-existing line, now made through the new local. That it installs the contextExtensions chain on the parsing context for good is a separate pre-existing bug, fixed by #38302.
- Verified with the new `compileFunction() > parsingContext` block in `test/js/node/vm/vm.test.ts`: 8 tests, 6 fail on main and on bun 1.4.0, the 2 that pin unchanged behavior (default realm, `cachedData`) pass either way, all 8 pass with the fix, and the same assertions hold under node v26.3.0.
- Also run with the fix: the rest of `test/js/node/vm/` (`script-leak.test.ts` times out locally under ASAN independent of this change), `test/js/node/test/parallel/test-vm-basic.js`, `test-vm-module-basic.js`, `test-vm-no-dynamic-import-callback.js`, `test/regression/issue/isArray-proxy-crash.test.ts`.

### Background
- Realm: a global object together with its own copies of the intrinsics (`Error`, `SyntaxError`, `Function.prototype`, ...). Each `vm` context is a realm of its own (a `NodeVMGlobalObject`), and `instanceof` against another realm's constructor is false. In JSC an object's realm is recorded in its `Structure`, so the realm of a new error or function is decided by which global object its structure is taken from.
- `parsingContext`: the `compileFunction` option naming the context to compile in. Bun keeps it in `CompileFunctionOptions::parsingContext` and builds the function's scope chain from it; before this change that scope chain was its only use.
- `constructAnonymousFunction`: wraps params and body into a `(function (...) {...})` program, compiles it, and returns the function expression. Its first parameter is the global object the error or the function is created from; the header comment now says so.
- `Error.prepareStackTrace`: the V8-style hook on a realm's `Error` constructor that formats `.stack`. Bun looks it up on the `Error` of the realm the error object was created in, which is why the fix also changes which hook runs.

