### PR TITLE
cli: stop aborting on --cwd and --tsconfig-override values longer than the path join buffer

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1383,9 +1383,8 @@ pub fn join_abs_string<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'a 
     PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf::<P>(cwd, tl_buf_mut(b), parts))
 }
 
-/// [`join_abs_string`] (thread-local buffer) when the result is sure to fit,
-/// otherwise into `spill` (grown as needed), for `parts` of arbitrary length
-/// such as argv. `spill` is untouched in the common case.
+/// [`join_abs_string`] (thread-local buffer) when the result fits, otherwise
+/// into `spill` (grown as needed). `spill` is untouched in the common case.
 pub fn join_abs_string_spill<'a, P: PlatformT>(
     cwd: &'a [u8],
     spill: &'a mut Vec<u8>,
@@ -1614,10 +1613,9 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
     normalize_string_node_t::<T, P>(&temp_buf[0..written], buf)
 }
 
-/// Buffer length that holds both `_join_abs_string_buf`'s unnormalized
-/// concatenation (`cwd`, the separator a bare Windows root gains, and each part
-/// behind a separator) and its normalized output, which on Windows can be one
-/// byte longer than its input (see [`normalize_string_spill`]).
+/// Buffer length that holds `_join_abs_string_buf`'s concatenation of `cwd` and
+/// `parts` (one separator each, plus the one a bare Windows root gains) as well
+/// as its normalized output.
 #[inline]
 fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -12,10 +12,14 @@ use bun_core::{ZStr, strings};
 // SAFETY invariant: each buffer has at most one live mutable borrow per thread;
 // callers must not re-enter the accessor while a previous borrow is alive.
 thread_local! {
-    static PARSER_JOIN_INPUT_BUFFER: UnsafeCell<[u8; 4096]> = const { UnsafeCell::new([0u8; 4096]) };
+    static PARSER_JOIN_INPUT_BUFFER: UnsafeCell<[u8; PARSER_JOIN_INPUT_BUFFER_LEN]> =
+        const { UnsafeCell::new([0u8; PARSER_JOIN_INPUT_BUFFER_LEN]) };
     static PARSER_BUFFER: UnsafeCell<[u8; PARSER_BUFFER_LEN]> =
         const { UnsafeCell::new([0u8; PARSER_BUFFER_LEN]) };
 }
+
+/// Output capacity of [`join_abs_string`] / [`join_abs_string_z`].
+const PARSER_JOIN_INPUT_BUFFER_LEN: usize = 4096;
 
 /// Output capacity of [`normalize_string`].
 const PARSER_BUFFER_LEN: usize = 1024;
@@ -1379,6 +1383,25 @@ pub fn join_abs_string<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'a 
     PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf::<P>(cwd, tl_buf_mut(b), parts))
 }
 
+/// [`join_abs_string`] (thread-local buffer) when the result is sure to fit,
+/// otherwise into `spill` (grown as needed), for `parts` of arbitrary length
+/// such as argv. `spill` is untouched in the common case.
+pub fn join_abs_string_spill<'a, P: PlatformT>(
+    cwd: &'a [u8],
+    spill: &'a mut Vec<u8>,
+    parts: &[&[u8]],
+) -> &'a [u8] {
+    debug_assert!(!matches!(P::P, Platform::Nt));
+    let needed = join_abs_needed(cwd.len(), parts);
+    if needed <= PARSER_JOIN_INPUT_BUFFER_LEN {
+        return join_abs_string::<P>(cwd, parts);
+    }
+    if spill.len() < needed {
+        spill.resize(needed, 0);
+    }
+    join_abs_string_buf::<P>(cwd, &mut spill[..], parts)
+}
+
 /// Convert parts of potentially invalid file paths into a single valid filpeath
 /// without querying the filesystem
 /// This is the equivalent of path.resolve
@@ -1591,6 +1614,15 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
     normalize_string_node_t::<T, P>(&temp_buf[0..written], buf)
 }
 
+/// Buffer length that holds both `_join_abs_string_buf`'s unnormalized
+/// concatenation (`cwd`, the separator a bare Windows root gains, and each part
+/// behind a separator) and its normalized output, which on Windows can be one
+/// byte longer than its input (see [`normalize_string_spill`]).
+#[inline]
+fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
+    parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2
+}
+
 /// Scratch buffer for `_join_abs_string_buf`'s unnormalized concatenation.
 /// Draws from the
 /// thread-local `path_buffer_pool` for the common case and only heap-allocates
@@ -1604,10 +1636,7 @@ enum JoinScratch {
 impl JoinScratch {
     #[inline]
     fn init(base: usize, parts: &[&[u8]]) -> Self {
-        let mut total = base + 2;
-        for p in parts {
-            total += p.len() + 1;
-        }
+        let total = join_abs_needed(base, parts);
         if total <= MAX_PATH_BYTES {
             JoinScratch::Pooled(crate::path_buffer_pool::get())
         } else {
@@ -1645,10 +1674,7 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     debug_assert!(!matches!(P::P, Platform::Nt));
     // Fast path: size check only — don't allocate a JoinScratch here since the
     // inner join_abs_string_buf already has its own (avoids doubling stack usage).
-    let mut total: usize = cwd.len() + 2;
-    for p in parts {
-        total += p.len() + 1;
-    }
+    let total = join_abs_needed(cwd.len(), parts);
     if total < buf.len() {
         return Some(join_abs_string_buf::<P>(cwd, buf, parts));
     }
@@ -2540,6 +2566,61 @@ mod tests {
             normalize_string_spill::<true, platform::Loose>(&mut spill, &long),
             &long[..]
         );
+    }
+
+    #[test]
+    fn join_abs_string_spill_leaves_spill_untouched_when_the_result_fits() {
+        let mut spill = Vec::new();
+        let out = join_abs_string_spill::<platform::Posix>(b"/work", &mut spill, &[b"a/../b.json"]);
+        assert_eq!(out, b"/work/b.json");
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn join_abs_string_spill_spills_a_part_longer_than_the_thread_local_buffer() {
+        let name = vec![b'a'; PARSER_JOIN_INPUT_BUFFER_LEN + 1];
+        let mut expected = b"/work/".to_vec();
+        expected.extend_from_slice(&name);
+
+        let mut spill = Vec::new();
+        let out = join_abs_string_spill::<platform::Posix>(b"/work", &mut spill, &[&name]);
+        assert_eq!(out, &expected[..]);
+        assert!(!spill.is_empty());
+    }
+
+    #[test]
+    fn join_abs_string_spill_spills_an_absolute_part_and_a_long_cwd_alike() {
+        let mut abs = b"/".to_vec();
+        abs.resize(PARSER_JOIN_INPUT_BUFFER_LEN * 2, b'a');
+        let mut spill = Vec::new();
+        assert_eq!(
+            join_abs_string_spill::<platform::Posix>(b"/", &mut spill, &[&abs]),
+            &abs[..]
+        );
+
+        let mut cwd = b"/".to_vec();
+        cwd.resize(PARSER_JOIN_INPUT_BUFFER_LEN, b'c');
+        let mut expected = cwd.clone();
+        expected.extend_from_slice(b"/x");
+        let mut spill = Vec::new();
+        assert_eq!(
+            join_abs_string_spill::<platform::Posix>(&cwd, &mut spill, &[b"./x"]),
+            &expected[..]
+        );
+    }
+
+    #[test]
+    fn join_abs_string_spill_normalizes_a_long_part_that_collapses() {
+        // `sub/../` repeated past the buffer size resolves back to the cwd.
+        let mut part = Vec::new();
+        while part.len() <= PARSER_JOIN_INPUT_BUFFER_LEN {
+            part.extend_from_slice(b"sub/../");
+        }
+        part.extend_from_slice(b"sub");
+
+        let mut spill = Vec::new();
+        let out = join_abs_string_spill::<platform::Posix>(b"/work", &mut spill, &[&part]);
+        assert_eq!(out, b"/work/sub");
     }
 
     #[test]

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -837,8 +837,6 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             let len = bun_sys::getcwd(&mut *outbuf)?;
             &outbuf[..len]
         };
-        // argv may not fit the thread-local buffer behind `join_abs`; `chdir`
-        // itself rejects a path longer than the OS limit with ENAMETOOLONG.
         let mut spill = Vec::new();
         let out =
             resolve_path::join_abs_string_spill::<platform::Loose>(base, &mut spill, &[cwd_arg]);
@@ -969,8 +967,6 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     }
 
     opts.tsconfig_override = args.option(b"--tsconfig-override").map(|ts| {
-        // argv may not fit the thread-local buffer behind `join_abs_string`;
-        // the resolver reports an over-long path when it fails to open it.
         let mut spill = Vec::new();
         Box::from(resolve_path::join_abs_string_spill::<platform::Auto>(
             ctx.args.absolute_working_dir.as_deref().unwrap(),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -35,6 +35,15 @@ fn slice_to_owned(input: &[&[u8]]) -> Vec<Box<[u8]>> {
     input.iter().map(|s| Box::<[u8]>::from(*s)).collect()
 }
 
+fn exit_could_not_change_directory(cwd_arg: &[u8], err: bun_sys::Error) -> ! {
+    Output::err(
+        err,
+        "Could not change directory to \"{}\"\n",
+        format_args!("{}", BStr::new(cwd_arg)),
+    );
+    Global::exit(1)
+}
+
 pub(crate) fn loader_resolver(input: &[u8]) -> crate::Result<api::Loader> {
     let option_loader = bun_ast::Loader::from_string(input).ok_or(crate::Error::InvalidLoader)?;
     Ok(option_loader.to_api())
@@ -828,27 +837,34 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     // `api::TransformOptions.absolute_working_dir` is `Option<Box<[u8]>>`,
     // so we dupe into a plain `Box<[u8]>`.
     let cwd: Box<[u8]> = if let Some(cwd_arg) = args.option(b"--cwd") {
-        let mut outbuf = PathBuffer::uninit();
+        let mut base_buf = PathBuffer::uninit();
         // An absolute --cwd needs no base; a relative one still requires a
         // live cwd (an exe-dir base would silently chdir somewhere else).
         let base: &[u8] = if bun_paths::is_absolute(cwd_arg) {
             b"/"
         } else {
-            let len = bun_sys::getcwd(&mut *outbuf)?;
-            &outbuf[..len]
+            let len = bun_sys::getcwd(&mut *base_buf)?;
+            &base_buf[..len]
         };
-        let out = resolve_path::join_abs::<platform::Loose>(base, cwd_arg);
-        // `chdir` wants a NUL-terminated path; `join_abs` returns a borrowed
-        // slice into a threadlocal buffer, so dupe-Z once and reuse for both
-        // the `chdir` arg and the stored `absolute_working_dir`.
-        let out_z = bun_core::ZBox::from_bytes(out);
-        if let bun_sys::Result::Err(err) = bun_sys::chdir(&out_z) {
-            Output::err(
-                err,
-                "Could not change directory to \"{}\"\n",
-                format_args!("{}", BStr::new(cwd_arg)),
-            );
-            Global::exit(1);
+        // argv can hold a path far longer than any the OS accepts; the unchecked
+        // joins (`join_abs` & co.) abort when the result overflows their buffer.
+        let mut out = bun_paths::path_buffer_pool::get();
+        let out_cap = out.len() - 1;
+        let out_len = match resolve_path::join_abs_string_buf_checked::<platform::Loose>(
+            base,
+            &mut out[..out_cap],
+            &[cwd_arg],
+        ) {
+            Some(joined) => joined.len(),
+            None => exit_could_not_change_directory(
+                cwd_arg,
+                bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::chdir),
+            ),
+        };
+        out[out_len] = 0;
+        let out_z = bun_core::ZStr::from_buf(&out[..], out_len);
+        if let bun_sys::Result::Err(err) = bun_sys::chdir(out_z) {
+            exit_could_not_change_directory(cwd_arg, err);
         }
         // Store the post-chdir physical path (mirrors process.chdir) so
         // process.cwd(), path.resolve, and the resolver agree on one form.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -35,15 +35,6 @@ fn slice_to_owned(input: &[&[u8]]) -> Vec<Box<[u8]>> {
     input.iter().map(|s| Box::<[u8]>::from(*s)).collect()
 }
 
-fn exit_could_not_change_directory(cwd_arg: &[u8], err: bun_sys::Error) -> ! {
-    Output::err(
-        err,
-        "Could not change directory to \"{}\"\n",
-        format_args!("{}", BStr::new(cwd_arg)),
-    );
-    Global::exit(1)
-}
-
 pub(crate) fn loader_resolver(input: &[u8]) -> crate::Result<api::Loader> {
     let option_loader = bun_ast::Loader::from_string(input).ok_or(crate::Error::InvalidLoader)?;
     Ok(option_loader.to_api())
@@ -837,34 +828,30 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     // `api::TransformOptions.absolute_working_dir` is `Option<Box<[u8]>>`,
     // so we dupe into a plain `Box<[u8]>`.
     let cwd: Box<[u8]> = if let Some(cwd_arg) = args.option(b"--cwd") {
-        let mut base_buf = PathBuffer::uninit();
+        let mut outbuf = PathBuffer::uninit();
         // An absolute --cwd needs no base; a relative one still requires a
         // live cwd (an exe-dir base would silently chdir somewhere else).
         let base: &[u8] = if bun_paths::is_absolute(cwd_arg) {
             b"/"
         } else {
-            let len = bun_sys::getcwd(&mut *base_buf)?;
-            &base_buf[..len]
+            let len = bun_sys::getcwd(&mut *outbuf)?;
+            &outbuf[..len]
         };
-        // argv can hold a path far longer than any the OS accepts; the unchecked
-        // joins (`join_abs` & co.) abort when the result overflows their buffer.
-        let mut out = bun_paths::path_buffer_pool::get();
-        let out_cap = out.len() - 1;
-        let out_len = match resolve_path::join_abs_string_buf_checked::<platform::Loose>(
-            base,
-            &mut out[..out_cap],
-            &[cwd_arg],
-        ) {
-            Some(joined) => joined.len(),
-            None => exit_could_not_change_directory(
-                cwd_arg,
-                bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::chdir),
-            ),
-        };
-        out[out_len] = 0;
-        let out_z = bun_core::ZStr::from_buf(&out[..], out_len);
-        if let bun_sys::Result::Err(err) = bun_sys::chdir(out_z) {
-            exit_could_not_change_directory(cwd_arg, err);
+        // argv may not fit the thread-local buffer behind `join_abs`; `chdir`
+        // itself rejects a path longer than the OS limit with ENAMETOOLONG.
+        let mut spill = Vec::new();
+        let out =
+            resolve_path::join_abs_string_spill::<platform::Loose>(base, &mut spill, &[cwd_arg]);
+        // `chdir` wants a NUL-terminated path, so dupe-Z once and reuse for both
+        // the `chdir` arg and the stored `absolute_working_dir`.
+        let out_z = bun_core::ZBox::from_bytes(out);
+        if let bun_sys::Result::Err(err) = bun_sys::chdir(&out_z) {
+            Output::err(
+                err,
+                "Could not change directory to \"{}\"\n",
+                format_args!("{}", BStr::new(cwd_arg)),
+            );
+            Global::exit(1);
         }
         // Store the post-chdir physical path (mirrors process.chdir) so
         // process.cwd(), path.resolve, and the resolver agree on one form.
@@ -981,17 +968,16 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         });
     }
 
-    opts.tsconfig_override = if let Some(ts) = args.option(b"--tsconfig-override") {
-        Some(
-            resolve_path::join_abs_string::<platform::Auto>(
-                ctx.args.absolute_working_dir.as_deref().unwrap(),
-                &[ts],
-            )
-            .into(),
-        )
-    } else {
-        None
-    };
+    opts.tsconfig_override = args.option(b"--tsconfig-override").map(|ts| {
+        // argv may not fit the thread-local buffer behind `join_abs_string`;
+        // the resolver reports an over-long path when it fails to open it.
+        let mut spill = Vec::new();
+        Box::from(resolve_path::join_abs_string_spill::<platform::Auto>(
+            ctx.args.absolute_working_dir.as_deref().unwrap(),
+            &mut spill,
+            &[ts],
+        ))
+    });
 
     opts.main_fields = slice_to_owned(args.options(b"--main-fields"));
     // we never actually supported inject.

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { describe, expect, it } from "bun:test";
 import { chmodSync } from "fs";
 import { bunEnv as bunEnv_, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
-import { join } from "path";
+import { basename, join } from "path";
 
 const bunEnv = {
   ...bunEnv_,
@@ -327,6 +327,56 @@ describe.concurrent("bun run", () => {
     expect(stdout).toMatch(/subdir/);
     // The exit code will not be 1 if it panics.
     expect(exitCode).toBe(0);
+  });
+
+  describe("--cwd longer than the OS path limit", () => {
+    // Longer than PATH_MAX on every platform (4096 on Linux, 1024 on macOS).
+    const tooLong = Buffer.alloc(5000, "a").toString();
+
+    for (const [kind, cwdArg] of [
+      ["absolute", "/" + tooLong],
+      ["relative", tooLong],
+    ] as const) {
+      it(`${kind} value is reported as an error instead of crashing`, async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--cwd", cwdArg, "-e", "console.log('ran')"],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toContain(`Could not change directory to "${cwdArg}"`);
+        // Windows leaves the verdict on a path this long to SetCurrentDirectoryW.
+        if (!isWindows) expect(stderr).toContain("ENAMETOOLONG");
+        expect(stdout).toBe("");
+        expect(proc.signalCode).toBeNull();
+        expect(exitCode).toBe(1);
+      });
+    }
+
+    it("value that only normalizes down to a path that fits is honored", async () => {
+      using dir = tempDir("bun-run-cwd-normalize", {
+        "subdir/.keep": "",
+      });
+      // 6006 bytes before normalization, "subdir" after it.
+      const cwdArg = "subdir" + Buffer.alloc(6000, "/../subdir").toString();
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--cwd", cwdArg, "-e", "console.log(process.cwd())"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(basename(stdout.trim())).toBe("subdir");
+      expect(exitCode).toBe(0);
+    });
   });
 
   it("DCE annotations are respected", async () => {

--- a/test/cli/run/tsconfig-override.test.ts
+++ b/test/cli/run/tsconfig-override.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "node:path";
 
 describe("bun run --tsconfig-override", () => {
@@ -301,5 +301,32 @@ describe("bun run --tsconfig-override", () => {
       expect(stderr).toBe("");
     }
     expect(exitCode).toBe(0);
+  });
+
+  describe.concurrent("path longer than the OS path limit", () => {
+    // Longer than PATH_MAX on every platform (4096 on Linux, 1024 on macOS).
+    const tooLong = Buffer.alloc(5000, "a").toString();
+
+    for (const [kind, tsconfigArg] of [
+      ["absolute", "/" + tooLong],
+      ["relative", tooLong],
+    ] as const) {
+      test(`${kind} path is reported as unreadable instead of crashing`, async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--tsconfig-override", tsconfigArg, "-e", "console.log('ran')"],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        // Windows leaves the verdict on a path this long to the file system.
+        if (!isWindows) expect(stderr).toContain(`Cannot read file "${path.resolve(tsconfigArg)}": ENAMETOOLONG`);
+        expect(stdout).toBe("ran\n");
+        expect(proc.signalCode).toBeNull();
+        expect(exitCode).toBe(0);
+      });
+    }
   });
 });


### PR DESCRIPTION
### Problem
- `bun --cwd <value> ...` aborts at startup when the value is longer than the path join buffer, instead of printing an error:
  ```
  $ bun --cwd "/$(head -c 5000 /dev/zero | tr '\0' a)" -e 0
  panic: range end index 5000 out of range for slice of length 4095
  ```
  (exit 134). A relative value of the same length, and `bun run` / `bun test` with the flag, abort the same way; so does `bun --tsconfig-override <value>` with a value of that length.
- Cause: both flags are resolved in `src/runtime/cli/Arguments.rs` (`parse`, the `--cwd` block and the `--tsconfig-override` assignment) with `resolve_path::join_abs` / `join_abs_string`, which normalize into a fixed 4096 byte thread-local buffer (`PARSER_JOIN_INPUT_BUFFER`, `src/paths/resolve_path.rs`) with no bounds check, so a value whose normalized form does not fit panics inside the normalizer, before the syscall that would have rejected it.

### Fix
- `src/paths/resolve_path.rs`: add `join_abs_string_spill`, the `join_abs` counterpart of the existing `normalize_string_spill` / `join_spill`: it uses the thread-local buffer when the result is known to fit and otherwise joins into a caller-provided `Vec`, grown as needed. The size bound it relies on (`join_abs_needed`) is the one `JoinScratch::init` and `join_abs_string_buf_checked` already computed inline; both now call the shared helper.
- `src/runtime/cli/Arguments.rs`: `--cwd` and `--tsconfig-override` resolve through `join_abs_string_spill`. Nothing else about either flag changes: `--cwd` still hands the result to `chdir`, which rejects anything over the OS limit itself, so an over-long value now prints the existing `ENAMETOOLONG: File name too long: Could not change directory to "<value>" (chdir)` and exits 1; `--tsconfig-override` is still stored and opened by the resolver, which already prints `error: Cannot read file "<path>": ENAMETOOLONG` for such a path (same as it does today for a value that happens to fit the buffer but not the OS limit), non-fatal at runtime and fatal for `bun build`, as for any other unreadable override.
- Why this shape: the OS (or the resolver's bounded `open`) is already the authority on path length for both flags, and reports the right errno, so the CLI only has to get the value there without going through a fixed buffer. Values that merely look long but normalize down (`a/../a/...`) keep working, which a length check on the argument would have broken; a test covers that.
- Scope: these are the two argv values that `Arguments::parse` itself turns into a path. Every other option `parse` accepts was probed with a 5000 byte value as well (`--env-file`, `--preload` / `--require` / `--import`, script and `bun build` entry paths, `--cpu-prof-dir` / `--cpu-prof-name`, `bun test --coverage-dir`, `bun build --outdir` / `--outfile` / `--root` / `--public-path` / `--external`, `-c`); the ones that still abort are in other code and each already has its own fix open, so they are intentionally left alone here:
  - `-c` / `--config` is resolved in `src/bunfig/arguments.rs`: #38370.
  - An absolute script, entry point or `--preload` path (and any absolute `import` / `require` specifier) over `PATH_MAX` aborts in the resolver's `load_as_file` (`src/resolver/resolver.rs`): #35857.
  - `bun build --external` goes through the unbounded `join_abs` primitive itself: #35863.
  - `bun install` / `bun add` parse `--cwd` with their own implementation in `src/install/PackageManager/CommandLineArguments.rs` (different joining rules and error path); a separate fix for it is in progress.
- Verified:
  - `test/cli/install/bun-run.test.ts`, new `--cwd longer than the OS path limit` block: the two over-long cases fail on the current release build with the panic above and pass with this branch; the normalizing case and the existing `--cwd` test pass both ways. Whole file passes (`bun bd test`).
  - `test/cli/run/tsconfig-override.test.ts`, new `path longer than the OS path limit` block: both cases fail on the release build and pass with this branch; whole file passes.
  - `cargo test -p bun_paths resolve_path::tests`: 4 new unit tests for `join_abs_string_spill` (fits, spills, absolute part and long cwd, long part that collapses), 8 pass.
  - By hand with the debug build: `--cwd` with `""`, `/`, `.`, `..`, `subdir/`, an absolute directory and a missing directory behave as before; `--cwd` values of about 4 KiB, 5 KB and 100 KB all print the `ENAMETOOLONG` error and exit 1; `--tsconfig-override` with a missing file still prints `Cannot find tsconfig file` and continues.

### Background
- `resolve_path::join_abs` / `join_abs_string` return a slice into a per-thread 4096 byte scratch buffer; the `*_string_buf` variants write into a caller buffer. Neither checks that the normalized result fits, so they are only safe for inputs whose length is already bounded. The file already has `normalize_string_spill` and `join_spill` for unbounded input: use the thread-local buffer when a cheap upper bound says the result fits, otherwise a caller `Vec`. This PR adds the missing `join_abs` member of that family.
- The upper bound: `_join_abs_string_buf` concatenates `cwd` and the parts with one separator each (plus one more when a bare Windows root needs a separator appended) and then normalizes, which never makes a path longer except for the Windows cases noted on `normalize_string_spill`, so `cwd.len() + sum(part.len() + 1) + 2` always holds both the concatenation and the output. That expression was already used in two places in the file; `join_abs_needed` names it.
- `chdir(2)` returns `ENAMETOOLONG` for any path at or over `PATH_MAX` (4096 on Linux, 1024 on macOS) or with a component over `NAME_MAX`; `Output::err(sys_error, ...)` prints it as `<ERRNO>: <strerror>: <message> (<syscall>)`, which is the message the `--cwd` block already prints for any `chdir` failure.
- The resolver opens `tsconfig_override` through `bun_sys::openat_a` / `open_a`, which return `ENAMETOOLONG` themselves for a path that does not fit a `PathBuffer`, and reports it as `Cannot read file "<path>": <errno>`; a long value that fits the buffer gets the same message from the kernel today.
