### PR TITLE
bundler: keep assets referenced by stylesheets and HTML documents out of JS chunks

### DIFF
--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -291,11 +291,8 @@ pub(crate) fn write<W: Write + ?Sized>(
         }
     }
 
-    // Assets referenced by this entry point's documents (`<img src>` in the
-    // HTML, `url()` in its stylesheets) carry no entry bits of their own (see
-    // `is_document`), so they are attributed through the documents that
-    // reference them. Assets imported from JS are reached through their own
-    // entry bits below.
+    // The assets of this entry point's documents carry no entry bits of their
+    // own (see `is_document`); only assets imported from JS do.
     let mut referenced_by_documents = AutoBitSet::init_empty(file_entry_bits.len())?;
     if !additional_output_files.is_empty() {
         let css_asts = linker_graph.ast.items_css();

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -47,6 +47,7 @@ use bun_resolver::fs::FileSystem;
 
 use crate::Graph::Graph;
 use crate::chunk::{Content, Flags};
+use crate::linker_context_mod::is_document;
 use crate::options::{Loader, OutputKind};
 use crate::options_impl::LoaderExt as _;
 use crate::{BundleV2, Chunk, LinkerGraph};
@@ -235,6 +236,31 @@ pub(crate) fn write<W: Write + ?Sized>(
     let file_entry_bits: &[AutoBitSet] = linker_graph.files.items_entry_bits();
     let mut already_visited_output_file = AutoBitSet::init_empty(additional_output_files.len())?;
 
+    // Assets referenced by this entry point's documents (`<img src>` in the
+    // HTML, `url()` in its stylesheets) carry no entry bits of their own (see
+    // `is_document`), so they are attributed through the documents that
+    // reference them. Assets imported from JS are reached through their own
+    // entry bits below.
+    let mut referenced_by_documents = AutoBitSet::init_empty(file_entry_bits.len())?;
+    if !additional_output_files.is_empty() {
+        let css_asts = linker_graph.ast.items_css();
+        let loaders = graph.input_files.items_loader();
+        let import_records = linker_graph.ast.items_import_records();
+        for source_index in linker_graph.reachable_files.iter() {
+            let source_index = source_index.get() as usize;
+            if !is_document(css_asts, loaders, source_index)
+                || !file_entry_bits[source_index].has_intersection(&entry_point_bits)
+            {
+                continue;
+            }
+            for record in import_records[source_index].iter() {
+                if record.source_index.is_valid() {
+                    referenced_by_documents.set(record.source_index.get() as usize);
+                }
+            }
+        }
+    }
+
     // Write all chunks that have files associated with this entry point.
     // Also include browser chunks from server builds (lazy-loaded chunks from dynamic imports).
     // When there's only one HTML import, all browser chunks belong to that manifest.
@@ -301,7 +327,9 @@ pub(crate) fn write<W: Write + ?Sized>(
             }
             let bits: &AutoBitSet = &file_entry_bits[source_index.get() as usize];
 
-            if bits.has_intersection(&entry_point_bits) {
+            if bits.has_intersection(&entry_point_bits)
+                || referenced_by_documents.is_set(source_index.get() as usize)
+            {
                 already_visited_output_file.set(i);
                 if !first {
                     writer.write_all(b",")?;

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -47,10 +47,11 @@ use bun_resolver::fs::FileSystem;
 
 use crate::Graph::Graph;
 use crate::chunk::{Content, Flags};
-use crate::linker_context_mod::is_document;
 use crate::options::{Loader, OutputKind};
 use crate::options_impl::LoaderExt as _;
 use crate::{BundleV2, Chunk, LinkerGraph};
+
+use crate::linker_context_mod::is_document;
 
 #[derive(Clone, Copy)]
 pub struct HTMLImportManifest<'a> {
@@ -236,31 +237,6 @@ pub(crate) fn write<W: Write + ?Sized>(
     let file_entry_bits: &[AutoBitSet] = linker_graph.files.items_entry_bits();
     let mut already_visited_output_file = AutoBitSet::init_empty(additional_output_files.len())?;
 
-    // Assets referenced by this entry point's documents (`<img src>` in the
-    // HTML, `url()` in its stylesheets) carry no entry bits of their own (see
-    // `is_document`), so they are attributed through the documents that
-    // reference them. Assets imported from JS are reached through their own
-    // entry bits below.
-    let mut referenced_by_documents = AutoBitSet::init_empty(file_entry_bits.len())?;
-    if !additional_output_files.is_empty() {
-        let css_asts = linker_graph.ast.items_css();
-        let loaders = graph.input_files.items_loader();
-        let import_records = linker_graph.ast.items_import_records();
-        for source_index in linker_graph.reachable_files.iter() {
-            let source_index = source_index.get() as usize;
-            if !is_document(css_asts, loaders, source_index)
-                || !file_entry_bits[source_index].has_intersection(&entry_point_bits)
-            {
-                continue;
-            }
-            for record in import_records[source_index].iter() {
-                if record.source_index.is_valid() {
-                    referenced_by_documents.set(record.source_index.get() as usize);
-                }
-            }
-        }
-    }
-
     // Write all chunks that have files associated with this entry point.
     // Also include browser chunks from server builds (lazy-loaded chunks from dynamic imports).
     // When there's only one HTML import, all browser chunks belong to that manifest.
@@ -312,6 +288,31 @@ pub(crate) fn write<W: Write + ?Sized>(
                     OutputKind::Chunk
                 },
             )?;
+        }
+    }
+
+    // Assets referenced by this entry point's documents (`<img src>` in the
+    // HTML, `url()` in its stylesheets) carry no entry bits of their own (see
+    // `is_document`), so they are attributed through the documents that
+    // reference them. Assets imported from JS are reached through their own
+    // entry bits below.
+    let mut referenced_by_documents = AutoBitSet::init_empty(file_entry_bits.len())?;
+    if !additional_output_files.is_empty() {
+        let css_asts = linker_graph.ast.items_css();
+        let loaders = graph.input_files.items_loader();
+        let import_records = linker_graph.ast.items_import_records();
+        for source_index in linker_graph.reachable_files.iter() {
+            let source_index = source_index.get() as usize;
+            if !is_document(css_asts, loaders, source_index)
+                || !file_entry_bits[source_index].has_intersection(&entry_point_bits)
+            {
+                continue;
+            }
+            for record in import_records[source_index].iter() {
+                if record.source_index.is_valid() {
+                    referenced_by_documents.set(record.source_index.get() as usize);
+                }
+            }
         }
     }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -852,6 +852,7 @@ impl<'a> LinkerContext<'a> {
         let css_reprs: *const [crate::bundled_ast::CssCol] = self.graph.ast.items_css();
         let side_effects: *const [SideEffects] =
             self.parse_graph().input_files.items_side_effects();
+        let loaders: *const [Loader] = self.parse_graph().input_files.items_loader();
         let entry_point_kinds: *const [EntryPoint::Kind] =
             std::ptr::from_ref(self.graph.files.items_entry_point_kind());
         let entry_points: *const [crate::IndexInt] = self.graph.entry_points.items_source_index();
@@ -866,6 +867,7 @@ impl<'a> LinkerContext<'a> {
         let (
             entry_points,
             side_effects,
+            loaders,
             import_records,
             entry_point_kinds,
             css_reprs,
@@ -877,6 +879,7 @@ impl<'a> LinkerContext<'a> {
             (
                 &*entry_points,
                 &*side_effects,
+                &*loaders,
                 &*import_records,
                 &*entry_point_kinds,
                 &*css_reprs,
@@ -898,6 +901,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 entry_point_kinds,
                 css_reprs,
+                loaders,
                 worklist: Vec::new(),
             };
 
@@ -927,6 +931,7 @@ impl<'a> LinkerContext<'a> {
                 import_records,
                 file_entry_bits,
                 css_reprs,
+                loaders,
                 queue: std::collections::VecDeque::new(),
             };
 
@@ -2580,7 +2585,41 @@ pub(crate) struct TreeShakeCtx<'a, 'r> {
     pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) entry_point_kinds: &'r [EntryPoint::Kind],
     pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub(crate) loaders: &'r [Loader],
     pub(crate) worklist: Vec<TreeShakeWork>,
+}
+
+/// Whether `source_index` is a stylesheet or an HTML document rather than a
+/// JS module.
+///
+/// A document takes part in linking only through the modules it references
+/// (see [`document_links_to`]). The assets it references (`url()`, `<img
+/// src>`, ...) are resolved when the document itself is printed and are
+/// copied to the output by `process_files_to_copy`; the lazy-export JS stub
+/// such an asset parses to is only a module when JS imports it. Marking it
+/// live with the document's entry bits would make `compute_chunks` treat the
+/// stub as JS reached by the document's entry point and emit a JS chunk for
+/// it. `HTMLImportManifest` and `MetafileBuilder` attribute these assets to
+/// the documents that reference them instead.
+pub(crate) fn is_document(
+    css_reprs: &[crate::bundled_ast::CssCol],
+    loaders: &[Loader],
+    source_index: usize,
+) -> bool {
+    css_reprs[source_index].is_some() || loaders[source_index] == Loader::Html
+}
+
+/// Whether an import record of a document (see [`is_document`]) pointing at
+/// `source_index` links a module (a stylesheet via `@import`/`composes`/
+/// `<link rel="stylesheet">`, a script via `<script src>`) as opposed to
+/// referencing an asset. A stylesheet pointing at a JS file is rejected by
+/// `scan_css_imports` before linking gets here.
+pub(crate) fn document_links_to(
+    css_reprs: &[crate::bundled_ast::CssCol],
+    loaders: &[Loader],
+    source_index: usize,
+) -> bool {
+    css_reprs[source_index].is_some() || loaders[source_index].is_javascript_like()
 }
 
 #[derive(Clone, Copy)]
@@ -2598,6 +2637,7 @@ pub(crate) struct CodeSplitCtx<'a, 'r> {
     pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) file_entry_bits: &'r mut [AutoBitSet],
     pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
+    pub(crate) loaders: &'r [Loader],
     pub(crate) queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
 }
 
@@ -2640,13 +2680,19 @@ impl<'a> LinkerContext<'a> {
             }
             let out_dist = distance + 1;
 
+            let from_document = is_document(ctx.css_reprs, ctx.loaders, source_index as usize);
             for record in ctx.import_records[source_index as usize].iter() {
-                if record.source_index.is_valid()
-                    && !self.is_external_dynamic_import(record, source_index)
-                    && !ctx.file_entry_bits[record.source_index.get() as usize]
-                        .is_set(entry_points_count)
+                if !record.source_index.is_valid() {
+                    continue;
+                }
+                let other = record.source_index.get();
+                if from_document && !document_links_to(ctx.css_reprs, ctx.loaders, other as usize) {
+                    continue;
+                }
+                if !self.is_external_dynamic_import(record, source_index)
+                    && !ctx.file_entry_bits[other as usize].is_set(entry_points_count)
                 {
-                    ctx.queue.push_back((record.source_index.get(), out_dist));
+                    ctx.queue.push_back((other, out_dist));
                 }
             }
 
@@ -2727,26 +2773,13 @@ impl<'a> LinkerContext<'a> {
             return;
         }
 
-        if ctx.css_reprs[source_index as usize].is_some() {
+        if is_document(ctx.css_reprs, ctx.loaders, source_index as usize) {
             for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
                     let other = record.source_index.get();
-                    if !self.graph.files_live.is_set(other as usize) {
-                        ctx.worklist.push(TreeShakeWork::File(other));
-                    }
-                }
-            }
-            return;
-        }
-
-        // HTML files can reference non-JS/CSS assets (favicons, images, etc.)
-        // via .url kind import records. Follow all import records for HTML files
-        // so these assets are marked live and included in the manifest.
-        if self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html {
-            for record in ctx.import_records[source_index as usize].iter() {
-                if record.source_index.is_valid() {
-                    let other = record.source_index.get();
-                    if !self.graph.files_live.is_set(other as usize) {
+                    if document_links_to(ctx.css_reprs, ctx.loaders, other as usize)
+                        && !self.graph.files_live.is_set(other as usize)
+                    {
                         ctx.worklist.push(TreeShakeWork::File(other));
                     }
                 }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2592,15 +2592,16 @@ pub(crate) struct TreeShakeCtx<'a, 'r> {
 /// Whether `source_index` is a stylesheet or an HTML document rather than a
 /// JS module.
 ///
-/// A document takes part in linking only through the modules it references
-/// (see [`document_links_to`]). The assets it references (`url()`, `<img
-/// src>`, ...) are resolved when the document itself is printed and are
-/// copied to the output by `process_files_to_copy`; the lazy-export JS stub
-/// such an asset parses to is only a module when JS imports it. Marking it
-/// live with the document's entry bits would make `compute_chunks` treat the
-/// stub as JS reached by the document's entry point and emit a JS chunk for
-/// it. `HTMLImportManifest` and `MetafileBuilder` attribute these assets to
-/// the documents that reference them instead.
+/// Tree shaking and code splitting follow a document's import records only
+/// into the modules it links (see [`document_links_to`]). The assets it
+/// references (`url()`, `<img src>`, ...) are resolved when the document
+/// itself is printed and are copied to the output by `process_files_to_copy`;
+/// the lazy-export JS stub such an asset parses to is only a module when JS
+/// imports it. Marking it live with the document's entry bits would make
+/// `compute_chunks` treat the stub as JS reached by the document's entry
+/// point and emit a JS chunk for it. Consequently such assets carry entry
+/// bits only from their JS importers; `HTMLImportManifest` and
+/// `MetafileBuilder` attribute them to the documents that reference them.
 pub(crate) fn is_document(
     css_reprs: &[crate::bundled_ast::CssCol],
     loaders: &[Loader],
@@ -2773,7 +2774,21 @@ impl<'a> LinkerContext<'a> {
             return;
         }
 
-        if is_document(ctx.css_reprs, ctx.loaders, source_index as usize) {
+        if ctx.css_reprs[source_index as usize].is_some() {
+            for record in ctx.import_records[source_index as usize].iter() {
+                if record.source_index.is_valid() {
+                    let other = record.source_index.get();
+                    if document_links_to(ctx.css_reprs, ctx.loaders, other as usize)
+                        && !self.graph.files_live.is_set(other as usize)
+                    {
+                        ctx.worklist.push(TreeShakeWork::File(other));
+                    }
+                }
+            }
+            return;
+        }
+
+        if ctx.loaders[source_index as usize] == Loader::Html {
             for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
                     let other = record.source_index.get();

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2589,19 +2589,12 @@ pub(crate) struct TreeShakeCtx<'a, 'r> {
     pub(crate) worklist: Vec<TreeShakeWork>,
 }
 
-/// Whether `source_index` is a stylesheet or an HTML document rather than a
-/// JS module.
-///
-/// Tree shaking and code splitting follow a document's import records only
-/// into the modules it links (see [`document_links_to`]). The assets it
-/// references (`url()`, `<img src>`, ...) are resolved when the document
-/// itself is printed and are copied to the output by `process_files_to_copy`;
-/// the lazy-export JS stub such an asset parses to is only a module when JS
-/// imports it. Marking it live with the document's entry bits would make
-/// `compute_chunks` treat the stub as JS reached by the document's entry
-/// point and emit a JS chunk for it. Consequently such assets carry entry
-/// bits only from their JS importers; `HTMLImportManifest` and
-/// `MetafileBuilder` attribute them to the documents that reference them.
+/// A stylesheet or an HTML document, as opposed to a JS module. Linking
+/// follows a document's import records only into the modules it links
+/// ([`document_links_to`]): its assets are printed into the document itself,
+/// so they carry no entry bits of their own (a document's entry bits would
+/// make `compute_chunks` emit a JS chunk for the asset's lazy-export stub),
+/// and the manifest and the metafile find them through the document's records.
 pub(crate) fn is_document(
     css_reprs: &[crate::bundled_ast::CssCol],
     loaders: &[Loader],
@@ -2610,11 +2603,9 @@ pub(crate) fn is_document(
     css_reprs[source_index].is_some() || loaders[source_index] == Loader::Html
 }
 
-/// Whether an import record of a document (see [`is_document`]) pointing at
-/// `source_index` links a module (a stylesheet via `@import`/`composes`/
-/// `<link rel="stylesheet">`, a script via `<script src>`) as opposed to
-/// referencing an asset. A stylesheet pointing at a JS file is rejected by
-/// `scan_css_imports` before linking gets here.
+/// Whether a document's import record to `source_index` links a module (a
+/// stylesheet or a script) rather than referencing an asset; see [`is_document`].
+/// `scan_css_imports` has already rejected stylesheets pointing at JS.
 pub(crate) fn document_links_to(
     css_reprs: &[crate::bundled_ast::CssCol],
     loaders: &[Loader],

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -221,11 +221,10 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
     // defer seen_sources.deinit() — handled by Drop
 
-    // Mark all files that appear in chunks. `compute_chunks` files documents
-    // too (an HTML entry point into its JS chunk, an imported stylesheet into
-    // its CSS chunk), but the assets they reference belong to no chunk (see
-    // `is_document`). Those are written as the documents' imports below, so
-    // they are listed as inputs as well.
+    // Mark all files that appear in chunks, plus the assets of the documents
+    // among them (HTML entry points sit in their JS chunk, imported stylesheets
+    // in their CSS chunk): those are in no chunk (see `is_document`) but are
+    // written as the documents' imports below.
     let css_asts = parse_graph.ast.items_css();
     for chunk in chunks.iter() {
         for &source_index in chunk.files_with_parts_in_chunk.keys() {

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -44,6 +44,7 @@ use bun_ast::ImportKind;
 use bun_ast::ImportRecordFlags;
 
 use crate::chunk::Content as ChunkContent;
+use crate::linker_context_mod::is_document;
 use crate::options::Loader;
 use crate::{Chunk, Index, LinkerContext};
 
@@ -220,11 +221,29 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
     // defer seen_sources.deinit() — handled by Drop
 
-    // Mark all files that appear in chunks
+    // Mark all files that appear in chunks. The assets referenced by the
+    // documents (HTML files, stylesheets) among them belong to no chunk (see
+    // `is_document`) but are written as those documents' imports below, so
+    // they are listed as inputs as well.
+    let css_asts = parse_graph.ast.items_css();
     for chunk in chunks.iter() {
         for &source_index in chunk.files_with_parts_in_chunk.keys() {
-            if (source_index as usize) < sources.len() {
-                seen_sources.set(source_index as usize);
+            let source_index = source_index as usize;
+            if source_index >= sources.len() {
+                continue;
+            }
+            seen_sources.set(source_index);
+
+            if source_index < import_records_list.len()
+                && is_document(css_asts, loaders, source_index)
+            {
+                for record in import_records_list[source_index].as_slice() {
+                    if record.source_index.is_valid()
+                        && (record.source_index.get() as usize) < sources.len()
+                    {
+                        seen_sources.set(record.source_index.get() as usize);
+                    }
+                }
             }
         }
     }

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -221,9 +221,10 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
     // defer seen_sources.deinit() — handled by Drop
 
-    // Mark all files that appear in chunks. The assets referenced by the
-    // documents (HTML files, stylesheets) among them belong to no chunk (see
-    // `is_document`) but are written as those documents' imports below, so
+    // Mark all files that appear in chunks. `compute_chunks` files documents
+    // too (an HTML entry point into its JS chunk, an imported stylesheet into
+    // its CSS chunk), but the assets they reference belong to no chunk (see
+    // `is_document`). Those are written as the documents' imports below, so
     // they are listed as inputs as well.
     let css_asts = parse_graph.ast.items_css();
     for chunk in chunks.iter() {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -328,6 +328,92 @@ describe("bundler", () => {
     },
   });
 
+  // The url() assets of a stylesheet are printed into the stylesheet itself.
+  // They are not JS modules reached by the stylesheet's entry point, so a CSS
+  // entry point must not produce a JS chunk for them.
+  itBundled("splitting/CSSEntryPointWithURLAssetEmitsNoJSChunk", {
+    files: {
+      "/app.ts": `console.log("app");`,
+      "/style.css": `.foo { background: url(./img.png); }`,
+      "/img.png": Buffer.from("not really a png"),
+    },
+    entryPoints: ["/app.ts", "/style.css"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["app.js", "style.css"]);
+      api.expectFile("/out/style.css").toContain("data:image/png;base64,");
+    },
+  });
+
+  // Same as above, but the asset is also imported from JS. The stylesheet's
+  // entry point must not count as a second importer that splits the asset's
+  // module out of app.js into a shared chunk.
+  itBundled("splitting/AssetImportedByJSAndReferencedByCSSEntryPoint", {
+    files: {
+      "/app.ts": `
+        import img from "./img.png";
+        console.log("app", img);
+      `,
+      "/style.css": `.foo { background: url(./img.png); }`,
+      "/img.png": Buffer.from("not really a png"),
+    },
+    entryPoints: ["/app.ts", "/style.css"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual([
+        "app.js",
+        expect.stringMatching(/^img-[a-z0-9]+\.png$/),
+        "style.css",
+      ]);
+      api.expectFile("/out/app.js").not.toContain("import");
+    },
+    run: {
+      file: "/out/app.js",
+      stdout: /^app \.\/img-[a-z0-9]+\.png$/,
+    },
+  });
+
+  // Likewise for an asset referenced from two HTML documents: it is not a JS
+  // module shared by the two pages, so there is nothing to split into a chunk
+  // that both page scripts would have to import.
+  itBundled("splitting/AssetSharedByTwoHTMLEntryPointsEmitsNoJSChunk", {
+    files: {
+      "/index.html": `<!DOCTYPE html><html><head><script type="module" src="./index.ts"></script></head><body><img src="./logo.png"></body></html>`,
+      "/about.html": `<!DOCTYPE html><html><head><script type="module" src="./about.ts"></script></head><body><img src="./logo.png"></body></html>`,
+      "/index.ts": `console.log("index");`,
+      "/about.ts": `console.log("about");`,
+      "/logo.png": Buffer.from("not really a png"),
+    },
+    entryPoints: ["/index.html", "/about.html"],
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    format: "esm",
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual([
+        expect.stringMatching(/^about-[a-z0-9]+\.js$/),
+        "about.html",
+        expect.stringMatching(/^index-[a-z0-9]+\.js$/),
+        "index.html",
+        expect.stringMatching(/^logo-[a-z0-9]+\.png$/),
+      ]);
+      for (const file of readdirSync(api.outdir)) {
+        if (file.endsWith(".js")) {
+          api.expectFile(join("out", file)).not.toContain("import");
+        }
+        if (file.endsWith(".html")) {
+          api.expectFile(join("out", file)).toMatch(/<img src="\.\/logo-[a-z0-9]+\.png">/);
+        }
+      }
+    },
+  });
+
   // N same-named cross-chunk exports must get unique aliases in O(N) total
   // (ExportRenamer::next_renamed_name). Debug/ASAN builds blow past the 15s
   // cap with far fewer files than release, hence the scaled N.

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -262,6 +262,86 @@ console.log(JSON.stringify(html.files.map(f => [f.input, f.loader, f.path])));
     },
   });
 
+  // Each page's manifest lists the assets referenced by that page's own
+  // documents: a stylesheet shared by both pages attributes its asset to both,
+  // while the stylesheet and the <img> only the second page has stay out of
+  // the first page's manifest. With code splitting, an asset shared by two
+  // pages used to additionally produce an empty JS chunk, which showed up in
+  // both manifests as a chunk entry without an input.
+  for (const splitting of [false, true]) {
+    itBundled(`html-import/per-page-document-assets${splitting ? "-with-splitting" : ""}`, {
+      outdir: "out/",
+      splitting,
+      files: {
+        "/server.js": `
+import a from "./a.html";
+import b from "./b.html";
+const project = html => html.files.map(f => [f.input ?? null, f.loader]).sort();
+console.log(JSON.stringify({ a: project(a), b: project(b) }));
+`,
+        "/a.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./shared.css" />
+  </head>
+  <body>
+    <img src="./shared-logo.png" />
+    <script type="module" src="./a.ts"></script>
+  </body>
+</html>`,
+        "/b.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./shared.css" />
+    <link rel="stylesheet" href="./b.css" />
+  </head>
+  <body>
+    <img src="./shared-logo.png" />
+    <img src="./b-only.png" />
+    <script type="module" src="./b.ts"></script>
+  </body>
+</html>`,
+        "/a.ts": `console.log("a");`,
+        "/b.ts": `console.log("b");`,
+        "/shared.css": `body { background: url(./shared-bg.png); }`,
+        "/b.css": `h1 { background: url(./b-bg.png); }`,
+        // The url() assets are >= 128 KiB so that the CSS bundler copies them
+        // instead of inlining them; assets referenced from HTML are always copied.
+        "/shared-bg.png": Buffer.alloc(128 * 1024, "s"),
+        "/b-bg.png": Buffer.alloc(128 * 1024, "b"),
+        "/shared-logo.png": "shared logo",
+        "/b-only.png": "b only",
+      },
+      entryPoints: ["/server.js"],
+      target: "bun",
+
+      run: {
+        validate({ stdout }) {
+          expect(JSON.parse(stdout)).toEqual({
+            a: [
+              ["a.html", "css"],
+              ["a.html", "html"],
+              ["a.html", "js"],
+              ["shared-bg.png", "file"],
+              ["shared-logo.png", "file"],
+            ],
+            b: [
+              ["b-bg.png", "file"],
+              ["b-only.png", "file"],
+              ["b.html", "css"],
+              ["b.html", "html"],
+              ["b.html", "js"],
+              ["shared-bg.png", "file"],
+              ["shared-logo.png", "file"],
+            ],
+          });
+        },
+      },
+    });
+  }
+
   // Test manifest with multiple HTML imports
   itBundled("html-import/multiple-manifests", {
     outdir: "out/",

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -207,6 +207,58 @@ console.log(JSON.stringify(html, null, 2));
       expect(faviconFile).toBeDefined();
       expect(faviconFile.loader).toBe("file");
       expect(faviconFile.headers["content-type"]).toBe("image/svg+xml");
+    },
+  });
+
+  // Assets referenced from the page's stylesheets (including @imported ones)
+  // are attributed to the page through the stylesheet, since they are not
+  // part of the JS module graph.
+  itBundled("html-import/stylesheet-url-assets-in-manifest", {
+    outdir: "out/",
+    files: {
+      "/server.js": `
+import html from "./index.html";
+console.log(JSON.stringify(html.files.map(f => [f.input, f.loader, f.path])));
+`,
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <script type="module" src="./app.ts"></script>
+  </body>
+</html>`,
+      "/app.ts": `console.log("app loaded");`,
+      "/styles.css": `@import "./theme.css";\nbody { margin: 0; }`,
+      "/theme.css": `body { background: url(./bg.png); }`,
+      // Large enough (>= 128 KiB) that the CSS bundler copies it to the output
+      // directory instead of inlining it as a data: URL; only copied assets
+      // have an output to serve.
+      "/bg.png": Buffer.alloc(128 * 1024, "x"),
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+
+    run: {
+      validate({ stdout }) {
+        const files: [string, string, string][] = JSON.parse(stdout);
+        expect(files.map(([input, loader]) => [input, loader])).toEqual([
+          ["index.html", "js"],
+          ["index.html", "html"],
+          ["index.html", "css"],
+          ["bg.png", "file"],
+        ]);
+        expect(files[3][2]).toMatch(/^\.\/bg-[a-z0-9]+\.png$/);
+      },
+    },
+
+    onAfterBundle(api) {
+      const pngs = readdirSync(api.join("out")).filter(f => f.endsWith(".png"));
+      expect(pngs).toEqual([expect.stringMatching(/^bg-[a-z0-9]+\.png$/)]);
+      const css = readdirSync(api.join("out")).find(f => f.endsWith(".css"))!;
+      expect(api.readFile(join("out", css))).toContain(`url("./${pngs[0]}")`);
     },
   });
 

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -521,6 +521,48 @@ describe("bundler metafile", () => {
     expect(Object.keys(cssOutput.inputs)).toEqual([styleKey]);
   });
 
+  test("metafile lists the assets an HTML page and its stylesheet reference as inputs but not as part of the JS output", async () => {
+    using dir = tempDir("metafile-html-assets", {
+      "index.html": `<!DOCTYPE html><html><head><link rel="stylesheet" href="./style.css"></head><body><img src="./logo.png"><script type="module" src="./app.ts"></script></body></html>`,
+      "style.css": `.foo { background: url(./bg.png); }`,
+      "app.ts": `console.log("app");`,
+      "logo.png": "not really a png",
+      "bg.png": "not really a png either",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/index.html`],
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+
+    const metafile = result.metafile as Metafile;
+    const basename = (key: string) => key.split(/[\\/]/).pop()!;
+    expect(Object.keys(metafile.inputs).map(basename).sort()).toEqual([
+      "app.ts",
+      "bg.png",
+      "index.html",
+      "logo.png",
+      "style.css",
+    ]);
+
+    // Every import edge written for the two documents resolves to an input.
+    for (const name of ["index.html", "style.css"]) {
+      const key = Object.keys(metafile.inputs).find(k => basename(k) === name)!;
+      expect(metafile.inputs[key].imports.length).toBeGreaterThan(0);
+      for (const imp of metafile.inputs[key].imports) {
+        expect(imp.path in metafile.inputs).toBe(true);
+      }
+    }
+
+    // The assets are emitted through the HTML and CSS outputs; the page's JS
+    // output is made of its script only.
+    const [, jsOutput] = Object.entries(metafile.outputs).find(([path]) => path.endsWith(".js"))!;
+    const jsInputs = Object.keys(jsOutput.inputs).map(basename);
+    expect(jsInputs).toContain("app.ts");
+    expect(jsInputs.filter(name => name.endsWith(".png"))).toEqual([]);
+  });
+
   test("metafile import paths match input keys for all importers of a shared module", async () => {
     // When the same module is imported from many files, every import record must emit the
     // resolved pretty path (matching the "inputs" key), not the raw "./b/shared.js" specifier.

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -488,6 +488,39 @@ describe("bundler metafile", () => {
     expect(foundCssBundle).toBe(true);
   });
 
+  test("metafile lists a stylesheet's url() asset as an input but not as part of the JS output", async () => {
+    using dir = tempDir("metafile-css-url-asset", {
+      "entry.js": `import "./style.css"; console.log("styled");`,
+      "style.css": `.foo { background: url(./img.png); }`,
+      "img.png": "not really a png",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+
+    const metafile = result.metafile as Metafile;
+    const styleKey = Object.keys(metafile.inputs).find(k => k.endsWith("style.css"))!;
+    expect(styleKey).toBeDefined();
+
+    // The url() is an import edge of the stylesheet, and every bundled import
+    // edge resolves to an input.
+    const imgImport = metafile.inputs[styleKey].imports.find(imp => imp.path.endsWith("img.png"))!;
+    expect(imgImport).toMatchObject({ kind: "url-token", original: "./img.png" });
+    expect(imgImport.path in metafile.inputs).toBe(true);
+
+    // The asset is emitted through the stylesheet; it contributes nothing to
+    // the JS output and is not listed as one of its inputs.
+    const [jsOutputKey, jsOutput] = Object.entries(metafile.outputs).find(([path]) => path.endsWith(".js"))!;
+    expect(jsOutputKey).toBeDefined();
+    expect(Object.keys(jsOutput.inputs).map(k => k.split(/[\\/]/).pop())).toEqual(["entry.js"]);
+
+    const [, cssOutput] = Object.entries(metafile.outputs).find(([path]) => path.endsWith(".css"))!;
+    expect(Object.keys(cssOutput.inputs)).toEqual([styleKey]);
+  });
+
   test("metafile import paths match input keys for all importers of a shared module", async () => {
     // When the same module is imported from many files, every import record must emit the
     // resolved pretty path (matching the "inputs" key), not the raw "./b/shared.js" specifier.


### PR DESCRIPTION
### Problem
- `bun build app.ts style.css --outdir out --splitting`, where `style.css` contains `url(./img.png)`, emits a 0-byte `app-<hash>.js` chunk that nothing imports. esbuild emits no such chunk for the same input.
- Two HTML entry points that both contain `<img src="./logo.png">`, built with `--splitting`, get an empty `index-<hash>.js` chunk that both page scripts `import`: one extra request per page for an empty file.
- An asset that `app.ts` imports and a CSS entry point also references with `url()` is split out of `app.js` into its own chunk (`var img_default = "./img-<hash>.png"; export { img_default }`), where esbuild keeps it inline in `app.js`.
- Cause: `mark_file_live_step` (`src/bundler/LinkerContext.rs`, the CSS and HTML branches) marks every file a stylesheet or HTML document references as live, and `mark_file_reachable_for_code_splitting` gives it the document's entry bits. An asset loaded with the file/dataurl/base64/text loader has a JS AST (a lazy-export stub), so the "Figure out which JS files are in which chunk" loop in `src/bundler/linker_context/computeChunks.rs` treats it as a JS module reached by the document's entry point: it creates a chunk keyed by `{css entry}` / `{page1, page2}` (no such chunk exists, so a new one is made, containing only the dead stub) or by `{app, css entry}` (splitting the stub out of `app.js`). `compute_cross_chunk_dependencies` then makes every entry point import the chunks that carry its bit, which is where the `import "./index-<hash>.js"` in both pages comes from.

### Fix
- Documents (stylesheets and HTML files) now follow their import records only into the modules they link: other stylesheets (`@import`, `composes`, `<link rel="stylesheet">`) and scripts (`<script src>`). Their asset references no longer make the asset live or give it entry bits (`document_links_to` applied inside the existing CSS and HTML branches of `mark_file_live_step`, and `is_document` / `document_links_to` in `mark_file_reachable_for_code_splitting`, `LinkerContext.rs`). A stylesheet cannot point at a JS file (`scan_css_imports` rejects that before linking), so for stylesheets this means CSS targets only, as before for those.
- The CSS and HTML branches of `mark_file_live_step` are deliberately left as two branches (the filter is applied inside each) rather than merged: #38307 and #38319 / #38455 each add stylesheet-specific fall-throughs to the CSS branch, and #38347 reworks the chunk part of the manifest. Checked with `git merge-tree` against the current heads of #38347, #38319, #38307, #38286 and #38455: this branch merges cleanly with each of them in either order. With #38347 the manifest block here runs after its widened `entry_point_bits` are computed, so stylesheets that a page only reaches through a lazy chunk then get their assets attributed as well.
- Why this is correct: an asset referenced by a document is not JS that the document's entry point needs. Its URL is printed by the CSS/HTML printer from `url_for_css` / `unique_key_for_additional_file`, and the file itself is copied by `process_files_to_copy` from the reachable-file set, before linking; neither looks at liveness or entry bits. The stub is a module only when JS imports it, and in that case it still gets exactly the entry bits of its JS importers, which is what esbuild computes too (esbuild detaches these import records from the graph at scan time, so its linker never sees the edge). Genuinely shared JS modules that tree-shake to nothing still get their (empty) shared chunk as before, matching esbuild; only document-to-asset edges are affected.
- The two consumers that relied on assets carrying entry bits now attribute them through the documents:
  - `HTMLImportManifest.rs`: the `files` array also lists assets referenced by any document whose entry bits intersect the manifest's entry point (the page itself, and the stylesheets linked from it, including `@import`ed ones, which keep getting the page's bits because document-to-stylesheet edges are still followed). Assets imported from JS are listed through their own bits as before. The output is the same as before for every case the old mechanism covered (#27821's test still passes, and fails if this attribution is removed).
  - `MetafileBuilder.rs`: `inputs` also lists the assets referenced by documents that are in a chunk, so the `url-token` import edge written for the stylesheet still resolves to an input key. The JS output's `inputs` no longer lists the asset with `bytesInOutput: 0`, which matches esbuild's metafile.
- Which targets count as linked modules: the HTML scanner (`HTMLScanner.rs`, `TAG_HANDLERS`) only produces records for scripts/workers, stylesheets, and asset tags (images, media, icons, fonts, manifest); there is no iframe or anchor handler, so a document never legitimately points at another HTML file or at JSON as a module (`resolve_import_records` also forces the `file` loader onto the JSON/TOML-like targets of asset tags so they are copied). The one output that changes outside of chunking is the degenerate `<img src="./other.html">`: before, following that edge bundled `other.html`'s scripts into the referencing page's JS (the tag itself was left untouched either way); now it bundles nothing, same as the tag. A `<script src="./data.json">` produces identical output before and after (the tag is left as is, nothing is bundled).
- Not changed: `compute_chunks` itself, so this composes with #38319 / #38307 / #38286 (the dynamically imported stylesheet there now simply has no dead asset stub in its chunk). A user-specified CSS entry point's files were already absent from the metafile; with this change the entry's assets are absent too instead of being listed as inputs of the stray chunk (that gap is tracked separately).
- Tests (all fail on the released build, pass with this change):
  - `test/bundler/bundler_splitting.test.ts`: `CSSEntryPointWithURLAssetEmitsNoJSChunk`, `AssetImportedByJSAndReferencedByCSSEntryPoint` (also runs the output), `AssetSharedByTwoHTMLEntryPointsEmitsNoJSChunk`
  - `test/bundler/metafile.test.ts`: one test for a JS entry point importing a stylesheet with a `url()` asset, one for an HTML entry point with an `<img>` and a stylesheet `url()` asset: the assets stay listed in `inputs` and every import edge of the documents resolves to an input, while the JS output's `inputs` no longer lists them.
  - `test/bundler/html-import-manifest.test.ts`: `per-page-document-assets-with-splitting`: two pages imported by one server file, sharing a stylesheet (with a copied `url()` asset) and an `<img>`, the second page with a stylesheet and an `<img>` of its own. On the released build both manifests additionally contain two chunk entries without an `input` (the empty asset chunk and the runtime chunk it drags along).
- Manifest attribution guards in `test/bundler/html-import-manifest.test.ts` (pass before and after, and fail if the new attribution or its per-page filter is removed, as does the existing `html-referenced-assets-in-manifest` from #27821): `stylesheet-url-assets-in-manifest` (a `url()` asset in an `@import`ed stylesheet) and `per-page-document-assets` (the non-splitting variant of the two-page case: the second page's stylesheet asset and `<img>` must not leak into the first page's manifest, the shared ones must appear in both).
- Also run, all passing: `bundler_splitting`, `html-import-manifest`, `metafile`, `bundler_html`, `bundler_html_server`, `bun-serve-html-manifest`, `esbuild/{css,loader,splitting,metafile}`, `bundler_loader`, `css/`, `standalone`, `compile-asset-bunfs`, `bun-build-api`, `bundler_edgecase`, `bundler_compile` (HTML import test), `regression/issue/22317`. `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` are clean.

### Background
- Entry bits: tree shaking first marks files live from each entry point (`mark_file_live_for_tree_shaking`), then a second pass records, per live file, the set of entry points that reach it (`file_entry_bits`). With `--splitting`, `compute_chunks` groups live JS files by that set: files reached by exactly one entry point go into its chunk, files reached by several go into a shared chunk keyed by the set, created on demand.
- Asset stubs: a file loaded with a non-JS loader (`file`, `dataurl`, `base64`, `text`, ...) is parsed into a small JS AST exporting its URL or contents, so that JS can `import` it. A stylesheet or HTML document referencing the same file does not use that AST: the CSS/HTML printer substitutes the asset's URL directly, and the file is copied to the output directory from the reachable-file set before linking.
- HTML import manifest: when server code imports an HTML file, the bundler embeds a JSON list of that page's outputs (JS/CSS chunks, the HTML, and the assets it needs) into the server bundle so `Bun.serve` can serve them. Until now it found the assets by checking which of them carried the page's entry bit; that is what #27821 added the HTML branch in `mark_file_live_step` for.

<details>
<summary>Repro output before / after</summary>

```sh
printf 'PNG' > img.png
printf '.foo { background: url(./img.png) }\n' > style.css
printf 'console.log("app")\n' > app.ts
bun build app.ts style.css --outdir out --splitting
```

Before:

```
  app.js           30 bytes  (entry point)
  app-hs26peg6.js  0 KB      (chunk)
  style.css        74 bytes  (asset)
```

After:

```
  app.js     30 bytes  (entry point)
  style.css  74 bytes  (asset)
```

Two HTML pages sharing `<img src="./logo.png">`, built with `--splitting`, before (`index-ksat6xxb.js` is empty):

```js
// out/index-tj70cc7g.js
import"./index-ksat6xxb.js";

// a.js
console.log("a");
```

After, each page's script is just its own code and no extra chunk is emitted.

`app.ts` importing `img.png` while `style.css` (an entry point) also references it, before: `app.js` imports `img_default` from a separate `app-<hash>.js` chunk holding only `var img_default = "./img-<hash>.png"`. After: that line is in `app.js`, as esbuild emits.
</details>
