### PR TITLE
docs: use code spans for flag names in the CLI flag references

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -228,7 +228,7 @@ To build for macOS x64:
 
 The segments of the `--target` value can appear in any order, as long as they're delimited by `-`.
 
-| --target             | Operating System | Architecture | Modern | Baseline | Libc  |
+| `--target`           | Operating System | Architecture | Modern | Baseline | Libc  |
 | -------------------- | ---------------- | ------------ | ------ | -------- | ----- |
 | bun-linux-x64        | Linux            | x64          | ✅     | ✅       | glibc |
 | bun-linux-arm64      | Linux            | arm64        | ✅     | N/A      | glibc |

--- a/docs/snippets/cli/add.mdx
+++ b/docs/snippets/cli/add.mdx
@@ -98,7 +98,7 @@ bun add <package> <@version>
 </ParamField>
 
 <ParamField path="--cafile" type="string">
-  Same as <code>--ca</code>, but as a file path to the certificate
+  Same as `--ca`, but as a file path to the certificate
 </ParamField>
 
 <ParamField path="--registry" type="string">

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -23,8 +23,8 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--env" type="string" default="disable">
-  Inline environment variables into the bundle as <code>process.env.${name}</code>. To inline variables matching a
-  prefix, use a glob like <code>FOO_PUBLIC_*</code>
+  Inline environment variables into the bundle as `process.env.${name}`. To inline variables matching a prefix, use a
+  glob like `FOO_PUBLIC_*`
 </ParamField>
 
 ### Output & File Handling
@@ -42,7 +42,7 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--banner" type="string">
-  Add a banner to the output (e.g. <code>"use client"</code> for React Server Components)
+  Add a banner to the output (e.g. `"use client"` for React Server Components)
 </ParamField>
 
 <ParamField path="--footer" type="string">
@@ -50,8 +50,7 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--format" type="string" default="esm">
-  Module format of the output bundle. One of <code>esm</code>, <code>cjs</code>, or <code>iife</code>. Defaults to{" "}
-  <code>cjs</code> when <code>--bytecode</code> is used.
+  Module format of the output bundle. One of `esm`, `cjs`, or `iife`. Defaults to `cjs` when `--bytecode` is used.
 </ParamField>
 
 ### File Naming
@@ -101,7 +100,7 @@ bun build <entry points>
 ### Minification & Optimization
 
 <ParamField path="--emit-dce-annotations" type="boolean" default="true">
-  Re-emit Dead Code Elimination annotations. Disabled when <code>--minify-whitespace</code> is used
+  Re-emit Dead Code Elimination annotations. Disabled when `--minify-whitespace` is used
 </ParamField>
 
 <ParamField path="--minify" type="boolean">
@@ -131,7 +130,7 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--no-clear-screen" type="boolean">
-  Don’t clear the terminal when rebuilding with <code>--watch</code>
+  Don’t clear the terminal when rebuilding with `--watch`
 </ParamField>
 
 <ParamField path="--react-fast-refresh" type="boolean">
@@ -194,9 +193,9 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--debug-dump-server-files" type="boolean">
-  When <code>--app</code> is set, dump all server files to disk even for static builds
+  When `--app` is set, dump all server files to disk even for static builds
 </ParamField>
 
 <ParamField path="--debug-no-minify" type="boolean">
-  When <code>--app</code> is set, disable all minification
+  When `--app` is set, disable all minification
 </ParamField>

--- a/docs/snippets/cli/link.mdx
+++ b/docs/snippets/cli/link.mdx
@@ -84,7 +84,7 @@ bun link <packages>
 </ParamField>
 
 <ParamField path="--cafile" type="string">
-  Same as <code>--ca</code>, but as a file path to the certificate
+  Same as `--ca`, but as a file path to the certificate
 </ParamField>
 
 <ParamField path="--registry" type="string">

--- a/docs/snippets/cli/outdated.mdx
+++ b/docs/snippets/cli/outdated.mdx
@@ -91,7 +91,7 @@ bun outdated <filter>
 </ParamField>
 
 <ParamField path="--cafile" type="string">
-  Same as <code>--ca</code>, but as a file path to the certificate
+  Same as `--ca`, but as a file path to the certificate
 </ParamField>
 
 <ParamField path="--registry" type="string">

--- a/docs/snippets/cli/patch.mdx
+++ b/docs/snippets/cli/patch.mdx
@@ -11,7 +11,7 @@ bun patch <package>@<version>
 </ParamField>
 
 <ParamField path="--patches-dir" type="string">
-  The directory to put the patch file in (only if --commit is used)
+  The directory to put the patch file in (only if `--commit` is used)
 </ParamField>
 
 ### Dependency Management
@@ -92,7 +92,7 @@ bun patch <package>@<version>
 </ParamField>
 
 <ParamField path="--cafile" type="string">
-  Same as <code>--ca</code>, but as a file path to the certificate
+  Same as `--ca`, but as a file path to the certificate
 </ParamField>
 
 <ParamField path="--registry" type="string">

--- a/docs/snippets/cli/remove.mdx
+++ b/docs/snippets/cli/remove.mdx
@@ -65,7 +65,7 @@ bun remove <package>
 </ParamField>
 
 <ParamField path="--cafile" type="string">
-  Same as <code>--ca</code>, but as a file path to the certificate
+  Same as `--ca`, but as a file path to the certificate
 </ParamField>
 
 <ParamField path="--registry" type="string">

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -29,7 +29,7 @@ bun run <file or script>
 ### Workspace Management
 
 <ParamField path="--elide-lines" type="number" default="10">
-  Number of lines of script output shown when using --filter (default: 10). Set to 0 to show all lines
+  Number of lines of script output shown when using `--filter` (default: 10). Set to 0 to show all lines
 </ParamField>
 
 <ParamField path="--filter" type="string">
@@ -49,7 +49,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--no-exit-on-error" type="boolean">
-  When using <code>--parallel</code> or <code>--sequential</code>, continue running other scripts when one fails
+  When using `--parallel` or `--sequential`, continue running other scripts when one fails
 </ParamField>
 
 ### Runtime &amp; Process Control
@@ -63,10 +63,9 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--interactive" type="boolean">
-  Open the Node.js-compatible REPL (<code>node:repl</code>). When combined with <code>-e</code>, starts the REPL and
-  then evaluates the script. Under <code>--interactive</code>, <code>-e</code> is raw JavaScript (matching{" "}
-  <code>node -i -e</code>); use <code>bun repl</code> for TypeScript. Distinct from <code>bun repl</code>, which is
-  Bun's native REPL.
+  Open the Node.js-compatible REPL (`node:repl`). When combined with `-e`, starts the REPL and then evaluates the
+  script. Under `--interactive`, `-e` is raw JavaScript (matching `node -i -e`); use `bun repl` for TypeScript. Distinct
+  from `bun repl`, which is Bun's native REPL.
 </ParamField>
 
 <ParamField path="--smol" type="boolean">
@@ -113,7 +112,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--watch-kill-signal" type="string" default="SIGTERM">
-  Signal whose handlers run when --watch restarts the process
+  Signal whose handlers run when `--watch` restarts the process
 </ParamField>
 
 <ParamField path="--hot" type="boolean">
@@ -121,7 +120,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--no-clear-screen" type="boolean">
-  Disable clearing the terminal screen on reload when --hot or --watch is enabled
+  Disable clearing the terminal screen on reload when `--hot` or `--watch` is enabled
 </ParamField>
 
 ### Debugging
@@ -145,11 +144,11 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--require" type="string">
-  Alias of --preload, for Node.js compatibility
+  Alias of `--preload`, for Node.js compatibility
 </ParamField>
 
 <ParamField path="--import" type="string">
-  Alias of --preload, for Node.js compatibility
+  Alias of `--preload`, for Node.js compatibility
 </ParamField>
 
 <ParamField path="--no-install" type="boolean">
@@ -162,7 +161,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="-i" type="boolean">
-  Auto-install dependencies during execution. Equivalent to --install=fallback
+  Auto-install dependencies during execution. Equivalent to `--install=fallback`
 </ParamField>
 
 <ParamField path="--prefer-offline" type="boolean">
@@ -178,7 +177,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--main-fields" type="string">
-  Main fields to lookup in <code>package.json</code>. Defaults to --target dependent
+  Main fields to lookup in `package.json`. Defaults to `--target` dependent
 </ParamField>
 
 <ParamField path="--preserve-symlinks" type="boolean">
@@ -200,18 +199,17 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--define" type="string">
-  Substitute K:V while parsing, e.g. <code>--define process.env.NODE_ENV:"development"</code>. Values are parsed as
-  JSON. Alias: <code>-d</code>
+  Substitute K:V while parsing, e.g. `--define process.env.NODE_ENV:"development"`. Values are parsed as JSON. Alias:
+  `-d`
 </ParamField>
 
 <ParamField path="--drop" type="string">
-  Remove function calls, e.g. <code>--drop=console</code> removes all <code>console.*</code> calls
+  Remove function calls, e.g. `--drop=console` removes all `console.*` calls
 </ParamField>
 
 <ParamField path="--loader" type="string">
-  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. Valid loaders: <code>js</code>,{" "}
-  <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>, <code>text</code>,{" "}
-  <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
+  Parse files with `.ext:loader`, e.g. `--loader .js:jsx`. Valid loaders: `js`, `jsx`, `ts`, `tsx`, `json`, `toml`,
+  `text`, `file`, `wasm`, `napi`. Alias: `-l`
 </ParamField>
 
 <ParamField path="--no-macros" type="boolean">
@@ -239,7 +237,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--ignore-dce-annotations" type="boolean">
-  Ignore tree-shaking annotations such as <code>@__PURE__</code>
+  Ignore tree-shaking annotations such as `@__PURE__`
 </ParamField>
 
 ### Networking &amp; Security

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -15,7 +15,7 @@ bun test <patterns>
 </ParamField>
 
 <ParamField path="--retry" type="number">
-  Retry failed tests up to <code>NUMBER</code> times. Overridden by per-test <code>{`{ retry: N }`}</code>
+  Retry failed tests up to `NUMBER` times. Overridden by per-test `{ retry: N }`
 </ParamField>
 
 <ParamField path="--concurrent" type="boolean">
@@ -51,16 +51,15 @@ bun test <patterns>
 ### Reporting
 
 <ParamField path="--reporter" type="string">
-  Test output reporter format. Available: <code>junit</code> (requires --reporter-outfile), <code>dots</code>. Default:
-  console output.
+  Test output reporter format. Available: `junit` (requires `--reporter-outfile`), `dots`. Default: console output.
 </ParamField>
 
 <ParamField path="--reporter-outfile" type="string">
-  Output file path for the reporter format (required with --reporter)
+  Output file path for the reporter format (required with `--reporter`)
 </ParamField>
 
 <ParamField path="--dots" type="boolean">
-  Enable dots reporter. Shorthand for --reporter=dots
+  Enable dots reporter. Shorthand for `--reporter=dots`
 </ParamField>
 
 ### Coverage

--- a/docs/snippets/cli/update.mdx
+++ b/docs/snippets/cli/update.mdx
@@ -61,7 +61,7 @@ bun update <name>@<version>
 </ParamField>
 
 <ParamField path="--cafile" type="string">
-  Same as <code>--ca</code>, but as a file path to the certificate
+  Same as `--ca`, but as a file path to the certificate
 </ParamField>
 
 <ParamField path="--registry" type="string">


### PR DESCRIPTION
### Problem

- On bun.com, the flag references imported from `docs/snippets/cli/*.mdx` render a number of flag names with an em dash. The bundler page has `<code>—bytecode</code>`, `<code>—minify-whitespace</code>`, `<code>—watch</code>`, `<code>—app</code>` and `<code>“use client”</code>`; the runtime page has `<code>—define process.env.NODE_ENV:“development”</code>`, `<code>—drop=console</code>`, `<code>—loader .js:jsx</code>`, `<code>—parallel</code>`, `<code>—sequential</code>`, `<code>—interactive</code>`; the add/link/outdated/patch/remove/update pages each have `<code>—ca</code>`. Copying one of these gives a flag bun rejects.
- Flags written as bare prose in the same bodies render the same way (`Defaults to —target dependent`, `requires —reporter-outfile`, `only if —commit is used`, 11 in total), as does the `—target` header cell of the target table in `docs/bundler/executables.mdx`.
- Two other raw `<code>` bodies in the same files are not literal either: `<code>process.env.${name}</code>` (`--env`, build.mdx:26) renders as `process.env.$` because `{name}` is an MDX expression (stock MDX throws `ReferenceError: name is not defined` on this file), and `<code>@__PURE__</code>` (`--ignore-dce-annotations`, run.mdx:242) renders as `@<strong>PURE</strong>`.
- Cause: the text inside a raw `<code>` element is ordinary markdown text to MDX, so the site's typography pass (`--` to em dash, straight quotes to curly), expression syntax and emphasis all apply to it. A backtick code span is exempt from all three. The `--react-compiler` row in the same build.mdx already uses backticks and renders as `<code>--target</code>`.

### Fix

- Flag names and code fragments in the affected ParamField bodies are now backtick code spans. Each body this touches is converted as a whole so it is plain markdown (no raw elements, no `{" "}`); bodies whose raw `<code>` content has nothing for these passes to rewrite (`package.json`, `-p`, ...) render correctly and are left alone. `<code>{`{ retry: N }`}</code>` in test.mdx becomes the `` `{ retry: N }` `` form that `docs/test/index.mdx` already uses. The `--target` header cell in executables.mdx gets the same treatment.
- Correct because a backtick span becomes an `inlineCode` node: smartypants, MDX expressions and emphasis only operate on text nodes, so its content is emitted verbatim. The site already renders such spans inside ParamField bodies correctly (`<code>--access restricted</code>` on the publish page comes from a backtick span in publish.mdx).
- Converting whole bodies rather than single spans is deliberate: prettier formats these bodies as JSX and is free to break a line between `</code>` and following punctuation, which JSX collapses but MDX renders as a space (`node -i -e );` is what it produced for the `--interactive` body when only the flag span was changed). A body that is plain markdown only ever breaks at spaces, which MDX renders as a space anyway.
- Verified by compiling each changed file at `main` and on this branch with `@mdx-js/mdx` + `remark-gfm` + `remark-smartypants` and rendering to HTML: 33 non-literal code spans / em-dashed flags before, 0 after (per-file counts below); prose is still smartened (`Bun’s`). `prettier --check` passes on the changed files. The before numbers match the live pages fetched today.
- Not touched: the `<pre><code>` examples block in init.mdx (renders as a single line with em dashes), which #25679 removes. #36904 and #38266 also edit the `--loader` body in run.mdx; whichever of the three lands last needs a one-hunk rebase.

### Background

- `docs/bundler/index.mdx`, `docs/runtime/index.mdx`, `docs/test/index.mdx` and `docs/pm/cli/*.mdx` import `docs/snippets/cli/<command>.mdx`, which list each flag as a `<ParamField path="--flag">` element whose body is the description. The `path` attribute is a JSX attribute and renders fine; only the body text is affected.
- In MDX, text between JSX/HTML tags is parsed as markdown, so a raw `<code>` element's children go through every remark text transform. A backtick span is recognised as code during parsing and is opaque to those transforms.
- smartypants is the remark plugin family behind "smart typography": in text nodes it turns `--` into a dash, straight quotes into curly quotes and `...` into an ellipsis. This is wanted for prose (`Bun's` to `Bun’s`) and wrong for anything a reader will copy.

<details>
<summary>Non-literal renderings per file, compiled with MDX + smartypants (before -> after)</summary>

```
docs/bundler/executables.mdx        non-literal <code>:  0 ->  0   em-dash flags in prose:  1 ->  0
docs/snippets/cli/add.mdx           non-literal <code>:  1 ->  0   em-dash flags in prose:  0 ->  0
docs/snippets/cli/build.mdx         non-literal <code>:  7 ->  0   em-dash flags in prose:  0 ->  0
docs/snippets/cli/link.mdx          non-literal <code>:  1 ->  0   em-dash flags in prose:  0 ->  0
docs/snippets/cli/outdated.mdx      non-literal <code>:  1 ->  0   em-dash flags in prose:  0 ->  0
docs/snippets/cli/patch.mdx         non-literal <code>:  1 ->  0   em-dash flags in prose:  1 ->  0
docs/snippets/cli/remove.mdx        non-literal <code>:  1 ->  0   em-dash flags in prose:  0 ->  0
docs/snippets/cli/run.mdx           non-literal <code>:  7 ->  0   em-dash flags in prose:  8 ->  0
docs/snippets/cli/test.mdx          non-literal <code>:  0 ->  0   em-dash flags in prose:  3 ->  0
docs/snippets/cli/update.mdx        non-literal <code>:  1 ->  0   em-dash flags in prose:  0 ->  0
total: 33 -> 0
```

"non-literal `<code>`" counts inline code elements whose rendered text contains an em/en dash, curly quote, ellipsis or nested emphasis, or equals `process.env.$`. The `{ retry: N }` span in test.mdx is not in these counts: stock MDX renders the old `<code>{`...`}</code>` form, but the live test page's server-rendered HTML ends that body at "per-test " and drops it, and the backtick form is what the rest of the docs use.

Live HTML at the time of writing, for reference: bundler page contains `<code>—bytecode</code>`, `<code>—minify-whitespace</code>`, `<code>—watch</code>`, 2x `<code>—app</code>`, `<code>“use client”</code>`, `<code>process.env.$</code>`; runtime page contains the six `<code>—...</code>` spans listed above, `<code>@<strong>PURE</strong></code>`, and the bare-prose `—filter`, `—watch`, `—hot`, `—preload`, `—install=fallback`, `—target`; executables page contains `<th>—target</th>`.

</details>
