### PR TITLE
node:vm: name a Script built without options evalmachine.<anonymous>

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -615,10 +615,6 @@ void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* err
     if (stack.isNull())
         return;
 
-    // `url` is resolved by the caller: `new Script` substitutes
-    // evalmachine.<anonymous> only when no filename was provided, while
-    // compileFunction has no such default. An explicit "" renders as ":<line>".
-
     // parseError.line() is already lineOffset-adjusted (JSC parses against a
     // SourceCode whose start position carries the offset), but JSC clamps a
     // negative provider start line to zero, so a negative offset comes back as
@@ -1448,7 +1444,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
     JSValue optionsArg = callFrame->argument(2);
     JSValue scriptDynamicImportCallback;
 
-    ScriptOptions options(optionsArg.toWTFString(globalObject), OrdinalNumber::fromZeroBasedInt(0), OrdinalNumber::fromZeroBasedInt(0));
+    ScriptOptions options;
     if (optionsArg.isString()) {
         options.filename = optionsArg.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
@@ -1498,7 +1494,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInThisContext, (JSGlobalObject * globalObjec
     JSValue importer;
 
     JSValue optionsArg = callFrame->argument(1);
-    ScriptOptions options(optionsArg.toWTFString(globalObject), OrdinalNumber::fromZeroBasedInt(0), OrdinalNumber::fromZeroBasedInt(0));
+    ScriptOptions options;
     if (optionsArg.isString()) {
         options.filename = optionsArg.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
@@ -1928,13 +1924,6 @@ BaseVMOptions::BaseVMOptions(String filename)
 {
 }
 
-BaseVMOptions::BaseVMOptions(String filename, OrdinalNumber lineOffset, OrdinalNumber columnOffset)
-    : filename(WTF::move(filename))
-    , lineOffset(lineOffset)
-    , columnOffset(columnOffset)
-{
-}
-
 bool BaseVMOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg)
 {
     JSObject* options = nullptr;
@@ -1951,14 +1940,11 @@ bool BaseVMOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
             if (filenameOpt.isString()) {
                 this->filename = filenameOpt.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, false);
-                this->filenameProvided = true;
                 any = true;
             } else if (!filenameOpt.isUndefined()) {
                 ERR::INVALID_ARG_TYPE(scope, globalObject, "options.filename"_s, "string"_s, filenameOpt);
                 return false;
             }
-        } else {
-            this->filename = "evalmachine.<anonymous>"_s;
         }
 
         auto lineOffsetOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "lineOffset"_s));
@@ -2066,13 +2052,6 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
     this->parsingContext = globalObject;
     bool any = BaseVMOptions::fromJS(globalObject, vm, scope, optionsArg);
     RETURN_IF_EXCEPTION(scope, false);
-
-    // Node's compileFunction defaults filename to the empty string, unlike
-    // `new Script` which defaults to "evalmachine.<anonymous>" (the default
-    // BaseVMOptions::fromJS applies). Reset so both compileFunction call
-    // shapes (with and without an options object) render the same origin.
-    if (!this->filenameProvided)
-        this->filename = String();
 
     if (!optionsArg.isUndefined() && !optionsArg.isString()) {
         JSObject* options = asObject(optionsArg);

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -30,8 +30,7 @@ bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedD
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset);
 JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::SourceCode& source);
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope);
-// `url` must be caller-resolved: `new Script` falls back to evalmachine.<anonymous>
-// when no filename was provided; compileFunction has no such default.
+// `url` is the caller's (already defaulted) filename; an explicit "" renders as ":<line>".
 void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* error, StringView sourceString, const String& url, const JSC::ParserError& parseError, OrdinalNumber lineOffset);
 void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSValue optionsArg, NodeVMContextOptions& outOptions, ASCIILiteral codeGenerationKey, JSValue* importer);
 NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSValue contextValue, bool canThrow);
@@ -51,12 +50,11 @@ public:
     OrdinalNumber lineOffset = OrdinalNumber::fromZeroBasedInt(0);
     OrdinalNumber columnOffset = OrdinalNumber::fromZeroBasedInt(0);
     bool failed = false;
-    bool filenameProvided = false;
 
     BaseVMOptions() = default;
     BaseVMOptions(String filename);
-    BaseVMOptions(String filename, OrdinalNumber lineOffset, OrdinalNumber columnOffset);
 
+    // Leaves `filename` at the constructor's default unless options.filename is a string.
     bool fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg);
     bool validateProduceCachedData(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSObject* options, bool& outProduceCachedData);
     bool validateCachedData(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSObject* options, WTF::Vector<uint8_t>& outCachedData);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -103,14 +103,12 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     }
 
     JSValue optionsArg = args.at(1);
-    ScriptOptions options(""_s);
+    ScriptOptions options;
     JSValue importer;
 
     if (optionsArg.isString()) {
         options.filename = optionsArg.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        // `new Script(src, "name")` is a provided filename, "" included.
-        options.filenameProvided = true;
     } else if (!options.fromJS(globalObject, vm, scope, optionsArg, &importer)) {
         RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
     }
@@ -149,10 +147,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
         RETURN_IF_EXCEPTION(scope, {});
         // Node always attaches the arrow header to compile-time SyntaxErrors
         // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
-        // An absent filename becomes evalmachine.<anonymous>; an explicitly
-        // provided one — including "" — is used verbatim.
-        String url = options.filenameProvided ? options.filename : "evalmachine.<anonymous>"_s;
-        decorateParseErrorStack(globalObject, vm, exception, sourceString, url, parseError, options.lineOffset);
+        decorateParseErrorStack(globalObject, vm, exception, sourceString, options.filename, parseError, options.lineOffset);
         throwException(globalObject, scope, exception);
         return {};
     }

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -12,7 +12,12 @@ public:
     std::optional<int64_t> timeout = std::nullopt;
     bool produceCachedData = false;
 
-    using BaseVMOptions::BaseVMOptions;
+    // Node's `new Script(code)` default (lib/vm.js); a filename the caller
+    // passes replaces it, "" included. compileFunction has no such default.
+    ScriptOptions()
+        : BaseVMOptions("evalmachine.<anonymous>"_s)
+    {
+    }
 
     bool fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg, JSValue* importer);
 };

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -12,8 +12,7 @@ public:
     std::optional<int64_t> timeout = std::nullopt;
     bool produceCachedData = false;
 
-    // Node's `new Script(code)` default (lib/vm.js); a filename the caller
-    // passes replaces it, "" included. compileFunction has no such default.
+    // Node's default filename for `new Script(code)` (lib/vm.js); compileFunction's is "".
     ScriptOptions()
         : BaseVMOptions("evalmachine.<anonymous>"_s)
     {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -4,6 +4,7 @@ import {
   compileFunction,
   constants,
   createContext,
+  createScript,
   runInContext,
   runInNewContext,
   runInThisContext,
@@ -11,6 +12,14 @@ import {
 } from "node:vm";
 
 function capture(_: any, _1?: any) {}
+
+// Node names a script whose caller gave no filename "evalmachine.<anonymous>"
+// (lib/vm.js). Only the column is JSC-specific.
+const EVALMACHINE_FRAME = /^\s+at evalmachine\.<anonymous>:1:\d+$/;
+// First "at ..." line of the stack returned by running `new Error().stack;`.
+function firstFrame(stack: string) {
+  return stack.split("\n")[1];
+}
 
 describe("vm", () => {
   describe("runInContext()", () => {
@@ -428,6 +437,50 @@ describe("Script", () => {
     expect(header(() => new Script("%%", ""))).toEqual([":1", "%%", "^", ""]);
   });
 
+  test("the source itself is named evalmachine.<anonymous> when no filename is given", () => {
+    // The default is the compiled source's name, not only the arrow header's:
+    // stack frames and CallSites read it too. Node names all of these
+    // evalmachine.<anonymous> (lib/vm.js destructuring default).
+    const code = "new Error().stack;";
+    const frames = [undefined, {}, { filename: undefined }].map(options =>
+      firstFrame(new Script(code, options).runInThisContext()),
+    );
+    expect(frames).toEqual([
+      expect.stringMatching(EVALMACHINE_FRAME),
+      expect.stringMatching(EVALMACHINE_FRAME),
+      expect.stringMatching(EVALMACHINE_FRAME),
+    ]);
+    expect(firstFrame(createScript(code).runInThisContext())).toMatch(EVALMACHINE_FRAME);
+
+    // A provided filename still wins in both option forms, "" included.
+    expect(firstFrame(new Script(code, "named.js").runInThisContext())).toMatch(/^\s+at named\.js:1:\d+$/);
+    expect(firstFrame(new Script(code, "").runInThisContext())).not.toContain("evalmachine");
+    expect(firstFrame(new Script(code, { filename: "" }).runInThisContext())).not.toContain("evalmachine");
+
+    // What CallSite-based tooling sees; Node returns the same string.
+    const prev = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, callSites) => callSites[0].getFileName();
+    try {
+      expect(new Script(code).runInThisContext()).toBe("evalmachine.<anonymous>");
+    } finally {
+      Error.prepareStackTrace = prev;
+    }
+
+    // Compile-time SyntaxErrors name the source in their frames as well. All
+    // three shapes are thrown from this one call site, so the whole stacks,
+    // not just the headers pinned above, must be identical.
+    const compileErrorStacks = [undefined, {}, { filename: undefined }].map(options => {
+      try {
+        new Script("%%", options);
+      } catch (e: any) {
+        return e.stack as string;
+      }
+      expect.unreachable();
+    });
+    expect(compileErrorStacks[0]).toStartWith("evalmachine.<anonymous>:1\n");
+    expect(compileErrorStacks).toEqual([compileErrorStacks[0], compileErrorStacks[0], compileErrorStacks[0]]);
+  });
+
   test("a throwing Error.prepareStackTrace does not escape the compile-time SyntaxError", () => {
     // Building the error materializes its stack, running a user
     // prepareStackTrace; if that throws, the SyntaxError must still be what is
@@ -598,6 +651,13 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
       });
       expect(result).toContain("foo.js");
     });
+    test("defaults the filename to evalmachine.<anonymous> like Node", () => {
+      const context = createContext({});
+      expect(firstFrame(fn("new Error().stack;", context))).toMatch(EVALMACHINE_FRAME);
+      expect(firstFrame(fn("new Error().stack;", context, { filename: undefined }))).toMatch(EVALMACHINE_FRAME);
+      // An explicitly empty filename is not replaced by the default.
+      expect(firstFrame(fn("new Error().stack;", context, { filename: "" }))).not.toContain("evalmachine");
+    });
   } else {
     test("can access global context", () => {
       const props = randomProps(2);
@@ -666,6 +726,12 @@ function testRunInContext({ fn, isIsolated, isNew }: TestRunInContextArg) {
         filename: "foo.js",
       });
       expect(result).toContain("foo.js");
+    });
+    test("defaults the filename to evalmachine.<anonymous> like Node", () => {
+      expect(firstFrame(fn("new Error().stack;"))).toMatch(EVALMACHINE_FRAME);
+      expect(firstFrame(fn("new Error().stack;", { filename: undefined }))).toMatch(EVALMACHINE_FRAME);
+      // An explicitly empty filename is not replaced by the default.
+      expect(firstFrame(fn("new Error().stack;", { filename: "" }))).not.toContain("evalmachine");
     });
   }
   test.todo("can specify filename", () => {


### PR DESCRIPTION
### Problem

- A `vm.Script` built without an options argument registers its source under an empty filename, so its stack frames print as `at file:///:1:10` and `CallSite.getFileName()` returns `"file:///"`. Node names it `evalmachine.<anonymous>` (`lib/vm.js`: `filename = 'evalmachine.<anonymous>'` destructuring default).
- Affected shapes on current main: `new Script(code)`, `new Script(code, { filename: undefined })`, `vm.createScript(code)`, `vm.runInThisContext(code)`, and `{ filename: undefined }` passed to any of the `vm.runIn*` wrappers. (`vm.runInContext(code, ctx)` and `vm.runInNewContext(code)` without options stopped being affected when #38381 made those two wrappers spread `options` into a fresh object; bun 1.4.0 still shows them.) The compile-time `SyntaxError` from `new Script("%%")` has the same problem in its frame (`at <parse> (:1)`); only its arrow header was already right.
- `new Script(code, {})` was already correct, so the two shapes disagreed.
- Cause: `constructScript` started from `ScriptOptions options(""_s)` (`src/jsc/bindings/NodeVMScript.cpp:106`) and the `evalmachine.<anonymous>` default lived inside `BaseVMOptions::fromJS` (`src/jsc/bindings/NodeVM.cpp:1963`), which only runs that branch when an options object exists and has no `filename` key. No options object, or `filename: undefined`, never reached it, and the empty name then rendered through the `SourceOrigin` fallback as `file:///`.

### Fix

- `ScriptOptions` now seeds `filename` with `evalmachine.<anonymous>` in its constructor; `BaseVMOptions::fromJS` only overwrites `filename` when `options.filename` is a string. The default is therefore in effect for every call shape, and a provided filename (string argument or `filename:` property, `""` included) still replaces it, as in Node.
- Why here: `fromJS` is a parser shared by `Script`, `compileFunction` and the run options, and the APIs have different defaults (Node's `compileFunction` defaults to `""`). Putting the `Script` default in the parser is what forced `CompileFunctionOptions::fromJS` to undo it afterwards and `constructScript` to track `filenameProvided` for its header. With the default on `ScriptOptions`, both workarounds are dead and are removed, and the compile-error header just uses `options.filename` like `compileFunction` already did.
- `compileFunction` keeps its empty default (default-constructed options, same as the reset produced before); an explicit `""` still renders the compile-error header as `:1` (existing tests in `vm.test.ts` pin both).
- Not changed here, pre-existing and byte-identical before and after this PR: how an explicitly empty name renders in runtime frames (`file:///`, Node prints `<anonymous>`), and the runtime arrow header in `handleException` (`NodeVM.cpp:561-567`), which is built from the error's top frame and still substitutes `evalmachine.<anonymous>` for an empty URL (it renders `evalmachine.<anonymous>:1` for an explicit `""` where Node renders `:1`, and `[native code]:0` when a builtin threw). That is a frame-selection problem in `handleException` and is left for a separate change. The `SourceTextModule` counterpart (frames named after the module identifier) is #38235.
- The two hunks in the binding-level `runInNewContext`/`runInThisContext` host functions in `NodeVM.cpp` are compile fixes, not behavior: those functions are unreachable (`vm.ts` builds both APIs on `Script` and never calls them), and they were the only users of the three-argument `BaseVMOptions` constructor, which is deleted here along with `ScriptOptions`' inherited constructors. #38228 deletes the functions themselves; whichever of the two lands second resolves by taking that deletion.
- Tests: `test/js/node/vm/vm.test.ts`. "defaults the filename to evalmachine.<anonymous> like Node" runs inside the shared matrix, so it covers `vm.runInContext`/`runInNewContext`/`runInThisContext` and the three `Script.prototype.runIn*` paths, each with no options, `{ filename: undefined }`, and `{ filename: "" }` (must stay non-default). "the source itself is named evalmachine.<anonymous> when no filename is given" covers `new Script` with `undefined`/`{}`/`{ filename: undefined }`, `createScript`, the string form (`"named.js"` and `""`), `CallSite.getFileName()`, and the compile-time `SyntaxError` stacks, which must be identical across the three shapes.
- Verified: the 7 new tests fail on the released `bun` (`USE_SYSTEM_BUN=1`) and on a debug build of current main's `src/` (`at file:///:1:10`; the two `vm.runInContext`/`runInNewContext` cases fail on their `{ filename: undefined }` assertion), and pass with the fix (`bun bd test test/js/node/vm/vm.test.ts`: 257 pass). All 97 vendored `test/js/node/test/parallel/test-vm-*` files, the three `sequential/test-vm-*` files, and the vendored buffer/util/repl tests that use `node:vm` pass on the fixed build; `test-vm-basic.js` in particular still pins `compileFunction`'s empty-name frames. The new tests also pass under `BUN_JSC_validateExceptionChecks=1`.

### Background

- `BaseVMOptions` (`NodeVM.h`) holds the `filename`/`lineOffset`/`columnOffset` common to the vm option bags; `ScriptOptions` (`new Script`), `CompileFunctionOptions` (`vm.compileFunction`) and `RunningScriptOptions` (`runIn*Context` on an existing script) derive from it and call `BaseVMOptions::fromJS` to read those properties from the user's options object.
- The filename becomes the `sourceURL` of the JSC `SourceCode` the script is compiled from. Stack frames, `CallSite.getFileName()` and the `<url>:<line>` arrow header Bun prepends to vm errors all read it. When it is empty, Bun's stack formatter falls back to the `SourceOrigin` URL, which for a vm script is `fileURLWithFileSystemPath(filename)`, i.e. `file:///` for an empty name; that fallback is why the bug showed up as `file:///`.
- `src/js/node/vm.ts` implements `runInContext`, `runInNewContext`, `runInThisContext` and `createScript` on top of `new Script(code, options)`, which is why they share the constructor's bug. Since #38381 the first two copy `options` into a fresh object first, so for them only a present-but-`undefined` `filename` still reaches the bug.

<details>
<summary>Before / after (bun 1.4.0 vs. this branch; node v26.3.0 for reference)</summary>

```
                                          before                       after / node
new Script(code)                          at file:///:1:10             at evalmachine.<anonymous>:1:10
new Script(code, {})                      at evalmachine.<anonymous>   at evalmachine.<anonymous>:1:10
new Script(code, {filename: undefined})   at file:///:1:10             at evalmachine.<anonymous>:1:10
createScript(code)                        at file:///:1:10             at evalmachine.<anonymous>:1:10
runInThisContext(code)                    at file:///:1:10             at evalmachine.<anonymous>:1:10
runInContext(code, ctx)                   at file:///:1:10 (*)         at evalmachine.<anonymous>:1:10
runInNewContext(code)                     at file:///:1:10 (*)         at evalmachine.<anonymous>:1:10
runIn*(…, {filename: undefined})          at file:///:1:10             at evalmachine.<anonymous>:1:10
getFileName(), no options                 "file:///"                   "evalmachine.<anonymous>"
new Script("%%") frame                    at <parse> (:1)              at <parse> (evalmachine.<anonymous>:1)

(*) already evalmachine.<anonymous> on main since #38381; still file:/// in 1.4.0.

unchanged:
new Script(code, "") / {filename: ""}     at file:///:1:10 (node: at <anonymous>:1:1); compile header ":1" in both
compileFunction(...) without filename     compile header ":1", frames file:/// (pinned by vendored test-vm-basic.js)
```

(Node reports column 1 where JSC reports the column of the `new Error` expression; the tests only check the name.)

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (8d95f75c3)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.56ms]
(pass) vm > runInContext() > can return a value [15.10ms]
(pass) vm > runInContext() > can return a complex value [15.27ms]
(pass) vm > runInContext() > can return the last value [14.97ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.81ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.32ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.45ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.33ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.42ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.06ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.21ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.69ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 29 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.35ms]
(pass) vm > runInContext() > can return a value [0.21ms]
(pass) vm > runInContext() > can return a complex value [0.20ms]
(pass) vm > runInContext() > can return the last value [0.19ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.23ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.21ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.13ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (8d95f75c3)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [23.24ms]
(pass) vm > runInContext() > can return a value [14.97ms]
(pass) vm > runInContext() > can return a complex value [15.45ms]
(pass) vm > runInContext() > can return the last value [14.41ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.10ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.52ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.45ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.27ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.25ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [14.60ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.60ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [14.61ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8d95f75c38
  features     baseline

22 deps, 123 codegen, 1176 objects in 639ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [39.00ms]
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch zlib
[zlib] up to date
[7/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[10/1237] gen .bind.ts → GeneratedBindings.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp       | 25 ++-------------
 src/jsc/bindings/NodeVM.h         |  6 ++--
 src/jsc/bindings/NodeVMScript.cpp |  9 ++----
 src/jsc/bindings/NodeVMScript.h   |  6 +++-
 test/js/node/vm/vm.test.ts        | 66 +++++++++++++++++++++++++++++++++++++++
 5 files changed, 77 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/NodeVM.cpp            5      8      0
src/jsc/bindings/NodeVM.h              1      2      0
src/jsc/bindings/NodeVMScript.cpp      2      3      0
src/jsc/bindings/NodeVMScript.h        2      2      0
test/js/node/vm/vm.test.ts             7      5      0
```

</details>

<!-- robobun:evidence:end -->