### PR TITLE
Make deepEquals and toEqual compare built-in constructors, mocks and callable Proxies by identity

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1244,6 +1244,16 @@ template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, boo
 std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2)
 {
     VM& vm = globalObject->vm();
+
+    // Two distinct callables are never equal (jest: `typeof a !== "object"`; the identical
+    // pair already returned from sameValue). This has to be a callability check rather than
+    // a JSFunctionType arm below: built-in constructors like Array and Map and mock functions
+    // are InternalFunctionType, and a Proxy over a function is ProxyObjectType, so all of
+    // them would otherwise reach the own-property walk and compare equal.
+    if (c1->isCallable() || c2->isCallable()) {
+        return false;
+    }
+
     uint8_t c1Type = c1->type();
     uint8_t c2Type = c2->type();
 
@@ -1736,10 +1746,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
         return true;
     }
-    case JSFunctionType: {
-        return false;
-    }
-
     case JSAsJSONType:
     case JSDOMWrapperType: {
         if (c2Type == c1Type) {

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 import vm from "node:vm";
 
@@ -49,7 +50,6 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     expect(deepEquals(b, a)).toBe(false);
   });
 
-  // we may change this in the future
   it("functions that are not reference-equal are never equal", () => {
     function foo() {}
     function bar() {}
@@ -57,6 +57,51 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     expect(deepEquals(foo, foo)).toBe(true);
     expect(deepEquals(foo, bar)).toBe(false);
     expect(deepEquals(foo, baz)).toBe(false);
+  });
+
+  // Built-in constructors, Function.prototype and mock functions are InternalFunction
+  // objects and a Proxy over a function is a ProxyObject, none of which is an ordinary
+  // JSFunction. Like ordinary functions, they have no own enumerable properties, so
+  // they must be compared by identity rather than by walking properties.
+  function target() {}
+  it.each<[string, unknown, unknown]>([
+    ["Array and Object", Array, Object],
+    ["Map and Set", Map, Set],
+    ["Symbol and Object", Symbol, Object],
+    ["BigInt and Object", BigInt, Object],
+    ["Function and Object", Function, Object],
+    ["Error and TypeError", Error, TypeError],
+    ["Uint8Array and Int8Array", Uint8Array, Int8Array],
+    ["Function.prototype and Object", Function.prototype, Object],
+    ["a built-in constructor and a plain object", Array, {}],
+    ["two mock functions", mock(() => 1), mock(() => 1)],
+    ["two Proxies over functions", new Proxy(function () {}, {}), new Proxy(function () {}, {})],
+    ["a Proxy over a built-in constructor and its target", new Proxy(Array, {}), Array],
+    ["a Proxy over a function and its target", new Proxy(target, {}), target],
+  ])("callables that are not reference-equal are never equal: %s", (_, a, b) => {
+    expect(deepEquals(a, b)).toBe(false);
+    expect(deepEquals(b, a)).toBe(false);
+    expect(deepEquals({ type: a }, { type: b })).toBe(false);
+    expect(deepEquals([a], [b])).toBe(false);
+    expect(deepEquals(new Set([a]), new Set([b]))).toBe(false);
+    expect(deepEquals(new Map([[a, 1]]), new Map([[b, 1]]))).toBe(false);
+    expect(deepEquals(new Map([["type", a]]), new Map([["type", b]]))).toBe(false);
+  });
+
+  it("the same callable is equal to itself wherever it appears", () => {
+    const mocked = mock(() => 1);
+    const proxied = new Proxy(function () {}, {});
+    expect(deepEquals(Array, Array)).toBe(true);
+    expect(deepEquals(proxied, proxied)).toBe(true);
+    expect(deepEquals({ type: Array, mocked, proxied }, { type: Array, mocked, proxied })).toBe(true);
+    expect(deepEquals([Map, mocked], [Map, mocked])).toBe(true);
+    expect(deepEquals(new Set([Map, Set]), new Set([Set, Map]))).toBe(true);
+    expect(deepEquals(new Map([[Array, mocked]]), new Map([[Array, mocked]]))).toBe(true);
+  });
+
+  it("a Proxy over a non-callable object is still compared by its properties", () => {
+    expect(deepEquals(new Proxy({ a: 1 }, {}), new Proxy({ a: 1 }, {}))).toBe(true);
+    expect(deepEquals(new Proxy({ a: 1 }, {}), new Proxy({ a: 2 }, {}))).toBe(false);
   });
 
   describe("global object", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -1223,6 +1223,58 @@ describe("expect()", () => {
     expect(f1).not.toEqual(f2);
   });
 
+  // Two different callables are never equal, whatever kind of function object they are.
+  // Built-in constructors and mock functions are not ordinary functions internally, and
+  // none of them has own enumerable properties, so a property walk would call them equal.
+  test("deepEquals compares every kind of callable by identity", () => {
+    expect(Array).not.toEqual(Object);
+    expect(Array).not.toStrictEqual(Object);
+    expect(Function.prototype).not.toEqual(Object);
+    expect(() => expect(Array).toEqual(Object)).toThrow();
+    expect(() => expect(Map).toStrictEqual(Set)).toThrow();
+
+    expect({ type: Array }).not.toEqual({ type: Object });
+    expect({ type: Array }).not.toStrictEqual({ type: Object });
+    expect({ type: Map }).not.toEqual({ type: Set });
+    expect({ type: Symbol }).not.toEqual({ type: Object });
+    expect({ type: BigInt }).not.toEqual({ type: Object });
+    expect({ type: Function }).not.toEqual({ type: Object });
+    expect({ type: Uint8Array }).not.toEqual({ type: Int8Array });
+
+    expect([Array]).not.toEqual([Object]);
+    expect([Array]).not.toStrictEqual([Object]);
+    expect([Array]).not.toContainEqual(Object);
+    expect(new Set([Array])).not.toEqual(new Set([Object]));
+    expect(new Map([[Array, 1]])).not.toEqual(new Map([[Object, 1]]));
+    expect(new Map([["type", Array]])).not.toEqual(new Map([["type", Object]]));
+
+    expect(jest.fn()).not.toEqual(jest.fn());
+    expect({ onChange: jest.fn() }).not.toEqual({ onChange: jest.fn() });
+    expect({ onChange: jest.fn() }).not.toStrictEqual({ onChange: jest.fn() });
+
+    expect(new Proxy(function () {}, {})).not.toEqual(new Proxy(function () {}, {}));
+    expect({ fn: new Proxy(() => {}, {}) }).not.toStrictEqual({ fn: new Proxy(() => {}, {}) });
+
+    expect({ type: Array }).not.toEqual(expect.objectContaining({ type: Object }));
+
+    const calledWith = jest.fn();
+    calledWith(Array);
+    expect(calledWith).toHaveBeenCalledWith(Array);
+    expect(calledWith).not.toHaveBeenCalledWith(Object);
+
+    // The same callable on both sides is still equal, and asymmetric matchers still apply.
+    const onChange = jest.fn();
+    const callable = new Proxy(() => {}, {});
+    expect(Array).toEqual(Array);
+    expect({ type: Array, onChange, callable }).toEqual({ type: Array, onChange, callable });
+    expect({ type: Array, onChange, callable }).toStrictEqual({ type: Array, onChange, callable });
+    expect([Map, Set]).toEqual([Map, Set]);
+    expect(new Set([Map, Set])).toEqual(new Set([Set, Map]));
+    expect(new Map([[Array, onChange]])).toEqual(new Map([[Array, onChange]]));
+    expect({ type: Array, onChange }).toEqual({ type: expect.any(Function), onChange: expect.any(Function) });
+    expect({ type: Array }).toEqual(expect.objectContaining({ type: Array }));
+  });
+
   test("deepEquals set and map", () => {
     let e = new Map();
     e.set("a", 1);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -633,6 +633,23 @@ const cases: Case[] = [
     strict: false,
     loose: false,
   },
+  // Built-in constructors are not ordinary functions internally (InternalFunction) and a
+  // Proxy over a function is a ProxyObject; node rejects any two distinct callables alike.
+  { name: "two distinct built-in constructors", a: () => Array, b: () => Object, strict: false, loose: false },
+  {
+    name: "objects holding distinct built-in constructors",
+    a: () => ({ type: Map }),
+    b: () => ({ type: Set }),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "two distinct Proxies over functions",
+    a: () => new Proxy(() => {}, {}),
+    b: () => new Proxy(() => {}, {}),
+    strict: false,
+    loose: false,
+  },
   { name: "an arguments object and an array", a: () => argumentsObject(1), b: () => [1], strict: false, loose: false },
   {
     name: "two equal arguments objects",


### PR DESCRIPTION
### Problem
- `expect(Array).toEqual(Object)` passes in bun:test. So do `toStrictEqual`, `expect({ type: Map }).toEqual({ type: Set })`, `expect(jest.fn()).toEqual(jest.fn())`, `expect(m).toHaveBeenCalledWith(Object)` after `m(Array)`, two distinct `new Proxy(fn, {})`, and the same pairs through `Bun.deepEquals`, `assert.deepEqual`, `assert.deepStrictEqual` and `util.isDeepStrictEqual`.
- Jest's `equals()` returns false for any two functions that are not `Object.is`-identical (`typeof a !== 'object'` after the class-name switch); node's `isDeepEqual` does the same (`typeof val1 !== 'object'`). Tests such as `expect(designTypeMetadata).toEqual({ x: Array })` therefore pass in bun when the value is `Object`.
- Cause: `specialObjectsDequal` in `src/jsc/bindings/bindings.cpp` rejected distinct functions with a `case JSFunctionType` arm only. `Array`, `Object`, `Map`, `Set`, `Symbol`, `BigInt`, `Function`, `Function.prototype` and bun:test mock functions are `InternalFunctionType`, and a Proxy over a function is `ProxyObjectType`, so they fell through to the own-enumerable-property walk, where two functions with no own enumerable properties compare equal. `String`, `Number` and `Boolean` happen to be `JSFunction` subclasses in JSC, which is why only some constructors were affected.

### Fix
- `specialObjectsDequal` now returns false when either cell `isCallable()`, before the type switch; the `JSFunctionType` arm is removed because the check subsumes it.
- Correct because the only way two callables can be equal under Jest or node is identity, and `Bun__deepEquals` has already returned true from `sameValue()` for that case by the time `specialObjectsDequal` runs. `isCallable()` is exactly the `typeof x === "function"` test both reference algorithms use, and it has no side effects (for a Proxy it reads a flag recorded at construction; no trap runs). Asymmetric matchers such as `expect.any(Function)` are still matched first, since that happens at the top of `Bun__deepEquals`.
- The helper is shared by every entry point, so `Bun.deepEquals` (both modes), `toEqual`/`toStrictEqual` and the matchers built on them (`toHaveBeenCalledWith`, `toContainEqual`, `expect.objectContaining`, ...), and node's `deepEqual`/`deepStrictEqual`/`isDeepStrictEqual`/`partialDeepStrictEqual` (which delegates callables to strict deep equality) all change together. Objects that are not callable, including Proxies over plain objects, take the same path as before.
- Intentionally not touched: `Bun__deepMatch` (`toMatchObject`, `Bun.deepMatch`) does not use `specialObjectsDequal` and has a wider gap (it also matches two distinct ordinary functions, which `Bun__deepEquals` already rejected). #38339 fixes that routine; the two diffs do not overlap.
- Tests: `test/js/bun/test/expect.test.js` ("deepEquals compares every kind of callable by identity"; all 25 of its `.not` assertions fail on the released binary when run one at a time), `test/js/bun/bun-object/deep-equals.test.ts` (table of callable pairs at the top level and nested in objects, arrays, Set members, Map keys and Map values, in strict and loose mode, plus identity and non-callable Proxy cases), and three new rows in the `test/js/node/assert/deep-equal.test.ts` matrix (9 new tests across `deepStrictEqual`, `deepEqual` and `isDeepStrictEqual`).
- Verified: the three files fail on the released binary only in the new tests (22, 1 and 9 failures) and pass with the fix; `test/js/bun/test/` (1615 tests), `test/js/node/assert/`, `deep-match.spec.ts`, `deep-equals-temporal.test.ts` and the upstream `test-assert*.js` / `test-util-isDeepStrictEqual.js` files pass with the fix, apart from two pre-existing failures unrelated to equality (a formatter stack overflow in `pretty-format-overflow.test.ts` that also reproduces with a primitive expected value, and a timing-suffix normalizer gap in `printing/diffexample.test.ts`), both reported separately.

### Background
- `Bun__deepEquals` is the single native routine behind `Bun.deepEquals`, the `toEqual` family and node's deep-equality functions; template flags select strict mode, asymmetric matchers and node's prototype rule. It first tries `sameValue()` (identity for objects), then calls `specialObjectsDequal` for each operand order to handle types with internal state (Set, Map, Date, typed arrays, ...), and only falls back to comparing own enumerable properties when that returns no verdict.
- JSC gives every heap object a `JSType`. Functions written in JS (including classes and `String`/`Number`/`Boolean`, which JSC implements as `JSFunction` subclasses) are `JSFunctionType`; most built-in constructors and embedder-defined functions, including bun:test's `JSMockFunction`, derive from `InternalFunction` and are `InternalFunctionType`; a Proxy is `ProxyObjectType` whatever it wraps. `JSCell::isCallable()` answers "is `typeof` this `"function"`" across all of them.
