### PR TITLE
GitHub Actions annotation and code frame caret: use the first frame that has a file, not a builtin frame on top

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5600,14 +5600,7 @@ impl VirtualMachine {
         let mut top_frame_is_builtin = false;
         if self.hide_bun_stackframes {
             for (i, frame) in frames.iter().enumerate() {
-                if frame.source_url.has_prefix_comptime(b"bun:")
-                    || frame.source_url.has_prefix_comptime(b"node:")
-                    || frame.source_url.is_empty()
-                    || frame.source_url.eql_comptime("native")
-                    || frame.source_url.eql_comptime("unknown")
-                    || frame.source_url.eql_comptime("[unknown]")
-                    || frame.source_url.has_prefix_comptime(b"[source:")
-                {
+                if !frame.has_user_source() {
                     top_frame_is_builtin = true;
                     continue;
                 }
@@ -6123,10 +6116,7 @@ impl VirtualMachine {
                 let mut top_frame: Option<&crate::ZigStackFrame> = frames.first();
                 if self.hide_bun_stackframes {
                     for frame in frames {
-                        if frame.position.is_invalid()
-                            || frame.source_url.has_prefix_comptime(b"bun:")
-                            || frame.source_url.has_prefix_comptime(b"node:")
-                        {
+                        if frame.position.is_invalid() || !frame.has_user_source() {
                             continue;
                         }
                         top_frame = Some(frame);
@@ -6549,29 +6539,26 @@ impl VirtualMachine {
         let name = &exception.name;
         let message = &exception.message;
         let frames = exception.stack.frames();
-        let top_frame = frames.first();
+        let location_frame = frames
+            .iter()
+            .find(|frame| frame.has_user_source() && !frame.position.is_invalid());
         let dir = bun_core::env_var::GITHUB_WORKSPACE::get()
             .unwrap_or_else(|| bun_bundler::bun_fs::FileSystem::instance().top_level_dir);
         bun_core::Output::flush();
 
         let writer = bun_core::Output::error_writer();
 
-        let mut has_location = false;
-        if let Some(frame) = top_frame {
-            if !frame.position.is_invalid() {
-                let source_url = frame.source_url.to_utf8();
-                let file = bun_paths::resolve_path::relative(dir, source_url.slice());
-                let _ = write!(
-                    writer,
-                    "\n::error file={},line={},col={},title=",
-                    bun_core::fmt::github_action_property(file),
-                    frame.position.line.one_based(),
-                    frame.position.column.one_based(),
-                );
-                has_location = true;
-            }
-        }
-        if !has_location {
+        if let Some(frame) = location_frame {
+            let source_url = frame.source_url.to_utf8();
+            let file = bun_paths::resolve_path::relative(dir, source_url.slice());
+            let _ = write!(
+                writer,
+                "\n::error file={},line={},col={},title=",
+                bun_core::fmt::github_action_property(file),
+                frame.position.line.one_based(),
+                frame.position.column.one_based(),
+            );
+        } else {
             let _ = writer.write_all(b"\n::error title=");
         }
 
@@ -6612,7 +6599,7 @@ impl VirtualMachine {
             let _ = writer.write_all(b"::");
         }
 
-        if top_frame.is_some() {
+        if !frames.is_empty() {
             // SAFETY: per-thread VM.
             let vm = VirtualMachine::get();
             let origin = if vm.is_from_devserver {

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -75,6 +75,22 @@ impl ZigStackFrame {
         jsc_stack_frame_index: -1,
     };
 
+    /// Whether `source_url` names a source the user can open. False for JSC's
+    /// JS builtins (no URL, or `native`/`unknown` once parsed back out of
+    /// `error.stack`), for Bun's own `bun:`/`node:` modules, and for sources
+    /// JSC could not attribute. The code frame and the GitHub Actions
+    /// annotation point at the first frame for which this is true.
+    pub(crate) fn has_user_source(&self) -> bool {
+        let url = &self.source_url;
+        !(url.is_empty()
+            || url.has_prefix_comptime(b"bun:")
+            || url.has_prefix_comptime(b"node:")
+            || url.eql_comptime("native")
+            || url.eql_comptime("unknown")
+            || url.eql_comptime("[unknown]")
+            || url.has_prefix_comptime(b"[source:"))
+    }
+
     pub fn name_formatter(&self, enable_color: bool) -> NameFormatter {
         NameFormatter {
             function_name: self.function_name,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -719,6 +719,78 @@ describe("bun test", () => {
       });
       expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
     });
+    // The frame on top of these stacks has no file to annotate: a JS builtin
+    // (`reduce`), the `native` / `unknown` placeholders such frames turn into
+    // once error.stack has been read, or one of bun's own `node:*` modules.
+    // The annotation has to point at the first frame below it that is in the
+    // test file. The test callbacks are async so the error reaches the
+    // reporter with its own stack; a synchronous throw is reported with the
+    // frames of the throw site instead, which would not have these on top.
+    test.each([
+      {
+        label: "a JS builtin",
+        body: `[].reduce((a, b) => a);`,
+        callee: "reduce",
+        title: "TypeError: reduce of empty array with no initial value",
+      },
+      {
+        label: "a JS builtin after error.stack was read",
+        body: `try { [].reduce((a, b) => a); } catch (e) { void e.stack; throw e; }`,
+        callee: "reduce",
+        title: "TypeError: reduce of empty array with no initial value",
+      },
+      {
+        label: "a node: module",
+        body: `new EventEmitter().emit("error");`,
+        callee: "emit",
+        title: "error: Unhandled error. (undefined)",
+      },
+      {
+        label: "a node: module after error.stack was read",
+        body: `try { new EventEmitter().emit("error"); } catch (e) { void e.stack; throw e; }`,
+        callee: "emit",
+        title: "error: Unhandled error. (undefined)",
+      },
+    ])("should annotate the first frame in the test file when the top frame is $label", ({ body, callee, title }) => {
+      const lines = [
+        `import { test } from "bun:test";`,
+        `import { EventEmitter } from "node:events";`,
+        `test("fail", async () => {`,
+        `  ${body}`,
+        `});`,
+      ];
+      const line = lines.findIndex(l => l.includes(body)) + 1;
+      const col = lines[line - 1].indexOf(callee) + 1;
+      const stderr = runTest({
+        input: [{ filename: "top-frame-has-no-file.test.ts", contents: lines.join("\n") }],
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toStartWith("::error file=");
+      expect(annotation!.replace(/^::error file=(?:[^,]*[\\/])?/, "")).toStartWith(
+        `top-frame-has-no-file.test.ts,line=${line},col=${col},title=${title}::`,
+      );
+    });
+    test("should annotate without a location when no frame has a file", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("fail", async () => {
+            const err = new Error("boom");
+            err.stack = "Error: boom\\n    at reduce (native:1:11)";
+            throw err;
+          });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toStartWith("::error title=error: boom::");
+      expect(annotation).toContain("at reduce (");
+    });
   });
   describe(".each", () => {
     test("should run tests with test.each", () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -149,3 +149,30 @@ test("Async functions frame should be included in stack trace", async () => {
         at async <anonymous> (file:NN:NN)"
   `);
 });
+
+// `reduce` throws from inside JSC's builtin, so the first frame has a
+// line:column inside the builtin's source and no file. The code frame shows
+// this file, so its caret has to be placed by this file's frame as well. Once
+// error.stack has been read, the frames are parsed back out of that string
+// and the builtin frame turns into the `native` placeholder.
+test.each([
+  ["fresh error", false],
+  ["error whose .stack has been read", true],
+])("code frame caret is placed by the first frame with a file, not a builtin frame on top: %s", (_, readStack) => {
+  let err: unknown;
+  try {
+    const emptyArray: number[] = [];
+    emptyArray.reduce((a, b) => a);
+  } catch (e) {
+    err = e;
+  }
+  if (readStack) void (err as Error).stack;
+
+  const lines = Bun.inspect(err).split("\n");
+  const header = lines.indexOf("TypeError: reduce of empty array with no initial value");
+  expect(header).toBeGreaterThanOrEqual(2);
+  const [sourceLine, caretLine] = lines.slice(header - 2, header);
+  expect(sourceLine).toEndWith("emptyArray.reduce((a, b) => a);");
+  expect(caretLine.trim()).toBe("^");
+  expect(caretLine.indexOf("^")).toBe(sourceLine.indexOf("reduce"));
+});


### PR DESCRIPTION
### Problem
- With `GITHUB_ACTIONS=true`, an error thrown from inside a JS builtin is annotated with an empty file and the builtin's internal position. `[].reduce((a, b) => a)` in `x.js` prints `::error file=,line=1,col=11,title=TypeError: reduce of empty array with no initial value::` (release; `line=12,col=9` on a debug build) instead of `file=x.js,line=1,col=4`.
- Same cause, other shapes of the top frame: `file=native,line=1,col=11` once `error.stack` has been read (the frames are then parsed back out of the string, where the builtin is printed as `native`), `file=unknown,line=1,col=1` for an error created below a native frame after `error.stack` was read, and `file=node%3Aevents,line=59,col=31` for an error created inside one of bun's own modules (`emitter.emit("error")` with no listener). None of these name a file in the repository, so GitHub shows the annotation in the run summary only.
- The caret under the code frame has the same bug: for `[].reduce((a, b) => a)` the source line shown is the user's, but the `^` is placed at the builtin's column. Same for the `native` / `unknown` cases; `node:` frames were already skipped there.
- Cause: `print_github_annotation` (`src/jsc/VirtualMachine.rs`) takes `frames[0]` and only checks that it has a position, and the caret code in `print_error_instance_body` skips only `bun:` / `node:` frames. The code that picks which file to show in the code frame (`remap_zig_exception`) already skips empty, `native`, `unknown`, `[unknown]`, `[source:...]`, `bun:` and `node:` frames, so the three consumers disagreed about which frame the error is attributed to. Reproduces on 1.4.0 and on main.

### Fix
- The skip list from `remap_zig_exception` becomes `ZigStackFrame::has_user_source()`; `remap_zig_exception` uses it unchanged, and the annotation and the caret now use it too, so all three point at the same frame: the first one whose `source_url` names a source the user can open. The annotation additionally requires a position, as before; if no frame qualifies it is emitted as `::error title=...` without a location, which is what it already did for a positionless top frame.
- Why this is correct: the source lines shown in the code frame come from the frame `remap_zig_exception` picks, so the caret has to be placed by that frame's column or it points at nothing in particular; and `file=` is only useful to GitHub for a file that exists in the checkout, which none of the skipped source URLs are. The frames below the skipped ones are already source-mapped (the per-frame loop at the end of `remap_zig_exception`), which is why the TypeScript test files below report their original columns. The annotation is not gated on `BUN_SHOW_BUN_STACKFRAMES` like the code frame is: that flag is about listing bun's internal frames, and an empty `file=` is wrong with or without it.
- The annotation's frame list is unchanged; it still prints every frame, including the builtin one.
- Tests:
  - `test/cli/test/bun-test.test.ts`, "support for Github Actions": four rows for a builtin / `node:` module top frame, each fresh and after `error.stack` was read (covering the empty, `native`, `node:` and `unknown` source URLs), asserting the exact `file=<test file>,line=,col=` of the call in the test file; plus a stack with no file in any frame, asserting `::error title=` and that the frame list is still printed.
  - `test/js/bun/test/stack.test.ts`: `Bun.inspect` of a `reduce` TypeError, fresh and after `.stack` was read, asserting the caret is under `reduce` on the user's line.
  - `USE_SYSTEM_BUN=1 bun test` on 1.4.0: all 7 new tests fail (`file=` / `file=native` / `file=node%3Aevents` / `file=unknown`, caret at the builtin's column). `bun bd test` with `src/` stashed: the same failures, with the debug build's builtin position (`line=12,col=9`). With the change: `bun-test.test.ts` 86 pass / 6 todo, `stack.test.ts` 8 pass / 1 todo.
  - Also green on the debug build: `test/js/bun/util/inspect.test.js`, `reportError.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/regression/issue/23022-stack-trace-iterator.test.ts`, `test/js/bun/sourcemap/`, `test/js/bun/console/`, `test/js/node/vm/vm.test.ts`, `vm-sourceUrl.test.ts`, `test/js/bun/test/bun_test.test.ts`. (`inspect-error.test.js` has two minified-file snapshots that already fail on main under a debug build because of the debug-only `at require (51:24)` frame; unchanged by this PR, #38308 and #38328 fix the helper.)
- Related open PRs: #38328 changes the same `print_github_annotation` block to key the location on the line being valid and print `col=` only when the column is; it fixes frames parsed without any position, while this PR is about frames that have a position but no file (`reduce (native:1:11)` still picks the builtin frame there). The two compose (the `find` here would use its line check); whichever lands second has a few-line rebase in that block. #35177 only changes how the builtin frame is rendered in the list, not which frame the location comes from.

### Background
- GitHub Actions workflow command: a line `::error file=F,line=L,col=C,title=T::body` on a job's output. The runner attaches it to file `F` in the checkout when it exists; otherwise it is listed without a file. Bun prints one per uncaught error / failed test when `GITHUB_ACTIONS` is set, from `print_github_annotation`, which runs at the end of the error printer (`print_error_instance_body`) on the same remapped `ZigException` the terminal output was printed from.
- `ZigStackFrame.source_url` for the frames of an error: an absolute path or URL for user code; empty for JSC's JS-implemented builtins (`Array.prototype.reduce` and friends are JS inside JSC, so unlike C++ natives they have a line:column, into the builtin's own source, but no URL); `node:<name>` / `bun:<name>` for bun's built-in modules; `native` / `unknown` when the frames were rebuilt by parsing `error.stack` (that string prints builtins as `native` and positionless native frames as `unknown`, and the parser gives the latter position 1:1); `[unknown]` / `[source:N]` are placeholders from the `prepareStackTrace` call-site path.
- Code frame: the numbered source lines, caret and `name: message` printed above the stack. `remap_zig_exception` picks the frame whose file to read (skipping the URLs above), source-maps it and reads the lines; `print_error_instance_body` later prints them and places the caret from a frame it picks itself, which is the second of the two loops unified here.
- Structured frames vs. parsed frames: JSC keeps an error's captured frames until `error.stack` is first read, then formats the string and drops them. After that, bun's printer rebuilds frames by parsing the string (`fromErrorInstance` in `ZigException.cpp`), which is why "after `error.stack` was read" is a separate shape in the tests.

<details>
<summary>Before / after on the probes</summary>

```
$ printf '[].reduce((a, b) => a);\n' > reduce.js && GITHUB_ACTIONS=true bun reduce.js

# before (1.4.0)
1 | [].reduce((a, b) => a);
              ^
TypeError: reduce of empty array with no initial value
      at reduce (1:11)
      at /tmp/reduce.js:1:4
::error file=,line=1,col=11,title=TypeError: reduce of empty array with no initial value::%0A      at reduce (1:11)%0A      at /tmp/reduce.js:1:4

# after
1 | [].reduce((a, b) => a);
       ^
TypeError: reduce of empty array with no initial value
      at reduce (1:11)
      at /tmp/reduce.js:1:4
::error file=reduce.js,line=1,col=4,title=TypeError: reduce of empty array with no initial value::%0A      at reduce (1:11)%0A      at /tmp/reduce.js:1:4
```

Other top frames, annotation location only, before (1.4.0) -> after; the call is on line 2 of each probe file:

```
[].reduce(...) after e.stack was read:          file=native,line=1,col=11         -> file=<probe>.js,line=2,col=10
new EventEmitter().emit("error"):               file=node%3Aevents,line=59,col=31 -> file=<probe>.js,line=2,col=20
same, after e.stack was read:                   file=unknown,line=1,col=1         -> file=<probe>.js,line=2,col=26
e.stack assigned with only a native frame:      file=native,line=1,col=11         -> (no file/line/col)
```

The first row is a CommonJS probe; in an ES module the top-level frame is printed without parentheses and the stack-string parser currently stops there (#38308), so that variant has no frame with a file and gets no location.

</details>
