### PR TITLE
paths: heap-backed relative_alloc and join_abs_string_buf_spill; use them in _nodeModulePaths and the runtime linker

### DIFF
--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -570,6 +570,8 @@ impl Linker {
         origin: &URL<'_>,
         import_path_format: ImportPathFormat,
     ) -> crate::Result<PFs::Path<'static>> {
+        // `source_path` may come straight from an `onResolve` plugin, so it is
+        // not bounded by a path buffer the way the thread-local `relative` requires.
         match import_path_format {
             ImportPathFormat::AbsolutePath => {
                 if namespace == b"node" {
@@ -577,20 +579,19 @@ impl Linker {
                 }
 
                 if namespace == b"bun" || namespace == b"file" || namespace.is_empty() {
-                    // `linker.fs.relative` is a thin wrapper over
-                    // `bun.path.relative`; the inline `bun_resolver::fs`
-                    // module doesn't expose it yet, so call the path layer
-                    // directly. The threadlocal-buffer result must be
-                    // dup'd to outlive this call.
-                    let relative_name =
-                        dupe(bun_paths::resolve_path::relative(source_dir, source_path));
+                    let relative_name = dupe(&bun_paths::resolve_path::relative_alloc(
+                        source_dir,
+                        source_path,
+                    )?);
                     Ok(PFs::Path::init_with_pretty(source_path, relative_name))
                 } else {
                     Ok(PFs::Path::init_with_namespace(source_path, namespace))
                 }
             }
             ImportPathFormat::Relative => {
-                let relative_name = bun_paths::resolve_path::relative(source_dir, source_path);
+                let relative_path =
+                    bun_paths::resolve_path::relative_alloc(source_dir, source_path)?;
+                let relative_name: &[u8] = &relative_path;
 
                 let text: &'static [u8];
                 let pretty: &'static [u8];
@@ -645,8 +646,9 @@ impl Linker {
                     }
 
                     let top_level_dir = self.fs().top_level_dir;
-                    let mut base: &[u8] =
-                        bun_paths::resolve_path::relative(top_level_dir, source_path);
+                    let relative_path =
+                        bun_paths::resolve_path::relative_alloc(top_level_dir, source_path)?;
+                    let mut base: &[u8] = &relative_path;
                     if let Some(dot) = strings::last_index_of_char(base, b'.') {
                         base = &base[0..dot];
                     }

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -570,8 +570,7 @@ impl Linker {
         origin: &URL<'_>,
         import_path_format: ImportPathFormat,
     ) -> crate::Result<PFs::Path<'static>> {
-        // `source_path` may come straight from an `onResolve` plugin, so it is
-        // not bounded by a path buffer the way the thread-local `relative` requires.
+        // `source_path` may be an unbounded `onResolve` result: no thread-local `relative`.
         match import_path_format {
             ImportPathFormat::AbsolutePath => {
                 if namespace == b"node" {

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -48,8 +48,7 @@ extern "C" fn node_module_paths_js_value(
         sliced.slice()
     };
     let mut buf = bun_paths::path_buffer_pool::get();
-    // `in_str` is whatever JS passed to `Module._nodeModulePaths`; like Node,
-    // this is string manipulation and has no path-length limit.
+    // Like Node's `_nodeModulePaths`, pure string manipulation: no length limit.
     let mut spill = Vec::new();
 
     let mut full_path: &[u8] = resolve_path::join_abs_string_buf_spill::<bun_paths::platform::Auto>(

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -48,10 +48,14 @@ extern "C" fn node_module_paths_js_value(
         sliced.slice()
     };
     let mut buf = bun_paths::path_buffer_pool::get();
+    // `in_str` is whatever JS passed to `Module._nodeModulePaths`; like Node,
+    // this is string manipulation and has no path-length limit.
+    let mut spill = Vec::new();
 
-    let mut full_path: &[u8] = resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+    let mut full_path: &[u8] = resolve_path::join_abs_string_buf_spill::<bun_paths::platform::Auto>(
         bun_paths::fs::FileSystem::instance().top_level_dir(),
         &mut **buf,
+        &mut spill,
         &[base_path],
     );
     let root_index: usize = {

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -2936,7 +2936,9 @@ mod tests {
         while from.len() + 2 < MAX_PATH_BYTES {
             from.extend_from_slice(b"/d");
         }
-        let rel = relative_alloc(&from, b"/t").unwrap();
+        // Two bytes, not one: the Windows arm drops a one-byte root-level
+        // target (pre-existing), which would hide what this test is about.
+        let rel = relative_alloc(&from, b"/tt").unwrap();
 
         let components = from.len() / 2;
         let mut expected = Vec::new();
@@ -2947,7 +2949,7 @@ mod tests {
             expected.extend_from_slice(b"..");
         }
         expected.push(SEP);
-        expected.push(b't');
+        expected.extend_from_slice(b"tt");
         assert_eq!(&rel[..], &expected[..]);
         assert!(rel.len() > MAX_PATH_BYTES);
     }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1758,9 +1758,8 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     Some(&buf[..len])
 }
 
-/// [`join_abs_string_buf`] into `buf` when the result fits, otherwise into
-/// `spill` (grown as needed, untouched in the common case): the caller-buffer
-/// form of [`join_abs_string_spill`], cf. [`join_z_buf_spill`].
+/// Caller-buffer form of [`join_abs_string_spill`] (cf. [`join_z_buf_spill`]):
+/// into `buf` when the result fits, otherwise into `spill`, grown as needed.
 pub fn join_abs_string_buf_spill<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1699,14 +1699,6 @@ enum JoinScratch {
     Heap(Vec<u8>),
 }
 
-/// Bound on what `_join_abs_string_buf` writes, scratch or output: the
-/// concatenation, the separator Windows adds after a bare share root, and the
-/// byte normalizing can add (see [`normalize_string_spill`]).
-#[inline]
-fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
-    parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2
-}
-
 impl JoinScratch {
     #[inline]
     fn init(base: usize, parts: &[&[u8]]) -> Self {
@@ -1767,7 +1759,8 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
 }
 
 /// [`join_abs_string_buf`] into `buf` when the result fits, otherwise into
-/// `spill` (grown as needed, untouched in the common case); cf. [`join_z_buf_spill`].
+/// `spill` (grown as needed, untouched in the common case): the caller-buffer
+/// form of [`join_abs_string_spill`], cf. [`join_z_buf_spill`].
 pub fn join_abs_string_buf_spill<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1703,8 +1703,8 @@ enum JoinScratch {
 /// concatenation, the separator Windows adds after a bare share root, and the
 /// byte normalizing can add (see [`normalize_string_spill`]).
 #[inline]
-fn join_abs_needed(base: usize, parts: &[&[u8]]) -> usize {
-    parts.iter().map(|p| p.len() + 1).sum::<usize>() + base + 2
+fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
+    parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2
 }
 
 impl JoinScratch {

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -662,7 +662,72 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     // two `&mut` borrows below are disjoint.
     let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
     let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
+    relative_platform_in::<P, ALWAYS_COPY>(
+        &mut relative_from_buf[..],
+        &mut relative_to_buf[..],
+        buf,
+        from,
+        to,
+    )
+}
 
+/// Bytes [`relative_platform_in`] may write into a scratch buffer while
+/// normalizing `path`: the normalized path (one byte longer than the input at
+/// most, see [`normalize_string_spill`]) behind a leading separator, or, for a
+/// relative input, the path joined onto `top_level_dir` ([`JoinScratch::init`]'s
+/// bound). Each input is normalized into either scratch buffer, so both are
+/// sized to the larger input.
+fn relative_scratch_needed<P: PlatformT>(path: &[u8]) -> usize {
+    if P::P.is_absolute(path) {
+        path.len() + 2
+    } else {
+        Fs::FileSystem::instance().top_level_dir().len() + path.len() + 4
+    }
+}
+
+/// Bytes the result of [`relative_to_common_path`] can occupy when both
+/// normalized inputs fit in `scratch` bytes: every component of `from` (two
+/// bytes at least, separator included) becomes at most a three-byte `/..`,
+/// followed by one separator and the tail of `to`.
+fn relative_out_needed(scratch: usize) -> usize {
+    (scratch + scratch / 2) + 1 + scratch
+}
+
+/// [`relative`] for inputs of any length. The thread-local buffers are
+/// `PathBuffer`s, which bounds not only `from` and `to` but also the result (a
+/// deep `from` becomes a long `../` chain); when any of the three might not
+/// fit, the work happens in heap buffers sized to the inputs instead.
+pub fn relative_alloc(from: &[u8], to: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+    let scratch = relative_scratch_needed::<platform::Auto>(from)
+        .max(relative_scratch_needed::<platform::Auto>(to));
+    let out_needed = relative_out_needed(scratch);
+    if scratch <= MAX_PATH_BYTES && out_needed <= MAX_PATH_BYTES {
+        return Ok(Box::from(relative_platform::<platform::Auto, false>(
+            from, to,
+        )));
+    }
+
+    let mut from_buf = vec![0u8; scratch];
+    let mut to_buf = vec![0u8; scratch];
+    let mut out = vec![0u8; out_needed];
+    Ok(Box::from(relative_platform_in::<platform::Auto, false>(
+        &mut from_buf,
+        &mut to_buf,
+        &mut out,
+        from,
+        to,
+    )))
+}
+
+/// The result borrows whichever of the three buffers it was left in: `out`, or
+/// `relative_to_buf` when `!ALWAYS_COPY` and the answer is a suffix of `to`.
+fn relative_platform_in<'a, P: PlatformT, const ALWAYS_COPY: bool>(
+    relative_from_buf: &'a mut [u8],
+    relative_to_buf: &'a mut [u8],
+    buf: &'a mut [u8],
+    from: &[u8],
+    to: &[u8],
+) -> &'a [u8] {
     let normalized_from: &[u8] = if P::P.is_absolute(from) {
         'brk: {
             if P::P == Platform::Loose && cfg!(windows) {
@@ -720,7 +785,7 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
         // Avoid aliasing relative_to_buf as both input (normalize result)
         // and output (join target): normalize into `buf` scratch (caller
         // output buffer, untouched until the final relative_normalized_buf call
-        // and disjoint from both threadlocals), then join into relative_to_buf.
+        // and disjoint from both scratch buffers), then join into relative_to_buf.
         let norm_len = normalize_string_buf::<true, P, true>(to, buf).len();
         join_abs_string_buf::<P>(
             Fs::FileSystem::instance().top_level_dir(),
@@ -742,11 +807,6 @@ pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
         from,
         to,
     )
-}
-
-pub fn relative_alloc(from: &[u8], to: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
-    let result = relative_platform::<platform::Auto, false>(from, to);
-    Ok(Box::<[u8]>::from(result))
 }
 
 // This function is based on Go's volumeNameLen function
@@ -1644,6 +1704,16 @@ enum JoinScratch {
     Heap(Vec<u8>),
 }
 
+/// Bytes `_join_abs_string_buf` can write for a `base`-byte cwd and `parts`:
+/// the concatenation (one separator per part, plus the one Windows inserts
+/// after a bare share root) and the byte Windows normalization can add to it
+/// (see [`normalize_string_spill`]); normalizing otherwise only removes bytes,
+/// so this bounds the output buffer as well as the scratch one.
+#[inline]
+fn join_abs_needed(base: usize, parts: &[&[u8]]) -> usize {
+    parts.iter().map(|p| p.len() + 1).sum::<usize>() + base + 2
+}
+
 impl JoinScratch {
     #[inline]
     fn init(base: usize, parts: &[&[u8]]) -> Self {
@@ -1701,6 +1771,28 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     let len = joined.len();
     buf[..len].copy_from_slice(joined);
     Some(&buf[..len])
+}
+
+/// [`join_abs_string_buf`] into `buf` when the result is known to fit,
+/// otherwise into `spill` (grown as needed); the [`join_z_buf_spill`] of the
+/// `path.resolve` family, for when the result is wanted whatever its length.
+/// `spill` is untouched in the common case.
+pub fn join_abs_string_buf_spill<'a, P: PlatformT>(
+    cwd: &'a [u8],
+    buf: &'a mut [u8],
+    spill: &'a mut Vec<u8>,
+    parts: &[&[u8]],
+) -> &'a [u8] {
+    let needed = join_abs_needed(cwd.len(), parts);
+    let out: &'a mut [u8] = if needed <= buf.len() {
+        buf
+    } else {
+        if spill.len() < needed {
+            spill.resize(needed, 0);
+        }
+        &mut spill[..]
+    };
+    join_abs_string_buf::<P>(cwd, out, parts)
 }
 
 pub fn join_abs_string_buf_z<'a, P: PlatformT>(
@@ -2534,6 +2626,45 @@ mod tests {
             .unwrap_or(text_len)
     }
 
+    /// Returns `haystack_len` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_last_index_of_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: test stub; callers pass a valid (ptr, len) pair.
+        let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        haystack
+            .iter()
+            .rposition(|&b| b == needle)
+            .unwrap_or(haystack_len)
+    }
+
+    /// Returns `usize::MAX` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_memrmem16(
+        haystack: *const u16,
+        haystack_len: usize,
+        needle: *const u16,
+        needle_len: usize,
+    ) -> usize {
+        // SAFETY: test stub; callers pass valid (ptr, len) pairs.
+        let (haystack, needle) = unsafe {
+            (
+                core::slice::from_raw_parts(haystack, haystack_len),
+                core::slice::from_raw_parts(needle, needle_len),
+            )
+        };
+        if needle_len > haystack_len {
+            return usize::MAX;
+        }
+        (0..=haystack_len - needle_len)
+            .rev()
+            .find(|&i| haystack[i..].starts_with(needle))
+            .unwrap_or(usize::MAX)
+    }
+
     #[test]
     fn normalize_string_spill_leaves_spill_untouched_when_the_input_fits() {
         let mut spill = Vec::new();
@@ -2709,5 +2840,115 @@ mod tests {
             join_string_buf_w_same::<platform::Windows>(&mut out, &[&long, &rest]),
             &expected[..]
         );
+    }
+
+    #[test]
+    fn join_abs_string_buf_spill_leaves_spill_untouched_when_the_result_fits() {
+        let mut buf = [0u8; 64];
+        let mut spill = Vec::new();
+        let out = join_abs_string_buf_spill::<platform::Posix>(
+            b"/cwd",
+            &mut buf,
+            &mut spill,
+            &[b"./lib/../x.js"],
+        );
+        assert_eq!(out, b"/cwd/x.js");
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn join_abs_string_buf_spill_spills_a_result_longer_than_the_buffer() {
+        let part = vec![b'p'; MAX_PATH_BYTES * 2];
+        let mut expected = b"/cwd/".to_vec();
+        expected.extend_from_slice(&part);
+
+        let mut buf = [0u8; MAX_PATH_BYTES];
+        let mut spill = Vec::new();
+        let out =
+            join_abs_string_buf_spill::<platform::Posix>(b"/cwd", &mut buf, &mut spill, &[&part]);
+        assert_eq!(out, &expected[..]);
+        assert!(!spill.is_empty());
+    }
+
+    #[test]
+    fn join_abs_string_buf_spill_uses_the_buffer_up_to_its_bound() {
+        // The longest input the bound lets into `buf` must still be joined
+        // there, and the same input one byte longer must spill.
+        let mut buf = [0u8; 64];
+        let cwd = b"/c";
+        let part = vec![b'q'; buf.len() - join_abs_needed(cwd.len(), &[b""])];
+        let mut spill = Vec::new();
+        let out = join_abs_string_buf_spill::<platform::Posix>(cwd, &mut buf, &mut spill, &[&part]);
+        assert_eq!(out.len(), cwd.len() + 1 + part.len());
+        assert!(spill.is_empty());
+
+        let mut longer = part;
+        longer.push(b'q');
+        let mut spill = Vec::new();
+        let out =
+            join_abs_string_buf_spill::<platform::Posix>(cwd, &mut buf, &mut spill, &[&longer]);
+        assert_eq!(out.len(), cwd.len() + 1 + longer.len());
+        assert!(!spill.is_empty());
+    }
+
+    #[test]
+    fn join_abs_string_buf_spill_accounts_for_windows_results_that_grow() {
+        // A cwd that is a bare share root gains a separator before the parts
+        // are appended; with a buffer sized exactly to the bound it must not
+        // overflow.
+        let cwd = b"\\\\server\\share";
+        let parts: [&[u8]; 1] = [b"x"];
+        let mut buf = vec![0u8; join_abs_needed(cwd.len(), &parts)];
+        let mut spill = Vec::new();
+        let out = join_abs_string_buf_spill::<platform::Windows>(cwd, &mut buf, &mut spill, &parts);
+        assert_eq!(out, b"\\\\server\\share\\x");
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn relative_alloc_matches_relative_for_paths_that_fit() {
+        let rel = relative_alloc(b"/a/b/c", b"/a/d/e.js").unwrap();
+        assert_eq!(
+            &rel[..],
+            relative_platform::<platform::Auto, false>(b"/a/b/c", b"/a/d/e.js")
+        );
+        #[cfg(not(windows))]
+        assert_eq!(&rel[..], b"../../d/e.js");
+    }
+
+    #[test]
+    fn relative_alloc_handles_a_target_longer_than_a_path_buffer() {
+        let mut to = b"/a/".to_vec();
+        to.resize(MAX_PATH_BYTES * 2, b't');
+        let rel = relative_alloc(b"/a/b", &to).unwrap();
+        let mut expected = b"../".to_vec();
+        expected.extend_from_slice(&to[b"/a/".len()..]);
+        #[cfg(not(windows))]
+        assert_eq!(&rel[..], &expected[..]);
+        #[cfg(windows)]
+        assert_eq!(rel.len(), expected.len());
+    }
+
+    #[test]
+    fn relative_alloc_handles_a_result_longer_than_a_path_buffer() {
+        // Both inputs fit in a PathBuffer; the `../` chain for `from` does not.
+        let mut from = Vec::new();
+        while from.len() + 2 < MAX_PATH_BYTES {
+            from.extend_from_slice(b"/d");
+        }
+        let rel = relative_alloc(&from, b"/t").unwrap();
+
+        let components = from.len() / 2;
+        let mut expected = Vec::new();
+        for i in 0..components {
+            if i > 0 {
+                expected.push(SEP);
+            }
+            expected.extend_from_slice(b"..");
+        }
+        expected.push(SEP);
+        expected.push(b't');
+        assert_eq!(&rel[..], &expected[..]);
+        assert!(rel.len() > MAX_PATH_BYTES);
     }
 }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -671,33 +671,28 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     )
 }
 
-/// Bytes [`relative_platform_in`] may write into a scratch buffer while
-/// normalizing `path`: the normalized path (one byte longer than the input at
-/// most, see [`normalize_string_spill`]) behind a leading separator, or, for a
-/// relative input, the path joined onto `top_level_dir` ([`JoinScratch::init`]'s
-/// bound). Each input is normalized into either scratch buffer, so both are
-/// sized to the larger input.
+/// Scratch [`relative_platform_in`] needs for one input: a leading separator
+/// plus the input normalized (which can grow by a byte, see
+/// [`normalize_string_spill`]), or that joined onto the cwd when it is relative.
 fn relative_scratch_needed<P: PlatformT>(path: &[u8]) -> usize {
     if P::P.is_absolute(path) {
         path.len() + 2
     } else {
-        Fs::FileSystem::instance().top_level_dir().len() + path.len() + 4
+        join_abs_needed(Fs::FileSystem::instance().top_level_dir().len(), &[path]) + 1
     }
 }
 
-/// Bytes the result of [`relative_to_common_path`] can occupy when both
-/// normalized inputs fit in `scratch` bytes: every component of `from` (two
-/// bytes at least, separator included) becomes at most a three-byte `/..`,
-/// followed by one separator and the tail of `to`.
+/// Result bound of [`relative_to_common_path`]: each component of `from` (two
+/// bytes or more) becomes at most a three-byte `/..`, then a separator and `to`.
 fn relative_out_needed(scratch: usize) -> usize {
     (scratch + scratch / 2) + 1 + scratch
 }
 
-/// [`relative`] for inputs of any length. The thread-local buffers are
-/// `PathBuffer`s, which bounds not only `from` and `to` but also the result (a
-/// deep `from` becomes a long `../` chain); when any of the three might not
-/// fit, the work happens in heap buffers sized to the inputs instead.
+/// [`relative`] for inputs of any length: the thread-local `PathBuffer`s bound
+/// `from`, `to` and the `../` chain alike, so when any of the three might not
+/// fit, the same code runs in heap buffers sized to the inputs.
 pub fn relative_alloc(from: &[u8], to: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+    // Either input may be normalized into either scratch buffer.
     let scratch = relative_scratch_needed::<platform::Auto>(from)
         .max(relative_scratch_needed::<platform::Auto>(to));
     let out_needed = relative_out_needed(scratch);
@@ -1704,11 +1699,9 @@ enum JoinScratch {
     Heap(Vec<u8>),
 }
 
-/// Bytes `_join_abs_string_buf` can write for a `base`-byte cwd and `parts`:
-/// the concatenation (one separator per part, plus the one Windows inserts
-/// after a bare share root) and the byte Windows normalization can add to it
-/// (see [`normalize_string_spill`]); normalizing otherwise only removes bytes,
-/// so this bounds the output buffer as well as the scratch one.
+/// Bound on what `_join_abs_string_buf` writes, scratch or output: the
+/// concatenation, the separator Windows adds after a bare share root, and the
+/// byte normalizing can add (see [`normalize_string_spill`]).
 #[inline]
 fn join_abs_needed(base: usize, parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + base + 2
@@ -1773,10 +1766,8 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     Some(&buf[..len])
 }
 
-/// [`join_abs_string_buf`] into `buf` when the result is known to fit,
-/// otherwise into `spill` (grown as needed); the [`join_z_buf_spill`] of the
-/// `path.resolve` family, for when the result is wanted whatever its length.
-/// `spill` is untouched in the common case.
+/// [`join_abs_string_buf`] into `buf` when the result fits, otherwise into
+/// `spill` (grown as needed, untouched in the common case); cf. [`join_z_buf_spill`].
 pub fn join_abs_string_buf_spill<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
@@ -2872,8 +2863,6 @@ mod tests {
 
     #[test]
     fn join_abs_string_buf_spill_uses_the_buffer_up_to_its_bound() {
-        // The longest input the bound lets into `buf` must still be joined
-        // there, and the same input one byte longer must spill.
         let mut buf = [0u8; 64];
         let cwd = b"/c";
         let part = vec![b'q'; buf.len() - join_abs_needed(cwd.len(), &[b""])];
@@ -2893,9 +2882,7 @@ mod tests {
 
     #[test]
     fn join_abs_string_buf_spill_accounts_for_windows_results_that_grow() {
-        // A cwd that is a bare share root gains a separator before the parts
-        // are appended; with a buffer sized exactly to the bound it must not
-        // overflow.
+        // A bare share root gains a separator; `buf` is sized exactly to the bound.
         let cwd = b"\\\\server\\share";
         let parts: [&[u8]; 1] = [b"x"];
         let mut buf = vec![0u8; join_abs_needed(cwd.len(), &parts)];
@@ -2936,8 +2923,7 @@ mod tests {
         while from.len() + 2 < MAX_PATH_BYTES {
             from.extend_from_slice(b"/d");
         }
-        // Two bytes, not one: the Windows arm drops a one-byte root-level
-        // target (pre-existing), which would hide what this test is about.
+        // Two bytes: the Windows arm drops one-byte root-level targets (pre-existing).
         let rel = relative_alloc(&from, b"/tt").unwrap();
 
         let components = from.len() / 2;

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1766,6 +1766,7 @@ pub fn join_abs_string_buf_spill<'a, P: PlatformT>(
     spill: &'a mut Vec<u8>,
     parts: &[&[u8]],
 ) -> &'a [u8] {
+    debug_assert!(!matches!(P::P, Platform::Nt));
     let needed = join_abs_needed(cwd.len(), parts);
     let out: &'a mut [u8] = if needed <= buf.len() {
         buf

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1036,3 +1036,60 @@ it("object loader: an error thrown by a getter on the exports object rejects the
   });
   expect(() => require("object-loader-throwing-esmodule")).toThrow(boom);
 });
+
+it.concurrent("an onResolve result longer than a path buffer is a resolve error, not a crash", async () => {
+  // The path a plugin returns for an import inside a module used to be run
+  // through the fixed-size relative-path buffers while that module was
+  // linked, which crashed the process. Long enough to exceed the buffers and
+  // the resolver's own specifier limit on every platform, Windows included.
+  const longPath = "/" + Buffer.alloc(150_000, "a").toString();
+  using dir = tempDir("plugin-onresolve-long-path", {
+    "preload.js": `
+      Bun.plugin({
+        name: "redirect-to-long-path",
+        setup(build) {
+          build.onResolve({ filter: /^\\.\\/child\\.js$/ }, () => ({ path: "/" + Buffer.alloc(150_000, "a").toString() }));
+        },
+      });
+    `,
+    "parent-require.js": `module.exports = require("./child.js");`,
+    "parent-import.mjs": `export * from "./child.js";`,
+    "entry.js": `
+      const attempt = async fn => {
+        try {
+          await fn();
+          return "loaded";
+        } catch ({ name, level, referrer, message }) {
+          return { name, level, referrer, message };
+        }
+      };
+      console.log(
+        JSON.stringify({
+          requireParent: require.resolve("./parent-require.js"),
+          importParent: require.resolve("./parent-import.mjs"),
+          viaRequire: await attempt(() => require("./parent-require.js")),
+          viaImport: await attempt(() => import("./parent-import.mjs")),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The fixture catches its own failures, so empty stdout means it crashed.
+  const { requireParent, importParent, ...results } = stdout.trim() ? JSON.parse(stdout) : { crashed: stderr };
+  const tooLong = (parent: string) => ({
+    name: "ResolveMessage",
+    level: "error",
+    referrer: parent,
+    message: `ENAMETOOLONG while resolving '${longPath}' from '${parent}'`,
+  });
+  expect(results).toEqual({ viaRequire: tooLong(requireParent), viaImport: tooLong(importParent) });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -486,6 +486,55 @@ console.log("survived", require("./late.js"));`,
     expect(_nodeModulePaths(ospath("/a/b/c/d") + path.sep)).toEqual(_nodeModulePaths("/a/b/c/d"));
   });
 
+  test("_nodeModulePaths() accepts paths longer than PATH_MAX", async () => {
+    // Like Node's, this is string manipulation: the input never has to exist
+    // or fit a path buffer. It used to be resolved into a fixed-size buffer,
+    // which crashed the process, so this runs in a child. The inputs are built
+    // on both sides rather than passed through argv (too long for Windows').
+    function inputs() {
+      return {
+        single: Buffer.alloc(100_000, "a").toString(),
+        segments: Array.from({ length: 100 }, (_, i) => `seg${i}-` + Buffer.alloc(56, "s").toString()),
+        relative: Buffer.alloc(5000, "r").toString(),
+      };
+    }
+    const { single, segments, relative } = inputs();
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const m = require("module");
+         ${inputs}
+         const { single, segments, relative } = inputs();
+         process.stdout.write(JSON.stringify({
+           single: m._nodeModulePaths("/" + single),
+           segments: m._nodeModulePaths("/" + segments.join("/")),
+           relative: m._nodeModulePaths(relative),
+           dot: m._nodeModulePaths("."),
+         }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { dot, ...results } = JSON.parse(stdout);
+
+    const root = path.resolve("/");
+    expect(results).toEqual({
+      single: [path.join(root, single, "node_modules"), path.join(root, "node_modules")],
+      segments: [
+        ...segments.map((_, i) => path.join(root, ...segments.slice(0, segments.length - i), "node_modules")),
+        path.join(root, "node_modules"),
+      ],
+      // A relative input resolves against the cwd, so its lookup chain is the
+      // cwd's own chain with one more entry in front.
+      relative: [path.join(path.dirname(dot[0]), relative, "node_modules"), ...dot],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("_nodeModulePaths() is stable across process.chdir()", async () => {
     // process.chdir() re-seeds the resolver's cached top-level dir with a
     // trailing separator; _nodeModulePaths("") then used to emit a duplicate


### PR DESCRIPTION
### Problem
- `require("module")._nodeModulePaths(p)` with a `p` longer than a path buffer aborts the process: `panic: range end index 5000 out of range for slice of length 4095` (Node returns the lookup list for any string; this is string manipulation). Site: `node_module_paths_js_value` in `src/jsc/resolver_jsc.rs` joins the argument onto the cwd with `join_abs_string_buf` into a pooled `PathBuffer`.
- A runtime `Bun.plugin` `onResolve` callback that returns a `file`-namespace path longer than a path buffer for an import or `require` inside a module aborts the process: `panic: range end index 150000 out of range for slice of length 4095`. Site: `Linker::generate_import_path` (`src/bundler/linker.rs`) computes the import's display name with `resolve_path::relative(source_dir, plugin_path)`. The 1.5 x `MAX_PATH_BYTES` specifier cap in `VirtualMachine::resolve` does not apply here because the path never goes through it before the linker; a 70 KB or 150 KB path still aborts. Both CJS and ESM parents hit it.
- Both joins bottom out in `normalize_string_generic_tz` (`src/paths/resolve_path.rs`), which writes into whatever buffer it is given with plain slice indexing. `relative()` normalizes both inputs into thread-local `PathBuffer`s and writes the result into a third; `relative_alloc` was just a `Box` around that result, so it had the same bound. The result buffer is also too small for valid inputs: `relative` of two paths that each fit a `PathBuffer` aborts once the `../` chain plus the tail does not (pinned by a unit test in this PR).

### Fix
- `relative_platform_buf` is split into a wrapper that supplies the thread-local buffers and `relative_platform_in`, which takes all three buffers as slices. Its body is unchanged.
- `relative_alloc` computes how much scratch each input needs (normalized, plus the cwd for a relative input, using the bound `JoinScratch::init` already uses) and how long the result can get (every component of `from` is at least two bytes and becomes at most a three-byte `/..`, then a separator and the tail of `to`); when all three fit in `MAX_PATH_BYTES` it calls the thread-local `relative` exactly as before, otherwise it runs the same code in heap buffers of those sizes. Its two existing callers (chunk directory templates, source map `sources`) get this for free.
- `join_abs_string_buf_spill` is added next to `join_abs_string_buf_checked`: same shape as `join_z_buf_spill`, joining into the caller's buffer when the bound (`join_abs_needed`) says the result fits and into a caller-owned `Vec` otherwise. Unlike the `_checked` variant it returns the result however long, which is what `_nodeModulePaths` needs.
- Overlap note: `join_abs_needed` and the thread-local `join_abs_string_spill` landed on main with #38368 while this PR was open; this PR now uses that helper instead of its own copy (dropped on rebase). `join_abs_string_buf_spill` is the caller-buffer form of `join_abs_string_spill`, the same pairing as `join_z_buf_spill` and `join_spill`. #37457 adds the same helper again and will drop its copy when it rebases; nothing else overlaps.
- `_nodeModulePaths` joins through the spill variant; the rest of the function is slicing and formatting and needed no change. All three arms of `generate_import_path` use `relative_alloc` (the `AbsolutePath` arm is the runtime one and the only one reproduced; the other two take the same `source_path` and already copied the result, so the change costs nothing there). The load that follows then fails with the resolver's normal `ENAMETOOLONG` `ResolveMessage`.
- Verified:
  - `cargo test -p bun_paths`: 25 pass, 7 new (spill fast path, spill, the exact bound, a Windows share root that grows by a byte, `relative_alloc` matching `relative`, a target longer than a `PathBuffer`, and a result longer than a `PathBuffer` from two inputs that fit; the last two abort on the thread-local `relative`, checked with a temporary `#[should_panic]` copy). The last test uses a two-byte target because the Windows arm of `relative` drops a one-byte root-level target (`C:\d\d` to `C:\t` gives `..\..`), a pre-existing bug found while writing it and reported separately.
  - `test/js/node/module/node-module-module.test.js`, "_nodeModulePaths() accepts paths longer than PATH_MAX": a child bun runs a 100000-byte component (longer than the buffer on Windows too), 100 components of 6 KB total, and a 5000-byte relative input; the output is compared against the lists Node produces (built with `path` in the test).
  - `test/js/bun/plugin/plugins.test.ts`, "an onResolve result longer than a path buffer is a resolve error, not a crash": a preload plugin returns a 150001-byte path (past the buffers and the specifier cap on every platform) for `./child.js`, required by one parent and re-exported by an ESM parent; both must surface a `ResolveMessage` naming the path and the parent.
  - `USE_SYSTEM_BUN=1`: both tests fail with the panics above. `bun bd test` on this branch: both pass; the full `plugins.test.ts` (39) and `node-module-module.test.js` (40) files pass, as do `bundler_splitting`, `bundler_naming`, `bundler_plugin`, `bun-build-api` and the `test/js/bun/sourcemap` files (the `relative_alloc` callers). `cargo check` of the touched crates for the Windows and macOS targets and `cargo clippy` are clean.
- The thread-local `relative()` itself (about 60 callers, most with paths that came from the filesystem) and the other unchecked writers are left as they are: making them grow in place touches the install crate's direct use of the relative buffers and is the writer-level change being discussed separately; #35863 bounds `join_abs_string_buf` from the other direction and does not overlap with these lines. The resolver's `load_as_file` window reached by the plugin path at 4096 to 6144 bytes is #35857's site.

### Background
- `bun_paths::resolve_path` works on byte slices and writes results into caller-provided or thread-local fixed buffers (`PathBuffer` = `[u8; MAX_PATH_BYTES]`: 4096 on Linux, 1024 on macOS, 98302 on Windows). The `*_spill` family (`join_spill`, `join_z_buf_spill`, `normalize_string_spill`) is the existing pattern for inputs that may be longer: use the fixed buffer when a cheap bound says the result fits, otherwise a `Vec` the caller owns.
- `join_abs_string_buf` is `path.resolve`: it concatenates the cwd and the parts into a scratch buffer and normalizes that into the output buffer, so the output is never longer than the concatenation (plus one byte Windows normalization can add, e.g. `C:` becoming `C:.`).
- `relative` is `path.relative`: it normalizes `from` and `to` (resolving relative ones against the cwd), finds their common prefix, and emits one `..` per remaining component of `from` followed by the rest of `to`.
- At runtime, every module is transpiled and then linked on its own: the linker resolves the module's import records, consulting runtime `onResolve` plugins for specifiers that look like they could be plugin-handled (an extension or a `ns:` prefix), and rewrites each record to the resolved path plus a shorter "pretty" name used for display. `_nodeModulePaths` is the `node:module` helper that returns the `node_modules` lookup chain for a directory; `module.paths` is computed with it lazily.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->