### PR TITLE
error printer: keep parsing error.stack past frames without a function name

### DIFF
--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -261,8 +261,7 @@ public:
     {
     }
 
-    // Index of the "(" before the location in "name (location)", or notFound for a
-    // bare "location", which is how frames without a function name are printed.
+    // The "(" opening the location of "name (location)"; notFound for a bare "location", which is how frames without a function name are printed.
     static size_t locationOpeningParenthesis(StringView line)
     {
         if (!line.endsWith(')'))

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -261,17 +261,14 @@ public:
     {
     }
 
-    // A frame is either "functionName (location)" or, when the frame has no
-    // function name (module top-level code, "unknown", "native"), a bare
-    // "location". Only the former ends with a parenthesis. Returns the index of
-    // the "(" opening the location, or notFound for a bare location.
+    // Index of the "(" before the location in "name (location)", or notFound for a
+    // bare "location", which is how frames without a function name are printed.
     static size_t locationOpeningParenthesis(StringView line)
     {
         if (!line.endsWith(')'))
             return WTF::notFound;
 
-        // Match the final ")" so that parentheses inside the location
-        // ("/app/(group)/page.js") or the function name are skipped over.
+        // Balance the final ")" so that a "(group)" inside the location is skipped.
         unsigned depth = 0;
         for (unsigned i = line.length(); i-- > 0;) {
             if (line[i] == ')')
@@ -280,7 +277,7 @@ public:
                 return i;
         }
 
-        // Unbalanced: more ")" than "(".
+        // More ")" than "(".
         return line.find('(');
     }
 

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -261,6 +261,29 @@ public:
     {
     }
 
+    // A frame is either "functionName (location)" or, when the frame has no
+    // function name (module top-level code, "unknown", "native"), a bare
+    // "location". Only the former ends with a parenthesis. Returns the index of
+    // the "(" opening the location, or notFound for a bare location.
+    static size_t locationOpeningParenthesis(StringView line)
+    {
+        if (!line.endsWith(')'))
+            return WTF::notFound;
+
+        // Match the final ")" so that parentheses inside the location
+        // ("/app/(group)/page.js") or the function name are skipped over.
+        unsigned depth = 0;
+        for (unsigned i = line.length(); i-- > 0;) {
+            if (line[i] == ')')
+                depth++;
+            else if (line[i] == '(' && --depth == 0)
+                return i;
+        }
+
+        // Unbalanced: more ")" than "(".
+        return line.find('(');
+    }
+
     bool parseFrame(StackFrame& frame)
     {
 
@@ -289,12 +312,9 @@ public:
         StringView line = stack.substring(start, end - start).trim(isASCIIWhitespace<char16_t>);
         offset = end;
 
-        // A frame is either "functionName (location)" or, when the frame has no
-        // function name (module top-level code, "unknown", "native"), a bare
-        // "location". Only the former ends with a parenthesis.
         StringView functionName;
         StringView lineInner = line;
-        auto openingParentheses = line.endsWith(')') ? line.reverseFind('(') : WTF::notFound;
+        auto openingParentheses = locationOpeningParenthesis(line);
         if (openingParentheses != WTF::notFound) {
             lineInner = StringView_slice(line, openingParentheses + 1, line.length() - 1);
             functionName = line.substring(0, openingParentheses);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -286,31 +286,25 @@ public:
             return false;
         }
 
-        StringView line = stack.substring(start, end - start);
+        StringView line = stack.substring(start, end - start).trim(isASCIIWhitespace<char16_t>);
         offset = end;
 
-        // the proper singular spelling is parenthesis
-        auto openingParentheses = line.reverseFind('(');
-        auto closingParentheses = line.reverseFind(')');
-
-        if (openingParentheses > closingParentheses)
-            openingParentheses = WTF::notFound;
-
-        if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound) {
-            // Special case: "unknown" frames don't have parentheses but are valid
-            // These appear in stack traces from certain error paths
-            if (line == "unknown"_s) {
-                frame.sourceURL = line;
-                frame.functionName = StringView();
-                return true;
-            }
-
-            // For any other frame without parentheses, terminate parsing as before
-            offset = stack.length();
-            return false;
+        // A frame is either "functionName (location)" or, when the frame has no
+        // function name (module top-level code, "unknown", "native"), a bare
+        // "location". Only the former ends with a parenthesis.
+        StringView functionName;
+        StringView lineInner = line;
+        auto openingParentheses = line.endsWith(')') ? line.reverseFind('(') : WTF::notFound;
+        if (openingParentheses != WTF::notFound) {
+            lineInner = StringView_slice(line, openingParentheses + 1, line.length() - 1);
+            functionName = line.substring(0, openingParentheses);
+            if (functionName.endsWith(' '))
+                functionName = functionName.substring(0, functionName.length() - 1);
+        } else if (line.startsWith("async "_s)) {
+            // V8 prints async module code as "at async file:///path/to/module.mjs:1:2"
+            frame.isAsync = true;
+            lineInner = line.substring(6);
         }
-
-        auto lineInner = StringView_slice(line, openingParentheses + 1, closingParentheses);
 
         {
             auto marker1 = 0;
@@ -382,8 +376,6 @@ public:
             }
         }
     done_block:
-
-        StringView functionName = line.substring(0, openingParentheses - 1);
 
         if (functionName == "global code"_s) {
             functionName = StringView();

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -9,21 +10,23 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
-5 |   const err2 = new Error("error 2", { cause: err });
+2 | import { bunEnv, bunExe, tempDir } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
+6 |   const err2 = new Error("error 2", { cause: err });
                        ^
 error: error 2
-      at <anonymous> ([dir]/inspect-error.test.js:5:20)
+      at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
+2 | import { bunEnv, bunExe, tempDir } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
                       ^
 error: error 1
-      at <anonymous> ([dir]/inspect-error.test.js:4:19)
+      at <anonymous> ([dir]/inspect-error.test.js:5:19)
 "
 `);
 });
@@ -35,15 +38,15 @@ test("Error", () => {
       .replaceAll("\\", "/")
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
-"27 | "
-28 | \`);
-29 | });
-30 | 
-31 | test("Error", () => {
-32 |   const err = new Error("my message");
+"30 | "
+31 | \`);
+32 | });
+33 | 
+34 | test("Error", () => {
+35 |   const err = new Error("my message");
                        ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:32:19)
+      at <anonymous> ([dir]/inspect-error.test.js:35:19)
 "
 `);
 });
@@ -71,22 +74,13 @@ note: "duplicateConstDecl" was originally declared here
   }
 });
 
-const normalizeError = str => {
-  // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
-    const splits = str.split("\n");
-    for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
-        splits.splice(i, 1);
-        i--;
-      }
-    }
-    return splits.join("\n");
-  }
-
-  return str;
-};
+const normalizeError = str =>
+  // remove debug-only stack trace frames of bun's own builtins, which have a
+  // position but no file, like "at require (51:24)"
+  str
+    .split("\n")
+    .filter(line => !/^\s*at \S+ \(:?\d+:\d+\)$/.test(line))
+    .join("\n");
 
 test("Error inside minified file (no color) ", () => {
   try {
@@ -111,7 +105,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:86:7)"
     `);
   }
 });
@@ -140,7 +134,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:114:7)"
     `);
   }
 });
@@ -154,7 +148,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:143:19)"
 `);
 });
 
@@ -187,4 +181,118 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
   expect(() => {
     throw err;
   }).toThrow();
+});
+
+// Once error.stack has been read (or assigned), JSC no longer has the frames of
+// the error and the printer parses the "    at ..." lines of that string instead.
+describe("printing the frames parsed back out of error.stack", () => {
+  const printedFrames = text =>
+    text
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at "));
+
+  const printStack = lines => {
+    const err = new Error("boom");
+    err.stack = lines.join("\n");
+    return printedFrames(Bun.inspect(err));
+  };
+
+  test("frames without a function name, as bun prints module top-level code and native frames", () => {
+    expect(
+      printStack([
+        "Error: boom",
+        "    at thrower (/fake/lib.mjs:2:13)",
+        "    at /fake/lib.mjs:4:1",
+        "    at unknown",
+        "    at load (/fake/main.mjs:4:3)",
+        "    at /fake/main.mjs:7",
+      ]),
+    ).toEqual([
+      "at thrower (/fake/lib.mjs:2:13)",
+      "at /fake/lib.mjs:4:1",
+      expect.stringMatching(/^at unknown\b/),
+      "at load (/fake/main.mjs:4:3)",
+      expect.stringMatching(/^at \/fake\/main\.mjs:7\b/),
+    ]);
+  });
+
+  test("frames without a function name, as node prints ES module top-level code", () => {
+    expect(
+      printStack([
+        "Error: boom",
+        "    at thrower (file:///fake/lib.mjs:2:13)",
+        "    at file:///fake/lib.mjs:4:1",
+        "    at async file:///fake/main.mjs:3:7",
+        "    at node:internal/main/run_main_module:36:49",
+      ]),
+    ).toEqual([
+      "at thrower (file:///fake/lib.mjs:2:13)",
+      "at file:///fake/lib.mjs:4:1",
+      "at file:///fake/main.mjs:3:7",
+      "at node:internal/main/run_main_module:36:49",
+    ]);
+  });
+
+  test("a path containing parentheses is not mistaken for a function name", () => {
+    expect(printStack(["Error: boom", "    at /fake/app/(group)/page.js:5:3"])).toEqual([
+      "at /fake/app/(group)/page.js:5:3",
+    ]);
+  });
+
+  test("CRLF line endings", () => {
+    expect(
+      printStack(["Error: boom\r", "    at thrower (/fake/lib.mjs:2:13)\r", "    at /fake/lib.mjs:4:1\r"]),
+    ).toEqual(["at thrower (/fake/lib.mjs:2:13)", "at /fake/lib.mjs:4:1"]);
+  });
+
+  test.concurrent("Bun.inspect and the uncaught exception printout show every frame of error.stack", async () => {
+    // require() puts the top-level frame of lib.mjs in the middle of the stack,
+    // with load() and the top-level frame of main.mjs below it.
+    using dir = tempDir("inspect-error-stack-string", {
+      "lib.mjs": ["function thrower() {", '  throw new Error("boom");', "}", "thrower();", ""].join("\n"),
+      "main.mjs": [
+        'import { createRequire } from "node:module";',
+        "const require = createRequire(import.meta.url);",
+        "function load() {",
+        '  require("./lib.mjs");',
+        "}",
+        "try {",
+        "  load();",
+        "} catch (e) {",
+        "  console.log(JSON.stringify({ stack: e.stack, inspect: Bun.inspect(e) }));",
+        "  throw e;",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const { stack, inspect } = JSON.parse(stdout);
+
+    // The frames of require() itself (between lib.mjs and load) are native and
+    // vary between debug and release builds, so only the frames of the two
+    // files are compared.
+    const prefix = String(dir).replaceAll("\\", "/") + "/";
+    const ownFrames = text =>
+      printedFrames(text.replaceAll("\\", "/").replaceAll(prefix, "")).filter(line => line.includes(".mjs"));
+    const expected = [
+      expect.stringMatching(/^at thrower \(lib\.mjs:\d+:\d+\)$/),
+      expect.stringMatching(/^at lib\.mjs:\d+(:\d+)?$/),
+      expect.stringMatching(/^at load \(main\.mjs:\d+:\d+\)$/),
+      expect.stringMatching(/^at main\.mjs:\d+(:\d+)?$/),
+    ];
+    expect({ stack: ownFrames(stack), inspect: ownFrames(inspect), uncaught: ownFrames(stderr) }).toEqual({
+      stack: expected,
+      inspect: expected,
+      uncaught: expected,
+    });
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -234,9 +234,18 @@ describe("printing the frames parsed back out of error.stack", () => {
     ]);
   });
 
-  test("a path containing parentheses is not mistaken for a function name", () => {
-    expect(printStack(["Error: boom", "    at /fake/app/(group)/page.js:5:3"])).toEqual([
-      "at /fake/app/(group)/page.js:5:3",
+  test("parentheses inside the path or the function name", () => {
+    expect(
+      printStack([
+        "Error: boom",
+        "    at render (/fake/app/(group)/page.js:5:3)",
+        "    at /fake/app/(group)/page.js:9:1",
+        "    at method (with parens) (/fake/lib.js:2:3)", // { "method (with parens)"() {} }
+      ]),
+    ).toEqual([
+      "at render (/fake/app/(group)/page.js:5:3)",
+      "at /fake/app/(group)/page.js:9:1",
+      "at method (with parens) (/fake/lib.js:2:3)",
     ]);
   });
 


### PR DESCRIPTION
### Problem

- After `error.stack` has been read (or assigned), `Bun.inspect(err)`, `console.error(err)`, the uncaught exception printout and the `bun test` failure output stop at the first frame that has no function name. For an error thrown from a module's top-level code that is the module frame itself, so the printed trace ends one frame early; when the module was loaded by `require()`, every frame below it (the caller of `require()` and up) is lost as well. Before `.stack` is read, the same error prints all of its frames.
- Reproduces on 1.3.14 and on current main:

  ```js
  function inner() { throw new Error("X"); }
  function mid() { inner(); }
  try { mid() } catch (e) { console.log(Bun.inspect(e)); }            // inner, mid, /tmp/m.js:4:7
  try { mid() } catch (e) { e.stack; console.log(Bun.inspect(e)); }   // inner, mid
  ```

- Cause: once `.stack` is materialized JSC drops the structured frames, so `fromErrorInstance` (`src/jsc/bindings/ZigException.cpp`) re-parses the stack string with `V8StackTraceIterator::parseFrame`. Frames without a function name are printed as a bare location (`    at /tmp/m.js:4:7`, no parentheses), and `parseFrame` only accepted such a line when it was literally `unknown` (#23034); for anything else it set `offset = stack.length()` and returned false, which ends the parse of the whole trace, not just of that line (`ZigException.cpp:299-311` before this change).
- The same code split every line at its last `(`, so a path containing parentheses was mis-parsed in both shapes: `at render (/app/(group)/page.js:5:3)` printed as `at render (/app (group)/page.js:5:3)` and the bare `at /app/(group)/page.js:9:1` as `at /app (group:1:1)`.

### Fix

- `parseFrame` decides the shape of a line by whether it ends with `)`. If it does not, the whole line is the location and the function name is empty (a leading `async `, which V8 prints for async module code, sets `isAsync`); the `unknown` special case is subsumed. If it does, the line is split at the `(` that balances the final `)` (`locationOpeningParenthesis`), falling back to the first `(` when the line has more `)` than `(`. The line is trimmed first so a trailing `\r` or space does not change its shape.
- Why this is correct: both Bun's formatter (`FormatStackTraceForJS.cpp` appends `" ("` and `')'` only when the function name is non-empty) and V8 emit exactly these two shapes, and only the named one ends with `)`. Balancing the final `)` gives the right split whenever the location and the name are themselves balanced, which covers real paths (`(group)` route directories, `file (1).js`), string-literal method names with parentheses, and V8's nested `eval at ... (...)` locations; the only inputs still split differently from before are ones the old code got wrong. The location of both shapes goes through the same `url[:line[:column]]` parser as before, so Windows paths, `file://` URLs and `node:` specifiers parse the same way in both. A frame with an empty function name and a position is printed by every consumer (`print_stack_trace`, the JUnit and GitHub Actions reporters) as `at <location>`, which is what the structured path prints for module code, so the re-parsed trace now matches the trace printed before `.stack` was read.
- Blast radius: lines the old code stopped at are now parsed as bare locations; lines with parentheses inside the location or the name are now split correctly; every other `name (location)` line splits exactly as before (for those, the last `(` is the balancing one). `test/regression/issue/23022-stack-trace-iterator.test.ts` (the `unknown` case) still passes.
- Tests: `test/js/bun/util/inspect-error.test.js`, new `describe("printing the frames parsed back out of error.stack")`: bare frames in the middle and at the end of a Bun-format stack, node's `file://` / `async file://` / `node:` top-level frames, parentheses inside the path (named and bare) and inside a function name, CRLF, and a two-file program whose `.stack`, `Bun.inspect()` and uncaught printout must all show the same four frames of the two files (top-level frame of the required module in the middle of the trace). All five fail on the release binary and on main's `src/` under `bun bd`, and pass with this change. The file's `normalizeError` helper is also updated: debug builds now print the builtin frame as `at require (51:24)` rather than `at require (:1:21)`, so the two minified-file tests were already failing under `bun bd` on main.
- Also run with this change: `inspect.test.js`, `reportError.test.ts`, `test/js/bun/test/stack.test.ts`, `error-name-preservation.test.ts`, `circular-error-stack*.test.ts`, `fix-bindings-stack-trace.test.ts`, `prepare-stack-trace-crash.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/cli/test/bun-test.test.ts`, `test/js/bun/test/bun_test.test.ts`, `bun-test.test.ts`: all pass.
- Related open PRs: #38296 fixes the positions of these re-parsed frames being source-mapped a second time, which is why the new end-to-end test asserts the frames but not their line:column; once both land, its "stack then inspect" test can assert the module frame too. #36602 carries an equivalent bare-location change inside its AggregateError work, and #35175 contains the same parenthesis balancing as part of its eval-frame work; whichever lands second is a small textual rebase.

### Background

- `error.stack` in JSC is computed lazily: `ErrorInstance` keeps the captured `JSC::StackFrame`s until the property is first read or written, formats them into the string, and then frees them. Bun's native error printer (`remap_zig_exception` in `src/jsc/VirtualMachine.rs`, which serves `Bun.inspect`, `console.*`, uncaught exceptions and the test reporters) therefore has two sources of frames: the structured frames if they still exist, otherwise the `.stack` string, which `fromErrorInstance` parses back into `ZigStackFrame`s with `V8StackTraceIterator`.
- V8 format (which Bun's `.stack` follows): each frame is a line starting with four spaces and `at `, followed by either `name (url:line:column)` or, when there is no name, just `url:line:column`. Module top-level code, Bun's native frames (`unknown`, `native`) and node's ESM top-level frames (`at file:///x.mjs:4:7`, `at async file:///x.mjs:4:7`) all take the second form.

<details>
<summary>First version of this PR</summary>

The first push only changed the bare-location handling and still split named frames at the last `(`; review pointed out that `at render (/app/(group)/page.js:5:3)` was therefore still mis-parsed, so the balancing split and its test were added.

</details>
