### PR TITLE
node: match Node's validateArray minLength error message

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1047,21 +1047,9 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JS
 }
 JSC::EncodedJSValue INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSValue name, JSC::JSValue value, const WTF::String& reason)
 {
-    WTF::StringBuilder builder;
-    builder.append("The argument '"_s);
-    auto& vm = JSC::getVM(globalObject);
-    determineSpecificType(vm, globalObject, builder, name);
+    auto nameString = name.toWTFString(globalObject);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
-
-    builder.append("' "_s);
-    builder.append(reason);
-    builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, value, true);
-    RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
-
-    throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_VALUE, builder.toString()));
-    throwScope.release();
-    return {};
+    return INVALID_ARG_VALUE(throwScope, globalObject, nameString, value, reason);
 }
 
 // for validateOneOf

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -351,7 +351,7 @@ JSC::EncodedJSValue V::validateArray(JSC::ThrowScope& scope, JSC::JSGlobalObject
     auto minLength_num = minLength.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (length_num < minLength_num) {
-        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, value, makeString("must be longer than "_s, minLength_num));
+        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, value, makeString("must have a length of at least "_s, minLength_num));
     }
     return JSValue::encode(jsUndefined());
 }
@@ -372,7 +372,7 @@ JSC::EncodedJSValue V::validateArray(JSC::ThrowScope& scope, JSC::JSGlobalObject
     auto minLength_num = minLength.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     if (length_num < minLength_num) {
-        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, value, makeString("must be longer than "_s, minLength_num));
+        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, name, value, makeString("must have a length of at least "_s, minLength_num));
     }
     return JSValue::encode(jsUndefined());
 }

--- a/test/js/node/internal/validators.test.ts
+++ b/test/js/node/internal/validators.test.ts
@@ -1,0 +1,44 @@
+import { exposedInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+
+// The same functions node's lib/internal/validators.js exports, backed by
+// src/jsc/bindings/NodeValidator.cpp. Expected messages are node v26.3.0's.
+const { validateArray } = exposedInternals["internal/validators"];
+
+describe("validateArray", () => {
+  test("accepts arrays that satisfy minLength", () => {
+    expect(() => validateArray([], "foo")).not.toThrow();
+    expect(() => validateArray([], "foo", 0)).not.toThrow();
+    expect(() => validateArray([1], "foo", 1)).not.toThrow();
+  });
+
+  test("array shorter than minLength: argument name", () => {
+    expect(() => validateArray([], "foo", 1)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The argument 'foo' must have a length of at least 1. Received []",
+      }),
+    );
+  });
+
+  test("array shorter than minLength: dotted name is a property", () => {
+    expect(() => validateArray([1], "options.foo", 2)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The property 'options.foo' must have a length of at least 2. Received [ 1 ]",
+      }),
+    );
+  });
+
+  test("non-array", () => {
+    expect(() => validateArray("x", "foo", 1)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "foo" argument must be an instance of Array. Received type string ('x')`,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Problem
- `validateArray(value, name, minLength)` (the native `internal/validators` export) throws a malformed `ERR_INVALID_ARG_VALUE` when the array is shorter than `minLength`:
  - bun: `The argument 'type string ('foo')' must be longer than 1. Received []`
  - node v26.3.0: `The argument 'foo' must have a length of at least 1. Received []`
- Name rendering: `src/jsc/bindings/NodeValidator.cpp:354` passes the name as a `JSValue`, and the `JSValue`-name overload of `Bun::ERR::INVALID_ARG_VALUE` (`src/jsc/bindings/ErrorCode.cpp:1048`) ran it through `determineSpecificType()`, the helper that describes a received *value* (`type string ('foo')`). It also always wrote `The argument`, where node writes `The property` for dotted names such as `options.foo`. That overload had no other callers.
- Reason text: both `validateArray` variants (`NodeValidator.cpp:354` and `:375`) say `must be longer than N`; node's `lib/internal/validators.js` says `must have a length of at least N`.
- Only reachable today through `bun:internal-for-testing` / vendored node tests: every in-tree `validateArray` caller passes `minLength` 0 or undefined.

### Fix
- The `JSValue`-name `INVALID_ARG_VALUE` overload now converts the name with `toWTFString()` and delegates to the `WTF::String`-name overload, which already produces node's `The argument '<name>'` / `The property '<dotted.name>'` form and the same `Received` rendering. Fixing the overload rather than the call site means any future `JSValue`-name caller gets the right message too.
- Both `validateArray` variants use node's reason text.
- Name conversion uses `ToString` semantics, the same thing node's template literal does, so a Symbol or throwing `toString()` name propagates the same error node raises.
- The Rust-side `validate_array` in `src/runtime/node/util/validators.rs` is a separate helper with its own message shape and is not touched here; its `min_length` is never set in-tree.
- Verified:
  - `test/js/node/internal/validators.test.ts` (new): the two `minLength` cases fail on the released binary and pass with this change; the non-array and success cases pass both ways and guard the unchanged paths.
  - `test-internal-validators-validateoneof.js`, `test-internal-validators-validateport.js`, `test-child-process-constructor.js`, `test-dns-setservers-type-check.js`, `test-process-setgroups.js`, `test-vm-basic.js`, `test-worker-process-argv.js` and the `argv`/`execArgv` tests in `worker_threads.test.ts` pass (the callers of both `validateArray` variants).
  - The new test also passes under `BUN_JSC_validateExceptionChecks=1`, including names whose `toString()` throws.
- The `ASCIILiteral`-name variant's new text is only reachable from C++ callers (`JSWorker.cpp`, `BunProcess.cpp`), all of which pass `minLength` 0, so it has no JS-observable test; it is changed for consistency with the `JSValue` variant.

### Background
- `internal/validators` is node's module of argument checkers (`validateArray`, `validateOneOf`, ...). Bun implements them natively in `src/jsc/bindings/NodeValidator.cpp`; tests reach them through `exposedInternals` in `bun:internal-for-testing`, the same hook that serves vendored node tests declaring `--expose-internals`.
- `Bun::ERR::*` in `src/jsc/bindings/ErrorCode.cpp` builds node-style coded errors. `INVALID_ARG_VALUE` is overloaded on the name type (`ASCIILiteral`, `WTF::String`, `JSValue`); the native validators use the `JSValue` overloads because they receive the name straight from JS.
- `determineSpecificType()` is the port of node's helper of the same name: it describes a received value for `ERR_INVALID_ARG_TYPE` messages (`type string ('foo')`, `an instance of Array`). It is the wrong tool for rendering an argument name.
- Node's `ERR_INVALID_ARG_VALUE` message is `The <argument|property> '<name>' <reason>. Received <inspect(value)>`, where `property` is used when the name contains a `.`.
