### PR TITLE
fs.watch: do not panic on directories deeper than PATH_MAX in recursive watches

### DIFF
--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -45,7 +45,7 @@ use bun_paths::PathBuffer;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use bun_paths::platform;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-use bun_paths::resolve_path::{join_string_buf, join_z_buf};
+use bun_paths::resolve_path::join_z_buf_spill;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 use bun_sys::FdExt;
 use bun_sys::{self as sys, E, Fd, Tag};
@@ -589,6 +589,11 @@ pub(crate) fn watch(
 /// (inotify delivers file events on the parent dir's wd so we only need a watch
 /// per directory; kqueue needs an fd per file too). Best-effort — an unreadable
 /// subdirectory just stops that branch (matches Node).
+///
+/// A directory can sit deeper than `PATH_MAX` (anything doing relative `mkdir`s
+/// can create one), so the joined paths are spilled to the heap when they
+/// outgrow a `PathBuffer`; `open`/`inotify_add_watch` then reject them with
+/// ENAMETOOLONG, which reaches `cb` like any other per-directory failure.
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 fn walk_subtree<const DIRS_ONLY: bool>(
     abs_dir: &ZStr,
@@ -606,7 +611,9 @@ fn walk_subtree<const DIRS_ONLY: bool>(
     let _close = sys::CloseOnDrop::new(dfd);
     let mut it = sys::dir_iterator::iterate(dfd);
     let mut abs_buf = path::path_buffer_pool::get();
+    let mut abs_spill: Vec<u8> = Vec::new();
     let mut rel_buf = path::path_buffer_pool::get();
+    let mut rel_spill: Vec<u8> = Vec::new();
     loop {
         let entry = match it.next() {
             Err(_) => return,
@@ -619,12 +626,20 @@ fn walk_subtree<const DIRS_ONLY: bool>(
         }
         // The iterator caches the UTF-8 transcode and exposes it as `slice_u8()`.
         let name = entry.name.slice_u8();
-        let child_abs =
-            join_z_buf::<platform::Posix>(abs_buf.as_mut_slice(), &[abs_dir.as_bytes(), name]);
+        let child_abs = join_z_buf_spill::<platform::Posix>(
+            abs_buf.as_mut_slice(),
+            &mut abs_spill,
+            &[abs_dir.as_bytes(), name],
+        );
         let child_rel: &[u8] = if rel_dir.is_empty() {
             name
         } else {
-            join_string_buf::<platform::Posix>(rel_buf.as_mut_slice(), &[rel_dir, name])
+            join_z_buf_spill::<platform::Posix>(
+                rel_buf.as_mut_slice(),
+                &mut rel_spill,
+                &[rel_dir, name],
+            )
+            .as_bytes()
         };
         cb(child_abs, child_rel, child_is_file);
         if !child_is_file {
@@ -892,6 +907,7 @@ impl Linux {
             }
         };
         let mut path_buf = PathBuffer::uninit();
+        let mut rel_spill: Vec<u8> = Vec::new();
 
         while running.load(Ordering::Acquire) {
             // SAFETY: buf is valid for buf.0.len() bytes; fd is a plain c_int.
@@ -1083,10 +1099,14 @@ impl Linux {
                     } else if name.is_empty() {
                         owner_subpath
                     } else {
-                        join_string_buf::<platform::Posix>(
+                        // The watched directory itself fits in PATH_MAX (inotify
+                        // accepted it) but `subpath/name` need not.
+                        join_z_buf_spill::<platform::Posix>(
                             path_buf.as_mut_slice(),
+                            &mut rel_spill,
                             &[owner_subpath, name],
                         )
+                        .as_bytes()
                     };
 
                     // SAFETY: owner_watcher live under manager.mutex; `emit` takes `&self`.
@@ -1111,8 +1131,10 @@ impl Linux {
                         && !name.is_empty()
                     {
                         let mut abs_buf = path::path_buffer_pool::get();
-                        let child_abs = join_z_buf::<platform::Posix>(
+                        let mut abs_spill: Vec<u8> = Vec::new();
+                        let child_abs = join_z_buf_spill::<platform::Posix>(
                             abs_buf.as_mut_slice(),
+                            &mut abs_spill,
                             &[watcher_path, owner_subpath, name],
                         );
                         // Borrowck: `rel` may borrow `path_buf`,

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -588,12 +588,8 @@ pub(crate) fn watch(
 /// subdirectories. When `dirs_only`, non-directory entries are skipped entirely
 /// (inotify delivers file events on the parent dir's wd so we only need a watch
 /// per directory; kqueue needs an fd per file too). Best-effort — an unreadable
-/// subdirectory just stops that branch (matches Node).
-///
-/// A directory can sit deeper than `PATH_MAX` (anything doing relative `mkdir`s
-/// can create one), so the joined paths are spilled to the heap when they
-/// outgrow a `PathBuffer`; `open`/`inotify_add_watch` then reject them with
-/// ENAMETOOLONG, which reaches `cb` like any other per-directory failure.
+/// subdirectory, or one deeper than `PATH_MAX` (its joined path spills past the
+/// `PathBuffer`), just stops that branch (matches Node).
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 fn walk_subtree<const DIRS_ONLY: bool>(
     abs_dir: &ZStr,
@@ -1099,8 +1095,6 @@ impl Linux {
                     } else if name.is_empty() {
                         owner_subpath
                     } else {
-                        // The watched directory itself fits in PATH_MAX (inotify
-                        // accepted it) but `subpath/name` need not.
                         join_z_buf_spill::<platform::Posix>(
                             path_buf.as_mut_slice(),
                             &mut rel_spill,

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -588,8 +588,7 @@ pub(crate) fn watch(
 /// subdirectories. When `dirs_only`, non-directory entries are skipped entirely
 /// (inotify delivers file events on the parent dir's wd so we only need a watch
 /// per directory; kqueue needs an fd per file too). Best-effort — an unreadable
-/// subdirectory, or one deeper than `PATH_MAX` (its joined path spills past the
-/// `PathBuffer`), just stops that branch (matches Node).
+/// subdirectory just stops that branch (matches Node).
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 fn walk_subtree<const DIRS_ONLY: bool>(
     abs_dir: &ZStr,

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -834,6 +834,125 @@ describe("fs.watch", () => {
       }
     },
   );
+
+  // A directory can sit deeper than PATH_MAX: every component is legal, it just
+  // has to be created relative to a cwd that is itself below the limit. The
+  // recursive walk used to join such an entry's path into a fixed PATH_MAX
+  // buffer and abort the process with a bounds panic, both during the initial
+  // walk inside fs.watch() and later on the inotify reader thread when an entry
+  // appeared under a watched directory that is close to the limit. inotify
+  // cannot watch a path that long (ENAMETOOLONG), so that subtree is reported
+  // through the 'error' event like any other registration failure; events whose
+  // relative path exceeds PATH_MAX are still delivered and the rest of the tree
+  // stays watched. Runs in a subprocess because the unfixed behavior is an abort.
+  test.skipIf(!isLinux)("recursive watch survives directories deeper than PATH_MAX", async () => {
+    const PATH_MAX = 4096;
+    // Absolute length of the deepest directory inotify can still watch. Any
+    // entry inside it (names below are NAME_MAX bytes) ends up beyond PATH_MAX.
+    const deepLength = PATH_MAX - 16;
+    const existingDir = Buffer.alloc(255, "e").toString();
+    const createdDir = Buffer.alloc(255, "d").toString();
+    const createdFile = Buffer.alloc(255, "f").toString();
+
+    using dir = tempDir("fs-watch-deeper-than-path-max", {});
+
+    const fixture = /* js */ `
+      const fs = require("fs"), path = require("path");
+      const deepLength = ${deepLength};
+      const existingDir = ${JSON.stringify(existingDir)};
+      const createdDir = ${JSON.stringify(createdDir)};
+      const createdFile = ${JSON.stringify(createdFile)};
+      const root = fs.realpathSync(process.env.WATCH_ROOT);
+
+      // root/ccc…/ccc…/ppp… with an absolute length of exactly deepLength.
+      process.chdir(root);
+      const segment = Buffer.alloc(200, "c").toString();
+      let length = root.length;
+      while (deepLength - length > 1 + 255) {
+        fs.mkdirSync(segment);
+        process.chdir(segment);
+        length += 1 + segment.length;
+      }
+      const last = Buffer.alloc(deepLength - length - 1, "p").toString();
+      fs.mkdirSync(last);
+      process.chdir(last);
+      const deep = process.cwd();
+      const deepRel = path.relative(root, deep);
+      // Exists before the watch starts, so the initial walk meets it.
+      fs.mkdirSync(existingDir);
+      process.chdir(root);
+
+      const events = [], errors = [], waiters = [];
+      const settle = () => {
+        for (const waiter of waiters.splice(0)) {
+          if (waiter.ready()) waiter.resolve();
+          else waiters.push(waiter);
+        }
+      };
+      const until = ready => new Promise(resolve => { waiters.push({ ready, resolve }); settle(); });
+      const delivered = name => () => events.some(event => event.name === name);
+
+      const watcher = fs.watch(root, { recursive: true }, (type, name) => {
+        events.push({ type, name });
+        settle();
+      });
+      watcher.on("error", error => {
+        errors.push({ code: error.code, syscall: error.syscall, path: error.path });
+        settle();
+      });
+
+      const deadline = setTimeout(() => {
+        console.log(JSON.stringify({
+          timedOut: true,
+          errors,
+          events: events.map(event => [event.type, String(event.name).length]),
+        }));
+        process.exit(1);
+      }, 4000);
+
+      (async () => {
+        await until(() => errors.length === 1);
+
+        // Created under a running watch: the absolute path is beyond PATH_MAX
+        // (reported), and so is the relative path (delivered).
+        process.chdir(deep);
+        fs.mkdirSync(createdDir);
+        process.chdir(root);
+        await until(() => errors.length === 2);
+        await until(delivered(path.join(deepRel, createdDir)));
+
+        // Nothing to register for a file; only its relative path is over the limit.
+        process.chdir(deep);
+        fs.writeFileSync(createdFile, "x");
+        process.chdir(root);
+        await until(delivered(path.join(deepRel, createdFile)));
+
+        fs.writeFileSync(path.join(root, "shallow.txt"), "x");
+        await until(delivered("shallow.txt"));
+
+        clearTimeout(deadline);
+        watcher.close();
+        console.log(JSON.stringify({ deep, relativeLength: path.join(deepRel, createdFile).length, errors }));
+      })();
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, WATCH_ROOT: String(dir) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result.deep).toHaveLength(deepLength);
+    expect(result.relativeLength).toBeGreaterThan(PATH_MAX);
+    expect(result.errors).toEqual([
+      { code: "ENAMETOOLONG", syscall: "watch", path: `${result.deep}/${existingDir}` },
+      { code: "ENAMETOOLONG", syscall: "watch", path: `${result.deep}/${createdDir}` },
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("fs.promises.watch", () => {

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -4,6 +4,8 @@ import {
   bunExe,
   bunRun,
   bunRunAsScript,
+  isASAN,
+  isDebug,
   isLinux,
   isMacOS,
   isWindows,
@@ -853,6 +855,10 @@ describe("fs.watch", () => {
     const existingDir = Buffer.alloc(255, "e").toString();
     const createdDir = Buffer.alloc(255, "d").toString();
     const createdFile = Buffer.alloc(255, "f").toString();
+    // Only there to dump what did arrive when an event goes missing; the whole
+    // scenario takes about a second under ASAN, and CI's per-test timeout is
+    // well above this.
+    const deadlineMs = isASAN || isDebug ? 30_000 : 10_000;
 
     using dir = tempDir("fs-watch-deeper-than-path-max", {});
 
@@ -908,7 +914,7 @@ describe("fs.watch", () => {
           events: events.map(event => [event.type, String(event.name).length]),
         }));
         process.exit(1);
-      }, 4000);
+      }, ${deadlineMs});
 
       (async () => {
         await until(() => errors.length === 1);


### PR DESCRIPTION
### Problem
- `fs.watch(dir, { recursive: true })` aborts the whole process when any directory under `dir` has an absolute path longer than PATH_MAX: `panic: range end index 4213 out of range for slice of length 4094`, exit code 134. Node watches the same tree without complaint.
- Such directories are easy to create: every component is legal, they only have to be made with a relative `mkdir` from a cwd that is itself below the limit (extracted archives, uploads directories, nested package contents).
- Cause: the recursive walk joins each entry's path into a fixed `PathBuffer` (`MAX_PATH_BYTES`, 4096 on Linux) with `join_z_buf` / `join_string_buf`, which index out of bounds when the result does not fit. Three sites in `src/runtime/node/path_watcher.rs`:
  - `walk_subtree` (absolute and relative joins), hit during the initial walk inside `fs.watch()` on Linux and FreeBSD.
  - the inotify reader thread's `subpath/name` join for the event's relative path: the watched directory fits in PATH_MAX, but `subpath` plus a 255 byte name need not, so creating a file in a watched directory close to the limit also aborted.
  - the reader thread's `watcher_path/subpath/name` join used to register a directory created under a running watch.

### Fix
- Use `join_z_buf_spill` at all three sites: the pooled buffer is used as before, and a `Vec` is only filled in when the joined path does not fit. This is the same helper `readdir({ recursive: true })` already uses for the same situation.
- No new policy is needed once the join cannot panic: `open`/`inotify_add_watch` reject the over-long path with ENAMETOOLONG, which goes through the existing 'error' event for subtree registration failures (#36415), events whose relative path exceeds PATH_MAX are delivered with the full relative path, and the rest of the tree stays watched. Relative paths that did fit before are byte for byte unchanged (same normalization, the extra NUL lands inside the buffer).
- Test: `test/js/node/watch/fs.watch.test.ts` ("recursive watch survives directories deeper than PATH_MAX"). It builds a tree whose deepest watchable directory is exactly 4080 bytes, puts a 255 byte directory in it before watching, then creates another directory and a file there while watching, and checks the two ENAMETOOLONG error events, the over-long relative event paths, and that a shallow write is still delivered. Fails on the current release with the panic above, passes with this change.
- `bun bd test test/js/node/watch/` (61 pass) and the ported `test-fs-watch-recursive-*.js` / `test-fs-watch-ignore-recursive-*.js` node tests pass against the debug build.

### Background
- PATH_MAX (4096 on Linux, 1024 on FreeBSD/macOS) bounds the length of a path string a single syscall accepts; it does not bound how deep a directory tree can be, since paths can be built up relative to the cwd or a directory fd. Such entries can be listed from their parent, but any path based syscall on them fails with ENAMETOOLONG.
- `PathBuffer` is bun's `[u8; MAX_PATH_BYTES]` scratch buffer for path syscalls; `join_z_buf` writes a normalized, NUL terminated join of its parts into one, and `join_z_buf_spill` is the variant that falls back to a caller provided `Vec` when the result would not fit.
- The recursive watcher on Linux holds one inotify watch per directory. The initial walk registers every existing directory; when a directory is created later, the reader thread registers it and walks it to pick up anything created before the watch attached. A registration failure is delivered to JS as an 'error' event on the FSWatcher without closing it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/watch/fs.watch.test.ts

<!-- robobun:evidence:end -->