### PR TITLE
cli: refuse to start when the cwd is longer than PATH_MAX instead of using the executable's directory

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4134,26 +4134,34 @@ pub fn getcwd(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
     Ok(ZStr::from_buf(&buf.0, len))
 }
 
-/// `getcwd` tolerating an unreachable cwd (e.g. deleted while we run): falls
-/// back to the executable's directory like Node's `Environment::GetCwd`, so
-/// startup proceeds and `process.cwd()` surfaces the real error later.
-pub fn getcwd_or_exe_dir(buf: &mut PathBuffer) -> &ZStr {
-    let len = match getcwd_len(buf) {
-        Ok(n) => n,
-        Err(_) => {
-            let dir: &[u8] = self_exe_path()
-                .ok()
-                .and_then(|p| dirname(p.as_bytes()))
-                // Reject a dir that can't fit with its NUL (paths from
-                // /proc/self/exe are not bounded by MAX_PATH_BYTES).
-                .filter(|d| d.len() < buf.0.len())
-                .unwrap_or(if cfg!(windows) { b"C:\\" } else { b"/" });
-            buf.0[..dir.len()].copy_from_slice(dir);
-            buf.0[dir.len()] = 0;
-            dir.len()
-        }
-    };
-    ZStr::from_buf(&buf.0, len)
+/// `getcwd` tolerating a cwd that was deleted while we run (`FileNotFound`):
+/// falls back to [`self_exe_dir`] like Node's `Environment::GetCwd`, so startup
+/// proceeds and `process.cwd()` surfaces the real error later.
+///
+/// Every other failure is returned. The usual one is a cwd whose path does not
+/// fit in `MAX_PATH_BYTES`: that directory exists, so resolving against any
+/// other directory would silently run that directory's files.
+pub fn getcwd_or_exe_dir(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
+    match getcwd_len(buf) {
+        Ok(len) => Ok(ZStr::from_buf(&buf.0, len)),
+        Err(crate::CrateError::FileNotFound) => Ok(self_exe_dir(buf)),
+        Err(err) => Err(err),
+    }
+}
+
+/// The directory containing the running executable (the filesystem root when
+/// it cannot be determined), written NUL-terminated into `buf`.
+pub fn self_exe_dir(buf: &mut PathBuffer) -> &ZStr {
+    let dir: &[u8] = self_exe_path()
+        .ok()
+        .and_then(|p| dirname(p.as_bytes()))
+        // Reject a dir that can't fit with its NUL (paths from
+        // /proc/self/exe are not bounded by MAX_PATH_BYTES).
+        .filter(|d| d.len() < buf.0.len())
+        .unwrap_or(if cfg!(windows) { b"C:\\" } else { b"/" });
+    buf.0[..dir.len()].copy_from_slice(dir);
+    buf.0[dir.len()] = 0;
+    ZStr::from_buf(&buf.0, dir.len())
 }
 
 /// Length-returning core of [`getcwd`]; `buf` holds the NUL-terminated path.
@@ -4165,7 +4173,14 @@ fn getcwd_len(buf: &mut PathBuffer) -> crate::CrateResult<usize> {
     unsafe {
         let p = libc::getcwd(buf.0.as_mut_ptr().cast(), buf.0.len());
         if p.is_null() {
-            return Err(crate::CrateError::Unexpected);
+            // glibc reports a cwd longer than the buffer as ERANGE; musl
+            // passes through the kernel's ENAMETOOLONG.
+            return Err(match crate::ffi::errno() {
+                libc::ENOENT => crate::CrateError::FileNotFound,
+                libc::ERANGE | libc::ENAMETOOLONG => crate::CrateError::NameTooLong,
+                libc::EACCES => crate::CrateError::AccessDenied,
+                _ => crate::CrateError::Unexpected,
+            });
         }
         Ok(libc::strlen(p))
     }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -745,6 +745,13 @@ fn replace_pid_placeholder(name: &[u8]) -> Box<[u8]> {
     out.into_boxed_slice()
 }
 
+/// The cwd was deleted or does not fit in a path buffer: the user's
+/// environment, reported as such rather than as an internal error.
+fn exit_without_cwd(err: bun_sys::Error) -> ! {
+    Output::err(err, "Could not get the current working directory", ());
+    Global::exit(1)
+}
+
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum BunCAStore {
@@ -834,8 +841,10 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         let base: &[u8] = if bun_paths::is_absolute(cwd_arg) {
             b"/"
         } else {
-            let len = bun_sys::getcwd(&mut *outbuf)?;
-            &outbuf[..len]
+            match bun_sys::getcwd(&mut *outbuf) {
+                Ok(len) => &outbuf[..len],
+                Err(err) => exit_without_cwd(err),
+            }
         };
         let out = resolve_path::join_abs::<platform::Loose>(base, cwd_arg);
         // `chdir` wants a NUL-terminated path; `join_abs` returns a borrowed
@@ -857,20 +866,30 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             Ok(p) => Box::<[u8]>::from(p.as_bytes()),
             Err(_) => Box::<[u8]>::from(out_z.as_bytes()),
         }
-    } else if matches!(
-        cmd,
-        CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::RunAsNodeCommand
-    ) {
-        // A deleted cwd must not abort the runtime (Node boots and lets
-        // `process.cwd()` throw later); fall back to the executable's dir.
-        let mut temp = PathBuffer::uninit();
-        Box::<[u8]>::from(bun_core::getcwd_or_exe_dir(&mut temp).as_bytes())
     } else {
-        // Everything else (install/test/build/...) must not silently act on
-        // whatever project happens to live above the executable.
         let mut temp = PathBuffer::uninit();
-        let len = bun_sys::getcwd(&mut *temp)?;
-        Box::<[u8]>::from(&temp[..len])
+        match bun_sys::getcwd(&mut *temp) {
+            Ok(len) => Box::<[u8]>::from(&temp[..len]),
+            // A deleted cwd must not abort the runtime (Node boots and lets
+            // `process.cwd()` throw later); fall back to the executable's dir.
+            // Only the runtime, and only for a deleted cwd: install/test/build
+            // must not act on whatever project lives above the executable, and
+            // a cwd that merely does not fit in PATH_MAX still exists, so
+            // resolving against any other directory would silently run that
+            // directory's files.
+            Err(err)
+                if err.get_errno() == bun_sys::E::ENOENT
+                    && matches!(
+                        cmd,
+                        CommandTag::AutoCommand
+                            | CommandTag::RunCommand
+                            | CommandTag::RunAsNodeCommand
+                    ) =>
+            {
+                Box::<[u8]>::from(bun_core::self_exe_dir(&mut temp).as_bytes())
+            }
+            Err(err) => exit_without_cwd(err),
+        }
     };
 
     // Not gated on .BunxCommand: bunx skips Arguments.parse entirely

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1022,7 +1022,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
             // entry_path must end with /[eval] for the transpiler to use eval_source
             let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
+            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf)?;
             let cwd_bytes = cwd.as_bytes();
             let mut eval_path: Vec<u8> = Vec::with_capacity(cwd_bytes.len() + EVAL_TRIGGER.len());
             eval_path.extend_from_slice(cwd_bytes);
@@ -2837,7 +2837,7 @@ impl RunCommand {
 
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + STDIN_TRIGGER.len()];
         let mut cwd_buf = PathBuffer::uninit();
-        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
+        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf)?;
         let cwd_bytes = cwd.as_bytes();
         let cwd_len = cwd_bytes.len();
         entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
@@ -2899,7 +2899,7 @@ impl RunCommand {
 
         let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
         let mut cwd_buf = PathBuffer::uninit();
-        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
+        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf)?;
         let cwd_bytes = cwd.as_bytes();
         let cwd_len = cwd_bytes.len();
         entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
@@ -2934,7 +2934,7 @@ impl RunCommand {
             // synthetic `[eval]` path under cwd
             let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
             let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
+            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf)?;
             let cwd_bytes = cwd.as_bytes();
             let cwd_len = cwd_bytes.len();
             entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
@@ -2968,7 +2968,7 @@ impl RunCommand {
             // platform separator) and then run the result through
             // `join_abs_string_buf::<Loose>` to collapse `.`/`..`.
             let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
+            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf)?;
             let cwd_len = cwd.as_bytes().len();
             cwd_buf[cwd_len] = b'/';
             let mut out_buf = PathBuffer::uninit();
@@ -3123,7 +3123,7 @@ impl RunCommand {
         // layout-identical newtypes over [u8; MAX_PATH_BYTES].
         let cwd = bun_core::getcwd_or_exe_dir(unsafe {
             &mut *entry_point_buf.as_mut_ptr().cast::<bun_core::PathBuffer>()
-        });
+        })?;
         let cwd_len = cwd.as_bytes().len();
         entry_point_buf[cwd_len..cwd_len + EVAL_TRIGGER.len()].copy_from_slice(EVAL_TRIGGER);
 

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
+import { mkdirSync, rmdirSync, rmSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, bunRun, isMacOS, isWindows, tempDir } from "harness";
+import { join } from "path";
 
 let cwd: string;
 
@@ -37,6 +38,87 @@ describe("bun", () => {
     expect(stdout.toString()).toBeEmpty();
     expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
+  });
+});
+
+// Windows never produces either failure: a directory in use as a cwd cannot be
+// deleted, and a cwd cannot outgrow the 32K-character buffer bun gives it.
+describe.skipIf(isWindows)("startup when getcwd fails", () => {
+  // PATH_MAX counts the trailing NUL: 4096 on Linux, 1024 on macOS.
+  const PATH_MAX = isMacOS ? 1024 : 4096;
+  const component = Buffer.alloc(200, "c").toString();
+
+  // chdir(2) only limits the length of each path argument, so a process can
+  // end up in a directory whose absolute path is longer than PATH_MAX; that
+  // directory exists and works, but getcwd(2) fails for it. Nothing can name
+  // it with an absolute path, so the test process parks itself in a directory
+  // that still comfortably has one and does everything else with relative paths.
+  function runBunFromCwdLongerThanPathMax(...args: string[]) {
+    using dir = tempDir("deep-cwd", {});
+    let reachable = String(dir);
+    while (reachable.length + 1 + component.length <= PATH_MAX - 256) {
+      reachable = join(reachable, component);
+    }
+    mkdirSync(reachable, { recursive: true });
+    const unreachable = join(component, component, component);
+    expect(reachable.length + 1 + unreachable.length).toBeGreaterThan(PATH_MAX);
+
+    const previousCwd = process.cwd();
+    process.chdir(reachable);
+    try {
+      mkdirSync(unreachable, { recursive: true });
+      writeFileSync(join(unreachable, "x.cjs"), `console.log("ran x.cjs from the deep cwd");`);
+      const { stdout, stderr, exitCode } = spawnSync({
+        cmd: [bunExe(), ...args],
+        cwd: unreachable,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+    } finally {
+      process.chdir(previousCwd);
+    }
+  }
+
+  // Before this was an error, bun silently used the directory containing its
+  // own executable instead: `bun x.cjs` here ran that directory's x.cjs and
+  // ignored this one, and `-e` resolved relative requires there.
+  test.each([
+    ["-e", ["-e", "console.log(__dirname)"]],
+    ["x.cjs", ["x.cjs"]],
+    ["run x.cjs", ["run", "x.cjs"]],
+    ["--cwd . x.cjs", ["--cwd", ".", "x.cjs"]],
+    ["test", ["test"]],
+  ])("`bun %s` refuses to start from a cwd longer than PATH_MAX", (_, args) => {
+    const { stdout, stderr, exitCode } = runBunFromCwdLongerThanPathMax(...args);
+    expect(stderr).toMatch(/^(ERANGE|ENAMETOOLONG): .*Could not get the current working directory \(getcwd\)\n$/);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  // Node boots in a deleted cwd and lets process.cwd() throw (its
+  // test-cwd-enoent tests); that is the one getcwd failure the runtime still
+  // starts through.
+  test("bun -e still starts from a deleted cwd", () => {
+    using dir = tempDir("deleted-cwd", { victim: {} });
+    const victim = join(String(dir), "victim");
+    const previousCwd = process.cwd();
+    process.chdir(victim);
+    try {
+      rmdirSync(victim);
+      const { stdout, stderr, exitCode } = spawnSync({
+        cmd: [bunExe(), "-e", `try { process.cwd(); console.log("cwd ok"); } catch (e) { console.log(e.code); }`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stdout.toString()).toBe("ENOENT\n");
+      expect(stderr.toString()).toBe("");
+      expect(exitCode).toBe(0);
+    } finally {
+      process.chdir(previousCwd);
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun x.cjs` started from a working directory whose absolute path is longer than PATH_MAX (4096 bytes on Linux, 1024 on macOS) runs `<directory containing the bun binary>/x.cjs` and exits 0; the `x.cjs` in the real cwd is ignored. With `-e`, `require("./mod.cjs")`, `path.resolve()` and `Bun.main` all point at the binary's directory while `fs.readFileSync("mod.cjs")` reads the real cwd. No warning is printed.
- Cause: `bun_core::getcwd_or_exe_dir` (`src/bun_core/util.rs:4140`) substituted the executable's directory on every `getcwd` failure, and `Arguments::parse` (`src/runtime/cli/Arguments.rs:867`) seeded `top_level_dir` for run/auto commands from it. The fallback exists for a cwd that was deleted (ENOENT), but `getcwd` also fails with ERANGE (glibc, macOS) or ENAMETOOLONG (musl) when the cwd's path does not fit in the 4096-byte buffer, and that directory still exists.
- Node refuses to start in that situation (`ERANGE: process.cwd failed with error result too large, uv_cwd`, exit 1). Bun's non-runtime commands already refused too, but with `error: An internal error occurred (ERANGE)`.

### Fix
- `getcwd_or_exe_dir` falls back to the executable's directory only for ENOENT and returns every other failure; `getcwd_len` now maps errno instead of collapsing everything to `Unexpected`. The `[eval]`/`[stdin]`/cron/feedback callers in `run_command.rs` propagate the error with `?`.
- `Arguments::parse` does the same for the startup cwd: ENOENT on a run/auto/node command keeps the exe-dir fallback (`bun_core::self_exe_dir`, the old fallback body split out); anything else, and a relative `--cwd` without a usable base, prints `ERANGE: Numerical result out of range: Could not get the current working directory (getcwd)` and exits 1. This is the same error path `--cwd` already uses for a failed `chdir`, so `bun test`/`bun build` get the readable message as well.
- Correct because the substituted directory is never what the user's relative paths mean: a deleted cwd has no files for them to refer to (and Node boots there too, which `test/js/node/test/parallel/test-cwd-enoent*.js` pin), while an over-long cwd does, so the only safe answer is to refuse.
- Verified with `test/cli/run/run_command.test.ts`: five `bun ...` invocations (`-e`, `x.cjs`, `run x.cjs`, `--cwd . x.cjs`, `test`) from a cwd longer than PATH_MAX must print that error and exit 1; they fail on the current release build (`-e` exits 0 printing the exe dir, `x.cjs` and `run x.cjs` print `Module not found "x.cjs"`, `--cwd .` and `test` print the internal-error line) and pass with this change. A sixth test pins that `bun -e` still boots from a deleted cwd and `process.cwd()` throws ENOENT there; it passes before and after.
- Also ran the four `test-cwd-enoent*.js` node tests, `test/cli/run/run-eval.test.ts` and `test/cli/run/as-node.test.ts` against the debug build; all pass. The original repro (bun hardlinked next to a planted `x.cjs`, cwd of 4300 bytes) now prints the error instead of running the planted file, and a 4000-byte cwd still runs the real file.

### Background
- PATH_MAX bounds the length of a path passed to a single syscall, not how deep a process can be: `chdir` one component at a time works indefinitely, but `getcwd` has to return the whole path and fails once it does not fit. Bun's `PathBuffer` is exactly PATH_MAX bytes, so such a cwd cannot be represented anywhere in the resolver, and startup is the only place to reject it.
- `top_level_dir` is the directory the runtime resolves the entry point, relative `require`/`import` and `path.resolve()` against. It is captured once at startup; `process.cwd()` does a fresh `getcwd` on every call, which is why it reported ERANGE while everything else used the exe dir.
- The exe-dir fallback mirrors Node's `Environment::GetCwd`, which substitutes the executable's directory when `uv_cwd` fails so that `node -e`, `-r` and the REPL still work after the shell's cwd is deleted; Node's own relative-script path fails regardless because `path.resolve` calls `process.cwd()`.

<details>
<summary>Not changed here</summary>

- `bun install` / `bun pm` / `bunx` do not go through this block; they already refuse an over-long cwd via `FileSystem::init(None)` with the generic `An internal error occurred (ERANGE)` line, unchanged.
- A deleted cwd plus a relative script (`cd dir; rmdir dir; bun x.cjs`) still resolves against the executable's directory, as before: that is the ENOENT fallback working as designed. Node errors there instead; tightening that is a separate decision.
- A cwd within a few bytes of PATH_MAX (4084..4095 on Linux) panics earlier in bunfig loading, and `process.chdir()` into a directory whose path is exactly PATH_MAX-1 bytes panics in `set_process_cwd`; both are tracked separately.
- #32357 (stale) maps the same ENOENT to a dedicated error variant for the generic root-error message; if it is revived, its mapping and the `FileNotFound` match here need to agree.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run_command.test.ts

<!-- robobun:evidence:end -->