### PR TITLE
node:module: accept a hashbang line at the start of a module._compile source

### DIFF
--- a/src/jsc/bindings/EmbedFunctionBody.h
+++ b/src/jsc/bindings/EmbedFunctionBody.h
@@ -8,13 +8,13 @@ struct EmbeddedFunctionBody {
     WTF::StringView rest;
 };
 
-// JSC only lexes "#!" as a comment at offset 0, so a body placed after a wrapper (vm.compileFunction, module._compile)
-// has it rewritten to a same-length "//" comment. "//# " and "//@ " would be a sourceURL directive, which a hashbang line never is.
+// JSC only lexes "#!" as a comment at offset 0; a body placed after a wrapper gets it rewritten to a same-length "//" comment.
 ALWAYS_INLINE EmbeddedFunctionBody embedFunctionBody(const WTF::String& body LIFETIME_BOUND)
 {
     if (!body.startsWith("#!"_s))
         return { ""_s, body };
     WTF::StringView rest = WTF::StringView(body).substring(2);
+    // "//# " and "//@ " would be a sourceURL directive; a hashbang line never is.
     if (rest.startsWith(u'#') || rest.startsWith(u'@'))
         return { "// "_s, rest.substring(1) };
     return { "//"_s, rest };

--- a/src/jsc/bindings/EmbedFunctionBody.h
+++ b/src/jsc/bindings/EmbedFunctionBody.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "root.h"
+
+namespace Bun {
+
+struct EmbeddedFunctionBody {
+    WTF::ASCIILiteral prefix;
+    WTF::StringView rest;
+};
+
+// JSC only lexes "#!" as a comment at offset 0, so a body placed after a wrapper (vm.compileFunction, module._compile)
+// has it rewritten to a same-length "//" comment. "//# " and "//@ " would be a sourceURL directive, which a hashbang line never is.
+ALWAYS_INLINE EmbeddedFunctionBody embedFunctionBody(const WTF::String& body LIFETIME_BOUND)
+{
+    if (!body.startsWith("#!"_s))
+        return { ""_s, body };
+    WTF::StringView rest = WTF::StringView(body).substring(2);
+    if (rest.startsWith(u'#') || rest.startsWith(u'@'))
+        return { "// "_s, rest.substring(1) };
+    return { "//"_s, rest };
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -75,6 +75,7 @@
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include "PathInlines.h"
+#include "EmbedFunctionBody.h"
 #include "wtf/NakedPtr.h"
 #include "wtf/URL.h"
 #include "wtf/text/StringImpl.h"
@@ -720,22 +721,6 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     return true;
 }
 
-struct EmbeddedModuleBody {
-    ASCIILiteral prefix;
-    StringView rest;
-};
-
-// JSC only lexes "#!" as a comment at offset 0 of the source, and here the body follows the wrapper.
-// Same-length rewrite, so no position in the body moves. "//# " and "//@ " would start a sourceURL directive, which a hashbang line never is.
-static EmbeddedModuleBody embedModuleBody(const String& source)
-{
-    if (!source.startsWith("#!"_s))
-        return { ""_s, source };
-    if (source.length() > 2 && (source[2] == '#' || source[2] == '@'))
-        return { "// "_s, StringView(source).substring(3) };
-    return { "//"_s, StringView(source).substring(2) };
-}
-
 JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * globalObject, CallFrame* callframe))
 {
     auto* moduleObject = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
@@ -753,7 +738,7 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     String filenameString = filenameValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    auto [bodyPrefix, body] = embedModuleBody(sourceString);
+    auto [bodyPrefix, body] = embedFunctionBody(sourceString);
     String wrappedString;
     auto* zigGlobalObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     if (zigGlobalObject->hasOverriddenModuleWrapper) [[unlikely]] {

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -720,6 +720,22 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     return true;
 }
 
+struct EmbeddedModuleBody {
+    ASCIILiteral prefix;
+    StringView rest;
+};
+
+// JSC only lexes "#!" as a comment at offset 0 of the source, and here the body follows the wrapper.
+// Same-length rewrite, so no position in the body moves. "//# " and "//@ " would start a sourceURL directive, which a hashbang line never is.
+static EmbeddedModuleBody embedModuleBody(const String& source)
+{
+    if (!source.startsWith("#!"_s))
+        return { ""_s, source };
+    if (source.length() > 2 && (source[2] == '#' || source[2] == '@'))
+        return { "// "_s, StringView(source).substring(3) };
+    return { "//"_s, StringView(source).substring(2) };
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * globalObject, CallFrame* callframe))
 {
     auto* moduleObject = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
@@ -737,17 +753,20 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     String filenameString = filenameValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
 
+    auto [bodyPrefix, body] = embedModuleBody(sourceString);
     String wrappedString;
     auto* zigGlobalObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     if (zigGlobalObject->hasOverriddenModuleWrapper) [[unlikely]] {
         wrappedString = makeString(
             zigGlobalObject->m_moduleWrapperStart,
-            sourceString,
+            bodyPrefix,
+            body,
             zigGlobalObject->m_moduleWrapperEnd);
     } else {
         wrappedString = makeString(
             "(function(exports,require,module,__filename,__dirname){"_s,
-            sourceString,
+            bodyPrefix,
+            body,
             "\n})"_s);
     }
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -513,8 +513,10 @@ console.log("survived", require("./late.js"));`,
   });
 
   describe("Module.prototype._compile with a hashbang line", () => {
-    // require.extensions hooks (pirates, esbuild-register, ...) pass _compile the
-    // contents of the file, and CLI entry files start with "#!". Node accepts it.
+    // Only text that user code hands to _compile itself (require-from-string style
+    // helpers, require.extensions handlers that readFileSync) still has the file's
+    // "#!" line; what bun's loader passes to an overridden _compile is transpiled
+    // output with the hashbang already removed. Node accepts the hashbang.
     function compile(source, filename = "/hashbang-test/module.js") {
       const module = new Module(filename);
       module._compile(source, filename);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -512,6 +512,132 @@ console.log("survived", require("./late.js"));`,
     expect(dn).toBe(path.dirname(filename));
   });
 
+  describe("Module.prototype._compile with a hashbang line", () => {
+    // require.extensions hooks (pirates, esbuild-register, ...) pass _compile the
+    // contents of the file, and CLI entry files start with "#!". Node accepts it.
+    function compile(source, filename = "/hashbang-test/module.js") {
+      const module = new Module(filename);
+      module._compile(source, filename);
+      return module.exports;
+    }
+
+    test.each([
+      ["\\n", "#!/usr/bin/env node\nmodule.exports = 42;\n", 42],
+      ["\\r\\n", "#!/usr/bin/env node\r\nmodule.exports = 'crlf';\r\n", "crlf"],
+      ["\\r", "#!/usr/bin/env node\rmodule.exports = 'cr';", "cr"],
+      ["\\u2028", "#!/usr/bin/env node\u2028module.exports = 'ls';", "ls"],
+      ["\\u2029", "#!/usr/bin/env node\u2029module.exports = 'ps';", "ps"],
+    ])("hashbang line ended by %s", (_, source, expected) => {
+      expect(compile(source)).toBe(expected);
+    });
+
+    test("source that is only a hashbang line", () => {
+      expect(compile("#!/usr/bin/env node")).toEqual({});
+      expect(compile("#!")).toEqual({});
+    });
+
+    test("a directive prologue after the hashbang still applies", () => {
+      const source = [
+        "#!/usr/bin/env node",
+        '"use strict";',
+        "module.exports = (function () { return this; })() === undefined;",
+      ].join("\n");
+      expect(compile(source)).toBe(true);
+    });
+
+    test("line numbers are unchanged", () => {
+      const filename = "/hashbang-test/lines.js";
+      const error = compile(["#!/usr/bin/env node", "", "module.exports = new Error('here');"].join("\n"), filename);
+      expect(error.stack).toContain(`${filename}:3:`);
+
+      let syntaxError;
+      try {
+        compile(["#!/usr/bin/env node", "var ok = 1;", "var = ;"].join("\n"), filename);
+      } catch (e) {
+        syntaxError = e;
+      }
+      expect(syntaxError).toBeInstanceOf(SyntaxError);
+      expect(syntaxError.stack).toMatch(/\/hashbang-test\/lines\.js:3\b/);
+    });
+
+    test("a hashbang line is not a sourceURL directive", () => {
+      const exportError = "module.exports = new Error('x');";
+      for (const marker of ["#", "@"]) {
+        const { stack } = compile(`#!${marker} sourceURL=fake.js\n${exportError}`, "/hashbang-test/real.js");
+        expect(stack).toContain("/hashbang-test/real.js:2:");
+        expect(stack).not.toContain("fake.js");
+      }
+      // The same line as a real comment is a directive, so the check above is meaningful.
+      const { stack } = compile(`//# sourceURL=directive.js\n${exportError}`, "/hashbang-test/real.js");
+      expect(stack).toContain("directive.js:2:");
+    });
+
+    test("a hashbang anywhere but offset 0 is still a syntax error, as in node", () => {
+      for (const source of [
+        " #!/usr/bin/env node\nmodule.exports = 1;",
+        "\n#!/usr/bin/env node\nmodule.exports = 1;",
+        "\uFEFF#!/usr/bin/env node\nmodule.exports = 1;",
+        "#\nmodule.exports = 1;",
+        "module.exports = 1;\n#!/usr/bin/env node\n",
+      ]) {
+        expect(() => compile(source)).toThrow(SyntaxError);
+      }
+    });
+
+    test("require.extensions hook that passes the file contents to _compile", async () => {
+      using dir = tempDir("compile-hashbang-hook", {
+        "cli.js": "#!/usr/bin/env node\nmodule.exports = new Error('x');\n",
+        "main.cjs": /* js */ `
+          const fs = require("node:fs");
+          require.extensions[".js"] = function (module, filename) {
+            module._compile(fs.readFileSync(filename, "utf8"), filename);
+          };
+          const error = require("./cli.js");
+          console.log(JSON.stringify({ frame: /cli\\.js:\\d+/.exec(error.stack)[0] }));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ frame: "cli.js:2" });
+      expect(exitCode).toBe(0);
+    });
+
+    test("with an overridden Module.wrapper", async () => {
+      // Module.wrapper is process-wide once assigned, so this runs in a child.
+      // Node rejects this combination (a patched wrapper makes it compile
+      // Module.wrap(source) as a script, which also breaks require() of every
+      // shebang file); bun's require() keeps working there and so does _compile.
+      const code = /* js */ `
+        const Module = require("node:module");
+        Module.wrapper = [
+          "(function (exports, require, module, __filename, __dirname) { globalThis.wrapped = (globalThis.wrapped ?? 0) + 1;",
+          "\\n});",
+        ];
+        const filename = "/hashbang-test/wrapped.js";
+        const m = new Module(filename);
+        m._compile(["#!/usr/bin/env node", "module.exports = new Error('x');"].join("\\n"), filename);
+        console.log(JSON.stringify({ wrapped: globalThis.wrapped, frame: /wrapped\\.js:\\d+/.exec(m.exports.stack)[0] }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ wrapped: 1, frame: "wrapped.js:2" });
+      expect(exitCode).toBe(0);
+    });
+  });
+
   test("Module._extensions", () => {
     expect(".js" in Module._extensions).toBeTrue();
     expect(".json" in Module._extensions).toBeTrue();


### PR DESCRIPTION
### Problem
- `module._compile("#!/usr/bin/env node\nmodule.exports = 42", filename)` throws `SyntaxError: Invalid character: '#'`. Node (v26.3.0) sets `module.exports` to 42.
- Who hits it: code that hands `_compile` text it read or produced itself, such as require-from-string style helpers (`new Module()` + `_compile(code, filename)`) and `require.extensions` handlers that `readFileSync` the file (or run their own transform; esbuild, swc and tsc all keep a `#!` line). CLI entry files start with `#!`.
- Who does not hit it: `require()` of a shebang file, and hooks in the pirates style that intercept `module._compile` from inside the default `.js` handler. Both get the transpiler's output, which has the hashbang removed already (`evaluateWithPotentiallyOverriddenCompile` passes transpiled source to an overridden `_compile`; verified on the released bun, the override receives an empty first line). Only the native `_compile`, called by user code with its own text, sees a `#!`.
- Cause: the native `_compile` (`src/jsc/bindings/JSCommonJSModule.cpp`, `functionJSCommonJSModule_compile`) builds the program `(function(exports,require,module,__filename,__dirname){` + source + `\n})` (or `Module.wrapper[0]` + source + `Module.wrapper[1]`). JSC's lexer only accepts `#!` at offset 0 of the text it is given (`parser/Lexer.cpp`, `case '#'`: `next == '!' && !currentOffset()`), so the `#` after the wrapper is a syntax error.
- Bun has exactly two native sites that put user text after a function wrapper: this one and `vm.compileFunction` (`NodeVM.cpp`, `stringifyAnonymousFunction`), which #38245 fixes the same way. The other wrapper sites are not affected: `Module.wrap()` only returns a string, as in Node, and the wrapper swaps in `JSCommonJSModule::evaluate` / `createCommonJSModule` operate on transpiler output.

### Fix
- New `src/jsc/bindings/EmbedFunctionBody.h`: `embedFunctionBody(body)` returns the pieces to concatenate in place of the body. For a body starting with `#!` that is `//` plus the rest; if the character after `#!` is `#` or `@` it is replaced by a space as well, so `#!# sourceURL=x` goes in as `//  sourceURL=x`.
- `_compile` calls it before concatenating, in both the default-wrapper and the `Module.wrapper` arm. Nothing else about the wrapper changes.
- Why a header: #38245 carries the identical rule as a file-local helper in `NodeVM.cpp`, and the `#`/`@` detail is the kind of thing two copies drift on. The header uses the same names as that helper, so whichever of the two PRs lands second only has to delete its local copy and include this file; until then the copies live in different namespaces (`Bun` here, `Bun::NodeVM` there) and do not collide.
- Correct because a hashbang line and a `//` comment both extend to the next line terminator, so JSC now compiles the function V8 compiles for the same text. The rewrite replaces characters without adding or removing any, so every line and column in the body stays where it was; stack traces and SyntaxError positions match a file whose first line is an ordinary comment.
- The `#`/`@` case: JSC reads `//# sourceURL=` and `//@ sourceURL=` (and `sourceMappingURL`) directives from `//` comments but not from hashbang lines, and neither does V8 (Node reports the real filename for `#!# sourceURL=fake.js`). Blanking the marker keeps the line a plain comment.
- Only offset 0 is rewritten. `" #!..."`, `"\n#!..."`, a BOM before `#!`, a lone `#` line and a `#!` on line 2 stay SyntaxErrors, as in Node (pinned by a test).
- With an assigned `Module.wrapper`, Node itself fails on this input: once the wrapper is patched it compiles `Module.wrap(source)` as a script, which breaks `_compile` and also `require()` for every shebang file. Bun's `require()` keeps working with a patched wrapper because of the transpiler, so `_compile` of the same file contents now works too rather than copying that failure. A test pins it and checks the custom wrapper still runs.
- Residual difference: `Function.prototype.toString()` of the wrapper function shows `//` where the file has `#!`. The function source is the text JSC parsed, so closing this would take a lexer change in the WebKit fork (accepting a hashbang at a caller-given offset); not done here, and before this change the input did not compile at all.
- Tests: `test/js/node/module/node-module-module.test.js`, `describe("Module.prototype._compile with a hashbang line")`. 11 of the 12 new tests fail on the released bun with `SyntaxError: Invalid character: '#'` (the 12th pins the rejected placements) and all pass with this change. Covered: `\n`, `\r\n`, `\r`, U+2028 and U+2029 line endings, a source that is only a hashbang, `"use strict"` after the hashbang, line numbers of a runtime error and of a SyntaxError, the `#`/`@` case with a `//# sourceURL=` control, a `require.extensions` handler passing file contents to `_compile`, and an assigned `Module.wrapper`.
- Also run on the debug build: all of `test/js/node/module/` (110 pass) and Node's `test-module-wrapper.js`.

### Background
- Hashbang comment: ECMAScript treats `#!` plus the rest of the line as a comment, but only as the very first characters of a Script or Module source text. Anywhere else `#` is only valid as the start of a private name, so it is a syntax error.
- `Module.prototype._compile(source, filename)`: the CommonJS loader step that turns file text into the `(exports, require, module, __filename, __dirname)` function and runs it. Node implements it with V8's `CompileFunction`, which scans the body like a script and so skips a leading hashbang; JSC has no equivalent, so bun builds the wrapper as text and evaluates it as a program. `vm.compileFunction` is the same construction for arbitrary parameter lists.
- `Module.wrapper`: the two strings placed around a module body. Assigning it makes bun (like Node) use those strings instead of the built-in ones; in bun the flag behind this is `hasOverriddenModuleWrapper`, and `_compile` concatenates the same way in both cases.
- sourceURL directive: a `//# sourceURL=name` (or `//@`) comment makes the engine report `name` in stack traces instead of the real file name; `//# sourceMappingURL=` works the same way for source maps. JSC looks for these right after `//`.

<details>
<summary>Node v26.3.0 vs bun with this change on the probe inputs</summary>

Accepted by both, same exports: `#!...\n` + body, the same with `\r\n`, `\r`, U+2028 and U+2029, a source that is only `#!/usr/bin/env node` or `#!`, and `"use strict"` on the line after the hashbang (module is strict in both).

Rejected by both with a SyntaxError: `" #!..."`, `"\n#!..."`, `"\uFEFF#!..."`, `"#\n..."`, a hashbang on line 2.

Both report the real filename for `#!# sourceURL=fake.js` and `#!@ sourceURL=fake.js`, and both honor a real `//# sourceURL=` on line 1. An Error created on line 3 reports line 3 in both; a SyntaxError on line 3 reports line 3 in both.

Differs, as described above: `_compile` of a hashbang source after assigning `Module.wrapper` throws in Node and works in bun. Column numbers and the SyntaxError stack layout differ for every `_compile` source, not only hashbang ones; pre-existing.

pirates-style check on the released bun: a `.js` handler that intercepts `module._compile` and then calls the default handler receives, for a file starting with `#!/usr/bin/env node`, source whose first line is empty, and the file loads; Node hands the same hook the `#!` line.
</details>

<details>
<summary>First revision of this PR</summary>

The first push had the same rewrite as a file-local `embedModuleBody` in `JSCommonJSModule.cpp` and described pirates-style hooks as affected. Review pointed out that #38245 adds the identical helper for `vm.compileFunction`, and that those hooks receive transpiled source on bun; the helper moved to the shared header and the description above was corrected.
</details>
