### PR TITLE
node:vm: accept undefined codeGeneration.strings/wasm like Node

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -721,7 +721,7 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
 
         auto allowStringsValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "strings"_s));
         RETURN_IF_EXCEPTION(scope, );
-        if (allowStringsValue) {
+        if (allowStringsValue && !allowStringsValue.isUndefined()) {
             if (!allowStringsValue.isBoolean()) {
                 ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".strings"_s), "boolean"_s, allowStringsValue);
                 return;
@@ -733,7 +733,7 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
 
         auto allowWasmValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "wasm"_s));
         RETURN_IF_EXCEPTION(scope, );
-        if (allowWasmValue) {
+        if (allowWasmValue && !allowWasmValue.isUndefined()) {
             if (!allowWasmValue.isBoolean()) {
                 ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey, ".wasm"_s), "boolean"_s, allowWasmValue);
                 return;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1010,6 +1010,48 @@ describe("codeGeneration options", () => {
     const evalResult = runInContext("eval('5 + 5');", context);
     expect(evalResult).toBe(10);
   });
+
+  describe("strings/wasm set to undefined", () => {
+    // In Node an undefined strings/wasm is the same as an omitted one:
+    // createContext() destructures them with `= true` defaults, and
+    // getContextOptions() only validates them when `!== undefined` (it then
+    // hands createContext() a `{ strings, wasm }` object with undefined holes).
+    const WASM_BYTES = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+    // Evaluated inside the context: reports which kinds of code generation it allows.
+    const probe = `
+      let strings = true, wasm = true;
+      try { eval("1"); } catch { strings = false; }
+      try { new WebAssembly.Module(WASM_BYTES); } catch { wasm = false; }
+      "strings=" + strings + " wasm=" + wasm;
+    `;
+
+    // createContext reads options.codeGeneration; vm.runInNewContext and
+    // Script#runInNewContext read options.contextCodeGeneration.
+    const entryPoints: Record<string, (codeGeneration: object) => string> = {
+      "createContext()": codeGeneration => runInContext(probe, createContext({ WASM_BYTES }, { codeGeneration })),
+      "runInNewContext()": contextCodeGeneration => runInNewContext(probe, { WASM_BYTES }, { contextCodeGeneration }),
+      "Script#runInNewContext()": contextCodeGeneration =>
+        new Script(probe).runInNewContext({ WASM_BYTES }, { contextCodeGeneration }),
+    };
+
+    describe.each(Object.entries(entryPoints))("%s", (_, run) => {
+      test("undefined is accepted and means the default (allowed)", () => {
+        expect(run({ strings: undefined })).toBe("strings=true wasm=true");
+        expect(run({ wasm: undefined })).toBe("strings=true wasm=true");
+        expect(run({ strings: undefined, wasm: undefined })).toBe("strings=true wasm=true");
+      });
+
+      test("undefined next to an explicit false leaves the false in effect", () => {
+        expect(run({ strings: false, wasm: undefined })).toBe("strings=false wasm=true");
+        expect(run({ strings: undefined, wasm: false })).toBe("strings=true wasm=false");
+      });
+
+      test.each([null, 0, 1, "false"])("%p is still rejected", value => {
+        expect(() => run({ strings: value })).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+        expect(() => run({ wasm: value })).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      });
+    });
+  });
 });
 
 describe("context options with throwing getters", () => {


### PR DESCRIPTION
### Problem
- `vm.createContext({}, { codeGeneration: { wasm: undefined } })` throws `TypeError [ERR_INVALID_ARG_TYPE]: The "options.codeGeneration.wasm" property must be of type boolean. Received undefined`. Same for `strings`, and for `contextCodeGeneration.{strings,wasm}` through `vm.runInNewContext()` and `Script#runInNewContext()`. Node accepts all of these.
- Cause: `getNodeVMContextOptions()` in `src/jsc/bindings/NodeVM.cpp` (lines 724 and 736) reads the two keys with `getIfPropertyExists()`, which returns `jsUndefined()` (a non-empty value) for a key that is present but set to `undefined`, and then only checks `isBoolean()`. The `name`, `origin`, `microtaskMode` and `codeGeneration` reads a few lines above already skip `undefined`; these two did not.
- This comes up with code that builds the options object the way Node's own `lib/vm.js` does: `getContextOptions()` passes `codeGeneration: { strings, wasm }` along with whichever of the two the caller left out still `undefined`, and user code that spreads optional settings produces the same shape.

### Fix
- Skip the boolean check when the value is `undefined`, so the key falls through to the default (`allowStrings`/`allowWasm` are initialized to `true` in `NodeVMContextOptions`). `null`, numbers and strings are still rejected with `ERR_INVALID_ARG_TYPE`.
- Matches Node: `createContext()` destructures `{ strings = true, wasm = true } = codeGeneration` before `validateBoolean`, and `getContextOptions()` only validates the two keys when they are `!== undefined`. Node rejects `null` for both, which this keeps.
- All three entry points share `getNodeVMContextOptions()` (`createContext` reads `codeGeneration`, `vm.runInNewContext` and `Script#runInNewContext` read `contextCodeGeneration`), so one change covers them.
- Independent of #38326 (runInNewContext context reuse): that PR does not touch these two reads, and its `Script#runInNewContext` still validates `contextCodeGeneration` through `getNodeVMContextOptions()`, so the undefined keys need this change with or without it. The two PRs change different lines of `NodeVM.cpp`.
- Test: `test/js/node/vm/vm.test.ts`, `codeGeneration options > strings/wasm set to undefined`. For each of the three entry points it checks that an undefined key is accepted and behaves as the default (eval and `WebAssembly.Module` both work), that an undefined key next to an explicit `false` leaves the `false` in effect, and that `null`/`0`/`1`/`"false"` are still rejected. The six acceptance tests fail on the current release (`USE_SYSTEM_BUN=1`) and pass with this change; the expected values were checked against node v26.3.0.
- Also ran: the full `test/js/node/vm/vm.test.ts` (232 pass, 0 fail) and all 95 `test/js/node/test/parallel/test-vm-*.js` files (including `test-vm-codegen.js` and `test-vm-basic.js`) against the debug build, all passing.

### Background
- `codeGeneration.strings` / `.wasm` are per-context switches for whether code running in a `vm` context may compile code from strings (`eval`, `new Function`) and compile WebAssembly. Both default to `true`.
- `JSObject::getIfPropertyExists()` returns an empty `JSValue` when the property is absent and the property's value (which may be `jsUndefined()`) when it exists, so `if (value)` alone distinguishes missing from present, not missing from `undefined`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (89da7ede3)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [36.11ms]
(pass) vm > runInContext() > can return a value [24.70ms]
(pass) vm > runInContext() > can return a complex value [25.24ms]
(pass) vm > runInContext() > can return the last value [23.78ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [23.10ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [22.76ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [20.14ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.08ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.42ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [16.66ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [24.26ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [19.17ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 6 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.50ms]
(pass) vm > runInContext() > can return a value [0.36ms]
(pass) vm > runInContext() > can return a complex value [0.32ms]
(pass) vm > runInContext() > can return the last value [0.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.23ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.33ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.25ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (89da7ede3)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [23.04ms]
(pass) vm > runInContext() > can return a value [16.53ms]
(pass) vm > runInContext() > can return a complex value [17.87ms]
(pass) vm > runInContext() > can return the last value [15.25ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [18.93ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [15.07ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.30ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.14ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [16.72ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [17.68ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [18.72ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.52ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     89da7ede33
  features     baseline

22 deps, 123 codegen, 1176 objects in 782ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [18.00ms]
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1238] gen bindgenv2
[6/1238] fetch zlib
[zlib] up to date
[7/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [41.00ms]
[10/1237] gen .bind.ts → GeneratedBindings.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp |  4 ++--
 test/js/node/vm/vm.test.ts  | 42 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 44 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/jsc/bindings/NodeVM.cpp      1      2      0
test/js/node/vm/vm.test.ts       2      2      0
```

</details>

**self-review** · no surviving concerns

26 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->