### PR TITLE
bundler: log the resolve error for an entry point too long for a path buffer

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -459,14 +459,6 @@ impl<'a> Transpiler<'a> {
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
         match self._resolve_entry_point(entry_point) {
             Ok(r) => Ok(r),
-            // Nothing that long names a directory whose cache could be stale
-            // (and the join below has a PathBuffer to fit `top_level_dir/entry/..` in).
-            Err(err)
-                if self.fs().top_level_dir.len() + entry_point.len() + 4
-                    > bun_paths::MAX_PATH_BYTES =>
-            {
-                Err(err)
-            }
             Err(err) => {
                 let mut cache_bust_buf = bun_paths::PathBuffer::uninit();
 
@@ -477,6 +469,14 @@ impl<'a> Transpiler<'a> {
                 // disjoint mutable borrows of `cache_bust_buf` across `break`,
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
+                    // Nothing that long names a directory whose cache could be
+                    // stale (and neither buster name below would fit
+                    // `cache_bust_buf`).
+                    if self.fs().top_level_dir.len() + entry_point.len() + 4
+                        > bun_paths::MAX_PATH_BYTES
+                    {
+                        break 'name false;
+                    }
                     if bun_paths::is_absolute(entry_point) {
                         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
                             entry_point,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -214,6 +214,42 @@ describe("Bun.build", () => {
     }
   });
 
+  test("an entry point too long for a path buffer is reported like any other missing one", async () => {
+    // Resolving it failed without logging anything, so the build went on
+    // with the entry point silently dropped: a successful build when another
+    // entry point was given, a crash in the linker when it was the only one.
+    // Runs in a child so the crash shows up as a failed assertion.
+    using dir = tempDir("build-api-long-entrypoint", { "valid.js": "console.log(1);" });
+    const fixture = /* ts */ `
+      // Longer than the path buffer on every platform, Windows included.
+      const long = Buffer.alloc(100_000, "a").toString();
+      const report = async (entrypoints: string[]) => {
+        const { success, outputs, logs } = await Bun.build({ entrypoints, throw: false });
+        return { success, outputs: outputs.length, logs: logs.map(log => [log.name, log.message]) };
+      };
+      console.log(JSON.stringify({
+        alone: await report([long]),
+        withValidEntryPoint: await report(["./valid.js", long]),
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const notFound = {
+      success: false,
+      outputs: 0,
+      logs: [["BuildMessage", `ModuleNotFound resolving "${Buffer.alloc(100_000, "a").toString()}" (entry point)`]],
+    };
+    expect(JSON.parse(stdout)).toEqual({ alone: notFound, withValidEntryPoint: notFound });
+    expect(exitCode).toBe(0);
+  });
+
   test("returns output files", async () => {
     Bun.gc(true);
     const build = await Bun.build({

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -369,6 +369,15 @@ describe("web worker", () => {
       expect(err.message).toBe("5");
       expect(err.error).toBe(null);
     });
+
+    test("names the entry point when its path is too long for a path buffer", async () => {
+      // Resolving it failed without logging anything, so the event carried
+      // "BuildMessage: undefined". Longer than the buffer on every platform.
+      const specifier = "./" + Buffer.alloc(100_000, "w").toString();
+      const worker = new Worker(specifier);
+      const [err] = await once(worker, "error");
+      expect(err.message).toBe(`BuildMessage: ModuleNotFound resolving "${specifier}" (entry point)`);
+    });
   });
 
   describe("terminate() races and lifecycle edges", () => {


### PR DESCRIPTION
### Problem
- `Bun.build({ entrypoints: [name] })` where `cwd/name` does not fit a path buffer (4096 bytes on Linux, 1024 on macOS) aborts the process instead of failing the build: `panic: index out of bounds: the len is 0 but the index is 0` (release) / `assertion failed: chunks.len() > 0` in `generateChunksInParallel.rs` (debug).
- With a second, valid entry point, `Bun.build({ entrypoints: ["./valid.js", name] })` instead succeeds: one output, no logs, the long entry point silently dropped.
- `new Worker(name)` with such a path fires its error event with `BuildMessage: undefined` (the "Worker prints error: undefined" face from the path-length census).
- Cause: `Transpiler::resolve_entry_point` (`src/bundler/transpiler.rs`) is documented as logging the resolve error before returning it, and all of its callers rely on that (`enqueue_entry_points_normal` in `bundle_v2.rs` just `continue`s on `Err`; the Worker code turns the log into the event's message). The guard added for paths too long to build the cache-buster name in a `PathBuffer` returned `Err` from a match arm ahead of the logging, so for those paths nothing was logged: the bundle went on with zero entry points, and the Worker converted an empty log.

### Fix
- The length guard now only skips the directory-cache bust (the part that needs the buffer) and falls through to the existing logging, so an over-long entry point is reported exactly like any other missing one: `ModuleNotFound resolving "<name>" (entry point)`. Entry points that fit take the same path as before.
- Verified:
  - `test/bundler/bun-build-api.test.ts`, "an entry point too long for a path buffer is reported like any other missing one": a child bun builds a 100000-byte entry point (longer than the buffer on Windows too) alone and next to a valid one; both must fail with that one message and no outputs.
  - `test/js/web/workers/worker.test.ts`, "names the entry point when its path is too long for a path buffer": the error event's message must name the entry point.
  - `USE_SYSTEM_BUN=1`: the build test fails (child aborts with the panic above; the two-entry-point case on its own reports `success: true`, 1 output), the worker test fails with `Received: "BuildMessage: undefined"`. `bun bd test` on this branch: both pass; the full `bun-build-api.test.ts` and `plugins.test.ts` files pass too. Three unrelated `terminate()` tests in `worker.test.ts` fail identically on an unmodified main debug build in this container (release passes them).
- The narrow window where `cwd/name` is within a few bytes of the buffer still reaches the unchecked `load_as_file` write in the resolver; that is #35857's site and is not touched here.

### Background
- `Bun.build` resolves each entry point up front with `resolve_entry_point`; on failure it retries once after invalidating the resolver's cache of the entry point's directory (so a file created moments ago is found), then logs the error. The bundle runs to the linker regardless and fails at the end if the log has errors, which is why a failure that was not logged turns into a build with no entry points at all.
- The cache-buster name is built in a stack `PathBuffer` (`[u8; MAX_PATH_BYTES]`) with unchecked joins, hence the guard: a path that long cannot name a directory that exists, so there is nothing to invalidate.
- A `Worker`'s entry point is resolved by the same function; the worker turns whatever the resolver logged into the `error` event's message.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->