### PR TITLE
bundler: emit a JS chunk for a dynamically imported stylesheet

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2736,6 +2736,24 @@ impl<'a> LinkerContext<'a> {
                     }
                 }
             }
+
+            // A dynamically imported stylesheet gets a JS chunk of its own (see
+            // `compute_chunks`) whose exports are the stylesheet's, so like any
+            // other entry point it has to keep every export alive. That is what
+            // the entry point part depends on. Stylesheets passed as entry points
+            // by the user only produce CSS, so their exports can stay dead.
+            if ctx.entry_point_kinds[source_index as usize] == EntryPoint::Kind::DynamicImport {
+                let part_index =
+                    self.graph.meta.items_entry_point_part_index()[source_index as usize];
+                if part_index.is_valid()
+                    && !ctx.parts_live[source_index as usize].is_set(part_index.get() as usize)
+                {
+                    ctx.worklist.push(TreeShakeWork::Part {
+                        part_index: part_index.get(),
+                        source_index,
+                    });
+                }
+            }
             return;
         }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2738,23 +2738,14 @@ impl<'a> LinkerContext<'a> {
             }
 
             // A dynamically imported stylesheet gets a JS chunk of its own (see
-            // `compute_chunks`) whose exports are the stylesheet's, so like any
-            // other entry point it has to keep every export alive. That is what
-            // the entry point part depends on. Stylesheets passed as entry points
-            // by the user only produce CSS, so their exports can stay dead.
-            if ctx.entry_point_kinds[source_index as usize] == EntryPoint::Kind::DynamicImport {
-                let part_index =
-                    self.graph.meta.items_entry_point_part_index()[source_index as usize];
-                if part_index.is_valid()
-                    && !ctx.parts_live[source_index as usize].is_set(part_index.get() as usize)
-                {
-                    ctx.worklist.push(TreeShakeWork::Part {
-                        part_index: part_index.get(),
-                        source_index,
-                    });
-                }
+            // `compute_chunks`) whose exports are the stylesheet's, so its JS
+            // parts are walked like any other entry point's: that keeps its entry
+            // point part, and through it every export, alive. Stylesheets passed
+            // as entry points by the user only produce CSS, so their exports can
+            // stay dead.
+            if ctx.entry_point_kinds[source_index as usize] != EntryPoint::Kind::DynamicImport {
+                return;
             }
-            return;
         }
 
         // HTML files can reference non-JS/CSS assets (favicons, images, etc.)

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2737,8 +2737,7 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // An import()ed stylesheet has a JS chunk of its own (`compute_chunks`), so its
-            // parts are walked below like any other entry point's to keep its exports alive.
+            // An import()ed stylesheet has its own JS chunk; walk its parts like an entry point's.
             if ctx.entry_point_kinds[source_index as usize] != EntryPoint::Kind::DynamicImport {
                 return;
             }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2737,12 +2737,8 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
-            // A dynamically imported stylesheet gets a JS chunk of its own (see
-            // `compute_chunks`) whose exports are the stylesheet's, so its JS
-            // parts are walked like any other entry point's: that keeps its entry
-            // point part, and through it every export, alive. Stylesheets passed
-            // as entry points by the user only produce CSS, so their exports can
-            // stay dead.
+            // An import()ed stylesheet has a JS chunk of its own (`compute_chunks`), so its
+            // parts are walked below like any other entry point's to keep its exports alive.
             if ctx.entry_point_kinds[source_index as usize] != EntryPoint::Kind::DynamicImport {
                 return;
             }

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -187,14 +187,7 @@ pub(crate) fn compute_chunks(
                 };
             }
 
-            // A stylesheet that is an entry point because a JS file `import()`s
-            // it is loaded as a JS module: the import() is rewritten to this
-            // entry point's chunk and evaluates to the stylesheet's exports (the
-            // CSS modules class map), so it also needs a JS chunk. esbuild has a
-            // separate JS stub file to chunk here; in Bun that JS lives in the
-            // CSS file's own source index, which the loop below keeps out of
-            // `files_with_parts_in_chunk`, so `find_imported_parts_in_js_order`
-            // prints it into this chunk by way of being the chunk's entry point.
+            // An import()ed stylesheet is loaded as a JS module, so it also needs a JS chunk.
             if this.graph.files.items_entry_point_kind()[source_index as usize]
                 != crate::EntryPoint::Kind::DynamicImport
             {
@@ -539,10 +532,7 @@ pub(crate) fn compute_chunks(
     // to look up the path for this chunk to use with the import.
     for (chunk_id, chunk) in chunks.iter_mut().enumerate() {
         if chunk.entry_point.is_entry_point() {
-            // JS entry points that import CSS files (and dynamically imported
-            // stylesheets) generate two chunks, a JS chunk and a CSS chunk. Don't
-            // link the CSS chunk to the file since the CSS chunk is secondary (the
-            // JS chunk is primary).
+            // An entry point with both a JS and a CSS chunk is linked to the JS chunk.
             if matches!(chunk.content, chunk::Content::Css(_))
                 && entry_point_to_js_chunk_idx[chunk.entry_point.entry_point_id() as usize]
                     != u32::MAX

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -169,7 +169,7 @@ pub(crate) fn compute_chunks(
                 let order_len = order.len() as usize;
                 *css_chunk_entry.value_ptr = Chunk {
                     entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
-                    entry_bits: entry_point_chunk_bits,
+                    entry_bits: entry_point_chunk_bits.clone()?,
                     content: chunk::Content::Css(chunk::CssChunk {
                         imports_in_chunk_in_order: order,
                         asts: (0..order_len)
@@ -186,6 +186,41 @@ pub(crate) fn compute_chunks(
                     ..Default::default()
                 };
             }
+
+            // A stylesheet that is an entry point because a JS file `import()`s
+            // it is loaded as a JS module: the import() is rewritten to this
+            // entry point's chunk and evaluates to the stylesheet's exports (the
+            // CSS modules class map), so it also needs a JS chunk. esbuild has a
+            // separate JS stub file to chunk here; in Bun that JS lives in the
+            // CSS file's own source index, which the loop below keeps out of
+            // `files_with_parts_in_chunk`, so `find_imported_parts_in_js_order`
+            // prints it into this chunk by way of being the chunk's entry point.
+            if this.graph.files.items_entry_point_kind()[source_index as usize]
+                != crate::EntryPoint::Kind::DynamicImport
+            {
+                continue;
+            }
+
+            let css_chunk_index = u32::try_from(css_chunk_entry.index).expect("int cast");
+            let js_chunk_entry = js_chunks.get_or_put(js_chunk_key)?;
+            entry_point_to_js_chunk_idx[entry_id_] =
+                u32::try_from(js_chunk_entry.index).expect("int cast");
+            js_chunks_with_css += 1;
+            *js_chunk_entry.value_ptr = Chunk {
+                entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
+                entry_bits: entry_point_chunk_bits,
+                content: chunk::Content::Javascript(chunk::JavaScriptChunk {
+                    css_chunks: Box::<[u32]>::from(&[css_chunk_index][..]),
+                    ..Default::default()
+                }),
+                output_source_map: SourceMapPieces::init(),
+                flags: make_flags(
+                    false,
+                    could_be_browser_target_from_server_build
+                        && ast_targets[source_index as usize] == Target::Browser,
+                ),
+                ..Default::default()
+            };
 
             continue;
         }
@@ -504,11 +539,13 @@ pub(crate) fn compute_chunks(
     // to look up the path for this chunk to use with the import.
     for (chunk_id, chunk) in chunks.iter_mut().enumerate() {
         if chunk.entry_point.is_entry_point() {
-            // JS entry points that import CSS files generate two chunks, a JS chunk
-            // and a CSS chunk. Don't link the CSS chunk to the JS file since the CSS
-            // chunk is secondary (the JS chunk is primary).
+            // JS entry points that import CSS files (and dynamically imported
+            // stylesheets) generate two chunks, a JS chunk and a CSS chunk. Don't
+            // link the CSS chunk to the file since the CSS chunk is secondary (the
+            // JS chunk is primary).
             if matches!(chunk.content, chunk::Content::Css(_))
-                && css_asts[chunk.entry_point.source_index() as usize].is_none()
+                && entry_point_to_js_chunk_idx[chunk.entry_point.entry_point_id() as usize]
+                    != u32::MAX
             {
                 continue;
             }

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -61,12 +61,8 @@ pub(crate) fn find_imported_parts_in_js_order(
             push(source_index);
         }
 
-        // CSS files are never in `files_with_parts_in_chunk`: a copy of their JS
-        // side is printed into every chunk that imports them (the entry bits
-        // check in `visit`). The JS chunk emitted for a dynamically imported
-        // stylesheet (see `compute_chunks`) contains no importer of the
-        // stylesheet, it is the stylesheet's own chunk, so visit the stylesheet
-        // itself.
+        // CSS files are never in `files_with_parts_in_chunk` (each importing chunk prints its
+        // own copy, see `visit`), so the chunk of an import()ed stylesheet visits it directly.
         let entry_point = chunk.entry_point;
         if entry_point.is_entry_point()
             && this.graph.ast.items_css()[entry_point.source_index() as usize].is_some()

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -46,16 +46,32 @@ pub(crate) fn find_imported_parts_in_js_order(
     chunk_index: u32,
 ) -> Result<(), crate::Error> {
     let mut chunk_order_array: Vec<Order> =
-        Vec::with_capacity(chunk.files_with_parts_in_chunk.count());
+        Vec::with_capacity(chunk.files_with_parts_in_chunk.count() + 1);
     {
         let distances = this.graph.files.items_distance_from_entry_point();
         let stable_source_indices = this.graph.stable_source_indices.slice();
-        for &source_index in chunk.files_with_parts_in_chunk.keys() {
+        let mut push = |source_index: IndexInt| {
             chunk_order_array.push(Order {
                 source_index,
                 distance: distances[source_index as usize],
                 tie_breaker: stable_source_indices[source_index as usize],
             });
+        };
+        for &source_index in chunk.files_with_parts_in_chunk.keys() {
+            push(source_index);
+        }
+
+        // CSS files are never in `files_with_parts_in_chunk`: a copy of their JS
+        // side is printed into every chunk that imports them (the entry bits
+        // check in `visit`). The JS chunk emitted for a dynamically imported
+        // stylesheet (see `compute_chunks`) contains no importer of the
+        // stylesheet, it is the stylesheet's own chunk, so visit the stylesheet
+        // itself.
+        let entry_point = chunk.entry_point;
+        if entry_point.is_entry_point()
+            && this.graph.ast.items_css()[entry_point.source_index() as usize].is_some()
+        {
+            push(entry_point.source_index());
         }
     }
 

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -327,6 +327,20 @@ describe("bundler", () => {
       expect(entry.imports.filter((i: { kind: string }) => i.kind === "dynamic-import")).toEqual([
         { path: stylesheetChunks[0][0], kind: "dynamic-import" },
       ]);
+      // The chunk declares what it exports. The export clause alone is emitted
+      // when the stylesheet's exports are not kept alive.
+      expect(api.readFile(join("/out", stylesheetChunks[0][0]))).toMatchInlineSnapshot(`
+        "// styles.module.css
+        var foo = "foo_-MSaAA";
+        var styles_module_default = {
+          foo
+        };
+        export {
+          styles_module_default as default,
+          foo
+        };
+        "
+      `);
     },
     run: {
       file: "/out/entry.js",
@@ -336,26 +350,44 @@ describe("bundler", () => {
   });
 
   // A stylesheet that one entry point imports statically and another one
-  // import()s: the static importer keeps its inline copy of the class map (it
-  // does not import the stylesheet's chunk), the dynamic importer loads the chunk.
+  // import()s: the static importer keeps its own inline copy of the stylesheet's
+  // JS (it does not import the stylesheet's chunk), the dynamic importer loads
+  // the chunk. Liveness is per file, not per chunk, so once the stylesheet is
+  // import()ed somewhere, the static importer's copy carries every export too,
+  // not only the `foo` it uses.
   itBundled("splitting/StaticAndDynamicImportOfSameCSSModule", {
     files: {
       "/static.js": `
-        import styles from './styles.module.css';
-        console.log('static', /^foo_/.test(styles.foo));
+        import { foo } from './styles.module.css';
+        console.log('static', /^foo_/.test(foo));
       `,
       "/dynamic.js": `
         const mod = await import('./styles.module.css');
-        console.log('dynamic', Object.keys(mod).join(','), /^foo_/.test(mod.default.foo));
+        console.log('dynamic', Object.keys(mod).join(','), /^bar_/.test(mod.default.bar));
       `,
-      "/styles.module.css": `.foo { color: red; }`,
+      "/styles.module.css": `
+        .foo { color: red; }
+        .bar { color: blue; }
+      `,
     },
     entryPoints: ["/static.js", "/dynamic.js"],
     splitting: true,
     outdir: "/out",
     metafile: true,
     onAfterBundle(api) {
-      expect(api.readFile("/out/static.js")).toMatch(/"foo_[^"]+"/);
+      expect(api.readFile("/out/static.js")).toMatchInlineSnapshot(`
+        "// styles.module.css
+        var foo = "foo_-MSaAA";
+        var bar = "bar_-MSaAA";
+        var styles_module_default = {
+          foo,
+          bar
+        };
+
+        // static.js
+        console.log("static", /^foo_/.test(foo));
+        "
+      `);
       expect(api.readFile("/out/dynamic.js")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
 
       const { outputs } = JSON.parse(api.readFile("/metafile.json"));
@@ -377,9 +409,35 @@ describe("bundler", () => {
       {
         file: "/out/dynamic.js",
         env,
-        stdout: "dynamic default,foo true",
+        stdout: "dynamic bar,default,foo true",
       },
     ],
+  });
+
+  // A stylesheet that is both a user-specified entry point and import()ed only
+  // gets its CSS output (entry point kinds are exclusive), so the import() is
+  // still rewritten to the .css output (or, with --css-chunking, to whatever
+  // chunk is at index 0) instead of a JS chunk exporting the class map.
+  itBundled("splitting/DynamicImportOfUserSpecifiedCSSEntryPoint", {
+    todo: true,
+    files: {
+      "/entry.js": `
+        const mod = await import('./styles.module.css');
+        console.log(Object.keys(mod).join(','), /^foo_/.test(mod.foo));
+      `,
+      "/styles.module.css": `.foo { color: red; }`,
+    },
+    entryPoints: ["/entry.js", "/styles.module.css"],
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/styles\.module[^"]*\.js"\)/);
+    },
+    run: {
+      file: "/out/entry.js",
+      env,
+      stdout: "default,foo true",
+    },
   });
 
   // A stylesheet the user passes as an entry point still only produces CSS.

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -290,6 +290,162 @@ describe("bundler", () => {
     },
   });
 
+  // import() of a stylesheet must resolve to the stylesheet's JS exports (the
+  // CSS modules class map), so the stylesheet needs a JS chunk of its own next
+  // to its CSS. Previously the import() was rewritten to the .css output.
+  itBundled("splitting/DynamicImportOfCSSModuleExports", {
+    files: {
+      "/entry.js": `
+        const mod = await import('./styles.module.css');
+        console.log(Object.keys(mod).join(','), mod.foo === mod.default.foo, /^foo_/.test(mod.foo));
+      `,
+      "/styles.module.css": `.foo { color: red; }`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    metafile: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
+      // The entry's own CSS bundle still carries the dynamically imported stylesheet.
+      expect(api.readFile("/out/entry.css")).toContain("color: red");
+
+      const { outputs } = JSON.parse(api.readFile("/metafile.json"));
+      const stylesheetChunks = Object.entries<any>(outputs).filter(
+        ([file, output]) => file.endsWith(".js") && output.entryPoint === "styles.module.css",
+      );
+      expect(stylesheetChunks).toEqual([
+        [
+          expect.stringMatching(/styles\.module-[a-z0-9]+\.js$/),
+          expect.objectContaining({
+            exports: ["default", "foo"],
+            cssBundle: expect.stringMatching(/\.css$/),
+          }),
+        ],
+      ]);
+      const entry = Object.entries<any>(outputs).find(([file]) => file.endsWith("entry.js"))![1];
+      expect(entry.imports.filter((i: { kind: string }) => i.kind === "dynamic-import")).toEqual([
+        { path: stylesheetChunks[0][0], kind: "dynamic-import" },
+      ]);
+    },
+    run: {
+      file: "/out/entry.js",
+      env,
+      stdout: "default,foo true true",
+    },
+  });
+
+  // A stylesheet that one entry point imports statically and another one
+  // import()s: the static importer keeps its inline copy of the class map (it
+  // does not import the stylesheet's chunk), the dynamic importer loads the chunk.
+  itBundled("splitting/StaticAndDynamicImportOfSameCSSModule", {
+    files: {
+      "/static.js": `
+        import styles from './styles.module.css';
+        console.log('static', /^foo_/.test(styles.foo));
+      `,
+      "/dynamic.js": `
+        const mod = await import('./styles.module.css');
+        console.log('dynamic', Object.keys(mod).join(','), /^foo_/.test(mod.default.foo));
+      `,
+      "/styles.module.css": `.foo { color: red; }`,
+    },
+    entryPoints: ["/static.js", "/dynamic.js"],
+    splitting: true,
+    outdir: "/out",
+    metafile: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out/static.js")).toMatch(/"foo_[^"]+"/);
+      expect(api.readFile("/out/dynamic.js")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
+
+      const { outputs } = JSON.parse(api.readFile("/metafile.json"));
+      const stylesheetChunks = Object.keys(outputs).filter(
+        file => file.endsWith(".js") && outputs[file].entryPoint === "styles.module.css",
+      );
+      expect(stylesheetChunks).toEqual([expect.stringMatching(/styles\.module-[a-z0-9]+\.js$/)]);
+      const importsOf = (name: string): { path: string; kind: string }[] =>
+        outputs[Object.keys(outputs).find(file => file.endsWith(name))!].imports;
+      expect(importsOf("dynamic.js")).toContainEqual({ path: stylesheetChunks[0], kind: "dynamic-import" });
+      expect(importsOf("static.js").map(i => i.path)).not.toContain(stylesheetChunks[0]);
+    },
+    run: [
+      {
+        file: "/out/static.js",
+        env,
+        stdout: "static true",
+      },
+      {
+        file: "/out/dynamic.js",
+        env,
+        stdout: "dynamic default,foo true",
+      },
+    ],
+  });
+
+  // A stylesheet the user passes as an entry point still only produces CSS.
+  itBundled("splitting/UserSpecifiedCSSEntryPointHasNoJSChunk", {
+    files: {
+      "/entry.js": `console.log('entry')`,
+      "/styles.module.css": `.foo { color: red; }`,
+    },
+    entryPoints: ["/entry.js", "/styles.module.css"],
+    splitting: true,
+    outdir: "/out",
+    metafile: true,
+    onAfterBundle(api) {
+      const { outputs } = JSON.parse(api.readFile("/metafile.json"));
+      const stylesheetOutputs = Object.entries<any>(outputs)
+        .filter(([, output]) => output.entryPoint === "styles.module.css")
+        .map(([file]) => file.slice(file.lastIndexOf("/") + 1));
+      expect(stylesheetOutputs).toEqual(["styles.module.css"]);
+    },
+  });
+
+  // With --css-chunking the import()ed stylesheet shares its CSS chunk with the
+  // importing entry point. The import() must still point at the stylesheet's JS
+  // chunk (it used to be rewritten to the importing entry point's own chunk).
+  test("splitting/DynamicImportOfCSSModuleWithCSSChunking", async () => {
+    using dir = tempDir("splitting-css-chunking-dynamic-import", {
+      "entry.js": `
+        import './styles.module.css';
+        import('./styles.module.css').then(mod => console.log(Object.keys(mod).join(','), /^foo_/.test(mod.default.foo)));
+      `,
+      "styles.module.css": `.foo { color: red; }`,
+    });
+    const root = String(dir);
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--splitting", "--css-chunking", "--outdir", "out", "./entry.js"],
+      env: bunEnv,
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildErr).toBe("");
+    expect(buildOut).toContain("entry.js");
+    expect(buildExit).toBe(0);
+
+    const outputs = readdirSync(join(root, "out")).sort();
+    expect(outputs.filter(file => file.endsWith(".css"))).toEqual(["entry.css"]);
+    expect(outputs.filter(file => file.endsWith(".js"))).toEqual([
+      "entry.js",
+      expect.stringMatching(/^styles\.module-[a-z0-9]+\.js$/),
+    ]);
+    expect(readFileSync(join(root, "out", "entry.js"), "utf8")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), join(root, "out", "entry.js")],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runErr).toBe("");
+    expect(runOut).toBe("default,foo true\n");
+    expect(runExit).toBe(0);
+  });
+
   itBundled("splitting/CircularDynamicImportsWithCSS", {
     files: {
       "/entry.js": `


### PR DESCRIPTION
### Problem
- With `--splitting`, `import("./style.module.css")` bundles to `import("./style.module-<hash>.css")`: the import() is pointed at the CSS output, so the class map is lost (`mod.default` is `{}` under bun, and a browser fails to load a stylesheet as a module). With `--css-chunking` it is rewritten to `import("./entry.js")`, the importing entry point's own chunk, instead.
- Cause: with code splitting every import()ed file becomes an entry point, and `compute_chunks` (`src/bundler/linker_context/computeChunks.rs`, the CSS branch of the entry point loop) creates only a CSS chunk for an entry point that is a stylesheet. `entry_point_chunk_index` for the stylesheet therefore names the CSS chunk (or, when that CSS chunk is shared with a JS entry point's CSS and so skipped, is left at its zeroed default, chunk 0), and that is the chunk `compute_cross_chunk_dependencies` rewrites the import() to.
- Found by #38307's author while fixing `require()` of a CSS file; the `require()` + `--splitting` half of that report (`__commonJS` not imported into the chunk) has the same cause as #38286 and is fixed there, this PR is the import() half.

### Fix
- `compute_chunks`: a stylesheet whose entry point kind is `DynamicImport` gets a JS chunk as well, with `css_chunks` pointing at its CSS chunk exactly like a JS entry point that imports CSS, and the "CSS chunk is secondary" rule that decides what `entry_point_chunk_index` names is now "the entry point also has a JS chunk" instead of "the entry point is not a stylesheet", so the import() is rewritten to the JS chunk. Stylesheets passed as entry points by the user are unchanged (no JS chunk, `entry_point_chunk_index` still names the CSS chunk).
- `find_imported_parts_in_js_order`: CSS files are deliberately kept out of `files_with_parts_in_chunk` (see Background), and the new chunk contains no importer of the stylesheet, so the chunk visits its own entry point when that entry point is a stylesheet. This keeps the copy model: other chunks still print their own copy of the stylesheet's JS and do not import the new chunk (pinned by `StaticAndDynamicImportOfSameCSSModule`), and since the stylesheet is not a member of the chunk, `compute_cross_chunk_dependencies` does not home its symbols there, which is what makes that work.
- `mark_file_live_step`: a stylesheet that is a `DynamicImport` entry point falls through to the ordinary walk of its parts instead of returning after its CSS import records, the same walk every JS entry point gets. That marks its entry point part live (the part step 6 of `scan_imports_and_exports` creates for every entry point, depending on everything the file exports), so the chunk declares what it exports; without it the chunk is just `export { style_module_default as default, foo }` and fails to load. The other part this walk reaches is the emptied lazy-export part, which prints nothing, as for every JSON import today.
- Observable consequence of that, by design of the copy model: liveness is per file, so once a stylesheet is import()ed anywhere in the build, every chunk that also imports it statically prints its complete JS (all class name variables and the default map) instead of only the exports it uses; for a plain `.css` file that is `var x_default = {}`. This is bounded to stylesheets that are import()ed, which did not work at all before; stylesheets that are not import()ed are walked exactly as before, so their chunks print the same parts and keep their hashes (this is why the walk is gated on the entry point kind rather than applied to all CSS files, which changes the hash of every chunk that links a stylesheet and fails `html-import-manifest.test.ts`). `StaticAndDynamicImportOfSameCSSModule` pins the static importer's output so this is a deliberate trade-off rather than an accident; the alternative, giving import()ed stylesheets a home chunk that static importers import from, would make every static importer depend on an extra chunk.
- Why this is the right shape: it is what esbuild emits for the same input (a `style.module-<hash>.js` chunk exporting `default` and the class names, plus the CSS chunk; esbuild's metafile for that chunk also has `entryPoint: style.module.css` and a `cssBundle`), produced through Bun's existing copy model for CSS files rather than by giving CSS files a home chunk, so nothing changes for builds that do not import() a stylesheet.
- Tests, all in `test/bundler/bundler_splitting.test.ts`: `DynamicImportOfCSSModuleExports` (import() resolves to the class map; metafile shows the chunk with `entryPoint`, `exports`, `cssBundle` and the entry's dynamic import of it; inline snapshot of the chunk; the entry's CSS bundle still contains the rule), `StaticAndDynamicImportOfSameCSSModule` (inline snapshot of the static importer's copy, which must not import the chunk; both entry points run), `DynamicImportOfCSSModuleWithCSSChunking` (the `--css-chunking` rewrite, via the CLI since the JS API has no such option), `UserSpecifiedCSSEntryPointHasNoJSChunk` (guard), and `DynamicImportOfUserSpecifiedCSSEntryPoint` as a `todo` for the case described under "Not changed". The first three fail on the released build at the `.css` rewrite; with only the `compute_chunks` / `find_imported_parts_in_js_order` changes they still fail, now on the two snapshots (chunk without declarations, static copy without the default map) and at run time, so both halves are exercised.
- Also run with this change, all passing: `bundler_splitting`, `css/css-modules`, `bundler_loader`, `html-import-manifest`, `metafile`, `bundler_html`, `bundler_compile_splitting`, `esbuild/{splitting,css}` (240 tests); the first revision additionally ran `esbuild/loader`, `bundler_regressions`, `bun-build-api`, `bundler_naming` and `bundler_edgecase` (485 tests in total). `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` are clean.
- Relationship to #38307 and #38286: #38307 replaces the same `return` in `mark_file_live_step` with `if wrap != Cjs { return; }`, so whichever lands second resolves that one hunk by combining the two conditions (`wrap != Cjs && kind != DynamicImport`); everything else merges cleanly. Verified by merging both open PRs into this branch locally: their test files and this one pass together, and a build with `require()` of a stylesheet in one entry point and `import()` of it in another works end to end (the stylesheet's chunk becomes `var require_style_module = __commonJS(...)` with its body from #38307 and its `import { __commonJS }` from #38286, followed by `export default require_style_module();`, and the importer gets the usual `.then(m => __toESM(m.default, 1))`).
- Not changed: a stylesheet that is both a user-specified entry point and import()ed keeps `UserSpecified` as its only entry point kind (`LinkerGraph::load`), so it still gets no JS chunk and the import() is still rewritten as before: to the `.css` output, or with `--css-chunking` (where its CSS chunk is shared with the importing entry point's) to chunk 0, the importer itself, because `entry_point_chunk_index` keeps its zeroed default. Pinned as the `todo` test above; fixing it means recording "is import()ed" separately from the entry point kind and deciding how that JS chunk is named, which is a follow-up. The new chunk's `BuildArtifact.loader` is `"css"`, following the existing rule that it reports the entry point's input loader (the CSS output of a `.ts` entry point reports `"ts"` today).

### Background
- Chunks and entry points: with `--splitting`, every user entry point and every import() target is an entry point and gets a chunk keyed by its own entry bit; files reachable from several entry points go into shared chunks. `entry_point_chunk_index` maps an entry point file to its chunk, and `compute_cross_chunk_dependencies` rewrites each cross-chunk import() to that chunk's path.
- A CSS file's JS side: a stylesheet imported from JS is parsed into a CSS AST plus a small lazy-export JS AST in the same source index (`export default {class map}` and one export per class name, or a CommonJS wrapper when required). esbuild gives that JS a separate stub file, which is an ordinary JS file for chunking; in Bun the two share a source index, which is why chunking and tree shaking have CSS-specific branches.
- Copy model: `compute_chunks` never puts CSS files into a chunk's `files_with_parts_in_chunk`; instead `find_imported_parts_in_js_order` prints a stylesheet's live JS parts into every chunk whose entry bits intersect the stylesheet's, when it reaches the stylesheet from an importer in the chunk (`css-module/BundleTwoFilesWithCodeSplitting`). Because no chunk is the home of those symbols, `compute_cross_chunk_dependencies` never generates cross-chunk imports for them and every chunk uses its local copy.
- Parts and liveness: each file's JS is split into parts; tree shaking (`mark_file_live_step`) marks a live file's non-removable parts live and follows part dependencies, and a single per-file bitset records the result, which every chunk printing the file consults. For each entry point, step 6 of `scan_imports_and_exports` adds a non-removable part depending on the parts that declare each export, which is how an entry point keeps its exports; `mark_file_live_step` returns early for CSS files (their CSS import records are all that matter for a stylesheet that is only linked), so it never reached that part for a stylesheet.

<details>
<summary>Repro and output before / after</summary>

```sh
printf '.foo { color: blue }\n' > style.module.css
printf 'const m = await import("./style.module.css");\nconsole.log(JSON.stringify(m.default));\n' > c.ts
bun build c.ts --outdir out --target bun --splitting && bun out/c.js
```

Before (`c.js`, prints `{}`; `style.module-k9bcxzyd.css` is the CSS output):

```js
// c.ts
var m = await import("./style.module-k9bcxzyd.css");
console.log(JSON.stringify(m.default));
```

After (prints `{"foo":"foo_Hg8gNQ"}`; `c.css` still contains the rule as before):

```js
// c.ts
var m = await import("./style.module-vvzbfbqf.js");
console.log(JSON.stringify(m.default));
```

```js
// style.module-vvzbfbqf.js
var foo = "foo_Hg8gNQ";
var style_module_default = {
  foo
};
export {
  style_module_default as default,
  foo
};
```

With `--css-chunking` and an entry point that also imports the stylesheet statically, the import() was rewritten to `import("./c.js")` (chunk 0) before and is rewritten to the new chunk after.

With only the `compute_chunks` / `find_imported_parts_in_js_order` changes, the new chunk is just the `export { ... }` clause and loading it fails with `SyntaxError: Exported binding 'style_module_default' needs to refer to a top-level declared variable.`

A stylesheet that references an asset (`url(./img.png)`) used to produce an additional empty JS chunk for the asset's stub when import()ed; with this change that dead stub lands in the stylesheet's chunk (same entry bits), where it prints nothing, and the chunk gets a side-effect import of the runtime chunk like any entry point whose bit the runtime carries. The same empty chunk for user-specified CSS entry points is a separate pre-existing issue and is not touched here.
</details>

<details>
<summary>Earlier revision</summary>

The first revision kept the stylesheet's exports alive by pushing its entry point part onto the tree-shaking worklist explicitly (reading `entry_point_part_index`) instead of falling through to the parts walk. The output is identical; the walk is the same mechanism every other entry point uses and merges with #38307's change to the same line as one combined condition, so the explicit form was dropped. The tests were also reshaped at the same time to snapshot the chunk and the static importer's copy rather than only running them.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
bun test v1.4.0 (72699e35e)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [952.09ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [610.56ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [639.19ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [640.35ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [638.74ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [713.24ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [733.58ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [1035.19ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [687.06ms]
304 |     entryPoints: ["/entry.js"],
305 |     splitting: true,
306 |     outdir: "/out",
307 |     metafile: true,
308 |     onAfterBundle(api) {
309 |       expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
                                                  ^
error: expect(received).toMatch(expected)


... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [34.73ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [31.89ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [37.88ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [44.38ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [38.70ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [32.67ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [38.95ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [42.13ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [26.07ms]
304 |     entryPoints: ["/entry.js"],
305 |     splitting: true,
306 |     outdir: "/out",
307 |     metafile: true,
308 |     onAfterBundle(api) {
309 |       expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
                                                  ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /import\("\.\/styles\.module-[a-z0-9]+\.js"\)/
Received: "var __require = /* @__PURE__ */ ((x) => typeof require !== \"undefined\" ? require :
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
bun test v1.4.0 (72699e35e)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [1011.79ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [662.19ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [640.03ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [681.68ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [622.74ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [654.03ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [688.46ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [965.47ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [737.87ms]
(pass) bundler > splitting/DynamicImportOfCSSModuleExports [606.50ms]
(pass) bundler > splitting/StaticAndDynamicImportOfSameCSSModule [1193.90ms]
(todo) bundler > splitting/DynamicImportOfUserSpecifiedCSSEntryPoint
(pass) bundler > splitting/UserSpecifiedCSSEntryPointHasNoJSChunk [96.67ms]
(pass) bundler > splitting/DynamicImportOfCSSModuleWithCSS
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     72699e35ec
  features     baseline

22 deps, 123 codegen, 1176 objects in 1569ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [24.00ms]
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1238] gen bindgenv2
[5/1238] gen .bind.ts → GeneratedBindings.cpp
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] fetch zlib
[zlib] up to date
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [22.00ms]
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to dat
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |   6 +-
 src/bundler/linker_context/computeChunks.rs        |  37 +++-
 .../findAllImportedPartsInJSOrder.rs               |  16 +-
 test/bundler/bundler_splitting.test.ts             | 214 +++++++++++++++++++++
 4 files changed, 265 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/LinkerContext.rs                                 10      5      0
src/bundler/linker_context/computeChunks.rs                   5      7      0
…bundler/linker_context/findAllImportedPartsInJSOrder.rs      3      4      0
test/bundler/bundler_splitting.test.ts                        2      9      0
```

</details>

<!-- robobun:evidence:end -->