### PR TITLE
Bump WebKit (oven-sh/WebKit#425 preview): coverage of if bodies that only break or continue

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "caad865eb1a6e5ca4427f5ea1f066140b11953e7";
+export const WEBKIT_VERSION = "autobuild-preview-pr-425-01bb96e5";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -589,3 +589,144 @@ Ran 1 test across 1 file."
 `);
   expect(result.exitCode).toBe(0);
 });
+
+/** Runs `bun test --coverage` in `dir` and returns whether each of `lines` of `file` was hit, missed, or not executable ("-"). */
+async function lineCoverage(dir: string, file: string, lines: number[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=lcov", "--coverage-dir=cov"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+
+  const record = readFileSync(path.join(dir, "cov", "lcov.info"), "utf-8")
+    .split("end_of_record")
+    .find(record => record.includes(`SF:${file}\n`))!;
+  const hits = new Map<number, number>();
+  for (const [, line, count] of record.matchAll(/^DA:(\d+),(\d+)$/gm)) {
+    hits.set(Number(line), Number(count));
+  }
+  return Object.fromEntries(
+    lines.map(line => [line, !hits.has(line) ? "-" : hits.get(line)! > 0 ? "hit" : "MISSED"] as const),
+  );
+}
+
+// JSC normally compiles `if (c) { break; }` / `if (c) { continue; }` down to a single conditional
+// jump with no bytecode for the body, which left the body's coverage block recording the path
+// that skipped it. The body line must be reported from what the body did, in both directions.
+test.concurrent("coverage of if bodies that only break or continue reflects whether they ran", async () => {
+  using dir = tempDir("cov", {
+    "lib.js": `export function continueTaken(xs) {
+  let n = 0;
+  for (const x of xs) {
+    if (x) {
+      continue;
+    }
+    n++;
+  }
+  return n;
+}
+export function continueSkipped(xs) {
+  let n = 0;
+  for (const x of xs) {
+    if (x) {
+      continue;
+    }
+    n++;
+  }
+  return n;
+}
+export function breakTaken() {
+  let i = 0;
+  while (true) {
+    if (i === 0) {
+      break;
+    }
+    i++;
+  }
+  return i;
+}
+export function breakSkipped(xs) {
+  let n = 0;
+  for (let i = 0; i < xs.length; i++) {
+    if (xs[i] < 0) {
+      break;
+    }
+    n++;
+  }
+  return n;
+}
+export function bracelessContinueTaken(xs) {
+  let n = 0;
+  for (const x of xs) {
+    if (x)
+      continue;
+    n++;
+  }
+  return n;
+}
+export function switchBreakTaken(v) {
+  let fellThrough = false;
+  switch (v) {
+    case 1:
+      if (v === 1) {
+        break;
+      }
+      fellThrough = true;
+      break;
+  }
+  return fellThrough;
+}
+export function constantConditionBreak() {
+  let spins = 0;
+  while (true) {
+    if (2 === 2) {
+      break;
+    }
+    spins++;
+  }
+  return spins;
+}
+`,
+    "lib.test.js": `import { test, expect } from "bun:test";
+import * as lib from "./lib.js";
+test("each if body either runs on every pass or never", () => {
+  expect(lib.continueTaken([1, 1])).toBe(0);
+  expect(lib.continueSkipped([0, 0])).toBe(2);
+  expect(lib.breakTaken()).toBe(0);
+  expect(lib.breakSkipped([1, 2])).toBe(2);
+  expect(lib.bracelessContinueTaken([1, 1])).toBe(0);
+  expect(lib.switchBreakTaken(1)).toBe(false);
+  expect(lib.constantConditionBreak()).toBe(0);
+});
+`,
+  });
+
+  // Each pair is the break/continue line followed by the statement the jump skips over.
+  expect(await lineCoverage(String(dir), "lib.js", [5, 7, 15, 17, 25, 27, 35, 37, 45, 46, 55, 57, 66, 68])).toEqual({
+    // continueTaken: `continue` ran on every iteration, `n++` never did
+    5: "hit",
+    7: "MISSED",
+    // continueSkipped
+    15: "MISSED",
+    17: "hit",
+    // breakTaken
+    25: "hit",
+    27: "MISSED",
+    // breakSkipped
+    35: "MISSED",
+    37: "hit",
+    // bracelessContinueTaken
+    45: "hit",
+    46: "MISSED",
+    // switchBreakTaken
+    55: "hit",
+    57: "MISSED",
+    // constantConditionBreak: the shape from #20141, the transpiler folds the condition to `true`
+    66: "hit",
+    68: "MISSED",
+  });
+});


### PR DESCRIPTION
Fixes #20141

### Problem

- `bun test --coverage` reports an `if` body that consists only of `break;` or `continue;` with the opposite of its real status: a `break;`/`continue;` line that ran on every iteration is listed as uncovered, and one that never ran is listed as covered. The `while (true) { if (2 === 2) { break; } }` function from #20141 reports its `break;` line as uncovered.
- The engine records the wrong block. `IfElseNode::emitBytecode` (`Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp`, `tryFoldBreakAndContinue`) folds such a body into the condition's jump: the condition jumps straight to the break/continue target when true and falls through when false, and the body gets no bytecode of its own. The `op_profile_control_flow` for the body's text range is still emitted right after the condition, which makes it the first instruction on the fall-through path. With the profiler on, `for (...) { if (xs[i]) { continue; } n++; }` compiled to:

  ```
  jtrue                condition, -> loop increment
  profile_control_flow <range of `{ continue; }`>     <- only reached when the condition is false
  profile_control_flow <range of `n++`>
  ```

- `src/sourcemap_jsc/CodeCoverage.rs` reports what the profiler recorded, so there is nothing to change on the bun side. (#38282 is about which lines a block is charged to, a separate problem; it does not change this one.)

### Fix

- oven-sh/WebKit#425: `tryFoldBreakAndContinue` returns false while profiler hooks are being emitted, so the body is emitted in full (profile op, jump, and the dead profile op after the jump). That is the shape `{ f(); continue; }` already produces, so nothing after bytecode generation sees anything new, and bytecode generated without the profiler is unchanged (dumped from both shells and compared). `trivialTarget()` already skips the same fold for the debugger, for the same reason: the statement needs bytecode of its own for the hook to sit in.
- This PR points `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-425-01bb96e5`) so CI runs against it. Before landing, oven-sh/WebKit#425 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha, which will be the current pin `caad865e` plus that one commit (the build prints this instruction itself once the preview release disappears). I will push the repin when #425 merges.
- Test: `test/cli/test/coverage.test.ts`, "coverage of if bodies that only break or continue reflects whether they ran". One fixture function per shape: for-of `continue` taken and skipped, `while` `break` taken, `for` `break` skipped, braceless `continue`, `break` out of a `switch` case, and the constant-condition shape from #20141. For each it asserts the lcov status of the `break;`/`continue;` line and of the statement the jump skips. The WebKit PR adds `JSTests/controlFlowProfiler/if-break-continue.js`, which checks the same shapes plus `else` branches, labeled targets and do-while at the basic-block level (`$vm` is not available under bun, so that half stays engine-side).
- Verification:
  - `bun bd --webkit-version=caad865eb1a6e5ca4427f5ea1f066140b11953e7 test test/cli/test/coverage.test.ts` (current pin): the new test fails with exactly the seven `break;`/`continue;` lines inverted; the seven lines after the jumps are already right.
  - `bun bd test test/cli/test/coverage.test.ts` (preview pin): all 13 tests pass, existing snapshots unchanged.
  - Both runs repeated with #38282's `src/` changes applied give the same two results, so the test does not care which of the two PRs lands first: it only asserts lines that hold a statement, and the fixture keeps a statement between each asserted line and the closing braces whose attribution #38282 changes.
  - The JSTest fails on the unpatched prebuilt `jsc` shell (`continueTaken: 'continue;' executed 0 times, expected 3.`) and passes, along with the rest of `JSTests/controlFlowProfiler`, on a local build of the patched engine, with and without the JIT.

### Background

- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit; `scripts/build/deps/webkit.ts` pins which build. An engine fix lands as a WebKit PR plus a pin bump here, and the `autobuild-preview-pr-*` tags are how a bump PR runs bun's suite against a WebKit PR before it merges.
- Control flow profiler: `--coverage` turns on JSC's control flow profiler. The bytecode generator then emits an `op_profile_control_flow` at the start of every basic block it knows about, and executing one marks that block as executed.
- Block text ranges: JSC derives each block's source range as "from this op's text offset up to the next emitted op's text offset" (`CodeBlock::insertBasicBlockBoundariesForControlFlowProfiler`). The ranges were right here; the op for the body was just placed on the wrong path.
- Line coverage: `CodeCoverage.rs` asks JSC for these ranges and marks every line touched by an executed range as hit, so a misplaced op becomes a wrong line status directly.
