### PR TITLE
bundler: list the chunks and assets reached through dynamic imports in the HTML import manifest

### DIFF
--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -182,9 +182,8 @@ pub(crate) fn write<W: Write + ?Sized>(
         &*bun_core::from_field_ptr!(BundleV2<'static>, graph, std::ptr::from_ref::<Graph>(graph))
     };
     let options = &bv2.transpiler().options;
-    // Must be sized from the same list as the files' entry bits (with code
-    // splitting it also holds the dynamic imports, unlike `graph.entry_points`):
-    // an `AutoBitSet` that fits inline never intersects a heap-allocated one.
+    // Same size as the files' entry bits (the linker's list includes the dynamic
+    // import entry points); differently sized `AutoBitSet`s never intersect.
     let mut entry_point_bits = AutoBitSet::init_empty(linker_graph.entry_points.len())?;
     let mut chunks_to_write = AutoBitSet::init_empty(chunks.len())?;
     let mut chunks_to_visit: Vec<u32> = Vec::new();
@@ -232,11 +231,9 @@ pub(crate) fn write<W: Write + ?Sized>(
         }
     }
 
-    // The page needs every chunk its own chunks import, transitively: shared
-    // chunks, its CSS chunk (possibly deduplicated into another page's), and
-    // the chunks of its dynamic imports, which are separate entry points when
-    // code splitting. Files reachable only from those entry points carry only
-    // their bits, so collect them too for the asset loop below.
+    // List everything the page's chunks import, transitively, and remember the
+    // entry points among them: with code splitting, a dynamic import is an entry
+    // point, and the assets only it reaches carry only its bit.
     while let Some(chunk_index) = chunks_to_visit.pop() {
         if chunks_to_write.is_set(chunk_index as usize) {
             continue;

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -46,7 +46,7 @@ use bun_paths::resolve_path::{platform, platform_to_posix_in_place, relative_nor
 use bun_resolver::fs::FileSystem;
 
 use crate::Graph::Graph;
-use crate::chunk::{Content, Flags};
+use crate::chunk::Content;
 use crate::options::{Loader, OutputKind};
 use crate::options_impl::LoaderExt as _;
 use crate::{BundleV2, Chunk, LinkerGraph};
@@ -182,7 +182,12 @@ pub(crate) fn write<W: Write + ?Sized>(
         &*bun_core::from_field_ptr!(BundleV2<'static>, graph, std::ptr::from_ref::<Graph>(graph))
     };
     let options = &bv2.transpiler().options;
-    let mut entry_point_bits = AutoBitSet::init_empty(graph.entry_points.len())?;
+    // Must be sized from the same list as the files' entry bits (with code
+    // splitting it also holds the dynamic imports, unlike `graph.entry_points`):
+    // an `AutoBitSet` that fits inline never intersects a heap-allocated one.
+    let mut entry_point_bits = AutoBitSet::init_empty(linker_graph.entry_points.len())?;
+    let mut chunks_to_write = AutoBitSet::init_empty(chunks.len())?;
+    let mut chunks_to_visit: Vec<u32> = Vec::new();
 
     let root_dir: &[u8] = if !options.root_dir.is_empty() {
         &options.root_dir[..]
@@ -199,10 +204,11 @@ pub(crate) fn write<W: Write + ?Sized>(
     let mut temp_buffer: Vec<u8> = Vec::new();
     let mut input_buffer: Vec<u8> = Vec::new();
 
-    for ch in chunks.iter() {
+    for (chunk_index, ch) in chunks.iter().enumerate() {
         if ch.entry_point.source_index() == browser_source_index && ch.entry_point.is_entry_point()
         {
             entry_point_bits.set(ch.entry_point.entry_point_id() as usize);
+            chunks_to_visit.push(chunk_index as u32);
 
             if matches!(ch.content, Content::Html) {
                 writer.write_all(b"\"index\":")?;
@@ -226,6 +232,30 @@ pub(crate) fn write<W: Write + ?Sized>(
         }
     }
 
+    // The page needs every chunk its own chunks import, transitively: shared
+    // chunks, its CSS chunk (possibly deduplicated into another page's), and
+    // the chunks of its dynamic imports, which are separate entry points when
+    // code splitting. Files reachable only from those entry points carry only
+    // their bits, so collect them too for the asset loop below.
+    while let Some(chunk_index) = chunks_to_visit.pop() {
+        if chunks_to_write.is_set(chunk_index as usize) {
+            continue;
+        }
+        chunks_to_write.set(chunk_index as usize);
+
+        let ch = &chunks[chunk_index as usize];
+        for import in ch.cross_chunk_imports.iter() {
+            let imported = &chunks[import.chunk_index as usize];
+            if imported.entry_point.is_entry_point() {
+                entry_point_bits.set(imported.entry_point.entry_point_id() as usize);
+            }
+            chunks_to_visit.push(import.chunk_index);
+        }
+        if let Content::Javascript(js) = &ch.content {
+            chunks_to_visit.extend_from_slice(&js.css_chunks);
+        }
+    }
+
     // Start the files array
 
     writer.write_all(b"\"files\":[")?;
@@ -236,16 +266,8 @@ pub(crate) fn write<W: Write + ?Sized>(
     let file_entry_bits: &[AutoBitSet] = linker_graph.files.items_entry_bits();
     let mut already_visited_output_file = AutoBitSet::init_empty(additional_output_files.len())?;
 
-    // Write all chunks that have files associated with this entry point.
-    // Also include browser chunks from server builds (lazy-loaded chunks from dynamic imports).
-    // When there's only one HTML import, all browser chunks belong to that manifest.
-    // When there are multiple HTML imports, only include chunks that intersect with this entry's bits.
-    let has_single_html_import = graph.html_imports.html_source_indices.len() == 1;
-    for ch in chunks.iter() {
-        if ch.entry_bits().has_intersection(&entry_point_bits)
-            || (has_single_html_import
-                && ch.flags.contains(Flags::IS_BROWSER_CHUNK_FROM_SERVER_BUILD))
-        {
+    for (chunk_index, ch) in chunks.iter().enumerate() {
+        if chunks_to_write.is_set(chunk_index) {
             if !first {
                 writer.write_all(b",")?;
             }

--- a/src/bundler/HTMLImportManifest.rs
+++ b/src/bundler/HTMLImportManifest.rs
@@ -182,8 +182,7 @@ pub(crate) fn write<W: Write + ?Sized>(
         &*bun_core::from_field_ptr!(BundleV2<'static>, graph, std::ptr::from_ref::<Graph>(graph))
     };
     let options = &bv2.transpiler().options;
-    // Same size as the files' entry bits (the linker's list includes the dynamic
-    // import entry points); differently sized `AutoBitSet`s never intersect.
+    // Same size as the files' entry bits: the linker's list also holds the dynamic imports.
     let mut entry_point_bits = AutoBitSet::init_empty(linker_graph.entry_points.len())?;
     let mut chunks_to_write = AutoBitSet::init_empty(chunks.len())?;
     let mut chunks_to_visit: Vec<u32> = Vec::new();
@@ -231,9 +230,7 @@ pub(crate) fn write<W: Write + ?Sized>(
         }
     }
 
-    // List everything the page's chunks import, transitively, and remember the
-    // entry points among them: with code splitting, a dynamic import is an entry
-    // point, and the assets only it reaches carry only its bit.
+    // Every chunk the page's chunks import, transitively.
     while let Some(chunk_index) = chunks_to_visit.pop() {
         if chunks_to_write.is_set(chunk_index as usize) {
             continue;
@@ -244,6 +241,7 @@ pub(crate) fn write<W: Write + ?Sized>(
         for import in ch.cross_chunk_imports.iter() {
             let imported = &chunks[import.chunk_index as usize];
             if imported.entry_point.is_entry_point() {
+                // A dynamic import's entry point: its bit is what the assets only it reaches carry.
                 entry_point_bits.set(imported.entry_point.entry_point_id() as usize);
             }
             chunks_to_visit.push(import.chunk_index);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -3,7 +3,41 @@ import { tempDir } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { SourceMapConsumer } from "source-map";
-import { itBundled } from "./expectBundled";
+import { type BundlerTestBundleAPI, itBundled } from "./expectBundled";
+
+interface ManifestFile {
+  input?: string;
+  path: string;
+  loader: string;
+  isEntry: boolean;
+  headers: Record<string, string>;
+}
+
+interface Manifest {
+  index: string;
+  files: ManifestFile[];
+}
+
+/** The manifests embedded in a bundled server entry point, in import order. */
+function readManifests(api: BundlerTestBundleAPI, file: string): Manifest[] {
+  const manifests = [...api.readFile(file).matchAll(/__jsonParse\("(.+?)"\)/gs)].map(match =>
+    JSON.parse(JSON.parse('"' + match[1] + '"')),
+  );
+  for (const manifest of manifests) {
+    for (const { path } of manifest.files) {
+      api.assertFileExists(join("out", path));
+    }
+  }
+  return manifests;
+}
+
+/** `[input, loader]` of every manifest entry that came from a source file, sorted. */
+function inputs(manifest: Manifest): [string, string][] {
+  return manifest.files
+    .filter(file => file.input !== undefined)
+    .map((file): [string, string] => [file.input!, file.loader])
+    .sort();
+}
 
 describe.concurrent("bundler", () => {
   // Test HTML import manifest with enhanced metadata
@@ -360,6 +394,175 @@ console.log("About manifest:", aboutHtml);
       `);
     },
   });
+
+  // With code splitting, each dynamically imported module is an entry point of
+  // its own, so the files only it reaches are not attributed to the HTML entry
+  // point. The manifest has to follow the page's dynamic imports to find them.
+  itBundled("html-import/splitting-lists-assets-of-lazy-chunks", {
+    outdir: "out/",
+    splitting: true,
+    target: "bun",
+    entryPoints: ["/server.js"],
+    files: {
+      "/server.js": `
+        import html from "./client.html";
+        import serverOnly from "./server-only.png";
+        console.log(html.index, serverOnly);
+      `,
+      "/client.html": `<!DOCTYPE html><html><head><script type="module" src="./client.js"></script></head><body></body></html>`,
+      "/client.js": `
+        import("./lazy-a.js").then(m => console.log(m.default));
+        import("./lazy-b.js").then(m => console.log(m.default));
+      `,
+      "/lazy-a.js": `
+        import a from "./a.png";
+        import shared from "./shared.js";
+        export default [a, shared, import("./lazier.js")];
+      `,
+      "/lazy-b.js": `
+        import shared from "./shared.js";
+        export default shared;
+      `,
+      "/lazier.js": `
+        import deep from "./deep.png";
+        export default deep;
+      `,
+      "/shared.js": `
+        import shared from "./shared.png";
+        export default shared;
+      `,
+      "/a.png": "a",
+      "/deep.png": "deep",
+      "/shared.png": "shared",
+      "/server-only.png": "server only",
+    },
+
+    onAfterBundle(api) {
+      const [manifest] = readManifests(api, "out/server.js");
+      expect(inputs(manifest)).toEqual([
+        ["a.png", "file"],
+        ["client.html", "html"],
+        ["client.html", "js"],
+        ["deep.png", "file"],
+        ["lazier.js", "js"],
+        ["lazy-a.js", "js"],
+        ["lazy-b.js", "js"],
+        ["shared.png", "file"],
+      ]);
+    },
+  });
+
+  // Each page only gets the chunks and assets its own code can load.
+  itBundled("html-import/splitting-attributes-lazy-chunks-to-their-page", {
+    outdir: "out/",
+    splitting: true,
+    target: "bun",
+    entryPoints: ["/server.js"],
+    files: {
+      "/server.js": `
+        import home from "./home.html";
+        import about from "./about.html";
+        console.log(home.index, about.index);
+      `,
+      "/home.html": `<!DOCTYPE html><html><head><script type="module" src="./home.js"></script></head><body></body></html>`,
+      "/about.html": `<!DOCTYPE html><html><head><script type="module" src="./about.js"></script></head><body></body></html>`,
+      "/home.js": `import("./home-lazy.js").then(m => console.log(m.default));`,
+      "/about.js": `import("./about-lazy.js").then(m => console.log(m.default));`,
+      "/home-lazy.js": `
+        import img from "./home.png";
+        export default img;
+      `,
+      "/about-lazy.js": `
+        import img from "./about.png";
+        export default img;
+      `,
+      "/home.png": "home",
+      "/about.png": "about",
+    },
+
+    onAfterBundle(api) {
+      const [home, about] = readManifests(api, "out/server.js");
+      expect(inputs(home)).toEqual([
+        ["home-lazy.js", "js"],
+        ["home.html", "html"],
+        ["home.html", "js"],
+        ["home.png", "file"],
+      ]);
+      expect(inputs(about)).toEqual([
+        ["about-lazy.js", "js"],
+        ["about.html", "html"],
+        ["about.html", "js"],
+        ["about.png", "file"],
+      ]);
+    },
+  });
+
+  // Pages with identical stylesheets share one CSS output file. It is created
+  // for whichever page comes first, but every page whose HTML links to it
+  // needs it in its manifest.
+  itBundled("html-import/shared-css-chunk-is-in-every-manifest", {
+    outdir: "out/",
+    target: "bun",
+    entryPoints: ["/server.js"],
+    files: {
+      "/server.js": `
+        import home from "./home.html";
+        import about from "./about.html";
+        console.log(home.index, about.index);
+      `,
+      "/home.html": `<!DOCTYPE html><html><head><link rel="stylesheet" href="./shared.css"></head><body>home</body></html>`,
+      "/about.html": `<!DOCTYPE html><html><head><link rel="stylesheet" href="./shared.css"></head><body>about</body></html>`,
+      "/shared.css": `body { margin: 0; }`,
+    },
+
+    onAfterBundle(api) {
+      const [home, about] = readManifests(api, "out/server.js");
+      const homeHref = api.readFile("out/home.html").match(/href="([^"]+)"/)![1];
+      const aboutHref = api.readFile("out/about.html").match(/href="([^"]+)"/)![1];
+      expect(aboutHref).toBe(homeHref);
+      expect(home.files.filter(file => file.loader === "css").map(file => file.path)).toEqual([homeHref]);
+      expect(about.files.filter(file => file.loader === "css").map(file => file.path)).toEqual([aboutHref]);
+    },
+  });
+
+  // Past 127 entry points the entry bits switch to a heap-allocated bitset.
+  // The manifest has to size its own bitset from the same entry point list as
+  // the files (which, with splitting, includes the dynamic imports), or the
+  // two never intersect and every asset goes missing.
+  {
+    const lazyCount = 130;
+    const files: Record<string, string> = {
+      "/server.js": `
+        import html from "./client.html";
+        console.log(html.index);
+      `,
+      "/client.html": `<!DOCTYPE html><html><head><script type="module" src="./client.js"></script></head><body></body></html>`,
+      "/icon.png": "icon",
+    };
+    let client = `import icon from "./icon.png";\nconsole.log(icon);\n`;
+    for (let i = 0; i < lazyCount; i++) {
+      files[`/lazy-${i}.js`] = `export default ${i};`;
+      client += `import("./lazy-${i}.js").then(m => console.log(m.default));\n`;
+    }
+    files["/client.js"] = client;
+
+    itBundled("html-import/splitting-more-than-127-entry-points", {
+      outdir: "out/",
+      splitting: true,
+      target: "bun",
+      entryPoints: ["/server.js"],
+      files,
+
+      onAfterBundle(api) {
+        const [manifest] = readManifests(api, "out/server.js");
+        const listed = inputs(manifest);
+        expect(listed).toContainEqual(["icon.png", "file"]);
+        expect(listed).toContainEqual(["client.html", "html"]);
+        expect(listed).toContainEqual(["client.html", "js"]);
+        expect(listed.filter(([input]) => input.startsWith("lazy-"))).toHaveLength(lazyCount);
+      },
+    });
+  }
 
   // The HTML chunk's etag must change when only a referenced JS/CSS chunk
   // changes; otherwise the browser 304s to a body that points at chunks the

--- a/test/js/bun/http/bun-serve-html-manifest.test.ts
+++ b/test/js/bun/http/bun-serve-html-manifest.test.ts
@@ -395,7 +395,11 @@ describe("Bun.serve HTML manifest", () => {
       stderr: "pipe",
       stdin: "ignore",
     });
-    const [buildStderr, buildExitCode] = await Promise.all([buildProc.stderr.text(), buildProc.exited]);
+    const [, buildStderr, buildExitCode] = await Promise.all([
+      buildProc.stdout.text(),
+      buildProc.stderr.text(),
+      buildProc.exited,
+    ]);
     expect(buildStderr).toBe("");
     expect(buildExitCode).toBe(0);
 

--- a/test/js/bun/http/bun-serve-html-manifest.test.ts
+++ b/test/js/bun/http/bun-serve-html-manifest.test.ts
@@ -372,7 +372,7 @@ describe("Bun.serve HTML manifest", () => {
         });
 
         // The page's own script, the lazy chunk, and the asset only the lazy chunk imports.
-        for (const file of readdirSync(".").sort()) {
+        for (const file of readdirSync(import.meta.dir).sort()) {
           if (!/^(index|lazy|logo)-/.test(file)) continue;
           const { status } = await fetch(new URL(file, server.url));
           console.log(file.replace(/-[a-z0-9]+\\./, "-[hash]."), status);

--- a/test/js/bun/http/bun-serve-html-manifest.test.ts
+++ b/test/js/bun/http/bun-serve-html-manifest.test.ts
@@ -350,4 +350,72 @@ describe("Bun.serve HTML manifest", () => {
         Has ETag: true"
     `);
   });
+
+  // With --splitting, a module that is only dynamically imported becomes its
+  // own chunk. The assets that only it imports still have to end up in the
+  // manifest, otherwise the page's lazy code requests files the server never
+  // registered routes for.
+  it("serves assets that only a lazily imported chunk references", async () => {
+    await using dir = tempDir("serve-html-lazy-asset", {
+      "server.ts": `
+        import { readdirSync } from "node:fs";
+        import index from "./index.html";
+
+        using server = Bun.serve({
+          port: 0,
+          routes: {
+            "/": index,
+          },
+          fetch() {
+            return new Response("not found", { status: 404 });
+          },
+        });
+
+        // The page's own script, the lazy chunk, and the asset only the lazy chunk imports.
+        for (const file of readdirSync(".").sort()) {
+          if (!/^(index|lazy|logo)-/.test(file)) continue;
+          const { status } = await fetch(new URL(file, server.url));
+          console.log(file.replace(/-[a-z0-9]+\\./, "-[hash]."), status);
+        }
+      `,
+      "index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.js"></script></head><body></body></html>`,
+      "app.js": `import("./lazy.js").then(m => console.log(m.default));`,
+      "lazy.js": `
+        import logo from "./logo.svg";
+        export default logo;
+      `,
+      "logo.svg": `<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+    });
+
+    await using buildProc = Bun.spawn({
+      cmd: [bunExe(), "build", "server.ts", "--outdir", "dist", "--target", "bun", "--splitting"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [buildStderr, buildExitCode] = await Promise.all([buildProc.stderr.text(), buildProc.exited]);
+    expect(buildStderr).toBe("");
+    expect(buildExitCode).toBe(0);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "server.js"],
+      cwd: join(dir, "dist"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
+      "index-[hash].js 200
+      lazy-[hash].js 200
+      logo-[hash].svg 200
+      "
+    `);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- In a server build that imports an HTML file and is built with `--splitting`, an asset (file loader) imported only by a dynamically imported module is copied to the outdir and referenced by the lazy chunk, but is missing from the manifest (`html.files`), so `Bun.serve` registers no route for it and the page's lazy code gets a 404. The lazy chunk itself is listed. Without `--splitting` the asset is listed.
- With two or more HTML imports and `--splitting`, the lazy chunks are missing from every manifest too, along with their assets, so `Bun.serve` 404s the `import()` itself.
- Cause, `src/bundler/HTMLImportManifest.rs`: the manifest selected chunks and assets by intersecting their entry bits with the HTML entry point's bit only. With code splitting, each dynamically imported module is an entry point of its own and the entry-bit traversal stops at dynamic imports (`is_external_dynamic_import`), so everything only a lazy module reaches carries the lazy entry point's bit, never the HTML's. Lazy chunks were only listed through a fallback that added every browser chunk to the manifest when the build had exactly one HTML import (#26024); assets had no such fallback, and builds with several HTML imports had none at all.
- Two more gaps in the same selection logic, found while reading it, fixed by the same change:
  - The manifest's bitset was sized from `graph.entry_points` (user entries plus HTML files), while the files' and chunks' bits are sized from the linker's list, which also contains the dynamic imports. `AutoBitSet::has_intersection` returns false between the inline variant (up to 127 bits) and the heap variant, so once a split build had more than 127 entry points in total, every asset dropped out of the manifest, including ones the page's own script imports statically.
  - Two pages linking identical stylesheets share one CSS output file. It is created for the first page, so the second page's manifest did not list the file its own `<link href>` points at.

### Fix
- Starting from the page's own chunks (the HTML chunk and the JS/CSS entry chunks created for the HTML entry point), walk `Chunk.cross_chunk_imports`, plus each JS chunk's `css_chunks`, and list every chunk reached. Every entry point chunk reached through a cross-chunk import (the dynamic imports, transitively) adds its entry point id to the bitset that selects assets, which is sized from the linker's entry point list. The single-HTML-import fallback is removed.
- Why this is the right set: `cross_chunk_imports` is exactly what the emitted chunk files import and `import()`, so a chunk is in the manifest iff the browser can reach it from the page; an asset's entry bits say which entry points' module graphs contain it, and the entry points reached by the walk are the ones whose graphs the page can load. The old single-import fallback is a subset of this: an entry chunk statically imports every chunk carrying its bit (`compute_cross_chunk_dependencies`), and a lazy entry chunk is reached through the `import()` that loads it. Only a chunk for an `import()` that tree shaking removed is no longer listed, and nothing references that file. Following `css_chunks` is how the HTML printer itself finds the page's stylesheet (`Chunk::get_css_chunk_for_html`), which is what makes the deduplicated CSS case come out right; CSS chunks reached that way do not contribute entry ids, since a deduplicated chunk carries the first page's id.
- Server-side files are unaffected: the walk never enters the server entry chunk, and the runtime chunk (which every entry point reaches) is not an entry point, so it contributes no bits. The existing manifest snapshots are unchanged, and #25628's compiled `--splitting` test still passes.
- Composes with #38337, which attributes document-referenced assets through documents whose bits intersect the same `entry_point_bits`; with this change that bitset also covers the lazy entry points (and is sized correctly past 127 entries).
- Verified:
  - `test/bundler/html-import-manifest.test.ts`: `splitting-lists-assets-of-lazy-chunks` (direct, nested and shared-chunk assets listed, server-only asset not), `splitting-attributes-lazy-chunks-to-their-page` (two pages, each manifest gets exactly its own lazy chunk and asset), `shared-css-chunk-is-in-every-manifest`, `splitting-more-than-127-entry-points`.
  - `test/js/bun/http/bun-serve-html-manifest.test.ts`: `serves assets that only a lazily imported chunk references` builds with `--splitting`, runs the output and fetches the asset (404 before, 200 after).
  - All five fail on the released build and on a debug build without the `src/` change; they pass with it.
  - Also passing: `html-import-manifest`, `bun-serve-html-manifest`, `regression/issue/25628`, `regression/issue/23569`, `bundler_html`, `bundler_html_server`, `bundler_splitting`, `bundler_compile_splitting`, the HTML import test in `bundler_compile`; `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` are clean.

### Background
- HTML import manifest: when server code does `import html from "./index.html"`, the bundler embeds a JSON list of that page's output files (HTML, JS and CSS chunks, assets, each with its path and headers) into the server bundle. `Bun.serve` turns every entry into a static route, so a file missing from the list is a 404 even though it exists in the outdir.
- Entry bits: after tree shaking, the linker records for each file which entry points reach it, as a bitset with one bit per entry in the linker's entry point list. With `--splitting`, every dynamically imported module is appended to that list as an entry point of its own, the traversal does not cross dynamic imports, and chunks are formed from files with identical bits. `Chunk.entry_bits` is the bitset a chunk was formed for.
- `cross_chunk_imports`: computed by `compute_cross_chunk_dependencies` for split builds; for each JS chunk, the other chunks it statically imports (every chunk it needs symbols or side effects from, and for entry chunks, every chunk carrying the entry's bit) plus the chunks its `import()` calls were rewritten to. It is the chunk-level dependency graph, and `append_isolated_hashes_for_imported_chunks` already walks it to compute output hashes.
- `AutoBitSet`: stores up to 127 bits inline and switches to a heap allocation above that; the two representations never intersect, so two bitsets must be created from the same count to be comparable.

<details>
<summary>Repro (release 1.4.0)</summary>

```sh
head -c 300000 /dev/urandom > big.png
printf '<!DOCTYPE html><html><head><script type="module" src="./client.js"></script></head><body></body></html>' > client.html
printf 'import("./lazy.js").then(m => console.log(m.default));\n' > client.js
printf 'import big from "./big.png";\nexport default big;\n' > lazy.js
printf 'import html from "./client.html";\nconsole.log(JSON.stringify(html.files.map(f => [f.input, f.path, f.loader])));\n' > server.js
bun build server.js --target=bun --outdir out --splitting && bun out/server.js
```

Before (`out/big-khdk8dkp.png` exists and `out/lazy-*.js` contains `var big_default = "./big-khdk8dkp.png"`):

```
[[null,"./server-08y1dfjd.js","js"],["client.html","./client-sfcrssnf.js","js"],["client.html","./client.html","html"],["lazy.js","./lazy-cq74adqd.js","js"]]
```

After:

```
[[null,"./server-08y1dfjd.js","js"],["client.html","./client-sfcrssnf.js","js"],["client.html","./client.html","html"],["lazy.js","./lazy-cq74adqd.js","js"],["big.png","./big-khdk8dkp.png","file"]]
```

Two HTML imports (`home.html` -> `import("./lazy.js")` -> `big.png`, `about.html` -> `import("./lazy2.js")` -> `other.png`), `--splitting`, output run from the outdir with both pages passed to `Bun.serve`, fetching every file on disk, before:

```
lazy-n88k6c28.js 404, big-a7kt5gy7.png 404, lazy2-j4exf8bf.js 404, other-zjjk94hc.png 404
```

After: all 200, and each manifest lists only its own lazy chunk and asset.

One HTML import whose script has 130 `import()`s and one static `import icon from "./icon.png"`, `--splitting`, before: the manifest lists the JS chunks and the HTML but no `file` entry; after: `icon.png` is listed. With 100 `import()`s it was listed before as well.

</details>
