### PR TITLE
install: report ENAMETOOLONG for a --cwd value that does not fit the path buffer

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1421,8 +1421,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/why<r>.
     }
 }
 
-/// `--cwd`: a value starting with `.` is resolved against the current directory, anything
-/// else is handed to `chdir` as given. Exits the process when the directory cannot be entered.
+/// `--cwd`. Exits the process when the directory cannot be entered.
 fn change_directory(arg: &[u8]) -> Result<(), crate::Error> {
     let mut buf = PathBuffer::uninit();
     let mut buf2 = PathBuffer::uninit();

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1295,37 +1295,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/why<r>.
             cli.concurrent_scripts = strings::parse_int::<usize>(concurrency, 10).ok();
         }
 
-        if let Some(cwd_) = args.option(b"--cwd") {
-            let mut buf = PathBuffer::uninit();
-            let mut buf2 = PathBuffer::uninit();
-
-            let final_path: &mut bun_core::ZStr = if !cwd_.is_empty() && cwd_[0] == b'.' {
-                let cwd_len = bun_sys::getcwd(&mut buf[..])?;
-                let cwd = &buf[..cwd_len];
-                let parts: [&[u8]; 1] = [cwd_];
-                let len = Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                    cwd,
-                    &mut buf2[..],
-                    &parts,
-                )
-                .len();
-                buf2[len] = 0;
-                bun_core::ZStr::from_buf_mut(&mut buf2[..], len)
-            } else {
-                buf[..cwd_.len()].copy_from_slice(cwd_);
-                buf[cwd_.len()] = 0;
-                bun_core::ZStr::from_buf_mut(&mut buf[..], cwd_.len())
-            };
-            if let Err(err) = bun_sys::chdir(final_path) {
-                Output::err_generic(
-                    "failed to change directory to \"{}\": {}\n",
-                    (
-                        bstr::BStr::new(final_path.as_bytes()),
-                        bstr::BStr::new(err.name()),
-                    ),
-                );
-                Global::crash();
-            }
+        if let Some(cwd) = args.option(b"--cwd") {
+            change_directory(cwd)?;
         }
 
         if subcommand == Subcommand::Update {
@@ -1448,4 +1419,50 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/why<r>.
 
         Ok(cli)
     }
+}
+
+/// `--cwd`: a value starting with `.` is resolved against the current directory, anything
+/// else is handed to `chdir` as given. Exits the process when the directory cannot be entered.
+fn change_directory(arg: &[u8]) -> Result<(), crate::Error> {
+    let mut buf = PathBuffer::uninit();
+    let mut buf2 = PathBuffer::uninit();
+    let too_long = || bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::chdir);
+
+    // Either buffer keeps its last byte for the NUL terminator `chdir` needs.
+    let resolved: Result<&bun_core::ZStr, bun_sys::Error> = if arg.first() == Some(&b'.') {
+        let cwd_len = bun_sys::getcwd(&mut buf[..])?;
+        let out_len = buf2.len() - 1;
+        match Path::resolve_path::join_abs_string_buf_checked::<Path::platform::Auto>(
+            &buf[..cwd_len],
+            &mut buf2[..out_len],
+            &[arg],
+        )
+        .map(|joined| joined.len())
+        {
+            Some(len) => {
+                buf2[len] = 0;
+                Ok(bun_core::ZStr::from_buf(&buf2[..], len))
+            }
+            None => Err(too_long()),
+        }
+    } else if arg.len() < buf.len() {
+        buf[..arg.len()].copy_from_slice(arg);
+        buf[arg.len()] = 0;
+        Ok(bun_core::ZStr::from_buf(&buf[..], arg.len()))
+    } else {
+        Err(too_long())
+    };
+
+    let (path, err) = match resolved {
+        Ok(path) => match bun_sys::chdir(path) {
+            Ok(()) => return Ok(()),
+            Err(err) => (path.as_bytes(), err),
+        },
+        Err(err) => (arg, err),
+    };
+    Output::err_generic(
+        "failed to change directory to \"{}\": {}\n",
+        (bstr::BStr::new(path), bstr::BStr::new(err.name())),
+    );
+    Global::crash();
 }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10324,9 +10324,10 @@ describe.concurrent.skipIf(isWindows)("--cwd that does not fit the path buffer",
       stderr: "pipe",
       env,
     });
-    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(err).toContain(`failed to change directory to "${cwd}": ENAMETOOLONG`);
+    expect(out).toBe("");
     expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6,6 +6,7 @@ import {
   bunEnv,
   bunExe,
   bunEnv as env,
+  isLinux,
   isWindows,
   joinP,
   readdirSorted,
@@ -10294,5 +10295,37 @@ it.each([
     expect(tarballRequests).toEqual([]);
     expect(out).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
+  });
+});
+
+// `--cwd` is staged in a PATH_MAX-sized buffer (4096 bytes on Linux, 1024 on the other POSIX
+// targets) before chdir. Values that did not leave room for the NUL terminator used to abort the
+// process; the buffer on Windows (~96 KiB) is larger than any command line, so only POSIX is affected.
+describe.concurrent.skipIf(isWindows)("--cwd that does not fit the path buffer", () => {
+  const PATH_MAX = isLinux ? 4096 : 1024;
+  const name = (length: number) => Buffer.alloc(length, "a").toString();
+
+  it.each([
+    ["install, PATH_MAX - 1 bytes (rejected by the kernel)", "install", name(PATH_MAX - 1)],
+    ["install, exactly PATH_MAX bytes", "install", name(PATH_MAX)],
+    ["install, longer than PATH_MAX", "install", name(PATH_MAX + 1000)],
+    ["install, ./ prefix longer than PATH_MAX", "install", "./" + name(PATH_MAX + 1000)],
+    ["add, longer than PATH_MAX", "add", name(PATH_MAX + 1000)],
+  ])("%s", async (_, subcommand, cwd) => {
+    using dir = tempDir("install-cwd-too-long", {
+      "package.json": JSON.stringify({ name: "foo", version: "0.0.1" }),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), subcommand, "--cwd", cwd, ...(subcommand === "add" ? ["bar"] : [])],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(err).toContain(`failed to change directory to "${cwd}": ENAMETOOLONG`);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6,6 +6,7 @@ import {
   bunEnv,
   bunExe,
   bunEnv as env,
+  isAndroid,
   isLinux,
   isWindows,
   joinP,
@@ -10298,11 +10299,11 @@ it.each([
   });
 });
 
-// `--cwd` is staged in a PATH_MAX-sized buffer (4096 bytes on Linux, 1024 on the other POSIX
-// targets) before chdir. Values that did not leave room for the NUL terminator used to abort the
+// `--cwd` is staged in a PATH_MAX-sized buffer (4096 bytes on Linux and Android, 1024 on macOS and
+// the BSDs) before chdir. Values that did not leave room for the NUL terminator used to abort the
 // process; the buffer on Windows (~96 KiB) is larger than any command line, so only POSIX is affected.
 describe.concurrent.skipIf(isWindows)("--cwd that does not fit the path buffer", () => {
-  const PATH_MAX = isLinux ? 4096 : 1024;
+  const PATH_MAX = isLinux || isAndroid ? 4096 : 1024;
   const name = (length: number) => Buffer.alloc(length, "a").toString();
 
   it.each([


### PR DESCRIPTION
### Problem
- Every package manager subcommand (`bun install`, `add`, `remove`, `update`, `pm`, ...) aborts when its `--cwd` value is at least `PATH_MAX` bytes long (4096 on Linux, 1024 on macOS), instead of printing an error:
  ```
  $ bun install --cwd "$(head -c 5000 /dev/zero | tr '\0' a)"
  panic: range end index 5000 out of range for slice of length 4096
  $ bun install --cwd "./$(head -c 5000 /dev/zero | tr '\0' a)"
  panic: range end index 5014 out of range for slice of length 4095
  $ bun install --cwd "$(head -c 4096 /dev/zero | tr '\0' a)"
  panic: index out of bounds: the len is 4096 but the index is 4096
  ```
  (exit 134). A value one byte shorter already printed `error: failed to change directory to "...": ENAMETOOLONG` and exited 1.
- Cause: the `--cwd` block in `src/install/PackageManager/CommandLineArguments.rs` (lines 1298-1329 on main) stages the value in a `PathBuffer` of exactly `PATH_MAX` bytes with no length check. A value not starting with `.` is copied in with `copy_from_slice` and then NUL-terminated one byte further; a value starting with `.` is resolved with the unchecked `join_abs_string_buf`, which panics inside the normalizer when the result does not fit the buffer.
- The runtime's global `bun --cwd` flag has the same bug in separate code (`src/runtime/cli/Arguments.rs`); that one is fixed in #38368. This PR only covers the package manager's own flag.

### Fix
- The block moves into `change_directory`. The `.`-prefixed branch resolves with `join_abs_string_buf_checked` into `PATH_MAX - 1` bytes of the buffer; the other branch copies the value only when it leaves that last byte free. Both keep the last byte for the NUL terminator `chdir` reads. When the value does not fit, the existing `failed to change directory to "<value>": <errno>` message is printed with `ENAMETOOLONG` and the process exits 1, the same as when `chdir` itself fails.
- Why `ENAMETOOLONG` is the right answer rather than some new error: `PATH_MAX` counts the terminator, so a path of `PATH_MAX` or more bytes is one `chdir` would reject with `ENAMETOOLONG` if it could be passed at all. The check only turns away values that could never have been entered, and the user sees the same line either side of the buffer boundary (the `PATH_MAX - 1` control in the test is the kernel's own rejection, printed through the unchanged `chdir` error path).
- Why the checked join rather than a length check on the argument in the `.` branch: that branch already normalizes (`--cwd ./moo/..` enters the parent), and `join_abs_string_buf_checked` fails only when the normalized result does not fit, so that behaviour is kept. Mapping its `None` to `ENAMETOOLONG` is how the lockfile code already treats it (`src/install/lockfile/Package/WorkspaceMap.rs`).
- Messages for failures that are not about length are unchanged: a missing directory still prints the value as given (`"/nonexistent"`) or, for a `.` value, the resolved path (`"/tmp/proj/nonexistent"`).
- Verified with the new `--cwd that does not fit the path buffer` block in `test/cli/install/bun-install.test.ts`: `PATH_MAX` bytes, `PATH_MAX + 1000` bytes, the `./` form, and `bun add`, plus `PATH_MAX - 1` as the kernel-rejected control. On the current release build the four new lengths abort with the panics above and the control passes; with this change all five pass, as does the existing `should handle --cwd` test.
- Checked by hand with the debug build that `--cwd moo`, `./moo`, `moo/`, `.`, `./moo/..`, an absolute path, `""`, a missing directory and `./<5000 bytes>/..` (normalizes to the cwd and succeeds) behave as before.
- The test block is skipped on Windows: `PathBuffer` there is about 96 KiB, longer than any command line, so the overflow is unreachable.

### Background
- `PathBuffer` is a `[u8; MAX_PATH_BYTES]` scratch buffer, where `MAX_PATH_BYTES` is the platform `PATH_MAX` (4096 on Linux, 1024 on macOS and the BSDs, `32767 * 3 + 1` on Windows). `PATH_MAX` includes the NUL terminator, so the longest path a syscall accepts is `PATH_MAX - 1` bytes.
- `join_abs_string_buf(cwd, buf, parts)` is `path.resolve` into a caller buffer; it assumes the result fits. `join_abs_string_buf_checked` is the variant for user-controlled input: it normalizes into heap scratch when needed and returns `None` only if the normalized result does not fit `buf`.
- `Output::err_generic` + `Global::crash()` is how this argument parser reports every invalid flag value: it prints `error: ...` and exits 1.
