### PR TITLE
docs: use a Docker cache mount for bun install in the Docker guide

### DIFF
--- a/docs/guides/ecosystem/docker.mdx
+++ b/docs/guides/ecosystem/docker.mdx
@@ -23,14 +23,19 @@ WORKDIR /usr/src/app
 # install dependencies into temp directory
 # this will cache them and speed up future builds
 FROM base AS install
+# keep Bun's package cache in a Docker cache mount, so that when package.json
+# or bun.lock change, bun install only downloads the packages that changed
+ENV BUN_INSTALL_CACHE_DIR=/root/.bun/install/cache
 RUN mkdir -p /temp/dev
 COPY package.json bun.lock /temp/dev/
-RUN cd /temp/dev && bun install --frozen-lockfile
+RUN --mount=type=cache,target=${BUN_INSTALL_CACHE_DIR} \
+    cd /temp/dev && bun install --frozen-lockfile
 
 # install with --production (exclude devDependencies)
 RUN mkdir -p /temp/prod
 COPY package.json bun.lock /temp/prod/
-RUN cd /temp/prod && bun install --frozen-lockfile --production
+RUN --mount=type=cache,target=${BUN_INSTALL_CACHE_DIR} \
+    cd /temp/prod && bun install --frozen-lockfile --production
 
 # copy node_modules from temp directory
 # then copy all (non-ignored) project files into the image
@@ -54,6 +59,10 @@ USER bun
 EXPOSE 3000/tcp
 ENTRYPOINT [ "bun", "run", "index.ts" ]
 ```
+
+---
+
+The `install` stage keeps Bun's [global cache](/pm/global-cache) in a Docker [cache mount](https://docs.docker.com/reference/dockerfile/#run---mounttypecache). Docker still re-runs `bun install` whenever `package.json` or `bun.lock` change, but packages that an earlier build already downloaded are installed from the cache instead of being downloaded again. Setting `BUN_INSTALL_CACHE_DIR` makes Bun use the mounted directory as its cache. Cache mounts require BuildKit, which is the default builder in Docker Desktop and in Docker Engine 23.0 and later.
 
 ---
 


### PR DESCRIPTION
### Problem
- The Dockerfile in the Docker guide (`docs/guides/ecosystem/docker.mdx`) runs `bun install` in a plain `RUN` step. Any change to `package.json` or `bun.lock` invalidates that layer, and the rebuild downloads every package again because the image starts with an empty Bun cache.
- #22093 by @avestura fixed this in the old `docs/guides/ecosystem/docker.md`. That file was deleted when the docs tree was replaced in #24201, and the change was not carried over (`rg 'mount=type=cache' docs` is empty on main). This PR ports it; #22093 is closed pointing here.

### Fix
- The `install` stage sets `ENV BUN_INSTALL_CACHE_DIR=/root/.bun/install/cache` and both `bun install` steps run with `--mount=type=cache,target=${BUN_INSTALL_CACHE_DIR}`.
- Adds one paragraph under the Dockerfile explaining what the mount does and that it needs BuildKit.
- Why it is correct:
  - `BUN_INSTALL_CACHE_DIR` takes precedence over every other way the cache location can be chosen (`bunfig.toml` `install.cache.dir`, `$BUN_INSTALL`, `$XDG_CACHE_HOME`, `$HOME`; see `fetch_cache_directory_path` in `src/install/PackageManager/PackageManagerDirectories.rs`), so Bun is guaranteed to write into the mounted directory rather than silently caching somewhere the mount does not cover.
  - A cache mount is a separate filesystem from the layer being built, so Bun's hardlink install backend gets `EXDEV` and falls back to copying (`Error::NotSameFileSystem` handling in `src/install/PackageInstall.rs`). `node_modules` ends up as a self-contained copy, which is required because the mount is gone after the `RUN` step. With the default settings nothing in `node_modules` links into the cache (the global store, which does symlink into the cache, is off by default).
  - The two `RUN` lines share one cache: the cache `id` defaults to the `target` path.
  - `${BUN_INSTALL_CACHE_DIR}` inside `--mount` is expanded by the builder from the stage's `ENV` (Dockerfile frontend 1.3.0, July 2021, "values for `RUN --mount` flag now support variable expansion"). `RUN --mount` itself requires BuildKit, which has been the default builder since Docker Engine 23.0; the guide already assumes Docker Desktop.
  - The `ENV` lives in the `install` stage only, so it does not end up in the `release` image.
- Compared to #22093: the cache path is `/root/.bun/install/cache` (Bun's default when building as root in `oven/bun`) instead of `/usr/.bun/install/cache`, and a short explanation was added to the guide text. The Dockerfile structure is otherwise the same as the original PR.
- Verification:
  - Ran `bun install` with `BUN_INSTALL_CACHE_DIR` pointed at a tmpfs (a different filesystem from the project, like a cache mount is). The cache was populated there and `node_modules` received regular copies (link count 1).
  - Copied `bun.lock` plus a modified `package.json` into a fresh directory (what the invalidated `COPY` layer produces) and ran `bun install --frozen-lockfile` with the network blocked: succeeded from the warm cache, and the same command with an empty cache dir failed with `ConnectionRefused downloading tarball`.
  - No Docker daemon is available where this was written, so the Dockerfile itself was not built here. The Docker-side facts above were checked against the BuildKit Dockerfile reference and the `dockerfile/1.3.0` release notes, and docs.docker.com publishes that same reference file at `/reference/dockerfile/`, which is where the new link points.
  - `prettier --check docs/guides/ecosystem/docker.mdx` passes.

### Background
- **Docker layer cache**: Docker skips a `RUN` step when the instruction and everything copied before it are unchanged. The guide copies `package.json` and `bun.lock` before `bun install`, so editing either one re-runs the install from scratch.
- **BuildKit cache mount** (`RUN --mount=type=cache,target=...`): a directory that BuildKit keeps on the build host and mounts into the container only while that `RUN` step executes. Its contents survive across builds and are not part of the resulting image layer, so anything the final image needs must be copied out of it during the step.
- **Bun global cache**: `bun install` keeps every downloaded package under one directory (by default `~/.bun/install/cache`) and installs into `node_modules` from there, hardlinking when the cache and the project are on the same filesystem and copying otherwise. `BUN_INSTALL_CACHE_DIR` overrides the location.
