### PR TITLE
FormData: throw when serializing an S3-backed entry instead of sending an empty part

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3955,8 +3955,10 @@ impl FormDataContext<'_> {
                             // only be fetched asynchronously. Emitting the part
                             // with an empty body would silently upload nothing.
                             self.failed = true;
+                            let entry_name = name.to_slice();
                             let _ = global_this.throw_type_error(format_args!(
-                                "FormData entry \"{name}\" is an S3 file, which cannot be read while serializing the body. Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)"
+                                "FormData entry {} is an S3 file, which cannot be read while serializing the body. Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)",
+                                bun_core::fmt::quote(entry_name.slice()),
                             ));
                         }
                         store::Data::File(file) => {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3939,7 +3939,9 @@ impl FormDataContext<'_> {
                 joiner.push_static(b"\r\n\r\n");
 
                 if blob.store.get().is_some() {
-                    if blob.size.get() == MAX_SIZE {
+                    // `resolve_size` zeroes an S3 blob's size; the S3 arm below
+                    // rejects the entry, so leave it untouched.
+                    if blob.size.get() == MAX_SIZE && !blob.is_s3() {
                         blob.resolve_size();
                     }
                     let store = blob
@@ -3949,8 +3951,13 @@ impl FormDataContext<'_> {
                         .expect("infallible: store present");
                     match &store.data {
                         store::Data::S3(_) => {
-                            // TODO: s3
-                            // we need to make this async and use download/downloadSlice
+                            // This serializer is synchronous and S3 objects can
+                            // only be fetched asynchronously. Emitting the part
+                            // with an empty body would silently upload nothing.
+                            self.failed = true;
+                            let _ = global_this.throw_type_error(format_args!(
+                                "FormData entry \"{name}\" is an S3 file, which cannot be read while serializing the body. Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)"
+                            ));
                         }
                         store::Data::File(file) => {
                             // TODO: make this async + lazy

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3939,8 +3939,7 @@ impl FormDataContext<'_> {
                 joiner.push_static(b"\r\n\r\n");
 
                 if blob.store.get().is_some() {
-                    // `resolve_size` zeroes an S3 blob's size; the S3 arm below
-                    // rejects the entry, so leave it untouched.
+                    // `resolve_size` would zero an S3 entry, which is rejected below.
                     if blob.size.get() == MAX_SIZE && !blob.is_s3() {
                         blob.resolve_size();
                     }
@@ -3951,9 +3950,6 @@ impl FormDataContext<'_> {
                         .expect("infallible: store present");
                     match &store.data {
                         store::Data::S3(_) => {
-                            // This serializer is synchronous and S3 objects can
-                            // only be fetched asynchronously. Emitting the part
-                            // with an empty body would silently upload nothing.
                             self.failed = true;
                             let entry_name = name.to_slice();
                             let _ = global_this.throw_type_error(format_args!(

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -1,3 +1,4 @@
+import { S3Client } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux } from "harness";
 
@@ -210,5 +211,95 @@ describe("multipart serialization (new Response(formData))", () => {
     // An extra copy of the blob bytes would put this at ~2x the blob size.
     expect(deltaMB).toBeLessThan(blobSizeMB * 1.5);
     expect(exitCode).toBe(0);
+  });
+});
+
+// The serializer is synchronous and an S3 object's bytes can only be fetched
+// asynchronously, so an S3-backed entry cannot be serialized. It used to be
+// written out as the part headers followed by an empty body: no error, no S3
+// request, and the receiver stored an empty file.
+describe("multipart serialization of S3-backed entries", () => {
+  // Nothing below performs an S3 request, so the endpoint only has to parse.
+  const s3 = new S3Client({
+    endpoint: "http://127.0.0.1:1",
+    bucket: "bucket",
+    accessKeyId: "access-key",
+    secretAccessKey: "secret-key",
+  });
+
+  const expectedMessage =
+    'FormData entry "report" is an S3 file, which cannot be read while serializing the body. ' +
+    "Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)";
+
+  function formDataWith(entry: Blob): FormData {
+    const formData = new FormData();
+    formData.append("before", "first");
+    formData.append("report", entry, "reports/2026.csv");
+    formData.append("after", "last");
+    return formData;
+  }
+
+  function thrownBy(fn: () => unknown): unknown {
+    try {
+      fn();
+    } catch (error) {
+      return error;
+    }
+    throw new Error("did not throw");
+  }
+
+  test.each([
+    ["S3Client.file()", () => s3.file("reports/2026.csv", { type: "text/csv" })],
+    ['Bun.file("s3://...")', () => Bun.file("s3://bucket/reports/2026.csv")],
+    ["a slice of an S3 file", () => s3.file("reports/2026.csv").slice(0, 16)],
+  ])("new Response(formData) throws for %s", (_label, makeEntry) => {
+    const formData = formDataWith(makeEntry());
+
+    const error = thrownBy(() => new Response(formData));
+    expect(error).toBeInstanceOf(TypeError);
+    expect((error as TypeError).message).toBe(expectedMessage);
+  });
+
+  // Serializing used to resolve the entry's size as well, which for an S3 blob
+  // turns the "unknown" NaN into 0.
+  test("serializing leaves the entry's unknown size alone", () => {
+    const formData = formDataWith(s3.file("reports/2026.csv"));
+    expect((formData.get("report") as Blob).size).toBeNaN();
+
+    try {
+      new Response(formData);
+    } catch {}
+
+    expect((formData.get("report") as Blob).size).toBeNaN();
+  });
+
+  test("new Request() throws", () => {
+    const formData = formDataWith(s3.file("reports/2026.csv"));
+
+    const error = thrownBy(() => new Request("http://localhost/upload", { method: "POST", body: formData }));
+    expect(error).toBeInstanceOf(TypeError);
+    expect((error as TypeError).message).toBe(expectedMessage);
+  });
+
+  test("fetch() rejects without sending a request", async () => {
+    const receivedBodies: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        receivedBodies.push(await request.text());
+        return new Response("stored");
+      },
+    });
+    const formData = formDataWith(s3.file("reports/2026.csv"));
+
+    const error = await fetch(server.url, { method: "POST", body: formData }).then(
+      response => {
+        throw new Error(`fetch() resolved with status ${response.status}`);
+      },
+      rejection => rejection,
+    );
+    expect(error).toBeInstanceOf(TypeError);
+    expect((error as TypeError).message).toBe(expectedMessage);
+    expect(receivedBodies).toEqual([]);
   });
 });

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -227,14 +227,19 @@ describe("multipart serialization of S3-backed entries", () => {
     secretAccessKey: "secret-key",
   });
 
-  const expectedMessage =
-    'FormData entry "report" is an S3 file, which cannot be read while serializing the body. ' +
-    "Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)";
+  // `quotedName` is the entry name as the message renders it, quotes included.
+  function messageFor(quotedName: string): string {
+    return (
+      `FormData entry ${quotedName} is an S3 file, which cannot be read while serializing the body. ` +
+      "Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)"
+    );
+  }
+  const expectedMessage = messageFor('"report"');
 
-  function formDataWith(entry: Blob): FormData {
+  function formDataWith(entry: Blob, name = "report"): FormData {
     const formData = new FormData();
     formData.append("before", "first");
-    formData.append("report", entry, "reports/2026.csv");
+    formData.append(name, entry, "reports/2026.csv");
     formData.append("after", "last");
     return formData;
   }
@@ -252,12 +257,26 @@ describe("multipart serialization of S3-backed entries", () => {
     ["S3Client.file()", () => s3.file("reports/2026.csv", { type: "text/csv" })],
     ['Bun.file("s3://...")', () => Bun.file("s3://bucket/reports/2026.csv")],
     ["a slice of an S3 file", () => s3.file("reports/2026.csv").slice(0, 16)],
+    // A single-blob File shares the source blob's store instead of copying it.
+    ["new File([s3file], name)", () => new File([s3.file("reports/2026.csv")], "wrapped.csv")],
   ])("new Response(formData) throws for %s", (_label, makeEntry) => {
     const formData = formDataWith(makeEntry());
 
     const error = thrownBy(() => new Response(formData));
     expect(error).toBeInstanceOf(TypeError);
     expect((error as TypeError).message).toBe(expectedMessage);
+  });
+
+  test.each([
+    ["a plain name", "report", '"report"'],
+    ["a non-ASCII name", "レポート ☺", '"レポート ☺"'],
+    ["a name containing a quote", 'quote"name', '"quote\\"name"'],
+    ["a name containing CRLF", "crlf\r\nname", '"crlf\\r\\nname"'],
+  ])("the message quotes %s", (_label, name, quotedName) => {
+    const formData = formDataWith(s3.file("reports/2026.csv"), name);
+
+    const error = thrownBy(() => new Response(formData));
+    expect((error as TypeError).message).toBe(messageFor(quotedName));
   });
 
   // Serializing used to resolve the entry's size as well, which for an S3 blob


### PR DESCRIPTION
### Problem
- `formData.append(name, s3file)` followed by `new Response(formData)`, `new Request(url, { body })` or `fetch(url, { body })` serializes the entry as its part headers followed by an empty body. Nothing throws, no S3 request is made, `fetch()` gets its 200 and the receiver stores a 0-byte file. Applies to `S3Client.file()`, `Bun.file("s3://...")`, slices of either, and `new File([s3file], name)`.
- Cause: `FormDataContext::on_entry` in `src/runtime/webcore/Blob.rs` builds the multipart body synchronously. Its `store::Data::S3` arm was a TODO that pushed nothing after the headers, while the `File` arm reads the file and the `Bytes` arm pushes the bytes.
- Same arm also called `blob.resolve_size()` first, which for an S3 store sets the entry's size from "unknown" to 0 (`formData.get(name).size` went from `NaN` to `0` after serializing).

### Fix
- The `S3` arm now marks the serialization failed and throws a `TypeError` naming the entry: `FormData entry "report" is an S3 file, which cannot be read while serializing the body. Read it first: formData.append(name, new Blob([await s3file.bytes()]), filename)`. The name goes through `bun_core::fmt::quote`, so a `"` or newline in it is escaped rather than breaking the message. This is the same failure path the `File` arm already uses for an unreadable file, so the constructors throw and `fetch()` rejects, and the partially built body is freed as before.
- `resolve_size()` is skipped for S3 entries, so a rejected entry keeps its unknown size.
- A `TypeError` is what the neighbouring body-init failures use (`Body::from_js` for a disturbed stream); the fetch spec also maps unreadable request bodies to a `TypeError` rejection. Reading the object here synchronously is not an option (network on the JS thread), and a streaming path is a separate feature: #35792 adds one for `Bun.file()` parts and explicitly leaves S3 entries on this buffered serializer, so it would get this error too.
- Verified with `test/js/web/html/FormData-multipart-serialization.test.ts` (new `describe` at the end: `Response`, `Request`, `fetch()` against a local server that must receive nothing, the four S3 blob shapes listed above, the quoting of plain, non-ASCII, `"` and CRLF entry names, and the size side effect). All eleven new tests fail on the released build (empty part is produced; `size` becomes 0) and pass with this change.
- Also run with the debug build: the rest of that file, `test/js/web/html/FormData.test.ts`, `FormData-file-error-leak.test.ts`, `test/js/bun/http/fetch-file-upload.test.ts`, `form-data-set-append.test.js`; the repro under `BUN_JSC_validateExceptionChecks=1`; `cargo fmt --check`.
- #37514 reworks how this function reports the `File` read error; the two changes touch adjacent lines, so whichever lands second needs a small rebase.

### Background
- A `Blob`'s bytes live in a `Store`, which is one of `Bytes` (in memory), `File` (a path or fd, read on demand) or `S3` (a bucket key, downloaded on demand). `S3Client.file()` and `Bun.file("s3://...")` both return blobs with an `S3` store; `.slice()` and `new File([blob])` share the source blob's store.
- `Blob::from_dom_form_data` is the only multipart serializer: every body init that receives a `FormData` (the `Response` and `Request` constructors and `fetch()`) calls it synchronously and gets back one in-memory blob holding the whole body. `FormDataContext::on_entry` is invoked once per entry and appends that entry's part to a `StringJoiner`.
- On failure the context sets `failed`, throws on the global object and `from_dom_form_data` drops the joiner and returns an empty blob; the callers check for the pending exception and propagate it (`fetch()` turns it into a rejected promise).
- `Blob::resolve_size()` fills in a blob's size lazily (stat for files); S3 sizes are only known after a network round trip, so for an S3 store it writes 0, and `.size` reports `NaN` only while the size is still the unresolved sentinel.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/html/FormData-multipart-serialization.test.ts

<!-- robobun:evidence:end -->
