### PR TITLE
Free a global object's console client together with the global

### DIFF
--- a/src/jsc/bindings/ConsoleObject.h
+++ b/src/jsc/bindings/ConsoleObject.h
@@ -10,6 +10,9 @@ using namespace JSC;
 
 class ConsoleObject final : public JSC::ConsoleClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ConsoleObject);
+    // ConsoleClient is CanMakeCheckedPtr: deleting one must go through this override
+    // (declared on the most derived class), which also catches a CheckedPtr outliving it.
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ConsoleObject);
 
 public:
     ~ConsoleObject() final {}

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1125,7 +1125,8 @@ void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* 
 
 void GlobalObject::setConsole(void* console)
 {
-    this->setConsoleClient(new Bun::ConsoleObject(console));
+    m_consoleObject = makeUnique<Bun::ConsoleObject>(console);
+    this->setConsoleClient(*m_consoleObject);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(errorConstructorPrepareStackTraceGetter,

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -33,6 +33,7 @@ class JSBuiltinInternalFunctions;
 } // namespace WebCore
 
 namespace Bun {
+class ConsoleObject;
 class InternalModuleRegistry;
 class NapiHandleScopeImpl;
 class JSNextTickQueue;
@@ -814,6 +815,10 @@ private:
     Lock m_gcLock;
     Ref<WebCore::DOMWrapperWorld> m_world;
     RefPtr<WebCore::Performance> m_performance { nullptr };
+    // JSGlobalObject::setConsoleClient only takes a WeakPtr; the client installed by
+    // setConsole() is owned here so it goes away with the global (ShadowRealm globals
+    // and retired `bun test --isolate` globals are collected while the VM keeps running).
+    std::unique_ptr<Bun::ConsoleObject> m_consoleObject;
 
 public:
     // De-optimization once `require("module")._resolveFilename` is written to

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -1,4 +1,6 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import { join } from "path";
 
 it("shadow realm works", () => {
   const red = new ShadowRealm();
@@ -7,4 +9,82 @@ it("shadow realm works", () => {
   const result = red.evaluate("globalThis.someValue = 2;");
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
+});
+
+// Every global object (the thread's own, and one per ShadowRealm) installs a
+// console client on itself. Those clients used to have no owner and outlived
+// their global. They are fastMalloc'd, which LeakSanitizer only sees with
+// bmalloc routed to the system allocator (Malloc=1), and only once the VM is
+// really torn down at exit (BUN_DESTRUCT_VM_ON_EXIT). The realms are created
+// from setImmediate because leaksan.supp suppresses everything allocated while
+// the entry module itself is being evaluated.
+describe.concurrent.skipIf(!isASAN || isWindows)("globals are freed together with their console client", () => {
+  const leakEnv = {
+    ...bunEnv,
+    Malloc: "1",
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+  };
+
+  // The realm's console.log is what exercises the console client; it writes
+  // straight to fd 1, so its output is complete before the script (or the
+  // worker running it) finishes.
+  const createRealms = /* js */ `
+    setImmediate(() => {
+      for (let i = 0; i < 3; i++) {
+        const result = new ShadowRealm().evaluate('console.log("from realm"); 1 + 1');
+        if (result !== 2) throw new Error("unexpected evaluate() result: " + result);
+      }
+    });
+  `;
+  const realmOutput = "from realm\n".repeat(3);
+
+  // LSan spends several seconds symbolizing a report against the debug binary:
+  // a failing run here, and today every run of the worker case (see below).
+  const timeout = 60_000;
+
+  it(
+    "on the main thread",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", createRealms],
+        env: leakEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: realmOutput, stderr: "", exitCode: 0 });
+    },
+    timeout,
+  );
+
+  it(
+    "in a worker",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("worker_threads");
+            const worker = new Worker(${JSON.stringify(createRealms)}, { eval: true });
+            worker.on("exit", code => console.log("worker exited", code));
+          `,
+        ],
+        env: leakEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe(realmOutput + "worker exited 0\n");
+      // Under Malloc=1 every worker thread still leaks its EventNames table
+      // (oven-sh/bun#38164), so the exit code cannot be asserted yet. Instead,
+      // nothing allocated while creating the worker's global or its realms'
+      // globals may show up in the report.
+      expect(stderr).not.toContain("deriveShadowRealmGlobalObject");
+      expect(stderr).not.toContain("Zig__GlobalObject__create");
+    },
+    timeout,
+  );
 });

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -5,7 +5,6 @@ leak:resolver.package_json.PackageJSON.parse__anon
 leak:resolver.resolver.Resolver.parseTSConfig
 leak:JSC::Identifier::fromString
 leak:jsc.JSGlobalObject.JSGlobalObject.create
-leak:Zig__GlobalObject__create
 leak:_objc_msgSend_uncached
 leak:WTF::AutomaticThread::start
 leak:Bun__transpileFile


### PR DESCRIPTION
### Problem
- Every `new ShadowRealm()` leaks the realm global's `Bun::ConsoleObject` (40 bytes) and the `WeakPtrImpl` JSC holds on it (32 bytes). LSan (with `Malloc=1`) reports them as `Bun::ConsoleObject::operator new` / `Zig::GlobalObject::setConsole` / `Zig::deriveShadowRealmGlobalObject` / `JSC::ShadowRealmObject::create`, on the main thread after `BUN_DESTRUCT_VM_ON_EXIT` teardown and after a worker's VM is torn down.
- Cause: `GlobalObject::setConsole()` (`src/jsc/bindings/ZigGlobalObject.cpp:1126`) does `setConsoleClient(new Bun::ConsoleObject(...))`. `JSGlobalObject::setConsoleClient` takes a `WeakPtr`, so nothing owns the object and nothing deletes it when the global is collected.
- The main thread's and every worker's global leak theirs the same way (72 bytes per global, the only LSan report an empty script produces under `Malloc=1`); those reports were hidden by the blanket `leak:Zig__GlobalObject__create` entry in `test/leaksan.supp`.

### Fix
- `Zig::GlobalObject` keeps the client in a `std::unique_ptr<Bun::ConsoleObject>` (`m_consoleObject`); `setConsole()` fills it and installs the `WeakPtr`, and the client is deleted when the global cell is destroyed. This covers every caller of `setConsole()`: `Zig__GlobalObject__create` (main thread and workers), `Zig__GlobalObject__createForTestIsolation`, `BakeCreateProdGlobal`, and `deriveShadowRealmGlobalObject`.
- `Bun::ConsoleObject` gets `WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR`. `JSC::ConsoleClient` is `CanMakeCheckedPtr`, and deleting such an object through a subclass without the override trips `ASSERTION FAILED: m_didBeginDeletion || deleteException == CheckedPtrDeleteCheckException::Yes` in debug builds (the first build of this change did). It also makes a `CheckedPtr` that outlives the client a detected error instead of a use-after-free.
- Why this is correct: the global is the only thing that references the client (`JSGlobalObject::m_consoleClient`, a `WeakPtr`; the Rust side ignores the pointer it is handed and resolves the console through the VM), and any code that can still call into a realm keeps that realm's global alive, so the client can never be reached after the global is destroyed. Deleting it at that point is exactly how WebCore owns `WorkerConsoleClient` (`std::unique_ptr` in `WorkerOrWorkletScriptController`, `WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR` on the client).
- `leak:Zig__GlobalObject__create` is removed from `test/leaksan.supp`: with the fix an empty script and a worker script run leak-free under `Malloc=1` with no suppressions at all, so the entry's only known job was hiding this leak. A sample of test files (`test/cli/test/isolation.test.ts`, worker, BroadcastChannel, console and jsc suites) passes under the CI LSan environment with it removed.
- Tests: `test/js/bun/jsc/shadow.test.js` creates realms from `setImmediate` under `Malloc=1` + `BUN_DESTRUCT_VM_ON_EXIT=1` + `detect_leaks=1`, on the main thread (expects a clean exit) and inside a `worker_threads` worker (expects no `deriveShadowRealmGlobalObject` / `Zig__GlobalObject__create` frames in the report; the exit code cannot be asserted there until #38164 frees the worker's `EventNames` table). Both fail on the unfixed build (`git stash push -- src/ && bun bd test ...`) and pass with it.
- Also run with the fix: the ported Node `test-shadow-realm*.js` tests (including the GC stress, which sweeps realm globals while the VM is running), a 100-realm GC loop that calls a realm function after its `ShadowRealm` wrapper was collected, `bun test --isolate` under `Malloc=1` LSan, and the production half of `test/bake/dev-and-prod.test.ts`.

### Background
- Console client: JSC's `console` object forwards every call to the `JSC::ConsoleClient` registered on the calling global object. `Bun::ConsoleObject` is Bun's implementation; it bridges into the Rust console code. Each `Zig::GlobalObject` installs one on itself.
- ShadowRealm: `new ShadowRealm()` asks the embedder (`deriveShadowRealmGlobalObject`) for a fresh global object in the same VM. It is an ordinary GC cell: when the realm becomes unreachable the cell is swept and `~GlobalObject` runs, long before the VM goes away. `bun test --isolate` retires globals the same way.
- `WeakPtr` / `CanMakeWeakPtr`: WTF's non-owning pointer. The target owns a small refcounted `WeakPtrImpl` that is cleared when the target is destroyed; `setConsoleClient` stores one of these, so the embedder must own the client itself.
- `CanMakeCheckedPtr` / `WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR`: WTF's dangling-pointer check. The object counts outstanding `CheckedPtr`s; the macro replaces `operator delete` on the most derived class with one that marks the deletion as begun (which the base destructor asserts in debug builds) and, if any `CheckedPtr` is still outstanding, zeroes the object instead of freeing it.
- `Malloc=1`: routes bmalloc/libpas (which backs `fastMalloc` and therefore this object) to the system allocator so ASAN/LSan can see those allocations. `BUN_DESTRUCT_VM_ON_EXIT=1` makes exit really destroy the VM, which is what frees the globals and turns the unowned clients into reported leaks.
