### PR TITLE
node:wasi: keep bindings.fs per WASI instance

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -406,7 +406,6 @@ var require_wasi = __commonJS({
       function (mod) {
         return mod && mod.__esModule ? mod : { default: mod };
       };
-    let fs;
     Object.defineProperty(exports, "__esModule", { value: true });
     var SC_OPEN_MAX = 32768;
     var types_1 = require_types();
@@ -586,7 +585,7 @@ var require_wasi = __commonJS({
         this.view = void 0;
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
         const bindings = this.bindings;
-        fs = bindings.fs;
+        const fs = bindings.fs;
         this.FD_MAP = /* @__PURE__ */ new Map([
           [
             constants_1.WASI_STDIN_FILENO,
@@ -1653,7 +1652,7 @@ var require_wasi = __commonJS({
       fstatSync(real_fd) {
         if (real_fd <= 2) {
           try {
-            return fs.fstatSync(real_fd);
+            return this.bindings.fs.fstatSync(real_fd);
           } catch {
             const now = new Date();
             return {
@@ -1678,7 +1677,7 @@ var require_wasi = __commonJS({
             };
           }
         }
-        return fs.fstatSync(real_fd);
+        return this.bindings.fs.fstatSync(real_fd);
       }
       shortPause() {
         if (this.sleep == null) return;

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -47,6 +47,82 @@ it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {
   expect(wasi.FD_MAP.get(0).rights).toEqual({ base: WASI_RIGHT_FD_READ, inheriting: BigInt(0) });
 });
 
+it("each instance keeps using its own bindings.fs after another instance is constructed", () => {
+  using dir = tempDir("wasi-bindings-fs", {
+    "file.txt": "",
+  });
+  const file = path.join(String(dir), "file.txt");
+
+  // Every fs call an instance makes is recorded under the tag of the fs it was given.
+  const calls = { first: [], second: [] };
+  const recordingFs = tag =>
+    new Proxy(fs, {
+      get(target, name) {
+        const value = target[name];
+        if (typeof value !== "function") return value;
+        return (...args) => {
+          calls[tag].push(name);
+          return value.apply(target, args);
+        };
+      },
+    });
+  const drain = () => {
+    const recorded = { first: calls.first, second: calls.second };
+    calls.first = [];
+    calls.second = [];
+    return recorded;
+  };
+  const bindingsWith = tag => ({ ...new WASI().bindings, fs: recordingFs(tag) });
+
+  const first = new WASI({ preopens: { "/": String(dir) }, bindings: bindingsWith("first") });
+  const second = new WASI({ preopens: { "/": String(dir) }, bindings: bindingsWith("second") });
+  expect(drain()).toEqual({ first: ["openSync"], second: ["openSync"] });
+
+  // WASI#fstatSync, both the stdio branch (fd <= 2) and the general one
+  first.fstatSync(1);
+  const realFd = fs.openSync(file, "r");
+  try {
+    first.fstatSync(realFd);
+  } finally {
+    fs.closeSync(realFd);
+  }
+  expect(drain()).toEqual({ first: ["fstatSync", "fstatSync"], second: [] });
+
+  second.fstatSync(1);
+  expect(drain()).toEqual({ first: [], second: ["fstatSync"] });
+
+  // The syscalls the guest imports (here: open a file, write to it, close it)
+  const WASI_ESUCCESS = 0;
+  const WASI_RIGHT_FD_WRITE = BigInt(64);
+  const preopenFd = 3;
+  const pathPtr = 1024;
+  const iovPtr = 2048;
+  const dataPtr = 4096;
+  const fdPtr = 8192;
+  const nwrittenPtr = fdPtr + 8;
+
+  first.setMemory(new WebAssembly.Memory({ initial: 1 }));
+  const memory = Buffer.from(first.memory.buffer);
+  const view = new DataView(first.memory.buffer);
+  const pathLen = memory.write("file.txt", pathPtr);
+  const dataLen = memory.write("written by first", dataPtr);
+  view.setUint32(iovPtr, dataPtr, true);
+  view.setUint32(iovPtr + 4, dataLen, true);
+
+  expect(first.wasiImport.path_open(preopenFd, 0, pathPtr, pathLen, 0, WASI_RIGHT_FD_WRITE, BigInt(0), 0, fdPtr)).toBe(
+    WASI_ESUCCESS,
+  );
+  const guestFd = view.getUint32(fdPtr, true);
+  expect(first.wasiImport.fd_write(guestFd, iovPtr, 1, nwrittenPtr)).toBe(WASI_ESUCCESS);
+  expect(view.getUint32(nwrittenPtr, true)).toBe(dataLen);
+  expect(first.wasiImport.fd_close(guestFd)).toBe(WASI_ESUCCESS);
+
+  const syscalls = drain();
+  expect(syscalls.second).toEqual([]);
+  expect(syscalls.first).toEqual(expect.arrayContaining(["openSync", "fstatSync", "writeSync", "closeSync"]));
+  expect(fs.readFileSync(file, "utf8")).toBe("written by first");
+});
+
 it("random_get fills only the requested window", () => {
   const wasi = new WASI({});
   wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));


### PR DESCRIPTION
### Problem
- `new WASI({ bindings })` is supposed to give that instance its own `bindings.fs`. Constructing a second `WASI` with a different `bindings.fs` silently switches every earlier instance over to the second one's `fs`: the first instance's `fstatSync()` and its `wasi_snapshot_preview1` syscalls (`path_open`, `fd_read`, `fd_write`, `fd_close`, ...) all start calling the newest instance's `fs`.
- Cause: `src/js/node/wasi.ts` keeps the fs binding in a module-level `let fs;` (line 409) that each constructor reassigns (`fs = bindings.fs;`, line 589). The ~33 `fs.*` call sites in the `wasiImport` closures and both branches of `WASI#fstatSync()` (lines 1656, 1681) read that shared variable, so whichever instance was constructed last wins.
- This came from 0dfde6f8c7b, which hoisted `fs` out of the constructor so that `fstatSync()` (which referenced an undeclared `bindings`) had something to read. Upstream wasi-js keeps `fs` constructor-local and reads `this.bindings.fs` in `fstatSync()`.
- Reproduces on bun 1.4.0:
  ```js
  const { WASI } = require("node:wasi");
  const fs = require("node:fs"), path = require("node:path");
  let calls = 0;
  const a = new WASI({ bindings: { fs: { ...fs, fstatSync: fd => (calls++, fs.fstatSync(fd)) }, path } });
  a.fstatSync(1);
  new WASI({ bindings: { fs, path } });
  a.fstatSync(1);
  console.log(calls); // 1, expected 2
  ```

### Fix
- Drop the module-level `let fs;` and make it `const fs = bindings.fs;` inside the constructor again. All `fs.*` call sites are in closures created by the constructor, so each instance's import object captures the `fs` it was constructed with.
- `WASI#fstatSync()` reads `this.bindings.fs`. Its callers (the module-level `stat()` helper via `wasi.fstatSync(...)`, and `fd_filestat_get`, `fd_filestat_set_times`, `fd_seek`, `path_filestat_set_times` via `this.fstatSync(...)`) all invoke it as a method on the instance.
- Why this is right: the `fs` an instance uses is part of that instance's configuration, and constructing an unrelated object must not change it. This is also exactly the shape upstream wasi-js has (`const fs = this.bindings.fs` in the constructor, `this.bindings.fs.fstatSync(...)` in `fstatSync()`), so the vendored copy only differs from upstream where Bun intentionally changed it. Default bindings (`node:fs` for every instance, which is what `bun run foo.wasm` uses) behave exactly as before.
- Overlaps with #38387 (getState()/setState() fix) in the constructor hunk; whichever lands second resolves it to `const fs = this.bindings.fs;`. After both land, `fstatSync()` follows the bindings installed by `setState()` and the syscall closures keep the constructor's `fs`, as upstream does.
- Verified with `test/js/bun/wasm/wasi.test.js` ("each instance keeps using its own bindings.fs after another instance is constructed"). The test constructs two instances whose `fs` bindings record which instance's fs each call went through, then checks the preopen open in the constructor, `fstatSync()` on both its stdio and general branches, and a `path_open` + `fd_write` + `fd_close` sequence through `wasiImport`, all on the instance constructed first.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/wasm/wasi.test.js`: the new test fails (the first instance's calls are recorded under the second instance's fs), the 5 existing tests pass.
  - `bun bd test test/js/bun/wasm/wasi.test.js`: 6 pass. With `src/` stashed, the new test fails on both its `fstatSync()` and its syscall assertions independently.
  - `bunx oxlint --config=oxlint.json src/js/node/wasi.ts` and prettier are clean.

### Background
- `node:wasi` in Bun is a vendored copy of wasi-js (`src/js/node/wasi.ts`). Besides Node's options it accepts a `bindings` object (`fs`, `path`, `isTTY`, `exit`, `kill`, `hrtime`) that the instance uses for host access; `bindings.fs` is how a guest can be pointed at something other than the real `node:fs`, e.g. an in-memory filesystem, and two instances with two different filesystems is the normal way to get two isolated sandboxes.
- `wasiImport` is the object of host functions (`fd_write`, `path_open`, ...) a WASI module imports; it is built once per instance, in the constructor, as a set of closures, which is why a constructor-local `const fs` is per instance.
- `WASI#fstatSync()` is an internal helper wrapping `fs.fstatSync` that falls back to fake stats for fds 0 to 2 when the host cannot stat them; it is the one `fs` user that is a class method rather than a constructor closure, hence `this.bindings.fs`.
