### PR TITLE
node:fs: reject the promise instead of throwing when a path is too long for any syscall

### DIFF
--- a/src/jsc/CallFrame.rs
+++ b/src/jsc/CallFrame.rs
@@ -242,12 +242,7 @@ pub struct ArgumentsSlice<'a> {
     pub all: &'a [JSValue],
     pub(crate) protected: IntegerBitSet<32>,
     pub will_be_async: bool,
-    /// An errno-class failure met while converting an argument (a path no
-    /// syscall could accept). Node surfaces these from the syscall itself, so
-    /// a binding that returns a promise must reject it with the error rather
-    /// than throw: when `will_be_async` the converter records it here and
-    /// hands back a placeholder, and the binding rejects with it after
-    /// parsing. Only the first failure is kept.
+    /// An errno a converter met under `will_be_async`; the binding rejects its promise with it.
     pub deferred_error: Option<Box<bun_sys::SystemError>>,
 }
 

--- a/src/jsc/CallFrame.rs
+++ b/src/jsc/CallFrame.rs
@@ -242,6 +242,13 @@ pub struct ArgumentsSlice<'a> {
     pub all: &'a [JSValue],
     pub(crate) protected: IntegerBitSet<32>,
     pub will_be_async: bool,
+    /// An errno-class failure met while converting an argument (a path no
+    /// syscall could accept). Node surfaces these from the syscall itself, so
+    /// a binding that returns a promise must reject it with the error rather
+    /// than throw: when `will_be_async` the converter records it here and
+    /// hands back a placeholder, and the binding rejects with it after
+    /// parsing. Only the first failure is kept.
+    pub deferred_error: Option<Box<bun_sys::SystemError>>,
 }
 
 impl<'a> ArgumentsSlice<'a> {
@@ -286,6 +293,7 @@ impl<'a> ArgumentsSlice<'a> {
             all: slice,
             protected: IntegerBitSet::<32>::init_empty(),
             will_be_async: false,
+            deferred_error: None,
         }
     }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4255,11 +4255,6 @@ pub mod args {
     }
     fs_args_path_forwarders!(Cp; src, dest);
     impl Cp {
-        #[inline]
-        pub(crate) fn into_thread_safe(mut self) -> ThreadSafe<Self> {
-            self.to_thread_safe();
-            ThreadSafe::adopt(self)
-        }
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Cp> {
             let src = PathLike::from_js_required(ctx, arguments, "src")?;
             // `Drop for PathLike` runs on early return.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1054,6 +1054,7 @@ mod _async_tasks {
         args::Exists,
         args::Access,
         args::CopyFile,
+        args::Cp,
     );
     impl_fs_argument!(@fd
         args::Fchown, args::FChmod, args::Fstat, args::Close, args::Futimes,

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -102,21 +102,17 @@ fn parse_async_args<A: FsArgument>(
         }
     };
 
-    let early_return = 'early: {
+    let rejection = 'rejection: {
         if A::HAVE_ABORT_SIGNAL {
             if let Some(abort_error) = args
                 .signal()
                 .and_then(|signal| signal.node_abort_error_if_aborted(global))
             {
-                break 'early JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global,
-                    abort_error,
-                );
+                break 'rejection abort_error;
             }
         }
         if let Some(err) = slice.deferred_error.take() {
-            break 'early JSPromise::rejected_promise(global, (*err).to_error_instance(global))
-                .to_js();
+            break 'rejection (*err).to_error_instance(global);
         }
         return Ok(args);
     };
@@ -125,7 +121,7 @@ fn parse_async_args<A: FsArgument>(
     drop(args);
     // SAFETY: not yet dropped; only drop site for this path.
     unsafe { ManuallyDrop::drop(&mut slice) };
-    Err(Ok(early_return))
+    Err(Ok(JSPromise::rejected_promise(global, rejection).to_js()))
 }
 
 #[inline(always)]

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -55,16 +55,28 @@ where
     }
 }
 
-/// Argument parsing shared by every promise-returning binding (`run_async`,
-/// `cp`, `readdir`). `Err` is what the binding returns instead of running the
-/// operation: a thrown validation error (node throws those synchronously
-/// too), or a promise already rejected, either with an already-aborted
-/// signal's error or with an errno-class argument failure
-/// (`ArgumentsSlice::deferred_error`), which node reports through the
-/// promise because it comes out of the syscall there.
+/// `Bindings(FunctionEnum).runAsync` for every operation except `.cp` /
+/// `.readdir` (those have bespoke entry points below).
 ///
-/// Callers take `bun_vm().as_mut()` for the task only once this has returned:
-/// parsing holds a shared borrow of the VM and can re-enter JS.
+/// `create_task` is `async_::<FunctionName>::create` — passed in because the
+/// Windows path picks `UVFSRequest` for a handful of fds-only ops while
+/// everything else uses `AsyncFSTask`, and that choice is encoded in the
+/// `async_::*` type aliases rather than derivable from `F` alone.
+fn run_async<A: FsArgument>(
+    this: &Binding,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    create_task: fn(&JSGlobalObject, &Binding, A, &mut VirtualMachine) -> JSValue,
+) -> JsResult<JSValue> {
+    let args = match parse_async_args::<A>(global, frame) {
+        Ok(args) => args,
+        Err(result) => return result,
+    };
+    let vm: &mut VirtualMachine = global.bun_vm().as_mut();
+    Ok(create_task(global, this, args, vm))
+}
+
+/// Parses a promise-returning binding's arguments; `Err` is what the binding returns instead.
 fn parse_async_args<A: FsArgument>(
     global: &JSGlobalObject,
     frame: &CallFrame,
@@ -75,10 +87,11 @@ fn parse_async_args<A: FsArgument>(
     slice.will_be_async = true;
 
     // `ManuallyDrop` keeps `slice` alive past return when ownership transfers
-    // to the Task: dropped only on the early-return branches; on the success
-    // path the Task owns `args` (whose protected JSValues are released by
-    // `Drop for ThreadSafe<A>` when the Task completes), and `slice` is
-    // intentionally not dropped — its `Drop`-unprotect would race that.
+    // to the Task: dropped only on the early-return
+    // error/abort branches; on the success path the Task owns `args` (whose
+    // protected JSValues are released by `Drop for ThreadSafe<A>` when the
+    // Task completes), and `slice` is intentionally not dropped — its
+    // `Drop`-unprotect would race that.
 
     let mut args = match <A as FsArgument>::from_js(global, &mut slice) {
         Ok(a) => a,
@@ -113,27 +126,6 @@ fn parse_async_args<A: FsArgument>(
     // SAFETY: not yet dropped; only drop site for this path.
     unsafe { ManuallyDrop::drop(&mut slice) };
     Err(Ok(early_return))
-}
-
-/// `Bindings(FunctionEnum).runAsync` for every operation except `.cp` /
-/// `.readdir` (those have bespoke entry points below).
-///
-/// `create_task` is `async_::<FunctionName>::create` — passed in because the
-/// Windows path picks `UVFSRequest` for a handful of fds-only ops while
-/// everything else uses `AsyncFSTask`, and that choice is encoded in the
-/// `async_::*` type aliases rather than derivable from `F` alone.
-fn run_async<A: FsArgument>(
-    this: &Binding,
-    global: &JSGlobalObject,
-    frame: &CallFrame,
-    create_task: fn(&JSGlobalObject, &Binding, A, &mut VirtualMachine) -> JSValue,
-) -> JsResult<JSValue> {
-    let args = match parse_async_args::<A>(global, frame) {
-        Ok(args) => args,
-        Err(result) => return result,
-    };
-    let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-    Ok(create_task(global, this, args, vm))
 }
 
 #[inline(always)]

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -4,6 +4,7 @@ use core::ptr::NonNull;
 use bun_jsc::call_frame::ArgumentsSlice;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsResult, SysErrorJsc as _};
+use bun_sys_jsc::SystemErrorJsc as _;
 
 use crate::node::fs::{
     self, AsyncCpTask, AsyncReaddirRecursiveTask, Flavor, FsArgument, FsReturn, NodeFS,
@@ -54,6 +55,66 @@ where
     }
 }
 
+/// Argument parsing shared by every promise-returning binding (`run_async`,
+/// `cp`, `readdir`). `Err` is what the binding returns instead of running the
+/// operation: a thrown validation error (node throws those synchronously
+/// too), or a promise already rejected, either with an already-aborted
+/// signal's error or with an errno-class argument failure
+/// (`ArgumentsSlice::deferred_error`), which node reports through the
+/// promise because it comes out of the syscall there.
+///
+/// Callers take `bun_vm().as_mut()` for the task only once this has returned:
+/// parsing holds a shared borrow of the VM and can re-enter JS.
+fn parse_async_args<A: FsArgument>(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> Result<A, JsResult<JSValue>> {
+    // SAFETY: JS-thread borrow of the per-thread VM; outlives `slice`.
+    let vm: &VirtualMachine = global.bun_vm();
+    let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
+    slice.will_be_async = true;
+
+    // `ManuallyDrop` keeps `slice` alive past return when ownership transfers
+    // to the Task: dropped only on the early-return branches; on the success
+    // path the Task owns `args` (whose protected JSValues are released by
+    // `Drop for ThreadSafe<A>` when the Task completes), and `slice` is
+    // intentionally not dropped — its `Drop`-unprotect would race that.
+
+    let mut args = match <A as FsArgument>::from_js(global, &mut slice) {
+        Ok(a) => a,
+        Err(err) => {
+            // SAFETY: not yet dropped; only drop site for this path.
+            unsafe { ManuallyDrop::drop(&mut slice) };
+            return Err(Err(err));
+        }
+    };
+
+    let early_return = 'early: {
+        if A::HAVE_ABORT_SIGNAL {
+            if let Some(abort_error) = args
+                .signal()
+                .and_then(|signal| signal.node_abort_error_if_aborted(global))
+            {
+                break 'early JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                    global,
+                    abort_error,
+                );
+            }
+        }
+        if let Some(err) = slice.deferred_error.take() {
+            break 'early JSPromise::rejected_promise(global, (*err).to_error_instance(global))
+                .to_js();
+        }
+        return Ok(args);
+    };
+
+    args.unprotect();
+    drop(args);
+    // SAFETY: not yet dropped; only drop site for this path.
+    unsafe { ManuallyDrop::drop(&mut slice) };
+    Err(Ok(early_return))
+}
+
 /// `Bindings(FunctionEnum).runAsync` for every operation except `.cp` /
 /// `.readdir` (those have bespoke entry points below).
 ///
@@ -67,47 +128,10 @@ fn run_async<A: FsArgument>(
     frame: &CallFrame,
     create_task: fn(&JSGlobalObject, &Binding, A, &mut VirtualMachine) -> JSValue,
 ) -> JsResult<JSValue> {
-    // SAFETY: JS-thread borrow of the per-thread VM; outlives `slice`.
-    let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-    let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
-    slice.will_be_async = true;
-
-    // `ManuallyDrop` keeps `slice` alive past return when ownership transfers
-    // to the Task: dropped only on the early-return
-    // error/abort branches; on the success path the Task owns `args` (whose
-    // protected JSValues are released by `Drop for ThreadSafe<A>` when the
-    // Task completes), and `slice` is intentionally not dropped — its
-    // `Drop`-unprotect would race that.
-
-    let mut args = match <A as FsArgument>::from_js(global, &mut slice) {
-        Ok(a) => a,
-        Err(err) => {
-            // SAFETY: not yet dropped; only drop site for this path.
-            unsafe { ManuallyDrop::drop(&mut slice) };
-            return Err(err);
-        }
+    let args = match parse_async_args::<A>(global, frame) {
+        Ok(args) => args,
+        Err(result) => return result,
     };
-
-    if A::HAVE_ABORT_SIGNAL {
-        if let Some(signal) = args.signal() {
-            if let Some(abort_error) = signal.node_abort_error_if_aborted(global) {
-                let promise =
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global,
-                        abort_error,
-                    );
-                args.unprotect();
-                drop(args);
-                // SAFETY: not yet dropped; only drop site for this path.
-                unsafe { ManuallyDrop::drop(&mut slice) };
-                return Ok(promise);
-            }
-        }
-    }
-
-    // The `cp` / `readdir` operations are handled by their dedicated
-    // bindings below.
-    // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
     let vm: &mut VirtualMachine = global.bun_vm().as_mut();
     Ok(create_task(global, this, args, vm))
 }
@@ -169,24 +193,12 @@ impl Binding {
 
     // ── Hand-written bindings for ops outside `NodeFSFunctionEnum` ────────
 
-    /// `callAsync(.cp)` — `AsyncCpTask::create` copies its paths via
-    /// `to_thread_safe()`, so the arena is dropped with `slice`.
+    /// `callAsync(.cp)`.
     pub(crate) fn cp(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        // SAFETY: JS-thread borrow of the per-thread VM; outlives `slice`.
-        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
-        slice.will_be_async = true;
-
-        let cp_args = match args::Cp::from_js(global, &mut slice) {
-            Ok(a) => a,
-            Err(err) => {
-                // SAFETY: not yet dropped; only drop site for this path.
-                unsafe { ManuallyDrop::drop(&mut slice) };
-                return Err(err);
-            }
+        let cp_args = match parse_async_args::<args::Cp>(global, frame) {
+            Ok(args) => args,
+            Err(result) => return result,
         };
-
-        // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         Ok(AsyncCpTask::create(global, this, cp_args, vm))
     }
@@ -218,21 +230,10 @@ impl Binding {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: JS-thread borrow of the per-thread VM; outlives `slice`.
-        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
-        slice.will_be_async = true;
-
-        let rd_args = match args::Readdir::from_js(global, &mut slice) {
-            Ok(a) => a,
-            Err(err) => {
-                // SAFETY: not yet dropped; only drop site for this path.
-                unsafe { ManuallyDrop::drop(&mut slice) };
-                return Err(err);
-            }
+        let rd_args = match parse_async_args::<args::Readdir>(global, frame) {
+            Ok(args) => args,
+            Err(result) => return result,
         };
-
-        // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         // /$bunfs/ is in-memory; readdir_inner handles it (recursive included).
         let is_bunfs = bun_standalone_graph::Graph::get().is_some()

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -903,6 +903,9 @@ pub trait PathLikeExt {
     ) -> JsResult<Option<PathLike>>
     where
         Self: Sized;
+    /// Throws every failure, ENAMETOOLONG included. Argument parsing goes
+    /// through [`Self::from_js`], which reports that one the way the binding
+    /// reports syscall errors (see [`Valid::path_length`]).
     fn from_bun_string(
         global: &JSGlobalObject,
         str: bun_core::String,
@@ -1145,7 +1148,7 @@ impl PathLikeExt for PathLike {
             return Ok(None);
         };
         use jsc::JSType;
-        match arg.js_type() {
+        let path = match arg.js_type() {
             JSType::Uint8Array | JSType::DataView => {
                 let mut buffer = Buffer::from_js_pinned(ctx, arg)
                     .unwrap_or_else(|| Buffer::from_typed_array(ctx, arg));
@@ -1160,7 +1163,7 @@ impl PathLikeExt for PathLike {
                 }
 
                 arguments.protect_eat();
-                Ok(Some(Self::Buffer(buffer)))
+                Self::Buffer(buffer)
             }
 
             JSType::ArrayBuffer => {
@@ -1177,17 +1180,13 @@ impl PathLikeExt for PathLike {
                 }
 
                 arguments.protect_eat();
-                Ok(Some(Self::Buffer(buffer)))
+                Self::Buffer(buffer)
             }
 
             JSType::String | JSType::StringObject | JSType::DerivedStringObject => {
                 let str = arg.to_bun_string(ctx)?;
                 arguments.eat();
-                Ok(Some(Self::from_bun_string(
-                    ctx,
-                    str,
-                    arguments.will_be_async,
-                )?))
+                path_like_from_string(ctx, str, arguments.will_be_async)?
             }
             _ => {
                 if let Some(domurl) = jsc::DOMURL::cast(arg) {
@@ -1228,17 +1227,14 @@ impl PathLikeExt for PathLike {
                             .throw());
                     }
                     arguments.eat();
-
-                    return Ok(Some(Self::from_bun_string(
-                        ctx,
-                        str,
-                        arguments.will_be_async,
-                    )?));
+                    path_like_from_string(ctx, str, arguments.will_be_async)?
+                } else {
+                    return Ok(None);
                 }
-
-                Ok(None)
             }
-        }
+        };
+
+        Valid::path_length(path, ctx, arguments).map(Some)
     }
 
     fn from_bun_string(
@@ -1246,40 +1242,50 @@ impl PathLikeExt for PathLike {
         str: bun_core::String,
         will_be_async: bool,
     ) -> JsResult<PathLike> {
-        if will_be_async {
-            let mut sliced = str.into_thread_safe_slice();
-
-            // Validate the UTF-8 byte length after conversion, since the path
-            // will be stored in a fixed-size PathBuffer.
-            Valid::path_string_length(sliced.slice().len(), global)?;
-            Valid::path_null_bytes(sliced.slice(), global)?;
-
-            sliced.report_extra_memory(global.vm());
-
-            if sliced.underlying.is_empty() {
-                return Ok(Self::EncodedSlice(core::mem::take(&mut sliced.utf8)));
-            }
-            Ok(Self::ThreadsafeString(sliced))
-        } else {
-            let mut sliced = str.into_slice();
-
-            // Validate the UTF-8 byte length after conversion, since the path
-            // will be stored in a fixed-size PathBuffer.
-            Valid::path_string_length(sliced.slice().len(), global)?;
-            Valid::path_null_bytes(sliced.slice(), global)?;
-
-            // Costs nothing to keep both around.
-            if sliced.is_wtf_allocated() {
-                return Ok(Self::SliceWithUnderlyingString(sliced));
-            }
-
-            sliced.report_extra_memory(global.vm());
-
-            // It is expensive to keep both around. `utf8` here is an Owned
-            // transcoded copy (UTF-16 or non-ASCII Latin-1 input), so the
-            // returned EncodedSlice is independent of `underlying`.
-            Ok(Self::EncodedSlice(core::mem::take(&mut sliced.utf8)))
+        let path = path_like_from_string(global, str, will_be_async)?;
+        match Valid::path_too_long(path.slice()) {
+            Some(err) => Err(global.throw_value(err.to_error_instance(global))),
+            None => Ok(path),
         }
+    }
+}
+
+/// The UTF-8 bytes of `str` as a `PathLike`, checked for NUL bytes only. The
+/// length check is the caller's: [`Valid::path_length`] while parsing
+/// arguments, so async bindings can report it through their promise, or
+/// [`PathLikeExt::from_bun_string`] to throw it.
+fn path_like_from_string(
+    global: &JSGlobalObject,
+    str: bun_core::String,
+    will_be_async: bool,
+) -> JsResult<PathLike> {
+    if will_be_async {
+        let mut sliced = str.into_thread_safe_slice();
+
+        Valid::path_null_bytes(sliced.slice(), global)?;
+
+        sliced.report_extra_memory(global.vm());
+
+        if sliced.underlying.is_empty() {
+            return Ok(PathLike::EncodedSlice(core::mem::take(&mut sliced.utf8)));
+        }
+        Ok(PathLike::ThreadsafeString(sliced))
+    } else {
+        let mut sliced = str.into_slice();
+
+        Valid::path_null_bytes(sliced.slice(), global)?;
+
+        // Costs nothing to keep both around.
+        if sliced.is_wtf_allocated() {
+            return Ok(PathLike::SliceWithUnderlyingString(sliced));
+        }
+
+        sliced.report_extra_memory(global.vm());
+
+        // It is expensive to keep both around. `utf8` here is an Owned
+        // transcoded copy (UTF-16 or non-ASCII Latin-1 input), so the
+        // returned EncodedSlice is independent of `underlying`.
+        Ok(PathLike::EncodedSlice(core::mem::take(&mut sliced.utf8)))
     }
 }
 
@@ -1288,39 +1294,51 @@ impl PathLikeExt for PathLike {
 pub struct Valid;
 
 impl Valid {
-    pub(crate) fn path_string_length(len: usize, ctx: &JSGlobalObject) -> JsResult<()> {
-        match len {
-            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
-            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
-            0..MAX_PATH_BYTES => Ok(()),
-            _ => {
-                let mut system_error =
-                    bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
-                        .to_system_error();
-                system_error.syscall = bun_core::String::DEAD;
-                Err(ctx.throw_value(system_error.to_error_instance(ctx)))
-            }
+    /// `PathBuffer` is `[u8; MAX_PATH_BYTES]` and `slice_z_with_force_copy`
+    /// needs room for the NUL, so a path this long never reaches a syscall;
+    /// this is the ENAMETOOLONG the syscall would have returned.
+    pub(crate) fn path_too_long(path: &[u8]) -> Option<bun_sys::SystemError> {
+        if path.len() < MAX_PATH_BYTES {
+            return None;
         }
+        let mut system_error =
+            bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+                .with_path(path)
+                .to_system_error();
+        system_error.syscall = bun_core::String::DEAD;
+        Some(system_error)
+    }
+
+    /// Length check for a parsed path argument. A sync binding throws the
+    /// error. A binding that returns a promise (`arguments.will_be_async`)
+    /// gets it recorded as `arguments.deferred_error` to reject with, plus an
+    /// empty placeholder so the remaining arguments still get validated; the
+    /// binding never runs the operation on the placeholder.
+    pub(crate) fn path_length(
+        path: PathLike,
+        ctx: &JSGlobalObject,
+        arguments: &mut ArgumentsSlice,
+    ) -> JsResult<PathLike> {
+        let Some(err) = Self::path_too_long(path.slice()) else {
+            return Ok(path);
+        };
+        drop(path);
+        if !arguments.will_be_async {
+            return Err(ctx.throw_value(err.to_error_instance(ctx)));
+        }
+        if arguments.deferred_error.is_none() {
+            arguments.deferred_error = Some(Box::new(err));
+        }
+        Ok(PathLike::default())
     }
 
     pub(crate) fn path_buffer(buffer: &Buffer, ctx: &JSGlobalObject) -> JsResult<()> {
-        let slice = buffer.slice();
-        match slice.len() {
-            0 => {
-                Err(ctx
-                    .throw_invalid_arguments(format_args!("Invalid path buffer: can't be empty")))
-            }
-            // Exclusive: `PathBuffer` is `[u8; MAX_PATH_BYTES]` and
-            // `slice_z_with_force_copy` needs `len + NUL ≤ MAX_PATH_BYTES`.
-            1..MAX_PATH_BYTES => Ok(()),
-            _ => {
-                let mut system_error =
-                    bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
-                        .to_system_error();
-                system_error.syscall = bun_core::String::DEAD;
-                Err(ctx.throw_value(system_error.to_error_instance(ctx)))
-            }
+        if buffer.slice().is_empty() {
+            return Err(
+                ctx.throw_invalid_arguments(format_args!("Invalid path buffer: can't be empty"))
+            );
         }
+        Ok(())
     }
 
     pub(crate) fn path_null_bytes(slice: &[u8], global: &JSGlobalObject) -> JsResult<()> {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -903,9 +903,7 @@ pub trait PathLikeExt {
     ) -> JsResult<Option<PathLike>>
     where
         Self: Sized;
-    /// Throws every failure, ENAMETOOLONG included. Argument parsing goes
-    /// through [`Self::from_js`], which reports that one the way the binding
-    /// reports syscall errors (see [`Valid::path_length`]).
+    /// Throws ENAMETOOLONG too; [`Self::from_js`] defers it for async bindings instead.
     fn from_bun_string(
         global: &JSGlobalObject,
         str: bun_core::String,
@@ -1250,10 +1248,7 @@ impl PathLikeExt for PathLike {
     }
 }
 
-/// The UTF-8 bytes of `str` as a `PathLike`, checked for NUL bytes only. The
-/// length check is the caller's: [`Valid::path_length`] while parsing
-/// arguments, so async bindings can report it through their promise, or
-/// [`PathLikeExt::from_bun_string`] to throw it.
+/// `str` as a `PathLike`, NUL-checked; the caller checks the length ([`Valid::path_length`]).
 fn path_like_from_string(
     global: &JSGlobalObject,
     str: bun_core::String,
@@ -1294,9 +1289,7 @@ fn path_like_from_string(
 pub struct Valid;
 
 impl Valid {
-    /// `PathBuffer` is `[u8; MAX_PATH_BYTES]` and `slice_z_with_force_copy`
-    /// needs room for the NUL, so a path this long never reaches a syscall;
-    /// this is the ENAMETOOLONG the syscall would have returned.
+    /// The ENAMETOOLONG the syscall would return: no `PathBuffer` fits this path plus its NUL.
     pub(crate) fn path_too_long(path: &[u8]) -> Option<bun_sys::SystemError> {
         if path.len() < MAX_PATH_BYTES {
             return None;
@@ -1309,11 +1302,7 @@ impl Valid {
         Some(system_error)
     }
 
-    /// Length check for a parsed path argument. A sync binding throws the
-    /// error. A binding that returns a promise (`arguments.will_be_async`)
-    /// gets it recorded as `arguments.deferred_error` to reject with, plus an
-    /// empty placeholder so the remaining arguments still get validated; the
-    /// binding never runs the operation on the placeholder.
+    /// Sync bindings throw; async ones get it as `arguments.deferred_error` and a placeholder path.
     pub(crate) fn path_length(
         path: PathLike,
         ctx: &JSGlobalObject,

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -312,7 +312,7 @@ impl ShellMkdirTask {
             )
         };
 
-        // `NodeFS` expects the `Valid::path_string_length` bound its JS callers
+        // `NodeFS` expects the `Valid::path_too_long` bound its JS callers
         // enforce; past it, `PathLike::slice_z` yields "" and mkdir reports ENOENT.
         if filepath.len() >= bun_paths::MAX_PATH_BYTES {
             this.err = Some(

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { isLinux, isMacOS, isPosix, isWindows, tempDir } from "harness";
 import fs from "node:fs";
+import { pathToFileURL } from "node:url";
 
 // On POSIX systems, MAX_PATH_BYTES is 4096.
 // Path validation must account for the actual UTF-8 byte length of strings,
@@ -232,5 +233,112 @@ describe.if(isWindows)("Buffer paths containing malformed byte sequences", () =>
     ]);
     expect(fs.readdirSync(String(dir) + "\\sub")).toEqual([]);
     expect(fs.readFileSync(String(dir) + "\\e\uFFFDF", "utf8")).toBe("4");
+  });
+});
+
+// A path of MAX_PATH_BYTES or more never reaches a syscall: the argument parser
+// produces the ENAMETOOLONG itself. Node gets that error from the syscall, so
+// it arrives through the callback like any other syscall error, and the
+// callback APIs (which call the native binding directly, unlike fs.promises'
+// async wrappers) must not throw it synchronously. The lengths clear
+// MAX_PATH_BYTES on every platform: 4096 Linux, 1024 macOS, 98302 Windows.
+describe("callback APIs report a path longer than MAX_PATH_BYTES through the callback", () => {
+  const tooLongLength = isWindows ? 100_000 : 5_000;
+  const tooLong = (isWindows ? "C:\\" : "/") + Buffer.alloc(tooLongLength, "a").toString();
+  // The operand that is not under test. Every operation below fails on
+  // `tooLong` before touching the filesystem, so this path is never created.
+  const other = "fs-path-length-other-operand";
+
+  type Callback = (err: unknown) => void;
+  // [name, call, whether node reports `tooLong` as `err.path` (it is the
+  // `dest` of the two-operand calls, and mkdtemp appends its suffix)]
+  const calls: [string, (cb: Callback) => void, boolean][] = [
+    ["access", cb => fs.access(tooLong, cb), true],
+    ["appendFile", cb => fs.appendFile(tooLong, "x", cb), true],
+    ["chmod", cb => fs.chmod(tooLong, 0o644, cb), true],
+    ["chown", cb => fs.chown(tooLong, 0, 0, cb), true],
+    ["copyFile", cb => fs.copyFile(tooLong, other, cb), true],
+    ["cp", cb => fs.cp(tooLong, other, cb), true],
+    ["lstat", cb => fs.lstat(tooLong, cb), true],
+    ["mkdir", cb => fs.mkdir(tooLong, cb), true],
+    ["mkdir recursive", cb => fs.mkdir(tooLong, { recursive: true }, cb), true],
+    ["mkdtemp", cb => fs.mkdtemp(tooLong, cb), false],
+    ["open", cb => fs.open(tooLong, "r", cb), true],
+    ["opendir", cb => fs.opendir(tooLong, cb), true],
+    ["readdir", cb => fs.readdir(tooLong, cb), true],
+    ["readdir recursive", cb => fs.readdir(tooLong, { recursive: true }, cb), true],
+    ["readFile", cb => fs.readFile(tooLong, cb), true],
+    ["readlink", cb => fs.readlink(tooLong, cb), true],
+    ["realpath", cb => fs.realpath(tooLong, cb), true],
+    ["realpath.native", cb => fs.realpath.native(tooLong, cb), true],
+    ["rename oldPath", cb => fs.rename(tooLong, other, cb), true],
+    ["rename newPath", cb => fs.rename(other, tooLong, cb), false],
+    ["rm", cb => fs.rm(tooLong, cb), true],
+    ["rmdir", cb => fs.rmdir(tooLong, cb), true],
+    ["stat", cb => fs.stat(tooLong, cb), true],
+    ["stat with a Buffer path", cb => fs.stat(Buffer.from(tooLong), cb), true],
+    ["stat with a file: URL path", cb => fs.stat(pathToFileURL(tooLong), cb), true],
+    ["statfs", cb => fs.statfs(tooLong, cb), true],
+    ["symlink", cb => fs.symlink(other, tooLong, cb), false],
+    ["truncate", cb => fs.truncate(tooLong, cb), true],
+    ["unlink", cb => fs.unlink(tooLong, cb), true],
+    ["utimes", cb => fs.utimes(tooLong, 0, 0, cb), true],
+    ["writeFile", cb => fs.writeFile(tooLong, "x", cb), true],
+  ];
+
+  it.each(calls)("fs.%s", async (_, call, pathIsReported) => {
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    let returned = false;
+    let calledBeforeReturning = false;
+    call(err => {
+      calledBeforeReturning = !returned;
+      resolve(err);
+    });
+    returned = true;
+    const err = (await promise) as NodeJS.ErrnoException;
+    expect(calledBeforeReturning).toBe(false);
+    expect(err.code).toBe("ENAMETOOLONG");
+    if (pathIsReported) {
+      expect(err.path).toBe(tooLong);
+    }
+  });
+
+  // https://github.com/oven-sh/bun/issues/25659
+  it("a relative path is reported the same way (#25659)", async () => {
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    const order: string[] = [];
+    fs.readFile(Buffer.alloc(tooLongLength, "a").toString(), err => {
+      order.push("callback");
+      resolve(err);
+    });
+    order.push("returned");
+    const err = (await promise) as NodeJS.ErrnoException;
+    expect(order).toEqual(["returned", "callback"]);
+    expect(err.code).toBe("ENAMETOOLONG");
+  });
+
+  it("fs.exists answers false", async () => {
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+    fs.exists(tooLong, resolve);
+    expect(await promise).toBe(false);
+  });
+
+  // Node validates the other arguments before issuing the syscall, so an
+  // invalid option still throws synchronously and wins over the path's errno.
+  it("an invalid option still throws synchronously", () => {
+    expect(() => fs.readdir(tooLong, { encoding: "bogus" as BufferEncoding }, () => {})).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    );
+    expect(() => fs.readFile(tooLong, { encoding: "bogus" as BufferEncoding }, () => {})).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    );
+  });
+
+  it("the sync variants throw it, naming the path", () => {
+    expect(() => fs.statSync(tooLong)).toThrow(expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong }));
+    expect(() => fs.statSync(Buffer.from(tooLong))).toThrow(
+      expect.objectContaining({ code: "ENAMETOOLONG", path: tooLong }),
+    );
+    expect(() => fs.renameSync(other, tooLong)).toThrow(expect.objectContaining({ code: "ENAMETOOLONG" }));
   });
 });


### PR DESCRIPTION
### Problem
- `fs.stat(p, cb)`, `fs.readFile(p, cb)`, `fs.access`, `open`, `readdir`, `realpath`, `unlink`, `mkdir`, `readlink`, `rmdir`, `rename`, `link`, `symlink`, `copyFile`, `writeFile`, `appendFile`, `truncate`, `statfs`, `mkdtemp`, `opendir`, `chmod`, `chown`, `utimes` (every callback API taking a path) throw `ENAMETOOLONG: name too long, open` synchronously when the path is `MAX_PATH_BYTES` (4096 Linux, 1024 macOS, 98302 Windows) or longer, and the callback never runs. Node 26 calls back with `ENAMETOOLONG` for all of them (outputs below).
- Cause: `PathLike::from_js` (src/runtime/node/types.rs, `Valid::path_string_length` / `Valid::path_buffer`) throws the error while the binding is still converting arguments. `fs.promises.*` only behaves because its `asyncWrap` is an `async function`; the callback layer in src/js/node/fs.ts calls the native binding directly, so the throw escapes to the caller. `Bun.file(p)` throws at construction for the same reason; that is a different entry point and is not changed here (see below).
- Fixes #25659. #36324 is an earlier attempt at the same bug that removes the parse-time length guard and re-adds the check at every dispatch site; this PR keeps the guard and is the smaller alternative (trade-off: #36324 also fills in a per-operation `err.syscall`, this PR leaves it `undefined` as today).

### Fix
- `ArgumentsSlice` (src/jsc/CallFrame.rs) gets `deferred_error: Option<Box<bun_sys::SystemError>>`.
- `Valid::path_length` (types.rs) runs once for every path form (string, `file:` URL, Buffer, ArrayBuffer) after conversion. Sync parsing (`will_be_async == false`) throws exactly as before. When the binding is parsing for an async operation it records the error on the slice instead and returns an empty placeholder path, so the remaining arguments are still validated (an invalid `encoding` still throws synchronously, as in node). The first recorded error wins for two-path operations.
- `parse_async_args` (src/runtime/node/node_fs_binding.rs) is the argument-parsing step the three promise-returning bindings (`run_async`, `cp`, `readdir`) now share; after a successful parse it returns a promise rejected with the recorded error, so the operation is never started on the placeholder. The already-aborted `AbortSignal` check stays ahead of it (node rejects with `AbortError` for `readFile(tooLong, { signal })` too). `args::Cp` joins the `FsArgument` list so `cp` can use the helper. This is the line that changes behaviour; the rest of the diff in that file is the three copies of the parse block collapsing into the helper.
- The already-aborted branch builds its rejected promise with `JSPromise::rejected_promise` like the deferred-error branch, instead of the deprecated `dangerously_create_rejected_promise_value_without_notifying_vm`. Nothing observable changes through `fs.*`/`fs.promises.*`, which always attach handlers to the binding's promise; it removes the deprecated call from the shared helper.
- The error now also carries `err.path` (sync and async). Since `to_system_error` formats the message into a 4096-byte buffer, the message of a Linux-length path is cut off after 4096 bytes (#38201 is changing that formatter); `err.path` itself is complete. `err.syscall` stays `undefined`, as before.
- Order change for a path that is both too long and contains NUL bytes: the NUL-byte `ERR_INVALID_ARG_VALUE` now wins, which is node's order (it validates NUL bytes before issuing the syscall).
- Not changed: `Bun.file(p)` / `Bun.write(p, ...)` still throw synchronously at argument conversion. Making those lazy means letting an over-long path into a Blob store and auditing every Blob/sendfile/copy path that copies the path into a fixed buffer, which is separate work.
- Verified: test/js/node/fs/fs-path-length.test.ts gains a describe covering 31 callback operations (string, Buffer and URL paths, both operands of `rename`, `mkdir`/`readdir` recursive, `opendir`, `realpath.native`), the callback not running synchronously, `fs.exists` answering `false`, an invalid option still throwing synchronously, the sync forms still throwing (now with `path`), and the #25659 repro. 34 of the 35 new tests fail on the unfixed build: 31 because the error is thrown synchronously, and `rm`, `cp` (already routed through a JS promise) and the sync-forms test because `err.path` was missing. All pass with the fix.
- Also run against the debug build: fs.test.ts, cp.test.ts, promises.test.js, dir.test.ts, fs-mkdir.test.ts, readdirSync-recursive-error-leak.test.ts and 35 ported node `test-fs-*` files touching path validation, abort signals and error shapes: no failures (abort-signal-leak-read-write-file.test.ts times out in this container on an unmodified build as well, 100k iterations at ~7ms each under debug ASAN). The matrix below also runs clean under `BUN_JSC_validateExceptionChecks=1`. `cargo clippy` on `bun_jsc` and `bun_runtime` is clean.

### Background
- `ArgumentsSlice` is the cursor the native bindings walk over a call's arguments. node:fs async bindings set its `will_be_async` flag before parsing so string arguments get copied into thread-safe forms; this PR uses the same flag to mean "this binding reports errors through a promise".
- `PathLike` is the parsed path argument. Every fs operation copies it into a `PathBuffer` (`[u8; MAX_PATH_BYTES]`, plus NUL) right before the syscall, which is why the parser rejects paths of `MAX_PATH_BYTES` or more up front: the copy is infallible and the rest of node_fs.rs relies on the length invariant. The kernel's own limit is the same number (PATH_MAX), so the early `ENAMETOOLONG` is the error the syscall would have produced; only its delivery was wrong.
- `bun_sys::SystemError` is the JS-facing error record (`code`, `errno`, `message`, `path`, ...); `to_error_instance` turns it into the JS `Error` that node-style fs errors are made of. The deferred slot holds this record and the binding converts it when it builds the rejected promise.
- The callback APIs in fs.ts are all of the form `binding.stat(path, options).then(ok, callback)`: whatever the binding returns as a rejected promise reaches the callback, whatever it throws reaches the caller.

Rebases: onto #40251 (main dropped the `has_exception()` guards after `?`-checked calls; the helper follows) and #40238 (`bun_core::String` owns its WTF ref, so `from_bun_string` / `path_like_from_string` take the string by value and use `into_slice` / `into_thread_safe_slice`). Both resolutions are mechanical; the behaviour is the one described above.

<details>
<summary>Matrix: node 26.3.0 vs this branch (sync = did the call throw; cb = code passed to the callback)</summary>

Node 26.3.0:

```
access             returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:access
appendFile         returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:open
chmod              returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:chmod
chown              returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:chown
copyFile (src)     returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:copyfile
lstat              returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:lstat
mkdir              returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:mkdir
mkdir recursive    returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:mkdir
mkdtemp            returned  cb:ENAMETOOLONG  syncCb:false path===input:false syscall:mkdtemp
open               returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:open
opendir            returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:opendir
readdir            returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:scandir
readdir recursive  returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:scandir
readFile           returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:open
readlink           returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:readlink
realpath           returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:lstat
realpath.native    returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:realpath
rename (oldPath)   returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:rename
rename (newPath)   returned  cb:ENAMETOOLONG  syncCb:false path===input:false syscall:rename
rm                 returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:lstat
rmdir              returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:rmdir
stat               returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:stat
statfs             returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:statfs
symlink (path)     returned  cb:ENAMETOOLONG  syncCb:false path===input:false syscall:symlink
truncate           returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:open
unlink             returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:unlink
utimes             returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:utime
writeFile          returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:open
stat (Buffer)      returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:stat
stat (URL)         returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:stat
cp                 returned  cb:ENAMETOOLONG  syncCb:false path===input:true  syscall:lstat
exists             -> false
readdir bogus encoding: THREW ERR_INVALID_ARG_VALUE
statSync: ENAMETOOLONG path===input:true syscall:stat
```

Bun 1.4.0 (unfixed): every line above except `rm`, `cp` and `exists` reads `THREW SYNCHRONOUSLY ENAMETOOLONG, callback NOT called`; `statSync` has no `path`.

This branch: every line reads `returned cb:ENAMETOOLONG syncCb:false path===input:true syscall:undefined` (`path` is the over-long operand also for `rename (newPath)`, `symlink` and `mkdtemp`, where node reports it as `dest` / with the template suffix), `exists -> false`, `readdir bogus encoding: THREW ERR_INVALID_ARG_VALUE`, `statSync: ENAMETOOLONG path===input:true`.

Known remaining difference: for `copyFile(missing, tooLong)` and `link(missing, tooLong)` node's kernel call fails on the first operand and reports `ENOENT`; this branch reports `ENAMETOOLONG` for the second. Both arrive through the callback. The tests use `rename`/`symlink` for the second-operand cases, where node also reports `ENAMETOOLONG`.

`readFile`/`writeFile` with an already-aborted signal and an over-long path reject with `AbortError` on both node and this branch; with a live signal both give `ENAMETOOLONG`; an unhandled `fs.promises.stat(tooLong)` reaches `unhandledRejection` on both.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs-path-length.test.ts

<!-- robobun:evidence:end -->
