### PR TITLE
bake: classify routes by reverse reachability from the client proxies

### DIFF
--- a/src/bundler/linker_context/StaticRouteVisitor.rs
+++ b/src/bundler/linker_context/StaticRouteVisitor.rs
@@ -1,115 +1,112 @@
-//! The `is_fully_static(source_index)` function returns whether or not
-//! `source_index` imports a file with `"use client"`.
+//! Decides whether a bake route (a server entry point) transitively imports a
+//! file with `"use client"`. A route that imports none is prerendered without
+//! the client entry script (`BakeRouteKind::FullyStaticRoute`), so a false
+//! negative here ships a page that never hydrates.
 //!
-//! TODO: Could we move this into the ReachableFileVisitor inside `bundle_v2.rs`?
+//! `LinkerGraph::load` points every server side import of a `"use client"`
+//! file at the boundary's generated reference proxy
+//! (`ServerComponentBoundary::reference_source_index`), so a route needs the
+//! client script iff it has an import path to one of those proxies. That is
+//! computed for every file at once by walking the import records backwards from
+//! the proxies. Each file is marked the first time it is reached, so import
+//! cycles need no special handling; a forward walk per route has to deal with
+//! a file whose only path to a proxy leads through a file the walk is still
+//! inside of (see the import cycle test in `test/bake/dev/production.test.ts`).
 
 use crate::mal_prelude::*;
-use bun_collections::{ArrayHashMap, AutoBitSet};
+use bun_alloc::AllocError;
+use bun_collections::AutoBitSet;
 use bun_core::env_var;
 
-use crate::import_record;
-use crate::{Index, LinkerContext, UseDirective};
+use crate::{LinkerContext, UseDirective};
 
-pub(crate) struct StaticRouteVisitor<'a> {
-    pub(crate) c: &'a LinkerContext<'a>,
-    pub(crate) cache: ArrayHashMap</* Index::Int */ u32, bool>,
-    pub(crate) visited: AutoBitSet,
+#[derive(Default)]
+pub(crate) struct StaticRouteVisitor {
+    /// The client reference proxies and every file that transitively imports
+    /// one, indexed by source index. Computed by the first query; only bake
+    /// production builds ever make one.
+    files_reaching_client: Option<AutoBitSet>,
 }
 
-impl<'a> StaticRouteVisitor<'a> {
-    /// This the quickest, simplest, dumbest way I can think of doing this.
-    /// Investigate performance. It can have false negatives (it doesn't properly
-    /// handle cycles), but that's okay as it's just used an optimization
-    pub(crate) fn has_transitive_use_client(&mut self, entry_point_source_index: u32) -> bool {
+impl StaticRouteVisitor {
+    pub(crate) fn has_transitive_use_client(
+        &mut self,
+        c: &LinkerContext,
+        entry_point_source_index: u32,
+    ) -> Result<bool, AllocError> {
         if cfg!(debug_assertions)
             && env_var::BUN_SSG_DISABLE_STATIC_ROUTE_VISITOR
                 .get()
                 .unwrap_or(false)
         {
-            return false;
+            return Ok(false);
         }
 
-        // `self.c` is `&'a LinkerContext` (Copy), so these slice
-        // borrows are tied to `'a`, not to `&self`, and do not conflict with
-        // the `&mut self` call below. `parse_graph()` is the safe backref
-        // accessor (one centralized `unsafe`, see `LinkerContext::parse_graph`).
-        let parse_graph = self.c.parse_graph();
-        let all_import_records: &[import_record::List<'_>] = parse_graph.ast.items_import_records();
-        let referenced_source_indices: &[u32] = parse_graph
-            .server_component_boundaries
-            .list
-            .items_reference_source_index();
-        let use_directives: &[UseDirective] = parse_graph
-            .server_component_boundaries
-            .list
-            .items_use_directive();
-
-        self.has_transitive_use_client_impl(
-            all_import_records,
-            referenced_source_indices,
-            use_directives,
-            Index::init(entry_point_source_index),
-        )
-    }
-
-    /// 1. Get AST for `source_index`
-    /// 2. Recursively traverse its imports in import records
-    /// 3. If any of the imports match any item in
-    ///    `referenced_source_indices` which has `use_directive ==
-    ///    .client`, then we know `source_index` is NOT fully
-    ///    static.
-    fn has_transitive_use_client_impl(
-        &mut self,
-        all_import_records: &[import_record::List<'_>],
-        referenced_source_indices: &[u32],
-        use_directives: &[UseDirective],
-        source_index: Index,
-    ) -> bool {
-        if let Some(result) = self.cache.get(&source_index.get()) {
-            return *result;
-        }
-        if self.visited.is_set(source_index.get() as usize) {
-            return false;
-        }
-        self.visited.set(source_index.get() as usize);
-
-        let import_records = &all_import_records[source_index.get() as usize];
-
-        let result = 'result: {
-            for import_record in import_records.as_slice() {
-                if !import_record.source_index.is_valid() {
-                    continue;
-                }
-
-                // check if this import is a client boundary
-                debug_assert_eq!(referenced_source_indices.len(), use_directives.len());
-                for (referenced_source_index, use_directive) in
-                    referenced_source_indices.iter().zip(use_directives)
-                {
-                    if *use_directive != UseDirective::Client {
-                        continue;
-                    }
-                    // it's a client boundary
-                    if *referenced_source_index == import_record.source_index.get() {
-                        break 'result true;
-                    }
-                }
-
-                // otherwise check its children
-                if self.has_transitive_use_client_impl(
-                    all_import_records,
-                    referenced_source_indices,
-                    use_directives,
-                    import_record.source_index,
-                ) {
-                    break 'result true;
-                }
-            }
-            false
+        let files_reaching_client = match &mut self.files_reaching_client {
+            Some(files) => files,
+            None => self.files_reaching_client.insert(files_reaching_client(c)?),
         };
-
-        self.cache.insert(source_index.get(), result);
-
-        result
+        Ok(files_reaching_client.is_set(entry_point_source_index as usize))
     }
+}
+
+fn files_reaching_client(c: &LinkerContext) -> Result<AutoBitSet, AllocError> {
+    let import_records = c.graph.ast.items_import_records();
+    let file_count = import_records.len();
+    let mut reaching = AutoBitSet::init_empty(file_count)?;
+
+    let boundaries = &c.parse_graph().server_component_boundaries.list;
+    let mut worklist: Vec<u32> = Vec::new();
+    for (&proxy, use_directive) in boundaries
+        .items_reference_source_index()
+        .iter()
+        .zip(boundaries.items_use_directive())
+    {
+        if *use_directive == UseDirective::Client && !reaching.is_set(proxy as usize) {
+            reaching.set(proxy as usize);
+            worklist.push(proxy);
+        }
+    }
+    if worklist.is_empty() {
+        return Ok(reaching);
+    }
+
+    // Every import record is an edge `importer -> imported`. Group the edges by
+    // imported file: the importers of `file` are
+    // `importers[importer_offsets[file]..importer_offsets[file + 1]]`.
+    let edges = import_records
+        .iter()
+        .enumerate()
+        .flat_map(|(importer, records)| {
+            records
+                .iter()
+                .filter(|record| record.source_index.is_valid())
+                .map(move |record| (importer as u32, record.source_index.get() as usize))
+        });
+
+    let mut importer_offsets = vec![0usize; file_count + 1];
+    for (_, imported) in edges.clone() {
+        importer_offsets[imported + 1] += 1;
+    }
+    for file in 0..file_count {
+        importer_offsets[file + 1] += importer_offsets[file];
+    }
+    let mut importers = vec![0u32; importer_offsets[file_count]];
+    let mut next_slot = importer_offsets[..file_count].to_vec();
+    for (importer, imported) in edges {
+        importers[next_slot[imported]] = importer;
+        next_slot[imported] += 1;
+    }
+
+    while let Some(file) = worklist.pop() {
+        let file = file as usize;
+        for &importer in &importers[importer_offsets[file]..importer_offsets[file + 1]] {
+            if !reaching.is_set(importer as usize) {
+                reaching.set(importer as usize);
+                worklist.push(importer);
+            }
+        }
+    }
+
+    Ok(reaching)
 }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -623,15 +623,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     // SAFETY: c points to LinkerContext which is the `linker` field of BundleV2.
     let bundler: &mut BundleV2 =
         unsafe { &mut *LinkerContext::bundle_v2_ptr(std::ptr::from_mut::<LinkerContext>(c)) };
-    let mut static_route_visitor = StaticRouteVisitor {
-        // SAFETY: launder via raw ptr so this long-lived
-        // shared borrow doesn't conflict with `c.log_disjoint()` inside
-        // the chunk loop below. `c` outlives `static_route_visitor`.
-        c: unsafe { bun_ptr::detach_lifetime_ref::<LinkerContext>(c) },
-        cache: bun_collections::ArrayHashMap::default(),
-        visited: AutoBitSet::init_empty(c.graph.files.len()).expect("oom"),
-    };
-    // defer static_route_visitor.deinit() — handled by Drop
+    let mut static_route_visitor = StaticRouteVisitor::default();
 
     // For standalone mode, resolve JS/CSS chunks so we can inline their content into HTML.
     // Closing tag escaping (</script → <\\/script, </style → <\\/style) is handled during
@@ -1128,10 +1120,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         } else {
                             // an error
                             // logger OOM-only
-                            // Split-borrow — `static_route_visitor.c` holds a
-                            // detached `&LinkerContext`; `log_disjoint` returns the
-                            // disjoint `Transpiler.log` backref so no `&mut c` is
-                            // materialized.
                             let _ = c.log_disjoint().add_error_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
@@ -1288,7 +1276,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             && side == options::Side::Server
                         {
                             extra.route = if static_route_visitor
-                                .has_transitive_use_client(chunk.entry_point.source_index())
+                                .has_transitive_use_client(c, chunk.entry_point.source_index())?
                             {
                                 BakeRouteKind::Route
                             } else {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
 import { bunEnv, bunExe } from "harness";
 import path from "path";
-import { tempDirWithBakeDeps } from "../bake-harness";
+import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
 
 const normalizePath = (path: string) => (process.platform === "win32" ? path.replaceAll("\\", "/") : path);
 const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", "\\") : path);
@@ -594,4 +594,81 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  test(
+    "route reaching a client component through an import cycle is not fully static",
+    async () => {
+      // Card and Panel only reach the "use client" component through the barrel
+      // file `components/index.ts`, which imports both of them back and lists
+      // the client component last. Each route imports one of the two, so
+      // whichever route is classified first, the other route's only path to the
+      // client component runs through the cycle; a walk that gives up on a file
+      // it is already inside of misclassifies that other route.
+      const dir = await tempDirWithBakeDeps("bake-production-use-client-import-cycle", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "components/Client.tsx": `"use client";
+export default function Client() {
+  return <button>client</button>;
+}`,
+        "components/index.ts": `export { default as Card } from "./Card";
+export { default as Panel } from "./Panel";
+export { default as Client } from "./Client";`,
+        "components/Card.tsx": `import { Client } from "./index";
+export default function Card() {
+  return <div>card <Client /></div>;
+}`,
+        "components/Panel.tsx": `import { Client } from "./index";
+export default function Panel() {
+  return <div>panel <Client /></div>;
+}`,
+        "pages/card.tsx": `import Card from "../components/Card";
+export default function CardPage() {
+  return <Card />;
+}`,
+        "pages/panel.tsx": `import Panel from "../components/Panel";
+export default function PanelPage() {
+  return <Panel />;
+}`,
+        // Control: a cycle without a client component in it stays fully static.
+        "lib/a.ts": `import { bName } from "./b";
+export const aName = "a";
+export function ab() { return aName + bName; }`,
+        "lib/b.ts": `import { aName } from "./a";
+export const bName = "b";
+export function ba() { return bName + aName; }`,
+        "pages/plain.tsx": `import { ab } from "../lib/a";
+export default function PlainPage() {
+  return <p>{ab()}</p>;
+}`,
+        "package.json": JSON.stringify({
+          "name": "test-app",
+          "version": "1.0.0",
+          "devDependencies": {
+            "react": "^18.0.0",
+            "react-dom": "^18.0.0",
+          },
+        }),
+      });
+
+      const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`.cwd(dir).throws(false);
+      expect(exitCode, stderr.toString()).toBe(0);
+
+      const read = (route: string) => Bun.file(path.join(dir, "dist", route, "index.html")).text();
+      const [card, panel, plain] = await Promise.all([read("card"), read("panel"), read("plain")]);
+
+      expect(card).toContain("<button>client</button>");
+      expect(panel).toContain("<button>client</button>");
+      expect(plain).toContain("<p>ab</p>");
+
+      const hasClientScript = (html: string) => html.includes('<script type="module"');
+      expect({
+        card: hasClientScript(card),
+        panel: hasClientScript(panel),
+        plain: hasClientScript(plain),
+      }).toEqual({ card: true, panel: true, plain: false });
+    },
+    // Three bundler graphs plus prerendering; too slow for the default timeout
+    // on debug and sanitizer builds.
+    30_000 * WAIT_MULTIPLIER,
+  );
 });


### PR DESCRIPTION
### Problem
- In a production bake build (`bun build --app`, built-in `react` framework), a route whose only path to a `"use client"` component runs through an import cycle can be emitted as `BakeRouteKind::FullyStaticRoute` and prerendered without its client entry `<script>`, so the client component on that page never hydrates.
- Cause: `src/bundler/linker_context/StaticRouteVisitor.rs` classified routes with a forward DFS whose `cache` and `visited` set are shared across routes. Reaching a file that is still on the DFS stack returns `false` for that edge, and the importing file then stores `false` for itself (`cache.insert` at the end of `has_transitive_use_client_impl`) even though its only path to a client component goes through the file on the stack. A route classified later that reaches the client component only through that file gets the cached `false`.
- Shape that triggers it: a barrel `components/index.ts` that re-exports `Card`, `Panel` and a `"use client"` component, with `Card` and `Panel` importing from the barrel, and one route per component. Whichever route is classified first finishes the other route's component while the barrel is still on the stack, so the other route is misclassified regardless of route order. The doc comment on the old code called the false negatives acceptable "as it's just used an optimization", but the result decides whether a page gets its script.

### Fix
- Replace the per-route walk with one reverse reachability pass (`files_reaching_client`): seed a bitset with the client reference proxies (`server_component_boundaries` entries with `UseDirective::Client`, using their `reference_source_index`), build the importer lists from every import record with a valid `source_index`, and walk from the proxies over importers, marking each file the first time it is reached. `has_transitive_use_client` is then a bitset lookup.
- Correct because `LinkerGraph::load` points every server side import of a `"use client"` file at its proxy, so "route needs the client script" is exactly "route has an import path to a proxy", and the set of files with such a path is the reverse closure of the proxies. The walk marks a file once and pushes it once, so cycles cannot produce a false negative and it runs in linear time in files plus import records. It follows the same edges (import records with a valid `source_index`, read at the same point in `generate_chunks_in_parallel`) and uses the same proxy set as before, so acyclic graphs classify exactly as they did; only routes that were previously misclassified through cycles change.
- The set is computed on the first query, so builds that never classify a route (everything except bake production builds) do nothing new; with no client boundaries it stops after allocating the bitset. It is also no longer recursive per edge, and the visitor no longer keeps a laundered `&LinkerContext` alive across the output loop (`c` is passed to the query), which removes an `unsafe` block from `generate_chunks_in_parallel`.
- Test: `test/bake/dev/production.test.ts` "route reaching a client component through an import cycle is not fully static" builds the barrel shape above with two routes and asserts both prerendered pages contain the client script, plus a control route whose import cycle contains no client component and must stay static. Fails on the release build and on a debug build without the `src/` change (`panel` page has no script), passes with it.
- Also ran with the debug build: the rest of `test/bake/dev/production.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bake/dev/ssg-pages-router.test.ts`, `test/bake/dev/import-meta-inline.test.ts`, `test/bundler/bundler_splitting.test.ts`, `test/bundler/esbuild/splitting.test.ts`, `test/bundler/bundler_html_server.test.ts`; `cargo clippy -p bun_bundler` and `cargo fmt` are clean.
- Not changed: routes that only reach a client component through `import()` are still classified after `compute_cross_chunk_dependencies` has cleared those records; #38238 moves the classification earlier and can call `files_reaching_client` once from there, the algorithm does not depend on where it runs.

### Background
- Server component boundary (SCB): a `"use client"` file in a bake build. Besides the client build of the file, the bundler generates a "client reference proxy" module for the server graph (`ServerComponentBoundary::reference_source_index`) whose exports are `registerClientReference(...)` stubs; `LinkerGraph::load` rewrites server side import records that point at the original file to point at the proxy.
- Fully static route: bake prerenders every server entry point ("route") to HTML. `generate_chunks_in_parallel` tags each route's output file with `BakeRouteKind`; `production.rs` turns `FullyStaticRoute` into the `noClient` flag read by `renderRoutesForProdStatic` (`src/js/builtins/Bake.ts`), which then renders the page with an empty module list, i.e. no client entry script.
- The importer lists are stored in CSR form (one offsets array indexed by file, one flat array of importers) so the pass allocates two arrays instead of one list per file.
