### PR TITLE
error printer: excerpt the frame picked for the code frame, not frame 0, for sources without a source map

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5724,7 +5724,7 @@ impl VirtualMachine {
             };
 
             if enable_source_code_preview.get() && code.slice().is_empty() {
-                exception.collect_source_lines(error_instance, global);
+                exception.collect_source_lines(error_instance, global, top as u8);
             }
 
             // Direct copy; both sides are `bun_core::Ordinal`.
@@ -5768,7 +5768,9 @@ impl VirtualMachine {
                 *source_code_slice = Some(code);
             }
         } else if enable_source_code_preview.get() {
-            exception.collect_source_lines(error_instance, global);
+            // Nothing to remap through (node:vm script, eval, new Function):
+            // excerpt the frame picked above straight from its JSC source.
+            exception.collect_source_lines(error_instance, global, top as u8);
         }
 
         drop(top_source_url);

--- a/src/jsc/ZigException.rs
+++ b/src/jsc/ZigException.rs
@@ -12,12 +12,15 @@ use crate::{JSErrorCode, JSGlobalObject, JSRuntimeType, JSValue, ZigStackFrame, 
 
 // SAFETY (safe fn): `JSValue` is a by-value scalar; `JSGlobalObject` is an
 // opaque `UnsafeCell`-backed handle (`&` is ABI-identical to non-null `*mut`);
-// `ZigException` is a `#[repr(C)]` out-param the C++ side fills in-place.
+// `ZigException` is a `#[repr(C)]` out-param the C++ side fills in-place;
+// `frame_index` is a by-value scalar that C++ bounds-checks against
+// `stack.frames_len`.
 unsafe extern "C" {
     pub(crate) safe fn ZigException__collectSourceLines(
         js_value: JSValue,
         global: &JSGlobalObject,
         exception: &mut ZigException,
+        frame_index: u8,
     );
 }
 
@@ -50,8 +53,18 @@ pub struct ZigException {
 }
 
 impl ZigException {
-    pub(crate) fn collect_source_lines(&mut self, value: JSValue, global: &JSGlobalObject) {
-        ZigException__collectSourceLines(value, global, self);
+    /// Fills `stack.source_lines_*` with the source around
+    /// `stack.frames()[frame_index]`, read from that frame's JSC source
+    /// provider. For sources bun transpiled, `remap_zig_exception` reads the
+    /// original file instead; this is the path for everything else (`node:vm`
+    /// scripts, `eval`, `new Function`).
+    pub(crate) fn collect_source_lines(
+        &mut self,
+        value: JSValue,
+        global: &JSGlobalObject,
+        frame_index: u8,
+    ) {
+        ZigException__collectSourceLines(value, global, self, frame_index);
     }
 
     // Kept as explicit `deinit` (not `Drop`) — this is a #[repr(C)] FFI

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -225,7 +225,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
 }
 
 static void populateStackFrame(JSC::VM& vm, ZigStackTrace& trace, const JSC::StackFrame& stackFrame,
-    ZigStackFrame& frame, bool is_top, JSC::SourceProvider** referenced_source_provider, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety)
+    ZigStackFrame& frame, JSC::SourceProvider** referenced_source_provider, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety)
 {
     if (flags == PopulateStackTraceFlags::OnlyPosition) {
         populateStackFrameMetadata(vm, globalObject, stackFrame, frame, finalizerSafety);
@@ -233,9 +233,9 @@ static void populateStackFrame(JSC::VM& vm, ZigStackTrace& trace, const JSC::Sta
             nullptr,
             0, frame.position, referenced_source_provider, flags);
     } else if (flags == PopulateStackTraceFlags::OnlySourceLines) {
-        populateStackFramePosition(stackFrame, is_top ? trace.source_lines_ptr : nullptr,
-            is_top ? trace.source_lines_numbers : nullptr,
-            is_top ? trace.source_lines_to_collect : 0, frame.position, referenced_source_provider, flags);
+        populateStackFramePosition(stackFrame, trace.source_lines_ptr,
+            trace.source_lines_numbers,
+            trace.source_lines_to_collect, frame.position, referenced_source_provider, flags);
     }
 }
 
@@ -421,7 +421,11 @@ public:
     }
 };
 
-static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer)
+// OnlyPosition fills `trace.frames_ptr` from `frames`. OnlySourceLines runs
+// later, after Rust has filtered the frames and picked the one whose source
+// to excerpt (`remap_zig_exception`), and collects the source lines of
+// `trace.frames_ptr[source_lines_frame_index]` only.
+static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer, uint8_t source_lines_frame_index = 0)
 {
     if (flags == PopulateStackTraceFlags::OnlyPosition) {
         uint8_t frame_i = 0;
@@ -439,18 +443,19 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
 
             ZigStackFrame& frame = trace.frames_ptr[frame_i];
             frame.jsc_stack_frame_index = static_cast<int32_t>(stack_frame_i);
-            populateStackFrame(vm, trace, frames[stack_frame_i], frame, frame_i == 0, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
+            populateStackFrame(vm, trace, frames[stack_frame_i], frame, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
             stack_frame_i++;
             frame_i++;
         }
         trace.frames_len = frame_i;
     } else if (flags == PopulateStackTraceFlags::OnlySourceLines) {
-        for (uint8_t i = 0; i < trace.frames_len; i++) {
-            ZigStackFrame& frame = trace.frames_ptr[i];
-            if (frame.jsc_stack_frame_index < 0 || static_cast<size_t>(frame.jsc_stack_frame_index) >= frames.size())
-                continue;
-            populateStackFrame(vm, trace, frames[frame.jsc_stack_frame_index], frame, i == 0, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
-        }
+        if (source_lines_frame_index >= trace.frames_len)
+            return;
+        ZigStackFrame& frame = trace.frames_ptr[source_lines_frame_index];
+        // -1 when the frames were parsed out of an `error.stack` string.
+        if (frame.jsc_stack_frame_index < 0 || static_cast<size_t>(frame.jsc_stack_frame_index) >= frames.size())
+            return;
+        populateStackFrame(vm, trace, frames[frame.jsc_stack_frame_index], frame, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
     }
 }
 
@@ -866,7 +871,8 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__toZigException(JSC::Enc
     exceptionFromString(*exception, value, global);
 }
 
-extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException, JSC::JSGlobalObject* global, ZigException* exception)
+// `frame_index` indexes `exception->stack.frames_ptr` (after Rust's frame filtering).
+extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException, JSC::JSGlobalObject* global, ZigException* exception, uint8_t frame_index)
 {
     JSC::JSValue value = JSC::JSValue::decode(jsException);
     if (value == JSC::JSValue {}) {
@@ -878,7 +884,7 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         JSValue unwrapped = jscException->value();
 
         if (jscException->stack().size() > 0) {
-            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
+            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::NotInFinalizer, frame_index);
         }
 
         exceptionFromString(*exception, unwrapped, global);
@@ -887,7 +893,7 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
 
     if (JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(value)) {
         if (error->stackTrace() != nullptr && error->stackTrace()->size() > 0) {
-            populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);
+            populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC, frame_index);
         }
         return;
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { EventEmitter } from "node:events";
 import {
   compileFunction,
   constants,
@@ -460,6 +461,118 @@ describe("Script", () => {
     } finally {
       Error.prepareStackTrace = prev;
     }
+  });
+});
+
+// The code frame bun prints above an error is the line of the first frame that
+// is in one of the user's sources. A vm script (like eval and new Function) has
+// no source map, so that line is cut out of the source JSC compiled. When the
+// error is thrown inside a JS builtin or one of bun's own modules, the user's
+// frame is not frame 0; the excerpt used to be cut out of frame 0's source
+// regardless, i.e. it showed the builtin's own text and line number.
+describe("code frame of an error thrown inside a builtin called from a source without a source map", () => {
+  type Expected = {
+    // Names the user's source in the stack; the excerpt has to be its line.
+    filename: string;
+    // The `name: message` line printed under the code frame.
+    header: string;
+    // The text of the line that calls into the builtin.
+    excerpt: string;
+  };
+
+  function expectCodeFrame(printed: string, { filename, header, excerpt }: Expected) {
+    const lines = printed.split("\n");
+    const headerIndex = lines.indexOf(header);
+    expect(headerIndex).toBeGreaterThanOrEqual(2);
+    const userFrame = printed.match(new RegExp(`${RegExp.escape(filename)}:(\\d+):\\d+`));
+    expect(userFrame).not.toBeNull();
+    // Directly above the header are the excerpt and the caret. The excerpt is
+    // labelled with the line the user's frame reports (line 2 of the source
+    // below; for new Function, 2 plus its `function anonymous(\n) {` wrapper).
+    expect(lines.slice(headerIndex - 2, headerIndex)).toEqual([
+      `${userFrame![1]} | ${excerpt}`,
+      expect.stringMatching(/^ +\^$/),
+    ]);
+  }
+
+  // The builtin is called from line 2 so that the excerpt's line number has to
+  // come from the user's frame as well as its text.
+  const source = '"line 1";\n[].reduce((a, b) => a);';
+  const reduce = {
+    excerpt: "[].reduce((a, b) => a);",
+    header: "TypeError: reduce of empty array with no initial value",
+  };
+  // displayErrors: false keeps node:vm from rewriting err.stack; the code frame
+  // under test is the one bun's error printer builds from the error's frames.
+  const displayErrors = false;
+
+  const cases: (Expected & { name: string; run(filename: string): unknown })[] = [
+    {
+      name: "vm.Script",
+      filename: "/virtual/script.js",
+      ...reduce,
+      run: filename => new Script(source, { filename }).runInThisContext({ displayErrors }),
+    },
+    {
+      name: "runInNewContext",
+      filename: "/virtual/new-context.js",
+      ...reduce,
+      run: filename => runInNewContext(source, {}, { filename, displayErrors }),
+    },
+    {
+      name: "eval",
+      filename: "/virtual/eval.js",
+      ...reduce,
+      run: filename => (0, eval)(`${source}\n//# sourceURL=${filename}`),
+    },
+    {
+      name: "new Function",
+      filename: "/virtual/function.js",
+      ...reduce,
+      run: filename => new Function(`${source}\n//# sourceURL=${filename}`)(),
+    },
+    {
+      // emit() with no "error" listener throws from inside bun's node:events,
+      // so the frame on top is a node:events frame rather than a JS builtin's.
+      name: "node: module on top of the stack",
+      filename: "/virtual/events.js",
+      header: "error: Unhandled error. (undefined)",
+      excerpt: 'emitter.emit("error");',
+      run: filename =>
+        runInNewContext(
+          '"line 1";\nemitter.emit("error");',
+          { emitter: new EventEmitter() },
+          { filename, displayErrors },
+        ),
+    },
+  ];
+
+  test.each(cases)("Bun.inspect: $name", testCase => {
+    let thrown: unknown;
+    try {
+      testCase.run(testCase.filename);
+    } catch (e) {
+      thrown = e;
+    }
+    expectCodeFrame(Bun.inspect(thrown), testCase);
+  });
+
+  test("uncaught error", async () => {
+    const filename = "/virtual/uncaught.js";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("node:vm").runInThisContext(${JSON.stringify(source)}, ${JSON.stringify({ filename, displayErrors })})`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expectCodeFrame(stderr, { filename, ...reduce });
+    expect(exitCode).toBe(1);
   });
 });
 


### PR DESCRIPTION
### Problem
- When an error is thrown inside a JS builtin (or one of bun's own `node:*` modules) that was called from a source bun did not transpile (a `node:vm` script, `eval`, `new Function`), the code frame above the error shows the builtin's own source instead of the user's line. Affects the uncaught-error output, `Bun.inspect(err)` and `console.error(err)`. Reproduces on 1.4.0 and on main:
  ```js
  const vm = require("node:vm");
  new vm.Script("[].reduce((a, b) => a)", { filename: "/virtual/r.js" }).runInThisContext({ displayErrors: false });
  ```
  prints
  ```
  1 | (function (callback )
                ^
  TypeError: reduce of empty array with no initial value
        at reduce (1:11)
        at /virtual/r.js:1:10
  ```
  (a debug build prints lines 7-12 of the `Array.prototype.reduce` builtin; with `emitter.emit("error")` and no listener it prints bun's `node:events` source). Expected, and what this PR prints: `1 | [].reduce((a, b) => a)`.
- The same stack in a file bun transpiled already shows the user's line, because that path reads the file itself (see below). Only the no-source-map path was wrong.
- Cause: `remap_zig_exception` (`src/jsc/VirtualMachine.rs`, the `top` loop around line 5599) picks the first frame that is in a user source, skipping builtin and `bun:`/`node:` frames. When the source map lookup for that frame finds nothing it calls `exception.collect_source_lines()`, and `populateStackTrace` in `src/jsc/bindings/ZigException.cpp` (the `OnlySourceLines` branch, line 448 on main) excerpted `frames[0]` unconditionally (`is_top = i == 0`); it was never told which frame had been picked (#22902 split the two passes and kept frame 0 for this one).

### Fix
- `ZigException__collectSourceLines` takes the index of the picked frame; the `OnlySourceLines` pass excerpts that frame only. Both Rust call sites pass `top`.
- Correct because `top` is already the frame whose `source_url` and position are shown as the code frame's location; the excerpt now comes from the same frame, which is what the transpiled-file path does when it reads `frames[top].source_url`. When nothing is skipped `top` is 0, so the common case is unchanged.
- The old pass also re-ran `populateStackFramePosition` on every other frame, which only rewrote positions with the values the first pass had already stored; nothing consumed that, so the loop is gone together with the now-constant `is_top` parameter.
- Does not change where the caret is drawn. The printer picks the frame for the caret column separately and, for a JS builtin on top, still uses the builtin's column; #38335 and #38349 fix that independently of this change, after which the caret column comes from the same frame as the excerpt. Also independent of #38244 (the context lines above the excerpt) and #38296: they change what happens around the `collect_source_lines()` calls, not which frame it reads. The tests here therefore check the excerpt line and only that a caret line follows it.
- Overlaps textually with #38324, which rewrites this collector (each frame pins its `SourceProvider`; `collectSourceLines` slices from it) but still slices `frames_ptr[0]`, so the bug in this PR survives it as-is. On top of #38324 this change reduces to passing `top` through to its `collectSourceLines` and indexing with it; I will rebase this PR to that shape if #38324 lands first.
- Verified with `test/js/node/vm/vm.test.ts` ("code frame of an error thrown inside a builtin called from a source without a source map": `vm.Script`, `runInNewContext`, `eval`, `new Function`, a `node:events` frame on top, and the uncaught-error output). All 6 fail on 1.4.0 with the builtin's text in the diff and pass with this change.
- `test/js/node/vm/*.test.ts`, `test/js/bun/test/stack.test.ts`, `test/js/bun/util/reportError.test.ts` pass; `test/js/bun/util/inspect-error.test.js` has two debug-build-only failures that reproduce without this change (tracked separately).
- 30,000 `Bun.inspect()` calls on this shape of error hold steady in RSS under ASAN with a small quarantine (the source provider ref taken for the excerpt is released in `ZigException::deinit` as before).

### Background
- Code frame: the `N | source text` line plus `^` that bun prints above an error's `name: message`. It is built in two steps. `JSC__JSValue__toZigException` (`OnlyPosition` pass) copies JSC's stack frames into `ZigStackTrace.frames`, recording each one's index into JSC's frame vector in `jsc_stack_frame_index`. `remap_zig_exception` then filters those frames, picks `top`, and either rebuilds the lines itself from the original file (sources bun transpiled: it has them on disk or in the source map) or, when there is no source map for the frame, asks C++ to cut the lines out of the `JSC::SourceProvider` of that frame (`OnlySourceLines` pass). The second case is the only one that can see a `node:vm` / `eval` / `new Function` source, which exists nowhere but inside JSC.
- A JS builtin such as `Array.prototype.reduce` is itself JavaScript inside JSC, so it appears as a frame with an empty source URL and a position inside the builtin's text; that text is what was being excerpted. Bun's `node:*` modules appear the same way with a `node:` URL.
- `frame_index` indexes `ZigStackTrace.frames` after Rust's filtering; the filtering swaps entries but each entry keeps its own `jsc_stack_frame_index`, so C++ still reaches the right JSC frame. Frames parsed out of an `error.stack` string carry `-1` there and get no excerpt, as before.
