### PR TITLE
ci: run the mordant lint pack as an advisory ratchet

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -113,3 +113,13 @@ export LLVM_VERSION_MAJOR=19
 - The script defaults to **format** mode (modifies files)
 - Always test locally before pushing workflow changes
 - Keep the exclusion list updated as new third-party code is added
+
+## mordant.yml Workflow
+
+Runs the [mordant](https://github.com/scarletindustries/mordant) lint pack over the Rust workspace via `bun run rust:mordant` (`scripts/rust-mordant.ts`). Advisory for now (`continue-on-error`).
+
+- The pack is pinned by commit in `Cargo.toml` under `[workspace.metadata.dylint]`. It builds and lints with its own nightly (its `rust-toolchain`), not ours, so a bump can also fail if this workspace stops compiling on that nightly.
+- Findings are errors. `mordant-baseline.toml` holds per-(lint, file) counts of the findings that predate the job, so only newly added findings fail a run. Fixing baselined findings needs no baseline update; regenerating it (`MORDANT_BASELINE_WRITE=1 bun run rust:mordant`) keeps the file honest and belongs in a bump PR.
+- Lints this repo has switched off, with reasons, are listed in `scripts/rust-mordant.ts`.
+
+To bump mordant: change the `rev` in `Cargo.toml`, run `bun run rust:mordant`, fix or baseline whatever the new revision reports, and put the triage in the PR description.

--- a/.github/workflows/mordant.yml
+++ b/.github/workflows/mordant.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/build/**"
       - "scripts/build.ts"
       - "scripts/rust-mordant.ts"
+      - "package.json"
       - "Cargo.toml"
       - "Cargo.lock"
       - "dylint.toml"

--- a/.github/workflows/mordant.yml
+++ b/.github/workflows/mordant.yml
@@ -1,0 +1,79 @@
+name: Mordant
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**/*.rs"
+      - "src/**/*.classes.ts"
+      - "src/codegen/**"
+      - "scripts/build/**"
+      - "scripts/build.ts"
+      - "scripts/rust-mordant.ts"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "dylint.toml"
+      - "mordant-baseline.toml"
+      - ".github/workflows/mordant.yml"
+      - ".github/actions/setup-bun/**"
+      - ".github/rust-matcher.json"
+
+env:
+  BUN_VERSION: "1.3.14"
+  LLVM_VERSION_MAJOR: "21"
+  DYLINT_VERSION: "6.0.3"
+  # Mordant (pinned in Cargo.toml's [workspace.metadata.dylint]) is built with,
+  # and lints us using, the nightly named in its own rust-toolchain file, which
+  # dylint selects itself; rustup fetches it on demand, so the pin is the only
+  # thing to bump. The outer cargo just needs to exist: point it at the
+  # runner's stable so rust-toolchain.toml's cross-target list is not installed.
+  RUSTUP_TOOLCHAIN: stable
+  RUSTUP_AUTO_INSTALL: "1"
+
+jobs:
+  mordant:
+    name: mordant
+    runs-on: ubuntu-latest
+    # Advisory while the pack is new: shows up on the PR, does not block it.
+    continue-on-error: true
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup system deps
+        # Same as clippy.yml: configure needs cmake/ninja and resolves a clang.
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${LLVM_VERSION_MAJOR} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends cmake ninja-build clang-${LLVM_VERSION_MAJOR} lld-${LLVM_VERSION_MAJOR} llvm-${LLVM_VERSION_MAJOR}
+
+      - name: Setup dylint
+        run: |
+          cargo install --locked cargo-dylint@"$DYLINT_VERSION" dylint-link@"$DYLINT_VERSION"
+          echo "::add-matcher::.github/rust-matcher.json"
+
+      - name: Generate codegen
+        # See clippy.yml: bun_runtime/bun_jsc/bun_core include!() generated files.
+        run: |
+          bun install --frozen-lockfile
+          bun scripts/build.ts --configure-only
+          ninja -C build/debug codegen clone-lolhtml
+
+      - name: mordant
+        env:
+          BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
+        run: bun run rust:mordant

--- a/.github/workflows/mordant.yml
+++ b/.github/workflows/mordant.yml
@@ -66,14 +66,8 @@ jobs:
           cargo install --locked cargo-dylint@"$DYLINT_VERSION" dylint-link@"$DYLINT_VERSION"
           echo "::add-matcher::.github/rust-matcher.json"
 
-      - name: Generate codegen
-        # See clippy.yml: bun_runtime/bun_jsc/bun_core include!() generated files.
-        run: |
-          bun install --frozen-lockfile
-          bun scripts/build.ts --configure-only
-          ninja -C build/debug codegen clone-lolhtml
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: mordant
-        env:
-          BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
         run: bun run rust:mordant

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,15 @@ members = [
 # heavy dev-dependencies (criterion, html5ever) never enter `Cargo.lock`.
 exclude = ["vendor"]
 
+# Lint pack run by `bun run rust:mordant` (.github/workflows/mordant.yml). Pinned:
+# bumping the rev is a PR of its own, where whatever the new revision finds gets
+# fixed or added to mordant-baseline.toml. Mordant brings its own nightly
+# (see its rust-toolchain), which must still be able to compile this workspace.
+[workspace.metadata.dylint]
+libraries = [
+    { git = "https://github.com/scarletindustries/mordant", rev = "fc46d7f86c2e5a1e5b7719a75abc2edf704a54e1" },
+]
+
 [workspace.package]
 version = "0.0.0"
 edition = "2024"

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,0 +1,6 @@
+[mordant]
+# Ratchet: per-(lint, file) counts of the findings that predate the job. A PR
+# fails only when it adds one. Regenerate after fixing some or bumping mordant:
+#   MORDANT_BASELINE_WRITE=1 bun run rust:mordant
+baseline = "mordant-baseline.toml"
+validator-resource-errors = ["bun_alloc::AllocError", "bun_sys::Error", "bun_errno::SystemErrno"]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,0 +1,66 @@
+[bun_bundler]
+"pub_invariant_fields:src/bundler/options.rs" = 3
+"stored_projection:src/bundler/ParseTask.rs" = 1
+
+[bun_core]
+"pub_invariant_fields:src/bun_core/string/mod.rs" = 1
+
+[bun_css]
+"pub_invariant_fields:src/css/properties/css_modules.rs" = 1
+"pub_invariant_fields:src/css/properties/display.rs" = 1
+"pub_invariant_fields:src/css/rules/container.rs" = 1
+"pub_invariant_fields:src/css/rules/font_face.rs" = 2
+"pub_invariant_fields:src/css/rules/page.rs" = 2
+"pub_invariant_fields:src/css/rules/property.rs" = 1
+
+[bun_install]
+"unread_none:src/install/PackageInstall.rs" = 1
+
+[bun_js_parser]
+"pub_invariant_fields:src/js_parser/parser.rs" = 1
+"pub_invariant_fields:src/js_parser/scan/scan_imports.rs" = 1
+
+[bun_options_types]
+"pub_invariant_fields:src/options_types/compile_target.rs" = 3
+
+[bun_picohttp]
+"pub_invariant_fields:src/picohttp/lib.rs" = 1
+
+[bun_resolver]
+"pub_invariant_fields:src/resolver/fs.rs" = 1
+"pub_invariant_fields:src/resolver/package_json.rs" = 1
+
+[bun_router]
+"pub_invariant_fields:src/router/lib.rs" = 1
+
+[bun_runtime]
+"bypassed_validator:src/runtime/cli/pack_command.rs" = 2
+"pub_invariant_fields:src/runtime/api/JSBundler.rs" = 7
+"pub_invariant_fields:src/runtime/api/bun/Terminal.rs" = 1
+"pub_invariant_fields:src/runtime/bake/bake_body.rs" = 1
+"pub_invariant_fields:src/runtime/bake/production.rs" = 2
+"pub_invariant_fields:src/runtime/cli/publish_command.rs" = 3
+"pub_invariant_fields:src/runtime/crypto/EVP.rs" = 1
+"pub_invariant_fields:src/runtime/crypto/PBKDF2.rs" = 1
+"pub_invariant_fields:src/runtime/node/node_fs.rs" = 6
+"pub_invariant_fields:src/runtime/node/node_fs_stat_watcher.rs" = 1
+"pub_invariant_fields:src/runtime/node/node_fs_watcher.rs" = 2
+"pub_invariant_fields:src/runtime/node/types.rs" = 1
+"pub_invariant_fields:src/runtime/server/ServerConfig.rs" = 13
+"pub_invariant_fields:src/runtime/socket/Handlers.rs" = 2
+"pub_invariant_fields:src/runtime/socket/udp_socket.rs" = 1
+"pub_invariant_fields:src/runtime/webcore/Request.rs" = 4
+"stored_projection:src/runtime/test_runner/bun_test.rs" = 1
+
+[bun_sql_jsc]
+"pub_invariant_fields:src/sql_jsc/mysql/MySQLValue.rs" = 2
+"pub_invariant_fields:src/sql_jsc/shared/QueryCtorArgs.rs" = 4
+
+[bun_standalone_graph]
+"pub_invariant_fields:src/standalone_graph/StandaloneModuleGraph.rs" = 1
+
+[bun_uws_sys]
+"pub_invariant_fields:src/uws_sys/socket.rs" = 1
+
+[bun_watcher]
+"pub_invariant_fields:src/watcher/KEventWatcher.rs" = 1

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rust:check": "cargo check --workspace --keep-going",
     "rust:check-all": "bun scripts/rust-check-all.ts",
     "rust:clippy": "cargo clippy --workspace --no-deps --keep-going",
+    "rust:mordant": "bun scripts/rust-mordant.ts",
     "rust:miri": "bun scripts/rust-miri.ts",
     "rust:timings": "bun scripts/rust-timings.ts",
     "codegen:string-maps": "for f in src/**/*.string-map.ts; do bun src/codegen/generate-string-map.ts \"$f\" \"${f%.string-map.ts}.generated.rs\"; done",

--- a/scripts/rust-mordant.ts
+++ b/scripts/rust-mordant.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+/**
+ * Runs the mordant lint pack (pinned under `[workspace.metadata.dylint]` in
+ * Cargo.toml) over the workspace. Findings are errors; the ones that predate
+ * the job are accepted per (lint, file) by mordant-baseline.toml, so a run
+ * fails only on findings a change adds. See dylint.toml.
+ *
+ *   bun run rust:mordant                            # what CI runs
+ *   MORDANT_BASELINE_WRITE=1 bun run rust:mordant   # rewrite the baseline
+ *
+ * Needs `cargo install cargo-dylint dylint-link`. Mordant is built with, and
+ * lints this workspace using, its own pinned nightly, so the first run also
+ * installs that toolchain.
+ */
+
+import { spawnSync } from "node:child_process";
+
+// Lints this repo has decided not to act on. Everything else in the pack is
+// on; add a lint here only with a reason.
+const off = [
+  // "list the variants instead of `_`": a per-site style call, ~500 today.
+  "wildcard_local_enum",
+  // Structs with several bools are nearly all option bags here; the state
+  // machines among them were found by hand once and are not worth the volume.
+  "flag_cluster",
+  // Most names it flags are real, on the C++/JS side or in a sibling crate.
+  "stale_safety_comment",
+  // Variants only ever tested through `!=` / `_`; checked, none were bugs.
+  "unread_error_variant",
+  // "make the guard a type": style.
+  "guard_flag",
+];
+
+const rustflags = [
+  // Mordant's nightly is older than rust-toolchain.toml's, so `#[allow]`s of
+  // lints added since then are unknown to it.
+  "-A unknown_lints",
+  ...off.map(lint => `-A ${lint}`),
+  process.env.DYLINT_RUSTFLAGS ?? "",
+].join(" ");
+
+const r = spawnSync("cargo", ["dylint", "--all", "--workspace", "--keep-going", "--", "--keep-going"], {
+  stdio: "inherit",
+  env: { ...process.env, DYLINT_RUSTFLAGS: rustflags },
+});
+if (r.error) {
+  console.error(
+    `could not run cargo dylint (${r.error.message}); install it with: cargo install cargo-dylint dylint-link`,
+  );
+  process.exit(1);
+}
+process.exit(r.status ?? 1);

--- a/scripts/rust-mordant.ts
+++ b/scripts/rust-mordant.ts
@@ -39,14 +39,21 @@ const rustflags = [
   process.env.DYLINT_RUSTFLAGS ?? "",
 ].join(" ");
 
+if (spawnSync("cargo", ["dylint", "--version"], { stdio: "ignore" }).status !== 0) {
+  console.error("cargo-dylint is not installed; run: cargo install cargo-dylint dylint-link");
+  process.exit(1);
+}
+
+// The crates' build.rs files include!() generated sources from
+// build/debug/codegen and lol_html is a path dependency under vendor/; the
+// build knows how to produce both, so ask it for just those targets.
+const prep = spawnSync("bun", ["scripts/build.ts", "--quiet", "--target=codegen", "--target=clone-lolhtml"], {
+  stdio: "inherit",
+});
+if (prep.status !== 0) process.exit(prep.status ?? 1);
+
 const r = spawnSync("cargo", ["dylint", "--all", "--workspace", "--keep-going", "--", "--keep-going"], {
   stdio: "inherit",
   env: { ...process.env, DYLINT_RUSTFLAGS: rustflags },
 });
-if (r.error) {
-  console.error(
-    `could not run cargo dylint (${r.error.message}); install it with: cargo install cargo-dylint dylint-link`,
-  );
-  process.exit(1);
-}
 process.exit(r.status ?? 1);


### PR DESCRIPTION
Adds a mordant job next to clippy. Over the last two days the pack turned up the .ok() misuse, the private-field constructors, the valkey and postgres state fixes and a few others, so this keeps new instances from coming back.

Pinned by commit in Cargo.toml. Bumping it is its own PR: change the rev, run bun run rust:mordant, deal with what the new revision reports. Notes in .github/workflows/CLAUDE.md.

Findings fail the run, and mordant-baseline.toml accepts the 81 that exist today per lint and file (76 pub_invariant_fields, the rest are in open PRs), so only added findings fail. Five style lints are off, listed with reasons in scripts/rust-mordant.ts.

Advisory (continue-on-error) to start; flip it once it has been quiet on a week or so of PRs.

Locally: a clean run exits 0 with no output, and adding a stray .ok() to a crate fails it with the finding annotated. First real run is on this PR.