### PR TITLE
error printer: don't invent a 1:1 position for frames parsed out of error.stack without one

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5360,7 +5360,9 @@ impl VirtualMachine {
                     }
                 };
             }
-            if has_name && !frame.position.is_invalid() {
+            // Frames parsed back out of error.stack can have a file without a
+            // position ("at foo (native)"); the formatter then prints the file alone.
+            if has_name && (!file.is_empty() || !frame.position.is_invalid()) {
                 pretty_write!(
                     "<r>      <d>at <r>{}<d> (<r>{}<d>)<r>\n",
                     frame.name_formatter(allow_ansi_colors),
@@ -5630,13 +5632,11 @@ impl VirtualMachine {
             Some(bun_sourcemap::mapping::Lookup {
                 mapping: bun_sourcemap::mapping::Mapping {
                     generated: bun_sourcemap::LineColumnOffset::default(),
+                    // Direct copy (both are `bun_core::Ordinal`) so that a frame
+                    // without a position stays INVALID instead of becoming 1:1.
                     original: bun_sourcemap::LineColumnOffset {
-                        lines: bun_sourcemap::Ordinal::from_zero_based(
-                            frames[top].position.line.zero_based().max(0),
-                        ),
-                        columns: bun_sourcemap::Ordinal::from_zero_based(
-                            frames[top].position.column.zero_based().max(0),
-                        ),
+                        lines: frames[top].position.line,
+                        columns: frames[top].position.column,
                     },
                     source_index: 0,
                     name_index: -1,
@@ -5688,6 +5688,11 @@ impl VirtualMachine {
                 }
                 if top_frame_is_builtin {
                     // Avoid printing "export default 'native'"
+                    break 'code bun_core::ZigStringSlice::EMPTY;
+                }
+                if !mapping.original.lines.is_valid() {
+                    // No line to preview (a frame parsed out of error.stack that
+                    // only names a file); line 1 would be an arbitrary choice.
                     break 'code bun_core::ZigStringSlice::EMPTY;
                 }
                 let mut log = bun_ast::Log::default();
@@ -6558,16 +6563,19 @@ impl VirtualMachine {
 
         let mut has_location = false;
         if let Some(frame) = top_frame {
-            if !frame.position.is_invalid() {
+            if frame.position.line.is_valid() {
                 let source_url = frame.source_url.to_utf8();
                 let file = bun_paths::resolve_path::relative(dir, source_url.slice());
                 let _ = write!(
                     writer,
-                    "\n::error file={},line={},col={},title=",
+                    "\n::error file={},line={},",
                     bun_core::fmt::github_action_property(file),
                     frame.position.line.one_based(),
-                    frame.position.column.one_based(),
                 );
+                if frame.position.column.is_valid() {
+                    let _ = write!(writer, "col={},", frame.position.column.one_based());
+                }
+                let _ = writer.write_all(b"title=");
                 has_location = true;
             }
         }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -245,8 +245,11 @@ public:
     public:
         StringView functionName {};
         StringView sourceURL {};
-        WTF::OrdinalNumber lineNumber = WTF::OrdinalNumber::fromZeroBasedInt(0);
-        WTF::OrdinalNumber columnNumber = WTF::OrdinalNumber::fromZeroBasedInt(0);
+        // beforeFirst() (-1) is ZigStackFramePosition's "unknown", so a frame
+        // printed without a line or column ("at foo (native)") stays unknown
+        // instead of becoming line 1, column 1.
+        WTF::OrdinalNumber lineNumber = WTF::OrdinalNumber::beforeFirst();
+        WTF::OrdinalNumber columnNumber = WTF::OrdinalNumber::beforeFirst();
 
         bool isConstructor = false;
         bool isGlobalCode = false;
@@ -611,6 +614,9 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
                         current.source_url = Bun::toStringRef(sourceURL);
                         current.position.line_zero_based = frame.lineNumber.zeroBasedInt();
                         current.position.column_zero_based = frame.columnNumber.zeroBasedInt();
+                        // `current = {}` zeroes byte_position; -1 keeps a frame without a
+                        // line and column equal to ZigStackFramePosition::INVALID.
+                        current.position.byte_position = -1;
 
                         current.remapped = true;
                         current.is_async = frame.isAsync;

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -9,21 +10,23 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
-5 |   const err2 = new Error("error 2", { cause: err });
+2 | import { bunEnv, bunExe, tempDir } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
+6 |   const err2 = new Error("error 2", { cause: err });
                        ^
 error: error 2
-      at <anonymous> ([dir]/inspect-error.test.js:5:20)
+      at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
+2 | import { bunEnv, bunExe, tempDir } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
                       ^
 error: error 1
-      at <anonymous> ([dir]/inspect-error.test.js:4:19)
+      at <anonymous> ([dir]/inspect-error.test.js:5:19)
 "
 `);
 });
@@ -35,15 +38,15 @@ test("Error", () => {
       .replaceAll("\\", "/")
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
-"27 | "
-28 | \`);
-29 | });
-30 | 
-31 | test("Error", () => {
-32 |   const err = new Error("my message");
+"30 | "
+31 | \`);
+32 | });
+33 | 
+34 | test("Error", () => {
+35 |   const err = new Error("my message");
                        ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:32:19)
+      at <anonymous> ([dir]/inspect-error.test.js:35:19)
 "
 `);
 });
@@ -71,22 +74,13 @@ note: "duplicateConstDecl" was originally declared here
   }
 });
 
-const normalizeError = str => {
-  // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
-    const splits = str.split("\n");
-    for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
-        splits.splice(i, 1);
-        i--;
-      }
-    }
-    return splits.join("\n");
-  }
-
-  return str;
-};
+const normalizeError = str =>
+  // remove debug-only stack trace frames of bun's own builtins, which have a
+  // position but no file, like "at require (51:24)"
+  str
+    .split("\n")
+    .filter(line => !/^\s*at \S+ \(:?\d+:\d+\)$/.test(line))
+    .join("\n");
 
 test("Error inside minified file (no color) ", () => {
   try {
@@ -111,7 +105,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:86:7)"
     `);
   }
 });
@@ -140,7 +134,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:114:7)"
     `);
   }
 });
@@ -154,7 +148,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:143:19)"
 `);
 });
 
@@ -187,4 +181,96 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
   expect(() => {
     throw err;
   }).toThrow();
+});
+
+// Once error.stack has been read (or assigned), JSC no longer has the frames of
+// the error and the printer parses the "    at ..." lines of that string instead.
+// A frame printed without a line and column (native code, "unknown") has no
+// position to parse, and must not come back out as line 1, column 1.
+describe("printing the frames parsed back out of error.stack without a position", () => {
+  const printedFrames = text =>
+    text
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at "));
+
+  const stackWithFrames = frames => ["Error: boom", ...frames.map(frame => `    at ${frame}`)].join("\n");
+
+  const inspectStack = frames => {
+    const err = new Error("boom");
+    err.stack = stackWithFrames(frames);
+    return Bun.inspect(err);
+  };
+
+  test("frames without a position, or with only a line, print as error.stack has them", () => {
+    const frames = [
+      "first (native)",
+      "second (node:child_process)",
+      "unknown",
+      "third (/fake/lib.js:3:4)",
+      "fourth (/fake/lib.js:7)",
+    ];
+    expect(printedFrames(inspectStack(frames))).toEqual(frames.map(frame => `at ${frame}`));
+  });
+
+  test("a native frame is the only frame, so the source preview is looked up for it", () => {
+    expect(printedFrames(inspectStack(["first (native)"]))).toEqual(["at first (native)"]);
+  });
+
+  const inspectedLines = frames => inspectStack(frames).trimEnd().split("\n");
+
+  test("no source preview for a frame that names a file but no line in it", () => {
+    using dir = tempDir("inspect-error-no-position", { "lib.js": "// line 1\n// line 2\n" });
+    const file = `${dir}/lib.js`;
+    expect(inspectedLines([`first (${file})`])).toEqual(["error: boom", `      at first (${file})`]);
+  });
+
+  test("the source preview and its caret belong to the first frame that has a position", () => {
+    using dir = tempDir("inspect-error-no-position", { "lib.js": "// line 1\n// line 2\n" });
+    const file = `${dir}/lib.js`;
+    expect(inspectedLines(["first (native)", `second (${file}:2:5)`])).toEqual([
+      "1 | // line 1",
+      "2 | // line 2",
+      "        ^",
+      "error: boom",
+      "      at first (native)",
+      `      at second (${file}:2:5)`,
+    ]);
+  });
+
+  describe.concurrent("uncaught exception printout and GitHub Actions annotation", () => {
+    const throwUncaught = async frames => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const err = new Error("boom"); err.stack = ${JSON.stringify(stackWithFrames(frames))}; throw err;`,
+        ],
+        env: { ...bunEnv, GITHUB_ACTIONS: "true", GITHUB_WORKSPACE: "/fake" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+      return {
+        frames: printedFrames(stderr),
+        annotation: stderr.split("\n").find(line => line.startsWith("::error ")),
+      };
+    };
+
+    test("top frame without a position: the annotation has no file, line or column", async () => {
+      expect(await throwUncaught(["first (native)", "unknown", "second (/fake/lib.js:3:4)"])).toEqual({
+        frames: ["at first (native)", "at unknown", "at second (/fake/lib.js:3:4)"],
+        annotation: expect.stringMatching(/^::error title=error: boom::/),
+      });
+    });
+
+    test("top frame with only a line: the annotation has no column", async () => {
+      expect(await throwUncaught(["first (/fake/lib.js:7)", "second (native)"])).toEqual({
+        frames: ["at first (/fake/lib.js:7)", "at second (native)"],
+        annotation: expect.stringMatching(/^::error file=(.*[\\/])?lib\.js,line=7,title=error: boom::/),
+      });
+    });
+  });
 });

--- a/test/regression/issue/23022-stack-trace-iterator.test.ts
+++ b/test/regression/issue/23022-stack-trace-iterator.test.ts
@@ -27,7 +27,8 @@ test("V8StackTraceIterator handles frames without parentheses (issue #23022)", a
   const stackFrames = err.stack?.split("\n").filter(line => line.trim().startsWith("at"));
   expect(stackFrames?.length).toBeGreaterThan(3);
 
-  // Ensure both "unknown" frames and regular frames are present
-  expect(inspected).toContain("at unknown");
+  // Ensure both "unknown" frames and regular frames are present. The "unknown"
+  // frame has no position in error.stack, so the printout must not invent one.
+  expect(inspected).toMatch(/^\s+at unknown$/m);
   expect(inspected).toContain("at _write");
 });


### PR DESCRIPTION
### Problem

- Once `error.stack` has been read or assigned, `Bun.inspect(err)`, `console.error(err)` and the uncaught exception printout rebuild the frames by parsing that string. Frames the string prints without a position come back out with one invented for them: `at foo (native)` prints as `at foo (native:1:1)`, `at unknown` as `at unknown:1:1`, and a frame with only a line, `at bar (x.js:7)`, as `at bar (x.js:7:1)`. Reproduces on 1.4.0 and on main:

  ```js
  const e = new Error("X");
  e.stack = "Error: X\n    at foo (native)\n    at unknown\n    at bar (/a/b.js:7)";
  console.log(Bun.inspect(e));   // foo (native:1:1), unknown:1:1, bar (/a/b.js:7:1)
  ```

  Real errors hit it too: after `.stack` is read, a `JSON.parse` SyntaxError prints `at parse (unknown:1:1)`, an indirect eval `at eval (unknown:1:1)`, and the `ERR_SOCKET_CLOSED` error in `test/regression/issue/23022-stack-trace-iterator.test.ts` prints `at unknown:1:1`.
- The invented position is also acted on: the source preview is looked up for it, so a stack whose first frame is `at first (native)` followed by a real frame draws the caret at column 1 instead of under the real frame's column, a frame naming a file without a line gets line 1 of that file previewed, and under `GITHUB_ACTIONS` the annotation for such an error is `::error file=../workspace/bun/native,line=1,col=1,...`.
- Cause, C++ side: `V8StackTraceIterator::StackFrame` (`src/jsc/bindings/ZigException.cpp:248`) initializes `lineNumber`/`columnNumber` to zero-based 0, a valid line 1 / column 1, and the copy in `fromErrorInstance` (`ZigException.cpp:612`) stores them unconditionally. `current = {}` also leaves `byte_position` at 0, so even with the ordinals unset the position would not equal `ZigStackFramePosition::INVALID`, which is what the Rust side tests with `is_invalid()`.
- Cause, Rust side (`src/jsc/VirtualMachine.rs`): `remap_zig_exception` builds the lookup for an already-remapped top frame with `.zero_based().max(0)` and writes it back, turning INVALID into 0:0 again (this dates back to the Zig version and was masked by the C++ default); `print_stack_trace` used `!position.is_invalid()` to decide whether a named frame has a file, so a frame with a file and no position would print as `at foo` with the file dropped; `print_github_annotation` printed `col=` whenever the position as a whole was set, which for a line-only frame is `col=0`.

### Fix

- `StackFrame` defaults the ordinals to `OrdinalNumber::beforeFirst()` (-1, the convention `CallSite.h` and `BunProcess.cpp` already use) and the copy sets `byte_position = -1`, the same explicit `-1, -1, -1` that `FormatStackTraceForJS.cpp` writes for frames it does not position. A frame whose location parsed to nothing is now exactly `ZigStackFramePosition::INVALID`; one that parsed a line only has a valid line and an invalid column.
- `remap_zig_exception` copies the top frame's ordinals into the lookup unchanged (both sides are `bun_core::Ordinal`, the same direct copy the write-back below it already does) and skips fetching the file for the preview when there is no line to preview. `print_stack_trace` prints `at name (file...)` when the frame has a file or a position. `print_github_annotation` keys the location on the line being valid and adds `col=` only when the column is.
- Why this is correct: the stack string is the only information these frames have, and it says there is no position, so the structured frame has to say the same thing with the sentinel every other producer uses (`Holder` initializes frames to it, the structured path leaves it for wasm frames, `FormatStackTraceForJS.cpp` writes it explicitly). The consumers already handle it: `SourceURLFormatter` prints `file`, `file:line` or `file:line:col` depending on which ordinals are valid, the JUnit reporter (`test_command.rs` `record_failure`) does the same, and the preview code skips frames whose position is invalid. The three places changed here were the ones that either used the sentinel as a proxy for "has a file" or clamped it away. The output now matches what `error.stack` itself says, and what Node prints for such frames (it never invents a position either).
- Blast radius beyond parsed frames: the only other producer of a frame with a file but no position is the dev server's browser error report (`error_report_request.rs`), and only when every frame is in the HMR runtime (otherwise those frames are dropped before printing); that case now prints `at fn (Bun HMR Runtime)` instead of `at fn`, which is what it already printed for such frames without a name. Structured frames are unaffected: `populateStackTrace` only keeps frames with a position or wasm frames, and wasm frames never get a file (`Zig::sourceURL` returns `[wasm code]`, which `populateStackFrameMetadata` discards), so they still print `at name` through the unchanged branch; builtin frames with a position but no file (`at require (51:24)` in debug builds) print as before. The GitHub annotation only changes for frames without a line (no location instead of a bogus one) or without a column (no `col=` instead of `col=0`/`col=1`).
- Interaction with open PRs: #37396 makes `error.stack` always print `:line:column` for frames that have one (today a frame at column 1 prints as `x.js:7`, which round-trips through this change as `x.js:7`, and through main as `x.js:7:1` by accident); once both land such frames round-trip exactly. #38308 and #36602 change the body of `parseFrame` and #38296 changes `remap_zig_exception` a few lines below the hunks here; none of them touch these lines, and the shared preamble of `inspect-error.test.js` (harness import, `normalizeError`, shifted snapshot line numbers) is byte-identical to theirs so either order rebases cleanly.
- Tests: `test/js/bun/util/inspect-error.test.js`, `describe("printing the frames parsed back out of error.stack without a position")`: the five frame shapes above through `Bun.inspect`; a native frame as the only frame (the clamp); a file without a line (no preview, no `:1:1`); a native frame above a positioned one (the caret belongs to the positioned one, which is what `byte_position = -1` buys); and two spawned uncaught errors under `GITHUB_ACTIONS=true` checking the printout and the annotation for a top frame without a position and with a line only. `test/regression/issue/23022-stack-trace-iterator.test.ts` now requires the `unknown` line to be exactly `at unknown`. All six fail on the release binary and on main's `src/` under `bun bd` (the `normalizeError` update in the same file also makes the two minified-file tests pass under `bun bd` again, as in #38308), and pass with this change.
- Also run with this change, all passing: `inspect.test.js`, `reportError.test.ts`, `test/js/bun/test/stack.test.ts`, `error-name-preservation.test.ts`, `circular-error-stack*.test.ts`, `fix-bindings-stack-trace.test.ts`, `prepare-stack-trace-crash.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/cli/test/bun-test.test.ts` (the existing annotation tests), `test/js/bun/test/bun_test.test.ts`.

### Background

- `error.stack` is lazy in JSC: an `ErrorInstance` keeps the captured `JSC::StackFrame`s until `.stack` is first read or written, formats them into the string, and drops them. Bun's native error printer (`remap_zig_exception` + `print_error_instance_body` in `VirtualMachine.rs`, behind `Bun.inspect`, `console.*`, uncaught exceptions and the test reporters) therefore has two sources of frames: the structured ones while they exist, otherwise the string, which `fromErrorInstance` parses back into `ZigStackFrame`s with `V8StackTraceIterator`.
- `ZigStackFrame` / `ZigStackFramePosition` are the `#[repr(C)]` structs shared between the C++ that fills them and the Rust that prints them. A position is three `i32`s: zero-based line, zero-based column and a byte offset, each `-1` when unknown; `ZigStackFramePosition::INVALID` is all three at `-1` and `is_invalid()` compares the whole struct. `bun_core::Ordinal` and `WTF::OrdinalNumber` are the same representation of "zero-based index, -1 means none" on the two sides.
- V8-format stack strings print a frame's location as `file`, `file:line` or `file:line:column`. Native functions print as `name (native)`, and frames with neither a name nor a file print as the bare word `unknown`; both are common in Bun's own stacks.

<details>
<summary>Outputs before and after</summary>

Release 1.4.0 / main, the repro from the test file:

```
error: boom
      at first (native:1:1)
      at second (node:child_process:1:1)
      at unknown:1:1
      at third (/fake/lib.js:3:4)
      at fourth (/fake/lib.js:7:1)
```

With this change:

```
error: boom
      at first (native)
      at second (node:child_process)
      at unknown
      at third (/fake/lib.js:3:4)
      at fourth (/fake/lib.js:7)
```

Real errors after `.stack` was read, with this change (`at <parse>` for `JSON.parse` previously printed as `at <parse> (1:1)`; its presence at all is a separate, already tracked issue):

```
SyntaxError: JSON Parse error: Expected '}'
      at <parse>
      at parse (unknown)

error: from eval
      at file:///tmp/caret/main.js:1:16
      at eval (unknown)
```

Annotations on release for the two spawned test cases:

```
::error file=../workspace/bun/native,line=1,col=1,title=error: boom::...
::error file=lib.js,line=7,col=1,title=error: boom::...
```

With this change:

```
::error title=error: boom::...
::error file=lib.js,line=7,title=error: boom::...
```

</details>
