### PR TITLE
node:vm: wall-clock `timeout` per run instead of the JSC watchdog

### DIFF
--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -166,6 +166,8 @@ public:
     // vmHandle's state byte (Bun__VmHandle__stateAddress): the per-callback "may run script" test is one load.
     const unsigned char* vmHandleState { nullptr };
     ALWAYS_INLINE bool scriptAllowed() const { return Bun__VmHandle__scriptAllowedInline(vmHandleState); }
+    // node:vm runs on this thread that currently have a `timeout` armed (Bun::NodeVMTimeout).
+    unsigned nodeVMTimeoutsArmed { 0 };
     Bun::JSCTaskScheduler deferredWorkTimer;
 
     // Linked list of StrongRootBlock cells backing bun_jsc::Strong handles

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -1,4 +1,5 @@
 #include "NodeVMModule.h"
+#include "../vm/NodeVMTimeout.h"
 #include "BunClientData.h"
 #include "NodeVMSourceTextModule.h"
 #include "NodeVMSyntheticModule.h"
@@ -9,7 +10,6 @@
 #include "JavaScriptCore/Exception.h"
 #include "JavaScriptCore/JSModuleRecord.h"
 #include "JavaScriptCore/JSPromise.h"
-#include "JavaScriptCore/Watchdog.h"
 
 #include "../vm/SigintWatcher.h"
 
@@ -45,8 +45,6 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
 
     return array;
 }
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout);
 
 void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 {
@@ -89,35 +87,17 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         NodeVMGlobalObject* nodeVmGlobalObject = NodeVM::getGlobalObjectFromContext(globalObject, m_context.get(), false);
         RETURN_IF_EXCEPTION(scope, {});
         if (nodeVmGlobalObject && nodeVmGlobalObject->hasOwnMicrotaskQueue()) {
-            std::optional<double> oldLimit;
-            if (timeout != 0)
-                setupWatchdog(vm, timeout, &oldLimit.emplace(), nullptr);
+            NodeVMTimeout timer(vm, timeout ? std::optional<double>(timeout) : std::nullopt);
             nodeVmGlobalObject->drainOwnMicrotasks();
-            if (timeout != 0)
-                vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-            // The drain may legitimately leave the termination exception
-            // pending (watchdog fired mid-checkpoint); observe it so the
-            // exception-check validator is satisfied before the TOP scope
-            // below, then convert it to ERR_SCRIPT_EXECUTION_*.
+            // The drain may leave the termination exception pending (timed out mid-checkpoint); observe it so the
+            // exception-check validator is satisfied before the TOP scope inside takeOwnTermination.
             std::ignore = scope.exception();
-            if ((vm.hasTerminationRequest() || vm.hasPendingTerminationException()) && !Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)) {
-                // The VM itself is being stopped; not ours to consume. Propagate the termination.
-                if (!vm.hasPendingTerminationException())
-                    vm.throwTerminationException();
+            if (timer.takeOwnTermination(globalObject, nodeVmGlobalObject, scope, *this))
                 return {};
-            }
-            if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-                DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                vm.clearHasTerminationRequest();
-                if (getSigintReceived()) {
-                    setSigintReceived(false);
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                } else {
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-                }
-                return {};
-            }
+            // Somebody else's termination (worker.terminate(), an enclosing run's timeout): keep unwinding.
+            if (vm.hasTerminationRequest() && !vm.hasPendingTerminationException())
+                vm.throwTerminationException();
+            RETURN_IF_EXCEPTION(scope, {});
         }
         return m_evaluationResult.get();
     }
@@ -221,12 +201,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     };
 
     setSigintReceived(false);
-
-    std::optional<double> oldLimit, newLimit;
-
-    if (timeout != 0) {
-        setupWatchdog(vm, timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
+    NodeVMTimeout timer(vm, timeout ? std::optional<double>(timeout) : std::nullopt);
 
     if (breakOnSigint) {
         auto holder = SigintWatcher::hold(nodeVmGlobalObject, this);
@@ -237,36 +212,15 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         drainAfterEvaluate();
     }
 
-    if (timeout != 0) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
-
-    // Evaluation (or the afterEvaluate drain) may leave an exception pending
-    // — a regular one is rethrown by VM_RETURN_IF_EXCEPTION below, a
-    // termination one is converted to ERR_SCRIPT_EXECUTION_* here. Observe it
-    // so the exception-check validator is satisfied before the TOP scope.
+    // Evaluation (or the afterEvaluate drain) may leave an exception pending: our own timeout/SIGINT becomes
+    // ERR_SCRIPT_EXECUTION_* here, anything else (including somebody else's termination) is rethrown by
+    // VM_RETURN_IF_EXCEPTION below. Observe it so the exception-check validator is satisfied before the TOP scope
+    // inside takeOwnTermination.
     std::ignore = scope.exception();
-    if ((vm.hasTerminationRequest() || vm.hasPendingTerminationException()) && !Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)) {
-        // The VM itself is being stopped; not ours to consume. Propagate the termination.
-        if (!vm.hasPendingTerminationException())
-            vm.throwTerminationException();
+    if (timer.takeOwnTermination(globalObject, nodeVmGlobalObject, scope, *this))
         return {};
-    }
-    if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (getSigintReceived()) {
-            setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
-        }
-    } else {
-        setSigintReceived(false);
-    }
+    if (vm.hasTerminationRequest() && !vm.hasPendingTerminationException())
+        vm.throwTerminationException();
 
     VM_RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -12,6 +12,7 @@
 #include "JavaScriptCore/SourceCodeKey.h"
 
 #include "NodeVMScriptFetcher.h"
+#include "../vm/NodeVMTimeout.h"
 #include "../vm/SigintWatcher.h"
 
 #include <bit>
@@ -307,58 +308,6 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
-{
-    if (vm.hasTerminationRequest()) {
-        // The whole VM is being stopped (worker terminate()/exit): that
-        // termination is not ours to consume. The caller rethrows what
-        // evaluate() caught like any other exception.
-        if (!Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle))
-            return false;
-        vm.drainMicrotasksForGlobalObject(globalObject);
-        // The termination may have fired inside an afterEvaluate microtask
-        // checkpoint, leaving the termination exception pending; clear it so
-        // the ERR_SCRIPT_EXECUTION_* error below replaces it.
-        if (vm.hasPendingTerminationException())
-            DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        if (script->getSigintReceived()) {
-            script->setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
-        }
-        return true;
-    }
-
-    return false;
-}
-
-void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeout)
-{
-    JSC::JSLockHolder locker(vm);
-    JSC::Watchdog& dog = vm.ensureWatchdog();
-    dog.enteredVM();
-
-    Seconds oldLimit = dog.getTimeLimit();
-
-    if (oldTimeout) {
-        *oldTimeout = oldLimit.milliseconds();
-    }
-
-    if (oldLimit.isInfinity() || timeout < oldLimit.milliseconds()) {
-        dog.setTimeLimit(WTF::Seconds::fromMilliseconds(timeout));
-    } else {
-        timeout = oldLimit.milliseconds();
-    }
-
-    if (newTimeout) {
-        *newTimeout = timeout;
-    }
-}
-
 static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVMScript* script, JSObject* contextifiedObject, JSValue optionsArg, bool allowStringInPlaceOfOptions = false)
 {
     VM& vm = JSC::getVM(globalObject);
@@ -385,13 +334,8 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
-
     script->setSigintReceived(false);
+    NodeVMTimeout timeout(vm, options.timeout);
 
     // Node performs the afterEvaluate microtask checkpoint inside the
     // watchdog/SIGINT scope, so a `timeout` also bounds microtasks the script
@@ -410,17 +354,16 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         drainAfterEvaluate();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
+    if (timeout.takeOwnTermination(globalObject, globalObject, scope, *script)) {
+        return {};
     }
-
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    // Somebody else's termination (worker.terminate(), an enclosing run's timeout): keep unwinding.
+    if (vm.hasTerminationRequest() || (exception && vm.isTerminationException(exception.get()))) [[unlikely]] {
+        JSC::throwException(globalObject, scope, vm.terminationException());
         return {};
     }
 
     RETURN_IF_EXCEPTION(scope, {});
-
-    script->setSigintReceived(false);
 
     if (exception) [[unlikely]] {
         // Node only decorates the error stack with the source line when
@@ -461,13 +404,8 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         result = JSC::evaluate(globalObject, script->source(), globalObject, exception);
     };
 
-    std::optional<double> oldLimit, newLimit;
-
-    if (options.timeout) {
-        setupWatchdog(vm, *options.timeout, &oldLimit.emplace(), &newLimit.emplace());
-    }
-
     script->setSigintReceived(false);
+    NodeVMTimeout timeout(vm, options.timeout);
 
     if (options.breakOnSigint) {
         auto holder = SigintWatcher::hold(globalObject, script);
@@ -477,15 +415,13 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         run();
     }
 
-    if (options.timeout) {
-        vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
-    }
-
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (timeout.takeOwnTermination(globalObject, globalObject, scope, *script)) {
         return {};
     }
-
-    script->setSigintReceived(false);
+    if (vm.hasTerminationRequest() || (exception && vm.isTerminationException(exception.get()))) [[unlikely]] {
+        JSC::throwException(globalObject, scope, vm.terminationException());
+        return {};
+    }
 
     if (exception) [[unlikely]] {
         // Node only decorates the error stack with the source line when

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3045,16 +3045,6 @@ void JSC__VM__collectAsync(JSC::VM* vm)
     vm->heap.collectAsync();
 }
 
-extern "C" bool JSC__VM__hasExecutionTimeLimit(JSC::VM* vm)
-{
-    JSC::JSLockHolder locker(vm);
-    if (vm->watchdog()) {
-        return vm->watchdog()->hasTimeLimit();
-    }
-
-    return false;
-}
-
 size_t JSC__VM__heapSize(JSC::VM* arg0)
 {
     return arg0->heap.size();
@@ -5061,19 +5051,6 @@ size_t JSC__VM__runGC(JSC::VM* vm, bool sync)
 [[ZIG_EXPORT(nothrow)]] bool JSC__VM__isJITEnabled()
 {
     return JSC::Options::useJIT();
-}
-
-void JSC__VM__clearExecutionTimeLimit(JSC::VM* vm)
-{
-    JSC::JSLockHolder locker(vm);
-    if (vm->watchdog())
-        vm->watchdog()->setTimeLimit(JSC::Watchdog::noTimeLimit);
-}
-void JSC__VM__setExecutionTimeLimit(JSC::VM* vm, double limit)
-{
-    JSC::JSLockHolder locker(vm);
-    JSC::Watchdog& watchdog = vm->ensureWatchdog();
-    watchdog.setTimeLimit(WTF::Seconds { limit });
 }
 
 bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -296,7 +296,6 @@ CPP_DECL void JSC__JSValue__toZigString(JSC::EncodedJSValue JSValue0, ZigString*
 #pragma mark - JSC::VM
 
 CPP_DECL size_t JSC__VM__blockBytesAllocated(JSC::VM* arg0);
-CPP_DECL void JSC__VM__clearExecutionTimeLimit(JSC::VM* arg0);
 CPP_DECL void JSC__VM__collectAsync(JSC::VM* arg0);
 CPP_DECL JSC::VM* JSC__VM__create(unsigned char HeapType0);
 CPP_DECL void JSC__VM__deleteAllCode(JSC::VM* arg0, JSC::JSGlobalObject* arg1);
@@ -316,7 +315,6 @@ CPP_DECL void JSC__VM__releaseWeakRefs(JSC::VM* arg0);
 CPP_DECL size_t JSC__VM__runGC(JSC::VM* arg0, bool arg1);
 CPP_DECL void JSC__VM__enableControlFlowProfiler(JSC::VM* arg0);
 CPP_DECL void JSC__VM__setExecutionForbidden(JSC::VM* arg0, bool arg1);
-CPP_DECL void JSC__VM__setExecutionTimeLimit(JSC::VM* arg0, double arg1);
 CPP_DECL void JSC__VM__shrinkFootprint(JSC::VM* arg0);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__VM__throwError(JSC::VM* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);

--- a/src/jsc/bindings/vm/NodeVMTimeout.cpp
+++ b/src/jsc/bindings/vm/NodeVMTimeout.cpp
@@ -1,0 +1,94 @@
+#include "NodeVMTimeout.h"
+#include "BunClientData.h"
+#include "ErrorCode.h"
+#include <JavaScriptCore/TopExceptionScope.h>
+#include <JavaScriptCore/VMTrapsInlines.h>
+#include <mutex>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/WorkQueue.h>
+
+namespace Bun {
+
+static WorkQueue& timerQueue()
+{
+    static LazyNeverDestroyed<Ref<WorkQueue>> queue;
+    static std::once_flag once;
+    std::call_once(once, [] { queue.construct(WorkQueue::create("bun: node:vm timeout"_s)); });
+    return queue.get();
+}
+
+NodeVMTimeout::NodeVMTimeout(JSC::VM& vm, std::optional<double> timeoutMs)
+    : m_vm(vm)
+    , m_timeoutMs(timeoutMs)
+{
+    if (!timeoutMs)
+        return;
+    vm.ensureTerminationException();
+    m_state = adoptRef(*new State);
+    {
+        Locker locker { m_state->lock };
+        m_state->vm = &vm;
+    }
+    WebCore::clientData(vm)->nodeVMTimeoutsArmed++;
+    timerQueue().dispatchAfter(Seconds::fromMilliseconds(*timeoutMs), [state = Ref { *m_state }] {
+        Locker locker { state->lock };
+        if (!state->vm)
+            return;
+        state->fired = true;
+        std::exchange(state->vm, nullptr)->notifyNeedTermination();
+    });
+}
+
+bool NodeVMTimeout::disarm()
+{
+    if (!m_state)
+        return false;
+    bool fired;
+    {
+        Locker locker { m_state->lock };
+        m_state->vm = nullptr;
+        fired = m_state->fired;
+    }
+    m_state = nullptr;
+    WebCore::clientData(m_vm)->nodeVMTimeoutsArmed--;
+    m_fired = fired;
+    return fired;
+}
+
+bool NodeVMTimeout::takeOwnTermination(JSC::JSGlobalObject* errorGlobalObject, JSC::JSGlobalObject* drainGlobalObject, JSC::ThrowScope& scope, SigintReceiver& receiver)
+{
+    JSC::VM& vm = m_vm;
+    disarm();
+    bool interrupted = receiver.getSigintReceived();
+    if (!m_fired && !interrupted)
+        return false;
+    // The VM is being stopped as well (worker.terminate() / exit): that wins, the caller rethrows.
+    if (!Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle))
+        return false;
+
+    {
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        // Requested but not yet delivered (the script finished in between): deliver it here rather than into
+        // whatever the caller runs next.
+        if (!vm.hasTerminationRequest())
+            std::ignore = vm.hasExceptionsAfterHandlingTraps();
+        if (drainGlobalObject)
+            vm.drainMicrotasksForGlobalObject(drainGlobalObject);
+        catchScope.clearException();
+    }
+    vm.clearHasTerminationRequest();
+    receiver.setSigintReceived(false);
+
+    if (interrupted)
+        throwError(errorGlobalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    else
+        throwError(errorGlobalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *m_timeoutMs, "ms"_s));
+    return true;
+}
+
+} // namespace Bun
+
+extern "C" bool JSC__VM__hasExecutionTimeLimit(JSC::VM* vm)
+{
+    return WebCore::clientData(*vm)->nodeVMTimeoutsArmed > 0;
+}

--- a/src/jsc/bindings/vm/NodeVMTimeout.h
+++ b/src/jsc/bindings/vm/NodeVMTimeout.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "root.h"
+#include "SigintReceiver.h"
+#include <wtf/Lock.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace Bun {
+
+// The `timeout` of one node:vm run: a wall-clock timer that asks the VM to terminate (the same request SIGINT and
+// worker.terminate() make) and remembers that it did, so the run can tell its own timeout from theirs.
+class NodeVMTimeout {
+    WTF_MAKE_NONCOPYABLE(NodeVMTimeout);
+    WTF_FORBID_HEAP_ALLOCATION;
+
+public:
+    NodeVMTimeout(JSC::VM&, std::optional<double> timeoutMs);
+    ~NodeVMTimeout() { disarm(); }
+
+    // The timer will not touch the VM after this returns. Whether it had already fired.
+    bool disarm();
+
+    // After the run: if this timeout or a SIGINT for `receiver` stopped it, take that termination off the VM (servicing
+    // the request first if the script finished before it was delivered) and throw ERR_SCRIPT_EXECUTION_{TIMEOUT,
+    // INTERRUPTED} into `scope`. Otherwise false: nothing happened, or the termination belongs to worker.terminate()
+    // or an enclosing run and the caller rethrows what it caught.
+    bool takeOwnTermination(JSC::JSGlobalObject* errorGlobalObject, JSC::JSGlobalObject* drainGlobalObject, JSC::ThrowScope&, SigintReceiver&);
+
+private:
+    struct State : public ThreadSafeRefCounted<State> {
+        Lock lock;
+        JSC::VM* vm WTF_GUARDED_BY_LOCK(lock) { nullptr }; // null once disarmed or fired
+        bool fired WTF_GUARDED_BY_LOCK(lock) { false };
+    };
+
+    JSC::VM& m_vm;
+    std::optional<double> m_timeoutMs;
+    RefPtr<State> m_state;
+    bool m_fired { false };
+};
+
+} // namespace Bun

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1484,3 +1484,97 @@ test("node:vm Object.defineProperty on the context global when the sandbox is an
   expect(stdout.trim()).toBe(JSON.stringify({ result: 1, sandboxArray: 1 }));
   expect(exitCode).toBe(0);
 });
+
+describe("timeout", () => {
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+  const busy = `(ms) => { const end = Date.now() + ms; while (Date.now() < end); }`;
+
+  // A run that ends before its `timeout` must leave nothing armed behind: the
+  // program that follows it (here 300ms of CPU, several times the timeout) has
+  // to keep running. Previously the watchdog stayed armed and terminated the
+  // outer program once it had used `timeout` ms of CPU, and the process hung.
+  test.concurrent.each([
+    ["returns early", `vm.runInNewContext("1 + 1", {}, { timeout: 20 })`],
+    ["throws early", `try { vm.runInNewContext("throw new Error('x')", {}, { timeout: 20 }) } catch {}`],
+    ["times out", `try { vm.runInNewContext("for (;;) {}", {}, { timeout: 20 }) } catch (e) { console.log(e.code) }`],
+    [
+      "runInThisContext",
+      `try { new vm.Script("for (;;) {}").runInThisContext({ timeout: 20 }) } catch (e) { console.log(e.code) }`,
+    ],
+  ])("a run that %s does not stop the program afterwards", async (_, call) => {
+    const { stdout, exitCode } = await run(`
+      const vm = require("node:vm");
+      const busy = ${busy};
+      for (let i = 0; i < 3; i++) { ${call}; busy(100); }
+      busy(300);
+      console.log("still running");
+    `);
+    expect(stdout.split("\n").at(-1)).toBe("still running");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("is wall-clock time, so a script that blocks without using CPU times out too", async () => {
+    const { stdout, exitCode } = await run(`
+      const vm = require("node:vm");
+      try {
+        console.log(vm.runInNewContext("Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 400); 'returned'", {}, { timeout: 30 }));
+      } catch (e) {
+        console.log(e.code);
+      }
+    `);
+    expect(stdout).toBe("ERR_SCRIPT_EXECUTION_TIMEOUT");
+    expect(exitCode).toBe(0);
+  });
+
+  // Nested runs each own their timeout: the run whose timer fired reports
+  // ERR_SCRIPT_EXECUTION_TIMEOUT, an inner run it interrupted just unwinds.
+  test.concurrent("an outer timeout interrupts an inner run that has none", async () => {
+    const { stdout, exitCode } = await run(`
+      const vm = require("node:vm");
+      try {
+        vm.runInNewContext("inner()", { inner: () => vm.runInNewContext("for (;;) {}", {}) }, { timeout: 30 });
+      } catch (e) {
+        console.log("outer:", e.code);
+      }
+      console.log("done");
+    `);
+    expect(stdout).toBe("outer: ERR_SCRIPT_EXECUTION_TIMEOUT\ndone");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an outer timeout wins over a longer inner one", async () => {
+    const { stdout, exitCode } = await run(`
+      const vm = require("node:vm");
+      const inner = () => { try { return vm.runInNewContext("for (;;) {}", {}, { timeout: 2000 }) } catch (e) { return "inner: " + e.code } };
+      try {
+        console.log(vm.runInNewContext("inner()", { inner }, { timeout: 30 }));
+      } catch (e) {
+        console.log("outer:", e.code);
+      }
+    `);
+    expect(stdout).toBe("outer: ERR_SCRIPT_EXECUTION_TIMEOUT");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an inner timeout is an ordinary error for the outer run", async () => {
+    const { stdout, exitCode } = await run(`
+      const vm = require("node:vm");
+      const busy = ${busy};
+      const inner = () => vm.runInNewContext("for (;;) {}", {}, { timeout: 20 });
+      console.log(vm.runInNewContext("let code; try { inner() } catch (e) { code = e.code } busy(200); code", { inner, busy }, { timeout: 5000 }));
+      busy(200);
+      console.log("done");
+    `);
+    expect(stdout).toBe("ERR_SCRIPT_EXECUTION_TIMEOUT\ndone");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Any program that ran a `vm` script with a `timeout` and then kept working was silently stopped: the JSC Watchdog behind `timeout` was never disarmed after the run, so once the *outer* program had used `timeout` ms of CPU the pending timer terminated it and the process idled forever (reproduces on 1.3.14):

```js
require("node:vm").runInNewContext("1 + 1", {}, { timeout: 50 });
const end = Date.now() + 500; while (Date.now() < end); // never gets past here
console.log("unreachable");
```

The Watchdog also measured CPU time (a script that blocks without using CPU never timed out) and was one shared limit for nested runs (an inner run without a timeout hit a `RELEASE_ASSERT` when the outer one fired; an inner run with a longer timeout claimed the outer's expiry as its own).

Each `Script`/`Module` run now owns a `NodeVMTimeout`: a wall-clock timer that requests the VM's termination — the request `SIGINT` and `worker.terminate()` already use — and remembers that it fired. After the run only a timeout or SIGINT this run owns becomes `ERR_SCRIPT_EXECUTION_{TIMEOUT,INTERRUPTED}` (servicing the request first if the script finished before it landed, so nothing is left for the caller); any other termination keeps unwinding to its owner. `spawnSync`'s check for an active vm timeout reads a per-thread counter instead of the watchdog.

Not addressed: `Atomics.wait` inside the script is still not woken by the request (#32802); the timeout is reported once it returns.

### How did you verify your code works?

New `describe("timeout")` cases in `test/js/node/vm/vm.test.ts` (5 of 8 fail on canary: hang, wrong owner, `RELEASE_ASSERT`); `vm.test.ts`, the worker/vm cases in `worker.test.ts`, and all 97 upstream `test-vm-*` files pass on a debug+ASAN build; nine timeout/nesting/microtask scenarios compared against Node by hand.