### PR TITLE
test: size the svelte reload stress tests for debug builds

### DIFF
--- a/test/js/third_party/svelte/svelte.test.ts
+++ b/test/js/third_party/svelte/svelte.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
+import { isDebug } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "./bun-loader-svelte";
+
+// Each reload compiles the component again through the plugin, 20-30ms apiece on a debug build, so
+// 1,000 of them blow the default per-test timeout there. Release builds keep the full count: the bugs
+// these loops have caught (#9521, the code cache collisions in #35778) only surfaced on a release
+// build after many reloads.
+const reloads = isDebug ? 50 : 1000;
 
 describe("require", () => {
   it("SSRs `<h1>Hello world!</h1>` with Svelte", () => {
@@ -10,10 +17,10 @@ describe("require", () => {
     expect(body).toBe("<!--[--><h1>Hello world!</h1><!--]-->");
   });
 
-  it("works if you require it 1,000 times", () => {
+  it(`works if you require it ${reloads} times`, () => {
     const prev = Bun.unsafe.gcAggressionLevel();
     Bun.unsafe.gcAggressionLevel(0);
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < reloads; i++) {
       const { default: App } = require("./hello.svelte?r" + i);
       expect(App).toBeFunction();
     }
@@ -23,10 +30,10 @@ describe("require", () => {
 });
 
 describe("dynamic import", () => {
-  it("works if you import it 1,000 times", async () => {
+  it(`works if you import it ${reloads} times`, async () => {
     const prev = Bun.unsafe.gcAggressionLevel();
     Bun.unsafe.gcAggressionLevel(0);
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < reloads; i++) {
       const { default: App } = await import("./hello.svelte?i" + i);
       expect(App).toBeFunction();
     }


### PR DESCRIPTION
### Problem
- `bun bd test test/js/third_party/svelte/svelte.test.ts` fails 2 of 4 on a clean checkout of main (f7ad274e3f), with a debug+ASAN build:
  ```
  (fail) require > works if you require it 1,000 times [34002.19ms]
    ^ this test timed out after 5000ms.
  (fail) dynamic import > works if you import it 1,000 times [27636.27ms]
    ^ this test timed out after 5000ms.
  ```
- Cause: `test/js/third_party/svelte/svelte.test.ts:16` and `:29` reload `./hello.svelte?r<i>` / `?i<i>` 1,000 times on every build type. Each reload runs the component through the `bun-loader-svelte` plugin (svelte compiler plus bun's transpiler), which costs about 0.5ms on a release build and 20-35ms on a debug build, so the loops take 20-35s there against bun test's default 5s per-test timeout.
- CI does not see this because `scripts/runner.node.mjs` passes its own `--timeout` (90s, tripled under ASAN). It breaks every local `bun bd test` run of the file, so nothing can be added to this file and verified with `bun bd test`.

### Fix
- `reloads = isDebug ? 50 : 1000`, used by both loops and interpolated into both test names (`works if you require it 50 times` / `... 1000 times`), so the name reports the count that actually ran.
- Why this keeps the coverage the loops exist for: release builds, which is what every CI test lane runs (the ASAN lane is a release build, `isDebug` is false there), still do the same 1,000 reloads as before. That is the configuration in which these loops have found bugs: the #9521 over-deref they were added for (#9530), and the code cache collisions written up in #35778, which a release lane hit on the 1,000x dynamic import test. Debug builds are the only configuration that changes, and on a debug build the count had no observable effect: with an over-release of the specifier string put back into `SourceProvider::create` locally, the file passed at 50 and at 1,000 alike (details below), so 1,000 reloads there bought 20-30s of runtime and a guaranteed timeout, not detection.
- Why 50: on the debug build here the require loop takes 2.3-2.8s at 50 (3.4s on the first run after a relink; the first ~20 reloads also warm up the svelte compiler in the JIT) and the import loop 1.3-1.8s, while 100 reloads measured 3.4-3.7s per loop, too close to the 5s budget on a loaded machine. Release is about 0.5ms per reload, so it does not need the reduction.
- No per-test timeout is added (test/CLAUDE.md).
- Verified:
  - `bun bd test test/js/third_party/svelte/svelte.test.ts`: 4 pass (require x50 in 2.3-2.8s, import x50 in 1.3-1.8s over four runs). Same command on main's version of the file: the 2 failures quoted above.
  - `USE_SYSTEM_BUN=1 bun test test/js/third_party/svelte/svelte.test.ts` (release): 4 pass, `require it 1000 times` in 0.44-0.60s and `import it 1000 times` in 0.33-0.51s, the same work as before.
  - Test-only change; nothing under `src/` is touched.

### Background
- `isDebug` (`test/harness.ts:29`) is true when the bun running the test reports a `-debug` version, which is what `bun bd` builds. Release builds, including CI's release ASAN lane, report a plain version, so they keep the 1,000 reloads.
- `bun bd` builds use a debug JavaScriptCore as well as a debug bun, so both halves of a reload (the svelte compiler running as JS, and bun transpiling its output) are slower than release, which is where the 40-60x per-reload gap comes from.
- `test/js/bun/util/text-loader.test.ts` has the same shape of stress test from the same fix and is being resized the same way in #38259; `test/js/bun/resolve/load-same-js-file-a-lot.test.ts` already scales its count by build type.

<details>
<summary>Experiment: does the debug count matter for the bug class these loops were added for?</summary>

#9521 was an extra `deref()` of the specifier string in `SourceProvider::create` (`src/jsc/bindings/ZigSourceProvider.cpp`). Today the Rust side hands the specifier over as a +1 ref that `~SourceProvider` releases, so to reproduce an immediate over-release I locally added two `resolvedSource.specifier.deref()` calls to `create()` (one cancels the +1, the second over-releases), rebuilt the debug+ASAN binary and ran the file:

- 50 reloads: 4 pass
- 50 reloads with `Malloc=1` (WTF on system malloc, so ASAN sees StringImpl frees): 4 pass
- 1,000 reloads: 2 pass, 2 fail, both failures being the pre-existing 5s timeouts (26.1s and 23.9s), no ASAN report

So on a debug build the two counts behave identically for this class; the over-released string stays reachable through other holders for the life of the test. The injected change was reverted before committing; this PR only touches the test file.
</details>
