### PR TITLE
test(s3): shrink the big list() fixture so it does not starve the concurrent tests on debug builds

### DIFF
--- a/test/js/bun/s3/s3-list-objects.test.ts
+++ b/test/js/bun/s3/s3-list-objects.test.ts
@@ -880,7 +880,10 @@ describe.concurrent("S3 - List Objects", () => {
   });
 
   it("Should work with big responses", async () => {
-    const contents = new Array(40 * 1000).fill("").map(x => ({
+    // S3 sends at most 1000 keys per page. 2000 keeps the body (~700KB) larger than one
+    // 512KB socket read, but small enough that parsing it (~0.3ms per entry on a debug build,
+    // all on the main thread) does not starve the other concurrent tests of their 5s timeout.
+    const contents = new Array(2000).fill("").map(x => ({
       key: randomUUIDv7(),
       eTag: '"4c6426ac7ef186464ecbb0d81cbfcb1e"',
       lastModified: new Date().toISOString(),


### PR DESCRIPTION
### Problem
- On a debug build, `bun bd test test/js/bun/s3/s3-list-objects.test.ts` fails every run: `(fail) S3 - List Objects > Should fall back to NoSuchKey for a 404 whose <Error> has no usable <Code> [14653.37ms]` / `^ this test timed out after 5000ms.` The file takes ~23s.
- Cause: `Should work with big responses` (test/js/bun/s3/s3-list-objects.test.ts:882) builds a 40,000 entry `ListBucketResult` (14.4MB). On a debug build that test occupies the main thread for ~18s (XML parse in `S3HttpSimpleTask::on_response` ~13s, plus building the fixture, rendering it in the `fetch` handler and `toEqual`). The same test takes ~380ms on a release build, where the fall-back test already reports ~350ms for the same reason.
- Every test in the file is in one `describe.concurrent`, so they all start together and their 5s timeouts run on the wall clock. The `NoSuchKey` fall-back test needs three sequential round trips through the main thread; its later iterations queue up behind the 13s parse, and its timer fires as soon as the main thread is free again. The other single round trip tests finish before the big response arrives (they still report 1.3s to 3.6s instead of ~20ms).
- Not a product bug: the parse cost is linear in the entry count (5k/10k/20k/40k entries take 1.6s/3.2s/6.8s/13.1s on the debug build), and a 14MB body with few elements lists in ~110ms on the same build.

### Fix
- The fixture goes from 40,000 entries to 2,000 (body 718KB), with a comment recording what the size has to satisfy.
- Still exercises what the test is for: S3 returns at most 1,000 keys per page, so 2,000 is twice the largest real response, and 718KB is larger than one `LIBUS_RECV_BUFFER_LENGTH` (512KB) read, so the response is still accumulated across several socket reads. Nothing between 718KB and 14MB takes a different path: one-shot HTTP consumers such as the S3 simple request receive the body in a single terminal callback either way, the parse is linear, and the byte volume case is already covered by the 5MB malformed response test at the bottom of this file.
- Debug build cost of the test drops from ~18s to ~1s, so it no longer eats the other concurrent tests' 5s budget. It was also within about 1.5x of timing itself out on a debug build, since its fixture build plus `fetch` handler already blocked for ~3.5s before the response even arrived.
- Verified: `bun bd test test/js/bun/s3/s3-list-objects.test.ts` on main fails as above in ~23s (4/4 runs, reproducing the report); with this change it passes in ~4.4s (3/3 runs, fall-back test ~150ms, big responses ~1.0s). `USE_SYSTEM_BUN=1 bun test` on the file passes in ~330ms (big responses ~20ms, fall-back ~17ms, down from ~380ms and ~350ms).
- This only shows up on debug builds, which is why CI (release and release ASAN) has been green; it started with #37194, which made the parse build a full document per entry and added the multi round trip test that surfaces the starvation.

### Background
- `describe.concurrent`: every test in the block is started before any of them finishes; a test's timeout measures wall clock from its start, so main thread time spent by one test counts against all of them.
- The S3 list response is parsed on the main thread: the HTTP thread collects the body and posts one task; `on_response` (src/runtime/webcore/s3/simple_request.rs) parses the XML and converts it to JS objects in that task, so nothing else on the JS thread runs until it returns.
- `LIBUS_RECV_BUFFER_LENGTH` (packages/bun-usockets/src/libusockets.h) is the size of the buffer one socket read lands in, so a body larger than it always arrives in more than one read.

<details>
<summary>Measurements (debug build, this file's fixture shape)</summary>

Full file on main:

```
(pass) S3 - List Objects > Should work with big responses [18233.93ms]
(fail) S3 - List Objects > Should fall back to NoSuchKey for a 404 whose <Error> has no usable <Code> [14653.37ms]
  ^ this test timed out after 5000ms.
Ran 42 tests across 1 file. [23.10s]
```

Same binary, same file, with only the big responses test deselected (`-t '^(?!.*big responses)'`):

```
(pass) S3 - List Objects > Should fall back to NoSuchKey for a 404 whose <Error> has no usable <Code> [153.65ms]
Ran 40 tests across 1 file. [3.80s]
```

Standalone `list()` against a prebuilt body, by entry count (debug build): 5,000 entries 1.63s, 10,000 3.25s, 20,000 6.81s, 40,000 13.07s. Release build, 40,000 entries: ~190ms. A 14MB body containing one huge text node instead of entries: 114ms on the debug build, so the cost is per element, not per byte.

Full file with the fixture at 1,000 / 2,000 / 4,000 entries: big responses 0.6s / 1.0s / 1.9s, file 4.1s / 4.4s / 5.3s, fall-back test 150ms to 190ms in every case.
</details>
