### PR TITLE
Bump mordant to 18a5734

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "4e08693333be204deef8e9ffd90a2a153e133e36" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "18a573447ab447acc0f52796188c601b9726b1bc" },
 ]
 
 [workspace.package]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -33,7 +33,6 @@
 "pub_invariant_fields:src/router/lib.rs" = 1
 
 [bun_runtime]
-"asymmetric_guard:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "bypassed_validator:src/runtime/cli/pack_command.rs" = 2
 "pub_invariant_fields:src/runtime/api/JSBundler.rs" = 7
 "pub_invariant_fields:src/runtime/api/bun/Terminal.rs" = 1


### PR DESCRIPTION
Picks up scarletindustries/mordant#8: asymmetric_guard no longer claims calls that sit under their own conditions. The h2_frame_parser entry from #38374 goes away and nothing else changes. bun run rust:mordant is clean.