### PR TITLE
install: ignore leading whitespace wherever a dependency literal is classified or re-parsed

### DIFF
--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -298,7 +298,8 @@ pub(crate) fn edit_update_no_args_in(
                         let version_literal = value
                             .as_utf8_string_literal()
                             .unwrap_or_else(|| bun_core::out_of_memory());
-                        let mut tag = dependency::Tag::infer(version_literal);
+                        let mut tag =
+                            dependency::Tag::infer(dependency::trim_literal(version_literal));
 
                         // npm versions only (and dist-tags with --latest); `catalog:` is handled by edit_catalogs_*.
                         if tag != dependency::Tag::Npm
@@ -403,7 +404,9 @@ pub(crate) fn edit_update_no_args_in(
                         let value_literal = value
                             .as_utf8_string_literal()
                             .unwrap_or_else(|| bun_core::out_of_memory());
-                        if dependency::Tag::infer(value_literal) == dependency::Tag::Catalog {
+                        if dependency::Tag::infer(dependency::trim_literal(value_literal))
+                            == dependency::Tag::Catalog
+                        {
                             continue;
                         }
 
@@ -499,8 +502,9 @@ pub(crate) fn edit_update_no_args_in(
                                     };
 
                                     if is_alias {
-                                        let dep_literal =
-                                            workspace_dep.version.literal.slice(string_buf);
+                                        let dep_literal = dependency::trim_literal(
+                                            workspace_dep.version.literal.slice(string_buf),
+                                        );
 
                                         // negative because the real package might have a scope
                                         // e.g. "dep": "npm:@foo/bar@1.2.3"
@@ -621,7 +625,7 @@ pub(crate) fn edit_catalogs_before_update(
             let version_literal = value
                 .as_utf8_string_literal()
                 .unwrap_or_else(|| bun_core::out_of_memory());
-            let mut tag = dependency::Tag::infer(version_literal);
+            let mut tag = dependency::Tag::infer(dependency::trim_literal(version_literal));
 
             let mut alias_at_index: Option<usize> = None;
             if strings::trim(version_literal, &strings::WHITESPACE_CHARS).starts_with(b"npm:") {
@@ -781,7 +785,7 @@ pub(crate) fn edit_catalogs_after_update(
         };
 
         new_literals[index] = Some(if info.is_alias {
-            let dep_literal = &info.original_version_literal;
+            let dep_literal = dependency::trim_literal(&info.original_version_literal);
             if let Some(at_index) = strings::last_index_of_char(dep_literal, b'@') {
                 let mut v = Vec::new();
                 write!(
@@ -917,8 +921,9 @@ pub(crate) fn edit(
                                         == Subcommand::Update
                                         && value.expr.as_utf8_string_literal().is_some_and(
                                             |version_literal| {
-                                                dependency::Tag::infer(version_literal)
-                                                    == dependency::Tag::Catalog
+                                                dependency::Tag::infer(dependency::trim_literal(
+                                                    version_literal,
+                                                )) == dependency::Tag::Catalog
                                             },
                                         );
 
@@ -937,8 +942,9 @@ pub(crate) fn edit(
                                                 else {
                                                     break 'add_packages_to_update;
                                                 };
-                                                let mut tag =
-                                                    dependency::Tag::infer(version_literal);
+                                                let mut tag = dependency::Tag::infer(
+                                                    dependency::trim_literal(version_literal),
+                                                );
 
                                                 if tag != dependency::Tag::Npm
                                                     && tag != dependency::Tag::DistTag
@@ -1423,7 +1429,8 @@ pub(crate) fn edit(
             let e_string = unsafe { &mut *e_string };
             // `bun update <pkg>` keeps a `catalog:` reference; `bun add` still replaces it.
             if manager.subcommand == Subcommand::Update
-                && dependency::Tag::infer(e_string.data.slice()) == dependency::Tag::Catalog
+                && dependency::Tag::infer(dependency::trim_literal(e_string.data.slice()))
+                    == dependency::Tag::Catalog
             {
                 continue;
             }
@@ -1518,7 +1525,9 @@ pub(crate) fn edit(
                                 };
 
                                 if entry.value.is_alias {
-                                    let dep_literal = &entry.value.original_version_literal;
+                                    let dep_literal = dependency::trim_literal(
+                                        &entry.value.original_version_literal,
+                                    );
 
                                     if let Some(at_index) =
                                         strings::last_index_of_char(dep_literal, b'@')

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -1164,9 +1164,7 @@ pub(crate) fn is_windows_abs_path_with_leading_slashes(dep: &[u8]) -> Option<&[u
     None
 }
 
-/// The specifier inside a version literal: a package.json value may carry leading whitespace
-/// (`" npm:foo@^1"`), which is not part of the specifier. Every path that classifies
-/// (`Tag::infer`) or parses a literal must look at these bytes, never at the raw literal.
+/// Literals may carry leading whitespace; classify and parse these bytes, not the raw literal.
 #[inline]
 pub fn trim_literal(literal: &[u8]) -> &[u8] {
     strings::trim_left(literal, b" \t\n\r")

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -693,7 +693,7 @@ impl VersionExt for Version {
         parse_with_tag(
             alias,
             Some(alias_hash),
-            sliced.slice,
+            trim_literal(sliced.slice),
             tag,
             &sliced,
             Some(ctx.log),

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -233,7 +233,7 @@ impl DependencyExt for Dependency {
                 Some(Semver::string::Builder::string_hash(
                     new_name.slice(out_slice),
                 )),
-                new_literal.slice(out_slice),
+                trim_literal(new_literal.slice(out_slice)),
                 self.version.tag,
                 &sliced,
                 None,
@@ -1164,6 +1164,14 @@ pub(crate) fn is_windows_abs_path_with_leading_slashes(dep: &[u8]) -> Option<&[u
     None
 }
 
+/// The specifier inside a version literal: a package.json value may carry leading whitespace
+/// (`" npm:foo@^1"`), which is not part of the specifier. Every path that classifies
+/// (`Tag::infer`) or parses a literal must look at these bytes, never at the raw literal.
+#[inline]
+pub fn trim_literal(literal: &[u8]) -> &[u8] {
+    strings::trim_left(literal, b" \t\n\r")
+}
+
 #[inline]
 pub fn parse<'a, 'b>(
     alias: String,
@@ -1173,7 +1181,7 @@ pub fn parse<'a, 'b>(
     log: impl Into<Option<&'a mut bun_ast::Log>>,
     manager: impl Into<Option<&'b mut PackageManager>>,
 ) -> Option<Version> {
-    let dep = strings::trim_left(dependency, b" \t\n\r");
+    let dep = trim_literal(dependency);
     parse_with_tag(
         alias,
         alias_hash.into(),
@@ -1194,7 +1202,7 @@ pub(crate) fn parse_with_optional_tag<'a, 'b>(
     log: impl Into<Option<&'a mut bun_ast::Log>>,
     package_manager: impl Into<Option<&'b mut PackageManager>>,
 ) -> Option<Version> {
-    let dep = strings::trim_left(dependency, b" \t\n\r");
+    let dep = trim_literal(dependency);
     parse_with_tag(
         alias,
         alias_hash.into(),

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1631,7 +1631,9 @@ impl Package<u64> {
     ) -> crate::Result<Option<Dependency>> {
         #[cfg(windows)]
         let external_version = 'brk: {
-            match tag.unwrap_or_else(|| dependency::version::Tag::infer(version)) {
+            match tag.unwrap_or_else(|| {
+                dependency::version::Tag::infer(dependency::trim_literal(version))
+            }) {
                 dependency::version::Tag::Workspace
                 | dependency::version::Tag::Folder
                 | dependency::version::Tag::Symlink
@@ -1683,9 +1685,10 @@ impl Package<u64> {
                 semver::string::Builder::string_hash(npm_name.slice(buf))
             }
             dependency::version::Tag::Workspace => {
-                if strings::has_prefix(sliced.slice, b"workspace:") {
+                let literal = dependency::trim_literal(sliced.slice);
+                if strings::has_prefix(literal, b"workspace:") {
                     'brk: {
-                        let input = &sliced.slice[b"workspace:".len()..];
+                        let input = &literal[b"workspace:".len()..];
                         let trimmed = strings::trim(input, &strings::WHITESPACE_CHARS);
                         if trimmed.len() != 1
                             || (trimmed[0] != b'*' && trimmed[0] != b'^' && trimmed[0] != b'~')
@@ -2298,7 +2301,7 @@ impl Package<u64> {
                             string_builder.count(value);
 
                             // If it's a folder or workspace, pessimistically assume we will need a maximum path
-                            match dependency::version::Tag::infer(value) {
+                            match dependency::version::Tag::infer(dependency::trim_literal(value)) {
                                 dependency::version::Tag::Folder
                                 | dependency::version::Tag::Workspace => {
                                     string_builder.cap += MAX_PATH_BYTES;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3315,6 +3315,7 @@ fn edit_root_package_json(
                     else {
                         continue;
                     };
+                    let package_spec = bun_install::dependency::trim_literal(package_spec);
                     if let Some(without_workspace_protocol) =
                         strings::without_prefix_if_possible_comptime(package_spec, b"workspace:")
                     {

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -2395,6 +2395,7 @@ fn preserve_version_prefix(
     original_version: &[u8],
     new_version: &[u8],
 ) -> crate::Result<Box<[u8]>> {
+    let original_version = dependency::trim_literal(original_version);
     if original_version.len() > 1 {
         let mut orig_version: &[u8] = original_version;
         let mut alias: Option<&[u8]> = None;

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5448,6 +5448,44 @@ describe("update", () => {
       });
     }
 
+    test("bun update --interactive keeps the alias and the range prefix", async () => {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: {
+            "aliased-dep": " npm:no-deps@^1.0.0",
+            "no-deps": "\t~1.0.0",
+          },
+        }),
+      );
+      await runBunInstall(env, packageDir);
+
+      // `a` selects every package, enter confirms. bunEnv lets the prompt read keys from a pipe.
+      await using proc = spawn({
+        cmd: [bunExe(), "update", "--interactive", "--latest"],
+        cwd: packageDir,
+        env,
+        stdin: new Blob(["a\r"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ out, err, exitCode }).toMatchObject({ exitCode: 0 });
+
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        dependencies: {
+          "aliased-dep": "npm:no-deps@^2.0.0",
+          "no-deps": "~2.0.0",
+        },
+      });
+      expect(await file(join(packageDir, "node_modules", "aliased-dep", "package.json")).json()).toMatchObject({
+        name: "no-deps",
+        version: "2.0.0",
+      });
+    });
+
     test("a catalog reference in an earlier dependency group is left alone", async () => {
       // devDependencies are visited before dependencies. The entry recorded for `dependencies`
       // must not be spent rewriting the `catalog:` reference.

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -5405,6 +5405,89 @@ describe("update", () => {
       });
     });
   });
+  describe("leading whitespace in the version literal", () => {
+    // The installer ignores leading whitespace in a package.json version, so each of these must
+    // end up exactly where the same command takes the value without the whitespace.
+    const cases: [dependency: string, version: string, args: string[], updated: string, installed: string][] = [
+      ["aliased-dep", " npm:no-deps@^1.0.0", ["aliased-dep"], "npm:no-deps@^1.1.0", "1.1.0"],
+      ["aliased-dep", " npm:no-deps@^1.0.0", [], "npm:no-deps@^1.1.0", "1.1.0"],
+      ["aliased-dep", " npm:no-deps@^1.0.0", ["--latest"], "npm:no-deps@^2.0.0", "2.0.0"],
+      ["aliased-dep", "\tnpm:no-deps@~1.0.0", [], "npm:no-deps@~1.0.1", "1.0.1"],
+      ["aliased-dep", "\tnpm:no-deps@~1.0.0", ["--latest"], "npm:no-deps@~2.0.0", "2.0.0"],
+      ["no-deps", " ^1.0.0", [], "^1.1.0", "1.1.0"],
+      ["no-deps", " ^1.0.0", ["no-deps"], "^1.1.0", "1.1.0"],
+      ["no-deps", " ^1.0.0", ["--latest"], "^2.0.0", "2.0.0"],
+      ["no-deps", "\n~1.0.0", [], "~1.0.1", "1.0.1"],
+    ];
+
+    for (const [dependency, version, args, updated, installed] of cases) {
+      test(`${JSON.stringify(version)} with \`bun update${args.map(arg => ` ${arg}`).join("")}\``, async () => {
+        await write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies: {
+              [dependency]: version,
+            },
+          }),
+        );
+
+        await runBunUpdate(env, packageDir, args);
+        assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+        expect(await file(packageJson).json()).toEqual({
+          name: "foo",
+          dependencies: {
+            [dependency]: updated,
+          },
+        });
+        expect(await file(join(packageDir, "node_modules", dependency, "package.json")).json()).toMatchObject({
+          name: "no-deps",
+          version: installed,
+        });
+      });
+    }
+
+    test("a catalog reference in an earlier dependency group is left alone", async () => {
+      // devDependencies are visited before dependencies. The entry recorded for `dependencies`
+      // must not be spent rewriting the `catalog:` reference.
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          workspaces: {
+            catalog: {
+              "no-deps": "^1.0.0",
+            },
+          },
+          devDependencies: {
+            "no-deps": " catalog:",
+          },
+          dependencies: {
+            "no-deps": " ^1.0.0",
+          },
+        }),
+      );
+
+      await runBunUpdate(env, packageDir);
+      assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        workspaces: {
+          catalog: {
+            "no-deps": "^1.1.0",
+          },
+        },
+        devDependencies: {
+          "no-deps": " catalog:",
+        },
+        dependencies: {
+          "no-deps": "^1.1.0",
+        },
+      });
+    });
+  });
   test("--no-save will update packages in node_modules and not save to package.json", async () => {
     await write(
       packageJson,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9883,49 +9883,56 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
   }
 });
 
-it("installs a file: dependency whose version literal has leading whitespace", async () => {
-  // The folder path is longer than an inline string so that it has to be appended to the
-  // lockfile's string buffer, which only has room for it if the literal was classified as a folder.
-  const literal = " file:./vendor/some-long-directory-name/lib";
-  using dir = tempDir("whitespace-file-dep", {
-    "package.json": JSON.stringify({
-      name: "my-app",
-      version: "1.0.0",
-      dependencies: {
-        lib: literal,
-      },
-    }),
-    "vendor/some-long-directory-name/lib/package.json": JSON.stringify({
-      name: "lib",
-      version: "1.0.0",
-    }),
+for (const lockfile of ["bun.lock", "bun.lockb"]) {
+  it(`installs a file: dependency whose version literal has leading whitespace (${lockfile})`, async () => {
+    // The folder path is longer than an inline string so that it has to be appended to the
+    // lockfile's string buffer, which only has room for it if the literal was classified as a folder.
+    const literal = " file:./vendor/some-long-directory-name/lib";
+    using dir = tempDir("whitespace-file-dep", {
+      "package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          lib: literal,
+        },
+      }),
+      "vendor/some-long-directory-name/lib/package.json": JSON.stringify({
+        name: "lib",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `install.saveTextLockfile = ${lockfile === "bun.lock"}`,
+    });
+
+    // The first pass resolves from package.json; the second installs from the lockfile the first
+    // pass wrote, which stores the literal as written and has to parse it as a folder again.
+    for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
+      await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), ...args],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+      expect(err).not.toContain("error:");
+      expect(out).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+
+      expect(await file(join(String(dir), "node_modules", "lib", "package.json")).json()).toEqual({
+        name: "lib",
+        version: "1.0.0",
+      });
+      if (lockfile === "bun.lock") {
+        expect(await file(join(String(dir), "bun.lock")).text()).toContain(`"lib": ${JSON.stringify(literal)}`);
+      } else {
+        expect(await exists(join(String(dir), "bun.lockb"))).toBe(true);
+      }
+    }
   });
-
-  // The first pass resolves from package.json; the second installs from the lockfile the first
-  // pass wrote, which must still carry the folder specifier.
-  for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
-    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
-
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), ...args],
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
-
-    expect(err).not.toContain("error:");
-    expect(out).toContain("1 package installed");
-    expect(exitCode).toBe(0);
-
-    expect(await file(join(String(dir), "node_modules", "lib", "package.json")).json()).toEqual({
-      name: "lib",
-      version: "1.0.0",
-    });
-    expect(await file(join(String(dir), "bun.lock")).text()).toContain(`"lib": ${JSON.stringify(literal)}`);
-  }
-});
+}
 
 it("fails when a transitive file: dependency's folder does not exist", async () => {
   using dir = tempDir("transitive-file-dep-missing", {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9883,6 +9883,50 @@ it("installs the transitive file: dependency of a file: dependency", async () =>
   }
 });
 
+it("installs a file: dependency whose version literal has leading whitespace", async () => {
+  // The folder path is longer than an inline string so that it has to be appended to the
+  // lockfile's string buffer, which only has room for it if the literal was classified as a folder.
+  const literal = " file:./vendor/some-long-directory-name/lib";
+  using dir = tempDir("whitespace-file-dep", {
+    "package.json": JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        lib: literal,
+      },
+    }),
+    "vendor/some-long-directory-name/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+    }),
+  });
+
+  // The first pass resolves from package.json; the second installs from the lockfile the first
+  // pass wrote, which must still carry the folder specifier.
+  for (const args of [["install"], ["install", "--frozen-lockfile"]]) {
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    expect(await file(join(String(dir), "node_modules", "lib", "package.json")).json()).toEqual({
+      name: "lib",
+      version: "1.0.0",
+    });
+    expect(await file(join(String(dir), "bun.lock")).text()).toContain(`"lib": ${JSON.stringify(literal)}`);
+  }
+});
+
 it("fails when a transitive file: dependency's folder does not exist", async () => {
   using dir = tempDir("transitive-file-dep-missing", {
     "package.json": JSON.stringify({

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -651,6 +651,8 @@ describe("workspaces", () => {
     { input: "workspace:1.1.x", expected: "1.1.x" },
     { input: "workspace:*", expected: "1.1.1" },
     { input: "workspace:-", expected: "-" },
+    // leading whitespace is not part of the specifier
+    { input: " workspace:^", expected: "^1.1.1" },
   ];
 
   for (const { input, expected } of withLockfileWorkspaceProtocolTests) {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -510,6 +510,8 @@ describe("workspace aliases", async () => {
     "workspace:@org/b@*",
     // missing version after `@`
     "workspace:@org/b@",
+    // leading whitespace is not part of the specifier
+    " workspace:@org/b@*",
   ];
   for (const version of shouldPass) {
     test.concurrent(`version range ${version} and workspace with no version`, async () => {
@@ -550,7 +552,13 @@ describe("workspace aliases", async () => {
       expect(files).toMatchObject([{ name: "@org/a" }, { name: "@org/b" }, { name: "@org/b" }]);
     });
   }
-  let shouldFail: string[] = ["workspace:@org/b@1.0.0", "workspace:@org/b@1", "workspace:@org/b"];
+  let shouldFail: string[] = [
+    "workspace:@org/b@1.0.0",
+    "workspace:@org/b@1",
+    "workspace:@org/b",
+    // leading whitespace is not part of the specifier
+    " workspace:@org/b@1.0.0",
+  ];
   for (const version of shouldFail) {
     test.concurrent(`version range ${version} and workspace with no version (should fail)`, async () => {
       using ctx = await setupTest();

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -511,6 +511,94 @@ describe("update", () => {
     });
     expect(exitCode).toBe(0);
   });
+
+  // Leading whitespace in a version literal is ignored by the installer, so `bun update` has to
+  // treat these entries exactly like their trimmed counterparts above.
+  for (const [flags, expected] of [
+    [[], { "no-deps": "^1.1.0", "aliased-dep": "npm:no-deps@~1.0.1" }],
+    [["--latest"], { "no-deps": "^2.0.0", "aliased-dep": "npm:no-deps@~2.0.0" }],
+  ] as const) {
+    test(`update ${flags.join(" ") || "(no args)"} updates catalog entries with leading whitespace`, async () => {
+      const { packageDir } = await registry.createTestDir();
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "catalog-update-whitespace",
+            workspaces: {
+              packages: ["packages/*"],
+              catalog: {
+                "no-deps": " ^1.0.0",
+                "aliased-dep": "\tnpm:no-deps@~1.0.0",
+              },
+            },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg1", "package.json"),
+          JSON.stringify({
+            name: "pkg1",
+            dependencies: {
+              "no-deps": "catalog:",
+              "aliased-dep": "catalog:",
+            },
+          }),
+        ),
+      ]);
+      await runBunInstall(bunEnv, packageDir);
+
+      const { err, exitCode } = await runUpdate(packageDir, ...flags);
+      expect(err).not.toContain("error:");
+
+      expect((await file(join(packageDir, "package.json")).json()).workspaces.catalog).toEqual(expected);
+      expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+        "no-deps": "catalog:",
+        "aliased-dep": "catalog:",
+      });
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  for (const flags of [[], ["--latest"]] as const) {
+    test(`update <pkg>${flags.length ? ` ${flags.join(" ")}` : ""} keeps a catalog reference with leading whitespace`, async () => {
+      const { packageDir } = await registry.createTestDir();
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "catalog-reference-whitespace",
+            workspaces: {
+              packages: ["packages/*"],
+              catalog: {
+                "no-deps": "^1.0.0",
+              },
+            },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg1", "package.json"),
+          JSON.stringify({
+            name: "pkg1",
+            dependencies: {
+              "no-deps": " catalog:",
+            },
+          }),
+        ),
+      ]);
+      await runBunInstall(bunEnv, packageDir);
+
+      const { err, exitCode } = await runUpdate(join(packageDir, "packages", "pkg1"), "no-deps", ...flags);
+      expect(err).not.toContain("error:");
+
+      expect((await file(join(packageDir, "packages", "pkg1", "package.json")).json()).dependencies).toEqual({
+        "no-deps": " catalog:",
+      });
+      expect((await file(join(packageDir, "package.json")).json()).workspaces.catalog).toEqual({
+        "no-deps": "^1.0.0",
+      });
+      expect(exitCode).toBe(0);
+    });
+  }
 });
 
 describe("errors", () => {

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -1,7 +1,8 @@
 import { file, spawn, write } from "bun";
+import { readTarball } from "bun:internal-for-testing";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { exists } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, runBunInstall } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, pack, runBunInstall } from "harness";
 import { join } from "path";
 
 var registry = new VerdaccioRegistry();
@@ -599,6 +600,50 @@ describe("update", () => {
       expect(exitCode).toBe(0);
     });
   }
+});
+
+describe("pack", () => {
+  test("replaces a catalog: reference with leading whitespace", async () => {
+    const { packageDir } = await registry.createTestDir();
+    const pkg1Dir = join(packageDir, "packages", "pkg1");
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-pack-whitespace",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: {
+              "no-deps": "^1.0.0",
+            },
+          },
+        }),
+      ),
+      write(
+        join(pkg1Dir, "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": " catalog:",
+          },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    await pack(pkg1Dir, bunEnv);
+
+    const tarball = readTarball(join(pkg1Dir, "pkg1-1.0.0.tgz"));
+    expect(tarball.entries).toMatchObject([{ pathname: "package/package.json" }]);
+    expect(JSON.parse(tarball.entries[0].contents)).toEqual({
+      name: "pkg1",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "^1.0.0",
+      },
+    });
+  });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
### Problem
- A package.json version value with leading whitespace, for example `"aliased-dep": " npm:no-deps@^1.0.0"`, installs fine, but `bun update aliased-dep` rewrites it to `"^1.1.0"`: the alias target is gone and the next install looks for a registry package called `aliased-dep`. A bare `bun update` (with or without `--latest`) leaves such an entry untouched in package.json while node_modules moves, `" ^1.0.0"` is skipped by a bare `bun update`, and `bun update <name>` replaces a `" catalog:"` reference with a concrete version (the same command keeps `"catalog:"`).
- Cause: `Dependency::parse` strips leading whitespace before calling `Tag::infer` (`src/install/dependency.rs`, `parse` / `parse_with_optional_tag`), so the installer accepts these values. The package.json editor classified the raw literal instead (`src/install/PackageManager/PackageJSONEditor.rs`: the before-install loop of `edit_update_no_args_in`, `edit_catalogs_before_update`, the `'add_packages_to_update` block and both `catalog:` checks in `edit`). `Tag::infer` switches on the first byte, so `" npm:..."` is not seen as an alias or a range and `" catalog:"` is not seen as a catalog reference; the entry is never recorded and the post-install write-back falls through to the code that writes a bare `^<version>`.
- The same raw-literal classification exists outside the editor, with worse symptoms:
  - `src/install/lockfile/Package.rs` pre-counts string buffer capacity with `Tag::infer(value)` and only reserves room for a folder path when the value classifies as one. `" file:./vendor/some-long-directory-name/lib"` is not classified as a folder there but is parsed as one a few lines later, so `bun install` dies with `panic: range end index 78 out of range for slice of length 43` in `StringBuilder::append_with_hash` (`lockfile.rs`), called from `Package::parse_dependency`.
  - `Dependency::clone_with_different_buffers` (`src/install/dependency.rs`) re-parses the stored literal with `parse_with_tag` without trimming. For `" file:./pkg"` the folder arm rejects `" file"` as a protocol and the clone becomes an empty version, so the first install writes `"pkg": ""` to bun.lock and the second one fails with `error: pkg@ failed to resolve`. For `" catalog:"` the catalog arm hits `debug_assert!(dependency.starts_with(b"catalog:"))` in debug builds; in release builds it reads the group name as `:` and `bun update` fails with `failed to resolve`. Every lockfile save goes through this clone. `Version::to_version`, which loads a dependency from `bun.lockb`, re-parses the stored literal the same way, so with a binary lockfile the second install of `" file:./vendor/..."` fails with `error: Unsupported protocol  file:./vendor/...`.
  - `Package::parse_dependency` checks `has_prefix(sliced.slice, b"workspace:")` on the raw literal, so `" workspace:@org/b@*"` is looked up under the dependency's own name and fails with `Workspace dependency "a1" not found`, and `" workspace:@org/b@1.0.0"` skips the version check.
  - Two commands outside the install crate rewrite package.json values the same way: `preserve_version_prefix` in `src/runtime/cli/update_interactive_command.rs` (`bun update -i`) writes `" npm:no-deps@^1.0.0"` back as `"2.0.0"` and `"\t~1.0.0"` as `"2.0.0"`, dropping the alias target and the range prefix, and `edit_root_package_json` in `src/runtime/cli/pack_command.rs` (`bun pm pack`, `bun publish`) leaves `" workspace:^"` and `" catalog:"` in the packed package.json instead of replacing them with versions.

### Fix
- Adds `dependency::trim_literal` (`src/install/dependency.rs`), the strip `parse` was already doing, and uses it at every place that classifies or re-parses a literal on its own: `parse` and `parse_with_optional_tag` (no behavior change, they now share the definition), `clone_with_different_buffers`, `to_version`, the capacity pre-count, the Windows-only path conversion in `parse_dependency` (the same `Tag::infer(version)` call three lines into the function; type-checked with `cargo check -p bun_install --target x86_64-pc-windows-msvc`, its conversion is a no-op for the forward-slash path the new test uses), the `workspace:` prefix check, the six `Tag::infer` calls in the editor, and the two CLI rewrites (`preserve_version_prefix`, `edit_root_package_json`), which import the same helper from `bun_install` rather than carrying their own copy of the rule.
- The editor also trims the literal it takes the `npm:<name>` prefix from when it writes the new version back (`edit` and `edit_catalogs_after_update` use the recorded literal, `edit_update_no_args_in` uses the lockfile's), so all three paths write `npm:no-deps@^1.1.0`, the same bytes they write for the value without the whitespace. Plain ranges were already rewritten from scratch (`" ^1.0.0"` became `"^2.0.0"` under `--latest` before this change), so this makes the alias case consistent with them.
- Why this is correct: `parse` defines what a literal means, and it has ignored leading ` \t\n\r` since the Zig implementation. Every site touched here is making a decision about the same literal `parse` accepts, so it has to look at the same bytes; otherwise the editor, the capacity count, and the clone disagree with the install they are describing. Only the bytes being classified change: `Dependency.version.literal`, the lockfile text, and `original_version_literal` are stored exactly as before (the folder test checks that bun.lock keeps the literal with its space), so existing lockfiles do not churn. Literals without leading whitespace are byte-for-byte unaffected because `trim_literal` is the identity on them.
- Not changed: the `parse_with_tag` arms that copy the raw literal into the value itself (`" latest"` looks up a dist-tag named `" latest"`, a bare `" ./pkg"` folder and a `" ./x.tgz"` local tarball keep the space in their path). That is a different shape of fix inside one function and is tracked separately. The remaining prefix checks found by grepping for `npm:` / `workspace:` / `catalog:` / `file:` (`bun why`, `bun audit`, the yarn/pnpm/package-lock migrations, `Resolution` parsing) look at resolution strings or other package managers' lockfiles, not package.json literals, and are left alone. `bun update <alias> --latest` 404s regardless of whitespace (#38224), so it is not in the matrix here.
- Tests, all failing on the current release and on this branch with `src/` stashed, passing with it:
  - `test/cli/install/bun-install-registry.test.ts` (`update > leading whitespace in the version literal`): 9 value/command combinations over `^` and `~` aliases and plain ranges with a space, tab and newline, crossed with `bun update`, `bun update <name>` and `bun update --latest` (7 of them fail before, 2 document that the already-working combinations keep working), plus a package listed in two dependency groups where the `" catalog:"` entry in the earlier group must survive (this is the only test that fails if the post-install `catalog:` check in `edit_update_no_args_in` is left untrimmed; verified by reverting that one line). A `bun update --interactive --latest` run driven through stdin (`a`, enter) checks that the same two literals come back as `npm:no-deps@^2.0.0` and `~2.0.0` (before: `2.0.0` for both).
  - `test/cli/install/catalogs.test.ts` (`update`): catalog entries with leading whitespace under `bun update` and `bun update --latest`; a `" catalog:"` reference kept by `bun update <pkg>` and `bun update <pkg> --latest`. These also exercise the clone fix: without it the debug build asserts during `bun install`.
  - `test/cli/install/bun-pack.test.ts`: `" workspace:^"` added to the existing protocol-replacement table (expects `^1.1.1`); `test/cli/install/catalogs.test.ts` (`pack`): a `" catalog:"` reference is replaced with the catalog's version in the packed package.json. Both shipped the protocol verbatim before.
  - `test/cli/install/bun-install.test.ts`: a `" file:"` dependency with a path longer than an inline string installs (the panic), and `bun install --frozen-lockfile` from the lockfile it wrote works; run once with bun.lock (which must keep the literal as written; the second pass covers the clone) and once with bun.lockb (the second pass covers `to_version`, and failed with the `Unsupported protocol` error until that call was trimmed).
  - `test/cli/install/bun-workspaces.test.ts` (`workspace aliases`): `" workspace:@org/b@*"` added to the passing set, `" workspace:@org/b@1.0.0"` to the set that must fail with `No matching version`.
- Also run with the debug build: all of `bun-install-registry.test.ts` (240 pass, 5 pre-existing todo), `catalogs.test.ts`, `bun-workspaces.test.ts`, `bun-update.test.ts`, `bun-add.test.ts`, `bun-lock.test.ts`, `bun-lockb.test.ts`, `overrides.test.ts`, `bun-pack.test.ts`, the three `test/cli/update_interactive_*.test.ts` files, and `bun-install.test.ts` (the 14 failures there are the bitbucket/gitlab/public-URL tests, which fail identically with the released binary in this sandbox because it has no network). `cargo clippy -p bun_install --no-deps`, `cargo check -p bun_runtime` and `cargo fmt --check` are clean.

### Background
- Version literal: the string value of a dependency entry in package.json (`"^1.0.0"`, `"npm:real-name@^1.0.0"`, `"file:./dir"`, `"catalog:"`, `"workspace:name@range"`). `Tag::infer` classifies one by looking at its first byte and prefix; `parse` turns it into a `Dependency.version`, keeping the original text as `version.literal`, which is what bun.lock prints and what the editor reads back.
- npm alias: `npm:<real-name>@<range>`; the key is a local name that need not exist in the registry, so writing the range back without the `npm:<real-name>@` prefix changes which package is installed.
- How `bun update` edits package.json: before the install it records the entries it intends to update (and, under `--latest`, swaps them for a `latest` placeholder in memory); after the install it writes the resolved versions back in the original pin style. An entry that was not recorded is either left alone or, for `bun update <name>`, written as a bare range from the request itself, which is how the alias was lost.
- Lockfile string buffer: all names and literals of a package.json live in one byte buffer. `Package::parse` first walks the entries to count how many bytes it will append, then appends; a folder dependency additionally appends its resolved relative path, so the count reserves `MAX_PATH_BYTES` for anything that classifies as a folder. Appending more than was counted is the slice panic above.
- Lockfile clone: when bun saves a lockfile it rebuilds it by cloning every dependency into a fresh buffer; `clone_with_different_buffers` copies the literal and re-parses it with the tag it already has. Loading a `bun.lockb` (`to_version`) re-parses stored literals the same way. These two re-parses are the only places besides `parse` that turn literal bytes into a version, which is why they need the same trim; the other `parse_with_tag` callers hand it a workspace path, a package's own `version` field, or a package-lock `resolved` URL, none of which is a package.json literal.

<details>
<summary>Behavior on the current release vs this branch (local test registry; no-deps has 1.0.0, 1.0.1, 1.1.0, 2.0.0)</summary>

| package.json value | command | before | after |
| --- | --- | --- | --- |
| `" npm:no-deps@^1.0.0"` | `update aliased-dep` | `^1.1.0` (alias lost) | `npm:no-deps@^1.1.0` |
| `" npm:no-deps@^1.0.0"` | `update` | unchanged, node_modules at 1.1.0 | `npm:no-deps@^1.1.0` |
| `" npm:no-deps@^1.0.0"` | `update --latest` | unchanged | `npm:no-deps@^2.0.0` |
| `"\tnpm:no-deps@~1.0.0"` | `update` | unchanged | `npm:no-deps@~1.0.1` |
| `" ^1.0.0"` | `update` | unchanged, node_modules at 1.1.0 | `^1.1.0` |
| `" ^1.0.0"` | `update no-deps` / `update --latest` | `^1.1.0` / `^2.0.0` (already worked) | same |
| `" catalog:"` in a workspace package | `update no-deps` | `^1.1.0` (reference lost) | unchanged |
| catalog entry `" ^1.0.0"` | `update` | unchanged | `^1.1.0` |
| catalog entry `"\tnpm:no-deps@~1.0.0"` | `update` | `"\tnpm:no-deps@~1.0.1"` | `npm:no-deps@~1.0.1` |
| `" file:./vendor/some-long-directory-name/lib"` | `install` | `panic: range end index 78 out of range for slice of length 43` | installs, bun.lock keeps the literal |
| `" file:./pkg"` | `install` twice | second run: `error: pkg@ failed to resolve` (bun.lock has `"pkg": ""`) | both succeed |
| `" file:./vendor/..."` with bun.lockb | `install` twice | second run: `error: Unsupported protocol  file:./vendor/...` | both succeed |
| `" workspace:@org/b@*"` | `install` | `Workspace dependency "a1" not found` | installs |
| `" npm:no-deps@^1.0.0"`, `"\t~1.0.0"` | `update -i --latest` | `2.0.0`, `2.0.0` | `npm:no-deps@^2.0.0`, `~2.0.0` |
| `" workspace:^"` | `pm pack` | tarball keeps `" workspace:^"` | `^1.1.1` |
| `" catalog:"` | `pm pack` | tarball keeps `" catalog:"` | `^1.0.0` (the catalog entry) |

</details>
