### PR TITLE
resolver: ignore differently-cased package.json and tsconfig.json on case-sensitive filesystems

### DIFF
--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -636,9 +636,7 @@ impl DirEntry {
         })
     }
 
-    /// Looks up an already-lowercase fixed name (`package.json`, ...). Callers
-    /// open that exact spelling next, so a hit stored under another case
-    /// (`Package.json`) only counts if the filesystem opens it too.
+    /// A hit stored under another case (`Package.json`) counts only if the probed spelling exists.
     pub(crate) fn get_comptime_query<'a>(
         &'a self,
         query_lower: &'static [u8],

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -636,12 +636,9 @@ impl DirEntry {
         })
     }
 
-    /// Looks up one of the fixed, already-lowercase names the resolver probes
-    /// directories for (`package.json`, `tsconfig.json`, `node_modules`, ...).
-    /// Callers go on to open `dir/<query_lower>` spelled exactly like that, so
-    /// an entry that only matched through the lowercased key (`Package.json`
-    /// on disk) counts only if the filesystem opens that spelling as well,
-    /// which it does iff it folds case itself.
+    /// Looks up an already-lowercase fixed name (`package.json`, ...). Callers
+    /// open that exact spelling next, so a hit stored under another case
+    /// (`Package.json`) only counts if the filesystem opens it too.
     pub(crate) fn get_comptime_query<'a>(
         &'a self,
         query_lower: &'static [u8],
@@ -658,8 +655,7 @@ impl DirEntry {
         Some(lookup)
     }
 
-    /// True if `dir/<query_lower>` exists under exactly that already-lowercase
-    /// name; see [`get_comptime_query`](Self::get_comptime_query).
+    /// See [`get_comptime_query`](Self::get_comptime_query).
     pub fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
         self.get_comptime_query(query_lower).is_some()
     }

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -636,24 +636,41 @@ impl DirEntry {
         })
     }
 
-    /// Looks up a cached entry by name. Takes a `&'static [u8]` that is
-    /// already lowercase, so no per-call lowercasing buffer is needed.
+    /// Looks up one of the fixed, already-lowercase names the resolver probes
+    /// directories for (`package.json`, `tsconfig.json`, `node_modules`, ...).
+    /// Callers go on to open `dir/<query_lower>` spelled exactly like that, so
+    /// an entry that only matched through the lowercased key (`Package.json`
+    /// on disk) counts only if the filesystem opens that spelling as well,
+    /// which it does iff it folds case itself.
     pub(crate) fn get_comptime_query<'a>(
         &'a self,
         query_lower: &'static [u8],
     ) -> Option<EntryLookup<'a>> {
         Self::debug_assert_entries_mutex_held();
         let &result_ptr = self.data.get(query_lower)?;
-        Some(EntryLookup {
+        let lookup = EntryLookup {
             entry: result_ptr,
             _marker: core::marker::PhantomData,
-        })
+        };
+        if lookup.entry().base() != query_lower && !self.spelling_exists(query_lower) {
+            return None;
+        }
+        Some(lookup)
     }
 
-    /// True if a cached entry exists for the given already-lowercase name.
+    /// True if `dir/<query_lower>` exists under exactly that already-lowercase
+    /// name; see [`get_comptime_query`](Self::get_comptime_query).
     pub fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
-        Self::debug_assert_entries_mutex_held();
-        self.data.contains_key(query_lower)
+        self.get_comptime_query(query_lower).is_some()
+    }
+
+    fn spelling_exists(&self, name: &[u8]) -> bool {
+        use bun_paths::resolve_path::{join_string_buf_z, platform};
+        let mut buf = bun_paths::path_buffer_pool::get();
+        bun_sys::exists_z(join_string_buf_z::<platform::Auto>(
+            &mut buf[..],
+            &[self.dir, name],
+        ))
     }
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -421,7 +421,7 @@ impl PackageJSON {
                         bun_ast::Loc::EMPTY,
                         format_args!(
                             "Cannot read file \"{}\": {}",
-                            bstr::BStr::new(input_path),
+                            bstr::BStr::new(package_json_path),
                             bstr::BStr::new(err.name())
                         ),
                     );

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1459,6 +1459,28 @@ export function tmpdirSync(pattern: string = "bun.test."): string {
   return fs.mkdtempSync(join(fs.realpathSync.native(os.tmpdir()), pattern));
 }
 
+let caseSensitiveFileSystem: boolean | undefined;
+
+/**
+ * Whether the filesystem holding the temporary directories (`tempDir`,
+ * `tempDirWithFiles`, the bundler test fixtures) treats names that differ only
+ * in case as different files. Usually true on Linux and false on macOS and
+ * Windows, but it depends on the mounted filesystem, so it is probed once on
+ * first use.
+ */
+export function isCaseSensitiveFileSystem(): boolean {
+  if (caseSensitiveFileSystem === undefined) {
+    const dir = tmpdirSync("bun.case-probe.");
+    try {
+      fs.writeFileSync(join(dir, "probe"), "");
+      caseSensitiveFileSystem = !fs.existsSync(join(dir, "PROBE"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  return caseSensitiveFileSystem;
+}
+
 export async function runBunInstall(
   env: NodeJS.Dict<string>,
   cwd: string,

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1708,9 +1708,11 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
 describe.concurrent("differently-cased package.json / tsconfig.json in a directory", () => {
   const aliasFixture = {
     "src/x.ts": `export const x = "via-alias";`,
+    "decoy/x.ts": `export const x = "via-decoy";`,
     "entry.ts": `import { x } from "@alias/x"; console.log(x);`,
   };
-  const aliasTsconfig = JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@alias/*": ["./src/*"] } } });
+  const aliasConfig = (target: string) =>
+    JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@alias/*": [`./${target}/*`] } } });
 
   async function bunBuild(dir: string, entry: string) {
     await using proc = Bun.spawn({
@@ -1756,34 +1758,42 @@ describe.concurrent("differently-cased package.json / tsconfig.json in a directo
       expect(exitCode).toBe(0);
     });
 
-    it("Tsconfig.json does not configure the directory", async () => {
-      using dir = tempDir("resolve-cased-tsconfig-ignored", { ...aliasFixture, "Tsconfig.json": aliasTsconfig });
+    it.each(["Tsconfig.json", "Jsconfig.json"])("%s does not configure the directory", async name => {
+      using dir = tempDir("resolve-cased-config-ignored", { ...aliasFixture, [name]: aliasConfig("src") });
       const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
       expect(stderr).toContain('Could not resolve: "@alias/x"');
       expect(stderr).not.toContain("Cannot find tsconfig file");
       expect(stdout).toBe("");
       expect(exitCode).toBe(1);
     });
-  });
 
-  it.skipIf(isCaseSensitiveFileSystem())("on a case-insensitive filesystem Tsconfig.json is the tsconfig", async () => {
-    using dir = tempDir("resolve-cased-tsconfig-folded", { ...aliasFixture, "Tsconfig.json": aliasTsconfig });
-    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
-    expect(stderr).toBe("");
-    expect(stdout).toContain("via-alias");
-    expect(exitCode).toBe(0);
-  });
-
-  it("tsconfig.json is still found when a Tsconfig.json sits next to it", async () => {
-    using dir = tempDir("resolve-cased-tsconfig-both", {
-      ...aliasFixture,
-      "Tsconfig.json": aliasTsconfig,
-      "tsconfig.json": aliasTsconfig,
+    // Whichever of the two files the lowercased listing ends up holding, the
+    // lowercase one is the configuration that applies.
+    it.each([
+      ["tsconfig.json", "Tsconfig.json"],
+      ["jsconfig.json", "Jsconfig.json"],
+    ])("%s is used when a %s with other contents sits next to it", async (lower, other) => {
+      using dir = tempDir("resolve-cased-config-both", {
+        ...aliasFixture,
+        [other]: aliasConfig("decoy"),
+        [lower]: aliasConfig("src"),
+      });
+      const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toContain("via-alias");
+      expect(stdout).not.toContain("via-decoy");
+      expect(exitCode).toBe(0);
     });
-    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
-    expect(stderr).toBe("");
-    expect(stdout).toContain("via-alias");
-    expect(exitCode).toBe(0);
+  });
+
+  describe.skipIf(isCaseSensitiveFileSystem())("on a case-insensitive filesystem it is the configuration file", () => {
+    it.each(["Tsconfig.json", "Jsconfig.json"])("%s configures the directory", async name => {
+      using dir = tempDir("resolve-cased-config-folded", { ...aliasFixture, [name]: aliasConfig("src") });
+      const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
+      expect(stderr).toBe("");
+      expect(stdout).toContain("via-alias");
+      expect(exitCode).toBe(0);
+    });
   });
 
   it.skipIf(isWindows)("a package.json that cannot be read is reported under its own path", async () => {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1,7 +1,18 @@
 import { pathToFileURL } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { chmodSync, chownSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  isCaseSensitiveFileSystem,
+  isLinux,
+  isMacOS,
+  isWindows,
+  joinP,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
 import { join, resolve, sep } from "path";
 
 const fixture = (...segs: string[]) => resolve(import.meta.dir, "fixtures", ...segs);
@@ -1686,6 +1697,108 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("index\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+// The resolver looks every directory up for package.json / tsconfig.json /
+// jsconfig.json in a listing keyed by lowercased name, then opens the
+// lowercase spelling. A differently-cased file on disk used to satisfy the
+// lookup and fail the open.
+describe.concurrent("differently-cased package.json / tsconfig.json in a directory", () => {
+  const aliasFixture = {
+    "src/x.ts": `export const x = "via-alias";`,
+    "entry.ts": `import { x } from "@alias/x"; console.log(x);`,
+  };
+  const aliasTsconfig = JSON.stringify({ compilerOptions: { baseUrl: ".", paths: { "@alias/*": ["./src/*"] } } });
+
+  async function bunBuild(dir: string, entry: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", entry],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  describe.skipIf(!isCaseSensitiveFileSystem())("on a case-sensitive filesystem it is an unrelated file", () => {
+    // Before: `error: Cannot read file ".../": ENOENT` (Package.json) or
+    // `error: Cannot find tsconfig file ".../tsconfig.json"` on every run.
+    it.each(["Package.json", "Tsconfig.json", "Jsconfig.json"])("%s next to the entry point is ignored", async name => {
+      using dir = tempDir("resolve-cased-dir-scan", {
+        [name]: "{}",
+        "entry.js": `console.log("ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ran\n");
+      expect(exitCode).toBe(0);
+    });
+
+    it("bun build succeeds next to a Package.json", async () => {
+      using dir = tempDir("resolve-cased-dir-scan-build", {
+        "Package.json": JSON.stringify({ name: "not-a-manifest-here" }),
+        "entry.js": `console.log("ran");`,
+      });
+      const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.js");
+      expect(stderr).toBe("");
+      expect(stdout).toContain("ran");
+      expect(exitCode).toBe(0);
+    });
+
+    it("Tsconfig.json does not configure the directory", async () => {
+      using dir = tempDir("resolve-cased-tsconfig-ignored", { ...aliasFixture, "Tsconfig.json": aliasTsconfig });
+      const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
+      expect(stderr).toContain('Could not resolve: "@alias/x"');
+      expect(stderr).not.toContain("Cannot find tsconfig file");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  it.skipIf(isCaseSensitiveFileSystem())("on a case-insensitive filesystem Tsconfig.json is the tsconfig", async () => {
+    using dir = tempDir("resolve-cased-tsconfig-folded", { ...aliasFixture, "Tsconfig.json": aliasTsconfig });
+    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toContain("via-alias");
+    expect(exitCode).toBe(0);
+  });
+
+  it("tsconfig.json is still found when a Tsconfig.json sits next to it", async () => {
+    using dir = tempDir("resolve-cased-tsconfig-both", {
+      ...aliasFixture,
+      "Tsconfig.json": aliasTsconfig,
+      "tsconfig.json": aliasTsconfig,
+    });
+    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toContain("via-alias");
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(isWindows)("a package.json that cannot be read is reported under its own path", async () => {
+    using dir = tempDir("resolve-unreadable-package-json", { "entry.js": `console.log("ran");` });
+    symlinkSync("does-not-exist.json", join(String(dir), "package.json"));
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`Cannot read file "${join(String(dir), "package.json")}": ENOENT`);
+    expect(stdout).toBe("ran\n");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- On a case-sensitive filesystem, a file named `Package.json` in the working directory (or any directory the resolver walks up through) makes every `bun <file>` print `error: Cannot read file "<dir>/": ENOENT`, and makes `bun build` exit 1. `Tsconfig.json` / `Jsconfig.json` do the same with `error: Cannot find tsconfig file "<dir>/tsconfig.json"`. Node, npm and tsc ignore these files.
- Cause: the per-directory listing in `src/resolver/fs.rs` is keyed by the lowercased basename, so `DirEntry::get_comptime_query(b"package.json")` returns the `Package.json` entry. Its callers in `dir_info_uncached` (`src/resolver/resolver.rs`, the `package.json`, `tsconfig.json`, `jsconfig.json`, `node_modules` and `.bin` probes) then open `<dir>/package.json` spelled exactly like that, which does not exist, and log the failure.
- The `package.json` read error also printed the directory instead of the file it failed to read (`src/resolver/package_json.rs`).

### Fix
- `get_comptime_query` keeps a hit whose on-disk name differs from the probed name only if the probed spelling exists on disk (`access()` / `GetFileAttributesW` on `<dir>/<name>`). That is true exactly on filesystems that fold case themselves, where the callers' open succeeds and the file really is the directory's `package.json`, so behavior there is unchanged apart from the one extra syscall. Exact-name hits and misses, which is every normal directory, are unchanged and make no syscall. `has_comptime_query` goes through the same path.
- The `package.json` read error names the `package.json` path.
- The other two `has_comptime_query` callers, `bun.lockb` in `src/install/PackageManager.rs` (runtime auto-install) and `package.json` in `src/runtime/cli/pm_view_command.rs`, also open the lowercase spelling next, so a `Bun.lockb` / `Package.json` now skips an open that was going to fail; the fallback they took after that failure is the path they take now.
- Only the fixed-name probes change. `DirEntry::get`, which serves import specifiers, is untouched: case-folded import resolution is existing behavior pinned by `test/bundler/esbuild/extra.test.ts` (`extra/CaseSensitiveImport`), and the case-mismatched extension/index/exports probes are being handled in #36054; same-directory siblings that differ only in case are #38011.
- Verified with `test/js/bun/resolve/resolve.test.ts` (`differently-cased package.json / tsconfig.json in a directory`): 6 of the new tests fail on the current release and pass with this change on Linux; the remaining one is a control that passes both ways. `isCaseSensitiveFileSystem()` is added to the test harness so the case-sensitive half is skipped where the filesystem folds case.
- The two tests that run on case-insensitive filesystems were also run on Windows (`Tsconfig.json` is picked up there, as before).
- `cargo check -p bun_resolver` for the linux, windows-msvc and apple-darwin targets; `test/bundler/esbuild/extra.test.ts`, the tsconfig tests and the rest of `test/js/bun/resolve/` still pass.

### Background
- The resolver never `stat`s candidate files one by one. It reads each directory once (`RealFS::read_directory`) into a `DirEntry`, a hash map from lowercased basename to `Entry`, and answers every lookup in that directory from the map. The lowercasing exists so that on macOS and Windows, where the filesystem itself is case-insensitive, a lookup finds the file the filesystem would have opened.
- `get_comptime_query` is the variant of that lookup used for the handful of fixed names the resolver probes in every directory it visits while building a `DirInfo` (`dir_info_uncached`); the result decides whether the directory gets a parsed `package.json` / `tsconfig.json` attached and whether it counts as having a `node_modules` folder.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->