### PR TITLE
node:vm: keep a vm SyntaxError's parse location out of the source map of the file its filename names

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -200,6 +200,7 @@ using namespace JSC;
     macro(validated) \
     macro(view) \
     macro(vmErrorDecorated) \
+    macro(vmParseError) \
     macro(warning) \
     macro(webStreamClosedPromise) \
     macro(webStreamControllerError) \

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -192,16 +192,19 @@ WTF::String formatStackTrace(
 
                 String sourceURLForFrame = err->sourceURL();
 
-                // If it's not a Zig::GlobalObject, don't bother source-mapping it.
-                if (globalObject && !sourceURLForFrame.isEmpty()) {
+                // Tagged by NodeVM::createParseError(): the URL is the filename the caller
+                // compiled its own string under, so a source map found under that name
+                // describes some other file. The parser's position stands as is, including
+                // as err.line (hasSet keeps the frame loop below from replacing it).
+                if (err->getDirect(vm, builtinNames(vm).vmParseErrorPrivateName())) {
+                    hasSet = true;
+                } else if (globalObject && !sourceURLForFrame.isEmpty()) {
                     // https://github.com/oven-sh/bun/issues/3595
-                    if (!sourceURLForFrame.isEmpty()) {
-                        remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
-                        // This ensures the lifetime of the sourceURL is accounted for correctly
-                        Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
+                    remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
+                    // This ensures the lifetime of the sourceURL is accounted for correctly
+                    Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
 
-                        sourceURLForFrame = remappedFrame.source_url.toWTFString();
-                    }
+                    sourceURLForFrame = remappedFrame.source_url.toWTFString();
                 }
 
                 // there is always a newline before each stack frame line, ensuring that the name + message
@@ -210,7 +213,7 @@ WTF::String formatStackTrace(
 
                 sb.append("    at <parse> ("_s);
 
-                sb.append(remappedFrame.source_url.toWTFString());
+                sb.append(sourceURLForFrame);
 
                 if (remappedFrame.remapped) {
                     errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(originalLine.oneBasedInt()), PropertyAttribute::DontEnum | 0);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -166,7 +166,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
             }
 
             if (actuallyValid) {
-                auto exception = error.toErrorObject(globalObject, sourceCode, -1);
+                auto exception = createParseError(globalObject, error, sourceCode);
                 // Building the error materializes its stack, running a user
                 // Error.prepareStackTrace that may throw; Node throws the
                 // SyntaxError anyway. Terminations survive tryClearException.
@@ -592,6 +592,24 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
         return true;
     }
     return false;
+}
+
+// ParserError::toErrorObject() with the error tagged as node:vm source first.
+// addErrorInfo() formats the stack before returning, and all it gives the
+// formatter is the URL the source was compiled under, which for node:vm is a
+// caller-chosen filename; the tag is what stops the formatter from remapping
+// the parse location through the source map of whatever file that name denotes.
+JSObject* createParseError(JSGlobalObject* globalObject, JSC::ParserError& parseError, JSC::SourceCode source)
+{
+    if (parseError.type() != JSC::ParserError::ErrorType::SyntaxError)
+        return parseError.toErrorObject(globalObject, source);
+
+    VM& vm = globalObject->vm();
+    auto* error = uncheckedDowncast<ErrorInstance>(createSyntaxError(globalObject, parseError.message()));
+    error->putDirect(vm, WebCore::builtinNames(vm).vmParseErrorPrivateName(), jsBoolean(true), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
+    addErrorInfo(vm, error, parseError.line(), source);
+    error->setParseError();
+    return error;
 }
 
 // Compile-time counterpart of handleException: prepends Node's arrow header

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -30,6 +30,9 @@ bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedD
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset);
 JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::SourceCode& source);
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope);
+// Every node:vm compile path turns its ParserError into an exception through
+// this rather than ParserError::toErrorObject(); see the definition.
+JSObject* createParseError(JSGlobalObject* globalObject, JSC::ParserError& parseError, JSC::SourceCode source);
 // `url` must be caller-resolved: `new Script` falls back to evalmachine.<anonymous>
 // when no filename was provided; compileFunction has no such default.
 void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* error, StringView sourceString, const String& url, const JSC::ParserError& parseError, OrdinalNumber lineOffset);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -140,7 +140,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     // via JSC::evaluate); compile-once via m_cachedExecutable is the follow-up.
     JSC::ParserError parseError;
     if (!JSC::checkSyntax(vm, source, parseError)) {
-        auto exception = parseError.toErrorObject(globalObject, source, -1);
+        auto exception = createParseError(globalObject, parseError, source);
         // Building the error materializes its stack, running a user
         // Error.prepareStackTrace that may throw; Node throws the SyntaxError
         // anyway. tryClearException leaves a termination for the check below.

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -179,7 +179,14 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         parserError);
 
     if (parserError.isValid()) {
-        throwException(globalObject, scope, parserError.toErrorObject(globalObject, m_sourceCode));
+        JSObject* exception = createParseError(globalObject, parserError, m_sourceCode);
+        // Building the error materializes its stack, running a user
+        // Error.prepareStackTrace that may throw; Node throws the SyntaxError
+        // anyway. tryClearException leaves a termination for the check below.
+        if (exception)
+            (void)scope.tryClearException();
+        RETURN_IF_EXCEPTION(scope, {});
+        throwException(globalObject, scope, exception);
         return {};
     }
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import {
   compileFunction,
   constants,
@@ -1483,4 +1483,101 @@ test("node:vm Object.defineProperty on the context global when the sandbox is an
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe(JSON.stringify({ result: 1, sandboxArray: 1 }));
   expect(exitCode).toBe(0);
+});
+
+describe("SyntaxError from compiling vm code under the filename of a file Bun transpiled", () => {
+  // Bun's source maps are keyed by filename, and the only thing a parser
+  // SyntaxError keeps of the source it came from is that filename, so the
+  // location it reports must not be looked up in the map of the file the vm
+  // code merely shares a name with. The fixture compiles vm code under its own
+  // path and under a name Bun never loaded; both must report the same thing.
+  // The fixture opens with a comment spanning PADDING lines that the transpiler
+  // strips, so every line its source map can produce is > PADDING, while the
+  // vm code's syntax error is on line 5: a remapped line can never pass for the
+  // physical one.
+  const PADDING = 20;
+  const padding = ["/*", ...Array.from({ length: PADDING - 2 }, () => " *"), " */"].join("\n") + "\n";
+  const body = String.raw`
+const vm = require("node:vm");
+const source = "\n\n\n\nlet let = 1;";
+const names = { own: __filename, other: "not-a-loaded-file.js" };
+const compile = {
+  script: name => new vm.Script(source, { filename: name }),
+  runInThisContext: name => vm.runInThisContext(source, { filename: name }),
+  runInContext: name => vm.runInContext(source, vm.createContext(), { filename: name }),
+  runInNewContext: name => vm.runInNewContext(source, {}, { filename: name }),
+  compileFunction: name => vm.compileFunction(source, [], { filename: name }),
+  sourceTextModule: name => new vm.SourceTextModule(source, { identifier: name }),
+};
+
+function thrown(fn) {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("did not throw");
+}
+
+function report(err) {
+  const lines = err.stack.split("\n");
+  return {
+    header: lines[0],
+    parseFrame: lines.find(line => line.includes("<parse>")) ?? null,
+    line: err.line,
+    originalLine: err.originalLine ?? null,
+    sourceURL: err.sourceURL ?? null,
+  };
+}
+
+const results = {};
+for (const [api, make] of Object.entries(compile)) {
+  results[api] = { own: report(thrown(() => make(names.own))), other: report(thrown(() => make(names.other))) };
+}
+console.log(JSON.stringify({ filename: __filename, results, inspected: Bun.inspect(thrown(() => compile.script(names.own))) }));
+`;
+
+  test("err.stack, err.line and Bun.inspect report the line in the vm code", async () => {
+    using dir = tempDir("vm-parse-error-own-filename", { "fixture.js": padding + body });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const { filename, results, inspected } = JSON.parse(stdout);
+
+    const asOther = (own: Record<string, unknown>) =>
+      Object.fromEntries(
+        Object.entries(own).map(([key, value]) => [
+          key,
+          typeof value === "string" ? value.replaceAll(filename, "not-a-loaded-file.js") : value,
+        ]),
+      );
+
+    // err.originalLine records the line a source map was applied to, so nothing
+    // compiled by vm gets one, whatever its name.
+    const physical = {
+      header: "not-a-loaded-file.js:5",
+      parseFrame: "    at <parse> (not-a-loaded-file.js:5)",
+      line: 5,
+      originalLine: null,
+      sourceURL: "not-a-loaded-file.js",
+    };
+    for (const api of ["script", "runInThisContext", "runInContext", "runInNewContext", "compileFunction"]) {
+      expect(asOther(results[api].own)).toEqual(physical);
+      expect(results[api].other).toEqual(physical);
+    }
+    // SourceTextModule does not yet compile under its identifier, so only the
+    // own/other equivalence is pinned for it.
+    expect(asOther(results.sourceTextModule.own)).toEqual(results.sourceTextModule.other);
+
+    // Bun.inspect (like the uncaught error printer) formats the frames of the
+    // already built stack string; it adds a column of its own, dropped here.
+    const inspectedParseFrame = inspected.split("\n").find((line: string) => line.includes("<parse>"));
+    expect(inspectedParseFrame.replace(/(:\d+)(:\d+)?\)$/, "$1)")).toEndWith(`at <parse> (${filename}:5)`);
+  });
 });


### PR DESCRIPTION
### Problem
- A SyntaxError from compiling node:vm code under a filename that Bun has loaded reports the wrong line: a script that runs `new vm.Script(src, { filename: __filename })` with `src` failing on its line 10 gets `err.line === 5` and `at <parse> (/tmp/remap_syntax_short.js:5)` in `err.stack` (5 being the line of the script that line 10 of its transpiled output maps back to; it varies with the host file), while the same source compiled under a name Bun never loaded reports 10. `err.originalLine` is set to 10. The arrow header node:vm prepends (`/tmp/remap_syntax_short.js:10` plus the source line) is right, so the error contradicts itself. Same for `vm.runInThisContext` / `runInContext` / `runInNewContext` (all built on `Script`) and `vm.compileFunction`. Repro in the details block.
- The vm code's line went through the source map of `index.js`. `formatStackTrace()` (src/jsc/bindings/FormatStackTraceForJS.cpp, the `<parse>` branch) builds a frame out of `err->sourceURL()` / `err->line()` and passes it to `Bun__remapStackFramePositions`, which is keyed by URL, and then overwrites `line` (which becomes `err.line`) with the result.
- At that point nothing else about the source is available. `ParserError::toErrorObject()` calls JSC's `addErrorInfo()`, which copies the provider's URL and the line onto the `ErrorInstance` and materializes `.stack` (running Bun's formatter) before returning the error to node:vm, so the `NodeVMScriptFetcher` that marks the provider as vm code (the signal #38344 uses for runtime frames) is not reachable from the formatter, and node:vm gets the error back only after the string has been built.
- `vm.SourceTextModule` compiles with no URL today, so its parse errors took the other path through the same branch: nothing remapped, `hasSet` stayed false, and the frame loop then published the first caller frame as the error's location (`err.line === 225`, `err.sourceURL === "node:vm"` for a parse error on line 5 of the module source).

### Fix
- `NodeVM::createParseError()` (src/jsc/bindings/NodeVM.cpp) replaces the three `toErrorObject()` calls (`new Script`, `compileFunction`, `SourceTextModule`). For a SyntaxError it does what `toErrorObject()` does (`createSyntaxError` + `addErrorInfo` + `setParseError`), but puts a private `vmParseError` property on the instance before `addErrorInfo()` runs; every other ParserError type is still delegated to `toErrorObject()`.
- The formatter's `<parse>` branch skips the remap for a tagged error and sets `hasSet`, so the frame shows `err->sourceURL()` and the parser's line, `err.line` keeps the parser's line, and no `originalLine` is written (`originalLine` means a map was applied; #38344 stops writing it for runtime frames in vm code for the same reason). Today an unloaded name gets an identity remap and `originalLine === line`; that goes away too.
- Why the tag is correct: node:vm compiles the caller's own string under a caller-chosen name, and Bun's source maps describe Bun's transpiled output of the file on disk that happens to have that name; the two share nothing but the name, so a map lookup can never apply to a vm parse location. This is the same argument #38344 makes for runtime frames; this PR covers the compile-time error, where the provider is gone and the tag is what carries the fact. Node reports the vm source's own line here (its arrow header; Node has neither `err.line` nor a `<parse>` frame), which is now also what Bun's header, `<parse>` frame and `err.line` agree on.
- Tagging the instance rather than, say, a flag set around the compile means anything that later re-formats the error (`Error.captureStackTrace`, or the error printer once it can mark string-parsed frames as vm frames) can still tell. `vmParseError` is a private symbol like node:vm's existing `vmErrorDecorated`, so it is not observable from JS.
- `createModuleRecord()` now clears an exception left by a throwing user `Error.prepareStackTrace` before throwing the SyntaxError, as `constructScript()` / `constructAnonymousFunction()` already do; without it the new test's SourceTextModule case aborts under `BUN_JSC_validateExceptionChecks=1` (which CI sets for this file on the ASAN lane). #38235 makes the same change at this site.
- Test: `test/js/node/vm/vm.test.ts`, "SyntaxError from compiling vm code under the filename of a file Bun transpiled". A fixture starting with a 20-line comment (so every line its source map can produce is > 20) compiles a source failing on line 5 under its own path and under an unloaded name through all six APIs and checks the header, `<parse>` frame, `err.line`, `err.originalLine`, `err.sourceURL` and the `<parse>` frame `Bun.inspect` prints. Fails on the released build with line 23 for the own-name cases; passes with this change, also under `BUN_JSC_validateExceptionChecks=1`.
- Also run against the debug build: the rest of `vm.test.ts`, `vm-sourceUrl.test.ts`, `test/js/bun/test/stack.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, the `test-vm-syntax-error-*`, `test-vm-module-errors`, `test-vm-source-map-url` and `test-repl-{recoverable,syntax-error-*,unexpected-token-recoverable}` node tests. `inspect-error.test.js` has two minified-file snapshot failures that are the known debug-build `require` frame, unrelated.
- Not changed: the source excerpt the error printer shows above a tagged error still comes from the file the name denotes (before this change it showed that file too, just at the remapped line). Fixing that needs the per-frame vm flag #38344 adds to `ZigStackFrame`; with it, the printer can flag the `<parse>` frame of a tagged error when it parses the stack string. Open PRs #37386 / #37432 / #36634 / #37459 edit the same `<parse>` branch for other reasons and compose with this; #38239 / #38317, which touch the `toErrorObject()` call sites, would switch to `createParseError()` on rebase.

### Background
- Source map remapping: Bun transpiles every file it loads, so positions JSC reports are in the transpiled output. `Bun__remapStackFramePositions` takes (URL, line, column) and, if Bun holds a source map for that URL, rewrites the position to the original file; `err.originalLine` is where the formatter stores the pre-remap line when it does this.
- `<parse>` frame: for a SyntaxError raised by JSC's parser there is no stack frame inside the rejected source, so Bun's `formatStackTrace()` synthesizes an `at <parse> (url:line)` line from the location `addErrorInfo()` recorded on the instance, and treats that location as the error's `line` / `sourceURL`.
- `addErrorInfo(vm, error, line, SourceCode)` (JSC `runtime/Error.cpp`): stores the source's URL and the line on the `ErrorInstance` and immediately materializes `.stack`, which invokes Bun's `computeErrorInfo` hook with only the frames, the line/column, the URL and the instance.
- node:vm's arrow header: `decorateParseErrorStack()` / `handleException()` (NodeVM.cpp) prepend Node's `url:line` + source line + caret to `.stack` after the error exists, computed from the ParserError directly, which is why it was already right.
- Private builtin names (`src/js/builtins/BunBuiltinNames.h`): per-VM private symbols C++ can use as property keys that JS code cannot name or enumerate.

<details>
<summary>Repro output on the released build</summary>

```js
// /tmp/remap_syntax_short.js
const vm = require("node:vm");
const src = "\n".repeat(9) + "let let = 1;"; // syntax error on physical line 10
for (const filename of [__filename, "not-a-loaded-file.js"]) {
  try { new vm.Script(src, { filename }); }
  catch (e) { console.log(e.line, e.originalLine, e.stack.split("\n").find(l => l.includes("<parse>"))); }
}
```

```
$ bun /tmp/remap_syntax_short.js            # 1.4.0
5 10     at <parse> (/tmp/remap_syntax_short.js:5)
10 10     at <parse> (not-a-loaded-file.js:10)

$ bun-debug /tmp/remap_syntax_short.js      # this branch
10 undefined     at <parse> (/tmp/remap_syntax_short.js:10)
10 undefined     at <parse> (not-a-loaded-file.js:10)
```

`vm.compileFunction` on the released build, same source on line 5 of the body: `line: 2, originalLine: 5, at <parse> (/tmp/remap_module.js:2)`. `new vm.SourceTextModule` on the released build, parse error on line 5: `line: 225, originalLine: 225, sourceURL: "node:vm"`; this branch: `line: 5`, no `originalLine` / `sourceURL`.

</details>
