### PR TITLE
bun-types: fix the family emoji width in the stringWidth example

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -585,7 +585,8 @@ declare module "bun" {
    * import { stringWidth } from "bun";
    *
    * console.log(stringWidth("abc")); // 3
-   * console.log(stringWidth("👩‍👩‍👧‍👦")); // 1
+   * console.log(stringWidth("👩‍👩‍👧‍👦")); // 2
+   * console.log(stringWidth("👩‍👩‍👧‍👦", { perCodePoint: true })); // 8
    * console.log(stringWidth("\u001b[31mhello\u001b[39m")); // 5
    * console.log(stringWidth("\u001b[31mhello\u001b[39m", { countAnsiEscapeCodes: false })); // 5
    * console.log(stringWidth("\u001b[31mhello\u001b[39m", { countAnsiEscapeCodes: true })); // 13

--- a/test/js/bun/util/stringWidth.test.ts
+++ b/test/js/bun/util/stringWidth.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { bunRun, tempDir } from "harness";
+import { join } from "node:path";
 import npmStringWidth from "string-width";
 
 expect.extend({
@@ -149,6 +151,26 @@ for (let matcher of ["toMatchNPMStringWidth", "toMatchNPMStringWidthExcludeANSI"
     expect("👨‍❤️‍💋‍👨")[matcher]();
   });
 }
+
+// The @example on `stringWidth` in bun.d.ts is what editors show on hover. It
+// kept claiming a family ZWJ sequence measures 1 after grapheme clustering made
+// it 2, so run the example and compare what it prints with what its comments say.
+test("bun.d.ts @example for stringWidth prints the widths its comments claim", async () => {
+  const dts = await Bun.file(join(import.meta.dir, "../../../../packages/bun-types/bun.d.ts")).text();
+  const declaration = dts.indexOf("\n  function stringWidth(");
+  const jsdoc = dts.slice(dts.lastIndexOf("/**", declaration), declaration);
+  const example = /```ts\n([\s\S]*?)```/.exec(jsdoc)![1].replace(/^[ \t]*\* ?/gm, "");
+  const claims = example.split("\n").filter(line => line.startsWith("console.log("));
+  expect(claims).not.toBeEmpty();
+
+  await using dir = tempDir("stringwidth-dts-example", { "example.ts": example });
+  const result = await bunRun(join(dir, "example.ts"));
+  expect(result).toSpawn();
+
+  const printed = result.stdout.split("\n");
+  expect(printed).toHaveLength(claims.length);
+  expect(claims.map((line, i) => line.replace(/ \/\/ .*$/, ` // ${printed[i]}`))).toEqual(claims);
+});
 
 // ============================================================================
 // Extended tests for stringWidth edge cases


### PR DESCRIPTION
### Problem
- The `@example` on `Bun.stringWidth` in `packages/bun-types/bun.d.ts` (line 588 on main) reads `console.log(stringWidth("👩‍👩‍👧‍👦")); // 1`.
- The runtime prints `2`, on the 1.4.0 release and on a debug build of main.
- The value dates from the original `stringWidth` commit (5147c0ba737, 2024) and was never updated when the implementation moved to grapheme clusters. The `perCodePoint` docs a few lines above it already say a family sequence measures 2 by default, so the file contradicted itself.

### Fix
- Change the example to `// 2`, and add the same string measured with `{ perCodePoint: true }` (`// 8`) on the next line, so the reader sees why a four-emoji sequence is 2 columns and how to get the per-code-point figure.
- `2` is the correct value to document: the runtime returns it, `test/js/bun/util/stringWidth.test.ts` already pins it (`"👩‍👩‍👧‍👦"` is 2, line 1251 on main), the `string-width` npm package the JSDoc says this API matches returns 2 as well (checked against `string-width@7.0.0`), and the `perCodePoint` docs in the same file describe it that way. `8` is what the runtime returns with `perCodePoint: true` (four emoji at 2 columns each, ZWJs at 0), matching that option's own docs.
- New test, `test/js/bun/util/stringWidth.test.ts` ("bun.d.ts @example for stringWidth prints the widths its comments claim"): extracts the example block from `bun.d.ts`, runs it, and compares what it prints with the `// N` comments. Fails on main on the `// 1` line, passes with this change, and covers every value in the example rather than just the family emoji, so a future width change has to update the example too.
- `bun bd test test/js/bun/util/stringWidth.test.ts`: 174 pass (173 pass, 1 fail with `packages/` stashed).
- `bun test test/integration/bun-types/bun-types.test.ts`: 15 pass.

### Background
- `Bun.stringWidth` returns the number of terminal columns a string occupies. By default it measures grapheme clusters: a user-perceived character such as an emoji joined out of several code points with U+200D ZERO WIDTH JOINER counts once, and emoji are 2 columns wide, so the family sequence is 2.
- `perCodePoint: true` switches to the algorithm Node uses for `util.inspect` and `console.table` alignment, which measures each code point separately: the four emoji in the family sequence are 2 columns each and the three joiners are 0, hence 8.
- `docs/runtime/utils.mdx` does not contain this example; its `stringWidth` values were checked and are correct, so only the `.d.ts` changes here.

<details>
<summary>Runtime check</summary>

```
$ bun -e 'console.log(Bun.stringWidth("👩‍👩‍👧‍👦"), Bun.stringWidth("👩‍👩‍👧‍👦", { perCodePoint: true }))'
2 8
```

Failure output of the new test on main:

```
  [
    "console.log(stringWidth("abc")); // 3",
-   "console.log(stringWidth("👩‍👩‍👧‍👦")); // 1",
+   "console.log(stringWidth("👩‍👩‍👧‍👦")); // 2",
    "console.log(stringWidth("\u001b[31mhello\u001b[39m")); // 5",
    ...
  ]
```
</details>
