### PR TITLE
bunfig: stop panicking when the config path does not fit in a path buffer

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,9 +17,7 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
-/// `dir/path`, NUL-terminated in `buf`. `dir` (cwd, `$HOME`, ...) and `path`
-/// (argv) are unbounded, so the result may not fit; `None` then. No file can be
-/// opened at such a path, so callers treat it like any other unreadable config.
+/// `None` when `dir/path` does not fit: nothing could be opened at such a path anyway.
 fn join_config_path<'buf>(
     dir: &[u8],
     path: &[u8],
@@ -43,8 +41,6 @@ fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
     join_config_path(dir, b".bunfig.toml", buf)
 }
 
-/// An auto-loaded bunfig that cannot be read is treated as absent; one the
-/// user asked for is fatal.
 fn unreadable_config(
     auto_loaded: bool,
     err: &bun_sys::Error,

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,22 +17,48 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
+/// `dir/path`, NUL-terminated in `buf`. `dir` (cwd, `$HOME`, ...) and `path`
+/// (argv) are unbounded, so the result may not fit; `None` then. No file can be
+/// opened at such a path, so callers treat it like any other unreadable config.
+fn join_config_path<'buf>(
+    dir: &[u8],
+    path: &[u8],
+    buf: &'buf mut PathBuffer,
+) -> Option<&'buf ZStr> {
+    let max_len = buf.len() - 1;
+    let len = resolve_path::join_abs_string_buf_checked::<platform::Auto>(
+        dir,
+        &mut buf[..max_len],
+        &[path],
+    )?
+    .len();
+    buf[len] = 0;
+    Some(ZStr::from_buf(&buf[..], len))
+}
+
 fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
-    let paths: [&[u8]; 1] = [b".bunfig.toml"];
+    let dir = env_var::XDG_CONFIG_HOME
+        .get()
+        .or_else(|| env_var::HOME.get())?;
+    join_config_path(dir, b".bunfig.toml", buf)
+}
 
-    if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            data_dir, &mut **buf, &paths,
-        ));
+/// An auto-loaded bunfig that cannot be read is treated as absent; one the
+/// user asked for is fatal.
+fn unreadable_config(
+    auto_loaded: bool,
+    err: &bun_sys::Error,
+    config_path: &[u8],
+) -> Result<(), crate::Error> {
+    if auto_loaded {
+        return Ok(());
     }
-
-    if let Some(home_dir) = env_var::HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            home_dir, &mut **buf, &paths,
-        ));
-    }
-
-    None
+    bun_core::pretty_errorln!(
+        "{}\nwhile reading config \"{}\"",
+        err,
+        BStr::new(config_path),
+    );
+    Global::exit(1);
 }
 
 fn load_bunfig(
@@ -44,17 +70,7 @@ fn load_bunfig(
     let source =
         match bun_ast::to_source(config_path, bun_ast::ToSourceOptions { convert_bom: true }) {
             Ok(s) => s,
-            Err(err) => {
-                if auto_loaded {
-                    return Ok(());
-                }
-                bun_core::pretty_errorln!(
-                    "{}\nwhile reading config \"{}\"",
-                    err,
-                    BStr::new(config_path.as_bytes()),
-                );
-                Global::exit(1);
-            }
+            Err(err) => return unreadable_config(auto_loaded, &err, config_path.as_bytes()),
         };
 
     bun_ast::stmt::data::Store::create();
@@ -187,11 +203,12 @@ pub fn load_config(
     if config_path_.is_empty() {
         return Ok(());
     }
-    let config_path_len: usize;
-    if config_path_[0] == b'/' {
-        config_buf[..config_path_.len()].copy_from_slice(config_path_);
-        config_buf[config_path_.len()] = 0;
-        config_path_len = config_path_.len();
+    let config_path: Option<&ZStr> = if config_path_[0] == b'/' {
+        if config_path_.len() < config_buf.len() {
+            Some(resolve_path::z(config_path_, &mut config_buf))
+        } else {
+            None
+        }
     } else {
         if ctx.args.absolute_working_dir.is_none() {
             let mut secondbuf = PathBuffer::uninit();
@@ -202,23 +219,20 @@ pub fn load_config(
             ctx.args.absolute_working_dir = Some(Box::<[u8]>::from(&secondbuf[..cwd_len]));
         }
 
-        // Reshaped for borrowck: `join_abs_string_buf` ties the
-        // returned slice's lifetime to both `cwd` (borrowed from `ctx.args`)
-        // and `config_buf`. We only need the length to NUL-terminate and
-        // re-wrap, so capture `joined.len()` and drop the `ctx` borrow before
-        // the `&mut ctx` call below.
-        config_path_len = {
-            let awd: &[u8] = ctx.args.absolute_working_dir.as_deref().unwrap();
-            let parts: [&[u8]; 2] = [awd, config_path_];
-            let joined =
-                resolve_path::join_abs_string_buf::<platform::Auto>(awd, &mut *config_buf, &parts);
-            joined.len()
-        };
-        config_buf[config_path_len] = 0;
-    }
-    // SAFETY: `config_buf[config_path_len] == 0` (written above on both arms);
-    // `config_buf` outlives the call.
-    let config_path = ZStr::from_buf(&config_buf[..], config_path_len);
+        join_config_path(
+            ctx.args.absolute_working_dir.as_deref().unwrap(),
+            config_path_,
+            &mut config_buf,
+        )
+    };
+    let Some(config_path) = config_path else {
+        return unreadable_config(
+            auto_loaded,
+            &bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+                .with_path(config_path_),
+            config_path_,
+        );
+    };
 
     if let Err(err) = load_config_path(cmd, auto_loaded, config_path, ctx) {
         report_bunfig_load_failure(ctx.log, err);

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 
 describe.concurrent("bunfig.toml type-mismatch error messages", () => {
   const cases: [config: string, expected: string][] = [
@@ -28,5 +30,216 @@ describe.concurrent("bunfig.toml type-mismatch error messages", () => {
     expect(stderr).not.toMatch(/\be_(string|boolean|number|object|array|null)\b/);
     expect(stdout).toBe("");
     expect(exitCode).not.toBe(0);
+  });
+});
+
+// bun builds every config path in a stack buffer of MAX_PATH_BYTES (the platform's
+// PATH_MAX, see bun_core), so the longest path it can hold is MAX_PATH_BYTES - 1
+// bytes plus the NUL terminator. Paths that do not fit used to overflow the buffer
+// (a panic at startup); they must be treated like any other unreadable config.
+//
+// On Windows the buffer is ~96 KiB, longer than any path, argument or environment
+// variable the OS accepts, so the overflow cannot be reached there.
+describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path buffer", () => {
+  const MAX_PATH_BYTES = process.platform === "linux" || process.platform === "android" ? 4096 : 1024;
+  // A TOML syntax error: every command fails to load it, and the error names the
+  // path the config was loaded from.
+  const INVALID_BUNFIG = "[install\n";
+  const SEGMENT = Buffer.alloc(200, "d").toString();
+
+  /** An absolute path below `root` that is exactly `length` bytes long (ASCII only). */
+  function pathOfLength(root: string, length: number): string {
+    let path = root;
+    // Leave room for the final component, which has to stay under NAME_MAX (255).
+    while (length - path.length > 256) path = join(path, SEGMENT);
+    path = join(path, Buffer.alloc(length - path.length - 1, "L").toString());
+    expect(path).toHaveLength(length);
+    return path;
+  }
+
+  /** Writes an invalid config at `configPath` and returns it. */
+  function invalidConfigAt(configPath: string): string {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, INVALID_BUNFIG);
+    return configPath;
+  }
+
+  async function runBun(args: string[], cwd: string, env: Record<string, string | undefined> = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: { ...bunEnv, ...env },
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+  type Result = Awaited<ReturnType<typeof runBun>>;
+
+  function expectLoadedFrom({ stdout, stderr, exitCode }: Result, configPath: string) {
+    expect(stderr).toContain(`at ${configPath}:`);
+    expect(stderr).toContain("failed to load bunfig");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  }
+
+  function expectNameTooLong({ stdout, stderr, exitCode }: Result, configArg: string) {
+    expect(stderr.replaceAll(configArg, "<config>")).toBe(
+      'ENAMETOOLONG: <config>: File name too long (open())\nwhile reading config "<config>"\n',
+    );
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  }
+
+  describe("bunfig.toml auto-loaded from the working directory", () => {
+    const PRINT_CWD_LENGTH = "console.log(process.cwd().length)";
+
+    test("is loaded when its path is exactly MAX_PATH_BYTES - 1 bytes", async () => {
+      using dir = tempDir("bunfig-long-cwd", {});
+      const cwd = pathOfLength(String(dir), MAX_PATH_BYTES - "/bunfig.toml".length - 1);
+      const config = invalidConfigAt(join(cwd, "bunfig.toml"));
+      expect(config).toHaveLength(MAX_PATH_BYTES - 1);
+
+      expectLoadedFrom(await runBun(["-e", PRINT_CWD_LENGTH], cwd), config);
+    });
+
+    // No bunfig.toml exists in these directories: its path would be too long to
+    // create, and the path is built (and used to overflow) before it is opened.
+    const skippedCases: [configPathWouldBe: string, cwdLength: number][] = [
+      ["exactly MAX_PATH_BYTES bytes, leaving no room for the NUL", MAX_PATH_BYTES - "/bunfig.toml".length],
+      ["longer than the buffer", MAX_PATH_BYTES - 1],
+    ];
+
+    test.each(skippedCases)("bun -e still runs when the bunfig.toml path would be %s", async (_, cwdLength) => {
+      using dir = tempDir("bunfig-long-cwd", {});
+      const cwd = pathOfLength(String(dir), cwdLength);
+      mkdirSync(cwd, { recursive: true });
+
+      expect(await runBun(["-e", PRINT_CWD_LENGTH], cwd)).toEqual({
+        stdout: `${cwdLength}\n`,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("bun <file> still runs when the bunfig.toml path does not fit", async () => {
+      using dir = tempDir("bunfig-long-cwd", {});
+      const cwdLength = MAX_PATH_BYTES - "/bunfig.toml".length;
+      const cwd = pathOfLength(String(dir), cwdLength);
+      mkdirSync(cwd, { recursive: true });
+      writeFileSync(join(cwd, "x.cjs"), PRINT_CWD_LENGTH);
+
+      expect(await runBun(["x.cjs"], cwd)).toEqual({
+        stdout: `${cwdLength}\n`,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
+  describe("--config=<relative path>", () => {
+    test("is loaded when the resolved path is exactly MAX_PATH_BYTES - 1 bytes", async () => {
+      using dir = tempDir("bunfig-long-config", {});
+      const config = invalidConfigAt(pathOfLength(String(dir), MAX_PATH_BYTES - 1));
+
+      expectLoadedFrom(await runBun([`--config=${relative(String(dir), config)}`, "-e", "1"], String(dir)), config);
+    });
+
+    test("fails with ENAMETOOLONG when the resolved path is MAX_PATH_BYTES bytes", async () => {
+      using dir = tempDir("bunfig-long-config", {});
+      const configArg = relative(String(dir), pathOfLength(String(dir), MAX_PATH_BYTES));
+
+      expectNameTooLong(await runBun([`--config=${configArg}`, "-e", "1"], String(dir)), configArg);
+    });
+
+    test("fails with ENAMETOOLONG when the argument alone is longer than the buffer", async () => {
+      using dir = tempDir("bunfig-long-config", {});
+      const configArg = Buffer.alloc(MAX_PATH_BYTES + 1000, "a").toString();
+
+      expectNameTooLong(await runBun([`--config=${configArg}`, "-e", "1"], String(dir)), configArg);
+    });
+
+    test("is loaded when a path longer than the buffer normalizes to one that fits", async () => {
+      using dir = tempDir("bunfig-long-config", { "bunfig.toml": INVALID_BUNFIG });
+      const configArg = "x/../".repeat(Math.ceil(MAX_PATH_BYTES / "x/../".length)) + "bunfig.toml";
+      expect(configArg.length).toBeGreaterThan(MAX_PATH_BYTES);
+
+      expectLoadedFrom(
+        await runBun([`--config=${configArg}`, "-e", "1"], String(dir)),
+        join(String(dir), "bunfig.toml"),
+      );
+    });
+  });
+
+  describe("--config=<absolute path>", () => {
+    test("is loaded when the path is exactly MAX_PATH_BYTES - 1 bytes", async () => {
+      using dir = tempDir("bunfig-long-config", {});
+      const config = invalidConfigAt(pathOfLength(String(dir), MAX_PATH_BYTES - 1));
+
+      expectLoadedFrom(await runBun([`--config=${config}`, "-e", "1"], String(dir)), config);
+    });
+
+    const tooLongCases: [pathIs: string, configArgBelow: (root: string) => string][] = [
+      ["exactly MAX_PATH_BYTES bytes", root => pathOfLength(root, MAX_PATH_BYTES)],
+      ["longer than the buffer", () => "/" + Buffer.alloc(MAX_PATH_BYTES + 1000, "a").toString()],
+    ];
+
+    test.each(tooLongCases)("fails with ENAMETOOLONG when the path is %s", async (_, configArgBelow) => {
+      using dir = tempDir("bunfig-long-config", {});
+      const configArg = configArgBelow(String(dir));
+
+      expectNameTooLong(await runBun([`--config=${configArg}`, "-e", "1"], String(dir)), configArg);
+    });
+  });
+
+  // Install commands also read $XDG_CONFIG_HOME/.bunfig.toml (or $HOME/.bunfig.toml).
+  // `bun pm cache` prints the cache directory once that config has been handled.
+  describe("global .bunfig.toml", () => {
+    const CACHE_DIR_MARKER = "/bunfig-global-test-cache-dir";
+    const PACKAGE_JSON = { "package.json": JSON.stringify({ name: "bunfig-global-test" }) };
+    async function pmCache(cwd: string, env: Record<string, string | undefined>): Promise<Result> {
+      const result = await runBun(["pm", "cache"], cwd, { BUN_INSTALL_CACHE_DIR: CACHE_DIR_MARKER, ...env });
+      return { ...result, stdout: result.stdout.trim() };
+    }
+
+    test("is loaded when its path is exactly MAX_PATH_BYTES - 1 bytes", async () => {
+      using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
+      const configHome = pathOfLength(String(dir), MAX_PATH_BYTES - "/.bunfig.toml".length - 1);
+      const config = invalidConfigAt(join(configHome, ".bunfig.toml"));
+      expect(config).toHaveLength(MAX_PATH_BYTES - 1);
+
+      expectLoadedFrom(await pmCache(String(dir), { XDG_CONFIG_HOME: configHome }), config);
+    });
+
+    // The directories never exist; only the length of the variable matters. The
+    // longest value used here still leaves room for the "/.npmrc" that install
+    // commands append to the same variables afterwards.
+    const skippedCases: [configPathWouldBe: string, configHomeLength: number][] = [
+      ["exactly MAX_PATH_BYTES bytes, leaving no room for the NUL", MAX_PATH_BYTES - "/.bunfig.toml".length],
+      ["longer than the buffer", MAX_PATH_BYTES - "/.npmrc".length - 1],
+    ];
+
+    test.each(skippedCases)("is skipped when its $XDG_CONFIG_HOME path would be %s", async (_, configHomeLength) => {
+      using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
+      const configHome = pathOfLength(String(dir), configHomeLength);
+
+      expect(await pmCache(String(dir), { XDG_CONFIG_HOME: configHome })).toEqual({
+        stdout: CACHE_DIR_MARKER,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("is skipped when its $HOME path would be exactly MAX_PATH_BYTES bytes", async () => {
+      using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
+      const home = pathOfLength(String(dir), MAX_PATH_BYTES - "/.bunfig.toml".length);
+
+      expect(await pmCache(String(dir), { HOME: home, XDG_CONFIG_HOME: undefined })).toEqual({
+        stdout: CACHE_DIR_MARKER,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
   });
 });

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -196,12 +196,16 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
   // Install commands also read $XDG_CONFIG_HOME/.bunfig.toml (or $HOME/.bunfig.toml).
   // `bun pm cache` prints the cache directory once that config has been handled.
   describe("global .bunfig.toml", () => {
-    const CACHE_DIR_MARKER = "/bunfig-global-test-cache-dir";
     const PACKAGE_JSON = { "package.json": JSON.stringify({ name: "bunfig-global-test" }) };
-    async function pmCache(cwd: string, env: Record<string, string | undefined>): Promise<Result> {
-      const result = await runBun(["pm", "cache"], cwd, { BUN_INSTALL_CACHE_DIR: CACHE_DIR_MARKER, ...env });
+    // `bun pm cache` creates the directory it prints, and silently falls back to
+    // node_modules/.cache when it cannot, so it has to live inside the temp dir.
+    const cacheDirIn = (dir: string) => join(dir, "install-cache");
+    async function pmCache(dir: string, env: Record<string, string | undefined>): Promise<Result> {
+      const result = await runBun(["pm", "cache"], dir, { BUN_INSTALL_CACHE_DIR: cacheDirIn(dir), ...env });
       return { ...result, stdout: result.stdout.trim() };
     }
+    /** The global config was skipped and the command went on to print the cache directory. */
+    const printedCacheDir = (dir: string): Result => ({ stdout: cacheDirIn(dir), stderr: "", exitCode: 0 });
 
     test("is loaded when its path is exactly MAX_PATH_BYTES - 1 bytes", async () => {
       using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
@@ -224,22 +228,16 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
       using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
       const configHome = pathOfLength(String(dir), configHomeLength);
 
-      expect(await pmCache(String(dir), { XDG_CONFIG_HOME: configHome })).toEqual({
-        stdout: CACHE_DIR_MARKER,
-        stderr: "",
-        exitCode: 0,
-      });
+      expect(await pmCache(String(dir), { XDG_CONFIG_HOME: configHome })).toEqual(printedCacheDir(String(dir)));
     });
 
     test("is skipped when its $HOME path would be exactly MAX_PATH_BYTES bytes", async () => {
       using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
       const home = pathOfLength(String(dir), MAX_PATH_BYTES - "/.bunfig.toml".length);
 
-      expect(await pmCache(String(dir), { HOME: home, XDG_CONFIG_HOME: undefined })).toEqual({
-        stdout: CACHE_DIR_MARKER,
-        stderr: "",
-        exitCode: 0,
-      });
+      expect(await pmCache(String(dir), { HOME: home, XDG_CONFIG_HOME: undefined })).toEqual(
+        printedCacheDir(String(dir)),
+      );
     });
   });
 });

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -47,13 +47,13 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
   const INVALID_BUNFIG = "[install\n";
   const SEGMENT = Buffer.alloc(200, "d").toString();
 
-  /** An absolute path below `root` that is exactly `length` bytes long (ASCII only). */
+  /** An absolute path below `root` whose UTF-8 encoding is exactly `length` bytes long. */
   function pathOfLength(root: string, length: number): string {
     let path = root;
     // Leave room for the final component, which has to stay under NAME_MAX (255).
-    while (length - path.length > 256) path = join(path, SEGMENT);
-    path = join(path, Buffer.alloc(length - path.length - 1, "L").toString());
-    expect(path).toHaveLength(length);
+    while (length - Buffer.byteLength(path) > 256) path = join(path, SEGMENT);
+    path = join(path, Buffer.alloc(length - Buffer.byteLength(path) - 1, "L").toString());
+    expect(Buffer.byteLength(path)).toBe(length);
     return path;
   }
 
@@ -93,31 +93,31 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
   }
 
   describe("bunfig.toml auto-loaded from the working directory", () => {
-    const PRINT_CWD_LENGTH = "console.log(process.cwd().length)";
+    const PRINT_CWD_BYTES = "console.log(Buffer.byteLength(process.cwd()))";
 
     test("is loaded when its path is exactly MAX_PATH_BYTES - 1 bytes", async () => {
       using dir = tempDir("bunfig-long-cwd", {});
       const cwd = pathOfLength(String(dir), MAX_PATH_BYTES - "/bunfig.toml".length - 1);
       const config = invalidConfigAt(join(cwd, "bunfig.toml"));
-      expect(config).toHaveLength(MAX_PATH_BYTES - 1);
+      expect(Buffer.byteLength(config)).toBe(MAX_PATH_BYTES - 1);
 
-      expectLoadedFrom(await runBun(["-e", PRINT_CWD_LENGTH], cwd), config);
+      expectLoadedFrom(await runBun(["-e", PRINT_CWD_BYTES], cwd), config);
     });
 
     // No bunfig.toml exists in these directories: its path would be too long to
     // create, and the path is built (and used to overflow) before it is opened.
-    const skippedCases: [configPathWouldBe: string, cwdLength: number][] = [
+    const skippedCases: [configPathWouldBe: string, cwdBytes: number][] = [
       ["exactly MAX_PATH_BYTES bytes, leaving no room for the NUL", MAX_PATH_BYTES - "/bunfig.toml".length],
       ["longer than the buffer", MAX_PATH_BYTES - 1],
     ];
 
-    test.each(skippedCases)("bun -e still runs when the bunfig.toml path would be %s", async (_, cwdLength) => {
+    test.each(skippedCases)("bun -e still runs when the bunfig.toml path would be %s", async (_, cwdBytes) => {
       using dir = tempDir("bunfig-long-cwd", {});
-      const cwd = pathOfLength(String(dir), cwdLength);
+      const cwd = pathOfLength(String(dir), cwdBytes);
       mkdirSync(cwd, { recursive: true });
 
-      expect(await runBun(["-e", PRINT_CWD_LENGTH], cwd)).toEqual({
-        stdout: `${cwdLength}\n`,
+      expect(await runBun(["-e", PRINT_CWD_BYTES], cwd)).toEqual({
+        stdout: `${cwdBytes}\n`,
         stderr: "",
         exitCode: 0,
       });
@@ -125,13 +125,13 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
 
     test("bun <file> still runs when the bunfig.toml path does not fit", async () => {
       using dir = tempDir("bunfig-long-cwd", {});
-      const cwdLength = MAX_PATH_BYTES - "/bunfig.toml".length;
-      const cwd = pathOfLength(String(dir), cwdLength);
+      const cwdBytes = MAX_PATH_BYTES - "/bunfig.toml".length;
+      const cwd = pathOfLength(String(dir), cwdBytes);
       mkdirSync(cwd, { recursive: true });
-      writeFileSync(join(cwd, "x.cjs"), PRINT_CWD_LENGTH);
+      writeFileSync(join(cwd, "x.cjs"), PRINT_CWD_BYTES);
 
       expect(await runBun(["x.cjs"], cwd)).toEqual({
-        stdout: `${cwdLength}\n`,
+        stdout: `${cwdBytes}\n`,
         stderr: "",
         exitCode: 0,
       });
@@ -211,7 +211,7 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
       using dir = tempDir("bunfig-long-global", PACKAGE_JSON);
       const configHome = pathOfLength(String(dir), MAX_PATH_BYTES - "/.bunfig.toml".length - 1);
       const config = invalidConfigAt(join(configHome, ".bunfig.toml"));
-      expect(config).toHaveLength(MAX_PATH_BYTES - 1);
+      expect(Buffer.byteLength(config)).toBe(MAX_PATH_BYTES - 1);
 
       expectLoadedFrom(await pmCache(String(dir), { XDG_CONFIG_HOME: configHome }), config);
     });

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -162,7 +162,9 @@ describe.concurrent.skipIf(isWindows)("config paths that do not fit in a path bu
 
     test("is loaded when a path longer than the buffer normalizes to one that fits", async () => {
       using dir = tempDir("bunfig-long-config", { "bunfig.toml": INVALID_BUNFIG });
-      const configArg = "x/../".repeat(Math.ceil(MAX_PATH_BYTES / "x/../".length)) + "bunfig.toml";
+      const hop = "x/../";
+      const hops = Buffer.alloc(Math.ceil(MAX_PATH_BYTES / hop.length) * hop.length, hop).toString();
+      const configArg = hops + "bunfig.toml";
       expect(configArg.length).toBeGreaterThan(MAX_PATH_BYTES);
 
       expectLoadedFrom(


### PR DESCRIPTION
### Problem
- `bun x.cjs`, `bun -e 0` and every command in `ALWAYS_LOADS_CONFIG` (`bun test`, `bun build`, `bun install`, `bun pm`, ...) crash at startup when the working directory is 4084..4095 bytes long on Linux (1012..1023 on macOS, where `MAX_PATH_BYTES` is 1024):
  - cwd of exactly `MAX_PATH_BYTES - 12` bytes: `panic: index out of bounds: the len is 4096 but the index is 4096`
  - longer: `panic: range end index 4101 out of range for slice of length 4095` (end index = cwd length + 11), top frame `bun_paths::resolve_path::normalize_string_generic_tz` (`src/paths/resolve_path.rs:1071`), called from `bun_bunfig::arguments::load_config`
- The same panics happen for `--config=<value>` when the value (absolute) or cwd + value (relative) is `MAX_PATH_BYTES` bytes or longer, and for `bun install` / `bun pm ...` when `$XDG_CONFIG_HOME` (or `$HOME`) is `MAX_PATH_BYTES - 13` bytes or longer.
- Cause, all in `src/bunfig/arguments.rs`:
  - `load_config` joined cwd + config name into a stack `PathBuffer` with the unchecked `join_abs_string_buf` (L213) and wrote the NUL at `config_buf[len]` (L217). A result of exactly `MAX_PATH_BYTES` bytes fits the join but the NUL write is out of bounds; anything longer overflows inside the join.
  - The absolute `--config` arm copied the argument into the buffer without a length check (L192).
  - `get_home_config_path` joined `$XDG_CONFIG_HOME` / `$HOME` + `.bunfig.toml` with the unchecked `join_abs_string_buf_z` (L24, L30), which writes the NUL itself.
- Reproduced on the release build of main. The cwd case only needs `bun -e 0` from a directory of that length: the path is built before anything is opened, so no bunfig.toml has to exist.

### Fix
- `join_config_path` builds `dir/name` with `join_abs_string_buf_checked` into `buf[..len - 1]` (reserving the NUL slot) and returns `None` when the result does not fit; the cwd join and `get_home_config_path` both use it. The absolute `--config` arm length-checks and uses `resolve_path::z`, the guard-then-`z` shape its other callers use.
- A path that does not fit takes the existing "config failed to open" route in `load_bunfig`, factored into `unreadable_config`: auto-loaded configs (`bunfig.toml` in the cwd, the global `.bunfig.toml`) are skipped, as they already are on any read error; an explicit `--config` exits 1 with `ENAMETOOLONG: <path>: File name too long (open())` / `while reading config "<path>"`, the message a kernel ENAMETOOLONG on the same flag already produces.
- Why this is correct: `open()` rejects any path of `MAX_PATH_BYTES` bytes or more (`bun_sys::openat_a` returns ENAMETOOLONG for the same condition before the syscall), so no file at such a path could have been loaded; the failure now takes the existing route instead of overflowing the buffer. `join_abs_string_buf_checked` normalizes before deciding, so a long `--config` value that normalizes to a path that fits still loads. For `bun <file>` / `bun -e`, `run_command` additionally loads `bunfig.toml` relative to the cwd when `load_config` loaded nothing, so a bunfig.toml in such a deep directory is still picked up there.
- The cwd is no longer also passed as the first `parts` entry: `join_abs_string_buf` already uses it as the base, so the result is identical, and the copy would have made the checked join count the cwd twice in its size estimate.
- Verified with `test/config/bunfig/bunfig-errors.test.ts` (15 new tests): on the unfixed build the 10 overflow cases fail with the panics above and the 5 boundary/normalization controls pass; with the fix all 20 tests in the file pass. Per site they cover the longest path that still loads (exactly `MAX_PATH_BYTES - 1` bytes, asserted through the absolute path in the parse error), the `MAX_PATH_BYTES` case that failed on the NUL write, and a longer one, for `bun -e` and `bun file.js` in a deep cwd, relative and absolute `--config`, and `$XDG_CONFIG_HOME` / `$HOME` through `bun pm cache`. Skipped on Windows, where the buffer (~96 KiB) is longer than any path, argument or environment value the OS accepts.
- Also green with the fix: `test/config/bunfig/preload.test.ts`, `test/cli/install/bun-run-bunfig.test.ts`, `test/cli/bunfig-test-options.test.ts`, `test/cli/install/npmrc.test.ts`, the global-bunfig tests in `test/cli/install/minimum-release-age.test.ts`; `cargo clippy -p bun_bunfig` and `cargo fmt` are clean.
- Out of scope, reported separately: `bun install` / `bun pm` with `$XDG_CONFIG_HOME` / `$HOME` of `MAX_PATH_BYTES - 7` bytes or longer still panic one step later in the `.npmrc` lookup (`src/install/PackageManager.rs`, same unchecked join), so the global-config tests here stay below that length; `--cwd <over-long value>` (`src/runtime/cli/Arguments.rs`) and `process.chdir()` into a directory of exactly `MAX_PATH_BYTES - 1` bytes are the same bug class at other sites. Working directories of `MAX_PATH_BYTES` bytes or more fail in `getcwd` before this code runs; #38363 covers those.

### Background
- `PathBuffer` is bun's fixed stack buffer for path syscalls, `MAX_PATH_BYTES` long (the platform's `PATH_MAX`: 4096 on Linux, 1024 on macOS). Paths in it are NUL-terminated, so the longest path it holds is `MAX_PATH_BYTES - 1` bytes.
- `resolve_path::join_abs_string_buf(cwd, buf, parts)` is `path.resolve` into a caller buffer: it concatenates, normalizes and writes the result, assuming it fits. `join_abs_string_buf_checked` is the variant for unbounded input and returns `None` instead of writing when the normalized result is longer than `buf`. `resolve_path::z` copies a slice into a `PathBuffer` with a NUL and expects the caller to have checked the length.
- bunfig loading: `load_config` loads `bunfig.toml` from the cwd for the commands in `ALWAYS_LOADS_CONFIG` and for `bun <file>` / `bun -e` (`auto_loaded`), or the `--config` value (not auto-loaded); install-family commands first load `$XDG_CONFIG_HOME/.bunfig.toml`, else `$HOME/.bunfig.toml`. `load_bunfig` ignores read errors for auto-loaded configs and exits with the error for explicit ones.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/config/bunfig/bunfig-errors.test.ts

<!-- robobun:evidence:end -->