### PR TITLE
bundler: bundle a 0-byte database with the sqlite loaders as a Database

### DIFF
--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -127,7 +127,10 @@ impl Loader {
     }
 
     pub fn handles_empty_file(self) -> bool {
-        matches!(self, Loader::Wasm | Loader::File | Loader::Text)
+        matches!(
+            self,
+            Loader::Wasm | Loader::File | Loader::Text | Loader::Sqlite | Loader::SqliteEmbedded
+        )
     }
 
     // `to_mime_type` / `from_mime_type` stay in bun_http_types as extension

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3992,11 +3992,14 @@ unsafe fn fetch_builtin_module(
                 // [`SQLITE_MODULE_SOURCE`]: the standalone-binary path reads
                 // the embedded blob via `readFileSync(import.meta.path)`
                 // (resolved through the `/$bunfs/` virtual root).
+                // `new Database(bytes)` rejects an empty buffer, but a 0-byte
+                // file is a valid empty database, which `:memory:` also is.
                 const SQLITE_MODULE_SOURCE_STANDALONE: &[u8] = b"\
 /* Generated code */
 import {Database} from 'bun:sqlite';
 import {readFileSync} from 'node:fs';
-export const db = new Database(readFileSync(import.meta.path));
+const bytes = readFileSync(import.meta.path);
+export const db = bytes.byteLength === 0 ? new Database(':memory:') : new Database(bytes);
 
 export const __esModule = true;
 export default db;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3988,12 +3988,10 @@ unsafe fn fetch_builtin_module(
             use bun_standalone_graph::StandaloneModuleGraph::ModuleFormat;
 
             if matches!(file.loader, Loader::Sqlite | Loader::SqliteEmbedded) {
-                // Distinct from
-                // [`SQLITE_MODULE_SOURCE`]: the standalone-binary path reads
-                // the embedded blob via `readFileSync(import.meta.path)`
-                // (resolved through the `/$bunfs/` virtual root).
-                // `new Database(bytes)` rejects an empty buffer; `:memory:` is
-                // the same empty database. The IIFE lets the buffer be collected.
+                // Unlike [`SQLITE_MODULE_SOURCE`], this reads the embedded blob
+                // back through the `/$bunfs/` virtual root. `new Database(bytes)`
+                // rejects an empty blob, hence `:memory:`; the IIFE keeps `bytes`
+                // collectable.
                 const SQLITE_MODULE_SOURCE_STANDALONE: &[u8] = b"\
 /* Generated code */
 import {Database} from 'bun:sqlite';

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3988,16 +3988,18 @@ unsafe fn fetch_builtin_module(
             use bun_standalone_graph::StandaloneModuleGraph::ModuleFormat;
 
             if matches!(file.loader, Loader::Sqlite | Loader::SqliteEmbedded) {
-                // Unlike [`SQLITE_MODULE_SOURCE`], this reads the embedded blob
-                // back through the `/$bunfs/` virtual root. `new Database(bytes)`
-                // rejects an empty blob, hence `:memory:`; the IIFE keeps `bytes`
-                // collectable.
+                // Distinct from
+                // [`SQLITE_MODULE_SOURCE`]: the standalone-binary path reads
+                // the embedded blob via `readFileSync(import.meta.path)`
+                // (resolved through the `/$bunfs/` virtual root).
                 const SQLITE_MODULE_SOURCE_STANDALONE: &[u8] = b"\
 /* Generated code */
 import {Database} from 'bun:sqlite';
 import {readFileSync} from 'node:fs';
 export const db = (() => {
+  // Scoped so the copy of the file can be collected once sqlite has it.
   const bytes = readFileSync(import.meta.path);
+  // An empty file is an empty database, but Database rejects empty buffers.
   return bytes.byteLength === 0 ? new Database(':memory:') : new Database(bytes);
 })();
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3992,11 +3992,8 @@ unsafe fn fetch_builtin_module(
                 // [`SQLITE_MODULE_SOURCE`]: the standalone-binary path reads
                 // the embedded blob via `readFileSync(import.meta.path)`
                 // (resolved through the `/$bunfs/` virtual root).
-                // `new Database(bytes)` rejects an empty buffer, but a 0-byte
-                // file is a valid empty database, which `:memory:` also is.
-                // The IIFE keeps `bytes` collectable: `Database` copies them
-                // into sqlite, and a module-level binding would pin a second
-                // copy of the database for the life of the process.
+                // `new Database(bytes)` rejects an empty buffer; `:memory:` is
+                // the same empty database. The IIFE lets the buffer be collected.
                 const SQLITE_MODULE_SOURCE_STANDALONE: &[u8] = b"\
 /* Generated code */
 import {Database} from 'bun:sqlite';

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3994,12 +3994,17 @@ unsafe fn fetch_builtin_module(
                 // (resolved through the `/$bunfs/` virtual root).
                 // `new Database(bytes)` rejects an empty buffer, but a 0-byte
                 // file is a valid empty database, which `:memory:` also is.
+                // The IIFE keeps `bytes` collectable: `Database` copies them
+                // into sqlite, and a module-level binding would pin a second
+                // copy of the database for the life of the process.
                 const SQLITE_MODULE_SOURCE_STANDALONE: &[u8] = b"\
 /* Generated code */
 import {Database} from 'bun:sqlite';
 import {readFileSync} from 'node:fs';
-const bytes = readFileSync(import.meta.path);
-export const db = bytes.byteLength === 0 ? new Database(':memory:') : new Database(bytes);
+export const db = (() => {
+  const bytes = readFileSync(import.meta.path);
+  return bytes.byteLength === 0 ? new Database(':memory:') : new Database(bytes);
+})();
 
 export const __esModule = true;
 export default db;

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -859,6 +859,22 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!" },
   });
+  // A 0-byte file is a valid (empty) database. It used to bundle as `{}`, and
+  // the embedded module must not hand the empty blob to `new Database(bytes)`,
+  // which rejects empty buffers.
+  itBundled("compile/EmbeddedSqliteEmpty", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import db from './db.sqlite' with {type: "sqlite", embed: "true"};
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        console.log(db.constructor.name, db.query("select message from messages").get().message);
+      `,
+      "/db.sqlite": "",
+    },
+    run: { stdout: "Database Hello, world!" },
+  });
   itBundled("compile/sqlite-file", {
     compile: true,
     files: {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -451,6 +451,67 @@ describe("bundler", async () => {
           api.assertFileExists(join("out", module.default));
         },
       });
+
+      // A 0-byte file is a valid (empty) SQLite database, so the sqlite loaders
+      // must see it like any other database: a Database on target bun, and the
+      // usual target error everywhere else. It used to become `export default {}`.
+      const useDb = /* js */ `
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        console.log(db.constructor.name, db.query("select message from messages").get().message);
+      `;
+      const sqliteEntry = /* js */ `import db from './empty.db' with {type: "sqlite", embed: "true"};${useDb}`;
+      const sqliteLoaderMapEntry = /* js */ `import db from './empty.db';${useDb}`;
+      if (target === "bun") {
+        itBundled(`${target}/loader-empty-sqlite-embedded`, {
+          target,
+          outdir: "/out",
+          files: {
+            "/entry.ts": sqliteEntry,
+            "/empty.db": "",
+          },
+          onAfterBundle(api) {
+            // The empty database is still copied into outdir next to the bundle.
+            const asset = readdirSync(api.outdir).find(x => x.endsWith(".db"))!;
+            expect(asset).toBeDefined();
+            expect(fs.statSync(join(api.outdir, asset)).size).toBe(0);
+          },
+          run: { stdout: "Database Hello, world!" },
+        });
+
+        itBundled(`${target}/loader-empty-sqlite-loader-map`, {
+          target,
+          loader: { ".db": "sqlite" },
+          files: {
+            "/entry.ts": sqliteLoaderMapEntry,
+            "/empty.db": "",
+          },
+          run: { stdout: "Database Hello, world!" },
+        });
+      } else {
+        itBundled(`${target}/loader-empty-sqlite-embedded`, {
+          target,
+          files: {
+            "/entry.ts": sqliteEntry,
+            "/empty.db": "",
+          },
+          bundleErrors: {
+            "/empty.db": ['To use the "sqlite" loader, set target to "bun"'],
+          },
+        });
+
+        itBundled(`${target}/loader-empty-sqlite-loader-map`, {
+          target,
+          loader: { ".db": "sqlite" },
+          files: {
+            "/entry.ts": sqliteLoaderMapEntry,
+            "/empty.db": "",
+          },
+          bundleErrors: {
+            "/empty.db": ['To use the "sqlite" loader, set target to "bun"'],
+          },
+        });
+      }
     }
   });
 

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -254,7 +254,7 @@ export interface BundlerTestInput {
   publicPath?: string;
   keepNames?: boolean;
   legalComments?: "none" | "inline" | "eof" | "linked" | "external";
-  loader?: Record<`.${string}`, Loader>;
+  loader?: Record<`.${string}`, Loader | "sqlite">;
   mangleProps?: RegExp;
   mangleQuoted?: boolean;
   mainFields?: string[];
@@ -617,7 +617,7 @@ function expectBundled(
   }
   if (!ESBUILD && loader) {
     const loaderValues = [...new Set(Object.values(loader))];
-    const supportedLoaderTypes = ["js", "jsx", "ts", "tsx", "css", "json", "text", "file", "wtf", "toml"];
+    const supportedLoaderTypes = ["js", "jsx", "ts", "tsx", "css", "json", "text", "file", "wtf", "toml", "sqlite"];
     const unsupportedLoaderTypes = loaderValues.filter(x => !supportedLoaderTypes.includes(x));
     if (unsupportedLoaderTypes.length > 0) {
       throw new Error(`loader '${unsupportedLoaderTypes.join("', '")}' not implemented in bun build`);


### PR DESCRIPTION
### Problem
- A 0-byte file imported through the `sqlite` / `sqlite_embedded` loader bundles as `var empty_default = {};` instead of a database module. With `with { type: "sqlite", embed: "true" }` on `--target bun`, `db` is a plain `{}` at runtime and no asset is emitted; the same happens with `--loader .db:sqlite`. Repro on bun 1.4.0 in the details block.
- Because the sqlite arm is skipped entirely, its target check is skipped too: a 0-byte database bundles successfully for `--target node` / `browser`, while a non-empty one fails with `To use the "sqlite" loader, set target to "bun"`.
- A 0-byte file is a valid, empty SQLite database. The runtime already treats it as one: `import db from "./empty.db" with { type: "sqlite" }` gives a working `Database` (pinned by `test/js/bun/resolve/import-empty.test.js`, "importing empty sqlite files returns database object"). Only the bundler disagrees.
- Cause: `ParseTask` short-circuits whitespace-only inputs to an empty module unless `loader.handles_empty_file()` (`src/bundler/ParseTask.rs:2618`, `is_empty` computed at `:2336`). `Loader::handles_empty_file` (`src/ast/loader.rs:129`) lists only `wasm`, `file` and `text`, so an empty input never reaches the `Loader::SqliteEmbedded | Loader::Sqlite` arm of `get_ast` (`ParseTask.rs:945`), which holds both the module body and the target error.

### Fix
- `Loader::handles_empty_file` also returns true for `Sqlite` and `SqliteEmbedded`, so an empty database goes through the same `get_ast` arm as a non-empty one: `import.meta.require(path, { type: "sqlite" }).db`, the content-hashed asset copy for the embedded form (a 0-byte asset, same as the `file` loader already produces), and the target error elsewhere.
- This is correct because that arm never looks at the bytes except to hash and copy them, so "empty" is not a special case for it, and routing through it makes the bundler agree with the runtime on what an empty `.db` import means. The only other caller of `handles_empty_file` is `Transpiler::parse_maybe_return_file_only` (`src/bundler/transpiler.rs:1506`), which no sqlite file reaches: the runtime module loader, the runtime transpiler store, `Bun.Transpiler` (`loader_from_js` rejects sqlite) and `bun build --no-bundle` all dispatch the sqlite loaders before calling `parse`.
- The standalone-executable module for an embedded database (`SQLITE_MODULE_SOURCE_STANDALONE` in `src/runtime/jsc_hooks.rs`) did `new Database(readFileSync(import.meta.path))`; for an empty blob that throws `ArrayBuffer must not be empty` (`JSSQLStatement.cpp:1296`, the deserialize path rejects empty buffers, as node:sqlite does too). It now opens `new Database(":memory:")` when the blob is empty, which is what deserializing an empty database amounts to (`new Database(bytes)` also yields a writable database whose `filename` is `":memory:"`). The buffer is read inside an IIFE rather than bound at module level, so it stays collectable after sqlite has copied it, as the previous single-expression form was. With only the loader change, a compiled executable with an empty embedded database would throw at import instead of yielding `{}`; with both, it gets a working database like the other two paths.
- Left alone on purpose: a whitespace-only "database" now also reaches the sqlite arm and fails at runtime like any other corrupt database file (before, it silently became `{}`); `napi` still takes the empty-module path, since a 0-byte addon is not loadable either way.
- Verified: `test/bundler/bundler_loader.test.ts` ("handles empty files"): `loader-empty-sqlite-embedded` and `loader-empty-sqlite-loader-map` for `bun` (a usable `Database`, and a 0-byte asset copied to outdir for the embedded form) and for `node` / `browser` (the target error). `test/bundler/bundler_compile.test.ts`: `compile/EmbeddedSqliteEmpty` (compiled executable with an empty embedded database creates a table and reads it back). All 7 fail on `USE_SYSTEM_BUN=1` (`db.exec is not a function`, no asset, or no error) and pass with this build; the compile test additionally fails with `ArrayBuffer must not be empty` when only the loader change is applied, so it covers the `jsc_hooks.rs` change.
- Also ran with this build: the rest of `bundler_loader.test.ts`, `bundler_bun.test.ts` and `test/js/bun/resolve/import-empty.test.js` (75 pass), and `bundler_compile.test.ts` (68 pass; `compile/HelloWorldWithProcessVersionsBun` fails on any debug build and is tracked separately).
- `test/bundler/expectBundled.ts`: `sqlite` added to the loader names the `loader:` option accepts, so the loader-map tests can use it (`bun build --loader` and `Bun.build({ loader })` both already accept it).

### Background
- Loaders: the bundler picks a `Loader` per input file from the import attribute (`with { type }`), the loader map (`--loader .db:sqlite`) or the extension. `sqlite` keeps the database external and emits a module that opens it by path; `sqlite_embedded` (what `embed: "true"` selects) additionally copies the file into the output as a content-hashed asset, or into the executable under `bun build --compile`, and opens that copy.
- `ParseTask` is the per-input unit of work in the bundler. `get_ast` builds a small "lazy export" module per loader; for the sqlite loaders that module is `export default import.meta.require(path, { type: "sqlite" }).db`, and the copy is requested by setting the file's unique asset key. Before calling `get_ast`, `ParseTask` replaces whitespace-only inputs with an empty module so that parsers for JS/JSON/TOML/CSS do not have to handle empty input; `handles_empty_file` is the opt-out list for loaders that do not parse the content.
- In a compiled executable, `import.meta.require` of the embedded copy is answered by `fetch_builtin_module` in `jsc_hooks.rs`, which returns a fixed module source that reads the embedded bytes back with `readFileSync` and builds a `Database` from them; outside `--compile`, the runtime sqlite loader opens the asset by path instead, and SQLite itself accepts a 0-byte file as an empty database.

<details>
<summary>Repro on bun 1.4.0 and with this branch</summary>

```
$ : > empty.db
$ printf 'import db from "./empty.db" with { type: "sqlite", embed: "true" };\nconsole.log(JSON.stringify(db), db.constructor.name);\n' > e.mjs

# bun 1.4.0
$ bun build ./e.mjs --target bun --outdir out && bun out/e.js
  e.js  130 bytes  (entry point)          # no asset
{} Object
$ bun build ./e.mjs --target node --outdir out2; echo $?
0

# this branch
$ bun build ./e.mjs --target bun --outdir out && bun out/e.js
  e.js               193 bytes  (entry point)
  empty-vvvada9m.db  0 KB       (asset)
{"filename":"/tmp/repro/out/empty-vvvada9m.db"} Database
$ bun build ./e.mjs --target node --outdir out2; echo $?
error: To use the "sqlite" loader, set target to "bun"
    at /tmp/repro/empty.db
1

# --compile, this branch with only the handles_empty_file change:
error: ArrayBuffer must not be empty
      at new Database (bun:sqlite:264:45)
      at /$bunfs/root/empty-vvvada9m.db:4:19
# with both changes: Database { ... } and queries work.
```
</details>
