### PR TITLE
Bun.serve: keep the connection-close mark across a pipelined request

### DIFF
--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -89,6 +89,10 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         HTTP_WRITE_CALLED = 2, // used
         HTTP_END_CALLED = 4, // used
         HTTP_RESPONSE_PENDING = 8, // used
+        /* Close once the response in flight has completed and flushed (HTTP/1.0
+         * or Connection: close request, or a response ended with closeConnection).
+         * Connection-scoped: a request pipelined behind the one that set it must
+         * not make the connection persistent again. */
         HTTP_CONNECTION_CLOSE = 16, // used
         HTTP_WROTE_CONTENT_LENGTH_HEADER = 32, // used
         HTTP_WROTE_DATE_HEADER = 64, // used
@@ -156,7 +160,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * There is one HttpResponseData per socket, reused by every request on a
          * keep-alive connection, so starting a new response clears the rest of the
          * word (resetResponseState) - these have to survive that. */
-        HTTP_CONNECTION_SCOPED = HTTP_NODE_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
+        HTTP_CONNECTION_SCOPED = HTTP_CONNECTION_CLOSE | HTTP_NODE_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
             | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN | HTTP_CLOSE_WHEN_IDLE,
     };
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -619,6 +619,103 @@ it.each([
   expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/helloooo");
 });
 
+// RFC 9112 9.3 / 9.6: an HTTP/1.0 request (Bun never answers one with
+// keep-alive), a request carrying Connection: close, or a response carrying
+// Connection: close makes the connection non-persistent. That mark belongs to
+// the connection, so an HTTP/1.1 request pipelined behind such a request in the
+// same TCP segment must not clear it: the server still has to close once it has
+// answered what it dispatched.
+describe("a request pipelined behind a non-persistent request does not keep the connection alive", () => {
+  const keepAliveFirst = "GET /first HTTP/1.1\r\nHost: x\r\n\r\n";
+  const pipelinedSecond = "GET /second HTTP/1.1\r\nHost: x\r\n\r\n";
+  const probe = "GET /probe HTTP/1.1\r\nHost: x\r\n\r\n";
+
+  // The handler must answer synchronously: Bun.serve only dispatches a
+  // pipelined request when the previous response has already completed
+  // (otherwise it closes the connection at the second request instead).
+  function startServer(firstResponseHeaders?: Record<string, string>) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const pathname = new URL(req.url).pathname;
+        // The ";" terminates the marker: the next response's status line
+        // follows the body directly on the wire.
+        return new Response("body:" + pathname + ";", {
+          headers: pathname === "/first" ? firstResponseHeaders : undefined,
+        });
+      },
+    });
+  }
+
+  // Writes both requests in one segment. Once the response to the pipelined
+  // request has arrived, sends a probe request: a server that closed the
+  // connection can never answer it, a server that was talked back into
+  // keep-alive answers it. Settles on whichever of the two happens.
+  async function pipelineThenProbe(port: number, first: string) {
+    const { promise, resolve } = Promise.withResolvers<"server closed" | "probe answered">();
+    let received = "";
+    let probeSent = false;
+    const socket = net.connect(port, "127.0.0.1");
+    socket.setEncoding("latin1");
+    socket.on("connect", () => socket.write(first + pipelinedSecond));
+    socket.on("data", chunk => {
+      received += chunk;
+      if (received.includes("body:/probe;")) {
+        resolve("probe answered");
+      } else if (!probeSent && received.includes("body:/second;")) {
+        probeSent = true;
+        socket.write(probe);
+      }
+    });
+    socket.on("end", () => resolve("server closed"));
+    socket.on("close", () => resolve("server closed"));
+    // ECONNRESET / EPIPE once the server has closed; "close" follows.
+    socket.on("error", () => {});
+    const outcome = await promise;
+    socket.destroy();
+    return { outcome, firstBody: received.match(/body:[^;]*;/)?.[0] ?? null };
+  }
+
+  it.each([
+    { label: "HTTP/1.0 request", first: "GET /first HTTP/1.0\r\nHost: x\r\n\r\n" },
+    {
+      label: "HTTP/1.0 request with Connection: keep-alive",
+      first: "GET /first HTTP/1.0\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
+    },
+    {
+      label: "HTTP/1.0 request with Connection: close",
+      first: "GET /first HTTP/1.0\r\nHost: x\r\nConnection: close\r\n\r\n",
+    },
+    {
+      label: "HTTP/1.1 request with Connection: close",
+      first: "GET /first HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+    },
+    {
+      label: "HTTP/1.1 request answered with Connection: close",
+      first: keepAliveFirst,
+      firstResponseHeaders: { connection: "close" },
+    },
+  ])(
+    "$label + pipelined HTTP/1.1 request: the server closes the connection",
+    async ({ first, firstResponseHeaders }) => {
+      using server = startServer(firstResponseHeaders);
+      expect(await pipelineThenProbe(server.port, first)).toEqual({
+        outcome: "server closed",
+        firstBody: "body:/first;",
+      });
+    },
+  );
+
+  it("control: a persistent HTTP/1.1 request + pipelined HTTP/1.1 request keeps the connection alive", async () => {
+    using server = startServer();
+    expect(await pipelineThenProbe(server.port, keepAliveFirst)).toEqual({
+      outcome: "probe answered",
+      firstBody: "body:/first;",
+    });
+  });
+});
+
 describe("streaming", () => {
   describe("error handler", () => {
     it("throw on pull renders headers, does not call error handler", async () => {


### PR DESCRIPTION
### Problem

- `Bun.serve` leaves a connection open that it had already marked for close when a well-formed HTTP/1.1 request is pipelined behind the request that marked it, in the same TCP segment. Affected first requests: `GET / HTTP/1.0` (with or without a `Connection` header), an HTTP/1.1 request with `Connection: close`, and an HTTP/1.1 request whose `Response` carries `Connection: close`. A request sent on that connection later is still served.
- Regression for the HTTP/1.0 shapes since #35864 (bdb738222e): `HttpParser.h` used to latch `isAncientHTTP` for the rest of the recv buffer, so the pipelined HTTP/1.1 request was itself treated as HTTP/1.0 and re-marked the connection for close. That PR made the flag per-request (needed for its Transfer-Encoding check), which exposed the bug below. The two `Connection: close` shapes were already broken the same way in released builds (checked on 1.3.14, where the three HTTP/1.0 shapes still close).
- Cause: `HttpResponseData::resetResponseState()` (`packages/bun-uws/src/HttpResponseData.h`) runs for every request dispatched on a connection (`HttpContext.h`, the request handler lambda) and clears the whole state word except `HTTP_CONNECTION_SCOPED`. `HTTP_CONNECTION_CLOSE` was not in that set, so dispatching the pipelined request wiped the close mark set by the previous request, and the post-parse `shouldCloseConnection()` gate in `HttpContext::onData` found nothing to act on.

```js
import net from "node:net";
const s = Bun.serve({ port: 0, fetch: req => new Response(new URL(req.url).pathname) });
const c = net.connect(s.port, "127.0.0.1", () =>
  c.write("GET /first HTTP/1.0\r\nHost: x\r\n\r\nGET /second HTTP/1.1\r\nHost: x\r\n\r\n"));
c.on("data", d => process.stdout.write(d));
c.on("end", () => console.log("\n-- server closed"));
// released (1.3.14 / 1.4.0): /first, /second, then the server closes
// current main:              /first, /second, connection stays open (a request sent later is served)
```

### Fix

- Adds `HTTP_CONNECTION_CLOSE` to `HTTP_CONNECTION_SCOPED`, so `resetResponseState()` keeps it.
- Correct because every setter of the bit means "close this connection once the response in flight has completed and flushed" (request was HTTP/1.0 or `Connection: close` in `HttpContext.h`; `end(..., closeConnection)` and close-delimited bodies in `HttpResponse.h`; a `Connection: close` response header in `NodeHTTP.cpp`; node:http's deferred `socket.end()` in `JSNodeHTTPServerSocket.cpp`), and nothing ever clears it on purpose: a connection that has been marked can not legitimately become persistent again. A fresh connection starts with a zeroed state word, so nothing leaks between connections.
- Behaviour with the fix matches released builds for the HTTP/1.0 shapes: the pipelined request is still answered and the existing `shouldCloseConnection()` gates (`onData` tail, `internalEnd`, `onWritable`) close the socket once that response has drained. Whether the pipelined request should be dispatched at all (RFC 9112 9.6) is a separate question, tracked in #33005 for `Bun.serve` and #35054 for node:http's `socket.end()`; both compose with this change.
- Test: `test/js/bun/http/serve.test.ts`, describe `a request pipelined behind a non-persistent request does not keep the connection alive`. Five first-request shapes (HTTP/1.0, HTTP/1.0 + `Connection: keep-alive`, HTTP/1.0 + `Connection: close`, HTTP/1.1 + `Connection: close`, HTTP/1.1 answered with `Connection: close`) each followed by a pipelined HTTP/1.1 request; the client sends a probe request once it has the pipelined response and the test settles on whichever comes first, the server closing or the probe being answered. All five fail on current main with `probe answered` and pass with the fix; on 1.3.14 the three HTTP/1.0 shapes pass and the two `Connection: close` shapes fail; the keep-alive control (`probe answered`) passes everywhere.
- Also run with the fix: the new describe 25x under `--rerun-each` (150/150), `serve.test.ts` (288 pass; the 4 failures, `requestIP v6`, privileged port, `#6583`, `/bun:info` loopback, fail identically on an unmodified build in this environment), `request-smuggling.test.ts` (87 pass), `bun-server.test.ts` (3 failures, same environment-only set as on an unmodified build), `bun-serve-headers/-file/-routes/-static`, `http-server-chunking`, `proxy-stress-protocol`, `serve-directory-routes`, `serve-direct-readable-stream` and 8 HTTP regression files (396 pass), `node-http.test.ts` (1 failure, `request via http proxy`, environment-only), 6 node:http connection-handling files (52 pass), and 55 vendored Node http keep-alive / pipeline / close / client-error tests (all pass).

### Background

- uWS keeps one `HttpResponseData` per socket and reuses it for every request on a keep-alive connection. Its `state` word mixes per-response bits (status written, Content-Length written, response pending, ...) with per-connection bits. `resetResponseState()` starts a new response by clearing the word down to `HTTP_CONNECTION_SCOPED`, the bits that describe the connection (parsing stopped, reads paused, peer FIN received, close when idle); that set is what this PR extends.
- Pipelining: `fenceAndConsumePostPadded` (`HttpParser.h`) loops over every request present in one recv buffer and dispatches each one through the `HttpContext.h` lambda. `Bun.serve` supports this only when the previous response completed synchronously (otherwise it closes the connection), which is why the test's handler returns a `Response` directly.
- Close gates: nothing closes a marked connection immediately. `shouldCloseConnection()` is consulted after the parse loop (`HttpContext::onData`), when a response ends (`internalEnd`) and when buffered output drains (`onWritable`), and each only acts once `HTTP_RESPONSE_PENDING` is clear and the socket has fully drained, so the response to the pipelined request is delivered before the FIN.
- HTTP/1.0 persistence (RFC 9112 9.3): a connection is persistent after an HTTP/1.0 request only if the response says `Connection: keep-alive`; `Bun.serve` never does, so it always marks such connections for close (`HttpContext.h`, `isAncient()`), independent of what the request's `Connection` header says.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->