### PR TITLE
node:fs: throw node's null-byte ERR_INVALID_ARG_VALUE from watchFile, unwatchFile and the Windows realpath ports

### DIFF
--- a/src/js/internal/fs/watchfile.ts
+++ b/src/js/internal/fs/watchfile.ts
@@ -1,7 +1,7 @@
 // fs.watchFile and fs.unwatchFile are lazily loaded so that the StatWatcher
 // machinery is not set up until it is actually used.
 const EventEmitter = require("node:events");
-const { getValidatedPath, throwIfNullBytesInFileName } = require("internal/validators");
+const { getValidatedPath } = require("internal/validators");
 
 // The native `node:fs` binding, shared via `internal/fs/binding`.
 const fs = require("internal/fs/binding");
@@ -80,7 +80,7 @@ function unwatchFile(filename, listener) {
   filename = getValidatedPath(filename);
 
   var stat = statWatchers.get(filename);
-  if (!stat) return throwIfNullBytesInFileName(filename);
+  if (!stat) return;
   if (listener) {
     stat.removeListener("change", listener);
     if (stat.listenerCount("change") !== 0) {

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -85,18 +85,23 @@ function validateBoolean(value, name) {
   if (typeof value !== "boolean") throw $ERR_INVALID_ARG_TYPE(name, "boolean", value);
 }
 
-/** Validate a string-or-URL path and return it resolved to an absolute path string. */
+/**
+ * Validate a string-or-URL path and return it resolved to an absolute path string.
+ * Like node's getValidatedPath, null bytes are rejected before resolving so the
+ * error reports the path as the caller passed it.
+ */
 function getValidatedPath(p: any) {
-  if (p instanceof URL) return Bun.fileURLToPath(p as URL);
-  if (typeof p !== "string") throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
-  if (p.startsWith("file:")) return Bun.fileURLToPath(p);
-  return require("node:path").resolve(p);
-}
-
-function throwIfNullBytesInFileName(filename: string) {
-  if (filename.indexOf("\u0000") !== -1) {
-    throw $ERR_INVALID_ARG_VALUE("path", "string without null bytes", filename);
+  if (p instanceof URL) {
+    p = Bun.fileURLToPath(p as URL);
+  } else if (typeof p !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("path", "string or URL", p);
+  } else if (p.startsWith("file:")) {
+    p = Bun.fileURLToPath(p);
   }
+  if (p.indexOf("\u0000") !== -1) {
+    throw $ERR_INVALID_ARG_VALUE("path", p, "must be a string, Uint8Array, or URL without null bytes");
+  }
+  return require("node:path").resolve(p);
 }
 
 /**
@@ -123,7 +128,7 @@ function getValidatedFsPath(p: any, propName: string = "path") {
 
 hideFromStack(validateLinkHeaderValue);
 hideFromStack(validateString, validateFunction, validateBoolean);
-hideFromStack(getValidatedPath, getValidatedFsPath, throwIfNullBytesInFileName);
+hideFromStack(getValidatedPath, getValidatedFsPath);
 
 export default {
   /** (value, name) */
@@ -164,6 +169,4 @@ export default {
   /** `(path)` — accepts a string or file URL, returns it resolved to an absolute path string */
   getValidatedPath,
   getValidatedFsPath,
-  /** `(filename)` */
-  throwIfNullBytesInFileName,
 };

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -2,13 +2,7 @@
 import type { Dirent as DirentType, PathLike, Stats as StatsType } from "fs";
 const promises = require("node:fs/promises");
 const types = require("node:util/types");
-const {
-  validateFunction,
-  validateInteger,
-  validateEncoding,
-  getValidatedPath,
-  throwIfNullBytesInFileName,
-} = require("internal/validators");
+const { validateFunction, validateInteger, validateEncoding, getValidatedPath } = require("internal/validators");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
@@ -708,19 +702,10 @@ const realpathSync: typeof import("node:fs").realpathSync =
         // This function is ported 1:1 from node.js, to emulate how it is unable to
         // resolve subst drives to their underlying location. The native call is
         // able to see through that.
-        if (p instanceof URL) {
-          const pathname = p.pathname;
-          if (pathname.indexOf("%00") != -1) {
-            throw $ERR_INVALID_ARG_VALUE("path", "string without null bytes", pathname);
-          }
-          p = Bun.fileURLToPath(p as URL);
-        } else {
-          if (typeof p !== "string") {
-            p += "";
-          }
-          p = getValidatedPath(p);
+        if (!(p instanceof URL) && typeof p !== "string") {
+          p += "";
         }
-        throwIfNullBytesInFileName(p);
+        p = getValidatedPath(p);
         const knownHard = new Set();
 
         // Current character position in p
@@ -828,19 +813,10 @@ const realpath: typeof import("node:fs").realpath =
             );
           }
         }
-        if (p instanceof URL) {
-          const pathname = p.pathname;
-          if (pathname.indexOf("%00") != -1) {
-            throw $ERR_INVALID_ARG_VALUE("path", "string without null bytes", pathname);
-          }
-          p = Bun.fileURLToPath(p as URL);
-        } else {
-          if (typeof p !== "string") {
-            p += "";
-          }
-          p = getValidatedPath(p);
+        if (!(p instanceof URL) && typeof p !== "string") {
+          p += "";
         }
-        throwIfNullBytesInFileName(p);
+        p = getValidatedPath(p);
 
         const knownHard = new Set();
         const pathModule = require("node:path");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -57,6 +57,7 @@ import fs, {
 } from "node:fs";
 import * as os from "node:os";
 import path, { dirname, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { inspect, promisify } from "node:util";
 
 import _promises, { type FileHandle } from "node:fs/promises";
@@ -2956,6 +2957,47 @@ it("realpath async", async () => {
   });
   expect(await promise).toBe(realpathSync(import.meta.path));
 }, 30_000);
+
+// On Windows, realpath and realpathSync are JS ports of node's implementation and
+// handle the path argument themselves (elsewhere the native binding does). Like
+// node, null bytes are rejected before the path is resolved, so the error reports
+// the path exactly as it was passed (for a URL: what fileURLToPath made of it), and
+// a URL goes through the same path.resolve() as a string afterwards.
+describe.if(isWindows)("realpath handles the path argument like node", () => {
+  const reason = "The argument 'path' must be a string, Uint8Array, or URL without null bytes";
+  const nulUrl = new URL("file:///C:/foo%00bar");
+  const cases: [name: string, input: string | URL, received: string][] = [
+    ["relative path string", "foo\0bar", "foo\0bar"],
+    ["file: URL", nulUrl, fileURLToPath(nulUrl)],
+  ];
+
+  for (const [name, input, received] of cases) {
+    const expected = expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_VALUE",
+      message: `${reason}. Received ${inspect(received)}`,
+    });
+
+    it(`realpathSync rejects a ${name}`, () => {
+      expect(() => fs.realpathSync(input)).toThrow(expected);
+    });
+
+    it(`realpath rejects a ${name} synchronously`, () => {
+      const callback = () => {
+        throw new Error("callback must not be called");
+      };
+      expect(() => fs.realpath(input, callback)).toThrow(expected);
+    });
+  }
+
+  it("a file: URL with a trailing slash resolves to the path without it", async () => {
+    using dir = tempDir("fs-realpath-url", {});
+    const dirPath = fs.realpathSync(String(dir));
+    const trailingSlashUrl = new URL(pathToFileURL(dirPath).href + "/");
+    expect(fs.realpathSync(trailingSlashUrl)).toBe(dirPath);
+    expect(await promisify(fs.realpath)(trailingSlashUrl)).toBe(dirPath);
+  });
+});
 
 describe("stat", () => {
   it("file metadata is correct", () => {

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -1,6 +1,8 @@
 import { pathToFileURL } from "bun";
 import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { inspect } from "node:util";
 import path from "path";
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -187,6 +189,49 @@ describe("fs.watchFile", () => {
       expect(watcher.listenerCount("change")).toBe(0);
     } finally {
       fs.unwatchFile(file);
+    }
+  });
+
+  test("a file: URL is path.resolve()d like a string, so a trailing slash still hits the same StatWatcher", () => {
+    const file = path.join(testDir, "watch.txt");
+    const trailingSlashUrl = new URL(pathToFileURL(file).href + "/");
+    const watcher = fs.watchFile(file, { interval: 50 }, () => {});
+    try {
+      expect(fs.watchFile(trailingSlashUrl, { interval: 50 }, () => {})).toBe(watcher);
+      expect(watcher.listenerCount("change")).toBe(2);
+
+      fs.unwatchFile(trailingSlashUrl);
+      expect(watcher.listenerCount("change")).toBe(0);
+    } finally {
+      fs.unwatchFile(file);
+      fs.unwatchFile(trailingSlashUrl);
+    }
+  });
+
+  // Like node, the path is validated before it is resolved, so the error reports
+  // the path exactly as it was passed (for a URL: what fileURLToPath made of it).
+  describe("null bytes in the path", () => {
+    const reason = "The argument 'path' must be a string, Uint8Array, or URL without null bytes";
+    const nulUrl = new URL("file:///C:/foo%00bar");
+    const cases: [name: string, input: string | URL, received: string][] = [
+      ["relative path string", "foo\0bar", "foo\0bar"],
+      ["file: URL", nulUrl, fileURLToPath(nulUrl)],
+    ];
+
+    for (const [name, input, received] of cases) {
+      const expected = expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_VALUE",
+        message: `${reason}. Received ${inspect(received)}`,
+      });
+
+      test(`watchFile rejects a ${name}`, () => {
+        expect(() => fs.watchFile(input, () => {})).toThrow(expected);
+      });
+
+      test(`unwatchFile rejects a ${name} even though nothing watches it`, () => {
+        expect(() => fs.unwatchFile(input)).toThrow(expected);
+      });
     }
   });
 


### PR DESCRIPTION
### Problem
- `fs.unwatchFile("a\0b")` throws `ERR_INVALID_ARG_VALUE` with the message `The argument 'path' /cwd/a\0b. Received 'string without null bytes'`. Node: `The argument 'path' must be a string, Uint8Array, or URL without null bytes. Received 'a\x00b'`.
- Cause: `throwIfNullBytesInFileName` (`src/js/internal/validators.ts:98`) and the two `%00` checks in the Windows `realpathSync` / `realpath` ports (`src/js/node/fs.ts:714`, `:834`) call `$ERR_INVALID_ARG_VALUE(name, value, reason)` with the last two arguments swapped, so the path lands in the reason slot and the literal text `'string without null bytes'` is reported as the received value. The reason text is also not node's.
- The Windows sites reproduce the same way: `fs.realpathSync(new URL("file:///C:/a%00b"))` throws `The argument 'path' /C:/a%00b. Received 'string without null bytes'`.
- The checks also ran after `path.resolve()`, so `watchFile` / `unwatchFile` reported `/cwd/a\0b` where node reports the path as passed.
- A `URL` argument skipped `path.resolve()` entirely: `watchFile(new URL(fileURL + "/"))` created a second `StatWatcher` for a file already being watched (and `unwatchFile` of one spelling left the other running), and on Windows `realpathSync(new URL(dirURL + "/"))` returned the path with a trailing backslash. Node resolves URL paths too.

### Fix
- `getValidatedPath` (the helper behind `watchFile`, `unwatchFile` and the Windows `realpath` / `realpathSync` ports) now rejects null bytes itself, after the URL conversion and before `path.resolve()`, with `$ERR_INVALID_ARG_VALUE("path", p, "must be a string, Uint8Array, or URL without null bytes")`, the same call `getValidatedFsPath` in the same file already makes. Every input kind (string, `URL`, bun's `file:` string) goes through that one check and then the one `path.resolve()`.
- `throwIfNullBytesInFileName`, its export, the `%00` sniffing of `url.pathname` in the realpath ports and the `unwatchFile` special case are deleted: `fileURLToPath` decodes `%00` to a NUL byte, which the shared check catches, so they had nothing left to do.
- Why this is right: it is node's order. Node's `getValidatedPath` (lib/internal/fs/utils.js) converts a URL, runs `nullCheck` on the unresolved path and throws exactly this error, and `watchFile`, `unwatchFile`, `realpath` and `realpathSync` call `pathModule.resolve()` afterwards. Every case in the new tests now produces node v26.3.0's output byte for byte.
- Blast radius: this `getValidatedPath` has exactly those four callers. POSIX `realpath` / `realpathSync` are the native binding and are untouched; the native check there renders the value as `"a\u0000b"` rather than node's `'a\x00b'`, which is a separate issue in `src/runtime/node/types.rs`.
- Verified:
  - `test/js/node/watch/fs.watchFile.test.ts`: 5 new tests fail on bun 1.4.0 and on the unfixed Windows canary, pass with this change on Linux and Windows x64.
  - `test/js/node/fs/fs.test.ts`: 5 new Windows-only tests for the realpath ports fail on the unfixed Windows canary and pass with the change on Windows x64; the rest of the file passes on Linux (511 pass).
  - Vendored node tests pass with the change on Linux and Windows: `test-fs-null-bytes`, `test-fs-watchfile`, `test-fs-watchfile-ref-unref`, `test-fs-watchfile-bigint`, `test-fs-watch-file-enoent-after-deletion`, `test-fs-options-immutable`, `test-fs-realpath`, `test-fs-realpath-native`, `test-fs-realpath-buffer-encoding`, plus `test-fs-realpath-on-substed-drive` on Windows.
  - A smoke script running the Windows realpath ports on a string, a `URL`, a trailing-slash `URL`, a `Buffer`, a relative path and a number prints the same output as node v26.3.0 for every input.

### Background
- `$ERR_INVALID_ARG_VALUE(name, value, reason)` is the builtin for node's error of the same name. The native side (`ERR_INVALID_ARG_VALUE` in `src/jsc/bindings/ErrorCode.cpp`) renders `The argument '<name>' <reason>. Received <inspect(value)>`, so swapping the last two arguments yields a plausible-looking but wrong message.
- `getValidatedPath` in `src/js/internal/validators.ts` is bun's counterpart of node's helper for the few fs functions implemented in JS. Unlike node's it also resolves the path, because its callers need an absolute one: `watchFile` / `unwatchFile` key their shared `StatWatcher` map by it, and the realpath ports walk it segment by segment.
- On Windows, `fs.realpath` and `fs.realpathSync` are JS ports of node's implementation (kept so that subst drives are reported the way node reports them); everywhere else they are the native binding, which does its own null-byte check. That is why the realpath tests are Windows-only and why POSIX realpath output does not change here.
