### PR TITLE
s3: stage simple-request results through the task pointer instead of a &mut self receiver

### DIFF
--- a/src/http/Signals.rs
+++ b/src/http/Signals.rs
@@ -102,7 +102,10 @@ impl Default for Store {
 }
 
 impl Store {
-    pub fn to(&mut self) -> Signals {
+    /// The flags' addresses, for the HTTP thread. `&self` on purpose: the owner keeps storing
+    /// into the flags (abort) while the HTTP thread holds these, so they must not descend from
+    /// an exclusive borrow of the store.
+    pub fn to(&self) -> Signals {
         Signals {
             header_progress: Some(NonNull::from(&self.header_progress)),
             response_body_streaming: Some(NonNull::from(&self.response_body_streaming)),
@@ -112,7 +115,7 @@ impl Store {
         }
     }
 
-    pub fn to_with_backpressure(&mut self) -> Signals {
+    pub fn to_with_backpressure(&self) -> Signals {
         Signals {
             body_receive_mode: Some(NonNull::from(&self.body_receive_mode)),
             ..self.to()

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -413,40 +413,48 @@ impl S3HttpSimpleTask {
         Ok(())
     }
 
-    fn stage_http_result(
-        &mut self,
+    /// Stores one result callback's payload on the task (HTTP thread). Takes the task as a
+    /// pointer because `stop_for_vm_teardown` may run on the JS thread at any point during
+    /// the call (test/internal/source-lints/s3-task-http-field.test.ts).
+    ///
+    /// # Safety
+    /// `this` is the live task this callback was registered with, and `stop_for_vm_teardown`
+    /// is the only thing that may touch it concurrently; `async_http` is the HTTP thread's
+    /// initialised copy of the request, live for the duration of the call.
+    unsafe fn stage_http_result(
+        this: *mut Self,
         async_http: *mut AsyncHTTP<'static>,
         mut result: HTTPClientResult<'_>,
     ) {
-        let previous_metadata = self.result.metadata.take();
-        result.body_into(&mut self.response_buffer.list);
-        // SAFETY: `result.body` (the only borrowed field) points at `self.response_buffer`,
-        // which lives for the task's lifetime — extending to `'static` here is sound for
-        // self-reference.
-        self.result = unsafe { result.detach_lifetime() };
-        if self.result.metadata.is_none() {
-            self.result.metadata = previous_metadata;
+        // SAFETY: fn contract. Every reference formed below covers one of `result`,
+        // `response_buffer` and `http` for one statement; `stop_for_vm_teardown` touches only
+        // `signal_store` and `async_http_id`. `detach_lifetime`: the stored result's `body` is
+        // never read; its bytes were just moved into `response_buffer`.
+        unsafe {
+            let previous_metadata = (*this).result.metadata.take();
+            result.body_into(&mut (*this).response_buffer.list);
+            (*this).result = result.detach_lifetime();
+            if (*this).result.metadata.is_none() {
+                (*this).result.metadata = previous_metadata;
+            }
+            // `AsyncHTTP` transitively owns Drop types (`HTTPClient`, header `EntryList`s), so
+            // a plain `=` here would (a) drop the old `http`, freeing heap buffers that
+            // `*async_http` (a bitwise clone created by the HTTP thread) still aliases, and
+            // (b) leave the http-thread side to drop them again → double-free. We instead
+            // write through `MaybeUninit` to suppress the LHS drop, doing a bitwise struct
+            // overwrite with no destructor on either side. Ownership of the inner heap data
+            // conceptually transfers here; the http-thread side must free only its outer
+            // allocation (TrivialDeinit).
+            core::ptr::write((*this).http.as_mut_ptr(), core::ptr::read(async_http));
         }
-        // `AsyncHTTP` transitively owns Drop types (`HTTPClient`, header
-        // `EntryList`s), so a plain `=` here would (a) drop the old `self.http`, freeing heap
-        // buffers that `*async_http` (a bitwise clone created by the HTTP thread) still
-        // aliases, and (b) leave the http-thread side to drop them again → double-free. We
-        // instead write through `MaybeUninit` to suppress the LHS drop, doing a bitwise struct
-        // overwrite with no destructor on either side. Ownership of the inner heap data
-        // conceptually transfers here; the http-thread side must free only its outer
-        // allocation (TrivialDeinit).
-        // SAFETY: `async_http` is a valid live pointer for the duration of this callback;
-        // `self.http` was initialised in `Self::schedule`, and nothing reads it on the JS
-        // thread while the request is in flight.
-        unsafe { core::ptr::write(self.http.as_mut_ptr(), core::ptr::read(async_http)) };
     }
 
     /// this is the AsyncHTTP callback and is always called from the HTTPThread
     ///
     /// # Safety
-    /// `this` must be a live heap pointer produced by `S3HttpSimpleTask::new` and exclusively
-    /// owned by the HTTP thread for the duration of this call. `async_http` must be a valid
-    /// pointer to an initialised `AsyncHTTP` for the duration of this call.
+    /// `this` must be the live task from `S3HttpSimpleTask::new` this callback was registered
+    /// with, which only the JS thread's `stop_for_vm_teardown` may touch concurrently;
+    /// `async_http` must point to an initialised `AsyncHTTP` for the duration of this call.
     //
     // `HTTPClientResultCallback` entrypoint: invoked by the HTTP thread with the raw task and
     // request pointers it captured at schedule time, both non-null by construction.
@@ -457,13 +465,13 @@ impl S3HttpSimpleTask {
         result: HTTPClientResult<'_>,
     ) {
         let is_done = !result.has_more;
-        // SAFETY: `this` was produced by `S3HttpSimpleTask::new` and is exclusively owned
-        // by the HTTP thread until the handoff below; this borrow is scoped to the call.
-        unsafe { (*this).stage_http_result(async_http, result) };
+        // SAFETY: fn contract, which is `stage_http_result`'s contract.
+        unsafe { Self::stage_http_result(this, async_http, result) };
         if is_done {
-            // SAFETY: same exclusivity as above; the queue takes ownership of the inline
-            // `concurrent_task` field's `next` link. The VM waits for its S3 requests
-            // (embedded work) before closing its handle: always queued.
+            // SAFETY: fn contract; `stop_for_vm_teardown` touches neither field used here.
+            // The queue takes ownership of the inline `concurrent_task` field's `next` link.
+            // The VM waits for its S3 requests (embedded work) before closing its handle:
+            // always queued.
             unsafe {
                 let handle = (*this).loop_handle.clone();
                 let queued = core::ptr::NonNull::from(

--- a/test/internal/source-lints/s3-task-http-field.test.ts
+++ b/test/internal/source-lints/s3-task-http-field.test.ts
@@ -25,6 +25,24 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //     handed the task back.
 // Any other access (a new JS-thread abort/resume path, a caller in client.rs
 // or multipart.rs) fails here; route it through `async_http_id` instead.
+//
+// The same window has a second rule, checked below for `S3HttpSimpleTask`: the
+// functions that run on the task while it is out (IN_FLIGHT_FNS) take it as a
+// raw pointer and borrow one field per statement, never as `&mut self`. While
+// the HTTP thread is inside one of them, the JS thread's `stop_for_vm_teardown`
+// (VM teardown, and the sweep between files under `bun test`) may store into
+// the task's `signal_store`; a `&mut self` argument is a protected exclusive
+// borrow of the whole task, atomics included, for the duration of the call, so
+// that store is undefined behaviour under Tree Borrows (the model `bun run
+// rust:miri` uses: "protected tags must never be Disabled") and Stacked
+// Borrows alike, and rustc passes the same claim to LLVM as `noalias`.
+// `http_callback` additionally returns only after the post that lets the JS
+// thread free the task. The simple task's other methods (`error_with_body`,
+// `fail_if_contains_error`, `release_portable`, `Drop`) run from `on_response`,
+// after the hand-back, and keep their receivers, hence a list rather than a
+// ban on every receiver in the file. The streaming task is not listed: it has
+// no after-the-hand-back phase (chunks are delivered while more arrive), so the
+// rule there is every method of the type, which is a different check.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const S3_DIR = "src/runtime/webcore/s3/";
@@ -58,9 +76,48 @@ const ALLOWED: Record<string, readonly string[]> = {
   [`${S3_DIR}download_stream.rs`]: ["schedule", "update_state", "release_portable"],
 };
 
+// file -> the functions that run on the task while it is out on the HTTP thread
+// (see the header comment); each must take the task as a raw pointer.
+const IN_FLIGHT_FNS: Record<string, readonly string[]> = {
+  [`${S3_DIR}simple_request.rs`]: ["http_callback", "stage_http_result", "release_at_shutdown", "stop_for_vm_teardown"],
+};
+
+// The first parameter of `fn <name>(..)`, up to the first `,` or `)` (a trailing
+// `()` unit type included), across rustfmt's one-parameter-per-line wrapping.
+// `(?!\w)` keeps `fn foo` from matching `fn foo_bar`.
+function firstParamPattern(fn: string): RegExp {
+  return new RegExp(String.raw`\bfn\s+${fn}(?!\w)\s*(?:<[^>]*>)?\s*\(\s*([^,()]*(?:\(\))?)`, "g");
+}
+
+// `release_at_shutdown` receives the type-erased `*mut ()`; the others `*mut Self`.
+const RAW_TASK_PARAM = /^this\s*:\s*\*\s*mut\b/;
+
+interface Declaration {
+  fn: string;
+  line: number;
+  firstParam: string;
+}
+
+function inFlightDeclarations(stripped: string, fns: readonly string[]): Declaration[] {
+  const found: Declaration[] = [];
+  for (const fn of fns) {
+    for (const m of stripped.matchAll(firstParamPattern(fn))) {
+      found.push({
+        fn,
+        line: stripped.slice(0, m.index).split("\n").length,
+        firstParam: m[1].replace(/\s+/g, " ").trim(),
+      });
+    }
+  }
+  return found;
+}
+
 const offenders: string[] = [];
 // `file::fn` for every access attributed to an ALLOWED function.
 const allowedHits = new Set<string>();
+// `file::fn` for every IN_FLIGHT_FNS declaration found, and the ones not taking a pointer.
+const inFlightDeclared: string[] = [];
+const receiverOffenders: string[] = [];
 let scanned = 0;
 for (const abs of globAllSources().rust) {
   if (!abs.endsWith(".rs")) continue;
@@ -83,6 +140,12 @@ for (const abs of globAllSources().rust) {
     }
     const line = stripped.slice(0, m.index).split("\n").length;
     offenders.push(`${source}:${line} (in fn ${fn}): ${m[0].replace(/\s+/g, "")}`);
+  }
+  for (const d of inFlightDeclarations(stripped, IN_FLIGHT_FNS[source] ?? [])) {
+    inFlightDeclared.push(`${source}::${d.fn}`);
+    if (!RAW_TASK_PARAM.test(d.firstParam)) {
+      receiverOffenders.push(`${source}:${d.line}: fn ${d.fn}(${d.firstParam}, ..)`);
+    }
   }
 }
 
@@ -136,4 +199,41 @@ test("every allowed function still touches the field", () => {
   // the real code, so the ban above cannot pass vacuously.
   const expected = Object.entries(ALLOWED).flatMap(([source, fns]) => fns.map(fn => `${source}::${fn}`));
   expect([...allowedHits].sort()).toEqual(expected.sort());
+});
+
+test("the receiver check reads the first parameter out of the spellings it claims to", () => {
+  const parsed = inFlightDeclarations(
+    [
+      // `stage_http_result` as it was, and as it is.
+      "fn stage_http_result(\n        &mut self,\n        async_http: *mut AsyncHTTP<'static>,\n    ) {",
+      "unsafe fn stage_http_result(\n        this: *mut Self,\n        async_http: *mut AsyncHTTP<'static>,\n    ) {",
+      // The other spellings of a task reference.
+      "pub(crate) fn http_callback(&self, async_http: *mut AsyncHTTP<'static>) {",
+      "pub(crate) unsafe fn release_at_shutdown(self: &mut Self) {",
+      "pub(crate) unsafe fn stop_for_vm_teardown<'a>(this: &'a mut Self) {",
+      // Type-erased is still a raw pointer.
+      "pub(crate) unsafe fn release_at_shutdown(this: *mut ()) {",
+      // Not the functions in question.
+      "fn stage_http_result_for_tests(&mut self) {}",
+    ].join("\n"),
+    IN_FLIGHT_FNS[`${S3_DIR}simple_request.rs`],
+  );
+  expect(parsed.map(d => [d.fn, d.firstParam, RAW_TASK_PARAM.test(d.firstParam)])).toEqual([
+    ["http_callback", "&self", false],
+    ["stage_http_result", "&mut self", false],
+    ["stage_http_result", "this: *mut Self", true],
+    ["release_at_shutdown", "self: &mut Self", false],
+    ["release_at_shutdown", "this: *mut ()", true],
+    ["stop_for_vm_teardown", "this: &'a mut Self", false],
+  ]);
+});
+
+test("every in-flight function is still declared under its listed name", () => {
+  // A rename would otherwise silently drop the function out of the check below.
+  const expected = Object.entries(IN_FLIGHT_FNS).flatMap(([source, fns]) => fns.map(fn => `${source}::${fn}`));
+  expect(inFlightDeclared.sort()).toEqual(expected.sort());
+});
+
+test("functions that run on an in-flight S3HttpSimpleTask take it as a raw pointer", () => {
+  expect(receiverOffenders).toEqual([]);
 });


### PR DESCRIPTION
Stacked on #38353: the base of this PR is that PR's branch, so the diff here is only this PR's own change (3 files). It lands after #38353, at which point it is rebased onto main.

### Problem

- `S3HttpSimpleTask::stage_http_result` (src/runtime/webcore/s3/simple_request.rs) is a `&mut self` method that the HTTP thread runs from `http_callback` for every result callback of a request that is still out.
- While it runs, the JS thread may run `S3HttpSimpleTask::stop_for_vm_teardown` on the same task (dispatched from `stop_active_handles`, src/runtime/jsc_hooks.rs:1819, for every request still registered: at worker `terminate()`, at `process.exit()`, and at the sweep `bun test` runs between files). With #38353 underneath, that function stores into `signal_store.aborted` and reads `async_http_id`, both fields of the task allocation.
- A `&mut self` argument is a protected exclusive borrow of the whole task for the duration of the call, interior-mutable bytes included (Background), so that store during the call is undefined behaviour under both of Rust's aliasing models, and rustc passes the same claim to LLVM as `noalias` on the argument. Miri rejects a reduction of the shape at the teardown store: Tree Borrows, `this foreign write access would cause the protected tag ... to become Disabled; protected tags must never be Disabled`, pointing at `&mut self`; Stacked Borrows, `would remove [Unique ...] which is strongly protected` (output below).
- The HTTP thread's other hold on `signal_store` has the same problem one level down: `signals::Store::to` and `to_with_backpressure` (src/http/Signals.rs) took `&mut self` to hand out the flags' addresses, so every pointer the HTTP client reads the abort flag through (`Signals`) descended from an exclusive borrow of a store the owner goes on storing into. Under Stacked Borrows the owner's later store invalidates those pointers; under Tree Borrows an unprotected `&mut` over interior-mutable bytes happens to tolerate it. This applies to all three owners of a `Store` (both S3 tasks and `FetchTasklet`).
- Natively benign today: `stage_http_result` never re-reads the flag and the `Signals` pointers are only used for atomic loads, so nothing observable goes wrong. There is no runtime repro; these are contract fixes found by analysis. The sibling findings on these task types are #38351 (the streaming task's `&mut self` methods) and #38353 (`stop_for_vm_teardown` reading `http`); this PR is the remaining piece, on top of #38353.

### Fix

- `stage_http_result` becomes `unsafe fn stage_http_result(this: *mut Self, ..)` and reaches the task through `(*this).field`, so each reference it forms covers one of `result`, `response_buffer`, `http` for one statement and the two fields teardown touches are never inside one. `http_callback` calls `Self::stage_http_result(this, ..)`. The body is otherwise the same statements in the same order (`(*this).result = ..` still drops the old value as `self.result = ..` did). This is the shape the file's other in-flight functions already have (`release_at_shutdown`, `stop_for_vm_teardown`, and `schedule` from #38353), and the tree's convention for objects another thread can touch during the call (src/CLAUDE.md, "Pointer provenance at FFI boundaries").
- The `# Safety` text of both functions is written once, against the post-#38353 state: the concurrent toucher is `stop_for_vm_teardown`, and what it touches is `signal_store` and `async_http_id`. That set is checkable by listing who holds a pointer to a live task: the HTTP callback context (HTTP thread), the active-handle registry (read only by `stop_active_handles`), and the task queue, which receives the task only from the final callback, after the HTTP thread's last access (`on_response` runs from there, src/runtime/dispatch.rs:365, or its teardown release at :1235); `grep -rn S3HttpSimpleTask src` shows no other holder.
- `Store::to` and `to_with_backpressure` take `&self`. They only take the fields' addresses, so nothing needed the exclusive borrow; the four callers compile unchanged. This is the same class as the receiver (a reference over `signal_store` that the owner's later stores conflict with), so it rides in this PR rather than a fourth one; it has no test of its own because it changes no behaviour, and the lint below is what this PR's gate rests on.
- Considered instead, and rejected: giving `Store` its own allocation so that a `&mut` over a task never covers the flags. It would not make an in-flight `&mut self` method sound: teardown would still have to read the store's pointer out of the task, and a foreign read of bytes under a protected `&mut`, followed by the method's own writes, is undefined behaviour under the same rules as the store into them is. `http_callback` would also still have to be pointer-shaped, since its post lets the JS thread free the task before it returns. So the receiver rule is needed either way, and the extra allocation per request would buy nothing.
- Lint: instead of a new file, the S3 task lint from #38353 (`test/internal/source-lints/s3-task-http-field.test.ts`, which already scans the two task files and attributes code to functions) gains the second rule of the same window: the functions that run on an in-flight `S3HttpSimpleTask` (`http_callback`, `stage_http_result`, `release_at_shutdown`, `stop_for_vm_teardown`) must take the task as a raw pointer. It checks that the listed functions are still declared (a rename cannot drop one out silently) and its parsing against banned and allowed spellings. The simple task's post-hand-back helpers (`error_with_body`, `fail_if_contains_error`, `release_portable`, `Drop`) keep their receivers, which is why this is a list; the streaming task has no post-hand-back phase, so its rule is every method, which is #38351's lint. Against the base (#38353's source) the new rule reports exactly `simple_request.rs:416: fn stage_http_result(&mut self, ..)` and #38353's own checks still pass; with this change everything passes (verified both ways with `git stash push -- src/`).
- Verified on the debug build of this stack: the whole `test/internal/source-lints/` directory (105 tests); the credential-free S3 files (s3-connection-close, s3-storage-class, s3-requester-pays, s3-insecure, s3-list-checksum-algorithm, s3-list-encode-overflow, s3-stream-cancel-leak, s3-stream-error-gc, s3-write-to-file-sync-close, s3-argument-validation: 56 tests); the five "VM teardown ordering" tests in worker_threads.test.ts, including #38353's two, which terminate a worker with requests in flight; fetch's abort tests (fetch-abort-queued, fetch-abort-socket-close-race, fetch-abort-stream-body, abort-signal-leak, the last needing a longer timeout than 5 s on debug as on the base), since fetch is a `Store::to_with_backpressure` caller; `cargo clippy --no-deps` on `bun_http` and `bun_runtime` and rustfmt clean. The Miri reduction below passes in the fixed shape under both models; it is not committed because it would exercise a copy of the shape, which the lint pins in the real file.
- Not here: `FetchTasklet`'s HTTP-thread callback holds a function-long `&mut` over the tasklet (`from_raw_mut`, FetchTasklet.rs:2417) while `abort_task` runs on the JS thread; that type's cross-thread ownership is being reworked in #31745, with #37703 converting its release path, so it is left to those.

### Background

- Protected references: under Stacked Borrows and Tree Borrows (the model `bun run rust:miri` uses), a reference passed as a function argument is protected until the function returns. For `&mut T` that means no other access at all to the bytes it covers; Tree Borrows gives a protected `&mut` that strength even over interior-mutable bytes such as atomics (only an unprotected one relaxes them), and only a shared `&T` leaves interior-mutable bytes open to other threads. A raw pointer asserts nothing, and a reference to one field covers only that field, which is why the fixed function takes `*mut Self` and borrows per field.
- Pointers inherit from what they were made through: a raw pointer taken out of a `&mut Store` is, to the aliasing models, a child of that exclusive borrow, and an access through the original owner that conflicts with the `&mut` can invalidate the children with it (Stacked Borrows does; Tree Borrows lets an unprotected `&mut` over interior-mutable bytes survive it). Taking the addresses through `&Store` removes the exclusive link.
- `S3HttpSimpleTask`: one heap object per non-streaming S3 operation (stat, get, put, delete, list, multipart commit/part). The JS thread builds it and `schedule`s it; the HTTP thread stages each result into it and, on the final one, posts the task itself back to the JS thread, which runs `on_response`, delivers the result and frees it. While it is out it is registered as an active handle so the VM's stop phase can abort it.
- `signal_store` / `Signals`: the task-owned block of atomic flags (`aborted` among them) and the struct of pointers to them that the HTTP client carries; setting `aborted` is how the owner asks for the request to fail. The stop phase sets it on the JS thread and asks the HTTP thread to close the socket; the task comes back through the normal final callback.

<details>
<summary>Miri reduction of the receiver shape (struct with an atomic field; one thread inside the method, the other storing into the atomic during the call)</summary>

```
$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri run --bin receiver          # &mut self, as on main
error: Undefined Behavior: write access through <4352> at alloc678[0x44] is forbidden
  --> src/receiver.rs:58:9
   |
58 |         (*this).aborted.store(true, Ordering::Relaxed);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
   |
   = help: the accessed tag <4352> is foreign to the protected tag <4316> (i.e., it is not a child)
   = help: this foreign write access would cause the protected tag <4316> (currently Reserved) to become Disabled
   = help: protected tags must never be Disabled
help: the protected tag <4316> was created here, in the initial state Reserved
  --> src/receiver.rs:39:26
   |
39 |     fn stage_http_result(&mut self, async_http: *mut AsyncHttp, body: &[u8]) {
   |                          ^^^^^^^^^

$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri run --bin receiver -- fixed  # this: *mut Self, field places
ok (fixed)

$ cargo miri run --bin receiver                                         # Stacked Borrows, as on main
error: Undefined Behavior: not granting access to tag <4547> because that would remove [Unique for <4507>] which is strongly protected

$ cargo miri run --bin receiver -- fixed
ok (fixed)
```

The reduction's method does the same three kinds of access as the real one (a `Vec` append into one field, a plain field assignment, a `ptr::write` into a `MaybeUninit` field) and parks inside the call on a static flag, kept outside the struct, until the other thread has stored into the atomic.
</details>

<details>
<summary>Earlier shape of this PR</summary>

This PR first went up against main as the receiver change plus its own lint file (`s3-simple-task-raw-access.test.ts`), without the `Signals.rs` change. Review of that shape found that it conflicted with #38353 inside this very function (both rewrite its comments), that its `# Safety` text could only be complete once #38353's `http` read was gone, that a per-type lint file duplicated the scanning #38353's lint already does, and that the `Store::to(&mut self)` chain left the HTTP thread's hold on `signal_store` in the same state the PR was fixing one level up. The current shape is the result: stacked on #38353, lint folded into its file, `Signals.rs` included.
</details>

