### PR TITLE
install: stop aborting on -g when $BUN_INSTALL, $XDG_CACHE_HOME or $HOME does not fit the global directory path buffer

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -294,9 +294,23 @@ pub use crate::config_version::ConfigVersion;
 pub use bun_install_types::DependencyGroup;
 pub use bun_install_types::NodeLinker::NodeLinker;
 
+/// mkdir -p + open `<base>/<parts...>`; `base` is an environment value of any length.
+fn make_open_dir_under(base: &[u8], parts: &[&[u8]]) -> crate::Result<bun_sys::Fd> {
+    use bun_paths::{platform, resolve_path::join_abs_string_buf_checked};
+    use bun_sys::{Dir, OpenDirOptions};
+
+    let mut buf = PathBuffer::uninit();
+    let Some(path) = join_abs_string_buf_checked::<platform::Auto>(base, &mut buf.0, parts) else {
+        return Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+    };
+    Dir::cwd()
+        .make_open_path(path, OpenDirOptions::default())
+        .map(|d| d.into_raw())
+        .map_err(Into::into)
+}
+
 // mkdir -p + open the dir. Callers store the raw `Fd` (`options.global_bin_dir: Fd`).
 pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd> {
-    use bun_paths::{platform, resolve_path::join_abs_string_buf};
     use bun_sys::{Dir, OpenDirOptions};
 
     if let Some(home_dir) = env_var::BUN_INSTALL_GLOBAL_DIR.get() {
@@ -314,33 +328,20 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
     }
 
     if let Some(home_dir) = env_var::BUN_INSTALL.get() {
-        let mut buf = PathBuffer::uninit();
-        let parts: [&[u8]; 2] = [b"install", b"global"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return make_open_dir_under(home_dir, &[b"install", b"global"]);
     }
 
     if let Some(home_dir) = env_var::XDG_CACHE_HOME
         .get()
         .or_else(|| env_var::HOME.get())
     {
-        let mut buf = PathBuffer::uninit();
-        let parts: [&[u8]; 3] = [b".bun", b"install", b"global"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return make_open_dir_under(home_dir, &[b".bun", b"install", b"global"]);
     }
 
     Err(crate::Error::NoGlobalDirectoryFound)
 }
 
 pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Result<bun_sys::Fd> {
-    use bun_paths::{platform, resolve_path::join_abs_string_buf};
     use bun_sys::{Dir, OpenDirOptions};
 
     if let Some(home_dir) = env_var::BUN_INSTALL_BIN.get() {
@@ -362,26 +363,14 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
     }
 
     if let Some(home_dir) = env_var::BUN_INSTALL.get() {
-        let mut buf = PathBuffer::uninit();
-        let parts: [&[u8]; 1] = [b"bin"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return make_open_dir_under(home_dir, &[b"bin"]);
     }
 
     if let Some(home_dir) = env_var::XDG_CACHE_HOME
         .get()
         .or_else(|| env_var::HOME.get())
     {
-        let mut buf = PathBuffer::uninit();
-        let parts: [&[u8]; 2] = [b".bun", b"bin"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return make_open_dir_under(home_dir, &[b".bun", b"bin"]);
     }
 
     Err(crate::Error::MissingGlobalBinDirectoryTrySettingBUNINSTALL)

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunEnv as env, isLinux, isWindows, readdirSorted, tempDir, tmpdirSync } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
 import {
@@ -935,4 +935,107 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stdout).toInclude("Cleared 'bun install' cache");
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
+});
+
+// The global directory (`$BUN_INSTALL/install/global`, otherwise `.bun/install/global` under
+// $XDG_CACHE_HOME or $HOME) and the global bin directory (`$BUN_INSTALL/bin`, otherwise `.bun/bin`
+// under the same two) are each joined in a path buffer of MAX_PATH_BYTES: 4096 bytes on Linux, 1024
+// on macOS. On Windows the buffer holds more than an environment variable can, so this is POSIX only.
+describe.concurrent.skipIf(isWindows)("global directories longer than the path buffer", () => {
+  const PATH_BUFFER_BYTES = isLinux ? 4096 : 1024;
+  const LONG_VALUE = "/" + Buffer.alloc(8192, "a").toString();
+
+  type GlobalDirectory = "global directory" | "global bin directory";
+  type Variable = "BUN_INSTALL" | "XDG_CACHE_HOME" | "HOME";
+
+  // A -g command opens the global directory (which has to contain a package.json) and then the
+  // global bin directory; `bun pm bin -g` prints the latter. Every variable the two lookups read is
+  // set, so that a case reaches exactly the arm it names: the directory not under test is named
+  // outright ($BUN_INSTALL_GLOBAL_DIR and $BUN_INSTALL_BIN are opened as given, not joined), and
+  // $XDG_CONFIG_HOME holds an .npmrc so that neither the bunfig nor the .npmrc lookup joins $HOME.
+  async function runGlobal(
+    args: string[],
+    directory: GlobalDirectory,
+    variable: Variable,
+    value: string | ((dir: string) => string),
+  ) {
+    using dir = tempDir("pm-global-dir-too-long", {
+      "global/package.json": JSON.stringify({ name: "global" }),
+      "xdg-config/.npmrc": "",
+    });
+    const spawnEnv: NodeJS.Dict<string> = {
+      ...env,
+      HOME: String(dir),
+      XDG_CONFIG_HOME: join(String(dir), "xdg-config"),
+    };
+    delete spawnEnv.BUN_INSTALL;
+    delete spawnEnv.BUN_INSTALL_GLOBAL_DIR;
+    delete spawnEnv.BUN_INSTALL_BIN;
+    delete spawnEnv.XDG_CACHE_HOME;
+    if (directory === "global directory") {
+      spawnEnv.BUN_INSTALL_BIN = join(String(dir), "bin");
+    } else {
+      spawnEnv.BUN_INSTALL_GLOBAL_DIR = join(String(dir), "global");
+    }
+    spawnEnv[variable] = typeof value === "string" ? value : value(String(dir));
+
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      env: spawnEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { dir: String(dir), stdout, stderr, exitCode };
+  }
+
+  function expectNameTooLong({ stdout, stderr, exitCode }: Awaited<ReturnType<typeof runGlobal>>) {
+    expect(stderr).toContain("ENAMETOOLONG");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  }
+
+  test.each<[GlobalDirectory, Variable]>([
+    ["global directory", "BUN_INSTALL"],
+    ["global directory", "XDG_CACHE_HOME"],
+    ["global directory", "HOME"],
+    ["global bin directory", "BUN_INSTALL"],
+    ["global bin directory", "XDG_CACHE_HOME"],
+    ["global bin directory", "HOME"],
+  ])("bun pm bin -g: %s from $%s", async (directory, variable) => {
+    expectNameTooLong(await runGlobal(["pm", "bin", "-g"], directory, variable, LONG_VALUE));
+  });
+
+  test("bun install -g: global directory from $BUN_INSTALL", async () => {
+    expectNameTooLong(await runGlobal(["install", "-g"], "global directory", "BUN_INSTALL", LONG_VALUE));
+  });
+
+  // A joined path of exactly the buffer size is already one byte longer than the OS accepts; one
+  // byte more and it does not fit the buffer either.
+  test.each([
+    ["exactly", 0],
+    ["one byte above", 1],
+  ])("global directory path %s the path buffer size", async (_, offset) => {
+    const suffix = "/install/global";
+    const value = "/" + Buffer.alloc(PATH_BUFFER_BYTES + offset - "/".length - suffix.length, "a").toString();
+    expect(Buffer.byteLength(value + suffix)).toBe(PATH_BUFFER_BYTES + offset);
+
+    expectNameTooLong(await runGlobal(["pm", "bin", "-g"], "global directory", "BUN_INSTALL", value));
+  });
+
+  // What has to fit the buffer is the normalized path, not the value as written.
+  test("a value that only fits the path buffer once normalized is used", async () => {
+    const { dir, stdout, stderr, exitCode } = await runGlobal(
+      ["pm", "bin", "-g"],
+      "global bin directory",
+      "BUN_INSTALL",
+      // `${dir}/x/../x/../...` normalizes to `${dir}` (path.join would normalize it here already).
+      dir => `${dir}/${Buffer.alloc(100_000, "x/../").toString()}`,
+    );
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe(join(dir, "bin") + "\n");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- Every `-g` command (`bun install -g`, `bun add -g`, `bun pm ls -g`, `bun pm bin -g`, `bun link`, ...) aborts when `$BUN_INSTALL`, or when that is unset `$XDG_CACHE_HOME` or `$HOME`, is longer than the path buffer (4096 bytes on Linux, 1024 on macOS):
  ```
  panic: range end index 5000 out of range for slice of length 4095
  ```
  (SIGABRT, exit 134, top frame `bun_paths::resolve_path::normalize_string_generic_tz`, `src/paths/resolve_path.rs:1071`.) Repro on main: `BUN_INSTALL=/$(head -c 5000 /dev/zero | tr '\0' a) bun pm ls -g`.
- The same length in `$BUN_INSTALL_GLOBAL_DIR` or `$BUN_INSTALL_BIN` already fails cleanly with `error: An internal error occurred (ENAMETOOLONG)`, exit 1: those values are opened as given and `openat_a` (`src/sys/lib.rs:6334`) rejects any path of `MAX_PATH_BYTES` bytes or more.
- Cause: `open_global_dir` and `open_global_bin_dir` in `src/install/PackageManager/PackageManagerOptions.rs` (lines 319, 332, 367 and 380 on main) join the environment value with `install/global`, `.bun/install/global`, `bin` or `.bun/bin` using the unchecked `join_abs_string_buf` into a stack `PathBuffer`. It normalizes straight into the buffer, so a result that does not fit is an out of bounds slice write instead of an error.

### Fix
- The four joins go through one helper, `make_open_dir_under`, which uses `join_abs_string_buf_checked` and returns `Error::Sys(ENAMETOOLONG)` when the joined path does not fit; otherwise it opens the path exactly as before.
- Why this is the right answer: a path that does not fit the buffer is at least `MAX_PATH_BYTES` bytes, which `openat_a` rejects with `ENAMETOOLONG` anyway, so the helper reports one layer earlier what a larger buffer would have reported. The error is the same `Error::Sys(ENAMETOOLONG)` value that `make_open_path` produces for an oversized `$BUN_INSTALL_GLOBAL_DIR` / `$BUN_INSTALL_BIN`, so every caller (`PackageManager::init`, `setup_global_dir`, the link/unlink commands) prints the message above and exits 1 without any caller changes.
- Nothing that worked before changes: the checked join measures the normalized result, so a value that is long as written but normalizes to a path that fits is still used, and a joined path of exactly the buffer size still gets `ENAMETOOLONG` from `openat_a` as it does today. Same pattern as #37531 (workspaces entries) and `lockfile/Package.rs` (folder dependencies).
- Tests: `test/cli/install/bun-pm.test.ts`, `describe("global directories longer than the path buffer")`, POSIX only (on Windows the buffer holds more than an environment variable can carry). Each case sets every variable the two lookups read, so it reaches exactly the arm it names; `$XDG_CONFIG_HOME` points at a directory with an `.npmrc` so the `$HOME` cases reach this code regardless of the separate `.npmrc` (#38372) and bunfig (#38370) joins:
  - `bun pm bin -g` with an 8 KiB value in each of the six arms (global directory and global bin directory, from `$BUN_INSTALL`, `$XDG_CACHE_HOME`, `$HOME`): `ENAMETOOLONG`, exit 1
  - `bun install -g` with an 8 KiB `$BUN_INSTALL`: same
  - global directory path of exactly the buffer size and one byte above it: `ENAMETOOLONG`, exit 1
  - a 100 kB `$BUN_INSTALL` that normalizes to a short directory: `bun pm bin -g` prints that directory's `bin`, exit 0
- Without the fix (`USE_SYSTEM_BUN=1`, and a debug build with `src/` stashed) 8 of the 10 cases fail with the panics above (`range end index 8192`, and `4096` for the one byte above case); the exactly-the-buffer-size and normalized cases pass both ways and pin down the boundary. With the fix the whole file passes (28 tests), as do the `-g` cases of `bun-install-registry.test.ts`; `cargo clippy -p bun_install` and `rustfmt` are clean.
- Related: #38390 fixes the same class of bug for the cache directory and also appends tests to `bun-pm.test.ts`, so whichever lands second needs a trivial rebase. #32515, #35454 and #36492 touch these two functions for other reasons and keep the unchecked join, so this is independent of them.

### Background
- `PathBuffer` is bun's fixed stack buffer for building syscall paths, `MAX_PATH_BYTES` long (the platform `PATH_MAX`: 4096 on Linux, 1024 on macOS, about 96 KiB on Windows). `openat_a` copies a path into one and adds the NUL, so the longest path it accepts is `MAX_PATH_BYTES - 1` bytes.
- `resolve_path::join_abs_string_buf(base, buf, parts)` is `path.resolve` into a caller buffer. It assumes the normalized result fits and indexes `buf` accordingly. `join_abs_string_buf_checked` is the variant for input of unbounded length: it normalizes first (into heap scratch when the input is large) and returns `None` instead of writing when the result is longer than `buf`.
- Global directories: for `-g` commands `PackageManager::init` opens the global directory (where the global `package.json` and `node_modules` live) and `setup_global_dir` opens the global bin directory (where bin links are created). The first choice for each is a directory named outright (`$BUN_INSTALL_GLOBAL_DIR` / bunfig `globalDir`, `$BUN_INSTALL_BIN` / bunfig `globalBinDir`), opened as given; the remaining choices are derived by joining `$BUN_INSTALL`, else `$XDG_CACHE_HOME`, else `$HOME` with a fixed suffix, which is the code changed here.

<details>
<summary>Probes on the release build of main</summary>

```
$ LONG=/$(head -c 8192 /dev/zero | tr '\0' a)
$ BUN_INSTALL=$LONG bun pm bin -g
panic: range end index 8192 out of range for slice of length 4095        (exit 134)
$ XDG_CACHE_HOME=$LONG bun pm bin -g                                       # BUN_INSTALL unset
panic: range end index 8192 out of range for slice of length 4095        (exit 134)
$ BUN_INSTALL_GLOBAL_DIR=<dir with package.json> BUN_INSTALL=$LONG bun pm bin -g   # bin dir arm
panic: range end index 8192 out of range for slice of length 4095        (exit 134)
$ BUN_INSTALL_GLOBAL_DIR=$LONG bun pm bin -g                               # opened as given
error: An internal error occurred (ENAMETOOLONG)                         (exit 1)
$ BUN_INSTALL_BIN=$LONG BUN_INSTALL_GLOBAL_DIR=<dir> bun pm bin -g         # opened as given
error: An internal error occurred (ENAMETOOLONG)                         (exit 1)

# Boundary, global directory arm (value + "/install/global"), Linux:
joined length 4096 -> error: An internal error occurred (ENAMETOOLONG)   (exit 1)
joined length 4097 -> panic: range end index 4096 out of range for slice of length 4095
joined length 4098 -> panic: range end index 4097 out of range for slice of length 4095

# Control: with both directories named outright, an 8 KiB $HOME, $XDG_CACHE_HOME or
# $BUN_INSTALL is harmless ($XDG_CONFIG_HOME holding an .npmrc), so the test cases
# above isolate these two functions.
```
</details>
