### PR TITLE
types: URLSearchParams.toJSON() values are string | string[]

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -67,7 +67,7 @@ declare module "buffer" {
 
 declare module "url" {
   interface URLSearchParams {
-    toJSON(): Record<string, string>;
+    toJSON(): Record<string, string | string[]>;
   }
 }
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -556,6 +556,31 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  describe("URLSearchParams.toJSON", () => {
+    typeTest("values are string for single keys and string[] for repeated keys", {
+      files: {
+        "urlsearchparams-tojson.ts": `
+          // Bun's URLSearchParams.toJSON() yields a string for single keys and a
+          // string[] for repeated keys — the same Record<string, string | string[]>
+          // query object Bun builds in src/js/node/url.ts.
+          type Equals<A, B> =
+            (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+          type Assert<T extends true> = T;
+
+          const params = new URLSearchParams("a=1&a=2&b=3");
+          type _toJSON = Assert<Equals<ReturnType<typeof params.toJSON>, Record<string, string | string[]>>>;
+
+          export {};
+        `,
+      },
+      emptyInterfaces: expectedEmptyInterfacesWhenNoDOM,
+      diagnostics: diagnostics => {
+        const relevantDiagnostics = diagnostics.filter(d => d.line?.startsWith("urlsearchparams-tojson.ts"));
+        expect(relevantDiagnostics).toEqual([]);
+      },
+    });
+  });
+
   describe("Bunland reaching for JSX", () => {
     typeTest("Bun.markdown.react() returns type compatible with React.ReactElement", {
       packages: ["@types/react", "@types/react-dom"],


### PR DESCRIPTION
### What does this PR do?

`URLSearchParams.prototype.toJSON()` in `packages/bun-types/overrides.d.ts` was typed as:

```ts
toJSON(): Record<string, string>;
```

But at runtime a key that appears more than once produces a **`string[]`**, not a `string`:

```js
new URLSearchParams("a=1&a=2&b=3").toJSON();
// => { a: [ "1", "2" ], b: "3" }
```

That's the same `Record<string, string | string[]>` query object Bun builds internally in [`src/js/node/url.ts`](https://github.com/oven-sh/bun/blob/main/src/js/node/url.ts) (assigned to `url.parse(url, true).query`, which Node types as `ParsedUrlQuery` = `{ [key: string]: string | string[] }`). So a repeated-key value was wrongly typed as `string`. This widens the value type to `string | string[]` to match the runtime.

### How did you verify your code works?

- Confirmed the runtime with `bun -e`: `new URLSearchParams("a=1&a=2&b=3").toJSON()` → `{ a: ["1","2"], b: "3" }` (repeated key → array, single key → string).
- Added a case to `test/integration/bun-types/bun-types.test.ts` (`URLSearchParams.toJSON`) asserting `ReturnType<typeof params.toJSON>` is exactly `Record<string, string | string[]>`.
  - It **passes** with this change and **fails** without it: reverting the `.d.ts` produces `Type 'false' does not satisfy the constraint 'true'` (2344) on the type-equality assertion.
- Ran the full `bun test test/integration/bun-types/bun-types.test.ts` suite; the existing `checks with lib.dom.d.ts` case still passes, confirming the change doesn't perturb the lib.dom merge.
