### PR TITLE
parser: honor the type attribute on export ... from statements

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3985,42 +3985,51 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut S::Import,
     ) -> Result<(), crate::Error> {
         if let Some(loader) = path.loader {
-            self.import_records.items_mut()[stmt.import_record_index as usize].loader =
-                Some(loader);
-
-            if loader == options::Loader::Sqlite || loader == options::Loader::SqliteEmbedded {
-                // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a.
-                for item in stmt.items.iter() {
-                    // `ClauseItem.alias` is an arena-owned `StoreStr` valid for 'a.
-                    let alias: &[u8] = item.alias.slice();
-                    if !(alias == b"default" || alias == b"db") {
-                        self.log().add_error(
-                            Some(self.source),
-                            item.name.loc,
-                            b"sqlite imports only support the \"default\" or \"db\" imports",
-                        );
-                        break;
-                    }
-                }
-            } else if loader == options::Loader::File || loader == options::Loader::Text {
-                // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a.
-                for item in stmt.items.iter() {
-                    // `ClauseItem.alias` is an arena-owned `StoreStr` valid for 'a.
-                    if item.alias.slice() != b"default" {
-                        self.log().add_error(
-                            Some(self.source),
-                            item.name.loc,
-                            b"This loader type only supports the \"default\" import",
-                        );
-                        break;
-                    }
-                }
-            }
+            // In an import clause, `ClauseItem.alias` is the name imported from the module.
+            self.set_import_record_loader(
+                stmt.import_record_index,
+                loader,
+                stmt.items
+                    .iter()
+                    .map(|item| (item.alias.slice(), item.name.loc)),
+            );
         } else if path.import_tag == bun_ast::ImportRecordTag::BakeResolveToSsrGraph {
             self.import_records.items_mut()[stmt.import_record_index as usize].tag =
                 path.import_tag;
         }
         Ok(())
+    }
+
+    /// Applies a `with { type: "..." }` attribute to the import record of an `import` or
+    /// `export ... from` statement. `imported_names` are the names the statement imports from
+    /// the module; loaders whose modules only have a fixed set of exports reject other names.
+    #[cold]
+    pub(crate) fn set_import_record_loader<'n>(
+        &mut self,
+        import_record_index: u32,
+        loader: options::Loader,
+        imported_names: impl Iterator<Item = (&'n [u8], bun_ast::Loc)>,
+    ) {
+        self.import_records.items_mut()[import_record_index as usize].loader = Some(loader);
+
+        let (exported_names, error): (&[&[u8]], &[u8]) = match loader {
+            options::Loader::Sqlite | options::Loader::SqliteEmbedded => (
+                &[b"default", b"db"],
+                b"sqlite imports only support the \"default\" or \"db\" imports",
+            ),
+            options::Loader::File | options::Loader::Text => (
+                &[b"default"],
+                b"This loader type only supports the \"default\" import",
+            ),
+            _ => return,
+        };
+
+        for (name, loc) in imported_names {
+            if !exported_names.contains(&name) {
+                self.log().add_error(Some(self.source), loc, error);
+                break;
+            }
+        }
     }
 
     pub(crate) fn create_default_name(&mut self, loc: bun_ast::Loc) -> js_ast::LocRef {

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1231,13 +1231,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     namespace_ref = p.store_name_in_ref(name);
                 }
 
-                let import_record_index = p.add_import_record(
-                    ImportKind::Stmt,
-                    path.loc,
-                    path.text,
-                    // TODO: import assertions
-                    // path.assertions
-                );
+                let import_record_index =
+                    p.add_import_record(ImportKind::Stmt, path.loc, path.text);
 
                 if path.is_macro {
                     p.log().add_error(
@@ -1249,8 +1244,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.log().add_error(
                         Some(p.source),
                         loc,
-                        b"cannot use export statement with \"type\" attribute",
+                        b"cannot use export statement with \"bunBakeGraph\" attribute",
                     );
+                } else if let Some(loader) = path.loader {
+                    // `export *` imports no particular name, so there is nothing to validate.
+                    p.set_import_record_loader(import_record_index, loader, core::iter::empty());
                 }
 
                 if Self::TRACK_SYMBOL_USAGE_DURING_PARSE_PASS {
@@ -1294,6 +1292,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                     }
 
+                    let import_record_index =
+                        p.add_import_record(ImportKind::Stmt, parsed_path.loc, parsed_path.text);
+
                     if parsed_path.is_macro {
                         p.log().add_error(
                             Some(p.source),
@@ -1304,12 +1305,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.log().add_error(
                             Some(p.source),
                             loc,
-                            b"export from cannot be used with \"type\" attribute",
+                            b"export from cannot be used with \"bunBakeGraph\" attribute",
+                        );
+                    } else if let Some(loader) = parsed_path.loader {
+                        // In `export { a as b } from "x"`, `original_name` ("a") is the name
+                        // imported from the module; `alias` ("b") is the name re-exported.
+                        p.set_import_record_loader(
+                            import_record_index,
+                            loader,
+                            export_clause
+                                .clauses
+                                .iter()
+                                .map(|item| (item.original_name.slice(), item.name.loc)),
                         );
                     }
 
-                    let import_record_index =
-                        p.add_import_record(ImportKind::Stmt, parsed_path.loc, parsed_path.text);
                     let path_name = fs::PathName::init(parsed_path.text);
                     let namespace_ref = {
                         use std::io::Write as _;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1450,6 +1450,36 @@ pub(crate) mod __gated_printer {
         }
     }
 
+    /// The `type` import attribute value that selects `loader`, i.e. what
+    /// `ImportRecord.loader` prints back out as so the runtime module loader picks
+    /// the same loader the source asked for.
+    fn import_attribute_type_name(loader: bun_ast::Loader) -> &'static [u8] {
+        use bun_ast::Loader;
+        match loader {
+            Loader::Jsx => b"jsx",
+            Loader::Js => b"js",
+            Loader::Ts => b"ts",
+            Loader::Tsx => b"tsx",
+            Loader::Css => b"css",
+            Loader::File => b"file",
+            Loader::Json => b"json",
+            Loader::Jsonc => b"jsonc",
+            Loader::Toml => b"toml",
+            Loader::Yaml => b"yaml",
+            Loader::Json5 => b"json5",
+            Loader::Xml => b"xml",
+            Loader::Wasm => b"wasm",
+            Loader::Napi => b"napi",
+            Loader::Base64 => b"base64",
+            Loader::Dataurl => b"dataurl",
+            Loader::Text => b"text",
+            Loader::Bunsh => b"sh",
+            Loader::Sqlite | Loader::SqliteEmbedded => b"sqlite",
+            Loader::Html => b"html",
+            Loader::Md => b"md",
+        }
+    }
+
     pub(crate) use bun_core::strings::encode_wtf8_rune as encode_wtf8_rune_t;
     /// `fn NewPrinter(...) type` → generic struct.
     pub(crate) struct Printer<
@@ -5227,32 +5257,24 @@ pub(crate) mod __gated_printer {
                         self.print_whitespacer(ws!(b"from "));
                     }
 
-                    let irp = &self.import_record(s.import_record_index as usize).path.text;
-                    self.print_import_record_path(
-                        self.import_record(s.import_record_index as usize),
-                    );
+                    let record = self.import_record(s.import_record_index as usize);
+                    self.print_import_record_path(record);
+                    self.print_import_record_type_attribute(record);
                     self.print_semicolon_after_statement();
 
-                    if Self::MAY_HAVE_MODULE_INFO {
-                        if let Some(mi) = self.module_info() {
-                            let irp_id = mi.str(irp);
-                            mi.request_module(
-                                irp_id,
-                                analyze_transpiled_module::FetchParameters::None,
-                            );
-                            if let Some(alias) = &s.alias {
-                                let alias_id = mi.str(alias.original_name.slice());
-                                mi.add_export_info_namespace(
-                                    alias_id,
-                                    irp_id,
-                                    analyze_transpiled_module::FetchParameters::None,
-                                );
-                            } else {
-                                mi.add_export_info_star(
-                                    irp_id,
-                                    analyze_transpiled_module::FetchParameters::None,
-                                );
-                            }
+                    if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
+                        let irp_id = self
+                            .module_info()
+                            .expect("infallible: module_info enabled")
+                            .str(record.path.text);
+                        let fetch_parameters = self.module_info_fetch_parameters(record);
+                        let mi = self.module_info().expect("infallible: module_info enabled");
+                        mi.request_module(irp_id, fetch_parameters);
+                        if let Some(alias) = &s.alias {
+                            let alias_id = mi.str(alias.original_name.slice());
+                            mi.add_export_info_namespace(alias_id, irp_id, fetch_parameters);
+                        } else {
+                            mi.add_export_info_star(irp_id, fetch_parameters);
                         }
                     }
                 }
@@ -5411,19 +5433,21 @@ pub(crate) mod __gated_printer {
                     }
 
                     self.print_whitespacer(ws!(b"} from "));
-                    let irp = &import_record.path.text;
                     self.print_import_record_path(import_record);
+                    self.print_import_record_type_attribute(import_record);
                     self.print_semicolon_after_statement();
 
                     if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
                         // reshaped for borrowck — re-borrow module_info per item so
                         // `name_for_symbol` (which needs `&mut self`) can run between uses.
-                        let irp_id = {
-                            let mi = self.module_info().expect("infallible: module_info enabled");
-                            let id = mi.str(irp);
-                            mi.request_module(id, analyze_transpiled_module::FetchParameters::None);
-                            id
-                        };
+                        let irp_id = self
+                            .module_info()
+                            .expect("infallible: module_info enabled")
+                            .str(import_record.path.text);
+                        let fetch_parameters = self.module_info_fetch_parameters(import_record);
+                        self.module_info()
+                            .expect("infallible: module_info enabled")
+                            .request_module(irp_id, fetch_parameters);
                         for item in slice_of(s.items).iter() {
                             let name = self.name_for_symbol(item.name.ref_);
                             let mi = self.module_info().expect("infallible: module_info enabled");
@@ -5433,7 +5457,7 @@ pub(crate) mod __gated_printer {
                                 alias_id,
                                 name_id,
                                 irp_id,
-                                analyze_transpiled_module::FetchParameters::None,
+                                fetch_parameters,
                             );
                         }
                     }
@@ -5855,131 +5879,26 @@ pub(crate) mod __gated_printer {
                     }
 
                     self.print_import_record_path(record);
-
-                    // backwards compatibility: previously, we always stripped type
-                    if IS_BUN_PLATFORM {
-                        if let Some(loader) = record.loader {
-                            use bun_ast::Loader;
-                            match loader {
-                                Loader::Jsx => {
-                                    self.print_whitespacer(ws!(b" with { type: \"jsx\" }"))
-                                }
-                                Loader::Js => {
-                                    self.print_whitespacer(ws!(b" with { type: \"js\" }"))
-                                }
-                                Loader::Ts => {
-                                    self.print_whitespacer(ws!(b" with { type: \"ts\" }"))
-                                }
-                                Loader::Tsx => {
-                                    self.print_whitespacer(ws!(b" with { type: \"tsx\" }"))
-                                }
-                                Loader::Css => {
-                                    self.print_whitespacer(ws!(b" with { type: \"css\" }"))
-                                }
-                                Loader::File => {
-                                    self.print_whitespacer(ws!(b" with { type: \"file\" }"))
-                                }
-                                Loader::Json => {
-                                    self.print_whitespacer(ws!(b" with { type: \"json\" }"))
-                                }
-                                Loader::Jsonc => {
-                                    self.print_whitespacer(ws!(b" with { type: \"jsonc\" }"))
-                                }
-                                Loader::Toml => {
-                                    self.print_whitespacer(ws!(b" with { type: \"toml\" }"))
-                                }
-                                Loader::Yaml => {
-                                    self.print_whitespacer(ws!(b" with { type: \"yaml\" }"))
-                                }
-                                Loader::Json5 => {
-                                    self.print_whitespacer(ws!(b" with { type: \"json5\" }"))
-                                }
-                                Loader::Xml => {
-                                    self.print_whitespacer(ws!(b" with { type: \"xml\" }"))
-                                }
-                                Loader::Wasm => {
-                                    self.print_whitespacer(ws!(b" with { type: \"wasm\" }"))
-                                }
-                                Loader::Napi => {
-                                    self.print_whitespacer(ws!(b" with { type: \"napi\" }"))
-                                }
-                                Loader::Base64 => {
-                                    self.print_whitespacer(ws!(b" with { type: \"base64\" }"))
-                                }
-                                Loader::Dataurl => {
-                                    self.print_whitespacer(ws!(b" with { type: \"dataurl\" }"))
-                                }
-                                Loader::Text => {
-                                    self.print_whitespacer(ws!(b" with { type: \"text\" }"))
-                                }
-                                Loader::Bunsh => {
-                                    self.print_whitespacer(ws!(b" with { type: \"sh\" }"))
-                                }
-                                Loader::Sqlite | Loader::SqliteEmbedded => {
-                                    self.print_whitespacer(ws!(b" with { type: \"sqlite\" }"))
-                                }
-                                Loader::Html => {
-                                    self.print_whitespacer(ws!(b" with { type: \"html\" }"))
-                                }
-                                Loader::Md => {
-                                    self.print_whitespacer(ws!(b" with { type: \"md\" }"))
-                                }
-                            }
-                        }
-                    }
+                    self.print_import_record_type_attribute(record);
                     self.print_semicolon_after_statement();
 
                     if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
                         // reshaped for borrowck — `module_info()` borrows `&mut self`,
                         // so we re-borrow it between `name_for_symbol` calls instead of holding
                         // a single long-lived `mi` across the whole block. `irp_id` is Copy.
-                        let import_record_path = &record.path.text;
-                        use analyze_transpiled_module::FetchParameters as FP;
-                        let (irp_id, fetch_parameters) = {
-                            let mi = self.module_info().expect("infallible: module_info enabled");
-                            let irp_id = mi.str(import_record_path);
-                            let fetch_parameters: FP = if IS_BUN_PLATFORM {
-                                if let Some(loader) = record.loader {
-                                    use bun_ast::Loader;
-                                    match loader {
-                                        Loader::Json => FP::Json,
-                                        Loader::Jsx => FP::host_defined(mi.str(b"jsx")),
-                                        Loader::Js => FP::host_defined(mi.str(b"js")),
-                                        Loader::Ts => FP::host_defined(mi.str(b"ts")),
-                                        Loader::Tsx => FP::host_defined(mi.str(b"tsx")),
-                                        Loader::Css => FP::host_defined(mi.str(b"css")),
-                                        Loader::File => FP::host_defined(mi.str(b"file")),
-                                        Loader::Jsonc => FP::host_defined(mi.str(b"jsonc")),
-                                        Loader::Toml => FP::host_defined(mi.str(b"toml")),
-                                        Loader::Yaml => FP::host_defined(mi.str(b"yaml")),
-                                        Loader::Wasm => FP::host_defined(mi.str(b"wasm")),
-                                        Loader::Napi => FP::host_defined(mi.str(b"napi")),
-                                        Loader::Base64 => FP::host_defined(mi.str(b"base64")),
-                                        Loader::Dataurl => FP::host_defined(mi.str(b"dataurl")),
-                                        Loader::Text => FP::host_defined(mi.str(b"text")),
-                                        Loader::Bunsh => FP::host_defined(mi.str(b"sh")),
-                                        Loader::Sqlite | Loader::SqliteEmbedded => {
-                                            FP::host_defined(mi.str(b"sqlite"))
-                                        }
-                                        Loader::Html => FP::host_defined(mi.str(b"html")),
-                                        Loader::Json5 => FP::host_defined(mi.str(b"json5")),
-                                        Loader::Xml => FP::host_defined(mi.str(b"xml")),
-                                        Loader::Md => FP::host_defined(mi.str(b"md")),
-                                    }
-                                } else {
-                                    FP::None
-                                }
-                            } else {
-                                FP::None
-                            };
-                            let phase = if phase_defer {
-                                analyze_transpiled_module::ModulePhase::Defer
-                            } else {
-                                analyze_transpiled_module::ModulePhase::Evaluation
-                            };
-                            mi.request_module_with_phase(irp_id, fetch_parameters, phase);
-                            (irp_id, fetch_parameters)
+                        let irp_id = self
+                            .module_info()
+                            .expect("infallible: module_info enabled")
+                            .str(record.path.text);
+                        let fetch_parameters = self.module_info_fetch_parameters(record);
+                        let phase = if phase_defer {
+                            analyze_transpiled_module::ModulePhase::Defer
+                        } else {
+                            analyze_transpiled_module::ModulePhase::Evaluation
                         };
+                        self.module_info()
+                            .expect("infallible: module_info enabled")
+                            .request_module_with_phase(irp_id, fetch_parameters, phase);
 
                         if let Some(name) = &s.default_name {
                             let local_name = self.name_for_symbol(name.ref_);
@@ -6133,6 +6052,42 @@ pub(crate) mod __gated_printer {
                 self.print(quote);
                 self.print_string_characters_utf8(import_record.path.text, quote);
                 self.print(quote);
+            }
+        }
+
+        /// Prints the `with { type: "..." }` clause for a record whose loader was chosen by
+        /// a `type` attribute, after the path of an `import` / `export ... from` statement.
+        /// Bun targets only: for other targets the attribute has always been stripped, and
+        /// the runtime module loader is what reads it back.
+        fn print_import_record_type_attribute(&mut self, import_record: &ImportRecord) {
+            if !IS_BUN_PLATFORM {
+                return;
+            }
+            let Some(loader) = import_record.loader else {
+                return;
+            };
+            self.print_whitespacer(ws!(b" with { type: \""));
+            self.print(import_attribute_type_name(loader));
+            self.print_whitespacer(ws!(b"\" }"));
+        }
+
+        /// The `ModuleInfo` counterpart of `print_import_record_type_attribute`: what JSC's own
+        /// analysis of the printed statement would record as the request's fetch parameters.
+        fn module_info_fetch_parameters(
+            &mut self,
+            import_record: &ImportRecord,
+        ) -> analyze_transpiled_module::FetchParameters {
+            use analyze_transpiled_module::FetchParameters as FP;
+            if !IS_BUN_PLATFORM {
+                return FP::None;
+            }
+            match import_record.loader {
+                None => FP::None,
+                Some(bun_ast::Loader::Json) => FP::Json,
+                Some(loader) => match self.module_info() {
+                    Some(mi) => FP::host_defined(mi.str(import_attribute_type_name(loader))),
+                    None => FP::None,
+                },
             }
         }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: `export ... from "x" with { type }` keeps the attribute in the printed
+/// output and in the ModuleInfo export records instead of dropping it.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -433,6 +433,29 @@ devTest("importing html file with text loader (#18154)", {
     await c.expectMessage("<div>hello world</div>");
   },
 });
+devTest("re-exporting html file with text loader", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { html, ns } from "./reexport.ts";
+      console.log(html);
+      console.log(ns.default);
+    `,
+    "reexport.ts": `
+      export { default as html } from "./app.html" with { type: "text" };
+      export * as ns from "./app.html" with { type: "text" };
+    `,
+    "app.html": "<div>hello world</div>",
+  },
+  htmlFiles: ["index.html"],
+  async test(dev) {
+    await using c = await dev.client("/", {});
+    await c.expectMessage("<div>hello world</div>", "<div>hello world</div>");
+  },
+});
 devTest("importing bun on the client", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -74,6 +74,54 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!", setCwd: true },
   });
+  // The same two cases reached through `export ... from`, which takes the attribute
+  // as well. A ".sqlite" extension alone already selects the sqlite loader, so these
+  // use ".db", which only the attribute can turn into a database.
+  itBundled("bun/embedded-sqlite-file-export-from", {
+    target: "bun",
+    outfile: "",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+        import { db } from './db.ts';
+        console.log(db.query("select message from messages LIMIT 1").get().message);
+      `,
+      "/db.ts": /* js */ `
+        export { default as db } from './app.db' with {type: "sqlite", embed: "true"};
+      `,
+      "/app.db": (() => {
+        const db = new Database(":memory:");
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        return db.serialize();
+      })(),
+    },
+    run: { stdout: "Hello, world!" },
+  });
+  itBundled("bun/sqlite-file-export-from", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        import { db, sameDb } from './db.ts';
+        console.log(db.query("select message from messages LIMIT 1").get().message, db === sameDb);
+      `,
+      "/db.ts": /* js */ `
+        export { default as db, db as sameDb } from './app.db' with {type: "sqlite"};
+      `,
+    },
+    runtimeFiles: {
+      "/app.db": (() => {
+        const db = new Database(":memory:");
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello, world!')");
+        return db.serialize();
+      })(),
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`from "./app.db" with { type: "sqlite" }`);
+    },
+    run: { stdout: "Hello, world! true", setCwd: true },
+  });
   itBundled("bun/TargetBunNoSourcemapMessage", {
     target: "bun",
     files: {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -81,8 +81,52 @@ describe("bundler", async () => {
             '[{"hello":{"@to":"world","b":"there","#text":"hi"}},{"greeting":{"@__proto__":"1","to":["world","you"]}},{"@__proto__":"1","to":["world","you"]}]',
         },
       });
+      // Without the attribute, these extensions would all get the "file" loader.
+      itBundled("bun/loader-type-attribute-on-export-from", {
+        target,
+        files: {
+          "/entry.ts": /* js */ `
+        import { text, ns, fromJs } from './reexport.ts';
+        console.write(JSON.stringify([text, ns.default, fromJs]));
+      `,
+          "/reexport.ts": /* js */ `
+        export { default as text } from './hello.foo' with {type: "text"};
+        export * as ns from './hello.notjson' with {type: "json"};
+        export * from './hello.notjs' with {type: "js"};
+      `,
+          "/hello.foo": "Hello, world!",
+          "/hello.notjson": JSON.stringify({ hello: "world" }),
+          "/hello.notjs": `export const fromJs = "from js";`,
+        },
+        run: { stdout: '["Hello, world!",{"hello":"world"},"from js"]' },
+      });
     });
   }
+
+  // The runtime transpiler goes through the same printer, so the attribute has to
+  // survive transpile-only output for `bun run` to see it on a re-export.
+  itBundled("bun/loader-type-attribute-on-export-from-no-bundle", {
+    target: "bun",
+    bundling: false,
+    files: {
+      "/entry.ts": /* js */ `
+        import hello from './hello.foo' with {type: "text"};
+        export { default as text } from './hello.foo' with {type: "text"};
+        export * as ns from './hello.foo' with {type: "text"};
+        export * from './hello.notjson' with {type: "json"};
+        console.log(hello);
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js").split("\n").filter(Boolean)).toEqual([
+        `import hello from "./hello.foo" with { type: "text" };`,
+        `export { default as text } from "./hello.foo" with { type: "text" };`,
+        `export * as ns from "./hello.foo" with { type: "text" };`,
+        `export * from "./hello.notjson" with { type: "json" };`,
+        `console.log(hello);`,
+      ]);
+    },
+  });
 
   itBundled("bun/loader-text-file", {
     target: "bun",

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -1,4 +1,6 @@
-import { bunExe, tempDir, tempDirWithFiles } from "harness";
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import * as path from "path";
 
 const loaders = ["js", "jsx", "ts", "tsx", "json", "jsonc", "toml", "yaml", "text", "sqlite", "file"];
@@ -360,4 +362,146 @@ describe("?raw", () => {
       expect(await fn(question_raw, null, filename + "?raw")).toEqual({ default: code });
     });
   }
+});
+
+// `export ... from` takes the same `with { type }` attribute as `import`. The files
+// below use an extension bun knows nothing about, so without the attribute they get
+// the "file" loader and the re-export resolves to a path string.
+describe.concurrent("type attribute on export ... from", () => {
+  function serializedDatabase(): Buffer {
+    const db = new Database(":memory:");
+    db.exec("create table messages (message text)");
+    db.exec("insert into messages values ('Hello, world!')");
+    return db.serialize();
+  }
+
+  async function run(files: Record<string, string | Buffer>) {
+    using dir = tempDir("export-from-type-attribute", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("export { default as name } from", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "data.unknownext": "hello from data",
+      "reexport.mjs": `export { default as text } from "./data.unknownext" with { type: "text" };`,
+      "main.mjs": `import { text } from "./reexport.mjs"; console.log(JSON.stringify(text));`,
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toBe('"hello from data"\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("export * as ns from", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "data.unknownext": "hello from data",
+      "reexport.mjs": `export * as ns from "./data.unknownext" with { type: "text" };`,
+      "main.mjs": `import { ns } from "./reexport.mjs"; console.log(JSON.stringify(ns.default));`,
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toBe('"hello from data"\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("export * from", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "data.unknownext": `{ "answer": 42 }`,
+      "reexport.mjs": `export * from "./data.unknownext" with { type: "json" };`,
+      "main.mjs": `import { answer } from "./reexport.mjs"; console.log(answer);`,
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toBe("42\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("sqlite re-exports may use the default and db names", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "app.unknownext": serializedDatabase(),
+      "reexport.mjs": `export { default as db, db as sameDb } from "./app.unknownext" with { type: "sqlite" };`,
+      "main.mjs": `
+        import { db, sameDb } from "./reexport.mjs";
+        console.log(db.query("select message from messages").get().message, db === sameDb);
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toBe("Hello, world! true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("an attribute matching the extension's loader keeps working", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "config.json": `{ "a": 1 }`,
+      "reexport.mjs": `
+        export { default as config } from "./config.json" with { type: "json" };
+        export * as ns from "./config.json" with { type: "json" };
+      `,
+      "main.mjs": `import { config, ns } from "./reexport.mjs"; console.log(JSON.stringify([config, ns.default]));`,
+    });
+    expect(stderr).toBe("");
+    expect(stdout).toBe('[{"a":1},{"a":1}]\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("text loader only exports default", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "data.unknownext": "hello from data",
+      "reexport.mjs": `export { notDefault as text } from "./data.unknownext" with { type: "text" };`,
+      "main.mjs": `import "./reexport.mjs";`,
+    });
+    expect(stderr).toContain('This loader type only supports the "default" import');
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("sqlite loader only exports default and db", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "app.unknownext": serializedDatabase(),
+      "reexport.mjs": `export { connection } from "./app.unknownext" with { type: "sqlite" };`,
+      "main.mjs": `import "./reexport.mjs";`,
+    });
+    expect(stderr).toContain('sqlite imports only support the "default" or "db" imports');
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
+  // `bun test --isolate` builds the module record from the transpiler's ModuleInfo
+  // instead of letting JSC re-parse the printed source, so the attribute also has to
+  // reach the export records. Debug builds diff the two and fail the import with
+  // "Imports different between parseFromSourceCode and fallbackParse" if they disagree.
+  test("the attribute reaches the module record under bun test --isolate", async () => {
+    using dir = tempDir("export-from-type-attribute-isolate", {
+      "text.unknownext": "hello from data",
+      "json.unknownext": `{ "answer": 42 }`,
+      "reexport.ts": `
+        export { default as text } from "./text.unknownext" with { type: "text" };
+        export * as ns from "./text.unknownext" with { type: "text" };
+        export * from "./json.unknownext" with { type: "json" };
+      `,
+      "reexport.test.ts": `
+        import { expect, test } from "bun:test";
+        import { answer, ns, text } from "./reexport.ts";
+        test("re-exports honor the type attribute", () => {
+          expect([text, ns.default, answer]).toEqual(["hello from data", "hello from data", 42]);
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "reexport.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Imports different");
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `export { default as text } from "./data.bin" with { type: "text" }`, `export * as ns from ... with { type }` and `export * from ... with { type }` ignore the attribute: the file is loaded with the loader its extension implies (`file` for `.bin`, so the re-export is a path string). `import text from "./data.bin" with { type: "text" }` honors it. Affects `bun run`, `bun build`, `bun build --no-bundle` and the dev server; `with { type: "sqlite" }` on a re-export bundles the database as a file asset and exports its path.
- `parse_path()` (src/js_parser/parse/mod.rs:1396) stores the `type` attribute in `ParsedPath.loader`. Import statements copy it onto the import record (`validate_and_set_import_type`, src/js_parser/p.rs). The two export-from branches in src/js_parser/parse/parse_stmt.rs (`export *` at ~1248, `export { .. } from` at ~1303) never look at `ParsedPath.loader`: they only check `ParsedPath.import_tag`, which since d502df353c (#16624, v1.2.5) is set for `bunBakeGraph` alone. Before that commit the attribute lived in `import_tag` and these branches rejected it; after it the attribute falls through.
- The printer (src/js_printer/lib.rs) only prints the `with { type }` clause back out for `S::Import`, so even with the record fixed, `bun run` (which transpiles and lets JSC's module loader read the attribute) would still drop it on re-exports.

### Fix
- parse_stmt.rs: both export-from branches set the record's loader from `ParsedPath.loader`, through a new `set_import_record_loader` shared with import statements (p.rs). It also keeps the existing name validation for sqlite (`default`/`db`) and text/file (`default`); for `export { a as b } from` the name imported from the module is `ClauseItem.original_name`, for imports it is `alias`. The remaining `import_tag` checks only ever fire for `bunBakeGraph`, so their messages now say that instead of claiming `type` is not allowed.
- js_printer: `S::ExportStar` and `S::ExportFrom` print the same ` with { type: "..." }` clause as `S::Import` and record the same `FetchParameters` in the ModuleInfo export records. The three statement kinds now share `print_import_record_type_attribute` / `module_info_fetch_parameters` / `import_attribute_type_name`, which replace the two per-loader match blocks that were inlined in the `S::Import` branch (output is byte-identical for imports, including the minified form).
- RuntimeTranspilerCache: version bump, since the printed output of re-exports changed.
- Why honoring is right rather than restoring the old hard error: the import attributes spec allows attributes on re-exports, Node requires `with { type: "json" }` on JSON re-exports, and Bun has accepted `export { default } from "./x.json" with { type: "json" }` since v1.2.5; a hard error would break that code. Everything downstream of the parser is already per import record (the bundler resolves, parses and externalizes records by `record.loader` regardless of which statement created them, and converts export-from into imports before printing), so a re-export record with a loader behaves exactly like an import record with one.
- Why the printer and ModuleInfo parts are needed: at runtime the transpiled source is what JSC analyzes, and the host loader picks the loader from the fetch parameters JSC passes for each module request, so the attribute has to survive printing on re-export statements too. Under `bun test --isolate` (and bytecode builds) the module record is built from ModuleInfo instead of JSC's own parse, so the export records need the matching fetch parameters; debug builds diff the two and reject the module if they disagree, which the `--isolate` test exercises.
- Verified with (all fail on the released 1.4.0 / without the src change, pass with it):
  - test/js/bun/import-attributes/import-attributes.test.ts: runtime `export { default as x } from`, `export * as ns from`, `export * from`, sqlite `default`/`db` re-export, the two validation errors, and a `bun test --isolate` run covering the ModuleInfo path (the JSON-with-matching-attribute case passes both ways and guards the decision above).
  - test/bundler/bundler_loader.test.ts: bundled re-exports with text/json/js attributes for bun and node targets, and `--no-bundle` output keeping the clause on all three statement kinds.
  - test/bundler/bundler_bun.test.ts: embedded and external sqlite through a re-export (`.db` extension, since `.sqlite` already maps to the sqlite loader on its own).
  - test/bake/dev/bundle.test.ts: dev server re-export of an `.html` file with the text loader.
  - Also ran bundler_loader, bundler_bun, transpiler, import-defer, isolation, type-export, webkit-upgrade-3722912f, 30887 and the source-lint suites; `cargo clippy` on bun_js_parser / bun_js_printer is clean.

### Background
- Import attributes: the `with { type: "..." }` clause on `import` and `export ... from` statements (ES2025). Bun uses the `type` value to pick a loader for the target file instead of the one implied by its extension; Bun's parser records that choice as `ImportRecord.loader` on the statement's import record. (`type: "macro"` and `bunBakeGraph` are separate attributes handled by `ParsedPath.is_macro` / `ParsedPath.import_tag`.)
- Import record: one entry per path referenced by a file (import, re-export, `require`, `import()`), holding the path, how it was referenced and the loader to use. The bundler resolves and parses files from these records, so a loader set on a record is honored no matter which statement produced it.
- Runtime transpile: `bun run` transpiles each file and hands the printed source to JSC. JSC collects the attributes of every module request and passes them as fetch parameters to Bun's module loader (`moduleLoaderFetch` in ZigGlobalObject.cpp), which is where the runtime reads the `type` attribute. Anything the printer drops is therefore lost at runtime.
- ModuleInfo: a description of a module's imports/exports/requested modules that the printer emits alongside the source. When it is present (`bun test --isolate`, bytecode builds) JSC builds the module record from it instead of re-analyzing the source, and each requested module and export entry carries fetch parameters that have to match what analyzing the printed source would give.
