### PR TITLE
Bun.Transpiler: make treeShaking remove unused declarations and their imports

### DIFF
--- a/docs/runtime/transpiler.mdx
+++ b/docs/runtime/transpiler.mdx
@@ -207,13 +207,19 @@ interface TranspilerOptions {
 
   // Specify a set of exports to eliminate
   // Or rename certain exports
+  // Enables treeShaking by default, so code only used by an eliminated export is removed too
   exports?: {
       eliminate?: string[];
       replace?: Record<string, string>;
   },
 
-  // Whether to remove unused imports from transpiled file
+  // Whether to remove top-level declarations (without side effects) that nothing
+  // exported or executed in the file refers to, and the imports they used
   // Default: false
+  treeShaking?: boolean,
+
+  // Whether to remove unused imports from transpiled file
+  // Default: the value of treeShaking
   trimUnusedImports?: boolean,
 
   // Whether to enable a set of JSX optimizations

--- a/docs/runtime/transpiler.mdx
+++ b/docs/runtime/transpiler.mdx
@@ -215,7 +215,7 @@ interface TranspilerOptions {
 
   // Whether to remove top-level declarations (without side effects) that nothing
   // exported or executed in the file refers to, and the imports they used
-  // Default: false
+  // Default: false, or true when exports has entries
   treeShaking?: boolean,
 
   // Whether to remove unused imports from transpiled file

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2728,7 +2728,24 @@ declare module "bun" {
       eliminate?: string[];
       replace?: Record<string, string>;
     };
+    /**
+     * Remove top-level functions, classes and variables (with side-effect-free
+     * initializers) that nothing exported or executed by the file refers to,
+     * then the imports they were the last users of (unless
+     * {@link trimUnusedImports} is `false`). Combined with `exports.eliminate`,
+     * this also removes whatever only the eliminated exports used. Only the one
+     * file being transformed is considered, and a direct `eval()` anywhere in it
+     * disables the removal.
+     *
+     * @default false (`true` when {@link exports} has entries)
+     */
     treeShaking?: boolean;
+    /**
+     * Remove imported bindings that the output does not use. Imports written
+     * without bindings (`import "./setup"`) are kept.
+     *
+     * Defaults to the value of {@link treeShaking}.
+     */
     trimUnusedImports?: boolean;
     jsxOptimizationInline?: boolean;
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1252,8 +1252,7 @@ pub struct BundleOptions<'a> {
     pub conditions: ESMConditions,
     pub tree_shaking: bool,
     pub tree_shaking_override: Option<bool>,
-    /// `Bun.Transpiler({ treeShaking })`. Separate from `tree_shaking`, which the
-    /// runtime enables too and which only splits a transformed file into parts.
+    /// Bun.Transpiler's treeShaking; distinct from `tree_shaking`, which the runtime sets too.
     pub remove_unused_declarations: bool,
     pub code_splitting: bool,
     pub source_map: SourceMapOption,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1252,9 +1252,8 @@ pub struct BundleOptions<'a> {
     pub conditions: ESMConditions,
     pub tree_shaking: bool,
     pub tree_shaking_override: Option<bool>,
-    /// Single-file tree shaking for `Bun.Transpiler({ treeShaking: true })`;
-    /// see `Runtime::Features::remove_unused_declarations`. `tree_shaking` by
-    /// itself only splits a transformed file into parts.
+    /// `Bun.Transpiler({ treeShaking })`. Separate from `tree_shaking`, which the
+    /// runtime enables too and which only splits a transformed file into parts.
     pub remove_unused_declarations: bool,
     pub code_splitting: bool,
     pub source_map: SourceMapOption,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1252,6 +1252,10 @@ pub struct BundleOptions<'a> {
     pub conditions: ESMConditions,
     pub tree_shaking: bool,
     pub tree_shaking_override: Option<bool>,
+    /// Single-file tree shaking for `Bun.Transpiler({ treeShaking: true })`;
+    /// see `Runtime::Features::remove_unused_declarations`. `tree_shaking` by
+    /// itself only splits a transformed file into parts.
+    pub remove_unused_declarations: bool,
     pub code_splitting: bool,
     pub source_map: SourceMapOption,
     pub packages: PackagesOption,
@@ -1456,6 +1460,7 @@ impl<'a> BundleOptions<'a> {
             },
             tree_shaking: self.tree_shaking,
             tree_shaking_override: self.tree_shaking_override,
+            remove_unused_declarations: self.remove_unused_declarations,
             code_splitting: self.code_splitting,
             source_map: self.source_map,
             packages: self.packages,
@@ -1701,6 +1706,7 @@ impl<'a> BundleOptions<'a> {
             }, // filled below
             tree_shaking: false,
             tree_shaking_override: None,
+            remove_unused_declarations: false,
             code_splitting: false,
             source_map: SourceMapOption::None,
             packages: PackagesOption::Bundle,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1597,6 +1597,7 @@ impl<'a> Transpiler<'a> {
                     .options
                     .trim_unused_imports
                     .unwrap_or_else(|| loader.is_typescript());
+                opts.features.remove_unused_declarations = self.options.remove_unused_declarations;
                 opts.features.no_macros = self.options.no_macros;
                 // `bun_ast::RuntimeTranspilerCache` is the single nominal
                 // type on both sides; thread the pointer directly.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7848,10 +7848,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             hmr_transform_ctx.finalize(self, head_parts)?;
         } else {
-            if self.options.features.remove_unused_declarations {
-                self.remove_unused_parts(parts);
-            }
-
             // Handle import paths after the whole file has been visited because we need
             // symbol usage counts to be able to remove unused type-only imports in
             // TypeScript code.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1272,7 +1272,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.deoptimize_common_js_named_exports();
     }
 
-    fn clear_symbol_usages_from_dead_part(&mut self, part: &js_ast::Part) {
+    pub(crate) fn clear_symbol_usages_from_dead_part(&mut self, part: &js_ast::Part) {
         let symbol_use_refs = part.symbol_uses.keys();
         let symbol_use_values = part.symbol_uses.values();
         let symbols = self.symbols.as_mut_slice();
@@ -7790,10 +7790,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let arena = self.arena;
 
-        // if (p.options.tree_shaking and p.options.features.trim_unused_imports) {
-        //     p.treeShake(&parts, false);
-        // }
-
         let bundling = self.options.bundle;
         let mut parts_end: usize = usize::from(bundling);
 
@@ -7852,6 +7848,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             hmr_transform_ctx.finalize(self, head_parts)?;
         } else {
+            if self.options.features.remove_unused_declarations {
+                self.remove_unused_parts(parts);
+            }
+
             // Handle import paths after the whole file has been visited because we need
             // symbol usage counts to be able to remove unused type-only imports in
             // TypeScript code.

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1123,6 +1123,11 @@ impl<'a> Parser<'a> {
         // `perf::Ctx` ends the span in its `Drop` impl — bind it for the rest of `_parse`.
         let _postvisit_tracer = bun_core::perf::trace("JSParser::postvisit");
 
+        // Before anything below reads use counts (`__dirname`, `exports`, runtime helpers).
+        if p.options.features.remove_unused_declarations {
+            p.remove_unused_parts(&mut before, &mut parts);
+        }
+
         let mut uses_dirname =
             p.symbols.as_slice()[p.dirname_ref.inner_index() as usize].use_count_estimate > 0;
         let mut uses_filename =

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -193,6 +193,7 @@ impl<'a> Options<'a> {
                 dead_code_elimination: f.dead_code_elimination,
                 set_breakpoint_on_first_line: f.set_breakpoint_on_first_line,
                 trim_unused_imports: f.trim_unused_imports,
+                remove_unused_declarations: f.remove_unused_declarations,
                 auto_polyfill_require: f.auto_polyfill_require,
                 replace_exports: Default::default(),
                 dont_bundle_twice: f.dont_bundle_twice,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -209,11 +209,8 @@ pub mod Runtime {
 
         pub trim_unused_imports: bool,
 
-        /// `Bun.Transpiler({ treeShaking: true })`. A standalone transform has no
-        /// linker, so the parser itself drops the top-level declarations that
-        /// nothing reachable from an export or a side effect uses, and then the
-        /// imports whose bindings all went away (see `P::remove_unused_parts`).
-        /// The runtime leaves this off: it enables `Options.tree_shaking` only to
+        /// `Bun.Transpiler({ treeShaking })`: run `P::remove_unused_parts`. Not
+        /// implied by `Options.tree_shaking`, which the runtime enables only to
         /// get one part per statement.
         pub remove_unused_declarations: bool,
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -209,6 +209,14 @@ pub mod Runtime {
 
         pub trim_unused_imports: bool,
 
+        /// `Bun.Transpiler({ treeShaking: true })`. A standalone transform has no
+        /// linker, so the parser itself drops the top-level declarations that
+        /// nothing reachable from an export or a side effect uses, and then the
+        /// imports whose bindings all went away (see `P::remove_unused_parts`).
+        /// The runtime leaves this off: it enables `Options.tree_shaking` only to
+        /// get one part per statement.
+        pub remove_unused_declarations: bool,
+
         /// Allow runtime usage of require(), converting `require` into `__require`
         pub auto_polyfill_require: bool,
 
@@ -292,6 +300,7 @@ pub mod Runtime {
                 dead_code_elimination: true,
                 set_breakpoint_on_first_line: false,
                 trim_unused_imports: false,
+                remove_unused_declarations: false,
                 auto_polyfill_require: false,
                 replace_exports: ReplaceableExportMap::default(),
                 dont_bundle_twice: false,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -209,9 +209,7 @@ pub mod Runtime {
 
         pub trim_unused_imports: bool,
 
-        /// `Bun.Transpiler({ treeShaking })`: run `P::remove_unused_parts`. Not
-        /// implied by `Options.tree_shaking`, which the runtime enables only to
-        /// get one part per statement.
+        /// Run `P::remove_unused_parts`; `Options.tree_shaking` alone only splits up parts.
         pub remove_unused_declarations: bool,
 
         /// Allow runtime usage of require(), converting `require` into `__require`

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -358,6 +358,8 @@ pub mod Runtime {
         // Takes `Wyhash` (NOT `Wyhash11`).
         pub(crate) fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
+            // Bun.Transpiler-only (like `replace_exports`), so never set on a cached parse.
+            debug_assert!(!self.remove_unused_declarations);
 
             let bools: [bool; 17] = [
                 self.top_level_await,

--- a/src/js_parser/scan/mod.rs
+++ b/src/js_parser/scan/mod.rs
@@ -1,3 +1,4 @@
 pub mod scan_imports;
 pub mod scan_side_effects;
 pub(crate) mod scan_symbols;
+pub(crate) mod scan_unused_parts;

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -265,13 +265,11 @@ impl<'a> ImportScanner<'a> {
                         // e.g. `import 'fancy-stylesheet-thing/style.css';`
                         // This is a breaking change though. We can make it an option with some guardrail
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
-                        //
-                        // `ts_use_counts` still counts references from code that single-file
-                        // tree shaking removed, which would leave `import "x"` behind.
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
                             && !p.options.preserve_unused_imports_ts)
+                            // `ts_use_counts` still counts the references made by tree-shaken code.
                             || ((!is_typescript_enabled
                                 || p.options.features.remove_unused_declarations)
                                 && p.options.features.trim_unused_imports

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -265,13 +265,14 @@ impl<'a> ImportScanner<'a> {
                         // e.g. `import 'fancy-stylesheet-thing/style.css';`
                         // This is a breaking change though. We can make it an option with some guardrail
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
+                        // Eliminated exports and removed declarations still count in ts_use_counts.
+                        let removes_code = p.options.features.remove_unused_declarations
+                            || p.options.features.replace_exports.count() > 0;
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
                             && !p.options.preserve_unused_imports_ts)
-                            // `ts_use_counts` still counts the references made by tree-shaken code.
-                            || ((!is_typescript_enabled
-                                || p.options.features.remove_unused_declarations)
+                            || ((!is_typescript_enabled || removes_code)
                                 && p.options.features.trim_unused_imports
                                 && found_imports
                                 && st.star_name_loc.is_empty()

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -266,10 +266,8 @@ impl<'a> ImportScanner<'a> {
                         // This is a breaking change though. We can make it an option with some guardrail
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
                         //
-                        // With single-file tree shaking, TypeScript's use counts still
-                        // include the references made by code that was removed
-                        // (eliminated exports, shaken declarations), which would leave
-                        // `import "x"` behind; apply the JavaScript rule there as well.
+                        // `ts_use_counts` still counts references from code that single-file
+                        // tree shaking removed, which would leave `import "x"` behind.
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -265,11 +265,17 @@ impl<'a> ImportScanner<'a> {
                         // e.g. `import 'fancy-stylesheet-thing/style.css';`
                         // This is a breaking change though. We can make it an option with some guardrail
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
+                        //
+                        // With single-file tree shaking, TypeScript's use counts still
+                        // include the references made by code that was removed
+                        // (eliminated exports, shaken declarations), which would leave
+                        // `import "x"` behind; apply the JavaScript rule there as well.
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
                             && !p.options.preserve_unused_imports_ts)
-                            || (!is_typescript_enabled
+                            || ((!is_typescript_enabled
+                                || p.options.features.remove_unused_declarations)
                                 && p.options.features.trim_unused_imports
                                 && found_imports
                                 && st.star_name_loc.is_empty()

--- a/src/js_parser/scan/scan_unused_parts.rs
+++ b/src/js_parser/scan/scan_unused_parts.rs
@@ -5,22 +5,14 @@ use bun_collections::HashMap;
 use bun_crash_handler::handle_oom::handle_oom;
 use smallvec::SmallVec;
 
-/// Which parts declare each top-level symbol, keyed by the symbol its `link`
-/// chain ends at: redeclaring a `var` or function creates a second symbol
-/// linked to the first, and every declaration of a live symbol has to stay
-/// (`export var x = 1; var x = 2;`).
+/// The parts declaring each top-level symbol, keyed by the end of the symbol's
+/// `link` chain (a redeclared `var` or function is two linked symbols).
 type DeclaringParts = HashMap<Ref, SmallVec<[u32; 1]>>;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    /// Single-file tree shaking (`features.remove_unused_declarations`).
-    ///
-    /// `Options.tree_shaking` gave every top-level statement its own part.
-    /// Parts that do anything other than declare something side-effect free
-    /// are roots; a declaration part survives only if a live part uses, or
-    /// also declares, one of its symbols. Removing a part also un-counts its
-    /// symbol uses, so the import scanner that runs next trims the imports only
-    /// it needed, and marks the `import()`/`require()` records inside it
-    /// unused, like the ones in dead control flow that are never created.
+    /// Single-file tree shaking (`features.remove_unused_declarations`): mark from
+    /// the parts that import, export or have side effects, sweep the declarations
+    /// nothing live reaches. Runs before the import scanner so their imports go too.
     pub(crate) fn remove_unused_parts(&mut self, parts: &mut ArenaVec<'a, js_ast::Part>) {
         // The bundler tree shakes in the linker, where cross-file uses are known.
         debug_assert!(!self.options.bundle);
@@ -56,6 +48,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             for &used in part.symbol_uses.keys() {
                 self.mark_declaring_parts_live(used, &declaring_parts, &mut live, &mut worklist);
             }
+            // Every declaration of a live symbol stays: `export var x = 1; var x = 2;`
             DeclaredSymbol::for_each_top_level_symbol(
                 &part.declared_symbols,
                 &mut (&mut live, &mut worklist),
@@ -76,6 +69,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 parts.push(part);
                 continue;
             }
+            // `scan()` and the linker skip unused records.
             for &record_index in part.import_record_indices.iter() {
                 self.import_records.items_mut()[record_index as usize]
                     .flags
@@ -103,9 +97,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Imports are kept here and trimmed by use count in the import scanner;
-    /// exports and everything `can_be_removed_if_unused` rejects keep the rest
-    /// of the file alive.
+    /// Imports stay here and get trimmed by use count in the import scanner.
     fn part_only_declares_removable_symbols(&self, part: &js_ast::Part) -> bool {
         part.can_be_removed_if_unused
             && part.stmts.iter().all(|stmt| match &stmt.data {
@@ -114,8 +106,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     !func.func.flags.contains(flags::Function::IsExport)
                 }
                 js_ast::StmtData::SClass(class) => !class.is_export,
-                // Generated companions of a declaration, e.g. the closure that
-                // fills in a TypeScript enum.
+                // Generated next to a declaration, e.g. a TypeScript enum's closure.
                 js_ast::StmtData::SExpr(expr) => expr.does_not_affect_tree_shaking,
                 js_ast::StmtData::SEmpty(_) => true,
                 _ => false,

--- a/src/js_parser/scan/scan_unused_parts.rs
+++ b/src/js_parser/scan/scan_unused_parts.rs
@@ -1,3 +1,4 @@
+use crate::RuntimeImports;
 use crate::p::P;
 use bun_alloc::ArenaVec;
 use bun_ast::{self as js_ast, DeclaredSymbol, ImportRecordFlags, Ref, flags};
@@ -9,8 +10,12 @@ use smallvec::SmallVec;
 type DeclaringParts = HashMap<Ref, SmallVec<[u32; 1]>>;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    /// Single-file tree shaking. Runs before the import scanner so the swept parts' imports go too.
-    pub(crate) fn remove_unused_parts(&mut self, parts: &mut ArenaVec<'a, js_ast::Part>) {
+    /// Single-file tree shaking of the hoisted (`before`) and remaining top-level parts.
+    pub(crate) fn remove_unused_parts(
+        &mut self,
+        before: &mut ArenaVec<'a, js_ast::Part>,
+        parts: &mut ArenaVec<'a, js_ast::Part>,
+    ) {
         // The bundler tree shakes in the linker, where cross-file uses are known.
         debug_assert!(!self.options.bundle);
 
@@ -20,11 +25,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let arena = self.arena;
-        let mut live = bun_alloc::vec_from_iter_in(core::iter::repeat_n(false, parts.len()), arena);
+        let hoisted = before.len();
+        let mut all = core::mem::replace(before, ArenaVec::new_in(arena));
+        all.append(parts);
+
+        let mut live = bun_alloc::vec_from_iter_in(core::iter::repeat_n(false, all.len()), arena);
         let mut worklist = ArenaVec::<u32>::new_in(arena);
         let mut declaring_parts = DeclaringParts::default();
 
-        for (i, part) in parts.iter().enumerate() {
+        for (i, part) in all.iter().enumerate() {
             if !self.part_only_declares_removable_symbols(part) {
                 live[i] = true;
                 worklist.push(i as u32);
@@ -41,7 +50,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         while let Some(i) = worklist.pop() {
-            let part = &parts[i as usize];
+            let part = &all[i as usize];
             for &used in part.symbol_uses.keys() {
                 self.mark_declaring_parts_live(used, &declaring_parts, &mut live, &mut worklist);
             }
@@ -55,15 +64,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
 
-        let live_count = live.iter().filter(|&&is_live| is_live).count();
-        if live_count == parts.len() {
-            return;
-        }
-
-        let all_parts = core::mem::replace(parts, ArenaVec::with_capacity_in(live_count, arena));
-        for (part, is_live) in all_parts.into_iter().zip(live.iter()) {
+        for (i, (part, is_live)) in all.into_iter().zip(live.iter()).enumerate() {
             if *is_live {
-                parts.push(part);
+                let kept = if i < hoisted {
+                    &mut *before
+                } else {
+                    &mut *parts
+                };
+                kept.push(part);
                 continue;
             }
             // `scan()` and the linker skip unused records.
@@ -74,6 +82,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             self.clear_symbol_usages_from_dead_part(&part);
         }
+
+        self.forget_unused_runtime_helpers();
     }
 
     fn mark_declaring_parts_live(
@@ -118,6 +128,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 return ref_;
             }
             ref_ = symbol.link.get();
+        }
+    }
+
+    /// A `bun:wrap` helper whose callers were all swept would otherwise still be imported.
+    fn forget_unused_runtime_helpers(&mut self) {
+        let mut unused: SmallVec<[&'static [u8]; 4]> = SmallVec::new();
+        let mut helpers = self.runtime_imports.iter();
+        while let Some(helper) = helpers.next() {
+            if self.symbols[helper.value.inner_index() as usize].use_count_estimate == 0 {
+                unused.push(RuntimeImports::ALL[helper.key as usize]);
+            }
+        }
+        for name in unused {
+            self.runtime_imports.put(name, Ref::NONE);
         }
     }
 }

--- a/src/js_parser/scan/scan_unused_parts.rs
+++ b/src/js_parser/scan/scan_unused_parts.rs
@@ -1,0 +1,103 @@
+use crate::p::P;
+use bun_alloc::ArenaVec;
+use bun_ast::{self as js_ast, Ref, flags};
+use bun_collections::HashMap;
+use bun_crash_handler::handle_oom::handle_oom;
+use smallvec::SmallVec;
+
+impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+    /// Single-file tree shaking (`features.remove_unused_declarations`).
+    ///
+    /// `Options.tree_shaking` gave every top-level statement its own part.
+    /// Parts that do anything other than declare something side-effect free
+    /// are roots; a declaration part survives only if a live part uses one of
+    /// its symbols. Removing a part also un-counts its symbol uses, so the
+    /// import scanner that runs next trims the imports only it needed.
+    pub(crate) fn remove_unused_parts(&mut self, parts: &mut ArenaVec<'a, js_ast::Part>) {
+        // The bundler tree shakes in the linker, where cross-file uses are known.
+        debug_assert!(!self.options.bundle);
+
+        // Code inside a direct eval() can name any top-level declaration.
+        if self.module_scope().contains_direct_eval {
+            return;
+        }
+
+        let arena = self.arena;
+        let mut live = bun_alloc::vec_from_iter_in(core::iter::repeat_n(false, parts.len()), arena);
+        let mut worklist = ArenaVec::<u32>::new_in(arena);
+        // Redeclaring a `var` or function creates a second symbol linked to the
+        // first, so both declarations are keyed by the symbol the links end at.
+        let mut declaring_parts: HashMap<Ref, SmallVec<[u32; 1]>> = HashMap::default();
+
+        for (i, part) in parts.iter().enumerate() {
+            if !self.part_only_declares_removable_symbols(part) {
+                live[i] = true;
+                worklist.push(i as u32);
+                continue;
+            }
+            for &declared in part.declared_symbols.refs() {
+                let key = self.follow_symbol_links(declared);
+                handle_oom(declaring_parts.get_or_put(key))
+                    .value_ptr
+                    .push(i as u32);
+            }
+        }
+
+        while let Some(i) = worklist.pop() {
+            for &used in parts[i as usize].symbol_uses.keys() {
+                let Some(declaring) = declaring_parts.get(&self.follow_symbol_links(used)) else {
+                    continue;
+                };
+                for &j in declaring {
+                    if !live[j as usize] {
+                        live[j as usize] = true;
+                        worklist.push(j);
+                    }
+                }
+            }
+        }
+
+        let live_count = live.iter().filter(|&&is_live| is_live).count();
+        if live_count == parts.len() {
+            return;
+        }
+
+        let all_parts = core::mem::replace(parts, ArenaVec::with_capacity_in(live_count, arena));
+        for (part, is_live) in all_parts.into_iter().zip(live.iter()) {
+            if *is_live {
+                parts.push(part);
+            } else {
+                self.clear_symbol_usages_from_dead_part(&part);
+            }
+        }
+    }
+
+    /// Imports are kept here and trimmed by use count in the import scanner;
+    /// exports and everything `can_be_removed_if_unused` rejects keep the rest
+    /// of the file alive.
+    fn part_only_declares_removable_symbols(&self, part: &js_ast::Part) -> bool {
+        part.can_be_removed_if_unused
+            && part.stmts.iter().all(|stmt| match &stmt.data {
+                js_ast::StmtData::SLocal(local) => !local.is_export,
+                js_ast::StmtData::SFunction(func) => {
+                    !func.func.flags.contains(flags::Function::IsExport)
+                }
+                js_ast::StmtData::SClass(class) => !class.is_export,
+                // Generated companions of a declaration, e.g. the closure that
+                // fills in a TypeScript enum.
+                js_ast::StmtData::SExpr(expr) => expr.does_not_affect_tree_shaking,
+                js_ast::StmtData::SEmpty(_) => true,
+                _ => false,
+            })
+    }
+
+    fn follow_symbol_links(&self, mut ref_: Ref) -> Ref {
+        loop {
+            let symbol = &self.symbols[ref_.inner_index() as usize];
+            if !symbol.has_link() {
+                return ref_;
+            }
+            ref_ = symbol.link.get();
+        }
+    }
+}

--- a/src/js_parser/scan/scan_unused_parts.rs
+++ b/src/js_parser/scan/scan_unused_parts.rs
@@ -1,18 +1,26 @@
 use crate::p::P;
 use bun_alloc::ArenaVec;
-use bun_ast::{self as js_ast, Ref, flags};
+use bun_ast::{self as js_ast, DeclaredSymbol, ImportRecordFlags, Ref, flags};
 use bun_collections::HashMap;
 use bun_crash_handler::handle_oom::handle_oom;
 use smallvec::SmallVec;
+
+/// Which parts declare each top-level symbol, keyed by the symbol its `link`
+/// chain ends at: redeclaring a `var` or function creates a second symbol
+/// linked to the first, and every declaration of a live symbol has to stay
+/// (`export var x = 1; var x = 2;`).
+type DeclaringParts = HashMap<Ref, SmallVec<[u32; 1]>>;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     /// Single-file tree shaking (`features.remove_unused_declarations`).
     ///
     /// `Options.tree_shaking` gave every top-level statement its own part.
     /// Parts that do anything other than declare something side-effect free
-    /// are roots; a declaration part survives only if a live part uses one of
-    /// its symbols. Removing a part also un-counts its symbol uses, so the
-    /// import scanner that runs next trims the imports only it needed.
+    /// are roots; a declaration part survives only if a live part uses, or
+    /// also declares, one of its symbols. Removing a part also un-counts its
+    /// symbol uses, so the import scanner that runs next trims the imports only
+    /// it needed, and marks the `import()`/`require()` records inside it
+    /// unused, like the ones in dead control flow that are never created.
     pub(crate) fn remove_unused_parts(&mut self, parts: &mut ArenaVec<'a, js_ast::Part>) {
         // The bundler tree shakes in the linker, where cross-file uses are known.
         debug_assert!(!self.options.bundle);
@@ -25,36 +33,36 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let arena = self.arena;
         let mut live = bun_alloc::vec_from_iter_in(core::iter::repeat_n(false, parts.len()), arena);
         let mut worklist = ArenaVec::<u32>::new_in(arena);
-        // Redeclaring a `var` or function creates a second symbol linked to the
-        // first, so both declarations are keyed by the symbol the links end at.
-        let mut declaring_parts: HashMap<Ref, SmallVec<[u32; 1]>> = HashMap::default();
+        let mut declaring_parts = DeclaringParts::default();
 
         for (i, part) in parts.iter().enumerate() {
             if !self.part_only_declares_removable_symbols(part) {
                 live[i] = true;
                 worklist.push(i as u32);
-                continue;
             }
-            for &declared in part.declared_symbols.refs() {
-                let key = self.follow_symbol_links(declared);
-                handle_oom(declaring_parts.get_or_put(key))
-                    .value_ptr
-                    .push(i as u32);
-            }
+            DeclaredSymbol::for_each_top_level_symbol(
+                &part.declared_symbols,
+                &mut declaring_parts,
+                |declaring_parts, declared| {
+                    handle_oom(declaring_parts.get_or_put(self.follow_symbol_links(declared)))
+                        .value_ptr
+                        .push(i as u32);
+                },
+            );
         }
 
         while let Some(i) = worklist.pop() {
-            for &used in parts[i as usize].symbol_uses.keys() {
-                let Some(declaring) = declaring_parts.get(&self.follow_symbol_links(used)) else {
-                    continue;
-                };
-                for &j in declaring {
-                    if !live[j as usize] {
-                        live[j as usize] = true;
-                        worklist.push(j);
-                    }
-                }
+            let part = &parts[i as usize];
+            for &used in part.symbol_uses.keys() {
+                self.mark_declaring_parts_live(used, &declaring_parts, &mut live, &mut worklist);
             }
+            DeclaredSymbol::for_each_top_level_symbol(
+                &part.declared_symbols,
+                &mut (&mut live, &mut worklist),
+                |(live, worklist), declared| {
+                    self.mark_declaring_parts_live(declared, &declaring_parts, live, worklist);
+                },
+            );
         }
 
         let live_count = live.iter().filter(|&&is_live| is_live).count();
@@ -66,8 +74,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         for (part, is_live) in all_parts.into_iter().zip(live.iter()) {
             if *is_live {
                 parts.push(part);
-            } else {
-                self.clear_symbol_usages_from_dead_part(&part);
+                continue;
+            }
+            for &record_index in part.import_record_indices.iter() {
+                self.import_records.items_mut()[record_index as usize]
+                    .flags
+                    .insert(ImportRecordFlags::IS_UNUSED);
+            }
+            self.clear_symbol_usages_from_dead_part(&part);
+        }
+    }
+
+    fn mark_declaring_parts_live(
+        &self,
+        symbol: Ref,
+        declaring_parts: &DeclaringParts,
+        live: &mut [bool],
+        worklist: &mut ArenaVec<'a, u32>,
+    ) {
+        let Some(declaring) = declaring_parts.get(&self.follow_symbol_links(symbol)) else {
+            return;
+        };
+        for &i in declaring {
+            if !live[i as usize] {
+                live[i as usize] = true;
+                worklist.push(i);
             }
         }
     }

--- a/src/js_parser/scan/scan_unused_parts.rs
+++ b/src/js_parser/scan/scan_unused_parts.rs
@@ -5,14 +5,11 @@ use bun_collections::HashMap;
 use bun_crash_handler::handle_oom::handle_oom;
 use smallvec::SmallVec;
 
-/// The parts declaring each top-level symbol, keyed by the end of the symbol's
-/// `link` chain (a redeclared `var` or function is two linked symbols).
+/// The parts declaring each top-level symbol, keyed by the end of the symbol's `link` chain.
 type DeclaringParts = HashMap<Ref, SmallVec<[u32; 1]>>;
 
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
-    /// Single-file tree shaking (`features.remove_unused_declarations`): mark from
-    /// the parts that import, export or have side effects, sweep the declarations
-    /// nothing live reaches. Runs before the import scanner so their imports go too.
+    /// Single-file tree shaking. Runs before the import scanner so the swept parts' imports go too.
     pub(crate) fn remove_unused_parts(&mut self, parts: &mut ArenaVec<'a, js_ast::Part>) {
         // The bundler tree shakes in the linker, where cross-file uses are known.
         debug_assert!(!self.options.bundle);
@@ -113,6 +110,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             })
     }
 
+    /// Redeclaring a `var` or function links the earlier symbol to the new one.
     fn follow_symbol_links(&self, mut ref_: Ref) -> Ref {
         loop {
             let symbol = &self.symbols[ref_.inner_index() as usize];

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1065,6 +1065,7 @@ impl JSTranspiler {
         transpiler.options.transform_only = !transpiler.options.allow_runtime;
 
         transpiler.options.tree_shaking = config.tree_shaking;
+        transpiler.options.remove_unused_declarations = config.tree_shaking;
         transpiler.options.trim_unused_imports = config.trim_unused_imports;
         transpiler.options.allow_runtime = config.runtime.allow_runtime;
         transpiler.options.auto_import_jsx = config.runtime.auto_import_jsx;

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3223,6 +3223,29 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+  // Bun.Transpiler's treeShaking drops imports whose users were removed; the bundler shares the
+  // parser but keeps every imported module for its side effects.
+  itBundled("edgecase/TSImportsOnlyUsedByRemovedCodeKeepSideEffects", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { helperDependency } from './side';
+        import { devOnly } from './side2';
+        function unusedHelper() { return helperDependency(); }
+        if (process.env.NODE_ENV !== 'production') { devOnly(); }
+        console.log('entry');
+      `,
+      "/side.ts": /* ts */ `
+        console.log('side');
+        export function helperDependency() {}
+      `,
+      "/side2.ts": /* ts */ `
+        console.log('side2');
+        export function devOnly() {}
+      `,
+    },
+    define: { "process.env.NODE_ENV": '"production"' },
+    run: { stdout: "side\nside2\nentry" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -252,3 +252,39 @@ describe("unterminated string literals in large files", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// Bun.Transpiler's treeShaking removes helpers nothing uses and the imports they held onto; the
+// runtime loader parses with the same parser but must keep loading every imported module.
+test("imports only referenced by unused or dead code are still loaded at runtime", async () => {
+  using dir = tempDir("runtime-keeps-unused-imports", {
+    "entry.ts": `
+      import { helperDependency } from "./side";
+      import { devOnly } from "./side2";
+      function unusedHelper() { return helperDependency(); }
+      if (false) { devOnly(); }
+      console.log("entry");
+    `,
+    "side.ts": `
+      console.log("side");
+      export function helperDependency() {}
+    `,
+    "side2.ts": `
+      console.log("side2");
+      export function devOnly() {}
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("side\nside2\nentry\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2076,6 +2076,25 @@ export default class {
         exports: ["default"],
         imports: [{ kind: "import-statement", path: "./for-effect" }],
       });
+      // require() only produces an import record with allowBunRuntime.
+      const withRequire = new Bun.Transpiler({
+        loader: "tsx",
+        allowBunRuntime: true,
+        exports: { eliminate: ["getStaticProps"] },
+      });
+      expect(
+        withRequire.scan(`
+          function loadData() { return [import("./server-db"), require("./server-cjs"), require.resolve("./server-bin")]; }
+          export function getStaticProps() { return loadData(); }
+          export default function Page() { return [import("./client-db"), require("./client-cjs")]; }
+        `),
+      ).toEqual({
+        exports: ["default"],
+        imports: [
+          { kind: "dynamic-import", path: "./client-db" },
+          { kind: "require-call", path: "./client-cjs" },
+        ],
+      });
     });
 
     it("exports.eliminate of an export clause frees the local it pointed at", () => {
@@ -2197,6 +2216,9 @@ export default class {
     it("treats every declaration of a redeclared symbol as one", () => {
       expect(shake("var x = 1;\nexport const y = x;\nvar x;")).toBe("var x = 1;\nexport const y = x;\nvar x;\n");
       expect(shake("var x = 1;\nvar x;\nexport const y = 2;")).toBe("export const y = 2;\n");
+      // The exported declaration is live, so the redeclaration that gives it its value must stay.
+      expect(shake("export var x = 1;\nvar x = 2;")).toBe("export var x = 1;\nvar x = 2;\n");
+      expect(shake("export function f() {}\nvar f = 2;")).toBe("export function f() {}\nvar f = 2;\n");
       expect(shake("enum E { A = 1 }\nenum E { B = 2 }\nexport const e = E;", {}, "ts")).toBe(
         [
           "var E;",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2013,7 +2013,7 @@ export default class {
       expect(output.includes("liveFS")).toBe(true);
     });
 
-    it.todo("supports replacing exports", () => {
+    it("supports replacing exports", () => {
       const output = transpiler.transformSync(`
         import deadFS from 'fs';
         import anotherDeadFS from 'fs';
@@ -2042,6 +2042,213 @@ export default class {
       expect(output.includes("__N_SSG")).toBe(true);
       expect(output.includes("localVarToReplace")).toBe(true);
       expect(output.includes("localVarToRemove")).toBe(false);
+    });
+  });
+
+  describe("treeShaking", () => {
+    const shake = (code, options = {}, loader = "tsx") =>
+      new Bun.Transpiler({ loader, treeShaking: true, trimUnusedImports: true, ...options }).transformSync(code);
+
+    // The Next.js-style use case: strip getStaticProps plus everything only it used.
+    const pageSource = `
+      import { readFileSync } from "node:fs";
+      import { serverHelper } from "./server-only";
+      const TABLE = { a: readFileSync };
+      function loadData() { return serverHelper(TABLE); }
+      export function getStaticProps() { return { props: loadData() }; }
+      export default function Page(p) { return p.x; }
+    `;
+    const pageWithoutServerCode = "export default function Page(p) {\n  return p.x;\n}\n";
+
+    it.each(["tsx", "jsx"])("exports.eliminate also removes what only the export used (%s)", loader => {
+      expect(shake(pageSource, { exports: { eliminate: ["getStaticProps"] } }, loader)).toBe(pageWithoutServerCode);
+    });
+
+    it("exports alone turns it on, for transform() too", async () => {
+      const transpiler = new Bun.Transpiler({ loader: "tsx", exports: { eliminate: ["getStaticProps"] } });
+      expect(await transpiler.transform(pageSource)).toBe(pageWithoutServerCode);
+      expect(transpiler.transformSync(pageSource)).toBe(pageWithoutServerCode);
+    });
+
+    it("scan() only reports the imports that survive", () => {
+      const transpiler = new Bun.Transpiler({ loader: "tsx", exports: { eliminate: ["getStaticProps"] } });
+      expect(transpiler.scan(`import "./for-effect";` + pageSource)).toEqual({
+        exports: ["default"],
+        imports: [{ kind: "import-statement", path: "./for-effect" }],
+      });
+    });
+
+    it("exports.eliminate of an export clause frees the local it pointed at", () => {
+      expect(
+        shake(
+          `import { db } from "./db";
+           var getStaticProps = function () { return db; };
+           export { getStaticProps };
+           export const keep = 1;`,
+          { exports: { eliminate: ["getStaticProps"] } },
+        ),
+      ).toBe("export const keep = 1;\n");
+    });
+
+    it("removes unused side-effect-free declarations", () => {
+      expect(
+        shake(
+          `import { a } from "a";
+           import * as ns from "ns";
+           import def, { named } from "mixed";
+           const table = { a, ns };
+           let [first, ...rest] = [def];
+           function helper() { return table; }
+           class Helper {}
+           class Sub extends Helper {}
+           enum Color { Red = 1 }
+           const x = 1, used = named, y = x;
+           export { used };`,
+        ),
+      ).toBe('import { named } from "mixed";\nconst used = named;\n\nexport { used };\n');
+    });
+
+    it("keeps declarations reachable from exports and top-level statements", () => {
+      expect(
+        shake(
+          `function byNamedExport() {}
+           function byClause() {}
+           function byDefault() {}
+           function byUse() { return byClause; }
+           function byCall() {}
+           function unused() { return byUse; }
+           let counter = 0;
+           export function inc() { counter++; return byNamedExport; }
+           export { byUse as use };
+           export default byDefault;
+           byCall();`,
+        ),
+      ).toBe(
+        [
+          "function byNamedExport() {}",
+          "function byClause() {}",
+          "function byDefault() {}",
+          "function byUse() {",
+          "  return byClause;",
+          "}",
+          "function byCall() {}",
+          "let counter = 0;",
+          "export function inc() {",
+          "  counter++;",
+          "  return byNamedExport;",
+          "}",
+          "",
+          "export { byUse as use };",
+          "export default byDefault;",
+          "byCall();",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    it("keeps declarations with side effects, and what they import", () => {
+      expect(
+        shake(
+          `import "./for-effect";
+           import { connect } from "./db";
+           import { build } from "./builder";
+           import { lookup } from "./globals";
+           const db = connect();
+           const built = /* @__PURE__ */ build();
+           const fromGlobal = lookup;
+           const global = someGlobal;
+           export const keep = 1;`,
+        ),
+      ).toBe(
+        [
+          'import"./for-effect";',
+          'import { connect } from "./db";',
+          "const db = connect();",
+          "const global = someGlobal;",
+          "export const keep = 1;",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    it("removes helpers that only reference each other", () => {
+      const source = `
+        import { h } from "./h";
+        function a(n) { return n ? a(n - 1) : b(); }
+        function b() { return a(1) || h(); }
+      `;
+      expect(shake(source + "export const keep = 1;")).toBe("export const keep = 1;\n");
+      expect(shake(source + "export { b };")).toBe(
+        [
+          'import { h } from "./h";',
+          "function a(n) {",
+          "  return n ? a(n - 1) : b();",
+          "}",
+          "function b() {",
+          "  return a(1) || h();",
+          "}",
+          "",
+          "export { b };",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    it("treats every declaration of a redeclared symbol as one", () => {
+      expect(shake("var x = 1;\nexport const y = x;\nvar x;")).toBe("var x = 1;\nexport const y = x;\nvar x;\n");
+      expect(shake("var x = 1;\nvar x;\nexport const y = 2;")).toBe("export const y = 2;\n");
+      expect(shake("enum E { A = 1 }\nenum E { B = 2 }\nexport const e = E;", {}, "ts")).toBe(
+        [
+          "var E;",
+          "((E) => {",
+          '  E[E["A"] = 1] = "A";',
+          "})(E ||= {});",
+          "((E) => {",
+          '  E[E["B"] = 2] = "B";',
+          "})(E ||= {});",
+          "export const e = E;",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    it("removes the JSX runtime import along with the only JSX", () => {
+      // Pin the dev runtime so the import below does not depend on NODE_ENV.
+      const options = { autoImportJSX: true, define: { "process.env.NODE_ENV": JSON.stringify("development") } };
+      expect(shake("function unused() { return <div />; }\nexport const keep = 1;", options)).toBe(
+        "export const keep = 1;\n",
+      );
+      expect(shake("export function Used() { return <div />; }", options)).toBe(
+        [
+          'import { jsxDEV as jsxDEV_7x81h0kn } from "react/jsx-dev-runtime";',
+          "export function Used() {",
+          '  return jsxDEV_7x81h0kn("div", {}, undefined, false, undefined, this);',
+          "}",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    it("leaves everything alone when a direct eval can see it", () => {
+      const source = `import { a } from "a";\nfunction maybeUsed() { return a; }\n`;
+      expect(shake(source + 'export const r = eval("maybeUsed()");')).toBe(
+        [
+          'import { a } from "a";',
+          "function maybeUsed() {",
+          "  return a;",
+          "}",
+          'export const r = eval("maybeUsed()");',
+          "",
+        ].join("\n"),
+      );
+      expect(shake(source + 'export const r = (0, eval)("1");')).toBe('export const r = (0, eval)("1");\n');
+    });
+
+    it("only runs when treeShaking is on and dead code elimination is enabled", () => {
+      const source = 'import { a } from "a";\nfunction unused() {\n  return a;\n}\nexport const keep = 1;\n';
+      expect(shake(source, { treeShaking: false })).toBe(source);
+      expect(shake(source, { deadCodeElimination: false })).toBe(source);
+      expect(shake(source, { trimUnusedImports: false })).toBe('import { a } from "a";\nexport const keep = 1;\n');
     });
   });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2109,6 +2109,15 @@ export default class {
       ).toBe("export const keep = 1;\n");
     });
 
+    it.each(["ts", "js"])("exports opts TypeScript imports into the same trimming as JavaScript (%s)", loader => {
+      const source = 'import { db } from "./db";\nexport function gone() {\n  return db;\n}\nexport const keep = 1;\n';
+      const options = { exports: { eliminate: ["gone"] }, treeShaking: false, trimUnusedImports: true };
+      expect(shake(source, options, loader)).toBe("export const keep = 1;\n");
+      expect(shake(source, { ...options, trimUnusedImports: false }, loader)).toBe(
+        'import { db } from "./db";\nexport const keep = 1;\n',
+      );
+    });
+
     it("removes unused side-effect-free declarations", () => {
       expect(
         shake(
@@ -2271,6 +2280,41 @@ export default class {
       expect(shake(source, { treeShaking: false })).toBe(source);
       expect(shake(source, { deadCodeElimination: false })).toBe(source);
       expect(shake(source, { trimUnusedImports: false })).toBe('import { a } from "a";\nexport const keep = 1;\n');
+    });
+
+    it("drops the __dirname/__filename and bun:wrap prologue when only removed code needed it", () => {
+      const helper = name => `function ${name}() { using f = null; return __dirname + __filename; }\n`;
+      expect(shake(helper("unused") + "export const keep = 1;")).toBe("export const keep = 1;\n");
+      const withoutHelperSuffixes = shake(helper("used") + "export const keep = used;").replace(
+        /(__using|__callDispose)_[a-z0-9]+/g,
+        "$1",
+      );
+      expect(withoutHelperSuffixes).toBe(
+        [
+          'var __dirname = "", __filename = "input.tsx";',
+          'import { __callDispose as __callDispose, __using as __using } from "bun:wrap";',
+          "function used() {",
+          "  let __bun_temp_ref_1$ = [];",
+          "  try {",
+          "    const f = __using(__bun_temp_ref_1$, null, 0);",
+          "    return __dirname + __filename;",
+          "  } catch (__bun_temp_ref_2$) {",
+          "    var __bun_temp_ref_3$ = __bun_temp_ref_2$, __bun_temp_ref_4$ = 1;",
+          "  } finally {",
+          "    __callDispose(__bun_temp_ref_1$, __bun_temp_ref_3$, __bun_temp_ref_4$);",
+          "  }",
+          "}",
+          "export const keep = used;",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    it("does not let removed code decide the module format", () => {
+      // Only the removed helper touched `module`, so the file stays ESM and import.meta.main is left alone.
+      expect(shake("function unused() { return module.exports; }\nconsole.log(import.meta.main);")).toBe(
+        "console.log(import.meta.main);\n",
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #12892

### Problem

- `Bun.Transpiler` with `exports: { eliminate: ["getStaticProps"] }` (or `treeShaking: true`) removes the export itself but keeps every top-level helper only that export used, and the helpers keep their imports alive. For the Next.js-style "strip `getStaticProps` and everything behind it" use this means the server-only modules still end up imported by the client output:
  ```ts
  import { readFileSync } from "node:fs";
  import { serverHelper } from "./server-only";
  const TABLE = { a: readFileSync };
  function loadData() { return serverHelper(TABLE); }
  export function getStaticProps() { return { props: loadData() }; }
  export default function Page(p) { return p.x; }
  ```
  eliminating `getStaticProps` today prints `Page` plus both imports, `TABLE` and `loadData`; only `Page` should remain.
- With a `ts`/`tsx` loader an import whose bindings were all removed additionally survives as a bare `import "./server-only";` (the `js`/`jsx` loaders drop it). That is #12892.
- Cause: `treeShaking` only makes the parser put each top-level statement in its own part (`parse_entry.rs`, the `tree_shaking` branch of `_parse`). The pass that removed the dead parts was added together with `exports.eliminate` in 2022 and commented out when the bundler was rewritten (#2312, the `p.treeShake(&parts, false)` comment at the top of `to_ast` in `src/js_parser/p.rs`); nothing replaced it for the non-bundling transform. The existing test only covers imports referenced directly inside the eliminated export, which die through `is_control_flow_dead`; anything reached through a helper needs the pass.
- Cause of the bare import: `scan_imports.rs` removes a TypeScript import statement only when `ts_use_counts` is zero, and those counts still include the references made by eliminated or removed code.

### Fix

- `src/js_parser/scan/scan_unused_parts.rs` (new): `remove_unused_parts`, run from `_parse` right after the visit pass, over the hoisted parts (`before`) and the rest. Imports, exports and any part `can_be_removed_if_unused` rejects are roots; a part holding only non-exported, side-effect-free declarations survives when a live part uses one of its symbols (`Part.symbol_uses` -> declaring parts) or declares the same symbol (`export var x = 1; var x = 2;` keeps the second statement). Mark and sweep rather than the old iterative use-count loop so helpers that reference themselves or each other go too; declared symbols are keyed through their `link` chain so both halves of a redeclared `var` or a multi-block enum are kept or removed together. A direct `eval()` in the file disables the pass.
- Removing a part gives its symbol uses back (`clear_symbol_usages_from_dead_part`), flags the `import()` / `require()` / `require.resolve()` records created inside it `IS_UNUSED` (so `scan()` and the non-bundling linker skip them, like the import statements the scanner trims), and un-registers `bun:wrap` helpers (`__using`, ...) that no longer have a caller. Running before the rest of `_parse` is what makes the post-visit decisions see the removal: otherwise a removed helper still produced `var __dirname = ...`, a bare `import "bun:wrap"` (unresolvable in browser output), or classified the file as CommonJS because it had touched `module`.
- The pass runs behind a new `remove_unused_declarations` flag (`Runtime::Features`, `BundleOptions`) that only `JSTranspiler` sets from `treeShaking`. It cannot be keyed on `tree_shaking` itself: the runtime loader and `bun build --no-bundle --target=bun` parse with `tree_shaking` on to get the per-statement parts (class / export default hoisting) and must keep their output unchanged. `hash_for_runtime_transpiler` asserts the flag is off on cached parses, and new spawned / `itBundled` pins check the runtime and the bundler still load modules whose only users were unused or dead code.
- `scan_imports.rs`: when either `remove_unused_declarations` or `replace_exports` is in effect, the TypeScript branch also applies the JavaScript rule, so an import whose bindings were all removed is removed outright instead of becoming a bare import. Keying on both means `exports` works with an explicit `treeShaking: false` too; this supersedes the scanner hunk in #35658.
- `scan()` goes through the same parse, so its `imports` now only lists what survives.
- `treeShaking` / `trimUnusedImports` get JSDoc and a docs entry describing this behaviour.
- Verified with `test/bundler/transpiler/transpiler.test.js`: new `treeShaking` block (the example above with both loaders and via `transform()`, `scan()` including dynamic imports, export clause elimination, the `exports` + `treeShaking: false` matrix, kept vs removed declarations, recursion, redeclarations, JSX runtime import, the `__dirname` / `bun:wrap` prologue, module format, direct eval, and the options that turn it off) plus the 2022 `supports replacing exports` test, un-todo'd because it now passes. All of them fail on the current release (except the JavaScript half of the loader matrix, which documents the behaviour TypeScript is brought in line with) and pass with this change. `test/bundler/transpiler/runtime-transpiler.test.ts` and `test/bundler/bundler_edgecase.test.ts` get the runtime / bundler pins; the rest of `test/bundler/transpiler`, `test/js/bun/transpiler` and `test/cli/run/transpiler-cache.test.ts` still pass.

### Background

- Part: the parser's unit of tree shaking, a group of top-level statements with the symbols it declares (`declared_symbols`) and the symbols it references (`symbol_uses`). `can_be_removed_if_unused` is computed per part by `stmts_can_be_removed_if_unused` and means the statements have no side effects; in the bundler the linker uses the same flag, here the parser has to do the removal itself because a transform never reaches the linker.
- `use_count_estimate` is the per-symbol reference count the import scanner uses to decide which import bindings to keep, and that `_parse` reads after visiting to decide whether to emit `__dirname`, which `bun:wrap` helpers to import and whether the file is CommonJS; `ts_use_counts` is the TypeScript-only count that also includes references from dead code, which is why TypeScript normally keeps the import statement (as a side-effect import) when only its bindings are dead.
- `exports.eliminate` works by visiting the export with `is_control_flow_dead` set, so nothing inside it counts as a use; it is also what makes `treeShaking` default to true in `JSTranspiler`.
- Side effects still win: `const db = connect()` and its import stay unless the call is annotated `/* @__PURE__ */`, like bundler tree shaking.

Not changed here, found while testing (pre-existing, independent of this pass):
- #33376: eliminating a hoistable export (`export class X {}`, `export default ...`) still aborts when it is the first statement; `exports.eliminate` reaches it with or without this change.
- `exports.replace` with a plain value (`{ getStaticProps: "x" }`) on an `export const` / `export var` still visits the replaced initializer as live, so helpers and imports only that initializer used are kept (the `["__N_SSG", true]` form and `eliminate` cascade). The marking lives in `visit_decls` / `s_export_default`, next to what #33378 and #33386 change.
- A `define` whose value is a property access on a local (`define: { X: "ns.value" }`) records no use of `ns`; `bun build --define X=ns.value` already drops `const ns` on main, and `Bun.Transpiler({ treeShaking: true })` now does the same.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->