### PR TITLE
napi: don't deliver terminations inside ungated functions

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -17,6 +17,7 @@
 
 #include "helpers.h"
 #include <JavaScriptCore/FrameTracers.h>
+#include <JavaScriptCore/VMTrapsInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <wtf/text/ExternalStringImpl.h>
@@ -106,50 +107,26 @@ using namespace Zig;
         NAPI_CHECK_ARG(_env, _env);        \
     } while (0)
 
-namespace {
-
-// JSC::SuspendExceptionScope, but only when an exception is pending on entry.
-class NapiSuspendExceptionScope {
-public:
-    explicit NapiSuspendExceptionScope(JSC::VM& vm)
-        : m_vm(vm)
-    {
-        if (vm.exceptionForInspection()) [[unlikely]] {
-            m_suspended.emplace(vm);
-        }
-    }
-
-    ~NapiSuspendExceptionScope()
-    {
-        if (!m_suspended) [[likely]] {
-            return;
-        }
-        // The trap behind a termination the body raised has fired; restoring over it would lose it.
-        bool bodyRaisedTermination = m_vm.hasPendingTerminationException();
-        m_suspended.reset();
-        if (bodyRaisedTermination) [[unlikely]] {
-            m_vm.throwTerminationException();
-        }
-    }
-
-    bool suspended() const { return m_suspended.has_value(); }
-
-private:
-    JSC::VM& m_vm;
-    std::optional<JSC::SuspendExceptionScope> m_suspended;
-};
-
-} // namespace
-
-// NAPI_PREAMBLE for what Node gates with CHECK_ENV only: callable while an exception is pending.
-#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                      \
-    NAPI_LOG_CURRENT_FUNCTION;                                                    \
-    NAPI_CHECK_ARG(_env, _env);                                                   \
-    NapiSuspendExceptionScope napi_preamble_suspended_exception__ { _env->vm() }; \
-    auto napi_preamble_throw_scope__ = DECLARE_TOP_EXCEPTION_SCOPE(_env->vm());   \
-    if (!napi_preamble_suspended_exception__.suspended()) {                       \
-        NAPI_RETURN_IF_VM_EXCEPTION(_env);                                        \
-    }
+// For the pure value constructors/accessors that Node implements with CHECK_ENV only: an addon may
+// call them while an exception is pending (node-addon-api builds the Error for a failed call this
+// way), and they never fail because a worker.terminate() / node:vm timeout has been requested. The
+// body must not run JS or addon callbacks.
+//
+// - An exception already on the VM is stashed so the body runs against a clean VM, and put back on
+//   return. Only when one is actually pending: JSC::SuspendExceptionScope restores the entry state
+//   unconditionally, so applied to a clean VM it would discard whatever the body raised.
+// - JSC::DeferTraps keeps the exception checks inside the body (its own and those in the JSC helpers
+//   it calls) from servicing VM traps, so a termination request that is waiting, or lands mid-call,
+//   stays a request and is delivered by the next check after the call returns instead of surfacing
+//   here as napi_pending_exception.
+#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                       \
+    NAPI_LOG_CURRENT_FUNCTION;                                                     \
+    NAPI_CHECK_ARG(_env, _env);                                                    \
+    std::optional<JSC::SuspendExceptionScope> napi_preamble_suspended_exception__; \
+    if (_env->vm().exceptionForInspection()) [[unlikely]]                          \
+        napi_preamble_suspended_exception__.emplace(_env->vm());                   \
+    JSC::DeferTraps napi_preamble_defer_traps__ { _env->vm() };                    \
+    auto napi_preamble_throw_scope__ = DECLARE_TOP_EXCEPTION_SCOPE(_env->vm());
 
 // Return an error code if arg is null. Only use for input validation.
 #define NAPI_CHECK_ARG(_env, arg)                               \
@@ -1478,23 +1455,19 @@ extern "C" napi_status napi_create_type_error(napi_env env, napi_value code,
     return createErrorWithNapiValues(env, code, msg, JSC::ErrorType::TypeError, result);
 }
 
-extern "C" JS_EXPORT napi_status
-node_api_create_external_string_latin1(napi_env env,
-    char* str,
-    size_t length,
-    napi_finalize finalize_callback,
-    void* finalize_hint,
-    napi_value* result,
-    bool* copied)
+// node_api_create_external_string_{latin1,utf16}. Sets `disposeNow` when nothing ended up
+// referencing the caller's buffer; the caller then runs the addon's finalizer itself, outside the
+// NAPI_PREAMBLE_NO_PENDING_CHECK scopes, which must not have addon code run under them.
+template<typename ExternalChar, typename Char>
+static napi_status createExternalString(napi_env env, Char* str, size_t length, napi_finalize finalize_callback, void* finalize_hint, napi_value* result, bool* copied, bool& disposeNow)
 {
-    // https://nodejs.org/api/n-api.html#node_api_create_external_string_latin1
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
     // Node's CHECK_NEW_STRING_ARGS: str may be null when length is 0.
     NAPI_RETURN_EARLY_IF_FALSE(env, length == 0 || str != nullptr, napi_invalid_arg);
     NAPI_CHECK_ARG(env, result);
     NAPI_RETURN_EARLY_IF_FALSE(env, length == NAPI_AUTO_LENGTH || length <= INT_MAX, napi_invalid_arg);
 
-    length = length == NAPI_AUTO_LENGTH ? strlen(str) : length;
+    length = length == NAPI_AUTO_LENGTH ? std::char_traits<Char>::length(str) : length;
     Zig::GlobalObject* globalObject = toJS(env);
 
     if (copied) {
@@ -1505,14 +1478,12 @@ node_api_create_external_string_latin1(napi_env env,
     // returning the empty string and disposing the caller's buffer immediately.
     if (length == 0) {
         *result = toNapi(JSC::jsEmptyString(JSC::getVM(globalObject)), globalObject);
-        env->doFinalizer(finalize_callback, str, finalize_hint);
-        // Ownership transferred; return ok even if doFinalizer promoted a
-        // pre-existing napi_throw to the VM, so the caller doesn't double-free.
-        return napi_set_last_error(env, napi_ok);
+        disposeNow = true;
+        NAPI_RETURN_SUCCESS(env);
     }
 
-    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const Latin1Character*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {
-        NAPI_LOG("latin1 string finalizer");
+    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const ExternalChar*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned) {
+        NAPI_LOG("external string finalizer");
         env->doFinalizer(finalize_callback, str, hint);
     });
 
@@ -1525,6 +1496,27 @@ node_api_create_external_string_latin1(napi_env env,
 }
 
 extern "C" JS_EXPORT napi_status
+node_api_create_external_string_latin1(napi_env env,
+    char* str,
+    size_t length,
+    napi_finalize finalize_callback,
+    void* finalize_hint,
+    napi_value* result,
+    bool* copied)
+{
+    // https://nodejs.org/api/n-api.html#node_api_create_external_string_latin1
+    bool disposeNow = false;
+    napi_status status = createExternalString<Latin1Character>(env, str, length, finalize_callback, finalize_hint, result, copied, disposeNow);
+    if (disposeNow) {
+        env->doFinalizer(finalize_callback, str, finalize_hint);
+        // Ownership transferred; still napi_ok if the finalizer left an exception pending, so the
+        // caller doesn't double-free.
+        return napi_set_last_error(env, napi_ok);
+    }
+    return status;
+}
+
+extern "C" JS_EXPORT napi_status
 node_api_create_external_string_utf16(napi_env env,
     char16_t* str,
     size_t length,
@@ -1534,40 +1526,13 @@ node_api_create_external_string_utf16(napi_env env,
     bool* copied)
 {
     // https://nodejs.org/api/n-api.html#node_api_create_external_string_utf16
-    NAPI_PREAMBLE_NO_PENDING_CHECK(env);
-    // Node's CHECK_NEW_STRING_ARGS: str may be null when length is 0.
-    NAPI_RETURN_EARLY_IF_FALSE(env, length == 0 || str != nullptr, napi_invalid_arg);
-    NAPI_CHECK_ARG(env, result);
-    NAPI_RETURN_EARLY_IF_FALSE(env, length == NAPI_AUTO_LENGTH || length <= INT_MAX, napi_invalid_arg);
-
-    length = length == NAPI_AUTO_LENGTH ? std::char_traits<char16_t>::length(str) : length;
-    Zig::GlobalObject* globalObject = toJS(env);
-
-    if (copied) {
-        *copied = false;
-    }
-
-    // WTF::ExternalStringImpl does not allow zero-length strings; match Node.js/V8 by
-    // returning the empty string and disposing the caller's buffer immediately.
-    if (length == 0) {
-        *result = toNapi(JSC::jsEmptyString(JSC::getVM(globalObject)), globalObject);
+    bool disposeNow = false;
+    napi_status status = createExternalString<char16_t>(env, str, length, finalize_callback, finalize_hint, result, copied, disposeNow);
+    if (disposeNow) {
         env->doFinalizer(finalize_callback, str, finalize_hint);
-        // Ownership transferred; return ok even if doFinalizer promoted a
-        // pre-existing napi_throw to the VM, so the caller doesn't double-free.
         return napi_set_last_error(env, napi_ok);
     }
-
-    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const char16_t*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {
-        NAPI_LOG("utf16 string finalizer");
-        env->doFinalizer(finalize_callback, str, hint);
-    });
-
-    JSString* out = JSC::jsString(JSC::getVM(globalObject), WTF::String(WTF::move(impl)));
-    ensureStillAliveHere(out);
-    *result = toNapi(out, globalObject);
-    ensureStillAliveHere(out);
-
-    NAPI_RETURN_SUCCESS(env);
+    return status;
 }
 
 extern "C" JS_EXPORT napi_status node_api_create_property_key_latin1(napi_env env, const char* str, size_t length, napi_value* result)
@@ -2925,7 +2890,6 @@ extern "C" napi_status napi_get_value_bigint_int64(napi_env env, napi_value valu
     JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isHeapBigInt(), napi_bigint_expected);
 
-    // Cannot throw for a bigint, but its exception check can deliver a pending termination.
     *result = jsValue.toBigInt64(toJS(env));
     NAPI_RETURN_IF_VM_EXCEPTION(env);
 
@@ -2959,7 +2923,6 @@ extern "C" napi_status napi_get_value_bigint_uint64(napi_env env, napi_value val
     JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isHeapBigInt(), napi_bigint_expected);
 
-    // Cannot throw for a bigint, but its exception check can deliver a pending termination.
     *result = jsValue.toBigUInt64(toJS(env));
     NAPI_RETURN_IF_VM_EXCEPTION(env);
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -107,17 +107,37 @@ using namespace Zig;
         NAPI_CHECK_ARG(_env, _env);        \
     } while (0)
 
-// NAPI_PREAMBLE for the value constructors/accessors Node gates with CHECK_ENV only: callable with an
-// exception pending (stashed for the call; only then, since the scope's restore is unconditional), and
-// never where a worker.terminate() / node:vm timeout is delivered (DeferTraps: the next exception check
-// after the call delivers it, as in Node). No JS or addon code may run under it.
-#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                       \
-    NAPI_LOG_CURRENT_FUNCTION;                                                     \
-    NAPI_CHECK_ARG(_env, _env);                                                    \
-    std::optional<JSC::SuspendExceptionScope> napi_preamble_suspended_exception__; \
-    if (_env->vm().exceptionForInspection()) [[unlikely]]                          \
-        napi_preamble_suspended_exception__.emplace(_env->vm());                   \
-    JSC::DeferTraps napi_preamble_defer_traps__ { _env->vm() };                    \
+// What the value constructors/accessors Node gates with CHECK_ENV only run under (NAPI_PREAMBLE_NO_PENDING_CHECK
+// here, `ungated!` in napi_body.rs): callable with an exception pending (stashed for the call; only then, since the
+// restore is unconditional) and never where a worker.terminate() / node:vm timeout is delivered (DeferTraps: the
+// next exception check after the call delivers it, as in Node). No JS or addon code may run under it.
+struct NapiUngatedScope {
+    explicit NapiUngatedScope(JSC::VM& vm)
+        : deferTraps(vm)
+    {
+        if (vm.exceptionForInspection()) [[unlikely]]
+            suspended.emplace(vm);
+    }
+    std::optional<JSC::SuspendExceptionScope> suspended;
+    JSC::DeferTraps deferTraps;
+};
+
+// Constructed in place in storage owned by the Rust caller (napi_body.rs `UngatedScope`).
+static_assert(sizeof(NapiUngatedScope) <= 80 && alignof(NapiUngatedScope) <= 8, "napi_body.rs UngatedScope storage is 80 bytes, 8-aligned");
+extern "C" void NapiUngatedScope__construct(void* storage, napi_env env)
+{
+    ASSERT(reinterpret_cast<uintptr_t>(storage) % alignof(NapiUngatedScope) == 0);
+    new (storage) NapiUngatedScope(env->vm());
+}
+extern "C" void NapiUngatedScope__destruct(void* storage)
+{
+    static_cast<NapiUngatedScope*>(storage)->~NapiUngatedScope();
+}
+
+#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                 \
+    NAPI_LOG_CURRENT_FUNCTION;                               \
+    NAPI_CHECK_ARG(_env, _env);                              \
+    NapiUngatedScope napi_preamble_ungated__ { _env->vm() }; \
     auto napi_preamble_throw_scope__ = DECLARE_TOP_EXCEPTION_SCOPE(_env->vm());
 
 // Return an error code if arg is null. Only use for input validation.

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -107,18 +107,10 @@ using namespace Zig;
         NAPI_CHECK_ARG(_env, _env);        \
     } while (0)
 
-// For the pure value constructors/accessors that Node implements with CHECK_ENV only: an addon may
-// call them while an exception is pending (node-addon-api builds the Error for a failed call this
-// way), and they never fail because a worker.terminate() / node:vm timeout has been requested. The
-// body must not run JS or addon callbacks.
-//
-// - An exception already on the VM is stashed so the body runs against a clean VM, and put back on
-//   return. Only when one is actually pending: JSC::SuspendExceptionScope restores the entry state
-//   unconditionally, so applied to a clean VM it would discard whatever the body raised.
-// - JSC::DeferTraps keeps the exception checks inside the body (its own and those in the JSC helpers
-//   it calls) from servicing VM traps, so a termination request that is waiting, or lands mid-call,
-//   stays a request and is delivered by the next check after the call returns instead of surfacing
-//   here as napi_pending_exception.
+// NAPI_PREAMBLE for the value constructors/accessors Node gates with CHECK_ENV only: callable with an
+// exception pending (stashed for the call; only then, since the scope's restore is unconditional), and
+// never where a worker.terminate() / node:vm timeout is delivered (DeferTraps: the next exception check
+// after the call delivers it, as in Node). No JS or addon code may run under it.
 #define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                       \
     NAPI_LOG_CURRENT_FUNCTION;                                                     \
     NAPI_CHECK_ARG(_env, _env);                                                    \
@@ -1455,9 +1447,8 @@ extern "C" napi_status napi_create_type_error(napi_env env, napi_value code,
     return createErrorWithNapiValues(env, code, msg, JSC::ErrorType::TypeError, result);
 }
 
-// node_api_create_external_string_{latin1,utf16}. Sets `disposeNow` when nothing ended up
-// referencing the caller's buffer; the caller then runs the addon's finalizer itself, outside the
-// NAPI_PREAMBLE_NO_PENDING_CHECK scopes, which must not have addon code run under them.
+// node_api_create_external_string_{latin1,utf16}. On `disposeNow` the caller runs the addon's
+// finalizer itself, once this function's preamble scopes have closed.
 template<typename ExternalChar, typename Char>
 static napi_status createExternalString(napi_env env, Char* str, size_t length, napi_finalize finalize_callback, void* finalize_hint, napi_value* result, bool* copied, bool& disposeNow)
 {
@@ -1509,8 +1500,7 @@ node_api_create_external_string_latin1(napi_env env,
     napi_status status = createExternalString<Latin1Character>(env, str, length, finalize_callback, finalize_hint, result, copied, disposeNow);
     if (disposeNow) {
         env->doFinalizer(finalize_callback, str, finalize_hint);
-        // Ownership transferred; still napi_ok if the finalizer left an exception pending, so the
-        // caller doesn't double-free.
+        // napi_ok even if the finalizer threw: the buffer is consumed either way.
         return napi_set_last_error(env, napi_ok);
     }
     return status;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1447,8 +1447,7 @@ extern "C" napi_status napi_create_type_error(napi_env env, napi_value code,
     return createErrorWithNapiValues(env, code, msg, JSC::ErrorType::TypeError, result);
 }
 
-// node_api_create_external_string_{latin1,utf16}. On `disposeNow` the caller runs the addon's
-// finalizer itself, once this function's preamble scopes have closed.
+// On `disposeNow` the caller runs the addon's finalizer, which must not run under this function's preamble.
 template<typename ExternalChar, typename Char>
 static napi_status createExternalString(napi_env env, Char* str, size_t length, napi_finalize finalize_callback, void* finalize_hint, napi_value* result, bool* copied, bool& disposeNow)
 {

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -106,16 +106,63 @@ using namespace Zig;
         NAPI_CHECK_ARG(_env, _env);        \
     } while (0)
 
+namespace {
+
+// The exception handling behind NAPI_PREAMBLE_NO_PENDING_CHECK. An exception that is already on the
+// VM on entry (a termination an earlier call materialised while a worker is being stopped, or one a
+// JSC internal left behind) is stashed so the body runs against a clean VM, and put back on return.
+// With nothing pending the VM is left alone, so whatever the body raises stays pending, as after
+// NAPI_PREAMBLE.
+//
+// The restore must not undo a TerminationException the body raised: the body's exception checks
+// service VM traps, which is how a node:vm timeout or worker.terminate() becomes an exception, and
+// the trap fires only once. A bare JSC::SuspendExceptionScope puts the entry state back
+// unconditionally, which dropped the termination and left the calling JS running forever.
+class NapiSuspendExceptionScope {
+public:
+    explicit NapiSuspendExceptionScope(JSC::VM& vm)
+        : m_vm(vm)
+    {
+        if (vm.exceptionForInspection()) [[unlikely]] {
+            m_suspended.emplace(vm);
+        }
+    }
+
+    ~NapiSuspendExceptionScope()
+    {
+        if (!m_suspended) [[likely]] {
+            return;
+        }
+        bool bodyRaisedTermination = m_vm.hasPendingTerminationException();
+        m_suspended.reset();
+        if (bodyRaisedTermination) [[unlikely]] {
+            m_vm.throwTerminationException();
+        }
+    }
+
+    bool suspended() const { return m_suspended.has_value(); }
+
+private:
+    JSC::VM& m_vm;
+    std::optional<JSC::SuspendExceptionScope> m_suspended;
+};
+
+} // namespace
+
 // Like NAPI_PREAMBLE but for pure value constructors/accessors, which Node lets an addon call while
 // an exception is pending (CHECK_ENV_NOT_IN_GC only) — node-addon-api relies on that to build the
-// Error it wraps a failed call in. Any exception already on the VM (a napi_throw*, or a termination
-// request that materialised in an earlier call while a worker is being stopped) is stashed for the
-// duration and restored on return; the throw scope still catches what the body itself raises.
-#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                       \
-    NAPI_LOG_CURRENT_FUNCTION;                                                     \
-    NAPI_CHECK_ARG(_env, _env);                                                    \
-    JSC::SuspendExceptionScope napi_preamble_suspended_exception__ { _env->vm() }; \
-    auto napi_preamble_throw_scope__ = DECLARE_TOP_EXCEPTION_SCOPE(_env->vm());
+// Error it wraps a failed call in. An exception already on the VM is stashed for the duration of the
+// call and restored on return (see NapiSuspendExceptionScope). With nothing pending this behaves like
+// NAPI_PREAMBLE minus the env check: the exception check services VM traps, so a termination that
+// is waiting to be delivered is raised here and reported as napi_pending_exception.
+#define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                      \
+    NAPI_LOG_CURRENT_FUNCTION;                                                    \
+    NAPI_CHECK_ARG(_env, _env);                                                   \
+    NapiSuspendExceptionScope napi_preamble_suspended_exception__ { _env->vm() }; \
+    auto napi_preamble_throw_scope__ = DECLARE_TOP_EXCEPTION_SCOPE(_env->vm());   \
+    if (!napi_preamble_suspended_exception__.suspended()) {                       \
+        NAPI_RETURN_IF_VM_EXCEPTION(_env);                                        \
+    }
 
 // Return an error code if arg is null. Only use for input validation.
 #define NAPI_CHECK_ARG(_env, arg)                               \
@@ -2891,9 +2938,10 @@ extern "C" napi_status napi_get_value_bigint_int64(napi_env env, napi_value valu
     JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isHeapBigInt(), napi_bigint_expected);
 
-    // toBigInt64 can throw if the value is not a bigint. we have already checked, so we shouldn't
-    // hit an exception here and it's okay to assert at the end
+    // The value is a bigint so the conversion itself cannot throw, but its exception check services
+    // VM traps, so a termination can become pending here.
     *result = jsValue.toBigInt64(toJS(env));
+    NAPI_RETURN_IF_VM_EXCEPTION(env);
 
     JSBigInt* bigint = jsValue.asHeapBigInt();
     auto length = bigint->length();
@@ -2925,8 +2973,8 @@ extern "C" napi_status napi_get_value_bigint_uint64(napi_env env, napi_value val
     JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isHeapBigInt(), napi_bigint_expected);
 
-    // toBigInt64 can throw if the value is not a bigint. we have already checked, so we shouldn't
-    // hit an exception here and it's okay to assert at the end
+    // As in napi_get_value_bigint_int64: the conversion cannot throw for a bigint, but its exception
+    // check services VM traps.
     *result = jsValue.toBigUInt64(toJS(env));
     NAPI_RETURN_IF_VM_EXCEPTION(env);
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -108,16 +108,10 @@ using namespace Zig;
 
 namespace {
 
-// The exception handling behind NAPI_PREAMBLE_NO_PENDING_CHECK. An exception that is already on the
-// VM on entry (a termination an earlier call materialised while a worker is being stopped, or one a
-// JSC internal left behind) is stashed so the body runs against a clean VM, and put back on return.
-// With nothing pending the VM is left alone, so whatever the body raises stays pending, as after
-// NAPI_PREAMBLE.
-//
-// The restore must not undo a TerminationException the body raised: the body's exception checks
-// service VM traps, which is how a node:vm timeout or worker.terminate() becomes an exception, and
-// the trap fires only once. A bare JSC::SuspendExceptionScope puts the entry state back
-// unconditionally, which dropped the termination and left the calling JS running forever.
+// Stashes an exception that is already pending when an ungated function is entered and puts it back
+// on return, except that a TerminationException the body raised in between wins: the body's exception
+// checks service VM traps (a node:vm timeout or worker.terminate() becomes an exception there, once),
+// and restoring the entry state over it would leave the calling script running forever.
 class NapiSuspendExceptionScope {
 public:
     explicit NapiSuspendExceptionScope(JSC::VM& vm)
@@ -150,11 +144,9 @@ private:
 } // namespace
 
 // Like NAPI_PREAMBLE but for pure value constructors/accessors, which Node lets an addon call while
-// an exception is pending (CHECK_ENV_NOT_IN_GC only) — node-addon-api relies on that to build the
-// Error it wraps a failed call in. An exception already on the VM is stashed for the duration of the
-// call and restored on return (see NapiSuspendExceptionScope). With nothing pending this behaves like
-// NAPI_PREAMBLE minus the env check: the exception check services VM traps, so a termination that
-// is waiting to be delivered is raised here and reported as napi_pending_exception.
+// an exception is pending (CHECK_ENV_NOT_IN_GC only); node-addon-api relies on that to build the
+// Error for a failed call. With nothing pending it checks for exceptions like NAPI_PREAMBLE does,
+// which also delivers a waiting termination as napi_pending_exception.
 #define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                      \
     NAPI_LOG_CURRENT_FUNCTION;                                                    \
     NAPI_CHECK_ARG(_env, _env);                                                   \
@@ -2938,8 +2930,7 @@ extern "C" napi_status napi_get_value_bigint_int64(napi_env env, napi_value valu
     JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isHeapBigInt(), napi_bigint_expected);
 
-    // The value is a bigint so the conversion itself cannot throw, but its exception check services
-    // VM traps, so a termination can become pending here.
+    // Cannot throw for a bigint, but its exception check can deliver a pending termination.
     *result = jsValue.toBigInt64(toJS(env));
     NAPI_RETURN_IF_VM_EXCEPTION(env);
 
@@ -2973,8 +2964,7 @@ extern "C" napi_status napi_get_value_bigint_uint64(napi_env env, napi_value val
     JSValue jsValue = toJS(value);
     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isHeapBigInt(), napi_bigint_expected);
 
-    // As in napi_get_value_bigint_int64: the conversion cannot throw for a bigint, but its exception
-    // check services VM traps.
+    // Cannot throw for a bigint, but its exception check can deliver a pending termination.
     *result = jsValue.toBigUInt64(toJS(env));
     NAPI_RETURN_IF_VM_EXCEPTION(env);
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -108,10 +108,7 @@ using namespace Zig;
 
 namespace {
 
-// Stashes an exception that is already pending when an ungated function is entered and puts it back
-// on return, except that a TerminationException the body raised in between wins: the body's exception
-// checks service VM traps (a node:vm timeout or worker.terminate() becomes an exception there, once),
-// and restoring the entry state over it would leave the calling script running forever.
+// JSC::SuspendExceptionScope, but only when an exception is pending on entry.
 class NapiSuspendExceptionScope {
 public:
     explicit NapiSuspendExceptionScope(JSC::VM& vm)
@@ -127,6 +124,7 @@ public:
         if (!m_suspended) [[likely]] {
             return;
         }
+        // The trap behind a termination the body raised has fired; restoring over it would lose it.
         bool bodyRaisedTermination = m_vm.hasPendingTerminationException();
         m_suspended.reset();
         if (bodyRaisedTermination) [[unlikely]] {
@@ -143,10 +141,8 @@ private:
 
 } // namespace
 
-// Like NAPI_PREAMBLE but for pure value constructors/accessors, which Node lets an addon call while
-// an exception is pending (CHECK_ENV_NOT_IN_GC only); node-addon-api relies on that to build the
-// Error for a failed call. With nothing pending it checks for exceptions like NAPI_PREAMBLE does,
-// which also delivers a waiting termination as napi_pending_exception.
+// NAPI_PREAMBLE for the pure value constructors/accessors that Node gates with CHECK_ENV only: they
+// keep working while an exception is pending, which node-addon-api relies on to build its Error.
 #define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                      \
     NAPI_LOG_CURRENT_FUNCTION;                                                    \
     NAPI_CHECK_ARG(_env, _env);                                                   \

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -141,8 +141,7 @@ private:
 
 } // namespace
 
-// NAPI_PREAMBLE for the pure value constructors/accessors that Node gates with CHECK_ENV only: they
-// keep working while an exception is pending, which node-addon-api relies on to build its Error.
+// NAPI_PREAMBLE for what Node gates with CHECK_ENV only: callable while an exception is pending.
 #define NAPI_PREAMBLE_NO_PENDING_CHECK(_env)                                      \
     NAPI_LOG_CURRENT_FUNCTION;                                                    \
     NAPI_CHECK_ARG(_env, _env);                                                   \

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -495,8 +495,7 @@ impl Drop for UngatedScopeGuard<'_> {
     }
 }
 
-/// `let $env = get_env!($raw)`, and the rest of the function runs under napi.cpp's `NapiUngatedScope` (which see):
-/// for what Node gates with `CHECK_ENV` only. The body must not run JS or addon code.
+/// `get_env!`, then the rest of the function runs under napi.cpp's `NapiUngatedScope` (which see): no JS or addon code.
 macro_rules! ungated {
     ($env:ident, $raw:expr) => {
         let $env = get_env!($raw);

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -96,6 +96,8 @@ unsafe extern "C" {
     /// The reference to its VM's handle the env holds (`BunVmHandleRef`).
     fn NapiEnv__vmHandle(env: *mut NapiEnv) -> *const bun_jsc::vm_handle::Shared;
     fn napi_set_last_error(env: napi_env, status: NapiStatus) -> napi_status;
+    fn NapiUngatedScope__construct(storage: *mut c_void, env: *mut NapiEnv);
+    fn NapiUngatedScope__destruct(storage: *mut c_void);
 }
 
 impl NapiEnv {
@@ -465,6 +467,44 @@ macro_rules! preamble {
     }};
 }
 
+/// napi.cpp's `NapiUngatedScope` (see the comment there), constructed in place in this storage.
+#[repr(C, align(8))]
+struct UngatedScope([core::mem::MaybeUninit<u8>; 80]);
+
+struct UngatedScopeGuard<'a>(&'a mut UngatedScope);
+
+impl UngatedScope {
+    #[inline]
+    fn enter<'a>(
+        storage: &'a mut core::mem::MaybeUninit<UngatedScope>,
+        env: &NapiEnv,
+    ) -> UngatedScopeGuard<'a> {
+        let this = storage.write(UngatedScope([core::mem::MaybeUninit::uninit(); 80]));
+        // SAFETY: storage is 80 bytes, 8-aligned, and stays put until the guard drops; napi.cpp
+        // static_asserts that NapiUngatedScope fits.
+        unsafe { NapiUngatedScope__construct(this.0.as_mut_ptr().cast(), env.as_mut_ptr()) };
+        UngatedScopeGuard(this)
+    }
+}
+
+impl Drop for UngatedScopeGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: constructed by `enter`, destroyed exactly once here.
+        unsafe { NapiUngatedScope__destruct(self.0.0.as_mut_ptr().cast()) };
+    }
+}
+
+/// `let $env = get_env!($raw)`, and the rest of the function runs under napi.cpp's `NapiUngatedScope` (which see):
+/// for what Node gates with `CHECK_ENV` only. The body must not run JS or addon code.
+macro_rules! ungated {
+    ($env:ident, $raw:expr) => {
+        let $env = get_env!($raw);
+        let mut napi_ungated_storage = ::core::mem::MaybeUninit::<UngatedScope>::uninit();
+        let _napi_ungated_scope = UngatedScope::enter(&mut napi_ungated_storage, $env);
+    };
+}
+
 macro_rules! get_out {
     ($env:expr, $ptr:expr) => {
         // SAFETY: caller passes raw out pointer; we treat non-null as &mut borrow.
@@ -514,7 +554,7 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 extern "C" fn napi_get_undefined(env_: napi_env, result_: *mut napi_value) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_undefined");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     result.set(env, JSValue::UNDEFINED);
@@ -524,7 +564,7 @@ extern "C" fn napi_get_undefined(env_: napi_env, result_: *mut napi_value) -> na
 #[unsafe(no_mangle)]
 extern "C" fn napi_get_null(env_: napi_env, result_: *mut napi_value) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_null");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     result.set(env, JSValue::NULL);
@@ -542,7 +582,7 @@ extern "C" fn napi_get_boolean(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_boolean");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     result.set(env, JSValue::from(value));
@@ -552,7 +592,7 @@ extern "C" fn napi_get_boolean(
 #[unsafe(no_mangle)]
 extern "C" fn napi_create_array(env_: napi_env, result_: *mut napi_value) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_array");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     let arr = match JSValue::create_empty_array(env.to_js(), 0) {
@@ -570,7 +610,7 @@ extern "C" fn napi_create_array_with_length(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_array_with_length");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
 
@@ -605,7 +645,7 @@ extern "C" fn napi_create_int32(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_int32");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     result.set(env, JSValue::js_number(value as f64));
@@ -619,7 +659,7 @@ extern "C" fn napi_create_uint32(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_uint32");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     result.set(env, JSValue::js_number(value as f64));
@@ -633,7 +673,7 @@ extern "C" fn napi_create_int64(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_create_int64");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     result.set(env, JSValue::js_number(value as f64));
@@ -647,7 +687,7 @@ extern "C" fn napi_create_string_latin1(
     length: usize,
     result_: *mut napi_value,
 ) -> napi_status {
-    let env = get_env!(env_);
+    ungated!(env, env_);
     let result = get_out!(env, result_);
 
     let slice: &[u8] = 'brk: {
@@ -703,7 +743,7 @@ extern "C" fn napi_create_string_utf8(
     length: usize,
     result_: *mut napi_value,
 ) -> napi_status {
-    let env = get_env!(env_);
+    ungated!(env, env_);
     let result = get_out!(env, result_);
 
     let slice: &[u8] = 'brk: {
@@ -744,7 +784,7 @@ extern "C" fn napi_create_string_utf16(
     length: usize,
     result_: *mut napi_value,
 ) -> napi_status {
-    let env = get_env!(env_);
+    ungated!(env, env_);
     let result = get_out!(env, result_);
 
     let slice: &[u16] = 'brk: {
@@ -969,7 +1009,7 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 extern "C" fn napi_is_array(env_: napi_env, value_: napi_value, result_: *mut bool) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_array");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     let value = value_.get();
@@ -1132,7 +1172,7 @@ extern "C" fn napi_open_handle_scope(
     result_: *mut napi_handle_scope,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_open_handle_scope");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     *result = NapiHandleScope::open(env, false);
@@ -1145,7 +1185,7 @@ extern "C" fn napi_close_handle_scope(
     handle_scope: napi_handle_scope,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_close_handle_scope");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     if !handle_scope.is_null() {
         NapiHandleScope::close(handle_scope, env);
@@ -1235,7 +1275,7 @@ extern "C" fn napi_open_escapable_handle_scope(
     result_: *mut napi_escapable_handle_scope,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_open_escapable_handle_scope");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     *result = NapiHandleScope::open(env, true);
@@ -1248,7 +1288,7 @@ extern "C" fn napi_close_escapable_handle_scope(
     scope: napi_escapable_handle_scope,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_close_escapable_handle_scope");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     if !scope.is_null() {
         NapiHandleScope::close(scope, env);
@@ -1264,7 +1304,7 @@ extern "C" fn napi_escape_handle(
     result_: *mut napi_value,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_escape_handle");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     // SAFETY: scope_ is a raw NAPI handle; non-null is treated as &NapiHandleScope.
@@ -1332,7 +1372,7 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 extern "C" fn napi_is_error(env_: napi_env, value_: napi_value, result_: *mut bool) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_error");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let value = value_.get();
     if value.is_empty() {
@@ -1358,7 +1398,7 @@ extern "C" fn napi_is_arraybuffer(
     result_: *mut bool,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_arraybuffer");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let result = get_out!(env, result_);
     let value = value_.get();
@@ -1403,7 +1443,7 @@ extern "C" fn napi_get_arraybuffer_info(
     byte_length: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_arraybuffer_info");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let arraybuffer = arraybuffer_.get();
     let Some(array_buffer) = arraybuffer.as_array_buffer(env.to_js()) else {
@@ -1437,7 +1477,7 @@ extern "C" fn napi_get_typedarray_info(
     maybe_byte_offset: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_typedarray_info");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let typedarray = typedarray_.get();
     if typedarray.is_empty_or_undefined_or_null() {
@@ -1498,7 +1538,7 @@ extern "C" fn napi_is_dataview(
     result_: *mut bool,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_dataview");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     let result = get_out!(env, result_);
     let value = value_.get();
     if value.is_empty() {
@@ -1519,7 +1559,7 @@ extern "C" fn napi_get_dataview_info(
     maybe_byte_offset: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_dataview_info");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let dataview = dataview_.get();
     if dataview.is_empty() {
@@ -1616,7 +1656,7 @@ extern "C" fn napi_is_promise(
     is_promise_: *mut bool,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_promise");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let value = value_.get();
     let is_promise = get_out!(env, is_promise_);
@@ -1657,7 +1697,7 @@ extern "C" fn napi_create_date(env_: napi_env, time: f64, result_: *mut napi_val
 #[unsafe(no_mangle)]
 extern "C" fn napi_is_date(env_: napi_env, value_: napi_value, is_date_: *mut bool) -> napi_status {
     bun_output::scoped_log!(napi, "napi_is_date");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     env.check_gc();
     let is_date = get_out!(env, is_date_);
     let value = value_.get();
@@ -2061,7 +2101,7 @@ extern "C" fn napi_get_buffer_info(
     length: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_buffer_info");
-    let env = get_env!(env_);
+    ungated!(env, env_);
     let value = value_.get();
     // Keep the pointer valid for the buffer's lifetime, as in Node.
     if !data.is_null() && !value.materialize_array_buffer_view_buffer() {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1453,10 +1453,9 @@ nativeTests.test_threadsafe_function_microtask_order = async () => {
 };
 
 // A script that only ever calls the ungated napi functions (ungated-calls-
-// spin-worker.js has the worker version) still has to be stoppable: the
-// termination is delivered inside one of those calls and must come back out of
-// it. Several rounds, since whether it lands inside a call or in the loop
-// itself is down to timing.
+// spin-worker.js has the worker version) still has to be stoppable when the
+// stop is requested while one of those calls is running. Several rounds, since
+// whether it lands inside a call or in the loop itself is down to timing.
 nativeTests.test_ungated_calls_vm_timeout = () => {
   const vm = require("node:vm");
   const spin = nativeTests.make_ungated_calls_spinner();
@@ -1483,11 +1482,12 @@ nativeTests.test_ungated_calls_worker_terminate = async () => {
   }
 };
 
-// Bun-only, see ungated_calls_until_terminated in standalone_tests.cpp.
-nativeTests.test_ungated_calls_termination_with_engine_exception = () => {
+// See ungated_calls_through_timeout in standalone_tests.cpp: 200ms of ungated
+// calls under a 20ms timeout.
+nativeTests.test_ungated_calls_through_vm_timeout = () => {
   const vm = require("node:vm");
   try {
-    vm.runInNewContext("f()", { f: nativeTests.ungated_calls_until_terminated }, { timeout: 20 });
+    vm.runInNewContext("f(200)", { f: nativeTests.ungated_calls_through_timeout }, { timeout: 20 });
     console.log("returned");
   } catch (e) {
     console.log(e.code);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1452,4 +1452,46 @@ nativeTests.test_threadsafe_function_microtask_order = async () => {
   }
 };
 
+// A script that only ever calls the ungated napi functions (ungated-calls-
+// spin-worker.js has the worker version) still has to be stoppable: the
+// termination is delivered inside one of those calls and must come back out of
+// it. Several rounds, since whether it lands inside a call or in the loop
+// itself is down to timing.
+nativeTests.test_ungated_calls_vm_timeout = () => {
+  const vm = require("node:vm");
+  const spin = nativeTests.make_ungated_calls_spinner();
+  for (let i = 0; i < 5; i++) {
+    try {
+      vm.runInNewContext("for (;;) spin(bigint, string);", { spin, bigint: -7n, string: "ungated" }, { timeout: 20 });
+      console.log("returned");
+    } catch (e) {
+      console.log(e.code);
+    }
+  }
+};
+
+nativeTests.test_ungated_calls_worker_terminate = async () => {
+  const { Worker } = require("node:worker_threads");
+  const path = require("node:path");
+  for (let i = 0; i < 2; i++) {
+    const worker = new Worker(path.join(__dirname, "ungated-calls-spin-worker.js"));
+    await new Promise((resolve, reject) => {
+      worker.once("message", resolve);
+      worker.once("error", reject);
+    });
+    console.log("terminate() resolved with", await worker.terminate());
+  }
+};
+
+// Bun-only, see ungated_calls_until_terminated in standalone_tests.cpp.
+nativeTests.test_ungated_calls_termination_with_engine_exception = () => {
+  const vm = require("node:vm");
+  try {
+    vm.runInNewContext("f()", { f: nativeTests.ungated_calls_until_terminated }, { timeout: 20 });
+    console.log("returned");
+  } catch (e) {
+    console.log(e.code);
+  }
+};
+
 module.exports = nativeTests;

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -3085,6 +3085,9 @@ ungated_calls_until_terminated(const Napi::CallbackInfo &info) {
   napi_is_exception_pending(env, &pending);
   printf("pending after napi_get_and_clear_last_exception: %s\n",
          pending ? "true" : "false");
+  // The driver prints the vm error after this returns; on Windows (no
+  // BlockingStdoutScope) a piped stdout is otherwise only flushed at exit.
+  fflush(stdout);
   return nullptr;
 }
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2920,6 +2920,174 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// The ungated functions (see test_pending_exception_gate) whose bodies contain
+// an exception check: a bigint, a string and a symbol round trip. Statuses are
+// ignored on purpose.
+static void ungated_calls_round(napi_env env, napi_value bigint,
+                                napi_value string) {
+  int64_t i64 = 0;
+  uint64_t u64 = 0;
+  bool lossless = false;
+  napi_get_value_bigint_int64(env, bigint, &i64, &lossless);
+  napi_get_value_bigint_uint64(env, bigint, &u64, &lossless);
+
+  char utf8[16];
+  char16_t utf16[16];
+  size_t written = 0;
+  napi_get_value_string_utf8(env, string, utf8, sizeof utf8, &written);
+  napi_get_value_string_utf16(env, string, utf16, 16, &written);
+
+  napi_value out = nullptr;
+  napi_create_bigint_int64(env, i64, &out);
+  napi_create_bigint_uint64(env, u64, &out);
+  napi_create_symbol(env, string, &out);
+}
+
+// spin(bigint, string): a callback that does nothing but ungated calls, for a
+// script or worker to loop on while it gets terminated (node:vm `timeout`,
+// worker.terminate()). The termination is delivered at whichever exception
+// check comes first; several rounds per call keep that inside one of these
+// calls nearly every time, and it has to come back out of the call for the
+// loop to end. A plain napi_callback rather than a Napi::Function, because
+// node-addon-api aborts the process if one of its own calls fails once the
+// termination is pending.
+static napi_value ungated_calls_spin(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value argv[2];
+  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok) {
+    return nullptr;
+  }
+  for (int i = 0; i < 32; i++) {
+    ungated_calls_round(env, argv[0], argv[1]);
+  }
+  return nullptr;
+}
+
+static napi_value make_ungated_calls_spinner(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value spin;
+  NODE_API_CALL(env, napi_create_function(env, "spin", NAPI_AUTO_LENGTH,
+                                          ungated_calls_spin, nullptr, &spin));
+  return spin;
+}
+
+// Leaves an exception pending on the engine itself, not just recorded by
+// napi_throw_error: Bun's napi_call_function raises the recorded exception
+// before refusing the call. Returns false if the setup failed (an error has
+// been thrown in that case).
+static bool arm_engine_exception(napi_env env) {
+  napi_value global, noop;
+  NODE_API_CALL_CUSTOM_RETURN(env, false, napi_get_global(env, &global));
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, false,
+      napi_create_function(
+          env, "noop", NAPI_AUTO_LENGTH,
+          [](napi_env, napi_callback_info) -> napi_value { return nullptr; },
+          nullptr, &noop));
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, false, napi_throw_error(env, "EPENDING", "still pending"));
+  printf("napi_call_function: status=%d\n",
+         (int)napi_call_function(env, global, noop, 0, nullptr, nullptr));
+  return true;
+}
+
+// The ungated calls while an engine exception is pending must succeed
+// (test_pending_exception_gate checks the recorded case) and that exception
+// must still be the one pending afterwards.
+static napi_value
+test_ungated_calls_with_engine_exception(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+#ifndef _WIN32
+  BlockingStdoutScope stdout_scope;
+#endif
+
+  napi_value bigint, string;
+  NODE_API_CALL(env, napi_create_bigint_int64(env, -7, &bigint));
+  NODE_API_CALL(
+      env, napi_create_string_utf8(env, "ungated", NAPI_AUTO_LENGTH, &string));
+  if (!arm_engine_exception(env)) {
+    return nullptr;
+  }
+
+  int64_t i64 = 0;
+  uint64_t u64 = 0;
+  bool lossless = false;
+  char utf8[16] = {0};
+  size_t written = 0;
+  napi_value out;
+  napi_status st;
+  st = napi_get_value_bigint_int64(env, bigint, &i64, &lossless);
+  printf("napi_get_value_bigint_int64: status=%d value=%" PRId64 "\n", (int)st,
+         i64);
+  st = napi_get_value_bigint_uint64(env, bigint, &u64, &lossless);
+  printf("napi_get_value_bigint_uint64: status=%d lossless=%d\n", (int)st,
+         (int)lossless);
+  st = napi_get_value_string_utf8(env, string, utf8, sizeof utf8, &written);
+  printf("napi_get_value_string_utf8: status=%d value=%s\n", (int)st, utf8);
+  st = napi_create_bigint_int64(env, i64, &out);
+  printf("napi_create_bigint_int64: status=%d\n", (int)st);
+  st = napi_create_bigint_uint64(env, u64, &out);
+  printf("napi_create_bigint_uint64: status=%d\n", (int)st);
+  st = napi_create_symbol(env, string, &out);
+  printf("napi_create_symbol: status=%d\n", (int)st);
+
+  bool pending = false;
+  napi_is_exception_pending(env, &pending);
+  printf("exception pending after: %s\n", pending ? "true" : "false");
+
+  napi_value exception, code;
+  NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exception));
+  NODE_API_CALL(env, napi_get_named_property(env, exception, "code", &code));
+  char code_buf[32] = {0};
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, code, code_buf,
+                                                sizeof code_buf, nullptr));
+  printf("pending exception code: %s\n", code_buf);
+
+  return ok(env);
+}
+
+// Bun-only. Run from a node:vm script with a `timeout`: with an engine
+// exception pending, keeps making an ungated call until the timeout's
+// termination is delivered inside one of them, which the call reports. The
+// termination must then be what is left pending (it is the one exception
+// napi_get_and_clear_last_exception cannot clear), not the exception the
+// call found pending when it was entered. Bounded so that a runtime that
+// never reports the termination fails instead of hanging.
+static napi_value
+ungated_calls_until_terminated(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+#ifndef _WIN32
+  BlockingStdoutScope stdout_scope;
+#endif
+
+  napi_value bigint;
+  NODE_API_CALL(env, napi_create_bigint_int64(env, -7, &bigint));
+  if (!arm_engine_exception(env)) {
+    return nullptr;
+  }
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  napi_status st;
+  do {
+    int64_t value;
+    bool lossless;
+    st = napi_get_value_bigint_int64(env, bigint, &value, &lossless);
+  } while (st == napi_ok && std::chrono::steady_clock::now() < deadline);
+  printf("napi_get_value_bigint_int64 eventually returned: status=%d\n",
+         (int)st);
+
+  napi_value exception;
+  napi_get_and_clear_last_exception(env, &exception);
+  bool pending = false;
+  napi_is_exception_pending(env, &pending);
+  printf("pending after napi_get_and_clear_last_exception: %s\n",
+         pending ? "true" : "false");
+  return nullptr;
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -4197,6 +4365,9 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
+  REGISTER_FUNCTION(env, exports, make_ungated_calls_spinner);
+  REGISTER_FUNCTION(env, exports, test_ungated_calls_with_engine_exception);
+  REGISTER_FUNCTION(env, exports, ungated_calls_until_terminated);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_status);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2921,8 +2921,9 @@ static napi_value test_pending_exception_gate(const Napi::CallbackInfo &info) {
 }
 
 // The ungated functions (see test_pending_exception_gate) whose bodies contain
-// an exception check: a bigint, a string and a symbol round trip. Statuses are
-// ignored on purpose.
+// an exception check: a bigint, a string and a symbol round trip, then an
+// array, a string and a typeof/is_array check (implemented separately in
+// Bun). Statuses are ignored on purpose.
 static void ungated_calls_round(napi_env env, napi_value bigint,
                                 napi_value string) {
   int64_t i64 = 0;
@@ -2941,6 +2942,13 @@ static void ungated_calls_round(napi_env env, napi_value bigint,
   napi_create_bigint_int64(env, i64, &out);
   napi_create_bigint_uint64(env, u64, &out);
   napi_create_symbol(env, string, &out);
+
+  bool is = false;
+  napi_create_array_with_length(env, 4, &out);
+  napi_is_array(env, out, &is);
+  napi_create_string_utf8(env, utf8, written, &out);
+  napi_create_int32(env, (int32_t)written, &out);
+  napi_get_boolean(env, is, &out);
 }
 
 // spin(bigint, string): a callback that does nothing but ungated calls, for a
@@ -3029,6 +3037,15 @@ test_ungated_calls_with_engine_exception(const Napi::CallbackInfo &info) {
   printf("napi_create_bigint_uint64: status=%d\n", (int)st);
   st = napi_create_symbol(env, string, &out);
   printf("napi_create_symbol: status=%d\n", (int)st);
+  st = napi_create_array_with_length(env, 4, &out);
+  printf("napi_create_array_with_length: status=%d\n", (int)st);
+  bool is_array = false;
+  st = napi_is_array(env, out, &is_array);
+  printf("napi_is_array: status=%d is_array=%d\n", (int)st, (int)is_array);
+  st = napi_create_string_utf8(env, utf8, NAPI_AUTO_LENGTH, &out);
+  printf("napi_create_string_utf8: status=%d\n", (int)st);
+  st = napi_create_int32(env, 7, &out);
+  printf("napi_create_int32: status=%d\n", (int)st);
 
   bool pending = false;
   napi_is_exception_pending(env, &pending);
@@ -3087,6 +3104,11 @@ ungated_calls_through_timeout(const Napi::CallbackInfo &info) {
     failures += napi_create_bigint_int64(env, i64, &out) != napi_ok;
     failures += napi_create_bigint_uint64(env, u64, &out) != napi_ok;
     failures += napi_create_symbol(env, string, &out) != napi_ok;
+    failures += napi_create_array_with_length(env, 4, &out) != napi_ok;
+    failures += napi_is_array(env, out, &lossless) != napi_ok;
+    failures +=
+        napi_create_string_utf8(env, utf8, NAPI_AUTO_LENGTH, &out) != napi_ok;
+    failures += napi_create_int32(env, 7, &out) != napi_ok;
   } while (std::chrono::steady_clock::now() < deadline);
   printf("ungated call failures: %u\n", failures);
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2945,12 +2945,10 @@ static void ungated_calls_round(napi_env env, napi_value bigint,
 
 // spin(bigint, string): a callback that does nothing but ungated calls, for a
 // script or worker to loop on while it gets terminated (node:vm `timeout`,
-// worker.terminate()). The termination is delivered at whichever exception
-// check comes first; several rounds per call keep that inside one of these
-// calls nearly every time, and it has to come back out of the call for the
-// loop to end. A plain napi_callback rather than a Napi::Function, because
-// node-addon-api aborts the process if one of its own calls fails once the
-// termination is pending.
+// worker.terminate()). Several rounds per call, so the request nearly always
+// lands while one of these calls is running; the loop must still stop once
+// control is back in JS. A plain napi_callback rather than a Napi::Function so
+// that only the calls under test are made.
 static napi_value ungated_calls_spin(napi_env env, napi_callback_info info) {
   size_t argc = 2;
   napi_value argv[2];
@@ -3043,50 +3041,62 @@ test_ungated_calls_with_engine_exception(const Napi::CallbackInfo &info) {
   NODE_API_CALL(env, napi_get_value_string_utf8(env, code, code_buf,
                                                 sizeof code_buf, nullptr));
   printf("pending exception code: %s\n", code_buf);
+  fflush(stdout);
 
   return ok(env);
 }
 
-// Bun-only. Run from a node:vm script with a `timeout`: with an engine
-// exception pending, keeps making an ungated call until the timeout's
-// termination is delivered inside one of them, which the call reports. The
-// termination must then be what is left pending (it is the one exception
-// napi_get_and_clear_last_exception cannot clear), not the exception the
-// call found pending when it was entered. Bounded so that a runtime that
-// never reports the termination fails instead of hanging.
+// ungated_calls_through_timeout(ms): run from a node:vm script whose `timeout`
+// is much shorter than `ms`. With an engine exception pending, loops through
+// the ungated calls for `ms`, so the timeout is requested while they run. None
+// of them may report it, the exception they found pending must still be the
+// (clearable) one pending afterwards, and the timeout must still stop the
+// script once this returns.
 static napi_value
-ungated_calls_until_terminated(const Napi::CallbackInfo &info) {
+ungated_calls_through_timeout(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
+  const auto duration =
+      std::chrono::milliseconds(info[0].As<Napi::Number>().Int64Value());
 
 #ifndef _WIN32
   BlockingStdoutScope stdout_scope;
 #endif
 
-  napi_value bigint;
+  napi_value bigint, string;
   NODE_API_CALL(env, napi_create_bigint_int64(env, -7, &bigint));
+  NODE_API_CALL(
+      env, napi_create_string_utf8(env, "ungated", NAPI_AUTO_LENGTH, &string));
   if (!arm_engine_exception(env)) {
     return nullptr;
   }
 
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::seconds(2);
-  napi_status st;
+  const auto deadline = std::chrono::steady_clock::now() + duration;
+  unsigned failures = 0;
   do {
-    int64_t value;
+    int64_t i64;
+    uint64_t u64;
     bool lossless;
-    st = napi_get_value_bigint_int64(env, bigint, &value, &lossless);
-  } while (st == napi_ok && std::chrono::steady_clock::now() < deadline);
-  printf("napi_get_value_bigint_int64 eventually returned: status=%d\n",
-         (int)st);
+    char utf8[16];
+    napi_value out;
+    failures +=
+        napi_get_value_bigint_int64(env, bigint, &i64, &lossless) != napi_ok;
+    failures +=
+        napi_get_value_bigint_uint64(env, bigint, &u64, &lossless) != napi_ok;
+    failures += napi_get_value_string_utf8(env, string, utf8, sizeof utf8,
+                                           nullptr) != napi_ok;
+    failures += napi_create_bigint_int64(env, i64, &out) != napi_ok;
+    failures += napi_create_bigint_uint64(env, u64, &out) != napi_ok;
+    failures += napi_create_symbol(env, string, &out) != napi_ok;
+  } while (std::chrono::steady_clock::now() < deadline);
+  printf("ungated call failures: %u\n", failures);
 
+  bool before = false, after = false;
   napi_value exception;
+  napi_is_exception_pending(env, &before);
   napi_get_and_clear_last_exception(env, &exception);
-  bool pending = false;
-  napi_is_exception_pending(env, &pending);
-  printf("pending after napi_get_and_clear_last_exception: %s\n",
-         pending ? "true" : "false");
-  // The driver prints the vm error after this returns; on Windows (no
-  // BlockingStdoutScope) a piped stdout is otherwise only flushed at exit.
+  napi_is_exception_pending(env, &after);
+  printf("exception pending: before clear=%s after clear=%s\n",
+         before ? "true" : "false", after ? "true" : "false");
   fflush(stdout);
   return nullptr;
 }
@@ -4370,7 +4380,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_pending_exception_gate);
   REGISTER_FUNCTION(env, exports, make_ungated_calls_spinner);
   REGISTER_FUNCTION(env, exports, test_ungated_calls_with_engine_exception);
-  REGISTER_FUNCTION(env, exports, ungated_calls_until_terminated);
+  REGISTER_FUNCTION(env, exports, ungated_calls_through_timeout);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_status);

--- a/test/napi/napi-app/ungated-calls-spin-worker.js
+++ b/test/napi/napi-app/ungated-calls-spin-worker.js
@@ -1,0 +1,8 @@
+// Loops on the ungated napi calls until the parent terminates this worker
+// (test_ungated_calls_worker_terminate in module.js).
+const { parentPort } = require("node:worker_threads");
+const nativeTests = require("./build/Debug/napitests.node");
+
+const spin = nativeTests.make_ungated_calls_spinner();
+parentPort.postMessage("spinning");
+for (;;) spin(-7n, "ungated");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -451,6 +451,81 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(result).toContain("side_effect arr[7]=undefined");
       expect(result).toContain("side_effect script_ran=false");
     });
+
+    // Same ungated functions, but with the exception pending on the engine
+    // (napi_call_function raises the napi_throw_error one before refusing),
+    // which is the state node-addon-api builds its Error object in. They must
+    // still succeed and must leave that exception pending.
+    it("ungated functions succeed while an engine exception is pending and preserve it", async () => {
+      const result = await checkSameOutput("test_ungated_calls_with_engine_exception", []);
+      expect(result).toBe(
+        [
+          "napi_call_function: status=10",
+          "napi_get_value_bigint_int64: status=0 value=-7",
+          "napi_get_value_bigint_uint64: status=0 lossless=0",
+          "napi_get_value_string_utf8: status=0 value=ungated",
+          "napi_create_bigint_int64: status=0",
+          "napi_create_bigint_uint64: status=0",
+          "napi_create_symbol: status=0",
+          "exception pending after: true",
+          "pending exception code: EPENDING",
+        ].join("\n"),
+      );
+    });
+
+    // Bun-only: a termination (here a node:vm timeout) delivered inside an
+    // ungated function while it has another exception stashed must be what the
+    // function leaves pending; putting the stashed exception back would throw
+    // the termination away. Node never delivers a termination inside these
+    // functions, so it has no equivalent of this state.
+    it("a termination delivered inside an ungated function wins over the stashed exception", async () => {
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          join(__dirname, "napi-app/main.js"),
+          "test_ungated_calls_termination_with_engine_exception",
+          "[]",
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({
+        stdout: stdout
+          .replaceAll("\r\n", "\n")
+          .replaceAll(/^\[\w+\].+$/gm, "")
+          .trim(),
+        stderr,
+        exitCode,
+      }).toEqual({
+        stdout: [
+          "napi_call_function: status=10",
+          "napi_get_value_bigint_int64 eventually returned: status=10",
+          "pending after napi_get_and_clear_last_exception: true",
+          "ERR_SCRIPT_EXECUTION_TIMEOUT",
+        ].join("\n"),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    // The ungated functions leave the engine's exception state as they found
+    // it, except that a termination (node:vm timeout, worker.terminate()) that
+    // gets delivered inside one of them must come out of the call: the request
+    // behind it is only delivered once, so a script looping through these calls
+    // would otherwise never stop. Hangs when broken.
+    it("a node:vm timeout interrupts a script looping through ungated functions", async () => {
+      const result = await checkSameOutput("test_ungated_calls_vm_timeout", []);
+      expect(result).toBe(Array(5).fill("ERR_SCRIPT_EXECUTION_TIMEOUT").join("\n"));
+    });
+
+    // Worker startup dominates this one: about two seconds per worker under a
+    // debug build, before any CI load.
+    it("worker.terminate() stops a worker looping through ungated functions", async () => {
+      const result = await checkSameOutput("test_ungated_calls_worker_terminate", []);
+      expect(result).toBe(`${Array(2).fill("terminate() resolved with 1").join("\n")}\nresolved to undefined`);
+    }, 30_000);
   });
 
   describe("status code alignment with Node.js", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -467,6 +467,10 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         "napi_create_bigint_int64: status=0",
         "napi_create_bigint_uint64: status=0",
         "napi_create_symbol: status=0",
+        "napi_create_array_with_length: status=0",
+        "napi_is_array: status=0 is_array=1",
+        "napi_create_string_utf8: status=0",
+        "napi_create_int32: status=0",
         "exception pending after: true",
         "pending exception code: EPENDING",
       ]);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -458,19 +458,18 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     // still succeed and must leave that exception pending.
     it("ungated functions succeed while an engine exception is pending and preserve it", async () => {
       const result = await checkSameOutput("test_ungated_calls_with_engine_exception", []);
-      expect(result).toBe(
-        [
-          "napi_call_function: status=10",
-          "napi_get_value_bigint_int64: status=0 value=-7",
-          "napi_get_value_bigint_uint64: status=0 lossless=0",
-          "napi_get_value_string_utf8: status=0 value=ungated",
-          "napi_create_bigint_int64: status=0",
-          "napi_create_bigint_uint64: status=0",
-          "napi_create_symbol: status=0",
-          "exception pending after: true",
-          "pending exception code: EPENDING",
-        ].join("\n"),
-      );
+      // printf() via the Windows CRT emits \r\n, so split on either ending.
+      expect(result.split(/\r?\n/)).toEqual([
+        "napi_call_function: status=10",
+        "napi_get_value_bigint_int64: status=0 value=-7",
+        "napi_get_value_bigint_uint64: status=0 lossless=0",
+        "napi_get_value_string_utf8: status=0 value=ungated",
+        "napi_create_bigint_int64: status=0",
+        "napi_create_bigint_uint64: status=0",
+        "napi_create_symbol: status=0",
+        "exception pending after: true",
+        "pending exception code: EPENDING",
+      ]);
     });
 
     // Bun-only: a termination (here a node:vm timeout) delivered inside an
@@ -491,11 +490,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The first three lines are printf() (\r\n via the Windows CRT), the last
+      // one is console.log.
       expect({
         stdout: stdout
-          .replaceAll("\r\n", "\n")
           .replaceAll(/^\[\w+\].+$/gm, "")
-          .trim(),
+          .trim()
+          .split(/\r?\n/),
         stderr,
         exitCode,
       }).toEqual({
@@ -504,7 +505,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
           "napi_get_value_bigint_int64 eventually returned: status=10",
           "pending after napi_get_and_clear_last_exception: true",
           "ERR_SCRIPT_EXECUTION_TIMEOUT",
-        ].join("\n"),
+        ],
         stderr: "",
         exitCode: 0,
       });
@@ -517,14 +518,18 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     // would otherwise never stop. Hangs when broken.
     it("a node:vm timeout interrupts a script looping through ungated functions", async () => {
       const result = await checkSameOutput("test_ungated_calls_vm_timeout", []);
-      expect(result).toBe(Array(5).fill("ERR_SCRIPT_EXECUTION_TIMEOUT").join("\n"));
+      expect(result.split(/\r?\n/)).toEqual(Array(5).fill("ERR_SCRIPT_EXECUTION_TIMEOUT"));
     });
 
     // Worker startup dominates this one: about two seconds per worker under a
     // debug build, before any CI load.
     it("worker.terminate() stops a worker looping through ungated functions", async () => {
       const result = await checkSameOutput("test_ungated_calls_worker_terminate", []);
-      expect(result).toBe(`${Array(2).fill("terminate() resolved with 1").join("\n")}\nresolved to undefined`);
+      expect(result.split(/\r?\n/)).toEqual([
+        "terminate() resolved with 1",
+        "terminate() resolved with 1",
+        "resolved to undefined",
+      ]);
     }, 30_000);
   });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -472,50 +472,22 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       ]);
     });
 
-    // Bun-only: a termination (here a node:vm timeout) delivered inside an
-    // ungated function while it has another exception stashed must be what the
-    // function leaves pending; putting the stashed exception back would throw
-    // the termination away. Node never delivers a termination inside these
-    // functions, so it has no equivalent of this state.
-    it("a termination delivered inside an ungated function wins over the stashed exception", async () => {
-      await using proc = spawn({
-        cmd: [
-          bunExe(),
-          join(__dirname, "napi-app/main.js"),
-          "test_ungated_calls_termination_with_engine_exception",
-          "[]",
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      // The first three lines are printf() (\r\n via the Windows CRT), the last
-      // one is console.log.
-      expect({
-        stdout: stdout
-          .replaceAll(/^\[\w+\].+$/gm, "")
-          .trim()
-          .split(/\r?\n/),
-        stderr,
-        exitCode,
-      }).toEqual({
-        stdout: [
-          "napi_call_function: status=10",
-          "napi_get_value_bigint_int64 eventually returned: status=10",
-          "pending after napi_get_and_clear_last_exception: true",
-          "ERR_SCRIPT_EXECUTION_TIMEOUT",
-        ],
-        stderr: "",
-        exitCode: 0,
-      });
+    // A node:vm timeout requested while the addon is inside those calls, again
+    // with an engine exception pending: none of the calls reports it, the
+    // exception they found is still the one pending when they are done, and the
+    // timeout still stops the script once the addon returns.
+    it("a termination requested during ungated calls is delivered after them, not by them", async () => {
+      const result = await checkSameOutput("test_ungated_calls_through_vm_timeout", []);
+      expect(result.split(/\r?\n/)).toEqual([
+        "napi_call_function: status=10",
+        "ungated call failures: 0",
+        "exception pending: before clear=true after clear=false",
+        "ERR_SCRIPT_EXECUTION_TIMEOUT",
+      ]);
     });
 
-    // The ungated functions leave the engine's exception state as they found
-    // it, except that a termination (node:vm timeout, worker.terminate()) that
-    // gets delivered inside one of them must come out of the call: the request
-    // behind it is only delivered once, so a script looping through these calls
-    // would otherwise never stop. Hangs when broken.
+    // A script / worker looping through ungated calls, stopped while inside one
+    // of them nearly every time. Hangs when the request is lost.
     it("a node:vm timeout interrupts a script looping through ungated functions", async () => {
       const result = await checkSameOutput("test_ungated_calls_vm_timeout", []);
       expect(result.split(/\r?\n/)).toEqual(Array(5).fill("ERR_SCRIPT_EXECUTION_TIMEOUT"));
@@ -525,11 +497,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     // debug build, before any CI load.
     it("worker.terminate() stops a worker looping through ungated functions", async () => {
       const result = await checkSameOutput("test_ungated_calls_worker_terminate", []);
-      expect(result.split(/\r?\n/)).toEqual([
-        "terminate() resolved with 1",
-        "terminate() resolved with 1",
-        "resolved to undefined",
-      ]);
+      expect(result.split(/\r?\n/)).toEqual([...Array(2).fill("terminate() resolved with 1"), "resolved to undefined"]);
     }, 30_000);
   });
 


### PR DESCRIPTION
### Problem
- Regression from #37075: a `node:vm` `timeout` or `worker.terminate()` is lost when it lands while an addon is inside one of the ungated N-API functions. Release builds keep running the script forever (`vm.runInNewContext(...)` never returns, `await worker.terminate()` never resolves); debug builds abort on the next exception check with `ASSERTION FAILED: !!(scope).exception() == vm.traps().needHandling(JSC::VMTraps::NeedExceptionHandling)`, or in `napi_get_value_bigint_int64` with `ASSERTION FAILED: Unexpected exception observed` from `NAPI_RETURN_SUCCESS`.
- Cause: #37075 rewrote `NAPI_PREAMBLE_NO_PENDING_CHECK` (`src/jsc/bindings/napi.cpp`) as an unconditional `JSC::SuspendExceptionScope`. That scope writes the `vm.exception` it saw on entry back when it exits. On entry nothing is pending; an exception check inside the body services the pending trap and raises the `TerminationException`; on exit the scope puts `null` back. The trap was consumed, so nothing raises it again. Of the 38 C++ users of the macro, the bodies with such a check are `napi_get_value_string_*`, `napi_get_value_bigint_int64/uint64`, `napi_create_bigint_int64/uint64` and `napi_create_symbol` with a description.
- Two related gaps in the same set of functions, fixed along the way: before #37075 (and in the first version of this PR) the C++ macro checked for exceptions on entry, so a waiting termination made the ungated call itself fail with `napi_pending_exception`; and the ungated functions implemented in `src/runtime/napi/napi_body.rs` (`napi_create_array*`, `napi_create_string_*`, `napi_create_int32/uint32/int64`, `napi_get_undefined/null/boolean`, `napi_is_*`, `napi_get_*_info`, handle scopes) had no handling at all: `napi_create_array` delivered a termination itself and failed, and the ones using `JsResult` helpers failed (release) or asserted (debug) with any exception pending on the VM. Node's `CHECK_ENV`-only functions never fail for either reason, and node-addon-api aborts the process (`Error::ThrowAsJavaScriptException napi_throw`) when one of them does; a node-addon-api callback making only ungated calls hit that under a `vm` timeout on Bun and not on Node.

### Fix
- `NapiUngatedScope` (napi.cpp) is what every ungated function now runs under: (a) it stashes the entry exception only when one is actually pending (`std::optional<JSC::SuspendExceptionScope>`), so a clean VM is left alone and whatever the body raises stays pending, and (b) it holds a `JSC::DeferTraps`, so no exception check inside the body (its own or in the JSC helpers it calls) services VM traps. A termination requested before or during the call stays a request and is delivered by the next check after the call returns (the caller's `RETURN_IF_EXCEPTION` in `NapiClass`, a JS loop check, or a gated N-API call). Nothing is lost, and the ungated calls never report a termination, as in Node.
- `NAPI_PREAMBLE_NO_PENDING_CHECK` declares one; the 26 Rust functions construct the same C++ object in place through `NapiUngatedScope__construct/__destruct` from an `ungated!` macro that replaces `get_env!` (80 bytes of 8-aligned storage, checked by a `static_assert`; a guard destroys it on every return path). This also covers what #36091 and #36093 were addressing separately (`napi_create_string_*` and the `*_info` accessors with a VM exception pending).
- Consequence of (b): no JS or addon code may run under the scope. The zero-length path of `node_api_create_external_string_{latin1,utf16}` ran the addon's finalizer there; the two functions now share one body (`createExternalString`) and run the finalizer after its scopes have closed. The other users only read, allocate, or register callbacks.
- `napi_get_value_bigint_int64` checks for an exception after its conversion like the `uint64` variant already did.
- Tests, in the `pending-exception gate` block of `test/napi/napi.test.ts` (addon side in `test/napi/napi-app/standalone_tests.cpp`, drivers in `module.js` and `ungated-calls-spin-worker.js`), all compared against Node's output; each round of ungated calls covers both the C++ and the Rust half:
  - a `node:vm` `timeout` on a script looping through the ungated functions: hangs without the fix (10/10 runs on a release build), asserts on a debug build
  - `worker.terminate()` of a worker doing the same: same failure modes
  - the ungated functions succeed with an exception pending on the VM and leave it pending
  - 200ms of ungated calls under a 20ms timeout with an exception pending: no call reports the timeout, the pending exception is still the original one afterwards, and the script still times out on return
- Verified on a debug+ASAN build at 12d4d5c: the four tests pass, the rest of `test/napi/napi.test.ts` is unchanged, and the upstream `test_string`, `test_array`, `test_typedarray`, `test_dataview`, `test_handle_scope`, `test_promise`, `test_date`, `test_error`, `test_exception`, `test_number`, `test_conversions`, `2_function_arguments`, `test_buffer`, `test_worker_terminate` suites pass (a few GC-heavy files exceed the 5s harness timeout under a local debug build and pass when run directly; same without this change). A node-addon-api wrapped function looping under `vm` timeouts, which aborted on every run of 20 with the entry check, survives 60/60 as on Node.


Supersedes #36091 and #36093 (per-function `SuspendExceptionScope` wrappers for `napi_create_string_*` and the `*_info` accessors); both are covered by `ungated!` here.

### Background
- Ungated functions: Node implements pure value constructors/accessors (`napi_create_object`, `napi_get_cb_info`, `napi_get_value_*`, references, ...) with `CHECK_ENV` only, so an addon may call them while an exception is pending, and they never fail because execution is being terminated. node-addon-api relies on both. In Bun these are split between `napi.cpp` (`NAPI_PREAMBLE_NO_PENDING_CHECK`) and `napi_body.rs` (`ungated!`); `NAPI_PREAMBLE` / `preamble!` are the gated versions that refuse while an exception is pending.
- VM traps: JSC delivers asynchronous requests (a watchdog timeout, which `node:vm`'s `timeout` uses, or a termination request, which `worker.terminate()` uses) by setting a trap bit. The next exception check that services traps (`RETURN_IF_EXCEPTION`, which most JSC entry points and Bun's `NAPI_RETURN_IF_VM_EXCEPTION` expand to) consumes the bit and throws the `TerminationException`, which is uncatchable from JS and is what unwinds the running script. Once thrown, it is the only record of the request.
- `JSC::DeferTraps` makes trap servicing a no-op for its scope: checks inside it see no exception and the bits stay set, so the first check after the scope delivers the request. `JSC::SuspendExceptionScope` clears `vm.exception` on construction and writes the saved value back unconditionally on destruction.

<details>
<summary>Earlier shape of this PR (3b36256 to 63653e1)</summary>

The first version kept the pre-#37075 entry check in the C++ macro (so a waiting termination was delivered by, and reported from, the ungated call) and wrapped the conditional suspend in a small scope object whose destructor re-raised a termination the body had delivered after putting the entry exception back. That fixed the hang but kept the Bun-only node-addon-api failure mode described under Problem, so it was replaced by the `DeferTraps` form (f599d79), which dbc32b6 then extended to the Rust-side functions. The Bun-only test that pinned the re-raise became the same-output "200ms of ungated calls under a 20ms timeout" test.

</details>
