### PR TITLE
sql(postgres): survive close() from inside a Bind encoder

### DIFF
--- a/src/sql/shared/ConnectionFlags.rs
+++ b/src/sql/shared/ConnectionFlags.rs
@@ -8,6 +8,9 @@ bitflags! {
         const USE_UNNAMED_PREPARED_STATEMENTS = 1 << 2;
         const WAITING_TO_PREPARE              = 1 << 3;
         const HAS_BACKPRESSURE                = 1 << 4;
+        /// A request is being encoded into the write buffer further up the
+        /// stack; see `PostgresSQLConnection::encode_request`.
+        const IS_DISPATCHING                  = 1 << 5;
     }
 }
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1375,7 +1375,11 @@ impl PostgresSQLConnection {
             self.disconnect();
         }
         self.unregister_auto_flusher();
-        self.write_buffer.with_mut(|b| b.clear_and_free());
+        // Closed from user JS inside an encoder: it still holds offsets into
+        // the buffer, so `encode_request` releases it once the encoder returns.
+        if !self.flags.get().contains(ConnectionFlags::IS_DISPATCHING) {
+            self.write_buffer.with_mut(|b| b.clear_and_free());
+        }
     }
 
     pub fn do_close(
@@ -1795,6 +1799,45 @@ impl PostgresSQLConnection {
             && self.pipelined_requests.get() == 0
     }
 
+    /// Runs `encode`, which appends one request's messages to `write_buffer`,
+    /// failing with `ConnectionClosed` if the connection is not connected once
+    /// it returns.
+    ///
+    /// Encoding a Bind converts the parameters through user JS (`valueOf()`,
+    /// `toString()`, `toJSON()`, getters), which can `close()` this connection
+    /// synchronously. That rejects and dequeues every request, including the
+    /// one being encoded, but the encoder still holds offsets into
+    /// `write_buffer` for the length prefixes it patches in on its way out, so
+    /// `close()` leaves the buffer alone while `IS_DISPATCHING` is set and it
+    /// is released here instead. The `ConnectionClosed` result sends the caller
+    /// down its encode-failure path, which is a no-op for a request that
+    /// `clean_up_requests` already rejected, and keeps it from recording the
+    /// request as written on a dead connection.
+    pub(crate) fn encode_request(
+        &self,
+        encode: impl FnOnce() -> Result<(), AnyPostgresError>,
+    ) -> Result<(), AnyPostgresError> {
+        if self.status.get() != Status::Connected {
+            return Err(AnyPostgresError::ConnectionClosed);
+        }
+        // Nested when user JS inside an encoder dispatches another query; the
+        // outermost encoder owns the flag and the buffer.
+        let outermost = !self.flags.get().contains(ConnectionFlags::IS_DISPATCHING);
+        self.update_flags(|f| f.insert(ConnectionFlags::IS_DISPATCHING));
+        let result = encode();
+        if outermost {
+            self.update_flags(|f| f.remove(ConnectionFlags::IS_DISPATCHING));
+        }
+        if self.status.get() == Status::Connected {
+            return result;
+        }
+        debug!("connection closed while encoding a request");
+        if outermost {
+            self.write_buffer.with_mut(|b| b.clear_and_free());
+        }
+        Err(AnyPostgresError::ConnectionClosed)
+    }
+
     /// Process pending requests and flush. Called from the enqueue path when
     /// unnamed prepared statements with params skip writeQuery+Sync and need
     /// advance() to send everything atomically on an idle connection.
@@ -1846,6 +1889,9 @@ impl PostgresSQLConnection {
             // (refcount ≥ 1 held by the queue). R-2: `ParentRef` yields `&T`
             // only — `PostgresSQLQuery` is Cell/JsCell-backed.
             let req = ParentRef::from(NonNull::new(req_ptr).expect("queue item non-null"));
+            // The encoders below run user JS, which can close() the connection
+            // and thereby drop the queue's ref mid-iteration (encode_request).
+            let _req_ref = req.ref_guard();
             match req.status.get() {
                 QueryStatus::Pending => {
                     // Optimistically account for this request leaving Pending; the
@@ -1948,6 +1994,11 @@ impl PostgresSQLConnection {
                                         postgres_sql_query::js::columns_get_cached(this_value)
                                             .unwrap_or_default();
                                     req.update_flags(|f| f.binary = !statement.fields.is_empty());
+                                    // Binding before the encoder runs: it was already taken out
+                                    // of pending_requests above, and a close() from inside the
+                                    // encoder cleans up Binding requests without touching that
+                                    // counter. The encode-failure paths below overwrite this.
+                                    req.status.set(QueryStatus::Binding);
 
                                     if self
                                         .flags
@@ -1961,7 +2012,7 @@ impl PostgresSQLConnection {
                                         debug!("parse, bind and execute unnamed stmt");
                                         let query_str = req.query.to_utf8();
                                         let global = self.global_object;
-                                        if let Err(err) =
+                                        if let Err(err) = self.encode_request(|| {
                                             PostgresRequest::parse_and_bind_and_execute(
                                                 &global,
                                                 query_str.slice(),
@@ -1971,7 +2022,7 @@ impl PostgresSQLConnection {
                                                 false,
                                                 self.writer(),
                                             )
-                                        {
+                                        }) {
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -1997,13 +2048,15 @@ impl PostgresSQLConnection {
                                     } else {
                                         debug!("binding and executing stmt");
                                         let global = self.global_object;
-                                        if let Err(err) = PostgresRequest::bind_and_execute(
-                                            &global,
-                                            statement,
-                                            binding_value,
-                                            columns_value,
-                                            self.writer(),
-                                        ) {
+                                        if let Err(err) = self.encode_request(|| {
+                                            PostgresRequest::bind_and_execute(
+                                                &global,
+                                                statement,
+                                                binding_value,
+                                                columns_value,
+                                                self.writer(),
+                                            )
+                                        }) {
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2028,7 +2081,6 @@ impl PostgresSQLConnection {
                                     self.update_flags(|f| {
                                         f.remove(ConnectionFlags::IS_READY_FOR_QUERY)
                                     });
-                                    req.status.set(QueryStatus::Binding);
                                     req.update_flags(|f| f.counter = RequestCounter::Pipelined);
                                     self.pipelined_requests
                                         .set(self.pipelined_requests.get() + 1);
@@ -2083,7 +2135,9 @@ impl PostgresSQLConnection {
                                                 .unwrap_or_default();
                                         debug!("prepareAndQueryWithSignature");
                                         let global = self.global_object;
-                                        if let Err(err) =
+                                        // See the Prepared arm: Binding before the encoder runs.
+                                        req.status.set(QueryStatus::Binding);
+                                        if let Err(err) = self.encode_request(|| {
                                             PostgresRequest::prepare_and_query_with_signature(
                                                 &global,
                                                 query_str.slice(),
@@ -2091,7 +2145,7 @@ impl PostgresSQLConnection {
                                                 self.writer(),
                                                 &mut statement.signature,
                                             )
-                                        {
+                                        }) {
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2120,7 +2174,6 @@ impl PostgresSQLConnection {
                                             f.remove(ConnectionFlags::IS_READY_FOR_QUERY);
                                             f.insert(ConnectionFlags::WAITING_TO_PREPARE);
                                         });
-                                        req.status.set(QueryStatus::Binding);
                                         statement.status = StatementStatus::Parsing;
                                         self.flush_data_and_reset_timeout();
                                         defer_cleanup!(self);
@@ -2155,7 +2208,9 @@ impl PostgresSQLConnection {
                                                 .unwrap_or_default();
                                         debug!("parseAndBindAndExecute (unnamed, first execution)");
                                         let global = self.global_object;
-                                        if let Err(err) =
+                                        // See the Prepared arm: Binding before the encoder runs.
+                                        req.status.set(QueryStatus::Binding);
+                                        if let Err(err) = self.encode_request(|| {
                                             PostgresRequest::parse_and_bind_and_execute(
                                                 &global,
                                                 query_str.slice(),
@@ -2165,7 +2220,7 @@ impl PostgresSQLConnection {
                                                 true,
                                                 self.writer(),
                                             )
-                                        {
+                                        }) {
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
@@ -2190,7 +2245,6 @@ impl PostgresSQLConnection {
                                             f.remove(ConnectionFlags::IS_READY_FOR_QUERY);
                                             f.insert(ConnectionFlags::WAITING_TO_PREPARE);
                                         });
-                                        req.status.set(QueryStatus::Binding);
                                         statement.status = StatementStatus::Parsing;
                                         req.update_flags(|f| f.counter = RequestCounter::Pipelined);
                                         self.pipelined_requests

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -668,13 +668,15 @@ impl PostgresSQLQuery {
                                 bun_core::scoped_log!(Postgres, "bindAndExecute");
 
                                 // bindAndExecute will bind + execute, it will change to running after binding is complete
-                                if let Err(err) = PostgresRequest::bind_and_execute(
-                                    global_object,
-                                    stmt,
-                                    binding_value,
-                                    columns_value,
-                                    writer,
-                                ) {
+                                if let Err(err) = connection.encode_request(|| {
+                                    PostgresRequest::bind_and_execute(
+                                        global_object,
+                                        stmt,
+                                        binding_value,
+                                        columns_value,
+                                        writer,
+                                    )
+                                }) {
                                     release_query_ref();
                                     return Err(throw_write_error(
                                         b"failed to bind and execute query",
@@ -726,13 +728,15 @@ impl PostgresSQLQuery {
                 if !has_params {
                     bun_core::scoped_log!(Postgres, "prepareAndQueryWithSignature");
                     // prepareAndQueryWithSignature will write + bind + execute, it will change to running after binding is complete
-                    if let Err(err) = PostgresRequest::prepare_and_query_with_signature(
-                        global_object,
-                        query_str.slice(),
-                        binding_value,
-                        writer,
-                        &mut signature,
-                    ) {
+                    if let Err(err) = connection.encode_request(|| {
+                        PostgresRequest::prepare_and_query_with_signature(
+                            global_object,
+                            query_str.slice(),
+                            binding_value,
+                            writer,
+                            &mut signature,
+                        )
+                    }) {
                         if connection_entry_value.is_some() {
                             let _ = connection
                                 .statements

--- a/test/js/sql/postgres-close-during-bind-fixture.ts
+++ b/test/js/sql/postgres-close-during-bind-fixture.ts
@@ -1,0 +1,126 @@
+// Fixture for postgres-close-during-bind.test.ts. Runs the scenario named by
+// SCENARIO against the server at DATABASE_URL in its own process, because
+// before the fix every scenario aborts the process (panic in the Bind encoder)
+// rather than failing an assertion.
+//
+// Each scenario binds a parameter whose conversion hook closes the reserved
+// connection it is being sent on, i.e. close() runs while that query's Bind
+// message is half encoded. `::int4` makes the server type the parameter as
+// int4, so with a prepared statement the parameter is sent in binary format
+// and the hook that runs is valueOf(); with prepare: false it is sent as text
+// and the hook is toString(). The scenario reports how every query settled and
+// which hook ran, then lets the process exit on its own: a request left
+// enqueued on the dead connection would keep the event loop alive and the
+// test would time out instead of seeing the exit.
+import { SQL, type ReservedSQL } from "bun";
+
+const url = process.env.DATABASE_URL!;
+
+function settle(promise: Promise<unknown>) {
+  return promise.then(
+    ok => ({ ok }),
+    (e: any) => ({ err: e?.code ?? e?.message ?? String(e) }),
+  );
+}
+
+let closedFrom: string | null = null;
+/** int4 parameter whose conversion closes `reserved`. */
+function closing(reserved: ReservedSQL) {
+  const close = (hook: string) => {
+    if (closedFrom === null) {
+      closedFrom = hook;
+      reserved.close();
+    }
+  };
+  return {
+    valueOf() {
+      close("valueOf");
+      return 1;
+    },
+    toString() {
+      close("toString");
+      return "1";
+    },
+  };
+}
+
+let aheadConverted = false;
+/** int4 parameter of the query dispatched ahead of the closing one; records that its Bind was encoded. */
+const ahead = {
+  valueOf() {
+    aheadConverted = true;
+    return 2;
+  },
+};
+
+// Every parameter above is a plain object, so all the queries of a scenario
+// share one prepared statement: the statement name is derived from the query
+// text plus the parameters' JS types.
+const warm = { valueOf: () => 0 };
+
+async function scenario(options: { prepare?: boolean }, run: (reserved: ReservedSQL) => Promise<object>) {
+  const sql = new SQL({ url, max: 1, ...options });
+  const reserved = await sql.reserve();
+  const result = await run(reserved);
+  // The pool hands out a fresh connection in place of the closed one.
+  const afterwards = await settle(sql`select 1 as ok`);
+  return { ...result, closedFrom, afterwards };
+}
+
+const scenarios: Record<string, () => Promise<object>> = {
+  // First execution of the statement: Parse round trip first, then the Bind is
+  // encoded from advance() while handling the server's ReadyForQuery.
+  async "first execution"() {
+    return scenario({}, async reserved => ({
+      outer: await settle(reserved`select ${closing(reserved)}::int4 as x`),
+    }));
+  },
+
+  // Same, with a second query on the statement queued ahead of the closing
+  // one: advance() encodes the first query's Bind, then the closing one, so
+  // close() finds one request already encoded in the queue and one being
+  // encoded behind it.
+  async "first execution, request queued ahead"() {
+    return scenario({}, async reserved => {
+      const first = reserved`select ${ahead}::int4 as x`.execute();
+      const outer = reserved`select ${closing(reserved)}::int4 as x`.execute();
+      return { ahead: await settle(first), outer: await settle(outer), aheadConverted };
+    });
+  },
+
+  // Statement already prepared: the Bind is encoded at dispatch time, from
+  // run(), before the request is enqueued.
+  async "prepared statement"() {
+    return scenario({}, async reserved => {
+      await reserved`select ${warm}::int4 as x`;
+      return { outer: await settle(reserved`select ${closing(reserved)}::int4 as x`) };
+    });
+  },
+
+  // Same, with another execution of the statement dispatched synchronously
+  // before it, so its Bind is still sitting unflushed in the write buffer when
+  // close() runs inside the second one's encoder.
+  async "prepared statement, request buffered ahead"() {
+    return scenario({}, async reserved => {
+      await reserved`select ${warm}::int4 as x`;
+      const first = reserved`select ${ahead}::int4 as x`.execute();
+      const outer = reserved`select ${closing(reserved)}::int4 as x`.execute();
+      return { ahead: await settle(first), outer: await settle(outer), aheadConverted };
+    });
+  },
+
+  // prepare: false encodes Parse+Bind+Execute in one batch from advance(); the
+  // parameter goes out in text format, so the hook that closes is toString().
+  async "unnamed statement (prepare: false)"() {
+    return scenario({ prepare: false }, async reserved => ({
+      outer: await settle(reserved`select ${closing(reserved)}::int4 as x`),
+    }));
+  },
+};
+
+const run = scenarios[process.env.SCENARIO!];
+if (!run) {
+  console.log(JSON.stringify({ error: `unknown scenario ${process.env.SCENARIO}` }));
+  process.exit(1);
+}
+console.log(JSON.stringify(await run()));

--- a/test/js/sql/postgres-close-during-bind.test.ts
+++ b/test/js/sql/postgres-close-during-bind.test.ts
@@ -1,0 +1,78 @@
+// Encoding a Bind message converts each parameter through user JS (valueOf /
+// toString / toJSON), and that JS can close the connection the query is being
+// encoded for (reserved.close()). close() rejected and dequeued every request
+// and freed the write buffer while the encoder was still in the middle of the
+// Bind, holding offsets into that buffer for the length prefixes it patches in
+// afterwards. When the conversion hook returned, the encoder appended to the
+// emptied buffer and patched at the stale offset:
+//
+//   panic: range start index 42 out of range for slice of length 4
+//   (Writer::pwrite, PostgresSQLConnection.rs; on the first execution of a
+//   statement, debug builds trip "pending_requests underflow" in
+//   clean_up_requests first, because advance() had already taken the request
+//   being encoded out of that counter)
+//
+// Now close() leaves the buffer to the encoder, whose caller releases it and
+// fails the request with ERR_POSTGRES_CONNECTION_CLOSED instead of recording
+// it as written on the dead connection. Each scenario runs in a subprocess and
+// reports how every query settled; before the fix the subprocess aborts, and a
+// request left behind on the dead connection would keep it alive until the
+// test times out.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer } from "harness";
+import path from "node:path";
+
+const fixture = path.join(import.meta.dir, "postgres-close-during-bind-fixture.ts");
+
+const closed = { err: "ERR_POSTGRES_CONNECTION_CLOSED" };
+const afterwards = { ok: [{ ok: 1 }] };
+
+const scenarios: Record<string, unknown> = {
+  "first execution": { outer: closed, closedFrom: "valueOf", afterwards },
+  "first execution, request queued ahead": {
+    ahead: closed,
+    outer: closed,
+    aheadConverted: true,
+    closedFrom: "valueOf",
+    afterwards,
+  },
+  "prepared statement": { outer: closed, closedFrom: "valueOf", afterwards },
+  "prepared statement, request buffered ahead": {
+    ahead: closed,
+    outer: closed,
+    aheadConverted: true,
+    closedFrom: "valueOf",
+    afterwards,
+  },
+  "unnamed statement (prepare: false)": { outer: closed, closedFrom: "toString", afterwards },
+};
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  for (const [scenario, expected] of Object.entries(scenarios)) {
+    test.concurrent(scenario, async () => {
+      await container.ready;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: {
+          ...bunEnv,
+          DATABASE_URL: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+          SCENARIO: scenario,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      let result: unknown = stdout;
+      try {
+        result = JSON.parse(stdout);
+      } catch {}
+      expect({ result, exitCode, stderr }).toEqual({
+        result: expected,
+        exitCode: 0,
+        // not asserted; included so a panic trace shows up in the diff
+        stderr: expect.any(String),
+      });
+    });
+  }
+});


### PR DESCRIPTION
### Problem
- Closing a reserved connection from inside a parameter conversion of a query running on it aborts the process:
  ```ts
  const reserved = await sql.reserve();
  await reserved`select ${{ valueOf() { reserved.close(); return 1; } }}::int4`;
  ```
  ```
  panic: range start index 42 out of range for slice of length 4
  ```
  in `Writer::pwrite` (`src/sql_jsc/postgres/PostgresSQLConnection.rs`). With `prepare: false` the same close panics on the int cast in `LengthWriter::write` instead; on the first execution of a statement debug builds trip `pending_requests underflow` in `clean_up_requests` first.
- Cause: `write_bind` (`src/sql_jsc/postgres/PostgresRequest.rs`) converts each parameter through user JS while it is in the middle of the Bind message, holding the offsets of the length prefixes it patches in afterwards (`LengthWriter`). `reserved.close()` runs synchronously to `PostgresSQLConnection::close()`, which rejects and dequeues every request and then frees `write_buffer`. When the conversion returns, the encoder appends to the emptied buffer and patches at the stale offset.
- On the first execution the Bind is encoded by `advance()`, which had already taken the head request out of `pending_requests` while leaving it `Pending`; `clean_up_requests` decrements it again for a `Pending` request (the debug underflow). It also drops the queue's ref on the request `advance()` is still using.
- For an already prepared statement the Bind is encoded by `PostgresSQLQuery::do_run` before the request is enqueued. Even without the panic, `do_run` would go on to enqueue the request and ref the event loop for a connection whose socket is already closed, so nothing would ever unref it.

### Fix
- `close()` leaves `write_buffer` alone while `ConnectionFlags::IS_DISPATCHING` is set. `PostgresSQLConnection::encode_request` sets the flag around the encoders, and once the encoder returns on a connection that is no longer `Connected` it releases the buffer itself and returns `ConnectionClosed`. All six callers of the three encoders that reach `write_bind` (`bind_and_execute`, `prepare_and_query_with_signature`, `parse_and_bind_and_execute`; four in `advance()`, two in `do_run`) go through it.
- `advance()` marks a request `Binding` before encoding it (it previously did so after) and holds a ref on the request for the iteration.
- Why this is correct:
  - The buffer is the encoder's until it returns: nothing else holds offsets into it, and the bytes are garbage either way once the connection is closed, so releasing it after the encoder returns loses nothing and removes the only reader of stale offsets.
  - `ConnectionClosed` sends each caller down its existing encode-failure path. In `advance()` that path rejects the request and pops or `Fail`-marks it, which is a no-op for a request `clean_up_requests` already rejected (the reject callbacks bail once the query target has been cleared) and does not touch the counters. In `do_run` it releases the refs it took and throws, so the request is never enqueued on the dead connection and the event loop is not ref'd; the query was already rejected with `ERR_POSTGRES_CONNECTION_CLOSED` by the connection's close handler, and the throw lands on a settled promise.
  - `Binding` is the state `advance()` gives the request right after the encode anyway; moving it before the encode means `clean_up_requests` takes its `Binding` arm, which decrements only the counter recorded in the request's flags (none yet) instead of `pending_requests`, which the request already left. Every failure path overwrites it with `Fail`.
  - The ref keeps the request, and through it the statement the encoder was handed, alive for the rest of the iteration. After `clean_up_requests` rejects and pops it, the only other ref is the JS wrapper's, and the rejected request no longer holds its wrapper alive, so a GC during the remaining conversions could otherwise free it under `advance()`.
  - `encode_request` saves and restores the flag so that a query dispatched from inside a conversion (the separate bug #38231 fixes; this flag is the same concept as the one that PR adds, and the second of the two to land should use one flag) nests without clearing the outer encoder's flag or releasing its buffer.
- Verified with `test/js/sql/postgres-close-during-bind.test.ts`, five scenarios in subprocesses against the `postgres_plain` service: both encode sites alone and with another execution of the statement queued or buffered ahead of the closing one (exercising the `offset > 0` path in `advance()` and the `Binding` cleanup of the request ahead), plus `prepare: false`. Each scenario also checks that the pool still serves a query afterwards and that the process exits on its own. Without the fix all five abort (release: the `pwrite`/int cast panics; debug: three `pending_requests underflow`, two `pwrite`); with it all five pass on the debug build.
- `test/js/sql/sql.test.ts` (postgres block, 853 tests) against the local service on the debug build: the 20 failures are the same set as without this change (15 are environment: md5/scram users, prepared transactions, catalog contents; 5 are the existing debug-build timing failures, re-checked individually on an unmodified debug build; `reserve connection` is the wall-clock assertion #38221 is replacing).
- `postgres-prepared-pipeline-reorder`, `postgres-split-prepare-reorder`, `postgres-simple-query-pipeline`, `postgres-finish-request-underflow`, `postgres-failed-connection-resurrection`, `postgres-error-then-datarow`, `postgres-frame-boundary`, `postgres-multi-statement-fields`, `sql-prepare-false`, `sql-close-pending-connection`, `sql-onconnect-onclose-throw`: pass.

### Background
- Extended query protocol: executing a prepared statement sends Bind (the parameter values) + Execute + Sync. Every frontend message starts with a 4-byte length that is only known once the body is written, so the encoder reserves the 4 bytes, remembers their offset into `write_buffer`, and patches them in place afterwards; the parameter values inside Bind are length-prefixed the same way.
- Converting a parameter is a JS call (`coerce` -> `valueOf()`, `String::from_js` -> `toString()`, `json_stringify_fast` -> `toJSON()`, getters on the binding objects), so arbitrary user code runs in the middle of a message. `reserved.close()` is synchronous all the way down to the native `close()`.
- Encode sites: a statement's first execution is Parse + Describe, then, when the server's ReadyForQuery arrives, `advance()` walks the request queue and encodes the Bind; an already prepared statement has its Bind encoded by `do_run` at dispatch time and is enqueued afterwards.
- `pending_requests` counts queued requests whose bytes have not been written yet; `advance()` decrements it when it starts writing a request. `clean_up_requests` decrements it for `Pending` requests (never written) and, for `Binding`/`Running` ones, decrements whichever pipelining counter the request's flags say it bumped.
- Requests are intrusively refcounted; the queue holds one ref and the JS wrapper another. While a request is in flight the request holds its wrapper strongly (so it cannot be collected); rejecting the request downgrades that to a weak reference, so once the queue's ref is gone too, a GC can collect the wrapper and free the request.
- `poll_ref` is the connection's keep-alive on the event loop; `do_run` refs it when it enqueues a request and the socket's close callback unrefs it.
