### PR TITLE
error printer: place the code frame caret by the excerpt, not by the top frame's column

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5762,6 +5762,7 @@ impl VirtualMachine {
                     current_line_number -= 1;
                 }
                 exception.stack.source_lines_len = take as u8;
+                exception.stack.source_lines_caret_column = frames[top].position.column;
             }
 
             if !code.slice().is_empty() {
@@ -6168,7 +6169,7 @@ impl VirtualMachine {
                         allow_ansi_color,
                         formatter.error_display_level,
                     )?;
-                } else if let Some(top) = top_frame {
+                } else {
                     did_print_name = true;
                     let display_line = source.line + 1;
                     let int_size = count_digits(display_line);
@@ -6197,7 +6198,7 @@ impl VirtualMachine {
                     } else {
                         pretty_write!(writer, "<r><b>{} |<r> {}\n", display_line, hl)?;
 
-                        let col = top.position.column.zero_based();
+                        let col = exception.stack.source_lines_caret_column.zero_based();
                         if clamped.len() < MAX_LINE_LENGTH_WITH_DIVOT
                             || (col as usize) > MAX_LINE_LENGTH_WITH_DIVOT
                         {

--- a/src/jsc/ZigException.rs
+++ b/src/jsc/ZigException.rs
@@ -168,6 +168,7 @@ impl Holder {
                     source_lines_numbers: self.source_line_numbers.as_mut_ptr(),
                     source_lines_len: Self::SOURCE_LINES_COUNT as u8,
                     source_lines_to_collect: Self::SOURCE_LINES_COUNT as u8,
+                    source_lines_caret_column: bun_core::Ordinal::INVALID,
                     frames_ptr: self.frames.as_mut_ptr(),
                     frames_len: 0,
                     frames_cap: Self::FRAME_COUNT as u8,

--- a/src/jsc/ZigStackTrace.rs
+++ b/src/jsc/ZigStackTrace.rs
@@ -17,11 +17,7 @@ pub struct ZigStackTrace {
     pub(crate) source_lines_numbers: *mut i32,
     pub(crate) source_lines_len: u8,
     pub(crate) source_lines_to_collect: u8,
-    /// Column of `source_lines_ptr[0]` the caret is drawn under; set together
-    /// with that line. Not necessarily the top frame's column: on the first
-    /// line of a source with a start column (node:vm's `columnOffset`) the
-    /// frame's column includes the offset, while the excerpt is the physical
-    /// line.
+    /// Column of `source_lines_ptr[0]` the caret is drawn under; filled together with that line.
     pub(crate) source_lines_caret_column: Ordinal,
 
     pub(crate) frames_ptr: *mut ZigStackFrame,

--- a/src/jsc/ZigStackTrace.rs
+++ b/src/jsc/ZigStackTrace.rs
@@ -2,6 +2,7 @@ use core::ptr;
 use core::ptr::NonNull;
 
 use crate::exception_list;
+use bun_core::Ordinal;
 use bun_core::String as BunString;
 use bun_core::ZigStringSlice;
 use bun_url::URL as ZigURL;
@@ -16,6 +17,12 @@ pub struct ZigStackTrace {
     pub(crate) source_lines_numbers: *mut i32,
     pub(crate) source_lines_len: u8,
     pub(crate) source_lines_to_collect: u8,
+    /// Column of `source_lines_ptr[0]` the caret is drawn under; set together
+    /// with that line. Not necessarily the top frame's column: on the first
+    /// line of a source with a start column (node:vm's `columnOffset`) the
+    /// frame's column includes the offset, while the excerpt is the physical
+    /// line.
+    pub(crate) source_lines_caret_column: Ordinal,
 
     pub(crate) frames_ptr: *mut ZigStackFrame,
     pub frames_len: u8,
@@ -36,6 +43,7 @@ impl ZigStackTrace {
             source_lines_numbers: ptr::dangling_mut(),
             source_lines_len: 0,
             source_lines_to_collect: 0,
+            source_lines_caret_column: Ordinal::INVALID,
 
             frames_ptr: frames_slice.as_mut_ptr(),
             frames_len: frames_slice.len().min(usize::from(u8::MAX)) as u8,

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -128,7 +128,7 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
 }
 
 static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunString* source_lines,
-    OrdinalNumber* source_line_numbers, uint8_t source_lines_count,
+    OrdinalNumber* source_line_numbers, int32_t* source_lines_caret_column, uint8_t source_lines_count,
     ZigStackFramePosition& position, JSC::SourceProvider** referenced_source_provider, PopulateStackTraceFlags flags)
 {
     auto code = stackFrame.codeBlock();
@@ -187,6 +187,14 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
         *referenced_source_provider = provider;
         source_lines[0] = Bun::toStringView(sourceString.substring(lineStart, lineEnd - lineStart));
         source_line_numbers[0] = location.line();
+        // The caret is measured from the excerpt's text (the printer trims the previous
+        // line's '\n' that lineStart is still on), not taken from location.column(): on
+        // the first line of a source with a start column (node:vm's columnOffset) the
+        // reported column includes that offset, which the excerpt does not contain.
+        int textStart = static_cast<int>(lineStart);
+        if (lineStart < sourceString.length() && sourceString[lineStart] == '\n')
+            textStart++;
+        *source_lines_caret_column = std::max(location.byte_position - textStart, 0);
 
         if (lineStart > 0) {
             auto byte_offset_in_source_string = lineStart - 1;
@@ -230,11 +238,12 @@ static void populateStackFrame(JSC::VM& vm, ZigStackTrace& trace, const JSC::Sta
     if (flags == PopulateStackTraceFlags::OnlyPosition) {
         populateStackFrameMetadata(vm, globalObject, stackFrame, frame, finalizerSafety);
         populateStackFramePosition(stackFrame, nullptr,
-            nullptr,
+            nullptr, nullptr,
             0, frame.position, referenced_source_provider, flags);
     } else if (flags == PopulateStackTraceFlags::OnlySourceLines) {
         populateStackFramePosition(stackFrame, is_top ? trace.source_lines_ptr : nullptr,
             is_top ? trace.source_lines_numbers : nullptr,
+            is_top ? &trace.source_lines_caret_column_zero_based : nullptr,
             is_top ? trace.source_lines_to_collect : 0, frame.position, referenced_source_provider, flags);
     }
 }
@@ -673,6 +682,7 @@ static void fromErrorInstance(ZigException& except, JSC::JSGlobalObject* global,
                                     auto str = jsStr->value(global);
                                     except.stack.source_lines_ptr[0] = Bun::toStringRef(str);
                                     except.stack.source_lines_numbers[0] = except.stack.frames_ptr[0].position.line();
+                                    except.stack.source_lines_caret_column_zero_based = except.stack.frames_ptr[0].position.column_zero_based;
                                     except.stack.source_lines_len = 1;
                                     except.remapped = true;
                                 }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -185,16 +185,14 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
             (*referenced_source_provider)->deref();
         }
         *referenced_source_provider = provider;
-        source_lines[0] = Bun::toStringView(sourceString.substring(lineStart, lineEnd - lineStart));
-        source_line_numbers[0] = location.line();
-        // The caret is measured from the excerpt's text (the printer trims the previous
-        // line's '\n' that lineStart is still on), not taken from location.column(): on
-        // the first line of a source with a start column (node:vm's columnOffset) the
-        // reported column includes that offset, which the excerpt does not contain.
-        int textStart = static_cast<int>(lineStart);
-        if (lineStart < sourceString.length() && sourceString[lineStart] == '\n')
+        // The scan above stops on the previous line's '\n' (the loop below counts on lineStart staying there); the excerpt starts after it.
+        unsigned int textStart = lineStart;
+        if (lineStart < lineEnd && sourceString[lineStart] == '\n')
             textStart++;
-        *source_lines_caret_column = std::max(location.byte_position - textStart, 0);
+        source_lines[0] = Bun::toStringView(sourceString.substring(textStart, lineEnd - textStart));
+        source_line_numbers[0] = location.line();
+        // Not location.column(): on the first line of a source with a start column (node:vm's columnOffset) that includes the offset.
+        *source_lines_caret_column = location.byte_position - static_cast<int>(textStart);
 
         if (lineStart > 0) {
             auto byte_offset_in_source_string = lineStart - 1;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -218,11 +218,7 @@ typedef struct ZigStackTrace {
     OrdinalNumber* source_lines_numbers;
     uint8_t source_lines_len;
     uint8_t source_lines_to_collect;
-    /// Column of `source_lines_ptr[0]` the error printer puts its caret under
-    /// (-1 if unset). Set by whoever fills `source_lines_ptr[0]`. It differs
-    /// from the top frame's column when the reported column does not count
-    /// from the start of the excerpted text: positions on the first line of a
-    /// source with a start column (node:vm's columnOffset) include that offset.
+    /// Column of `source_lines_ptr[0]` the caret is drawn under (-1 if unset); filled together with that line.
     int32_t source_lines_caret_column_zero_based;
     ZigStackFrame* frames_ptr;
     uint8_t frames_len;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -218,6 +218,12 @@ typedef struct ZigStackTrace {
     OrdinalNumber* source_lines_numbers;
     uint8_t source_lines_len;
     uint8_t source_lines_to_collect;
+    /// Column of `source_lines_ptr[0]` the error printer puts its caret under
+    /// (-1 if unset). Set by whoever fills `source_lines_ptr[0]`. It differs
+    /// from the top frame's column when the reported column does not count
+    /// from the start of the excerpted text: positions on the first line of a
+    /// source with a start column (node:vm's columnOffset) include that offset.
+    int32_t source_lines_caret_column_zero_based;
     ZigStackFrame* frames_ptr;
     uint8_t frames_len;
     uint8_t frames_cap;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -913,7 +913,7 @@ describe("code frame of an error thrown from a source compiled with columnOffset
     expect({ text, caret }).toEqual({ text: plain.text, caret: plain.caret });
   });
 
-  test("uncaught error output", async () => {
+  test.concurrent("uncaught error output", async () => {
     const code = 'throw new Error("x")';
     async function uncaught(columnOffset: number) {
       const options = { filename, columnOffset, displayErrors: false };
@@ -927,8 +927,9 @@ describe("code frame of an error thrown from a source compiled with columnOffset
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       const frame = parseCodeFrame(stderr);
+      expect(stdout).toBe("");
       expect(exitCode).toBe(1);
       return frame;
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -847,6 +847,98 @@ resp.text().then((a) => {
   }
 });
 
+describe("code frame of an error thrown from a source compiled with columnOffset", () => {
+  const filename = "/virtual/caret.js";
+
+  // The code frame Bun's error printer puts above an error: the excerpted line,
+  // the column of that line the caret sits under, and the top frame's position.
+  function parseCodeFrame(printed: string) {
+    expect(printed).toMatch(/^\d+ \| .*\n *\^\n/m);
+    expect(printed).toMatch(/\/virtual\/caret\.js:\d+:\d+/);
+    const lines = printed.split("\n");
+    const caretIndex = lines.findIndex(line => line.trim() === "^");
+    const textStart = lines[caretIndex - 1].indexOf("| ") + 2;
+    const [, line, column] = printed.match(/\/virtual\/caret\.js:(\d+):(\d+)/)!;
+    return {
+      text: lines[caretIndex - 1].slice(textStart),
+      caret: lines[caretIndex].indexOf("^") - textStart,
+      line: Number(line),
+      column: Number(column),
+    };
+  }
+
+  function inspectThrown(run: () => void) {
+    let thrown: unknown;
+    try {
+      run();
+    } catch (e) {
+      thrown = e;
+    }
+    return parseCodeFrame(Bun.inspect(thrown, { colors: false }));
+  }
+
+  // displayErrors: false keeps node:vm from replacing err.stack with its own
+  // source line and caret; the code frame under test is the printer's.
+  const script = (code: string, columnOffset: number) => () =>
+    new Script(code, { filename, columnOffset }).runInThisContext({ displayErrors: false });
+
+  test.each(['throw new Error("x")', "null.x;", '"use strict"; missing;'])(
+    "the caret stays under the token on the first line: %s",
+    code => {
+      const plain = inspectThrown(script(code, 0));
+      expect(plain.caret).toBeGreaterThan(0);
+      // columnOffset is added to the reported column of the first line (as in
+      // Node), but the excerpt is the physical line, so the caret must not move.
+      expect(inspectThrown(script(code, 20))).toEqual({ ...plain, column: plain.column + 20 });
+    },
+  );
+
+  test("lines after the first do not get the offset", () => {
+    const code = '"line 1";\nthrow new Error("x")';
+    const plain = inspectThrown(script(code, 0));
+    expect(plain).toMatchObject({ text: 'throw new Error("x")', line: 2 });
+    expect(inspectThrown(script(code, 20))).toEqual(plain);
+  });
+
+  test("compileFunction", () => {
+    const body = 'throw new Error("x")';
+    const fn = (columnOffset: number) => () => compileFunction(body, [], { filename, columnOffset })();
+    const plain = inspectThrown(fn(0));
+    expect(plain).toMatchObject({ text: body });
+    expect(plain.caret).toBeGreaterThan(0);
+    // Only the excerpt is compared: which line and column compileFunction
+    // reports for its body is its own business, the caret has to follow the
+    // text either way.
+    const { text, caret } = inspectThrown(fn(20));
+    expect({ text, caret }).toEqual({ text: plain.text, caret: plain.caret });
+  });
+
+  test("uncaught error output", async () => {
+    const code = 'throw new Error("x")';
+    async function uncaught(columnOffset: number) {
+      const options = { filename, columnOffset, displayErrors: false };
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `require("node:vm").runInThisContext(${JSON.stringify(code)}, ${JSON.stringify(options)})`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const frame = parseCodeFrame(stderr);
+      expect(exitCode).toBe(1);
+      return frame;
+    }
+    const [plain, shifted] = await Promise.all([uncaught(0), uncaught(20)]);
+    expect(plain).toMatchObject({ text: code, line: 1 });
+    expect(plain.caret).toBeGreaterThan(0);
+    expect(shifted).toEqual({ ...plain, column: plain.column + 20 });
+  });
+});
+
 test("can't use export syntax in vm.Script", () => {
   // vm.Script now parses eagerly (like Node), so the SyntaxError surfaces at
   // construction rather than at runInThisContext()/createCachedData().


### PR DESCRIPTION
### Problem
- The caret under the source excerpt that Bun prints above an uncaught error (and above `Bun.inspect(err)` / `console.error(err)`) is drawn `columnOffset` columns too far right when the error is on the first line of a `node:vm` source compiled with a `columnOffset`. `new vm.Script('throw new Error("x")', { filename: "s.js", columnOffset: 20 }).runInThisContext({ displayErrors: false })` prints `1 | throw new Error("x")` with the `^` 20 columns to the right of `new`, past the end of the line. The frame line under it, `at s.js:1:27`, is correct: Node adds `columnOffset` to the first line's reported columns.
- Same mechanism with a builtin on top of the stack: for `[].reduce((a, b) => a)` in `x.js`, the excerpt is the user's line but the caret is drawn at the builtin's own column (11 on a release build, 9 on a debug build) instead of under `reduce`.
- Cause: the excerpt and the caret come from two different places. `populateStackFramePosition` (`src/jsc/bindings/ZigException.cpp`) cuts `source_lines[0]` out of the source text by byte offset, and `remap_zig_exception` (`src/jsc/VirtualMachine.rs`) rebuilds the lines from the file of the frame it picks; `print_error_instance_body` then indents the caret by the column of a frame it picks itself. A frame's column is what Node-style stack frames report, not an index into the printed line: on the first line of a source with a start column JSC adds that start column (`CodeBlock::expressionInfoForBytecodeIndex` adds `firstLineColumnOffset()` there), and the frame the printer picks is not always the frame the lines were taken from.

### Fix
- `ZigStackTrace` gets a caret column that belongs to `source_lines[0]` and is written by whoever writes that line: `populateStackFramePosition` takes the position's byte offset minus the offset it cuts the line at; the `lineText` path in `fromErrorInstance` and the source-map path in `remap_zig_exception` store the column they built the line from. The printer indents the caret by it. Frame positions (`at file:line:col`, `error.stack`, `prepareStackTrace`) are unchanged.
- `populateStackFramePosition` used to cut the error line starting on the previous line's `\n` (its backward scan stops on that byte, and the lines-above loop depends on it staying there) and left the printer to trim the `\n`. The line is now cut from the byte after it, so the caret offset and the stored text have the same origin. Every printer trimmed that newline (`SourceLine::trimmed_text`), so output is unchanged; the only thing that sees the difference is the error line in the inspector's `LifecycleReporter.error` payload, whose source-map-built lines never had the newline anyway.
- Why this is right: the caret is an index into the text being printed, so it has to be derived from that text. The byte offset JSC records for a position is an offset into the same provider text the line is cut from, so `byte_position - textStart` is exact whatever the source's start line or column is, and it stays exact through the `new X()` walk-back in `getAdjustedPositionForBytecode`, which moves the byte offset along with the column. It is also what Node does for its own arrow header (`GetErrorSource` subtracts the script origin's column offset on the first line), and what node:vm's header in Bun already does (`handleException` in `NodeVM.cpp`); the printer was the remaining consumer doing otherwise. On the source-map path the stored column is the one the printer used before, so transpiled files print exactly as they did.
- The field is an `int32_t` in the C struct and a `bun_core::Ordinal` on the Rust side, the same split `ZigStackFramePosition` uses (a `WTF::OrdinalNumber` member would make `ZigException` non-C-compatible for the `extern "C"` declaration that returns it by value). It occupies existing padding, so the layout of the surrounding fields is unchanged on both sides.
- Verified with `test/js/node/vm/vm.test.ts`, "code frame of an error thrown from a source compiled with columnOffset": `vm.Script` first-line errors from a construct, a property access and an unresolvable identifier (caret equal to the un-offset run, frame column shifted by the offset), an error on the second line (identical to the un-offset run), `compileFunction` (the caret follows the text; this one passes today because compileFunction currently ignores `columnOffset`, and pins the printer for #38240, which makes it apply), and the uncaught printer in a subprocess through `vm.runInThisContext`. 4 of the 6 fail on the released 1.4.0 (caret at 26 instead of 6, frame column 27 in both), which prints the same output as a debug build of main for the repro; all 6 pass with the change.
- Also run on the debug build: `inspect-error.test.js` (its two minified-file snapshots fail without this change too, from a debug-only `at require` frame), `inspect.test.js`, `reportError.test.ts`, `vm-sourceUrl.test.ts`, the rest of `vm.test.ts`, `bun/test/stack.test.ts`, `test-test.test.ts` and the other `bun test` output tests, `console-log.test.ts`, the caret-asserting regression tests, and the source-mapped code frame in `bundler_bun.test.ts` (`bun/TargetBunSourcemapInline`, where `new` is walked back across a line).
- Overlaps with open PRs: #38335 fixes the builtin-on-top caret from the other direction (making the printer pick the frame `remap_zig_exception` picked) along with the GitHub Actions annotation; with this PR the caret no longer depends on the printer's frame choice and its caret test passes either way, the annotation half is independent, and the two diffs do not touch the same lines. #38244 rewrites the excerpt block in `populateStackFramePosition`; on top of it the new line is `byte_position` minus its line start. #38240 strips compileFunction's wrapper from the first excerpted line; the caret then has to be measured from that start too, which the compileFunction test here catches.

### Background
- Code frame: the numbered source lines, the caret line and the `name: message` line Bun prints above a stack trace, for uncaught errors and for `Bun.inspect` / `console.error` of an Error. `remap_zig_exception` fills `ZigStackTrace.source_lines` (index 0 is the error's line, higher indices the lines above it), either from the original file through a source map or, when nothing maps (vm, eval, `new Function`, builtins), by calling `populateStackFramePosition`, which slices the lines out of JSC's copy of the source; `print_error_instance_body` renders them.
- `ZigStackTrace` / `ZigException`: C structs declared in `headers-handwritten.h` and mirrored by `#[repr(C)]` structs in `src/jsc/`; Rust allocates them (`zig_exception::Holder`) and C++ fills them in. The source lines and their line numbers live on the trace; each frame only has its own position.
- Frame position: for every bytecode JSC records a line/column and a character offset into the source provider's text (the "divot") marking where an error there is attributed. `getAdjustedPositionForBytecode` turns this into Bun's `ZigStackFramePosition` (line, column, byte offset), moving `new X()` positions back onto the `new` keyword. The column is the one Node-style frames print; for a `SourceCode` that does not start at column 0 (node:vm's `columnOffset`, which Node defines as added to the first line's columns only) JSC adds the start column to positions on the first line, so on that line the column is not an index into the physical text.

<details>
<summary>Before / after</summary>

```
$ cat caret.js
const vm = require("node:vm");
new vm.Script('throw new Error("x")', { filename: "/virtual/s.js", columnOffset: 20 })
  .runInThisContext({ displayErrors: false });

# before
1 | throw new Error("x")
                              ^
error: x
      at /virtual/s.js:1:27

# after
1 | throw new Error("x")
          ^
error: x
      at /virtual/s.js:1:27

$ echo '[].reduce((a, b) => a);' > reduce.js

# before
1 | [].reduce((a, b) => a);
              ^
TypeError: reduce of empty array with no initial value
      at reduce (1:11)
      at reduce.js:1:4

# after
1 | [].reduce((a, b) => a);
       ^
TypeError: reduce of empty array with no initial value
      at reduce (1:11)
      at reduce.js:1:4
```

With `columnOffset: 0`, or with the error on any line but the first, the output is the same before and after. `displayErrors: false` only keeps node:vm from replacing `err.stack` with its own header; the same excerpt is printed by `Bun.inspect(err)`.
</details>
