### PR TITLE
bundler: stop rendering "././" output paths from naming templates that start with [dir]

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4265,14 +4265,9 @@ pub mod bv2_impl {
                                     .to_vec()
                                     .into_boxed_slice();
                             }
-                            let mut v = Vec::new();
                             template
-                                .print(
-                                    &mut v,
-                                    !self.transpiler.options.compile_mode.is_executable(),
-                                )
-                                .expect("oom");
-                            v.into_boxed_slice()
+                                .render(!self.transpiler.options.compile_mode.is_executable())
+                                .into_boxed_slice()
                         };
 
                         let loader = loaders[index];

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -388,17 +388,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             let chunk = &mut chunks[index];
             chunk.template.placeholder.hash = Some(hash.digest());
 
-            let mut rel_path: Vec<u8> = Vec::new();
-            // Use the byte-writer (`PathTemplate::print`) directly —
-            // routing through `Display`/`write!` goes via `from_utf8_lossy`,
-            // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
-            // the output path.
             // Disk output sanitizes leading `..`; `--compile` keeps it so
             // runtime bunfs references to out-of-root entrypoints resolve.
-            chunk
+            let mut rel_path: Vec<u8> = chunk
                 .template
-                .print(&mut rel_path, !c.options.compile_mode.is_executable())
-                .expect("write to Vec<u8>");
+                .render(!c.options.compile_mode.is_executable());
             path::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
 
             if path_names_map.get_or_put(&rel_path)?.found_existing {
@@ -408,18 +402,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     *dup.value_ptr = DuplicateEntry::default();
                 }
                 dup.value_ptr.sources.push(bun_ptr::BackRef::new(&*chunk));
-                continue;
-            }
-
-            // resolve any /./ and /../ occurrences
-            // use resolvePosix since we asserted above all seps are '/'
-            #[cfg(windows)]
-            if strings::index_of(&rel_path, b"/./").is_some() {
-                let mut buf = bun_paths::PathBuffer::uninit();
-                let rel_path_fixed: Box<[u8]> = Box::from(&*path::resolve_path::normalize_buf::<
-                    path::platform::Posix,
-                >(&rel_path, &mut buf));
-                chunk.final_rel_path = rel_path_fixed;
                 continue;
             }
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2181,6 +2181,70 @@ pub fn write_sanitized_parent_dirs<W: bun_io::Write>(
     }
 }
 
+/// Drops every `.` segment after the first one, in place: `././a.js` becomes
+/// `./a.js` and `./static/./a.js` becomes `./static/a.js`. The first segment is
+/// kept because a leading `./` is the shape every default template renders to
+/// (`[dir]` renders as `.` at the root so that `[dir]/[name].[ext]` yields
+/// `./a.js`, not `/a.js`).
+fn remove_redundant_dot_segments(path: &mut Vec<u8>) {
+    // `write_replacing_slashes_on_windows` emits native separators; on POSIX a
+    // `\` is an ordinary file name byte.
+    const SEPARATORS: &[u8] = if cfg!(windows) { b"/\\" } else { b"/" };
+    let mut read = 0;
+    let mut write = 0;
+    let mut is_first_segment = true;
+    while read < path.len() {
+        // `next` is the start of the following segment, so `read..next` is this
+        // segment plus the separator that ends it (if any).
+        let (segment_end, next) = match strings::index_of_any(&path[read..], SEPARATORS) {
+            Some(i) => (read + i, read + i + 1),
+            None => (path.len(), path.len()),
+        };
+        if is_first_segment || &path[read..segment_end] != b"." {
+            if write != read {
+                path.copy_within(read..next, write);
+            }
+            write += next - read;
+        }
+        is_first_segment = false;
+        read = next;
+    }
+    path.truncate(write);
+}
+
+#[cfg(test)]
+#[test]
+fn remove_redundant_dot_segments_keeps_only_the_leading_one() {
+    fn run(path: &[u8]) -> Vec<u8> {
+        let mut out = path.to_vec();
+        remove_redundant_dot_segments(&mut out);
+        out
+    }
+    // A user `[dir]/[name].[ext]` gets a `./` prefix from the CLI / `Bun.build`
+    // and `[dir]` renders as `.` at the root.
+    assert_eq!(run(b"././a.js"), b"./a.js");
+    assert_eq!(run(b"./static/./a.js"), b"./static/a.js");
+    assert_eq!(run(b"static/./a.js"), b"static/a.js");
+    assert_eq!(run(b"./././a.js"), b"./a.js");
+    // Everything the default templates render is already in canonical form.
+    assert_eq!(run(b"./a.js"), b"./a.js");
+    assert_eq!(run(b"./chunk-abc123.js"), b"./chunk-abc123.js");
+    assert_eq!(run(b"pages/a.html"), b"pages/a.html");
+    assert_eq!(run(b"./pages/a.html"), b"./pages/a.html");
+    assert_eq!(run(b"a.js"), b"a.js");
+    assert_eq!(run(b""), b"");
+    // `..`, `_.._` and dotfiles are real segments.
+    assert_eq!(run(b"../a.js"), b"../a.js");
+    assert_eq!(run(b"./../a.js"), b"./../a.js");
+    assert_eq!(run(b"./_.._/a.js"), b"./_.._/a.js");
+    assert_eq!(run(b"././.env"), b"./.env");
+    assert_eq!(run(b"./.well-known/./a.txt"), b"./.well-known/a.txt");
+    #[cfg(windows)]
+    assert_eq!(run(br".\.\a.js"), br".\a.js");
+    #[cfg(not(windows))]
+    assert_eq!(run(br"./.\a.js"), br"./.\a.js");
+}
+
 #[cfg(test)]
 #[test]
 fn write_sanitized_parent_dirs_rewrites_every_dotdot_segment() {
@@ -2320,7 +2384,7 @@ impl PathTemplate {
         placeholder: PlaceholderConst::DEFAULT,
     };
 
-    pub(crate) fn print<W: bun_io::Write>(
+    fn print<W: bun_io::Write>(
         &self,
         writer: &mut W,
         sanitize_parent_dirs: bool,
@@ -2335,6 +2399,25 @@ impl PathTemplate {
             &self.placeholder.target,
             sanitize_parent_dirs,
         )
+    }
+
+    /// Renders the outdir-relative output path of a chunk or asset.
+    ///
+    /// Works on raw bytes rather than `Display`, which would go through
+    /// `from_utf8_lossy` and corrupt non-UTF-8 directory names.
+    ///
+    /// The CLI and `Bun.build` prefix user templates with `./`, and `[dir]` is
+    /// `.` for a source at the root, so a user `[dir]/[name].[ext]` prints as
+    /// `././a.js` (and `static/[dir]/...` as `./static/./a.js`). The redundant
+    /// segments are removed here, before the path reaches the HTML import
+    /// manifest, the metafile, public path joins and standalone executable
+    /// keys, so those all see the `./a.js` the default templates produce.
+    pub(crate) fn render(&self, sanitize_parent_dirs: bool) -> Vec<u8> {
+        let mut path = Vec::new();
+        self.print(&mut path, sanitize_parent_dirs)
+            .expect("writing to a Vec<u8> cannot fail");
+        remove_redundant_dot_segments(&mut path);
+        path
     }
 }
 
@@ -2417,9 +2500,7 @@ impl core::fmt::Display for PathTemplateConst {
 
 impl core::fmt::Display for PathTemplate {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut buf = Vec::<u8>::new();
-        self.print(&mut buf, true).map_err(|_| core::fmt::Error)?;
-        write!(f, "{}", bstr::BStr::new(&buf))
+        write!(f, "{}", bstr::BStr::new(&self.render(true)))
     }
 }
 

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -303,6 +303,42 @@ describe("bundler", () => {
       },
     ],
   });
+  // The naming option gets a "./" prefix and `[dir]` renders as "." for a file at
+  // the root, so templates starting with `[dir]` used to render "././a.js". That
+  // string is what the metafile reports and what gets appended to publicPath.
+  itBundled("naming/DirTemplateAtRoot", {
+    backend: "api",
+    files: {
+      "/a.js": /* js */ `
+        import { shared } from "./shared.js";
+        console.log("a", shared);
+      `,
+      "/sub/c.js": /* js */ `
+        import { shared } from "../shared.js";
+        console.log("c", shared);
+      `,
+      "/shared.js": /* js */ `
+        export const shared = 1;
+      `,
+    },
+    entryPoints: ["/a.js", "/sub/c.js"],
+    outputPaths: ["/out/a.js", "/out/sub/c.js"],
+    splitting: true,
+    chunkNaming: "[dir]/[name]-[hash].[ext]",
+    publicPath: "https://cdn.example/",
+    metafile: true,
+    onAfterBundle(api) {
+      const outputs = Object.keys(JSON.parse(api.readFile("metafile.json")).outputs);
+      expect(outputs).toHaveLength(3);
+      expect(outputs).toContain("./a.js");
+      expect(outputs).toContain("./sub/c.js");
+      const chunk = outputs.find(key => key !== "./a.js" && key !== "./sub/c.js")!;
+      expect(chunk).toMatch(/^\.\/[^./][^/]*\.js$/);
+
+      const specifier = api.readFile("out/a.js").match(/from "(https:\/\/cdn\.example\/[^"]*)"/)![1];
+      expect(specifier).toBe("https://cdn.example/" + chunk.slice("./".length));
+    },
+  });
   // A non-ASCII ID_Continue basename char is preserved in the generated
   // CommonJS wrapper symbol, not replaced per-code-point (nor per-UTF-8-byte,
   // which once regressed to `require_caf__utils`).

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -357,6 +357,107 @@ console.log("About manifest:", aboutHtml);
           },
         ]
       `);
+    },
+  });
+
+  // Both `bun build --*-naming` and `Bun.build({ naming })` prefix the template
+  // with "./", and `[dir]` is "." for a file at the root, so a template starting
+  // with `[dir]` used to produce "././index.html" (and "static/[dir]/..." used to
+  // produce "./static/./favicon.svg") in `index` and `files[].path`. The default
+  // templates produce "./index.html"; custom ones must match.
+  const dirTemplateFiles = {
+    "/server.js": `
+import index from "./index.html";
+import about from "./pages/about.html";
+export { index, about };
+`,
+    "/index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./styles.css">
+    <link rel="icon" href="./favicon.svg">
+    <script type="module" src="./app.js"></script>
+  </head>
+  <body></body>
+</html>`,
+    "/styles.css": `body { margin: 0; }`,
+    "/favicon.svg": `<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+    "/app.js": `console.log("app");`,
+    "/pages/about.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="icon" href="./logo.svg">
+    <script type="module" src="./about-page.js"></script>
+  </head>
+  <body></body>
+</html>`,
+    "/pages/logo.svg": `<svg xmlns="http://www.w3.org/2000/svg"><g></g></svg>`,
+    "/pages/about-page.js": `console.log("about");`,
+  };
+
+  function readManifestPaths(serverCode: string) {
+    const manifests = [...serverCode.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(
+      match => JSON.parse(JSON.parse('"' + match[1] + '"')) as { index: string; files: Array<{ path: string }> },
+    );
+    expect(manifests).toHaveLength(2);
+    const normalize = (p: string) =>
+      p
+        // Asset paths are still printed with the native separator on Windows;
+        // this test is only about the "." segments.
+        .replaceAll("\\", "/")
+        .replace(/-[a-z0-9]{8}\./, "-HASH.");
+    return manifests.map(manifest => ({
+      index: normalize(manifest.index),
+      files: manifest.files.map(file => normalize(file.path)),
+    }));
+  }
+
+  // `Bun.build` (itBundled's api backend passes naming.entry = "[dir]/[name].[ext]" itself).
+  itBundled("html-import/manifest-paths-with-dir-template-api", {
+    outdir: "out/",
+    backend: "api",
+    files: dirTemplateFiles,
+    entryPoints: ["/server.js"],
+    target: "bun",
+    chunkNaming: "[dir]/[name]-[hash].[ext]",
+    assetNaming: "[dir]/[name]-[hash].[ext]",
+    onAfterBundle(api) {
+      expect(readManifestPaths(api.readFile("out/server.js"))).toEqual([
+        {
+          index: "./index.html",
+          files: ["./index-HASH.js", "./index.html", "./index-HASH.css", "./favicon-HASH.svg"],
+        },
+        {
+          index: "./pages/about.html",
+          files: ["./pages/about-HASH.js", "./pages/about.html", "./pages/logo-HASH.svg"],
+        },
+      ]);
+    },
+  });
+
+  // `bun build --entry-naming/--chunk-naming/--asset-naming`.
+  itBundled("html-import/manifest-paths-with-dir-template-cli", {
+    outdir: "out/",
+    backend: "cli",
+    files: dirTemplateFiles,
+    entryPoints: ["/server.js"],
+    target: "bun",
+    entryNaming: "[dir]/[name]-[hash].[ext]",
+    chunkNaming: "[dir]/[name]-[hash].[ext]",
+    assetNaming: "static/[dir]/[name]-[hash].[ext]",
+    onAfterBundle(api) {
+      const serverFile = readdirSync(api.join("out")).find(name => /^server-[a-z0-9]{8}\.js$/.test(name));
+      expect(serverFile).toBeDefined();
+      expect(readManifestPaths(api.readFile(join("out", serverFile!)))).toEqual([
+        {
+          index: "./index-HASH.html",
+          files: ["./index-HASH.js", "./index-HASH.html", "./index-HASH.css", "./static/favicon-HASH.svg"],
+        },
+        {
+          index: "./pages/about-HASH.html",
+          files: ["./pages/about-HASH.js", "./pages/about-HASH.html", "./static/pages/logo-HASH.svg"],
+        },
+      ]);
     },
   });
 


### PR DESCRIPTION
### Problem

- A server build that imports an HTML file and uses a naming template starting with `[dir]` (`bun build --entry-naming "[dir]/[name].[ext]"`, or `Bun.build({ naming: { entry: "[dir]/[name].[ext]" } })`) embeds `"index":"././home.html"` and `"path":"././home-<hash>.js"` in the HTML import manifest. The default templates give `./home.html`. Same for `--chunk-naming` and `--asset-naming`, and `static/[dir]/...` gives `./static/./home.html`.
- The same string is reused everywhere the output path is exposed: metafile output keys (`"././server.js"`), the value appended to `--public-path` (`https://cdn.example/./a-<hash>.js`, because `cheap_prefix_normalizer` strips one `./`), the `bun build` summary (`./server.js`), and the embedded file keys of `--compile`.
- Cause: `src/runtime/cli/Arguments.rs:2571` and `src/runtime/api/JSBundler.rs:998` prefix user templates with `./`, and `path_template_print` (`src/bundler/options.rs`) renders `[dir]` as `.` for a file at the root, so `./[dir]/[name].[ext]` renders as `././a.js`. The rendered bytes are stored verbatim as `chunk.final_rel_path` (`src/bundler/linker_context/generateChunksInParallel.rs`) and as the asset's `dest_path` (`src/bundler/bundle_v2.rs`, `process_files_to_copy`); `HTMLImportManifest.rs` and the other consumers copy them through.
- Windows additionally had a `#[cfg(windows)]` block in `generateChunksInParallel.rs` that ran a full normalize whenever `/./` appeared, which also drops the leading `./`: the same build printed `home.html` on Windows, `././home.html` on Linux, and `./home.html` with the default templates.

### Fix

- `PathTemplate::render` renders the template and removes every `.` segment after the first one; both render sites (chunks and copied assets) go through it, and `print` becomes private so nothing can bypass it. The Windows-only block is deleted because a `/./` can no longer reach it.
- The first segment is kept on purpose: `./x` is the shape every default template renders (`./chunk-[hash].[ext]`, `./[name]-[hash].[ext]`, and `[dir]/[name].[ext]` at the root), and the existing manifest and metafile snapshots encode it. Custom templates now render the same shape on every platform.
- Removing a `.` segment never changes which file is written (the OS resolves it the same way); it only changes the string handed to the manifest, metafile, public path join, summary and `--compile` keys, which now all agree with the defaults.
- Fixing it at the render site rather than in the manifest writer is required for `--compile`: `StandaloneModuleGraph.rs` keys the embedded files by the same `dest_path` string the manifest prints, so the two must be derived from one path.
- `..`, `_.._`, `//` and separators are left alone. `--compile` relies on a leading `..` surviving, `naming/WithPathTraversal` relies on a literal `..` being left to the filesystem, and asset paths on Windows still carry `\` (that is a separate bug, #34557).
- Chunk hashes are unaffected (the content hash covers the template text, not the rendered path), so no existing snapshot changes.
- Verified with:
  - `test/bundler/html-import-manifest.test.ts` (`manifest-paths-with-dir-template-api` / `-cli`): root and nested HTML imports, JS/CSS/HTML chunks and assets, `[dir]/...` and `static/[dir]/...` templates, through both `Bun.build` and the CLI flags. Fail on the release binary with `././index.html` / `./static/./favicon-….svg`, pass with `bun bd test`.
  - `test/bundler/bundler_naming.test.ts` (`naming/DirTemplateAtRoot`): metafile keys and the `publicPath` import specifier. Fails on the release binary with `././a.js`, passes with `bun bd test`.
  - Rust unit test for the helper in `options.rs`, run with `cargo miri test -p bun_bundler --lib` (the bundler crate's unit tests cannot link outside miri).
  - `bun bd test` on `bundler_naming`, `html-import-manifest`, `bun-serve-html-manifest`, `metafile`, `bundler_html`, `bundler_html_server`, `bundler_files`, `bundler_loader`, `bundler_edgecase`, `bun-build-api`, `bundler_splitting`, `bundler_compile_splitting`, `compile-asset-bunfs`, `standalone`: all green.
  - Windows debug build: chunk paths now come out as `./home.html` like the other platforms, `.\.\icon-….png` becomes `.\icon-….png`, and `naming/EntryNamingTemplate1`, `naming/WithPathTraversal`, `naming/ImplicitOutbase2`, `naming/DirTemplateAtRoot` pass without the removed block (itBundled tests have to be forced to run there, see #34552).
- #34557 and #37502 touch the same two render sites (separators and a length check respectively); all three compose, whichever lands later needs a one-line rebase.

### Background

- Naming templates (`--entry-naming`, `--chunk-naming`, `--asset-naming`, `Bun.build({ naming })`) describe output paths with `[dir]`, `[name]`, `[hash]`, `[ext]` placeholders. `[dir]` is the source file's directory relative to the project root; for a file at the root it is empty and is rendered as `.` so that `[dir]/[name].[ext]` gives `./a.js` rather than `/a.js`.
- `final_rel_path` (chunks) and `dest_path` (copied assets) are the outdir-relative output paths computed once per build after hashing. The HTML import manifest, the metafile, the import paths printed into other chunks, the build summary and the `--compile` file table all read them.
- The HTML import manifest is the JSON object a server build embeds for `import home from "./home.html"`: `index` is the HTML file's output path and `files[]` lists every output the page needs, each with its outdir-relative `path`. `Bun.serve` turns those paths into routes, and users read `files[].path` directly (for example to upload or precompress the files).

<details>
<summary>Repro, before and after</summary>

```
$ printf '<script type="module" src="./home.js"></script>' > home.html
$ echo 'console.log(1)' > home.js
$ printf 'import home from "./home.html";\nconsole.log(home.index, home.files.map(f => f.path));\n' > server.js
$ bun build server.js --target=bun --outdir out --entry-naming "[dir]/[name].[ext]" \
    --chunk-naming "[dir]/[name]-[hash].[ext]" --asset-naming "[dir]/[name]-[hash].[ext]" \
    --public-path https://cdn.example/ --metafile=out/meta.json && bun out/server.js
```

bun 1.4.0:

```
  ./server.js         0.58 KB    (entry point)
  ./home-e95jb7ta.js  27 bytes   (entry point)
  ./home.html         123 bytes  (entry point)
././home.html [ "././home-e95jb7ta.js", "././home.html" ]
metafile outputs: [ "././server.js", "././home-e95jb7ta.js", "././home.html" ]
home.html: <script ... src="https://cdn.example/./home-e95jb7ta.js">
```

This branch:

```
  server.js         0.58 KB    (entry point)
  home-e95jb7ta.js  27 bytes   (entry point)
  home.html         123 bytes  (entry point)
./home.html [ "./home-e95jb7ta.js", "./home.html" ]
metafile outputs: [ "./server.js", "./home-e95jb7ta.js", "./home.html" ]
home.html: <script ... src="https://cdn.example/home-e95jb7ta.js">
```

Same build with the default templates, on both versions: `./home.html [ "./home-…js", "./home.html" ]`.

</details>
