### PR TITLE
bake: prerender routes that have layouts

### DIFF
--- a/src/js/builtins/Bake.ts
+++ b/src/js/builtins/Bake.ts
@@ -111,7 +111,8 @@ export async function renderRoutesForProdStatic(
     if (fileList.length > 1) {
       let anyPromise = false;
       let loaded = fileList.map(
-        x => loadedModules[x] ?? ((anyPromise = true), import(allServerFiles[x]).then(x => (loadedModules[x] = x))),
+        id =>
+          loadedModules[id] ?? ((anyPromise = true), import(allServerFiles[id]).then(mod => (loadedModules[id] = mod))),
       );
       modulesForFiles.push(anyPromise ? await Promise.all(loaded) : loaded);
     } else {

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1035,6 +1035,12 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         next = route.parent;
         file_count = 1;
         let mut css_file_count: u32 = 0;
+        // The page and every layout are separate entry points; all must be static.
+        let mut fully_static = pt
+            .output_file(main_file_route_index)
+            .bake_extra
+            .route
+            .is_fully_static();
         file_list
             .put_index(
                 global,
@@ -1058,6 +1064,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             css_file_count += 1;
         }
         if let Some(file) = route.file_layout {
+            fully_static &= pt.output_file(file).bake_extra.route.is_fully_static();
             file_list
                 .put_index(
                     global,
@@ -1081,6 +1088,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         while let Some(parent_index) = next {
             let parent = router.route_ptr(parent_index);
             if let Some(file) = parent.file_layout {
+                fully_static &= pt.output_file(file).bake_extra.route.is_fully_static();
                 file_list
                     .put_index(
                         global,
@@ -1137,14 +1145,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 global,
                 u32::try_from(nav_index).expect("int cast"),
                 JSValue::js_number_from_int32(
-                    TypeAndFlags::new(
-                        route.r#type.get(),
-                        pt.output_file(main_file_route_index)
-                            .bake_extra
-                            .route
-                            .is_fully_static(),
-                    )
-                    .bits(),
+                    TypeAndFlags::new(route.r#type.get(), fully_static).bits(),
                 ),
             )
             .map_err(js_err)?;

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -594,4 +594,110 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  test.concurrent("prerenders routes that have layouts", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-layouts", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/_layout.tsx": `export default function RootLayout({ children }) {
+  return <main id="root-layout">{children}</main>;
+}`,
+      "pages/index.tsx": `export default function IndexPage() {
+  return <p>index page</p>;
+}`,
+      "pages/docs/_layout.tsx": `export default function DocsLayout({ children }) {
+  return <section id="docs-layout">{children}</section>;
+}`,
+      "pages/docs/index.tsx": `export default function DocsPage() {
+  return <p>docs page</p>;
+}`,
+      "pages/docs/intro.tsx": `export default function IntroPage() {
+  return <p>intro page</p>;
+}`,
+    });
+
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(exitCode, stderr.toString()).toBe(0);
+
+    // The prerendered <body> up to the inline RSC payload script.
+    const bodyOf = async (...route: string[]) => {
+      const html = await Bun.file(path.join(dir, "dist", ...route, "index.html")).text();
+      return html.slice(html.indexOf("<body>") + "<body>".length, html.indexOf("<script>"));
+    };
+
+    expect({
+      "/": await bodyOf(),
+      "/docs": await bodyOf("docs"),
+      "/docs/intro": await bodyOf("docs", "intro"),
+    }).toEqual({
+      "/": '<main id="root-layout"><p>index page</p></main>',
+      "/docs": '<main id="root-layout"><section id="docs-layout"><p>docs page</p></section></main>',
+      "/docs/intro": '<main id="root-layout"><section id="docs-layout"><p>intro page</p></section></main>',
+    });
+  });
+
+  test.concurrent("a route is only fully static when its page and every layout are", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-layout-client", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "components/Client.tsx": `"use client";
+
+export default function Client() {
+  return <button>client</button>;
+}`,
+      "pages/_layout.tsx": `export default function RootLayout({ children }) {
+  return <main>{children}</main>;
+}`,
+      "pages/index.tsx": `export default function IndexPage() {
+  return <p>index page</p>;
+}`,
+      "pages/about.tsx": `import Client from "../components/Client";
+
+export default function AboutPage() {
+  return <p>about page<Client /></p>;
+}`,
+      "pages/docs/_layout.tsx": `import Client from "../../components/Client";
+
+export default function DocsLayout({ children }) {
+  return <section><Client />{children}</section>;
+}`,
+      "pages/docs/index.tsx": `export default function DocsPage() {
+  return <p>docs page</p>;
+}`,
+      "pages/docs/intro.tsx": `export default function IntroPage() {
+  return <p>intro page</p>;
+}`,
+    });
+
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(exitCode, stderr.toString()).toBe(0);
+
+    const inspectRoute = async (...route: string[]) => {
+      const html = await Bun.file(path.join(dir, "dist", ...route, "index.html")).text();
+      return {
+        rendersClientComponent: html.includes("<button>client</button>"),
+        loadsClientEntry: html.includes('<script type="module"'),
+      };
+    };
+
+    expect({
+      // static page inside a static layout
+      "/": await inspectRoute(),
+      // the page itself renders a client component
+      "/about": await inspectRoute("about"),
+      // only the route's own layout renders a client component
+      "/docs": await inspectRoute("docs"),
+      // only a parent route's layout renders a client component
+      "/docs/intro": await inspectRoute("docs", "intro"),
+    }).toEqual({
+      "/": { rendersClientComponent: false, loadsClientEntry: false },
+      "/about": { rendersClientComponent: true, loadsClientEntry: true },
+      "/docs": { rendersClientComponent: true, loadsClientEntry: true },
+      "/docs/intro": { rendersClientComponent: true, loadsClientEntry: true },
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `bun build --app` with the built-in `react` framework exits 1 as soon as any route has a `_layout.tsx`:
  ```
  loaded = fileList.map((x) => loadedModules[x] ?? (anyPromise = !0, import(allServerFiles[x]).then((x2) => loadedModules[x2] = x2)));
  TypeError: No default value
  ```
- Cause: in `renderRoutesForProdStatic` (`src/js/builtins/Bake.ts:114`) the `.then` callback's parameter shadows the file index `x`, so the loaded module namespace is used as the key into `loadedModules`. Converting a module namespace object to a property key throws `No default value` (it has a null prototype, so there is no `toString`/`valueOf`). The branch only runs for routes with more than one file, i.e. routes with layouts, which no production test had.
- Once the build gets past that, the route's `no_client` flag is computed from the page file alone (`src/runtime/bake/production.rs:1142`). Every layout is bundled as its own server entry point and gets its own `BakeExtra.route` classification (`generateChunksInParallel.rs:1287`), so a static page inside a layout that renders a `"use client"` component is flagged fully static and prerendered without the client entry `<script>`: the component's markup is in the HTML but nothing hydrates it.

### Fix
- `Bake.ts`: the `.then` callback stores the module under the outer file index instead of under itself.
- `production.rs`: `fully_static` starts from the page's classification and is and-ed with the classification of each layout while the route's file list is being filled (the route's own layout and every parent route's layout); that value is what goes into `TypeAndFlags`. This is the only consumer of the classification, and it matches what the flag means: the client entry can only be dropped when nothing rendered for the route (page or layout) needs it.
- A route whose page and layouts are all static still gets `no_client`, so the existing optimization is unchanged for that case.
- Tests in `test/bake/dev/production.test.ts`:
  - "prerenders routes that have layouts": one and two levels of layouts, plus a page that inherits a layout from its parent route; asserts the exact prerendered `<body>` so the nesting order (inner-most first, root last) is checked too. Fails on the release build with the `No default value` error above.
  - "a route is only fully static when its page and every layout are": a static page in a static layout gets no client entry; a page that renders a client component, a page whose own layout does, and a page whose parent route's layout does all get one. Fails on the release build with the error above; with only the `Bake.ts` change applied it fails on `/docs` and `/docs/intro` (`loadsClientEntry: false`); passes with both.
- Also ran the rest of `test/bake/dev/production.test.ts` against the debug build (11 pass).

### Background
- Bake production build (`bun build --app`): the bundler emits each page and layout file under `pages/` as a separate server entry point, then `renderRoutesForProdStatic` imports each route's files (`[page, inner-most layout, ..., root layout]`, cached per file index in `loadedModules`) and calls the framework's `prerender` for each route.
- Fully static route / `no_client`: after linking, each server entry point is classified as `FullyStaticRoute` when it does not transitively import a `"use client"` module. For such routes `renderRoutesForProdStatic` passes `modules: []` to `prerender`, so the built-in React framework emits no `<script type="module">` for the client entry; otherwise it emits it as a React bootstrap module, which is what hydrates the client components on the page.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->