### PR TITLE
node:vm: check codeGeneration and contextExtensions entries with validateObject like Node

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -712,10 +712,8 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
             return;
         }
 
-        if (!codeGenerationValue.isObject()) {
-            ERR::INVALID_ARG_TYPE(scope, globalObject, WTF::makeString("options."_s, codeGenerationKey), "object"_s, codeGenerationValue);
-            return;
-        }
+        V::validateObject(scope, globalObject, codeGenerationValue, WTF::makeString("options."_s, codeGenerationKey));
+        RETURN_IF_EXCEPTION(scope, );
 
         JSObject* codeGenerationObject = asObject(codeGenerationValue);
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -2128,8 +2128,8 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
                 for (unsigned i = 0; i < length; i++) {
                     JSValue extension = contextExtensionsArray->getIndex(globalObject, i);
                     RETURN_IF_EXCEPTION(scope, {});
-                    if (!extension.isObject())
-                        return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.contextExtensions[0]"_s, "object"_s, extension);
+                    V::validateObject(scope, globalObject, extension, WTF::makeString("options.contextExtensions["_s, i, "]"_s));
+                    RETURN_IF_EXCEPTION(scope, {});
                 }
             } else {
                 return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -649,7 +649,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globa
     return JSValue::encode(jsUndefined());
 }
 
-JSC::EncodedJSValue V::validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name)
+JSC::EncodedJSValue V::validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, const WTF::String& name)
 {
     bool isArray = JSC::isArray(globalObject, value);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -629,8 +629,6 @@ JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject
     return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, "must be one of: "_s, value, oneOf);
 }
 
-// `name` is whatever ERR::INVALID_ARG_TYPE accepts (JSValue, ASCIILiteral or
-// WTF::String); it is only converted on the error path.
 template<typename Name>
 static JSC::EncodedJSValue validateObjectImpl(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, const Name& name)
 {

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -629,39 +629,40 @@ JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject
     return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, "must be one of: "_s, value, oneOf);
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+// `name` is whatever ERR::INVALID_ARG_TYPE accepts (JSValue, ASCIILiteral or
+// WTF::String); it is only converted on the error path.
+template<typename Name>
+static JSC::EncodedJSValue validateObjectImpl(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, const Name& name)
 {
-    auto& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto value = callFrame->argument(0);
-
     bool isArray = JSC::isArray(globalObject, value);
     RETURN_IF_EXCEPTION(scope, {});
     if (value.isNull() || isArray || value.isCallable()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "object"_s, value);
     }
 
     if (!value.isObject()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, callFrame->argument(1), "object"_s, value);
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "object"_s, value);
     }
 
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunction_validateObject, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    return validateObjectImpl(scope, globalObject, callFrame->argument(0), callFrame->argument(1));
+}
+
+JSC::EncodedJSValue V::validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name)
+{
+    return validateObjectImpl(scope, globalObject, value, name);
+}
+
 JSC::EncodedJSValue V::validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, const WTF::String& name)
 {
-    bool isArray = JSC::isArray(globalObject, value);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (value.isNull() || isArray || value.isCallable()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "object"_s, value);
-    }
-
-    if (!value.isObject()) {
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "object"_s, value);
-    }
-
-    return JSValue::encode(jsUndefined());
+    return validateObjectImpl(scope, globalObject, value, name);
 }
 
 //

--- a/src/jsc/bindings/NodeValidator.h
+++ b/src/jsc/bindings/NodeValidator.h
@@ -43,7 +43,7 @@ JSC::EncodedJSValue validateInt32(JSC::ThrowScope& scope, JSC::JSGlobalObject* g
 JSC::EncodedJSValue validateFunction(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
 JSC::EncodedJSValue validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const ASCIILiteral> oneOf);
 JSC::EncodedJSValue validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const int32_t> oneOf, int32_t* out = nullptr);
-JSC::EncodedJSValue validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
+JSC::EncodedJSValue validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, const WTF::String& name);
 JSC::EncodedJSValue validateBoolean(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
 
 }

--- a/src/jsc/bindings/NodeValidator.h
+++ b/src/jsc/bindings/NodeValidator.h
@@ -43,6 +43,7 @@ JSC::EncodedJSValue validateInt32(JSC::ThrowScope& scope, JSC::JSGlobalObject* g
 JSC::EncodedJSValue validateFunction(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
 JSC::EncodedJSValue validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const ASCIILiteral> oneOf);
 JSC::EncodedJSValue validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const int32_t> oneOf, int32_t* out = nullptr);
+JSC::EncodedJSValue validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
 JSC::EncodedJSValue validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, const WTF::String& name);
 JSC::EncodedJSValue validateBoolean(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1010,6 +1010,75 @@ describe("codeGeneration options", () => {
     const evalResult = runInContext("eval('5 + 5');", context);
     expect(evalResult).toBe(10);
   });
+
+  describe("the codeGeneration option itself is checked like Node's validateObject()", () => {
+    function thrownBy(fn: () => unknown) {
+      try {
+        fn();
+      } catch (e: any) {
+        return { name: e.name, code: e.code, message: e.message };
+      }
+      return "did not throw";
+    }
+    const invalidArgType = (optionName: string, received: string) => ({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "${optionName}" property must be of type object. Received ${received}`,
+    });
+
+    // createContext() reads options.codeGeneration; vm.runInNewContext() and
+    // Script#runInNewContext() read options.contextCodeGeneration.
+    const entryPoints: [name: string, optionName: string, run: (codeGeneration: unknown) => unknown][] = [
+      ["createContext()", "options.codeGeneration", codeGeneration => createContext({}, { codeGeneration } as any)],
+      [
+        "runInNewContext()",
+        "options.contextCodeGeneration",
+        contextCodeGeneration => runInNewContext("1", {}, { contextCodeGeneration } as any),
+      ],
+      [
+        "Script#runInNewContext()",
+        "options.contextCodeGeneration",
+        contextCodeGeneration => new Script("1").runInNewContext({}, { contextCodeGeneration } as any),
+      ],
+    ];
+
+    describe.each(entryPoints)("%s", (_, optionName, run) => {
+      test("rejects an array", () => {
+        expect(thrownBy(() => run([]))).toEqual(invalidArgType(optionName, "an instance of Array"));
+        expect(thrownBy(() => run(["strings"]))).toEqual(invalidArgType(optionName, "an instance of Array"));
+      });
+
+      test("rejects a function", () => {
+        const arrow = async () => {};
+        expect(thrownBy(() => run(function codegen() {}))).toEqual(invalidArgType(optionName, "function codegen"));
+        expect(thrownBy(() => run(class Codegen {}))).toEqual(invalidArgType(optionName, "function Codegen"));
+        expect(thrownBy(() => run(arrow))).toEqual(invalidArgType(optionName, "function arrow"));
+      });
+
+      test("sees through proxies the way Array.isArray() and typeof do", () => {
+        expect(thrownBy(() => run(new Proxy([], {})))).toEqual(invalidArgType(optionName, "an instance of Array"));
+        expect(thrownBy(() => run(new Proxy(function codegen() {}, {})))).toMatchObject({
+          code: "ERR_INVALID_ARG_TYPE",
+        });
+        expect(() => run(new Proxy({}, {}))).not.toThrow();
+      });
+
+      test("still rejects null and primitives", () => {
+        expect(thrownBy(() => run(null))).toEqual(invalidArgType(optionName, "null"));
+        expect(thrownBy(() => run(1))).toEqual(invalidArgType(optionName, "type number (1)"));
+        expect(thrownBy(() => run("strings"))).toEqual(invalidArgType(optionName, "type string ('strings')"));
+        expect(thrownBy(() => run(true))).toEqual(invalidArgType(optionName, "type boolean (true)"));
+      });
+
+      test("still accepts any other object, and undefined", () => {
+        expect(() => run({})).not.toThrow();
+        expect(() => run({ strings: true, wasm: true })).not.toThrow();
+        expect(() => run(Object.create(null))).not.toThrow();
+        expect(() => run(new (class CodeGeneration {})())).not.toThrow();
+        expect(() => run(undefined)).not.toThrow();
+      });
+    });
+  });
 });
 
 describe("the options argument", () => {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -12,6 +12,15 @@ import {
 
 function capture(_: any, _1?: any) {}
 
+// The error Node's validateObject() throws for a nested option (lib/internal/validators.js).
+function notAnObjectError(optionName: string, received: string) {
+  return expect.objectContaining({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: `The "${optionName}" property must be of type object. Received ${received}`,
+  });
+}
+
 describe("vm", () => {
   describe("runInContext()", () => {
     testRunInContext({ fn: runInContext, isIsolated: true });
@@ -100,6 +109,21 @@ describe("vm", () => {
         contextExtensions: undefined,
       })();
       expect(result).toBe(2);
+    });
+
+    test("each contextExtensions entry is checked like Node's validateObject(), under its own index", () => {
+      const compile = (...contextExtensions: unknown[]) =>
+        compileFunction("return 1;", [], { contextExtensions } as any);
+      expect(() => compile([])).toThrow(notAnObjectError("options.contextExtensions[0]", "an instance of Array"));
+      expect(() => compile({}, function ext() {})).toThrow(
+        notAnObjectError("options.contextExtensions[1]", "function ext"),
+      );
+      expect(() => compile({}, {}, 1)).toThrow(notAnObjectError("options.contextExtensions[2]", "type number (1)"));
+      expect(() => compile({}, undefined)).toThrow(notAnObjectError("options.contextExtensions[1]", "undefined"));
+      // Node lets null through validateObject() and then fails a native assertion; rejecting it is the sane version.
+      expect(() => compile(null)).toThrow(notAnObjectError("options.contextExtensions[0]", "null"));
+
+      expect(compileFunction("return a + b;", [], { contextExtensions: [{ a: 1 }, { b: 2 }] })()).toBe(3);
     });
 
     // Security tests
@@ -1012,20 +1036,6 @@ describe("codeGeneration options", () => {
   });
 
   describe("the codeGeneration option itself is checked like Node's validateObject()", () => {
-    function thrownBy(fn: () => unknown) {
-      try {
-        fn();
-      } catch (e: any) {
-        return { name: e.name, code: e.code, message: e.message };
-      }
-      return "did not throw";
-    }
-    const invalidArgType = (optionName: string, received: string) => ({
-      name: "TypeError",
-      code: "ERR_INVALID_ARG_TYPE",
-      message: `The "${optionName}" property must be of type object. Received ${received}`,
-    });
-
     // createContext() reads options.codeGeneration; vm.runInNewContext() and
     // Script#runInNewContext() read options.contextCodeGeneration.
     const entryPoints: [name: string, optionName: string, run: (codeGeneration: unknown) => unknown][] = [
@@ -1044,30 +1054,32 @@ describe("codeGeneration options", () => {
 
     describe.each(entryPoints)("%s", (_, optionName, run) => {
       test("rejects an array", () => {
-        expect(thrownBy(() => run([]))).toEqual(invalidArgType(optionName, "an instance of Array"));
-        expect(thrownBy(() => run(["strings"]))).toEqual(invalidArgType(optionName, "an instance of Array"));
+        expect(() => run([])).toThrow(notAnObjectError(optionName, "an instance of Array"));
+        expect(() => run(["strings"])).toThrow(notAnObjectError(optionName, "an instance of Array"));
       });
 
       test("rejects a function", () => {
         const arrow = async () => {};
-        expect(thrownBy(() => run(function codegen() {}))).toEqual(invalidArgType(optionName, "function codegen"));
-        expect(thrownBy(() => run(class Codegen {}))).toEqual(invalidArgType(optionName, "function Codegen"));
-        expect(thrownBy(() => run(arrow))).toEqual(invalidArgType(optionName, "function arrow"));
+        expect(() => run(function codegen() {})).toThrow(notAnObjectError(optionName, "function codegen"));
+        expect(() => run(class Codegen {})).toThrow(notAnObjectError(optionName, "function Codegen"));
+        expect(() => run(arrow)).toThrow(notAnObjectError(optionName, "function arrow"));
       });
 
       test("sees through proxies the way Array.isArray() and typeof do", () => {
-        expect(thrownBy(() => run(new Proxy([], {})))).toEqual(invalidArgType(optionName, "an instance of Array"));
-        expect(thrownBy(() => run(new Proxy(function codegen() {}, {})))).toMatchObject({
-          code: "ERR_INVALID_ARG_TYPE",
-        });
+        expect(() => run(new Proxy([], {}))).toThrow(notAnObjectError(optionName, "an instance of Array"));
+        // Only the code: Bun renders a callable Proxy as "function " with no name
+        // (Node prints the target's name), which is an error-formatting detail.
+        expect(() => run(new Proxy(function codegen() {}, {}))).toThrow(
+          expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+        );
         expect(() => run(new Proxy({}, {}))).not.toThrow();
       });
 
       test("still rejects null and primitives", () => {
-        expect(thrownBy(() => run(null))).toEqual(invalidArgType(optionName, "null"));
-        expect(thrownBy(() => run(1))).toEqual(invalidArgType(optionName, "type number (1)"));
-        expect(thrownBy(() => run("strings"))).toEqual(invalidArgType(optionName, "type string ('strings')"));
-        expect(thrownBy(() => run(true))).toEqual(invalidArgType(optionName, "type boolean (true)"));
+        expect(() => run(null)).toThrow(notAnObjectError(optionName, "null"));
+        expect(() => run(1)).toThrow(notAnObjectError(optionName, "type number (1)"));
+        expect(() => run("strings")).toThrow(notAnObjectError(optionName, "type string ('strings')"));
+        expect(() => run(true)).toThrow(notAnObjectError(optionName, "type boolean (true)"));
       });
 
       test("still accepts any other object, and undefined", () => {


### PR DESCRIPTION
### Problem
- `vm.createContext({}, { codeGeneration: [] })` and `{ codeGeneration: function () {} }` are accepted; Node throws `ERR_INVALID_ARG_TYPE: The "options.codeGeneration" property must be of type object. Received an instance of Array` (or `Received function ...`). Same for `contextCodeGeneration` on `vm.runInNewContext()` and `Script#runInNewContext()`, which return the script's result instead of throwing.
- `vm.compileFunction("", [], { contextExtensions: [[]] })` and `[function () {}]` are accepted too (Node: `The "options.contextExtensions[0]" property must be of type object. Received an instance of Array`), and a bad entry at any index is reported as `contextExtensions[0]`; Node names the real index.
- Cause: two option checks in `src/jsc/bindings/NodeVM.cpp` use `JSValue::isObject()`, which is true for arrays and functions: the `codeGeneration`/`contextCodeGeneration` container in `getNodeVMContextOptions()` (line 715; all three entry points read the option through it) and the `contextExtensions[i]` loop in `CompileFunctionOptions::fromJS()` (line 2131, with a hard-coded `[0]` in the message). Node's lib/vm.js checks both with `validateObject()`.
- #38381 converted the two checks of the `options` argument itself to `V::validateObject()` and left these two, which need a name built at runtime, to this PR. After it, these are the last `isObject()` option checks in the file.
- Found by comparing against node v26.3.0 while looking at this function; there is no user report, and the vendored Node tests only cover the `1`/`null` cases that were already rejected (test-vm-codegen.js, test-vm-basic.js).

### Fix
- Both checks call `V::validateObject()` (`src/jsc/bindings/NodeValidator.cpp`), Bun's native port of Node's `validateObject()`, with the name built with `makeString` (`"options." + key`, `"options.contextExtensions[" + i + "]"`). `null` and primitives produce the same error as before; the `contextExtensions` message now carries the real index.
- `V::validateObject()` gets a `const WTF::String&` overload next to the existing `ASCIILiteral` one. The two overloads and the JS-facing `jsFunction_validateObject` (`require("internal/validators").validateObject`, whose name is a `JSValue`) now share one implementation, `validateObjectImpl<Name>`; the name is only converted when an error is thrown, so the 20 existing `"..."_s` callers do not build a `String` on the success path.
- Why this is right: it matches Node. `validateObject()` rejects `null`, `Array.isArray(value)` and functions; `V::validateObject()` uses JSC's `isArray()` (the IsArray operation, so a Proxy around an array is rejected too) and `isCallable()`, and checks for an exception after `isArray()` because a revoked Proxy throws there (Node throws a TypeError from `Array.isArray` in that case as well). Error name, code and message are identical to Node's for arrays, named functions, classes, `null`, primitives and the `contextExtensions` index. One intentional difference: Node passes `null` through its `contextExtensions` check (`kValidateObjectAllowNullable`) and then dies on a native assertion (`Assertion failed: val->IsObject()`, node v26.3.0); Bun keeps rejecting it with `ERR_INVALID_ARG_TYPE`, as it did before.
- Verified with `test/js/node/vm/vm.test.ts`: "the codeGeneration option itself is checked like Node's validateObject()" (3 entry points x arrays, function/class/arrow, Proxy-of-array, Proxy-of-function, and the still-rejected `null`/primitives and still-accepted objects/`undefined`) and "each contextExtensions entry is checked like Node's validateObject(), under its own index". 10 of the 16 tests fail on bun 1.4.0, all pass with this change; the whole file passes (266).
- Also run with this change: `test-vm-basic.js` (asserts the `contextExtensions[0]` message), `test-vm-codegen.js`, `test-vm-options-validation.js` and the other `test-vm-*context*`/`*create*` node tests; for the other `validateObject` users, `process-execve.test.ts`, `test-process-threadCpuUsage-*.js`, `test-crypto-prime.js`, `test-crypto-keygen*.js`, `test-crypto-key-objects.js`, `test-crypto-dh-stateless.js`, `test-vm-module-*.js` and `test-vm-measure-memory*.js` (JS-side `validateObject`); the new tests also pass under `BUN_JSC_validateExceptionChecks=1`.
- The Proxy-of-function test only checks the error code: Bun renders a callable Proxy as `function ` without a name (Node prints the target's name), which is a `determineSpecificType` detail tracked separately.
- Related open PRs, all independent: #38314 changes the nested `strings`/`wasm` reads a few lines below the first hunk (its tests sit next to these, so whichever lands second gets a trivial test conflict); #38326, #34623 and #33077 each add a JS-side `getContextOptions()` for `vm.runInNewContext()` only, while `createContext()` and `Script#runInNewContext()` are native and still reach the check fixed here; #38373 covers `createContext()` validating options for an already-contextified sandbox.

### Background
- `createContext(sandbox, { codeGeneration: { strings, wasm } })` controls whether code in the new context may use `eval`/`new Function` and compile WebAssembly; `vm.runInNewContext()` and `Script#runInNewContext()` take the same object as `contextCodeGeneration`. `compileFunction(code, params, { contextExtensions: [obj, ...] })` wraps the function in one `with`-style scope per object. Bun reads the first group in `getNodeVMContextOptions()` and the second in `CompileFunctionOptions::fromJS()`, both in NodeVM.cpp.
- Node's `validateObject(value, name)` (lib/internal/validators.js) is the check Node applies to option objects: `ERR_INVALID_ARG_TYPE` for `null`, non-objects, arrays and functions. `Bun::V::validateObject` is the native equivalent, used by the `node:crypto`, `process` and `Worker` bindings; `jsFunction_validateObject` exposes the same check to Bun's built-in JS modules.
- `JSC::isArray(globalObject, value)` implements the spec's IsArray: true for arrays and for Proxies whose target is an array, and it throws for a revoked Proxy, hence the throw-scope check right after it. `JSValue::isCallable()` is the native equivalent of `typeof value === "function"`.
- `ASCIILiteral` is WTF's type for a `"..."_s` string literal; converting one to a `WTF::String` allocates a small `StringImpl` header, which is why the literal overload is kept rather than widening the parameter.

<details>
<summary>Probe: node v26.3.0 vs bun 1.4.0</summary>

```
createContext codeGeneration: []              node: ERR_INVALID_ARG_TYPE   bun: accepted
createContext codeGeneration: function        node: ERR_INVALID_ARG_TYPE   bun: accepted
createContext codeGeneration: class           node: ERR_INVALID_ARG_TYPE   bun: accepted
createContext codeGeneration: Proxy(array)    node: ERR_INVALID_ARG_TYPE   bun: accepted
createContext codeGeneration: null / 1        node: ERR_INVALID_ARG_TYPE   bun: ERR_INVALID_ARG_TYPE
createContext codeGeneration: {} / Object.create(null) / new Date()   both: accepted
runInNewContext contextCodeGeneration: [] / function          node: ERR_INVALID_ARG_TYPE   bun: returns 1
Script#runInNewContext contextCodeGeneration: [] / function   node: ERR_INVALID_ARG_TYPE   bun: returns 1
createContext codeGeneration: revoked Proxy   node: TypeError from IsArray   bun (after): TypeError from Array.isArray

compileFunction contextExtensions: [[]]        node: ...contextExtensions[0]... an instance of Array   bun: accepted
compileFunction contextExtensions: [fn]        node: ...contextExtensions[0]... function ext          bun: accepted
compileFunction contextExtensions: [{}, 1]     node: ...contextExtensions[1]... type number (1)       bun: ...contextExtensions[0]...
compileFunction contextExtensions: [{}, []]    node: ...contextExtensions[1]... an instance of Array  bun: accepted
compileFunction contextExtensions: [null]      node: aborts (Assertion failed: val->IsObject())       bun: ERR_INVALID_ARG_TYPE (unchanged)
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (9bd6acae6)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [38.61ms]
(pass) vm > runInContext() > can return a value [26.39ms]
(pass) vm > runInContext() > can return a complex value [26.98ms]
(pass) vm > runInContext() > can return the last value [26.64ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [29.03ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [16.02ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.94ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.88ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [17.45ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [16.13ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.69ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [16.22ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 62 skipped
bun test v1.4.0-canary.1 (d8a339921)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.36ms]
(pass) vm > runInContext() > can return a value [0.25ms]
(pass) vm > runInContext() > can return a complex value [0.20ms]
(pass) vm > runInContext() > can return the last value [0.22ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.22ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.26ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.19ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (9bd6acae6)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [41.09ms]
(pass) vm > runInContext() > can return a value [28.24ms]
(pass) vm > runInContext() > can return a complex value [28.80ms]
(pass) vm > runInContext() > can return the last value [27.95ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [31.39ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [25.67ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [30.21ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [29.05ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [29.07ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [28.37ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [28.10ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [27.94ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 776ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/17] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/17] gen cpp.rs (cppbind)
[2/17] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install_types v0.0.0 (/workspace/bun/src/install_types)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeVM.cpp        | 10 ++---
 src/jsc/bindings/NodeValidator.cpp | 35 ++++++++--------
 src/jsc/bindings/NodeValidator.h   |  1 +
 test/js/node/vm/vm.test.ts         | 81 ++++++++++++++++++++++++++++++++++++++
 4 files changed, 103 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/NodeVM.cpp             6      3      0
src/jsc/bindings/NodeValidator.cpp      5      5      0
src/jsc/bindings/NodeValidator.h        2      4      0
test/js/node/vm/vm.test.ts              8      9      0
```

</details>

**root cause** · written by the author bot

The vm option parsing in getNodeVMContextOptions() and in the compileFunction contextExtensions loop only checked JSValue::isObject(), which is true for arrays and functions, so codeGeneration, contextCodeGeneration and each contextExtensions entry accepted values that Node's validateObject() rejects with ERR_INVALID_ARG_TYPE. The fix replaces those checks with the shared V::validateObject() helper, which rejects null, arrays (via isArray, so proxies are covered) and callables using the same option name and "object" type as Node; a WTF::String overload was added so the contextExtensions nam…

<!-- robobun:evidence:end -->