### PR TITLE
test: size error-gc-test.test.js loops for debug builds

### DIFF
--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -1,15 +1,23 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { tmpdirSync } from "harness";
+import { isDebug, tmpdirSync } from "harness";
 import { join } from "path";
+
 // This test checks that printing stack traces increments and decrements
 // reference-counted strings
+//
+// Debug builds run Bun.inspect(err) ~30x and Bun.gc(true) ~20x slower than release, which puts every
+// test below past the default 5s timeout at the release counts. They also assert the first time a
+// string's refcount goes wrong (WTFStringImplStruct::ref/deref in bun_alloc), so they don't need the
+// repetition release builds rely on to turn an unbalanced ref into a visible failure.
 test("error gc test", () => {
-  for (let i = 0; i < 100; i++) {
+  const errors = isDebug ? 5 : 100;
+  const inspectsPerError = isDebug ? 100 : 1000;
+  for (let i = 0; i < errors; i++) {
     var fn = function yo() {
       var err = (function innerOne() {
         var err = new Error();
-        for (let i = 0; i < 1000; i++) {
+        for (let i = 0; i < inspectsPerError; i++) {
           Bun.inspect(err);
         }
         Bun.gc(true);
@@ -30,14 +38,16 @@ test("error gc test", () => {
 });
 
 test("error gc test #2", () => {
-  for (let i = 0; i < 1000; i++) {
+  const iterations = isDebug ? 100 : 1000;
+  for (let i = 0; i < iterations; i++) {
     new Error().stack;
     Bun.gc();
   }
 });
 
 test("error gc test #3", () => {
-  for (let i = 0; i < 1000; i++) {
+  const iterations = isDebug ? 100 : 1000;
+  for (let i = 0; i < iterations; i++) {
     var err = new Error();
     Error.captureStackTrace(err);
     Bun.inspect(err);
@@ -90,7 +100,8 @@ test("error gc test #4", () => {
     }
   }
 
-  for (let i = 0; i < 1000; i++) {
+  const iterations = isDebug ? 10 : 1000;
+  for (let i = 0; i < iterations; i++) {
     iterate();
   }
 });


### PR DESCRIPTION
### Problem
- `bun bd test test/js/bun/util/error-gc-test.test.js` always fails on a debug build, on a clean checkout of main:
  ```
  (fail) error gc test [92037.49ms]
    ^ this test timed out after 5000ms.
  (fail) error gc test #2 [6986.80ms]
  (fail) error gc test #3 [7497.05ms]
  (fail) error gc test #4 [47917.83ms]
   0 pass, 4 fail, Ran 4 tests across 1 file. [157.23s]
  ```
  The tests are synchronous, so each one runs to completion and is then reported as timed out; the file takes about 2.5 minutes to fail.
- Cause: the loop counts in `test/js/bun/util/error-gc-test.test.js` are sized for release builds. Test 1 inspects an error 1000 times and runs two `Bun.gc(true)` per outer iteration, 100 times over; tests #2 and #3 create an error and call `Bun.gc()` 1000 times; test #4 runs a failing `readFileSync`, `Bun.inspect` and two `Bun.gc(true)` 1000 times. On a debug+ASAN build `Bun.inspect(err)` costs about 0.9ms (0.03ms on release) and `Bun.gc(true)` about 20ms (1ms on release), so the four tests take 17x to 38x longer than on a release build of the same machine (2.4s / 0.4s / 0.45s / 2.3s).
- CI does not see this because `scripts/runner.node.mjs` passes its own `--timeout` (90s, tripled under ASAN). It breaks every local `bun bd test` run of the file, and nothing can be added to the file and pass under `bun bd test`.

### Fix
- Each test picks its count with `isDebug` from `test/harness.ts`: test 1 runs 5 errors x 100 inspects (was 100 x 1000), tests #2 and #3 run 100 iterations (was 1000), test #4 runs 10 (was 1000). Release builds keep the existing counts, so CI (release and release ASAN lanes) runs exactly the work it ran before.
- Why the smaller counts still cover what the file exists for: the tests guard against the stack trace formatter unbalancing the refcount of the strings it reads (source URL, function name, the ENOENT path; the original fix is c6f6db95ff "Ref the strings", today `Bun::toStringRef` in `src/jsc/bindings/ZigException.cpp`). Debug builds assert on the refcount the first time it goes wrong (`debug_assert!(old > 0)` in `WTFStringImplStruct::ref`/`deref`, `src/bun_alloc/lib.rs`), so the repetition only buys something on release builds, where a string freed early is noticed only once its memory is reused or freed again. Checked by reintroducing the bug: with line 125 of `ZigException.cpp` changed to the non-ref'ing `Bun::toString`, the reduced file still crashes inside the first error of test 1 (details below).
- Why these numbers: they keep each test under about a second on the debug+ASAN build here (10 and 25 iterations of test #4 measure 0.64s and 1.59s; 5 x 100 and 10 x 100 of test 1 measure 0.78s and 1.6s), which leaves room for slower machines under the 5s default. No per-test timeout is added (test/CLAUDE.md).
- Verified:
  - `bun bd test test/js/bun/util/error-gc-test.test.js` (debug+ASAN): 4 pass, 797ms / 740ms / 758ms / 783ms. The same command on the unmodified file is the failure quoted above.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/util/error-gc-test.test.js` (release, unchanged counts): 4 pass, 2.46s / 0.48s / 0.53s / 2.63s, the same work as before the change.
  - Test-only change, so there is nothing under `src/` to stash for a fail-before run; the before/after above is the test file itself.

### Background
- `isDebug` (`test/harness.ts`) is true when the bun running the tests reports a debug version, which is what `bun bd` builds. The release ASAN builds CI runs are not debug builds and keep the full counts: they have no refcount assertion, and ASAN alone is not a substitute for the repetition, because the strings live in libpas (WebKit's allocator, which ASAN does not instrument) rather than in ASAN's heap; the libpas panic in the experiment below is that allocator reporting the double free on an ASAN build.
- `Bun.gc(true)` is a synchronous full collection that also throws away compiled code (`JSC__VM__runGC` in `src/jsc/bindings/bindings.cpp`); `Bun.gc()` only requests an asynchronous one. The `gc(true)` calls are what make tests 1 and #4 the slow ones.
- Same kind of change as #38259 (text-loader.test.ts), #36929 (load-same-js-file-a-lot.test.ts), #37835 (heap-snapshot.test.ts) and #37488 (highway-strings.test.ts); this PR only touches error-gc-test.test.js.

<details>
<summary>Reintroducing the bug against the reduced counts</summary>

`src/jsc/bindings/ZigException.cpp:125` changed from `Bun::toStringRef(functionName)` to `Bun::toString(functionName)` (no ref, the pre-c6f6db95ff behavior), rebuilt with `bun bd`, then `bun bd test test/js/bun/util/error-gc-test.test.js` with this PR's counts. The run dies before test 1 reports a result:

```
panic: assertion failed: old > 0
[17239] pas panic: deallocation did fail at 0x725efe250960: Alloc bit not set in pas_segregated_page_deallocate_with_page
...
<bun_alloc::WTFStringImplStruct>::ref
```

The `src/` change was reverted before the verification runs above.
</details>
