### PR TITLE
error printer: size the own-property column from the names it actually prints

### DIFF
--- a/src/jsc/JSPropertyIterator.rs
+++ b/src/jsc/JSPropertyIterator.rs
@@ -117,18 +117,13 @@ pub struct JSPropertyIterator<'a> {
 }
 
 impl<'a> JSPropertyIterator<'a> {
-    pub(crate) fn get_longest_property_name(&self) -> usize {
-        if let Some(iter) = self.impl_ {
-            // `JSPropertyIteratorImpl`/`JSObject` are opaque ZST handles;
-            // `opaque_mut`/`opaque_ref` are the centralised zero-byte deref proofs.
-            Bun__JSPropertyIterator__getLongestPropertyName(
-                JSPropertyIteratorImpl::opaque_mut(iter.as_ptr()),
-                self.global_object,
-                JSObject::opaque_ref(self.object),
-            )
-        } else {
-            0
-        }
+    /// Restarts iteration from the first property. The property names were
+    /// collected once by [`Self::init`], so a second pass yields the same
+    /// names as the first.
+    pub(crate) fn reset(&mut self) {
+        self.i = 0;
+        self.iter_i = 0;
+        self.value = JSValue::ZERO;
     }
 
     /// `object` should be a `JSC::JSObject`. Non-objects will be runtime converted.
@@ -336,9 +331,4 @@ unsafe extern "C" {
         i: usize,
     );
     fn Bun__JSPropertyIterator__deinit(iter: *mut JSPropertyIteratorImpl);
-    safe fn Bun__JSPropertyIterator__getLongestPropertyName(
-        iter: &mut JSPropertyIteratorImpl,
-        global_object: &JSGlobalObject,
-        object: &JSObject,
-    ) -> usize;
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6269,97 +6269,133 @@ impl VirtualMachine {
                     only_non_index_properties: true,
                 },
             )?;
-            let longest_name = iterator.get_longest_property_name().min(10);
-            let mut is_first_property = true;
-            while let Some(field) = iterator.next()? {
-                let value = iterator.value;
+
+            /// How the property block below shows one own enumerable property.
+            enum OwnProperty {
+                /// Already shown elsewhere (the `name: message` line, the stack
+                /// trace, the `code` line), or not printable.
+                Hidden,
+                /// Printed in full after the stack trace (`errors_to_append`).
+                AppendedError,
+                /// Printed as a ` name: value` line in the property block.
+                Inline,
+            }
+            let classify = |field: &bun_core::String, value: JSValue| -> OwnProperty {
                 if field.eql_comptime(b"message")
                     || field.eql_comptime(b"name")
                     || field.eql_comptime(b"stack")
                 {
-                    continue;
+                    return OwnProperty::Hidden;
                 }
                 if field.eql_comptime(b"code") && code.is_some() {
-                    continue;
+                    return OwnProperty::Hidden;
                 }
-
                 let kind = value.js_type();
                 if kind == JSType::ErrorInstance && !prev_had_errors {
-                    if field.eql_comptime(b"cause") {
-                        saw_cause = true;
-                    }
-                    value.protect();
-                    errors_to_append.push(value);
+                    OwnProperty::AppendedError
                 } else if kind.is_object()
                     || kind.is_array()
                     || value.is_primitive()
                     || kind.is_string_like()
                 {
-                    let prev_disable_inspect_custom = formatter.disable_inspect_custom;
-                    let prev_quote_strings = formatter.quote_strings;
-                    let prev_max_depth = formatter.max_depth;
-                    let prev_format_buffer_as_text = formatter.format_buffer_as_text;
-                    formatter.depth += 1;
-                    formatter.format_buffer_as_text = true;
-                    formatter.max_depth = 1;
-                    formatter.quote_strings = true;
-                    formatter.disable_inspect_custom = true;
-                    // Hand-rolled drop guard restores the formatter state.
-                    struct RestoreFmt<'a, 'f> {
-                        f: &'a mut crate::console_object::Formatter<'f>,
-                        d: bool,
-                        q: bool,
-                        m: u16,
-                        b: bool,
-                    }
-                    impl Drop for RestoreFmt<'_, '_> {
-                        fn drop(&mut self) {
-                            self.f.depth -= 1;
-                            self.f.max_depth = self.m;
-                            self.f.quote_strings = self.q;
-                            self.f.disable_inspect_custom = self.d;
-                            self.f.format_buffer_as_text = self.b;
+                    OwnProperty::Inline
+                } else {
+                    OwnProperty::Hidden
+                }
+            };
+
+            // Names are right-aligned to the longest name the block actually
+            // contains: the inline properties plus the `code` line that follows
+            // them. Accessors never come out of the iterator (`observable: false`).
+            let mut longest_name: usize = if code.is_some() { b"code".len() } else { 0 };
+            while let Some(field) = iterator.next()? {
+                if matches!(classify(&field, iterator.value), OwnProperty::Inline) {
+                    longest_name = longest_name.max(field.length());
+                }
+            }
+            let longest_name = longest_name.min(10);
+            iterator.reset();
+
+            let mut is_first_property = true;
+            while let Some(field) = iterator.next()? {
+                let value = iterator.value;
+                match classify(&field, value) {
+                    OwnProperty::Hidden => continue,
+                    OwnProperty::AppendedError => {
+                        if field.eql_comptime(b"cause") {
+                            saw_cause = true;
                         }
+                        value.protect();
+                        errors_to_append.push(value);
+                        continue;
                     }
-                    let restore = RestoreFmt {
-                        f: formatter,
-                        d: prev_disable_inspect_custom,
-                        q: prev_quote_strings,
-                        m: prev_max_depth,
-                        b: prev_format_buffer_as_text,
-                    };
-                    let formatter = &mut *restore.f;
+                    OwnProperty::Inline => {}
+                }
 
-                    let pad_left = longest_name.saturating_sub(field.length());
-                    is_first_property = false;
-                    splat_space(writer, pad_left as u64)?;
-                    pretty_write!(writer, " {}<r><d>:<r> ", field)?;
+                let prev_disable_inspect_custom = formatter.disable_inspect_custom;
+                let prev_quote_strings = formatter.quote_strings;
+                let prev_max_depth = formatter.max_depth;
+                let prev_format_buffer_as_text = formatter.format_buffer_as_text;
+                formatter.depth += 1;
+                formatter.format_buffer_as_text = true;
+                formatter.max_depth = 1;
+                formatter.quote_strings = true;
+                formatter.disable_inspect_custom = true;
+                // Hand-rolled drop guard restores the formatter state.
+                struct RestoreFmt<'a, 'f> {
+                    f: &'a mut crate::console_object::Formatter<'f>,
+                    d: bool,
+                    q: bool,
+                    m: u16,
+                    b: bool,
+                }
+                impl Drop for RestoreFmt<'_, '_> {
+                    fn drop(&mut self) {
+                        self.f.depth -= 1;
+                        self.f.max_depth = self.m;
+                        self.f.quote_strings = self.q;
+                        self.f.disable_inspect_custom = self.d;
+                        self.f.format_buffer_as_text = self.b;
+                    }
+                }
+                let restore = RestoreFmt {
+                    f: formatter,
+                    d: prev_disable_inspect_custom,
+                    q: prev_quote_strings,
+                    m: prev_max_depth,
+                    b: prev_format_buffer_as_text,
+                };
+                let formatter = &mut *restore.f;
 
-                    if allow_side_effects && global_ref.has_exception() {
+                let pad_left = longest_name.saturating_sub(field.length());
+                is_first_property = false;
+                splat_space(writer, pad_left as u64)?;
+                pretty_write!(writer, " {}<r><d>:<r> ", field)?;
+
+                if allow_side_effects && global_ref.has_exception() {
+                    global_ref.clear_exception();
+                }
+
+                let tag = Tag::get_advanced(
+                    value,
+                    global_ref,
+                    TagOptions::DISABLE_INSPECT_CUSTOM | TagOptions::HIDE_GLOBAL,
+                )?;
+                let _ = if allow_ansi_color {
+                    formatter.format::<true>(tag, writer, value, global_ref)
+                } else {
+                    formatter.format::<false>(tag, writer, value, global_ref)
+                };
+
+                if allow_side_effects {
+                    if global_ref.has_exception() {
                         global_ref.clear_exception();
                     }
-
-                    let tag = Tag::get_advanced(
-                        value,
-                        global_ref,
-                        TagOptions::DISABLE_INSPECT_CUSTOM | TagOptions::HIDE_GLOBAL,
-                    )?;
-                    let _ = if allow_ansi_color {
-                        formatter.format::<true>(tag, writer, value, global_ref)
-                    } else {
-                        formatter.format::<false>(tag, writer, value, global_ref)
-                    };
-
-                    if allow_side_effects {
-                        if global_ref.has_exception() {
-                            global_ref.clear_exception();
-                        }
-                    } else if global_ref.has_exception() || formatter.failed {
-                        return Ok(());
-                    }
-
-                    pretty_write!(writer, "<r><d>,<r>\n")?;
+                } else if global_ref.has_exception() || formatter.failed {
+                    return Ok(());
                 }
+
+                pretty_write!(writer, "<r><d>,<r>\n")?;
             }
 
             if let Some(code_str) = code {

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -97,18 +97,6 @@ extern "C" JSPropertyIterator* Bun__JSPropertyIterator__create(JSC::JSGlobalObje
     return JSPropertyIterator::create(vm, array.releaseData());
 }
 
-extern "C" size_t Bun__JSPropertyIterator__getLongestPropertyName(JSPropertyIterator* iter, JSC::JSGlobalObject* globalObject, JSC::JSObject* object)
-{
-    size_t longest = 0;
-    for (const auto& prop : iter->properties->propertyNameVector()) {
-        if (prop.length() > longest) {
-            longest = prop.length();
-        }
-    }
-
-    return longest;
-}
-
 static EncodedJSValue getOwnProxyObject(JSPropertyIterator* iter, JSObject* object, const JSC::Identifier& prop, BunString* propertyName)
 {
     auto& vm = iter->vm;

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
 import { join } from "node:path";
 
@@ -148,4 +148,143 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+describe("own properties of a printed error are right-aligned to the longest name that is printed", () => {
+  const message = "own property width";
+
+  // A printed error looks like: (source preview), the `name: message` line, one
+  // ` name: value` line per own property (right-aligned), a blank line, then the
+  // stack frames. Returns the property lines. Trailing commas are dropped so
+  // these tests only pin the alignment.
+  function propertyLines(output: string): string[] {
+    const lines = output.split("\n");
+    const start = lines.findIndex(line => line.endsWith(`: ${message}`));
+    if (start === -1) throw new Error(`message line not found in:\n${output}`);
+    const block: string[] = [];
+    for (const line of lines.slice(start + 1)) {
+      if (line === "" || line.trimStart().startsWith("at ")) break;
+      block.push(line.replace(/,$/, ""));
+    }
+    return block;
+  }
+
+  function expectPropertyLines(err: Error, expected: string[]) {
+    expect(propertyLines(Bun.inspect(err))).toEqual(expected);
+    expect(propertyLines(Bun.stripANSI(Bun.inspect(err, { colors: true })))).toEqual(expected);
+  }
+
+  function define(err: Error, name: string, descriptor: PropertyDescriptor): Error {
+    Object.defineProperty(err, name, descriptor);
+    return err;
+  }
+
+  class CodedError extends Error {}
+  Object.defineProperty(CodedError.prototype, "code", { value: "E_X" });
+
+  test.each<[string, () => Error, string[]]>([
+    [
+      "two printed properties",
+      () => Object.assign(new Error(message), { id: 1, status: 500 }),
+      ["     id: 1", " status: 500"],
+    ],
+    [
+      "names longer than 10 characters do not widen the column further",
+      () => Object.assign(new Error(message), { a: 1, averyveryverylongname: 2 }),
+      ["          a: 1", " averyveryverylongname: 2"],
+    ],
+    [
+      "an Error-valued property is printed after the stack trace, not in the block",
+      () => Object.assign(new Error(message), { a: 1, someCause: new Error("inner") }),
+      [" a: 1"],
+    ],
+    [
+      "an Error-valued property with a name longer than 10 characters",
+      () => Object.assign(new Error(message), { a: 1, averyveryverylongname: new Error("inner") }),
+      [" a: 1"],
+    ],
+    [
+      "an enumerable accessor is not printed",
+      () => define(Object.assign(new Error(message), { a: 1 }), "longAccessor", { get: () => 1, enumerable: true }),
+      [" a: 1"],
+    ],
+    [
+      "an own enumerable name is shown on the message line",
+      () => Object.assign(new Error(message), { name: "MyError", id: 1 }),
+      [" id: 1"],
+    ],
+    [
+      "an own enumerable message is shown on the message line",
+      () => Object.assign(define(new Error(message), "message", { value: message, enumerable: true }), { id: 1 }),
+      [" id: 1"],
+    ],
+    [
+      "an own enumerable stack is shown as the stack trace",
+      () => {
+        const err = new Error(message);
+        return Object.assign(define(err, "stack", { value: err.stack, enumerable: true }), { id: 1 });
+      },
+      [" id: 1"],
+    ],
+    [
+      "an own string code is printed as the last line",
+      () => Object.assign(new Error(message), { id: 1, code: "E_X" }),
+      ["   id: 1", ' code: "E_X"'],
+    ],
+    [
+      "a string code inherited from the prototype is printed as the last line",
+      () => Object.assign(new CodedError(message), { id: 1 }),
+      ["   id: 1", ' code: "E_X"'],
+    ],
+    [
+      "a non-enumerable own string code is printed as the last line",
+      () => Object.assign(define(new Error(message), "code", { value: "E_X" }), { id: 1 }),
+      ["   id: 1", ' code: "E_X"'],
+    ],
+    [
+      "a string code and an Error-valued property",
+      () => Object.assign(new Error(message), { abc: 1, someCause: new Error("inner"), code: "E_X" }),
+      ["  abc: 1", ' code: "E_X"'],
+    ],
+  ])("%s", (_, makeError, expected) => {
+    expectPropertyLines(makeError(), expected);
+  });
+
+  test("an Error-valued property is still printed after the stack trace", () => {
+    const output = Bun.inspect(Object.assign(new Error(message), { a: 1, someCause: new Error("inner marker") }));
+    expect(output.indexOf("inner marker")).toBeGreaterThan(output.indexOf(" a: 1"));
+  });
+
+  test("inside a nested error, Error-valued properties are printed in the block and count toward the width", () => {
+    const inner = Object.assign(new Error("inner"), { a: 1, someCause: new Error("deep") });
+    const lines = Bun.inspect(new Error(message, { cause: inner })).split("\n");
+    const colon = (name: string) => {
+      const line = lines.find(line => line.trimStart().startsWith(`${name}:`));
+      if (line === undefined) throw new Error(`${name} line not found in:\n${lines.join("\n")}`);
+      return line.indexOf(":");
+    };
+    expect(colon("a")).toBe(colon("someCause"));
+  });
+
+  test("uncaught error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const err = new Error(${JSON.stringify(message)});
+         err.name = "MyError";
+         err.id = 7;
+         err.someCause = new Error("inner marker");
+         throw err;`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(propertyLines(stderr)).toEqual([" id: 7"]);
+    expect(stderr.indexOf("inner marker")).toBeGreaterThan(stderr.indexOf(" id: 7"));
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 1 });
+  });
 });


### PR DESCRIPTION
### Problem

- The own-property block printed under an error's message is right-aligned to a width taken from every own enumerable property name, but the loop that prints the block skips several of those names, so the lines it does print can be padded to a width nothing on screen uses:
  ```
  $ bun -e 'const e = new Error("boom"); e.a = 1; e.someCause = new Error("inner"); console.error(e)'
  error: boom
           a: 1,        <- padded to the width of someCause, which is printed after the stack trace
  ```
  The skipped names are `message` / `name` / `stack` (an own enumerable `name` is what every `this.name = "MyError"` constructor produces), the own `code` entry when the string `code` line is printed instead, Error-valued properties (printed in full after the stack trace) and enumerable accessors (never yielded by the iterator).
- The opposite case is also misaligned: a string `code` that lives on the prototype or is a non-enumerable own property is printed as the last line of the block but does not count toward the width, so `id: 1` is printed narrower than the `code: "E_X"` line under it.
- Cause: `print_error_instance_body` (`src/jsc/VirtualMachine.rs`) takes the width from `Bun__JSPropertyIterator__getLongestPropertyName` (`src/jsc/bindings/JSPropertyIterator.cpp`), which looks at the whole property name array and knows nothing about which names the printer is about to skip or add. Same output for uncaught errors, `console.error(err)` and `Bun.inspect(err)`, since they share this function. Pre-existing (the Zig version behaved the same), reproduced on 1.4.0.

### Fix

- The decision of what happens to a property (hidden, appended after the stack trace, printed inline) is moved into one local `classify` closure, and the iterator is run twice over the names it already collected: the first pass takes the width from the names `classify` reports as inline, starting from `"code".len()` when the `code` line will be printed; the second pass prints exactly as before. `JSPropertyIterator::reset` replaces `get_longest_property_name`, and the C++ helper, which had no other caller, is removed.
- Correct because both passes ask the same function, so the width is by construction the maximum over the lines the block ends up containing; the `prev_had_errors` branch (inside a nested error, Error-valued properties are printed inline) is covered the same way because it is part of `classify`. The second pass is safe to run because the iterator uses `observable: false` (VM-inquiry reads, no getters or proxies run between the passes, so the object cannot change) and the name array is collected once at `init`. The `.min(10)` cap and the bytes written per line are unchanged, so errors whose longest own name was already a printed one (for example the ENOENT dump in `stack.test.ts`) print byte for byte as before.
- Verified with `test/js/bun/test/stack.test.ts`: `Bun.inspect`, with and without colors, for each skipped kind of name (Error-valued property, Error-valued property longer than the cap, accessor, own enumerable `name` / `message` / `stack`), for a `code` line coming from an own enumerable, prototype and non-enumerable own `code`, for `code` plus an Error-valued property, for two unaffected cases (two printed properties, the 10 character cap), for the Error-valued property still being printed after the trace, for the nested-error case, and for an uncaught error in a child process. 10 of the new cases fail on the released binary (`USE_SYSTEM_BUN=1`), all pass with `bun bd test`. The expectations strip the trailing comma so they are independent of #38290.
- Also ran `test/js/bun/util/{inspect-error,reportError,inspect}.test` with the debug build; the only failures are the two pre-existing minified-file snapshots that pick up a debug-only `at require` frame, which fail identically without this change.
- Related open PRs in the same block: #38290 (trailing comma on the last line) and #35172 (non-Error `cause` line); whichever lands second needs a small rebase. #35172 would add `"cause".len()` to the width the same way `code` is added here.

### Background

- `print_error_instance_body` is the native printer behind uncaught exceptions, unhandled rejections, `console.error(err)` and `Bun.inspect(err)`. For an Error instance it prints the source preview, the `name: message` line, then the block this PR is about: one right-aligned ` name: value,` line per own enumerable data property (names capped at 10 columns), the string `code` as the last line, a blank line, the stack frames, and finally any Error-valued properties and `cause`, each printed as a full error of its own. Inside one of those nested prints (`prev_had_errors`), Error-valued properties are instead rendered inline in the block, to stop the recursion.
- `code` is looked up separately (`getCodePropertyVMInquiry`, own or inherited data property); when it is a string it is printed as the dedicated last line and the own `code` entry, if any, is skipped by the loop.
- `JSPropertyIterator` (`src/jsc/JSPropertyIterator.rs` over `bindings/JSPropertyIterator.cpp`) collects the property names once at `init` and yields `(name, value)` pairs on `next()`. With `observable: false` the value is read through a VM-inquiry slot, which runs no user code and yields nothing for accessors, so those properties are skipped before the printer sees them.
