### PR TITLE
node:vm: reject array and function options like Node's validateObject

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -89,10 +89,15 @@ function createContext(contextObject?, options?) {
   return context;
 }
 
+// Node's runInContext()/runInNewContext() (lib/vm.js) spread `options` into a
+// fresh object before handing it to Script, so unlike the Script methods they
+// accept any non-string options value.
 function runInContext(code, context, options) {
   validateContext(context);
   if (typeof options === "string") {
     options = { filename: options };
+  } else {
+    options = { ...options };
   }
   return new Script(code, options).runInContext(context, options);
 }
@@ -110,6 +115,8 @@ function runInNewContext(code, context, options) {
   }
   if (typeof options === "string") {
     options = { filename: options };
+  } else {
+    options = { ...options };
   }
   context = createContext(context, options);
   return createScript(code, options).runInNewContext(context, options);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1660,9 +1660,9 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
 
     JSValue optionsArg = callFrame->argument(1);
 
-    // Validate options argument
-    if (!optionsArg.isUndefined() && !optionsArg.isObject()) {
-        return ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, optionsArg);
+    if (!optionsArg.isUndefined()) {
+        V::validateObject(scope, globalObject, optionsArg, "options"_s);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     JSValue importer;
@@ -1941,12 +1941,9 @@ bool BaseVMOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
     bool any = false;
 
     if (!optionsArg.isUndefined()) {
-        if (optionsArg.isObject()) {
-            options = asObject(optionsArg);
-        } else {
-            auto _ = ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, optionsArg);
-            return false;
-        }
+        V::validateObject(scope, globalObject, optionsArg, "options"_s);
+        RETURN_IF_EXCEPTION(scope, false);
+        options = asObject(optionsArg);
 
         auto filenameOpt = options->getIfPropertyExists(globalObject, builtinNames(vm).filenamePublicName());
         RETURN_IF_EXCEPTION(scope, false);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1012,6 +1012,49 @@ describe("codeGeneration options", () => {
   });
 });
 
+describe("the options argument", () => {
+  // Node checks `options` with validateObject() (lib/vm.js), which rejects
+  // arrays and functions as well as null and primitives.
+  const script = new Script("1 + 1;");
+  const entryPoints: Record<string, (options: unknown) => unknown> = {
+    "createContext()": options => createContext({}, options as any),
+    "new Script()": options => new Script("1 + 1;", options as any),
+    "compileFunction()": options => compileFunction("return 1 + 1;", [], options as any),
+    "vm.runInThisContext()": options => runInThisContext("1 + 1;", options as any),
+    "Script#runInThisContext()": options => script.runInThisContext(options as any),
+    "Script#runInContext()": options => script.runInContext(createContext({}), options as any),
+    "Script#runInNewContext()": options => script.runInNewContext({}, options as any),
+  };
+  const invalidOptions: [description: string, options: unknown, received: string][] = [
+    ["an array", [], "an instance of Array"],
+    ["a Proxy around an array", new Proxy([], {}), "an instance of Array"],
+    ["a function", function foo() {}, "function foo"],
+    ["null", null, "null"],
+    ["a number", 1, "type number (1)"],
+  ];
+
+  describe.each(Object.entries(entryPoints))("%s", (_, run) => {
+    test.each(invalidOptions)("rejects %s", (_, options, received) => {
+      expect(() => run(options)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "options" argument must be of type object. Received ${received}`,
+        }),
+      );
+    });
+  });
+
+  test("vm.runInContext() and vm.runInNewContext() copy options into a fresh object like Node", () => {
+    // lib/vm.js spreads `options` before handing it to Script, so any
+    // non-string value behaves like passing no options to these two.
+    for (const [, options] of invalidOptions) {
+      expect(runInContext("1 + 1;", createContext({}), options as any)).toBe(2);
+      expect(runInNewContext("1 + 1;", {}, options as any)).toBe(2);
+    }
+  });
+});
+
 describe("context options with throwing getters", () => {
   // Without the fix, reading these options with a pending exception aborted
   // the process, so run the matrix in a subprocess.


### PR DESCRIPTION
### Problem
- `vm.createContext({}, [])`, `vm.createContext({}, function () {})`, `new vm.Script("1", [])`, `vm.compileFunction("1", [], [])`, `vm.runInThisContext("1", [])`, `script.runInThisContext([])`, `script.runInContext(ctx, [])` and `script.runInNewContext({}, [])` are all accepted. Node throws from every one of them: `TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received an instance of Array` (`Received function foo` for a function).
- Cause: both native checks of the `options` argument use `JSValue::isObject()`, which is true for arrays and functions: `vmModule_createContext()` and `BaseVMOptions::fromJS()` in `src/jsc/bindings/NodeVM.cpp`. Node's lib/vm.js checks the same argument with `validateObject(options, 'options')`.
- `null` and primitives were already rejected by those checks, so arrays and functions were the only values slipping through.

### Fix
- Both checks now call `Bun::V::validateObject()` (`src/jsc/bindings/NodeValidator.cpp`), the native port of Node's `validateObject()` that `BunProcess.cpp` already uses. The error has Node's code and message; a Proxy around an array is reported as `an instance of Array` too, like `Array.isArray`.
- `vm.runInContext()` and `vm.runInNewContext()` spread `options` into a fresh object, as lib/vm.js does, so they still accept any non-string options value. Node accepts `[]`, a function, `null` and `1` there; before this change the two wrappers handed the value straight to `Script`, so they rejected `null`/`1` and would have started rejecting arrays and functions as well.
- `Script#runInNewContext()` is left in Node's order: context options are read and the context is created, then `runInContext()` rejects the value. `getNodeVMContextOptions()` already tolerates non-objects the way Node's `getContextOptions()` does, so it needed no change.
- Why this is right: every entry point whose `options` reaches `validateObject()` in lib/vm.js (`createContext`, the `Script` constructor, `getRunInContextArgs()` behind the three run methods, `compileFunction`) now rejects exactly what it rejects, and the two wrappers whose `options` never reaches it still accept everything. The whole matrix below was checked against node v26.3.0; the only remaining differences are the two pre-existing ones noted there, which #38373 covers and which are about the context argument, not `options`.
- Verified with `test/js/node/vm/vm.test.ts` (`the options argument`): 36 cases, 22 fail on the current build (arrays, proxied arrays and functions across the 7 entry points, plus the wrapper case), all pass with the fix.
- All 97 `test/js/node/test/parallel/test-vm-*` files and the 3 sequential ones pass with the fix; the rest of `test/js/node/vm` passes as well.

### Background
- Node's `validateObject(value, name)` (lib/internal/validators.js) throws `ERR_INVALID_ARG_TYPE` for `null`, anything `Array.isArray()` accepts, functions, and non-objects. `Bun::V::validateObject` implements the same four checks natively (`isNull`, `JSC::isArray`, `isCallable`, `!isObject`).
- `BaseVMOptions::fromJS()` parses the options shared by all scripts (`filename`, `lineOffset`, `columnOffset`). `ScriptOptions::fromJS` (the `Script` constructor), `RunningScriptOptions::fromJS` (`runInThisContext`, `runInContext`, `runInNewContext`) and `CompileFunctionOptions::fromJS` (`compileFunction`) all call it first, so it is the one place the `options` argument is type-checked for those entry points.
- lib/vm.js's `runInContext()` and `runInNewContext()` never pass the caller's value on: they build a new object with `{ ...options }` (and `runInNewContext()` derives the context options from it separately). That is why `vm.runInNewContext("1", {}, [])` works in Node while `new vm.Script("1").runInNewContext({}, [])` throws.

Related open PRs, all independent of this one: #38371 (same change for `options.codeGeneration`), #38373 (`createContext()` returns an existing context before looking at `options`), #38326 (`Script#runInNewContext()` reusing an existing context). #38317 also copies `options` in the two wrappers, there in order to attach the parsing context to the copy; the native check in this PR is what makes the copy matter for validation, and whichever of the two lands second only has to drop its duplicate copy line.

<details>
<summary>node v26.3.0 vs bun, options argument matrix</summary>

`ok` means the call succeeded; otherwise the error code is shown. `existing` is a sandbox that was already passed to `createContext()`.

| call | node | bun before | bun after |
| --- | --- | --- | --- |
| `createContext({}, [])` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `createContext({}, function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `createContext({}, null)` / `createContext({}, 1)` | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE |
| `createContext(undefined, [])` / `createContext(DONT_CONTEXTIFY, [])` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `new Script("1", [])` / `new Script("1", function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `compileFunction("1", [], [])` / `(..., function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `vm.runInThisContext("1", [])` / `(..., function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `script.runInThisContext([])` / `(function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `script.runInContext(existing, [])` / `(..., function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `script.runInNewContext({}, [])` / `(..., function () {})` | ERR_INVALID_ARG_TYPE | ok | ERR_INVALID_ARG_TYPE |
| `vm.runInContext("1", existing, [])` / function | ok | ok | ok |
| `vm.runInNewContext("1", {}, [])` / function | ok | ok | ok |
| `vm.runInContext("1", existing, 1)` / `null` / `true` / symbol | ok | ERR_INVALID_ARG_TYPE | ok |
| `vm.runInNewContext("1", {}, 1)` / `null` / `true` / symbol | ok | ERR_INVALID_ARG_TYPE | ok |

Unchanged pre-existing differences, not about `options`:

| call | node | bun |
| --- | --- | --- |
| `createContext(existing, [])` | ok (returns before validating options) | ERR_INVALID_ARG_TYPE (#38373) |
| `createContext(function () {}, {})` | ERR_INVALID_ARG_TYPE (`"object"` argument) | ok |

</details>
