### PR TITLE
bundler: emit the module.exports body of a require()d CSS file

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2619,6 +2619,11 @@ impl<'a> LinkerContext<'a> {
         // does O(V*E) work when shorter paths are discovered late on
         // diamond-shaped DAGs.
         debug_assert!(ctx.queue.is_empty());
+        // A stylesheet entry point only gets a CSS chunk (`compute_chunks`), so
+        // its bit must not reach the runtime through the JS parts of the
+        // stylesheets it reaches: under `--splitting` that bit would move the
+        // runtime out of the chunks that print those parts.
+        let from_css_entry_point = ctx.css_reprs[source_index as usize].is_some();
         ctx.queue.push_back((source_index, distance));
 
         while let Some((source_index, distance)) = ctx.queue.pop_front() {
@@ -2650,19 +2655,12 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // A stylesheet's source index also holds the JS stub printed for it
-            // (the CommonJS wrapper when it is require()d, the namespace object
-            // when it is import-starred), whose parts depend on the runtime.
-            // Only the parts tree shaking kept get printed, so only those pull
-            // their dependencies into the chunk: the stub's namespace-export
-            // part uses `__export` whether or not anything import-stars it, and
-            // following it would put the runtime into every chunk that merely
-            // links a stylesheet.
-            let is_css = ctx.css_reprs[source_index as usize].is_some();
+            // Of the JS parts a stylesheet also carries, only the live ones get printed.
+            let live_parts_only = ctx.css_reprs[source_index as usize].is_some();
             let parts_live = &self.graph.parts_live[source_index as usize];
             let parts = ctx.parts[source_index as usize].as_slice();
             for (part_index, part) in parts.iter().enumerate() {
-                if is_css && !parts_live.is_set(part_index) {
+                if live_parts_only && (from_css_entry_point || !parts_live.is_set(part_index)) {
                     continue;
                 }
                 for dependency in part.dependencies.iter() {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2650,12 +2650,21 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // CSS files only follow their import records.
-            if ctx.css_reprs[source_index as usize].is_some() {
-                continue;
-            }
-
-            for part in ctx.parts[source_index as usize].as_slice() {
+            // A stylesheet's source index also holds the JS stub printed for it
+            // (the CommonJS wrapper when it is require()d, the namespace object
+            // when it is import-starred), whose parts depend on the runtime.
+            // Only the parts tree shaking kept get printed, so only those pull
+            // their dependencies into the chunk: the stub's namespace-export
+            // part uses `__export` whether or not anything import-stars it, and
+            // following it would put the runtime into every chunk that merely
+            // links a stylesheet.
+            let is_css = ctx.css_reprs[source_index as usize].is_some();
+            let parts_live = &self.graph.parts_live[source_index as usize];
+            let parts = ctx.parts[source_index as usize].as_slice();
+            for (part_index, part) in parts.iter().enumerate() {
+                if is_css && !parts_live.is_set(part_index) {
+                    continue;
+                }
                 for dependency in part.dependencies.iter() {
                     let dep = dependency.source_index.get();
                     if dep != source_index
@@ -2736,7 +2745,16 @@ impl<'a> LinkerContext<'a> {
                     }
                 }
             }
-            return;
+
+            // The JS printed for a stylesheet lives in this same source index.
+            // ESM importers reach its export parts through part dependencies,
+            // but when it is require()d (or import()ed without splitting)
+            // `generate_code_for_lazy_export` leaves a `module.exports = ...`
+            // part here that nothing depends on. Keep it the way the parts of
+            // every other CommonJS-wrapped file are kept: by walking the file.
+            if self.graph.meta.items_flags()[source_index as usize].wrap != WrapKind::Cjs {
+                return;
+            }
         }
 
         // HTML files can reference non-JS/CSS assets (favicons, images, etc.)

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -274,12 +274,13 @@ pub(crate) fn scan_imports_and_exports(
             // SAFETY: `split_raw()`-derived column ptrs carry root provenance
             // from the `MultiArrayList` heap buffer; this block holds no other
             // borrow into ast/meta/files and makes no `&mut this` calls, so
-            // the reborrows are exclusive for the block. All five derefs share
+            // the reborrows are exclusive for the block. All six derefs share
             // the same invariant, so they are grouped under one `unsafe`.
             let mut dependency_wrapper = unsafe {
                 DependencyWrapper {
                     flags: &mut *flags,
                     import_records: &*import_records_list,
+                    css_asts: &*css_asts,
                     exports_kind: &mut *exports_kind,
                     entry_point_kinds: &*entry_point_kinds,
                     export_star_map: HashMap::default(),
@@ -1145,6 +1146,7 @@ struct DependencyWrapper<'a> {
     flags: &'a mut [js_meta::Flags],
     exports_kind: &'a mut [ExportsKind],
     import_records: &'a [ImportRecordList<'a>],
+    css_asts: &'a [bundled_ast::CssCol],
     export_star_map: HashMap<IndexInt, ()>,
     entry_point_kinds: &'a [EntryPoint::Kind],
     export_star_records: &'a [bun_alloc::AstVec<u32>],
@@ -1217,6 +1219,14 @@ impl DependencyWrapper<'_> {
                     ExportsKind::Cjs => WrapKind::Cjs,
                     _ => WrapKind::Esm,
                 };
+            }
+
+            // The import records of a CSS file (`@import`, `url()`, `composes`)
+            // belong to its stylesheet, not to the JS stub that gets wrapped
+            // here; the stub evaluates nothing from them. Wrapping them would
+            // only emit empty `init_*` closures for the referenced files.
+            if self.css_asts[source_index as usize].is_some() {
+                continue;
             }
 
             for record in self.import_records[source_index as usize].as_slice() {

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -216,6 +217,48 @@ describe("css", () => {
       { file: "/out/a.js", stdout: "{}" },
       { file: "/out/b.js", stdout: '{"b":"b_Kd7Gww"}' },
     ],
+  });
+
+  // A stylesheet that is itself an entry point only produces a CSS file, so
+  // reaching the runtime from it must not count: the runtime has to stay in
+  // entry.js, the one chunk that prints the stylesheet's wrapper, instead of
+  // being split into a chunk of its own.
+  itBundled("css-module/RequireCssThatIsAlsoAnEntryPointWithSplitting", {
+    files: {
+      "/entry.js": `
+        console.log(JSON.stringify(require('./styles.module.css')));
+        export {};
+      `,
+      "/styles.module.css": `.foo { color: red }`,
+    },
+    entryPoints: ["/entry.js", "/styles.module.css"],
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["entry.css", "entry.js", "styles.module.css"]);
+      api.expectFile("/out/entry.js").toContain("var __commonJS =");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: '{"foo":"foo_-MSaAA"}',
+    },
+  });
+
+  itBundled("css-module/RequireCssThatIsAlsoAnEntryPointInCjsFormat", {
+    files: {
+      "/entry.js": `
+        console.log(JSON.stringify(require('./styles.module.css')));
+        export {};
+      `,
+      "/styles.module.css": `.foo { color: red }`,
+    },
+    entryPoints: ["/entry.js", "/styles.module.css"],
+    format: "cjs",
+    outdir: "/out",
+    run: {
+      file: "/out/entry.js",
+      stdout: '{"foo":"foo_-MSaAA"}',
+    },
   });
 
   // Wrapping a CSS file must not wrap the files its stylesheet references:

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -100,6 +100,167 @@ describe("css", () => {
     },
   });
 
+  // A require()'d CSS file is wrapped in a CommonJS closure whose body is the
+  // `module.exports = ...` assignment of its lazy export. That body used to be
+  // tree-shaken away, so require() returned `{}` and the class map was lost,
+  // and since the wrapper was the only thing in this bundle that needs the
+  // runtime, `__commonJS` itself was missing from the output as well.
+  itBundled("css-module/RequireCssModule", {
+    files: {
+      "/entry.js": `
+        const styles = require('./styles.module.css');
+        const plain = require('./plain.css');
+        console.log(JSON.stringify(styles), JSON.stringify(plain));
+        export {};
+      `,
+      "/styles.module.css": `
+        .foo { composes: base from './base.module.css'; color: red }
+        .bar { composes: foo; color: blue }
+      `,
+      "/base.module.css": `.base { padding: 0 }`,
+      "/plain.css": `.plain { color: green }`,
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+
+        // styles.module.css
+        var require_styles_module = __commonJS(function(exports, module) {
+          module.exports = {
+            foo: "base_1Cz41w foo_-MSaAA",
+            bar: "base_1Cz41w foo_-MSaAA bar_-MSaAA"
+          };
+        });
+
+        // plain.css
+        var require_plain = __commonJS(function(exports, module) {
+          module.exports = {};
+        });
+
+        // entry.js
+        var styles = require_styles_module();
+        var plain = require_plain();
+        console.log(JSON.stringify(styles), JSON.stringify(plain));
+        "
+      `);
+    },
+    run: {
+      stdout: '{"foo":"base_1Cz41w foo_-MSaAA","bar":"base_1Cz41w foo_-MSaAA bar_-MSaAA"} {}',
+    },
+  });
+
+  // Without code splitting, import() of a CSS file goes through the same
+  // CommonJS wrapper as require().
+  itBundled("css-module/DynamicImportCssModuleWithoutSplitting", {
+    files: {
+      "/entry.js": `
+        const { default: styles } = await import('./styles.module.css');
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `.foo { color: red }`,
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain("__toESM(require_styles_module()");
+    },
+    run: {
+      stdout: '{"foo":"foo_-MSaAA"}',
+    },
+  });
+
+  // Only the parts of a CSS file's JS side that actually get printed may pull
+  // the runtime into a chunk: a.js needs `__commonJS` for its require(), while
+  // b.js, which only reads the class map, must not pick up the helper that
+  // a.js made live.
+  itBundled("css-module/RequireCssInOneEntryDoesNotAddRuntimeToOthers", {
+    files: {
+      "/a.js": `
+        console.log(JSON.stringify(require('./a.css')));
+        export {};
+      `,
+      "/b.js": `
+        import styles from './b.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/a.css": `.a { color: red }`,
+      "/b.module.css": `.b { color: blue }`,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/a.js").toMatchInlineSnapshot(`
+        "var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+
+        // a.css
+        var require_a = __commonJS(function(exports, module) {
+          module.exports = {};
+        });
+
+        // a.js
+        console.log(JSON.stringify(require_a()));
+        "
+      `);
+      api.expectFile("/out/b.js").toMatchInlineSnapshot(`
+        "// b.module.css
+        var b_module_default = {
+          b: "b_Kd7Gww"
+        };
+
+        // b.js
+        console.log(JSON.stringify(b_module_default));
+        "
+      `);
+    },
+    run: [
+      { file: "/out/a.js", stdout: "{}" },
+      { file: "/out/b.js", stdout: '{"b":"b_Kd7Gww"}' },
+    ],
+  });
+
+  // Wrapping a CSS file must not wrap the files its stylesheet references:
+  // the stub evaluates nothing from them. The asset used to come out as an
+  // empty `init_img` closure (plus the `__esm` helper) that entry.js then
+  // had to call.
+  itBundled("css-module/RequireCssDoesNotWrapStylesheetDependencies", {
+    files: {
+      "/entry.js": `
+        import img from './img.png';
+        const styles = require('./styles.css');
+        console.log(JSON.stringify(styles), typeof img);
+      `,
+      "/styles.css": `
+        @import './base.css';
+        .styles { background: url('./img.png') }
+      `,
+      "/base.css": `.base { color: red }`,
+      "/img.png": "not really a png",
+    },
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+
+        // styles.css
+        var require_styles = __commonJS(function(exports, module) {
+          module.exports = {};
+        });
+
+        // img.png
+        var img_default = "./img-qwe8ze7q.png";
+
+        // entry.js
+        var styles = require_styles();
+        console.log(JSON.stringify(styles), typeof img_default);
+        "
+      `);
+      api.expectFile("/out/entry.css").toContain(".base {");
+    },
+    run: {
+      stdout: "{} string",
+    },
+  });
+
   // https://github.com/oven-sh/bun/issues/18921
   // The `animation` shorthand and `animation-name` longhand must scope their
   // referenced `@keyframes` name to the SAME hashed name the keyframes rule


### PR DESCRIPTION
### Problem
- `require("./x.module.css")`, and `import("./x.module.css")` without `--splitting`, bundle the CSS file to `var require_x_module = __commonJS(function(exports, module) {});`, so it evaluates to `{}` and the class map is lost. Plain `.css` gets the same empty wrapper. `import x from` and `import * as` are fine.
- When nothing else in the bundle uses the runtime (for example an entry point without exports), the output also lacks the definition of `__commonJS` and throws `ReferenceError: __commonJS is not defined` when loaded.
- Cause of the empty body: for a CommonJS-wrapped file, `generate_code_for_lazy_export` (`src/bundler/linker_context/generateCodeForLazyExport.rs:377`) rewrites the CSS file's lazy-export part into `module.exports = {...}`. Nothing depends on that part, and `mark_file_live_step` (`src/bundler/LinkerContext.rs:2730`) returned from its CSS branch before the walk that keeps the non-removable parts of every other live file, so the part was never live and `generate_code_for_file_in_chunk_js` skipped it.
- Cause of the missing `__commonJS`: `mark_file_reachable_for_code_splitting` (`src/bundler/LinkerContext.rs:2653`) likewise `continue`d for CSS files before following part dependencies. The wrapper part's dependency on the runtime's `__commonJS` part therefore never gave the runtime the entry point's bit, and the runtime was left out of the chunk.
- Related: wrapping a CSS file also propagated, in step 2 of `scan_imports_and_exports` (`DependencyWrapper::wrap`), into the stylesheet's own import records. An asset referenced by `url()` from a required stylesheet came out as `var init_img = () => {};` plus the `__esm` helper, and a JS import of the same asset gained an `init_img()` call.

### Fix
- `mark_file_live_step`: a CSS file whose wrap kind is `Cjs` falls through to the normal parts walk after following its CSS import records. The lazy-export part is the wrapper's body, and this is exactly how the parts of every other CommonJS-wrapped file (JSON, TOML, `.cjs`) are kept. ESM-imported CSS files are unchanged: their exports are reached through part dependencies, and the gate also leaves `--format internal_bake_dev` output as it is.
- `mark_file_reachable_for_code_splitting`: for a CSS file, follow the dependencies of its live parts. The live parts are precisely what gets printed for the file, so the runtime is reached exactly when the chunk prints something that uses it (the CommonJS wrapper here, or the `__export` namespace object of a namespace import). Following every part, as is done for JS files, would pull the runtime into every chunk that links a stylesheet, because every ESM-imported CSS stub has a namespace-export part depending on `__export`; that is what fails `test/bundler/html-import-manifest.test.ts` on #38286, which removes the `continue` unconditionally, and `RequireCssInOneEntryDoesNotAddRuntimeToOthers` below pins it.
- `DependencyWrapper::wrap`: wrapping a CSS file no longer descends into its import records. The stub evaluates nothing from its `@import` / `url()` / `composes` targets (composed class names are printed as strings at bundle time), so wrapping them only produced the empty closures above. esbuild's stub for a CSS file has no import records at all.
- Verified with `bun bd test test/bundler/css/css-modules.test.ts`: four new tests, each failing on the released build (`{}` output, the `ReferenceError`, snapshots containing the empty wrapper and `init_img`), passing with the fix.
- Also run, unchanged: `bundler_loader`, `bundler_splitting`, `html-import-manifest`, `bundler_html`, `bundler_html_server`, `metafile`, `bundler_edgecase`, `bundler_cjs`, `bundler_cjs2esm`, `bun-build-api`, `bundler_regressions`, `bundler_defer`, `bundler_bun`, `bundler_compile_splitting`, and the esbuild `css`, `loader`, `splitting`, `default`, `dce`, `importstar`, `metafile` suites (907 tests, 0 failures). `cargo clippy -p bun_bundler` is clean.
- Relationship to #38286 (namespace import of a CSS file): its reachability hunk is the unconditional form of the one here, so the two touch the same lines; its cross-chunk change for `--splitting` is not part of this PR. With this PR the namespace-import case works without `--splitting` as well. `--splitting` combined with `require()` or `import()` of a CSS file is a separate, pre-existing problem (cross-chunk imports and CSS dynamic-import entry points) that this PR does not address.

### Background
- Lazy export: loaders such as JSON, TOML and CSS do not parse to JS. The parser builds a two-part JS AST for them (`to_lazy_export_ast`) whose part 1 holds a single `SLazyExport` expression, and `generate_code_for_lazy_export` later turns it into either `module.exports = expr` (when the file ends up CommonJS, i.e. it was `require()`d) or generated `export` parts. For CSS the expression is the class-name map (`{}` for plain CSS), and the same source index also carries the stylesheet. esbuild gives this stub its own source index, which is where the CSS special cases in these passes come from.
- Parts and liveness: every file is split into parts. Tree shaking (`mark_file_live_step`) marks a live file's non-removable parts live and follows part dependencies; only live parts are printed. The CommonJS wrapper `var require_x = __commonJS(...)` is a synthesized part that importers depend on, and its body is the file's other live parts.
- Entry bits: after tree shaking, `mark_file_reachable_for_code_splitting` records which entry points reach each file through import records and part dependencies. A file's live parts are printed into a chunk only if the file carries that chunk's entry bit; this is how the runtime module (`__commonJS`, `__export`, ...) gets into a chunk.
- Wrapping propagation: when a file gets wrapped, step 2 of `scan_imports_and_exports` wraps the files it imports too, so that they are evaluated lazily together with it.

<details>
<summary>Repro and output</summary>

```sh
printf '.foo { color: blue }\n' > style.module.css
printf 'const s = require("./style.module.css");\nconsole.log(JSON.stringify(s));\nexport {};\n' > entry.ts
bun build entry.ts --outdir out && bun out/entry.js
```

Before:

```js
// style.module.css
var require_style_module = __commonJS(function(exports, module) {});

// entry.ts
var s = require_style_module();
console.log(JSON.stringify(s));
```

```
ReferenceError: __commonJS is not defined
```

(With an entry point that does reach the runtime for another reason, it runs and prints `{}`.)

After:

```js
var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);

// style.module.css
var require_style_module = __commonJS(function(exports, module) {
  module.exports = {
    foo: "foo_Hg8gNQ"
  };
});

// entry.ts
var s = require_style_module();
console.log(JSON.stringify(s));
```

```
{"foo":"foo_Hg8gNQ"}
```

Output of `require("./a.css")` where `a.css` contains `url(./img.png)`, before (the `__esm` line and the `img.png` block are gone after):

```js
var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
var __esm = (fn, res) => () => (fn && (res = fn(fn = 0)), res);

// a.css
var require_a = __commonJS(function(exports, module) {});

// img.png
var init_img = () => {};
```

</details>
