### PR TITLE
node:vm: stop leaking compileFunction contextExtensions into later global lookups

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1619,8 +1619,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
         }
     }
 
-    options.parsingContext->setGlobalScopeExtension(functionScope);
-
     // Create the function using constructAnonymousFunction with the appropriate scope chain
     JSFunction* function = constructAnonymousFunction(globalObject, ArgList(constructFunctionArgs), sourceOrigin, WTF::move(options), JSC::SourceTaintedOrigin::Untainted, functionScope);
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -269,6 +269,63 @@ describe("vm", () => {
         expect(e).toBeTruthy();
       }
     });
+
+    describe("contextExtensions", () => {
+      // Node (V8's ScriptCompiler::CompileFunction) wraps the extensions around
+      // the compiled function only. Nothing else running in the realm may see them.
+      const probe = "[typeof fromFirstExtension, typeof fromSecondExtension]";
+      const extensions = () => [{ fromFirstExtension: "first" }, { fromSecondExtension: "second" }];
+
+      test("are visible to the compiled function, later extensions shadow earlier ones", () => {
+        const fn = compileFunction(
+          "return [fromFirstExtension, fromSecondExtension, shadowed, () => shadowed, eval('shadowed')]",
+          [],
+          {
+            contextExtensions: [
+              { fromFirstExtension: "first", shadowed: "from first" },
+              { fromSecondExtension: "second", shadowed: "from second" },
+            ],
+          },
+        );
+        const [first, second, shadowed, closure, evaluated] = fn();
+        expect([first, second, shadowed, closure(), evaluated]).toEqual([
+          "first",
+          "second",
+          "from second",
+          "from second",
+          "from second",
+        ]);
+      });
+
+      test("are not visible to code that runs in the realm afterwards", () => {
+        const compiledEarlier = compileFunction(`return ${probe}`);
+        const fn = compileFunction(`return ${probe}`, [], { contextExtensions: extensions() });
+        expect(fn()).toEqual(["string", "string"]);
+
+        const notVisible = ["undefined", "undefined"];
+        // @ts-expect-error these identifiers are deliberately undeclared
+        expect([typeof fromFirstExtension, typeof fromSecondExtension]).toEqual(notVisible);
+        expect(runInThisContext(probe)).toEqual(notVisible);
+        expect(new Function(`return ${probe}`)()).toEqual(notVisible);
+        expect((0, eval)(probe)).toEqual(notVisible);
+        expect(compiledEarlier()).toEqual(notVisible);
+        expect(compileFunction(`return ${probe}`)()).toEqual(notVisible);
+      });
+
+      test("are not visible to code that runs in parsingContext afterwards", () => {
+        const parsingContext = createContext({});
+        const compiledEarlier = compileFunction(`return ${probe}`, [], { parsingContext });
+        const fn = compileFunction(`return ${probe}`, [], { parsingContext, contextExtensions: extensions() });
+        expect(fn()).toEqual(["string", "string"]);
+
+        const notVisible = ["undefined", "undefined"];
+        expect(runInContext(probe, parsingContext)).toEqual(notVisible);
+        expect(runInContext(`new Function("return ${probe}")()`, parsingContext)).toEqual(notVisible);
+        expect(compiledEarlier()).toEqual(notVisible);
+        expect(compileFunction(`return ${probe}`, [], { parsingContext })()).toEqual(notVisible);
+        expect(runInThisContext(probe)).toEqual(notVisible);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- After one `vm.compileFunction(code, params, { contextExtensions: [ext] })` call, the properties of the last extension object resolve as globals from every later piece of code in that realm: ordinary module code, `vm.runInThisContext`, `new Function`, indirect `eval`, and functions that were compiled earlier. With `parsingContext` the same happens inside that context (`vm.runInContext("typeof x", ctx)` sees a previous compile's extensions). Node scopes the extensions to the compiled function only.
  ```js
  vm.compileFunction("return leaked", [], { contextExtensions: [{ leaked: 1 }] });
  vm.runInThisContext("typeof leaked"); // bun: "number", node: "undefined"
  ```
- Cause: `vmModuleCompileFunction` in `src/jsc/bindings/NodeVM.cpp` called `options.parsingContext->setGlobalScopeExtension(functionScope)` before compiling and never cleared it. `JSScope::resolve` (`vendor/WebKit/Source/JavaScriptCore/runtime/JSScope.cpp`) consults the realm's global scope extension whenever a lookup reaches the global object, so the `JSWithScope` chain stayed visible realm-wide. Without extensions the global object itself was installed, which is inert; a later extension-less compile therefore also happened to overwrite an earlier leak, so the symptom depends on call order.

### Fix
- Delete the `setGlobalScopeExtension` call. Nothing else in Bun installs a global scope extension, so the realm stays in the same state it is in before any `compileFunction` call.
- Correct because the extensions already reach the compiled function through its own scope chain: `functionScope` (the `JSWithScope` chain on top of the context's global scope) is both what `ProgramCodeBlock::create` links against and the scope the `JSFunction` is created with. When JSC links a lookup against a chain containing a `JSWithScope` it marks the lookup `Dynamic` (`JSScope::abstractAccess`), and the runtime walk then finds the extension object before it ever reaches the global object, so the hook contributed nothing to the function itself. The hook also only ever exposed the head of the chain (`JSScope::objectAtScope`), which is why only the last extension leaked.
- `cachedData` is unaffected: the `globalScopeExtension()` reads that remain in `NodeVM.cpp`, `NodeVMScript.cpp` and `NodeVMSourceTextModule.cpp` only choose `TaintedByWithScopeLexicallyScopedFeature` for a `SourceCodeKey`, and `SourceCodeFlags` keeps just the strict-mode bit of those features (`parser/SourceCodeKey.h`), so cached data produced before this change still decodes.
- Verified with `test/js/node/vm/vm.test.ts` (`compileFunction() > contextExtensions`): the two "not visible" tests fail on the current release (`"string"` where `"undefined"` is expected) and pass with this change; the third test pins the behavior the function itself relies on (visibility, later extensions shadowing earlier ones, closures and direct `eval` inside the function).
  - Each probed path (module `typeof`, `runInThisContext`, `new Function`, indirect `eval`, an earlier compiled function, and the `parsingContext` equivalents) was also checked individually: all leak before, none after, and the output matches node v26.3.0.
  - `test/js/node/test/parallel/test-vm-basic.js` (covers `contextExtensions`, `parsingContext` and `cachedData` for `compileFunction`) passes.
  - `test/regression/issue/isArray-proxy-crash.test.ts` passes.
- Touches the line #38297 also edits, and sits next to the line #38305 edits (a function compiled without extensions cannot see global `let`/`const` bindings; not changed here). Whichever of these lands later needs a trivial rebase; the three changes are independent.

### Background
- Scope chain: every function carries the chain of scopes it closes over; identifier lookups walk it and end at the realm's global object. `vm.compileFunction` builds one `JSWithScope` per `contextExtensions` entry (same as a `with (ext) {}` block) and creates the function with that chain, mirroring how V8's `ScriptCompiler::CompileFunction` implements the option.
- Global scope extension: a per-realm hook on `JSGlobalObject` (`setGlobalScopeExtension` / `clearGlobalScopeExtension`). When any lookup in the realm reaches the global object and misses, JSC also checks the object installed there. JSC's own users install it around a single evaluation and clear it afterwards, or install it once for the lifetime of an embedding context; it is realm state, not per-function state.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (280b00571)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.57ms]
(pass) vm > runInContext() > can return a value [16.10ms]
(pass) vm > runInContext() > can return a complex value [17.12ms]
(pass) vm > runInContext() > can return the last value [15.73ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.60ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.50ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.22ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.60ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [16.96ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.58ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.63ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.90ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 2 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.53ms]
(pass) vm > runInContext() > can return a value [0.36ms]
(pass) vm > runInContext() > can return a complex value [0.31ms]
(pass) vm > runInContext() > can return the last value [0.25ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.29ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.28ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.31ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.23ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (280b00571)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.64ms]
(pass) vm > runInContext() > can return a value [15.09ms]
(pass) vm > runInContext() > can return a complex value [15.87ms]
(pass) vm > runInContext() > can return the last value [14.68ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [17.10ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.06ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.47ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.70ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.44ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.64ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.91ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.30ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     280b005719
  features     baseline

22 deps, 123 codegen, 1176 objects in 870ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [20.00ms]
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] gen bindgenv2
[6/1237] fetch zlib
[zlib] up to date
[7/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[8/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/P
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp |  2 --
 test/js/node/vm/vm.test.ts  | 57 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 57 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      5      3      0
test/js/node/vm/vm.test.ts       1      1      0
```

</details>

<!-- robobun:evidence:end -->