### PR TITLE
install: stop panicking when the cache directory setting does not fit the path buffer

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -332,11 +332,14 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
             // encapsulates the BackRef deref + singleton-liveness invariant.
             let env = unsafe { &*this }.env_mut();
             // SAFETY: shared read of `options`; disjoint from `cache_directory_path`.
-            let cache_dir = fetch_cache_directory_path(env, Some(unsafe { &(*this).options }));
-            // SAFETY: see fn safety contract.
-            unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
+            let opened = fetch_cache_directory_path(env, Some(unsafe { &(*this).options }))
+                .and_then(|cache_dir| {
+                    // SAFETY: see fn safety contract.
+                    unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
+                    Dir::cwd().make_open_path(&cache_dir.path, Default::default())
+                });
 
-            match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+            match opened {
                 Ok(d) => return d,
                 Err(_) => {
                     // SAFETY: narrow `&mut enable` projection; disjoint from
@@ -375,46 +378,35 @@ pub struct CacheDir {
     pub path: Vec<u8>,
 }
 
-pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
-    if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
-        return CacheDir {
-            path: FileSystem::instance().abs(&[dir]).to_vec(),
-        };
-    }
+/// Fails with `ENAMETOOLONG` when the configured directory (user-controlled, so
+/// possibly longer than any path the OS accepts) does not fit a `PathBuffer`.
+pub fn fetch_cache_directory_path(
+    env: &mut DotEnvLoader,
+    options: Option<&Options>,
+) -> sys::Maybe<CacheDir> {
+    let parts: &[&[u8]] = if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
+        &[dir]
+    } else if let Some(dir) = options
+        .map(|opts| opts.cache_directory)
+        .filter(|dir| !dir.is_empty())
+    {
+        &[dir]
+    } else if let Some(dir) = env.get(b"BUN_INSTALL") {
+        &[dir, b"install/", b"cache/"]
+    } else if let Some(dir) = env_var::XDG_CACHE_HOME
+        .get()
+        .or_else(|| env_var::HOME.get())
+    {
+        &[dir, b".bun/", b"install/", b"cache/"]
+    } else {
+        &[b"node_modules/.bun-cache"]
+    };
 
-    if let Some(opts) = options {
-        if !opts.cache_directory.is_empty() {
-            return CacheDir {
-                path: FileSystem::instance().abs(&[opts.cache_directory]).to_vec(),
-            };
-        }
-    }
-
-    if let Some(dir) = env.get(b"BUN_INSTALL") {
-        let parts: [&[u8]; 3] = [dir, b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
-        let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    if let Some(dir) = env_var::HOME.get() {
-        let parts: [&[u8]; 4] = [dir, b".bun/", b"install/", b"cache/"];
-        return CacheDir {
-            path: FileSystem::instance().abs(&parts).to_vec(),
-        };
-    }
-
-    let fallback_parts: [&[u8]; 1] = [b"node_modules/.bun-cache"];
-    CacheDir {
-        path: FileSystem::instance().abs(&fallback_parts).to_vec(),
-    }
+    let mut buf = path::path_buffer_pool::get();
+    let Some(abs) = FileSystem::instance().abs_buf_checked(parts, &mut buf[..]) else {
+        return Err(sys::Error::from_code(sys::E::ENAMETOOLONG, sys::Tag::open).with_path(parts[0]));
+    };
+    Ok(CacheDir { path: abs.to_vec() })
 }
 
 // ─────────────────────── cached folder name printers ──────────────────────────

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -374,9 +374,12 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
 
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
-                let cache_dir = fetch_cache_directory_path(&mut process_env, None);
+                let opened =
+                    fetch_cache_directory_path(&mut process_env, None).and_then(|cache_dir| {
+                        Dir::cwd().make_open_path(&cache_dir.path, Default::default())
+                    });
                 let mut rm_buf = PathBuffer::uninit();
-                let rm_dir = match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
+                let rm_dir = match opened {
                     Ok(d) => d,
                     Err(err) => {
                         bun_core::pretty_errorln!(

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunEnv as env, isWindows, readdirSorted, tempDir, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
 import {
@@ -935,4 +935,133 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stdout).toInclude("Cleared 'bun install' cache");
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
+});
+
+// The cache directory setting (the first one set of $BUN_INSTALL_CACHE_DIR, --cache-dir,
+// $BUN_INSTALL/install/cache, $XDG_CACHE_HOME/.bun/install/cache, $HOME/.bun/install/cache) is
+// joined into a path buffer of MAX_PATH_BYTES: 4096 bytes on Linux, 1024 on macOS. A value that
+// does not fit is unusable in the same way as a directory the OS refuses to create, and bun falls
+// back to node_modules/.cache of the project like it does for those. On Windows the buffer holds
+// more than an environment variable or argument can carry.
+describe.concurrent.skipIf(isWindows)("cache directory setting longer than the path buffer", () => {
+  // Longer than the buffer on every POSIX platform (the Linux one is the largest).
+  const tooLong = "/" + Buffer.alloc(2 * 4096, "a").toString();
+
+  const project = {
+    "package.json": JSON.stringify({ name: "pm-cache-too-long", version: "1.0.0" }),
+    // $XDG_CONFIG_HOME stands in for $HOME when bun looks for .npmrc and .bunfig.toml, so the
+    // oversized $HOME below is only ever used as a cache directory candidate.
+    "config/.npmrc": "",
+  };
+
+  // Every lower precedence setting points at a usable directory: the fallback must be
+  // node_modules/.cache, not the next candidate.
+  function cacheEnv(dir: string, setting: Record<string, string>): NodeJS.Dict<string> {
+    const spawnEnv: NodeJS.Dict<string> = {
+      ...env,
+      HOME: join(dir, "home"),
+      XDG_CONFIG_HOME: join(dir, "config"),
+    };
+    delete spawnEnv.BUN_INSTALL_CACHE_DIR;
+    delete spawnEnv.BUN_INSTALL;
+    delete spawnEnv.XDG_CACHE_HOME;
+    return { ...spawnEnv, ...setting };
+  }
+
+  async function runPm(dir: string, args: string[], setting: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", ...args],
+      cwd: dir,
+      env: cacheEnv(dir, setting),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.each(["BUN_INSTALL_CACHE_DIR", "BUN_INSTALL", "XDG_CACHE_HOME", "HOME"])(
+    "bun pm cache falls back to node_modules/.cache when $%s does not fit",
+    async name => {
+      using dir = tempDir("pm-cache-too-long", project);
+
+      const { stdout, stderr, exitCode } = await runPm(String(dir), ["cache"], { [name]: tooLong });
+
+      expect(stderr).toBe("");
+      expect(stdout).toBe(join(String(dir), "node_modules", ".cache"));
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test("bun pm cache falls back to node_modules/.cache when --cache-dir does not fit", async () => {
+    using dir = tempDir("pm-cache-too-long-flag", project);
+
+    const { stdout, stderr, exitCode } = await runPm(String(dir), ["--cache-dir", tooLong, "cache"], {});
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe(join(String(dir), "node_modules", ".cache"));
+    expect(exitCode).toBe(0);
+  });
+
+  // A directory that fits the buffer but that the OS rejects (one name longer than NAME_MAX) has
+  // always been handled this way; the oversized values above take the same route.
+  test("bun pm cache falls back to node_modules/.cache when the OS rejects the directory", async () => {
+    using dir = tempDir("pm-cache-os-rejects", project);
+    const tooLongForTheOS = join(String(dir), Buffer.alloc(300, "a").toString());
+
+    const { stdout, stderr, exitCode } = await runPm(String(dir), ["cache"], {
+      BUN_INSTALL_CACHE_DIR: tooLongForTheOS,
+    });
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe(join(String(dir), "node_modules", ".cache"));
+    expect(exitCode).toBe(0);
+  });
+
+  // What has to fit the buffer is the normalized directory, not the value as written.
+  test("bun pm cache uses a directory that only fits the path buffer once normalized", async () => {
+    using dir = tempDir("pm-cache-long-normalized", project);
+    const cacheDir = `${String(dir)}/${Buffer.alloc("x/../".length * 2000, "x/../").toString()}cache`;
+
+    const { stdout, stderr, exitCode } = await runPm(String(dir), ["cache"], { BUN_INSTALL_CACHE_DIR: cacheDir });
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe(join(String(dir), "cache"));
+    expect(exitCode).toBe(0);
+  });
+
+  // `bun pm cache rm` has no fallback: it reports the directory it could not open.
+  test("bun pm cache rm reports ENAMETOOLONG when $BUN_INSTALL_CACHE_DIR does not fit", async () => {
+    using dir = tempDir("pm-cache-rm-too-long", project);
+
+    const { stdout, stderr, exitCode } = await runPm(String(dir), ["cache", "rm"], { BUN_INSTALL_CACHE_DIR: tooLong });
+
+    expect(stderr).toContain("ENAMETOOLONG getting cache directory");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+    expect(await exists(join(String(dir), "node_modules"))).toBeFalse();
+  });
+
+  test("bun install falls back to node_modules/.cache when $BUN_INSTALL_CACHE_DIR does not fit", async () => {
+    using dir = tempDir("pm-cache-too-long-install", {
+      ...project,
+      "package.json": JSON.stringify({ name: "pm-cache-too-long", dependencies: { moo: "./moo" } }),
+      "moo/package.json": JSON.stringify({ name: "moo", version: "0.1.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: cacheEnv(String(dir), { BUN_INSTALL_CACHE_DIR: tooLong }),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+    expect(await exists(join(String(dir), "node_modules", "moo", "package.json"))).toBeTrue();
+    expect(await exists(join(String(dir), "node_modules", ".cache"))).toBeTrue();
+  });
 });


### PR DESCRIPTION
### Problem

- `bun pm cache` aborts when the cache directory setting is longer than about 4 KB:

  ```
  $ BUN_INSTALL_CACHE_DIR="/$(head -c 5000 /dev/zero | tr '\0' a)" bun pm cache
  panic: range end index 5000 out of range for slice of length 4095
  ```

  exit 134. Same for `--cache-dir`, `[install.cache] dir` in bunfig.toml, `$BUN_INSTALL`, `$XDG_CACHE_HOME` and `$HOME` (the first one set wins), for `bun pm cache rm`, and for `bun install` in any project that has at least one dependency, since that opens the cache directory too (`install_with_manager.rs:1605`). Reproduced on the 1.4.0 canary and on main.
- Cause: `fetch_cache_directory_path` (`src/install/PackageManager/PackageManagerDirectories.rs:378-418`) builds every candidate with `FileSystem::abs` (`src/resolver/lib.rs:369`), which is `join_abs_string` into the thread local `PARSER_JOIN_INPUT_BUFFER`, a fixed `[u8; 4096]` on every platform (`src/paths/resolve_path.rs:15`, `:1378`). The normalizer has no bounds check on its output buffer (`resolve_path.rs:1071`), so a value that does not fit panics. The value is taken from the environment, the command line or a config file, so this should be an error, not a crash.
- A directory that fits the buffer but that the OS rejects (for example one whose name is longer than NAME_MAX, or one under a regular file) already has defined behavior today: installs and `bun pm cache` silently use `node_modules/.cache` of the project (`ensure_cache_directory`, `PackageManagerDirectories.rs:339-348`), and `bun pm cache rm` prints `<errno> getting cache directory` and exits 1 (`package_manager_command.rs:379-388`).

### Fix

- `fetch_cache_directory_path` picks the candidate's parts as before and joins them once with `FileSystem::abs_buf_checked` into a pooled `PathBuffer`. It now returns `Maybe<CacheDir>`; when the normalized path does not fit it returns `ENAMETOOLONG`.
- Both callers chain the join with the `make_open_path` they already did, so an oversized value takes exactly the route a directory the OS rejects takes: `ensure_cache_directory` disables the cache and uses `node_modules/.cache`, `bun pm cache rm` prints `ENAMETOOLONG getting cache directory` and exits 1.
- Why this is the right answer: a path that does not fit `MAX_PATH_BYTES` cannot be opened or created anyway. `openat_a` (`src/sys/lib.rs:6334`) returns `ENAMETOOLONG` for it before the syscall, and the OS would return the same. Reporting it from the join is the same result one step earlier, and the callers' existing handling of that result is what the fix reuses. In particular the value is not silently replaced by the next candidate (an unusable `$BUN_INSTALL_CACHE_DIR` does not make bun use `$BUN_INSTALL/install/cache`), which is also how the OS-rejected case behaves today; the tests pin this by giving every lower precedence setting a usable directory.
- The check is on the normalized path, so a value that is long as written but normalizes to something short (`x/../x/../.../cache`) keeps working as it does today.
- Before: the limit was the 4096 byte join buffer on every platform. After: `MAX_PATH_BYTES` (4096 on Linux, 1024 on macOS, more than an environment variable can hold on Windows), which is the OS limit the path is checked against anyway.
- Verified with `test/cli/install/bun-pm.test.ts`, new `describe` block `cache directory setting longer than the path buffer` (POSIX only: on Windows the buffer is larger than any value that can be passed in): `bun pm cache` with an 8 KiB `$BUN_INSTALL_CACHE_DIR`, `$BUN_INSTALL`, `$XDG_CACHE_HOME`, `$HOME` and `--cache-dir` prints `node_modules/.cache`, `bun pm cache rm` prints `ENAMETOOLONG getting cache directory` and exits 1, `bun install` with a folder dependency installs it using `node_modules/.cache`; two guards that pass before and after pin the OS-rejected case and the normalizes-short case.
  - `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-pm.test.ts -t "longer than the path buffer"`: 7 fail with the panic above, the 2 guards pass
  - `bun bd test test/cli/install/bun-pm.test.ts`: 27 pass
  - `bun bd test test/cli/install/npmrc.test.ts` (also exercises `bun pm cache`): 31 pass
  - `cargo check -p bun_install -p bun_runtime`, `cargo fmt`

Related: #38372 and #38370 fix the `$HOME` / `$XDG_CONFIG_HOME` joins for `.npmrc` and `bunfig.toml`, which an oversized `$HOME` reaches before this code; the `$HOME` test here sets `XDG_CONFIG_HOME` so it exercises this function regardless of those. #35863 changes the shared join primitive to return an empty path on overflow; this call site reports `ENAMETOOLONG` with or without it. `open_global_dir` / `open_global_bin_dir` in `PackageManagerOptions.rs` have the same unchecked joins for `-g` commands and are left to a separate change.

### Background

- `PathBuffer` is a `[u8; MAX_PATH_BYTES]` (`MAX_PATH_BYTES` = the platform's `PATH_MAX`: 4096 on Linux, 1024 on macOS, 32767 * 3 + 1 on Windows). Every path syscall wrapper in `bun_sys` copies the path into one and fails with `ENAMETOOLONG` when it does not fit, so a path longer than that can never reach the OS. `path_buffer_pool::get()` hands out a pooled one instead of putting it on the stack.
- `join_abs_string` / `FileSystem::abs` resolve `parts` against the project directory (like `path.resolve`) into a fixed thread local buffer with no overflow check; `join_abs_string_buf_checked` / `FileSystem::abs_buf_checked` do the same into a caller supplied buffer and return `None` when the normalized result does not fit. The checked variant is what the other fixes of this kind use (#37531).
- The cache directory is opened lazily by `ensure_cache_directory`. If the configured directory cannot be opened or created, it turns the `Enable::CACHE` flag off and uses `node_modules/.cache` inside the project instead; `bun pm cache` prints whichever directory ended up being opened. `bun pm cache rm` resolves the directory itself from the process environment and has no fallback.
