### PR TITLE
node:vm: use Node's descriptions for the vm.constants symbols

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1872,10 +1872,10 @@ JSC::JSValue createNodeVMBinding(Zig::GlobalObject* globalObject)
 void configureNodeVM(JSC::VM& vm, Zig::GlobalObject* globalObject)
 {
     globalObject->m_nodeVMDontContextify.initLater([](const LazyProperty<JSC::JSGlobalObject, Symbol>::Initializer& init) {
-        init.set(JSC::Symbol::createWithDescription(init.vm, "vm_dont_contextify"_s));
+        init.set(JSC::Symbol::createWithDescription(init.vm, "vm_context_no_contextify"_s));
     });
     globalObject->m_nodeVMUseMainContextDefaultLoader.initLater([](const LazyProperty<JSC::JSGlobalObject, Symbol>::Initializer& init) {
-        init.set(JSC::Symbol::createWithDescription(init.vm, "vm_use_main_context_default_loader"_s));
+        init.set(JSC::Symbol::createWithDescription(init.vm, "vm_dynamic_import_main_context_default"_s));
     });
 
     globalObject->m_NodeVMScriptClassStructure.initLater(

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { inspect } from "node:util";
 import {
   compileFunction,
   constants,
   createContext,
+  isContext,
   runInContext,
   runInNewContext,
   runInThisContext,
@@ -1074,6 +1076,62 @@ describe("context options with throwing getters", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe(expected);
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("constants", () => {
+  test("symbols use Node's descriptions", () => {
+    const { DONT_CONTEXTIFY, USE_MAIN_CONTEXT_DEFAULT_LOADER } = constants;
+
+    expect({
+      DONT_CONTEXTIFY: DONT_CONTEXTIFY.description,
+      USE_MAIN_CONTEXT_DEFAULT_LOADER: USE_MAIN_CONTEXT_DEFAULT_LOADER.description,
+    }).toEqual({
+      DONT_CONTEXTIFY: "vm_context_no_contextify",
+      USE_MAIN_CONTEXT_DEFAULT_LOADER: "vm_dynamic_import_main_context_default",
+    });
+
+    expect(String(DONT_CONTEXTIFY)).toBe("Symbol(vm_context_no_contextify)");
+    expect(String(USE_MAIN_CONTEXT_DEFAULT_LOADER)).toBe("Symbol(vm_dynamic_import_main_context_default)");
+    expect(inspect(constants)).toBe(
+      "[Object: null prototype] {\n" +
+        "  USE_MAIN_CONTEXT_DEFAULT_LOADER: Symbol(vm_dynamic_import_main_context_default),\n" +
+        "  DONT_CONTEXTIFY: Symbol(vm_context_no_contextify)\n" +
+        "}",
+    );
+  });
+
+  test("symbols are echoed with Node's descriptions in ERR_INVALID_ARG_TYPE messages", () => {
+    const { DONT_CONTEXTIFY, USE_MAIN_CONTEXT_DEFAULT_LOADER } = constants;
+
+    expect(() => isContext(DONT_CONTEXTIFY as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "object" argument must be of type object. Received type symbol (Symbol(vm_context_no_contextify))',
+      }),
+    );
+    expect(() => isContext(USE_MAIN_CONTEXT_DEFAULT_LOADER as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "object" argument must be of type object. Received type symbol (Symbol(vm_dynamic_import_main_context_default))',
+      }),
+    );
+    expect(() => new Script("1", { importModuleDynamically: DONT_CONTEXTIFY as any })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "options.importModuleDynamically" property must be of type function. Received type symbol (Symbol(vm_context_no_contextify))',
+      }),
+    );
+    expect(() => runInContext("1", USE_MAIN_CONTEXT_DEFAULT_LOADER as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "object" argument must be of type object. Received type symbol (Symbol(vm_dynamic_import_main_context_default))',
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
### Problem
- `vm.constants.DONT_CONTEXTIFY` is `Symbol(vm_dont_contextify)` in Bun; Node's is `Symbol(vm_context_no_contextify)`.
- `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER` is `Symbol(vm_use_main_context_default_loader)` in Bun; Node's is `Symbol(vm_dynamic_import_main_context_default)`.
- The description is user-visible: `.description`, `String(sym)`, `util.inspect(vm.constants)`, and every `ERR_INVALID_ARG_TYPE` message that echoes one of the symbols differ from Node, e.g. `vm.isContext(vm.constants.DONT_CONTEXTIFY)` throws `Received type symbol (Symbol(vm_dont_contextify))` where Node says `(Symbol(vm_context_no_contextify))`, so exact-message assertions ported from Node fail.
- Cause: the two literals passed to `Symbol::createWithDescription` in `configureNodeVM` (src/jsc/bindings/NodeVM.cpp:1875 and :1878).

### Fix
- Change the two description literals to Node's (`vm_context_no_contextify`, `vm_dynamic_import_main_context_default`), verified against node v26.3.0.
- Matches Node. Nothing in src/ or test/ reads the descriptions: every consumer (`getContextArg`, `isUseMainContextDefaultLoaderConstant`, src/js/node/vm.ts) compares the symbols by identity, so this changes only what is printed.
- Test: `test/js/node/vm/vm.test.ts` ("constants" block) asserts the descriptions, `String()`, `util.inspect(vm.constants)`, and the `ERR_INVALID_ARG_TYPE` messages from `isContext`, `runInContext` and the `Script` `importModuleDynamically` option for both symbols. The expected strings are Node v26.3.0's verbatim output.
- Fails on bun 1.4.0 (`USE_SYSTEM_BUN=1`) with the old descriptions, passes with `bun bd test`.
- Full `test/js/node/vm/vm.test.ts` and `test/js/node/test/parallel/test-vm-context-dont-contextify.js` pass with the debug build.

### Background
- `vm.constants.DONT_CONTEXTIFY` is a sentinel passed as the context argument of `vm.createContext()` and friends to get a context whose global is not backed by a sandbox object; `USE_MAIN_CONTEXT_DEFAULT_LOADER` is a sentinel accepted for the `importModuleDynamically` option. Both are ordinary (non-registered) symbols created once per global object; the description is the string inside `Symbol(...)`.
- Node's `ERR_INVALID_ARG_TYPE` messages end with `Received type symbol (<inspect of the value>)`, and symbols are not truncated there, so the full description ends up in the message.
