### PR TITLE
install: make BUN_CONFIG_NO_VERIFY disable integrity verification when set

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -669,7 +669,7 @@ impl Options {
         }
 
         if let Some(check_bool) = env.get(b"BUN_CONFIG_NO_VERIFY") {
-            self.do_.set(Do::VERIFY_INTEGRITY, check_bool != b"0");
+            self.do_.set(Do::VERIFY_INTEGRITY, check_bool == b"0");
         }
 
         // Update should never read from manifest cache

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -758,6 +758,74 @@ describe.concurrent("tarball integrity metadata forms", () => {
     expect(stdout).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
   });
+
+  it("--no-verify installs a tarball whose bytes don't match the advertised integrity", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
+
+    await using server = serveManifest(other.sha512, real.tgz);
+    using dir = projectDir("integrity-no-verify-flag", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--no-verify"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).not.toContain("Integrity check failed");
+    expect(stdout).toContain("1 package installed");
+    expect(await file(join(String(dir), "node_modules", "pkg", "package.json")).json()).toEqual({
+      name: "pkg",
+      version: "1.0.0",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("BUN_CONFIG_NO_VERIFY=1 skips the integrity check like --no-verify", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
+
+    await using server = serveManifest(other.sha512, real.tgz);
+    using dir = projectDir("integrity-no-verify-env-1", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), BUN_CONFIG_NO_VERIFY: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).not.toContain("Integrity check failed");
+    expect(stdout).toContain("1 package installed");
+    expect(await file(join(String(dir), "node_modules", "pkg", "package.json")).json()).toEqual({
+      name: "pkg",
+      version: "1.0.0",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("BUN_CONFIG_NO_VERIFY=0 keeps the integrity check enabled", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
+
+    await using server = serveManifest(other.sha512, real.tgz);
+    using dir = projectDir("integrity-no-verify-env-0", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), BUN_CONFIG_NO_VERIFY: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr + stdout).toContain("Integrity check failed");
+    expect(stdout).not.toContain("1 package installed");
+    expect(exitCode).not.toBe(0);
+  });
 });
 
 describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download failure (%s)", linker => {


### PR DESCRIPTION
### Problem
- `BUN_CONFIG_NO_VERIFY=0` turns tarball integrity verification off: a tarball whose bytes do not match the sha512 advertised by the registry installs with exit code 0 and the advertised hash is written to `bun.lock`.
- `BUN_CONFIG_NO_VERIFY=1` (or any other value) leaves verification on, so the variable cannot be used for what its name says.
- Cause: `src/install/PackageManager/PackageManagerOptions.rs:672` sets `Do::VERIFY_INTEGRITY` to `value != "0"`, the opposite of the `BUN_CONFIG_SKIP_*` variables handled a few lines above it (`value == "0"`). The comparison has been inverted since the variable was added alongside `--no-verify` in b897ad3ec2 (2022) and was ported as is.
- `--no-verify` itself is unaffected.

### Fix
- `PackageManagerOptions.rs:672`: `check_bool != b"0"` becomes `check_bool == b"0"`, so `BUN_CONFIG_NO_VERIFY=<anything but 0>` skips verification (same as `--no-verify`) and `BUN_CONFIG_NO_VERIFY=0` keeps it on, matching how `BUN_CONFIG_SKIP_SAVE_LOCKFILE`, `BUN_CONFIG_SKIP_LOAD_LOCKFILE` and `BUN_CONFIG_SKIP_INSTALL_PACKAGES` are read right above it. This is the only line of behavior change.
- `--no-verify` still wins when both are given; it is applied after the env var, unchanged.
- The variable is not documented anywhere (docs only list the `BUN_CONFIG_SKIP_*` ones), and this is its only reference in the repo, so nothing in CI or tests depended on the inverted reading.
- Verified with `test/cli/install/bun-install-tarball-integrity.test.ts`, three new cases in the existing "tarball integrity metadata forms" block. The registry advertises the sha512 of a different tarball than the one it serves:
  - `BUN_CONFIG_NO_VERIFY=1 skips the integrity check like --no-verify`: fails on main (main prints `Integrity check failed`), passes with this change.
  - `BUN_CONFIG_NO_VERIFY=0 keeps the integrity check enabled`: fails on main (main installs the package), passes with this change.
  - `--no-verify installs a tarball whose bytes don't match the advertised integrity`: passes on main and here; pins the behavior the env var now mirrors.
- The rest of the file (19 tests) passes with the debug build.

### Background
- During `bun install`, each registry tarball is hashed while it is extracted and compared against the `dist.integrity` value from the package manifest (or the lockfile); a mismatch is reported as `Integrity check failed for tarball: <name>` and the install fails. `--no-verify` turns that comparison off by clearing the `Do::VERIFY_INTEGRITY` option bit; `BUN_CONFIG_NO_VERIFY` is the environment-variable form of the same switch.
- `Do` is the bitflags set of per-run actions in `PackageManagerOptions.rs` (save lockfile, install packages, verify integrity, ...). The `BUN_CONFIG_*` environment variables are read in `Options::load` and are applied before the CLI flags, so flags override them.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
bun test v1.4.0 (5ca9aa12a)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [296.66ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [351.77ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [362.18ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [161.47ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [572.99ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [807.31ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [405.09ms]
(pass) tarball integrity > should store consistent integrity hash for local tarball across reinstalls [628.35ms]
(pass) tarba
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [33.99ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [32.90ms]
796 |       env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), BUN_CONFIG_NO_VERIFY: "1" },
797 |       stdout: "pipe",
798 |       stderr: "pipe",
799 |     });
800 |     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
801 |     expect(stderr + stdout).not.toContain("Integrity check failed");
                                      ^
error: expect(received).not.toContain(expected)

Expected to not contain: "Integrity check failed"
Received: "Resolving dependencies\nerror: Integrity check failed for tarball: pkg\nResolved, downloaded and extracted [4]\nerror: IntegrityCheckFailed extracting tarball from pkg\nbun install v1.4.0-canary.1 (b7a043103)\n"

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-tarball-integrity.test.ts:801:33)
(fail) tarba
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
bun test v1.4.0 (5ca9aa12a)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [372.27ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [456.93ms]
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [533.89ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [690.64ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [339.45ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [1032.20ms]
(pass) tarball integrity > should store consistent integrity hash for local tarball across reinstalls [766.62ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [564.74ms]
(pass) tarb
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 809ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../PackageManager/PackageManagerOptions.rs        |  2 +-
 .../install/bun-install-tarball-integrity.test.ts  | 68 ++++++++++++++++++++++
 2 files changed, 69 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/install/PackageManager/PackageManagerOptions.rs         2      1      0
test/cli/install/bun-install-tarball-integrity.test.ts      2      1      0
```

</details>

**root cause** · written by the author bot

The BUN_CONFIG_NO_VERIFY environment variable was read with inverted polarity in PackageManagerOptions.rs, assigning the result of a check_bool != "0" comparison to the VERIFY_INTEGRITY flag, so setting it to 1 kept tarball integrity verification on while setting it to 0 silently disabled it. The fix flips that comparison so the variable clears VERIFY_INTEGRITY when truthy and leaves it set when 0, matching the BUN_CONFIG_SKIP_* variables beside it and the documented --no-verify flag, which is still applied afterwards and keeps its precedence. Three new tests in bun-install-tarball-integrit…

<!-- robobun:evidence:end -->