### PR TITLE
fetch: re-send a Bun.file() body when following a redirect

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -195,6 +195,7 @@ fn make_client<'a>(
         compress: None,
         compressed_request_body: Vec::new(),
         compressed_body_len: 0,
+        buffered_sendfile_body: Vec::new(),
     }
 }
 
@@ -754,6 +755,8 @@ impl<'a> AsyncHTTP<'a> {
                     // populated by the clone (`on_start` → `client.start`); it
                     // owns the decompressor / compressed_body buffers.
                     drop(core::mem::take(&mut client.state));
+                    // After `state`: its `original_request_body` borrows this.
+                    drop(core::mem::take(&mut client.buffered_sendfile_body));
                 }
                 let elapsed = (*this).elapsed;
                 bun_core::scoped_log!(AsyncHTTP, "onAsyncHTTPCallback: {:?}", elapsed);

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1006,6 +1006,8 @@ impl HttpThread {
                 client.close_proxy_tunnel(false);
                 drop(core::mem::take(&mut client.custom_ssl_ctx));
                 drop(core::mem::take(&mut client.state));
+                // After `state`: its `original_request_body` borrows this.
+                drop(core::mem::take(&mut client.buffered_sendfile_body));
                 if let Some(f) = release.release_at_shutdown {
                     f(release.ctx);
                 }

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -37,8 +37,7 @@ pub struct InternalState<'a> {
     // outlives-holder invariant (the backing `original_request_body` is a
     // sibling field, so it lives exactly as long as this struct).
     pub(crate) request_body: bun_ptr::RawSlice<u8>,
-    /// Send cursor for a `Sendfile` body (the `request_body` counterpart).
-    /// `original_request_body` stays untouched so a redirect can replay it.
+    /// Send cursor for a `Sendfile` body; `original_request_body` stays untouched for redirects.
     pub(crate) sendfile: Option<SendFile>,
     pub(crate) original_request_body: HTTPRequestBody<'a>,
     pub(crate) request_sent_len: usize,

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -2,7 +2,9 @@ use crate::Error;
 use bun_core::MutableString;
 use bun_core::Output;
 
-use crate::{CertificateInfo, Decompressor, Encoding, HTTPRequestBody, HTTPResponseMetadata};
+use crate::{
+    CertificateInfo, Decompressor, Encoding, HTTPRequestBody, HTTPResponseMetadata, SendFile,
+};
 
 bun_core::define_scoped_log!(log, HTTPInternalState, hidden);
 
@@ -35,6 +37,11 @@ pub struct InternalState<'a> {
     // outlives-holder invariant (the backing `original_request_body` is a
     // sibling field, so it lives exactly as long as this struct).
     pub(crate) request_body: bun_ptr::RawSlice<u8>,
+    /// Send cursor for a `Sendfile` body, the counterpart of `request_body`
+    /// for `Bytes`: `SendFile::write` advances this copy, so
+    /// `original_request_body` keeps describing the whole file range and a
+    /// redirect can hand it to `start()` again.
+    pub(crate) sendfile: Option<SendFile>,
     pub(crate) original_request_body: HTTPRequestBody<'a>,
     pub(crate) request_sent_len: usize,
     pub(crate) fail: Option<Error>,
@@ -121,6 +128,7 @@ impl Default for InternalState<'_> {
             content_length: None,
             total_body_received: 0,
             request_body: bun_ptr::RawSlice::EMPTY,
+            sendfile: None,
             original_request_body: HTTPRequestBody::Bytes(b""),
             request_sent_len: 0,
             fail: None,
@@ -136,9 +144,14 @@ impl Default for InternalState<'_> {
 impl<'a> InternalState<'a> {
     pub(crate) fn init(body: HTTPRequestBody<'a>) -> InternalState<'a> {
         let request_body = bun_ptr::RawSlice::new(body.slice());
+        let sendfile = match &body {
+            HTTPRequestBody::Sendfile(sendfile) => Some(*sendfile),
+            _ => None,
+        };
         InternalState {
             original_request_body: body,
             request_body,
+            sendfile,
             compressed_body: MutableString::init_empty(),
             response_message_buffer: MutableString::init_empty(),
             decoded_body: MutableString::init_empty(),

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -37,10 +37,8 @@ pub struct InternalState<'a> {
     // outlives-holder invariant (the backing `original_request_body` is a
     // sibling field, so it lives exactly as long as this struct).
     pub(crate) request_body: bun_ptr::RawSlice<u8>,
-    /// Send cursor for a `Sendfile` body, the counterpart of `request_body`
-    /// for `Bytes`: `SendFile::write` advances this copy, so
-    /// `original_request_body` keeps describing the whole file range and a
-    /// redirect can hand it to `start()` again.
+    /// Send cursor for a `Sendfile` body (the `request_body` counterpart).
+    /// `original_request_body` stays untouched so a redirect can replay it.
     pub(crate) sendfile: Option<SendFile>,
     pub(crate) original_request_body: HTTPRequestBody<'a>,
     pub(crate) request_sent_len: usize,

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -5,6 +5,9 @@ use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
 
+/// A request body sent with `sendfile(2)`. The fd is owned by the JS-side
+/// `FetchTasklet`, which keeps it open until the request has delivered its
+/// final result, so every redirect hop can send the same range again.
 #[derive(Copy, Clone)]
 pub struct SendFile {
     pub fd: Fd,
@@ -20,6 +23,24 @@ impl SendFile {
             return false;
         }
         url.is_http() && url.href.len() > 0
+    }
+
+    /// The `content_size` bytes this body advertises as its Content-Length,
+    /// read into memory for a hop that cannot `sendfile(2)` (see
+    /// `HTTPClient::buffer_sendfile_body_for_tls`). Shorter if the file
+    /// shrank since the request was built; the hop's Content-Length is the
+    /// returned length, so the request stays well-formed either way.
+    pub(crate) fn read_to_vec(&self) -> crate::Result<Vec<u8>> {
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes
+            .try_reserve_exact(self.content_size)
+            .map_err(|_| bun_alloc::AllocError)?;
+        bytes.resize(self.content_size, 0);
+        let read = bun_sys::File::borrow(&self.fd)
+            .pread_all(&mut bytes, self.offset as u64)
+            .map_err(bun_errno::SystemErrno::from)?;
+        bytes.truncate(read);
+        Ok(bytes)
     }
 
     // Takes the resolved fd directly rather than the socket; callers pass

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -5,9 +5,8 @@ use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
 
-/// A request body sent with `sendfile(2)`. The fd is owned by the JS-side
-/// `FetchTasklet`, which keeps it open until the request has delivered its
-/// final result, so every redirect hop can send the same range again.
+/// A request body sent with `sendfile(2)`. The JS-side `FetchTasklet` owns
+/// the fd and keeps it open until the final result, so redirect hops reuse it.
 #[derive(Copy, Clone)]
 pub struct SendFile {
     pub fd: Fd,
@@ -25,11 +24,9 @@ impl SendFile {
         url.is_http() && url.href.len() > 0
     }
 
-    /// The `content_size` bytes this body advertises as its Content-Length,
-    /// read into memory for a hop that cannot `sendfile(2)` (see
-    /// `HTTPClient::buffer_sendfile_body_for_tls`). Shorter if the file
-    /// shrank since the request was built; the hop's Content-Length is the
-    /// returned length, so the request stays well-formed either way.
+    /// Reads the `content_size` bytes this body advertises, for a hop that
+    /// cannot `sendfile(2)`. Shorter if the file shrank; the caller's
+    /// Content-Length is the returned length.
     pub(crate) fn read_to_vec(&self) -> crate::Result<Vec<u8>> {
         let mut bytes: Vec<u8> = Vec::new();
         bytes

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -5,8 +5,7 @@ use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
 
-/// A request body sent with `sendfile(2)`. The JS-side `FetchTasklet` owns
-/// the fd and keeps it open until the final result, so redirect hops reuse it.
+/// A body sent with `sendfile(2)`; the JS-side `FetchTasklet` owns the fd for the whole request.
 #[derive(Copy, Clone)]
 pub struct SendFile {
     pub fd: Fd,
@@ -24,9 +23,7 @@ impl SendFile {
         url.is_http() && url.href.len() > 0
     }
 
-    /// Reads the `content_size` bytes this body advertises, for a hop that
-    /// cannot `sendfile(2)`. Shorter if the file shrank; the caller's
-    /// Content-Length is the returned length.
+    /// Reads the advertised `content_size` bytes (fewer if the file shrank) for a non-sendfile hop.
     pub(crate) fn read_to_vec(&self) -> crate::Result<Vec<u8>> {
         let mut bytes: Vec<u8> = Vec::new();
         bytes

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -879,9 +879,7 @@ pub struct HTTPClient<'a> {
     /// Compressed length for `Content-Length`; 0 when `compress` is None or
     /// the body hasn't been compressed yet.
     pub(crate) compressed_body_len: usize,
-    /// A `Sendfile` body read into memory for a TLS hop
-    /// (`buffer_sendfile_body_for_tls`). `state.original_request_body` borrows
-    /// it, so it must outlive `state`; clone-owned like `compressed_request_body`.
+    /// A `Sendfile` body read into memory for a TLS hop, borrowed by `state.original_request_body`.
     pub(crate) buffered_sendfile_body: Vec<u8>,
 }
 
@@ -2161,8 +2159,7 @@ impl<'a> HTTPClient<'a> {
         if in_progress
             && self.allow_retry
             && self.method.is_idempotent()
-            // Only an in-memory body is retried; a Stream body is consumed as it
-            // is written and cannot be replayed.
+            // Only an in-memory body is retried; a Stream body is consumed as it is written.
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
             && self.state.response_stage != ResponseStage::Body
             && self.state.response_stage != ResponseStage::BodyChunk
@@ -2692,10 +2689,7 @@ impl<'a> HTTPClient<'a> {
         self.start(request_body);
     }
 
-    /// The body for the next redirect hop. `Bytes` and `Sendfile` replay as-is
-    /// (the send cursors live in `state`, not in the body). A `Stream` only
-    /// reaches this on a 303, already downgraded to a bodiless GET.
-    /// Call before `state.reset()`.
+    /// The body for the next hop; a `Stream` only reaches this on a 303, already a bodiless GET.
     fn request_body_for_redirect(&self) -> HTTPRequestBody<'a> {
         if !self.state.flags.resend_request_body_on_redirect {
             return HTTPRequestBody::Bytes(b"");
@@ -2919,11 +2913,7 @@ impl<'a> HTTPClient<'a> {
         self.complete_connecting_process();
     }
 
-    /// `sendfile(2)` needs a plaintext socket with no CONNECT tunnel, but a
-    /// redirect to `https://` (or an `https://` proxy from the environment) can
-    /// route a `Sendfile` body onto TLS. Read the file into
-    /// `buffered_sendfile_body` and send it as `Bytes`, as a direct `https://`
-    /// fetch would.
+    /// A redirect or env `https://` proxy can put a `Sendfile` body on TLS; send it as `Bytes` there.
     fn buffer_sendfile_body_for_tls<const IS_SSL: bool>(&mut self) -> crate::Result<()> {
         let HTTPRequestBody::Sendfile(sendfile) = self.state.original_request_body else {
             return Ok(());

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -879,13 +879,9 @@ pub struct HTTPClient<'a> {
     /// Compressed length for `Content-Length`; 0 when `compress` is None or
     /// the body hasn't been compressed yet.
     pub(crate) compressed_body_len: usize,
-    /// A `Sendfile` body read into memory because a hop has to send it over
-    /// TLS (see [`buffer_sendfile_body_for_tls`]); `state.original_request_body`
-    /// borrows it as `Bytes` from then on, so it is filled at most once per
-    /// request and, like `compressed_request_body`, freed only when the
-    /// HTTP-thread clone is torn down.
-    ///
-    /// [`buffer_sendfile_body_for_tls`]: Self::buffer_sendfile_body_for_tls
+    /// A `Sendfile` body read into memory for a TLS hop
+    /// (`buffer_sendfile_body_for_tls`). `state.original_request_body` borrows
+    /// it, so it must outlive `state`; clone-owned like `compressed_request_body`.
     pub(crate) buffered_sendfile_body: Vec<u8>,
 }
 
@@ -2165,9 +2161,8 @@ impl<'a> HTTPClient<'a> {
         if in_progress
             && self.allow_retry
             && self.method.is_idempotent()
-            // Only an in-memory body is retried. A Stream body in particular is
-            // consumed as it is written, so retrying it would silently replay a
-            // truncated request.
+            // Only an in-memory body is retried; a Stream body is consumed as it
+            // is written and cannot be replayed.
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
             && self.state.response_stage != ResponseStage::Body
             && self.state.response_stage != ResponseStage::BodyChunk
@@ -2697,14 +2692,10 @@ impl<'a> HTTPClient<'a> {
         self.start(request_body);
     }
 
-    /// The body for the hop a redirect is about to start. The send path never
-    /// advances `original_request_body` (its cursors are `state.request_body`
-    /// and `state.sendfile`), so a `Bytes` or `Sendfile` body goes to `start()`
-    /// again unchanged. A `Stream` body only gets this far on a 303, which
-    /// `handle_response_metadata` has already turned into a bodiless GET; every
-    /// other status fails it with `RequestBodyNotReusable` instead.
-    ///
-    /// Must run before `state.reset()`, which clears both the flag and the body.
+    /// The body for the next redirect hop. `Bytes` and `Sendfile` replay as-is
+    /// (the send cursors live in `state`, not in the body). A `Stream` only
+    /// reaches this on a 303, already downgraded to a bodiless GET.
+    /// Call before `state.reset()`.
     fn request_body_for_redirect(&self) -> HTTPRequestBody<'a> {
         if !self.state.flags.resend_request_body_on_redirect {
             return HTTPRequestBody::Bytes(b"");
@@ -2928,13 +2919,11 @@ impl<'a> HTTPClient<'a> {
         self.complete_connecting_process();
     }
 
-    /// `sendfile(2)` copies the file straight onto the socket's fd, so a
-    /// `Sendfile` body needs a plaintext socket with no CONNECT tunnel inside
-    /// it; `on_writable` panics otherwise. `fetch()` only builds one for such a
-    /// request, but a redirect to `https://` (or an `https://` proxy taken from
-    /// the environment) can route it onto a TLS hop. For that hop, read the
-    /// file into `buffered_sendfile_body` and send it as `Bytes`, which is how
-    /// `fetch()` sends a file to an `https://` URL in the first place.
+    /// `sendfile(2)` needs a plaintext socket with no CONNECT tunnel, but a
+    /// redirect to `https://` (or an `https://` proxy from the environment) can
+    /// route a `Sendfile` body onto TLS. Read the file into
+    /// `buffered_sendfile_body` and send it as `Bytes`, as a direct `https://`
+    /// fetch would.
     fn buffer_sendfile_body_for_tls<const IS_SSL: bool>(&mut self) -> crate::Result<()> {
         let HTTPRequestBody::Sendfile(sendfile) = self.state.original_request_body else {
             return Ok(());
@@ -2945,10 +2934,9 @@ impl<'a> HTTPClient<'a> {
         }
         debug_assert!(self.buffered_sendfile_body.is_empty());
         self.buffered_sendfile_body = sendfile.read_to_vec()?;
-        // SAFETY: `buffered_sendfile_body` is only assigned here, and this runs
-        // at most once per request: the body is `Bytes` from now on, including
-        // the copies `request_body_for_redirect` hands to later hops. The Vec
-        // lives on `self`, which outlives every `InternalState` that borrows it.
+        // SAFETY: the Vec is assigned only here, once per request (the body is
+        // `Bytes` from now on), and lives on `self`, which outlives every
+        // `InternalState` that borrows it.
         let bytes: &'a [u8] = unsafe { bun_ptr::detach_lifetime(&self.buffered_sendfile_body) };
         self.state = InternalState::init(HTTPRequestBody::Bytes(bytes));
         Ok(())

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -879,6 +879,14 @@ pub struct HTTPClient<'a> {
     /// Compressed length for `Content-Length`; 0 when `compress` is None or
     /// the body hasn't been compressed yet.
     pub(crate) compressed_body_len: usize,
+    /// A `Sendfile` body read into memory because a hop has to send it over
+    /// TLS (see [`buffer_sendfile_body_for_tls`]); `state.original_request_body`
+    /// borrows it as `Bytes` from then on, so it is filled at most once per
+    /// request and, like `compressed_request_body`, freed only when the
+    /// HTTP-thread clone is torn down.
+    ///
+    /// [`buffer_sendfile_body_for_tls`]: Self::buffer_sendfile_body_for_tls
+    pub(crate) buffered_sendfile_body: Vec<u8>,
 }
 
 impl<'a> HTTPClient<'a> {
@@ -2157,9 +2165,9 @@ impl<'a> HTTPClient<'a> {
         if in_progress
             && self.allow_retry
             && self.method.is_idempotent()
-            // Only a Bytes body can be rebuilt from `original_request_body`.
-            // Stream/Sendfile bodies are consumed as they are written, so a
-            // retry would silently replay a truncated request.
+            // Only an in-memory body is retried. A Stream body in particular is
+            // consumed as it is written, so retrying it would silently replay a
+            // truncated request.
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
             && self.state.response_stage != ResponseStage::Body
             && self.state.response_stage != ResponseStage::BodyChunk
@@ -2615,17 +2623,7 @@ impl<'a> HTTPClient<'a> {
         // Decided before unix_socket_path is cleared below: a unix-socket connection must not be pooled.
         let keep_alive_possible = self.is_keep_alive_possible();
         self.unix_socket_path = b"";
-        // TODO: what we do with stream body?
-        let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
-            && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
-        {
-            match &self.state.original_request_body {
-                HTTPRequestBody::Bytes(b) => b,
-                _ => unreachable!(),
-            }
-        } else {
-            b""
-        };
+        let request_body = self.request_body_for_redirect();
 
         self.state.response_message_buffer = MutableString::default();
 
@@ -2696,7 +2694,26 @@ impl<'a> HTTPClient<'a> {
         self.flags.protocol = Protocol::Http1_1;
         self.reevaluate_proxy_for_redirect();
 
-        self.start(HTTPRequestBody::Bytes(request_body));
+        self.start(request_body);
+    }
+
+    /// The body for the hop a redirect is about to start. The send path never
+    /// advances `original_request_body` (its cursors are `state.request_body`
+    /// and `state.sendfile`), so a `Bytes` or `Sendfile` body goes to `start()`
+    /// again unchanged. A `Stream` body only gets this far on a 303, which
+    /// `handle_response_metadata` has already turned into a bodiless GET; every
+    /// other status fails it with `RequestBodyNotReusable` instead.
+    ///
+    /// Must run before `state.reset()`, which clears both the flag and the body.
+    fn request_body_for_redirect(&self) -> HTTPRequestBody<'a> {
+        if !self.state.flags.resend_request_body_on_redirect {
+            return HTTPRequestBody::Bytes(b"");
+        }
+        match self.state.original_request_body {
+            HTTPRequestBody::Bytes(bytes) => HTTPRequestBody::Bytes(bytes),
+            HTTPRequestBody::Sendfile(sendfile) => HTTPRequestBody::Sendfile(sendfile),
+            HTTPRequestBody::Stream(_) => HTTPRequestBody::Bytes(b""),
+        }
     }
 
     /// Re-resolve `http_proxy` against the post-redirect `self.url`. The
@@ -2763,6 +2780,12 @@ impl<'a> HTTPClient<'a> {
         // Aborted before connecting
         if self.signals.get(signals::Field::Aborted) {
             self.fail(crate::Error::AbortedBeforeConnecting);
+            self.complete_connecting_process();
+            return;
+        }
+
+        if let Err(err) = self.buffer_sendfile_body_for_tls::<IS_SSL>() {
+            self.fail(err);
             self.complete_connecting_process();
             return;
         }
@@ -2903,6 +2926,32 @@ impl<'a> HTTPClient<'a> {
             self.register_abort_tracker::<IS_SSL>(socket);
         }
         self.complete_connecting_process();
+    }
+
+    /// `sendfile(2)` copies the file straight onto the socket's fd, so a
+    /// `Sendfile` body needs a plaintext socket with no CONNECT tunnel inside
+    /// it; `on_writable` panics otherwise. `fetch()` only builds one for such a
+    /// request, but a redirect to `https://` (or an `https://` proxy taken from
+    /// the environment) can route it onto a TLS hop. For that hop, read the
+    /// file into `buffered_sendfile_body` and send it as `Bytes`, which is how
+    /// `fetch()` sends a file to an `https://` URL in the first place.
+    fn buffer_sendfile_body_for_tls<const IS_SSL: bool>(&mut self) -> crate::Result<()> {
+        let HTTPRequestBody::Sendfile(sendfile) = self.state.original_request_body else {
+            return Ok(());
+        };
+        let tunnels_through_proxy = self.http_proxy.is_some() && self.url.is_https();
+        if !IS_SSL && !tunnels_through_proxy {
+            return Ok(());
+        }
+        debug_assert!(self.buffered_sendfile_body.is_empty());
+        self.buffered_sendfile_body = sendfile.read_to_vec()?;
+        // SAFETY: `buffered_sendfile_body` is only assigned here, and this runs
+        // at most once per request: the body is `Bytes` from now on, including
+        // the copies `request_body_for_redirect` hands to later hops. The Vec
+        // lives on `self`, which outlives every `InternalState` that borrows it.
+        let bytes: &'a [u8] = unsafe { bun_ptr::detach_lifetime(&self.buffered_sendfile_body) };
+        self.state = InternalState::init(HTTPRequestBody::Bytes(bytes));
+        Ok(())
     }
 
     /// Body length for `Content-Length` — the compressed length once
@@ -3386,7 +3435,7 @@ impl<'a> HTTPClient<'a> {
                     self.set_timeout(&socket);
                 }
 
-                match &mut self.state.original_request_body {
+                match self.state.original_request_body {
                     HTTPRequestBody::Bytes(_) => {
                         let to_send = self.request_body();
                         if !to_send.is_empty() {
@@ -3412,13 +3461,18 @@ impl<'a> HTTPClient<'a> {
                         // flush without adding any new data
                         self.flush_stream::<IS_SSL>(socket);
                     }
-                    HTTPRequestBody::Sendfile(sendfile) => {
+                    HTTPRequestBody::Sendfile(_) => {
                         if IS_SSL {
                             panic!(
                                 "sendfile is only supported without SSL. This code should never have been reached!"
                             );
                         }
 
+                        let sendfile = self
+                            .state
+                            .sendfile
+                            .as_mut()
+                            .expect("InternalState::init seats the cursor for a Sendfile body");
                         // sendfile.write() takes the raw fd, not the socket handle.
                         match sendfile.write(socket.fd()) {
                             #[cfg(not(windows))]
@@ -4331,16 +4385,7 @@ impl<'a> HTTPClient<'a> {
             self.flags.is_streaming_request_body = false;
         }
         self.unix_socket_path = b"";
-        let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
-            && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
-        {
-            match &self.state.original_request_body {
-                HTTPRequestBody::Bytes(b) => b,
-                _ => unreachable!(),
-            }
-        } else {
-            b""
-        };
+        let request_body = self.request_body_for_redirect();
         self.state.response_message_buffer = MutableString::default();
         self.remaining_redirect_count = self.remaining_redirect_count.saturating_sub(1);
         self.flags.redirected = true;
@@ -4356,7 +4401,7 @@ impl<'a> HTTPClient<'a> {
         self.flags.proxy_tunneling = false;
         self.flags.protocol = Protocol::Http1_1;
         self.reevaluate_proxy_for_redirect();
-        self.start(HTTPRequestBody::Bytes(request_body));
+        self.start(request_body);
     }
 
     pub(crate) fn progress_update_h3(&mut self) {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,10 +1,11 @@
 import axios from "axios";
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
 import net from "node:net";
+import { join } from "node:path";
 import tls from "node:tls";
 async function createProxyServer(is_tls: boolean) {
   const serverArgs = [];
@@ -227,6 +228,65 @@ for (const proxy_tls of [false, true]) {
     }
   }
 }
+
+// fetch() uploads a Bun.file() of 32 KiB or more with sendfile(2), which needs a
+// plaintext connection, and decides that before a proxy from the environment
+// is applied. The HTTP client has to fall back to uploading the file as
+// ordinary bytes whenever the connection it ends up on is TLS (an https://
+// proxy) or a CONNECT tunnel (a redirect onto an https:// origin through a
+// proxy); it used to abort with "sendfile is only supported without SSL" in
+// the first case and send an empty body in the second.
+describe("Bun.file() body that would use sendfile, with a proxy from the environment", () => {
+  const SIZE = 64 * 1024;
+
+  // Subprocess: the proxy environment is read when the process starts.
+  async function uploadFromChild(url: string, proxyEnv: Record<string, string>) {
+    using dir = tempDir("proxy-sendfile-body", { "body.bin": Buffer.alloc(SIZE, "a") });
+    const env = { ...bunEnv };
+    for (const key of PROXY_ENV_KEYS) delete env[key];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const res = await fetch(${JSON.stringify(url)}, {
+          method: "POST",
+          body: Bun.file(${JSON.stringify(join(String(dir), "body.bin"))}),
+          tls: { rejectUnauthorized: false },
+        });
+        console.log(res.status, (await res.text()).length);`,
+      ],
+      env: { ...env, ...proxyEnv },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("is uploaded through a TLS proxy", async () => {
+    expect(await uploadFromChild(String(httpServer.url), { http_proxy: httpsProxyServer.url })).toEqual({
+      stdout: `200 ${SIZE}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("is re-uploaded through a CONNECT tunnel when the origin redirects to https", async () => {
+    using origin = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        await req.arrayBuffer();
+        return new Response(null, { status: 307, headers: { Location: String(httpsServer.url) } });
+      },
+    });
+    const proxyEnv = { http_proxy: httpProxyServer.url, https_proxy: httpProxyServer.url };
+    expect(await uploadFromChild(String(origin.url), proxyEnv)).toEqual({
+      stdout: `200 ${SIZE}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
 
 for (const server_tls of [false, true]) {
   describe.concurrent(`proxy can handle redirects with ${server_tls ? "TLS" : "non-TLS"} server`, () => {

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
+import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import net from "node:net";
+import { join } from "node:path";
 
 // WHATWG HTTP-redirect fetch runs on the response head (status line + Location);
 // the 3xx body is discarded, not awaited. A redirecting server that never finishes
@@ -175,6 +177,195 @@ it("fetch() preserves body on redirect", async () => {
 
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("hello");
+});
+
+// A Bun.file() body of 32 KiB or more is uploaded with sendfile(2) instead of
+// being read into memory. When following a redirect, the HTTP client only
+// re-sent in-memory bodies: the sendfile body went out on the next hop as
+// `Content-Length: 0` with no body, and the fetch still resolved with that
+// hop's 200. (Below 32 KiB the file is read into memory up front and was
+// always replayed.)
+describe("fetch() re-sends a Bun.file() body when following a redirect", () => {
+  const FILE = randomBytes(96 * 1024);
+
+  type Hop = { method: string; path: string; contentLength: string | null; bytes: number; matches: boolean };
+
+  // Records every request it receives into `hops`. Paths listed in `redirects`
+  // answer with that redirect (after reading the body); anything else is the
+  // final 200.
+  function serveHops(
+    hops: Hop[],
+    expectedBody: Uint8Array,
+    redirects: Record<string, { status: number; location: string }>,
+    tlsOptions?: typeof tls,
+  ) {
+    return Bun.serve({
+      port: 0,
+      tls: tlsOptions,
+      async fetch(req) {
+        const { pathname } = new URL(req.url);
+        const body = Buffer.from(await req.arrayBuffer());
+        hops.push({
+          method: req.method,
+          path: pathname,
+          contentLength: req.headers.get("content-length"),
+          bytes: body.byteLength,
+          matches: body.equals(expectedBody),
+        });
+        const redirect = redirects[pathname];
+        if (redirect) {
+          return new Response(null, { status: redirect.status, headers: { Location: redirect.location } });
+        }
+        return new Response("final");
+      },
+    });
+  }
+
+  const received = (method: string, path: string, body: Uint8Array = FILE): Hop => ({
+    method,
+    path,
+    contentLength: String(body.byteLength),
+    bytes: body.byteLength,
+    matches: true,
+  });
+
+  it.concurrent.each([
+    [307, "POST"],
+    [308, "POST"],
+    [307, "PATCH"],
+    [301, "PUT"],
+    [302, "PUT"],
+    [302, "DELETE"],
+  ])("%d keeps the %s body", async (status, method) => {
+    using dir = tempDir("fetch-redirect-sendfile", { "body.bin": FILE });
+    const hops: Hop[] = [];
+    using server = serveHops(hops, FILE, { "/start": { status, location: "/final" } });
+
+    const res = await fetch(new URL("/start", server.url), { method, body: Bun.file(join(String(dir), "body.bin")) });
+
+    expect({ status: res.status, redirected: res.redirected, text: await res.text(), hops }).toEqual({
+      status: 200,
+      redirected: true,
+      text: "final",
+      hops: [received(method, "/start"), received(method, "/final")],
+    });
+  });
+
+  // https://fetch.spec.whatwg.org/#http-redirect-fetch: 303 (and 301/302 for
+  // POST) switch to GET and drop the body; the file must not be re-sent there.
+  it.concurrent.each([
+    [303, "POST"],
+    [303, "PUT"],
+    [301, "POST"],
+    [302, "POST"],
+  ])("%d drops the %s body and switches to GET", async (status, method) => {
+    using dir = tempDir("fetch-redirect-sendfile", { "body.bin": FILE });
+    const hops: Hop[] = [];
+    using server = serveHops(hops, FILE, { "/start": { status, location: "/final" } });
+
+    const res = await fetch(new URL("/start", server.url), { method, body: Bun.file(join(String(dir), "body.bin")) });
+
+    expect({ status: res.status, redirected: res.redirected, text: await res.text(), hops }).toEqual({
+      status: 200,
+      redirected: true,
+      text: "final",
+      hops: [
+        received(method, "/start"),
+        { method: "GET", path: "/final", contentLength: null, bytes: 0, matches: false },
+      ],
+    });
+  });
+
+  it.concurrent("re-sends the same slice of the file on every hop of a chain", async () => {
+    const SLICE_START = 4096;
+    const slice = FILE.subarray(SLICE_START, SLICE_START + 40 * 1024);
+    using dir = tempDir("fetch-redirect-sendfile", { "body.bin": FILE });
+    const hops: Hop[] = [];
+    using server = serveHops(hops, slice, {
+      "/start": { status: 307, location: "/second" },
+      "/second": { status: 308, location: "/final" },
+    });
+
+    const res = await fetch(new URL("/start", server.url), {
+      method: "POST",
+      body: Bun.file(join(String(dir), "body.bin")).slice(SLICE_START, SLICE_START + slice.byteLength),
+    });
+
+    expect({ status: res.status, text: await res.text(), hops }).toEqual({
+      status: 200,
+      text: "final",
+      hops: [received("POST", "/start", slice), received("POST", "/second", slice), received("POST", "/final", slice)],
+    });
+  });
+
+  // sendfile(2) needs a plaintext socket. A redirect onto https has to upload
+  // the same file bytes over TLS instead, and a further redirect from there
+  // has to send them once more.
+  it.concurrent("re-sends the body when the redirect crosses over to https", async () => {
+    using dir = tempDir("fetch-redirect-sendfile", { "body.bin": FILE });
+    const secureHops: Hop[] = [];
+    using secure = serveHops(secureHops, FILE, { "/secure": { status: 308, location: "/final" } }, tls);
+    const plainHops: Hop[] = [];
+    using plain = serveHops(plainHops, FILE, {
+      "/start": { status: 307, location: `https://127.0.0.1:${secure.port}/secure` },
+    });
+
+    const res = await fetch(new URL("/start", plain.url), {
+      method: "PUT",
+      body: Bun.file(join(String(dir), "body.bin")),
+      tls: { ca: tls.cert },
+    });
+
+    expect({ status: res.status, url: res.url, text: await res.text(), plainHops, secureHops }).toEqual({
+      status: 200,
+      url: `https://127.0.0.1:${secure.port}/final`,
+      text: "final",
+      plainHops: [received("PUT", "/start")],
+      secureHops: [received("PUT", "/secure"), received("PUT", "/final")],
+    });
+  });
+
+  // A server may redirect as soon as it has seen the request head, while the
+  // file is still being uploaded to it. The next hop must get the whole file
+  // from the beginning, not the remainder of the interrupted upload.
+  it.concurrent("re-sends the whole file after a redirect that interrupted the upload", async () => {
+    const BIG = randomBytes(4 * 1024 * 1024);
+    using dir = tempDir("fetch-redirect-sendfile", { "body.bin": BIG });
+    const hops: Hop[] = [];
+    using final = serveHops(hops, BIG, {});
+
+    const sockets = new Set<net.Socket>();
+    const redirector = net.createServer(socket => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        // Stop reading so the upload backs up, then redirect it mid-flight.
+        socket.pause();
+        socket.write(
+          `HTTP/1.1 307 Temporary Redirect\r\nLocation: ${final.url.origin}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`,
+        );
+      });
+    });
+    await once(redirector.listen(0, "127.0.0.1"), "listening");
+    const { port } = redirector.address() as net.AddressInfo;
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/start`, {
+        method: "POST",
+        body: Bun.file(join(String(dir), "body.bin")),
+      });
+      expect({ status: res.status, text: await res.text(), hops }).toEqual({
+        status: 200,
+        text: "final",
+        hops: [received("POST", "/final", BIG)],
+      });
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      redirector.close();
+      await once(redirector, "close");
+    }
+  });
 });
 
 it.each(["file:/etc/hosts", "file:hosts"])(


### PR DESCRIPTION
### Problem
- `fetch(url, { method: "POST", body: Bun.file(path) })` through a 307/308 (or a 301/302 with a non-POST method) uploads the file to the first hop, then sends the redirected request with `Content-Length: 0` and no body, and resolves with the second hop's 200 as if the upload had succeeded. Only files of 32 KiB or more are affected; smaller ones are replayed correctly.
- `fetch.rs` sends a file of `st_size >= 32 KiB` to a plain `http://` URL as `HTTPRequestBody::Sendfile`. `HTTPClient::do_redirect` (and `do_redirect_multiplexed`) replayed only `HTTPRequestBody::Bytes` and substituted `b""` for everything else (`src/http/lib.rs`, next to the old `// TODO: what we do with stream body?`). `handle_response_metadata` rejects only `Stream` bodies with `RequestBodyNotReusable`, so a `Sendfile` body was neither replayed nor rejected.
- Same check, second symptom: with `http_proxy=https://...` in the environment, the same request aborts the process on the first hop with `panic: sendfile is only supported without SSL. This code should never have been reached!`. `fetch.rs` decides on sendfile by looking at the explicit `proxy` option only; the environment proxy is resolved afterwards in `FetchTasklet`, so the sendfile body reached a TLS connection.

### Fix
- `InternalState` gets a `sendfile` cursor next to the existing `request_body` cursor for `Bytes`; `SendFile::write` now advances that copy, so `state.original_request_body` still describes the whole file range after a hop has (partially) uploaded it.
- Both `do_redirect` variants go through `request_body_for_redirect()`, which hands a `Bytes` or `Sendfile` body to `start()` again unchanged (a `Stream` body only reaches this point on a 303, which has already become a bodiless GET). This is what WHATWG HTTP-redirect fetch asks for: a body with a source is re-sent on 307/308, and the existing 303 / 301+302-POST downgrade to GET is unchanged.
- `start_()` calls `buffer_sendfile_body_for_tls()`: if the body is a `Sendfile` but this hop is a TLS socket (`IS_SSL`) or will CONNECT-tunnel through a proxy (the same `http_proxy.is_some() && url.is_https()` predicate the pool uses), the file range is `pread` into a new client-owned `buffered_sendfile_body` and the hop is started with a `Bytes` body. A request built for an `https://` URL in the first place is already uploaded this way, so a redirect onto https behaves like fetching the final URL directly. The buffer is filled at most once per request (the body is `Bytes` from then on) and is freed where `compressed_request_body` is freed, after `state`, which borrows it. This same path replaces the environment-proxy panic above; a plain `http://` environment proxy keeps using sendfile as before.
- The fd behind the `Sendfile` stays valid across hops: it is owned by the `FetchTasklet`, which closes it only after the final result is delivered.
- The keep-alive retry in `on_close` is left as is (in-memory bodies only); only its comment was updated.
- Verified:
  - `test/js/web/fetch/fetch-redirect.test.ts`: new describe block. 9 of the 13 new cases fail on the unfixed build (hop 2 receives `Content-Length: 0`), all pass with the fix. Covers 307/308/301/302 with POST/PUT/PATCH/DELETE, the 303 and 301/302-POST downgrade (unchanged behavior), a `Bun.file().slice()` window across a 3-hop chain, an http -> https -> https chain, and a server that redirects while the 4 MiB upload is still in flight (a probe confirmed hop 1 had accepted ~2.6 MiB at that point and hop 2 received all 4 MiB byte-exact).
  - `test/js/bun/http/proxy.test.ts`: new describe block, two subprocess tests with proxies from the environment. Before: the TLS-proxy case aborts with the panic above and the redirect-into-CONNECT-tunnel case uploads 0 bytes; both pass with the fix. The full file (69 tests) passes.
  - `fetch-file-upload`, `fetch-compress`, `fetch-keepalive`, `fetch-url-after-redirect`, `fetch-http2-client`, `fetch-http3-client` pass on the debug build. `cargo clippy -p bun_http` and `cargo fmt --check` are clean.

### Background
- `HTTPRequestBody` (`src/http/HTTPRequestBody.rs`) is the HTTP thread's view of a request body: `Bytes` (a borrowed in-memory slice), `Sendfile` (an fd plus offset/length, written with `sendfile(2)` straight from the file to the socket fd, so it only works on a plaintext socket), or `Stream` (chunks pushed from a JS `ReadableStream`, which cannot be replayed).
- `InternalState` is the per-attempt state of an `HTTPClient`; `do_redirect` resets it and calls `start()` with the body for the next hop, so anything that must survive a hop has to be taken out of it first or live on the `HTTPClient` itself (which is why the new buffer is a client field).
- The `HTTPClient` that runs a request is a bitwise copy of the JS-thread original made when the request is picked up by the HTTP thread, so buffers it allocates on its own (`redirect`, `compressed_request_body`, now `buffered_sendfile_body`) are freed explicitly in the two teardown sites in `AsyncHTTP.rs` and `HTTPThread.rs` rather than by dropping the struct.

<details>
<summary>Repro (before: hop 2 gets 0 bytes; after: 32768)</summary>

```js
import { createServer } from "node:http";
import { writeFileSync, mkdtempSync } from "node:fs";
import { tmpdir } from "node:os"; import { join } from "node:path";
const p = join(mkdtempSync(join(tmpdir(), "frd-")), "body.bin");
const N = Number(process.argv[2] ?? 32768);
writeFileSync(p, Buffer.alloc(N, 0x61));
const srv = createServer((req, res) => {
  let n = 0; req.on("data", c => n += c.length).on("end", () => {
    console.log("server saw", req.method, req.url, "content-length:", req.headers["content-length"], "body bytes:", n);
    if (req.url === "/upload") { res.writeHead(307, { Location: "/upload2" }); res.end(); }
    else { res.writeHead(200); res.end(String(n)); }
  });
}).listen(0, "127.0.0.1", async () => {
  const r = await fetch(`http://127.0.0.1:${srv.address().port}/upload`, { method: "POST", body: Bun.file(p) });
  console.log("client:", r.status, "hop-2 received", await r.text(), "of", N);
  srv.close();
});
```

Before (bun 1.4.0 and current main):

```
server saw POST /upload content-length: 32768 body bytes: 32768
server saw POST /upload2 content-length: 0 body bytes: 0
client: 200 hop-2 received 0 of 32768
```

After:

```
server saw POST /upload content-length: 32768 body bytes: 32768
server saw POST /upload2 content-length: 32768 body bytes: 32768
client: 200 hop-2 received 32768 of 32768
```

</details>

<details>
<summary>Notes on the buffered fallback</summary>

- The fallback read runs synchronously on the HTTP thread, once, for the rare hop that moves a sendfile upload onto TLS. Failing such a redirect with `RequestBodyNotReusable` instead would also be spec-conformant; buffering was chosen because a request that starts out on https already buffers the same file on the JS thread, so this keeps the redirected and the direct request equivalent. Easy to switch if buffering on the HTTP thread is not wanted.
- If the file shrank between the first hop and the fallback read, the hop sends the bytes that are there with a matching `Content-Length`, which is also what a fresh `fetch()` of the same `Bun.file()` would send at that point. #36212 deals separately with files truncated while sendfile is running.
- Related but distinct: #35792 adds redirect replay for streaming FormData bodies and touches the same `do_redirect` lines; whichever lands second needs a trivial rebase.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch-redirect.test.ts

<!-- robobun:evidence:end -->