### PR TITLE
process: ignore falsy prevValue in cpuUsage() and threadCpuUsage() like Node

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3851,7 +3851,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionCpuUsage, (JSC::JSGlobalObject * global
 
     if (callFrame->argumentCount() > 0) {
         JSValue comparatorValue = callFrame->argument(0);
-        if (!comparatorValue.isUndefined()) {
+        // Node ignores any falsy prevValue, not just undefined:
+        // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L129
+        if (comparatorValue.toBoolean(globalObject)) {
             JSC::JSObject* comparator = comparatorValue.getObject();
             if (!comparator) [[unlikely]] {
                 return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "prevValue"_s, "object"_s, comparatorValue);
@@ -3914,7 +3916,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionThreadCpuUsage, (JSC::JSGlobalObject * 
     double userComparator = 0;
     double systemComparator = 0;
     JSValue prevValue = callFrame->argument(0);
-    if (!prevValue.isUndefined()) {
+    // Node ignores any falsy prevValue, not just undefined:
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L169
+    if (prevValue.toBoolean(globalObject)) {
         Bun::V::validateObject(throwScope, globalObject, prevValue, "prevValue"_s);
         RETURN_IF_EXCEPTION(throwScope, {});
         JSC::JSObject* comparator = prevValue.getObject();

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1088,6 +1088,67 @@ describe.concurrent(() => {
     });
   });
 
+  // Node only looks at prevValue when it is truthy (`if (prevValue)` in
+  // lib/internal/process/per_thread.js), so a falsy one behaves like no argument.
+  describe.each(["cpuUsage", "threadCpuUsage"])("process.%s prevValue", name => {
+    it.each([null, 0, false, "", NaN, 0n])("ignores falsy prevValue %p", prevValue => {
+      const usage = process[name](prevValue);
+      expect(usage).toEqual({ user: expect.any(Number), system: expect.any(Number) });
+      expect(usage.user).toBeGreaterThanOrEqual(0);
+      expect(usage.system).toBeGreaterThanOrEqual(0);
+    });
+
+    it.each([
+      [1, "Received type number (1)"],
+      [true, "Received type boolean (true)"],
+      ["x", "Received type string ('x')"],
+      [1n, "Received type bigint (1n)"],
+    ])("still rejects truthy non-object prevValue %p", (prevValue, received) => {
+      expect(() => process[name](prevValue)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "prevValue" argument must be of type object. ${received}`,
+        }),
+      );
+    });
+
+    it.each([
+      [
+        {},
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        'The "prevValue.user" property must be of type number. Received undefined',
+      ],
+      [
+        { user: "x", system: 1 },
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        `The "prevValue.user" property must be of type number. Received type string ('x')`,
+      ],
+      [
+        { user: 1, system: "x" },
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        `The "prevValue.system" property must be of type number. Received type string ('x')`,
+      ],
+      [
+        { user: -1, system: 1 },
+        "RangeError",
+        "ERR_INVALID_ARG_VALUE",
+        "The property 'prevValue.user' is invalid. Received -1",
+      ],
+      [
+        { user: 1, system: -1 },
+        "RangeError",
+        "ERR_INVALID_ARG_VALUE",
+        "The property 'prevValue.system' is invalid. Received -1",
+      ],
+    ])("still rejects truthy invalid prevValue %o", (prevValue, errorName, code, message) => {
+      expect(() => process[name](prevValue)).toThrow(expect.objectContaining({ name: errorName, code, message }));
+    });
+  });
+
   if (process.platform !== "win32") {
     it("process.getegid", () => {
       expect(typeof process.getegid()).toBe("number");


### PR DESCRIPTION
### Problem
- `process.cpuUsage(null)` and `process.threadCpuUsage(null)` throw `TypeError [ERR_INVALID_ARG_TYPE]: The "prevValue" argument must be of type object. Received null`. Same for `0`, `false`, `""`, `NaN` and `0n`.
- Node returns the current usage for every falsy `prevValue`: both functions in `lib/internal/process/per_thread.js` gate the previous-value handling on `if (prevValue)` ([cpuUsage](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L129), [threadCpuUsage](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L169)).
- Bun gates on `!prevValue.isUndefined()` instead, in `Process_functionCpuUsage` (`src/jsc/bindings/BunProcess.cpp:3854`) and `Process_functionThreadCpuUsage` (`src/jsc/bindings/BunProcess.cpp:3917`), so `undefined` is the only value that skips validation.

### Fix
- Both gates now use `JSValue::toBoolean()`, the engine's ToBoolean, which is what Node's `if (prevValue)` evaluates. These two functions are the only callers of this pattern; `process.hrtime(prev)` is unaffected because Node itself uses `time !== undefined` there, and Bun already matches it.
- Nothing inside the gate changed: every truthy value goes through the same object, `user` and `system` checks as before, so invalid objects and truthy primitives still throw Node's errors (asserted in the new tests).
- Test: `test/js/node/process/process.test.js`, new `describe.each(["cpuUsage", "threadCpuUsage"])` block. The 12 "ignores falsy prevValue" cases fail on the unfixed build with the error above and pass with this change; the 18 "still rejects" cases pass on both and pin the truthy behavior, including the exact messages Node prints.
- Also run with this change: the whole `process.test.js` file (195 pass), and the upstream `test/js/node/test/parallel/test-process-cpuUsage.js`, `test-process-threadCpuUsage-main-thread.js`, `test-process-threadCpuUsage-worker-threads.js` and `test-worker-cpu-usage.js` (all exit 0).
- Not changed here: when `prevValue` is a truthy array or function, Node reads `.user` first and only then calls `validateObject`, so `process.cpuUsage([])` reports `"prevValue"` in Node but `"prevValue.user"` in Bun, and `threadCpuUsage` rejects arrays or functions that do carry valid `user`/`system` properties. That is the validation order for truthy values, a separate issue from this gate, and it is tracked separately.

### Background
- `prevValue` is the optional previous reading; when given, both functions return the difference between the current reading and it, otherwise the absolute reading.
- Node implements both functions in JS on top of a native getter, so "was a previous value given" is a plain JS truthiness test. Bun implements them directly as host functions in C++, where `callFrame->argument(0)` is `undefined` when the argument is missing; `toBoolean()` is the C++ equivalent of the JS truthiness test and cannot throw or run user code.

<details>
<summary>Repro under Node v26.3.0, Bun 1.4.0 and this branch</summary>

```js
for (const fn of ["cpuUsage", "threadCpuUsage"]) {
  for (const v of [null, 0, false, "", NaN, 0n]) {
    try { process[fn](v); console.log(fn, "ok"); }
    catch (e) { console.log(fn, e.code, e.message); }
  }
}
```

Node v26.3.0 and this branch print `ok` for all 12 lines. Bun 1.4.0 prints, for each function:

```
cpuUsage ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received null
cpuUsage ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received type number (0)
cpuUsage ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received type boolean (false)
cpuUsage ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received type string ('')
cpuUsage ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received type number (NaN)
cpuUsage ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received type bigint (0n)
```

The truthy cases asserted by the new tests (`1`, `true`, `"x"`, `1n`, `{}`, bad `user`/`system`) produce byte-identical `name`, `code` and `message` under Node v26.3.0 and Bun, before and after this change.
</details>
