### PR TITLE
shell: reap a child that is killed while its command is torn down early

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -852,7 +852,9 @@ impl Cmd {
 
     /// [`Self::deinit`] for the VM-shutdown finalizer: defuses the
     /// `> ${arraybuffer}` unpins first — the heap sweep already deleted the
-    /// `JSC::ArrayBuffer` impls they would write to.
+    /// `JSC::ArrayBuffer` impls they would write to — and tells the subprocess
+    /// that the event loop is going away, so a child that is still running is
+    /// not left to an exit watch nothing will ever run again.
     #[cfg(not(windows))]
     pub(crate) fn deinit_from_finalizer(interp: &Interpreter, this: NodeId) {
         {
@@ -861,8 +863,11 @@ impl Cmd {
                 Exec::Builtin(b) => b.defuse_array_buf_pins(),
                 Exec::Subproc(sub) if !sub.child.is_null() => {
                     // SAFETY: `child` is the live heap::alloc'd subprocess;
-                    // the call only writes its own fields.
-                    unsafe { ShellSubprocess::defuse_array_buffer_unpins(sub.child) };
+                    // these only write its own fields.
+                    unsafe {
+                        ShellSubprocess::defuse_array_buffer_unpins(sub.child);
+                        (*sub.child).event_loop_is_shutting_down = true;
+                    }
                 }
                 _ => {}
             }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -247,6 +247,12 @@ pub struct ShellSubprocess {
     pub(crate) stderr: Readable,
 
     pub closed: EnumSet<StdioKind>,
+
+    /// Set by `Cmd::deinit_from_finalizer`: the VM, and with it the event
+    /// loop the exit watch is registered on, is being destroyed, so
+    /// [`Self::close_process`] must tear the watch down rather than leave it
+    /// to reap a still-running child (nothing would ever run it).
+    pub(crate) event_loop_is_shutting_down: bool,
 }
 
 pub(crate) type SignalCode = bun_core::SignalCode;
@@ -352,10 +358,19 @@ impl ShellSubprocess {
             return;
         }
         // SAFETY: `process` was produced by `to_process` (heap::alloc) and is
-        // live until the deref below drops the last strong ref.
+        // live until the deref below drops our strong ref.
         unsafe {
-            (*process).set_exit_handler_default();
-            (*process).close();
+            // The child may still be alive here: a stdio `start()` failure in
+            // `spawn_maybe_sync_impl` or a pipe read error finishing the `Cmd`
+            // both kill it and tear this subprocess down without waiting for
+            // it to exit. `disown` keeps the exit watch armed in that case so
+            // the child is still reaped; the watch drops the `Process` once it
+            // has. After a normal exit both calls are the same `detach()`.
+            if self.event_loop_is_shutting_down {
+                (*process).detach();
+            } else {
+                (*process).disown();
+            }
             // Release the intrusive ref taken by `to_process`. `*mut Process`
             // has no Drop, so this must be explicit.
             bun_ptr::ThreadSafeRefCount::<Process>::deref(process);
@@ -843,6 +858,7 @@ impl ShellSubprocess {
                 stderr,
                 cmd_parent,
                 closed: EnumSet::empty(),
+                event_loop_is_shutting_down: false,
             });
         }
         // Ownership of the now-initialised Box is released as a raw pointer

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -626,6 +626,30 @@ impl Process {
         self.exit_handler = ProcessExitHandler::default();
     }
 
+    /// [`Self::detach`] for an owner that is letting go of a child which may
+    /// still be running (typically right after `kill()`). Once the process has
+    /// exited, or nothing is watching it, this is exactly `detach()`. While
+    /// it is alive and watched, `close()` would unregister the watch and leave
+    /// the child as a zombie for the rest of this process's life, because the
+    /// watch is what `wait4`s it. So instead only the exit handler is dropped
+    /// and the watch stops keeping the event loop alive; it stays armed, and
+    /// the exit delivery reaps the child, `close()`s (via `on_exit`) and
+    /// releases the ref it holds on this `Process`. The caller may therefore
+    /// `deref()` its own ref immediately after this returns.
+    ///
+    /// Windows: libuv owns the wait and the `uv_process_t` lives inside this
+    /// struct, so the handle has to be closed before the owner's ref goes
+    /// away; this is plain `detach()` there.
+    pub fn disown(&mut self) {
+        #[cfg(unix)]
+        if !self.has_exited() && self.poller.is_armed() {
+            self.exit_handler = ProcessExitHandler::default();
+            self.disable_keeping_event_loop_alive();
+            return;
+        }
+        self.detach();
+    }
+
     pub fn kill(&mut self, signal: u8) -> Maybe<()> {
         #[cfg(unix)]
         {
@@ -860,6 +884,17 @@ impl PollerPosix {
             PollerPosix::Fd(poll) => Some(unsafe { poll.as_mut() }),
             _ => None,
         }
+    }
+
+    /// Whether an exit delivery is still pending: the pidfd / kqueue poll is
+    /// registered, or the waiter thread has the pid. Either one holds the
+    /// `Process` ref taken in `watch()` / `rewatch_posix()` and `wait4`s the
+    /// child when it exits.
+    fn is_armed(&mut self) -> bool {
+        if let Some(poll) = self.fd_poll_mut() {
+            return poll.is_registered();
+        }
+        matches!(self, PollerPosix::WaiterThread(_))
     }
 
     pub(crate) fn enable_keeping_event_loop_alive(&mut self, ctx: bun_io::EventLoopCtx) {

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -34,6 +34,16 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            recv guarantees the streaming inner loop's mid-read
 //                            flush (`head_start` past the half-buffer cutoff)
 //                            fires in a single poll wake.
+//   SHELL_FAIL_EPOLL_WRITABLE=1 every epoll_ctl ADD asking for EPOLLOUT on a
+//                            socket this process made with socketpair() (the
+//                            child stdio pipes) fails with ENOMEM. Only writers
+//                            ask for EPOLLOUT, so this fails the child's
+//                            buffer-stdin writer's start() (the only stdio
+//                            start() whose failure is returned to the spawn
+//                            instead of reported through a callback) and
+//                            nothing else: the stdout/stderr readers poll for
+//                            EPOLLIN, and the shell's writers to the fixture's
+//                            own stdio sit on inherited fds.
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -58,6 +68,7 @@ const SHIM_C = /* c */ `
 static ssize_t (*real_recv)(int, void *, size_t, int);
 static long (*real_syscall)(long, long, long, long, long, long, long);
 static int (*real_close)(int);
+static int (*real_socketpair)(int, int, int, int *);
 static int fail_recv = -1;
 static int fail_epoll = -1;
 static int fail_epoll_after = -1;
@@ -65,9 +76,11 @@ static int recv_one_chunk = -1;
 static int recv_eagain_first = -1;
 static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
 static int recv_bulk = -1;       /* 0 = off, N >= 1 = number of fabricated full-buffer recvs */
+static int fail_epoll_writable = -1;
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
 static unsigned char bulk_count[MAX_FD];
+static unsigned char own_socketpair[MAX_FD];
 
 static void init_modes(void) {
   if (fail_recv < 0) fail_recv = getenv("SHELL_FAIL_RECV") != NULL;
@@ -83,6 +96,7 @@ static void init_modes(void) {
     const char *s = getenv("SHELL_RECV_BULK");
     recv_bulk = s ? atoi(s) : 0;
   }
+  if (fail_epoll_writable < 0) fail_epoll_writable = getenv("SHELL_FAIL_EPOLL_WRITABLE") != NULL;
 }
 
 static int is_unix_sock(int fd) {
@@ -98,6 +112,28 @@ static int is_pipe_like(int fd) {
   if (fstat(fd, &st) != 0) return 0;
   if (S_ISFIFO(st.st_mode)) return 1;
   return is_unix_sock(fd);
+}
+
+// Reset the per-fd state on close so a recycled fd number starts fresh. Bun
+// closes through syscall(SYS_close), so both close entry points land here.
+static void forget_fd(int fd) {
+  if (fd >= 0 && fd < MAX_FD) {
+    recv_count[fd] = 0;
+    epoll_count[fd] = 0;
+    bulk_count[fd] = 0;
+    own_socketpair[fd] = 0;
+  }
+}
+
+int socketpair(int domain, int type, int protocol, int sv[2]) {
+  if (!real_socketpair) real_socketpair = (int (*)(int, int, int, int *))dlsym(RTLD_NEXT, "socketpair");
+  int rc = real_socketpair(domain, type, protocol, sv);
+  if (rc == 0) {
+    for (int i = 0; i < 2; i++) {
+      if (sv[i] >= 0 && sv[i] < MAX_FD) own_socketpair[sv[i]] = 1;
+    }
+  }
+  return rc;
 }
 
 ssize_t recv(int fd, void *buf, size_t len, int flags) {
@@ -145,9 +181,16 @@ long syscall(long number, ...) {
     real_syscall = (long (*)(long, long, long, long, long, long, long))dlsym(RTLD_NEXT, "syscall");
     init_modes();
   }
+  if (number == SYS_close) forget_fd((int)a);
   if (number == SYS_epoll_ctl) {
     int op = (int)b;
     int target = (int)c;
+    const struct epoll_event *event = (const struct epoll_event *)d;
+    if (fail_epoll_writable && op == EPOLL_CTL_ADD && target >= 0 && target < MAX_FD && own_socketpair[target] &&
+        event && (event->events & EPOLLOUT)) {
+      errno = ENOMEM;
+      return -1;
+    }
     if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD) {
       if (fail_epoll && is_pipe_like(target)) {
         errno = ENOMEM;
@@ -170,14 +213,9 @@ long syscall(long number, ...) {
   return real_syscall(number, a, b, c, d, e, f);
 }
 
-// Reset the per-fd counters on close so a recycled fd number starts fresh.
 int close(int fd) {
   if (!real_close) real_close = (int (*)(int))dlsym(RTLD_NEXT, "close");
-  if (fd >= 0 && fd < MAX_FD) {
-    recv_count[fd] = 0;
-    epoll_count[fd] = 0;
-    bulk_count[fd] = 0;
-  }
+  forget_fd(fd);
   return real_close(fd);
 }
 `;
@@ -234,6 +272,62 @@ const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.nothrow();
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+// Runs a command whose child the shell kills while tearing the command down
+// early, then reports every process still parented to this one. A child the
+// shell killed but never wait()ed for stays listed as a zombie (state "Z")
+// until this process exits, so the poll only drains once the shell has
+// actually reaped it. Reaping happens from the event loop, which is what the
+// sleep between polls yields to. The fault mode in the environment picks the
+// teardown:
+//
+//   SHELL_FAIL_EPOLL_WRITABLE fails the `< ${blob}` stdin writer's start()
+//     inside the spawn; the shell SIGTERMs the child and drops the subprocess
+//     before returning the error.
+//   SHELL_FAIL_EPOLL_AFTER + SHELL_RECV_ONE_CHUNK finish the command with the
+//     reader error while `sleep` is still running; the command's teardown
+//     SIGKILLs it.
+const REAP_FIXTURE = /* js */ `
+import { $ } from "bun";
+import { readdirSync, readFileSync } from "node:fs";
+
+function childrenOfThisProcess() {
+  const out = [];
+  for (const name of readdirSync("/proc")) {
+    if (!/^[0-9]+$/.test(name)) continue;
+    let stat;
+    try {
+      stat = readFileSync("/proc/" + name + "/stat", "utf8");
+    } catch {
+      continue; // exited between readdir and read
+    }
+    // "pid (comm) state ppid ..." -- comm is user controlled, so split after its closing paren.
+    const close = stat.lastIndexOf(")");
+    const [state, ppid] = stat.slice(close + 2).split(" ");
+    if (Number(ppid) !== process.pid) continue;
+    out.push({ comm: stat.slice(stat.indexOf("(") + 1, close), state });
+  }
+  return out;
+}
+
+const results = [];
+for (let i = 0; i < 3; i++) {
+  const r = process.env.SHELL_FAIL_EPOLL_WRITABLE
+    ? await $\`cat < \${new Blob(["never written"])}\`.quiet().nothrow()
+    : await $\`sleep 5\`.quiet().nothrow();
+  results.push({ exitCode: r.exitCode, stderr: r.stderr.toString() });
+}
+
+// A reaped child disappears within a few loop ticks; a leaked zombie never does,
+// so give up well inside the test timeout and report it.
+let remaining = childrenOfThisProcess();
+const deadline = Date.now() + 3_000;
+while (remaining.length !== 0 && Date.now() < deadline) {
+  await Bun.sleep(5);
+  remaining = childrenOfThisProcess();
+}
+console.log(JSON.stringify({ results, remaining }));
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -246,6 +340,7 @@ beforeAll(async () => {
     "quiet-chunk.js": QUIET_CHUNK_FIXTURE,
     "poll-chunk.js": POLL_CHUNK_FIXTURE,
     "tee-chunk.js": TEE_CHUNK_FIXTURE,
+    "reap.js": REAP_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -273,6 +368,7 @@ const MODES = [
   "SHELL_FAIL_EPOLL_AFTER",
   "SHELL_RECV_ONE_CHUNK",
   "SHELL_RECV_EAGAIN_FIRST",
+  "SHELL_FAIL_EPOLL_WRITABLE",
 ] as const;
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
 const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK"] as const;
@@ -295,7 +391,10 @@ function shimEnv(
   return env;
 }
 
-async function expectShellFault(
+// Runs a fixture under the shim and returns its last stdout line (the JSON it
+// prints) along with stderr and the exit code, so one combined assertion can
+// surface a crash's stderr and exit code in the diff.
+async function runShellFaultFixture(
   script: string,
   modes: (typeof MODES)[number][],
   extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
@@ -319,8 +418,15 @@ async function expectShellFault(
   } catch {
     parsed = line;
   }
-  // One combined assertion so a crash surfaces stderr and the exit code in the diff.
-  expect({ parsed, stderr, exitCode }).toEqual({
+  return { parsed, stderr, exitCode };
+}
+
+async function expectShellFault(
+  script: string,
+  modes: (typeof MODES)[number][],
+  extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
+) {
+  expect(await runShellFaultFixture(script, modes, extraEnv)).toEqual({
     parsed: { exitCode: ENOMEM },
     stderr: expect.any(String),
     exitCode: 0,
@@ -463,6 +569,36 @@ test.concurrent.skipIf(!isLinux || !cc || !mkfifo || !cat)(
       readerStderr: "",
       exitCode: 0,
       readerExitCode: 0,
+    });
+  },
+);
+
+// Regression: both early teardowns below closed the Process (unregistering its
+// pidfd watch) right after signalling the still-running child, so nothing ever
+// wait()ed for it and every such command left a zombie behind for the life of
+// the bun process. The fixture reports those as `remaining` entries in state
+// "Z"; the `results` pin down that each command really did fail the intended
+// way, since a child that ran to completion is reaped regardless.
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell reaps the child it kills when the buffer stdin writer fails to start",
+  async () => {
+    const failed = { exitCode: 1, stderr: expect.stringContaining("Cannot allocate memory") };
+    expect(await runShellFaultFixture("reap.js", ["SHELL_FAIL_EPOLL_WRITABLE"])).toEqual({
+      parsed: { results: [failed, failed, failed], remaining: [] },
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "shell reaps the child it kills when a pipe read error finishes the command first",
+  async () => {
+    const failed = { exitCode: ENOMEM, stderr: "" };
+    expect(await runShellFaultFixture("reap.js", ["SHELL_FAIL_EPOLL_AFTER", "SHELL_RECV_ONE_CHUNK"])).toEqual({
+      parsed: { results: [failed, failed, failed], remaining: [] },
+      stderr: "",
+      exitCode: 0,
     });
   },
 );


### PR DESCRIPTION
### Problem
- Every shell command whose child the shell kills during an early teardown leaves a zombie process behind for the rest of the bun process. Two paths do this today, both reproduced on bun 1.4.0 and on main:
  - `cat < ${blob}` (or `< ${bytes}`) whose buffer stdin writer fails to start. `spawn_maybe_sync_impl` (`src/runtime/shell/subproc.rs`) sends the child SIGTERM and calls `abort_after_failed_start`; the command reports the errno (`bun: Cannot allocate memory`, exit 1). Registration fails like this in production when `fs.epoll.max_user_watches` is exhausted.
  - A stdout/stderr pipe read error that finishes the `Cmd` while the child is still running. `Cmd::deinit` (`src/runtime/shell/states/Cmd.rs`) sends it SIGKILL and drops the subprocess.
- Cause: both end in `ShellSubprocess::close_process`, which called `Process::close()` (`src/spawn/process.rs`). `close()` unregisters the pidfd (kqueue on macOS) watch and closes the pidfd. That watch is the only thing that ever calls `wait4` on the child, so once it is gone the child that was just signalled is never reaped. The waiter-thread fallback (kernels without pidfd) is not affected, since that thread reaps on its own.

### Fix
- `Process::disown()` (new): if the process has exited, or nothing is watching it, it is `detach()` as before. If it is alive and watched, it only clears the exit handler and the watch's event-loop keep-alive and leaves the watch registered. The exit delivery then runs as for any other process: `wait4` reaps the child, `on_exit` closes the poll and the pidfd, there is no handler to call, and the delivery releases the ref the watch holds on the `Process`, which frees it.
- Why this is correct:
  - The watch already owns a ref on the `Process` (taken in `watch()` / `rewatch_posix()`) and the delivery already releases it; `close()` is what released that ref early on this path. So the owner can drop its own ref right after `disown()` and the `Process` lives exactly as long as the watch does. `Poller::is_armed()` is the same condition `close()` uses to decide whether that ref exists.
  - Clearing the exit handler is what makes the later delivery safe: the `ShellSubprocess` that used to be the handler is freed immediately after.
  - Dropping the keep-alive keeps today's exit behavior: a script that ends before the killed child is reaped still exits, and init reaps the child; a child that ignores SIGTERM cannot keep bun alive.
  - On Windows `disown()` is `detach()`: libuv owns the wait there and the `uv_process_t` lives inside the `Process`, so the handle has to be closed before the owner's ref goes. There is no zombie to reap on Windows. (The shell also does not reach this path on Windows; `abort_after_failed_start` leaks the subprocess there by design.)
  - After a normal exit `disown()` and the old code are the same `detach()`, so the common path is unchanged.
- `close_process` keeps calling `detach()` when the command is being torn down by the VM-shutdown finalizer (`Cmd::deinit_from_finalizer`, reached by `worker.terminate()` mid-command): the event loop the watch is registered on is going away with the VM, so a watch left armed there would never fire and would leak the `Process` (the existing `shell-worker-terminate-leak.test.ts` LSan tests catch exactly that). That path keeps its current behavior, which the "kills a live Bun.$ subprocess" test in that file already documents.
- Tests (`test/js/bun/shell/shell-pipe-read-fault.test.ts`, two new cases, Linux only like the rest of the file): a fixture runs the failing command three times, then lists the processes whose parent is the fixture until the list is empty. Unfixed (bun 1.4.0 and main) both report three children in state `Z` (`cat` for the stdin-writer failure, `sleep` for the read error) after the 3s deadline; with the fix the list drains on the first poll. The exit codes and stderr in the same assertion pin down that each command failed the intended way, since a child that ran to completion is reaped either way.
- Also run on the ASAN debug build: the rest of `shell-pipe-read-fault.test.ts`, `shell-worker-terminate-leak.test.ts` (7 pass; 5 of them failed with a leaked `Process` before the finalizer exception above was added), `bunshell.test.ts` (423 pass), `shell-hang`, `epipe`, `shell-write-fault`, `exec`, `shell-blocking-pipe`. `leak.test.ts`'s `memleak_*` cases time out on this machine the same way for builtin-only commands such as `cd` (no subprocess involved), so that is the machine, not this change. `cargo check -p bun_spawn` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, `cargo clippy -p bun_spawn`, `cargo fmt`.

### Background
- `Process` (`src/spawn/process.rs`) is the intrusively refcounted record of a spawned child shared by `Bun.spawn`, the shell, lifecycle scripts and others. Its `poller` is how the exit is noticed: on Linux a `FilePoll` on the child's pidfd, on macOS a kqueue `EVFILT_PROC` filter, or on kernels without pidfd a waiter thread. `watch()` registers it and takes a ref on the `Process`; when it fires, `on_wait_pid` calls `wait4`, which is what removes the zombie from the process table, then `on_exit` runs the owner's exit handler and the delivery releases that ref. `close()` unregisters the poller and releases its ref without waiting; `detach()` is `close()` plus clearing the exit handler, and is what owners call once the exit has been delivered.
- A zombie is a child that has exited but whose parent has not called `wait4` on it. It holds a pid and a process-table slot until the parent waits for it or exits (then init reaps it). A long-lived bun process (a server, a test runner) that hits either path above accumulates one per failed command.
- `ShellSubprocess` (`src/runtime/shell/subproc.rs`) is the shell's owner of a `Process` for one external command, installed as its exit handler. It is freed when its `Cmd` finishes, which normally happens after the exit was delivered, but the two paths above finish the `Cmd` first and kill the child on the way out.
- The shell interpreter is a JS object; when its VM is destroyed while a command is still in flight, a finalizer (`Interpreter::deinit_from_finalizer` to `Cmd::deinit_from_finalizer`) tears the live commands down. Nothing on that VM's event loop runs afterwards.

<details>
<summary>Repro outside the test</summary>

`shim.c` fails the writer's `epoll_ctl` registration (bun issues it through `syscall(2)`); readers and the pidfd watch register for `EPOLLIN`, so only the stdin writer's `start()` fails.

```c
// cc -shared -fPIC -o shim.so shim.c -ldl
#define _GNU_SOURCE
#include <dlfcn.h>
#include <errno.h>
#include <stdarg.h>
#include <sys/epoll.h>
#include <sys/syscall.h>
static long (*real)(long, long, long, long, long, long, long);
long syscall(long n, ...) {
  va_list ap; long a, b, c, d, e, f;
  va_start(ap, n); a = va_arg(ap, long); b = va_arg(ap, long); c = va_arg(ap, long);
  d = va_arg(ap, long); e = va_arg(ap, long); f = va_arg(ap, long); va_end(ap);
  if (!real) real = dlsym(RTLD_NEXT, "syscall");
  if (n == SYS_epoll_ctl && (int)b == EPOLL_CTL_ADD && d && (((struct epoll_event *)d)->events & EPOLLOUT)) {
    errno = ENOSPC; return -1;
  }
  return real(n, a, b, c, d, e, f);
}
```

```js
import { $ } from "bun";
for (let i = 0; i < 3; i++) await $`cat < ${new Blob(["data"])}`.quiet().nothrow(); // each: exit 1
await Bun.sleep(300);
console.log(Bun.spawnSync({ cmd: ["ps", "-o", "pid,ppid,stat,comm", "--ppid", String(process.pid)] }).stdout.toString());
```

```
$ LD_PRELOAD=./shim.so bun zombie.js          # bun 1.4.0, and main before this change
    PID    PPID STAT COMMAND
    944     935 Z    cat
    945     935 Z    cat
    946     935 Z    cat
    947     935 R    ps
$ LD_PRELOAD=./shim.so bun-debug zombie.js    # with this change
    PID    PPID STAT COMMAND
  15587   15574 R    ps
```

</details>

<details>
<summary>Overlap with #38367</summary>

#38367 fixes the fd leak on the first path above and was found together with this bug. It does not touch the process teardown, and this PR does not touch the fds. Both PRs add the same `SHELL_FAIL_EPOLL_WRITABLE` shim mode and the same `runShellFaultFixture` helper to `shell-pipe-read-fault.test.ts`, copied verbatim here so that whichever lands second only has to drop its duplicate of those hunks; the fixtures and test cases are distinct.

</details>
