### PR TITLE
node:vm: don't remap vm code through the source map of the file its filename names

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5626,7 +5626,9 @@ impl VirtualMachine {
         let top_source_url = frames[top].source_url.to_utf8();
 
         let already_remapped = frames[top].remapped;
-        let maybe_lookup: Option<bun_sourcemap::mapping::Lookup> = if already_remapped {
+        let maybe_lookup: Option<bun_sourcemap::mapping::Lookup> = if frames[top].is_node_vm {
+            None
+        } else if already_remapped {
             Some(bun_sourcemap::mapping::Lookup {
                 mapping: bun_sourcemap::mapping::Mapping {
                     generated: bun_sourcemap::LineColumnOffset::default(),
@@ -5775,7 +5777,7 @@ impl VirtualMachine {
 
         if frames.len() > 1 {
             for i in 0..frames.len() {
-                if i == top || frames[i].position.is_invalid() {
+                if i == top || frames[i].position.is_invalid() || frames[i].is_node_vm {
                     continue;
                 }
                 let source_url = frames[i].source_url.to_utf8();

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -23,9 +23,22 @@ pub struct ZigStackFrame {
     /// This informs formatters whether to display as a blob URL or not
     pub remapped: bool,
 
+    /// Set by C++ (`Zig::isNodeVMSource`) for code compiled by `node:vm`. Its
+    /// `source_url` is whatever filename the caller passed, so it must never be
+    /// looked up in the source map table even when it names a file Bun transpiled.
+    pub is_node_vm: bool,
+
     /// -1 means not set.
     pub jsc_stack_frame_index: i32,
 }
+
+// Mirrors `struct ZigStackFrame` in `src/jsc/bindings/headers-handwritten.h`,
+// which C++ populates in place.
+bun_core::assert_ffi_layout!(
+    ZigStackFrame, 72, 8;
+    function_name @ 0, source_url @ 24, position @ 48, code_type @ 60, is_async @ 61,
+    remapped @ 62, is_node_vm @ 63, jsc_stack_frame_index @ 64,
+);
 
 impl ZigStackFrame {
     /// Explicit deref of owned strings.
@@ -72,6 +85,7 @@ impl ZigStackFrame {
         position: ZigStackFramePosition::INVALID,
         is_async: false,
         remapped: false,
+        is_node_vm: false,
         jsc_stack_frame_index: -1,
     };
 

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -524,6 +524,26 @@ String sourceURL(JSC::VM& vm, JSC::JSFunction* function)
     return Zig::sourceURL(function->jsExecutable()->source());
 }
 
+bool isNodeVMSource(JSC::SourceProvider* sourceProvider)
+{
+    if (!sourceProvider) [[unlikely]] {
+        return false;
+    }
+
+    auto* fetcher = sourceProvider->sourceOrigin().fetcher();
+    return fetcher && fetcher->fetcherType() == JSC::ScriptFetcher::Type::NodeVM;
+}
+
+bool isNodeVMSource(const JSC::StackFrame& frame)
+{
+    auto* codeBlock = frame.codeBlock();
+    if (!codeBlock || !codeBlock->ownerExecutable()) {
+        return false;
+    }
+
+    return isNodeVMSource(codeBlock->source().provider());
+}
+
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
 {
     auto codeType = codeBlock->codeType();

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -220,6 +220,14 @@ String sourceURL(JSC::VM& vm, const JSC::StackFrame& frame);
 String sourceURL(JSC::StackVisitor& visitor);
 String sourceURL(JSC::VM& vm, JSC::JSFunction* function);
 
+// True for code compiled by node:vm (every node:vm compile path attaches a
+// NodeVMScriptFetcher to its SourceOrigin). node:vm compiles the string it was
+// given as-is under a caller-chosen filename, while Bun's source maps are keyed
+// by filename, so positions in such code must never be remapped, even when the
+// filename is a file Bun transpiled.
+bool isNodeVMSource(JSC::SourceProvider* sourceProvider);
+bool isNodeVMSource(const JSC::StackFrame& frame);
+
 enum class FinalizerSafety {
     NotInFinalizer,
     MustNotTriggerGC,

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -254,7 +254,7 @@ WTF::String formatStackTrace(
         StackFrame& frame = stackTrace.at(i);
         ZigStackFrame& remappedFrame = remappedFrames[i];
         // Match `ZigStackFramePosition::INVALID` exactly so the Rust batch loop's
-        // `position.isInvalid()` skips frames we never populate (vm-context
+        // `position.isInvalid()` skips frames we never populate (node:vm
         // frames, frames without line/col info). memset alone leaves
         // `line_start_byte = 0` which fails that byte-compare.
         remappedFrame.position.line_zero_based = -1;
@@ -265,26 +265,14 @@ WTF::String formatStackTrace(
         if (!frame.hasLineAndColumnInfo()) continue;
 
         originalLineColumns[i] = frame.computeLineAndColumn();
-
-        JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
-        if (auto* callee = frame.callee()) {
-            if (auto* object = callee->getObject()) {
-                globalObjectForFrame = object->globalObject();
-            }
-        }
-
         sourceURLs[i] = Zig::sourceURL(vm, frame);
 
-        bool isDefinitelyNotRunninginNodeVMGlobalObject = globalObject == globalObjectForFrame;
-        bool isDefaultGlobalObjectInAFinalizer = (globalObject && !lexicalGlobalObject && !errorInstance);
-        if (isDefinitelyNotRunninginNodeVMGlobalObject || isDefaultGlobalObjectInAFinalizer) {
-            // https://github.com/oven-sh/bun/issues/3595
-            if (!sourceURLs[i].isEmpty()) {
-                remappedFrame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line).zeroBasedInt();
-                remappedFrame.position.column_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column).zeroBasedInt();
-                remappedFrame.source_url = Bun::toStringRef(sourceURLs[i]);
-                anyRemap = true;
-            }
+        // https://github.com/oven-sh/bun/issues/3595
+        if (!sourceURLs[i].isEmpty() && !Zig::isNodeVMSource(frame)) {
+            remappedFrame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line).zeroBasedInt();
+            remappedFrame.position.column_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column).zeroBasedInt();
+            remappedFrame.source_url = Bun::toStringRef(sourceURLs[i]);
+            anyRemap = true;
         }
     }
 
@@ -440,8 +428,6 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     // Create the call sites (one per frame)
     Zig::createCallSitesFromFrames(globalObject, lexicalGlobalObject, stackTrace, callSites);
 
-    // We need to sourcemap it if it's a GlobalObject.
-
     const int n = stackTrace.size();
     WTF::Vector<ZigStackFrame, 8> remappedFrames;
     WTF::Vector<WTF::String, 8> sourceURLs;
@@ -461,33 +447,18 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
         frame.position.column_zero_based = -1;
         frame.position.byte_position = -1;
 
-        // When you use node:vm, the global object can be different on a
-        // per-frame basis. We should sourcemap the frames which are in Bun's
-        // global object, and not sourcemap the frames which are in a different
-        // global object.
-        JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
+        if (Zig::isNodeVMSource(stackFrame))
+            continue;
 
-        if (stackFrame.hasLineAndColumnInfo()) {
-            auto* callee = stackFrame.callee();
-            // https://github.com/oven-sh/bun/issues/17698
-            if (callee) {
-                if (auto* object = callee->getObject()) {
-                    globalObjectForFrame = object->globalObject();
-                }
-            }
+        if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
+            frame.position.line_zero_based = sourcePositions->line.zeroBasedInt();
+            frame.position.column_zero_based = sourcePositions->column.zeroBasedInt();
         }
 
-        if (globalObjectForFrame == globalObject) {
-            if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
-                frame.position.line_zero_based = sourcePositions->line.zeroBasedInt();
-                frame.position.column_zero_based = sourcePositions->column.zeroBasedInt();
-            }
-
-            if (!sourceURLs[i].isEmpty()) {
-                frame.source_url = Bun::toStringRef(sourceURLs[i]);
-                didRemap[i] = true;
-                anyRemap = true;
-            }
+        if (!sourceURLs[i].isEmpty()) {
+            frame.source_url = Bun::toStringRef(sourceURLs[i]);
+            didRemap[i] = true;
+            anyRemap = true;
         }
     }
 
@@ -616,7 +587,7 @@ WTF::String computeErrorInfoWrapperToString(JSC::VM& vm, Vector<StackFrame>& sta
 void computeLineColumnWithSourcemap(JSC::VM& vm, JSC::SourceProvider* _Nonnull sourceProvider, JSC::LineColumn& lineColumn, WTF::String& remappedSourceURL)
 {
     auto sourceURL = sourceProvider->sourceURL();
-    if (sourceURL.isEmpty()) {
+    if (sourceURL.isEmpty() || Zig::isNodeVMSource(sourceProvider)) {
         return;
     }
 

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -86,6 +86,7 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
 
     auto sourceURL = Zig::sourceURL(vm, stackFrame);
     frame.source_url = Bun::toStringRef(sourceURL);
+    frame.is_node_vm = Zig::isNodeVMSource(stackFrame);
     auto m_codeBlock = stackFrame.codeBlock();
     if (m_codeBlock) {
         switch (m_codeBlock->codeType()) {

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -199,6 +199,8 @@ typedef struct ZigStackFrame {
     ZigStackFrameCode code_type;
     bool is_async;
     bool remapped;
+    // See Zig::isNodeVMSource(). The error printer skips source maps for these.
+    bool is_node_vm;
     int32_t jsc_stack_frame_index;
 
     ZigStackFrame()
@@ -208,6 +210,7 @@ typedef struct ZigStackFrame {
         , code_type {}
         , is_async(false)
         , remapped(false)
+        , is_node_vm(false)
         , jsc_stack_frame_index(-1)
     {
     }

--- a/src/runtime/bake/dev_server/error_report_request.rs
+++ b/src/runtime/bake/dev_server/error_report_request.rs
@@ -152,6 +152,7 @@ impl ErrorReportRequest {
                 code_type: ZigStackFrameCode::NONE,
                 is_async: false,
                 remapped: false,
+                is_node_vm: false,
                 jsc_stack_frame_index: -1,
             });
         }

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
+import { pathToFileURL } from "url";
 
 // Every workload below is time-bounded for 100ms. On Windows JSC's
 // SamplingProfiler effectively ticks at the ~15.6ms default timer quantum, and
@@ -443,5 +444,56 @@ describe.concurrent("--cpu-prof", () => {
     // Validate markdown file
     const mdContent = readFileSync(join(String(dir), mdFiles[0]), "utf-8");
     expect(mdContent).toContain("# CPU Profile");
+  });
+
+  test("vm code compiled under the filename of the profiled file keeps its own positions", async () => {
+    // Source maps are keyed by filename. `f` is compiled by node:vm on line 5 of
+    // its source, under the fixture's own filename ("own") or under a name Bun
+    // never loaded ("other"); both must report the same, physical position. The
+    // PADDING-line comment is stripped by the transpiler, so any line the
+    // fixture's source map could produce is > PADDING and never mistaken for 5.
+    const PADDING = 20;
+    const padding = ["/*", ...Array.from({ length: PADDING - 2 }, () => " *"), " */"].join("\n") + "\n";
+    const body = String.raw`
+const vm = require("node:vm");
+const name = process.argv[2] === "own" ? __filename : "not-a-loaded-file.js";
+const source = "\n\n\n\n(function f() { for (const end = performance.now() + 100; performance.now() < end; ) {} })";
+const f = vm.runInThisContext(source, { filename: name });
+f();
+console.log(name);
+`;
+    using dir = tempDir("cpu-prof-vm-filename", { "fixture.js": padding + body });
+
+    const profileFor = async (kind: string) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--cpu-prof", `--cpu-prof-name=${kind}.cpuprofile`, "fixture.js", kind],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      const profile = JSON.parse(readFileSync(join(String(dir), `${kind}.cpuprofile`), "utf8"));
+      const fNodes = profile.nodes.filter((n: any) => n.callFrame.functionName === "f");
+      expect(fNodes.length).toBeGreaterThan(0);
+      return {
+        name: stdout.trim(),
+        callFrames: [
+          ...new Set(
+            fNodes.map((n: any) => JSON.stringify([n.callFrame.url, n.callFrame.lineNumber, n.callFrame.columnNumber])),
+          ),
+        ].map(s => JSON.parse(s as string)),
+        tickLines: new Set(fNodes.flatMap((n: any) => (n.positionTicks ?? []).map((t: any) => t.line))),
+      };
+    };
+    const [own, other] = await Promise.all([profileFor("own"), profileFor("other")]);
+
+    // callFrame.lineNumber is 0-based; positionTicks.line is 1-based.
+    expect(other.callFrames).toEqual([["not-a-loaded-file.js", 4, expect.any(Number)]]);
+    const [[, line, column]] = other.callFrames;
+    expect(own.callFrames).toEqual([[pathToFileURL(own.name).href, line, column]]);
+    expect(other.tickLines).toEqual(new Set([5]));
+    expect(own.tickLines).toEqual(new Set([5]));
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import {
   compileFunction,
   constants,
@@ -1074,6 +1074,159 @@ describe("context options with throwing getters", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe(expected);
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("vm code compiled under the filename of a file Bun transpiled", () => {
+  // Bun's source maps are keyed by filename. The fixture compiles vm code under
+  // its own path, and that code must keep its physical positions instead of
+  // being remapped through the fixture's source map. The fixture opens with a
+  // comment spanning PADDING lines that the transpiler strips, so every line
+  // its source map can produce is > PADDING, while every vm function below
+  // sits on line 5 of its source: a remapped position can never be mistaken
+  // for the physical one. "other" compiles the same code under a name Bun never
+  // loaded and is what "own" has to match.
+  const PADDING = 20;
+  const padding = ["/*", ...Array.from({ length: PADDING - 2 }, () => " *"), " */"].join("\n") + "\n";
+  const body = String.raw`
+const vm = require("node:vm");
+const source = "\n\n\n\n(function f() { throw new Error('boom'); })";
+const moduleSource = "\n\n\n\nexport function f() { throw new Error('boom'); }";
+const callingBackSource = "\n\n\n\n(function f(callback) { callback(); })";
+const names = { own: __filename, other: "not-a-loaded-file.js" };
+const compile = {
+  script: name => new vm.Script(source, { filename: name }).runInThisContext(),
+  runInThisContext: name => vm.runInThisContext(source, { filename: name }),
+  runInNewContext: name => vm.runInNewContext(source, {}, { filename: name }),
+  compileFunction: name => vm.compileFunction("\n\n\n\nthrow new Error('boom')", [], { filename: name }),
+};
+
+function thrown(fn) {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("did not throw");
+}
+
+function position(err) {
+  const [, line, column] = /:(\d+):(\d+)\)?$/.exec(err.stack.split("\n")[1]);
+  return { line: +line, column: +column, errLine: err.line, originalLine: err.originalLine ?? null };
+}
+
+function perName(collect) {
+  return Object.fromEntries(Object.entries(names).map(([kind, name]) => [kind, collect(name)]));
+}
+
+async function collect() {
+  const results = {};
+  for (const [api, make] of Object.entries(compile)) {
+    results[api] = perName(name => position(thrown(make(name))));
+  }
+
+  results.sourceTextModule = {};
+  for (const [kind, name] of Object.entries(names)) {
+    const module = new vm.SourceTextModule(moduleSource, { identifier: name });
+    await module.link(() => {});
+    await module.evaluate();
+    results.sourceTextModule[kind] = position(thrown(module.namespace.f));
+  }
+
+  // Error.prepareStackTrace receives CallSites, which are remapped separately
+  // from the stack string.
+  Error.prepareStackTrace = (_, callSites) => callSites;
+  results.callSite = perName(name => {
+    const site = thrown(compile.script(name)).stack[0];
+    return { fileName: site.getFileName(), line: site.getLineNumber(), column: site.getColumnNumber() };
+  });
+  Error.prepareStackTrace = undefined;
+
+  // Bun.inspect (like the uncaught-error printer) remaps the JSC frames itself,
+  // handling the top frame separately from the rest. In callingBack the vm
+  // frame is the second one: the error is thrown by a callback from this file.
+  results.inspect = {
+    script: perName(name => Bun.inspect(thrown(compile.script(name)))),
+    runInNewContext: perName(name => Bun.inspect(thrown(compile.runInNewContext(name)))),
+    callingBack: perName(name => {
+      const f = vm.runInThisContext(callingBackSource, { filename: name });
+      return Bun.inspect(thrown(() => f(() => { throw new Error("boom"); })));
+    }),
+  };
+  return results;
+}
+
+const uncaught = process.argv[2];
+if (uncaught) {
+  console.log(__filename);
+  compile.script(names[uncaught])();
+} else {
+  collect().then(results => console.log(JSON.stringify({ filename: __filename, results })));
+}
+`;
+  // Line (in the fixture file) of the `fn();` call inside thrown(): the frame
+  // below the vm frame. It is only reported at this line if the fixture's own
+  // source map still applies.
+  const thrownCallLine = PADDING + body.split("\n").indexOf("    fn();") + 1;
+  const otherFrame = "at f (not-a-loaded-file.js:5:";
+  const ownToOther = (output: string, filename: string) =>
+    output.replace(`at f (${filename}:`, "at f (not-a-loaded-file.js:");
+
+  test.concurrent("error.stack, CallSites and Bun.inspect report the physical position", async () => {
+    using dir = tempDir("vm-own-filename", { "fixture.js": padding + body });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const { filename, results } = JSON.parse(stdout);
+
+    for (const api of ["script", "runInThisContext", "runInNewContext", "compileFunction", "sourceTextModule"]) {
+      expect(results[api].own).toEqual(results[api].other);
+    }
+    for (const api of ["script", "runInThisContext", "runInNewContext", "sourceTextModule"]) {
+      expect(results[api].own).toMatchObject({ line: 5, errLine: 5, originalLine: null });
+    }
+    // compileFunction's body line is reported relative to its wrapper, so only
+    // the own/other equality above pins it; like every other vm frame it must
+    // not have been remapped at all.
+    expect(results.compileFunction.own.originalLine).toBeNull();
+
+    expect(results.callSite.other).toMatchObject({ fileName: "not-a-loaded-file.js", line: 5 });
+    expect(results.callSite.own).toEqual({ ...results.callSite.other, fileName: filename });
+
+    for (const api of ["script", "runInNewContext"]) {
+      expect(results.inspect[api].other).toContain("5 | (function f() { throw new Error('boom'); })");
+    }
+    for (const { own, other } of Object.values<any>(results.inspect)) {
+      expect(other).toContain(otherFrame);
+      expect(other).toContain(`at thrown (${filename}:${thrownCallLine}:`);
+      expect(ownToOther(own, filename)).toBe(other);
+    }
+  });
+
+  test.concurrent("the uncaught error printer reports the physical position", async () => {
+    using dir = tempDir("vm-own-filename-uncaught", { "fixture.js": padding + body });
+    const run = async (kind: string) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.js", kind],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(exitCode).toBe(1);
+      return { filename: stdout.trim(), stderr };
+    };
+    const [own, other] = await Promise.all([run("own"), run("other")]);
+
+    expect(other.stderr).toContain("5 | (function f() { throw new Error('boom'); })");
+    expect(other.stderr).toContain(otherFrame);
+    expect(ownToOther(own.stderr, own.filename)).toBe(other.stderr);
   });
 });
 


### PR DESCRIPTION
### Problem
- vm code compiled under the filename of a file Bun transpiled gets its positions remapped through that file's source map. In the repro below the throw is on physical line 10 of the vm source; under the host's own filename Bun prints `at f (/tmp/prrepro/remap_script.js:5:48)` with `err.line === 5`, `err.originalLine === 10`. Under any other name it prints `:10:32`; Node prints line 10 under both.
- Which wrong line comes out depends on what the host's transpiled output has on that line, so it varies with the host file (the new tests pad the host so it always happens).
- Affected: `error.stack`, `Error.prepareStackTrace` call sites, `Bun.inspect(err)` / `console.error(err)` / the uncaught exception output (wrong line, plus a code frame taken from the host file), and `--cpu-prof` (`callFrame.lineNumber` and `positionTicks` of the vm function).
- Cause: the source map table is keyed by file path, and the remap sites decide eligibility by name.
  - `formatStackTrace` and `computeErrorInfoWithPrepareStackTrace` (`src/jsc/bindings/FormatStackTraceForJS.cpp`) excluded vm code by comparing the frame callee's global object with the error's. That only catches vm *contexts*; `runInThisContext`, `Script#runInThisContext` and `compileFunction` run in the main realm. Once #38235 names `SourceTextModule` frames after their identifier, `identifier: import.meta.path` gets there too.
  - `remap_zig_exception` (`src/jsc/VirtualMachine.rs`, the error printer) and `computeLineColumnWithSourcemap` (the profiler callback) had no exclusion at all, so the printer misreports vm code even in a separate context.
- Pre-existing (1.4.0 and main).

### Fix
- `Zig::isNodeVMSource()` (`ErrorStackTrace.cpp`): a frame is vm code if its `SourceProvider`'s `SourceOrigin` carries a `NodeVMScriptFetcher`. Every node:vm compile path attaches one (`Script`, `runInThisContext`, `runInContext`/`runInNewContext`, `compileFunction`, `SourceTextModule`), `eval` inside vm code inherits the origin, and nothing else in Bun creates a fetcher.
- Both stack formatters skip the remap request for such frames. This replaces the realm comparison (and its finalizer special case) instead of stacking on it: the comparison was an approximation of this predicate. Side effect: frames from other `Zig::GlobalObject`s (ShadowRealm, `bun test --isolate` leftovers) are Bun-loaded code and now remap like main-realm frames instead of being skipped.
- `populateStackFrameMetadata` stores the result in a new `ZigStackFrame.is_node_vm` (occupies the existing padding byte; the Rust side now asserts the layout) and `remap_zig_exception` skips those frames. A vm top frame falls through to the existing `collect_source_lines` path, so the code frame comes from the vm source, exactly as it already does for non-colliding names.
- `computeLineColumnWithSourcemap` returns early for such providers; the profiler uses it for both definition and sample positions.
- Why this is right: node:vm compiles the string it is given verbatim, so its positions are already final and the filename is only a label, which is what Node reports. The opposite rule ("remap only Bun's own providers") would break the `require.extensions` flow, where Bun's transpiled output is handed to an overridden `module._compile` and compiled in a plain `StringSourceProvider` under the file's name; remapping that by name is intended.
- Intentionally unchanged: `Bun__CallFrame__getCallerSrcLoc`, `Bun__CallFrame__getLineNumber` and `InspectorTestReporterAgent` also remap by name, but they locate `test()`/`expect()`/inline snapshot calls, which only mean anything for code Bun loaded from the test file itself.
- Known remaining gap: the synthetic `<parse>` frame and `err.line` of a vm *SyntaxError* are still remapped by name. JSC's `addErrorInfo` materializes the error before Bun sees anything but the URL string, so that needs a different fix.
- Tests:
  - `test/js/node/vm/vm.test.ts`, "vm code compiled under the filename of a file Bun transpiled": a fixture compiles the same code under its own path and under an unrelated name and requires identical results for `error.stack` (`Script`, `runInThisContext`, `runInNewContext`, `compileFunction`, `SourceTextModule`), `prepareStackTrace` call sites, `Bun.inspect` (vm frame on top, in a separate context, and below a host frame) and the uncaught output, plus the physical line 5 and the fixture's own frame still being remapped. Before the fix the own-name variants reported line 23 of the fixture.
  - `test/cli/run/cpu-prof.test.ts`, "vm code compiled under the filename of the profiled file keeps its own positions": `callFrame` line/column and `positionTicks` match the unrelated-name run (before: line 23 instead of 4).
  - Also run: `test/js/node/vm/`, `test/js/bun/sourcemap/`, `test/js/node/module/sourcemap*`, `test/js/bun/test/stack.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/regression/issue/29240.test.ts`, Node's `test-vm-source-map-url`, `test-vm-syntax-error-*`, `test-vm-module-errors`. The two "Error inside minified file" snapshots in `inspect-error.test.js` fail identically on main with this debug build.
- #38296 touches the same per-frame loop in `remap_zig_exception`; whichever lands second needs a one-line rebase.

### Background
- Bun transpiles every module it loads and keeps the resulting source map in a per-VM table keyed by the module's path (`SavedSourceMap`). Formatting a stack looks each frame's `(sourceURL, line, column)` up in that table, so any frame whose URL equals a transpiled module's path is remapped, whatever code it came from.
- A `SourceProvider` is JSC's handle to one compiled source text. Bun's modules use `Zig::SourceProvider`; node:vm uses JSC's `StringSourceProvider` with the caller's `filename` as its URL. Each provider has a `SourceOrigin`, which may carry a `ScriptFetcher`; Bun's JSC fork gives fetchers a `fetcherType()`, and node:vm already attaches a `NodeVMScriptFetcher` to everything it compiles so that `import()` inside vm code can find its `importModuleDynamically` callback. This change reuses that marker.
- `ZigStackFrame` is the `#[repr(C)]` frame record the C++ bindings fill from JSC frames and the Rust error printer remaps and prints. Stack strings take a different route: C++ builds the request frames itself and remaps them in a batch via `Bun__remapStackFramePositions`.

<details>
<summary>Repro (release 1.4.0 vs this branch)</summary>

```js
// /tmp/prrepro/remap_script.js
const vm = require("node:vm");
const src = "\n".repeat(9) + "(function f() { throw new Error('boom'); })"; // f is on physical line 10
for (const filename of [__filename, "not-a-loaded-file.js"]) {
  const f = new vm.Script(src, { filename }).runInThisContext();
  try { f(); } catch (e) { console.log(e.stack.split("\n").find(l => / at f/.test(l)), e.line, e.originalLine); }
}
```

```
# bun 1.4.0
    at f (/tmp/prrepro/remap_script.js:5:48) 5 10
    at f (not-a-loaded-file.js:10:32) 10 10
# this branch
    at f (/tmp/prrepro/remap_script.js:10:32) 10 undefined
    at f (not-a-loaded-file.js:10:32) 10 undefined
# node
    at f (/tmp/prrepro/remap_script.js:10:23) undefined undefined
    at f (not-a-loaded-file.js:10:23) undefined undefined
```

The column difference from Node exists under both names and is unrelated (#37396). `originalLine` is only set on frames that went through a source map, so it is now absent for vm frames under either name; before it was set under both.

In the padded test fixtures, the own-name uncaught output showed fixture lines 18 to 23 as the code frame above `at f (fixture.js:23:16)`, and `--cpu-prof` reported `callFrame.lineNumber` 23 with ticks on line 24. The unrelated-name runs, and this branch under both names, show the vm source with `:5:` and report line 4 (0-based) with ticks on line 5.
</details>
