### PR TITLE
node:vm: throw runInContext/runInNewContext compile errors from the context's realm

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -200,6 +200,7 @@ using namespace JSC;
     macro(validated) \
     macro(view) \
     macro(vmErrorDecorated) \
+    macro(vmParsingContext) \
     macro(warning) \
     macro(webStreamClosedPromise) \
     macro(webStreamControllerError) \

--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -89,11 +89,15 @@ function createContext(contextObject?, options?) {
   return context;
 }
 
+// runInContext/runInNewContext compile the script inside the context it will
+// run in, like Node (lib/vm.js sets options[kParsingContext] on a copy of the
+// options), so a compile error is that context's SyntaxError. The marker is a
+// private name: user options cannot set it, and a plain `new Script` still
+// compiles in the main realm.
 function runInContext(code, context, options) {
   validateContext(context);
-  if (typeof options === "string") {
-    options = { filename: options };
-  }
+  options = typeof options === "string" ? { filename: options } : { ...options };
+  $putByIdDirectPrivate(options, "vmParsingContext", context);
   return new Script(code, options).runInContext(context, options);
 }
 
@@ -112,6 +116,8 @@ function runInNewContext(code, context, options) {
     options = { filename: options };
   }
   context = createContext(context, options);
+  options = { ...options };
+  $putByIdDirectPrivate(options, "vmParsingContext", context);
   return createScript(code, options).runInNewContext(context, options);
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -601,7 +601,12 @@ void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* err
 {
     UNUSED_PARAM(globalObject);
     auto* errorInstance = dynamicDowncast<ErrorInstance>(error);
-    if (!errorInstance)
+    // Stack overflow and out-of-memory ParserErrors have no position to point
+    // at. toErrorObject() also builds those without materializing a stack, so
+    // returning here is what makes the materialization below a no-op rather
+    // than a first materialization that runs a user Error.prepareStackTrace
+    // outside the caller's exception handling.
+    if (!errorInstance || parseError.line() < 0)
         return;
 
     // The caller's toErrorObject() already materialized the stack (running any

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -19,7 +19,7 @@
 namespace Bun {
 using namespace NodeVM;
 
-bool ScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg, JSValue* importer)
+bool ScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg, JSValue* importer, NodeVMGlobalObject** parsingContext)
 {
     if (importer) {
         *importer = jsUndefined();
@@ -82,6 +82,18 @@ bool ScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
                 return false;
             }
         }
+
+        if (parsingContext) {
+            // A private name, so only vm.ts can set it; a user-supplied
+            // `parsingContext` property is not an option of vm.Script.
+            JSValue parsingContextValue = options->getDirect(vm, WebCore::builtinNames(vm).vmParsingContextPrivateName());
+            if (parsingContextValue) {
+                *parsingContext = getGlobalObjectFromContext(globalObject, parsingContextValue, true);
+                RETURN_IF_EXCEPTION(scope, false);
+                ASSERT(*parsingContext);
+                any = true;
+            }
+        }
     }
 
     return any;
@@ -105,13 +117,14 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     JSValue optionsArg = args.at(1);
     ScriptOptions options(""_s);
     JSValue importer;
+    NodeVMGlobalObject* parsingContext = nullptr;
 
     if (optionsArg.isString()) {
         options.filename = optionsArg.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         // `new Script(src, "name")` is a provided filename, "" included.
         options.filenameProvided = true;
-    } else if (!options.fromJS(globalObject, vm, scope, optionsArg, &importer)) {
+    } else if (!options.fromJS(globalObject, vm, scope, optionsArg, &importer, &parsingContext)) {
         RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
     }
 
@@ -140,7 +153,13 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     // via JSC::evaluate); compile-once via m_cachedExecutable is the follow-up.
     JSC::ParserError parseError;
     if (!JSC::checkSyntax(vm, source, parseError)) {
-        auto exception = parseError.toErrorObject(globalObject, source, -1);
+        // Node compiles inside the parsing context, so a compile error is that
+        // realm's SyntaxError/RangeError and that realm's Error.prepareStackTrace
+        // formats it. Both follow from where the error object is created: its
+        // structure decides instanceof, and the stack formatter looks the hook
+        // up on the error's own realm.
+        JSGlobalObject* errorGlobalObject = parsingContext ? parsingContext : globalObject;
+        auto exception = parseError.toErrorObject(errorGlobalObject, source, -1);
         // Building the error materializes its stack, running a user
         // Error.prepareStackTrace that may throw; Node throws the SyntaxError
         // anyway. tryClearException leaves a termination for the check below.
@@ -152,7 +171,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
         // An absent filename becomes evalmachine.<anonymous>; an explicitly
         // provided one — including "" — is used verbatim.
         String url = options.filenameProvided ? options.filename : "evalmachine.<anonymous>"_s;
-        decorateParseErrorStack(globalObject, vm, exception, sourceString, url, parseError, options.lineOffset);
+        decorateParseErrorStack(errorGlobalObject, vm, exception, sourceString, url, parseError, options.lineOffset);
         throwException(globalObject, scope, exception);
         return {};
     }

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -14,7 +14,12 @@ public:
 
     using BaseVMOptions::BaseVMOptions;
 
-    bool fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg, JSValue* importer);
+    // `parsingContext` receives the context named by the private
+    // vmParsingContext option, which only vm.ts sets (Node's kParsingContext:
+    // runInContext/runInNewContext compile inside the context they run in).
+    // Left untouched when the option is absent, so `new vm.Script` keeps
+    // compiling in the caller's realm.
+    bool fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg, JSValue* importer, NodeVMGlobalObject** parsingContext = nullptr);
 };
 
 class NodeVMScriptConstructor final : public JSC::InternalFunction {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -463,6 +463,187 @@ describe("Script", () => {
   });
 });
 
+describe("compile errors come from the context the code is compiled in", () => {
+  // Node's runInContext/runInNewContext compile the source inside the target
+  // context (lib/vm.js passes it as the Script's parsing context), so an error
+  // the compile throws is an instance of that context's constructors, not the
+  // caller's. A bare `new Script` has no parsing context and compiles in the
+  // caller's realm.
+  const thrownBy = (fn: () => unknown): any => {
+    try {
+      fn();
+    } catch (e) {
+      return e;
+    }
+    throw new Error("expected a throw");
+  };
+  const realmOf = (context: object) => ({
+    Error: runInContext("Error", context),
+    SyntaxError: runInContext("SyntaxError", context),
+    RangeError: runInContext("RangeError", context),
+  });
+  const header = (err: any) => err.stack.split("\n").slice(0, 4);
+
+  test("runInContext throws the context's SyntaxError, still decorated with the arrow header", () => {
+    const context = createContext({});
+    const realm = realmOf(context);
+    const cases: [options: any, url: string][] = [
+      [undefined, "evalmachine.<anonymous>"],
+      ["named.js", "named.js"],
+      [{ filename: "opts.js" }, "opts.js"],
+      [{ filename: "opts.js", displayErrors: false }, "opts.js"],
+    ];
+    for (const [options, url] of cases) {
+      const err = thrownBy(() => runInContext("%%", context, options));
+      expect(err).toBeInstanceOf(realm.SyntaxError);
+      expect(err).not.toBeInstanceOf(Error);
+      expect(err.message).toBe("Unexpected token '%'");
+      expect(header(err)).toEqual([`${url}:1`, "%%", "^", ""]);
+    }
+  });
+
+  test("runInContext with a DONT_CONTEXTIFY context", () => {
+    const context = createContext(constants.DONT_CONTEXTIFY);
+    const err = thrownBy(() => runInContext("%%", context));
+    expect(err).toBeInstanceOf(realmOf(context).SyntaxError);
+    expect(err).not.toBeInstanceOf(Error);
+  });
+
+  test("runInNewContext throws the SyntaxError of the context it creates for (or finds on) the sandbox", () => {
+    const sandbox = {};
+    const err = thrownBy(() => runInNewContext("%%", sandbox));
+    // runInNewContext contextified the sandbox; runInContext now resolves to
+    // that same context.
+    expect(err).toBeInstanceOf(realmOf(sandbox).SyntaxError);
+    expect(err).not.toBeInstanceOf(Error);
+    expect(header(err)).toEqual(["evalmachine.<anonymous>:1", "%%", "^", ""]);
+
+    const context = createContext({});
+    const realm = realmOf(context);
+    expect(thrownBy(() => runInNewContext("%%", context))).toBeInstanceOf(realm.SyntaxError);
+    expect(thrownBy(() => runInNewContext("%%", context, "named.js"))).toBeInstanceOf(realm.SyntaxError);
+    expect(thrownBy(() => runInNewContext("%%", context, { filename: "opts.js" }))).toBeInstanceOf(realm.SyntaxError);
+
+    // No handle on the context at all: the error is still not the caller's.
+    for (const err of [
+      thrownBy(() => runInNewContext("%%")),
+      thrownBy(() => runInNewContext("%%", constants.DONT_CONTEXTIFY)),
+    ]) {
+      expect(err.name).toBe("SyntaxError");
+      expect(err).not.toBeInstanceOf(Error);
+    }
+  });
+
+  test("the parser's stack overflow RangeError comes from the context too, and gets no arrow header", () => {
+    const context = createContext({});
+    const realm = realmOf(context);
+    const tooDeep = Buffer.alloc(100_000, "(").toString();
+    for (const err of [
+      thrownBy(() => runInContext(tooDeep, context)),
+      thrownBy(() => runInNewContext(tooDeep, context)),
+    ]) {
+      expect(err).toBeInstanceOf(realm.RangeError);
+      expect(err).not.toBeInstanceOf(Error);
+      // There is no source position to point at, so the stack starts with the
+      // error itself rather than a "<url>:-1" header. (Node's header here
+      // points at a line inside its own lib/vm.js, which has no equivalent.)
+      expect(err.stack.split("\n")[0]).toStartWith("RangeError: ");
+    }
+    // Same for the other compile path that shares the decoration; this one
+    // compiles in the caller's realm.
+    for (const err of [thrownBy(() => new Script(tooDeep)), thrownBy(() => compileFunction(tooDeep))]) {
+      expect(err).toBeInstanceOf(RangeError);
+      expect(err.stack.split("\n")[0]).toStartWith("RangeError: ");
+    }
+  });
+
+  test("the context's Error.prepareStackTrace formats the error, under the arrow header", () => {
+    const calls: string[] = [];
+    const context = createContext({ calls });
+    runInContext(
+      `Error.prepareStackTrace = err => {
+        calls.push("context:" + err.constructor.name);
+        return "formatted by the context";
+      };`,
+      context,
+    );
+    const prev = Error.prepareStackTrace;
+    Error.prepareStackTrace = err => {
+      calls.push("caller:" + err.constructor.name);
+      return "formatted by the caller";
+    };
+    let inContext: any, inNewContext: any, bare: any;
+    try {
+      inContext = thrownBy(() => runInContext("%%", context, { filename: "a.js" }));
+      inNewContext = thrownBy(() => runInNewContext("%%", context, { filename: "b.js" }));
+      bare = thrownBy(() => new Script("%%", { filename: "c.js" }));
+    } finally {
+      Error.prepareStackTrace = prev;
+    }
+    expect(calls).toEqual(["context:SyntaxError", "context:SyntaxError", "caller:SyntaxError"]);
+    expect(inContext.stack).toBe("a.js:1\n%%\n^\n\nformatted by the context");
+    expect(inNewContext.stack).toBe("b.js:1\n%%\n^\n\nformatted by the context");
+    expect(bare.stack).toBe("c.js:1\n%%\n^\n\nformatted by the caller");
+  });
+
+  test("a throwing Error.prepareStackTrace in the context does not escape the compile error", () => {
+    // Context-realm counterpart of the main-realm test in describe("Script"):
+    // the stack is materialized while the error is built, the hook's throw is
+    // dropped, and the SyntaxError with its header is what comes out.
+    const context = createContext({});
+    runInContext(
+      `Error.prepareStackTrace = () => {
+        throw new Error("boom-from-prepareStackTrace");
+      };`,
+      context,
+    );
+    const err = thrownBy(() => runInContext("%%", context));
+    expect(err).toBeInstanceOf(realmOf(context).SyntaxError);
+    expect(err.message).toBe("Unexpected token '%'");
+    expect(header(err)).toEqual(["evalmachine.<anonymous>:1", "%%", "^", ""]);
+  });
+
+  test("new Script and runInThisContext keep compiling in the caller's realm", () => {
+    const context = createContext({});
+    const realm = realmOf(context);
+    const errors = [
+      thrownBy(() => new Script("%%")),
+      thrownBy(() => runInThisContext("%%")),
+      // compileFunction's option name is not a vm.Script option; Node ignores it here too.
+      thrownBy(() => new Script("%%", { parsingContext: context } as any)),
+      thrownBy(() => runInThisContext("%%", { parsingContext: context } as any)),
+    ];
+    for (const err of errors) {
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err).not.toBeInstanceOf(realm.SyntaxError);
+    }
+  });
+
+  test("options are copied like Node's { ...options }: getters run once, frozen objects work, defaults apply", () => {
+    const context = createContext({});
+    const realm = realmOf(context);
+    let reads = 0;
+    const options = Object.freeze({
+      get filename() {
+        reads++;
+        return "getter.js";
+      },
+    });
+    expect(runInContext("new Error().stack", context, options)).toContain("getter.js");
+    expect(reads).toBe(1);
+    reads = 0;
+    expect(runInNewContext("new Error().stack", {}, options)).toContain("getter.js");
+    expect(reads).toBe(1);
+    // The parsing context travels on the copy, so a frozen options object still gets it.
+    expect(thrownBy(() => runInContext("%%", context, options))).toBeInstanceOf(realm.SyntaxError);
+    expect(thrownBy(() => runInNewContext("%%", context, options))).toBeInstanceOf(realm.SyntaxError);
+
+    // With no options at all the script is still named the way Node names it.
+    expect(runInContext("new Error().stack", context)).toContain("at evalmachine.<anonymous>:1");
+    expect(runInNewContext("new Error().stack", {})).toContain("at evalmachine.<anonymous>:1");
+  });
+});
+
 type TestRunInContextArg =
   | { fn: typeof runInContext; isIsolated: true; isNew?: boolean }
   | { fn: typeof runInThisContext; isIsolated?: false; isNew?: boolean };


### PR DESCRIPTION
### Problem
- `vm.runInContext("%%", ctx)` and `vm.runInNewContext("%%", sandbox)` throw the main realm's `SyntaxError`: `err instanceof SyntaxError` is `true` and `err instanceof vm.runInContext("SyntaxError", ctx)` is `false`. Node v26.3.0 gives `false` / `true`. Same for the parser's stack overflow `RangeError`, and the main realm's `Error.prepareStackTrace` formats the error instead of the context's. `new vm.Script("%%")` is correct already (Node compiles that in the caller's realm too).
- Cause: `runInContext` / `runInNewContext` in `src/js/node/vm.ts` build a plain `new Script(code, options)`, and the constructor (`constructScript`, `src/jsc/bindings/NodeVMScript.cpp`) creates the parse error with `parseError.toErrorObject(globalObject, ...)`, where `globalObject` is the realm the constructor was called from. Node's `lib/vm.js` passes the context to the Script as `options[kParsingContext]` and `node_contextify.cc` compiles inside it, so the error is the context's.
- Found on the side, fixed here because the new test trips it: `decorateParseErrorStack` (`src/jsc/bindings/NodeVM.cpp`) materializes the stack of a parse error that has no position (parser stack overflow). `toErrorObject` only materializes the stack of positioned `SyntaxError`s, so for those errors this was the first materialization, running a user `Error.prepareStackTrace` outside the caller's `tryClearException` / `RETURN_IF_EXCEPTION` handling. `BUN_JSC_validateExceptionChecks=1` aborts on main for `new vm.Script("(".repeat(1e5))` and for the same input through `vm.compileFunction`, and the error carried a meaningless `evalmachine.<anonymous>:-1` header.

### Fix
- `vm.ts`: `runInContext` / `runInNewContext` copy the options the way Node does (`{ ...options }`) and set the context on the copy under a private name (`vmParsingContext`, added to `BunBuiltinNames.h`, via `$putByIdDirectPrivate`, same pattern as `sharedFd` in `dgram.ts`). `runInNewContext` uses what `createContext()` returned, which is the context `runInContext(sandbox)` resolves to afterwards.
- `ScriptOptions::fromJS` reads that private property (`getDirect`, so no traps or getters run) and resolves it with the existing `getGlobalObjectFromContext`, which accepts every shape `createContext()` can hand back (contextified sandbox, `DONT_CONTEXTIFY` handle, global proxy). `constructScript` creates the parse error in that global object.
- Why this is the whole fix: in JSC the realm of an error object is decided by the global object its structure is taken from, which is what `instanceof` against the context's constructors checks, and Bun's stack formatter (`computeErrorInfoToJSValueWithoutSkipping`, `FormatStackTraceForJS.cpp`) looks `Error.prepareStackTrace` up on the error's own realm, so the hook follows automatically. The existing "a throwing prepareStackTrace is swallowed, terminations propagate" handling is realm independent, as is the arrow header decoration. Nothing about evaluation changes: a valid script runs exactly as before.
- Not public API: user code cannot create a private-name property, so `new vm.Script(code, { parsingContext })` or any other option keeps compiling in the caller's realm (pinned by a test). `new Script`, `createScript` and `runInThisContext` are untouched, as in Node.
- Consequences of the options copy, all matching Node (`lib/vm.js` does the same copy): option getters run once instead of twice (Script constructor plus `runInContext`), a frozen options object works, and `runInContext(code, ctx)` / `runInNewContext(code, sandbox)` with no options now name the script `evalmachine.<anonymous>` in stack frames instead of `file:///` (the object form already did; the bare `new Script(code)` / `runInThisContext(code)` shapes still say `file:///` and are tracked separately). Non-object options to `runInContext` (`42`, `null`) are now accepted, as Node accepts them.
- `decorateParseErrorStack` returns early when the parse error has no position (`parseError.line() < 0`). That is the same line #38040 adds for its own reasons (no header for position-less errors); it is here so the stack overflow path is exception-check clean and testable on the ASAN lane. Whichever lands second has a one-line identical-change conflict.
- Verified with the new `describe("compile errors come from the context the code is compiled in")` block in `test/js/node/vm/vm.test.ts`: 8 tests, 7 fail on bun 1.4.0 / main (the 8th pins the unchanged `new Script` / `runInThisContext` realm), all 8 pass with the fix. The same assertions were run as a plain script under node v26.3.0: every realm, header, `prepareStackTrace` routing and options-copy assertion holds there too. Two are deliberately Bun-specific: the stack overflow error's first stack line (Node puts a header there as well, but one pointing at a line of its own `lib/vm.js`), and the throwing-hook test, which is the context-realm twin of the existing main-realm test and pins Bun's existing behavior of materializing the stack while the error is built (V8 formats lazily, so in Node the hook throws again on the first `.stack` read instead).
- Also run with the fix: `test/js/node/vm/vm.test.ts` with `BUN_JSC_validateExceptionChecks=1` (222 pass; without the decorate change the new stack overflow case aborts), the rest of `test/js/node/vm/` (`script-leak.test.ts` exceeds its 5 s budget under the debug+ASAN build independent of this change), all 97 `test/js/node/test/parallel/test-vm-*` files plus the 3 `sequential/test-vm-*` files, `test/js/bun/repl/`, and the other test files that use `runInContext` / `runInNewContext` (`vm-sourceUrl`, `happy-dom-vm-16277`, `regression/issue/09778`, `transpiler/repl-transform`, `v8/capture-stack-trace`).

### Background
- Realm: a global object plus its own copies of the intrinsics (`Error`, `SyntaxError`, `Function.prototype`, ...). Every `vm` context is a realm of its own (a `NodeVMGlobalObject`); `instanceof` across realms is false. `vmModuleContextMap()` on the main global maps a contextified sandbox object to its `NodeVMGlobalObject`; `getGlobalObjectFromContext` is the lookup the run methods already use.
- Parsing context: Node's name for the context a `vm.Script` is compiled in. `vm.compileFunction` exposes it as a real option; for `vm.Script` it is internal (`kParsingContext`, a module-private symbol), set only by `runInContext` / `runInNewContext`.
- Private names: Bun's builtin JS can store properties under private symbols (`$putByIdDirectPrivate(obj, "name", v)`, names declared in `BunBuiltinNames.h`); C++ reads them with `builtinNames(vm).namePrivateName()`. User code has no way to reach these keys, which is what keeps the marker out of the public option surface.
- `ParserError::toErrorObject`: turns a JSC parse failure into an error object of the given global object. For a positioned `SyntaxError` it also materializes the `stack` property (which is when `Error.prepareStackTrace` runs); for a parser stack overflow it creates a `RangeError` and leaves the stack lazy.
- Arrow header: Node prefixes compile-time errors with `<url>:<line>\n<source line>\n^\n\n`; `decorateParseErrorStack` is Bun's implementation, `handleException` the runtime counterpart.

<details>
<summary>Probe (node v26.3.0 vs bun 1.4.0)</summary>

```js
const vm = require("node:vm");
const ctx = vm.createContext({});
const CtxSyntaxError = vm.runInContext("SyntaxError", ctx);
try { vm.runInContext("%%", ctx); } catch (e) {
  console.log(e instanceof SyntaxError, e instanceof CtxSyntaxError);   // node: false true   bun: true false
}
try { vm.runInNewContext("%%", {}); } catch (e) {
  console.log(e instanceof SyntaxError);                                 // node: false        bun: true
}
try { vm.runInContext(Buffer.alloc(1e5, "(").toString(), ctx); } catch (e) {
  console.log(e.name, e instanceof RangeError);                          // node: RangeError false   bun: RangeError true
}
vm.runInContext("Error.prepareStackTrace = e => 'CTX:' + e.message", ctx);
Error.prepareStackTrace = e => "MAIN:" + e.message;
try { vm.runInContext("%%", ctx); } catch (e) {
  console.log(e.stack.split("\n").at(-1));                               // node: CTX:Unexpected token '%'   bun: MAIN:Unexpected token '%'
}
try { new vm.Script("%%"); } catch (e) {
  console.log(e instanceof SyntaxError);                                 // node: true   bun: true (unchanged by this PR)
}
```

</details>
