### PR TITLE
css: report the diagnostic's line without its line breaks in position.lineText

### DIFF
--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -173,6 +173,24 @@ pub struct ErrorLocation {
     pub(crate) column: u32,
 }
 
+/// The text of 0-based `line` in `contents` without its terminator, or `None`
+/// when `contents` has fewer lines. Lines end where the tokenizer's
+/// `consume_newline` ends them: at `\n`, `\f`, `\r\n` or a lone `\r`.
+fn line_text(contents: &[u8], line: u32) -> Option<&[u8]> {
+    const LINE_TERMINATORS: &[u8] = b"\r\n\x0c";
+    let mut rest = contents;
+    for _ in 0..line {
+        let end = bun_core::strings::index_of_any(rest, LINE_TERMINATORS)?;
+        let terminator_len = if rest[end] == b'\r' && rest.get(end + 1) == Some(&b'\n') {
+            2
+        } else {
+            1
+        };
+        rest = &rest[end + terminator_len..];
+    }
+    Some(bun_core::strings::index_of_any(rest, LINE_TERMINATORS).map_or(rest, |end| &rest[..end]))
+}
+
 impl ErrorLocation {
     pub(crate) fn to_location(
         &self,
@@ -182,8 +200,8 @@ impl ErrorLocation {
         // (`Str` placeholder per src/logger/lib.rs); the slice borrows
         // `source.contents` which outlives the diagnostic. Re-thread once
         // `bun_ast::Location` grows a real lifetime.
-        let line_text = bun_core::strings::get_lines_in_text::<1>(&source.contents, self.line)
-            .map(|lines| unsafe { &*std::ptr::from_ref::<[u8]>(lines.as_slice()[0]) });
+        let line_text = line_text(&source.contents, self.line)
+            .map(|line| unsafe { &*std::ptr::from_ref::<[u8]>(line) });
         Ok(bun_ast::Location {
             file: std::borrow::Cow::Borrowed(source.path.text),
             namespace: source.path.namespace,

--- a/test/js/bun/css/error-line-text.test.ts
+++ b/test/js/bun/css/error-line-text.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// `position.lineText` of a CSS BuildMessage is the text of the reported line
+// without its line terminator, like the JS parser's diagnostics. The CSS
+// tokenizer counts `\n`, `\r\n`, a lone `\r` and a form feed as line breaks, so
+// the line has to be looked up with the same rules for `line` and `lineText`
+// to describe the same line.
+
+const IMPORT_ERROR = "@import rules must come before any other rules except @charset and @layer";
+
+async function cssDiagnostics(source: string) {
+  using dir = tempDir("css-line-text", { "in.css": source });
+  const result = await Bun.build({ entrypoints: [join(String(dir), "in.css")], throw: false });
+  return result.logs.map(({ message, position }) => ({
+    message,
+    line: position?.line,
+    lineText: position?.lineText,
+  }));
+}
+
+const importAfterRule: [name: string, source: string, line: number, lineText: string][] = [
+  ["LF, error on line 2", 'a { color: red; }\n@import "x";\n', 2, '@import "x";'],
+  ["CRLF, error on line 2", 'a { color: red; }\r\n@import "x";\r\n', 2, '@import "x";'],
+  ["LF, blank line before the error", 'a { color: red; }\n\n@import "x";\n', 3, '@import "x";'],
+  ["LF, error on the first line", 'a {} @import "x";\nb {}\n', 1, 'a {} @import "x";'],
+  ["CRLF, error on the first line", 'a {} @import "x";\r\nb {}\r\n', 1, 'a {} @import "x";'],
+  ["LF, error on a last line without a line break", 'a { color: red; }\n@import "x";', 2, '@import "x";'],
+  ["CRLF, error on a last line without a line break", 'a { color: red; }\r\n@import "x";', 2, '@import "x";'],
+  ["lone CR line breaks", 'a { color: red; }\r@import "x";\r', 2, '@import "x";'],
+  ["form feed line break", 'a { color: red; }\f@import "x";\n', 2, '@import "x";'],
+  ["whitespace around the line's content is kept", 'a { color: red; }\n  @import "x";  \n', 2, '  @import "x";  '],
+];
+
+for (const [name, source, line, lineText] of importAfterRule) {
+  test.concurrent(`parse error lineText: ${name}`, async () => {
+    expect(await cssDiagnostics(source)).toEqual([{ message: IMPORT_ERROR, line, lineText }]);
+  });
+}
+
+test.concurrent("parse error lineText: error at the end of input after the last line break", async () => {
+  // A stray `}` is reported at the end of input, on the empty line after it.
+  expect(await cssDiagnostics("a { color: red; }\n}\n")).toEqual([
+    { message: "Unexpected end of input", line: 3, lineText: "" },
+  ]);
+});
+
+test.concurrent("minify error lineText is the reported line without line breaks", async () => {
+  // Nested two-selector rules that the default browser targets cannot express
+  // natively; expanding 17 levels of them trips the selector expansion limit,
+  // which is reported on one of the nested rules.
+  const rule = "co :is(.bar), .bar :is(.baz) {";
+  const source = "/* nested */\n" + (rule + "\n").repeat(17) + "color: red;\n" + "}\n".repeat(17);
+  const [diagnostic, ...rest] = await cssDiagnostics(source);
+  expect(rest).toEqual([]);
+  expect(diagnostic.message).toStartWith("Nested CSS rules expand to more than");
+  expect(diagnostic.line).toBeGreaterThan(1);
+  expect(diagnostic.lineText).toBe(rule);
+});
+
+test.concurrent("bun build prints the code frame for an error on a last line without a line break", async () => {
+  using dir = tempDir("css-line-text-cli", { "in.css": 'a { color: red; }\n@import "x";' });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "in.css"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain(`2 | @import "x";\n`);
+  expect(stderr).toContain(`error: ${IMPORT_ERROR}`);
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
### Problem
- `position.lineText` of a CSS `BuildMessage` (a parse or minify error from `Bun.build` / `bun build`) is not the text of the reported line:
  - on line 2 and later it starts with the `\n` that ended the previous line, and in LF files it also ends with its own `\n`: `"\n@import \"x\";\n"` instead of `"@import \"x\";"`
  - on the last line of a file without a trailing line break it is `""`, and `bun build` prints no code frame for the error
  - in a file with lone `\r` or form feed line breaks it is the whole file, while `line` counts those breaks the way the CSS tokenizer does
- JS parser diagnostics return the bare line for the same inputs (`Location::init_or_null_impl` in `src/ast/lib.rs`), so consumers of `Location.line_text` that do not trim (`src/jsc/BuildMessage.rs`, the bake error overlay in `src/runtime/bake/dev_server/serialized_failure.rs`, `src/runtime/server/DevErrorPage.rs`) only see the bad shape for CSS.
- Cause: `ErrorLocation::to_location` (`src/css/error.rs`) took the line from `bun_core::strings::get_lines_in_text`, the helper that cuts the lines for the error code frame printer, and stored its range as is. Those ranges are shaped for the printers that trim them: every range after the first begins at the previous line's terminator, LF lines keep their own, an unterminated final line is not returned (#36683), and the helper only splits on `\n` / `\r\n`.

### Fix
- `to_location` looks the line up itself: walk `line` terminators from the start of the source, splitting where the tokenizer's `consume_newline` counts a line break (`\n`, `\r\n`, a lone `\r`, form feed), and take the text up to the next one. The result never contains a terminator, exists for an unterminated last line, and is the same line the reported `line` number refers to.
- This is the right layer because the tokenizer's line numbering is CSS specific (form feed, lone CR), and because `Location.line_text` is a terminator free line for every other producer, so fixing the one producer fixes every consumer (`BuildMessage`, the CLI printer, the bake overlay, the dev error page) without teaching each of them to trim. `get_lines_in_text` is unchanged; its remaining caller (stack trace code frames in `VirtualMachine.rs`) depends on the current shape, and its own first-line `\r` and unterminated-last-line defects are handled in #38338 and #36683. This change does not conflict with either and no longer depends on them.
- Parse errors and minify errors are the two producers of CSS diagnostics with a location; both go through `Err::add_to_logger` -> `to_location`, and both are covered by the test.
- Verified with `test/js/bun/css/error-line-text.test.ts`: 11 of its 13 tests fail on the released binary (the LF first-line and end-of-input cases are regression guards), all pass with a debug build. Cases: LF / CRLF on line 2, a blank line before the error, line 1 of LF and CRLF files, an unterminated last line in LF and CRLF files, lone CR, form feed, surrounding whitespace kept, an error at the end of input, a minify error, and the `bun build` code frame for an unterminated last line.
  - `test/js/bun/css/invalid-utf8-column.test.ts`, `nested-selector-list-expansion.test.ts`, `selector-list-error-recovery.test.ts`, `nth-anplusb-ident.test.ts`, `attr-selector-namespace-star.test.ts`, `nested-function-backtracking.test.ts`, `test/bundler/bundler_defer.test.ts` and `test/bake/dev/css.test.ts` still pass.
  - `cargo clippy -p bun_css` and the `byte-search` source lint are clean.

### Background
- `Location` (`src/ast/lib.rs`) is the logger's position record attached to a diagnostic; `line_text` is the text of the line the diagnostic is on, kept so consumers do not have to re-read the source. The JS parser fills it from the byte offset of the error; the CSS parser only has a 0-based line and a column (`ErrorLocation`), so it has to find the line in the source text.
- `get_lines_in_text` / `index_of_line_ranges` (`src/bun_core/string/immutable.rs`) return the N lines ending at a target line for the code frame above a stack trace. The printers that consume it (`trimmed_text()` in `src/jsc/ZigStackTrace.rs`, the logger's own code frame in `src/ast/lib.rs`) strip the line breaks it leaves in the ranges, which is why the CLI output for a CSS error looked fine while the raw `lineText` did not.
- The CSS tokenizer (`consume_newline` in `src/css/css_parser.rs`, ported from rust-cssparser) advances the line number on `\n`, `\f`, and `\r` (with `\r\n` counted once), following the CSS Syntax preprocessing rules.

<details>
<summary>Repro</summary>

```sh
printf 'a { color: red; }\n@import "x";\n' > lf.css
printf 'a { color: red; }\r\n@import "x";\r\n' > crlf.css
printf 'a { color: red; }\n@import "x";' > noeol.css
cat > t.js <<'EOF'
for (const f of ["./lf.css", "./crlf.css", "./noeol.css"]) {
  const r = await Bun.build({ entrypoints: [f], throw: false });
  for (const m of r.logs) console.log(f, m.position.line, JSON.stringify(m.position.lineText));
}
EOF
bun t.js
bun build ./noeol.css
```

Before (bun 1.4.0):

```
./lf.css 2 "\n@import \"x\";\n"
./crlf.css 2 "\n@import \"x\";"
./noeol.css 2 ""

error: @import rules must come before any other rules except @charset and @layer
    at /tmp/x/noeol.css:2:8
```

After:

```
./lf.css 2 "@import \"x\";"
./crlf.css 2 "@import \"x\";"
./noeol.css 2 "@import \"x\";"

2 | @import "x";
           ^
error: @import rules must come before any other rules except @charset and @layer
    at /tmp/x/noeol.css:2:8
```
</details>
