### PR TITLE
install: stop aborting on link: specifiers and patch paths longer than the path buffers

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1537,16 +1537,29 @@ impl<'a> PackageInstaller<'a> {
                     installer.cache_dir = Fd::cwd();
                 } else {
                     let global_link_dir = package_manager::global_link_dir_path(self.manager_mut());
-                    let buf = self.folder_path_buf.as_mut_slice();
-                    let mut len = 0usize;
-                    buf[len..len + global_link_dir.len()].copy_from_slice(global_link_dir);
-                    len += global_link_dir.len();
-                    if global_link_dir[global_link_dir.len() - 1] != SEP {
-                        buf[len] = SEP;
-                        len += 1;
+                    let sep_len = (global_link_dir[global_link_dir.len() - 1] != SEP) as usize;
+                    let len = global_link_dir.len() + sep_len + folder.len();
+                    // `folder` is the `link:` specifier as written in package.json.
+                    if len >= self.folder_path_buf.len() {
+                        Output::err(
+                            "ENAMETOOLONG",
+                            "link path for package <b>{}<r> is too long",
+                            (bstr::BStr::new(pkg_name.slice(string_buf!())),),
+                        );
+                        self.summary.fail += 1;
+                        self.increment_tree_install_count(
+                            !is_pending_package_install,
+                            self.current_tree_id,
+                            log_level,
+                        );
+                        return;
                     }
-                    buf[len..len + folder.len()].copy_from_slice(folder);
-                    len += folder.len();
+                    let buf = self.folder_path_buf.as_mut_slice();
+                    buf[..global_link_dir.len()].copy_from_slice(global_link_dir);
+                    if sep_len != 0 {
+                        buf[global_link_dir.len()] = SEP;
+                    }
+                    buf[global_link_dir.len() + sep_len..len].copy_from_slice(folder);
                     buf[len] = 0;
                     // SAFETY: buf[len] == 0 written above
                     installer.cache_dir_subpath = ZStr::from_buf(&self.folder_path_buf, len);

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1541,11 +1541,13 @@ impl<'a> PackageInstaller<'a> {
                     let len = global_link_dir.len() + sep_len + folder.len();
                     // `folder` is the `link:` specifier as written in package.json.
                     if len >= self.folder_path_buf.len() {
-                        Output::err(
-                            "ENAMETOOLONG",
-                            "link path for package <b>{}<r> is too long",
-                            (bstr::BStr::new(pkg_name.slice(string_buf!())),),
-                        );
+                        if log_level != Options::LogLevel::Silent {
+                            Output::err(
+                                "ENAMETOOLONG",
+                                "link path for package <b>{}<r> is too long",
+                                (bstr::BStr::new(pkg_name.slice(string_buf!())),),
+                            );
+                        }
                         self.summary.fail += 1;
                         self.increment_tree_install_count(
                             !is_pending_package_install,

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -393,9 +393,11 @@ impl PatchTask {
         let patchfile_path = &patch.patchfilepath;
 
         let mut absolute_patchfile_path_buf = PathBuffer::uninit();
+        let mut absolute_patchfile_path_spill = Vec::new();
         // 1. Parse the patch file
-        let absolute_patchfile_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+        let absolute_patchfile_path = path::resolve_path::join_z_buf_spill::<path::platform::Auto>(
             &mut absolute_patchfile_path_buf.0,
+            &mut absolute_patchfile_path_spill,
             &[dir, patchfile_path],
         );
         // TODO: can the patch file be anything other than utf-8?
@@ -608,9 +610,11 @@ impl PatchTask {
         let patchfile_path = &calc_hash.patchfile_path;
 
         let mut absolute_patchfile_path_buf = PathBuffer::uninit();
+        let mut absolute_patchfile_path_spill = Vec::new();
         // parse the patch file
-        let absolute_patchfile_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+        let absolute_patchfile_path = path::resolve_path::join_z_buf_spill::<path::platform::Auto>(
             &mut absolute_patchfile_path_buf.0,
+            &mut absolute_patchfile_path_spill,
             &[dir, patchfile_path],
         );
 
@@ -638,12 +642,10 @@ impl PatchTask {
                     );
                     return None;
                 }
-                bun_ast::add_warning_pretty!(
-                    log,
+                log.add_error_fmt(
                     None,
                     Loc::EMPTY,
-                    "patchfile <b>{}<r> is empty, please restore or delete it.",
-                    BStr::new(absolute_patchfile_path.as_bytes()),
+                    format_args!("failed to read patch file: {}", e),
                 );
                 return None;
             }

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use bun_core::fmt::QuotedFormatter;
 use bun_core::{ZStr, strings};
-use bun_paths::{self, MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR, resolve_path};
+use bun_paths::{self, PathBuffer, SEP, SEP_STR, resolve_path};
 use bun_resolver::fs::FileSystem;
 use bun_semver::{self as semver, String as SemverString};
 use bun_sys::{self, Fd, File, O};
@@ -35,7 +35,6 @@ pub(crate) struct PackageWorkspaceSearchPathFormatter<'a> {
 
 impl<'a> fmt::Display for PackageWorkspaceSearchPathFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut joined = [0u8; MAX_PATH_BYTES + 2];
         // Caller constructs this formatter only when
         // `self.version.tag == .workspace`.
         let workspace = self.version.workspace();
@@ -50,23 +49,21 @@ impl<'a> fmt::Display for PackageWorkspaceSearchPathFormatter<'a> {
 
         let search_path = self.manager.lockfile.str(str_to_use);
 
-        // SAFETY: joined[2..] is exactly MAX_PATH_BYTES bytes long.
-        let joined_path: &mut PathBuffer =
-            unsafe { &mut *joined.as_mut_ptr().add(2).cast::<PathBuffer>() };
+        let mut joined = PathBuffer::uninit();
+        let mut dot_slash_rel = Vec::new();
         let rel: &[u8] = match normalize_package_json_path(
             GlobalOrRelative::Relative(dependency::version::Tag::Workspace),
-            joined_path,
+            &mut joined,
             search_path,
         ) {
             Some(paths)
                 if !strings::starts_with_char(paths.rel, b'.')
                     && !strings::starts_with_char(paths.rel, SEP) =>
             {
-                joined[0] = b'.';
-                joined[1] = SEP;
-                // `paths.rel` points into `joined[2..]`; extend the view backward
-                // by the two bytes just written via safe slicing of `joined`.
-                &joined[..paths.rel.len() + 2]
+                dot_slash_rel.push(b'.');
+                dot_slash_rel.push(SEP);
+                dot_slash_rel.extend_from_slice(paths.rel);
+                dot_slash_rel.as_slice()
             }
             Some(paths) => paths.rel,
             // Too long to be a path; show it as written.
@@ -180,8 +177,6 @@ struct Paths<'a> {
 }
 
 /// Returns `None` when the `package.json` path does not fit `joined`.
-/// `non_normalized_path` is taken from the user's package.json, so it can be
-/// arbitrarily long.
 fn normalize_package_json_path<'a>(
     global_or_relative: GlobalOrRelative<'_>,
     joined: &'a mut PathBuffer,
@@ -439,9 +434,8 @@ pub(crate) fn get_or_put(
 
     let result: crate::Result<LockfilePackage> = match global_or_relative {
         GlobalOrRelative::Global(_) => 'global: {
-            // `non_normalized_path` may point into the lockfile's string buffer,
-            // which `read_package_json_from_disk` grows before the resolver
-            // copies `folder_path` into it.
+            // Copied because reading the package.json may reallocate the lockfile
+            // string buffer `non_normalized_path` points into.
             let folder_path: Box<[u8]> = Box::from(non_normalized_path);
             let mut resolver: SymlinkResolver = NewResolver {
                 folder_path: &folder_path,

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use bun_core::fmt::QuotedFormatter;
 use bun_core::{ZStr, strings};
-use bun_paths::{self, MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR};
+use bun_paths::{self, MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR, resolve_path};
 use bun_resolver::fs::FileSystem;
 use bun_semver::{self as semver, String as SemverString};
 use bun_sys::{self, Fd, File, O};
@@ -48,34 +48,40 @@ impl<'a> fmt::Display for PackageWorkspaceSearchPathFormatter<'a> {
             ))
             .unwrap_or(workspace);
 
+        let search_path = self.manager.lockfile.str(str_to_use);
+
         // SAFETY: joined[2..] is exactly MAX_PATH_BYTES bytes long.
         let joined_path: &mut PathBuffer =
             unsafe { &mut *joined.as_mut_ptr().add(2).cast::<PathBuffer>() };
-        let mut paths = normalize_package_json_path(
+        let rel: &[u8] = match normalize_package_json_path(
             GlobalOrRelative::Relative(dependency::version::Tag::Workspace),
             joined_path,
-            self.manager.lockfile.str(str_to_use),
-        );
-
-        if !strings::starts_with_char(paths.rel, b'.') && !strings::starts_with_char(paths.rel, SEP)
-        {
-            joined[0] = b'.';
-            joined[1] = SEP;
-            // `paths.rel` points into `joined[2..]`; extend the view backward
-            // by the two bytes just written via safe slicing of `joined`.
-            let n = paths.rel.len() + 2;
-            paths.rel = &joined[..n];
-        }
+            search_path,
+        ) {
+            Some(paths)
+                if !strings::starts_with_char(paths.rel, b'.')
+                    && !strings::starts_with_char(paths.rel, SEP) =>
+            {
+                joined[0] = b'.';
+                joined[1] = SEP;
+                // `paths.rel` points into `joined[2..]`; extend the view backward
+                // by the two bytes just written via safe slicing of `joined`.
+                &joined[..paths.rel.len() + 2]
+            }
+            Some(paths) => paths.rel,
+            // Too long to be a path; show it as written.
+            None => search_path,
+        };
 
         if self.quoted {
-            let quoted = QuotedFormatter { text: paths.rel };
+            let quoted = QuotedFormatter { text: rel };
             fmt::Display::fmt(&quoted, f)
         } else {
             // `fmt::Formatter` only accepts `&str`, so non-UTF-8 path bytes are emitted lossily
             // (U+FFFD) via `bstr::BStr`'s Display. Both current callers pass
             // `quoted = true`, so this branch is unreached today; if a future
             // caller needs byte-exact output it must use an `io::Write` sink.
-            write!(f, "{}", bstr::BStr::new(paths.rel))
+            write!(f, "{}", bstr::BStr::new(rel))
         }
     }
 }
@@ -91,10 +97,6 @@ pub struct Entry {
 
 // bun_collections::HashMap currently ignores the context/load-factor
 // type params (backed by std HashMap); identity hashing is a TODO(perf).
-
-fn normalize(path: &[u8]) -> &[u8] {
-    FileSystem::instance().normalize(path)
-}
 
 pub(crate) fn hash(normalized_path: &[u8]) -> u64 {
     bun_wyhash::hash(normalized_path)
@@ -177,84 +179,82 @@ struct Paths<'a> {
     rel: &'a [u8],
 }
 
+/// Returns `None` when the `package.json` path does not fit `joined`.
+/// `non_normalized_path` is taken from the user's package.json, so it can be
+/// arbitrarily long.
 fn normalize_package_json_path<'a>(
     global_or_relative: GlobalOrRelative<'_>,
     joined: &'a mut PathBuffer,
     non_normalized_path: &[u8],
-) -> Paths<'a> {
-    let abs: &[u8];
-
+) -> Option<Paths<'a>> {
+    let mut normalize_spill = Vec::new();
     // We consider it valid if there is a package.json in the folder
-    let normalized: &[u8] = if non_normalized_path.len() == 1 && non_normalized_path[0] == b'.' {
+    let normalized: &[u8] = if non_normalized_path == b"." {
         non_normalized_path
     } else if bun_paths::is_absolute(non_normalized_path) {
         strings::trim_right(non_normalized_path, SEP_STR.as_bytes())
     } else {
-        strings::trim_right(normalize(non_normalized_path), SEP_STR.as_bytes())
+        strings::trim_right(
+            resolve_path::normalize_string_spill::<true, bun_paths::platform::Auto>(
+                &mut normalize_spill,
+                non_normalized_path,
+            ),
+            SEP_STR.as_bytes(),
+        )
     };
 
     const PACKAGE_JSON_LEN: usize = "/package.json".len();
 
-    let rel: &[u8] = if strings::starts_with_char(normalized, b'.') {
-        let mut tempcat = PathBuffer::uninit();
+    // The last byte of `joined` is reserved for the NUL terminator.
+    let capacity = joined.len() - 1;
 
-        tempcat[..normalized.len()].copy_from_slice(normalized);
-        tempcat[normalized.len()] = SEP;
-        tempcat[normalized.len() + 1..normalized.len() + PACKAGE_JSON_LEN]
-            .copy_from_slice(b"package.json");
-        let parts: [&[u8]; 2] = [
-            FileSystem::instance().top_level_dir(),
-            &tempcat[0..normalized.len() + PACKAGE_JSON_LEN],
-        ];
-        abs = FileSystem::instance().abs_buf(&parts, joined);
-        FileSystem::instance().relative(
-            FileSystem::instance().top_level_dir(),
-            &abs[0..abs.len() - PACKAGE_JSON_LEN],
-        )
+    let abs_len = if strings::starts_with_char(normalized, b'.') {
+        let parts: [&[u8]; 2] = [normalized, b"package.json"];
+        FileSystem::instance()
+            .abs_buf_checked(&parts, &mut joined[..capacity])?
+            .len()
     } else {
-        let joined_len = joined.len();
-        let mut remain: &mut [u8] = &mut joined[..];
-        match &global_or_relative {
-            GlobalOrRelative::Global(path) | GlobalOrRelative::CacheFolder(path) => {
-                if !path.is_empty() {
-                    let offset = path
-                        .len()
-                        .saturating_sub((path[path.len().saturating_sub(1)] == SEP) as usize);
-                    if offset > 0 {
-                        remain[0..offset].copy_from_slice(&path[0..offset]);
-                    }
-                    remain = &mut remain[offset..];
-                    if !normalized.is_empty() {
-                        if (path[path.len() - 1] != SEP) && (normalized[0] != SEP) {
-                            remain[0] = SEP;
-                            remain = &mut remain[1..];
-                        }
-                    }
-                }
+        let (prefix, needs_sep): (&[u8], bool) = match global_or_relative {
+            GlobalOrRelative::Global(path) | GlobalOrRelative::CacheFolder(path)
+                if !path.is_empty() =>
+            {
+                let ends_with_sep = path[path.len() - 1] == SEP;
+                (
+                    &path[..path.len() - ends_with_sep as usize],
+                    !normalized.is_empty() && !ends_with_sep && normalized[0] != SEP,
+                )
             }
-            GlobalOrRelative::Relative(_) => {}
+            _ => (b"", false),
+        };
+        let abs_len = prefix.len() + needs_sep as usize + normalized.len() + PACKAGE_JSON_LEN;
+        if abs_len > capacity {
+            return None;
         }
-        remain[..normalized.len()].copy_from_slice(normalized);
-        remain[normalized.len()] = SEP;
-        remain[normalized.len() + 1..normalized.len() + PACKAGE_JSON_LEN]
-            .copy_from_slice(b"package.json");
-        let remain_after = remain.len() - (normalized.len() + PACKAGE_JSON_LEN);
-        // Compute abs len from remaining capacity.
-        let abs_len = joined_len - remain_after;
-        abs = &joined[0..abs_len];
-        // We store the folder name without package.json
-        FileSystem::instance().relative(
-            FileSystem::instance().top_level_dir(),
-            &abs[0..abs.len() - PACKAGE_JSON_LEN],
-        )
+
+        let mut len = prefix.len();
+        joined[..len].copy_from_slice(prefix);
+        if needs_sep {
+            joined[len] = SEP;
+            len += 1;
+        }
+        joined[len..len + normalized.len()].copy_from_slice(normalized);
+        len += normalized.len();
+        joined[len] = SEP;
+        joined[len + 1..len + PACKAGE_JSON_LEN].copy_from_slice(b"package.json");
+        abs_len
     };
-    let abs_len = abs.len();
+
+    // We store the folder name without package.json
+    let rel = FileSystem::instance().relative(
+        FileSystem::instance().top_level_dir(),
+        &joined[..abs_len - PACKAGE_JSON_LEN],
+    );
     joined[abs_len] = 0;
 
-    Paths {
+    Some(Paths {
         abs: ZStr::from_buf(joined, abs_len),
         rel,
-    }
+    })
 }
 
 fn read_package_json_from_disk<R: FolderResolverImpl>(
@@ -386,7 +386,11 @@ pub(crate) fn get_or_put(
     let mut joined = PathBuffer::uninit();
     #[cfg(windows)]
     let mut rel_buf = PathBuffer::uninit();
-    let paths = normalize_package_json_path(global_or_relative, &mut joined, non_normalized_path);
+    let Some(paths) =
+        normalize_package_json_path(global_or_relative, &mut joined, non_normalized_path)
+    else {
+        return FolderResolution::Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+    };
 
     #[cfg(not(windows))]
     let abs = paths.abs;
@@ -435,10 +439,12 @@ pub(crate) fn get_or_put(
 
     let result: crate::Result<LockfilePackage> = match global_or_relative {
         GlobalOrRelative::Global(_) => 'global: {
-            let mut path = PathBuffer::uninit();
-            path[..non_normalized_path.len()].copy_from_slice(non_normalized_path);
+            // `non_normalized_path` may point into the lockfile's string buffer,
+            // which `read_package_json_from_disk` grows before the resolver
+            // copies `folder_path` into it.
+            let folder_path: Box<[u8]> = Box::from(non_normalized_path);
             let mut resolver: SymlinkResolver = NewResolver {
-                folder_path: &path[0..non_normalized_path.len()],
+                folder_path: &folder_path,
             };
             break 'global read_package_json_from_disk(
                 manager,

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -434,8 +434,7 @@ pub(crate) fn get_or_put(
 
     let result: crate::Result<LockfilePackage> = match global_or_relative {
         GlobalOrRelative::Global(_) => 'global: {
-            // Copied because reading the package.json may reallocate the lockfile
-            // string buffer `non_normalized_path` points into.
+            // `non_normalized_path` may alias the lockfile string buffer, which grows below.
             let folder_path: Box<[u8]> = Box::from(non_normalized_path);
             let mut resolver: SymlinkResolver = NewResolver {
                 folder_path: &folder_path,

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -420,14 +420,6 @@ pub mod fs {
             }
         }
 
-        /// Normalizes `str` in the shared scratch space, returning the input
-        /// unchanged when already normalized.
-        #[inline]
-        pub fn normalize<'a>(&self, str: &'a [u8]) -> &'a [u8] {
-            use bun_paths::resolve_path::{normalize_string, platform};
-            normalize_string::<true, platform::Auto>(str)
-        }
-
         /// The process-global directory-name interning store.
         #[inline]
         pub fn dirname_store(&self) -> &'static DirnameStore {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1307,7 +1307,7 @@ describe("patchedDependencies path longer than the path buffer", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // The path is handed to the OS as is. POSIX rejects anything longer than
     // PATH_MAX with ENAMETOOLONG; Windows may report it as missing instead.

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -4,6 +4,7 @@ import { rmSync } from "fs";
 import {
   bunEnv,
   bunExe,
+  isWindows,
   normalizeBunSnapshot as normalizeBunSnapshot_,
   runBunInstall,
   tempDir,
@@ -1282,5 +1283,38 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
       });
       await installUnpatched(packageDir);
     });
+  });
+});
+
+describe("patchedDependencies path longer than the path buffer", () => {
+  // Hashing a patch joins its path onto the project directory in a path buffer
+  // (4096 bytes on Linux, 1024 on macOS, ~96 KiB on Windows). The join used to
+  // write past the buffer for a path that did not fit, aborting the install.
+  const longName = Buffer.alloc(100_000, "p").toString();
+
+  test("install reports the path instead of crashing", async () => {
+    using dir = tempDir("patch-path-too-long", {
+      "package.json": JSON.stringify({
+        name: "patch-path-too-long",
+        patchedDependencies: { "is-odd@3.0.1": `patches/${longName}.patch` },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // The path is handed to the OS as is. POSIX rejects anything longer than
+    // PATH_MAX with ENAMETOOLONG; Windows may report it as missing instead.
+    if (!isWindows) {
+      expect(stderr).toContain("error: failed to read patch file: ENAMETOOLONG: ");
+    }
+    expect(stderr).toContain(`${longName}.patch`);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10331,7 +10331,7 @@ describe.skipIf(isWindows)("file: dependency whose package.json path is around t
       stderr: "pipe",
       env,
     });
-    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { folder, err, exitCode };
   }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6,6 +6,7 @@ import {
   bunEnv,
   bunExe,
   bunEnv as env,
+  isLinux,
   isWindows,
   joinP,
   normalizeBunSnapshot,
@@ -10297,6 +10298,64 @@ it("does not install transitive file: dependencies with overlong folder targets"
   expect(err).toContain("unsafe folder path");
   expect(out).not.toContain("2 packages installed");
   expect(exitCode).toBe(1);
+});
+
+// Resolving a folder dependency appends "/package.json" and a NUL to its absolute path in a
+// path buffer (4096 bytes on Linux, 1024 on macOS). The absolute path itself is checked
+// against the buffer when package.json is parsed, but the appended bytes were not, so a
+// folder path within 13 bytes of the buffer size aborted the install. Windows' buffer is
+// larger than any path the OS accepts, so the boundary cannot be reached there.
+describe.skipIf(isWindows)("file: dependency whose package.json path is around the path buffer size", () => {
+  const PATH_BUFFER_BYTES = isLinux ? 4096 : 1024;
+
+  // A relative path of exactly `bytes` bytes made of one letter directory names, so that a
+  // path which fits the buffer is rejected by the OS as missing, not as too long.
+  function pathOfLength(bytes: number) {
+    const tail = bytes % 2 === 0 ? "dd" : "d";
+    return Buffer.alloc(bytes - tail.length, "d/").toString() + tail;
+  }
+
+  // `packageJsonPathBytes` is the length of `<project>/<folder>/package.json`.
+  async function installFolderDependency(projectDir: string, packageJsonPathBytes: number) {
+    const folder = pathOfLength(
+      packageJsonPathBytes - Buffer.byteLength(projectDir) - "/".length - "/package.json".length,
+    );
+    await writeFile(
+      join(projectDir, "package.json"),
+      JSON.stringify({ name: "my-app", dependencies: { dep: `file:./${folder}` } }),
+    );
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { folder, err, exitCode };
+  }
+
+  it("is looked up on disk when the path and its NUL terminator fit", async () => {
+    using dir = tempDir("file-dep-path-buffer-fits", {});
+
+    const { folder, err, exitCode } = await installFolderDependency(String(dir), PATH_BUFFER_BYTES - 1);
+
+    expect(err).toContain(`error: Could not find package.json for "file:${folder}"`);
+    expect(exitCode).toBe(1);
+  });
+
+  it.each([
+    ["exactly the buffer size, leaving no room for the NUL terminator", 0],
+    // The folder path alone fits; "/package.json" is what does not.
+    ['longer than the buffer by less than the appended "/package.json"', 8],
+  ])("fails with ENAMETOOLONG when it is %s", async (_, extraBytes) => {
+    using dir = tempDir("file-dep-path-buffer-overflow", {});
+
+    const { err, exitCode } = await installFolderDependency(String(dir), PATH_BUFFER_BYTES + extraBytes);
+
+    expect(err).toContain("error: ENAMETOOLONG");
+    expect(exitCode).toBe(1);
+  });
 });
 
 for (const field of ["resolutions", "overrides"]) {

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -1,5 +1,5 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { access, mkdir, writeFile } from "fs/promises";
 import {
   bunExe,
@@ -470,4 +470,87 @@ it("should link dependency without crashing", async () => {
 
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
+});
+
+// A `link:` target is normalized and joined onto the global link directory in
+// fixed-size buffers (the normalizer's is 1024 bytes, the others are a path
+// buffer). These used to be written without a length check, so a long enough
+// specifier aborted `bun install` instead of failing the dependency.
+describe("link: specifier longer than the path buffers", () => {
+  // Longer than every buffer on every platform (the Windows path buffer is ~96 KiB).
+  const LONG_SPEC_BYTES = 100_000;
+
+  async function run(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  it("fails to resolve a name that does not fit", async () => {
+    const target = Buffer.alloc(LONG_SPEC_BYTES, "n").toString();
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: `link:${target}` } }),
+    );
+
+    const { err, exitCode } = await run(package_dir, "install");
+
+    expect(err).toContain("error: ENAMETOOLONG");
+    expect(err).toContain("error: bar@link:" + target.slice(0, 64));
+    expect(exitCode).toBe(1);
+  });
+
+  // `x/../` segments normalize away, so this resolves to the linked package, but
+  // the specifier itself (which is what gets linked) is still too long for a path.
+  it("fails to install a linked package whose specifier only fits once normalized", async () => {
+    const link_name = basename(link_dir).slice("bun-link.".length);
+    await writeFile(join(link_dir, "package.json"), JSON.stringify({ name: link_name, version: "0.0.1" }));
+    const registered = await run(link_dir, "link");
+    expect(registered.err).toBe("");
+    expect(registered.out).toContain(`Success! Registered "${link_name}"`);
+    expect(registered.exitCode).toBe(0);
+
+    try {
+      const target = Buffer.alloc(LONG_SPEC_BYTES, "x/../").toString() + link_name;
+      await writeFile(
+        join(package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { [link_name]: `link:${target}` } }),
+      );
+
+      const { out, err, exitCode } = await run(package_dir, "install");
+
+      expect(err).toContain(`ENAMETOOLONG: link path for package ${link_name} is too long`);
+      expect(out).toContain("Failed to install 1 package");
+      expect(await file(join(package_dir, "node_modules", link_name, "package.json")).exists()).toBe(false);
+      expect(exitCode).toBe(1);
+    } finally {
+      await run(link_dir, "unlink");
+    }
+  });
+
+  it("still resolves a specifier that normalizes to a linked package", async () => {
+    const link_name = basename(link_dir).slice("bun-link.".length);
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+        dependencies: { [link_name]: "link:" + Buffer.alloc(LONG_SPEC_BYTES, "x/../").toString() + link_name },
+      }),
+    );
+
+    // Nothing is registered under this name: resolution gets as far as looking
+    // the name up in the link directory, like `link:${link_name}` would.
+    const { err, exitCode } = await run(package_dir, "install");
+
+    expect(err).toContain(`error: Package "${link_name}" is not linked`);
+    expect(err).not.toContain("ENAMETOOLONG");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -529,6 +529,9 @@ describe("link: specifier longer than the path buffers", () => {
       expect(out).toContain("Failed to install 1 package");
       expect(await file(join(package_dir, "node_modules", link_name, "package.json")).exists()).toBe(false);
       expect(exitCode).toBe(1);
+
+      // Like the other per-package failures, the error respects --silent.
+      expect(await run(package_dir, "install", "--silent")).toEqual({ out: "", err: "", exitCode: 1 });
     } finally {
       await run(link_dir, "unlink");
     }

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -512,11 +512,12 @@ describe("link: specifier longer than the path buffers", () => {
     const link_name = basename(link_dir).slice("bun-link.".length);
     await writeFile(join(link_dir, "package.json"), JSON.stringify({ name: link_name, version: "0.0.1" }));
     const registered = await run(link_dir, "link");
-    expect(registered.err).toBe("");
-    expect(registered.out).toContain(`Success! Registered "${link_name}"`);
-    expect(registered.exitCode).toBe(0);
-
+    let unlinked: Awaited<ReturnType<typeof run>>;
     try {
+      expect(registered.err).toBe("");
+      expect(registered.out).toContain(`Success! Registered "${link_name}"`);
+      expect(registered.exitCode).toBe(0);
+
       const target = Buffer.alloc(LONG_SPEC_BYTES, "x/../").toString() + link_name;
       await writeFile(
         join(package_dir, "package.json"),
@@ -533,8 +534,12 @@ describe("link: specifier longer than the path buffers", () => {
       // Like the other per-package failures, the error respects --silent.
       expect(await run(package_dir, "install", "--silent")).toEqual({ out: "", err: "", exitCode: 1 });
     } finally {
-      await run(link_dir, "unlink");
+      // Runs whether or not the assertions above passed; checked below so that a
+      // failure above is the one reported.
+      unlinked = await run(link_dir, "unlink");
     }
+    expect(unlinked.out).toContain(`success: unlinked package "${link_name}"`);
+    expect(unlinked.exitCode).toBe(0);
   });
 
   it("still resolves a specifier that normalizes to a linked package", async () => {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -591,6 +591,7 @@ describe("workspace aliases", async () => {
       const err = await stderr.text();
       if (version === "workspace:@org/b") {
         expect(err).toContain('Workspace dependency "a1" not found');
+        expect(err).toMatch(/Searched in "\.[\\/]packages[\\/]pkg1[\\/]@org[\\/]b"/);
       } else {
         expect(err).toContain(`No matching version for workspace dependency "a1". Version: "${version}"`);
       }


### PR DESCRIPTION
### Problem
- `bun install` aborts on two more package.json values that are longer than bun's fixed path buffers (4096 bytes on Linux, 1024 on macOS, 32767 * 3 + 1 on Windows). Both are pre-existing in 1.4.0; the sibling `workspace:` and local `.tgz` cases are fixed by #37462 and are not touched here.
- `"x": "link:<name>"`, `src/install/resolvers/folder_resolver.rs`, `normalize_package_json_path`, three overflows in one function:
  - the name is normalized through the 1024 byte thread-local scratch of `normalize_string`, so any name over 1024 bytes aborts: `panic: range end index 1025 out of range for slice of length 1024`
  - `"/package.json"` and the NUL terminator are appended to the absolute path without a length check. This one is also reachable with a `file:` dependency: the folder path itself is length-checked when package.json is parsed (`lockfile/Package.rs`), the 13 appended bytes are not, so a folder whose absolute path is within 13 bytes of the buffer size aborts: `panic: range end index 4104 out of range for slice of length 4096`, or `panic: index out of bounds: the len is 4096 but the index is 4096` for the NUL
  - `get_or_put` copies the name as written into a stack `PathBuffer` before reading the target's package.json, so a name that only fits once normalized (`x/../x/../.../foo`) aborts after resolving: `panic: range end index 100003 out of range for slice of length 4096`
- Once the resolver accepts such a name, the hoisted installer (`src/install/PackageInstaller.rs`, `Symlink` arm of `install_package_with_name_and_resolution`) concatenates the global link directory and the name into `folder_path_buf` without a length check: `panic: range end index 5063 out of range for slice of length 4096`.
- `"patchedDependencies": { "x@1.0.0": "patches/<long>.patch" }`, `src/install/patch_install.rs`: `calc_hash` (on a thread pool worker, for every entry, whether or not `x` is a dependency) and `apply` join the path onto the project directory with `join_z_buf` into a `PathBuffer`: `panic: range end index 5033 out of range for slice of length 4094`.

### Fix
- `normalize_package_json_path` returns `None` when the package.json path does not fit: the name is normalized with `normalize_string_spill` (heap when longer than the scratch), the `.`-prefixed branch joins with `abs_buf_checked`, the other branch computes the length up front, and the last byte of the buffer is reserved for the NUL. `get_or_put` maps `None` to `Error::Sys(ENAMETOOLONG)`, which prints exactly what the OS-rejected case already prints (`error: ENAMETOOLONG` ... `x@link:... failed to resolve`, exit 1). The `Searched in` formatter now builds its `./`-prefixed message by appending the relative path to an owned buffer (instead of writing the prefix in front of the path buffer through a pointer cast) and prints the value as written when it does not fit; its output is unchanged and `bun-workspaces.test.ts` now asserts it.
- The resolver's copy of the name moves to a `Box<[u8]>`. The copy is still needed (the slice can point into the lockfile string buffer, which reading the target's package.json grows), it just no longer has a fixed size.
- The hoisted installer checks the concatenated length and fails the package (`ENAMETOOLONG: link path for package foo is too long`, `Failed to install 1 package`, exit 1; nothing is printed under `--silent`), the same way the `Folder` arm above it fails an over-long folder path. Such a target could never be linked anyway: `symlink(2)` rejects targets longer than PATH_MAX.
- The patch tasks join with `join_z_buf_spill`, so the path is built on the heap when it does not fit and the OS rejects it. `calc_hash`'s non-ENOENT stat failure used to add a warning saying the patch file is empty (never printed, the main thread then printed a generic "Failed to calculate hash"); it now adds an error with the errno: `error: failed to read patch file: ENAMETOOLONG: /proj/patches/ppp...patch: File name too long (stat())`, exit 1 as before.
- `FileSystem::normalize` in `src/resolver/lib.rs` was the only remaining wrapper around the 1024 byte scratch and has no callers left, so it is removed. The other two direct `normalize_string` callers outside `bun_paths` (`run_command.rs`, Windows only, and the shell's `rm`) have their own open PRs (#37528, #37521).
- Tests, each of which aborts on the unfixed build (`USE_SYSTEM_BUN=1`) and passes with `bun bd test`:
  - `test/cli/install/bun-link.test.ts`: a 100 kB `link:` name fails with `ENAMETOOLONG`; a 100 kB `x/../` name that normalizes to a registered link resolves and then fails in the installer (and fails quietly with `--silent`); the same name for an unregistered package fails with the usual `Package "..." is not linked` (pins that a long name goes through normal resolution)
  - `test/cli/install/bun-install.test.ts` (POSIX): a `file:` dependency whose package.json path is exactly the buffer size, or longer by less than `"/package.json"`, fails with `ENAMETOOLONG`; one byte below the buffer size it is still looked up on disk (`Could not find package.json`), which passes before and after and pins the boundary
  - `test/cli/install/bun-install-patch.test.ts`: a 100 kB patch path fails with the error above (the errno assertion is skipped on Windows, which may report the path as missing instead)
- Also run: the whole of `bun-install-patch.test.ts`, `bad-workspace.test.ts` and `bun-workspaces.test.ts`, and the `file:` tests of `bun-install.test.ts`, all green. `bun-link.test.ts`'s "should link dependency without crashing" fails on main with a debug build independently of this change (the debug-only stack dump on install failure lands in stdout, see #37335). `cargo check -p bun_install` passes for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`; clippy is clean.

### Not in this PR
- `--linker isolated` has its own copy of the installer overflow: `isolated_install/Installer.rs` `append_store_path` appends the link name into a length-assuming path (`panic: index out of bounds: the len is 4096 but the index is 4096`). It is reachable today from a bun.lock with a long `link:` resolution and, after this PR, from a `link:` name that only fits once normalized. Reported separately; it sits in the area #37424 is changing.
- `workspace:<long path>` and `./<long>.tgz`: #37462.

### Background
- `PathBuffer` is a stack array of `MAX_PATH_BYTES` (the OS PATH_MAX) that most of the install code builds paths in. The joining helpers in `bun_paths::resolve_path` write into whatever buffer they are given and index out of bounds if the result does not fit; the `_checked` variants return `None` instead and the `_spill` variants grow a caller-provided `Vec` instead. `normalize_string` is the variant that writes into a 1024 byte thread-local buffer.
- The folder resolver (`folder_resolver.rs`) is shared by `file:` folders, `workspace:` packages and `link:` names: it builds the absolute path of the target's `package.json`, reads it and records the package. For `link:` the prefix is the global link directory (`bun link` registers packages there) and the recorded resolution is the name exactly as written, which is what the installers later symlink to.
- `patchedDependencies` are hashed on a thread pool before anything is installed (`PatchTask::calc_hash`), so the patch path is joined even when the patched package is not a dependency.

<details>
<summary>Probe: all shapes on the unfixed and fixed builds (Linux, offline)</summary>

```
unfixed (1.4.0)                                               fixed
link 300 bytes          error: ENAMETOOLONG (OS)              same
link 1025 bytes         panic ... length 1024                 error: ENAMETOOLONG
link 5000 / 100000      panic ... length 1024                 error: ENAMETOOLONG
link 100k of x/../foo   panic ... length 4096 (get_or_put)    Package "x" is not linked
  (foo registered)      panic ... length 4096 (get_or_put)    ENAMETOOLONG: link path for package foo is too long
file: pkg.json path
  = buffer - 1          Could not find package.json           same
  = buffer              panic: index out of bounds 4096       error: ENAMETOOLONG
  = buffer + 8          panic ... 4104 out of range for 4096  error: ENAMETOOLONG
patch path 300 bytes    Couldn't find patch file              same
patch path 5000 / 100k  panic ... length 4094                 error: failed to read patch file: ENAMETOOLONG: ...
workspace: not found    Searched in "./packages/x"            same
```

Rebase onto `1b88ad3`: `bun-install-patch.test.ts` had gained a `describe` block at the end of the file on main (patchedDependencies declared by a dependency), so the new block here now follows it and the harness import merges both lists. `install_package_with_name_and_resolution` had turned its `IS_PENDING_PACKAGE_INSTALL` const generic into the `is_pending_package_install` parameter, so the new Symlink check passes that, like the Folder arm next to it. No other changes.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-patch.test.ts test/cli/install/bun-install.test.ts test/cli/install/bun-link.test.ts

<!-- robobun:evidence:end -->
