### PR TITLE
node:vm: return an existing context from createContext() before validating options

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -74,10 +74,11 @@ function pruneTrackedContexts() {
 }
 
 function createContext(contextObject?, options?) {
-  if (typeof options === "object" && options !== null) {
+  const alreadyContextified = $isObject(contextObject) && isContext(contextObject);
+  // Node returns an existing context before it reads or validates `options`.
+  if (!alreadyContextified && typeof options === "object" && options !== null) {
     validateOneOf(options.microtaskMode, "options.microtaskMode", ["afterEvaluate", undefined]);
   }
-  const alreadyContextified = $isObject(contextObject) && isContext(contextObject);
   const context = createContextNative(contextObject, options);
   if (!alreadyContextified) {
     if (trackedContexts.length >= trackedContextsPruneAt) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1648,8 +1648,6 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    NodeVMContextOptions contextOptions {};
-
     JSValue contextArg = callFrame->argument(0);
     bool notContextified = getContextArg(globalObject, contextArg);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1658,22 +1656,9 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
         return ERR::INVALID_ARG_TYPE(scope, globalObject, "context"_s, "object"_s, contextArg);
     }
 
-    JSValue optionsArg = callFrame->argument(1);
-
-    // Validate options argument
-    if (!optionsArg.isUndefined() && !optionsArg.isObject()) {
-        return ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, optionsArg);
-    }
-
-    JSValue importer;
-
-    getNodeVMContextOptions(globalObject, vm, scope, optionsArg, contextOptions, "codeGeneration", &importer);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    contextOptions.notContextified = notContextified;
-
     JSObject* sandbox = asObject(contextArg);
 
+    // Node returns an existing context before it reads or validates `options`.
     if (isContext(globalObject, sandbox)) {
         if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(sandbox)) {
             if (auto* targetContext = dynamicDowncast<NodeVMGlobalObject>(proxy->target())) {
@@ -1684,6 +1669,21 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
         }
         return JSValue::encode(sandbox);
     }
+
+    JSValue optionsArg = callFrame->argument(1);
+
+    // Validate options argument
+    if (!optionsArg.isUndefined() && !optionsArg.isObject()) {
+        return ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, optionsArg);
+    }
+
+    NodeVMContextOptions contextOptions {};
+    JSValue importer;
+
+    getNodeVMContextOptions(globalObject, vm, scope, optionsArg, contextOptions, "codeGeneration", &importer);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    contextOptions.notContextified = notContextified;
 
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1077,6 +1077,127 @@ describe("context options with throwing getters", () => {
   });
 });
 
+describe("createContext() on an object that is already a context", () => {
+  // Node's createContext() returns an existing context before it looks at
+  // `options`, so options that are rejected for a fresh sandbox are ignored
+  // here. Expected messages were checked against node v26.3.0.
+  const invalidOptions: [description: string, options: unknown, rejection: { code: string; message: string }][] = [
+    [
+      "options is not an object",
+      1,
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options" argument must be of type object. Received type number (1)',
+      },
+    ],
+    [
+      "options is null",
+      null,
+      { code: "ERR_INVALID_ARG_TYPE", message: 'The "options" argument must be of type object. Received null' },
+    ],
+    [
+      "name is not a string",
+      { name: 1 },
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.name" property must be of type string. Received type number (1)',
+      },
+    ],
+    [
+      "origin is not a string",
+      { origin: 1 },
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.origin" property must be of type string. Received type number (1)',
+      },
+    ],
+    [
+      "codeGeneration is not an object",
+      { codeGeneration: 1 },
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.codeGeneration" property must be of type object. Received type number (1)',
+      },
+    ],
+    [
+      "codeGeneration.strings is not a boolean",
+      { codeGeneration: { strings: 1 } },
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.codeGeneration.strings" property must be of type boolean. Received type number (1)',
+      },
+    ],
+    [
+      "codeGeneration.wasm is not a boolean",
+      { codeGeneration: { wasm: 1 } },
+      {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.codeGeneration.wasm" property must be of type boolean. Received type number (1)',
+      },
+    ],
+    [
+      "microtaskMode is not 'afterEvaluate'",
+      { microtaskMode: "x" },
+      {
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received 'x'",
+      },
+    ],
+  ];
+
+  test.each(invalidOptions)("%s: a contextified sandbox is returned as-is", (_, options) => {
+    const context = createContext({});
+    expect(createContext(context, options as any)).toBe(context);
+  });
+
+  test.each(invalidOptions)("%s: a DONT_CONTEXTIFY context is returned as-is", (_, options) => {
+    const context = createContext(constants.DONT_CONTEXTIFY);
+    expect(createContext(context, options as any)).toBe(context);
+  });
+
+  test.each(invalidOptions)("%s: still rejected when the sandbox is not a context yet", (_, options, rejection) => {
+    expect(() => createContext({}, options as any)).toThrow(expect.objectContaining(rejection));
+    expect(() => createContext(constants.DONT_CONTEXTIFY, options as any)).toThrow(expect.objectContaining(rejection));
+  });
+
+  test("the options are not read at all", () => {
+    const options = {};
+    for (const key of ["name", "origin", "codeGeneration", "importModuleDynamically", "microtaskMode"]) {
+      Object.defineProperty(options, key, {
+        get() {
+          throw new Error(`read options.${key}`);
+        },
+        enumerable: true,
+      });
+    }
+    const context = createContext({});
+    expect(createContext(context, options)).toBe(context);
+    expect(() => createContext({}, options)).toThrow(/^read options\./);
+  });
+
+  test("the existing context keeps its own options", () => {
+    const context = createContext({}, { codeGeneration: { strings: true } });
+    expect(createContext(context, { codeGeneration: { strings: "no" } } as any)).toBe(context);
+    expect(createContext(context, { codeGeneration: { strings: false } })).toBe(context);
+    expect(runInContext("eval('1 + 1')", context)).toBe(2);
+  });
+
+  test("runInNewContext() on an existing context only validates its own context options", () => {
+    const context = createContext({});
+    // `codeGeneration` is a createContext() option, not a runInNewContext()
+    // one, so it is never looked at once createContext() has returned early.
+    expect(runInNewContext("1", context, { codeGeneration: 1 } as any)).toBe(1);
+    // `contextCodeGeneration` is validated by runInNewContext() itself,
+    // whether or not the context already exists.
+    expect(() => runInNewContext("1", context, { contextCodeGeneration: 1 } as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: 'The "options.contextCodeGeneration" property must be of type object. Received type number (1)',
+      }),
+    );
+  });
+});
+
 describe("DONT_CONTEXTIFY", () => {
   test("globalThis prototype chain stays inside the sandbox realm", () => {
     const ctx = createContext(constants.DONT_CONTEXTIFY);


### PR DESCRIPTION
### Problem
- `vm.createContext(ctx, options)` throws when `ctx` is already a context and `options` is invalid, e.g. `vm.createContext(ctx, { codeGeneration: 1 })` throws `TypeError [ERR_INVALID_ARG_TYPE]: The "options.codeGeneration" property must be of type object. Received type number (1)`. Same for `{ name: 1 }`, `{ origin: 1 }`, `{ codeGeneration: { strings: 1 } }`, `{ codeGeneration: { wasm: 1 } }`, `{ microtaskMode: "x" }` (`ERR_INVALID_ARG_VALUE`), and a non-object `options` such as `1` or `null`. Node v26.3.0 returns `ctx` for every one of these. Getters on `options` are also invoked, which Node never does for an existing context.
- Cause: `vmModule_createContext()` in `src/jsc/bindings/NodeVM.cpp` checked the `options` argument and ran `getNodeVMContextOptions()` before its `isContext(sandbox)` early return, and the `createContext()` wrapper in `src/js/node/vm.ts` ran `validateOneOf(options.microtaskMode, ...)` before calling the native function at all. Node's `lib/vm.js` `createContext()` starts with `if (isContext(contextObject)) return contextObject;` and only validates after that.
- Through `vm.runInNewContext(code, ctx, options)`, which calls `createContext()` first, the same early validation also rejected `options` objects that carry a `codeGeneration` key (a `createContext()` option name that `runInNewContext()` does not use); Node runs the code.

### Fix
- `vmModule_createContext()`: the `isContext()` early return (unchanged in what it returns, including the `DONT_CONTEXTIFY` handle mapping) moves ahead of the `options` checks; `contextOptions` is declared where it is first used. `vm.ts` `createContext()` computes `alreadyContextified` (which it already needed for `measureMemory()` tracking) first and skips the `microtaskMode` check when it is set. The JS check stays for fresh sandboxes because it produces Node's exact `validateOneOf` message; the native one formats differently.
- Why this is correct: it is Node's order of operations. `createContext()` on an existing context is a no-op that returns its argument, and Node's `DONT_CONTEXTIFY` symbol is excluded from the early return; Bun gets the same exclusion because `getContextArg()` replaces the symbol with a fresh object, which is never a context, so `createContext(vm.constants.DONT_CONTEXTIFY, badOptions)` still throws. `isContext()` cannot throw, so nothing changes for the exception scope.
- Nothing else reaches the moved code: `createContextNative` is only called from the `vm.ts` wrapper, and `Script#runInNewContext()` / `vm.runInNewContext()` keep validating their own `contextCodeGeneration` option on an existing context, which is also what Node's `getContextOptions()` does (pinned by a test).
- Tests: `test/js/node/vm/vm.test.ts`, `describe("createContext() on an object that is already a context")`. The eight invalid option shapes above are checked against a contextified sandbox and a `DONT_CONTEXTIFY` context (returned as-is), and against a fresh sandbox and the `DONT_CONTEXTIFY` symbol (still rejected, with the message checked). Plus: option getters are not invoked for an existing context, the existing context keeps its own `codeGeneration` settings, and the `runInNewContext()` case from Problem. 19 of the 27 tests fail on bun 1.4.0 (the 8 "still rejected" ones are regression guards); all 27 pass with the fix. The same assertions, run as a plain script, all pass on node v26.3.0.
- Also run with the fix: the whole of `vm.test.ts` (241 pass, 0 fail); the other files in `test/js/node/vm/` (all pass except `script-leak.test.ts`, which does not use `createContext()` and only exceeds its 5 s budget on this debug+ASAN machine, taking 21 s); all 98 vendored `test-vm-*` files in `test/js/node/test/{parallel,sequential}` (including `test-vm-basic.js` and `test-vm-codegen.js`, which assert the option errors on fresh sandboxes); and the new tests under `BUN_JSC_validateExceptionChecks=1`.
- Related open PRs, none of which makes this change: #38371 (validates the `codeGeneration` container; its description lists this behavior as intentionally left alone), #38314 (`strings`/`wasm` set to `undefined`), and #38326 (`runInNewContext()` context reuse; it edits the lines just below the moved block in `vmModule_createContext()` and rewrites the `vm.ts` wrapper, so whichever of the two lands second needs a small rebase, with the same resolution: early return first, validation second).

### Background
- A vm context is an object that `vm.createContext()` has associated with its own realm (global object, `Object`, `Error`, ...). In Bun that realm is a `NodeVMGlobalObject`, and `isContext()` checks a weak map from sandbox object to realm; it also recognizes the handle returned for `createContext(vm.constants.DONT_CONTEXTIFY)` (a context with no user sandbox object).
- `createContext()` options (`name`, `origin`, `codeGeneration`, `microtaskMode`, `importModuleDynamically`) describe the realm to create. They are fixed when the realm is made, which is why Node neither applies nor validates them for an object that already has one.
- Bun's `vm.createContext` is a JS wrapper in `src/js/node/vm.ts` around the native `vmModule_createContext`; the wrapper validates `microtaskMode` itself to get Node's message text, the native side validates the rest.
