### PR TITLE
node:vm: resolve global let/const/class bindings from compileFunction bodies

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1593,16 +1593,17 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
     // Create the source origin
     SourceOrigin sourceOrigin { WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher };
 
-    // Process contextExtensions if they exist
-    JSScope* functionScope = options.parsingContext ? options.parsingContext : globalObject;
+    // globalScope() is the global lexical environment (script-level let/const/
+    // class bindings), which precedes the global object in every ordinary scope
+    // chain; a chain starting at the global object itself cannot see them.
+    JSScope* functionScope = options.parsingContext->globalScope();
 
     if (!options.contextExtensions.isUndefinedOrNull() && !options.contextExtensions.isEmpty() && options.contextExtensions.isObject() && isArray(globalObject, options.contextExtensions)) {
         auto* contextExtensionsArray = dynamicDowncast<JSArray>(options.contextExtensions);
         unsigned length = contextExtensionsArray ? contextExtensionsArray->length() : 0;
 
         if (length > 0) {
-            // Get the global scope from the parsing context
-            JSScope* currentScope = options.parsingContext->globalScope();
+            JSScope* currentScope = functionScope;
 
             // Create JSWithScope objects for each context extension
             for (unsigned i = 0; i < length; i++) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1595,7 +1595,9 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
 
     // globalScope() is the global lexical environment (script-level let/const/
     // class bindings), which precedes the global object in every ordinary scope
-    // chain; a chain starting at the global object itself cannot see them.
+    // chain; a chain starting at the global object itself cannot see them. The
+    // chain is given to the compiled function only: setGlobalScopeExtension()
+    // would expose it to every unresolved lookup in the realm.
     JSScope* functionScope = options.parsingContext->globalScope();
 
     if (!options.contextExtensions.isUndefinedOrNull() && !options.contextExtensions.isEmpty() && options.contextExtensions.isObject() && isArray(globalObject, options.contextExtensions)) {
@@ -1619,8 +1621,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
             functionScope = currentScope;
         }
     }
-
-    options.parsingContext->setGlobalScopeExtension(functionScope);
 
     // Create the function using constructAnonymousFunction with the appropriate scope chain
     JSFunction* function = constructAnonymousFunction(globalObject, ArgList(constructFunctionArgs), sourceOrigin, WTF::move(options), JSC::SourceTaintedOrigin::Untainted, functionScope);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1593,11 +1593,8 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
     // Create the source origin
     SourceOrigin sourceOrigin { WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher };
 
-    // globalScope() is the global lexical environment (script-level let/const/
-    // class bindings), which precedes the global object in every ordinary scope
-    // chain; a chain starting at the global object itself cannot see them. The
-    // chain is given to the compiled function only: setGlobalScopeExtension()
-    // would expose it to every unresolved lookup in the realm.
+    // globalScope() is the global lexical environment, which holds script-level
+    // let/const/class bindings; a chain rooted at the global object skips them.
     JSScope* functionScope = options.parsingContext->globalScope();
 
     if (!options.contextExtensions.isUndefinedOrNull() && !options.contextExtensions.isEmpty() && options.contextExtensions.isObject() && isArray(globalObject, options.contextExtensions)) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1593,8 +1593,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleCompileFunction, (JSGlobalObject * globalObject
     // Create the source origin
     SourceOrigin sourceOrigin { WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher };
 
-    // globalScope() is the global lexical environment, which holds script-level
-    // let/const/class bindings; a chain rooted at the global object skips them.
     JSScope* functionScope = options.parsingContext->globalScope();
 
     if (!options.contextExtensions.isUndefinedOrNull() && !options.contextExtensions.isEmpty() && options.contextExtensions.isObject() && isArray(globalObject, options.contextExtensions)) {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -305,10 +305,11 @@ describe("vm", () => {
         expect(fn()).toEqual(["var", "let", "const", "function"]);
       });
 
-      test("are visible when declared after the function was compiled", () => {
+      test("are visible once declared, even after the function was compiled and called", () => {
         const { run, options } = setup();
         const [name] = randomProps(1);
         const fn = compileFunction(`return ${name};`, [], options);
+        expect(fn).toThrow(`${name} is not defined`);
         run(`let ${name} = "declared later";`);
         expect(fn()).toBe("declared later");
       });
@@ -322,7 +323,7 @@ describe("vm", () => {
         expect(Object.hasOwn(globalObject, name)).toBe(false);
       });
 
-      test("are shadowed by contextExtensions", () => {
+      test("are shadowed by contextExtensions, which only the compiled function sees", () => {
         const { run, options } = setup();
         const [shadowed, visible, extensionOnly] = randomProps(3);
         run(`let ${shadowed} = "lexical"; let ${visible} = "lexical";`);
@@ -331,6 +332,9 @@ describe("vm", () => {
           contextExtensions: [{ [shadowed]: "extension", [extensionOnly]: "extension" }],
         });
         expect(fn()).toEqual(["extension", "lexical", "extension"]);
+        // The scope chain built for fn must not be installed on the context itself.
+        expect(run(`[${shadowed}, typeof ${extensionOnly}]`)).toEqual(["lexical", "undefined"]);
+        expect(compileFunction(`return typeof ${extensionOnly};`, [], options)()).toBe("undefined");
       });
     });
   });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -269,6 +269,70 @@ describe("vm", () => {
         expect(e).toBeTruthy();
       }
     });
+
+    // Top-level let/const/class declared by a script live in the context's
+    // global lexical environment, not on its global object. Like Node, the
+    // compiled function resolves names through it, whether it is compiled in
+    // the caller's context or in a parsingContext.
+    describe.each([
+      [
+        "this context",
+        () => ({
+          run: (code: string) => runInThisContext(code),
+          options: {},
+          globalObject: globalThis as object,
+        }),
+      ],
+      [
+        "a parsingContext",
+        () => {
+          // Undeclared sloppy-mode assignments made inside the context land on
+          // the contextified object, the way they land on globalThis above.
+          const context = createContext({});
+          return {
+            run: (code: string) => runInContext(code, context),
+            options: { parsingContext: context },
+            globalObject: context as object,
+          };
+        },
+      ],
+    ])("global lexical bindings of %s", (_label, setup) => {
+      test("are visible to the compiled function", () => {
+        const { run, options } = setup();
+        const [v, l, c, k] = randomProps(4);
+        run(`var ${v} = "var"; let ${l} = "let"; const ${c} = "const"; class ${k} {}`);
+        const fn = compileFunction(`return [${v}, ${l}, ${c}, typeof ${k}];`, [], options);
+        expect(fn()).toEqual(["var", "let", "const", "function"]);
+      });
+
+      test("are visible when declared after the function was compiled", () => {
+        const { run, options } = setup();
+        const [name] = randomProps(1);
+        const fn = compileFunction(`return ${name};`, [], options);
+        run(`let ${name} = "declared later";`);
+        expect(fn()).toBe("declared later");
+      });
+
+      test("receive assignments instead of a new global property being created", () => {
+        const { run, options, globalObject } = setup();
+        const [name] = randomProps(1);
+        run(`let ${name} = "initial";`);
+        compileFunction(`${name} = "assigned";`, [], options)();
+        expect(run(name)).toBe("assigned");
+        expect(Object.hasOwn(globalObject, name)).toBe(false);
+      });
+
+      test("are shadowed by contextExtensions", () => {
+        const { run, options } = setup();
+        const [shadowed, visible, extensionOnly] = randomProps(3);
+        run(`let ${shadowed} = "lexical"; let ${visible} = "lexical";`);
+        const fn = compileFunction(`return [${shadowed}, ${visible}, ${extensionOnly}];`, [], {
+          ...options,
+          contextExtensions: [{ [shadowed]: "extension", [extensionOnly]: "extension" }],
+        });
+        expect(fn()).toEqual(["extension", "lexical", "extension"]);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `vm.compileFunction("return x")()` throws `ReferenceError: x is not defined` when `x` was declared with `let`, `const` or `class` by a script in that context (`vm.runInThisContext`, or `vm.runInContext` when compiling with `parsingContext`). `var` declarations and global properties resolve fine. Node returns the binding's value.
- A sloppy-mode assignment to such a binding from the compiled body leaves the binding untouched and creates a property on the global object (the sandbox, for a context) instead.
- Both work as soon as any `contextExtensions` entry is passed, even `[{}]`.
- Cause: `vmModuleCompileFunction` (src/jsc/bindings/NodeVM.cpp:1597 on main) creates the function with the global object itself as its scope, so its scope chain is `[global object]`. Script-level lexical bindings live in the global lexical environment, which ordinary scope chains visit before the global object, so the compiled body never consults it. The `contextExtensions` branch builds its with-scopes on `parsingContext->globalScope()` (the lexical environment), which is why that path works.
- Present since `compileFunction` was added in #18285.

### Fix
- Create the function on `options.parsingContext->globalScope()`, giving the chain `[global lexical environment -> global object]`, and stack the `contextExtensions` with-scopes on that same base. `parsingContext` is always set by this point (`CompileFunctionOptions::fromJS` initializes it to the caller's global, and so does the fallback in `vmModuleCompileFunction`), so the old `parsingContext ? parsingContext : globalObject` never chose anything.
- This is the chain every other entry into a context's code gets: JSC's Function constructor creates functions on `globalObject->globalScope()` (FunctionConstructor.cpp), `Interpreter::executeProgram` runs scripts in it, module environments chain to it, and `JSScope::abstractAccess` has a dedicated `GlobalLexicalVar` resolution for it. It also matches Node, where a compiled function resolves script-level bindings like any other function of the context.
- Also drop the `options.parsingContext->setGlobalScopeExtension(functionScope)` call that followed. It installed the chain realm-wide, where `JSScope::resolve` consults it for every lookup that misses on the global object. On main that is inert without extensions (it installed the global object, which the lookup had just checked) and is the extension leak #38302 fixes with extensions. Combined with the first change alone, it would have installed the lexical environment, so after any plain `compileFunction()` call the unresolved identifiers of functions created directly on the global object (JSC builtins, Bun's internal modules) would have started resolving to the user's script-level `let`/`const` bindings; a reference to an undeclared `bindings` in node:wasi's `getState()` made this observable (see the details below). The chain is already what the function is created with, so the call contributed nothing to the function itself. This is the same one-line deletion as #38302, whose tests pass on this branch; whichever lands second rebases onto an identical deletion.
- `contextExtensions` keep shadowing lexical bindings (the with-scopes still sit in front of the base), and lookups through a with-scope are linked as `Dynamic` regardless of the realm-wide hook, which is why the function does not need it. Both are pinned by the tests.
- Verified with test/js/node/vm/vm.test.ts: the `global lexical bindings of ...` cases run the same four tests against the caller's context and against a `parsingContext` (visibility of `var`/`let`/`const`/`class`, a binding declared after the function was compiled and first called, assignment updating the binding without creating a global property, and extensions shadowing bindings while staying invisible to the context and to later compiles). All 8 fail on bun 1.4.0 and pass here. The rest of vm.test.ts, the other test/js/node/vm/ files, #38302's tests, and the vendored test-vm-basic.js, test-vm-module-basic.js, test-vm-no-dynamic-import-callback.js, test-vm-function-declaration.js, test-vm-context.js, test-vm-strict-assign.js, test-vm-not-strict.js, test-vm-cached-data.js and test-vm-createcacheddata.js pass with the debug build.
- Not done here: `constructAnonymousFunction` still takes the realm and the scope as separate parameters (#38297 changes which realm is passed). Once #38297, #38302 and this land, the realm, the base scope and the with-scope chain can all be derived from `parsingContext` in one place; that is a follow-up rather than something to fold into three concurrent one-line PRs.

### Background
- Global lexical environment (`JSGlobalLexicalEnvironment`, returned by `JSGlobalObject::globalScope()`): the JSC object holding a realm's script-level `let`/`const`/`class` bindings. Unlike `var` and function declarations, these are not properties of the global object. Its parent scope is the global object, so an ordinary scope chain ends with `... -> global lexical environment -> global object`.
- Scope of a `JSFunction`: the `JSScope*` it is created with. Free identifiers in the body are resolved by walking outwards from it, so a function created directly on the global object only sees global properties. JSC and Bun create their builtins and internal modules that way, since those reference no user bindings.
- `contextExtensions`: objects compileFunction places in front of the chain as `with`-style scopes (`JSWithScope`), so their properties shadow whatever is behind them. V8 builds the same chain for Node.
- Global scope extension (`JSGlobalObject::setGlobalScopeExtension`): a realm-wide hook that `JSScope::resolve` checks after a lookup has reached the global object and missed. JSC's own users (`evaluateWithScopeExtension`, the debugger) install it around a single evaluation and clear it afterwards.

<details>
<summary>Repro</summary>

```js
const vm = require("node:vm");
vm.runInThisContext("let lexical = 42; var hoisted = 43;");
vm.compileFunction("return hoisted")();                                // 43 everywhere
vm.compileFunction("return lexical")();                                // bun 1.4.0: ReferenceError, node: 42
vm.compileFunction("return lexical", [], { contextExtensions: [{}] })(); // 42 everywhere

const context = vm.createContext({});
vm.runInContext("let fromContext = 7;", context);
vm.compileFunction("return fromContext", [], { parsingContext: context })(); // bun 1.4.0: ReferenceError, node: 7
vm.compileFunction("fromContext = 8", [], { parsingContext: context })();
vm.runInContext("fromContext", context);                                // bun 1.4.0: 7 (and context.fromContext === 8), node: 8
```

With this change every line matches node v26.3.0.
</details>

<details>
<summary>Why the setGlobalScopeExtension call had to go in the same change</summary>

The first revision of this PR only changed the base scope and argued the remaining `setGlobalScopeExtension` call was unobservable because every lookup walks the lexical environment before reaching the global object. That is true for user code, but not for functions created directly on the global object. node:wasi's `WASI#getState()`/`setState()` reference an undeclared `bindings` (a separate bug), which makes the difference visible:

```js
const vm = require("node:vm");
const { WASI } = require("node:wasi");
const w = new WASI({ version: "preview1" });
vm.runInThisContext("let bindings = 'user-script-let';");
w.setState({ env: {}, FD_MAP: new Map(), bindings: "written-by-builtin" }); // ReferenceError on 1.4.0 and here
vm.compileFunction("");
w.setState({ env: {}, FD_MAP: new Map(), bindings: "written-by-builtin" }); // 1.4.0 and here: ReferenceError again
vm.runInThisContext("bindings");                                          // 1.4.0 and here: 'user-script-let'
```

With only the base-scope change, the second `setState` succeeded and overwrote the user's `let bindings`. Removing the call keeps the realm in the state it is in before any `compileFunction` call, which is also what the `which only the compiled function sees` assertions in the new tests check (they fail on 1.4.0 because of the extension leak, and would fail on the first revision for the same reason).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (ed9368854)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.64ms]
(pass) vm > runInContext() > can return a value [15.29ms]
(pass) vm > runInContext() > can return a complex value [15.48ms]
(pass) vm > runInContext() > can return the last value [14.67ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [15.97ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.45ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.25ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.67ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.50ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.95ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.09ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.82ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 8 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.32ms]
(pass) vm > runInContext() > can return a value [0.20ms]
(pass) vm > runInContext() > can return a complex value [0.20ms]
(pass) vm > runInContext() > can return the last value [0.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.27ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.13ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.13ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (ed9368854)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.63ms]
(pass) vm > runInContext() > can return a value [15.38ms]
(pass) vm > runInContext() > can return a complex value [16.08ms]
(pass) vm > runInContext() > can return the last value [15.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.97ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.20ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.16ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.70ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.68ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.84ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.54ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.41ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ed93688544
  features     baseline

22 deps, 123 codegen, 1176 objects in 738ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [53.00ms]
[5/1238] fetch zlib
[zlib] up to date
[6/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [3.00ms]
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1237] gen ProcessBindingConstants.lut.h

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp |  8 ++----
 test/js/node/vm/vm.test.ts  | 68 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 70 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      7      6      0
test/js/node/vm/vm.test.ts       4      4      0
```

</details>

**root cause** · written by the author bot

vm.compileFunction without contextExtensions built the compiled function's scope chain directly on the global object, bypassing the JSGlobalLexicalEnvironment where top level let, const and class bindings declared by scripts live, so those identifiers resolved as undefined even though var bindings were found and the contextExtensions path, which already stacked its with scopes on the lexical environment, worked. The fix bases the function's scope on parsingContext->globalScope() in both paths, matching what JSC's own Function constructor does, and removes the realm-wide setGlobalScopeExtens…

<!-- robobun:evidence:end -->