### PR TITLE
process.chdir: stop appending a separator to the cached cwd (aborts at PATH_MAX - 1)

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4977,10 +4977,8 @@ impl VirtualMachine {
                 return bun_sys::Result::Err(err);
             }
         };
-        // Stored exactly as `getcwd` returned it (no trailing separator), the same
-        // shape `FileSystem::init` stores at startup. `getcwd` returns at most
-        // `MAX_PATH_BYTES - 1` bytes, so the NUL always fits; a separator plus the
-        // NUL would not.
+        // No trailing separator, matching the shape `FileSystem::init` stores at
+        // startup; `getcwd` fills at most `MAX_PATH_BYTES - 1` bytes, so the NUL fits.
         fs.top_level_dir_buf[..into_cwd_len].copy_from_slice(&buf[..into_cwd_len]);
         fs.top_level_dir_buf[into_cwd_len] = 0;
         // SAFETY: `top_level_dir_buf` is a process-lifetime field of the

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4977,8 +4977,6 @@ impl VirtualMachine {
                 return bun_sys::Result::Err(err);
             }
         };
-        // No trailing separator, matching the shape `FileSystem::init` stores at
-        // startup; `getcwd` fills at most `MAX_PATH_BYTES - 1` bytes, so the NUL fits.
         fs.top_level_dir_buf[..into_cwd_len].copy_from_slice(&buf[..into_cwd_len]);
         fs.top_level_dir_buf[into_cwd_len] = 0;
         // SAFETY: `top_level_dir_buf` is a process-lifetime field of the

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4977,6 +4977,10 @@ impl VirtualMachine {
                 return bun_sys::Result::Err(err);
             }
         };
+        // Stored exactly as `getcwd` returned it (no trailing separator), the same
+        // shape `FileSystem::init` stores at startup. `getcwd` returns at most
+        // `MAX_PATH_BYTES - 1` bytes, so the NUL always fits; a separator plus the
+        // NUL would not.
         fs.top_level_dir_buf[..into_cwd_len].copy_from_slice(&buf[..into_cwd_len]);
         fs.top_level_dir_buf[into_cwd_len] = 0;
         // SAFETY: `top_level_dir_buf` is a process-lifetime field of the
@@ -4984,14 +4988,6 @@ impl VirtualMachine {
         // backing storage.
         fs.top_level_dir =
             unsafe { bun_ptr::detach_lifetime(&fs.top_level_dir_buf[..into_cwd_len]) };
-        let len = fs.top_level_dir.len();
-        if fs.top_level_dir_buf[len - 1] != bun_paths::SEP {
-            fs.top_level_dir_buf[len] = bun_paths::SEP;
-            fs.top_level_dir_buf[len + 1] = 0;
-            // SAFETY: see above.
-            fs.top_level_dir =
-                unsafe { bun_ptr::detach_lifetime(&fs.top_level_dir_buf[..len + 1]) };
-        }
         bun_core::set_top_level_dir(fs.top_level_dir);
         Ok(())
     }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,8 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { mkdirSync } from "fs";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -312,6 +313,82 @@ it("process.chdir() on root dir", () => {
   } finally {
     process.chdir(cwd);
   }
+});
+
+// The cwd bun caches for the resolver is stored as getcwd() returned it, both at
+// startup and after process.chdir(). It is what a failing chdir reports as `path`,
+// where node reports process.cwd().
+it("process.chdir() error path is process.cwd() after an earlier successful chdir", () => {
+  using dir = tempDir("process-chdir-error-path", {});
+  const cwd = process.cwd();
+  try {
+    process.chdir(String(dir));
+    const newCwd = process.cwd();
+    let error;
+    try {
+      process.chdir("does-not-exist");
+    } catch (e) {
+      error = e;
+    }
+    expect({ code: error.code, path: error.path, dest: error.dest, message: error.message }).toEqual({
+      code: "ENOENT",
+      path: newCwd,
+      dest: "does-not-exist",
+      message: `ENOENT: no such file or directory, chdir '${newCwd}' -> 'does-not-exist'`,
+    });
+  } finally {
+    process.chdir(cwd);
+  }
+});
+
+// MAX_PATH_BYTES (src/bun_core/util.rs) is 4096 on Linux and 1024 on macOS and the
+// BSDs; getcwd() can return one byte less than that. Windows' limit (~98 KB of
+// UTF-8) is not reachable with a real directory tree.
+it.skipIf(isWindows)("process.chdir() into a directory whose path is MAX_PATH_BYTES - 1 bytes long", async () => {
+  const target = (isLinux ? 4096 : 1024) - 1;
+  using dir = tempDir("process-chdir-path-max", {});
+
+  const segment = Buffer.alloc(200, "d").toString();
+  let parent = String(dir);
+  while (target - Buffer.byteLength(parent) > 256) {
+    parent = join(parent, segment);
+    mkdirSync(parent);
+  }
+  const deepest = join(parent, Buffer.alloc(target - Buffer.byteLength(parent) - 1, "L").toString());
+  expect(Buffer.byteLength(deepest)).toBe(target);
+  mkdirSync(deepest);
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const target = ${JSON.stringify(deepest)};
+       process.chdir(target);
+       let error;
+       try {
+         process.chdir("does-not-exist");
+       } catch (e) {
+         error = e;
+       }
+       console.log(JSON.stringify({
+         cwdIsTarget: process.cwd() === target,
+         cwdBytes: Buffer.byteLength(process.cwd()),
+         errorCode: error.code,
+         errorPathIsTarget: error.path === target,
+       }));`,
+    ],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout:
+      JSON.stringify({ cwdIsTarget: true, cwdBytes: target, errorCode: "ENOENT", errorPathIsTarget: true }) + "\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 it("process.hrtime()", async () => {


### PR DESCRIPTION
### Problem
- `process.chdir(dir)` aborts the process when the absolute path of `dir` is exactly `MAX_PATH_BYTES - 1` bytes long (4095 on Linux, 1023 on macOS). The `chdir(2)` itself succeeds; 4094 bytes works.
  ```
  panic: index out of bounds: the len is 4096 but the index is 4096
  ```
- `VirtualMachine::set_process_cwd` (src/jsc/VirtualMachine.rs) copies `getcwd()` into `fs.top_level_dir_buf` (a `PathBuffer`, `MAX_PATH_BYTES` bytes) and then appends a separator at `[len]` and a NUL at `[len + 1]`. `getcwd()` can return `MAX_PATH_BYTES - 1` bytes, so `[len + 1]` is one past the end.
- The appended separator is also the only place bun produces a cwd in that shape: `FileSystem::init` (startup) and `PackageManager` store `getcwd()` verbatim. The post-chdir shape leaks to JS: a failing `process.chdir()` that follows a successful one reports `path: "/tmp/x/"` (and the same in `message`), where Node reports `process.cwd()`, i.e. `"/tmp/x"`.

### Fix
- `set_process_cwd` stores the `getcwd()` result as is and no longer appends a separator. The remaining writes are `[..len]` and the NUL at `[len]`, which every `getcwd` implementation in `bun_sys` guarantees fit (POSIX `getcwd` NUL-terminates inside the buffer; the Windows wrapper encodes into `buf[..len - 1]`).
- Correct because the value after `chdir` now has the same shape as the value bun runs with from startup until the first `chdir`, and every reader of `top_level_dir` already handles that shape: the resolver strips a trailing slash before using a directory as a cache key, `join_abs*` inserts the separator itself, `relative*` / `is_parent_or_equal` accept both, and the sites that slice a prefix off a path (`ZigStackFrame`, junit reporter, `BunObject::get_public_path`) strip the leading separator afterwards. `DevServer::relative_path` even asserts the root has no trailing slash, which the old post-chdir value violated (#36396 works around that in bake).
- The removed block is the surviving half of an old invariant: until e1cfea4925 (#16026, January 2025) startup also appended a separator. That commit removed the startup half (and added the two node `chdir` tests) but left this one, so since then every process that never calls `process.chdir()` has run with the no-separator shape and only a `chdir()` switched shapes. The Rust port carried that over as is.
- Matches Node for the error case: Node's `Chdir` reports `uv_cwd()` as `path`, so `err.path === process.cwd()` also after an earlier successful `chdir` (`test-process-chdir-errormessage.js` only covers the case with no prior `chdir`).
- Verified with `bun bd test test/js/node/process/process.test.js`: two new tests, one chdirs into a directory built to exactly `MAX_PATH_BYTES - 1` bytes in a `bun -e` child (skipped on Windows, whose limit is about 98 KB), one checks `err.path` / `err.message` after a successful in-process `chdir`. Both fail on the current release (the panic above, and `path: "/tmp/.../"`), both pass with the fix.
- Also run with the fix: `test-process-chdir.js`, `test-process-chdir-errormessage.js`, `test/cli/test/isolation.test.ts` (the `--isolate` cwd restore goes through `set_process_cwd`), `bundler_edgecase` / `bundler_plugin` / `bundler_html` / `bundler_splitting` / `bun-build-api` (the API backend runs `Bun.build` after an in-process `chdir`), and a `Glob.scan()` without `cwd` after `chdir` compared against fast-glob, since `GlobWalker` reads `top_level_dir` directly.

Related open PRs that touch the same function for other bugs: #36584 (torn reads from worker threads; its rewrite re-appends the separator and would need the same removal) and #32410 (getcwd failing after chdir).

### Background
- `top_level_dir` is the resolver's cached copy of the process cwd (`bun_resolver::fs::FileSystem`, mirrored into `bun_core::top_level_dir()`). Module resolution for sources without a directory, `Glob.scan()` without `cwd`, the default `cwd` of `Bun.spawn`, error stack printing and similar consumers read it instead of calling `getcwd()` each time; `process.chdir()` is what refreshes it. `process.cwd()` itself is a real `getcwd()` call and was never affected.
- `PathBuffer` is `[u8; MAX_PATH_BYTES]` (`src/bun_core/util.rs`): 4096 on Linux, 1024 on macOS and the BSDs, `32767 * 3 + 1` on Windows. `getcwd` into it yields at most `MAX_PATH_BYTES - 1` bytes, leaving room for exactly one more byte.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->