### PR TITLE
bundler: give the browser side of a server build its own copy of the runtime

### DIFF
--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -78,12 +78,7 @@ pub struct Graph<'a> {
     /// OutputPiece.Kind.HTMLManifest corresponds to indices into the array.
     pub(crate) html_imports: HtmlImports,
 
-    /// A second copy of the bundler runtime, parsed for `Target::Browser`. A
-    /// server-side build creates it together with its client transpiler, so the
-    /// browser files it pulls in through HTML imports take `__toESM`,
-    /// `__require`, ... from a runtime built for the browser instead of sharing
-    /// `Index::RUNTIME` (and therefore output chunks) with the server code.
-    /// `Index::INVALID` when the build has no such browser side.
+    /// Runtime copy parsed for the browser side of a server build (HTML imports); invalid if none.
     pub(crate) browser_runtime_source_index: Index,
 
     pub(crate) estimated_file_loader_count: usize,
@@ -232,8 +227,7 @@ impl<'a> Graph<'a> {
         &mut self.build_graphs[target]
     }
 
-    /// The copy of the runtime that files parsed for `target` import their
-    /// helpers from.
+    /// The runtime copy that files parsed for `target` import their helpers from.
     #[inline]
     pub(crate) fn runtime_source_index_for_target(&self, target: options::Target) -> Index {
         if target == options::Target::Browser && self.browser_runtime_source_index.is_valid() {

--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -78,6 +78,14 @@ pub struct Graph<'a> {
     /// OutputPiece.Kind.HTMLManifest corresponds to indices into the array.
     pub(crate) html_imports: HtmlImports,
 
+    /// A second copy of the bundler runtime, parsed for `Target::Browser`. A
+    /// server-side build creates it together with its client transpiler, so the
+    /// browser files it pulls in through HTML imports take `__toESM`,
+    /// `__require`, ... from a runtime built for the browser instead of sharing
+    /// `Index::RUNTIME` (and therefore output chunks) with the server code.
+    /// `Index::INVALID` when the build has no such browser side.
+    pub(crate) browser_runtime_source_index: Index,
+
     pub(crate) estimated_file_loader_count: usize,
 
     /// For Bake, a count of the CSS asts is used to make precise
@@ -175,6 +183,7 @@ impl<'a> Graph<'a> {
             build_graphs: EnumMap::default(),
             server_component_boundaries: server_component_boundary::List::default(),
             html_imports: HtmlImports::default(),
+            browser_runtime_source_index: Index::INVALID,
             estimated_file_loader_count: 0,
             css_file_count: 0,
             additional_output_files: Vec::new(),
@@ -221,6 +230,17 @@ impl<'a> Graph<'a> {
         target: options::Target,
     ) -> &mut PathToSourceIndexMap {
         &mut self.build_graphs[target]
+    }
+
+    /// The copy of the runtime that files parsed for `target` import their
+    /// helpers from.
+    #[inline]
+    pub(crate) fn runtime_source_index_for_target(&self, target: options::Target) -> Index {
+        if target == options::Target::Browser && self.browser_runtime_source_index.is_valid() {
+            self.browser_runtime_source_index
+        } else {
+            Index::RUNTIME
+        }
     }
 
     /// Schedule a task to be run on the JS thread which resolves the promise of

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -91,15 +91,8 @@ pub struct LinkerContext<'a> {
     pub(crate) resolver: Option<bun_ptr::ParentRef<Resolver<'a>>>,
     pub(crate) cycle_detector: Vec<ImportTracker>,
 
-    /// We may need to refer to the "__esm" and/or "__commonJS" runtime symbols
-    pub(crate) cjs_runtime_ref: Ref,
-    pub(crate) esm_runtime_ref: Ref,
-
     /// We may need to refer to the CommonJS "module" symbol for exports
     pub(crate) unbound_module_ref: Ref,
-
-    /// We may need to refer to the "__promiseAll" runtime symbol
-    pub(crate) promise_all_runtime_ref: Ref,
 
     pub(crate) options: LinkerOptions,
 
@@ -144,10 +137,7 @@ impl<'a> Default for LinkerContext<'a> {
             log: core::ptr::null_mut(),
             resolver: None,
             cycle_detector: Vec::new(),
-            cjs_runtime_ref: Ref::NONE,
-            esm_runtime_ref: Ref::NONE,
             unbound_module_ref: Ref::NONE,
-            promise_all_runtime_ref: Ref::NONE,
             options: Default::default(),
             r#loop: None,
             unique_key_buf: Box::default(),
@@ -456,6 +446,9 @@ impl<'a> LinkerContext<'a> {
         // Note: `reachable_files` is `Vec<Index>`; clone the
         // caller-owned slice into the linker arena.
         self.graph.reachable_files = reachable.to_vec();
+        // SAFETY: parse_graph is valid backref just assigned above
+        self.graph.browser_runtime_source_index =
+            unsafe { (*self.parse_graph).browser_runtime_source_index };
 
         // SAFETY: parse_graph is valid backref just assigned above
         let sources: &[Source] = unsafe { (*self.parse_graph).input_files.items_source() };
@@ -469,22 +462,6 @@ impl<'a> LinkerContext<'a> {
             unsafe { &(*self.parse_graph).entry_point_original_names },
         )?;
         dyn_entry_points.clear_retaining_capacity();
-
-        let runtime_named_exports =
-            &self.graph.ast.items_named_exports()[Index::RUNTIME.get() as usize];
-
-        self.esm_runtime_ref = runtime_named_exports
-            .get(b"__esm")
-            .expect("infallible: runtime export")
-            .ref_;
-        self.cjs_runtime_ref = runtime_named_exports
-            .get(b"__commonJS")
-            .expect("infallible: runtime export")
-            .ref_;
-        self.promise_all_runtime_ref = runtime_named_exports
-            .get(b"__promiseAll")
-            .expect("infallible: runtime export")
-            .ref_;
 
         if self.options.output_format == Format::Cjs {
             self.unbound_module_ref = self.graph.generate_new_symbol(
@@ -616,8 +593,6 @@ impl<'a> LinkerContext<'a> {
         // SAFETY: see above; sole accessor of `html_imports` for this scope.
         let server_len = unsafe { (*parse_graph).html_imports.server_source_indices.len() };
         if server_len > 0 {
-            let actual_ref = self.graph.runtime_function(b"__jsonParse");
-
             for i in 0..server_len as usize {
                 // SAFETY: `server_source_indices` is a stable Vec; index
                 // bounded by `server_len`.
@@ -662,6 +637,7 @@ impl<'a> LinkerContext<'a> {
                 .ref_;
 
                 // Make the __jsonParse in that file point to the __jsonParse in the runtime chunk.
+                let actual_ref = self.graph.runtime_function_for(html_import, b"__jsonParse");
                 // SAFETY: `original_ref`'s symbol slot is disjoint from any live borrow here
                 // (only `actual_ref` is held, a `Copy` value).
                 unsafe { self.graph.symbol_mut(original_ref) }
@@ -675,7 +651,7 @@ impl<'a> LinkerContext<'a> {
                         Index::part(1u32).get(),
                         actual_ref,
                         1,
-                        Index::RUNTIME,
+                        Index::source(actual_ref.source_index()),
                     )
                     .expect("OOM");
             }
@@ -743,7 +719,7 @@ impl<'a> LinkerContext<'a> {
             let mut source_index: u32 = 0;
             while (source_index as usize) < files_len {
                 // Skip runtime
-                if source_index == Index::RUNTIME.get() {
+                if self.graph.is_runtime_source(source_index) {
                     source_index += 1;
                     continue;
                 }
@@ -2008,6 +1984,7 @@ impl<'a> LinkerContext<'a> {
 
     pub(crate) fn should_remove_import_export_stmt(
         &mut self,
+        source_index: crate::IndexInt,
         stmts: &mut StmtList,
         loc: Loc,
         namespace_ref: Ref,
@@ -2126,9 +2103,10 @@ impl<'a> LinkerContext<'a> {
                 );
 
                 if other_flags.is_async_or_has_async_dependency {
+                    let promise_all_ref = self.runtime_function_for(source_index, b"__promiseAll");
                     stmts
                         .inside_wrapper_prefix
-                        .append_async_dependency(init_call, self.promise_all_runtime_ref)?;
+                        .append_async_dependency(init_call, promise_all_ref)?;
                 } else {
                     stmts
                         .inside_wrapper_prefix
@@ -2159,6 +2137,8 @@ impl<'a> LinkerContext<'a> {
             stmts: bun_ast::StoreSlice::new_mut(out_stmts),
             ..Default::default()
         }];
+        let enable_source_maps = self.options.source_maps != SourceMapOption::None
+            && !self.graph.is_runtime_source(source_index.get());
 
         // SAFETY: parse_graph backref; raw deref because `parse_graph` is held
         // across `RequireOrImportMetaCallback::init(self)` (`&mut self`) below.
@@ -2264,8 +2244,6 @@ impl<'a> LinkerContext<'a> {
             core::mem::transmute::<renamer::Renamer<'_, '_>, renamer::Renamer<'_, '_>>(r)
         };
 
-        let enable_source_maps =
-            self.options.source_maps != SourceMapOption::None && !source_index.is_runtime();
         let result = if enable_source_maps {
             js_printer::print_with_writer::<&mut js_printer::BufferPrinter, true>(
                 &mut printer,
@@ -2930,6 +2908,14 @@ use bun_ast::{DependencyList, ImportItemStatus, PartSymbolUseMap};
 // below resolve unchanged.
 pub(crate) use crate::bundle_v2::{ImportTrackerIterator, ImportTrackerStatus};
 
+/// See [`LinkerContext::runtime_print_refs_for`].
+#[derive(Clone, Copy)]
+pub(crate) struct RuntimePrintRefs {
+    pub(crate) to_common_js_ref: Ref,
+    pub(crate) to_esm_ref: Ref,
+    pub(crate) require_ref: Option<Ref>,
+}
+
 /// Field-wise eq for `ImportTracker`.
 #[inline]
 fn import_tracker_eq(a: &ImportTracker, b: &ImportTracker) -> bool {
@@ -2939,10 +2925,37 @@ fn import_tracker_eq(a: &ImportTracker, b: &ImportTracker) -> bool {
 }
 
 impl<'a> LinkerContext<'a> {
-    /// Looks up the symbol `Ref` for a named export of the runtime module.
+    /// Looks up the symbol `Ref` of the runtime helper `name` in the runtime
+    /// copy that file `source_index` uses (see
+    /// `LinkerGraph::runtime_source_index_for`).
     #[inline]
-    pub(crate) fn runtime_function(&self, name: &[u8]) -> Ref {
-        self.graph.runtime_function(name)
+    pub(crate) fn runtime_function_for(&self, source_index: crate::IndexInt, name: &[u8]) -> Ref {
+        self.graph.runtime_function_for(source_index, name)
+    }
+
+    /// The runtime helpers the printer itself emits references to (interop
+    /// wrappers around `require()` / `import()` and the `require` polyfill),
+    /// taken from the runtime copy that file `source_index` uses. Code printed
+    /// for a chunk must take them from the side the chunk belongs to, or a
+    /// browser chunk would end up referencing the server runtime's symbols.
+    pub(crate) fn runtime_print_refs_for(&self, source_index: crate::IndexInt) -> RuntimePrintRefs {
+        let runtime_source_index = self.graph.runtime_source_index_for(source_index);
+        let runtime_members =
+            &self.graph.ast.items_module_scope()[runtime_source_index as usize].members;
+        let helper = |name: &[u8]| {
+            self.graph.symbols.follow(
+                runtime_members
+                    .get(name)
+                    .expect("runtime helper must be declared by the runtime module")
+                    .ref_,
+            )
+        };
+        RuntimePrintRefs {
+            to_common_js_ref: helper(b"__toCommonJS"),
+            to_esm_ref: helper(b"__toESM"),
+            // CommonJS output keeps calling the real `require`.
+            require_ref: (self.options.output_format != Format::Cjs).then(|| helper(b"__require")),
+        }
     }
 
     /// Returns the part indices within file `id` that declare the
@@ -2952,11 +2965,11 @@ impl<'a> LinkerContext<'a> {
         self.graph.top_level_symbol_to_parts(id, r#ref)
     }
 
-    /// Returns the part indices in the runtime module that declare the
-    /// top-level symbol `ref`.
+    /// Returns the part indices that declare the runtime helper `ref` (a ref
+    /// obtained from [`Self::runtime_function_for`]) in its runtime copy.
     #[inline]
     pub(crate) fn top_level_symbols_to_parts_for_runtime(&self, r#ref: Ref) -> &[u32] {
-        self.top_level_symbols_to_parts(Index::RUNTIME.get(), r#ref)
+        self.top_level_symbols_to_parts(r#ref.source_index(), r#ref)
     }
 
     /// Note: returns `'static` so callers can hold the source across a
@@ -3070,22 +3083,9 @@ impl<'a> LinkerContext<'a> {
             // dependencies and let the general-purpose reachability analysis take care
             // of it.
             WrapKind::Cjs => {
-                let common_js_parts =
-                    self.top_level_symbols_to_parts_for_runtime(self.cjs_runtime_ref);
-
-                // Note: the inner loop is intentionally a no-op
-                // (`if r#ref.eql(...) continue;` only).
-                for &part_id in common_js_parts {
-                    let runtime_parts =
-                        self.graph.ast.items_parts()[Index::RUNTIME.get() as usize].as_slice();
-                    let part: &Part = &runtime_parts[part_id as usize];
-                    let symbol_refs = part.symbol_uses.keys();
-                    for r#ref in symbol_refs {
-                        if *r#ref == self.cjs_runtime_ref {
-                            continue;
-                        }
-                    }
-                }
+                let cjs_runtime_ref = self.runtime_function_for(source_index, b"__commonJS");
+                let runtime_source_index = bun_ast::Index::source(cjs_runtime_ref.source_index());
+                let common_js_parts = self.top_level_symbols_to_parts_for_runtime(cjs_runtime_ref);
 
                 // generate a dummy part that depends on the "__commonJS" symbol.
                 let dependencies: DependencyList =
@@ -3094,7 +3094,7 @@ impl<'a> LinkerContext<'a> {
                         for &part in common_js_parts {
                             deps.append_assume_capacity(Dependency {
                                 part_index: part,
-                                source_index: bun_ast::Index::RUNTIME,
+                                source_index: runtime_source_index,
                             });
                         }
                         deps
@@ -3143,9 +3143,9 @@ impl<'a> LinkerContext<'a> {
                         .generate_symbol_import_and_use(
                             source_index,
                             part_index,
-                            self.cjs_runtime_ref,
+                            cjs_runtime_ref,
                             1,
-                            crate::Index::RUNTIME,
+                            runtime_source_index,
                         )
                         .expect("unreachable");
                 }
@@ -3186,10 +3186,16 @@ impl<'a> LinkerContext<'a> {
 
                 let needs_promise_all = async_import_count >= 2;
 
+                let esm_runtime_ref = self.runtime_function_for(source_index, b"__esm");
+                let promise_all_runtime_ref =
+                    self.runtime_function_for(source_index, b"__promiseAll");
+                // Both helpers live in the same runtime copy.
+                let runtime_source_index = bun_ast::Index::source(esm_runtime_ref.source_index());
+
                 let esm_parts: &[u32] = if wrapper_ref.is_valid()
                     && self.options.output_format != Format::InternalBakeDev
                 {
-                    self.top_level_symbols_to_parts_for_runtime(self.esm_runtime_ref)
+                    self.top_level_symbols_to_parts_for_runtime(esm_runtime_ref)
                 } else {
                     &[]
                 };
@@ -3198,7 +3204,7 @@ impl<'a> LinkerContext<'a> {
                     && wrapper_ref.is_valid()
                     && self.options.output_format != Format::InternalBakeDev
                 {
-                    self.top_level_symbols_to_parts_for_runtime(self.promise_all_runtime_ref)
+                    self.top_level_symbols_to_parts_for_runtime(promise_all_runtime_ref)
                 } else {
                     &[]
                 };
@@ -3209,13 +3215,13 @@ impl<'a> LinkerContext<'a> {
                 for &part in esm_parts {
                     dependencies.append_assume_capacity(Dependency {
                         part_index: part,
-                        source_index: bun_ast::Index::RUNTIME,
+                        source_index: runtime_source_index,
                     });
                 }
                 for &part in promise_all_parts {
                     dependencies.append_assume_capacity(Dependency {
                         part_index: part,
-                        source_index: bun_ast::Index::RUNTIME,
+                        source_index: runtime_source_index,
                     });
                 }
 
@@ -3246,9 +3252,9 @@ impl<'a> LinkerContext<'a> {
                         .generate_symbol_import_and_use(
                             source_index,
                             part_index,
-                            self.esm_runtime_ref,
+                            esm_runtime_ref,
                             1,
-                            crate::Index::RUNTIME,
+                            runtime_source_index,
                         )
                         .expect("OOM");
 
@@ -3258,9 +3264,9 @@ impl<'a> LinkerContext<'a> {
                             .generate_symbol_import_and_use(
                                 source_index,
                                 part_index,
-                                self.promise_all_runtime_ref,
+                                promise_all_runtime_ref,
                                 1,
-                                crate::Index::RUNTIME,
+                                runtime_source_index,
                             )
                             .expect("OOM");
                     }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2137,8 +2137,9 @@ impl<'a> LinkerContext<'a> {
             stmts: bun_ast::StoreSlice::new_mut(out_stmts),
             ..Default::default()
         }];
-        let enable_source_maps = self.options.source_maps != SourceMapOption::None
-            && !self.graph.is_runtime_source(source_index.get());
+        let source_is_runtime = self.graph.is_runtime_source(source_index.get());
+        let enable_source_maps =
+            self.options.source_maps != SourceMapOption::None && !source_is_runtime;
 
         // SAFETY: parse_graph backref; raw deref because `parse_graph` is held
         // across `RequireOrImportMetaCallback::init(self)` (`&mut self`) below.
@@ -2187,6 +2188,7 @@ impl<'a> LinkerContext<'a> {
             minify_syntax: self.options.minify_syntax,
             input_module_type: ast.exports_kind.into(),
             module_type: self.options.output_format,
+            source_is_runtime,
             print_dce_annotations: self.options.emit_dce_annotations,
             has_run_symbol_renamer: true,
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2927,19 +2927,13 @@ fn import_tracker_eq(a: &ImportTracker, b: &ImportTracker) -> bool {
 }
 
 impl<'a> LinkerContext<'a> {
-    /// Looks up the symbol `Ref` of the runtime helper `name` in the runtime
-    /// copy that file `source_index` uses (see
-    /// `LinkerGraph::runtime_source_index_for`).
+    /// Looks up the runtime helper `name` in the runtime copy that file `source_index` uses.
     #[inline]
     pub(crate) fn runtime_function_for(&self, source_index: crate::IndexInt, name: &[u8]) -> Ref {
         self.graph.runtime_function_for(source_index, name)
     }
 
-    /// The runtime helpers the printer itself emits references to (interop
-    /// wrappers around `require()` / `import()` and the `require` polyfill),
-    /// taken from the runtime copy that file `source_index` uses. Code printed
-    /// for a chunk must take them from the side the chunk belongs to, or a
-    /// browser chunk would end up referencing the server runtime's symbols.
+    /// The interop helpers the printer references, from the runtime copy file `source_index` uses.
     pub(crate) fn runtime_print_refs_for(&self, source_index: crate::IndexInt) -> RuntimePrintRefs {
         let runtime_source_index = self.graph.runtime_source_index_for(source_index);
         let runtime_members =
@@ -2967,8 +2961,7 @@ impl<'a> LinkerContext<'a> {
         self.graph.top_level_symbol_to_parts(id, r#ref)
     }
 
-    /// Returns the part indices that declare the runtime helper `ref` (a ref
-    /// obtained from [`Self::runtime_function_for`]) in its runtime copy.
+    /// Returns the part indices that declare the runtime helper `ref` in its runtime copy.
     #[inline]
     pub(crate) fn top_level_symbols_to_parts_for_runtime(&self, r#ref: Ref) -> &[u32] {
         self.top_level_symbols_to_parts(r#ref.source_index(), r#ref)

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -10,6 +10,7 @@ use bun_collections::{AutoBitSet, DynamicBitSetUnmanaged as BitSet, MultiArrayLi
 use bun_core::RawSlice;
 
 use crate::IndexStringMap::IndexStringMap;
+use crate::options::Target;
 use crate::{ImportTracker, Index, JSAst, Part, Ref, UseDirective, import_record, index, part};
 // `items_<field>()` column accessors — bring the `*ListExt` traits into scope.
 // Note: `BundledAstColumns` is emitted by `bun_collections::multi_array_columns!`
@@ -212,6 +213,12 @@ pub struct LinkerGraph<'a> {
 
     pub(crate) is_scb_bitset: BitSet,
 
+    /// Copied from `Graph::browser_runtime_source_index` in `load`. Every
+    /// runtime helper the linker hands to a file goes through
+    /// [`Self::runtime_source_index_for`] so that browser files of a server
+    /// build use this copy and never share a chunk with `Index::RUNTIME`.
+    pub(crate) browser_runtime_source_index: Index,
+
     /// This is for cross-module inlining of detected inlinable constants
     // const_values: bun_ast::Ast::ConstValuesMap,
     /// This is for cross-module inlining of TypeScript enum constants
@@ -226,8 +233,8 @@ pub struct LinkerGraph<'a> {
 //   (no new allocations) for the duration of any worker-pool fan-out that
 //   holds `&LinkerGraph`.
 // - `files_live` / `parts_live` / `is_scb_bitset` / `reachable_files` /
-//   `stable_source_indices` / `code_splitting` / `ts_enums` are populated
-//   before fan-out and only read by workers.
+//   `stable_source_indices` / `code_splitting` / `browser_runtime_source_index` /
+//   `ts_enums` are populated before fan-out and only read by workers.
 // - `ast` / `meta` / `files` columns that workers mutate are split out via
 //   `split_mut()` into disjoint `&mut [_]` *before* the pool runs (see
 //   `compute_cross_chunk_dependencies`); workers never reach those columns
@@ -275,6 +282,7 @@ impl Default for LinkerGraph<'_> {
             reachable_files: Vec::new(),
             stable_source_indices: Vec::new(),
             is_scb_bitset: BitSet::default(),
+            browser_runtime_source_index: Index::INVALID,
             ts_enums: bun_ast::ast_result::TsEnumsMap::default(),
         }
     }
@@ -291,8 +299,12 @@ impl Default for LinkerGraph<'_> {
 // thin forwarders for call sites that don't have a split in hand.
 // ──────────────────────────────────────────────────────────────────────────
 
-fn runtime_function(named_exports: &[bundled_ast::NamedExports], name: &[u8]) -> Ref {
-    named_exports[Index::RUNTIME.get() as usize]
+fn runtime_function(
+    named_exports: &[bundled_ast::NamedExports],
+    runtime_source_index: index::Int,
+    name: &[u8],
+) -> Ref {
+    named_exports[runtime_source_index as usize]
         .get(name)
         .expect("runtime function must be a named export of the runtime module")
         .ref_
@@ -477,8 +489,33 @@ pub(crate) fn generate_symbol_import_and_use(
 }
 
 impl<'a> LinkerGraph<'a> {
-    pub(crate) fn runtime_function(&self, name: &[u8]) -> Ref {
-        runtime_function(self.ast.items_named_exports(), name)
+    /// The copy of the runtime that `source_index` takes its helpers from.
+    /// There is only ever a second copy in a server-side build with browser
+    /// files (HTML imports); everything else resolves to `Index::RUNTIME`.
+    pub(crate) fn runtime_source_index_for(&self, source_index: index::Int) -> index::Int {
+        if self.browser_runtime_source_index.is_valid()
+            && self.ast.items_target()[source_index as usize] == Target::Browser
+        {
+            return self.browser_runtime_source_index.get();
+        }
+        Index::RUNTIME.get()
+    }
+
+    pub(crate) fn is_runtime_source(&self, source_index: index::Int) -> bool {
+        source_index == Index::RUNTIME.get()
+            || (self.browser_runtime_source_index.is_valid()
+                && source_index == self.browser_runtime_source_index.get())
+    }
+
+    /// Looks up the helper `name` in the runtime copy that `source_index` uses.
+    /// The returned ref's `source_index()` is that runtime copy, which is what
+    /// dependencies on the helper's parts have to point at.
+    pub(crate) fn runtime_function_for(&self, source_index: index::Int, name: &[u8]) -> Ref {
+        runtime_function(
+            self.ast.items_named_exports(),
+            self.runtime_source_index_for(source_index),
+            name,
+        )
     }
 
     /// Shared-ref view of a symbol that is known to exist (the `Ref` was
@@ -551,13 +588,13 @@ impl<'a> LinkerGraph<'a> {
             source_index
         );
 
-        let ref_ = self.runtime_function(name);
+        let ref_ = self.runtime_function_for(source_index, name);
         self.generate_symbol_import_and_use(
             source_index,
             entry_point_part_index.get(),
             ref_,
             count,
-            Index::RUNTIME,
+            Index::source(ref_.source_index()),
         )
     }
 

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -213,10 +213,7 @@ pub struct LinkerGraph<'a> {
 
     pub(crate) is_scb_bitset: BitSet,
 
-    /// Copied from `Graph::browser_runtime_source_index` in `load`. Every
-    /// runtime helper the linker hands to a file goes through
-    /// [`Self::runtime_source_index_for`] so that browser files of a server
-    /// build use this copy and never share a chunk with `Index::RUNTIME`.
+    /// `Graph::browser_runtime_source_index`, copied in `LinkerContext::load`.
     pub(crate) browser_runtime_source_index: Index,
 
     /// This is for cross-module inlining of detected inlinable constants
@@ -233,8 +230,9 @@ pub struct LinkerGraph<'a> {
 //   (no new allocations) for the duration of any worker-pool fan-out that
 //   holds `&LinkerGraph`.
 // - `files_live` / `parts_live` / `is_scb_bitset` / `reachable_files` /
-//   `stable_source_indices` / `code_splitting` / `browser_runtime_source_index` /
-//   `ts_enums` are populated before fan-out and only read by workers.
+//   `stable_source_indices` / `code_splitting` / `ts_enums` are populated
+//   before fan-out and only read by workers.
+// - `browser_runtime_source_index` is set in `load`, before fan-out, and only read by workers.
 // - `ast` / `meta` / `files` columns that workers mutate are split out via
 //   `split_mut()` into disjoint `&mut [_]` *before* the pool runs (see
 //   `compute_cross_chunk_dependencies`); workers never reach those columns
@@ -489,9 +487,7 @@ pub(crate) fn generate_symbol_import_and_use(
 }
 
 impl<'a> LinkerGraph<'a> {
-    /// The copy of the runtime that `source_index` takes its helpers from.
-    /// There is only ever a second copy in a server-side build with browser
-    /// files (HTML imports); everything else resolves to `Index::RUNTIME`.
+    /// The runtime copy that file `source_index` takes its helpers from.
     pub(crate) fn runtime_source_index_for(&self, source_index: index::Int) -> index::Int {
         if self.browser_runtime_source_index.is_valid()
             && self.ast.items_target()[source_index as usize] == Target::Browser
@@ -507,9 +503,7 @@ impl<'a> LinkerGraph<'a> {
                 && source_index == self.browser_runtime_source_index.get())
     }
 
-    /// Looks up the helper `name` in the runtime copy that `source_index` uses.
-    /// The returned ref's `source_index()` is that runtime copy, which is what
-    /// dependencies on the helper's parts have to point at.
+    /// Helper `name` from the runtime copy `source_index` uses; the ref lives in that copy.
     pub(crate) fn runtime_function_for(&self, source_index: index::Int, name: &[u8]) -> Ref {
         runtime_function(
             self.ast.items_named_exports(),

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -117,9 +117,7 @@ pub struct ParseTask {
     pub(crate) package_version: ast::StoreStr,
     pub(crate) package_name: ast::StoreStr,
     pub(crate) is_entry_point: bool,
-    /// This task parses a copy of the bundler runtime (`Index::RUNTIME`, or the
-    /// browser copy a server build adds for its HTML imports). The runtime is
-    /// always tree-shaken and always honors its own `@__PURE__` annotations.
+    /// Parses a copy of the bundler runtime (`Index::RUNTIME` or a server build's browser copy).
     pub(crate) is_runtime: bool,
 }
 

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -117,6 +117,10 @@ pub struct ParseTask {
     pub(crate) package_version: ast::StoreStr,
     pub(crate) package_name: ast::StoreStr,
     pub(crate) is_entry_point: bool,
+    /// This task parses a copy of the bundler runtime (`Index::RUNTIME`, or the
+    /// browser copy a server build adds for its HTML imports). The runtime is
+    /// always tree-shaken and always honors its own `@__PURE__` annotations.
+    pub(crate) is_runtime: bool,
 }
 
 pub enum ParseTaskStage {
@@ -282,14 +286,18 @@ impl ParseTask {
             stage: ParseTaskStage::NeedsSourceCode,
             tree_shaking: false,
             is_entry_point: false,
+            is_runtime: false,
         }
     }
 
     /// Re-export of `parse_worker::get_runtime_source` as an associated fn so
     /// callers can spell it `ParseTask::get_runtime_source`.
     #[inline]
-    pub(crate) fn get_runtime_source(target: options::Target) -> RuntimeSource {
-        parse_worker::get_runtime_source(target)
+    pub(crate) fn get_runtime_source(
+        target: options::Target,
+        source_index: Index,
+    ) -> RuntimeSource {
+        parse_worker::get_runtime_source(target, source_index)
     }
 }
 
@@ -323,6 +331,7 @@ impl Default for ParseTask {
             package_version: ast::StoreStr::EMPTY,
             package_name: ast::StoreStr::EMPTY,
             is_entry_point: false,
+            is_runtime: false,
         }
     }
 }
@@ -495,7 +504,7 @@ export var __callDispose = (stack, error, hasError) => {
 pub mod parse_worker {
     use super::*;
 
-    fn get_runtime_source_comptime(target: options::Target) -> RuntimeSource {
+    fn get_runtime_source_comptime(target: options::Target, source_index: Index) -> RuntimeSource {
         use const_format::concatcp;
 
         let runtime_code: &'static str = match target {
@@ -538,9 +547,10 @@ pub mod parse_worker {
                 ..Default::default()
             },
             contents_or_fd: ContentsOrFd::Contents(runtime_code.as_bytes()),
-            source_index: Index::RUNTIME,
+            source_index,
             loader: Some(Loader::Js),
             known_target: target,
+            is_runtime: true,
             // defaults:
             secondary_path_for_commonjs_interop: None,
             external_free_function: ExternalFreeFunction::NONE,
@@ -574,16 +584,17 @@ pub mod parse_worker {
                 is_symlink: false,
             },
             contents: std::borrow::Cow::Borrowed(runtime_code.as_bytes()),
-            // `Source.index` is `bun_ast::Index` (newtype `u32`),
-            // distinct from `bun_ast::Index`. Runtime source is index 0.
-            index: bun_ast::Index(Index::RUNTIME.get()),
+            index: source_index,
             ..Default::default()
         };
         RuntimeSource { parse_task, source }
     }
 
-    pub(crate) fn get_runtime_source(target: options::Target) -> RuntimeSource {
-        get_runtime_source_comptime(target)
+    pub(crate) fn get_runtime_source(
+        target: options::Target,
+        source_index: Index,
+    ) -> RuntimeSource {
+        get_runtime_source_comptime(target, source_index)
     }
 
     // ───────────────────────────────────────────────────────────────────────────
@@ -1545,7 +1556,7 @@ pub mod parse_worker {
         from_plugin: &mut bool,
     ) -> core::result::Result<CacheEntry, AnyError> {
         let might_have_on_parse_plugins = 'brk: {
-            if task.source_index.is_runtime() {
+            if task.is_runtime {
                 break 'brk false;
             }
             // SAFETY: ctx backref is valid for the bundle pass (outlives `'r`).
@@ -2433,6 +2444,7 @@ pub mod parse_worker {
             loader,
         );
         opts.bundle = true;
+        opts.source_is_runtime = task.is_runtime;
         opts.warn_about_unbundled_modules = false;
         // `AllowUnresolved` is the same nominal type on
         // both sides (re-export in options.rs). `'static` erasure: `topts` borrows
@@ -2454,7 +2466,7 @@ pub mod parse_worker {
         };
         opts.package_version = task.package_version.slice();
 
-        opts.features.allow_runtime = !task.source_index.is_runtime();
+        opts.features.allow_runtime = !task.is_runtime;
         opts.features.unwrap_commonjs_to_esm =
             output_format == options::Format::Esm && FeatureFlags::UNWRAP_COMMONJS_TO_ESM;
         opts.features.top_level_await = output_format == options::Format::Esm
@@ -2497,7 +2509,7 @@ pub mod parse_worker {
         // targeting Bun there is no need to lower them.
         opts.features.lower_using = !target.is_bun();
         opts.features.hot_module_reloading =
-            output_format == options::Format::InternalBakeDev && !task.source_index.is_runtime();
+            output_format == options::Format::InternalBakeDev && !task.is_runtime;
         opts.features.auto_polyfill_require =
             output_format == options::Format::Esm && !opts.features.hot_module_reloading;
         opts.features.react_fast_refresh =
@@ -2582,8 +2594,7 @@ pub mod parse_worker {
             }
         });
 
-        opts.ignore_dce_annotations =
-            topts.ignore_dce_annotations && !task.source_index.is_runtime();
+        opts.ignore_dce_annotations = topts.ignore_dce_annotations && !task.is_runtime;
 
         // For files that are not user-specified entrypoints, set `import.meta.main` to `false`.
         // Entrypoints will have `import.meta.main` set as "unknown", unless we use `--compile`,
@@ -2594,7 +2605,7 @@ pub mod parse_worker {
             opts.lower_import_meta_main_for_node_js = true;
         }
 
-        opts.tree_shaking = if task.source_index.is_runtime() {
+        opts.tree_shaking = if task.is_runtime {
             true
         } else {
             topts.tree_shaking

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1550,13 +1550,6 @@ pub mod bv2_impl {
             }
         }
 
-        /// Called when a server-side build first needs to bundle browser code (an
-        /// HTML entry point or HTML import). Besides the transpiler, the browser
-        /// side gets its own copy of the runtime (see
-        /// `Graph::browser_runtime_source_index`). Bake builds hand in their
-        /// client transpiler up front and are not affected: they keep sharing
-        /// `Index::RUNTIME` across both sides (`bake::production` writes that one
-        /// shared runtime chunk out for the client itself).
         fn ensure_client_transpiler(&mut self) {
             if self.client_transpiler.is_none() {
                 let _ = self
@@ -1564,6 +1557,7 @@ pub mod bv2_impl {
                     .unwrap_or_else(|e: Error| {
                         panic!("Failed to initialize client transpiler: {}", e.name());
                     });
+                // Bake passes its client transpiler in, so it keeps the single shared runtime.
                 debug_assert!(self.graph.browser_runtime_source_index.is_invalid());
                 self.graph.browser_runtime_source_index = self
                     .enqueue_runtime(Target::Browser)
@@ -3283,11 +3277,7 @@ pub mod bv2_impl {
             Ok(())
         }
 
-        /// Adds a copy of the bundler runtime built for `target` to the graph and
-        /// schedules its parse. The copy takes the next free source index, so the
-        /// main copy has to be added before anything else to land at
-        /// `Index::RUNTIME`; the browser copy of a server build (see
-        /// `Graph::browser_runtime_source_index`) can be added at any point.
+        /// Takes the next source index; the main copy must go first to land at `Index::RUNTIME`.
         fn enqueue_runtime(&mut self, target: options::Target) -> Result<Index, Error> {
             let source_index = Index::init(self.graph.input_files.len());
             let rt = ParseTask::get_runtime_source(target, source_index);
@@ -6946,9 +6936,7 @@ pub mod bv2_impl {
                 )?
                 .unwrap(),
             );
-            // The parser leaves `target` at its browser default; this manifest
-            // module belongs to the importing (server) side of the build, which is
-            // what selects the runtime copy it takes `__jsonParse` from.
+            // The parser defaults `target` to browser; this module belongs to the importing side.
             ast_for_html_entrypoint.target = target;
 
             let fake_input_file = crate::Graph::InputFile {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1550,12 +1550,25 @@ pub mod bv2_impl {
             }
         }
 
+        /// Called when a server-side build first needs to bundle browser code (an
+        /// HTML entry point or HTML import). Besides the transpiler, the browser
+        /// side gets its own copy of the runtime (see
+        /// `Graph::browser_runtime_source_index`). Bake builds hand in their
+        /// client transpiler up front and are not affected: they keep sharing
+        /// `Index::RUNTIME` across both sides (`bake::production` writes that one
+        /// shared runtime chunk out for the client itself).
         fn ensure_client_transpiler(&mut self) {
             if self.client_transpiler.is_none() {
                 let _ = self
                     .initialize_client_transpiler()
                     .unwrap_or_else(|e: Error| {
                         panic!("Failed to initialize client transpiler: {}", e.name());
+                    });
+                debug_assert!(self.graph.browser_runtime_source_index.is_invalid());
+                self.graph.browser_runtime_source_index = self
+                    .enqueue_runtime(Target::Browser)
+                    .unwrap_or_else(|e: Error| {
+                        panic!("Failed to enqueue browser runtime: {}", e.name());
                     });
             }
         }
@@ -1937,6 +1950,7 @@ pub mod bv2_impl {
             // null `&Map` via `mem::zeroed()` (UB even though it was never read
             // when `scb_bitset` is `None`).
             let scb_list = self.graph.server_component_boundaries.slice();
+            let browser_runtime_source_index = self.graph.browser_runtime_source_index;
 
             // reshaped for borrowck — `Slice<T>` is a value-type
             // snapshot of column pointers (does not borrow `self.graph.ast`), so
@@ -1967,6 +1981,9 @@ pub mod bv2_impl {
             // If we don't include the runtime, __toESM or __toCommonJS will not get
             // imported and weird things will happen
             visitor.visit::<false>(Index::RUNTIME, false);
+            if browser_runtime_source_index.is_valid() {
+                visitor.visit::<false>(browser_runtime_source_index, false);
+            }
 
             if self.transpiler.options.code_splitting {
                 for entry_point in self.graph.entry_points.iter().copied() {
@@ -3260,8 +3277,20 @@ pub mod bv2_impl {
 
         /// Common prelude shared by all enqueue_entry_points_* variants: add the runtime task.
         fn enqueue_entry_points_common(&mut self) -> Result<(), Error> {
-            // Add the runtime
-            let rt = ParseTask::get_runtime_source(self.transpiler.options.target);
+            debug_assert_eq!(self.graph.input_files.len(), 0);
+            let source_index = self.enqueue_runtime(self.transpiler.options.target)?;
+            debug_assert_eq!(source_index, Index::RUNTIME);
+            Ok(())
+        }
+
+        /// Adds a copy of the bundler runtime built for `target` to the graph and
+        /// schedules its parse. The copy takes the next free source index, so the
+        /// main copy has to be added before anything else to land at
+        /// `Index::RUNTIME`; the browser copy of a server build (see
+        /// `Graph::browser_runtime_source_index`) can be added at any point.
+        fn enqueue_runtime(&mut self, target: options::Target) -> Result<Index, Error> {
+            let source_index = Index::init(self.graph.input_files.len());
+            let rt = ParseTask::get_runtime_source(target, source_index);
             self.graph.input_files.append(crate::Graph::InputFile {
                 source: rt.source,
                 loader: Loader::Js,
@@ -3271,8 +3300,8 @@ pub mod bv2_impl {
 
             // try this.graph.entry_points.append(arena, Index.runtime);
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
-            self.path_to_source_index_map(self.transpiler.options.target)
-                .put(&b"bun:wrap"[..], Index::RUNTIME.get())
+            self.path_to_source_index_map(target)
+                .put(&b"bun:wrap"[..], source_index.get())
                 .expect("oom");
             // SAFETY: arena (`self.graph.heap`) outlives the bundle pass; coerce the
             // `&mut ParseTask` to `*mut` immediately so the `&self` borrow from
@@ -3290,7 +3319,7 @@ pub mod bv2_impl {
             }
             self.increment_scan_counter();
             self.graph.pool().schedule(runtime_parse_task);
-            Ok(())
+            Ok(source_index)
         }
 
         fn clone_ast(&mut self) -> Result<(), Error> {
@@ -3932,7 +3961,10 @@ pub mod bv2_impl {
                 this.process_server_component_manifest_files()?;
 
                 let reachable_files = this.find_reachable_files()?;
-                *reachable_files_count = reachable_files.len().saturating_sub(1); // - 1 for the runtime
+                // Don't count the runtime copies as bundled modules.
+                *reachable_files_count = reachable_files.len().saturating_sub(
+                    1 + usize::from(this.graph.browser_runtime_source_index.is_valid()),
+                );
 
                 this.process_files_to_copy(&reachable_files)?;
 
@@ -5954,6 +5986,7 @@ pub mod bv2_impl {
             let source = ctx.source;
             let loader = ctx.loader;
             let source_dir = source.path.source_dir();
+            let runtime_source_index = self.graph.runtime_source_index_for_target(ctx.target);
             let mut estimated_resolve_queue_count: usize = 0;
             for import_record in ctx.import_records.iter_mut() {
                 if import_record
@@ -5961,7 +5994,7 @@ pub mod bv2_impl {
                     .contains(bun_ast::ImportRecordFlags::IS_INTERNAL)
                 {
                     import_record.tag = bun_ast::ImportRecordTag::Runtime;
-                    import_record.source_index = Index::RUNTIME;
+                    import_record.source_index = runtime_source_index;
                 }
 
                 // For non-dev-server builds, barrel-deferred records need their
@@ -6040,7 +6073,7 @@ pub mod bv2_impl {
                     import_record.path.namespace = b"bun";
                     import_record.tag = bun_ast::ImportRecordTag::Runtime;
                     import_record.path.text = b"wrap";
-                    import_record.source_index = Index::RUNTIME;
+                    import_record.source_index = runtime_source_index;
                     continue;
                 }
 
@@ -6892,7 +6925,7 @@ pub mod bv2_impl {
                 (&raw mut *transpiler.options.define, transpiler.log)
             };
 
-            let ast_for_html_entrypoint = JSAst::init(
+            let mut ast_for_html_entrypoint = JSAst::init(
                 bun_js_parser::new_lazy_export_ast(
                     heap,
                     // SAFETY: `define`/`log` live for `'a` (owned by the Transpiler).
@@ -6913,6 +6946,10 @@ pub mod bv2_impl {
                 )?
                 .unwrap(),
             );
+            // The parser leaves `target` at its browser default; this manifest
+            // module belongs to the importing (server) side of the build, which is
+            // what selects the runtime copy it takes `__jsonParse` from.
+            ast_for_html_entrypoint.target = target;
 
             let fake_input_file = crate::Graph::InputFile {
                 source: empty_html_file_source.clone(),

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -45,7 +45,7 @@ use bun_ast::ImportRecordFlags;
 
 use crate::chunk::Content as ChunkContent;
 use crate::options::Loader;
-use crate::{Chunk, Index, LinkerContext};
+use crate::{Chunk, LinkerContext};
 
 #[inline]
 fn fmt_size(bytes: u64) -> bfmt::SizeFormatter {
@@ -89,7 +89,7 @@ pub(crate) fn generate_chunk_json(
         if file_source_index as usize >= sources.len() {
             continue;
         }
-        if file_source_index == Index::RUNTIME.get() {
+        if c.graph.is_runtime_source(file_source_index) {
             continue;
         }
 
@@ -242,7 +242,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
         }
 
         // Skip runtime and other special files
-        if source_index == Index::RUNTIME.get() {
+        if c.graph.is_runtime_source(source_index) {
             continue;
         }
 
@@ -298,7 +298,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                 // `source_index` without rewriting the path. Externals/chunk refs fall through.
                 let import_path: &[u8] = 'path: {
                     if record.source_index.is_valid()
-                        && record.source_index.get() != Index::RUNTIME.get()
+                        && !c.graph.is_runtime_source(record.source_index.get())
                     {
                         let idx = record.source_index.get() as usize;
                         if idx < sources.len() {

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -97,6 +97,7 @@ pub(crate) fn convert_stmts_for_chunk(
                     // "import * as ns from 'path'"
                     // "import {foo} from 'path'"
                     if c.should_remove_import_export_stmt(
+                        source_index,
                         stmts,
                         stmt.loc,
                         s.namespace_ref,
@@ -117,6 +118,7 @@ pub(crate) fn convert_stmts_for_chunk(
                     // "export * as ns from 'path'"
                     if let Some(alias) = &s.alias {
                         if c.should_remove_import_export_stmt(
+                            source_index,
                             stmts,
                             stmt.loc,
                             s.namespace_ref,
@@ -181,7 +183,8 @@ pub(crate) fn convert_stmts_for_chunk(
                             );
 
                             // Prefix this module with "__reExport(exports, ns, module.exports)"
-                            let export_star_ref = c.runtime_function(b"__reExport");
+                            let export_star_ref =
+                                c.runtime_function_for(source_index, b"__reExport");
                             let args_len = 2 + usize::from(module_exports_for_export.is_some());
                             let mut args: Vec<Expr> = Vec::with_capacity(args_len);
                             args.push(Expr::init(
@@ -298,7 +301,8 @@ pub(crate) fn convert_stmts_for_chunk(
                             };
 
                             // Prefix this module with "__reExport(exports, require(path), module.exports)"
-                            let export_star_ref = c.runtime_function(b"__reExport");
+                            let export_star_ref =
+                                c.runtime_function_for(source_index, b"__reExport");
                             let args_len = 2 + usize::from(module_exports_for_export.is_some());
                             let mut args: Vec<Expr> = Vec::with_capacity(args_len);
                             args.push(Expr::init(
@@ -348,6 +352,7 @@ pub(crate) fn convert_stmts_for_chunk(
                 bun_ast::StmtData::SExportFrom(s) => {
                     // "export {foo} from 'path'"
                     if c.should_remove_import_export_stmt(
+                        source_index,
                         stmts,
                         stmt.loc,
                         s.namespace_ref,

--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -568,7 +568,7 @@ impl LinkerContext<'_> {
         // "__export(exports, { foo: () => foo })"
         let mut export_ref = Ref::NONE;
         if !properties.is_empty() {
-            export_ref = self.runtime_function(b"__export");
+            export_ref = self.runtime_function_for(id, b"__export");
             // `bumpalo::Vec` → `Vec` via the global heap;
             // `G::PropertyList` is `Vec<Property>` and currently has no
             // arena-backed `move_from_list`, so re-own.
@@ -605,7 +605,7 @@ impl LinkerContext<'_> {
             ns_export_dependencies.ensure_unused_capacity(parts.len());
             for &part_index in parts {
                 ns_export_dependencies.append_assume_capacity(Dependency {
-                    source_index: bun_ast::Index::RUNTIME,
+                    source_index: bun_ast::Index::source(export_ref.source_index()),
                     part_index,
                 });
             }
@@ -620,7 +620,7 @@ impl LinkerContext<'_> {
         // bundle (including the entry point module) may do "import * as" to get
         // access to the exports object and should NOT see the "__esModule" flag.
         if force_include_exports_for_entry_point {
-            let to_common_js_ref = self.runtime_function(b"__toCommonJS");
+            let to_common_js_ref = self.runtime_function_for(id, b"__toCommonJS");
             emit_export_stmt!(Stmt::assign(
                 Expr::allocate(
                     arena,

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -133,6 +133,10 @@ fn run_visits<const WITH_CODE_SPLITTING: bool, const WITH_SCB: bool>(
     chunk_order_array: &[Order],
 ) {
     visitor.visit::<WITH_CODE_SPLITTING, WITH_SCB>(Index::RUNTIME.value());
+    let browser_runtime_source_index = visitor.c.graph.browser_runtime_source_index;
+    if browser_runtime_source_index.is_valid() {
+        visitor.visit::<WITH_CODE_SPLITTING, WITH_SCB>(browser_runtime_source_index.value());
+    }
     for order in chunk_order_array {
         visitor.visit::<WITH_CODE_SPLITTING, WITH_SCB>(order.source_index);
     }
@@ -220,7 +224,7 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                         && part_index != bun_ast::NAMESPACE_EXPORT_PART_INDEX
                         && self.c.should_include_part(source_index, part)
                     {
-                        let js_parts = if source_index == Index::RUNTIME.value() {
+                        let js_parts = if self.c.graph.is_runtime_source(source_index) {
                             &mut self.parts_prefix
                         } else {
                             &mut self.part_ranges

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -71,7 +71,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     // - one part range per file
     if c.options.output_format == OutputFormat::InternalBakeDev {
         'brk: {
-            if part_range.source_index.is_runtime() {
+            if c.graph.is_runtime_source(source_index as u32) {
                 debug_assert!(c.dev_server.is_none());
                 break 'brk; // this is from `bun build --format=internal_bake_dev`
             }
@@ -597,7 +597,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     E::Call {
                         target: Expr::init(
                             E::Identifier {
-                                ref_: c.cjs_runtime_ref,
+                                ref_: c.runtime_function_for(source_index as u32, b"__commonJS"),
                                 ..Default::default()
                             },
                             bun_ast::Loc::EMPTY,
@@ -817,9 +817,10 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     )]);
 
                     // "var init_foo = __esm(...);"
+                    let esm_runtime_ref = c.runtime_function_for(source_index as u32, b"__esm");
                     let value = Expr::init(
                         E::Call {
-                            target: Expr::init_identifier(c.esm_runtime_ref, bun_ast::Loc::EMPTY),
+                            target: Expr::init_identifier(esm_runtime_ref, bun_ast::Loc::EMPTY),
                             args: Vec::move_from_list(esm_args),
                             ..Default::default()
                         },

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -1,15 +1,12 @@
-use crate::mal_prelude::*;
 use core::sync::atomic::Ordering;
 
-use bun_ast::Scope;
 use bun_js_printer::{self as js_printer, PrintResult};
 use bun_threading::thread_pool as ThreadPoolLib;
 
 use crate::analyze_transpiled_module::ModuleInfo;
 use crate::linker_context_mod::LinkerContext;
-use crate::options::OutputFormat;
 use crate::thread_pool::Worker;
-use crate::{Chunk, CompileResult, Index, PartRange};
+use crate::{Chunk, CompileResult, PartRange};
 
 use super::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_js;
 
@@ -99,28 +96,7 @@ fn generate_compile_result_for_js_chunk_impl(
         .expect("Worker.stmt_list set in create()");
     stmt_list.reset();
 
-    let runtime_scope: &mut Scope = &mut c.graph.ast.items_module_scope_mut()
-        [c.graph.files.items_input_file()[Index::RUNTIME.get() as usize].get() as usize];
-    let runtime_members = &runtime_scope.members;
-    let to_common_js_ref = c.graph.symbols.follow(
-        runtime_members
-            .get(b"__toCommonJS".as_slice())
-            .unwrap()
-            .ref_,
-    );
-    let to_esm_ref = c
-        .graph
-        .symbols
-        .follow(runtime_members.get(b"__toESM".as_slice()).unwrap().ref_);
-    let runtime_require_ref = if c.options.output_format == OutputFormat::Cjs {
-        None
-    } else {
-        Some(
-            c.graph
-                .symbols
-                .follow(runtime_members.get(b"__require".as_slice()).unwrap().ref_),
-        )
-    };
+    let runtime_refs = c.runtime_print_refs_for(part_range.source_index.get());
 
     // `worker.arena` (= `BackRef` to `worker.heap`) is a disjoint field from
     // `worker.temporary_arena` / `worker.stmt_list` borrowed `&mut` above, so
@@ -146,9 +122,9 @@ fn generate_compile_result_for_js_chunk_impl(
         unsafe { (*renamer_ptr).as_renamer() },
         chunk,
         part_range,
-        to_common_js_ref,
-        to_esm_ref,
-        runtime_require_ref,
+        runtime_refs.to_common_js_ref,
+        runtime_refs.to_esm_ref,
+        runtime_refs.require_ref,
         stmt_list,
         worker_alloc,
         &**arena,
@@ -161,7 +137,7 @@ fn generate_compile_result_for_js_chunk_impl(
         PrintResult::Result(r) => r.code.len(),
         _ => 0,
     };
-    if code_len > 0 && !part_range.source_index.is_runtime() {
+    if code_len > 0 && !c.graph.is_runtime_source(part_range.source_index.get()) {
         // CONCURRENCY: the map's key set is frozen before parallel codegen; we
         // only need a shared `&AtomicUsize` to RMW the counter. Using `get`
         // (not `get_ptr_mut`) avoids materializing an aliased `&mut` to a slot

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -10,7 +10,7 @@ use crate::{
     ThreadPool,
 };
 use bun_alloc::Arena;
-use bun_ast::{self as js_ast, B, Binding, E, Expr, G, Part, Ref, S, Scope, Stmt, StmtOrExpr};
+use bun_ast::{self as js_ast, B, Binding, E, Expr, G, Part, Ref, S, Stmt, StmtOrExpr};
 use bun_ast::{ImportRecord, ImportRecordFlags, ImportRecordTag};
 use bun_collections::MultiArrayList;
 use bun_collections::VecExt;
@@ -71,27 +71,9 @@ pub(crate) fn post_process_js_chunk(
     let mut cross_chunk_prefix: PrintResult;
     let mut cross_chunk_suffix: PrintResult;
 
-    let runtime_input_file =
-        c.graph.files.items_input_file()[Index::RUNTIME.value() as usize].get() as usize;
-    let runtime_scope: &mut Scope = &mut c.graph.ast.items_module_scope_mut()[runtime_input_file];
-    let runtime_members = &mut runtime_scope.members;
-    let to_common_js_ref = c
-        .graph
-        .symbols
-        .follow(runtime_members.get(&b"__toCommonJS"[..]).unwrap().ref_);
-    let to_esm_ref = c
-        .graph
-        .symbols
-        .follow(runtime_members.get(&b"__toESM"[..]).unwrap().ref_);
-    let runtime_require_ref = if c.options.output_format == options::OutputFormat::Cjs {
-        None
-    } else {
-        Some(
-            c.graph
-                .symbols
-                .follow(runtime_members.get(&b"__require"[..]).unwrap().ref_),
-        )
-    };
+    // Every file in a chunk is on the same side of the build as the file the
+    // chunk was created for, so that file selects the runtime copy.
+    let runtime_refs = c.runtime_print_refs_for(chunk.entry_point.source_index());
 
     // The chunk's module record, assembled in output order: the printer records
     // the cross-chunk prefix imports below, then the per-part-range results
@@ -117,7 +99,7 @@ pub(crate) fn post_process_js_chunk(
             indent: Default::default(),
             has_run_symbol_renamer: true,
 
-            require_ref: runtime_require_ref,
+            require_ref: runtime_refs.require_ref,
             minify_whitespace: c.options.minify_whitespace,
             minify_identifiers: c.options.minify_identifiers,
             minify_syntax: c.options.minify_syntax,
@@ -258,8 +240,8 @@ pub(crate) fn post_process_js_chunk(
         if chunk.is_entry_point() {
             break 'brk generate_entry_point_tail_js(
                 c,
-                to_common_js_ref,
-                to_esm_ref,
+                runtime_refs.to_common_js_ref,
+                runtime_refs.to_esm_ref,
                 chunk.entry_point.source_index(),
                 worker_arena,
                 &arena,
@@ -398,7 +380,7 @@ pub(crate) fn post_process_js_chunk(
     if c.options.output_format == options::OutputFormat::InternalBakeDev {
         for compile_result in compile_results.iter() {
             let source_index = compile_result.source_index();
-            if source_index != Index::RUNTIME.value() {
+            if !c.graph.is_runtime_source(source_index) {
                 break;
             }
             line_offset.advance(compile_result.code());
@@ -457,12 +439,13 @@ pub(crate) fn post_process_js_chunk(
     let targets: &[options::Target] = c.parse_graph().ast.items_target();
     for compile_result in compile_results.iter() {
         let source_index = compile_result.source_index();
-        let is_runtime = source_index == Index::RUNTIME.value();
+        let is_runtime = c.graph.is_runtime_source(source_index);
 
         // TODO: extracated legal comments
 
         // Add a comment with the file path before the file contents
         if show_comments
+            && !is_runtime
             && source_index != prev_filename_comment
             && !compile_result.code().is_empty()
         {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -71,8 +71,7 @@ pub(crate) fn post_process_js_chunk(
     let mut cross_chunk_prefix: PrintResult;
     let mut cross_chunk_suffix: PrintResult;
 
-    // Every file in a chunk is on the same side of the build as the file the
-    // chunk was created for, so that file selects the runtime copy.
+    // Every file in a chunk is on the same side of the build as the file the chunk was created for.
     let runtime_refs = c.runtime_print_refs_for(chunk.entry_point.source_index());
 
     // The chunk's module record, assembled in output order: the printer records

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1142,8 +1142,7 @@ struct DependencyWrapper<'a> {
     entry_point_kinds: &'a [EntryPoint::Kind],
     export_star_records: &'a [bun_alloc::AstVec<u32>],
     output_format: options::Format,
-    /// `LinkerGraph::browser_runtime_source_index`; `wrap` must skip it just
-    /// like `Index::RUNTIME`.
+    /// `LinkerGraph::browser_runtime_source_index`; `wrap` skips it like `Index::RUNTIME`.
     browser_runtime_source_index: Index,
     wrap_stack: Vec<IndexInt>,
 }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -285,6 +285,7 @@ pub(crate) fn scan_imports_and_exports(
                     export_star_map: HashMap::default(),
                     export_star_records: &*export_star_import_records,
                     output_format,
+                    browser_runtime_source_index: this.graph.browser_runtime_source_index,
                     wrap_stack: Vec::new(),
                 }
             };
@@ -509,7 +510,6 @@ pub(crate) fn scan_imports_and_exports(
         let _trace = perf::trace("Bundler.BindImportsToExports");
         // const needs_export_symbol_from_runtime: []const bool = this.graph.meta.items().needs_export_symbol_from_runtime;
 
-        let mut runtime_export_symbol_ref: Ref = Ref::NONE;
         let mut ident_scratch: Vec<u8> = Vec::new();
 
         for source_index_ in &reachable {
@@ -671,18 +671,11 @@ pub(crate) fn scan_imports_and_exports(
             // previous step. The previous step can't do this because it's running in
             // parallel and can't safely mutate the "importsToBind" map of another file.
             if flag.needs_export_symbol_from_runtime {
-                if !runtime_export_symbol_ref.is_valid() {
-                    runtime_export_symbol_ref = this.runtime_function(b"__export");
-                }
-
-                debug_assert!(runtime_export_symbol_ref.is_valid());
-
-                this.graph.generate_symbol_import_and_use(
+                this.graph.generate_runtime_symbol_import_and_use(
                     source_index,
-                    bun_ast::NAMESPACE_EXPORT_PART_INDEX,
-                    runtime_export_symbol_ref,
+                    Index::part(bun_ast::NAMESPACE_EXPORT_PART_INDEX),
+                    b"__export",
                     1,
-                    Index::RUNTIME,
                 )?;
             }
 
@@ -1149,6 +1142,9 @@ struct DependencyWrapper<'a> {
     entry_point_kinds: &'a [EntryPoint::Kind],
     export_star_records: &'a [bun_alloc::AstVec<u32>],
     output_format: options::Format,
+    /// `LinkerGraph::browser_runtime_source_index`; `wrap` must skip it just
+    /// like `Index::RUNTIME`.
+    browser_runtime_source_index: Index,
     wrap_stack: Vec<IndexInt>,
 }
 
@@ -1206,8 +1202,11 @@ impl DependencyWrapper<'_> {
             }
             flag.did_wrap_dependencies = true;
 
-            // Never wrap the runtime file since it always comes first
-            if source_index == Index::RUNTIME.get() {
+            // Never wrap the runtime files since they always come first
+            if source_index == Index::RUNTIME.get()
+                || (self.browser_runtime_source_index.is_valid()
+                    && source_index == self.browser_runtime_source_index.get())
+            {
                 continue;
             }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1555,6 +1555,7 @@ impl<'a> Transpiler<'a> {
                     features: js_ast::RuntimeFeatures::default(),
                     tree_shaking: self.options.tree_shaking,
                     bundle: false,
+                    source_is_runtime: false,
                     code_splitting: false,
                     package_version: b"",
                     macro_context: None,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -785,9 +785,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub(crate) const ALLOW_MACROS: bool = !cfg!(target_family = "wasm");
 
-    /// use this instead of checking p.source.index: when not bundling,
-    /// p.source.index is `0`, and a bundle can hold more than one copy of the
-    /// runtime (see `Options::source_is_runtime`).
+    /// Not `source.index == 0`: unbundled files are 0 too, and a bundle can hold two copies.
     #[inline]
     pub(crate) fn is_source_runtime(&self) -> bool {
         self.options.source_is_runtime

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -785,12 +785,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub(crate) const ALLOW_MACROS: bool = !cfg!(target_family = "wasm");
 
-    /// use this instead of checking p.source.index
-    /// because when not bundling, p.source.index is `0`
+    /// use this instead of checking p.source.index: when not bundling,
+    /// p.source.index is `0`, and a bundle can hold more than one copy of the
+    /// runtime (see `Options::source_is_runtime`).
     #[inline]
     pub(crate) fn is_source_runtime(&self) -> bool {
-        // Index 0 is the synthetic runtime chunk.
-        self.options.bundle && self.source.index.0 == 0
+        self.options.source_is_runtime
     }
 
     /// Extracts a matchable "shape" from a dynamic import argument.

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -76,6 +76,11 @@ pub struct Options<'a> {
 
     pub tree_shaking: bool,
     pub bundle: bool,
+    /// The source is a copy of the bundler runtime (`src/runtime.js`). A bundle
+    /// may contain more than one copy (a server build parses a second one for
+    /// the browser side of its HTML imports), so this cannot be derived from
+    /// the source index.
+    pub source_is_runtime: bool,
     pub code_splitting: bool,
     pub package_version: &'a [u8],
 
@@ -123,6 +128,7 @@ impl<'a> Default for Options<'a> {
             features: RuntimeFeatures::default(),
             tree_shaking: false,
             bundle: false,
+            source_is_runtime: false,
             code_splitting: false,
             package_version: b"",
             macro_context: None,
@@ -206,6 +212,7 @@ impl<'a> Options<'a> {
             },
             tree_shaking: self.tree_shaking,
             bundle: self.bundle,
+            source_is_runtime: self.source_is_runtime,
             code_splitting: self.code_splitting,
             package_version: self.package_version,
             macro_context: None,
@@ -274,6 +281,7 @@ impl<'a> Options<'a> {
             features: RuntimeFeatures::default(),
             tree_shaking: false,
             bundle: false,
+            source_is_runtime: false,
             code_splitting: false,
             package_version: b"",
             // Materializing an invalid `&mut T` is immediate UB regardless of

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -76,10 +76,7 @@ pub struct Options<'a> {
 
     pub tree_shaking: bool,
     pub bundle: bool,
-    /// The source is a copy of the bundler runtime (`src/runtime.js`). A bundle
-    /// may contain more than one copy (a server build parses a second one for
-    /// the browser side of its HTML imports), so this cannot be derived from
-    /// the source index.
+    /// The source is a copy of the bundler runtime (a bundle can contain more than one).
     pub source_is_runtime: bool,
     pub code_splitting: bool,
     pub package_version: &'a [u8],

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1175,6 +1175,11 @@ pub struct Options<'a> {
     /// Controls whether __toESM uses Node ESM semantics (isNodeMode=1 for .esm) or respects __esModule markers.
     pub input_module_type: bundle_opts::ModuleType,
     pub module_type: bundle_opts::Format,
+    /// The source being printed is a copy of the bundler runtime. The dev server
+    /// format prints it as plain top-level code rather than as a module; a
+    /// bundle can contain more than one copy, so the bundler says which sources
+    /// these are instead of the printer assuming source index 0.
+    pub source_is_runtime: bool,
 
     // /// Used for cross-module inlining of import items when bundling
     // const_values: Ast.ConstValuesMap = .{},
@@ -1241,6 +1246,7 @@ impl<'a> Default for Options<'a> {
             require_or_import_meta_for_source_callback: RequireOrImportMetaCallback::default(),
             input_module_type: bundle_opts::ModuleType::Unknown,
             module_type: bundle_opts::Format::Esm,
+            source_is_runtime: false,
             ts_enums: None,
             line_offset_tables: None,
             mangled_props: None,
@@ -7704,6 +7710,7 @@ pub(crate) fn print_with_writer_and_platform<
     type PrinterType<'a, W, const B: bool, const G: bool> =
         Printer<'a, W, /*ASCII_ONLY=*/ B, B, false, G>;
     let module_type = opts.module_type;
+    let source_is_runtime = opts.source_is_runtime;
     let mut opts = opts;
     let source_map_builder = get_source_map_builder::<IS_BUN_PLATFORM>(
         GenerateSourceMap::eager_if(GENERATE_SOURCE_MAPS),
@@ -7729,8 +7736,7 @@ pub(crate) fn print_with_writer_and_platform<
     printer.binary_expression_stack = Vec::new();
     // defer: temporary_bindings.deinit / writer.* = printer.writer.* — handled by move-out below.
 
-    // `Index::is_runtime` ⇔ `index.value == 0`.
-    if module_type == bundle_opts::Format::InternalBakeDev && source.index.0 != 0 {
+    if module_type == bundle_opts::Format::InternalBakeDev && !source_is_runtime {
         printer.print_dev_server_module(source, ast, &parts[0]);
     } else {
         // The IIFE wrapper is done in `postProcessJSChunk`, so we just manually

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1175,10 +1175,7 @@ pub struct Options<'a> {
     /// Controls whether __toESM uses Node ESM semantics (isNodeMode=1 for .esm) or respects __esModule markers.
     pub input_module_type: bundle_opts::ModuleType,
     pub module_type: bundle_opts::Format,
-    /// The source being printed is a copy of the bundler runtime. The dev server
-    /// format prints it as plain top-level code rather than as a module; a
-    /// bundle can contain more than one copy, so the bundler says which sources
-    /// these are instead of the printer assuming source index 0.
+    /// A bundler runtime copy; the dev server format prints it as plain code, not as a module.
     pub source_is_runtime: bool,
 
     // /// Used for cross-module inlining of import items when bundling

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -400,8 +400,10 @@ console.log("About manifest:", aboutHtml);
   // different targets and must not share output files. These tests build
   // browser code that needs runtime helpers and check that what the server
   // serves never contains server code, and vice versa.
-  type ManifestFile = { input?: string; path: string; loader: string; isEntry: boolean };
-  type Manifest = { index: string; files: ManifestFile[] };
+  //
+  // Output files, manifest entries and import specifiers are all matched up by
+  // file name, so nothing here depends on how the manifest spells its paths.
+  type ManifestFile = { name: string; loader: string; isEntry: boolean };
 
   async function buildServerWithHtmlImport(dir: string, options: Partial<Parameters<typeof Bun.build>[0]> = {}) {
     const result = await Bun.build({
@@ -413,21 +415,26 @@ console.log("About manifest:", aboutHtml);
     expect(result.logs).toBeEmpty();
     expect(result.success).toBe(true);
 
+    // JS output file name -> contents
     const outputs = new Map<string, string>();
     for (const output of result.outputs) {
       if (output.path.endsWith(".js")) {
-        outputs.set("./" + basename(output.path), await output.text());
+        outputs.set(basename(output.path), await output.text());
       }
     }
-    const server = outputs.get("./server.js")!;
-    const manifests = [...server.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(
-      m => JSON.parse(JSON.parse('"' + m[1] + '"')) as Manifest,
+    const server = outputs.get("server.js")!;
+    // One manifest per HTML import, in import order.
+    const manifests: ManifestFile[][] = [...server.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(m =>
+      (JSON.parse(JSON.parse('"' + m[1] + '"')).files as { path: string; loader: string; isEntry: boolean }[]).map(
+        f => ({ name: basename(f.path), loader: f.loader, isEntry: f.isEntry }),
+      ),
     );
     return { outputs, server, manifests };
   }
 
+  // File names of the chunks `code` imports with static imports or import().
   function importedChunks(code: string): string[] {
-    return [...code.matchAll(/^import[^;]*?"(\.\/[^"]+\.js)"/gm)].map(m => m[1]);
+    return [...code.matchAll(/^import[^;]*?"(\.\/[^"]+\.js)"/gm)].map(m => basename(m[1]));
   }
 
   // Browser runtime: `__require` is a shim around a global `require`. Server
@@ -454,8 +461,9 @@ console.log("About manifest:", aboutHtml);
     const { outputs, server, manifests } = await buildServerWithHtmlImport(String(dir));
 
     const [manifest] = manifests;
-    const clientChunk = manifest.files.find(f => f.input === "client.html" && f.loader === "js")!;
-    const client = outputs.get(clientChunk.path)!;
+    const jsEntries = manifest.filter(f => f.loader === "js" && f.isEntry);
+    expect(jsEntries).toHaveLength(1);
+    const client = outputs.get(jsEntries[0].name)!;
 
     // Browser output is built from the browser runtime.
     expect(client).toContain(browserRequireShim);
@@ -485,14 +493,14 @@ console.log("About manifest:", aboutHtml);
     const { outputs, server, manifests } = await buildServerWithHtmlImport(String(dir), { splitting: true });
 
     const [manifest] = manifests;
-    const browserFiles = manifest.files.filter(f => f.loader === "js").map(f => f.path);
-    const sharedChunks = manifest.files.filter(f => f.loader === "js" && !f.isEntry).map(f => f.path);
+    const browserFiles = manifest.filter(f => f.loader === "js").map(f => f.name);
+    const sharedChunks = manifest.filter(f => f.loader === "js" && !f.isEntry).map(f => f.name);
     expect(sharedChunks).toHaveLength(1);
     const [runtimeChunk] = sharedChunks;
 
     // Everything the manifest tells the server to serve is browser code.
-    for (const path of browserFiles) {
-      const code = outputs.get(path)!;
+    for (const name of browserFiles) {
+      const code = outputs.get(name)!;
       expect(code).not.toContain("// @bun");
       expect(code).not.toContain("import.meta.require");
       expect(code).not.toContain("__jsonParse");
@@ -510,9 +518,7 @@ console.log("About manifest:", aboutHtml);
     expect(importedChunks(server)).toEqual([]);
 
     // No output file straddles the two sides.
-    for (const path of outputs.keys()) {
-      expect(path === "./server.js" || browserFiles.includes(path)).toBe(true);
-    }
+    expect([...outputs.keys()].filter(name => name !== "server.js").sort()).toEqual([...browserFiles].sort());
   });
 
   test("html-import/runtime-chunk-shared-by-several-html-imports-stays-browser-only", async () => {
@@ -537,7 +543,7 @@ console.log("About manifest:", aboutHtml);
     // Both pages need `__toESM`/`__commonJS`, so the browser runtime is a chunk
     // shared by the two pages and listed in both manifests.
     const [homeShared, aboutShared] = manifests.map(m =>
-      m.files.filter(f => f.loader === "js" && !f.isEntry).map(f => f.path),
+      m.filter(f => f.loader === "js" && !f.isEntry).map(f => f.name),
     );
     expect(homeShared).toHaveLength(1);
     expect(aboutShared).toEqual(homeShared);

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { itBundled } from "./expectBundled";
 
 describe.concurrent("bundler", () => {
@@ -106,11 +106,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-sjg7egv9.js",
+                "path": "./client-n6nsv5xk.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "efKwB-6QGwk",
+                  "etag": "NYY12TsFXfM",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -120,7 +120,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "sJJm55rxM4I",
+                  "etag": "n-UhEHjBQQc",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -393,6 +393,163 @@ console.log("About manifest:", aboutHtml);
     expect(jsA.path).not.toBe(jsB.path);
     expect(htmlA.path).toBe(htmlB.path);
     expect(htmlA.headers.etag).not.toBe(htmlB.headers.etag);
+  });
+
+  // The server side and the browser side of a build each need their own copy of
+  // the bundler runtime (`__toESM`, `__require`, ...): the two are built for
+  // different targets and must not share output files. These tests build
+  // browser code that needs runtime helpers and check that what the server
+  // serves never contains server code, and vice versa.
+  type ManifestFile = { input?: string; path: string; loader: string; isEntry: boolean };
+  type Manifest = { index: string; files: ManifestFile[] };
+
+  async function buildServerWithHtmlImport(dir: string, options: Partial<Parameters<typeof Bun.build>[0]> = {}) {
+    const result = await Bun.build({
+      entrypoints: [join(dir, "server.ts")],
+      outdir: join(dir, "out"),
+      target: "bun",
+      ...options,
+    });
+    expect(result.logs).toBeEmpty();
+    expect(result.success).toBe(true);
+
+    const outputs = new Map<string, string>();
+    for (const output of result.outputs) {
+      if (output.path.endsWith(".js")) {
+        outputs.set("./" + basename(output.path), await output.text());
+      }
+    }
+    const server = outputs.get("./server.js")!;
+    const manifests = [...server.matchAll(/__jsonParse\("(.+?)"\)/gs)].map(
+      m => JSON.parse(JSON.parse('"' + m[1] + '"')) as Manifest,
+    );
+    return { outputs, server, manifests };
+  }
+
+  function importedChunks(code: string): string[] {
+    return [...code.matchAll(/^import[^;]*?"(\.\/[^"]+\.js)"/gm)].map(m => m[1]);
+  }
+
+  // Browser runtime: `__require` is a shim around a global `require`. Server
+  // runtime: `__require = import.meta.require`, and the chunk is tagged `// @bun`.
+  const browserRequireShim = "Dynamic require of";
+
+  const runtimeUsers = {
+    // A CommonJS dependency makes the importer need `__toESM` and `__commonJS`;
+    // a `require()` of something that is not bundled makes it need `__require`.
+    "client.html": `<!doctype html><script type="module" src="./client.js"></script>`,
+    "client.js": `
+      import dep from "./dep.cjs";
+      globalThis.load = name => require(name);
+      console.log(dep);
+    `,
+    "dep.cjs": `module.exports = "dep";`,
+  };
+
+  test("html-import/browser-chunks-get-the-browser-runtime", async () => {
+    await using dir = tempDir("html-import-runtime", {
+      "server.ts": `import html from "./client.html"; console.log(JSON.stringify(html));`,
+      ...runtimeUsers,
+    });
+    const { outputs, server, manifests } = await buildServerWithHtmlImport(String(dir));
+
+    const [manifest] = manifests;
+    const clientChunk = manifest.files.find(f => f.input === "client.html" && f.loader === "js")!;
+    const client = outputs.get(clientChunk.path)!;
+
+    // Browser output is built from the browser runtime.
+    expect(client).toContain(browserRequireShim);
+    expect(client).not.toContain("import.meta.require");
+    expect(client).not.toContain("// @bun");
+    // Helpers only the server uses do not leak into the browser output.
+    expect(client).not.toContain("__jsonParse");
+
+    // The server entry keeps its own runtime, and does not carry the browser's helpers.
+    expect(server).toStartWith("// @bun\n");
+    expect(server).toContain("var __jsonParse");
+    expect(server).not.toContain("__commonJS");
+    expect(server).not.toContain(browserRequireShim);
+    expect(importedChunks(server)).toEqual([]);
+  });
+
+  test("html-import/splitting-does-not-share-the-runtime-chunk-between-server-and-browser", async () => {
+    await using dir = tempDir("html-import-runtime-splitting", {
+      "server.ts": `import html from "./client.html"; console.log(JSON.stringify(html));`,
+      ...runtimeUsers,
+      // A second browser entry point that needs the runtime too, so the browser
+      // side's runtime goes into a chunk shared by the two browser entries.
+      "client.js": runtimeUsers["client.js"] + `import("./lazy.js").then(m => console.log(m.default));`,
+      "lazy.js": `import other from "./other.cjs"; export default other;`,
+      "other.cjs": `module.exports = "other";`,
+    });
+    const { outputs, server, manifests } = await buildServerWithHtmlImport(String(dir), { splitting: true });
+
+    const [manifest] = manifests;
+    const browserFiles = manifest.files.filter(f => f.loader === "js").map(f => f.path);
+    const sharedChunks = manifest.files.filter(f => f.loader === "js" && !f.isEntry).map(f => f.path);
+    expect(sharedChunks).toHaveLength(1);
+    const [runtimeChunk] = sharedChunks;
+
+    // Everything the manifest tells the server to serve is browser code.
+    for (const path of browserFiles) {
+      const code = outputs.get(path)!;
+      expect(code).not.toContain("// @bun");
+      expect(code).not.toContain("import.meta.require");
+      expect(code).not.toContain("__jsonParse");
+      for (const imported of importedChunks(code)) {
+        expect(browserFiles).toContain(imported);
+      }
+    }
+    expect(outputs.get(runtimeChunk)!).toContain(browserRequireShim);
+
+    // The server entry is the only server-side file: its runtime helper is
+    // inlined, and it imports nothing the browser uses.
+    expect(server).toStartWith("// @bun\n");
+    expect(server).toContain("var __jsonParse");
+    expect(server).not.toContain("__commonJS");
+    expect(importedChunks(server)).toEqual([]);
+
+    // No output file straddles the two sides.
+    for (const path of outputs.keys()) {
+      expect(path === "./server.js" || browserFiles.includes(path)).toBe(true);
+    }
+  });
+
+  test("html-import/runtime-chunk-shared-by-several-html-imports-stays-browser-only", async () => {
+    const page = (script: string) => `<!doctype html><script type="module" src="./${script}"></script>`;
+    const usesCjs = (dep: string) => `import dep from "./${dep}"; console.log(dep);`;
+    await using dir = tempDir("html-import-runtime-multi", {
+      "server.ts": `
+        import home from "./home.html";
+        import about from "./about.html";
+        console.log(JSON.stringify([home, about]));
+      `,
+      "home.html": page("home.js"),
+      "about.html": page("about.js"),
+      "home.js": usesCjs("home-dep.cjs"),
+      "about.js": usesCjs("about-dep.cjs"),
+      "home-dep.cjs": `module.exports = "home";`,
+      "about-dep.cjs": `module.exports = "about";`,
+    });
+    const { outputs, server, manifests } = await buildServerWithHtmlImport(String(dir), { splitting: true });
+    expect(manifests).toHaveLength(2);
+
+    // Both pages need `__toESM`/`__commonJS`, so the browser runtime is a chunk
+    // shared by the two pages and listed in both manifests.
+    const [homeShared, aboutShared] = manifests.map(m =>
+      m.files.filter(f => f.loader === "js" && !f.isEntry).map(f => f.path),
+    );
+    expect(homeShared).toHaveLength(1);
+    expect(aboutShared).toEqual(homeShared);
+    const runtimeChunk = outputs.get(homeShared[0])!;
+    expect(runtimeChunk).toContain("__commonJS");
+    expect(runtimeChunk).not.toContain("// @bun");
+    expect(runtimeChunk).not.toContain("__jsonParse");
+
+    // The server's two manifests are parsed with the server's own `__jsonParse`.
+    expect(server).toStartWith("// @bun\n");
+    expect(server).toContain("var __jsonParse");
+    expect(importedChunks(server)).toEqual([]);
   });
 
   // Test that import with {type: 'file'} still works as a file import


### PR DESCRIPTION
### Problem
- A `--target=bun` (or `node`) build that imports an HTML file bundles two module graphs, one per target, but parsed one copy of the bundler runtime (`runtime.js`), with the server flavor. It was the only source shared by both graphs.
- Every browser chunk therefore got server helpers: `var __require = import.meta.require;` is emitted into the JS a page loads (the browser flavor is a shim around a global `require`), and `__using`/`__callDispose` come without their browser fallbacks. This happens with or without `--splitting`.
- Runtime tree shaking is per file, so the server entry also carried the helpers only the browser used (`__commonJS`, ...) and the browser chunks carried the server's `__jsonParse`.
- With `--splitting`, the runtime was reachable from the server entry and from the browser entries, so `compute_chunks` (`src/bundler/linker_context/computeChunks.rs`, the "which JS files are in which chunk" loop) keyed it by that combined bit set: one chunk, starting with `// @bun`, that `server.js` imports `__jsonParse` from, that every browser chunk imports `__require` from, and that is listed in the HTML import manifest, i.e. served to the browser.
- Cause: `enqueue_entry_points_common` (`src/bundler/bundle_v2.rs`) parsed the runtime once for the main target, `resolve_import_records` bound every file's runtime imports to `Index::RUNTIME`, and the linker's helper lookups (`runtime_function`, `cjs_runtime_ref`, `generateCompileResultForJSChunk.rs`, `postProcessJSChunk.rs`, ...) all hardcoded `Index::RUNTIME`.

### Fix
- `ensure_client_transpiler` (the point where a server build starts bundling browser code, for an HTML import or an HTML entry point) now also enqueues a second copy of the runtime parsed for `Target::Browser`, recorded in `Graph::browser_runtime_source_index`. `enqueue_entry_points_common` and this path share `enqueue_runtime`.
- `resolve_import_records` binds a file's runtime import records (the parser's `bun:wrap` import and user-written `import ... from "bun:wrap"`) to the copy for the file's target.
- Linker: `LinkerGraph::runtime_source_index_for(file)` picks the copy from the file's `ast.target`; every place that used to look up a helper in `Index::RUNTIME` now goes through `runtime_function_for(file, name)` / `generate_runtime_symbol_import_and_use`, and dependencies on the helper's parts use the ref's own source index. The printer's interop refs (`__toESM`, `__toCommonJS`, `__require`) are taken per part range / per chunk (`runtime_print_refs_for`), since a chunk's code must name the symbols of its own side. The "is this the runtime" special cases (never wrap it, print its parts first, no path comment, no source map, not a metafile input, skip TLA validation) use `is_runtime_source`, and `find_reachable_files` visits the second copy like the first.
- The server-side HTML manifest stub created by `generate_server_html_module` gets the importing side's target (the parser leaves `target` at the browser default), so `runtime_source_index_for` and the existing browser-chunk flagging in `compute_chunks` see it as a server file.
- The parser gets `ParserOptions::source_is_runtime` (set from the new `ParseTask::is_runtime`) instead of inferring "this is the runtime" from source index 0; this is what keeps `require` untouched inside the runtime's own `__require` shim and disables helper imports into the runtime, so the second copy is parsed exactly like the first.
- The printer had the same source-index-0 test for deciding what the dev server format (`--format=internal_bake_dev`, also used by the bake dev server) prints as a module; it now gets `js_printer::Options::source_is_runtime` from the linker instead. For the first copy this is the same decision as before (`test/bake/dev/{esm,bundle}.test.ts` and the `internal_bake_dev` tests in `bundler_loader.test.ts` pass); the second copy only shows up in that format together with an HTML file, which already trips a pre-existing `debug_assert` in `print_dev_server_module` on main, so that combination is not testable here and is reported separately.
- Why this is the right shape: everything else in these builds is already duplicated per target through the per-target `path_to_source_index_map`; the runtime was the one exception. Once each side's files depend on their own copy, entry bits, chunk assignment, cross-chunk imports, the `// @bun` pragma, chunk naming and the manifest all come out right without special cases, and the browser copy is the one `bun build --target=browser` would have produced (the shared browser chunk in the repro is byte-identical to the runtime chunk of a plain browser build, same content hash). With no browser side, `browser_runtime_source_index` is invalid and every helper resolves to `Index::RUNTIME` as before.
- Bake is unaffected: it passes its client transpiler in up front, so `ensure_client_transpiler` never takes the branch, and it keeps the single shared runtime chunk that `bake::production` writes out for the client itself.
- The `[name]` of the shared browser chunk is still the first entry point's (`server-<hash>.js` from the CLI, `chunk-<hash>.js` from the API / `--compile`); that is how every shared split chunk is named today and is tracked separately in #36326.
- Verified with `test/bundler/html-import-manifest.test.ts`: three new tests (no splitting: browser chunk has the browser `__require` and no `__jsonParse`, server entry has no `__commonJS`; splitting: the only shared chunk is browser-flavored and `server.js` imports nothing the manifest lists; two HTML imports with splitting: the shared runtime chunk is in both manifests and has no `// @bun`). They fail on the release build with `var __require = import.meta.require;` in the browser chunk and `// @bun` on the shared chunk, on Linux and on Windows (checked against a Windows x64 build of this branch as well; the tests select manifest entries by loader/isEntry and compare file names, since the manifest's `input` field is not a plain relative name on Windows today). The existing `manifest-with-metadata` inline snapshot changes because the browser chunk no longer contains the server's `__jsonParse`, which moves its content hash and the HTML etag.
- Also run, all passing: `test/bundler/{bundler_html,bundler_html_server,bundler_splitting,bundler_compile_splitting,bundler_bun,bundler_browser,bundler_cjs,bundler_cjs2esm,bundler_naming,metafile,bundler_edgecase,bundler_regressions,bun-build-api,bundler_plugin,standalone,compile-asset-bunfs}.test.ts`, `test/bundler/esbuild/{splitting,default}.test.ts`, `test/bundler/transpiler/transpiler.test.js`, `test/js/bun/http/bun-serve-html{,-manifest}.test.ts`, the HTML-import regression tests in `test/regression/issue`, `test/bake/dev-and-prod.test.ts` and `test/bake/dev/{esm,bundle,html,production}.test.ts`; `cargo clippy` on `bun_bundler`, `bun_js_parser` and `bun_js_printer` and `cargo fmt --check` are clean.
- Manually checked `--target=node` (server gets the `createRequire` flavor, browser its own), an HTML file passed directly as an entry point next to the server entry, `--minify --splitting` (both sides still run), `--compile --splitting` (the compiled server serves the browser entry and the runtime chunk it imports, now a browser chunk), and the metafile.
- Related: #38286 makes CSS namespace imports pull the runtime into a chunk; with this change a browser-side stylesheet pulls in the browser copy. The two diffs do not touch the same functions.

### Background
- Runtime: a generated module (`src/runtime.js` plus a per-target tail in `ParseTask.rs`) holding the helpers bundled code calls, such as `__commonJS`, `__toESM`, `__require`, `__jsonParse`. It is parsed as source index 0 (`Index::RUNTIME`). Files reach it in two ways: the parser emits an internal `import {...} from "bun:wrap"` for the helpers it uses, and the linker adds part dependencies for the helpers it introduces itself (wrappers, `__export`, the HTML manifest's `__jsonParse`).
- HTML import in a server build: `import page from "./index.html"` in `--target=bun` code makes the bundler build the HTML file and everything it references as a browser-target graph in the same build, and replaces the import with a manifest (the list of output files, paths and etags) that `Bun.serve` uses to serve them. Each source file is parsed once per target (`build_graphs[target]`), so the two graphs share no files.
- Entry bits and chunks (`--splitting`): every file is marked with the entry points that reach it; files with the same set of entry points form one chunk, so a file reached by several entries becomes a shared chunk those entries import. Whether a chunk is server or browser code (pragma, naming, public path, manifest listing) is decided from the target of the file the chunk was created for.

<details>
<summary>Repro output before / after</summary>

```sh
printf '<script type="module" src="./client.js"></script>' > client.html
printf 'import("./lazy.js").then(m => console.log(m.default));\n' > client.js
printf 'export default 1;\n' > lazy.js
printf 'import html from "./client.html";\nconsole.log(html.files.map(f => f.path));\n' > server.js
bun build server.js --target=bun --outdir out --splitting
```

Before, `out/server-08y1dfjd.js` (imported by `server.js`, `client-*.js` and `lazy-*.js`, listed in the manifest):

```js
// @bun
var __jsonParse = (a) => JSON.parse(a);
var __require = import.meta.require;

export { __jsonParse, __require };
```

After, `server.js` starts with `// @bun\nvar __jsonParse = ...` and imports nothing; the chunk the browser files import is

```js
var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
  ...
export { __require };
```

which is byte-for-byte the runtime chunk `bun build client.js --target=browser --splitting` emits (same `c3taa3cg` hash).

Without `--splitting`, the browser chunk of a client that imports a CommonJS file and calls `require()` went from containing `var __jsonParse = ...; var __require = import.meta.require;` to the browser `__require` shim and no `__jsonParse`; the server entry went from 1.81 KB (every helper the browser used) to 0.61 KB.
</details>
