### PR TITLE
bunfig: fall back to $HOME/.bunfig.toml when $XDG_CONFIG_HOME has none

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,42 +17,23 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
-/// Resolve a user-level config file (`.bunfig.toml`, `.npmrc`) to
-/// `$XDG_CONFIG_HOME/<name>` when it exists there, otherwise `$HOME/<name>`.
-///
-/// The existence probe is what makes this a fallback rather than an override:
-/// many Linux setups export `XDG_CONFIG_HOME` by default, so preferring it
-/// unconditionally hides a pre-existing `$HOME/.npmrc` from users who never
-/// opted into XDG.
-pub fn user_config_path<'a>(buf: &'a mut PathBuffer, name: &[u8]) -> Option<&'a ZStr> {
-    let paths: [&[u8]; 1] = [name];
+/// `$XDG_CONFIG_HOME/.bunfig.toml` when that file exists, otherwise
+/// `$HOME/.bunfig.toml` (same rule as the user-level `.npmrc` in
+/// `PackageManager::init`). Many desktops and CI runners export
+/// `XDG_CONFIG_HOME` without ever putting a bunfig there.
+fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
+    let paths: [&[u8]; 1] = [b".bunfig.toml"];
 
-    let dir = match (env_var::XDG_CONFIG_HOME.get(), env_var::HOME.get()) {
-        (Some(xdg_dir), Some(home_dir)) => {
-            let mut probe = bun_paths::path_buffer_pool::get();
-            let candidate = resolve_path::join_abs_string_buf_z::<platform::Auto>(
-                xdg_dir,
-                &mut probe[..],
-                &paths,
-            );
-            if bun_sys::exists_z(candidate) {
-                xdg_dir
-            } else {
-                home_dir
-            }
-        }
-        (Some(xdg_dir), None) => xdg_dir,
-        (None, Some(home_dir)) => home_dir,
-        (None, None) => return None,
-    };
+    let xdg_dir = env_var::XDG_CONFIG_HOME.get_not_empty().filter(|xdg_dir| {
+        bun_sys::exists_z(resolve_path::join_abs_string_buf_z::<platform::Auto>(
+            xdg_dir, &mut **buf, &paths,
+        ))
+    });
+    let dir = xdg_dir.or_else(|| env_var::HOME.get_not_empty())?;
 
     Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
         dir, &mut **buf, &paths,
     ))
-}
-
-fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
-    user_config_path(buf, b".bunfig.toml")
 }
 
 fn load_bunfig(

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,22 +17,42 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
+/// Resolve a user-level config file (`.bunfig.toml`, `.npmrc`) to
+/// `$XDG_CONFIG_HOME/<name>` when it exists there, otherwise `$HOME/<name>`.
+///
+/// The existence probe is what makes this a fallback rather than an override:
+/// many Linux setups export `XDG_CONFIG_HOME` by default, so preferring it
+/// unconditionally hides a pre-existing `$HOME/.npmrc` from users who never
+/// opted into XDG.
+pub fn user_config_path<'a>(buf: &'a mut PathBuffer, name: &[u8]) -> Option<&'a ZStr> {
+    let paths: [&[u8]; 1] = [name];
+
+    let dir = match (env_var::XDG_CONFIG_HOME.get(), env_var::HOME.get()) {
+        (Some(xdg_dir), Some(home_dir)) => {
+            let mut probe = bun_paths::path_buffer_pool::get();
+            let candidate = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+                xdg_dir,
+                &mut probe[..],
+                &paths,
+            );
+            if bun_sys::exists_z(candidate) {
+                xdg_dir
+            } else {
+                home_dir
+            }
+        }
+        (Some(xdg_dir), None) => xdg_dir,
+        (None, Some(home_dir)) => home_dir,
+        (None, None) => return None,
+    };
+
+    Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
+        dir, &mut **buf, &paths,
+    ))
+}
+
 fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
-    let paths: [&[u8]; 1] = [b".bunfig.toml"];
-
-    if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            data_dir, &mut **buf, &paths,
-        ));
-    }
-
-    if let Some(home_dir) = env_var::HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            home_dir, &mut **buf, &paths,
-        ));
-    }
-
-    None
+    user_config_path(buf, b".bunfig.toml")
 }
 
 fn load_bunfig(

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -2,7 +2,7 @@ import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { rm } from "fs/promises";
 import { VerdaccioRegistry, bunExe, bunEnv as env, tempDir } from "harness";
-import { join } from "path";
+import { basename, join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
 
@@ -221,6 +221,67 @@ registry = http://localhost:${registry.port}/
       using dir = tempDir("npmrc-xdg-empty", { ...pkg, "home/.npmrc": npmrc(1) });
       const result = await publishDryRun(String(dir), { XDG_CONFIG_HOME: "" });
       expect(result).toEqual(usesRegistry(1));
+    });
+  });
+
+  // The global .bunfig.toml is looked up with the same rule as the user .npmrc above.
+  describe("global .bunfig.toml lookup", () => {
+    const bunfig = (cacheDir: string) => `[install]\ncache = "${cacheDir}"\n`;
+    const pkg = { "pkg/package.json": JSON.stringify({ name: "bunfig-lookup", version: "0.0.1" }) };
+
+    // `bun pm cache` prints the install cache directory. Each candidate .bunfig.toml
+    // points it at a differently named directory, so the output shows which file was
+    // read. BUN_INSTALL_CACHE_DIR would take precedence over bunfig, and CI runners
+    // set it as well as XDG_CONFIG_HOME, so both are removed.
+    async function pmCache(dir: string, envOverride: Record<string, string>) {
+      const spawnEnv = { ...env, HOME: join(dir, "home"), USERPROFILE: join(dir, "home") };
+      delete spawnEnv.XDG_CONFIG_HOME;
+      delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "pm", "cache"],
+        cwd: join(dir, "pkg"),
+        env: { ...spawnEnv, ...envOverride },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { cacheDir: basename(stdout.trim()), stderr, exitCode };
+    }
+
+    const usesCacheDir = (cacheDir: string) => ({ cacheDir, stderr: "", exitCode: 0 });
+
+    it.concurrent("uses $XDG_CONFIG_HOME/.bunfig.toml when it exists", async () => {
+      using dir = tempDir("bunfig-xdg", {
+        ...pkg,
+        "home/.bunfig.toml": bunfig("home-cache"),
+        "xdg/.bunfig.toml": bunfig("xdg-cache"),
+      });
+      const result = await pmCache(String(dir), { XDG_CONFIG_HOME: join(String(dir), "xdg") });
+      expect(result).toEqual(usesCacheDir("xdg-cache"));
+    });
+
+    // https://github.com/oven-sh/bun/issues/23128
+    it.concurrent("falls back to $HOME/.bunfig.toml when $XDG_CONFIG_HOME has no .bunfig.toml", async () => {
+      using dir = tempDir("bunfig-xdg-without-bunfig", {
+        ...pkg,
+        "home/.bunfig.toml": bunfig("home-cache"),
+        "xdg/.keep": "",
+      });
+      const result = await pmCache(String(dir), { XDG_CONFIG_HOME: join(String(dir), "xdg") });
+      expect(result).toEqual(usesCacheDir("home-cache"));
+    });
+
+    it.concurrent("uses $HOME/.bunfig.toml when $XDG_CONFIG_HOME is unset", async () => {
+      using dir = tempDir("bunfig-xdg-unset", { ...pkg, "home/.bunfig.toml": bunfig("home-cache") });
+      const result = await pmCache(String(dir), {});
+      expect(result).toEqual(usesCacheDir("home-cache"));
+    });
+
+    it.concurrent("uses $HOME/.bunfig.toml when $XDG_CONFIG_HOME is empty", async () => {
+      using dir = tempDir("bunfig-xdg-empty", { ...pkg, "home/.bunfig.toml": bunfig("home-cache") });
+      const result = await pmCache(String(dir), { XDG_CONFIG_HOME: "" });
+      expect(result).toEqual(usesCacheDir("home-cache"));
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

The global bunfig lookup returned `$XDG_CONFIG_HOME/.bunfig.toml` whenever the variable was set, without checking the file exists, so on machines that export `XDG_CONFIG_HOME` (GitHub Actions runners, most Linux desktops) `$HOME/.bunfig.toml` was never read. It now uses the XDG path only if that file exists and otherwise `$HOME/.bunfig.toml`, and an empty `XDG_CONFIG_HOME` or `HOME` counts as unset. Same rule #36289 applied to the user-level `.npmrc`.

Fixes #23128 (the bunfig half; the `.npmrc` half landed in #36289).

Supersedes #36486. The first commit is @Properrr's from that PR; the second folds in the empty-variable handling and tests so this can go through CI on an in-repo branch.

### How did you verify your code works?

`bun bd test test/cli/install/npmrc.test.ts`: the four new `global .bunfig.toml lookup` cases pass. Drove the debug binary by hand with `bun pm cache` and a `~/.bunfig.toml` setting `install.cache`: XDG pointing at an empty dir, `XDG_CONFIG_HOME=""` and XDG unset all print the home cache dir, XDG with its own file prints the XDG one. Released bun 1.3.14 prints the default cache dir for the empty-dir case, which is the bug.

Not verified here: Windows.