### PR TITLE
shell: close the stdio pipes of a subprocess whose stdin writer failed to start

### DIFF
--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -451,9 +451,10 @@ impl ShellSubprocess {
         }
     }
 
-    /// Tear down a subprocess whose stdio start() failed. Marks pending pipe readers as
-    /// errored so PipeReader.deinit's done-assert passes, drops the exit handler so a
-    /// later onProcessExit doesn't touch the freed Subprocess, then deinits.
+    /// Tear down a subprocess whose stdio start() failed. Releases the buffer-stdin
+    /// writer, marks pending pipe readers as errored so PipeReader.deinit's done-assert
+    /// passes (a reader that never started closes its pipe fd there), drops the exit
+    /// handler so a later onProcessExit doesn't touch the freed Subprocess, then deinits.
     ///
     /// Windows: PipeReader.deinit asserts the libuv source is closed. Whether the source
     /// is uv-initialized depends on how far startWithCurrentPipe got, so a blind close or
@@ -467,6 +468,21 @@ impl ShellSubprocess {
         }
         #[cfg(not(windows))]
         {
+            // Release the slot's `create()` ref ourselves: a writer whose
+            // `start()` failed never reaches `on_close_io`, and one that did
+            // start (a sibling failed) must not reach it after we free `this`.
+            // `close()` re-enters `on_close_io` (and releases `start()`'s ref
+            // if it was taken), so the slot is emptied first, through `this`
+            // rather than a `Box` the re-entry would alias.
+            // SAFETY: `this` is the live subprocess from `spawn`; the borrow of
+            // the slot ends with the `replace`, before `close()` re-enters.
+            let stdin = unsafe { core::mem::replace(&mut (*this).stdin, Writable::Ignore) };
+            if let Writable::Buffer(buffer) = stdin {
+                // SAFETY: single-threaded; the slot held the only handle to the
+                // writer, so no other borrow of it is live.
+                unsafe { buffer_mut(&buffer) }.close();
+                buffer.deref();
+            }
             // SAFETY: `this` was created via `heap::alloc` in `spawn` and is
             // uniquely owned here; reclaim and tear down.
             let mut subproc = unsafe { bun_core::heap::take(this) };
@@ -1004,6 +1020,9 @@ pub enum WritableInitError {
 pub enum Writable {
     Pipe(FileSinkPtr),
     Fd(Fd),
+    /// Holds `create()`'s ref (`RefPtr` has no `Drop`). Released by
+    /// `ShellSubprocess::on_close_io` once the writer closes, or by
+    /// `abort_after_failed_start` when the spawn is abandoned before then.
     Buffer(RefPtr<StaticPipeWriter>),
     Memfd(Fd),
     Inherit,
@@ -1199,9 +1218,9 @@ impl Writable {
             Writable::Buffer(buffer) => {
                 // SAFETY: single-threaded; temporary `&mut` for the call only.
                 unsafe { buffer_mut(buffer) }.update_ref(false);
-                // Intentionally does NOT reassign `*self` — the variant tag is
-                // left as `Writable::Buffer`. RefPtr's Drop (on
-                // Subprocess teardown) handles the final deref.
+                // A writer still here is in flight (see the variant's doc for
+                // who releases the ref); closing it would re-enter this
+                // subprocess mid-drop, so it is left alone.
             }
             Writable::Memfd(fd) => {
                 fd.close();
@@ -1539,6 +1558,9 @@ pub struct PipeReader {
     pub(crate) process: Option<*mut ShellSubprocess>,
     pub(crate) event_loop: EventLoopHandle,
     pub(crate) state: PipeReaderState,
+    /// POSIX: our end of the child's stdio pipe, owned here until `start()`
+    /// hands it to `reader`. Still `Some` on a reader that never started
+    /// (the spawn was aborted first), in which case `drop` closes it.
     #[cfg_attr(windows, allow(dead_code))]
     pub(crate) stdio_result: StdioResult,
     pub(crate) out_type: OutKind,
@@ -1868,7 +1890,7 @@ impl PipeReader {
         }
 
         #[cfg(not(windows))]
-        match self.reader.start(self.stdio_result.unwrap(), true) {
+        match self.reader.start(self.stdio_result.take().unwrap(), true) {
             bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             bun_sys::Result::Ok(()) => {
                 // `reader.start` reports a poll-registration failure through
@@ -2194,6 +2216,11 @@ impl Drop for PipeReader {
         #[cfg(unix)]
         {
             debug_assert!(self.reader.is_done() || matches!(self.state, PipeReaderState::Err(_)));
+        }
+        #[cfg(not(windows))]
+        if let Some(fd) = self.stdio_result.take() {
+            // Never started, so `reader` never took the fd over.
+            fd.close();
         }
 
         #[cfg(windows)]

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -34,6 +34,16 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            recv guarantees the streaming inner loop's mid-read
 //                            flush (`head_start` past the half-buffer cutoff)
 //                            fires in a single poll wake.
+//   SHELL_FAIL_EPOLL_WRITABLE=1 every epoll_ctl ADD asking for EPOLLOUT on a
+//                            socket this process made with socketpair() (the
+//                            child stdio pipes) fails with ENOMEM. Only writers
+//                            ask for EPOLLOUT, so this fails the child's
+//                            buffer-stdin writer's start() (the only stdio
+//                            start() whose failure is returned to the spawn
+//                            instead of reported through a callback) and
+//                            nothing else: the stdout/stderr readers poll for
+//                            EPOLLIN, and the shell's writers to the fixture's
+//                            own stdio sit on inherited fds.
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -58,6 +68,7 @@ const SHIM_C = /* c */ `
 static ssize_t (*real_recv)(int, void *, size_t, int);
 static long (*real_syscall)(long, long, long, long, long, long, long);
 static int (*real_close)(int);
+static int (*real_socketpair)(int, int, int, int *);
 static int fail_recv = -1;
 static int fail_epoll = -1;
 static int fail_epoll_after = -1;
@@ -65,9 +76,11 @@ static int recv_one_chunk = -1;
 static int recv_eagain_first = -1;
 static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
 static int recv_bulk = -1;       /* 0 = off, N >= 1 = number of fabricated full-buffer recvs */
+static int fail_epoll_writable = -1;
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
 static unsigned char bulk_count[MAX_FD];
+static unsigned char own_socketpair[MAX_FD];
 
 static void init_modes(void) {
   if (fail_recv < 0) fail_recv = getenv("SHELL_FAIL_RECV") != NULL;
@@ -83,6 +96,7 @@ static void init_modes(void) {
     const char *s = getenv("SHELL_RECV_BULK");
     recv_bulk = s ? atoi(s) : 0;
   }
+  if (fail_epoll_writable < 0) fail_epoll_writable = getenv("SHELL_FAIL_EPOLL_WRITABLE") != NULL;
 }
 
 static int is_unix_sock(int fd) {
@@ -98,6 +112,28 @@ static int is_pipe_like(int fd) {
   if (fstat(fd, &st) != 0) return 0;
   if (S_ISFIFO(st.st_mode)) return 1;
   return is_unix_sock(fd);
+}
+
+// Reset the per-fd state on close so a recycled fd number starts fresh. Bun
+// closes through syscall(SYS_close), so both close entry points land here.
+static void forget_fd(int fd) {
+  if (fd >= 0 && fd < MAX_FD) {
+    recv_count[fd] = 0;
+    epoll_count[fd] = 0;
+    bulk_count[fd] = 0;
+    own_socketpair[fd] = 0;
+  }
+}
+
+int socketpair(int domain, int type, int protocol, int sv[2]) {
+  if (!real_socketpair) real_socketpair = (int (*)(int, int, int, int *))dlsym(RTLD_NEXT, "socketpair");
+  int rc = real_socketpair(domain, type, protocol, sv);
+  if (rc == 0) {
+    for (int i = 0; i < 2; i++) {
+      if (sv[i] >= 0 && sv[i] < MAX_FD) own_socketpair[sv[i]] = 1;
+    }
+  }
+  return rc;
 }
 
 ssize_t recv(int fd, void *buf, size_t len, int flags) {
@@ -145,9 +181,16 @@ long syscall(long number, ...) {
     real_syscall = (long (*)(long, long, long, long, long, long, long))dlsym(RTLD_NEXT, "syscall");
     init_modes();
   }
+  if (number == SYS_close) forget_fd((int)a);
   if (number == SYS_epoll_ctl) {
     int op = (int)b;
     int target = (int)c;
+    const struct epoll_event *event = (const struct epoll_event *)d;
+    if (fail_epoll_writable && op == EPOLL_CTL_ADD && target >= 0 && target < MAX_FD && own_socketpair[target] &&
+        event && (event->events & EPOLLOUT)) {
+      errno = ENOMEM;
+      return -1;
+    }
     if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD) {
       if (fail_epoll && is_pipe_like(target)) {
         errno = ENOMEM;
@@ -170,14 +213,9 @@ long syscall(long number, ...) {
   return real_syscall(number, a, b, c, d, e, f);
 }
 
-// Reset the per-fd counters on close so a recycled fd number starts fresh.
 int close(int fd) {
   if (!real_close) real_close = (int (*)(int))dlsym(RTLD_NEXT, "close");
-  if (fd >= 0 && fd < MAX_FD) {
-    recv_count[fd] = 0;
-    epoll_count[fd] = 0;
-    bulk_count[fd] = 0;
-  }
+  forget_fd(fd);
   return real_close(fd);
 }
 `;
@@ -234,6 +272,58 @@ const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.nothrow();
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+// For SHELL_FAIL_EPOLL_WRITABLE: `< ${blob}` / `< ${bytes}` give the child a
+// buffer-stdin writer, which spawn_async starts before the stdout/stderr
+// readers. Its failed start() aborts the spawn; the command reports the errno
+// and everything the spawn had set up must be closed again: the two pipe ends
+// the never-started readers were holding and the writer's own stdin pipe end.
+// The fds are listed with their inode so a reused number cannot hide a leak.
+const STDIN_START_FAULT_FIXTURE = /* js */ `
+import { readdirSync, readlinkSync } from "node:fs";
+import { $ } from "bun";
+
+function openFds() {
+  const fds = [];
+  for (const fd of readdirSync("/proc/self/fd")) {
+    // The readdir handle itself is already closed again by the time we get here.
+    try {
+      fds.push(fd + ":" + readlinkSync("/proc/self/fd/" + fd));
+    } catch {}
+  }
+  return fds;
+}
+
+// Whatever a spawn sets up once (work pool, closer threads, the writers for
+// this process's own stdio) must not count against the failed commands, so
+// take the baseline after a successful command of each kind below.
+await $\`head -c 0 /dev/zero\`;
+await $\`head -c 0 /dev/zero\`.quiet();
+const before = openFds();
+
+const results = [];
+async function run(cmd) {
+  const r = await cmd.nothrow();
+  results.push({ exitCode: r.exitCode, stderr: r.stderr.toString() });
+}
+// .quiet() gives the readers plain capture pipes; without it they also tee
+// into this process's stdio, the shell's other reader setup.
+await run($\`cat < \${new Blob(["blob stdin"])}\`.quiet());
+await run($\`cat < \${new TextEncoder().encode("buffer stdin")}\`.quiet());
+await run($\`cat < \${new Blob(["blob stdin"])}\`);
+
+// Pipe ends held by a poll are closed on the work pool, so wait for the set to
+// drain; a real leak never drains and the deadline (well inside the test's
+// own timeout, so the list below is what gets reported) shows what is left.
+let leaked;
+const deadline = Date.now() + 2000;
+while (true) {
+  leaked = openFds().filter(fd => !before.includes(fd));
+  if (leaked.length === 0 || Date.now() > deadline) break;
+  await Bun.sleep(10);
+}
+console.log(JSON.stringify({ results, leaked }));
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -246,6 +336,7 @@ beforeAll(async () => {
     "quiet-chunk.js": QUIET_CHUNK_FIXTURE,
     "poll-chunk.js": POLL_CHUNK_FIXTURE,
     "tee-chunk.js": TEE_CHUNK_FIXTURE,
+    "stdin-start-fault.js": STDIN_START_FAULT_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -273,6 +364,7 @@ const MODES = [
   "SHELL_FAIL_EPOLL_AFTER",
   "SHELL_RECV_ONE_CHUNK",
   "SHELL_RECV_EAGAIN_FIRST",
+  "SHELL_FAIL_EPOLL_WRITABLE",
 ] as const;
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
 const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK"] as const;
@@ -295,7 +387,10 @@ function shimEnv(
   return env;
 }
 
-async function expectShellFault(
+// Runs a fixture under the shim and returns its last stdout line (the JSON it
+// prints) along with stderr and the exit code, so one combined assertion can
+// surface a crash's stderr and exit code in the diff.
+async function runShellFaultFixture(
   script: string,
   modes: (typeof MODES)[number][],
   extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
@@ -319,8 +414,15 @@ async function expectShellFault(
   } catch {
     parsed = line;
   }
-  // One combined assertion so a crash surfaces stderr and the exit code in the diff.
-  expect({ parsed, stderr, exitCode }).toEqual({
+  return { parsed, stderr, exitCode };
+}
+
+async function expectShellFault(
+  script: string,
+  modes: (typeof MODES)[number][],
+  extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
+) {
+  expect(await runShellFaultFixture(script, modes, extraEnv)).toEqual({
     parsed: { exitCode: ENOMEM },
     stderr: expect.any(String),
     exitCode: 0,
@@ -352,6 +454,23 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell survives synchronous epoll_ctl failures registering both pipes",
   async () => {
     await expectShellFault("both-pipes.js", ["SHELL_FAIL_EPOLL"]);
+  },
+);
+
+// Regression: abort_after_failed_start dropped the stdout/stderr PipeReaders
+// without closing the pipe ends they had not handed to their readers yet, and
+// never released the stdin writer, so every failed command leaked three
+// sockets (the writer's fd went with it).
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell closes every stdio pipe of a command whose buffer stdin writer failed to start",
+  async () => {
+    const failed = { exitCode: 1, stderr: expect.stringContaining("Cannot allocate memory") };
+    expect(await runShellFaultFixture("stdin-start-fault.js", ["SHELL_FAIL_EPOLL_WRITABLE"])).toEqual({
+      parsed: { results: [failed, failed, failed], leaked: [] },
+      // The un-quieted command also tees its error message here.
+      stderr: expect.stringContaining("Cannot allocate memory"),
+      exitCode: 0,
+    });
   },
 );
 


### PR DESCRIPTION
### Problem
- A shell command with a buffer stdin (`cat < ${blob}`, `< ${bytes}`) whose stdin writer fails to start leaks three sockets for the life of the process. The command itself fails as intended (`bun: Cannot allocate memory`, exit 1); the leak is in the cleanup. Reproduced on bun 1.4.0 and on main with an LD_PRELOAD shim that fails the writer's `epoll_ctl` registration, which is what `fs.epoll.max_user_watches` exhaustion does.
- `ShellSubprocess::spawn_maybe_sync_impl` (`src/runtime/shell/subproc.rs`) starts the stdin writer before the stdout/stderr readers. When that start fails, `abort_after_failed_start` drops the subprocess. The two `PipeReader`s were never started, so the parent end of each pipe is still in `PipeReader::stdio_result`, and nothing closes it: `PosixBufferedReader` only closes an fd it was started with. Two of the three fds.
- The same function never releases the stdin slot. `Writable::Buffer` holds the `create()` ref of the `StaticPipeWriter`, normally released by `on_close_io` when the writer closes, and a writer whose `start()` failed never closes. `Writable::finalize` only unrefs it; its comment relied on a `RefPtr` drop that does not exist (`RefPtr` has no `Drop`; the Zig version called `deref()` here). The writer, its Blob/ArrayBuffer source and the fd its failed start left in its poll all leak. The third fd.

### Fix
- `PipeReader` owns the pipe fd until `start()` hands it to the reader (`stdio_result.take()`), and its `Drop` closes an fd that was never handed over. Correct because the reader closes the fd on every path where it was started, so the two never both close it, and a reader dropped without starting holds a fresh pipe end that nothing else references. This covers any path that drops an unstarted reader, not just today's stdin-first ordering.
- `abort_after_failed_start` empties the stdin slot, closes the writer and releases the slot's ref. The slot is emptied first because `close()` reports back through `on_close_io`, which must find nothing left to release; it runs through the raw pointer before the `Box` is reclaimed so that re-entry aliases nothing. Same shape as `deinit_in_flight_io` below it. It is also right for the other arm that reaches this function (a reader start failing after the writer started): `close()` then releases the writer's own `start()` ref via `on_close`, and this releases `create()`'s.
- What `close()` does to a writer whose registration failed, on main today: `PosixBufferedWriter::start` had already put the fd in a poll before `epoll_ctl` failed, so `PosixBufferedWriter::close` goes through `PollOrFd::close_impl`, which releases that poll (unregistering is a no-op, nothing was registered), hands the fd to `Closer`, and calls `on_close` synchronously. `on_close` skips the `start()` ref because `started` is false and reaches `on_close_io`, which sees the emptied slot. The `deref()` that follows is the last ref, and the writer's `Drop` finds the handle already closed. With #38354 the handle is already `Closed` when we get here, so `close()` does nothing and `deref()` alone frees the writer.
- #38354 (open) makes `StaticPipeWriter::start` close its fd itself on failure and hands the reader leak off to this PR. The two compose: with it, `close()` here finds no fd and `deref()` still frees the writer; the reader change is independent of it.
- `Writable::finalize` is unchanged in behavior; its comment and the `Writable::Buffer` doc now name the sites that release the ref.
- Test: `test/js/bun/shell/shell-pipe-read-fault.test.ts`, new shim mode `SHELL_FAIL_EPOLL_WRITABLE`. It fails `EPOLL_CTL_ADD` with `EPOLLOUT` on sockets the process itself created with `socketpair()`, so exactly the child's stdin writer fails and the shell's writers to the fixture's own stdio keep working. The fixture runs `< ${blob}` and `< ${bytes}` quietly and one un-quieted `< ${blob}` (capture readers), then lists `/proc/self/fd` by inode until it returns to the baseline. Unfixed: nine leaked sockets (three per command), all three commands failing with ENOMEM. Fixed: the same failures and an empty list. The wait is bounded at 2s so the unfixed run reports the list rather than timing out. 5/5 runs on the ASAN debug build.
- Also on the debug build: the rest of that file (the shim now also resets its per-fd state on `syscall(SYS_close)`, which is how bun closes fds), `bunshell.test.ts` (423 pass), `leak.test.ts`, `shell-write-fault`, `epipe`, `shelloutput`, `bunshell-file`, `bunshell-instance`, `exec`, `shell-hang`, `throw`, `lazy`, `pipeline_stack`, `shell-worker-terminate-leak`, `shell-cmdsub-crash`; `cargo clippy -p bun_runtime`, `cargo fmt`, `cargo check -p bun_runtime` for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`. `leak.test.ts`'s `memleak_*` cases and `shell-blocking-pipe`'s heap-snapshot case time out on this machine identically with and without the change.

### Background
- The shell runs an external command through `ShellSubprocess`. Each piped stdio is a socketpair: the child gets one end, the parent end is wrapped in a `PipeReader` (stdout/stderr) or, for a Blob/ArrayBuffer stdin, a `StaticPipeWriter` that writes the bytes into the child. The wrappers are created first and started afterwards; starting registers the fd with the event loop (`epoll_ctl` on Linux).
- On POSIX a reader reports a registration failure through a callback, so the writer's `start()` is the only stdio start that returns an error to the spawn, and therefore the only way `abort_after_failed_start` is reached today.
- `RefPtr` is bun's intrusive refcount handle. Dropping it does not release the ref; every holder must `deref()` explicitly. A `StaticPipeWriter` has two refs: `create()`'s, held by the owner's stdin slot and released in `on_close_io`, and `start()`'s, held while a write is in flight.
- `on_close_io` is how a stdio object tells its `ShellSubprocess` it closed; for stdin it empties the slot and releases `create()`'s ref. It runs from inside the writer's `close()`, which is why teardown has to empty the slot before calling `close()`.
- An fd held by a registered poll is closed on the thread pool (`Closer`), which is why the test waits for the fd set to drain instead of reading it once.

<details>
<summary>Repro outside the test</summary>

```c
// shim.c: cc -shared -fPIC -o shim.so shim.c -ldl
#define _GNU_SOURCE
#include <dlfcn.h>
#include <errno.h>
#include <stdarg.h>
#include <sys/epoll.h>
#include <sys/syscall.h>
static long (*real)(long, long, long, long, long, long, long);
long syscall(long n, ...) {
  va_list ap; long a, b, c, d, e, f;
  va_start(ap, n); a = va_arg(ap, long); b = va_arg(ap, long); c = va_arg(ap, long);
  d = va_arg(ap, long); e = va_arg(ap, long); f = va_arg(ap, long); va_end(ap);
  if (!real) real = dlsym(RTLD_NEXT, "syscall");
  if (n == SYS_epoll_ctl && (int)b == EPOLL_CTL_ADD && d && (((struct epoll_event *)d)->events & EPOLLOUT)) {
    errno = ENOSPC; return -1;
  }
  return real(n, a, b, c, d, e, f);
}
```

```js
import { readdirSync, readlinkSync } from "node:fs";
const fds = () => readdirSync("/proc/self/fd").flatMap(fd => { try { return [fd + ":" + readlinkSync("/proc/self/fd/" + fd)]; } catch { return []; } });
const before = fds();
const r = await Bun.$`cat < ${new Blob(["data"])}`.quiet().nothrow();
await Bun.sleep(100);
console.log(r.exitCode, JSON.stringify(r.stderr.toString()), fds().filter(x => !before.includes(x)));
```

```
$ LD_PRELOAD=./shim.so bun repro.js        # bun 1.4.0, and main before this change
1 "bun: No space left on device: \n" [ "10:socket:[...]", "11:socket:[...]", "13:socket:[...]" ]
$ LD_PRELOAD=./shim.so bun-debug repro.js  # with this change
1 "bun: No space left on device: \n" []
```

Noticed on the way and handed off separately: the SIGTERM'd child on this path is never reaped (one zombie per failed command), because `close_process` tears the watcher down before the child has exited.
</details>
