### PR TITLE
strings: drop the '\r' from line 1 of CRLF files in error code frames

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1797,11 +1797,12 @@ pub(crate) fn index_of_line_ranges<const LINE_RANGE_COUNT: usize>(
                     };
                 }
                 CR => {
+                    let cr_i = cursor.i;
                     if iter.next(&mut cursor) && cursor.c == NL {
                         current_line += 1;
                         break 'brk LineRange {
                             start: 0,
-                            end: cursor.i,
+                            end: cr_i,
                         };
                     }
                 }
@@ -1822,7 +1823,10 @@ pub(crate) fn index_of_line_ranges<const LINE_RANGE_COUNT: usize>(
         return ranges;
     }
 
-    let mut prev_end = first_newline_range.end;
+    // Every later range starts at the '\n' that ended the line before it
+    // (callers trim it), so resume from the '\n' the cursor stopped on rather
+    // than from the first range's end, which for CRLF is the '\r' before it.
+    let mut prev_end = cursor.i;
     while let Some(current_i) =
         index_of_newline_or_non_ascii_check_start::<true>(text, cursor.i + u32::from(cursor.width))
     {

--- a/test/js/bun/util/inspect-error-crlf.test.ts
+++ b/test/js/bun/util/inspect-error-crlf.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// The code frame above an error is cut out of the original file, so a CRLF file
+// has to print exactly like an LF one. Line 1 used to keep its "\r" (the lines
+// after it never did), which also leaked into Bun.inspect(err) strings.
+//
+// inspect-error.test.js pins its own line numbers in inline snapshots, so these
+// live next to it instead of in it.
+describe.concurrent("code frame of a file with CRLF line endings", () => {
+  async function run(entry: string) {
+    using dir = tempDir("inspect-error-crlf", { "entry.js": entry });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.split("\n"), stderr: stderr.split("\n"), exitCode };
+  }
+
+  test("uncaught error below line 1", async () => {
+    const { stdout, stderr, exitCode } = await run("'L1';\r\n'L2';\r\nthrow new Error('x');\r\n");
+    expect({ stdout, stderr: stderr.slice(0, 5), exitCode }).toEqual({
+      stdout: [""],
+      stderr: ["1 | 'L1';", "2 | 'L2';", "3 | throw new Error('x');", "              ^", "error: x"],
+      exitCode: 1,
+    });
+  });
+
+  test("uncaught error on line 1", async () => {
+    const { stdout, stderr, exitCode } = await run("throw new Error('x');\r\n'L2';\r\n");
+    expect({ stdout, stderr: stderr.slice(0, 3), exitCode }).toEqual({
+      stdout: [""],
+      stderr: ["1 | throw new Error('x');", "              ^", "error: x"],
+      exitCode: 1,
+    });
+  });
+
+  test("empty line 1", async () => {
+    const { stdout, stderr, exitCode } = await run("\r\nthrow new Error('x');\r\n");
+    expect({ stdout, stderr: stderr.slice(0, 4), exitCode }).toEqual({
+      stdout: [""],
+      stderr: ["1 | ", "2 | throw new Error('x');", "              ^", "error: x"],
+      exitCode: 1,
+    });
+  });
+
+  test("Bun.inspect(error)", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      "'L1';\r\nconst err = new Error('x');\r\nprocess.stdout.write(Bun.inspect(err));\r\n",
+    );
+    expect({ stdout: stdout.slice(0, 4), stderr, exitCode }).toEqual({
+      stdout: ["1 | 'L1';", "2 | const err = new Error('x');", "                    ^", "error: x"],
+      stderr: [""],
+      exitCode: 0,
+    });
+  });
+
+  // The CSS parser locates its diagnostics with the same line lookup, and
+  // BuildMessage exposes the line as position.lineText.
+  test("CSS syntax error on line 1", async () => {
+    using dir = tempDir("inspect-error-crlf", { "entry.css": "}\r\na {}\r\n" });
+    const result = await Bun.build({ entrypoints: [`${dir}/entry.css`], throw: false });
+    expect(result.logs.map(log => [log.position?.line, log.position?.lineText])).toEqual([[1, "}"]]);
+  });
+});


### PR DESCRIPTION
### Problem
- In the code frame bun prints above an uncaught error (and in `Bun.inspect(err)` / `console.error(err)` output) from a file with CRLF line endings, line 1 keeps its carriage return: `1 | 'L1';\r`. Lines 2 and later print cleanly. Only visible when line 1 is inside the preview window (the error is on one of the first 6 lines).
- The same `\r` shows up as `position.lineText` (`"}\r"`) of a CSS diagnostic reported on line 1 of a CRLF stylesheet, since the CSS parser locates its diagnostics with the same helper.
- Cause: `index_of_line_ranges` in `src/bun_core/string/immutable.rs`. The scan for the first line (line 1799 on main) ends the range at the `\n` of a `\r\n` pair, so the `\r` stays inside it. The main loop (line 1842 on main) ends every later line at the `\r`, which is why only line 1 is affected. The display helper (`trimmed_text()` in `src/jsc/ZigStackTrace.rs`) strips `\n` only, and the inspector's `LifecycleReporter.error` payload and `BuildMessage.position.lineText` use the ranges as they are.

### Fix
- End the first line's range at the `\r` when the first line break is `\r\n`, the same boundary the main loop already uses for every other line.
- Keep resuming the scan from the `\n` (`prev_end = cursor.i`, which is the `\n` in both the `\n` and `\r\n` cases, so the main loop is unchanged). Later ranges deliberately start at the `\n` that ended the previous line because `trimmed_text()` strips `\n` from both ends; starting them at the `\r` instead would put `\r\n` at the front of line 2, which `trimmed_text()` does not strip.
- Fixing the range rather than adding `\r` to `trimmed_text()` fixes every consumer of the helper at once (code frame, `Bun.inspect`, CSS `lineText`, inspector payload) and matches what the helper already does for lines 2+. LF files are unaffected: their first range already ended at the `\n` exclusive, and `prev_end` has the same value as before.
- The open #36683 changes the tail of this function (unterminated final line); this change is confined to the first-line scan and does not overlap with it. The vm/eval code frame comes from a different producer (`ZigException.cpp`, handled in #38244) and is not affected either way.
- Verified with `test/js/bun/util/inspect-error-crlf.test.ts`: uncaught error below line 1, on line 1 (the `target_line == 0` early return), empty line 1, `Bun.inspect(err)`, and a CSS diagnostic on line 1. All 5 fail on the released binary and on a debug build of main with `src/` stashed; all pass with the fix. The existing `inspect-error.test.js`, `reportError.test.ts`, `test-test.test.ts`, `run-eval.test.ts`, and the CSS error tests still pass. These tests are a sibling file because `inspect-error.test.js` pins its own line numbers in inline snapshots, so adding an import there rewrites unrelated snapshots.

### Background
- Code frame: the numbered source lines, caret and `name: message` bun prints above a stack trace. For transpiled files `remap_zig_exception` (`src/jsc/VirtualMachine.rs`) re-reads the original file and calls `get_lines_in_text`, which wraps `index_of_line_ranges`, to cut out the error line and up to 5 lines above it.
- `index_of_line_ranges` returns one `(start, end)` byte range per line. It scans the first line separately from the rest: the first range starts at byte 0, and each later range starts where the previous line's terminator was found (`prev_end`), so lines 2+ carry a leading `\n` that the printers trim (`trimmed_text()` in `ZigStackTrace.rs`, and the logger's own trimming for CSS diagnostics printed by bun itself).
- Consumers that do not trim: `InspectorLifecycleAgent.cpp` sends the strings to debugger frontends as `sourceLines`, and `BuildMessage.rs` exposes a CSS diagnostic's line as `position.lineText`.

<details>
<summary>Repro</summary>

```sh
printf "'L1';\r\n'L2';\r\nthrow new Error('x');\r\n" > crlf.js
bun crlf.js 2>&1 | head -3 | cat -A
```

Before:

```
1 | 'L1';^M$
2 | 'L2';$
3 | throw new Error('x');$
```

After:

```
1 | 'L1';$
2 | 'L2';$
3 | throw new Error('x');$
```

CSS, before and after (`printf '}\r\na {}\r\n' > a.css`, then `Bun.build({ entrypoints: ["./a.css"], throw: false })`): `logs[0].position.lineText` is `"}\r"` before and `"}"` after. Diagnostics on lines 2+ of a CSS file still carry the leading `\n` described above; that is a separate shape in the CSS consumer and is not changed here.
</details>
