### PR TITLE
darwin-ci: drain the tart agent and its guests before baking

### DIFF
--- a/scripts/darwin-ci/lib/agent.ts
+++ b/scripts/darwin-ci/lib/agent.ts
@@ -114,3 +114,16 @@ async function unload(target: string): Promise<void> {
   await $`sudo launchctl bootout ${target}`.quiet().nothrow();
   await poll(30, 2000, async () => ((await succeeds($`sudo launchctl print ${target}`)) ? undefined : true));
 }
+
+// a host runs at most two guests, so the agent and its job guests have to be gone before a bake can boot one
+export async function drainTartAgent(): Promise<void> {
+  const user = config.ciUser;
+  await unload(`gui/${await ciUserId()}/${agentLabel}`);
+  const guests = (await output($`sudo -u ${user} -H ${config.tart.bin} list --source local --quiet`))
+    .split("\n")
+    .filter(name => name.startsWith("bk-"));
+  for (const guest of guests) {
+    await $`sudo -u ${user} -H ${config.tart.bin} stop ${guest} --timeout 5`.quiet().nothrow();
+    await $`sudo -u ${user} -H ${config.tart.bin} delete ${guest}`.quiet().nothrow();
+  }
+}

--- a/scripts/darwin-ci/lib/agent.ts
+++ b/scripts/darwin-ci/lib/agent.ts
@@ -127,3 +127,10 @@ export async function drainTartAgent(): Promise<void> {
     await $`sudo -u ${user} -H ${config.tart.bin} delete ${guest}`.quiet().nothrow();
   }
 }
+
+// after a failed bake the previous image and config are still in place, so the old agent can simply come back
+export async function resumeTartAgent(): Promise<void> {
+  const plist = `/Library/LaunchAgents/${agentLabel}.plist`;
+  if (!(await Bun.file(plist).exists())) return;
+  await $`sudo launchctl bootstrap gui/${await ciUserId()} ${plist}`.quiet().nothrow();
+}

--- a/scripts/darwin-ci/main.ts
+++ b/scripts/darwin-ci/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { $ } from "bun";
 import { parseArgs } from "node:util";
-import { installBareAgent, installTartAgent } from "./lib/agent";
+import { drainTartAgent, installBareAgent, installTartAgent } from "./lib/agent";
 import { bake } from "./lib/bake";
 import { ciUserExists, enableAutoLogin, ensureCiUser } from "./lib/ci-user";
 import { config } from "./lib/config";
@@ -111,6 +111,7 @@ async function provisionTart(): Promise<void> {
   }
 
   step(`bake ${config.tart.image} as ${user}`);
+  await drainTartAgent();
   await $`sudo -u ${user} -H /usr/local/bin/bun ${main} bake --base ${values.base!} --ref ${values.ref!}`;
 
   step("agent");

--- a/scripts/darwin-ci/main.ts
+++ b/scripts/darwin-ci/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { $ } from "bun";
 import { parseArgs } from "node:util";
-import { drainTartAgent, installBareAgent, installTartAgent } from "./lib/agent";
+import { drainTartAgent, installBareAgent, installTartAgent, resumeTartAgent } from "./lib/agent";
 import { bake } from "./lib/bake";
 import { ciUserExists, enableAutoLogin, ensureCiUser } from "./lib/ci-user";
 import { config } from "./lib/config";
@@ -112,7 +112,12 @@ async function provisionTart(): Promise<void> {
 
   step(`bake ${config.tart.image} as ${user}`);
   await drainTartAgent();
-  await $`sudo -u ${user} -H /usr/local/bin/bun ${main} bake --base ${values.base!} --ref ${values.ref!}`;
+  const baked =
+    await $`sudo -u ${user} -H /usr/local/bin/bun ${main} bake --base ${values.base!} --ref ${values.ref!}`.nothrow();
+  if (baked.exitCode !== 0) {
+    await resumeTartAgent();
+    fail("bake failed; previous image and agent left in service");
+  }
 
   step("agent");
   await installTartAgent(agentOptions);


### PR DESCRIPTION
`provision … tart` reaches its bake step with the agent already running whenever the host has rebooted since setup (the agent is a LaunchAgent that starts at the CI user's login). Its two job guests then occupy both of the host's VM slots and the bake guest fails to start with "The number of VMs exceeds the system limit".

This unloads the agent and removes any `bk-*` guests before baking; `install-agent` brings the agent back afterwards as before. Hit while re-provisioning a host after an OS upgrade; verified by re-running provision on that host.