### PR TITLE
Bump mordant to 4e08693

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "fc46d7f86c2e5a1e5b7719a75abc2edf704a54e1" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "4e08693333be204deef8e9ffd90a2a153e133e36" },
 ]
 
 [workspace.package]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,6 +1,5 @@
 [bun_bundler]
 "pub_invariant_fields:src/bundler/options.rs" = 3
-"stored_projection:src/bundler/ParseTask.rs" = 1
 
 [bun_core]
 "pub_invariant_fields:src/bun_core/string/mod.rs" = 1
@@ -34,6 +33,7 @@
 "pub_invariant_fields:src/router/lib.rs" = 1
 
 [bun_runtime]
+"asymmetric_guard:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "bypassed_validator:src/runtime/cli/pack_command.rs" = 2
 "pub_invariant_fields:src/runtime/api/JSBundler.rs" = 7
 "pub_invariant_fields:src/runtime/api/bun/Terminal.rs" = 1


### PR DESCRIPTION
Picks up scarletindustries/mordant#7 (a field that is also assigned is not a stored projection), which removes the ParseTask entry from the baseline.

Regenerating the baseline also added one entry that has nothing to do with the bump: asymmetric_guard on the free_resources call #38044 added in h2_frame_parser.rs. Looked at it; freeing the stream on the transition to CLOSED is right whatever can_send_data reads, so it is baselined rather than changed. First time that lint has fired here, so keeping an eye on whether it earns its place.

bun run rust:mordant is clean with the new pin and baseline.