### PR TITLE
node:wasi: fix getState() and setState() throwing ReferenceError

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -585,8 +585,7 @@ var require_wasi = __commonJS({
         this.memory = void 0;
         this.view = void 0;
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
-        const bindings = this.bindings;
-        fs = bindings.fs;
+        fs = this.bindings.fs;
         this.FD_MAP = /* @__PURE__ */ new Map([
           [
             constants_1.WASI_STDIN_FILENO,
@@ -625,7 +624,7 @@ var require_wasi = __commonJS({
             },
           ],
         ]);
-        const path = bindings.path;
+        const path = this.bindings.path;
         for (const [k, v] of Object.entries(preopens)) {
           const real = fs.openSync(v, nodeFsConstants.O_RDONLY);
           const newfd = this.getUnusedFileDescriptor();
@@ -1596,22 +1595,22 @@ var require_wasi = __commonJS({
                   const ms = nsToMs(waitTimeNs);
                   sleep.$call(this, ms);
                 } else {
-                  const end = BigInt(bindings.hrtime()) + waitTimeNs;
-                  while (BigInt(bindings.hrtime()) < end) {}
+                  const end = BigInt(this.bindings.hrtime()) + waitTimeNs;
+                  while (BigInt(this.bindings.hrtime()) < end) {}
                 }
               }
             }
             return constants_1.WASI_ESUCCESS;
           },
           proc_exit: rval => {
-            bindings.exit(rval);
+            this.bindings.exit(rval);
             return constants_1.WASI_ESUCCESS;
           },
           proc_raise: sig => {
             if (!(sig in constants_1.SIGNAL_MAP)) {
               return constants_1.WASI_EINVAL;
             }
-            bindings.kill(constants_1.SIGNAL_MAP[sig]);
+            this.bindings.kill(constants_1.SIGNAL_MAP[sig]);
             return constants_1.WASI_ESUCCESS;
           },
           random_get: (bufPtr, bufLen) => {
@@ -1643,12 +1642,12 @@ var require_wasi = __commonJS({
         };
       }
       getState() {
-        return { env: this.env, FD_MAP: this.FD_MAP, bindings: bindings };
+        return { env: this.env, FD_MAP: this.FD_MAP, bindings: this.bindings };
       }
       setState(state) {
         this.env = state.env;
         this.FD_MAP = state.FD_MAP;
-        bindings = state.bindings;
+        this.bindings = state.bindings;
       }
       fstatSync(real_fd) {
         if (real_fd <= 2) {

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -1,5 +1,5 @@
 import { spawnSync } from "bun";
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
@@ -162,4 +162,77 @@ it("path_* syscalls cannot escape the preopened directory", () => {
     WASI_ESUCCESS,
   );
   expect(wasi.FD_MAP.has(4)).toBe(true);
+});
+
+describe("getState() / setState()", () => {
+  // The constructor reads bindings.fs and bindings.path; proc_exit and proc_raise
+  // call bindings.exit and bindings.kill, so those record instead of touching the
+  // host process.
+  function makeBindings(calls, tag) {
+    return {
+      fs,
+      path,
+      hrtime: () => process.hrtime.bigint(),
+      isTTY: () => false,
+      randomFillSync: array => crypto.getRandomValues(array),
+      exit: code => calls.push([tag, "exit", code]),
+      kill: signal => calls.push([tag, "kill", signal]),
+    };
+  }
+
+  it("getState() returns the env, FD_MAP and bindings of the instance", () => {
+    const withDefaults = new WASI({ version: "preview1" });
+    expect(withDefaults.getState()).toEqual({
+      env: withDefaults.env,
+      FD_MAP: withDefaults.FD_MAP,
+      bindings: withDefaults.bindings,
+    });
+
+    const env = { WASI_TEST: "1" };
+    const bindings = makeBindings([], "custom");
+    const wasi = new WASI({ env, bindings });
+    const state = wasi.getState();
+    expect(state).toEqual({ env, FD_MAP: wasi.FD_MAP, bindings });
+    expect(state.bindings).toBe(bindings);
+  });
+
+  it("setState() installs env, FD_MAP and bindings taken from another instance", () => {
+    const source = new WASI({ env: { FROM: "source" }, bindings: makeBindings([], "source") });
+    const target = new WASI({ env: { FROM: "target" }, bindings: makeBindings([], "target") });
+    const sourceState = source.getState();
+
+    target.setState(sourceState);
+
+    expect(target.env).toBe(source.env);
+    expect(target.FD_MAP).toBe(source.FD_MAP);
+    expect(target.bindings).toBe(source.bindings);
+    expect(target.getState()).toEqual(sourceState);
+  });
+
+  it("proc_exit and proc_raise call the bindings installed by setState()", () => {
+    const WASI_ESUCCESS = 0;
+    const WASI_SIGABRT = 0;
+    const calls = [];
+    const originalBindings = makeBindings(calls, "original");
+    const wasi = new WASI({ bindings: originalBindings });
+
+    expect(wasi.wasiImport.proc_exit(3)).toBe(WASI_ESUCCESS);
+    expect(wasi.wasiImport.proc_raise(WASI_SIGABRT)).toBe(WASI_ESUCCESS);
+
+    wasi.setState({ env: wasi.env, FD_MAP: wasi.FD_MAP, bindings: makeBindings(calls, "replaced") });
+    expect(wasi.wasiImport.proc_exit(4)).toBe(WASI_ESUCCESS);
+    expect(wasi.wasiImport.proc_raise(WASI_SIGABRT)).toBe(WASI_ESUCCESS);
+
+    wasi.setState({ env: wasi.env, FD_MAP: wasi.FD_MAP, bindings: originalBindings });
+    expect(wasi.wasiImport.proc_exit(5)).toBe(WASI_ESUCCESS);
+    expect(wasi.bindings).toBe(originalBindings);
+
+    expect(calls).toEqual([
+      ["original", "exit", 3],
+      ["original", "kill", "SIGABRT"],
+      ["replaced", "exit", 4],
+      ["replaced", "kill", "SIGABRT"],
+      ["original", "exit", 5],
+    ]);
+  });
 });


### PR DESCRIPTION
### Problem
- `new WASI().getState()` and `new WASI().setState(state)` both throw `ReferenceError: bindings is not defined` (Bun 1.4.0 and main). `setState()` has already overwritten `this.env` and `this.FD_MAP` when it throws.
- `src/js/node/wasi.ts` is a vendored copy of wasi-js. The vendored constructor captures `const bindings = this.bindings` (wasi.ts:588) and the rest of the file was rewritten to read that local instead of `this.bindings`.
- `getState()` (wasi.ts:1646) and `setState()` (wasi.ts:1651) are methods outside the constructor, so for them `bindings` is an undeclared identifier: reading it throws, and assigning it throws too because class bodies are strict mode code.
- The import closures (`proc_exit`, `proc_raise`, the busy-wait in `poll_oneoff`) also read the constructor local, so patching only the two methods would make `setState()` return without error and still have no effect on what the wasm module calls.

### Fix
- Remove the constructor local and read `this.bindings` at every site; `setState()` assigns `this.bindings`.
- This is what upstream wasi-js does (`getState()`/`setState()` return and assign `this.bindings`, the imports call `this.bindings.exit/kill/hrtime`). The three import closures are arrow functions created in the constructor, so `this` inside them is the WASI instance.
- The only documented use of these methods (cowasm snapshots the state with `getState()`, installs a copy whose `bindings.exit` records the exit code, runs the program, then restores the snapshot with `setState()`) depends on `proc_exit` seeing the bindings installed by `setState()`, which is why the closures are switched over as well.
- `bindings.fs` and `bindings.path` are still read at construction time, as upstream also does. (`fs` being a module level variable shared by every instance is a separate, pre-existing problem and is not changed here.)
- Verified with `test/js/bun/wasm/wasi.test.js`: three new tests (`getState()` shape with default and custom bindings, `getState()` to `setState()` round trip between two instances, `proc_exit`/`proc_raise` calling the bindings installed by `setState()`). On main all three fail with the ReferenceError (one inside `getState()`, one inside `setState()`); with the fix the file passes 8/8.
- `oxlint --config=oxlint.json src/js/node/wasi.ts` reports nothing.

### Background
- Bun's `node:wasi` is the wasi-js package inlined into `src/js/node/wasi.ts`. `getState()`, `setState()` and the `bindings` constructor option are wasi-js APIs; Node's `WASI` class has none of them, so there is no Node behavior to match.
- `bindings` is wasi-js's host interface object (`fs`, `path`, `hrtime`, `exit`, `kill`, `isTTY`, `randomFillSync`). Bun fills it with the node modules by default; callers can pass their own via `new WASI({ bindings })`.
- `wasiImport` is the object of host functions the wasm module imports as `wasi_snapshot_preview1`. It is built in the constructor; `proc_exit` and `proc_raise` forward to `bindings.exit` and `bindings.kill`.
