### PR TITLE
event loop: run completions left on the macro loop after the macro returned

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1195,7 +1195,7 @@ impl VirtualMachine {
                 + self.active_tasks
                 + el.tasks.readable_length()
                 + el.yield_tasks.len()
-                + (!el.concurrent_tasks.is_empty() as usize)
+                + (el.has_concurrent_tasks() as usize)
                 + (el.has_pending_refs() as usize)
                 > 0)
     }

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -74,6 +74,8 @@ enum State {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LoopKind {
     Regular,
+    /// Once the macro has returned, the regular loop drains this queue too
+    /// (`EventLoop::finished_macro_loop`).
     Macro,
 }
 

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -74,8 +74,8 @@ enum State {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LoopKind {
     Regular,
-    /// Once the macro has returned, the regular loop drains this queue too
-    /// (`EventLoop::finished_macro_loop`).
+    /// Once the macro has returned, the regular loop services this loop's
+    /// queue and keep-alive deltas too (`EventLoop::finished_macro_loop`).
     Macro,
 }
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -13,6 +13,7 @@ use core::ptr::NonNull;
 use core::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 
 use bun_io::{self as Async, Waker};
+use bun_threading::unbounded_queue::Batch;
 use bun_uws as uws;
 
 use crate::js_promise::Status as PromiseStatus;
@@ -513,47 +514,51 @@ impl EventLoop {
 
         self.run_imminent_gc_timer();
 
-        let concurrent = self.concurrent_tasks.pop_batch();
-        let count = concurrent.count;
-        if count == 0 {
-            return 0;
-        }
-
-        let mut iter = concurrent.iterator();
         let start_count = self.tasks.readable_length();
-        let _ = self.tasks.ensure_unused_capacity(count);
-
-        // Defer destruction of the ConcurrentTask to avoid issues with pointer aliasing
-        let mut to_destroy: Option<*mut ConcurrentTaskItem> = None;
-
-        loop {
-            let task = iter.next();
-            if task.is_null() {
-                break;
-            }
-            if let Some(dest) = to_destroy.take() {
-                // SAFETY: dest was returned by iterator and marked auto_delete; uniquely owned here
-                let _ = unsafe { bun_core::heap::take(dest) };
-            }
-
-            // SAFETY: `task` is non-null (checked above) and owned by this
-            // batch; only shared reads follow (`auto_delete`, the `task` copy).
-            let task_ref = unsafe { &*task };
-            if task_ref.auto_delete() {
-                to_destroy = Some(task);
-            }
-
-            // LinearFifo's fields are private — `write_item` is the
-            // public path (single-slot copy, same complexity).
-            let _ = self.tasks.write_item(task_ref.task);
+        let posted = self.concurrent_tasks.pop_batch();
+        self.take_concurrent_batch(posted);
+        if let Some(posted) = self
+            .finished_macro_loop()
+            .map(|macro_loop| macro_loop.concurrent_tasks.pop_batch())
+        {
+            self.take_concurrent_batch(posted);
         }
-
-        if let Some(dest) = to_destroy {
-            // SAFETY: see above
-            let _ = unsafe { bun_core::heap::take(dest) };
-        }
-
         self.tasks.readable_length() - start_count
+    }
+
+    /// Move a popped batch into `self.tasks`, freeing the heap `ConcurrentTask` carriers.
+    fn take_concurrent_batch(&mut self, batch: Batch<ConcurrentTaskItem>) {
+        if batch.count == 0 {
+            return;
+        }
+        let _ = self.tasks.ensure_unused_capacity(batch.count);
+        let mut iter = batch.iterator();
+        while let Some(node) = NonNull::new(iter.next()) {
+            // SAFETY: a node of the popped batch; the iterator has already moved past it.
+            let task = unsafe { ConcurrentTaskItem::into_task(node) };
+            let _ = self.tasks.write_item(task);
+        }
+    }
+
+    /// The macro loop, when this is the regular loop and no macro is running.
+    /// Work a macro started posts its completion there (`LoopKind::Macro`), but
+    /// that loop only ticks while a macro is being waited on, so whatever
+    /// completes after the macro returned would otherwise sit there forever,
+    /// holding its keep-alive on the platform loop both loops share.
+    fn finished_macro_loop(&self) -> Option<&EventLoop> {
+        let vm = self.vm_ref();
+        (vm.has_enabled_macro_mode
+            && !vm.macro_mode
+            && core::ptr::eq(self, &raw const vm.regular_event_loop))
+        .then_some(&vm.macro_event_loop)
+    }
+
+    /// Other threads have posted work that this loop's next drain will pick up.
+    pub(crate) fn has_concurrent_tasks(&self) -> bool {
+        !self.concurrent_tasks.is_empty()
+            || self
+                .finished_macro_loop()
+                .is_some_and(|macro_loop| !macro_loop.concurrent_tasks.is_empty())
     }
 
     /// Fold refs/unrefs queued through `ref_keep_alive`/`unref_keep_alive`
@@ -643,7 +648,7 @@ impl EventLoop {
     /// Work is queued that the next `tick()` will run: the poll before it must
     /// not block.
     pub fn has_pending_tasks(&self) -> bool {
-        self.tasks.readable_length() > 0 || !self.concurrent_tasks.is_empty()
+        self.tasks.readable_length() > 0 || self.has_concurrent_tasks()
     }
 
     pub fn tick(&mut self) {
@@ -730,27 +735,6 @@ impl EventLoop {
         let _ = self.tasks.write_item(task);
     }
 
-    /// Move whatever other threads posted (`concurrent_tasks`) into
-    /// `self.tasks`, freeing the heap `ConcurrentTask` carriers, so one pass
-    /// over `self.tasks` releases everything. Called by `release_queued_tasks`
-    /// in teardown, after `join_child_workers()` (every child has posted its
-    /// close task by then) and before the JSC VM is destroyed (so captured
-    /// `Ref<>`s in queued C++ lambdas drop against a live heap).
-    fn take_concurrent_tasks(&mut self) {
-        let mut iter = self.concurrent_tasks.pop_batch().iterator();
-        loop {
-            let node = iter.next();
-            if node.is_null() {
-                break;
-            }
-            // SAFETY: `node` is non-null and owned by the popped batch; the
-            // iterator advanced past it before returning.
-            let task =
-                unsafe { ConcurrentTask::ConcurrentTask::into_task(NonNull::new_unchecked(node)) };
-            let _ = self.tasks.write_item(task);
-        }
-    }
-
     /// Release, without running, every task still queued — what other
     /// threads posted and what this thread enqueued — through each type's
     /// `Taskable::release_unrun`, and refuse (release on arrival) anything
@@ -759,7 +743,8 @@ impl EventLoop {
     /// once more after `Closed`.
     pub fn release_queued_tasks(&mut self) {
         self.closed_for_tasks = true;
-        self.take_concurrent_tasks();
+        let posted = self.concurrent_tasks.pop_batch();
+        self.take_concurrent_batch(posted);
         let _ = self.promote_yield_tasks();
         while let Some(task) = self.tasks.read_item() {
             // SAFETY: JS thread, heap alive; `task` just left the queue.

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -480,9 +480,12 @@ impl EventLoop {
     }
 
     /// Whether a keep-alive delta (`ref_keep_alive`, here or through a
-    /// `VmHandle`) has been queued but not yet applied to the loop's `active` count.
+    /// `Ticket`) has been queued but not yet applied to the loop's `active` count.
     pub fn has_pending_refs(&self) -> bool {
         self.concurrent_ref.load(Ordering::SeqCst) > 0
+            || self
+                .finished_macro_loop()
+                .is_some_and(|macro_loop| macro_loop.concurrent_ref.load(Ordering::SeqCst) > 0)
     }
 
     pub fn run_imminent_gc_timer(&mut self) {
@@ -517,10 +520,9 @@ impl EventLoop {
         let start_count = self.tasks.readable_length();
         let posted = self.concurrent_tasks.pop_batch();
         self.take_concurrent_batch(posted);
-        if let Some(posted) = self
-            .finished_macro_loop()
-            .map(|macro_loop| macro_loop.concurrent_tasks.pop_batch())
-        {
+        if let Some(macro_loop) = self.finished_macro_loop() {
+            macro_loop.apply_concurrent_ref_delta();
+            let posted = macro_loop.concurrent_tasks.pop_batch();
             self.take_concurrent_batch(posted);
         }
         self.tasks.readable_length() - start_count
@@ -541,10 +543,11 @@ impl EventLoop {
     }
 
     /// The macro loop, when this is the regular loop and no macro is running.
-    /// Work a macro started posts its completion there (`LoopKind::Macro`), but
-    /// that loop only ticks while a macro is being waited on, so whatever
-    /// completes after the macro returned would otherwise sit there forever,
-    /// holding its keep-alive on the platform loop both loops share.
+    /// Work a macro started posts its completion and its keep-alive release
+    /// there (`LoopKind::Macro`), but that loop only ticks while a macro is
+    /// being waited on, so whatever finishes after the macro returned would
+    /// otherwise sit there forever, and the platform loop both loops share
+    /// would stay alive for it.
     fn finished_macro_loop(&self) -> Option<&EventLoop> {
         let vm = self.vm_ref();
         (vm.has_enabled_macro_mode

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,13 +182,14 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
-// Async work a macro starts without awaiting it posts its completion to the loop that was current
-// when the work started, the macro loop, which stops ticking as soon as the macro returns. Work that
-// is still pending at that point (always the case for work started inside the macro call itself) has
-// to be run by the regular event loop from there. When it was not, the completion kept the process
-// alive forever: `bun run` printed the value and then never exited, which here shows up as the child
-// never exiting. The top-level case usually finishes while the macro module is still being loaded and
-// covers the continuation running from the macro loop itself.
+// Async work a macro starts without awaiting it posts its completion (and, for WebCrypto, the release
+// of its keep-alive) to the loop that was current when the work started, the macro loop, which stops
+// ticking as soon as the macro returns. Work that is still pending at that point (always the case for
+// work started inside the macro call itself) has to be picked up by the regular event loop from there.
+// When it was not, the work kept the process alive forever: `bun run` printed the value and then never
+// exited, which here shows up as the child never exiting. The top-level case usually finishes while
+// the macro module is still being loaded and covers the continuation running from the macro loop
+// itself.
 describe("work a macro starts without awaiting it", () => {
   const cases: [name: string, macroSource: string][] = [
     [
@@ -216,6 +217,17 @@ describe("work a macro starts without awaiting it", () => {
       [
         `export function m() {`,
         `  fetch(process.env.MACRO_TEST_URL!).then(res => res.text()).then(body => console.log(body));`,
+        `  return 1;`,
+        `}`,
+      ].join("\n"),
+    ],
+    [
+      // Inputs of 64 bytes or more are hashed on the WebCrypto work queue, which releases its keep-alive
+      // through the macro loop rather than completing through a thread-pool job like the cases above.
+      "a crypto.subtle.digest() inside the macro",
+      [
+        `export function m() {`,
+        `  crypto.subtle.digest("SHA-256", new Uint8Array(4096)).then(() => console.log("settled"));`,
         `  return 1;`,
         `}`,
       ].join("\n"),

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,6 +182,73 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
+// Async work a macro starts without awaiting it posts its completion to the loop that was current
+// when the work started, the macro loop, which stops ticking as soon as the macro returns. Work that
+// is still pending at that point (always the case for work started inside the macro call itself) has
+// to be run by the regular event loop from there. When it was not, the completion kept the process
+// alive forever: `bun run` printed the value and then never exited, which here shows up as the child
+// never exiting. The top-level case usually finishes while the macro module is still being loaded and
+// covers the continuation running from the macro loop itself.
+describe("work a macro starts without awaiting it", () => {
+  const cases: [name: string, macroSource: string][] = [
+    [
+      "an fs.promises call inside the macro",
+      [
+        `import { promises as fs } from "node:fs";`,
+        `export function m() {`,
+        `  fs.stat(import.meta.dir).then(() => console.log("settled"));`,
+        `  return 1;`,
+        `}`,
+      ].join("\n"),
+    ],
+    [
+      "an fs.promises call at the macro module's top level",
+      [
+        `import { promises as fs } from "node:fs";`,
+        `fs.stat(import.meta.dir).then(() => console.log("settled"));`,
+        `export function m() {`,
+        `  return 1;`,
+        `}`,
+      ].join("\n"),
+    ],
+    [
+      "a fetch() inside the macro",
+      [
+        `export function m() {`,
+        `  fetch(process.env.MACRO_TEST_URL!).then(res => res.text()).then(body => console.log(body));`,
+        `  return 1;`,
+        `}`,
+      ].join("\n"),
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s still lets the process exit", async (_name, macroSource) => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response("settled") });
+    using dir = tempDir("macro-unawaited-work", {
+      "m.ts": macroSource,
+      "index.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log("value", m());\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "index.ts"],
+      env: { ...bunEnv, MACRO_TEST_URL: server.url.href },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug builds also print "[macro] call m". The continuation runs on the macro loop if the work
+    // finishes while the macro is still being waited on, and on the regular loop otherwise, so its
+    // position relative to the entry module's own output varies; hence the sort.
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .filter(line => !line.startsWith("[macro]"))
+      .sort();
+    expect({ lines, stderr }).toEqual({ lines: ["settled", "value 1"], stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `


### PR DESCRIPTION
### Problem
- Since #37075, `bun index.ts` where `index.ts` calls a macro that starts async work without awaiting it (an un-awaited `fs.promises.stat()`, `fetch()` or `crypto.subtle.digest()` inside the macro; the same at the macro module's top level when the work outlasts loading that module) prints its output and then never exits. 1.3.14 exits 0.
- Off-thread work now captures its destination loop when it is created: `Job::schedule` takes `vm.ticket()` (`src/jsc/job.rs:331`), which records `current_loop_kind()` (`src/jsc/VmHandle.rs:519`, `src/jsc/VirtualMachine.rs:903`). While a macro runs that is `LoopKind::Macro`, so the completion is posted to `macro_event_loop.concurrent_tasks` (`loop_of` + push, `src/jsc/VmHandle.rs:159-179`).
- The macro loop only ticks inside `wait_for_promise` while a macro is being waited on. Once the macro has returned nothing pops that queue, and the job's keep-alive (taken on the uSockets loop both embedded loops share, `job.rs:316`, released only when the completion runs) keeps `is_event_loop_alive()` true forever.
- The macro loop has a second per-loop channel with the same problem: a Macro-kind `Ticket::unref_keep_alive()` (`VmHandle.rs:245`, used by WebCrypto's work queue, `src/jsc/CppTask.rs:75`, for inputs hashed off thread) adds its `-1` to `macro_event_loop.concurrent_ref`, which only a tick of that loop folds into the platform loop. The WebCrypto result itself is posted to the regular loop and runs; the keep-alive is what stays stuck. This channel exists since #38299 made `ConcurrentCppTask` carry a ticket instead of always releasing on the regular loop.
- Before #37075 the producers looked the loop up at completion time and landed on the regular loop, which is why this used to work.

### Fix
- `EventLoop::tick_concurrent_with_count` on the regular loop also services the macro loop: it folds that loop's `concurrent_ref` delta (`apply_concurrent_ref_delta`, the same function each loop runs on itself) and pops its concurrent queue. Gated by `finished_macro_loop()` (`src/jsc/event_loop.rs:551`): the VM has run a macro (`has_enabled_macro_mode`), no macro is running right now (`!macro_mode`), and the loop doing the drain is the regular one (so the macro loop itself and spawnSync's isolated loop never adopt it).
- The exit decision sees the same state: `has_pending_tasks()` (poll must not block) and `is_event_loop_alive_excluding_immediates()` go through `has_concurrent_tasks()`, and `has_pending_refs()` also looks at the macro loop, so work sitting on the macro loop counts the same as work on the regular loop.
- Correct because at any moment only one of the two loops ticks: while a macro runs, `vm.event_loop` points at the macro loop and it services itself as before (awaited macros are unchanged, and the regular loop's queue still waits until the macro returns); once it returns, the regular loop owns whatever is left or arrives later. A post or unref already wakes the shared platform loop, so a late one is picked up on the next tick. Draining only in `disable_macro_mode()` would not be enough: in the repro the completion is posted after that runs. Picking the loop at post time instead would put a read of the JS thread's macro state back on the posting thread, which is the race #37075 removed.
- For programs that never run a macro the drain is unchanged apart from one `bool` check (`has_enabled_macro_mode` is false). The batch transfer into `tasks` is factored into `take_concurrent_batch` (built on `ConcurrentTask::into_task`), which the teardown release path (`release_queued_tasks`) now shares instead of carrying its own copy.
- Rebased onto main after #38299 (tickets + the waiting teardown) merged; the diff applies unchanged there, since it only touches the drain on the consuming side. Re-verified on main at 7ba276f: the three in-macro cases below still hang without the fix and pass with it.
- Verified with `test/bundler/transpiler/macro-test.test.ts`, four new cases that assert the child prints both the macro's value and the un-awaited continuation's output and exits 0. The three cases that start the work inside the macro call (`fs.promises`, `fetch()`, a 4 KiB `crypto.subtle.digest()`) time out without the fix (the child never exits) and pass with it; the digest case also times out with only the first commit of this PR. The top-level `fs.stat` case passes either way on current main, because the stat usually completes while the macro loop is still being ticked to load the macro module; it covers the continuation running from the macro loop. Top-level work that outlasts the module load (a fetch against a server that answers after 300 ms, checked by hand) hangs without the fix and exits with it. The rest of that file, `transpiler.test.js`, the macro cases in `bundler_edgecase` / `bun-build-api`, `web-crypto.test.ts`, `spawn.test.ts` and the worker teardown tests pass with the debug build; the file also passes with a release build.

### Background
- A VM embeds two `EventLoop`s, `regular_event_loop` and `macro_event_loop`, plus `vm.event_loop`, a pointer to whichever is current. `MacroModeGuard` points it at the macro loop for the duration of a macro call (and of loading the macro module) so that the user program's queued work does not run in the middle of transpiling; a macro that returns a promise is settled by ticking that loop. Both loops sit on the same uSockets/libuv platform loop, whose active count is what keep-alives adjust and what `is_event_loop_alive()` reads.
- Each `EventLoop` has two things other threads write to: `concurrent_tasks`, the MPSC queue of completions (each tick moves a batch of it into the loop's own `tasks` FIFO and runs them), and `concurrent_ref`, a pending keep-alive delta that `apply_concurrent_ref_delta` folds into the platform loop's active count at the top of each tick. A `Ticket` (`VmHandle.rs`) is what off-thread work holds to reach either; its `LoopKind`, fixed when the work is created, says which loop's pair it writes to.
- In `bun run`, macros in the entry file (and in every file when transpiling happens on the main thread, e.g. with plugins) execute in the main VM, which is why this hangs the process. Macros in files transpiled on the thread pool and in `bun build` run in per-thread VMs whose regular loop never ticks, so there the same stranded work is only a leak, which is unchanged here.
- A sync macro calling `setImmediate()` also hangs, on 1.3.14 as well (immediates are per-loop too); that is pre-existing and not touched by this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.0 (af84237cd)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.04ms]
(pass) latin1 string [0.01ms]
(pass) ascii string
(pass) type coercion [0.09ms]
(pass) escaping [0.15ms]
(pass) utf16 string
(pass) import aliases [0.02ms]
(pass) default import [0.01ms]
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.07ms]
(pass) object argument with a sparse numeric key [9.95ms]
(pass) object destructuring of a macro result keeps every bound property regardless of key order or repeated keys [8.28ms]
(pass) work a macro starts without awaiting it > a crypto.subtle.digest() inside the macro still lets the process exit [8.20ms]
(fail) work a macro starts without awaiting it > an fs.promises call inside the macro still lets the process exit [5000.09ms]
  ^ this test timed out after 5000ms.
(fail) work a macro starts without awaiting it > an fs.promises call at the macro module's top level still lets the process exit [5000.07ms]
  ^ this test timed out after 5000ms.
(fail) work a macro starts without awaiting it > a fetch() inside the macro still lets the process exit [5000.06ms]
  ^ this test timed out after 5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.0 (af84237cd)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 667ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/663] cc obj/vendor/tinycc/x86_64-gen.c.o
[2/663] cc obj/vendor/tinycc/tccelf.c.o
[3/663] cc obj/vendor/tinycc/x86_64-link.c.o
[4/663] cc obj/vendor/tinycc/tccrun.c.o
[5/663] cc obj/vendor/tinycc/tccasm.c.o
[6/663] cc obj/vendor/tinycc/i386-asm.c.o
[7/663] fetch boringssl
[boringssl] up to date
[8/241] fetch hdrhistogram
[hdrhistogram] up to date
[9/238] fetch mimalloc
[mimalloc] up to date
[10/238] gen ZigGeneratedClasses.lut.h
Generating /workspace/bun/build/release/codegen/ZigGeneratedClasses.lut.h from /workspace/bun/build/release/codegen/ZigGeneratedClasses.lut.txt
[11/238] fetch highway
[highway] up to date
[12/229] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[13/229] cc obj/codegen/InternalModuleRegistryConstants.S.o
[14/229] fetch lolhtml
[lolhtml] up to date
[15/229] fetch WebKit (prebuilt)
[WebKit] up to date
[16/229] cc obj/vendor/mimalloc/src/static.c.o
[17/229] fetch lsquic
[lsquic] up to date
[18/160] cc obj/packages/bun-usockets/src/udp.c.o
[19/160] c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                  |   2 +-
 src/jsc/VmHandle.rs                        |   2 +
 src/jsc/event_loop.rs                      | 108 +++++++++++++----------------
 test/bundler/transpiler/macro-test.test.ts |  79 +++++++++++++++++++++
 4 files changed, 130 insertions(+), 61 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/VirtualMachine.rs                       5      1      0
src/jsc/VmHandle.rs                             6      7      0
src/jsc/event_loop.rs                          17     15      0
test/bundler/transpiler/macro-test.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->


