### PR TITLE
node: render native validateOneOf errors like Node and type-check vm microtaskMode

### DIFF
--- a/src/js/node/vm.ts
+++ b/src/js/node/vm.ts
@@ -111,6 +111,12 @@ function runInNewContext(code, context, options) {
   if (typeof options === "string") {
     options = { filename: options };
   }
+  // Node's getContextOptions() type-checks microtaskMode before createContext() checks its value:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/vm.js#L219-L220
+  const microtaskMode = options?.microtaskMode;
+  if (microtaskMode !== undefined) {
+    validateString(microtaskMode, "options.microtaskMode");
+  }
   context = createContext(context, options);
   return createScript(code, options).runInNewContext(context, options);
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1108,35 +1108,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
     return {};
 }
 
-JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, WTF::ASCIILiteral reason, JSC::JSValue value, const std::span<const ASCIILiteral> oneOf)
-{
-    WTF::StringBuilder builder;
-    builder.append("The "_s);
-    if (WTF::find(name.span(), '.') != WTF::notFound) {
-        builder.append("property '"_s);
-    } else {
-        builder.append("argument '"_s);
-    }
-    builder.append(name);
-    builder.append("' "_s);
-    builder.append(reason);
-
-    bool first = true;
-    for (ASCIILiteral oneOfStr : oneOf) {
-        if (!first) {
-            builder.append(", "_s);
-        }
-        first = false;
-        builder.append('`');
-        builder.append(oneOfStr);
-        builder.append('`');
-    }
-
-    throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
-    throwScope.release();
-    return {};
-}
-
+// for validateOneOf: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L200
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, WTF::ASCIILiteral reason, JSC::JSValue value, const std::span<const int32_t> oneOf)
 {
     WTF::StringBuilder builder;
@@ -1158,6 +1130,9 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
         first = false;
         builder.append(oneOfStr);
     }
+    builder.append(". Received "_s);
+    JSValueToStringSafe(globalObject, builder, value, true);
+    RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
     throwScope.release();

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -101,7 +101,6 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
 JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, ASCIILiteral message);
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, JSC::JSValue value, const WTF::String& reason = "is invalid"_s);
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue name, JSC::JSValue value, WTF::ASCIILiteral reason, JSC::JSArray* oneOf);
-JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, WTF::ASCIILiteral reason, JSC::JSValue value, std::span<const ASCIILiteral> oneOf);
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, WTF::ASCIILiteral reason, JSC::JSValue value, std::span<const int32_t> oneOf);
 JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, WTF::ASCIILiteral name, JSC::JSValue value, const WTF::String& reason = "is invalid"_s);
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue name, JSC::JSValue value, const WTF::String& reason = "is invalid"_s);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -685,20 +685,23 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
     }
 
     // microtaskMode: "afterEvaluate" gives the context its own microtask
-    // queue. Validated here (not only in vm.ts) so native entry points like
-    // script.runInNewContext reject invalid values the way Node does.
+    // queue. Only script.runInNewContext reaches this with an unchecked value
+    // (vm.ts createContext() runs validateOneOf first), and on that path Node's
+    // getContextOptions() validateString()s it before createContext()'s
+    // validateOneOf() runs:
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/vm.js#L219-L220
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/vm.js#L254-L256
     JSValue microtaskModeValue = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "microtaskMode"_s));
     RETURN_IF_EXCEPTION(scope, );
     if (microtaskModeValue && !microtaskModeValue.isUndefined()) {
-        bool isAfterEvaluate = false;
-        if (microtaskModeValue.isString()) {
-            String microtaskMode = microtaskModeValue.toWTFString(globalObject);
-            RETURN_IF_EXCEPTION(scope, );
-            isAfterEvaluate = microtaskMode == "afterEvaluate"_s;
+        if (!microtaskModeValue.isString()) {
+            ERR::INVALID_ARG_TYPE(scope, globalObject, "options.microtaskMode"_s, "string"_s, microtaskModeValue);
+            return;
         }
-        if (!isAfterEvaluate) {
-            static constexpr ASCIILiteral oneOf[] = { "afterEvaluate"_s, "undefined"_s };
-            ERR::INVALID_ARG_VALUE(scope, globalObject, "options.microtaskMode"_s, "must be one of: "_s, microtaskModeValue, oneOf);
+        String microtaskMode = microtaskModeValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, );
+        if (microtaskMode != "afterEvaluate"_s) {
+            ERR::INVALID_ARG_VALUE(scope, globalObject, "options.microtaskMode"_s, microtaskModeValue, "must be one of: 'afterEvaluate', undefined"_s);
             return;
         }
         outOptions.ownMicrotaskQueue = true;

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -589,27 +589,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateOneOf, (JSC::JSGlobalObject * global
     return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "values"_s, "Array"_s, arrayValue);
 }
 
-JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const ASCIILiteral> oneOf)
-{
-    if (!value.isString()) {
-        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, "must be one of: "_s, value, oneOf);
-    }
-
-    JSC::JSString* valueStr = value.toString(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto valueView = valueStr->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    for (ASCIILiteral oneOfStr : oneOf) {
-
-        if (valueView == oneOfStr) {
-            return JSValue::encode(jsUndefined());
-        }
-    }
-
-    return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, "must be one of: "_s, value, oneOf);
-}
-
 JSC::EncodedJSValue V::validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const int32_t> oneOf, int32_t* out)
 {
     if (!value.isInt32()) {

--- a/src/jsc/bindings/NodeValidator.h
+++ b/src/jsc/bindings/NodeValidator.h
@@ -41,7 +41,6 @@ JSC::EncodedJSValue validateUint32(JSC::ThrowScope& scope, JSC::JSGlobalObject* 
 JSC::EncodedJSValue validateInt32(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, JSValue name, JSValue min, JSValue max);
 JSC::EncodedJSValue validateInt32(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name, JSValue min, JSValue max, int32_t* out = nullptr);
 JSC::EncodedJSValue validateFunction(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
-JSC::EncodedJSValue validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const ASCIILiteral> oneOf);
 JSC::EncodedJSValue validateOneOf(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, ASCIILiteral name, JSValue value, std::span<const int32_t> oneOf, int32_t* out = nullptr);
 JSC::EncodedJSValue validateObject(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);
 JSC::EncodedJSValue validateBoolean(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, ASCIILiteral name);

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { describe, expect, it, test } from "bun:test";
+import { describe, expect, it, jest, test } from "bun:test";
 import {
   createCipheriv,
   createDecipheriv,
@@ -806,6 +806,34 @@ describe("crypto.KeyObjects", () => {
       });
     });
   });
+
+  // Node's validateOneOf(length, "options.length", [128, 192, 256]) message,
+  // including the inspected value after "Received".
+  describe.each([
+    ["7", 7],
+    ["128.5", 128.5],
+    ["'128'", "128"],
+    ["undefined", undefined],
+    ["null", null],
+    ["{ bits: 128 }", { bits: 128 }],
+  ])("generateKey aes with length %s", (received, length) => {
+    const expected = expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_VALUE",
+      message: `The property 'options.length' must be one of: 128, 192, 256. Received ${received}`,
+    });
+
+    test("generateKeySync", () => {
+      expect(() => generateKeySync("aes", { length })).toThrow(expected);
+    });
+
+    test("generateKey", () => {
+      const callback = jest.fn();
+      expect(() => generateKey("aes", { length }, callback)).toThrow(expected);
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Test async elliptic curve key generation with 'jwk' encoding and named curve", () => {
     ["P-384", "P-256", "P-521", "secp256k1"].forEach(curve => {
       const test = curve === "secp256k1" ? it.skip : it;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1012,6 +1012,65 @@ describe("codeGeneration options", () => {
   });
 });
 
+describe("microtaskMode option", () => {
+  // Node's createContext() checks microtaskMode with
+  // validateOneOf(..., ["afterEvaluate", undefined]); the runInNewContext entry
+  // points first go through getContextOptions(), which validateString()s it.
+  const code = "Promise.resolve().then(() => { globalThis.ran = true; }); 1;";
+  const entryPoints: Record<string, (sandbox: any, options: any) => unknown> = {
+    "createContext()": (sandbox, options) => runInContext(code, createContext(sandbox, options)),
+    "runInNewContext()": (sandbox, options) => runInNewContext(code, sandbox, options),
+    "Script#runInNewContext()": (sandbox, options) => new Script(code).runInNewContext(sandbox, options),
+  };
+  const invalidValue = (received: string) =>
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_VALUE",
+      message: `The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received ${received}`,
+    });
+  const invalidType = (received: string) =>
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "options.microtaskMode" property must be of type string. Received ${received}`,
+    });
+  const nonStrings: [unknown, string, string][] = [
+    [1, "1", "type number (1)"],
+    [null, "null", "null"],
+    [{}, "{}", "an instance of Object"],
+  ];
+
+  describe.each(Object.entries(entryPoints))("%s", (_, run) => {
+    test("accepts undefined", () => {
+      expect(run({}, {})).toBe(1);
+      expect(run({}, { microtaskMode: undefined })).toBe(1);
+    });
+
+    test("'afterEvaluate' runs the context's microtasks before returning", () => {
+      const sandbox: any = {};
+      expect(run(sandbox, { microtaskMode: "afterEvaluate" })).toBe(1);
+      expect(sandbox.ran).toBe(true);
+    });
+
+    test("rejects other strings with Node's validateOneOf message", () => {
+      expect(() => run({}, { microtaskMode: "x" })).toThrow(invalidValue("'x'"));
+      expect(() => run({}, { microtaskMode: "it's" })).toThrow(invalidValue(`"it's"`));
+    });
+  });
+
+  test.each(nonStrings)("createContext() reports a non-string (%p) as an invalid value", (microtaskMode, inspected) => {
+    expect(() => entryPoints["createContext()"]({}, { microtaskMode })).toThrow(invalidValue(inspected));
+  });
+
+  test.each(nonStrings)(
+    "the runInNewContext entry points report a non-string (%p) as an invalid type",
+    (microtaskMode, _, received) => {
+      expect(() => entryPoints["runInNewContext()"]({}, { microtaskMode })).toThrow(invalidType(received));
+      expect(() => entryPoints["Script#runInNewContext()"]({}, { microtaskMode })).toThrow(invalidType(received));
+    },
+  );
+});
+
 describe("context options with throwing getters", () => {
   // Without the fix, reading these options with a pending exception aborted
   // the process, so run the matrix in a subprocess.


### PR DESCRIPTION
### Problem
- `crypto.generateKeySync("aes", { length: 7 })` (and `generateKey`) throws `ERR_INVALID_ARG_VALUE` with `The property 'options.length' must be one of: 128, 192, 256`. Node v26.3.0 appends `. Received 7`.
- `new vm.Script("1").runInNewContext({}, { microtaskMode: "x" })` throws ``The property 'options.microtaskMode' must be one of: `afterEvaluate`, `undefined` `` (backticks, `undefined` presented as a string, no received value). Node: `The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received 'x'`.
- `new vm.Script("1").runInNewContext({}, { microtaskMode: 1 })` and `vm.runInNewContext("1", {}, { microtaskMode: 1 })` throw that same `ERR_INVALID_ARG_VALUE`. Node throws `ERR_INVALID_ARG_TYPE`: `The "options.microtaskMode" property must be of type string. Received type number (1)`.
- Cause, message text: the two `std::span` "must be one of" overloads of `Bun::ERR::INVALID_ARG_VALUE` in `src/jsc/bindings/ErrorCode.cpp` (formerly lines 1111 and 1140) never appended `. Received ...` (their `value` parameter was unused), and the `ASCIILiteral` one wrapped each choice in backticks. The `JSArray*` overload a few lines above, which backs the JS-side `validateOneOf`, already formats like Node.
- Cause, error code: `getNodeVMContextOptions()` in `src/jsc/bindings/NodeVM.cpp` (line 692) reported every bad `microtaskMode` as an invalid value, and the `vm.ts` `runInNewContext()` wrapper went straight to `createContext()`'s `validateOneOf`. Node's `runInNewContext` paths first run `getContextOptions()`, which `validateString()`s the option ([lib/vm.js#L219-L220](https://github.com/nodejs/node/blob/v26.3.0/lib/vm.js#L219-L220)); only `createContext()` itself uses `validateOneOf` ([lib/vm.js#L254-L256](https://github.com/nodejs/node/blob/v26.3.0/lib/vm.js#L254-L256)).

### Fix
- `ErrorCode.cpp`: the `int32_t` span overload appends `. Received ` plus the same `JSValueToStringSafe(value, true)` rendering every other `INVALID_ARG_VALUE` overload uses (this is the line that fixes the crypto message). Its caller, `V::validateOneOf(int32 span)`, is unchanged.
- `ErrorCode.cpp/.h`, `NodeValidator.cpp/.h`: the `ASCIILiteral` span overload is deleted instead of fixed. Its only live caller was the vm `microtaskMode` check, whose Node list is `['afterEvaluate', undefined]`: a bare `undefined` next to a quoted string, which a list of string literals cannot express. With that caller moved off it, only `V::validateOneOf(ASCIILiteral span)` referenced it, and that wrapper has had no callers since it was added, so it is deleted too.
- `NodeVM.cpp`: a non-string `microtaskMode` is now `ERR_INVALID_ARG_TYPE`; a string other than `"afterEvaluate"` goes through the plain `INVALID_ARG_VALUE(name, value, reason)` overload with Node's literal reason, the same pattern `KeyObject.cpp` uses for its mixed lists. The only caller that reaches this block with an unvalidated value is `Script#runInNewContext`, because the `vm.ts` `createContext()` wrapper still runs `validateOneOf` first; that wrapper is left in place since `createContext()` needs value semantics for non-strings too (Node reports `createContext({}, { microtaskMode: 1 })` as an invalid value, pinned by a test).
- `vm.ts`: `runInNewContext()` runs `validateString` on `microtaskMode` before calling `createContext()`, which is where Node's `getContextOptions()` does it.
- Why this is correct: every message and code above is Node v26.3.0's observed output. The script in the details below makes the same 39 assertions as the new tests with `node:assert`; it passes on node v26.3.0 and on this branch, and fails on bun 1.4.0.
- Tests: `test/js/node/crypto/crypto.key-objects.test.ts` (`generateKey aes with length ...`, 12 cases over `generateKeySync` and `generateKey`, all fail on 1.4.0) and `test/js/node/vm/vm.test.ts` (`microtaskMode option`, 15 cases over `createContext()`, `runInNewContext()` and `Script#runInNewContext()`; the `Script#runInNewContext()` string case and the three non-string cases fail on 1.4.0, the rest pin the accepted values, the `afterEvaluate` behavior, and the entry points that already matched).
- Also run: both files in full; the vendored `test-crypto-secret-keygen.js` (asserts this message with a prefix regex), `test-vm-basic.js`, `test-vm-codegen.js`, `test-vm-context.js`, `test-vm-options-validation.js`, `test-vm-new-script-new-context.js`, `test-vm-script-after-evaluate.js`, `test-vm-module-after-evaluate.js`, `test-vm-timeout-escape-promise{,-2}.js`; the new tests under `BUN_JSC_validateExceptionChecks=1`. No other test in the tree asserts the old text.
- Not changed here: the rendering shared by every `ERR_INVALID_ARG_VALUE` path still differs from Node in two small ways that this overload now inherits (no 128-character cap on the inspected value, and `-0` printed as `0`); those are being tracked separately. Open node:vm PRs #38326, #38373, #38371 and #38314 touch other parts of `getNodeVMContextOptions()` and the `vm.ts` wrappers but not these lines; #38326 rewrites `vm.ts` `runInNewContext()`, so whichever lands second carries the `validateString` line over.

### Background
- `validateOneOf(value, name, list)` is Node's helper for enum-like options. Its message is `The <argument|property> '<name>' must be one of: <list>. Received <util.inspect(value)>`, where string choices are quoted and other choices are `String()`ed ([validators.js#L200](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L200)); `property` is used when the name contains a dot.
- Bun has three native renderers of that message in `ErrorCode.cpp`: one taking a `JSArray*` (used by the JS-side `validateOneOf`) and, before this PR, two taking a `std::span` of `ASCIILiteral` or `int32_t` choices, wrapped by `V::validateOneOf` in `NodeValidator.cpp` for C++ callers. `generateKey('aes')` is the one `int32` user ([keygen.js#L379](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/crypto/keygen.js#L379) in Node).
- `microtaskMode: "afterEvaluate"` gives a vm context its own microtask queue, drained after each evaluation. It can be passed to `vm.createContext()` directly, or to `vm.runInNewContext()` / `Script#runInNewContext()`, which create the context for you. In Bun, `createContext()` and `runInNewContext()` are `vm.ts` wrappers over native code, while `Script#runInNewContext()` is native; all three end up in `getNodeVMContextOptions()`.

<details>
<summary>Node v26.3.0 vs bun 1.4.0 vs this branch</summary>

```
$ node repro.js
generateKeySync('aes', { length: 7 })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.length' must be one of: 128, 192, 256. Received 7
generateKeySync('aes', { length: '128' })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.length' must be one of: 128, 192, 256. Received '128'
generateKey('aes', { length: 7 }, cb)
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.length' must be one of: 128, 192, 256. Received 7
Script#runInNewContext({}, { microtaskMode: 'x' })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received 'x'
Script#runInNewContext({}, { microtaskMode: 1 })
  TypeError ERR_INVALID_ARG_TYPE
  The "options.microtaskMode" property must be of type string. Received type number (1)
vm.runInNewContext('1', {}, { microtaskMode: 1 })
  TypeError ERR_INVALID_ARG_TYPE
  The "options.microtaskMode" property must be of type string. Received type number (1)
vm.createContext({}, { microtaskMode: 1 })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received 1

$ bun repro.js   # 1.4.0
generateKeySync('aes', { length: 7 })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.length' must be one of: 128, 192, 256
generateKeySync('aes', { length: '128' })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.length' must be one of: 128, 192, 256
generateKey('aes', { length: 7 }, cb)
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.length' must be one of: 128, 192, 256
Script#runInNewContext({}, { microtaskMode: 'x' })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.microtaskMode' must be one of: `afterEvaluate`, `undefined`
Script#runInNewContext({}, { microtaskMode: 1 })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.microtaskMode' must be one of: `afterEvaluate`, `undefined`
vm.runInNewContext('1', {}, { microtaskMode: 1 })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received 1
vm.createContext({}, { microtaskMode: 1 })
  TypeError ERR_INVALID_ARG_VALUE
  The property 'options.microtaskMode' must be one of: 'afterEvaluate', undefined. Received 1
```

With this branch, `bun repro.js` prints the node output above for every case.

Shared assertion script (same checks as the new tests, written with `node:assert`):

```
$ node parity-check.js
node v26.3.0: 39 checks passed
$ bun parity-check.js            # 1.4.0
AssertionError: Expected values to be strictly equal:
+ "The property 'options.length' must be one of: 128, 192, 256"
- "The property 'options.length' must be one of: 128, 192, 256. Received 7"
$ bun bd parity-check.js         # this branch
bun 1.4.0-debug: 39 checks passed
```

</details>
