### PR TITLE
node:vm: run runInNewContext() in the sandbox's existing context

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -115,11 +115,9 @@ function runInNewContext(code, context, options) {
   return createScript(code, options).runInNewContext(context, options);
 }
 
-// Node's getContextOptions(): runInNewContext() takes the context options under
-// context-prefixed names, createContext() under the plain ones. The context
-// created from these is the one Script#runInNewContext() then runs in. The
-// options are validated here under the caller's names and copied key by key,
-// so createContext() never reports them as options.codeGeneration.*.
+// Node's getContextOptions(): runInNewContext() spells these options with a
+// context- prefix, createContext() without. Validated here so errors name the
+// option the caller passed.
 function getContextOptions(options) {
   if (!$isObject(options)) {
     return undefined;

--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -117,19 +117,31 @@ function runInNewContext(code, context, options) {
 
 // Node's getContextOptions(): runInNewContext() takes the context options under
 // context-prefixed names, createContext() under the plain ones. The context
-// created from these is the one Script#runInNewContext() then runs in.
+// created from these is the one Script#runInNewContext() then runs in. The
+// options are validated here under the caller's names and copied key by key,
+// so createContext() never reports them as options.codeGeneration.*.
 function getContextOptions(options) {
   if (!$isObject(options)) {
     return undefined;
   }
-  const { contextCodeGeneration, microtaskMode } = options;
+  const { contextName, contextOrigin, contextCodeGeneration, microtaskMode } = options;
+  if (contextName !== undefined) validateString(contextName, "options.contextName");
+  if (contextOrigin !== undefined) validateString(contextOrigin, "options.contextOrigin");
+  let codeGeneration: { strings?: boolean; wasm?: boolean } | undefined;
   if (contextCodeGeneration !== undefined) {
     validateObject(contextCodeGeneration, "options.contextCodeGeneration");
     const { strings, wasm } = contextCodeGeneration;
-    if (strings !== undefined) validateBoolean(strings, "options.contextCodeGeneration.strings");
-    if (wasm !== undefined) validateBoolean(wasm, "options.contextCodeGeneration.wasm");
+    codeGeneration = {};
+    if (strings !== undefined) {
+      validateBoolean(strings, "options.contextCodeGeneration.strings");
+      codeGeneration.strings = strings;
+    }
+    if (wasm !== undefined) {
+      validateBoolean(wasm, "options.contextCodeGeneration.wasm");
+      codeGeneration.wasm = wasm;
+    }
   }
-  return { codeGeneration: contextCodeGeneration, microtaskMode };
+  return { name: contextName, origin: contextOrigin, codeGeneration, microtaskMode };
 }
 
 function createScript(code, options) {

--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -88,8 +88,7 @@ function runInNewContext(code, context, options) {
   return createScript(code, options).runInNewContext(context, options);
 }
 
-// Node's getContextOptions(): runInNewContext() spells these with a context- prefix,
-// createContext() without. Validated here so errors name the option the caller passed.
+// Node's getContextOptions(); validated here so errors name the option the caller passed.
 function getContextOptions(options) {
   if (!$isObject(options)) {
     return undefined;
@@ -145,8 +144,7 @@ function measureMemory(options = kEmptyObject) {
   const result: any = { total: measurement() };
   if (mode === "detailed") {
     result.current = measurement();
-    // One entry per live context, like Node; every context, whichever API made
-    // it, is in the registry isContext() reads.
+    // One entry per live context, like Node.
     const other: object[] = [];
     for (let remaining = contextCount(); remaining > 0; remaining--) {
       other.push(measurement());

--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -45,6 +45,7 @@ const {
   Module: ModuleNative,
   createContext: createContextNative,
   isContext,
+  contextCount,
   compileFunction,
   isModuleNamespaceObject,
   kLinked,
@@ -54,39 +55,11 @@ const {
   USE_MAIN_CONTEXT_DEFAULT_LOADER,
 } = vm;
 
-// Live vm contexts, tracked so measureMemory({ mode: "detailed" }) can report
-// one entry per context like Node. WeakRefs so tracking doesn't keep contexts
-// alive; dead entries are pruned on each measurement and, amortized, on
-// creation (so a process that never measures doesn't accumulate dead refs).
-const trackedContexts: WeakRef<object>[] = [];
-let trackedContextsPruneAt = 64;
-
-function pruneTrackedContexts() {
-  let alive = 0;
-  for (let i = 0; i < trackedContexts.length; i++) {
-    const ref = trackedContexts[i];
-    if (ref.deref() !== undefined) {
-      trackedContexts[alive++] = ref;
-    }
-  }
-  trackedContexts.length = alive;
-  return alive;
-}
-
 function createContext(contextObject?, options?) {
   if (typeof options === "object" && options !== null) {
     validateOneOf(options.microtaskMode, "options.microtaskMode", ["afterEvaluate", undefined]);
   }
-  const alreadyContextified = $isObject(contextObject) && isContext(contextObject);
-  const context = createContextNative(contextObject, options);
-  if (!alreadyContextified) {
-    if (trackedContexts.length >= trackedContextsPruneAt) {
-      const alive = pruneTrackedContexts();
-      trackedContextsPruneAt = alive * 2 < 64 ? 64 : alive * 2;
-    }
-    trackedContexts.push(new WeakRef(context));
-  }
-  return context;
+  return createContextNative(contextObject, options);
 }
 
 function runInContext(code, context, options) {
@@ -115,9 +88,8 @@ function runInNewContext(code, context, options) {
   return createScript(code, options).runInNewContext(context, options);
 }
 
-// Node's getContextOptions(): runInNewContext() spells these options with a
-// context- prefix, createContext() without. Validated here so errors name the
-// option the caller passed.
+// Node's getContextOptions(): runInNewContext() spells these with a context- prefix,
+// createContext() without. Validated here so errors name the option the caller passed.
 function getContextOptions(options) {
   if (!$isObject(options)) {
     return undefined;
@@ -173,16 +145,12 @@ function measureMemory(options = kEmptyObject) {
   const result: any = { total: measurement() };
   if (mode === "detailed") {
     result.current = measurement();
+    // One entry per live context, like Node; every context, whichever API made
+    // it, is in the registry isContext() reads.
     const other: object[] = [];
-    let aliveCount = 0;
-    for (let i = 0; i < trackedContexts.length; i++) {
-      const ref = trackedContexts[i];
-      if (ref.deref() !== undefined) {
-        trackedContexts[aliveCount++] = ref;
-        other.push(measurement());
-      }
+    for (let remaining = contextCount(); remaining > 0; remaining--) {
+      other.push(measurement());
     }
-    trackedContexts.length = aliveCount;
     result.other = other;
   }
 

--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -111,8 +111,25 @@ function runInNewContext(code, context, options) {
   if (typeof options === "string") {
     options = { filename: options };
   }
-  context = createContext(context, options);
+  context = createContext(context, getContextOptions(options));
   return createScript(code, options).runInNewContext(context, options);
+}
+
+// Node's getContextOptions(): runInNewContext() takes the context options under
+// context-prefixed names, createContext() under the plain ones. The context
+// created from these is the one Script#runInNewContext() then runs in.
+function getContextOptions(options) {
+  if (!$isObject(options)) {
+    return undefined;
+  }
+  const { contextCodeGeneration, microtaskMode } = options;
+  if (contextCodeGeneration !== undefined) {
+    validateObject(contextCodeGeneration, "options.contextCodeGeneration");
+    const { strings, wasm } = contextCodeGeneration;
+    if (strings !== undefined) validateBoolean(strings, "options.contextCodeGeneration.strings");
+    if (wasm !== undefined) validateBoolean(wasm, "options.contextCodeGeneration.wasm");
+  }
+  return { codeGeneration: contextCodeGeneration, microtaskMode };
 }
 
 function createScript(code, options) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1657,6 +1657,12 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_isContext, (JSGlobalObject * globalObject, Cal
     return JSValue::encode(jsBoolean(isContext(globalObject, contextArg)));
 }
 
+// Contexts whose sandbox was still alive at the last GC, for measureMemory().
+JSC_DEFINE_HOST_FUNCTION(vmModule_contextCount, (JSGlobalObject * globalObject, CallFrame*))
+{
+    return JSValue::encode(jsNumber(defaultGlobalObject(globalObject)->vmModuleContextMap()->size()));
+}
+
 const ClassInfo NodeVMGlobalObject::s_info = { "NodeVMGlobalObject"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NodeVMGlobalObject) };
 
 bool NodeVMGlobalObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSC::DeletePropertySlot& slot)
@@ -1760,6 +1766,9 @@ JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "isContext"_s)),
         JSC::JSFunction::create(vm, globalObject, 0, "isContext"_s, vmModule_isContext, ImplementationVisibility::Public), 0);
+    obj->putDirect(
+        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "contextCount"_s)),
+        JSC::JSFunction::create(vm, globalObject, 0, "contextCount"_s, vmModule_contextCount, ImplementationVisibility::Public), 0);
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "runInThisContext"_s)),
         JSC::JSFunction::create(vm, globalObject, 0, "runInThisContext"_s, vmModuleRunInThisContext, ImplementationVisibility::Public), 0);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -842,6 +842,27 @@ bool getContextArg(JSGlobalObject* globalObject, JSValue& contextArg)
     return false;
 }
 
+NodeVMGlobalObject* makeContext(JSGlobalObject* globalObject, JSObject* sandbox, const NodeVMContextOptions& contextOptions, JSValue importer)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+
+    auto* context = NodeVMGlobalObject::create(vm, zigGlobalObject->NodeVMGlobalObjectStructure(), contextOptions, importer);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    context->setContextifiedObject(sandbox);
+    zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, context);
+
+    if (contextOptions.notContextified) {
+        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, context);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        context->setSpecialSandbox(specialSandbox);
+    }
+
+    return context;
+}
+
 bool isUseMainContextDefaultLoaderConstant(JSGlobalObject* globalObject, JSValue value)
 {
     if (value.isSymbol()) {
@@ -1685,24 +1706,10 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
         return JSValue::encode(sandbox);
     }
 
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-
-    auto* targetContext = NodeVMGlobalObject::create(vm,
-        zigGlobalObject->NodeVMGlobalObjectStructure(),
-        contextOptions, importer);
-
+    auto* targetContext = makeContext(globalObject, sandbox, contextOptions, importer);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Set sandbox as contextified object
-    targetContext->setContextifiedObject(sandbox);
-
-    // Store context in WeakMap for isContext checks
-    zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, targetContext);
-
     if (notContextified) {
-        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
-        RETURN_IF_EXCEPTION(scope, {});
-        targetContext->setSpecialSandbox(specialSandbox);
         return JSValue::encode(targetContext->specialSandbox());
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -853,8 +853,7 @@ NodeVMGlobalObject* makeContext(JSGlobalObject* globalObject, JSObject* sandbox,
 
     context->setContextifiedObject(sandbox);
 
-    // Keyed on what the caller holds: for DONT_CONTEXTIFY that is the handle, since
-    // the first run replaces the placeholder `sandbox` and GC would drop the entry.
+    // Keyed on the object the caller holds; a DONT_CONTEXTIFY placeholder `sandbox` is dropped by the first run.
     JSObject* key = sandbox;
     if (contextOptions.notContextified) {
         auto* specialSandbox = NodeVMSpecialSandbox::create(vm, context);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -853,14 +853,18 @@ NodeVMGlobalObject* makeContext(JSGlobalObject* globalObject, JSObject* sandbox,
 
     context->setContextifiedObject(sandbox);
 
+    // Keyed on what the caller holds: for DONT_CONTEXTIFY that is the handle, since
+    // the first run replaces the placeholder `sandbox` and GC would drop the entry.
+    JSObject* key = sandbox;
     if (contextOptions.notContextified) {
         auto* specialSandbox = NodeVMSpecialSandbox::create(vm, context);
         RETURN_IF_EXCEPTION(scope, nullptr);
         context->setSpecialSandbox(specialSandbox);
+        key = specialSandbox;
     }
 
     // Registered last, so a lookup never yields a half-built context.
-    zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, context);
+    zigGlobalObject->vmModuleContextMap()->set(vm, key, context);
     return context;
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -852,7 +852,6 @@ NodeVMGlobalObject* makeContext(JSGlobalObject* globalObject, JSObject* sandbox,
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     context->setContextifiedObject(sandbox);
-    zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, context);
 
     if (contextOptions.notContextified) {
         auto* specialSandbox = NodeVMSpecialSandbox::create(vm, context);
@@ -860,6 +859,8 @@ NodeVMGlobalObject* makeContext(JSGlobalObject* globalObject, JSObject* sandbox,
         context->setSpecialSandbox(specialSandbox);
     }
 
+    // Registered last, so a lookup never yields a half-built context.
+    zigGlobalObject->vmModuleContextMap()->set(vm, sandbox, context);
     return context;
 }
 
@@ -1431,78 +1432,6 @@ void NodeVMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_dynamicImportCallback);
 }
 
-JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    JSValue code = callFrame->argument(0);
-    if (!code.isString())
-        return ERR::INVALID_ARG_TYPE(scope, globalObject, "code"_s, "string"_s, code);
-
-    JSValue contextArg = callFrame->argument(1);
-    bool notContextified = getContextArg(globalObject, contextArg);
-
-    if (!contextArg.isObject()) {
-        return ERR::INVALID_ARG_TYPE(scope, globalObject, "context"_s, "object"_s, contextArg);
-    }
-
-    JSObject* sandbox = asObject(contextArg);
-
-    JSValue contextOptionsArg = callFrame->argument(2);
-    NodeVMContextOptions contextOptions {};
-
-    JSValue globalObjectDynamicImportCallback;
-
-    getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &globalObjectDynamicImportCallback);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    contextOptions.notContextified = notContextified;
-
-    // Create context and run code
-    auto* context = NodeVMGlobalObject::create(vm,
-        defaultGlobalObject(globalObject)->NodeVMGlobalObjectStructure(),
-        contextOptions, globalObjectDynamicImportCallback);
-
-    context->setContextifiedObject(sandbox);
-
-    JSValue optionsArg = callFrame->argument(2);
-    JSValue scriptDynamicImportCallback;
-
-    ScriptOptions options(optionsArg.toWTFString(globalObject), OrdinalNumber::fromZeroBasedInt(0), OrdinalNumber::fromZeroBasedInt(0));
-    if (optionsArg.isString()) {
-        options.filename = optionsArg.toWTFString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-    } else if (!options.fromJS(globalObject, vm, scope, optionsArg, &scriptDynamicImportCallback)) {
-        RETURN_IF_EXCEPTION(scope, {});
-    }
-
-    RefPtr fetcher(NodeVMScriptFetcher::create(vm, scriptDynamicImportCallback, jsUndefined()));
-
-    SourceCode sourceCode(
-        JSC::StringSourceProvider::create(
-            code.toString(globalObject)->value(globalObject),
-            JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher),
-            options.filename,
-            JSC::SourceTaintedOrigin::Untainted,
-            TextPosition(options.lineOffset, options.columnOffset)),
-        options.lineOffset.zeroBasedInt(),
-        options.columnOffset.zeroBasedInt());
-
-    NakedPtr<JSC::Exception> exception;
-    JSValue result = JSC::evaluate(context, sourceCode, context, exception);
-
-    if (exception) [[unlikely]] {
-        if (handleException(globalObject, vm, exception, scope)) {
-            return {};
-        }
-        JSC::throwException(globalObject, scope, exception.get());
-        return {};
-    }
-
-    return JSValue::encode(result);
-}
-
 JSC_DEFINE_HOST_FUNCTION(vmModuleRunInThisContext, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = JSC::getVM(globalObject);
@@ -1831,9 +1760,6 @@ JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "isContext"_s)),
         JSC::JSFunction::create(vm, globalObject, 0, "isContext"_s, vmModule_isContext, ImplementationVisibility::Public), 0);
-    obj->putDirect(
-        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "runInNewContext"_s)),
-        JSC::JSFunction::create(vm, globalObject, 0, "runInNewContext"_s, vmModuleRunInNewContext, ImplementationVisibility::Public), 0);
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "runInThisContext"_s)),
         JSC::JSFunction::create(vm, globalObject, 0, "runInThisContext"_s, vmModuleRunInThisContext, ImplementationVisibility::Public), 0);

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -176,7 +176,6 @@ void configureNodeVM(JSC::VM&, Zig::GlobalObject*);
 // VM module functions
 JSC_DECLARE_HOST_FUNCTION(vmModule_createContext);
 JSC_DECLARE_HOST_FUNCTION(vmModule_isContext);
-JSC_DECLARE_HOST_FUNCTION(vmModuleRunInNewContext);
 JSC_DECLARE_HOST_FUNCTION(vmModuleRunInThisContext);
 
 } // namespace Bun

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -174,6 +174,7 @@ void configureNodeVM(JSC::VM&, Zig::GlobalObject*);
 // VM module functions
 JSC_DECLARE_HOST_FUNCTION(vmModule_createContext);
 JSC_DECLARE_HOST_FUNCTION(vmModule_isContext);
+JSC_DECLARE_HOST_FUNCTION(vmModule_contextCount);
 JSC_DECLARE_HOST_FUNCTION(vmModuleRunInThisContext);
 
 } // namespace Bun

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -41,9 +41,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
 JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin);
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
-// Creates and registers the realm behind `sandbox` (Node's makeContext). Callers
-// first check whether the sandbox is a context already: createContext() and
-// Script#runInNewContext() reuse that realm rather than make a second one.
+// Creates and registers the realm behind `sandbox`; callers reuse an existing one first (Node's makeContext).
 NodeVMGlobalObject* makeContext(JSC::JSGlobalObject* globalObject, JSObject* sandbox, const NodeVMContextOptions& contextOptions, JSValue importer);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -41,6 +41,10 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
 JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin);
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
+// Creates and registers the realm behind `sandbox` (Node's makeContext). Callers
+// first check whether the sandbox is a context already: createContext() and
+// Script#runInNewContext() reuse that realm rather than make a second one.
+NodeVMGlobalObject* makeContext(JSC::JSGlobalObject* globalObject, JSObject* sandbox, const NodeVMContextOptions& contextOptions, JSValue importer);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);
 
 } // namespace NodeVM

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -638,30 +638,29 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
         return {};
     }
 
-    JSValue contextOptionsArg = callFrame->argument(1);
+    JSValue optionsArg = callFrame->argument(1);
     NodeVMContextOptions contextOptions {};
     JSValue importer;
 
-    getNodeVMContextOptions(globalObject, vm, scope, contextOptionsArg, contextOptions, "contextCodeGeneration", &importer);
+    // Node validates the context options even when the sandbox turns out to be
+    // a context already (lib/vm.js getContextOptions runs before createContext).
+    getNodeVMContextOptions(globalObject, vm, scope, optionsArg, contextOptions, "contextCodeGeneration", &importer);
     RETURN_IF_EXCEPTION(scope, {});
 
-    contextOptions.notContextified = notContextified;
-
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSObject* context = asObject(contextObjectValue);
-    auto* targetContext = NodeVMGlobalObject::create(vm,
-        zigGlobalObject->NodeVMGlobalObjectStructure(),
-        contextOptions, importer);
+    // Like Node's createContext(), a sandbox that is already a context (or a
+    // context's global) keeps its realm: top-level let/const/class bindings and
+    // intrinsics must be shared with every other run against the same sandbox.
+    JSObject* sandbox = asObject(contextObjectValue);
+    NodeVMGlobalObject* context = getGlobalObjectFromContext(globalObject, sandbox, false);
     RETURN_IF_EXCEPTION(scope, {});
-
-    if (notContextified) {
-        auto* specialSandbox = NodeVMSpecialSandbox::create(vm, targetContext);
+    if (!context) {
+        contextOptions.notContextified = notContextified;
+        context = makeContext(globalObject, sandbox, contextOptions, importer);
         RETURN_IF_EXCEPTION(scope, {});
-        targetContext->setSpecialSandbox(specialSandbox);
-        RELEASE_AND_RETURN(scope, runInContext(targetContext, script, targetContext->specialSandbox(), callFrame->argument(1)));
     }
 
-    RELEASE_AND_RETURN(scope, runInContext(targetContext, script, context, callFrame->argument(1)));
+    JSObject* contextifiedObject = context->isNotContextified() ? context->specialSandbox() : context->contextifiedObject();
+    RELEASE_AND_RETURN(scope, runInContext(context, script, contextifiedObject, optionsArg));
 }
 
 class NodeVMScriptPrototype final : public JSC::JSNonFinalObject {

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -642,14 +642,11 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
     NodeVMContextOptions contextOptions {};
     JSValue importer;
 
-    // Node validates the context options even when the sandbox turns out to be
-    // a context already (lib/vm.js getContextOptions runs before createContext).
+    // Validated even for an existing context, like Node's getContextOptions().
     getNodeVMContextOptions(globalObject, vm, scope, optionsArg, contextOptions, "contextCodeGeneration", &importer);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Like Node's createContext(), a sandbox that is already a context (or a
-    // context's global) keeps its realm: top-level let/const/class bindings and
-    // intrinsics must be shared with every other run against the same sandbox.
+    // createContext() semantics: an object that is already a context keeps its realm.
     JSObject* sandbox = asObject(contextObjectValue);
     NodeVMGlobalObject* context = getGlobalObjectFromContext(globalObject, sandbox, false);
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1215,15 +1215,23 @@ describe("runInNewContext() on a sandbox that is already a context", () => {
     expect(sandbox.viaGlobal).toBe(1);
   });
 
-  test.concurrent("measureMemory() still lists a context created by vm.runInNewContext()", async () => {
+  test.concurrent("measureMemory() lists one entry per context, however the context was made", async () => {
     const code = `
       const vm = require("node:vm");
       const count = async () => (await vm.measureMemory({ mode: "detailed" })).other.length;
-      const before = await count();
-      const sandbox = {};
-      vm.runInNewContext("1", sandbox);
-      const after = await count();
-      console.log(before, after, vm.isContext(sandbox));
+      const counts = [await count()];
+      const held = [vm.createContext({}), {}, {}, vm.createContext(vm.constants.DONT_CONTEXTIFY)];
+      counts.push(await count());
+      vm.runInNewContext("1", held[1]);
+      counts.push(await count());
+      new vm.Script("1").runInNewContext(held[2]);
+      counts.push(await count());
+      // Reuse adds nothing.
+      vm.runInNewContext("1", held[1]);
+      new vm.Script("1").runInNewContext(held[2]);
+      vm.runInNewContext("1", held[3]);
+      counts.push(await count());
+      console.log(counts.join(" "), held.every(vm.isContext));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", code],
@@ -1232,7 +1240,7 @@ describe("runInNewContext() on a sandbox that is already a context", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("ExperimentalWarning");
-    expect(stdout).toBe("0 1 true\n");
+    expect(stdout).toBe("0 2 3 4 4 true\n");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1163,13 +1163,16 @@ describe("runInNewContext() on a sandbox that is already a context", () => {
     expect(new Script("eval('2 + 2')").runInNewContext(context, options)).toBe(4);
   });
 
-  test("context options are still validated for an existing context", () => {
+  test("context options are validated under runInNewContext's option names, for new and existing contexts", () => {
     const context = createContext({});
+    const sandbox = {};
     const messages: string[] = [];
     for (const fn of [
       () => runInNewContext("1", context, { contextCodeGeneration: 1 }),
       () => runInNewContext("1", context, { contextCodeGeneration: { wasm: 1 } }),
-      () => runInNewContext("1", {}, { contextCodeGeneration: { strings: "no" } }),
+      () => runInNewContext("1", context, { contextName: 1 }),
+      () => runInNewContext("1", sandbox, { contextCodeGeneration: { strings: "no" } }),
+      () => runInNewContext("1", sandbox, { contextOrigin: null }),
       () => new Script("1").runInNewContext(context, { contextCodeGeneration: { strings: "no" } }),
     ]) {
       try {
@@ -1182,9 +1185,13 @@ describe("runInNewContext() on a sandbox that is already a context", () => {
     expect(messages).toEqual([
       'ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration" property must be of type object. Received type number (1)',
       'ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration.wasm" property must be of type boolean. Received type number (1)',
+      'ERR_INVALID_ARG_TYPE: The "options.contextName" property must be of type string. Received type number (1)',
       `ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration.strings" property must be of type boolean. Received type string ('no')`,
+      'ERR_INVALID_ARG_TYPE: The "options.contextOrigin" property must be of type string. Received null',
       `ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration.strings" property must be of type boolean. Received type string ('no')`,
     ]);
+    // Like Node, invalid options are rejected before the sandbox is contextified.
+    expect(isContext(sandbox)).toBe(false);
   });
 
   test("every distinct or omitted sandbox still gets its own realm", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1218,7 +1218,12 @@ describe("runInNewContext() on a sandbox that is already a context", () => {
   test.concurrent("measureMemory() lists one entry per context, however the context was made", async () => {
     const code = `
       const vm = require("node:vm");
-      const count = async () => (await vm.measureMemory({ mode: "detailed" })).other.length;
+      // A context is live as long as the object the caller holds for it is, so a
+      // full GC before each measurement must not change the numbers.
+      const count = async () => {
+        Bun.gc(true);
+        return (await vm.measureMemory({ mode: "detailed" })).other.length;
+      };
       const counts = [await count()];
       const held = [vm.createContext({}), {}, {}, vm.createContext(vm.constants.DONT_CONTEXTIFY)];
       counts.push(await count());
@@ -1226,10 +1231,11 @@ describe("runInNewContext() on a sandbox that is already a context", () => {
       counts.push(await count());
       new vm.Script("1").runInNewContext(held[2]);
       counts.push(await count());
-      // Reuse adds nothing.
+      // Running again in any of them (the DONT_CONTEXTIFY one included) adds nothing.
       vm.runInNewContext("1", held[1]);
       new vm.Script("1").runInNewContext(held[2]);
       vm.runInNewContext("1", held[3]);
+      vm.runInContext("1", held[3]);
       counts.push(await count());
       console.log(counts.join(" "), held.every(vm.isContext));
     `;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -4,6 +4,7 @@ import {
   compileFunction,
   constants,
   createContext,
+  isContext,
   runInContext,
   runInNewContext,
   runInThisContext,
@@ -1017,20 +1018,22 @@ describe("context options with throwing getters", () => {
   // the process, so run the matrix in a subprocess.
   test.concurrent("the getter's exception propagates to the caller", async () => {
     // Each entry point tests the context-option keys it actually reads:
-    // createContext takes codeGeneration, Script#runInNewContext takes
-    // contextCodeGeneration, and vm.runInNewContext goes through both.
+    // createContext takes codeGeneration; Script#runInNewContext and
+    // vm.runInNewContext (which maps contextCodeGeneration into its own
+    // createContext call) take contextCodeGeneration.
     // A dotted key puts the throwing getter on the nested object.
-    const codeGenerationKeys = (key: string) => [key, `${key}.strings`, `${key}.wasm`];
-    const contextKeys = (...codeGenerationKeyNames: string[]) => [
+    const contextKeys = (codeGenerationKey: string) => [
       "name",
       "origin",
-      ...codeGenerationKeyNames.flatMap(codeGenerationKeys),
+      codeGenerationKey,
+      `${codeGenerationKey}.strings`,
+      `${codeGenerationKey}.wasm`,
       "importModuleDynamically",
       "microtaskMode",
     ];
     const matrix = {
       createContext: contextKeys("codeGeneration"),
-      runInNewContext: contextKeys("codeGeneration", "contextCodeGeneration"),
+      runInNewContext: contextKeys("contextCodeGeneration"),
       scriptRunInNewContext: contextKeys("contextCodeGeneration"),
     };
     const code = `
@@ -1073,6 +1076,156 @@ describe("context options with throwing getters", () => {
         .join("\n") + "\nsurvived\n";
     expect(stderr).toBe("");
     expect(stdout).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("runInNewContext() on a sandbox that is already a context", () => {
+  // Node's runInNewContext() is createContext() + runInContext(), and
+  // createContext() returns an object that is already a context as-is, so
+  // every run against one sandbox shares a single realm.
+
+  test("vm.runInNewContext() reuses the realm it created for the sandbox", () => {
+    const sandbox = {};
+    const ObjectCtor = runInNewContext("Object", sandbox);
+    expect(ObjectCtor).not.toBe(Object);
+    expect(runInNewContext("Object", sandbox)).toBe(ObjectCtor);
+    expect(runInContext("Object", sandbox)).toBe(ObjectCtor);
+    expect(new Script("Object").runInNewContext(sandbox)).toBe(ObjectCtor);
+    expect(new Script("Object").runInContext(sandbox)).toBe(ObjectCtor);
+  });
+
+  test("vm.runInNewContext() and Script#runInNewContext() reuse a context from createContext()", () => {
+    const context = createContext({});
+    const ObjectCtor = runInContext("Object", context);
+    expect(runInNewContext("Object", context)).toBe(ObjectCtor);
+    expect(new Script("Object").runInNewContext(context)).toBe(ObjectCtor);
+  });
+
+  test("top-level let/const/class declarations persist across runs on the same sandbox", () => {
+    const sandbox = {};
+    runInNewContext("var v = 1; let l = 2; const c = 3; class K {}", sandbox);
+    // var becomes a sandbox property; the lexical bindings live in the realm.
+    expect(sandbox).toEqual({ v: 1 });
+    expect(runInNewContext("[v, l, c, typeof K].join()", sandbox)).toBe("1,2,3,function");
+    expect(runInContext("[v, l, c, typeof K].join()", sandbox)).toBe("1,2,3,function");
+    expect(new Script("[v, l, c, typeof K].join()").runInNewContext(sandbox)).toBe("1,2,3,function");
+    // Same realm, so redeclaring is a SyntaxError (raised in that realm) like in Node.
+    expect(() => runInNewContext("let l = 4", sandbox)).toThrow(runInContext("SyntaxError", sandbox));
+  });
+
+  test("values made by vm.runInNewContext() are instances of the sandbox's own intrinsics", () => {
+    const sandbox = {};
+    const error = runInNewContext("new Error('boom')", sandbox);
+    expect(error).not.toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(runInContext("Error", sandbox));
+    expect(error).toBeInstanceOf(runInNewContext("Error", sandbox));
+  });
+
+  test("Script#runInNewContext() contextifies a plain object once", () => {
+    const sandbox = {};
+    expect(isContext(sandbox)).toBe(false);
+    const ObjectCtor = new Script("Object").runInNewContext(sandbox);
+    expect(isContext(sandbox)).toBe(true);
+    expect(new Script("Object").runInNewContext(sandbox)).toBe(ObjectCtor);
+    expect(runInContext("Object", sandbox)).toBe(ObjectCtor);
+  });
+
+  test("context options given when Script#runInNewContext() creates the context stick to it", () => {
+    const sandbox = {};
+    new Script("1").runInNewContext(sandbox, { contextCodeGeneration: { strings: false } });
+    const EvalErrorCtor = runInContext("EvalError", sandbox);
+    expect(() => runInContext("eval('1')", sandbox)).toThrow(EvalErrorCtor);
+    expect(() => new Script("eval('1')").runInNewContext(sandbox)).toThrow(EvalErrorCtor);
+  });
+
+  test("context options given when vm.runInNewContext() creates the context stick to it", () => {
+    const sandbox = {};
+    let thrown: unknown;
+    try {
+      runInNewContext("eval('1')", sandbox, { contextCodeGeneration: { strings: false } });
+    } catch (e) {
+      thrown = e;
+    }
+    const EvalErrorCtor = runInContext("EvalError", sandbox);
+    expect(thrown).toBeInstanceOf(EvalErrorCtor);
+    expect(() => runInContext("eval('1')", sandbox)).toThrow(EvalErrorCtor);
+
+    const queued: Record<string, unknown> = {};
+    runInNewContext("Promise.resolve().then(() => { settled = true; })", queued, { microtaskMode: "afterEvaluate" });
+    expect(queued.settled).toBe(true);
+  });
+
+  test("context options are ignored for an existing context, like createContext()", () => {
+    const context = createContext({});
+    const options = { contextCodeGeneration: { strings: false, wasm: false } };
+    expect(runInNewContext("eval('1 + 1')", context, options)).toBe(2);
+    expect(new Script("eval('2 + 2')").runInNewContext(context, options)).toBe(4);
+  });
+
+  test("context options are still validated for an existing context", () => {
+    const context = createContext({});
+    const messages: string[] = [];
+    for (const fn of [
+      () => runInNewContext("1", context, { contextCodeGeneration: 1 }),
+      () => runInNewContext("1", context, { contextCodeGeneration: { wasm: 1 } }),
+      () => runInNewContext("1", {}, { contextCodeGeneration: { strings: "no" } }),
+      () => new Script("1").runInNewContext(context, { contextCodeGeneration: { strings: "no" } }),
+    ]) {
+      try {
+        fn();
+        messages.push("did not throw");
+      } catch (e: any) {
+        messages.push(`${e.code}: ${e.message}`);
+      }
+    }
+    expect(messages).toEqual([
+      'ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration" property must be of type object. Received type number (1)',
+      'ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration.wasm" property must be of type boolean. Received type number (1)',
+      `ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration.strings" property must be of type boolean. Received type string ('no')`,
+      `ERR_INVALID_ARG_TYPE: The "options.contextCodeGeneration.strings" property must be of type boolean. Received type string ('no')`,
+    ]);
+  });
+
+  test("every distinct or omitted sandbox still gets its own realm", () => {
+    expect(runInNewContext("Object", {})).not.toBe(runInNewContext("Object", {}));
+    expect(runInNewContext("Object")).not.toBe(runInNewContext("Object"));
+    const script = new Script("Object");
+    expect(script.runInNewContext({})).not.toBe(script.runInNewContext({}));
+    expect(script.runInNewContext()).not.toBe(script.runInNewContext());
+    expect(runInNewContext("Object", constants.DONT_CONTEXTIFY)).not.toBe(
+      runInNewContext("Object", constants.DONT_CONTEXTIFY),
+    );
+  });
+
+  test("a context's own globalThis runs in that context without recursing into itself", () => {
+    const sandbox: Record<string, unknown> = {};
+    const contextGlobal = runInNewContext("globalThis", sandbox);
+    const ObjectCtor = runInContext("Object", sandbox);
+    expect(new Script("Object").runInNewContext(contextGlobal)).toBe(ObjectCtor);
+    expect(runInNewContext("Object", contextGlobal)).toBe(ObjectCtor);
+    runInNewContext("var viaGlobal = 1", contextGlobal);
+    expect(sandbox.viaGlobal).toBe(1);
+  });
+
+  test.concurrent("measureMemory() still lists a context created by vm.runInNewContext()", async () => {
+    const code = `
+      const vm = require("node:vm");
+      const count = async () => (await vm.measureMemory({ mode: "detailed" })).other.length;
+      const before = await count();
+      const sandbox = {};
+      vm.runInNewContext("1", sandbox);
+      const after = await count();
+      console.log(before, after, vm.isContext(sandbox));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("ExperimentalWarning");
+    expect(stdout).toBe("0 1 true\n");
     expect(exitCode).toBe(0);
   });
 });
@@ -1133,6 +1286,17 @@ describe("DONT_CONTEXTIFY", () => {
 
     ctx.fromOutside = 456;
     expect(runInContext("fromOutside", ctx)).toBe(456);
+  });
+
+  test("runInNewContext() on a DONT_CONTEXTIFY context runs in that context", () => {
+    const ctx = createContext(constants.DONT_CONTEXTIFY);
+    const ObjectCtor = runInContext("Object", ctx);
+    expect(runInNewContext("Object", ctx)).toBe(ObjectCtor);
+    expect(new Script("Object").runInNewContext(ctx)).toBe(ObjectCtor);
+
+    runInNewContext("let viaVm = 1", ctx);
+    new Script("let viaScript = 2").runInNewContext(ctx);
+    expect(runInContext("[viaVm, viaScript].join()", ctx)).toBe("1,2");
   });
 });
 


### PR DESCRIPTION
### Problem
- `vm.runInNewContext(code, sandbox)` evaluates in a brand-new realm on every call, even when `sandbox` is already a context. Node reuses the sandbox's context: `vm.runInNewContext("Object", sb) === vm.runInNewContext("Object", sb)` is `true` in node v26.3.0 and `false` in bun 1.4.0 / main, `vm.runInNewContext("let q = 1", sb); vm.runInNewContext("q", sb)` is `1` in node and `ReferenceError: q is not defined` in bun, and values produced by `runInNewContext` fail `instanceof` against constructors read back with `runInContext` on the same sandbox. Same for `new vm.Script(...).runInNewContext(ctx)` on a context made by `createContext()`.
- Cause: `scriptRunInNewContext` (`src/jsc/bindings/NodeVMScript.cpp`) called `NodeVMGlobalObject::create` unconditionally, without consulting `vmModuleContextMap()` the way `scriptRunInContext` and `vmModule_createContext` do, and did not register the global it made. Because `vm.runInNewContext` in `src/js/node/vm.ts` first calls `createContext()` (which creates and registers a realm) and then the native method, every `vm.runInNewContext(code, sandbox)` call built two realms: the registered one that `runInContext()` later finds, and a throwaway one the code actually ran in.
- Side effects of the same cause: a sandbox first used via `script.runInNewContext(sb)` never became a context (`vm.isContext(sb)` stayed `false`, `vm.runInContext(code, sb)` threw `ERR_INVALID_ARG_TYPE`), and `vm.runInNewContext(code, sb, { contextCodeGeneration })` was only honored because the throwaway realm was built from those options; the registered realm was created by `createContext()` reading `codeGeneration`, a key `runInNewContext` options do not carry.

### Fix
- `scriptRunInNewContext` resolves the sandbox with `getGlobalObjectFromContext()` and runs in that realm when there is one. Only an object that is not a context yet gets a realm, through a new `NodeVM::makeContext()` that `vmModule_createContext` uses too: create, attach the sandbox (and the `DONT_CONTEXTIFY` handle), then register in `vmModuleContextMap()` as the last step so a lookup never returns a half-built context. The map key is the object the caller gets back: the sandbox, or for `DONT_CONTEXTIFY` the handle. Keying the internal placeholder object (what `createContext` did) left an entry that only the context's own `m_sandbox` kept alive, and the first run replaces `m_sandbox`, so the entry was collected while the context was still in use. The unreachable native `vmModuleRunInNewContext` binding (vm.ts never used it) is deleted, which leaves `makeContext()` as the only caller of `NodeVMGlobalObject::create`, so every context is registered and the entry points cannot drift apart again.
- The run passes the context's own sandbox (or its `DONT_CONTEXTIFY` handle) to the evaluation helper rather than the argument, so handing it a context's `globalThis` proxy runs in that context instead of installing the proxy as its own sandbox (that self-reference is the recursion #36238 fixes for `runInContext`).
- `vm.runInNewContext` maps its options onto the `createContext()` names the way Node's `getContextOptions()` does (`contextName` / `contextOrigin` / `contextCodeGeneration` / `microtaskMode` to `name` / `origin` / `codeGeneration` / `microtaskMode`), since the context created there is now the one the script runs in. They are validated under the caller's names first, so messages still read `options.contextCodeGeneration.wasm` and, as in Node, an invalid option is rejected before the sandbox is contextified. Also as in Node, `importModuleDynamically` is not copied onto the context: the `Script` built from the same options carries it, and that is what an `import()` in the code resolves through (the context-level callback only serves code with no script of its own). Before, the throwaway realm happened to receive it as well; a direct `script.runInNewContext(freshObject, options)` still sets it, unchanged.
- Why this is correct: it is Node's definition of the API. `lib/vm.js` implements both `vm.runInNewContext()` and `Script#runInNewContext()` as `createContext(contextObject, getContextOptions(options))` followed by `runInContext()`, and `createContext()` returns an object that is already a context unchanged. That also fixes the behaviors that follow from it and are pinned by the tests: context options are validated but ignored for an existing context (node returns `2` for `vm.runInNewContext("eval('1+1')", ctx, { contextCodeGeneration: { strings: false } })`; bun used to throw `EvalError`), options given when `runInNewContext` creates the context stay with it for later runs, and a redeclared top-level `let` is a `SyntaxError` from the context's realm. A missing sandbox or `DONT_CONTEXTIFY` still gets a fresh realm per call, since `getContextArg` makes a new object each time.
- Each `vm.runInNewContext(code, sandbox)` call now builds one realm instead of two. `measureMemory({ mode: "detailed" })` now takes its per-context entries from the same weak map (`contextCount()` binding, the map's live key count), so it agrees with `isContext()` for contexts made by `createContext()`, `vm.runInNewContext()` and `Script#runInNewContext()` alike (node prints the same counts for the sequence in the test); the WeakRef list vm.ts kept for this, which only saw the `createContext()` wrapper, is gone.
- Verification: new `describe("runInNewContext() on a sandbox that is already a context")` block plus a `DONT_CONTEXTIFY` case in `test/js/node/vm/vm.test.ts` (12 of the 13 new tests fail on bun 1.4.0, all pass with the fix); the same assertions run as a plain script pass on node v26.3.0. The "throwing getters" matrix there drops the `codeGeneration.*` keys that `vm.runInNewContext` no longer reads (node never reads them).
- Also run with the fix: `vm.test.ts` under `BUN_JSC_validateExceptionChecks=1`; all 100 vendored `test-vm-*` files (parallel + sequential), including `test-vm-codegen.js`, `test-vm-basic.js`, `test-vm-context-dont-contextify.js`, `test-vm-new-script-new-context.js`; the rest of `test/js/node/vm/`; the other test files using `runInNewContext` (`util`, `util-promisify`, `capture-stack-trace`, `regression/issue/09778`, `domjit`) and a few `test-repl-*` context tests. `script-leak.test.ts` and the DOMJIT stress loops exceed their time budgets on this debug+ASAN build with and without the change (CI expects 1.9 s / 10.4 s for them on ASAN; they are roughly 10x slower here).
- Related open PRs, none of which covers this bug: #34623 and #33077 each add an early return to `scriptRunInNewContext` that is taken only for a `DONT_CONTEXTIFY` handle (a `JSGlobalProxy` of a not-contextified global, resp. a `NodeVMSpecialSandbox`), plus their own option remap in `vm.ts` for that case; a plain contextified sandbox is neither, so they still build an unregistered second realm for it. The lookup here subsumes both early returns, so the overlap is a textual conflict at the same lines for whichever lands later. #38317 adds two lines right after the `createContext()` call edited here; same kind of conflict. The explicit `strings: undefined` / `wasm: undefined` rejection in the native `getNodeVMContextOptions` is pre-existing, still reached through `Script#runInNewContext`, and tracked separately.

### Background
- Context: what `vm.createContext(sandbox)` produces. In Bun it is a `NodeVMGlobalObject`, a separate realm (its own global object and its own copies of `Object`, `Error`, etc.) whose property access is forwarded to the user's sandbox object. `vmModuleContextMap()` on the main global is a `JSWeakMap` from sandbox object to its `NodeVMGlobalObject`; being in that map is what `isContext()` means, and `getGlobalObjectFromContext()` is the lookup that also accepts a context's `globalThis` proxy and the `DONT_CONTEXTIFY` handle.
- Sandbox vs realm: `var` declarations and plain assignments in context code become properties of the sandbox object, but top-level `let` / `const` / `class` bindings live in the realm's global lexical environment, so they only survive across calls if the calls share the realm. `instanceof` across realms is false for the same reason.
- `DONT_CONTEXTIFY`: `createContext(vm.constants.DONT_CONTEXTIFY)` makes a context with no user sandbox; Bun creates an internal placeholder object to stand in as the sandbox and returns a `NodeVMSpecialSandbox` handle that resolves back to the realm; after this PR the handle is also what is registered in the map. Runs against such a context pass the handle to the evaluation helper, which is what `runInContext()` already does.
- `contextCodeGeneration` / `microtaskMode`: `runInNewContext` options that configure the context being created (`codeGeneration` and `microtaskMode` in `createContext()` terms). They are fixed when the `NodeVMGlobalObject` is made, which is why they have to reach whichever call creates it and why node ignores them for an existing context. `contextName` / `contextOrigin` are validated and forwarded the same way; Bun's native side currently validates `name` / `origin` and stores neither.

<details>
<summary>Probe (node v26.3.0 vs bun 1.4.0; the fixed build prints node's column)</summary>

```js
const vm = require("node:vm");
const sb = {};
vm.runInNewContext("Object", sb) === vm.runInNewContext("Object", sb);   // node: true   bun: false
vm.runInNewContext("let q = 1", sb); vm.runInNewContext("q", sb);        // node: 1      bun: ReferenceError: q is not defined
vm.runInNewContext("Object", sb) === vm.runInContext("Object", sb);      // node: true   bun: false
const ctx = vm.createContext({});
new vm.Script("Object").runInNewContext(ctx) === new vm.Script("Object").runInContext(ctx); // node: true  bun: false
const fresh = {};
new vm.Script("1").runInNewContext(fresh); vm.isContext(fresh);          // node: true   bun: false
vm.runInNewContext("eval('1+1')", ctx, { contextCodeGeneration: { strings: false } }); // node: 2  bun: EvalError
vm.runInNewContext("Object") !== vm.runInNewContext("Object");           // node: true   bun: true (unchanged)
```

</details>

<details>
<summary>Earlier revision of this description</summary>

The first push registered the sandbox before attaching the DONT_CONTEXTIFY handle, kept the unused native `vmModuleRunInNewContext`, mapped only `contextCodeGeneration` / `microtaskMode` in `vm.ts`, and left `measureMemory()` on the WeakRef list filled by the JS `createContext()` wrapper (so a context made directly by `Script#runInNewContext()` was registered but not listed). Review feedback moved the registration last, removed the dead binding, extended the mapping to `contextName` / `contextOrigin` (validated in JS first, which is also what keeps `test-vm-basic.js`'s `options.contextName` messages intact), switched `measureMemory()` to the registry, and then (second review round) changed the map key of a `DONT_CONTEXTIFY` context from the placeholder object to the handle, since the registry-based count exposed that the placeholder entry was collected after the first run; the measureMemory test now collects garbage before each measurement. The validation and measureMemory tests grew accordingly, which is why the fail-before count went from 10 to 12.

</details>
