### PR TITLE
bundler: list CSS entry points in the metafile and report copied asset sizes

### DIFF
--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -113,6 +113,10 @@ pub struct InputFile {
     pub additional_files: AstVec<AdditionalFile>,
     pub unique_key_for_additional_file: Box<[u8], AstAlloc>,
     pub content_hash_for_additional_file: u64,
+    /// Length of `source.contents` before `process_files_to_copy` moved the
+    /// bytes into this file's asset `OutputFile`, which leaves `source.contents`
+    /// empty. `None` for files that are not copied.
+    pub copied_contents_len: Option<usize>,
     pub flags: InputFileFlags,
 }
 
@@ -126,6 +130,7 @@ impl Default for InputFile {
             additional_files: AstAlloc::vec(),
             unique_key_for_additional_file: AstAlloc::vec().into_boxed_slice(),
             content_hash_for_additional_file: 0,
+            copied_contents_len: None,
             flags: InputFileFlags::default(),
         }
     }
@@ -143,6 +148,7 @@ bun_collections::multi_array_columns! {
         additional_files: AstVec<AdditionalFile>,
         unique_key_for_additional_file: Box<[u8], AstAlloc>,
         content_hash_for_additional_file: u64,
+        copied_contents_len: Option<usize>,
         flags: InputFileFlags,
     }
 }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4180,11 +4180,12 @@ pub mod bv2_impl {
                 let self_ptr: *mut Self = self;
                 // SAFETY: see note above — disjoint MultiArrayList columns,
                 // raw-ptr sidestep for split-borrow against `transpiler_for_target`
-                // inside the loop. All six column derefs share the same invariant.
+                // inside the loop. All seven column derefs share the same invariant.
                 let (
                     unique_key_for_additional_files,
                     content_hashes_for_additional_files,
                     sources,
+                    copied_contents_lens,
                     targets,
                     additional_files,
                     loaders,
@@ -4199,6 +4200,10 @@ pub mod bv2_impl {
                             .input_files
                             .items_content_hash_for_additional_file(),
                         (*self_ptr).graph.input_files.items_source_mut(),
+                        (*self_ptr)
+                            .graph
+                            .input_files
+                            .items_copied_contents_len_mut(),
                         (*self_ptr).graph.ast.items_target(),
                         (*self_ptr).graph.input_files.items_additional_files_mut(),
                         (*self_ptr).graph.input_files.items_loader(),
@@ -4282,6 +4287,7 @@ pub mod bv2_impl {
                         // out instead of `to_vec()`-cloning,
                         // which is prohibitively expensive for large assets.
                         let contents_len = source.contents.len();
+                        copied_contents_lens[index] = Some(contents_len);
                         let contents = match core::mem::take(&mut source.contents) {
                             std::borrow::Cow::Owned(v) => v.into_boxed_slice(),
                             std::borrow::Cow::Borrowed(b) => Box::<[u8]>::from(b),

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -141,9 +141,12 @@ pub(crate) fn generate_chunk_json(
     json.extend_from_slice(b"\n      ]");
 
     // Write exports and entry point if applicable
-    // Use sorted_and_filtered_export_aliases for deterministic output and to exclude internal exports
+    // Use sorted_and_filtered_export_aliases for deterministic output and to exclude internal exports.
+    // Only JS output has exports: a CSS chunk's entry point is either a JS file
+    // (whose exports belong to the JS chunk) or a stylesheet (whose JS-side
+    // exports are not printed into the CSS).
     json.extend_from_slice(b",\n      \"exports\": [");
-    if chunk.entry_point.is_entry_point() {
+    if chunk.entry_point.is_entry_point() && matches!(chunk.content, ChunkContent::Javascript(_)) {
         let entry_source_index = chunk.entry_point.source_index();
         // Use sources.len as the authoritative bounds check
         if (entry_source_index as usize) < sources.len() {
@@ -214,6 +217,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let parse_graph = c.parse_graph();
     let sources = parse_graph.input_files.items_source();
     let loaders = parse_graph.input_files.items_loader();
+    let copied_contents_lens = parse_graph.input_files.items_copied_contents_len();
     let import_records_list = parse_graph.ast.items_import_records();
 
     // Iterate through all files in chunks to collect unique source indices
@@ -272,8 +276,10 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
             j.push_owned(buf.into_boxed_slice());
         }
         {
+            let bytes =
+                copied_contents_lens[source_index as usize].unwrap_or(source.contents.len());
             let mut buf: Vec<u8> = Vec::new();
-            write!(buf, ": {{\n      \"bytes\": {}", source.contents.len())?;
+            write!(buf, ": {{\n      \"bytes\": {}", bytes)?;
             j.push_owned(buf.into_boxed_slice());
         }
 

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -31,6 +31,24 @@ fn make_flags(has_html_chunk: bool, is_browser_chunk_from_server_build: bool) ->
     f
 }
 
+/// The stylesheets printed into a CSS chunk, each with a zeroed `bytesInOutput`
+/// counter that `generate_compile_result_for_css_chunk` adds to. The metafile
+/// lists a chunk's inputs (and the inputs of the whole build) from this map, so a
+/// stylesheet missing from it never shows up in the metafile.
+fn css_files_with_parts_in_chunk(
+    order: &[chunk::CssImportOrder],
+) -> ArrayHashMap<IndexInt, AtomicUsize> {
+    let mut files: ArrayHashMap<IndexInt, AtomicUsize> = ArrayHashMap::new();
+    for entry in order {
+        if let chunk::CssImportOrderKind::SourceIndex(source_index) = &entry.kind {
+            files
+                .put(source_index.get(), AtomicUsize::new(0))
+                .expect("oom");
+        }
+    }
+    files
+}
+
 #[inline(never)]
 pub(crate) fn compute_chunks(
     this: &mut LinkerContext,
@@ -167,6 +185,7 @@ pub(crate) fn compute_chunks(
             if !css_chunk_entry.found_existing {
                 // const css_chunk_entry = try js_chunks.getOrPut();
                 let order_len = order.len() as usize;
+                let files_with_parts_in_chunk = css_files_with_parts_in_chunk(order.slice());
                 *css_chunk_entry.value_ptr = Chunk {
                     entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
                     entry_bits: entry_point_chunk_bits,
@@ -177,6 +196,7 @@ pub(crate) fn compute_chunks(
                             .collect::<Vec<_>>()
                             .into_boxed_slice(),
                     }),
+                    files_with_parts_in_chunk,
                     output_source_map: SourceMapPieces::init(),
                     flags: make_flags(
                         has_html_chunk,
@@ -249,15 +269,7 @@ pub(crate) fn compute_chunks(
 
                 if !css_chunk_entry.found_existing {
                     let order_len = order.len() as usize;
-                    let mut css_files_with_parts_in_chunk: ArrayHashMap<IndexInt, AtomicUsize> =
-                        ArrayHashMap::new();
-                    for entry in order.slice() {
-                        if let chunk::CssImportOrderKind::SourceIndex(si) = &entry.kind {
-                            css_files_with_parts_in_chunk
-                                .put(si.get(), AtomicUsize::new(0))
-                                .expect("oom");
-                        }
-                    }
+                    let files_with_parts_in_chunk = css_files_with_parts_in_chunk(order.slice());
                     *css_chunk_entry.value_ptr = Chunk {
                         entry_point: chunk::EntryPoint::new(source_index, entry_bit, true, false),
                         entry_bits: entry_bits.clone()?,
@@ -268,7 +280,7 @@ pub(crate) fn compute_chunks(
                                 .collect::<Vec<_>>()
                                 .into_boxed_slice(),
                         }),
-                        files_with_parts_in_chunk: css_files_with_parts_in_chunk,
+                        files_with_parts_in_chunk,
                         output_source_map: SourceMapPieces::init(),
                         flags: make_flags(
                             has_html_chunk,

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
+import { basename } from "node:path";
 
 // Type definitions for metafile structure
 interface MetafileImport {
@@ -13,7 +14,7 @@ interface MetafileImport {
 interface MetafileInput {
   bytes: number;
   imports: MetafileImport[];
-  format?: "esm" | "cjs";
+  format?: "esm" | "cjs" | "json" | "css";
 }
 
 interface MetafileOutput {
@@ -28,6 +29,11 @@ interface MetafileOutput {
 interface Metafile {
   inputs: Record<string, MetafileInput>;
   outputs: Record<string, MetafileOutput>;
+}
+
+/** Re-keys `inputs` / `outputs` by file name, since the keys are paths that depend on where the temp dir is. */
+function byBasename<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).map(([path, value]) => [basename(path), value]));
 }
 
 describe("bundler metafile", () => {
@@ -611,6 +617,111 @@ describe("bundler metafile", () => {
 
     expect(aImportsB).toBe(true);
     expect(bImportsA).toBe(true);
+  });
+
+  test.concurrent("metafile lists a CSS entry point and the stylesheets it imports", async () => {
+    const entryCss = `@import "./reset.css";\n.foo { color: red; }\n`;
+    const resetCss = `* { margin: 0; }\n`;
+    using dir = tempDir("metafile-css-entry-point", {
+      "entry.css": entryCss,
+      "reset.css": resetCss,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.css`],
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+    const metafile = result.metafile as Metafile;
+
+    expect(byBasename(metafile.inputs)).toEqual({
+      "entry.css": {
+        bytes: Buffer.byteLength(entryCss),
+        imports: [{ path: expect.stringMatching(/reset\.css$/), kind: "import-rule", original: "./reset.css" }],
+        format: "css",
+      },
+      "reset.css": {
+        bytes: Buffer.byteLength(resetCss),
+        imports: [],
+        format: "css",
+      },
+    });
+
+    const outputs = byBasename(metafile.outputs);
+    expect(Object.keys(outputs)).toEqual(["entry.css"]);
+    const output = outputs["entry.css"];
+    expect(byBasename(output.inputs)).toEqual({
+      "entry.css": { bytesInOutput: expect.any(Number) },
+      "reset.css": { bytesInOutput: expect.any(Number) },
+    });
+    for (const { bytesInOutput } of Object.values(output.inputs)) {
+      expect(bytesInOutput).toBeGreaterThan(0);
+    }
+    expect(output.exports).toEqual([]);
+    expect(output.entryPoint).toMatch(/entry\.css$/);
+  });
+
+  test.concurrent("metafile only lists exports on JS outputs", async () => {
+    using dir = tempDir("metafile-css-output-exports", {
+      "lib.js": `import "./styles.module.css"; export const x = 1; export default 2;`,
+      "styles.module.css": `.foo { color: red; }`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/lib.js`, `${dir}/styles.module.css`],
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+
+    const outputs = byBasename((result.metafile as Metafile).outputs);
+    const exportsByOutput = Object.fromEntries(Object.entries(outputs).map(([file, output]) => [file, output.exports]));
+    expect(exportsByOutput).toEqual({
+      "lib.js": ["default", "x"],
+      // The CSS bundle of the JS entry point does not repeat the JS exports.
+      "lib.css": [],
+      // A CSS module's class names are exports of its JS side, not of its stylesheet.
+      "styles.module.css": [],
+    });
+  });
+
+  test.concurrent("metafile reports the size of a copied asset", async () => {
+    using dir = tempDir("metafile-copied-asset-bytes", {
+      "entry.js": `import url from "./image.png"; console.log(url);`,
+      "image.png": Buffer.alloc(4096, 1),
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+
+    const inputs = byBasename((result.metafile as Metafile).inputs);
+    expect(inputs["image.png"]).toEqual({ bytes: 4096, imports: [] });
+  });
+
+  test.concurrent("metafile reports the size of an asset whose contents come from an onLoad plugin", async () => {
+    using dir = tempDir("metafile-plugin-asset-bytes", {
+      "entry.js": `import url from "./image.png"; console.log(url);`,
+      "image.png": "on disk",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      metafile: true,
+      plugins: [
+        {
+          name: "generate-image",
+          setup(build) {
+            build.onLoad({ filter: /\.png$/ }, () => ({ contents: new Uint8Array(2048), loader: "file" }));
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+
+    const inputs = byBasename((result.metafile as Metafile).inputs);
+    expect(inputs["image.png"]).toEqual({ bytes: 2048, imports: [] });
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.build({ entrypoints: ["./style.css"], metafile: true })` returns `inputs: {}`: the stylesheet and everything it `@import`s are missing, and `outputs["./style.css"].inputs` is `{}` as well. esbuild lists them (`inputs: { "style.css": { bytesInOutput: N } }`). The same files do show up when a JS entry point imports the stylesheet.
  - Cause: the CSS entry point branch of `compute_chunks` (`src/bundler/linker_context/computeChunks.rs`, "Create chunks for entry points") builds the CSS chunk with `files_with_parts_in_chunk` left empty; the branch below it, for a JS entry point that imports CSS, fills the map from the CSS import order. `MetafileBuilder::generate` derives the `inputs` section from that map, `generate_chunk_json` derives each output's `inputs` from it, and `generate_compile_result_for_css_chunk` only adds `bytesInOutput` for files present in it.
- CSS outputs list exports: a CSS entry point's output has `exports: ["default"]` (plus the class names for a `.module.css`), and the CSS bundle of a JS entry point repeats the JS entry's exports (`entry.css` below lists `["x"]`). esbuild's CSS outputs have no exports.
  - Cause: `generate_chunk_json` writes the exports of the chunk's entry point source for every entry point chunk, regardless of the chunk's content. Those exports belong to the stylesheet's JS side (what `import styles from "./x.module.css"` sees) or to the JS entry, neither of which is in the CSS file.
- A copied asset reports `"bytes": 0` in `inputs`: `import img from "./big.png"` with a 200 KB file gives `inputs["big.png"].bytes === 0` (esbuild: 200000). Same for an asset whose contents an `onLoad` plugin returns with `loader: "file"`.
  - Cause: `process_files_to_copy` (`src/bundler/bundle_v2.rs`) moves `source.contents` out of the input file to hand the buffer to the asset `OutputFile`, and `MetafileBuilder::generate` later reads `source.contents.len()`, which is 0 by then. The Zig version shared the slice with the `OutputFile` instead of moving it, so this regressed in the Rust port.

### Fix
- `compute_chunks`: both CSS chunk constructions seed `files_with_parts_in_chunk` from the CSS import order through one helper (`css_files_with_parts_in_chunk`), so a CSS entry point's chunk takes the same metafile path as a JS entry point's CSS bundle. Nothing else reads the map for CSS chunks: `find_all_imported_parts_in_js_order` and the `compute_cross_chunk_dependencies` walk skip CSS chunks, and the CSS printer only adds to the counters.
- `generate_chunk_json`: exports are written for JS chunks only. CSS and HTML outputs keep `exports: []`, because Bun's and esbuild's metafile types both declare `exports: string[]` on every output and a JS entry's CSS bundle already emitted `[]` whenever the entry had no exports. The JS chunk that #38319 adds for a dynamically imported stylesheet has `Content::Javascript`, so it still lists the stylesheet's exports, as that PR's tests expect.
- `InputFile` gets a `copied_contents_len` column that `process_files_to_copy` sets where it moves the bytes out; `MetafileBuilder::generate` reads it and otherwise falls back to `source.contents.len()`. The move itself stays, it is what makes the handoff of plugin-provided assets zero-copy. The length is not read back from the asset `OutputFile` because by the time the metafile is assembled `generate_chunks_in_parallel` has drained `graph.additional_output_files` into the caller's output list (and standalone HTML builds never create those output files), so the input file keeps the one number the metafile needs.
- Tests in `test/bundler/metafile.test.ts`; all four fail on the released build (1.4.0) and pass with this change:
  - `metafile lists a CSS entry point and the stylesheets it imports` (inputs with sizes, output inputs with non-zero `bytesInOutput`, `exports: []`, `entryPoint`)
  - `metafile only lists exports on JS outputs` (JS entry with exports importing a CSS module, plus the module as a second entry point: covers both CSS chunk constructions)
  - `metafile reports the size of a copied asset` (file read from disk, the `Cow::Borrowed` arm of `process_files_to_copy`)
  - `metafile reports the size of an asset whose contents come from an onLoad plugin` (the `Cow::Owned` arm; the file on disk has a different size, so the number has to come from the plugin's bytes)
- Also run with the debug build, all passing: `esbuild/metafile`, `esbuild/css`, `esbuild/loader`, `esbuild/default`, `css/css-modules`, `bundler_splitting`, `bundler_files`, `bundler_loader`, `bundler_plugin`, `bundler_html`, `bundler_naming`, `bun-build-api`. `cargo clippy -p bun_bundler --no-deps` and `cargo fmt` are clean.
- Composes with #38337, which lists additional inputs starting from the same map; once a CSS entry point's chunk has entries in it, that PR's handling of documents applies to CSS entry points as well. Both PRs add tests to `metafile.test.ts` at different places.

### Background
- Chunk: the linker's unit of output. Every entry point gets a chunk. A JS entry point that imports CSS additionally gets a CSS chunk holding the stylesheets in import order; a CSS entry point gets only a CSS chunk. `Chunk.files_with_parts_in_chunk` maps each source file printed into the chunk to a byte counter: the printers add what they printed for each file, and this map is the metafile's only record of which inputs an output was made from.
- Copied assets: files loaded with the `file` loader (also `napi`, `wasm`, `sqlite`) are emitted unchanged as their own output file. JS that imports one gets a small stub module exporting the asset's URL, which is why the asset also shows up as an input of the JS output with a small `bytesInOutput`. `process_files_to_copy` runs before linking and creates the asset `OutputFile` for each reachable copied file.
- `Source.contents` is a `Cow`: bytes the bundler read itself are borrowed from a per-build arena; bytes an `onLoad` plugin returned for a copied asset are owned so they can be handed to the `OutputFile` without copying. `process_files_to_copy` takes the `Cow` in both cases, which is what empties the source.
- `InputFile` is stored as a struct of arrays (`MultiArrayList`); a field added to the struct and to its `multi_array_columns!` list gets a typed column accessor, which is how the new length gets from `process_files_to_copy` to the metafile builder.

<details>
<summary>Repro output before / after</summary>

```sh
cd $(mktemp -d)
printf '@import "./other.css";\n.foo { color: red }\n' > style.css
printf '.bar { color: blue }\n' > other.css
head -c 200000 /dev/zero > big.png
printf 'import img from "./big.png"; import "./style.css"; export const x = img;\n' > entry.js
bun build ./style.css ./entry.js --outdir=out --metafile=meta.json
```

Before (1.4.0), with the input keys shortened to file names:

```json
"inputs": { "style.css": { "bytes": 43 }, "entry.js": { "bytes": 73 }, "big.png": { "bytes": 0 }, "other.css": { "bytes": 21 } }
"outputs": {
  "./entry.js":  { "inputs": { "big.png": { "bytesInOutput": 47 }, "entry.js": { "bytesInOutput": 21 } }, "exports": ["x"], "entryPoint": "entry.js" },
  "./style.css": { "inputs": {}, "exports": ["default"], "entryPoint": "style.css" },
  "./entry.css": { "inputs": { "other.css": { "bytesInOutput": 24 }, "style.css": { "bytesInOutput": 23 } }, "exports": ["x"], "entryPoint": "entry.js" }
}
```

With `./style.css` as the only entry point, `inputs` is `{}` altogether.

After:

```json
"inputs": { "style.css": { "bytes": 43 }, "entry.js": { "bytes": 73 }, "other.css": { "bytes": 21 }, "big.png": { "bytes": 200000 } }
"outputs": {
  "./entry.js":  { "inputs": { "big.png": { "bytesInOutput": 47 }, "entry.js": { "bytesInOutput": 21 } }, "exports": ["x"], "entryPoint": "entry.js" },
  "./style.css": { "inputs": { "other.css": { "bytesInOutput": 24 }, "style.css": { "bytesInOutput": 23 } }, "exports": [], "entryPoint": "style.css" },
  "./entry.css": { "inputs": { "other.css": { "bytesInOutput": 24 }, "style.css": { "bytesInOutput": 23 } }, "exports": [], "entryPoint": "entry.js" }
}
```
</details>
