### PR TITLE
io: leave the fd with the caller when a POSIX pipe writer fails to start

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -527,6 +527,9 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
 
     /// On POSIX a `MovableIfWindowsFd` never transfers ownership, so callers
     /// pass the plain `Fd` (via `MovableIfWindowsFd::get_posix()` when needed).
+    ///
+    /// On `Err` the writer does not hold `fd`: the caller still owns it and is
+    /// the one that closes it.
     pub fn start(&mut self, rawfd: Fd, pollable: bool) -> sys::Result<()> {
         let fd = rawfd;
         self.pollable = pollable;
@@ -535,7 +538,8 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
             self.handle = PollOrFd::Fd(fd);
             return sys::Result::Ok(());
         }
-        let poll = match self.get_poll() {
+        let existing_poll = self.get_poll();
+        let poll = match existing_poll {
             Some(p) => p,
             None => {
                 let p = self.create_poll(fd);
@@ -547,6 +551,10 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
 
         match poll.register_with_fd(loop_, FilePollKind::Writable, fd) {
             sys::Result::Err(err) => {
+                // A poll from an earlier start() still holds that start's fd.
+                if existing_poll.is_none() {
+                    self.handle.close_without_closing_fd();
+                }
                 return sys::Result::Err(err);
             }
             sys::Result::Ok(()) => {
@@ -1042,6 +1050,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         );
     }
 
+    /// On `Err` the writer does not hold `fd`: the caller still owns it and is
+    /// the one that closes it.
     pub fn start(&mut self, fd: Fd, is_pollable: bool) -> sys::Result<()> {
         if !is_pollable {
             self.close();
@@ -1051,7 +1061,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
 
         // SAFETY: parent BACKREF set via set_parent; outlives this writer.
         let loop_ = unsafe { Parent::event_loop(self.parent()) };
-        let poll = match self.get_poll() {
+        let existing_poll = self.get_poll();
+        let poll = match existing_poll {
             Some(p) => p,
             None => {
                 let p = FilePollRef::init(
@@ -1066,6 +1077,10 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
 
         match poll.register_with_fd(loop_.loop_(), FilePollKind::Writable, fd) {
             sys::Result::Err(err) => {
+                // A poll from an earlier start() still holds that start's fd.
+                if existing_poll.is_none() {
+                    self.handle.close_without_closing_fd();
+                }
                 return sys::Result::Err(err);
             }
             sys::Result::Ok(()) => {}

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -528,8 +528,7 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
     /// On POSIX a `MovableIfWindowsFd` never transfers ownership, so callers
     /// pass the plain `Fd` (via `MovableIfWindowsFd::get_posix()` when needed).
     ///
-    /// On `Err` the writer does not hold `fd`: the caller still owns it and is
-    /// the one that closes it.
+    /// On `Err` the writer holds nothing; `fd` is still the caller's to close.
     pub fn start(&mut self, rawfd: Fd, pollable: bool) -> sys::Result<()> {
         let fd = rawfd;
         self.pollable = pollable;
@@ -1050,8 +1049,7 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         );
     }
 
-    /// On `Err` the writer does not hold `fd`: the caller still owns it and is
-    /// the one that closes it.
+    /// On `Err` the writer holds nothing; `fd` is still the caller's to close.
     pub fn start(&mut self, fd: Fd, is_pollable: bool) -> sys::Result<()> {
         if !is_pollable {
             self.close();

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -128,6 +128,12 @@ impl PollOrFd {
     {
         self.close_impl(ctx, on_close_fn, true);
     }
+
+    /// Releases the poll (unregistering it) and leaves the fd open: for owners
+    /// that close the fd themselves.
+    pub fn close_without_closing_fd(&mut self) {
+        self.close_impl(None, None::<fn(*mut c_void)>, false);
+    }
 }
 
 // Sunk to `bun_io` so `FilePoll::file_type()` needs no aio→io edge; re-export

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -129,8 +129,7 @@ impl PollOrFd {
         self.close_impl(ctx, on_close_fn, true);
     }
 
-    /// Releases the poll (unregistering it) and leaves the fd open: for owners
-    /// that close the fd themselves.
+    /// Unregisters and releases the poll; the fd stays open for its owner to close.
     pub fn close_without_closing_fd(&mut self) {
         self.close_impl(None, None::<fn(*mut c_void)>, false);
     }

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -59,8 +59,6 @@ impl PollOrFd {
     ) where
         F: FnOnce(*mut c_void),
     {
-        #[cfg(windows)]
-        let _ = close_fd;
         let fd = self.get_fd();
         #[cfg(target_os = "macos")]
         let mut close_async = true;
@@ -100,7 +98,9 @@ impl PollOrFd {
             // TODO: We should make this call compatible using bun.FD
             #[cfg(windows)]
             {
-                crate::closer::Closer::close(fd, bun_sys::windows::libuv::Loop::get());
+                if close_fd {
+                    crate::closer::Closer::close(fd, bun_sys::windows::libuv::Loop::get());
+                }
             }
             #[cfg(not(windows))]
             {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -462,20 +462,15 @@ impl Terminal {
         {
             sys::Result::Ok(()) => terminal.ref_(),
             sys::Result::Err(_) => {
-                // POSIX: writer.start() may have allocated a poll holding write_fd
-                // before registerWithFd failed; closeInternal → writer.close()
-                // frees the poll and closes write_fd. Windows: writer.start()
-                // failure leaves source==null so writer.close() is a no-op; close
-                // write_fd directly. Pre-set writer_done so onWriterClose's deref
-                // is skipped and the struct isn't freed mid-closeInternal.
+                // A failed writer.start() leaves write_fd with us: close both pty
+                // fds here, closeInternal releases master/slave. The writer holds
+                // nothing, so its close() reports nothing; WRITER_DONE keeps
+                // onWriterClose a no-op either way, as the only ref is dropped below.
                 terminal.update_flags(|f| f.insert(Flags::WRITER_DONE));
                 terminal.read_fd.get().close();
                 terminal.read_fd.set(Fd::INVALID);
-                #[cfg(windows)]
-                {
-                    terminal.write_fd.get().close();
-                    terminal.write_fd.set(Fd::INVALID);
-                }
+                terminal.write_fd.get().close();
+                terminal.write_fd.set(Fd::INVALID);
                 terminal.close_internal();
                 terminal.deref_();
                 return Err(InitError::WriterStartFailed);

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -462,10 +462,7 @@ impl Terminal {
         {
             sys::Result::Ok(()) => terminal.ref_(),
             sys::Result::Err(_) => {
-                // A failed writer.start() leaves write_fd with us: close both pty
-                // fds here, closeInternal releases master/slave. The writer holds
-                // nothing, so its close() reports nothing; WRITER_DONE keeps
-                // onWriterClose a no-op either way, as the only ref is dropped below.
+                // The writer took neither its ref nor write_fd, and the reader never started.
                 terminal.update_flags(|f| f.insert(Flags::WRITER_DONE));
                 terminal.read_fd.get().close();
                 terminal.read_fd.set(Fd::INVALID);

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1724,11 +1724,19 @@ fn spawn_maybe_sync(
         }
     }
 
-    if let Writable::Buffer(buffer) = subprocess.stdin.get() {
-        if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
-            let _ = subprocess.try_kill(subprocess.kill_signal);
-            return Err(global_this.throw_value(err.to_js(global_this)));
-        }
+    let stdin_start_err = match subprocess.stdin.get() {
+        Writable::Buffer(buffer) => Writable::buffer_writer_mut(buffer).start().err(),
+        _ => None,
+    };
+    if let Some(err) = stdin_start_err {
+        // On POSIX the writer holds nothing after a failed start(), so closing
+        // it at exit will not report on_close_io; retire the slot here or the
+        // Buffer counts as pending activity and pins the wrapper for good.
+        // (Windows adopts the pipe before start(), which cannot fail there.)
+        #[cfg(not(windows))]
+        subprocess.on_close_io(Subprocess::StdioKind::Stdin);
+        let _ = subprocess.try_kill(subprocess.kill_signal);
+        return Err(global_this.throw_value(err.to_js(global_this)));
     }
 
     **should_close_memfd = false;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1729,11 +1729,8 @@ fn spawn_maybe_sync(
         _ => None,
     };
     if let Some(err) = stdin_start_err {
-        // On POSIX the writer holds nothing after a failed start(), so closing
-        // it at exit will not report on_close_io; retire the slot here or the
-        // Buffer counts as pending activity and pins the wrapper for good.
-        // (Windows adopts the pipe before start(), which cannot fail there.)
-        #[cfg(not(windows))]
+        // An unstarted writer never reports on_close; a Buffer left here pins the wrapper.
+        #[cfg(not(windows))] // Windows adopts the pipe at create and start() cannot fail there.
         subprocess.on_close_io(Subprocess::StdioKind::Stdin);
         let _ = subprocess.try_kill(subprocess.kill_signal);
         return Err(global_this.throw_value(err.to_js(global_this)));

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -237,12 +237,15 @@ impl<'a> Writable<'a> {
         match stdio {
             Stdio::Dup2(_) => panic!("TODO dup2 stdio"),
             Stdio::Pipe | Stdio::ReadableStream(_) => {
-                let pipe_ref = FileSink::create(evtloop, result.unwrap());
+                let fd = result.unwrap();
+                let pipe_ref = FileSink::create(evtloop, fd);
                 let pipe = Self::pipe_sink_mut(&pipe_ref);
 
-                match pipe.writer.with_mut(|w| w.start(pipe.fd.get(), true)) {
+                match pipe.writer.with_mut(|w| w.start(fd, true)) {
                     bun_sys::Result::Ok(()) => {}
                     bun_sys::Result::Err(_err) => {
+                        // The writer did not take `fd`; nothing else closes it.
+                        fd.close();
                         if let Stdio::ReadableStream(rs) = stdio {
                             rs.cancel(global)?;
                         }

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -369,12 +369,6 @@ impl IOWriter {
                     s.flags.pollable = false;
                     s.flags.nonblock = false;
                     s.flags.is_socket = false;
-                    if matches!(s.writer.handle, bun_io::pipes::PollOrFd::Poll(_)) {
-                        s.writer
-                            .handle
-                            .close_impl(None, None::<fn(*mut c_void)>, false);
-                    }
-                    s.writer.handle = bun_io::pipes::PollOrFd::Closed;
                     return self.__start();
                 }
                 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -385,12 +379,6 @@ impl IOWriter {
                         s.flags.pollable = false;
                         s.flags.nonblock = false;
                         s.flags.is_socket = false;
-                        if matches!(s.writer.handle, bun_io::pipes::PollOrFd::Poll(_)) {
-                            s.writer
-                                .handle
-                                .close_impl(None, None::<fn(*mut c_void)>, false);
-                        }
-                        s.writer.handle = bun_io::pipes::PollOrFd::Closed;
                         return self.__start();
                     }
                 }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -180,9 +180,14 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         }
         #[cfg(not(windows))]
         {
+            use bun_sys::FdExt as _;
             // On POSIX `StdioResult` is an `Option<Fd>`.
-            match self.writer.start(self.stdio_result.unwrap(), true) {
+            let fd = self.stdio_result.unwrap();
+            match self.writer.start(fd, true) {
                 bun_sys::Result::Err(err) => {
+                    // The writer did not take `fd`; nothing else closes it.
+                    self.stdio_result = None;
+                    fd.close();
                     // start() failed: `started` stays false so no release
                     // site fires — release start()'s `+1` here.
                     // SAFETY: `self` is the live `Self` we ref'd at the top

--- a/test/js/bun/spawn/spawn-pipe-start-error.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-start-error.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isWindows } from "harness";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isLinux, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 
 // On Windows, when the initial uv_read_start on a subprocess stdout/stderr
 // pipe fails (observed from libuv as UV_EINVAL after a bad FileAccessInformation
@@ -60,5 +61,148 @@ try {
     // MAGIC_VALID debug panic, and exitCode is the debug crash handler's.
     expect(stderr.trim()).toBe("OK");
     expect(exitCode).toBe(0);
+  },
+);
+
+// POSIX counterpart for the writers. When a pipe writer's start() fails to
+// register its fd with the event loop, the writer no longer holds the fd and
+// the caller that opened it closes it: the subprocess stdin FileSink
+// (Writable::init), the buffered stdin StaticPipeWriter, and Bun.Terminal's
+// pty writer each do so on their own error path. Each fixture provokes that
+// failure and checks that the fd is closed exactly once: an fd left open shows
+// up in /proc/self/fd, a second close of the same number trips the debug
+// build's EBADF assertion on stderr.
+//
+// Bun registers FilePolls through syscall(SYS_epoll_ctl, ...) rather than the
+// epoll_ctl() wrapper, so the shim interposes syscall() and fails every
+// EPOLL_CTL_ADD asking for writability with ENOSPC (what an exhausted
+// fs.epoll.max_user_watches returns). Readable registrations, and uSockets,
+// which uses the wrapper, are unaffected.
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <sys/epoll.h>
+#include <sys/syscall.h>
+
+static long (*real_syscall)(long, ...);
+
+long syscall(long number, ...) {
+  va_list ap;
+  va_start(ap, number);
+  long a1 = va_arg(ap, long), a2 = va_arg(ap, long), a3 = va_arg(ap, long);
+  long a4 = va_arg(ap, long), a5 = va_arg(ap, long), a6 = va_arg(ap, long);
+  va_end(ap);
+  if (number == SYS_epoll_ctl && a2 == EPOLL_CTL_ADD && a4 != 0 &&
+      (((struct epoll_event *)a4)->events & EPOLLOUT)) {
+    errno = ENOSPC;
+    return -1;
+  }
+  if (!real_syscall) real_syscall = (long (*)(long, ...))dlsym(RTLD_NEXT, "syscall");
+  return real_syscall(number, a1, a2, a3, a4, a5, a6);
+}
+`;
+
+// The argument selects what to construct; the report is the error it threw
+// and how many fds are still open afterwards, compared to before. Fds that
+// the error path releases asynchronously (the child's pidfd once its exit is
+// reaped, anything owned by a wrapper that is only released by its finalizer)
+// get a bounded window to go away; a leaked fd is reported once it lapses.
+const FIXTURE = /* js */ `
+const fs = require("node:fs");
+const openFds = () => fs.readdirSync("/proc/self/fd").length;
+const before = openFds();
+let error = null;
+try {
+  switch (process.argv[2]) {
+    case "stdin-pipe":
+      Bun.spawn({ cmd: ["true"], stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+      break;
+    case "stdin-buffer":
+      Bun.spawn({ cmd: ["true"], stdin: Buffer.from("data"), stdout: "ignore", stderr: "ignore" });
+      break;
+    case "terminal":
+      new Bun.Terminal({});
+      break;
+  }
+} catch (e) {
+  error = { code: e.code, message: e.message };
+}
+const deadline = performance.now() + 2000;
+while (openFds() > before && performance.now() < deadline) {
+  Bun.gc(true);
+  await Bun.sleep(5);
+}
+console.log(JSON.stringify({ error, leaked: openFds() - before }));
+`;
+
+describe.skipIf(!isLinux || !cc)(
+  "a pipe writer whose event loop registration fails leaves its fd to the caller",
+  () => {
+    let dir: ReturnType<typeof tempDir>;
+
+    beforeAll(async () => {
+      dir = tempDir("writer-start-error", { "shim.c": SHIM_C, "fixture.js": FIXTURE });
+      await using ccProc = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", join(String(dir), "shim.so"), join(String(dir), "shim.c"), "-ldl"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+      if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+    });
+
+    afterAll(() => {
+      dir?.[Symbol.dispose]();
+    });
+
+    async function runFixture(kind: string, env: Record<string, string> = {}) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.js", kind],
+        cwd: String(dir),
+        env: { ...bunEnv, ...env, LD_PRELOAD: join(String(dir), "shim.so") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      let report: unknown = stdout;
+      try {
+        report = JSON.parse(stdout);
+      } catch {}
+      return { report, stderr, exitCode };
+    }
+
+    test.concurrent("Bun.spawn with stdin: 'pipe' closes the stdin pipe exactly once", async () => {
+      expect(await runFixture("stdin-pipe")).toEqual({
+        // The spawn bindings report a failed stdin setup generically, so only
+        // the fact that it threw is pinned down here.
+        report: { error: { message: expect.any(String) }, leaked: 0 },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("Bun.spawn with a buffer stdin closes the stdin pipe exactly once", async () => {
+      // On Linux a buffer stdin normally travels through a memfd and never gets
+      // a writer; disabling that takes the pipe writer path every other
+      // platform uses.
+      expect(await runFixture("stdin-buffer", { BUN_FEATURE_FLAG_DISABLE_MEMFD: "1" })).toEqual({
+        report: { error: { code: "ENOSPC", message: "ENOSPC: no space left on device, epoll_ctl" }, leaked: 0 },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("new Bun.Terminal() closes the pty fds exactly once", async () => {
+      expect(await runFixture("terminal")).toEqual({
+        report: { error: { message: "Failed to start terminal writer" }, leaked: 0 },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
   },
 );

--- a/test/js/bun/spawn/spawn-pipe-start-error.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-start-error.test.ts
@@ -117,10 +117,10 @@ long syscall(long number, ...) {
 // pidfd once its exit is reaped, a wrapper that becomes collectable only then)
 // get a bounded window; whatever is still there when it lapses is reported.
 const FIXTURE = /* js */ `
-const fs = require("node:fs");
-const { heapStats } = require("bun:jsc");
+import { readdirSync } from "node:fs";
+import { heapStats } from "bun:jsc";
 const kind = process.argv[2];
-const openFds = () => fs.readdirSync("/proc/self/fd").length;
+const openFds = () => readdirSync("/proc/self/fd").length;
 const wrappers = () => {
   const counts = heapStats().objectTypeCounts;
   return (counts.Subprocess ?? 0) + (counts.Terminal ?? 0);

--- a/test/js/bun/spawn/spawn-pipe-start-error.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-start-error.test.ts
@@ -69,9 +69,12 @@ try {
 // the caller that opened it closes it: the subprocess stdin FileSink
 // (Writable::init), the buffered stdin StaticPipeWriter, and Bun.Terminal's
 // pty writer each do so on their own error path. Each fixture provokes that
-// failure and checks that the fd is closed exactly once: an fd left open shows
+// failure and checks that the fd is closed exactly once (an fd left open shows
 // up in /proc/self/fd, a second close of the same number trips the debug
-// build's EBADF assertion on stderr.
+// build's EBADF assertion on stderr) and that the object whose writer failed
+// is still released: with nothing left to close, the writer never reports
+// on_close, so the owner has to retire it on the error path itself, or a
+// buffer stdin keeps its Subprocess wrapper alive as pending activity forever.
 //
 // Bun registers FilePolls through syscall(SYS_epoll_ctl, ...) rather than the
 // epoll_ctl() wrapper, so the shim interposes syscall() and fails every
@@ -107,17 +110,36 @@ long syscall(long number, ...) {
 `;
 
 // The argument selects what to construct; the report is the error it threw
-// and how many fds are still open afterwards, compared to before. Fds that
-// the error path releases asynchronously (the child's pidfd once its exit is
-// reaped, anything owned by a wrapper that is only released by its finalizer)
-// get a bounded window to go away; a leaked fd is reported once it lapses.
+// plus how many fds and Subprocess/Terminal wrappers outlive it, relative to a
+// baseline taken just before. Both classes create their prototype (which
+// heapStats counts under the class name) lazily, so the baseline is taken
+// after materializing it. Releases that happen asynchronously (the child's
+// pidfd once its exit is reaped, a wrapper that becomes collectable only then)
+// get a bounded window; whatever is still there when it lapses is reported.
 const FIXTURE = /* js */ `
 const fs = require("node:fs");
+const { heapStats } = require("bun:jsc");
+const kind = process.argv[2];
 const openFds = () => fs.readdirSync("/proc/self/fd").length;
-const before = openFds();
+const wrappers = () => {
+  const counts = heapStats().objectTypeCounts;
+  return (counts.Subprocess ?? 0) + (counts.Terminal ?? 0);
+};
+
+// Parked on globalThis so the baseline keeps counting it: a local that is never
+// read again is not kept alive across the awaits below.
+if (kind === "terminal") {
+  globalThis.anchor = Bun.Terminal.prototype;
+} else {
+  globalThis.anchor = Bun.spawn({ cmd: ["true"], stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+  await globalThis.anchor.exited;
+}
+const fdBaseline = openFds();
+const wrapperBaseline = wrappers();
+
 let error = null;
 try {
-  switch (process.argv[2]) {
+  switch (kind) {
     case "stdin-pipe":
       Bun.spawn({ cmd: ["true"], stdin: "pipe", stdout: "ignore", stderr: "ignore" });
       break;
@@ -132,11 +154,11 @@ try {
   error = { code: e.code, message: e.message };
 }
 const deadline = performance.now() + 2000;
-while (openFds() > before && performance.now() < deadline) {
+while ((openFds() > fdBaseline || wrappers() > wrapperBaseline) && performance.now() < deadline) {
   Bun.gc(true);
   await Bun.sleep(5);
 }
-console.log(JSON.stringify({ error, leaked: openFds() - before }));
+console.log(JSON.stringify({ error, leakedFds: openFds() - fdBaseline, leakedWrappers: wrappers() - wrapperBaseline }));
 `;
 
 describe.skipIf(!isLinux || !cc)(
@@ -180,26 +202,33 @@ describe.skipIf(!isLinux || !cc)(
       expect(await runFixture("stdin-pipe")).toEqual({
         // The spawn bindings report a failed stdin setup generically, so only
         // the fact that it threw is pinned down here.
-        report: { error: { message: expect.any(String) }, leaked: 0 },
+        report: { error: { message: expect.any(String) }, leakedFds: 0, leakedWrappers: 0 },
         stderr: "",
         exitCode: 0,
       });
     });
 
-    test.concurrent("Bun.spawn with a buffer stdin closes the stdin pipe exactly once", async () => {
-      // On Linux a buffer stdin normally travels through a memfd and never gets
-      // a writer; disabling that takes the pipe writer path every other
-      // platform uses.
-      expect(await runFixture("stdin-buffer", { BUN_FEATURE_FLAG_DISABLE_MEMFD: "1" })).toEqual({
-        report: { error: { code: "ENOSPC", message: "ENOSPC: no space left on device, epoll_ctl" }, leaked: 0 },
-        stderr: "",
-        exitCode: 0,
-      });
-    });
+    test.concurrent(
+      "Bun.spawn with a buffer stdin closes the stdin pipe exactly once and releases the Subprocess",
+      async () => {
+        // On Linux a buffer stdin normally travels through a memfd and never gets
+        // a writer; disabling that takes the pipe writer path every other
+        // platform uses.
+        expect(await runFixture("stdin-buffer", { BUN_FEATURE_FLAG_DISABLE_MEMFD: "1" })).toEqual({
+          report: {
+            error: { code: "ENOSPC", message: "ENOSPC: no space left on device, epoll_ctl" },
+            leakedFds: 0,
+            leakedWrappers: 0,
+          },
+          stderr: "",
+          exitCode: 0,
+        });
+      },
+    );
 
     test.concurrent("new Bun.Terminal() closes the pty fds exactly once", async () => {
       expect(await runFixture("terminal")).toEqual({
-        report: { error: { message: "Failed to start terminal writer" }, leaked: 0 },
+        report: { error: { message: "Failed to start terminal writer" }, leakedFds: 0, leakedWrappers: 0 },
         stderr: "",
         exitCode: 0,
       });

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -703,7 +703,11 @@ it.skipIf(!isLinux)("Bun.file(fd).writer() whose registration fails closes the d
     // opens themselves from blocking; the loop waits for both to have opened.
     const fifoWriter = fs.openSync(fifoPath, "r+");
     const parked = [1, 2].map(() => fs.promises.readFile(fifoPath));
-    while (fdsOf(fifoPath).length < 3) await Bun.sleep(1);
+    const parkedBy = performance.now() + 2000;
+    while (fdsOf(fifoPath).length < 3) {
+      if (performance.now() > parkedBy) throw new Error("the two readFile() calls never opened the FIFO");
+      await Bun.sleep(1);
+    }
 
     const before = fdsOf(sock);
     const first = Bun.file(sock).writer();

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -663,6 +663,96 @@ it("Bun.file(fd).writer() write/end under GC pressure does not crash", async () 
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });
 
+// Bun.file(fd).writer() dups the fd and registers the dup with the event loop.
+// When that registration fails, FileSink::setup closed the dup, but the writer
+// still held it in its poll, so tearing the sink down queued a second close of
+// the same fd number on the thread pool. By the time it ran the number usually
+// belonged to someone else (here: the /dev/null fd opened right after), and in
+// debug builds it tripped the EBADF assertion in Closer.
+//
+// Linux-only: the registration failure is provoked through epoll keying its
+// entries on (open file, fd number), so a registration whose fd number is
+// closed from under it survives as long as the file does and the next dup that
+// lands on that number fails with EEXIST. kqueue drops the registration with
+// the fd, so this cannot be set up on macOS.
+it.skipIf(!isLinux)("Bun.file(fd).writer() whose registration fails closes the dup exactly once", async () => {
+  const fifoPath = join(tmpdirSync(), "parking.fifo");
+  mkfifo(fifoPath, 0o666);
+  const src = `
+    const { createSocketPair } = require("bun:internal-for-testing");
+    const fs = require("node:fs");
+    const fifoPath = ${JSON.stringify(fifoPath)};
+    const [sock] = createSocketPair();
+
+    function fdsOf(target) {
+      const { dev, ino } = typeof target === "number" ? fs.fstatSync(target) : fs.statSync(target);
+      const out = [];
+      for (let fd = 0; fd < 64; fd++) {
+        try {
+          const st = fs.fstatSync(fd);
+          if (st.dev === dev && st.ino === ino) out.push(fd);
+        } catch {}
+      }
+      return out;
+    }
+
+    // Park both thread-pool threads (UV_THREADPOOL_SIZE=2): each readFile opens
+    // the FIFO and blocks in read() until the write side is closed below, so a
+    // close queued on the pool by the failing writer() cannot run before we
+    // have reused its fd number. Holding the FIFO open read-write keeps the
+    // opens themselves from blocking; the loop waits for both to have opened.
+    const fifoWriter = fs.openSync(fifoPath, "r+");
+    const parked = [1, 2].map(() => fs.promises.readFile(fifoPath));
+    while (fdsOf(fifoPath).length < 3) await Bun.sleep(1);
+
+    const before = fdsOf(sock);
+    const first = Bun.file(sock).writer();
+    const [n, ...extra] = fdsOf(sock).filter(fd => !before.includes(fd));
+    if (n === undefined || extra.length) throw new Error("expected exactly one new dup of the socket");
+
+    // Close the first sink's dup behind its back. sock keeps the socket alive,
+    // so its epoll registration for n outlives the fd number and the next dup
+    // to land on n fails to register.
+    fs.closeSync(n);
+
+    let code;
+    try {
+      Bun.file(sock).writer();
+    } catch (e) {
+      code = e.code;
+    }
+    // The failed writer() closed n; this unrelated fd gets the number back.
+    const reused = fs.openSync("/dev/null", "r");
+
+    fs.closeSync(fifoWriter);
+    const parkedBytes = (await Promise.all(parked)).map(buf => buf.length);
+    // One more round trip through the now-free pool: whatever the failed
+    // writer() queued there has run by the time this resolves.
+    await fs.promises.stat("/dev/null");
+
+    let reusedStillOpen = true;
+    try {
+      fs.fstatSync(reused);
+    } catch {
+      reusedStillOpen = false;
+    }
+    console.log(JSON.stringify({ code, reusedIsN: reused === n, parkedBytes, reusedStillOpen }));
+    // first must outlive the check: ending or collecting it closes n as well.
+    first.unref();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: { ...bunEnv, UV_THREADPOOL_SIZE: "2" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ code: "EEXIST", reusedIsN: true, parkedBytes: [0, 0], reusedStillOpen: true }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 // Skipped on Windows: the Windows FileSink writer hands bytes to uv_fs_write on
 // the libuv threadpool and never registers an AutoFlusher synchronously, so the
 // on_exit drain this suite exercises is a no-op there and every process.exit()


### PR DESCRIPTION
### Problem
- ASAN test workers (`bun test --test-worker --isolate`) die with `panic: assertion failed: err.is_none()` in `<bun_core::util::Fd as bun_sys::fd::FdExt>::close` (`src/sys/fd.rs:73`), called from `bun_io::closer::Closer` on a thread pool thread: the deferred `close(2)` got EBADF, so the fd number had already been closed by someone else. Seen three times across seven PR builds (for example build 94781); the worker's in-flight file is reported as the crash and passes on retry, so it never fails a build.
- Cause: `PosixStreamingWriter::start` (`src/io/PipeWriter.rs`) stores the fd in a freshly created poll and then registers it. When `epoll_ctl` fails it returns `Err` with the poll still holding the fd. `FileSink::setup` (`src/runtime/webcore/FileSink.rs:679`) closes the fd on that `Err`, and `Blob.writer()` then releases the sink, whose writer `Drop` hands the same fd number to `Closer`. Debug builds trip the assertion; release builds close whatever fd has been given that number in the meantime (reproduced: a `/dev/null` fd opened right after came back EBADF).
- What makes the registration fail in CI is the `EEXIST` from #37968: under `--isolate` each file's `process.stdout`/`stderr` sink leaves a stale epoll entry keyed on a dup number that a later dup lands on. Since `internal/fs/streams` wraps `Bun.file(fd).writer()` in a try/catch, that failure is silent and only the double close is visible. #38008 removes that trigger; this PR fixes the double close, which follows any registration failure (ENOSPC when `max_user_watches` is exhausted, for instance).
- `PosixBufferedWriter::start` has the same shape. Its callers happened to rely on the opposite convention (the writer closes the fd on failure), as did `Bun.Terminal` and the subprocess stdin `FileSink`, so the two conventions coexisted and the callers disagreed about who owns the fd after a failed `start()`.

### Fix
- A failed `start()` on either POSIX writer releases the poll it created (`PollOrFd::close_without_closing_fd`, new) and leaves the fd with the caller. A poll left over from an earlier `start()` is not touched: it still holds that earlier fd, which the writer does own (the shell re-arms its writer this way).
- Why this direction: it makes `start()` have no effect on failure, matches the Windows writer (a failed open never adopts the handle), and makes the fd's owner the same on every path: whoever passed it in closes it on `Err`, the writer closes it after `Ok`. `FileSink::setup` is already written this way and is now correct without changes.
- Callers that relied on the writer closing the fd on failure now close it themselves: `Bun.Terminal` closes its pty write fd on every platform (the Windows branch already did), `Writable::init` closes the stdin pipe after releasing the sink, `StaticPipeWriter::start` closes its `stdio_result`. The shell `IOWriter`'s EINVAL/EPERM retry no longer needs to tear the poll down itself; it owns its fd separately and is otherwise unchanged.
- The same callers also relied on the writer's later `close()` reporting `on_close`, which an empty writer no longer does. For `Bun.spawn` with a buffer stdin that report was what retired the `Writable::Buffer` slot; left in place it counts as pending activity and pins the `Subprocess` wrapper forever (caught in review). The spawn bindings now retire the slot on that error path themselves (`on_close_io(Stdin)`), on POSIX only since Windows adopts the pipe before `start()` and cannot fail there. The shell drops its subprocess outright on this path and `Bun.Terminal` destroys itself, so they needed nothing.
- `close_impl` on Windows ignored its `close_fd` argument; it now honors it so the new helper means the same thing on every platform (no live Windows caller passes `false`; `PollOrFd` only backs the POSIX reader and writers).
- Verification:
  - `test/js/bun/util/filesink.test.ts` ("whose registration fails closes the dup exactly once"): recreates the CI condition on a socketpair fd (close a sink's dup from under it, the next dup gets EEXIST), with the thread pool parked so the stray close has to land on the fd that reused the number. Unfixed debug and release builds report `reusedStillOpen: false`; with the fix it stays open. Linux only, as kqueue drops registrations with the fd.
  - `test/js/bun/spawn/spawn-pipe-start-error.test.ts`: an LD_PRELOAD shim fails every writable `epoll_ctl` registration (Bun issues them through `syscall(2)`), and fixtures for `stdin: "pipe"`, a buffer stdin (memfd disabled so the pipe writer path is taken) and `new Bun.Terminal()` assert that the fd count and the number of live `Subprocess`/`Terminal` wrappers return to baseline with an empty stderr. All three pass on bun 1.4.0 and with this PR; with the three caller-side closes removed each fixture reports `leakedFds: 1`, and without the bindings change the buffer fixture reports `leakedWrappers: 1`. 30/30 runs stable on the debug build.
  - Also run: filesink, bunshell, shell file-io/epipe/output, spawn, spawnSync, terminal, spawn stdin stream suites; `cargo fmt --check` and `cargo clippy` on `bun_io`/`bun_spawn`; `cargo check` of `bun_io`, `bun_spawn` and `bun_runtime` for `x86_64-pc-windows-msvc`.

### Background
- `PollOrFd` is the handle inside the POSIX pipe readers and writers: either a bare fd or a `FilePoll`, the event loop's epoll/kqueue registration, which records the fd it watches. Closing the handle unregisters the poll and then closes the fd, normally through `Closer`, which performs the `close(2)` on the thread pool so the event loop does not block on it. That delay is why the second close lands after the fd number has been reused.
- `Fd::close` asserts that `close(2)` did not return EBADF in debug and ASAN builds, because for an internally owned fd EBADF means a double close and therefore a possible close of an unrelated fd. That assertion is the crash in the report and is intentionally left in place.
- `FileSink` is the native writer behind `Bun.file(...).writer()`, `process.stdout`/`stderr` and a piped subprocess stdin; `StaticPipeWriter` writes a Buffer/Blob stdin into a child; both own a `PosixStreamingWriter`/`PosixBufferedWriter` from `src/io/PipeWriter.rs`.
- A `Subprocess` holds a strong reference to its own JS wrapper while it has pending activity: a child that has not exited, or a stdio slot still in use. Each slot is retired through `on_close_io`, which the stdio object reports when it closes; once the slots are retired and the child has exited, the reference is downgraded and the wrapper becomes collectable.
- Registering a pollable fd can fail in production with ENOSPC (`fs.epoll.max_user_watches`) or, as in #37968, EEXIST when epoll still holds an entry for the same open file under the same fd number; epoll keys entries on (open file, fd number), so an entry outlives an fd number that was closed while another fd kept the file open.

<details>
<summary>Bugs noticed on the way, tracked separately</summary>

- `ShellSubprocess::abort_after_failed_start` leaks the not-yet-started stdout/stderr pipe fds when the buffered stdin writer fails to start (visible with the shim from the new test). Handed off.
- The security scanner's handling of a failed `StaticPipeWriter::start` releases one ref too many; #37898 already changes that site.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts, test/js/bun/spawn/spawn-pipe-start-error.test.ts

<!-- robobun:evidence:end -->