### PR TITLE
Bun.write: carry the promise as the WriteFile job's JS side so a stopped worker releases it

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3740,7 +3740,7 @@ use crate::webcore::s3_file as S3File;
 // The `write_file` module name coexists with `pub fn write_file` below (module
 // vs value namespace); alias the module so the call sites read unambiguously.
 use self::write_file as write_file_mod;
-use self::write_file::{WriteFilePromise, WriteFileWaitFromLockedValueTask};
+use self::write_file::WriteFileWaitFromLockedValueTask;
 use bun_bundler::options_impl::LoaderExt as _;
 use bun_jsc::JsClass as _;
 use bun_jsc::zig_string::ZigString as JscZigString;
@@ -4634,26 +4634,18 @@ pub(crate) fn write_file_with_source_destination(
     let source_type = source_store.data.tag();
 
     if destination_type == store::DataTag::File && source_type == store::DataTag::Bytes {
-        let write_file_promise = bun_core::heap::into_raw(Box::new(WriteFilePromise {
-            promise: jsc::JSPromiseStrong::default(),
-            global_this: ctx,
-        }));
-
         // The borrowed views below are +0 on the store ref;
         // `WriteFile::create` takes its own ref.
         #[cfg(windows)]
         {
-            let promise = JSPromise::create(ctx);
-            let promise_value = promise.as_value(ctx);
+            let promise = jsc::JSPromiseStrong::init(ctx);
+            let promise_value = promise.value();
             promise_value.ensure_still_alive();
-            // SAFETY: write_file_promise was just produced by heap::alloc above; sole owner.
-            unsafe { (*write_file_promise).promise.set(ctx, promise_value) };
             match write_file_mod::WriteFileWindows::create(
                 ctx.bun_vm().event_loop(),
                 destination_blob.borrowed_view(),
                 source_blob.borrowed_view(),
-                write_file_promise,
-                WriteFilePromise::run,
+                promise,
                 options.mkdirp_if_not_exists.unwrap_or(true),
             ) {
                 Err(write_file_mod::WriteFileWindowsError::WriteFileWindowsDeinitialized) => {}
@@ -4670,18 +4662,14 @@ pub(crate) fn write_file_with_source_destination(
             let file_copier = write_file_mod::WriteFile::create(
                 destination_blob.borrowed_view(),
                 source_blob.borrowed_view(),
-                write_file_promise,
-                WriteFilePromise::run,
                 options.mkdirp_if_not_exists.unwrap_or(true),
             )
             .expect("unreachable");
             // Defer promise creation until we're just about to schedule the task.
-            // SAFETY: write_file_promise was just produced by heap::alloc above; sole owner.
-            unsafe { (*write_file_promise).promise = jsc::JSPromiseStrong::init(ctx) };
-            // SAFETY: same `write_file_promise` as above; still solely owned here.
-            let promise_value = unsafe { (*write_file_promise).promise.value() };
+            let promise = jsc::JSPromiseStrong::init(ctx);
+            let promise_value = promise.value();
             promise_value.ensure_still_alive();
-            write_file_mod::WriteFile::schedule(file_copier, ctx);
+            write_file_mod::WriteFile::schedule(file_copier, promise, ctx);
             return Ok(promise_value);
         }
     }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -24,30 +24,34 @@ use crate::webcore::body;
 
 bun_output::declare_scope!(WriteFile, hidden);
 
-// A tagged result-or-error union. Modeled
-// as a plain Rust enum: it only ever travels through the Rust fn-pointer
-// callbacks below (`WriteFileOnWriteFileCallback`), never across FFI, so the
-// layout is unconstrained.
-pub enum WriteFileResultType {
-    Result(SizeType),
-    Err(Box<SystemError>),
-}
-
-pub type WriteFileOnWriteFileCallback =
-    fn(ctx: *mut c_void, count: WriteFileResultType) -> Result<(), JsTerminated>;
-
 /// The completion token a `WriteFile` keeps across its async I/O.
 pub type WriteFileTask = bun_jsc::Completion<WriteFile>;
 
-// SAFETY: the two blobs are native values holding store refs (atomic counts);
-// io-loop registration state and an opaque completion ctx that only the
-// JS-thread completion dereferences — nothing used off-thread is thread-affine.
+/// Settle the `Bun.write()` promise with what the write produced. JS thread;
+/// the `WriteFile`/`WriteFileWindows` that did the writing is already freed.
+fn settle(
+    mut promise: jsc::JSPromiseStrong,
+    global: &JSGlobalObject,
+    result: Result<SizeType, SystemError>,
+) -> Result<(), JsTerminated> {
+    match result {
+        Ok(wrote) => promise.resolve(global, JSValue::js_number_from_uint64(wrote as u64)),
+        Err(err) => promise.reject_with_async_stack(global, Ok(err.to_error_instance(global))),
+    }
+}
+
+// SAFETY: the two blobs are native values holding store refs (atomic counts)
+// plus io-loop registration state — nothing thread-affine. The promise the
+// write settles lives in the job's JS side, never here.
 unsafe impl Send for WriteFile {}
 
 impl bun_jsc::JobContext for WriteFile {
     type OffThread = Self;
-    /// The completion is delivered through `on_complete_callback(ctx, ..)`.
-    type Js = ();
+    /// The `Bun.write()` promise: settled by `then`, or released by the VM's
+    /// teardown on the JS thread if the write is still out by then. Nothing
+    /// else in the job needs that thread, so the `WriteFile` a stopped VM
+    /// refuses or releases unrun is freed wherever that happens.
+    type Js = jsc::JSPromiseStrong;
     fn run(
         this: &mut Self,
         _vm: &bun_jsc::vm_handle::Borrow,
@@ -57,16 +61,20 @@ impl bun_jsc::JobContext for WriteFile {
         this.run(done);
         None
     }
-    fn then(this: Self, _: (), cx: &bun_jsc::JsThread<'_>) -> jsc::JsResult<()> {
-        Ok(WriteFile::then(this, cx.global())?)
+    fn then(
+        this: Self,
+        promise: jsc::JSPromiseStrong,
+        cx: &bun_jsc::JsThread<'_>,
+    ) -> jsc::JsResult<()> {
+        Ok(WriteFile::then(this, promise, cx.global())?)
     }
 }
 
 impl WriteFile {
-    /// JS thread: hand a prepared `WriteFile` to the work pool (the job is
-    /// its one heap allocation).
-    pub fn schedule(this: WriteFile, global: &JSGlobalObject) {
-        bun_jsc::Job::<WriteFile>::schedule(&global.js_thread(), this, ());
+    /// JS thread: hand a prepared `WriteFile` and the promise it settles to the
+    /// work pool (the job is its one heap allocation).
+    pub fn schedule(this: WriteFile, promise: jsc::JSPromiseStrong, global: &JSGlobalObject) {
+        bun_jsc::Job::<WriteFile>::schedule(&global.js_thread(), this, promise);
     }
 }
 
@@ -85,8 +93,6 @@ pub struct WriteFile {
     pub(crate) io_request: io::Request,
     pub(crate) state: AtomicU8, // ClosingState
 
-    pub(crate) on_complete_ctx: *mut c_void,
-    pub(crate) on_complete_callback: WriteFileOnWriteFileCallback,
     pub(crate) total_written: usize,
 
     #[cfg(not(windows))]
@@ -230,11 +236,9 @@ impl WriteFile {
     }
 
     #[cfg(not(windows))]
-    pub(crate) fn create_with_ctx(
+    pub(crate) fn create(
         file_blob: Blob,
         bytes_blob: Blob,
-        on_write_file_context: *mut c_void,
-        on_complete_callback: WriteFileOnWriteFileCallback,
         mkdirp_if_not_exists: bool,
     ) -> Result<WriteFile, Error> {
         let write_file = WriteFile {
@@ -251,8 +255,6 @@ impl WriteFile {
             io_poll: io::Poll::default(),
             io_request: io::Request::new(Self::on_request_writable),
             state: AtomicU8::new(ClosingState::Running as u8),
-            on_complete_ctx: on_write_file_context,
-            on_complete_callback,
             total_written: 0,
             could_block: false,
             close_after_io: false,
@@ -262,26 +264,6 @@ impl WriteFile {
         // `borrowed_view()`'s `StoreRef::clone`) and dropping the `WriteFile`
         // in `then` runs `StoreRef::drop`, so the ref/deref pair is RAII.
         Ok(write_file)
-    }
-
-    #[cfg(not(windows))]
-    pub(crate) fn create<C>(
-        file_blob: Blob,
-        bytes_blob: Blob,
-        context: *mut C,
-        callback: WriteFileOnWriteFileCallback,
-        mkdirp_if_not_exists: bool,
-    ) -> Result<WriteFile, Error> {
-        // The caller supplies a
-        // `*mut c_void`-typed callback directly (see `WriteFilePromise::run`),
-        // so this is just a `.cast()` on `context`.
-        WriteFile::create_with_ctx(
-            file_blob,
-            bytes_blob,
-            context.cast::<c_void>(),
-            callback,
-            mkdirp_if_not_exists,
-        )
     }
 
     // reshaped for borrowck — take (off, len) here and re-derive the slice
@@ -327,11 +309,15 @@ impl WriteFile {
         true
     }
 
-    pub(crate) fn then(mut this: WriteFile, _global: &JSGlobalObject) -> Result<(), JsTerminated> {
-        let cb = this.on_complete_callback;
-        let cb_ctx = this.on_complete_ctx;
-        let system_error = this.system_error.take();
-        let total_written = this.total_written;
+    pub(crate) fn then(
+        mut this: WriteFile,
+        promise: jsc::JSPromiseStrong,
+        global: &JSGlobalObject,
+    ) -> Result<(), JsTerminated> {
+        let result = match this.system_error.take() {
+            Some(err) => Err(err),
+            None => Ok(this.total_written as SizeType),
+        };
         // Cleanup is RAII: dropping the `Box` runs `WriteFile`'s field-drop
         // glue, which drops `bytes_blob.store`/`file_blob.store: Option<
         // StoreRef>` → `Store::deref()` — exactly one deref each.
@@ -341,16 +327,7 @@ impl WriteFile {
         // not an unbalanced ref.)
         drop(this);
 
-        if let Some(err) = system_error {
-            cb(cb_ctx, WriteFileResultType::Err(Box::new(err)))?;
-            return Ok(());
-        }
-
-        cb(
-            cb_ctx,
-            WriteFileResultType::Result(total_written as SizeType),
-        )?;
-        Ok(())
+        settle(promise, global, result)
     }
 
     pub(crate) fn run(&mut self, task: WriteFileTask) {
@@ -572,8 +549,8 @@ mod windows_impl {
         pub(crate) io_request: uv::fs_t,
         pub(crate) file_blob: Blob,
         pub(crate) bytes_blob: Blob,
-        pub(crate) on_complete_callback: WriteFileOnWriteFileCallback,
-        pub(crate) on_complete_ctx: *mut c_void,
+        /// The `Bun.write()` promise, settled by `run_from_js_thread`.
+        pub(crate) promise: jsc::JSPromiseStrong,
         pub(crate) mkdirp_if_not_exists: bool,
         pub(crate) uv_bufs: [uv::uv_buf_t; 1],
 
@@ -611,12 +588,13 @@ mod windows_impl {
     }
 
     impl WriteFileWindows {
-        pub(crate) fn create_with_ctx(
+        /// Starts the write. The promise is settled from the libuv completion,
+        /// or already by the time this returns `Err` (a synchronous failure).
+        pub(crate) fn create(
+            event_loop: *mut EventLoop,
             file_blob: Blob,
             bytes_blob: Blob,
-            event_loop: *mut EventLoop,
-            on_write_file_context: *mut c_void,
-            on_complete_callback: WriteFileOnWriteFileCallback,
+            promise: jsc::JSPromiseStrong,
             mkdirp_if_not_exists: bool,
         ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
             let mkdirp = mkdirp_if_not_exists
@@ -632,8 +610,7 @@ mod windows_impl {
             let write_file = Self::new(WriteFileWindows {
                 file_blob,
                 bytes_blob,
-                on_complete_ctx: on_write_file_context,
-                on_complete_callback,
+                promise,
                 mkdirp_if_not_exists: mkdirp,
                 io_request: bun_core::ffi::zeroed::<uv::fs_t>(),
                 uv_bufs: [uv::uv_buf_t {
@@ -1049,28 +1026,27 @@ mod windows_impl {
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
         /// On return, `*this` has been freed and must not be accessed again.
         pub(crate) unsafe fn run_from_js_thread(this: *mut Self) -> WriteFileWindowsError {
-            // SAFETY: caller contract — `this` is live; copy out everything we
-            // need before `deinit` frees the allocation.
-            let (cb, cb_ctx) = unsafe { ((*this).on_complete_callback, (*this).on_complete_ctx) };
+            // SAFETY: caller contract — `this` is live; take out everything the
+            // settle needs before `deinit` frees the allocation (`global_ref` is
+            // `'static`: the global outlives its event loop).
+            let (promise, global, result) = unsafe {
+                let result = match (*this).to_system_error() {
+                    Some(err) => Err(err),
+                    None => Ok((*this).total_written as SizeType),
+                };
+                (
+                    (*this).promise.take(),
+                    (*(*this).event_loop).global_ref(),
+                    result,
+                )
+            };
+            // SAFETY: caller contract — `this` is live; consumed here.
+            unsafe { Self::deinit(this) };
 
-            // SAFETY: caller contract — `this` is live.
-            if let Some(err) = unsafe { (*this).to_system_error() } {
-                // SAFETY: caller contract — `this` is live; consumed here.
-                unsafe { Self::deinit(this) };
-                if let Err(e) = cb(cb_ctx, WriteFileResultType::Err(Box::new(err))) {
-                    return e.into();
-                }
-            } else {
-                // SAFETY: caller contract — `this` is live.
-                let wrote = unsafe { (*this).total_written };
-                // SAFETY: caller contract — `this` is live; consumed here.
-                unsafe { Self::deinit(this) };
-                if let Err(e) = cb(cb_ctx, WriteFileResultType::Result(wrote as SizeType)) {
-                    return e.into();
-                }
+            match settle(promise, global, result) {
+                Ok(()) => WriteFileWindowsError::WriteFileWindowsDeinitialized,
+                Err(terminated) => terminated.into(),
             }
-
-            WriteFileWindowsError::WriteFileWindowsDeinitialized
         }
 
         /// # Safety
@@ -1200,7 +1176,7 @@ mod windows_impl {
                     aio::Closer::close(Fd::from_uv(fd), (*this).io_request.loop_);
                 }
                 // The store derefs happen via `StoreRef::drop` when the Box is
-                // reclaimed below (paired with the RAII note in `create_with_ctx`).
+                // reclaimed below (paired with the RAII note in `create`).
                 (*this).poll_ref.disable();
                 // (*this).io_request is a valid uv_fs_t embedded in this struct; uv_fs_req_cleanup
                 // is safe on a zeroed or previously-used req.
@@ -1209,74 +1185,6 @@ mod windows_impl {
                 drop(bun_core::heap::take(this));
             }
         }
-
-        pub(crate) fn create<C>(
-            event_loop: *mut EventLoop,
-            file_blob: Blob,
-            bytes_blob: Blob,
-            context: *mut C,
-            callback: WriteFileOnWriteFileCallback,
-            mkdirp_if_not_exists: bool,
-        ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
-            // see `WriteFile::create` — caller supplies an erased
-            // `*mut c_void` callback directly; `context` is just `.cast()`ed.
-            WriteFileWindows::create_with_ctx(
-                file_blob,
-                bytes_blob,
-                event_loop,
-                context.cast::<c_void>(),
-                callback,
-                mkdirp_if_not_exists,
-            )
-        }
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-
-pub struct WriteFilePromise {
-    pub(crate) promise: jsc::JSPromiseStrong,
-    pub global_this: *const JSGlobalObject,
-}
-
-impl WriteFilePromise {
-    pub(crate) fn run(
-        handler: *mut c_void,
-        count: WriteFileResultType,
-    ) -> Result<(), JsTerminated> {
-        let handler = handler.cast::<Self>();
-        // SAFETY: handler is the Box-allocated WriteFilePromise created in
-        // Blob.rs (`heap::into_raw(Box::new(WriteFilePromise { .. }))`); consumed here.
-        // `swap()` releases the Strong's handle slot and yields a GC-owned `*mut JSPromise`,
-        // which stays valid past `drop(heap::take(handler))`.
-        let (promise, global_this): (*mut JSPromise, &JSGlobalObject) = unsafe {
-            let h = &mut *handler;
-            let promise = std::ptr::from_mut::<JSPromise>(h.promise.swap());
-            let global_this = &*h.global_this;
-            drop(bun_core::heap::take(handler));
-            (promise, global_this)
-        };
-        // SAFETY: GC-owned cell (kept alive below); scoped shared access.
-        let value = unsafe { (*promise).to_js() };
-        value.ensure_still_alive();
-        match count {
-            WriteFileResultType::Err(err) => {
-                // SAFETY: GC-owned cell; the error build's shared borrow ends before the
-                // scoped exclusive `reject` borrow.
-                unsafe {
-                    let err_js = err.to_error_instance_with_async_stack(global_this, &*promise);
-                    (*promise).reject(global_this, Ok(err_js))?;
-                }
-            }
-            WriteFileResultType::Result(wrote) => {
-                // SAFETY: GC-owned cell; exclusive borrow scoped to the call.
-                unsafe {
-                    (*promise)
-                        .resolve(global_this, JSValue::js_number_from_uint64(wrote as u64))?;
-                }
-            }
-        }
-        Ok(())
     }
 }
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -944,3 +944,106 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(f.name).toBe(filePath);
   });
 });
+
+// A Bun.write() that goes through the work pool (a Blob source always does; the
+// sync fast path only takes strings and views under 256 KiB) carries the promise
+// it will settle. When the worker that started it stops first, the job is
+// released instead of completed, on one of three paths; each of them used to
+// leak the promise (LSan: a direct leak allocated in
+// write_file_with_source_destination). The write is started from an immediate
+// because test/leaksan.supp suppresses everything allocated while a module is
+// being evaluated.
+describe.skipIf(!isASAN || isWindows)("Bun.write() released by the teardown of the worker that started it", () => {
+  const writeThen = rest => `
+    const { workerData, parentPort } = require("node:worker_threads");
+    setImmediate(() => {
+      Bun.write(workerData.out, new Blob(["x"]));
+      ${rest}
+    });
+  `;
+  // Holds the worker's JS thread until the pool has written the byte, so the
+  // completion the pool posts right after is still queued when the thread stops.
+  const WAIT_FOR_THE_BYTE = `
+    const fs = require("node:fs");
+    const tick = new Int32Array(new SharedArrayBuffer(4));
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline && !(fs.existsSync(workerData.out) && fs.statSync(workerData.out).size === 1)) {
+      Atomics.wait(tick, 0, 0, 1);
+    }
+  `;
+  const rows = [
+    {
+      name: "completion refused: the worker exited before the pool posted it",
+      // The gate parks the pool's post until the worker's VM handle has closed.
+      env: { BUN_DEBUG_TEST_WORKER_REFUSAL_GATE: "1" },
+      worker: writeThen(`setImmediate(() => setImmediate(() => process.exit(0)));`),
+      refused: true,
+      workerExitCode: 0,
+    },
+    {
+      name: "completion queued: process.exit() with the completion undispatched",
+      worker: writeThen(WAIT_FOR_THE_BYTE + `process.exit(0);`),
+      refused: false,
+      workerExitCode: 0,
+    },
+    {
+      name: "completion queued: worker.terminate() with the completion undispatched",
+      // Parks until the parent has called terminate() (the parent releases it).
+      worker: writeThen(WAIT_FOR_THE_BYTE + `parentPort.postMessage("armed"); Atomics.wait(workerData.ctl, 0, 0);`),
+      parent: `w.once("message", () => { w.terminate(); Atomics.store(ctl, 0, 1); Atomics.notify(ctl, 0); });`,
+      refused: false,
+      workerExitCode: 1,
+    },
+  ];
+
+  for (const row of rows) {
+    test.concurrent(
+      row.name,
+      async () => {
+        using dir = tempDir("bun-write-worker-teardown", {});
+        const host = `
+          const { Worker } = require("node:worker_threads");
+          const out = ${JSON.stringify(join(String(dir), "out.bin"))};
+          const ctl = new Int32Array(new SharedArrayBuffer(4));
+          const w = new Worker(${JSON.stringify(row.worker)}, { eval: true, workerData: { out, ctl } });
+          w.on("error", e => { console.error("worker error:", e); });
+          // The file's content is the proof that the pool ran the write at all.
+          w.on("exit", code => console.log("worker exit", code, require("node:fs").readFileSync(out, "utf8")));
+          ${row.parent ?? ""}
+        `;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", host],
+          env: {
+            ...bunEnv,
+            ...row.env,
+            // Tear the main thread's VM down too, so LSan sees only what the worker left behind.
+            BUN_DESTRUCT_VM_ON_EXIT: "1",
+            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+            LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        // The refusal gate names what it refused on stderr; anything else there (an LSan report) is a failure.
+        const refusals = stderr.split("\n").filter(line => line.startsWith("[vm_handle] refused "));
+        expect({
+          stdout,
+          stderr: stderr
+            .split("\n")
+            .filter(line => line && !line.startsWith("[vm_handle] refused "))
+            .join("\n"),
+          refusedTheWrite: refusals.some(line => line.includes("blob::write_file::WriteFile")),
+          exitCode,
+        }).toEqual({
+          stdout: `worker exit ${row.workerExitCode} x\n`,
+          stderr: "",
+          refusedTheWrite: row.refused,
+          exitCode: 0,
+        });
+      },
+      // Symbolizing an LSan report on the debug binary takes well over the default timeout.
+      60_000,
+    );
+  }
+});


### PR DESCRIPTION
### Problem
- An async `Bun.write()` (any Blob source, or a string / view of 256 KiB or more) runs as a `WriteFile` pool job on POSIX. When the worker that started it stops before the write completes, the promise it was going to settle leaks. Under LSan:
  ```
  Direct leak of 16 byte(s) in 1 object(s) allocated from:
      ... bun_runtime::webcore::blob::write_file_with_source_destination src/runtime/webcore/Blob.rs:4637
  ```
- Cause: `WriteFile` declared `type Js = ()` and kept its completion in its off-thread part instead, as an erased `(on_complete_ctx, on_complete_callback)` pair (`write_file.rs:88`). The ctx was a `Box<WriteFilePromise>` holding the `JSPromiseStrong`, allocated in `write_file_with_source_destination` (`Blob.rs:4637`) and freed only by `WriteFilePromise::run`, i.e. only when the completion actually ran (`WriteFile::then`).
- A stopped VM never runs the completion. It releases the job through `JobList::release_all_js` (teardown), `Job::release_unrun_on` (a completion queued or dispatched after the stop) or `Postable::release_refused` (posted after the handle closed), and all three only drop the `WriteFile`, which has nothing that frees the box. Same latent gap #37236 fixed for `ReadFile` and called out for `WriteFile`.

### Fix
- The promise is the job's `type Js` now (`JSPromiseStrong`, which is `JsAffine`), exactly the shape `CopyFile` already uses: `then` takes it and settles it through one `settle()` helper; on every other path the `Job` machinery drops it on the JS thread with the heap alive, and the `WriteFile` a stopped VM refuses or releases unrun contains nothing JS-affine. No per-write "is the VM gone" code is needed: this is the partition the job carrier already enforces.
- `WriteFileWindows` (the libuv twin, driven on the JS thread) owns the promise as a field and settles it from `run_from_js_thread` through the same helper. It is not a pool job, and a worker's teardown drains its in-flight uv requests, so this half is about keeping one completion shape on both platforms rather than a leak seen there. Intentionally untouched: its mkdirp hop through the pool can still be refused by a closed worker, which abandons the whole struct (noted in `on_mkdirp_complete_concurrent`, and what the ticket work in #38299 is about); that is the same before and after this change.
- Deleted with their last users: `WriteFilePromise`, `WriteFileResultType`, `WriteFileOnWriteFileCallback`, and the `create_with_ctx` / `create<C>` pairs on both structs (collapsed into one `create` each). The settle itself is unchanged: resolve with the byte count, or reject with the `SystemError` plus the promise's async stack.
- Verified with `test/js/bun/io/bun-write.test.js` (new describe, ASAN builds only): a worker starts a pool write and is stopped on each of the three release paths with `detect_leaks=1` and the CI suppressions. Fails on the unfixed debug build on all three rows with the report above, passes with the fix. The rows also assert the refusal really happened (row 1) and that the pool wrote the file (all rows), so they cannot pass without the write having been a job.
- Also run locally on the fixed debug build: the rest of `bun-write.test.js`, `blob.test.ts`, `blob-write.test.ts`, `worker-refused-completion.test.ts` (16/16), the `fs` / `pool` / `counted` families of the terminate funnel fixture; `cargo check` and clippy of `bun_runtime` for `x86_64-pc-windows-msvc` (no new findings in the touched files).

### Background
- **Job / `JobContext`** (`src/jsc/job.rs`): a unit of work that leaves the JS thread for the work pool and comes back. It has two partitions. `OffThread` is what the pool body sees and is freed wherever the job ends up being released. `Js` is the completion's JS-thread state (promises, handles); the carrier keeps every live job in the VM's `JobList` and drops the `Js` side itself on the JS thread when the VM tears down, so a job's JS handles are released exactly once regardless of which thread releases the rest of the job.
- **`JsAffine`**: the marker for types that may only be used and dropped on their VM's JS thread; `type Js` must be one. `JSPromiseStrong` is.
- **`JSPromiseStrong`**: a GC root (a slot in the VM's strong-root blocks) holding a `JSPromise` plus the resolve / reject helpers; dropping it releases the slot. The 16 bytes LSan sees are the box that used to wrap it, but the root slot was held until the VM died as well.
- **Why the test starts the write from `setImmediate`**: `test/leaksan.supp` suppresses every allocation whose stack contains module evaluation, so a write started at the worker's top level leaks invisibly (this is also why the existing per-producer refusal rows, which start their work at top level, did not catch this).
- **`BUN_DEBUG_TEST_WORKER_REFUSAL_GATE`** (builds with assertions, which includes the ASAN lanes): parks a cross-thread post until the worker's handle has closed, so the refused path runs deterministically and is named on stderr; the first test row uses it, the other two stop the worker with the completion already queued.

<details>
<summary>Fail-before output of the new rows on the unfixed debug build</summary>

```
(fail) ... > completion refused: the worker exited before the pool posted it
    "refusedTheWrite": true,
+   "exitCode": 1,
+ Direct leak of 16 byte(s) in 1 object(s) allocated from:
+     #12 in bun_runtime::webcore::blob::write_file_with_source_destination src/runtime/webcore/Blob.rs:4637:59
(fail) ... > completion queued: process.exit() with the completion undispatched
+ Direct leak of 16 byte(s) in 1 object(s) allocated from:
+     #12 in bun_runtime::webcore::blob::write_file_with_source_destination src/runtime/webcore/Blob.rs:4637:59
(fail) ... > completion queued: worker.terminate() with the completion undispatched
+ Direct leak of 16 byte(s) in 1 object(s) allocated from:
+     #12 in bun_runtime::webcore::blob::write_file_with_source_destination src/runtime/webcore/Blob.rs:4637:59
 0 pass
 3 fail
```
</details>
