### PR TITLE
node:vm: accept DONT_CONTEXTIFY contexts as compileFunction parsingContext

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -2094,17 +2094,10 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
         RETURN_IF_EXCEPTION(scope, {});
 
         if (!parsingContextValue.isEmpty() && !parsingContextValue.isUndefined()) {
-            if (parsingContextValue.isNull() || !parsingContextValue.isObject())
-                return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
-
-            JSObject* context = asObject(parsingContextValue);
-            auto* zigGlobalObject = defaultGlobalObject(globalObject);
-            JSValue scopeValue = zigGlobalObject->vmModuleContextMap()->get(context);
-
-            if (scopeValue.isUndefined())
-                return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
-
-            parsingContext = dynamicDowncast<NodeVMGlobalObject>(scopeValue);
+            // Node validates this with isContext(), so every shape isContext() accepts must
+            // resolve here; createContext(DONT_CONTEXTIFY) results are not in vmModuleContextMap.
+            parsingContext = getGlobalObjectFromContext(globalObject, parsingContextValue, false);
+            RETURN_IF_EXCEPTION(scope, false);
             if (!parsingContext)
                 return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.parsingContext"_s, "Context"_s, parsingContextValue);
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1703,7 +1703,10 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
         auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
         RETURN_IF_EXCEPTION(scope, {});
         targetContext->setSpecialSandbox(specialSandbox);
-        return JSValue::encode(targetContext->specialSandbox());
+        // The property hooks read the contextified object. Script#runInContext installs this object
+        // there on its first run; compileFunction and modules never do, so install it up front.
+        targetContext->setContextifiedObject(specialSandbox);
+        return JSValue::encode(specialSandbox);
     }
 
     return JSValue::encode(sandbox);
@@ -2094,8 +2097,6 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
         RETURN_IF_EXCEPTION(scope, {});
 
         if (!parsingContextValue.isEmpty() && !parsingContextValue.isUndefined()) {
-            // Node validates this with isContext(), so every shape isContext() accepts must
-            // resolve here; createContext(DONT_CONTEXTIFY) results are not in vmModuleContextMap.
             parsingContext = getGlobalObjectFromContext(globalObject, parsingContextValue, false);
             RETURN_IF_EXCEPTION(scope, false);
             if (!parsingContext)

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1703,9 +1703,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
         auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
         RETURN_IF_EXCEPTION(scope, {});
         targetContext->setSpecialSandbox(specialSandbox);
-        // The property hooks read the contextified object. Script#runInContext installs this object
-        // there on its first run; compileFunction and modules never do, so install it up front.
-        targetContext->setContextifiedObject(specialSandbox);
         return JSValue::encode(specialSandbox);
     }
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -141,7 +141,12 @@ public:
     // (microtaskMode: "afterEvaluate" contexts only; no-op otherwise).
     void drainOwnMicrotasks();
     NodeVMSpecialSandbox* specialSandbox() const { return m_specialSandbox.get(); }
-    void setSpecialSandbox(NodeVMSpecialSandbox* sandbox) { m_specialSandbox.set(vm(), this, sandbox); }
+    // A DONT_CONTEXTIFY context's property hooks forward to its special sandbox.
+    void setSpecialSandbox(NodeVMSpecialSandbox* sandbox)
+    {
+        m_specialSandbox.set(vm(), this, sandbox);
+        m_sandbox.set(vm(), this, sandbox);
+    }
     JSValue dynamicImportCallback() const { return m_dynamicImportCallback.get(); }
 
     // Override property access to delegate to contextified object

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -4,6 +4,7 @@ import {
   compileFunction,
   constants,
   createContext,
+  isContext,
   runInContext,
   runInNewContext,
   runInThisContext,
@@ -100,6 +101,68 @@ describe("vm", () => {
         contextExtensions: undefined,
       })();
       expect(result).toBe(2);
+    });
+
+    test("parsingContext accepts a DONT_CONTEXTIFY context and compiles the function inside it", () => {
+      const ctx = createContext(constants.DONT_CONTEXTIFY);
+      expect(isContext(ctx)).toBe(true);
+      ctx.fromOutside = 400;
+      runInContext("globalThis.fromInside = 56", ctx);
+
+      const fn = compileFunction(
+        "globalThis.fromFunction = fromOutside + fromInside; return [typeof process, fromOutside, fromInside, Array];",
+        [],
+        { parsingContext: ctx },
+      );
+      const [processType, fromOutside, fromInside, ArrayInContext] = fn();
+
+      expect([processType, fromOutside, fromInside]).toEqual(["undefined", 400, 56]);
+      expect(ArrayInContext).toBe(runInContext("Array", ctx));
+      expect(ArrayInContext).not.toBe(Array);
+      expect(ctx.fromFunction).toBe(456);
+      expect(runInContext("fromFunction", ctx)).toBe(456);
+      expect("fromFunction" in globalThis).toBe(false);
+    });
+
+    test("parsingContext accepts the this and globalThis values of a DONT_CONTEXTIFY context", () => {
+      const ctx = createContext(constants.DONT_CONTEXTIFY);
+      ctx.marker = "dont-contextify";
+
+      for (const code of ["this", "globalThis"]) {
+        const parsingContext = runInContext(code, ctx);
+        expect(isContext(parsingContext)).toBe(true);
+        expect(compileFunction("return marker", [], { parsingContext })()).toBe("dont-contextify");
+      }
+    });
+
+    test("params and contextExtensions work with a DONT_CONTEXTIFY parsingContext", () => {
+      const ctx = createContext(constants.DONT_CONTEXTIFY);
+      ctx.fromContext = 1;
+
+      const fn = compileFunction("return [fromContext, fromExtension, fromParam]", ["fromParam"], {
+        parsingContext: ctx,
+        contextExtensions: [{ fromExtension: 2 }],
+      });
+
+      expect([...fn(3)]).toEqual([1, 2, 3]);
+    });
+
+    test("parsingContext rejects values that are not contexts", () => {
+      const notContexts = [
+        {},
+        null,
+        1,
+        "context",
+        constants.DONT_CONTEXTIFY,
+        Object.create(createContext(constants.DONT_CONTEXTIFY)),
+        Object.create(createContext({})),
+      ];
+
+      for (const parsingContext of notContexts) {
+        const compile = () => compileFunction("return 1", [], { parsingContext });
+        expect(compile).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+        expect(compile).toThrow(/^The "options\.parsingContext" property must be an instance of Context\./);
+      }
     });
 
     // Security tests

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -9,6 +9,7 @@ import {
   runInNewContext,
   runInThisContext,
   Script,
+  SourceTextModule,
 } from "node:vm";
 
 function capture(_: any, _1?: any) {}
@@ -122,6 +123,27 @@ describe("vm", () => {
       expect(ctx.fromFunction).toBe(456);
       expect(runInContext("fromFunction", ctx)).toBe(456);
       expect("fromFunction" in globalThis).toBe(false);
+    });
+
+    test("a DONT_CONTEXTIFY parsingContext works before any script has run in the context", () => {
+      // No runInContext() before compileFunction(): the context is used exactly as createContext() returned it.
+      const ctx = createContext(constants.DONT_CONTEXTIFY);
+      ctx.a = 1;
+      ctx.b = 2;
+
+      const result = compileFunction(
+        "const keysBefore = Object.keys(this); const deleted = delete a; return { keysBefore, deleted, aType: typeof a, keysAfter: Object.keys(this) };",
+        [],
+        { parsingContext: ctx },
+      )();
+
+      expect({ ...result, keysBefore: [...result.keysBefore], keysAfter: [...result.keysAfter] }).toEqual({
+        keysBefore: ["a", "b"],
+        deleted: true,
+        aType: "undefined",
+        keysAfter: ["b"],
+      });
+      expect(Object.keys(ctx)).toEqual(["b"]);
     });
 
     test("parsingContext accepts the this and globalThis values of a DONT_CONTEXTIFY context", () => {
@@ -1196,6 +1218,33 @@ describe("DONT_CONTEXTIFY", () => {
 
     ctx.fromOutside = 456;
     expect(runInContext("fromOutside", ctx)).toBe(456);
+  });
+
+  test("a module evaluated in a context no script has run in sees the same global as a script would", async () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    ctx.a = 1;
+    ctx.b = 2;
+
+    // Module code has no `this`; a sloppy function's `this` is the context's global object.
+    const mod = new SourceTextModule(
+      `const g = Function("return this")();
+       export const keysBefore = Object.keys(g);
+       export const deleted = delete g.a;
+       export const keysAfter = Object.keys(g);`,
+      { context: ctx },
+    );
+    await mod.link(() => {
+      throw new Error("unexpected import");
+    });
+    await mod.evaluate();
+
+    const { keysBefore, deleted, keysAfter } = mod.namespace as any;
+    expect({ keysBefore: [...keysBefore], deleted, keysAfter: [...keysAfter] }).toEqual({
+      keysBefore: ["a", "b"],
+      deleted: true,
+      keysAfter: ["b"],
+    });
+    expect(Object.keys(ctx)).toEqual(["b"]);
   });
 });
 


### PR DESCRIPTION
### Problem
- `vm.compileFunction(code, params, { parsingContext })` throws `TypeError [ERR_INVALID_ARG_TYPE]: The "options.parsingContext" property must be an instance of Context. Received an instance of Object` when `parsingContext` is a context created with `vm.constants.DONT_CONTEXTIFY`. The same object is accepted by `vm.isContext()` and `vm.runInContext()`, and Node (v26.3.0) accepts it in `compileFunction` too.
  ```js
  const ctx = vm.createContext(vm.constants.DONT_CONTEXTIFY);
  vm.isContext(ctx);                                           // true
  vm.compileFunction("return 1", [], { parsingContext: ctx }); // bun: throws, node: returns a function
  ```
- Cause: `CompileFunctionOptions::fromJS` (`src/jsc/bindings/NodeVM.cpp`, the `parsingContext` branch near line 2100) resolved the option with a bare `vmModuleContextMap` lookup. That map is keyed by the object `createContext` was given; for `DONT_CONTEXTIFY` that is an internal placeholder, and the caller gets a `NodeVMSpecialSandbox` instead, so the lookup misses. The value of `this` inside such a context (its global proxy) misses for the same reason. Every other vm entry point resolves contexts through `getGlobalObjectFromContext` (`NodeVM.cpp:748`), which handles the three shapes `isContext()` (`NodeVM.cpp:811`) reports as contexts.
- Second, found while reviewing the first: a `DONT_CONTEXTIFY` context fresh out of `createContext` still has the placeholder installed as its contextified object (`vmModule_createContext`, `NodeVM.cpp:1697`). Only `Script#runInContext` (`NodeVMScript.cpp:380`) replaces it with the special sandbox, as a side effect of its first run. `NodeVMGlobalObject::deleteProperty` and `getOwnPropertyNames` read that field, so until some script has run in the context, `delete a` from code running in it returns `true` and leaves `ctx.a` in place, and `Object.keys()` of its global is `[]`. After one `runInContext` the same code matches Node. `compileFunction` and `SourceTextModule` never install anything, so they are the consumers that observe the fresh state; for `compileFunction` this PR's first change is what makes that state reachable.

### Fix
- `fromJS` resolves `parsingContext` with `getGlobalObjectFromContext(globalObject, value, /* canThrow */ false)` and throws the existing `ERR_INVALID_ARG_TYPE` when that returns null (it returns null for null and non-object values too). Node validates this option with `isContext(parsingContext)` (`lib/vm.js`), so the accepted set has to be the set `isContext()` accepts; `getGlobalObjectFromContext` checks the same three shapes as `isContext()`, so the two stay in sync instead of `compileFunction` keeping a narrower private copy. The error for non-contexts is unchanged, including the "Received ..." suffix that `test/js/node/test/parallel/test-vm-basic.js` checks.
- `NodeVMGlobalObject::setSpecialSandbox` (`NodeVM.h`) now also installs the special sandbox as the contextified object, so both places that build a `DONT_CONTEXTIFY` context (`vmModule_createContext`, and `Script#runInNewContext` at `NodeVMScript.cpp:657`, which already did this by hand through `runInContext`) produce a context in the same state. This is the state every `DONT_CONTEXTIFY` context already reached after its first `runInContext`, so primed and unprimed contexts now behave the same and nothing that ran a script first changes. The placeholder is no longer referenced after `createContext` returns, so its weak map entry goes away with it.
- Verified with `test/js/node/vm/vm.test.ts`: five new tests under `describe("compileFunction()")` and one under `describe("DONT_CONTEXTIFY")`. On main the `compileFunction` ones fail with the error above and the module one gets `[]` for the keys; the "before any script has run" test and the module test also fail with only the lookup change applied (keys `[]`, `delete` ineffective), so they pin the second change. The rejection test passes before and after. The same assertions hold on Node v26.3.0 (`--experimental-vm-modules` for the module one).
- `bun bd test test/js/node/vm/`: 220 pass, 0 fail in `vm.test.ts`, also clean under `BUN_JSC_validateExceptionChecks=1`; the other five files in the directory pass.
- All 97 upstream `test/js/node/test/parallel/test-vm-*` tests exit 0 with the debug build, including `test-vm-basic.js` and `test-vm-context-dont-contextify.js`.

### Background
- `vm.createContext(sandbox)` creates a `NodeVMGlobalObject` (a JSC global object, one per context), stores `sandbox` as its contextified object, and records `sandbox -> global` in `vmModuleContextMap`, a WeakMap on the main global. The global's property hooks (`getOwnPropertySlot`, `put`, `deleteProperty`, `getOwnPropertyNames`, `defineOwnProperty`) forward to the contextified object, which is how code in the context reads and writes the caller's sandbox.
- `vm.constants.DONT_CONTEXTIFY` (Node 22.8+) asks for a context with no user sandbox: code runs against the context's real global. Bun builds one by substituting an empty placeholder object for the symbol, creating the context around it, and handing the caller a `NodeVMSpecialSandbox`, a small object that forwards reads to the context's global and holds the properties written to it. The global's hooks special-case this mode: lookups and writes consult the special sandbox directly, while `deleteProperty` and `getOwnPropertyNames` go through whatever object is installed as the contextified object, which is why that object has to be the special sandbox and not the placeholder.
- `getGlobalObjectFromContext` maps a caller-visible context value back to its `NodeVMGlobalObject`: a `vmModuleContextMap` hit, a `NodeVMSpecialSandbox`, or a `JSGlobalProxy` (JSC's wrapper that `this` evaluates to at the top level of a global) whose target is a `NodeVMGlobalObject`. `isContext()` answers true for exactly these shapes. With `canThrow` false it returns null for anything else, so each caller raises its own error; `compileFunction` keeps the `options.parsingContext` error Node uses.
- `parsingContext` becomes the scope the compiled body resolves free identifiers in (and, in sloppy mode, its `this`), so a function compiled against a `DONT_CONTEXTIFY` context sees that context's globals and intrinsics and not the caller's; the tests check `Array` identity and property visibility in both directions.

<details>
<summary>Notes</summary>

- The `JSGlobalProxy` shape is also accepted for contextified contexts (`vm.isContext(vm.runInContext("globalThis", vm.createContext({})))` is already `true` in Bun, `false` in Node). This PR does not change that; `compileFunction` inherits whatever `isContext()` decides, which is the point of sharing the lookup.
- Two open PRs touch the second change: #38326 moves this block into a `makeContext` helper (the line would move there), and #36238 makes `Script#runInContext` install the context's current contextified object instead of the caller's argument, which on its own would make the placeholder state permanent for every `createContext(DONT_CONTEXTIFY)` context. The second change here (or its equivalent in `makeContext`) needs to be in before #36238; the "before any script has run" tests would catch the combination.
- In a `DONT_CONTEXTIFY` context, top-level `var` declarations made by `runInContext` are not visible to later lookups, and top-level `this` is not `===` the context (both tracked in #34623), so the tests use property assignment and intrinsic identity rather than `var`, and do not compare `this` with `globalThis`.
- `test/js/node/vm/script-leak.test.ts` times out locally under the debug ASAN build (25s of `new vm.Script` compiles against a 5s limit); it does not touch either changed path.
</details>
