### PR TITLE
node errors: cut the ERR_INVALID_ARG_VALUE received value at 128 chars like node

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -488,10 +488,9 @@ impl JSGlobalObject {
         Ok(str)
     }
 
-    /// Renders `value` the way Node's `ERR_INVALID_ARG_VALUE` does (`util.inspect`
-    /// quoting, cut to 128 chars + "...", via the same C++ formatter the C++
-    /// overloads use). Returns a +1-ref'd string wrapped in [`OwnedString`] so the
-    /// ref is released on drop.
+    /// The "Received ..." value of an `ERR_INVALID_ARG_VALUE` message, rendered (and cut
+    /// to 128 chars) by the same C++ helper the C++ overloads use. The +1 ref is
+    /// released when the returned [`OwnedString`] drops.
     pub fn inspect_for_error_message(global: &Self, value: JSValue) -> JsResult<OwnedString> {
         crate::top_scope!(scope, global);
         let str = OwnedString::new(Bun__ErrorCode__inspectForErrorMessage(global, value));

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -489,8 +489,9 @@ impl JSGlobalObject {
     }
 
     /// Renders `value` the way Node's `ERR_INVALID_ARG_VALUE` does (`util.inspect`
-    /// quoting, via the same C++ formatter the C++ overloads use). Returns a
-    /// +1-ref'd string wrapped in [`OwnedString`] so the ref is released on drop.
+    /// quoting, cut to 128 chars + "...", via the same C++ formatter the C++
+    /// overloads use). Returns a +1-ref'd string wrapped in [`OwnedString`] so the
+    /// ref is released on drop.
     pub fn inspect_for_error_message(global: &Self, value: JSValue) -> JsResult<OwnedString> {
         crate::top_scope!(scope, global);
         let str = OwnedString::new(Bun__ErrorCode__inspectForErrorMessage(global, value));

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -517,9 +517,7 @@ extern "C" BunString Bun__ErrorCode__determineSpecificType(JSC::JSGlobalObject* 
     return Bun::toStringRef(builder.toString());
 }
 
-// The "Received ..." part of ERR_INVALID_ARG_VALUE. Node renders the value with
-// `util.inspect` ('w', not determineSpecificType's "type string ('w')") and cuts
-// the result to 128 characters followed by "...".
+// ERR_INVALID_ARG_VALUE inspects the value (not determineSpecificType) and keeps at most 128 chars of it:
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1471-L1478
 static void appendInvalidArgValueReceived(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue value)
 {
@@ -532,8 +530,7 @@ static void appendInvalidArgValueReceived(JSC::JSGlobalObject* globalObject, WTF
     }
 }
 
-// Expose the formatter above so Rust-side ERR_INVALID_ARG_VALUE paths render
-// the value exactly like the C++ overloads.
+// Rust-side ERR_INVALID_ARG_VALUE messages (JSGlobalObject::inspect_for_error_message).
 extern "C" BunString Bun__ErrorCode__inspectForErrorMessage(JSC::JSGlobalObject* globalObject, EncodedJSValue value)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -517,14 +517,28 @@ extern "C" BunString Bun__ErrorCode__determineSpecificType(JSC::JSGlobalObject* 
     return Bun::toStringRef(builder.toString());
 }
 
-// Node's ERR_INVALID_ARG_VALUE renders the value with `util.inspect` ('w'),
-// not `determineSpecificType` ("type string ('w')"). Expose the formatter the
-// C++ INVALID_ARG_VALUE overloads use so Rust-side error paths match exactly.
+// The "Received ..." part of ERR_INVALID_ARG_VALUE. Node renders the value with
+// `util.inspect` ('w', not determineSpecificType's "type string ('w')") and cuts
+// the result to 128 characters followed by "...".
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1471-L1478
+static void appendInvalidArgValueReceived(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue value)
+{
+    constexpr unsigned maxInspectedLength = 128;
+    const unsigned start = builder.length();
+    JSValueToStringSafe(globalObject, builder, value, true);
+    if (builder.length() - start > maxInspectedLength) {
+        builder.shrink(start + maxInspectedLength);
+        builder.append("..."_s);
+    }
+}
+
+// Expose the formatter above so Rust-side ERR_INVALID_ARG_VALUE paths render
+// the value exactly like the C++ overloads.
 extern "C" BunString Bun__ErrorCode__inspectForErrorMessage(JSC::JSGlobalObject* globalObject, EncodedJSValue value)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
     WTF::StringBuilder builder;
-    JSValueToStringSafe(globalObject, builder, JSValue::decode(value), true);
+    appendInvalidArgValueReceived(globalObject, builder, JSValue::decode(value));
     RETURN_IF_EXCEPTION(scope, Zig::BunStringEmpty);
     return Bun::toStringRef(builder.toString());
 }
@@ -1016,7 +1030,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
     builder.append("' "_s);
     builder.append(reason);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, value, true);
+    appendInvalidArgValueReceived(globalObject, builder, value);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
@@ -1036,7 +1050,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JS
     builder.append("' "_s);
     builder.append(reason);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, value, true);
+    appendInvalidArgValueReceived(globalObject, builder, value);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s, "ERR_INVALID_ARG_VALUE"_s);
@@ -1056,7 +1070,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
     builder.append("' "_s);
     builder.append(reason);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, value, true);
+    appendInvalidArgValueReceived(globalObject, builder, value);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
@@ -1100,7 +1114,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
         }
     }
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, value, true);
+    appendInvalidArgValueReceived(globalObject, builder, value);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
@@ -1178,8 +1192,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobal
     builder.append("' "_s);
     builder.append(reason);
     builder.append(". Received "_s);
-
-    JSValueToStringSafe(globalObject, builder, value, true);
+    appendInvalidArgValueReceived(globalObject, builder, value);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
@@ -1686,7 +1699,7 @@ static JSValue ERR_INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalO
 
     if (reason.isUndefined()) {
         builder.append(" is invalid. Received "_s);
-        JSValueToStringSafe(globalObject, builder, value, true);
+        appendInvalidArgValueReceived(globalObject, builder, value);
         RETURN_IF_EXCEPTION(throwScope, {});
         return createError(globalObject, code, builder.toString());
     }
@@ -1700,7 +1713,7 @@ static JSValue ERR_INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalO
     builder.append(' ');
     builder.append(reasonView);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, value, true);
+    appendInvalidArgValueReceived(globalObject, builder, value);
     RETURN_IF_EXCEPTION(throwScope, {});
     return createError(globalObject, code, builder.toString());
 }

--- a/test/js/node/errors/invalid-arg-value-received.test.ts
+++ b/test/js/node/errors/invalid-arg-value-received.test.ts
@@ -15,7 +15,8 @@ import { createRequire } from "node:module";
 import net from "node:net";
 
 const long = "x".repeat(200);
-// inspect(long) is 'xxx…' (202 chars); node keeps the opening quote plus 127 x's.
+// `long` inspects to 202 characters (quotes included); the first 128 of them are
+// the opening quote plus 127 x's.
 const longCut = "'" + "x".repeat(127) + "...";
 
 function thrownBy(fn: () => unknown) {
@@ -164,12 +165,14 @@ describe("ERR_INVALID_ARG_VALUE cuts the received value at 128 characters like n
         );
     `;
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--experimental-stream-iter", "-e", script],
+      // --no-warnings silences the stream/iter ExperimentalWarning so stderr is empty on success.
+      cmd: [bunExe(), "--no-warnings", "--experimental-stream-iter", "-e", script],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
       name: "RangeError",
       code: "ERR_INVALID_ARG_VALUE",

--- a/test/js/node/errors/invalid-arg-value-received.test.ts
+++ b/test/js/node/errors/invalid-arg-value-received.test.ts
@@ -1,0 +1,180 @@
+// Node's ERR_INVALID_ARG_VALUE renders the received value with util.inspect and,
+// when that is longer than 128 characters, keeps the first 128 and appends "...".
+// Every Bun path that builds the message (the C++ overloads in ErrorCode.cpp, the
+// $ERR_INVALID_ARG_VALUE dispatch used by the JS builtins, and the Rust callers of
+// inspect_for_error_message) has to apply the same cut. The expected messages below
+// are what node v26 prints for the same calls.
+import { exposedInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { fork } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+import fs from "node:fs";
+import http from "node:http";
+import { createRequire } from "node:module";
+import net from "node:net";
+
+const long = "x".repeat(200);
+// inspect(long) is 'xxx…' (202 chars); node keeps the opening quote plus 127 x's.
+const longCut = "'" + "x".repeat(127) + "...";
+
+function thrownBy(fn: () => unknown) {
+  try {
+    fn();
+  } catch (e: any) {
+    return { name: e.constructor.name, code: e.code, message: e.message };
+  }
+  throw new Error("expected the call to throw");
+}
+
+function received(message: string) {
+  const marker = ". Received ";
+  const index = message.indexOf(marker);
+  expect(index).toBeGreaterThan(0);
+  return message.slice(index + marker.length);
+}
+
+describe("ERR_INVALID_ARG_VALUE cuts the received value at 128 characters like node", () => {
+  test.each([
+    [
+      "Buffer#fill (native, default reason)",
+      () => Buffer.alloc(4).fill(long, "hex"),
+      `The argument 'value' is invalid. Received ${longCut}`,
+    ],
+    [
+      "module.createRequire (native, custom reason)",
+      () => createRequire(long),
+      `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received ${longCut}`,
+    ],
+    [
+      "validateOneOf via http.Agent scheduling (native, list of allowed values)",
+      () => new http.Agent({ scheduling: long as any }),
+      `The argument 'scheduling' must be one of: 'fifo', 'lifo'. Received ${longCut}`,
+    ],
+    [
+      "crypto.generateKeyPairSync encoding format (native, computed property name)",
+      () => generateKeyPairSync("ed25519", { publicKeyEncoding: { format: long as any, type: "spki" } }),
+      `The property 'options.publicKeyEncoding.format' is invalid. Received ${longCut}`,
+    ],
+    [
+      "net.Socket objectMode ($ERR_INVALID_ARG_VALUE with a reason)",
+      () => new net.Socket({ objectMode: long } as any),
+      `The property 'options.objectMode' is not supported. Received ${longCut}`,
+    ],
+    [
+      "child_process.fork stdio ($ERR_INVALID_ARG_VALUE without a reason)",
+      () => fork("/does-not-matter-validation-throws-first.js", [], { stdio: long as any }),
+      `The argument 'stdio' is invalid. Received ${longCut}`,
+    ],
+    [
+      "fs.openSync flags (rust, inspect_for_error_message)",
+      () => fs.openSync("x", long),
+      `The argument 'flags' is invalid. Received ${longCut}`,
+    ],
+    [
+      "fs.openSync mode (rust, inspect_for_error_message)",
+      () => fs.openSync("x", "r", "9".repeat(200)),
+      `The argument 'mode' must be a 32-bit unsigned integer or an octal string. Received '${"9".repeat(127)}...`,
+    ],
+    [
+      "non-latin1 string",
+      () => Buffer.alloc(4).fill("\u00e9\u4e2d".repeat(100), "hex"),
+      `The argument 'value' is invalid. Received '${"\u00e9\u4e2d".repeat(63)}\u00e9...`,
+    ],
+  ])("%s", (_name, fn, message) => {
+    expect(thrownBy(fn)).toEqual({ name: "TypeError", code: "ERR_INVALID_ARG_VALUE", message });
+  });
+
+  test("a value that inspects to exactly 128 characters is kept whole", () => {
+    const value = "q".repeat(126);
+    expect(thrownBy(() => Buffer.alloc(4).fill(value, "hex")).message).toBe(
+      `The argument 'value' is invalid. Received '${value}'`,
+    );
+  });
+
+  test("a value that inspects to 129 characters is cut", () => {
+    const value = "q".repeat(127);
+    expect(thrownBy(() => Buffer.alloc(4).fill(value, "hex")).message).toBe(
+      `The argument 'value' is invalid. Received '${value}...`,
+    );
+  });
+
+  test("short values are not touched", () => {
+    expect(thrownBy(() => Buffer.alloc(4).fill("zz z", "hex")).message).toBe(
+      "The argument 'value' is invalid. Received 'zz z'",
+    );
+    expect(thrownBy(() => new http.Agent({ scheduling: 42 as any })).message).toBe(
+      "The argument 'scheduling' must be one of: 'fifo', 'lifo'. Received 42",
+    );
+  });
+
+  test("objects are cut after being inspected", () => {
+    const error = thrownBy(() => new http.Agent({ scheduling: { mode: long } as any }));
+    expect(error).toMatchObject({ name: "TypeError", code: "ERR_INVALID_ARG_VALUE" });
+    const value = received(error.message);
+    expect(value).toStartWith("{ mode: ");
+    expect(value).toEndWith("...");
+    expect(value).toHaveLength(128 + "...".length);
+  });
+
+  test("the RangeError overload (ReadableByteStreamController BYOB view) is cut too", async () => {
+    let error: any;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const request = controller.byobRequest!;
+        try {
+          // byteOffset 1 can never match the request's write position of 0.
+          request.respondWithNewView(new Uint8Array(200).subarray(1));
+        } catch (e) {
+          error = e;
+        }
+        controller.close();
+        request.respond(0);
+      },
+    });
+    await stream.getReader({ mode: "byob" }).read(new Uint8Array(200));
+
+    expect(error).toBeInstanceOf(RangeError);
+    expect(error.code).toBe("ERR_INVALID_ARG_VALUE");
+    expect(error.message).toStartWith(
+      "The argument 'view' must match the BYOB request's current write position. Received Uint8Array(199) [",
+    );
+    expect(received(error.message)).toEndWith("...");
+    expect(received(error.message)).toHaveLength(128 + "...".length);
+  });
+
+  test("validateArray minLength (native overload taking the name as a JSValue) is cut too", () => {
+    const { validateArray } = exposedInternals["internal/validators"];
+    const error = thrownBy(() => validateArray(new Array(60).fill("abcdef"), "list", 100));
+    expect(error.code).toBe("ERR_INVALID_ARG_VALUE");
+    expect(received(error.message)).toStartWith('[ "abcdef", ');
+    expect(received(error.message)).toEndWith("...");
+    expect(received(error.message)).toHaveLength(128 + "...".length);
+  });
+
+  test("$ERR_INVALID_ARG_VALUE_RangeError (stream/iter encoding) is cut too", async () => {
+    const script = `
+      const { text } = require("node:stream/iter");
+      Promise.resolve()
+        .then(() => text(["a"], { encoding: "x".repeat(200) }))
+        .then(
+          () => console.log("resolved"),
+          e => console.log(JSON.stringify({ name: e.constructor.name, code: e.code, message: e.message })),
+        );
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--experimental-stream-iter", "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({
+      name: "RangeError",
+      code: "ERR_INVALID_ARG_VALUE",
+      message: `The property 'options.encoding' is invalid. Received ${longCut}`,
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- Every `ERR_INVALID_ARG_VALUE` Bun throws echoes the whole inspected value after `. Received `. Node cuts it: when the `util.inspect` output is longer than 128 characters it keeps the first 128 and appends `...` ([lib/internal/errors.js](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1471-L1478)).
- `Buffer.alloc(4).fill("q".repeat(200), "hex")`: node's message is 173 characters (`Received 'qqq...`), Bun's is 244 (the full value). Same for objects, `validateOneOf` lists, the JS builtins' `$ERR_INVALID_ARG_VALUE`, and the Rust `fs` paths.
- Cause: the seven message builders in `src/jsc/bindings/ErrorCode.cpp` (the `Bun::ERR::INVALID_ARG_VALUE` overloads, `INVALID_ARG_VALUE_RangeError`, and the static `ERR_INVALID_ARG_VALUE` behind the JS dispatch) and `Bun__ErrorCode__inspectForErrorMessage` (what Rust's `inspect_for_error_message` calls) each append `JSValueToStringSafe(value, true)` directly, with no length cut anywhere.

### Fix
- Add `appendInvalidArgValueReceived()` in `ErrorCode.cpp`: renders the value as before, then if more than 128 characters were appended, shrinks the builder back to 128 and appends `...`. All eight places above now call it instead of `JSValueToStringSafe` directly, so the cut lives in one spot and a future overload gets it by using the same helper.
- Correct because it is node's exact formula applied to the same input: node slices the inspected string at 128 UTF-16 code units, and `StringBuilder::shrink` cuts at 128 code units of the same rendering, so the resulting messages are byte for byte what node prints (including the 128-or-shorter untouched case and the cut falling inside a multi-byte or surrogate sequence). Only the `Received` tail changes; codes, error types, and messages whose value inspects to 128 characters or less are unchanged.
- `inspect_for_error_message` is only used to build `ERR_INVALID_ARG_VALUE` messages (`fs` flags and mode in `types.rs`, `CryptoHasher` encoding), so applying the cut inside it is right for every caller; its Rust doc comment is updated.
- Test: `test/js/node/errors/invalid-arg-value-received.test.ts` (new file: the renderer is shared by many modules and has no test file of its own). It goes through each builder from a public API: `Buffer#fill` and `createRequire` (literal-name overload, with and without a reason), `http.Agent` scheduling (`validateOneOf` list overload), `generateKeyPairSync` encoding (computed-name overload), `net.Socket` and `child_process.fork` (JS dispatch with and without a reason), `fs.openSync` flags and mode (Rust), BYOB `respondWithNewView` (RangeError overload), `stream/iter` (`$ERR_INVALID_ARG_VALUE_RangeError`), plus `validateArray` through the exposed internals for the one overload no public API reaches with a long value. It also pins the 128/129 boundary, a non-latin1 value, and that short values are untouched. The node-reachable cases assert the exact message node v26.3.0 produces.
- Verified: 14 of the 16 cases fail on `USE_SYSTEM_BUN=1` (full value echoed; the two "not cut" controls pass both ways), all 16 pass with `bun bd test`, also under `BUN_JSC_validateExceptionChecks=1`. A node-vs-`bun bd` comparison of 16 calls produced identical messages for 14 and identical lengths for all 16 (details below). The vendored node tests for the touched paths (`test-buffer-fill`, `test-fs-open*`, `test-http-agent-scheduling`, `test-child-process-fork-stdio-string-variant`, `test-crypto-keygen-key-objects`, `test-whatwg-readablebytestream*`) and `test/js/node/vm/vm.test.ts` still pass.

### Background
- `ERR_INVALID_ARG_VALUE` messages have the shape `The <argument|property> '<name>' <reason>. Received <value>`. Node produces `<value>` with `util.inspect`; Bun's equivalent is `JSValueToStringSafe(..., quotesLikeInspect = true)` in `ErrorCode.cpp`, which quotes strings like inspect does and renders objects inline through Bun's inspector. Bun reaches that renderer from three directions: C++ callers use the `Bun::ERR::INVALID_ARG_VALUE` overloads, JS builtins call `$ERR_INVALID_ARG_VALUE(name, value, reason?)`, which dispatches to the static `ERR_INVALID_ARG_VALUE` in the same file, and Rust callers format the message themselves around `JSGlobalObject::inspect_for_error_message`, which calls `Bun__ErrorCode__inspectForErrorMessage`.
- `WTF::StringBuilder::shrink(n)` truncates the builder to its first `n` code units; recording the length before rendering the value and shrinking afterwards cuts only the value, not the message prefix.
- Not changed here: Bun renders objects on one line where node's inspect wraps at 80 columns, and uses double quotes for strings nested in objects. That is a pre-existing difference in the renderer itself, visible in 2 of the 16 comparison cases below; the cut is applied identically in both.

<details>
<summary>node v26.3.0 vs bun bd, 16 calls (probe script output diff)</summary>

Only two lines differ, both from the single-line vs wrapped rendering; every length matches.

```
13,14c13,14
< string containing a single quote (...) => ERR_INVALID_ARG_VALUE | 173 | "... Received \"it's \\n\" +\n  '\\n' + ... +..."
< array value => ERR_INVALID_ARG_VALUE | 198 | "... Received [\n  1234567, 1234567, ... 123..."
---
> string containing a single quote (...) => ERR_INVALID_ARG_VALUE | 173 | "... Received \"it's \\n\\n\\n ... \\n..."
> array value => ERR_INVALID_ARG_VALUE | 198 | "... Received [ 1234567, 1234567, ... 1234567, ..."
```

Identical in both: `Buffer#fill` (173), `createRequire` (304 -> 173 on bun), `http.Agent` scheduling (198), `generateKeyPairSync` format (200), `net.Socket` objectMode (192), `fork` stdio (173), `fs.openSync` flags (173) and mode (214), exactly-128 kept (170), 129 cut (173), UTF-16 value, value cut inside a surrogate pair, short string and number values untouched.

</details>
