### PR TITLE
Recursive mkdir: never give mkdir(2) a name with a trailing separator (Bun.write, fs.mkdir, mkdir -p follow a dangling symlink on macOS)

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,14 +437,12 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// Length of `path` without its trailing separator run (a lone `/` stays), the
-/// name the recursive mkdir gives mkdir(2): on macOS and FreeBSD `mkdir("link/")`
-/// follows the symlink and creates its target, whereas `mkdir("link")` fails
-/// with EEXIST everywhere. Only the names given to mkdir(2) are trimmed; what
-/// the walk reports keeps the caller's spelling, as node does. Windows has no
-/// such mkdir behaviour and its roots (`C:\`) end in a separator.
+/// Length of `path` without its trailing separator run (a lone `/` stays). On
+/// macOS and FreeBSD, mkdir(2) of `link/` creates the symlink's target, so the
+/// recursive mkdir gives mkdir(2) this name and reports `path` as spelled, like node.
 fn mkdir_name_len(path: &OSPathSliceZ) -> usize {
     let mut len = path.len();
+    // Windows roots (`C:\`) end in a separator, and its mkdir does not follow `link\`.
     if cfg!(not(windows)) {
         while len > 1 && bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[len - 1]) {
             len -= 1;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,6 +437,27 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
+/// Length of the name the recursive mkdir hands to mkdir(2) for `path`: the
+/// path without its trailing separator run (a lone `/` stays).
+///
+/// Given `link/`, mkdir(2) on macOS and FreeBSD resolves the symlink and
+/// creates its target, where `link` fails with EEXIST (Linux fails both), so
+/// `mkdir -p dangling/`, or a `Bun.write` to `dangling//f` (whose parent is
+/// derived as `dangling/`), would create the link's target. Only the names
+/// given to mkdir(2) are trimmed; everything the walk reports (the stat of an
+/// existing entry, the returned first directory, error paths, `on_create_dir`)
+/// keeps the caller's spelling, as node does. On Windows a trailing separator
+/// has no such effect.
+fn mkdir_name_len(path: &OSPathSliceZ) -> usize {
+    let mut len = path.len();
+    if cfg!(not(windows)) {
+        while len > 1 && bun_paths::is_sep_native_t::<OSPathChar>((&path[..])[len - 1]) {
+            len -= 1;
+        }
+    }
+    len
+}
+
 /// Check whether a directory exists at `(fd, path)` — dispatches on path element width. On
 /// Windows `OSPathSliceZ` is already `&WStr`, so forward to the wide overload
 /// instead of narrowing to UTF-8 and re-widening. POSIX is a forwarder.
@@ -5657,11 +5678,24 @@ impl NodeFS {
         path: &OSPathSliceZ,
         mode: Mode,
     ) -> Maybe<ret::Mkdir> {
-        let len: u16 = path.len() as u16;
+        // The walk below works on the name without its trailing separators (see
+        // `mkdir_name_len`); `path` itself is what gets reported.
+        let len: u16 = mkdir_name_len(path) as u16;
 
         // First, attempt to create the desired directory
         // If that fails, then walk back up the path until we have a match
-        match mkdir_os_path(path, mode) {
+        let first_attempt = if len as usize == path.len() {
+            mkdir_os_path(path, mode)
+        } else {
+            let mut name_buf = paths::os_path_buffer_pool::get();
+            name_buf[..len as usize].copy_from_slice(&(&path[..])[..len as usize]);
+            name_buf[len as usize] = 0;
+            // SAFETY: `name_buf[..len]` was just copied from `path` and
+            // `name_buf[len]` set to NUL; the slice is in-bounds.
+            let name = unsafe { OSPathSliceZ::from_raw(name_buf.as_ptr(), len as usize) };
+            mkdir_os_path(name, mode)
+        };
+        match first_attempt {
             Err(err) => match err.get_errno() {
                 // `mkpath_np` in macOS also checks for `EISDIR`.
                 // it is unclear if macOS lies about if the existing item is
@@ -5701,9 +5735,7 @@ impl NodeFS {
                     }
                 }
                 _ => {
-                    return Err(err.with_path(
-                        self.os_path_into_sync_error_buf(&(&path[..])[..len as usize]),
-                    ));
+                    return Err(err.with_path(self.os_path_into_sync_error_buf(&path[..])));
                 }
             },
             Ok(_) => {
@@ -5859,8 +5891,8 @@ impl NodeFS {
 
         // Our final directory will not have a trailing separator
         // so we have to create it once again
-        // SAFETY: `working_mem[..len]` is the full input path and `working_mem[len]`
-        // was just set to NUL; the slice is in-bounds.
+        // SAFETY: `working_mem[..len]` is the input path (minus trailing separators)
+        // and `working_mem[len]` was just set to NUL; the slice is in-bounds.
         let final_ = unsafe { OSPathSliceZ::from_raw(working_mem.as_ptr(), len as usize) };
         match mkdir_os_path(final_, mode) {
             Err(err) => match err.get_errno() {
@@ -5877,7 +5909,7 @@ impl NodeFS {
             Ok(_) => {}
         }
 
-        ctx.on_create_dir(final_);
+        ctx.on_create_dir(path);
         if !RETURN_PATH {
             return Ok(StringOrUndefined::None);
         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -437,17 +437,12 @@ fn openat_os_path(dirfd: FD, path: &OSPathSliceZ, flags: i32, mode: Mode) -> May
     sys::openat_windows(dirfd, path.as_slice(), flags, mode)
 }
 
-/// Length of the name the recursive mkdir hands to mkdir(2) for `path`: the
-/// path without its trailing separator run (a lone `/` stays).
-///
-/// Given `link/`, mkdir(2) on macOS and FreeBSD resolves the symlink and
-/// creates its target, where `link` fails with EEXIST (Linux fails both), so
-/// `mkdir -p dangling/`, or a `Bun.write` to `dangling//f` (whose parent is
-/// derived as `dangling/`), would create the link's target. Only the names
-/// given to mkdir(2) are trimmed; everything the walk reports (the stat of an
-/// existing entry, the returned first directory, error paths, `on_create_dir`)
-/// keeps the caller's spelling, as node does. On Windows a trailing separator
-/// has no such effect.
+/// Length of `path` without its trailing separator run (a lone `/` stays), the
+/// name the recursive mkdir gives mkdir(2): on macOS and FreeBSD `mkdir("link/")`
+/// follows the symlink and creates its target, whereas `mkdir("link")` fails
+/// with EEXIST everywhere. Only the names given to mkdir(2) are trimmed; what
+/// the walk reports keeps the caller's spelling, as node does. Windows has no
+/// such mkdir behaviour and its roots (`C:\`) end in a separator.
 fn mkdir_name_len(path: &OSPathSliceZ) -> usize {
     let mut len = path.len();
     if cfg!(not(windows)) {
@@ -5678,8 +5673,6 @@ impl NodeFS {
         path: &OSPathSliceZ,
         mode: Mode,
     ) -> Maybe<ret::Mkdir> {
-        // The walk below works on the name without its trailing separators (see
-        // `mkdir_name_len`); `path` itself is what gets reported.
         let len: u16 = mkdir_name_len(path) as u16;
 
         // First, attempt to create the desired directory

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4327,25 +4327,6 @@ pub enum Retry {
     No,
 }
 
-/// The directory `createPath` creates for a destination that does not exist.
-///
-/// `dirname` keeps a separator run (`a//f` -> `a/`), and `mkdir_recursive`
-/// begins by handing its argument to mkdir(2) as is. With a trailing
-/// separator, mkdir(2) on macOS and FreeBSD follows a symlink at that name and
-/// creates the link's target (Linux fails with EEXIST for both spellings), so
-/// the parent is named without the run, `a`, which every kernel treats alike.
-/// Windows normalizes the path inside `mkdir_recursive`, and its roots (`C:\`)
-/// keep their separator.
-fn parent_dir_to_create(path: &[u8]) -> Option<&[u8]> {
-    let mut dir = bun_core::dirname(path)?;
-    if cfg!(not(windows)) {
-        while dir.len() > 1 && bun_paths::is_sep_native(dir[dir.len() - 1]) {
-            dir = &dir[..dir.len() - 1];
-        }
-    }
-    Some(dir)
-}
-
 // TODO: move this to bun_sys?
 // we choose not to inline this so that the path buffer is not on the stack unless necessary.
 #[inline(never)]
@@ -4356,7 +4337,7 @@ pub(crate) fn mkdir_if_not_exists<T: MkdirpTarget>(
     err_path: &[u8],
 ) -> Retry {
     if err.get_errno() == bun_sys::E::ENOENT && this.mkdirp_if_not_exists() {
-        if let Some(dirname) = parent_dir_to_create(path_string.as_bytes()) {
+        if let Some(dirname) = bun_core::dirname(path_string.as_bytes()) {
             let mut node_fs = node::fs::NodeFS::default();
             match node_fs.mkdir_recursive(&node::fs::args::Mkdir {
                 path: node::PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
@@ -4479,7 +4460,7 @@ fn write_file_with_empty_source_to_destination(
                                 }
                                 let dirpath: &[u8] = match &file.pathlike {
                                     PathOrFileDescriptor::Path(path) => {
-                                        match parent_dir_to_create(path.slice()) {
+                                        match bun_core::dirname(path.slice()) {
                                             Some(d) => d,
                                             None => break 'err,
                                         }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4327,6 +4327,25 @@ pub enum Retry {
     No,
 }
 
+/// The directory `createPath` creates for a destination that does not exist.
+///
+/// `dirname` keeps a separator run (`a//f` -> `a/`), and `mkdir_recursive`
+/// begins by handing its argument to mkdir(2) as is. With a trailing
+/// separator, mkdir(2) on macOS and FreeBSD follows a symlink at that name and
+/// creates the link's target (Linux fails with EEXIST for both spellings), so
+/// the parent is named without the run, `a`, which every kernel treats alike.
+/// Windows normalizes the path inside `mkdir_recursive`, and its roots (`C:\`)
+/// keep their separator.
+fn parent_dir_to_create(path: &[u8]) -> Option<&[u8]> {
+    let mut dir = bun_core::dirname(path)?;
+    if cfg!(not(windows)) {
+        while dir.len() > 1 && bun_paths::is_sep_native(dir[dir.len() - 1]) {
+            dir = &dir[..dir.len() - 1];
+        }
+    }
+    Some(dir)
+}
+
 // TODO: move this to bun_sys?
 // we choose not to inline this so that the path buffer is not on the stack unless necessary.
 #[inline(never)]
@@ -4337,7 +4356,7 @@ pub(crate) fn mkdir_if_not_exists<T: MkdirpTarget>(
     err_path: &[u8],
 ) -> Retry {
     if err.get_errno() == bun_sys::E::ENOENT && this.mkdirp_if_not_exists() {
-        if let Some(dirname) = bun_core::dirname(path_string.as_bytes()) {
+        if let Some(dirname) = parent_dir_to_create(path_string.as_bytes()) {
             let mut node_fs = node::fs::NodeFS::default();
             match node_fs.mkdir_recursive(&node::fs::args::Mkdir {
                 path: node::PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
@@ -4460,7 +4479,7 @@ fn write_file_with_empty_source_to_destination(
                                 }
                                 let dirpath: &[u8] = match &file.pathlike {
                                     PathOrFileDescriptor::Path(path) => {
-                                        match bun_core::dirname(path.slice()) {
+                                        match parent_dir_to_create(path.slice()) {
                                             Some(d) => d,
                                             None => break 'err,
                                         }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -765,6 +765,59 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         );
       });
     });
+
+    // Each source kind creates the parent on its own code path: a string is
+    // written through open(), an empty string through truncate(), and a
+    // Bun.file through the copy path (clonefile() on macOS).
+    const sources = {
+      "string": () => "contents",
+      "empty string": () => "",
+      "Bun.file": dir => Bun.file(join(dir, "src.txt")),
+    };
+
+    describe("destination spelled with doubled separators", () => {
+      for (const [name, source] of Object.entries(sources)) {
+        it(`creates the parent (${name})`, async () => {
+          using dir = tempDir("bun-write-doubled-sep", { "src.txt": "contents" });
+          const expected = source(String(dir));
+
+          await Bun.write(`${dir}/a//b//file`, expected);
+
+          expect(fs.readdirSync(String(dir)).sort()).toEqual(["a", "src.txt"]);
+          expect(fs.readdirSync(join(String(dir), "a"))).toEqual(["b"]);
+          expect(await Bun.file(join(String(dir), "a", "b", "file")).text()).toBe(
+            typeof expected === "string" ? expected : "contents",
+          );
+        });
+      }
+    });
+
+    // The parent of `dangling//file` is derived as `dangling/`, and that name
+    // used to go to mkdir(2) as is. With the trailing separator, mkdir(2) on
+    // macOS and FreeBSD follows the symlink and creates its target, so the
+    // write created `missing` and landed in it; Linux fails the mkdir with
+    // EEXIST for either spelling, so on Linux these pass with or without the
+    // fix. Skipped on Windows, where the path is normalized before mkdir.
+    describe.skipIf(isWindows)("destination parent is a dangling symlink", () => {
+      for (const [name, source] of Object.entries(sources)) {
+        for (const dest of ["dangling/file", "dangling//file"]) {
+          it(`rejects and creates nothing (${name}, ${dest})`, async () => {
+            using dir = tempDir("bun-write-dangling-parent", { "src.txt": "contents" });
+            fs.symlinkSync("missing", join(String(dir), "dangling"));
+
+            const err = await Bun.write(`${dir}/${dest}`, source(String(dir))).then(
+              () => "resolved",
+              e => e.code,
+            );
+            // The empty-string write reports the parent mkdir's own error, which
+            // is EEXIST until the recursive mkdir reports ENOENT for a dangling
+            // link as node does; the other two report the ENOENT of the write.
+            expect(name === "empty string" ? ["EEXIST", "ENOENT"] : ["ENOENT"]).toContain(err);
+            expect(fs.readdirSync(String(dir)).sort()).toEqual(["dangling", "src.txt"]);
+          });
+        }
+      }
+    });
   });
 
   test("timed output should work", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -792,12 +792,13 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       }
     });
 
-    // The parent of `dangling//file` is derived as `dangling/`, and that name
-    // used to go to mkdir(2) as is. With the trailing separator, mkdir(2) on
-    // macOS and FreeBSD follows the symlink and creates its target, so the
-    // write created `missing` and landed in it; Linux fails the mkdir with
-    // EEXIST for either spelling, so on Linux these pass with or without the
-    // fix. Skipped on Windows, where the path is normalized before mkdir.
+    // The parent of `dangling//file` is derived as `dangling/`, and the
+    // recursive mkdir used to hand that name to mkdir(2) as is. With the
+    // trailing separator, mkdir(2) on macOS and FreeBSD follows the symlink and
+    // creates its target, so the write created `missing` and landed in it.
+    // Linux fails that mkdir with EEXIST for either spelling, so there these
+    // cases pass regardless. Skipped on Windows, where the path is normalized
+    // before mkdir and the reported code differs.
     describe.skipIf(isWindows)("destination parent is a dangling symlink", () => {
       for (const [name, source] of Object.entries(sources)) {
         for (const dest of ["dangling/file", "dangling//file"]) {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -7,7 +7,7 @@
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
-import { mkdir, rm, stat } from "fs/promises";
+import { mkdir, readdir, rm, stat, symlink } from "fs/promises";
 import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
@@ -1177,6 +1177,35 @@ booga"
       } finally {
         chmodSync(noaccess, 0o755);
       }
+    });
+  });
+
+  // A relative operand is joined with the cwd, which normalizes it, so only an
+  // absolute operand reaches the recursive mkdir with its trailing separator.
+  // Skipped on Windows, where the path is normalized before the walk as well.
+  describe.skipIf(isWindows)("mkdir -p with a trailing separator", () => {
+    // The walk used to hand the spelled name (`c/d/`) to mkdir(2) as well as the
+    // names it derives from it, which made -v report `d` twice; coreutils
+    // reports `c` and `c/d/`.
+    test("-v reports each created directory once, the operand as spelled", async () => {
+      await using dir = tempDir("mkdir-p-trailing-sep", {});
+      const { stdout, stderr, exitCode } = await $`mkdir -pv ${dir}/c/d/`.quiet();
+      expect(stderr.toString()).toBe("");
+      expect(stdout.toString()).toBe(`${dir}/c\n${dir}/c/d/\n`);
+      expect(exitCode).toBe(0);
+      expect(await readdir(join(dir, "c"))).toEqual(["d"]);
+    });
+
+    // mkdir(2) of `dangling/` creates the link's target on macOS and FreeBSD;
+    // the directory is created under the name `dangling` instead, which exists.
+    test("fails on a dangling symlink and creates nothing", async () => {
+      await using dir = tempDir("mkdir-p-dangling", {});
+      await symlink("missing", join(dir, "dangling"));
+      const { stdout, stderr, exitCode } = await $`mkdir -pv ${dir}/dangling/`.quiet();
+      expect(stdout.toString()).toBe("");
+      expect(stderr.toString()).toStartWith(`mkdir: ${dir}/dangling/: `);
+      expect(exitCode).toBe(1);
+      expect(await readdir(String(dir))).toEqual(["dangling"]);
     });
   });
 

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -305,6 +305,61 @@ describe("fs.mkdir - return values", () => {
   });
 });
 
+// The recursive mkdir creates the directories under their names without the
+// trailing separators (mkdir(2) of `link/` creates the link's target on macOS
+// and FreeBSD), but everything it reports keeps the path as spelled, like node.
+// Skipped on Windows, where the path is normalized before the walk.
+describe.skipIf(isWindows)("fs.mkdir - recursive with a trailing separator", () => {
+  let tmpdir: string;
+
+  beforeEach(() => {
+    tmpdir = getTmpDir();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpdir, { recursive: true, force: true });
+    } catch (err) {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("returns the path as spelled when it is the directory created", () => {
+    expect(fs.mkdirSync(`${tmpdir}/a/`, { recursive: true })).toBe(`${tmpdir}/a/`);
+    expect(fs.mkdirSync(`${tmpdir}/b//`, { recursive: true })).toBe(`${tmpdir}/b//`);
+    expect(fs.readdirSync(tmpdir).sort()).toEqual(["a", "b"]);
+  });
+
+  it("returns the first directory created when parents are created as well", async () => {
+    expect(fs.mkdirSync(`${tmpdir}/c/d/`, { recursive: true })).toBe(`${tmpdir}/c`);
+    expect(await fs.promises.mkdir(`${tmpdir}/e/f/`, { recursive: true })).toBe(`${tmpdir}/e`);
+    expect(fs.readdirSync(path.join(tmpdir, "c"))).toEqual(["d"]);
+    expect(fs.readdirSync(path.join(tmpdir, "e"))).toEqual(["f"]);
+  });
+
+  it("returns undefined when the directory already exists", () => {
+    fs.mkdirSync(path.join(tmpdir, "existing"));
+    expect(fs.mkdirSync(`${tmpdir}/existing/`, { recursive: true })).toBeUndefined();
+  });
+
+  // Before the trailing separator was dropped from the name given to mkdir(2),
+  // this created `missing` on macOS and FreeBSD. The code is EEXIST until the
+  // walk reports the stat error for an entry it cannot follow (node: ENOENT).
+  it("fails on a dangling symlink and creates nothing", async () => {
+    fs.symlinkSync("missing", path.join(tmpdir, "dangling"));
+
+    for (const pathname of [`${tmpdir}/dangling/`, `${tmpdir}/dangling//`]) {
+      const err = await fs.promises.mkdir(pathname, { recursive: true }).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toMatchObject({ syscall: "mkdir", path: pathname });
+      expect(["EEXIST", "ENOENT"]).toContain(err.code);
+    }
+    expect(fs.readdirSync(tmpdir)).toEqual(["dangling"]);
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/34413
 describe.skipIf(!isWindows)("fs.mkdir - recursive with ReadOnly attribute (Windows)", () => {
   let tmpdir: string;

--- a/test/js/node/fs/fs-mkdir.test.ts
+++ b/test/js/node/fs/fs-mkdir.test.ts
@@ -317,11 +317,7 @@ describe.skipIf(isWindows)("fs.mkdir - recursive with a trailing separator", () 
   });
 
   afterEach(() => {
-    try {
-      fs.rmSync(tmpdir, { recursive: true, force: true });
-    } catch (err) {
-      // Ignore cleanup errors
-    }
+    fs.rmSync(tmpdir, { recursive: true, force: true });
   });
 
   it("returns the path as spelled when it is the directory created", () => {


### PR DESCRIPTION
### Problem
- On macOS and FreeBSD, `Bun.write("dangling//f.txt", data)` with `dangling -> missing` (a symlink whose target does not exist) creates the directory `missing` and writes `missing/f.txt` through the link. `Bun.write("dangling/f.txt", data)` rejects with ENOENT, as do both spellings on Linux. `fs.mkdirSync("dangling/", { recursive: true })` and `mkdir -p /abs/dangling/` (the shell builtin) create `missing` the same way; node on Linux and coreutils `mkdir -p` both fail.
- Cause: `NodeFS::mkdir_recursive_os_path_impl` (`src/runtime/node/node_fs.rs`, the engine behind `fs.mkdir({ recursive })`, the shell builtin, `fs.cp`'s destination directories, `Bun__mkdirp` and `Bun.write`'s `createPath`) hands the name it is given to `mkdir(2)` verbatim, for its first attempt and again for its final one. Given a trailing separator, `mkdir(2)` on the BSD-derived kernels resolves a symlink at that name and creates the link's target; Linux returns EEXIST for `dangling/` and `dangling` alike. `Bun.write` reaches this with `dirname("dangling//f.txt")`, which is `"dangling/"` (`bun_core::dirname` keeps a separator run by contract); `fs.mkdir` and the builtin reach it with the user's own spelling.
- The same trailing separator is visible on Linux: because the walk also created the final directory under its `c/d/` spelling, `mkdir -pv /abs/c/d/` reported `d` twice (`c`, `c/d`, `c/d/`); coreutils reports `c` and `c/d/`.
- Found while working on #38222, which fixes the other place a separator run reaches `mkdir(2)` from this walk (the prefixes it derives itself, `dangling/` out of `dangling//out`). #38097 strips the separator for `fs.cp`'s single-file destinations at the call site; with this change that strip is covered by the engine.

### Fix
- `mkdir_name_len` computes the length of the name without its trailing separator run (a lone `/` stays; no-op on Windows), and the walk works on that length: the first attempt uses a trimmed copy when the spelling has a trailing separator (otherwise the caller's string, as before), and the final attempt, which already builds its name from the walk's buffer, gets the trimmed name for free.
- Everything the walk reports keeps the caller's spelling: the stat that decides whether an EEXIST is fine, the returned first directory, error paths and `on_create_dir` (the builtin's `-v`) all use `path` as given. That is node's behaviour, verified against node v26.3.0 on Linux: `mkdirSync("T/a/")` returns `T/a/`, `"T/b/c/"` returns `T/b`, `"T/d//"` returns `T/d//`, and the error for `"T/dangling/"` names `T/dangling/`. Using the spelled path for the stat also keeps `mkdirSync("file/")` distinguishable from `"file"` (node: ENOTDIR vs EEXIST), which #38146 relies on when it starts reporting the stat error.
- Why the engine and not the callers: the walk's invariant is that no name it gives `mkdir(2)` ends in a separator (its own comment before the final attempt already assumes this), and on Windows the engine's path conversion already normalizes that away; the POSIX side was the gap. Fixing it here covers every caller in one place instead of a strip per caller (the first version of this PR did it in `Blob.rs` only; #38097 adds another for `fs.cp`). Trimming inside `bun_core::dirname` would be the wrong layer: its non-collapsing contract is documented and widely relied on.
- Not trimmed on Windows: `CreateDirectory` has no such symlink behaviour, JS paths are normalized before the walk, and roots such as `\\?\C:\` must keep their separator.
- Tests:
  - `test/js/bun/shell/bunshell.test.ts`: `mkdir -pv /abs/c/d/` must print exactly `c` and `c/d/`. Fails on the unfixed build on Linux (three lines), passes with the fix; this is the Linux-observable half of the bug. Plus `mkdir -p /abs/dangling/` exits 1 and creates nothing.
  - `test/js/node/fs/fs-mkdir.test.ts`: the returned path for `a/`, `b//`, `c/d/`, `e/f/` and an existing `existing/` (the node values above), and `dangling/` / `dangling//` failing with the path as spelled and nothing created.
  - `test/js/bun/io/bun-write.test.js`: for each source kind (string, empty string, `Bun.file`, one per `Bun.write` code path) a write to `dangling/file` and `dangling//file` rejects and creates nothing, and a write to `a//b//file` creates `a/b/file`.
  - The symlink cases themselves are only observable on the darwin and FreeBSD kernels, so on Linux they pass before and after; the darwin CI lanes exercise them. They are skipped on Windows (normalized path; the reported code there also differs until #38146). The dangling cases accept EEXIST or ENOENT: bun reports EEXIST today and #38146 changes it to ENOENT (node's code), independently of this change.
- Verified: the three files above, `test/js/node/fs/cp.test.ts`, `fs.test.ts -t mkdir`, `test/cli/test/coverage.test.ts` (the `--coverage-dir` caller), the whole `bunshell.test.ts`, node's `test-fs-mkdir*.js` and all 77 `test-fs-cp-*` tests pass with the debug build; `cargo fmt` and `cargo clippy -p bun_runtime` are clean. On Linux a temporary print confirmed the name reaching `mkdir(2)` for `Bun.write` changes from `dangling/` (and `dangling//`) to `dangling` for all three source kinds, with user-visible results unchanged (details below).

### Background
- `fs.mkdir(p, { recursive: true })` in bun is `mkdir_recursive_os_path_impl`: it tries `mkdir(2)` on the full name; on ENOENT it walks up the path trying each prefix until one succeeds, then back down creating the rest, and finally creates the full name again. The shell's `mkdir -p`, `fs.cp`'s directory destinations, `Bun__mkdirp` and `Bun.write`'s `createPath` (which derives the parent with `dirname` after a failed open) all call it, so whatever string they pass reaches the kernel at least once.
- Node's `MKDirpSync` passes its argument to `mkdir(2)` as given and, on success or error, reports that spelling: the first directory it created is returned as spelled, and an EEXIST is followed by a `stat` of the spelled path to decide whether it is a directory. The change keeps all of that and only alters the name given to `mkdir(2)`.
- POSIX pathname resolution follows a symlink in the last component when a slash follows it; XNU and FreeBSD apply this to `mkdir(2)`, so `mkdir("link/")` creates the link's target. Linux reports EEXIST for any existing name given to `mkdir`, trailing slash or not, which is why the symlink half of the bug is platform specific and the `-v` half is not.
- A dangling symlink is one whose target does not exist: opening through it fails with ENOENT, creating something with its name fails with EEXIST.

<details>
<summary>Earlier version of this PR</summary>

The first revision stripped the separator run in `Blob.rs` only (a `parent_dir_to_create` helper used by `mkdir_if_not_exists` and the empty-source write), which fixed `Bun.write` but left `fs.mkdir`, the shell builtin and the other callers of the walk affected and duplicated the strip #38097 adds for `fs.cp`. Review pointed at the engine as the place that should hold the invariant; this revision moves it there and `Blob.rs` is unchanged from main (so #38167, which reworks the empty-source path in `Blob.rs` and keeps calling the recursive mkdir, is unaffected and covered).
</details>

<details>
<summary>Name handed to mkdir(2) by Bun.write before and after (Linux, temporary print)</summary>

Directory contains `dangling -> missing` and `src.txt`. Sources: `"x"`, `""`, `Bun.file("src.txt")`; identical for all three, shown once.

```
destination                  before                after
dangling/f.txt               "dangling"            "dangling"
dangling//f.txt              "dangling/"           "dangling"
dangling///f.txt             "dangling//"          "dangling"
/tmp/t/dangling//f.txt       "/tmp/t/dangling/"    "/tmp/t/dangling"
x//f.txt                     "x/"                  "x"            (created, file written)
```

Linux outcome before and after: the string and Bun.file writes reject with ENOENT, the empty write with EEXIST (the walk's error, see #38146), and the directory still holds only `dangling` and `src.txt`. On macOS and FreeBSD the `//` and `///` spellings created `missing` before this change.

Shell builtin on Linux, `mkdir -pv` with the absolute operand shown, before / after:

```
c/d/        c, c/d, c/d/   /   c, c/d/          (coreutils: c, c/d/)
a/          a/             /   a/
dangling/   exit 1, "File exists", nothing created, both
```
</details>
