### PR TITLE
bake: make DevServer::relative_path work when the root is the filesystem root

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5950,17 +5950,22 @@ impl DevServer {
         relative_path_buf: &'a mut PathBuffer,
         path: &'a [u8],
     ) -> &'a [u8] {
-        debug_assert!(self.root[self.root.len() - 1] != b'/');
-
         if !paths::is_absolute(path) {
             return path;
         }
 
-        if path.len() > self.root.len()
-            && path[self.root.len()] == b'/'
-            && path.starts_with(&self.root)
-        {
-            return &path[self.root.len() + 1..];
+        if let Some(rest) = path.strip_prefix(&*self.root) {
+            // A root that already ends in a separator (the filesystem root,
+            // when the server is started from `/`) needs no separator
+            // stripped from `rest`.
+            let rel = if self.root.ends_with(b"/") {
+                Some(rest)
+            } else {
+                rest.strip_prefix(b"/")
+            };
+            if let Some(rel) = rel {
+                return rel;
+            }
         }
 
         if path.len() + self.root.len() * 2 >= paths::MAX_PATH_BYTES {

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1,7 +1,7 @@
 import type { Server, Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir, tempDirWithFiles } from "harness";
-import { join } from "path";
+import { join, parse } from "path";
 
 function replaceHash(html: string) {
   return html
@@ -717,6 +717,50 @@ test("wildcard static routes", async () => {
       expect(text).toContain("<title>Error Page</title>");
     }
   }
+});
+
+test("dev server serves html routes when the cwd is the filesystem root", async () => {
+  // The dev server's root is the cwd. Starting from the filesystem root is the
+  // one case where the root ends in a separator; debug builds used to abort in
+  // DevServer::relative_path on the first bundle.
+  using dir = tempDir("bun-serve-html-fs-root", {
+    "index.html": /*html*/ `<!DOCTYPE html>
+      <html>
+        <head><script type="module" src="./app.js"></script></head>
+        <body><h1>served from the filesystem root</h1></body>
+      </html>`,
+    "app.js": /*js*/ `console.log("served from the filesystem root");`,
+    "serve.js": /*js*/ `
+      import html from "./index.html";
+      const server = Bun.serve({ port: 0, development: true, routes: { "/": html } });
+      const page = await fetch(server.url);
+      const pageText = await page.text();
+      const scriptSrc = pageText.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1];
+      const script = await fetch(new URL(scriptSrc, server.url));
+      const scriptText = await script.text();
+      server.stop(true);
+      console.log(
+        JSON.stringify({
+          page: page.status,
+          pageHasHeading: pageText.includes("served from the filesystem root"),
+          script: script.status,
+          scriptHasApp: scriptText.includes('"served from the filesystem root"'),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(String(dir), "serve.js")],
+    env: bunEnv,
+    cwd: parse(process.cwd()).root,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe(JSON.stringify({ page: 200, pageHasHeading: true, script: 200, scriptHasApp: true }));
+  expect(exitCode).toBe(0);
 });
 
 test("serve html with JSX runtime in development mode", async () => {


### PR DESCRIPTION
### Problem
- A development-mode `Bun.serve` with an HTML route, started while the cwd is the filesystem root (`cd / && bun serve.mjs`, the default `WORKDIR` of many containers), aborts assertion-enabled builds (`bun bd`, the ASAN CI lane) on the first bundle:
  ```
  panic: assertion failed: self.root[self.root.len() - 1] != b'/'
  <bun_runtime::bake::dev_server_body::DevServer>::relative_path   src/runtime/bake/DevServer.rs:5953
  bun_runtime::bake::dev_server_body::finalize_bundle
  ```
- The dev server root is the cwd. `DevServer::relative_path` (`src/runtime/bake/DevServer.rs:5953`) asserts that the root never ends in `/` because its fast path expects the separator between the root and the file to be in `path`. The filesystem root is the one directory whose path consists of nothing but that separator, so the assertion can never hold for it.
- Release builds compile the assertion out and take the `relative_platform_buf` slow path for every file, so they serve normally; only assertion-enabled builds abort.

### Fix
- `relative_path` strips the root from the path, then strips the `/` after it only when the root did not already end in one. The assertion goes away because the fast path no longer depends on the shape of the root: it returns what the slow path returns for `/`, for a normal root, and for a root that happens to end in a separator.
- This is correct because the relative path of `/a/b.js` from `/` is `a/b.js` and from `/a` it is `b.js`: in both cases it is the path minus the root minus exactly one separator, and for `/` that separator is the root itself.
- Windows is unaffected: native paths there use `\`, so the `/` checks fail exactly as before and those paths keep going through `relative_platform_buf`, which converts the separators.
- #36396 covers the other way this assertion fired (`process.chdir()` leaves `top_level_dir` with a trailing separator) by normalizing the root in `DevServer::init`. That normalization keeps `/` as `/`, so it does not cover this case; the two changes touch different lines and do not depend on each other.
- Test: `test/js/bun/http/bun-serve-html.test.ts`, "dev server serves html routes when the cwd is the filesystem root". It spawns bun with `cwd` set to the filesystem root and serves an HTML route and its bundled script. Without the fix the child aborts with the panic above under `bun bd`; with it the test passes in about 0.5s. Release builds pass either way, since the only release-visible difference is which branch computes the relative path.
- Also ran with the debug build: the rest of `bun-serve-html.test.ts`, `test/bake/dev/{html,bundle,esm,sourcemap,hot}.test.ts` (all pass), and the repro from `/` by hand (now prints `Bundled page in 90ms: tmp/devroot/index.html` and `status 200`).

### Background
- The bake dev server is what `Bun.serve` uses for HTML routes when `development` is on: it bundles files on demand. `DevServer.root` is the project root (the cwd), and `relative_path` turns absolute file paths into root-relative posix paths that become HMR module IDs, error-report file names and log output. It has a fast path (slice the root prefix off) and a slow path (`relative_platform_buf`, a general relative-path computation into a scratch buffer).
- `debug_assert!` is enabled in `bun bd` builds and in the ASAN CI lane (`scripts/build/rust.ts` turns `debug-assertions` on whenever `cfg.assertions` is set, which defaults to `debug || asan`), and compiled out of release builds.
