### PR TITLE
docs: update the Bun.unsafe.mimallocDump() sample output for mimalloc 3

### DIFF
--- a/docs/project/benchmarking.mdx
+++ b/docs/project/benchmarking.mdx
@@ -187,32 +187,47 @@ Once imported, you should see something like this:
 
 ### Native heap stats
 
-Bun uses mimalloc for the other heap. To print a summary of non-JavaScript memory usage, call `Bun.unsafe.mimallocDump()`.
+Bun uses mimalloc for the other heap. To print a summary of non-JavaScript memory usage to stderr, call `Bun.unsafe.mimallocDump()`.
 
 ```ts
 Bun.unsafe.mimallocDump();
 ```
 
 ```txt
-heap stats:    peak      total      freed    current       unit      count
-  reserved:   64.0 MiB   64.0 MiB      0       64.0 MiB                        not all freed!
- committed:   64.0 MiB   64.0 MiB      0       64.0 MiB                        not all freed!
-     reset:      0          0          0          0                            ok
-   touched:  128.5 KiB  128.5 KiB    5.4 MiB   -5.3 MiB                        ok
-  segments:      1          1          0          1                            not all freed!
--abandoned:      0          0          0          0                            ok
-   -cached:      0          0          0          0                            ok
-     pages:      0          0         53        -53                            ok
--abandoned:      0          0          0          0                            ok
- -extended:      0
- -noretire:      0
-     mmaps:      0
-   commits:      0
-   threads:      0          0          0          0                            ok
-  searches:     0.0 avg
-numa nodes:       1
-   elapsed:       0.068 s
-   process: user: 0.061 s, system: 0.014 s, faults: 0, rss: 57.4 MiB, commit: 64.0 MiB
+subproc 0
+ pages           peak       total     current       block      total#
+  touched   :     0           0           0                                ok
+  pages     :    48          60          48
+  abandoned :     1           1           1
+  reclaima  :     0
+  reclaimf  :     0
+  reabandon :     0
+  waits     :     0
+  extended  :     0
+  retire    :     0
+  searches  :     0.7 avg
+
+ arenas          peak       total     current       block      total#
+  reserved  :     1.0 GiB     1.0 GiB     1.0 GiB
+  committed :    38.8 MiB    38.8 MiB    38.8 MiB
+  reset     :     0
+  purged    :     0
+  arenas    :     2
+  rollback  :     0
+  mmaps     :     5
+  commits   :     3
+  resets    :     0
+  purges    :     0
+  guarded   :     0
+  theaps    :     9           9           8
+  heaps     :     4           5           4
+  heap waits:     0
+
+ process         peak       total     current       block      total#
+  threads   :     8           8           8
+  numa nodes:     2
+  elapsed   :     0.006 s
+  process   : user: 0.003 s, system: 0.005 s, faults: 0, peak rss: 26.2 MiB, peak commit: 38.8 MiB
 ```
 
 ## CPU profiling


### PR DESCRIPTION
### Problem

- The "Native heap stats" section of `docs/project/benchmarking.mdx` tells readers to call `Bun.unsafe.mimallocDump()`, but the sample output under it is mimalloc v2's format: a `heap stats:` header with `peak/total/freed/current/unit/count` columns and `segments`, `-abandoned`, `-cached`, `not all freed!` rows.
- #33706 rewrote the prose from `MIMALLOC_SHOW_STATS=1` to `Bun.unsafe.mimallocDump()` and left the old sample block behind.
- Bun ships mimalloc v3 (main pins 3.5.0 in `scripts/build/deps/mimalloc.ts`). Its `mi_stats_print_out` prints a `subproc 0` line followed by `pages`, `arenas` and `process` sections with `peak/total/current/block/total#` columns; the v2 `segments` rows are commented out in v3's `_mi_stats_print` (`vendor/mimalloc/src/stats.c`). Nothing in the documented sample matches what the function prints.
- The prose also does not say where the output goes. `dump_mimalloc` in `src/runtime/api/UnsafeObject.rs` writes it to stderr, which matters to anyone capturing stdout.

### Fix

- Replace the sample block with the stderr of `Bun.unsafe.mimallocDump()` captured from a release build, verbatim except for trailing whitespace and the trailing blank line.
- Say in the prose that the summary goes to stderr.
- This is correct because the block claims to show what the function prints, and this is what it prints. The layout comes from `_mi_stats_print` and `mi_print_header` in mimalloc's `stats.c`, which are identical between the pin the sample was captured with (3.4.3) and the pin on main (3.5.0); the numbers are sample data from one run, as in the old block.
- Docs only: no runtime or type change, so no test.

Verification:

- The block in the diff is byte-identical to the captured output after stripping trailing whitespace.
- A debug build of this branch (mimalloc 3.5.0) prints the same `subproc 0` line and the same `pages` / `arenas` / `process` sections with the same row labels in the same order (compared mechanically), plus a `blocks` table that only debug builds have.
- Both builds write the stats to stderr and nothing to stdout.
- `prettier --check docs/project/benchmarking.mdx` passes.

### Background

- `Bun.unsafe.mimallocDump()` calls mimalloc's `mi_stats_print_out`, which formats the statistics of Bun's native heap (everything that is not the JavaScriptCore heap) and passes the text to a callback. Bun's callback writes to stderr.
- mimalloc v2 managed memory in thread-local segments, which is where the `segments` rows in the old sample came from. v3 removed segments; its statistics are grouped by pages (the per-size-class blocks of memory allocations are carved from) and arenas (the large OS reservations pages come from), hence the `pages` and `arenas` sections.
- `theaps` are v3's thread-local heaps. `subproc 0` is the sub-process: mimalloc's container for all process-wide state, of which Bun has one, so the dump always starts with that line.
- `MI_STAT` is mimalloc's compile-time statistics level. Bun's build leaves it at the default, which is 0 in release builds (the sections shown in the docs) and 2 in debug builds (additionally a per-size-class `blocks` table).

<details>
<summary>Output of the debug build of this branch, for comparison with the documented release output</summary>

```
subproc 0
 blocks          peak       total     current       block      total#
  (per-size-class rows, debug builds only)
  malloc req:               154.9 KiB

 pages           peak       total     current       block      total#
  touched   :   217.6 KiB   217.6 KiB   217.6 KiB
  pages     :    11          13           2
  abandoned :     0           0           0
  reclaima  :     0
  reclaimf  :     0
  reabandon :     0
  waits     :     0
  extended  :    14
  retire    :     8
  searches  :     0.0 avg

 arenas          peak       total     current       block      total#
  reserved  :     1.0 GiB     1.0 GiB     1.0 GiB
  committed :     6.9 MiB     6.9 MiB     6.9 MiB
  reset     :     0
  purged    :     0
  arenas    :     1
  rollback  :     0
  mmaps     :     3
  commits   :     3
  resets    :     0
  purges    :     0
  guarded   :     0
  theaps    :     2           2           1
  heaps     :     3           4           3
  heap waits:     0

 process         peak       total     current       block      total#
  threads   :     1           1           1
  numa nodes:     1
  elapsed   :     0.371 s
  process   : user: 0.303 s, system: 0.117 s, faults: 0, peak rss: 316.6 MiB, peak commit: 6.9 MiB
```

</details>
