### PR TITLE
node:tls: keep the handle attached while a client handshake protocol failure is reported

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -396,6 +396,47 @@ function tlsHandshakeError(verifyError) {
   return new ConnResetException("socket hang up");
 }
 
+// Node's onerror for a handshake that never finished: the socket is destroyed
+// with the error, but _destroy then closes the handle from a microtask, after
+// the next-tick 'error' emission, so the listener still sees a live socket
+// (remoteAddress, tlsClientError's socket argument, ...) and 'close' reports
+// hadError. https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L480-L488
+function destroyOnHandshakeError(self, err) {
+  self._hadError = true;
+  self._closeAfterHandlingError = true;
+  self.destroy(err);
+}
+
+// Shared client handshake dispatch for the two client handler tables.
+function onClientHandshake(self, socket, success, verifyError) {
+  if (!success && verifyError?.code === "ECONNRESET") {
+    // will be handled in onConnectEnd
+    return;
+  }
+  // The second argument is "authorized" (handshake + verification +
+  // hostname), matching the public Bun.connect handshake callback. node:tls
+  // decides what to do with verification results in JS via the
+  // rejectUnauthorized / checkServerIdentity handling in
+  // onClientHandshakeComplete, so a verification-class result (an X509 code
+  // such as UNABLE_TO_VERIFY_LEAF_SIGNATURE, or the native hostname verdict)
+  // still means the TLS session itself was established. Only a fatal TLS
+  // protocol failure tears the socket down here: those arrive as EPROTO
+  // carrying the OpenSSL "error:...:SSL routines:..." reason (or an already
+  // decomposed ERR_SSL_* / ERR_OSSL_* code).
+  const isProtocolFailure =
+    !success &&
+    verifyError?.code != null &&
+    (verifyError.code === "EPROTO" || /^ERR_(SSL|OSSL)_/.test(verifyError.code));
+  if (isProtocolFailure) {
+    // Surface the OpenSSL reason instead of letting the close path report a
+    // generic disconnect.
+    destroyOnHandshakeError(self, tlsHandshakeError(verifyError));
+    return;
+  }
+
+  onClientHandshakeComplete(self, socket, verifyError);
+}
+
 const SocketHandlers: SocketHandler = {
   close(socket, err) {
     const self = socket.data;
@@ -525,32 +566,7 @@ const SocketHandlers: SocketHandler = {
   handshake(socket, success, verifyError) {
     const { data: self } = socket;
     if (!self) return;
-    if (!success && verifyError?.code === "ECONNRESET") {
-      // will be handled in onConnectEnd
-      return;
-    }
-    // The second argument is "authorized" (handshake + verification +
-    // hostname), matching the public Bun.connect handshake callback. node:tls
-    // decides what to do with verification results in JS via the
-    // rejectUnauthorized / checkServerIdentity handling below, so a
-    // verification-class result (an X509 code such as
-    // UNABLE_TO_VERIFY_LEAF_SIGNATURE, or the native hostname verdict) still
-    // means the TLS session itself was established. Only a fatal TLS protocol
-    // failure tears the socket down here: those arrive as EPROTO carrying the
-    // OpenSSL "error:...:SSL routines:..." reason (or an already decomposed
-    // ERR_SSL_* / ERR_OSSL_* code).
-    const isProtocolFailure =
-      !success &&
-      verifyError?.code != null &&
-      (verifyError.code === "EPROTO" || /^ERR_(SSL|OSSL)_/.test(verifyError.code));
-    if (isProtocolFailure) {
-      // Surface the OpenSSL reason instead of letting the close path report a
-      // generic disconnect.
-      self.destroy(tlsHandshakeError(verifyError));
-      return;
-    }
-
-    onClientHandshakeComplete(self, socket, verifyError);
+    onClientHandshake(self, socket, success, verifyError);
   },
   timeout(socket) {
     const self = socket.data;
@@ -909,14 +925,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         err = tlsHandshakeError(verifyError);
       }
       self.servername = socket.getServername();
-      self._hadError = true;
-      // Node's onerror destroys *with* the error when the handshake never
-      // finished, so 'close' reports hadError === true; the socket stays
-      // reachable for the 'tlsClientError' listener because the destroy is
-      // deferred through _closeAfterHandlingError.
-      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L480-L488
-      self._closeAfterHandlingError = true;
-      self.destroy(err);
+      destroyOnHandshakeError(self, err);
       return;
     }
     self._securePending = false;
@@ -1347,32 +1356,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   handshake(socket, success, verifyError) {
     $debug("Bun.Socket handshake");
     const { self } = socket.data;
-    if (!success && verifyError?.code === "ECONNRESET") {
-      // will be handled in onConnectEnd
-      return;
-    }
-    // The second argument is "authorized" (handshake + verification +
-    // hostname), matching the public Bun.connect handshake callback. node:tls
-    // decides what to do with verification results in JS via the
-    // rejectUnauthorized / checkServerIdentity handling below, so a
-    // verification-class result (an X509 code such as
-    // UNABLE_TO_VERIFY_LEAF_SIGNATURE, or the native hostname verdict) still
-    // means the TLS session itself was established. Only a fatal TLS protocol
-    // failure tears the socket down here: those arrive as EPROTO carrying the
-    // OpenSSL "error:...:SSL routines:..." reason (or an already decomposed
-    // ERR_SSL_* / ERR_OSSL_* code).
-    const isProtocolFailure =
-      !success &&
-      verifyError?.code != null &&
-      (verifyError.code === "EPROTO" || /^ERR_(SSL|OSSL)_/.test(verifyError.code));
-    if (isProtocolFailure) {
-      // Surface the OpenSSL reason instead of letting the close path report a
-      // generic disconnect.
-      self.destroy(tlsHandshakeError(verifyError));
-      return;
-    }
-
-    onClientHandshakeComplete(self, socket, verifyError);
+    onClientHandshake(self, socket, success, verifyError);
   },
   error(socket, error) {
     $debug("Bun.Socket error");

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1023,6 +1023,139 @@ it("https.request reports an impossible version window as a TLS error, not a cer
   expect(body).toBe("ok");
 });
 
+// A handshake that fails with a TLS protocol error goes through node's onerror
+// (https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L480-L488):
+// the socket is destroyed with the error, but its handle is released only after
+// 'error' has been emitted, so the listener can still read the peer's address,
+// and 'close' then reports hadError. Bun used to release the handle before
+// 'error' fired. A certificate verification failure is not routed that way in
+// node (onConnectSecure destroys outright), so the handle is gone by the time
+// its 'error' fires; that case pins the boundary of the deferred teardown.
+describe("a handshake protocol failure keeps the socket inspectable inside 'error'", () => {
+  // Everything the 'error' listener can observe, followed by the 'close' that
+  // has to come after it. Resolves on 'close'; a handshake that unexpectedly
+  // completes shows up in the recorded events instead of hanging the test.
+  function observe(socket: TLSSocket & { _hadError?: boolean }) {
+    const events: unknown[] = [];
+    const { promise, resolve } = Promise.withResolvers<unknown[]>();
+    socket.on("secureConnect", () => events.push("secureConnect"));
+    socket.on("error", (error: Error & { code?: string }) => {
+      events.push({
+        error: error.code,
+        destroyed: socket.destroyed,
+        // Set by node's onerror (and read by its onConnectEnd and by
+        // _http_outgoing's onFinish); node's onConnectSecure leaves it alone.
+        _hadError: socket._hadError,
+        remoteAddress: socket.remoteAddress,
+        remotePort: socket.remotePort,
+      });
+    });
+    socket.on("close", hadError => {
+      events.push({ close: hadError });
+      resolve(events);
+    });
+    return promise;
+  }
+
+  // Answers whatever the client sends (its ClientHello) with plaintext, which
+  // the client's TLS engine rejects as WRONG_VERSION_NUMBER.
+  async function listenPlaintext() {
+    const peers: net.Socket[] = [];
+    const server = net.createServer(peer => {
+      peers.push(peer);
+      peer.on("error", () => {});
+      peer.on("data", () => peer.write("HTTP/1.1 400 Bad Request\r\n\r\n"));
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return {
+      port: (server.address() as AddressInfo).port,
+      async [Symbol.asyncDispose]() {
+        for (const peer of peers) peer.destroy();
+        await server[Symbol.asyncDispose]();
+      },
+    };
+  }
+
+  async function listenTLS(options: tls.TlsOptions) {
+    const server = tls.createServer({ ...COMMON_CERT_, ...options }, socket => socket.on("error", () => {}));
+    server.on("tlsClientError", () => {});
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return server;
+  }
+
+  it("tls.connect() against a peer that does not speak TLS", async () => {
+    await using peer = await listenPlaintext();
+    const events = await observe(tlsConnect({ host: "127.0.0.1", port: peer.port, servername: "localhost" }));
+    expect(events).toEqual([
+      {
+        error: "ERR_SSL_WRONG_VERSION_NUMBER",
+        destroyed: true,
+        _hadError: true,
+        remoteAddress: "127.0.0.1",
+        remotePort: peer.port,
+      },
+      { close: true },
+    ]);
+  });
+
+  it("tls.connect({ socket }) upgrading a connected socket to a peer that does not speak TLS", async () => {
+    await using peer = await listenPlaintext();
+    const plain = net.connect({ host: "127.0.0.1", port: peer.port });
+    plain.on("error", () => {});
+    try {
+      await once(plain, "connect");
+      const events = await observe(tlsConnect({ socket: plain, servername: "localhost" }));
+      expect(events).toEqual([
+        {
+          error: "ERR_SSL_WRONG_VERSION_NUMBER",
+          destroyed: true,
+          _hadError: true,
+          remoteAddress: "127.0.0.1",
+          remotePort: peer.port,
+        },
+        { close: true },
+      ]);
+    } finally {
+      plain.destroy();
+    }
+  });
+
+  it("a fatal alert sent by a TLS peer", async () => {
+    await using server = await listenTLS({ minVersion: "TLSv1.3" });
+    const { port } = server.address() as AddressInfo;
+    const events = await observe(
+      tlsConnect({ host: "127.0.0.1", port, servername: "localhost", ca: COMMON_CERT_.cert, maxVersion: "TLSv1.2" }),
+    );
+    expect(events).toEqual([
+      {
+        error: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION",
+        destroyed: true,
+        _hadError: true,
+        remoteAddress: "127.0.0.1",
+        remotePort: port,
+      },
+      { close: true },
+    ]);
+  });
+
+  it("a certificate verification failure is destroyed outright, as in node", async () => {
+    await using server = await listenTLS({});
+    const { port } = server.address() as AddressInfo;
+    // No `ca`, so the self-signed server certificate is rejected.
+    const events = await observe(tlsConnect({ host: "127.0.0.1", port, servername: "localhost" }));
+    expect(events).toEqual([
+      {
+        error: "DEPTH_ZERO_SELF_SIGNED_CERT",
+        destroyed: true,
+        _hadError: false,
+        remoteAddress: undefined,
+        remotePort: undefined,
+      },
+      { close: true },
+    ]);
+  });
+});
+
 describe("rejectUnauthorized only treats a literal `false` as opting out", () => {
   // Node applies `options.rejectUnauthorized !== false`, so other falsy
   // values must keep peer verification enabled.


### PR DESCRIPTION
### Problem
- When a `tls.connect()` handshake fails with a TLS protocol error (the peer answers in plaintext: `ERR_SSL_WRONG_VERSION_NUMBER`; the peer sends a fatal alert: `ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION`), the socket's `'error'` listener already finds `socket._handle === null`, so `socket.remoteAddress` / `remotePort` read as `undefined` and `socket._hadError` is still `false`. Node keeps the handle attached through `'error'` (remoteAddress readable, `_hadError === true`); `'close'` then fires with `hadError === true` in both.
- Cause: the client handshake handlers' protocol-failure branch (`src/js/node/net.ts`, duplicated in `SocketHandlers.handshake` and `SocketHandlers2.handshake`) called `self.destroy(tlsHandshakeError(verifyError))` directly, so `Socket.prototype._destroy` closed and detached the handle synchronously, before the `'error'` emission that streams schedule on the next tick. Node routes these failures through its tls `onerror`, which sets `_hadError` and `_closeAfterHandlingError` before `destroy(err)` (lib/internal/tls/wrap.js v26.3.0 L480-L488). Bun's server-side handshake branch already did exactly that; the client branch did not.
- Affects `tls.connect()` and `tls.connect({ socket })` alike (both use the same handler table). A certificate verification failure is unaffected and stays the same in both runtimes: node's `onConnectSecure` destroys outright there, and so does `onClientHandshakeComplete`.

### Fix
- `destroyOnHandshakeError(self, err)` sets `_hadError` and `_closeAfterHandlingError` and destroys: the three lines the server-side handshake branch used inline, now shared by it and by the client protocol-failure branch.
- The client protocol-failure branch (ECONNRESET deferral, `isProtocolFailure`, destroy) was copy-pasted in both client handler tables; it is now one `onClientHandshake()` that both tables delegate to, so the fix has a single site.
- Why this is correct: it is node's teardown for this failure class. `_destroy` already implements the `_closeAfterHandlingError` arm (close the handle from a microtask, emit `'close'` from the handle close, then detach), and the drain order puts the next-tick `'error'` before that microtask. The client handshake failure is dispatched from the event loop, and Bun drains next ticks and microtasks when that callback returns, before the native layer gets to close the socket itself, so the handle is live inside `'error'` and `'close'` is still emitted exactly once with `hadError === true`. This is the same sequence the server-side branch has relied on.
- `_hadError = true` is what node's `onerror` sets; node's `onConnectEnd` and `_http_outgoing`'s `onFinish` read it. Observable effect beyond the flag itself: an https request whose handshake fails no longer emits `'finish'` from its failed header flush before the error, which is what that check exists for.
- One deliberate non-match: when node detects the same failure through a pending write (for example `https.request`, or a `write()` before `'secureConnect'`), it reports an `EPROTO` errno error through the write path and closes the handle synchronously. Bun reports every protocol failure through one handshake dispatch (already with the `ERR_SSL_*` code on both paths before this change), so after this change that flavor keeps the handle through `'error'` too. Not replicated: it would mean picking the teardown based on whether a write happened to be queued.
- Verified with `test/js/node/tls/node-tls-connect.test.ts` (new `describe` block: plain `tls.connect()`, `tls.connect({ socket })` upgrade, a fatal alert from a real TLS server, and the certificate failure pinning the boundary). The three protocol-failure cases fail on the unfixed build on `_hadError` / `remoteAddress` and pass with the fix; the repro scripts print the same lines as node v26.3.0 for all four cases.
- Also run: the rest of `test/js/node/tls/*.test.ts` (connect, server, upgrade, cert, hostname verification, renegotiation, context, churn, syscall faults), the https-related `test/js/node/http` suites, and all 245 vendored `test-tls-*.js` / `test-https-*.js` node tests (only unrelated differences: one `node:test`-based file that needs `bun test`, and one slow CA-store test that passes when run alone). #38028's `tls.connect({ socket })` event-order tests were also run with that branch merged on top of this one and pass.

### Background
- `_closeAfterHandlingError` (node's `net.Socket` flag, ported in `Socket.prototype._destroy`): normally `_destroy` closes and detaches the handle synchronously, and the stream layer emits `'error'` on the next tick, so listeners see a handle-less socket. With the flag set, `_destroy` leaves the handle attached and closes it from `queueMicrotask`; `'close'` is emitted from that close, and only then is `_handle` nulled. The next-tick queue is drained before the microtask queue, so `'error'` listeners see the live handle. Node's tls `onerror` uses it so `'error'` / `tlsClientError` listeners can still inspect the socket.
- `_hadError`: node's tls-level "this socket already reported a failure" flag. It guards `onConnectEnd` (so a peer disconnect is not reported on top of the real error) and is read by `_http_outgoing` to suppress `'finish'` on a request whose socket failed.
- `tlsHandshakeError()`: turns the native `EPROTO` + OpenSSL reason string the handshake callback receives into node's `ERR_SSL_<REASON>` error.
- `SocketHandlers` / `SocketHandlers2`: the two native callback tables used for client sockets in `net.ts` (fd adoption vs. ordinary connects); they differ only in how they find the `net.Socket` behind the native socket, which is why their handshake bodies were duplicated.
