### PR TITLE
error printer: keep async and <anonymous> frame names once error.stack has been read

### DIFF
--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -251,8 +251,7 @@ public:
         bool isConstructor = false;
         bool isGlobalCode = false;
         bool isAsync = false;
-        // The frame was printed as "name (url)" or "<anonymous> (url)" rather
-        // than as a bare "url" (module top-level code, native frames).
+        // Printed as "name (url)" or "<anonymous> (url)", not as a bare "url".
         bool isFunction = false;
     };
 

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -251,6 +251,9 @@ public:
         bool isConstructor = false;
         bool isGlobalCode = false;
         bool isAsync = false;
+        // The frame was printed as "name (url)" or "<anonymous> (url)" rather
+        // than as a bare "url" (module top-level code, native frames).
+        bool isFunction = false;
     };
 
     WTF::StringView stack;
@@ -399,6 +402,8 @@ public:
             frame.isConstructor = true;
             functionName = functionName.substring(4);
         }
+
+        frame.isFunction = !functionName.isEmpty();
 
         if (functionName == "<anonymous>"_s) {
             functionName = StringView();
@@ -619,6 +624,8 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
                             current.code_type = ZigStackFrameCodeConstructor;
                         } else if (frame.isGlobalCode) {
                             current.code_type = ZigStackFrameCodeGlobal;
+                        } else if (frame.isFunction) {
+                            current.code_type = ZigStackFrameCodeFunction;
                         }
 
                         except.stack.frames_len += 1;

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -596,10 +596,9 @@ test("error.stack doesnt lose frames", () => {
           at middle (<dir>/inspect.test.ts:<num>:<num>)
           at IGNORE_ME_BEFORE_THIS_LINE (<dir>/inspect.test.ts:<num>:<num>)
           at accessErrorStackProperty (<dir>/inspect.test.ts:<num>:<num>)
-          at <dir>/inspect.test.ts:<num>:<num>
+          at <anonymous> (<dir>/inspect.test.ts:<num>:<num>)
     "
   `);
 
-  // We allow it to differ by the existence of <anonymous> as a string. But that's it.
-  expect(no.split("\n").slice(0, -2).join("\n").trim()).toBe(yes.split("\n").slice(0, -2).join("\n").trim());
+  expect(yes).toBe(no);
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
 import { join } from "node:path";
 
@@ -148,4 +148,103 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// Once error.stack has been read (or assigned), JSC no longer has the frames of
+// the error, and Bun.inspect / console.error / the uncaught error output print
+// the frames parsed back out of that string instead.
+describe("printing the frames parsed back out of error.stack", () => {
+  const printedFrames = (text: string) =>
+    text
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at "));
+
+  // "at async outer (/x.js:1:2)" -> "at async outer": where the frames point is
+  // not what is being tested here.
+  const withoutLocation = (line: string) => line.replace(/ \(.*$/, "");
+
+  test("async, <anonymous>, new and bare frames print as they do in error.stack", () => {
+    const err = new Error("boom");
+    err.stack = [
+      "Error: boom",
+      "    at async fetchUser (/fake/api.js:10:9)",
+      "    at async <anonymous> (/fake/app.js:4:3)",
+      "    at <anonymous> (/fake/app.js:9:1)",
+      "    at new Client (/fake/client.js:2:11)",
+      "    at run (/fake/main.js:7:5)",
+      "    at global code (/fake/main.js:12:1)",
+      "    at unknown",
+    ].join("\n");
+
+    const expected = [
+      "at async fetchUser (/fake/api.js:10:9)",
+      "at async <anonymous> (/fake/app.js:4:3)",
+      "at <anonymous> (/fake/app.js:9:1)",
+      "at new Client (/fake/client.js:2:11)",
+      "at run (/fake/main.js:7:5)",
+      "at /fake/main.js:12:1",
+      expect.stringMatching(/^at unknown\b/),
+    ];
+    expect(printedFrames(Bun.inspect(err, { colors: false }))).toEqual(expected);
+    expect(printedFrames(Bun.stripANSI(Bun.inspect(err, { colors: true })))).toEqual(expected);
+  });
+
+  test("Bun.inspect prints the same frames before and after error.stack has been read", async () => {
+    async function inner() {
+      await 1;
+      throw new Error("boom");
+    }
+    async function outer() {
+      await inner();
+    }
+    const err: Error = await (async () => {
+      await outer();
+    })().catch(e => e);
+
+    const ownFrames = (text: string) =>
+      printedFrames(text)
+        .filter(line => line.includes("stack.test.ts"))
+        .map(withoutLocation);
+    const before = ownFrames(Bun.inspect(err));
+    const stack = ownFrames(err.stack!);
+    const after = ownFrames(Bun.inspect(err));
+
+    expect(before).toEqual(["at inner", "at async outer", "at async <anonymous>"]);
+    expect({ stack, after }).toEqual({ stack: before, after: before });
+  });
+
+  test("console.error and the unhandled rejection output keep the async frames", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          async function inner() {
+            await 1;
+            throw new Error("boom");
+          }
+          async function outer() {
+            await inner();
+          }
+          (async () => {
+            await outer();
+          })().catch(e => {
+            e.stack; // e.g. a logger reading it
+            console.error(e);
+            throw e;
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Printed once by console.error(e) and once as an unhandled rejection.
+    const expected = ["at inner", "at async outer", "at async <anonymous>"];
+    expect(printedFrames(stderr).map(withoutLocation)).toEqual([...expected, ...expected]);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -240,11 +240,12 @@ describe("printing the frames parsed back out of error.stack", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Printed once by console.error(e) and once as an unhandled rejection.
     const expected = ["at inner", "at async outer", "at async <anonymous>"];
     expect(printedFrames(stderr).map(withoutLocation)).toEqual([...expected, ...expected]);
+    expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem

- Once `error.stack` has been read (or assigned), `Bun.inspect(err)`, `console.error(err)` and the unhandled rejection output print `at mid (...)` for a frame that `error.stack` shows as `at async mid (...)`, and print a bare `at /app/main.js:9:9` for a frame it shows as `at async <anonymous> (...)` or `at <anonymous> (...)`. Before `.stack` is read the same error prints these frames the way `error.stack` does, so the printed trace depends on whether a logger or error reporter touched `.stack` first. Reproduces on 1.4.0 and on main (repro and output below).
- Cause: once `.stack` is materialized JSC drops the structured frames, so `fromErrorInstance` (`src/jsc/bindings/ZigException.cpp`) re-parses the string with `V8StackTraceIterator`. Its callback copied `is_async` but only set `code_type` for `new X` (Constructor) and `global code` (Global) lines; every other frame was left as `ZigStackFrameCodeNone`. `NameFormatter` (`src/jsc/ZigStackFrame.rs`) renders the `async ` prefix and the `<anonymous>` placeholder only in its `FUNCTION` arm; the fallback arm prints the name as-is, and `parseFrame` turns `<anonymous>` into an empty name, so those frames printed as a bare location. The structured path marks the same frames `ZigStackFrameCodeFunction` (`populateStackFrameMetadata`), which is why it prints them correctly. The `is_async` of parsed frames has been set since #22517 but never reached the formatter.

### Fix

- `parseFrame` records whether the line had a name part (`name (url)` or `<anonymous> (url)`, as opposed to a bare `url`), and the callback marks such frames `ZigStackFrameCodeFunction`; `new X` and `global code` lines keep their Constructor / Global types as before.
- This gives the parsed frames the `code_type` the structured path gives function frames, so the same formatter arm renders both and the output no longer depends on whether `.stack` was materialized. `error.stack` only prints a name part (including `<anonymous>`) for frames that had a callee, and prints module top-level and native frames as a bare location, so "had a name part" is exactly the set of frames the structured path marks Function.
- Output for named non-async frames is unchanged (`FUNCTION` and the fallback arm both print the bare name); the only lines that change are the ones gaining `async ` or `<anonymous>`, and both now match `error.stack` and the pre-`.stack` printout. Bare-location lines (`at unknown` today, and the lines #38308 starts accepting) stay `None` and still print as a bare location, so nothing gains an invented `<anonymous>`.
- Verified with the new describe block in `test/js/bun/test/stack.test.ts`: an assigned stack string covering async named, async anonymous, anonymous, `new`, plain, `global code` and bare `unknown` frames (with and without colors); a real async chain whose printed frame names have to be the same before `.stack` is read, in `.stack`, and after; and a spawned process checking `console.error` and the unhandled rejection output. All three fail on main and pass with the fix.
- One existing test changes: `test/cli/inspect/inspect.test.ts` "error.stack doesnt lose frames" compares `Bun.inspect` output with and without reading `error.stack` and had snapshotted the bare-location rendering of the last frame for the `error.stack` case, comparing the two outputs minus that frame. The two outputs are now identical, so its snapshot is updated and it compares them in full.
- Also ran `test/js/bun/test`, `test/cli/test` and the inspect / reportError / vm printer tests against the debug build; the only failures are unrelated to frame printing and happen without this change too (a `[2.46s]` timing suffix, ANSI expectations without a TTY, the `--parallel` worker scaling timing, the deep-nesting `pretty_format` SIGSEGV that #34885 addresses, and the debug-only `at require (51:24)` frame in `inspect-error.test.js`).
- Open PRs in the same function, all independent of this one: #38308 (accept bare-location lines in `parseFrame`), #38296 (positions of re-parsed frames remapped twice), #35685 (async module frames; it changes the formatter's fallback arm for nameless async frames, which this change does not touch).

### Background

- A JSC `ErrorInstance` keeps its captured `JSC::StackFrame`s only until the `stack` property is first materialized (read or assigned); after that only the string is left. Bun's error printer (`toZigException` -> `fromErrorInstance`) therefore has two producers of `ZigStackFrame`s: `populateStackFrameMetadata` for JSC frames, and the `V8StackTraceIterator` re-parse of the string.
- `ZigStackFrame.code_type` (None / Eval / Module / Function / Global / Wasm / Constructor) selects how `NameFormatter` renders the name: Function renders `[async ]name` or `[async ]<anonymous>`, Constructor renders `new name`, Global renders nothing, and the fallback renders the name as-is. `print_stack_trace` (`src/jsc/VirtualMachine.rs`) prints `at NAME (LOCATION)` when the formatter produced anything and `at LOCATION` otherwise, which is how a `<anonymous>` frame with `code_type == None` collapsed to a bare location.
- `error.stack` lines (`FormatStackTraceForJS.cpp`) look like `    at [async ]name (url:line:col)`, with `<anonymous>` substituted when a function or eval frame has no name, and a bare `    at url:line:col` for frames without a callee (module top-level code, native frames).

<details>
<summary>Repro</summary>

```js
async function inner() { await 1; throw new Error("X"); }
async function mid() { await inner(); }
(async () => { await mid(); })().catch(e => {
  console.log(Bun.inspect(e));   // before .stack is read
  e.stack;                       // e.g. a logger
  console.log(Bun.inspect(e));   // after
});
```

Frames of the two prints on bun 1.4.0 and main:

```
      at inner (/tmp/x.js:1:45)
      at async mid (/tmp/x.js:2:30)
      at async <anonymous> (/tmp/x.js:3:22)

      at inner (/tmp/x.js:1:45)
      at mid (/tmp/x.js:1:32)
      at /tmp/x.js:1:54
```

With this change the second print becomes:

```
      at inner (/tmp/x.js:1:45)
      at async mid (/tmp/x.js:1:32)
      at async <anonymous> (/tmp/x.js:1:54)
```

The line:column of the re-parsed frames being off is the separate double remap fixed by #38296; `error.stack` itself is unaffected either way.

</details>
