### PR TITLE
docs: port five stale docs PRs onto the current pages

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -180,6 +180,16 @@ To avoid conflicts with Scoop, use `scoop update bun` instead.
 
 </Tip>
 
+<Accordion title="Seeing `HTTPError`?">
+
+`bun upgrade` looks up the latest release through the GitHub API. If `GITHUB_TOKEN` or `GITHUB_ACCESS_TOKEN` is set in your environment, it is sent with that request, and an expired or invalid token makes the upgrade fail with `Bun upgrade failed with error: HTTPError`. Fix the token, or run the upgrade without it:
+
+```bash terminal icon="terminal"
+GITHUB_TOKEN= bun upgrade
+```
+
+</Accordion>
+
 ---
 
 ## Canary Builds

--- a/docs/pm/cli/publish.mdx
+++ b/docs/pm/cli/publish.mdx
@@ -7,6 +7,12 @@ import Publish from "/snippets/cli/publish.mdx";
 
 `bun publish` packs your package into a tarball, strips catalog and workspace protocols from the `package.json` (resolving versions if necessary), and publishes to the registry specified in your configuration files. Both `bunfig.toml` and `.npmrc` files are supported.
 
+<Note>
+  `workspace:*`, `workspace:^`, and `workspace:~` dependencies are replaced with the version of the referenced workspace
+  package, so each workspace package referenced this way needs a `version` field in its `package.json`. Without one,
+  publishing fails with `Failed to resolve workspace version`.
+</Note>
+
 ```sh terminal icon="terminal"
 ## Publishing the package from the current working directory
 bun publish

--- a/docs/pm/cli/publish.mdx
+++ b/docs/pm/cli/publish.mdx
@@ -10,7 +10,7 @@ import Publish from "/snippets/cli/publish.mdx";
 <Note>
   `workspace:*`, `workspace:^`, and `workspace:~` dependencies are replaced with the version of the referenced workspace
   package, so each workspace package referenced this way needs a `version` field in its `package.json`. Without one,
-  publishing fails with `Failed to resolve workspace version`.
+  both `bun publish` and `bun pm pack` fail with `Failed to resolve workspace version`.
 </Note>
 
 ```sh terminal icon="terminal"

--- a/docs/runtime/auto-install.mdx
+++ b/docs/runtime/auto-install.mdx
@@ -51,6 +51,7 @@ To bypass version resolution entirely, specify a version or version range direct
 import { z } from "zod@3.0.0"; // specific version
 import { z } from "zod@next"; // npm tag
 import { z } from "zod@^3.20.0"; // semver range
+import { parse } from "csv-parse@5.3.10/sync"; // subpath of a specific version
 ```
 
 ---

--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -309,6 +309,12 @@ Bun supports import path re-mapping through TypeScript's [`compilerOptions.paths
 }
 ```
 
+To use a different file instead of your project's `tsconfig.json`, pass `--tsconfig-override`:
+
+```bash terminal icon="terminal"
+bun --tsconfig-override ./tsconfig.custom.json index.ts
+```
+
 Bun also supports [Node.js-style subpath imports](https://nodejs.org/api/packages.html#subpath-imports) in `package.json`, where mapped paths must start with `#`. TypeScript and editors resolve these too, and you can use both mechanisms together.
 
 ```json package.json icon="file-json"

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -311,11 +311,11 @@ const upload = $`sleep 1 && echo "upload finished"`.nothrow().then(({ exitCode }
 
 await $`echo "doing other work"`;
 
-// Wait for it once you need the result
+// Later, wait for it to finish
 await upload;
 ```
 
-The process stays alive until the background command finishes, even if you never `await` it. A background command that fails rejects its promise like any other `$` command, so use `.nothrow()` or `.catch()` to keep the failure from becoming an unhandled rejection.
+The process stays alive until the background command finishes, even if you never `await` it. A background command that exits with a non-zero code rejects its promise like any other `$` command, and nothing is waiting on it, so use `.nothrow()` as in the example above, or attach a `.catch()`, to keep that from becoming an unhandled rejection.
 
 ---
 

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -297,6 +297,28 @@ Use the `$(...)` syntax instead.
 
 ---
 
+## Background commands
+
+Bash's `&` operator is not supported. A `$` command doesn't start until you `await` it, call `.then()` on it, or call an output method like `.text()`, so to run a command in the background, call `.then()` and keep going:
+
+```js
+import { $ } from "bun";
+
+// Starts now, but nothing waits for it yet
+const upload = $`sleep 1 && echo "upload finished"`.nothrow().then(({ exitCode }) => {
+  console.log(`upload exited with ${exitCode}`);
+});
+
+await $`echo "doing other work"`;
+
+// Wait for it once you need the result
+await upload;
+```
+
+The process stays alive until the background command finishes, even if you never `await` it. A background command that fails rejects its promise like any other `$` command, so use `.nothrow()` or `.catch()` to keep the failure from becoming an unhandled rejection.
+
+---
+
 ## Environment variables
 
 Set environment variables like in bash:


### PR DESCRIPTION
### Problem
- #24201 replaced the old `docs/**/*.md` tree with the current `.mdx` pages, so several small docs PRs that were still open now target files that no longer exist and cannot be merged as-is.
- Five of them add information that is still correct and still missing from the current pages. This PR ports those five; the originals are being closed pointing here. Each port is its own commit with the original author as co-author.

### Fix
One commit per ported PR. Every claim below was re-checked against the current `bun` binary, not taken from the original PR.

- #16901 (`docs/runtime/module-resolution.mdx`, "Path re-mapping", where the old path mapping section ended up): mention `--tsconfig-override`. Verified: with a project `tsconfig.json` mapping `alias` to one file and a second tsconfig mapping it to another, `bun --tsconfig-override ./tsconfig.custom.json index.ts` resolves through the second one (both `bun` and `bun run`). Related, and still open: #22959 asks for the flag to appear in `bun build --help` and `bun test --help`, which this PR does not touch (verified: `bun run --help` lists it, `bun build --help` and `bun test --help` still do not).
- #18698 (`docs/runtime/auto-install.mdx`, "Version specifiers"): add a `pkg@version/subpath` example. Verified against the test suite's local registry in a directory with no `node_modules`: `import pkg from "no-deps@1.0.1/package.json"` installs 1.0.1 (latest is 2.0.0) and resolves the subpath; `no-deps@^1.0.0/index.js` resolves to 1.1.0. The parser documents this form in `src/resolver/package_json.rs` (`Package::parse_version`).
- #23863 (`docs/pm/cli/publish.mdx`): note that a workspace package referenced with `workspace:*`, `^`, or `~` needs a `version` field. This is what #23857 (the issue behind that PR) ran into. Verified: a workspace where `pkg-a` depends on `pkg-b` via `workspace:*` and `pkg-b` has no version makes `bun publish --dry-run` and `bun pm pack` in `pkg-a` fail with ``Failed to resolve workspace version for "pkg-b" in `dependencies`.``; the replacement lives in `edit_root_package_json` in `src/runtime/cli/pack_command.rs`. The note deliberately does not say where the version is read from, since #36279 and #36285 are changing that.
- #24166 (`docs/runtime/shell.mdx`, new "Background commands" section): `&` is unsupported; `.then()` starts a command without waiting for it. Verified: `` $`sleep 1 &` `` fails with `Background commands "&" are not supported yet.` (`src/shell_parser/parse.rs`); a `$` command does not run until `await`/`.then()` (`ShellPromise#then` calls `#run()` in `src/js/builtins/shell.ts`); the snippet in the section runs as written and prints `doing other work` before `upload finished`; a backgrounded command keeps the process alive until it finishes; one that exits non-zero without `.nothrow()`/`.catch()` makes the process exit 1 with an unhandled `ShellError`, while either of those keeps it at exit 0. The closing paragraph is deliberately scoped to non-zero exit codes: the native interpreter only ever calls the resolve callback (`Interpreter::finish` in `src/runtime/shell/interpreter.rs`; the reject callback has no call sites), and the JS wrapper turns that into a rejection only for a non-zero code with throwing enabled. Setup problems such as a missing `cwd` throw synchronously from the call that starts the command, so neither `.nothrow()` nor `.catch()` applies to them. The original PR's wording was rewritten around those checks.
- #23010 (`docs/installation.mdx`, "Upgrading"): `bun upgrade` fails with `HTTPError` when `GITHUB_TOKEN` or `GITHUB_ACCESS_TOKEN` holds a bad token, and `GITHUB_TOKEN= bun upgrade` avoids it. Verified by pointing `GITHUB_API_DOMAIN` at a local server that answers 401 whenever an `Authorization` header is present: either variable set to a bad value produces `Bun upgrade failed with error: HTTPError` (a 401 falls into the catch-all arm in `get_latest_version`, `src/runtime/cli/upgrade_command.rs`), and `GITHUB_TOKEN=` (empty) sends no header even when `GITHUB_ACCESS_TOKEN` is still set, because an empty `GITHUB_TOKEN` short-circuits the `or_else` lookup. Related to #11523, which stays open; this only documents the behavior.

`prettier --check` passes on the five files.

### Background
- Auto-install: when no `node_modules` exists, Bun installs imported packages into its global cache at import time. An import specifier can pin the version inline (`zod@3.0.0`); the parser splits `name@version/subpath` into its three parts, so a subpath can follow the version.
- `workspace:` protocol: inside a monorepo, a dependency on a sibling package is written as `workspace:*` (or `^`/`~`). At pack/publish time Bun rewrites it to a real version range built from the sibling's version, since the protocol means nothing to the registry.
- `ShellPromise`: `` $`...` `` returns a promise subclass that parses the command immediately but only starts executing it when something subscribes to it (`await`, `.then()`, or an output helper like `.text()`), which is what makes the `.then()`-and-keep-going pattern work.
- `bun upgrade` asks the GitHub releases API for the latest version before downloading. It attaches `GITHUB_TOKEN`/`GITHUB_ACCESS_TOKEN` as a bearer token when either is set, and any status other than 200/403/404/429/5xx is reported as the generic `HTTPError`.

<details>
<summary>Closed as stale without porting</summary>

- #21181: obsolete; `net.Server#getConnections` exists and `http.Server#getConnections` was added in #31587 (#4459 is closed), so `docs/runtime/nodejs-compat.mdx` is right to list `node:net` as fully implemented.
- #24188: a type assertion on `req.json()` in one example; not worth carrying over.
- #24322: the PowerShell one-liners already use `bun.sh/install.ps1` since #24764; the remaining `bun.com/install` URLs are intentional.
</details>

