### PR TITLE
install: fail the isolated install with ENAMETOOLONG when a link: target does not fit the path buffer

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2072,7 +2072,7 @@ pub(crate) fn install_isolated_packages(
             task.installer = installer_backref;
         }
 
-        // `append_store_path` runs on worker threads via `&Installer` and
+        // `append_dependency_path` runs on worker threads via `&Installer` and
         // can't take `&mut PackageManager` there, so ensure the
         // global link dir once on the main thread before any `.symlink`
         // resolution can be reached by a task. Guarded so installs without

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -342,6 +342,15 @@ impl<'a> Installer<'a> {
                     ),
                 );
             }
+            TaskError::LinkPathTooLong(link_pkg_id) => {
+                Output::err(
+                    "ENAMETOOLONG",
+                    "link path for package <b>{}<r> is too long",
+                    (bstr::BStr::new(
+                        pkg_names[*link_pkg_id as usize].slice(string_buf),
+                    ),),
+                );
+            }
             TaskError::Patching(patch_log) => {
                 Output::err_generic(
                     "failed to patch package: {}@{}",
@@ -646,6 +655,9 @@ pub struct DownloadError {
 pub enum TaskError {
     LinkPackage(sys::Error),
     SymlinkDependencies(sys::Error),
+    /// `<global link dir>/<link: target>` of this `link:` dependency does not
+    /// fit in a path buffer. See `Installer::append_dependency_path`.
+    LinkPathTooLong(PackageID),
     RunScripts(crate::Error),
     Binaries(crate::Error),
     Patching(Log),
@@ -657,6 +669,7 @@ impl TaskError {
         match self {
             TaskError::LinkPackage(err) => TaskError::LinkPackage(err.clone()),
             TaskError::SymlinkDependencies(err) => TaskError::SymlinkDependencies(err.clone()),
+            TaskError::LinkPathTooLong(pkg_id) => TaskError::LinkPathTooLong(*pkg_id),
             TaskError::Binaries(err) => TaskError::Binaries(*err),
             TaskError::RunScripts(err) => TaskError::RunScripts(*err),
             TaskError::Patching(_log) => {
@@ -1497,8 +1510,10 @@ impl Task {
                                 dep.entry_id,
                                 Which::Final,
                             );
-                        } else {
-                            installer.append_store_path(&mut dep_store_path, dep.entry_id);
+                        } else if let Err(err) =
+                            installer.append_dependency_path(&mut dep_store_path, dep.entry_id)
+                        {
+                            return Ok(Yield::failure(err));
                         }
 
                         // A `dest.save()` `ResetScope` guard would hold `&mut dest`,
@@ -2675,6 +2690,52 @@ impl<'a> Installer<'a> {
         self.append_store_path(buf, entry_id);
     }
 
+    /// `append_store_path` for the entry a dependency symlink points at. This
+    /// is the one place a `link:` package's path is needed: it is never
+    /// installed (`install_isolated_packages` marks its entry done up front),
+    /// its dependents link straight to `<global link dir>/<link: target>`.
+    ///
+    /// The `link:` target is stored as written in package.json or bun.lock, so
+    /// unlike every other input of these path builders it is not bounded by a
+    /// path buffer. A target that does not fit fails the dependent instead.
+    pub(crate) fn append_dependency_path(
+        &self,
+        buf: &mut AutoAbsPath,
+        entry_id: StoreEntryId,
+    ) -> core::result::Result<(), TaskError> {
+        let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
+        let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
+        let pkg_res = self.lockfile().packages.items_resolution()[pkg_id as usize];
+
+        if pkg_res.tag != ResolutionTag::Symlink {
+            self.append_store_path(buf, entry_id);
+            return Ok(());
+        }
+
+        // Lazily ensuring the global link dir would mutate `*PackageManager`,
+        // but this runs on worker threads, so the lazy init is hoisted to the
+        // main thread (`install_isolated_packages`, before any `start_task`).
+        // Reading the cached field here is then equivalent.
+        let link_dir_path: &[u8] = &self.manager().global_link_dir_path;
+        debug_assert!(
+            !link_dir_path.is_empty(),
+            "global_link_dir_path must be ensured before tasks start",
+        );
+        let string_buf = self.lockfile().buffers.string_bytes.as_slice();
+        let link_target = pkg_res.symlink().slice(string_buf);
+
+        let mut target = paths::AutoAbsPathChecked::init();
+        if target.append(link_dir_path).is_err() || target.append(link_target).is_err() {
+            return Err(TaskError::LinkPathTooLong(pkg_id));
+        }
+
+        paths::PathLike::clear(buf);
+        // Same unit width and `target` passed the length check, so this fits.
+        buf.append(target.slice()).assume_ok();
+        Ok(())
+    }
+
+    /// `entry_id` must not be a `link:` package; see `append_dependency_path`.
     pub(crate) fn append_store_path(&self, buf: &mut impl paths::PathLike, entry_id: StoreEntryId) {
         let string_buf = self.lockfile().buffers.string_bytes.as_slice();
 
@@ -2721,21 +2782,7 @@ impl<'a> Installer<'a> {
                 buf.append(pkg_res.workspace().slice(string_buf));
             }
             ResolutionTag::Symlink => {
-                // Lazily ensuring the global link dir would mutate
-                // `*PackageManager`, but `append_store_path` is
-                // `&self` and may run on worker
-                // threads, so the lazy init is hoisted to the main-thread caller
-                // (`isolated_install::install_packages`, before any `start_task`).
-                // Reading the cached field here is then equivalent.
-                let symlink_dir_path: &[u8] = &self.manager().global_link_dir_path;
-                debug_assert!(
-                    !symlink_dir_path.is_empty(),
-                    "global_link_dir_path must be ensured before tasks start",
-                );
-
-                buf.clear();
-                buf.append(symlink_dir_path);
-                buf.append(pkg_res.symlink().slice(string_buf));
+                unreachable!("link: packages have no store path; see append_dependency_path")
             }
             _ => {
                 let pkg_name = pkg_names[pkg_id as usize];

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, isLinux, isWindows, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { dirname, join } from "path";
 
@@ -2506,6 +2506,160 @@ test("invalid --linker value is echoed back in the error", async () => {
   expect(stderr).toContain('--linker: "isoalted"');
   expect(stderr).toContain("'isolated' or 'hoisted'");
   expect(exitCode).toBe(1);
+});
+
+describe("link: dependencies", () => {
+  // Size of the buffer install paths are built in (`MAX_PATH_BYTES`): PATH_MAX
+  // on Linux and macOS, the UTF-8 worst case of a 32767 character path on Windows.
+  const MAX_PATH_BYTES = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
+
+  // A `link:` target that resolves to the registered `linked` package but is
+  // about `length` bytes as written. The target is stored and joined onto the
+  // global link dir as written, so the `x/..` segments count against the buffer.
+  function linkTarget(length: number): string {
+    const segments = Math.floor((length - "linked".length) / "x/../".length);
+    return Buffer.alloc(segments * "x/../".length, "x/../").toString() + "linked";
+  }
+
+  const linkedPackageJson = JSON.stringify({ name: "linked", version: "1.0.0" });
+
+  // Registers `<dir>/linked` in a global link dir private to the test, so the
+  // dir every `link:` target is joined onto is `<dir>/global/node_modules`.
+  async function registerLinked(dir: string) {
+    const env = {
+      ...bunEnv,
+      BUN_INSTALL_GLOBAL_DIR: join(dir, "global"),
+      BUN_INSTALL_CACHE_DIR: join(dir, "cache"),
+    };
+    await using proc = spawn({
+      cmd: [bunExe(), "link"],
+      cwd: join(dir, "linked"),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain('Registered "linked"');
+    expect(exitCode).toBe(0);
+
+    return { env, projectDir: join(dir, "project"), linkDir: join(dir, "global", "node_modules") };
+  }
+
+  async function installIsolated(env: NodeJS.Dict<string>, cwd: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--linker=isolated"],
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("links the package when the target fits", async () => {
+    using dir = tempDir("isolated-link-fits", {
+      "linked/package.json": linkedPackageJson,
+      "project/package.json": JSON.stringify({
+        name: "link-fits",
+        dependencies: { linked: "link:" + linkTarget(256) },
+      }),
+    });
+    const { env, projectDir } = await registerLinked(String(dir));
+
+    const { stderr, exitCode } = await installIsolated(env, projectDir);
+
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(lstatSync(join(projectDir, "node_modules", "linked")).isSymbolicLink()).toBeTrue();
+    expect(await file(join(projectDir, "node_modules", "linked", "package.json")).json()).toEqual({
+      name: "linked",
+      version: "1.0.0",
+    });
+  });
+
+  test.concurrent("fails with ENAMETOOLONG when the target in bun.lock does not fit", async () => {
+    // A lockfile resolution is used as-is, so this never passes through the
+    // resolver: the linker is the first thing that builds a path from it.
+    const target = linkTarget(MAX_PATH_BYTES + 64);
+    using dir = tempDir("isolated-link-lockfile-too-long", {
+      "linked/package.json": linkedPackageJson,
+      "project/package.json": JSON.stringify({
+        name: "link-from-lockfile",
+        dependencies: { linked: "link:linked" },
+      }),
+      "project/bun.lock": `{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "link-from-lockfile",
+      "dependencies": {
+        "linked": "link:linked",
+      },
+    },
+  },
+  "packages": {
+    "linked": ["linked@link:${target}", {}],
+  }
+}
+`,
+    });
+    const { env, projectDir } = await registerLinked(String(dir));
+
+    const { stdout, stderr, exitCode } = await installIsolated(env, projectDir);
+
+    expect(stderr).toContain("ENAMETOOLONG: link path for package linked is too long");
+    expect(stdout).toContain("Failed to install 1 package");
+    expect(exitCode).toBe(1);
+    expect(() => lstatSync(join(projectDir, "node_modules", "linked"))).toThrow();
+  });
+
+  test.concurrent("fails with ENAMETOOLONG when the target in package.json does not fit", async () => {
+    // Fits on its own, so it resolves; does not fit once joined onto the link dir.
+    const target = linkTarget(MAX_PATH_BYTES - 16);
+    using dir = tempDir("isolated-link-package-json-too-long", {
+      "linked/package.json": linkedPackageJson,
+      "project/package.json": JSON.stringify({
+        name: "link-from-package-json",
+        dependencies: { linked: "link:" + target },
+      }),
+    });
+    const { env, projectDir, linkDir } = await registerLinked(String(dir));
+    expect(linkDir.length + "/".length + target.length).toBeGreaterThanOrEqual(MAX_PATH_BYTES);
+
+    const { stdout, stderr, exitCode } = await installIsolated(env, projectDir);
+
+    expect(stderr).toContain("ENAMETOOLONG: link path for package linked is too long");
+    expect(stdout).toContain("Failed to install 1 package");
+    expect(exitCode).toBe(1);
+    expect(() => lstatSync(join(projectDir, "node_modules", "linked"))).toThrow();
+  });
+
+  test.concurrent("fails the workspace package that depends on a target that does not fit", async () => {
+    const target = linkTarget(MAX_PATH_BYTES - 16);
+    using dir = tempDir("isolated-link-workspace-too-long", {
+      "linked/package.json": linkedPackageJson,
+      "project/package.json": JSON.stringify({
+        name: "link-from-workspace",
+        workspaces: ["packages/*"],
+      }),
+      "project/packages/app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: { linked: "link:" + target },
+      }),
+    });
+    const { env, projectDir, linkDir } = await registerLinked(String(dir));
+    expect(linkDir.length + "/".length + target.length).toBeGreaterThanOrEqual(MAX_PATH_BYTES);
+
+    const { stdout, stderr, exitCode } = await installIsolated(env, projectDir);
+
+    expect(stderr).toContain("ENAMETOOLONG: link path for package linked is too long");
+    expect(stdout).toContain("Failed to install 1 package");
+    expect(exitCode).toBe(1);
+    expect(() => lstatSync(join(projectDir, "packages", "app", "node_modules", "linked"))).toThrow();
+  });
 });
 
 describe("hoist", () => {


### PR DESCRIPTION
### Problem
- `bun install --linker isolated` aborts when a `link:` dependency's target, as written, is too long for the global link dir plus the target to fit in a path buffer (4096 bytes on Linux, 1024 on macOS, 32767 * 3 + 1 on Windows):
  ```
  panic: index out of bounds: the len is 4096 but the index is 4096
  ```
  exit code 134, in `Installer::append_store_path` (`src/install/isolated_install/Installer.rs:2738` on main), called from `Step::SymlinkDependencies` (`Installer.rs:1501`) on a thread pool worker.
- Cause: the `Symlink` arm of `append_store_path` appends the global link dir and then the `link:` target into its `buf`, which is an `impl PathLike`. `PathLike` is only implemented for `CheckLength::ASSUME` paths (`src/paths/lib.rs:376`), whose `append` skips the length check and indexes straight into the pooled `PathBuffer`. Every other input of the store path builders is bounded before it gets there; the `link:` target is not: the folder resolver records it exactly as written (`src/install/resolvers/folder_resolver.rs:123`) and `bun.lock` stores it verbatim (`src/install/resolution.rs:167`).
- Reachable today from a `bun.lock` whose resolution is `x@link:<anything long>` (the lockfile is used as-is, the resolver never sees it), and from package.json with a target such as `x/../x/../.../foo` that is short enough to resolve on its own (the `x/..` segments normalize away and `foo` is registered with `bun link`) but too long once joined onto the link dir. #38359 fixes the resolver's own buffer copies and the hoisted linker's copy of this overflow and explicitly leaves this site out; once it lands, package.json targets of any length reach this code.

### Fix
- `Step::SymlinkDependencies` builds the dependency's path through a new `Installer::append_dependency_path`. For every resolution but `link:` it calls `append_store_path` as before; for `link:` it builds `<global link dir>/<target>` in an `AutoAbsPathChecked` (the existing length-checked path type, `src/paths/Path.rs`), copies the result into the caller's buffer when it fits, and otherwise fails the dependent's task with a new `TaskError::LinkPathTooLong`, which `on_task_fail` reports as
  ```
  ENAMETOOLONG: link path for package foo is too long
  Failed to install 1 package
  ```
  with exit code 1. That is the message #38359 adds to the hoisted linker for the same dependency, so both linkers report this case the same way.
- The `Symlink` arm of `append_store_path` becomes `unreachable!`: `link:` packages never run an install task (`install_isolated_packages` marks their entries done before any task starts), so the only code that asks for one's path is the dependency symlink step, which now goes through `append_dependency_path`. The other `append_store_path` callers pass the running entry itself or an npm/git/tarball entry, which is why they are not made fallible.
- Why failing is right: the length as written is what gets joined and handed to `symlink(2)`, which rejects a target longer than PATH_MAX with the same errno, so such a dependency could never have been linked; the check only replaces the abort with that error. The new helper takes a concrete `AutoAbsPath` (u8) rather than `impl PathLike`, so the check is against the buffer it actually writes to (on Windows the u8 and u16 buffers have different limits).
- Tests, in `test/cli/install/isolated-install.test.ts` (`link: dependencies`), each with a `bun link`-registered package in a private `BUN_INSTALL_GLOBAL_DIR`:
  - a 256 byte `x/../` target installs and `node_modules/linked` resolves to the package (passes before and after; there was no isolated `link:` coverage);
  - a `bun.lock` resolution 64 bytes longer than the buffer;
  - a package.json target 16 bytes shorter than the buffer (resolves, overflows once joined onto the link dir);
  - the same target declared by a workspace package instead of the root.
  The last three abort with the panic above on the unfixed build (`USE_SYSTEM_BUN=1`) and pass with `bun bd test`.
- Also run: the whole of `isolated-install.test.ts` (66 pass); `cargo check -p bun_install` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`; clippy is clean for the crate.

### Background
- The isolated linker installs each package once into `node_modules/.bun/<store path>/` and gives every dependent a symlink to it. `Step::SymlinkDependencies` is the per-package task step that creates those links; `append_store_path` computes where a package lives so the link can point at it. A `link:` package is the exception: it is not installed anywhere, dependents link directly into the global link dir (`<global dir>/node_modules`, where `bun link` registers packages), so its "store path" is the link dir plus the target as written.
- `bun_paths::Path` builds paths in a pooled buffer of `MAX_PATH_BYTES`. Its `CheckLength` parameter decides whether `append` returns `Err(MaxPathExceeded)` for input that does not fit (`CHECK`, e.g. `AutoAbsPathChecked`) or assumes it fits (`ASSUME`, the default; an over-long input is an index out of bounds). The `PathLike` trait the store path builders take is deliberately implemented only for `ASSUME` paths, so unbounded input has to be checked on a concrete checked path, which is what the new helper does.
- `TaskError` is how a worker-thread task reports failure: the main thread drains it into `Installer::on_task_fail`, which prints the error, counts it in the install summary (`Failed to install N packages`, exit code 1) and unblocks dependents.

<details>
<summary>Repro (Linux) before and after</summary>

```sh
export BUN_INSTALL=$(mktemp -d); mkdir foo proj
echo '{"name":"foo","version":"1.0.0"}' > foo/package.json && (cd foo && bun link)
cd proj
# package.json route: 4078 bytes as written, normalizes to "foo"
bun -e 'require("fs").writeFileSync("package.json", JSON.stringify({name:"proj",dependencies:{foo:"link:"+"x/../".repeat(815)+"foo"}}))'
bun install --linker isolated
```

Before (1.4.0-canary, and the same with the `link:` target placed in `bun.lock` instead):

```
panic: index out of bounds: the len is 4096 but the index is 4096
```

After:

```
ENAMETOOLONG: link path for package foo is too long

Failed to install 1 package
```

exit code 1. A target that fits (`"x/../".repeat(100) + "foo"`) still installs and `node_modules/foo` points at `<link dir>/foo`, unchanged.
</details>
