### PR TITLE
install: do not abort when $XDG_CONFIG_HOME or $HOME is too long for the .npmrc path buffer

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -21,7 +21,7 @@ use bun_event_loop::{self, AnyEventLoop, EventLoopHandle};
 use bun_http as http;
 use bun_ini as ini;
 use bun_paths::resolve_path::{self, PosixToWinNormalizer, platform};
-use bun_paths::{DELIMITER, PathBuffer, SEP, SEP_STR};
+use bun_paths::{DELIMITER, MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR};
 use bun_semver as Semver;
 use bun_sys::{self, Fd};
 use bun_threading::{ThreadPool, UnboundedQueue, thread_pool};
@@ -1434,6 +1434,22 @@ pub(crate) fn get() -> *mut PackageManager {
 // init
 // ──────────────────────────────────────────────────────────────────────────
 
+/// `<dir>/.npmrc` for the user-level `.npmrc` candidates in [`init`]. `dir` is
+/// `$XDG_CONFIG_HOME` or `$HOME`, so it can be longer than `buf`; a path that
+/// does not fit could not be opened either, and `None` makes the caller treat
+/// it like a missing file.
+fn user_npmrc_path<'a>(dir: &[u8], buf: &'a mut PathBuffer) -> Option<&'a ZStr> {
+    // The last byte is reserved for the NUL terminator.
+    let len = resolve_path::join_abs_string_buf_checked::<platform::Auto>(
+        dir,
+        &mut buf[..MAX_PATH_BYTES - 1],
+        &[b".npmrc"],
+    )?
+    .len();
+    buf[len] = 0;
+    Some(ZStr::from_buf(&buf[..], len))
+}
+
 /// Returns `&'static mut PackageManager` — the process-singleton (held in
 /// `holder::RAW_PTR`) is leaked for the process lifetime and `init()` is called
 /// exactly once on the single CLI dispatch thread. Every
@@ -1877,24 +1893,18 @@ pub fn init(
         let npmrc_local = ZBox::from_bytes(b".npmrc");
 
         let mut buf = PathBuffer::uninit();
-        let parts = [b"./.npmrc" as &[u8]];
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
         // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
         let mut global_len: usize = 0;
         if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
-            let p =
-                resolve_path::join_abs_string_buf_z::<platform::Auto>(xdg_dir, &mut buf, &parts);
-            if bun_sys::exists_z(p) {
-                global_len = p.len();
-            }
+            global_len = user_npmrc_path(xdg_dir, &mut buf)
+                .filter(|p| bun_sys::exists_z(p))
+                .map_or(0, ZStr::len);
         }
         if global_len == 0 {
             if let Some(home_dir) = bun_core::env_var::HOME.get_not_empty() {
-                global_len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
-                    home_dir, &mut buf, &parts,
-                )
-                .len();
+                global_len = user_npmrc_path(home_dir, &mut buf).map_or(0, ZStr::len);
             }
         }
 

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1,7 +1,8 @@
 import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunExe, bunEnv as env, tempDir } from "harness";
+import { VerdaccioRegistry, bunExe, bunEnv as env, isLinux, isWindows, tempDir } from "harness";
 import { join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
@@ -221,6 +222,53 @@ registry = http://localhost:${registry.port}/
       using dir = tempDir("npmrc-xdg-empty", { ...pkg, "home/.npmrc": npmrc(1) });
       const result = await publishDryRun(String(dir), { XDG_CONFIG_HOME: "" });
       expect(result).toEqual(usesRegistry(1));
+    });
+
+    // The candidate paths are built in a buffer of MAX_PATH_BYTES (4096 on Linux, 1024 on the
+    // other POSIX platforms; on Windows it is larger than any environment variable can be), so
+    // the longest directory whose "/.npmrc" and NUL terminator still fit is MAX_PATH_BYTES - 8
+    // bytes. A longer directory cannot contain an openable .npmrc and counts as having none.
+    describe.skipIf(isWindows)("$HOME longer than the path buffer", () => {
+      const MAX_PATH_BYTES = isLinux ? 4096 : 1024;
+      const LONGEST_HOME = MAX_PATH_BYTES - 8;
+
+      // xdg/ has no .npmrc, so the lookup falls through to $HOME. The global bunfig.toml lookup
+      // starts at $XDG_CONFIG_HOME too; the bunfig there keeps it away from the oversized $HOME,
+      // which is not what is under test here.
+      const xdg = { "xdg/.bunfig.toml": "" };
+      const envWith = (dir: string, home: string) => ({ XDG_CONFIG_HOME: join(dir, "xdg"), HOME: home });
+
+      // An absolute path of exactly `length` bytes. Nothing exists there.
+      const missingHome = (length: number) => "/" + Buffer.alloc(length - 1, "a").toString();
+
+      it.concurrent("reads $HOME/.npmrc from the longest $HOME that fits", async () => {
+        using dir = tempDir("npmrc-home-longest", { ...pkg, ...xdg });
+        // Pad `<dir>/home/` out to exactly LONGEST_HOME bytes with nested directories of 200
+        // bytes each (NAME_MAX is 255); the last byte is never a separator.
+        const prefix = join(String(dir), "home") + "/";
+        const padding = Buffer.alloc(LONGEST_HOME - Buffer.byteLength(prefix), "a");
+        for (let i = 200; i < padding.length - 1; i += 201) padding[i] = "/".charCodeAt(0);
+        const home = prefix + padding.toString();
+        expect(Buffer.byteLength(home)).toBe(LONGEST_HOME);
+        mkdirSync(home, { recursive: true });
+        writeFileSync(join(home, ".npmrc"), npmrc(1));
+
+        const result = await publishDryRun(String(dir), envWith(String(dir), home));
+        expect(result).toEqual(usesRegistry(1));
+      });
+
+      // The project .npmrc is the only one left, and shows the command still ran normally.
+      it.concurrent("skips a $HOME one byte longer than fits", async () => {
+        using dir = tempDir("npmrc-home-one-too-long", { ...pkg, ...xdg, "pkg/.npmrc": npmrc(3) });
+        const result = await publishDryRun(String(dir), envWith(String(dir), missingHome(LONGEST_HOME + 1)));
+        expect(result).toEqual(usesRegistry(3));
+      });
+
+      it.concurrent("skips a $HOME longer than the whole buffer", async () => {
+        using dir = tempDir("npmrc-home-too-long", { ...pkg, ...xdg, "pkg/.npmrc": npmrc(3) });
+        const result = await publishDryRun(String(dir), envWith(String(dir), missingHome(MAX_PATH_BYTES + 1000)));
+        expect(result).toEqual(usesRegistry(3));
+      });
     });
   });
 


### PR DESCRIPTION
### Problem
- `bun install`, `bun pm ...`, `bun publish` and the other commands that go through `PackageManager::init` abort at startup when `$XDG_CONFIG_HOME` (or, when that directory has no `.npmrc`, `$HOME`) is `MAX_PATH_BYTES - 7` bytes or longer (4089 on Linux, 1017 on macOS):
  - exactly `MAX_PATH_BYTES - 7` bytes: `panic: index out of bounds: the len is 4096 but the index is 4096`
  - longer: `panic: range end index 5000 out of range for slice of length 4095`, top frame `bun_paths::resolve_path::normalize_string_generic_tz` (`src/paths/resolve_path.rs:1071`), called from `bun_install::package_manager_real::init`
- Cause: `src/install/PackageManager.rs:1887` and `:1894` join the environment value and `.npmrc` into a stack `PathBuffer` with the unchecked `join_abs_string_buf_z`. It normalizes into the buffer without a size check and then writes the NUL terminator at `result.len()`, so a result of exactly `MAX_PATH_BYTES - 1` bytes fails on the NUL write and anything longer overflows inside the normalization.
- Reproduced on the release build of main (`XDG_CONFIG_HOME=<short dir without .npmrc> HOME=/aaaa...<5000 bytes> bun pm cache` in any directory with a package.json, exit 134). The values are environment input, so this should never be a crash.

### Fix
- New `user_npmrc_path(dir, buf)` builds `dir/.npmrc` with `join_abs_string_buf_checked` into `buf[..MAX_PATH_BYTES - 1]`, writes the NUL itself, and returns `None` when the result does not fit. Both candidates (`$XDG_CONFIG_HOME`, then `$HOME`) use it; `None` leaves `global_len` at 0, which is the existing "no user-level .npmrc" path.
- Why treating it as absent is right: a path that does not fit is `MAX_PATH_BYTES` bytes or longer, which `open()` rejects with `ENAMETOOLONG` (`bun_sys::openat_a` checks the same `>= MAX_PATH_BYTES` bound itself), and `load_npmrc_config` already skips user-level candidates that fail to open (`src/ini/lib.rs:1232`). So the outcome is exactly what a larger buffer would have produced, and no `.npmrc` that could be read before is skipped now: the longest directory that fits, `MAX_PATH_BYTES - 8` bytes, still loads, and its `.npmrc` path is the longest one `open()` accepts.
- The `parts` literal changes from `./.npmrc` to `.npmrc`; the join normalizes both to the same path.
- Verified with three new cases in `test/cli/install/npmrc.test.ts` ("user .npmrc lookup > $HOME longer than the path buffer"): the longest `$HOME` that fits (built as a real directory of exactly `MAX_PATH_BYTES - 8` bytes) still has its `.npmrc` honored, `$HOME` one byte longer is skipped, `$HOME` longer than the whole buffer is skipped. On the unfixed build the last two fail with the two panics above; with the fix all 34 tests in the file pass. Skipped on Windows, where the buffer (~96 KiB) is longer than any environment value.
- The tests drive the `$HOME` candidate (with `$XDG_CONFIG_HOME` pointing at a short directory) because the global `.bunfig.toml` lookup in `src/bunfig/arguments.rs` reads `$XDG_CONFIG_HOME` (or `$HOME` when it is unset) before this code with the same unchecked join and a longer file name, so an oversized value there still aborts earlier; #38370 fixes that site. Both candidates here share `user_npmrc_path`, and the existing lookup tests in the same `describe` cover the `$XDG_CONFIG_HOME` candidate when the path fits.
- `cargo clippy -p bun_install` and `rustfmt --check` are clean.

### Background
- `PathBuffer` is bun's fixed stack buffer for path syscalls, `MAX_PATH_BYTES` long (the platform `PATH_MAX`: 4096 on Linux, 1024 on macOS). Paths in it are NUL-terminated, so the longest path it can hold is `MAX_PATH_BYTES - 1` bytes, which is also the longest path `open()` accepts.
- `resolve_path::join_abs_string_buf_z(cwd, buf, parts)` is `path.resolve` into a caller buffer plus a NUL terminator; it assumes the result fits. `join_abs_string_buf_checked` is the variant for input of unbounded length: it normalizes first and returns `None` instead of writing when the result is longer than `buf`, so it has to be given a buffer one byte short of the NUL slot the caller fills in.
- User-level `.npmrc` lookup: `PackageManager::init` uses `$XDG_CONFIG_HOME/.npmrc` when that file exists, otherwise `$HOME/.npmrc` (#36289), and passes the result together with the project `.npmrc` to `load_npmrc_config`, which ignores candidates it cannot read.
