### PR TITLE
node:vm: reject functions as the context argument like Node

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -749,17 +749,12 @@ NodeVMGlobalObject* getGlobalObjectFromContext(JSGlobalObject* globalObject, JSV
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
-    if (contextValue.isUndefinedOrNull()) {
-        if (canThrow) {
-            ERR::INVALID_ARG_TYPE(scope, globalObject, "context"_s, "object"_s, contextValue);
-        }
-        return nullptr;
+    if (canThrow) {
+        validateContextArg(scope, globalObject, contextValue);
+        RETURN_IF_EXCEPTION(scope, nullptr);
     }
 
     if (!contextValue.isObject()) {
-        if (canThrow) {
-            ERR::INVALID_ARG_TYPE(scope, globalObject, "context"_s, "object"_s, contextValue);
-        }
         return nullptr;
     }
 
@@ -806,6 +801,14 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_VM_VARIATION(JSC::ThrowScope& throwScope, 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_INVALID_ARG_TYPE, makeString("The \""_s, name, "\" argument must be an vm.Context"_s)));
     throwScope.release();
     return {};
+}
+
+JSC::EncodedJSValue validateContextArg(JSC::ThrowScope& scope, JSGlobalObject* globalObject, JSValue contextArg)
+{
+    if (!contextArg.isObject() || contextArg.isCallable()) {
+        return ERR::INVALID_ARG_TYPE(scope, globalObject, "object"_s, "object"_s, contextArg);
+    }
+    return JSValue::encode(jsUndefined());
 }
 
 bool isContext(JSGlobalObject* globalObject, JSValue value)
@@ -1654,9 +1657,8 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
     bool notContextified = getContextArg(globalObject, contextArg);
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (!contextArg.isObject()) {
-        return ERR::INVALID_ARG_TYPE(scope, globalObject, "context"_s, "object"_s, contextArg);
-    }
+    validateContextArg(scope, globalObject, contextArg);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSValue optionsArg = callFrame->argument(1);
 
@@ -1711,13 +1713,11 @@ JSC_DEFINE_HOST_FUNCTION(vmModule_createContext, (JSGlobalObject * globalObject,
 
 JSC_DEFINE_HOST_FUNCTION(vmModule_isContext, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    ArgList args(callFrame);
     JSValue contextArg = callFrame->argument(0);
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!contextArg || !contextArg.isObject()) {
-        return ERR::INVALID_ARG_TYPE(scope, globalObject, "object"_s, "object"_s, contextArg);
-    }
+    validateContextArg(scope, globalObject, contextArg);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsBoolean(isContext(globalObject, contextArg)));
 }
 

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -39,6 +39,10 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_VM_VARIATION(JSC::ThrowScope& throwScope, 
 // For vm.compileFunction we need to return an anonymous function expression. This code is adapted from/inspired by JSC::constructFunction, which is used for function declarations.
 JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, const ArgList& args, const SourceOrigin& sourceOrigin, CompileFunctionOptions&& options, JSC::SourceTaintedOrigin sourceTaintOrigin, JSC::JSScope* scope);
 JSPromise* importModule(JSGlobalObject* globalObject, JSString* moduleNameValue, RefPtr<JSC::ScriptFetchParameters> parameters, const SourceOrigin& sourceOrigin);
+// Node's isContext() validates its argument with validateObject(object, "object", kValidateObjectAllowArray),
+// and createContext()/runInContext()/runInNewContext() validate their context argument through it:
+// arrays pass; null, primitives and functions throw ERR_INVALID_ARG_TYPE.
+JSC::EncodedJSValue validateContextArg(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue contextArg);
 bool isContext(JSC::JSGlobalObject* globalObject, JSValue);
 bool getContextArg(JSC::JSGlobalObject* globalObject, JSValue& contextArg);
 bool isUseMainContextDefaultLoaderConstant(JSC::JSGlobalObject* globalObject, JSValue value);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -633,10 +633,8 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInNewContext, (JSGlobalObject * globalObject, 
 
     bool notContextified = NodeVM::getContextArg(globalObject, contextObjectValue);
 
-    if (!contextObjectValue || !contextObjectValue.isObject()) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Context must be an object"_s);
-        return {};
-    }
+    NodeVM::validateContextArg(scope, globalObject, contextObjectValue);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSValue contextOptionsArg = callFrame->argument(1);
     NodeVMContextOptions contextOptions {};

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -4,6 +4,7 @@ import {
   compileFunction,
   constants,
   createContext,
+  isContext,
   runInContext,
   runInNewContext,
   runInThisContext,
@@ -1151,6 +1152,106 @@ test("Loader is not defined in vm context", () => {
   expect(runInContext("Object.hasOwn(globalThis, 'Loader');", customContext)).toBe(true);
   // Ensure internal JSC Loader properties are not leaking through
   expect(runInContext("typeof Loader.registry;", customContext)).toBe("undefined");
+});
+
+describe("the context argument", () => {
+  // Node routes every context argument through isContext() (lib/vm.js), whose
+  // validateObject(object, "object", kValidateObjectAllowArray) accepts arrays
+  // and rejects functions along with null and primitives. Expected messages
+  // were checked against node v26.3.0.
+  const script = new Script("1 + 1;");
+  // These contextify the argument; undefined and DONT_CONTEXTIFY mean "a fresh one".
+  const contextifying: Record<string, (context: unknown) => unknown> = {
+    "createContext()": context => runInContext("1 + 1;", createContext(context as any)),
+    "vm.runInNewContext()": context => runInNewContext("1 + 1;", context as any),
+    "Script#runInNewContext()": context => script.runInNewContext(context as any),
+  };
+  // These expect an existing context.
+  const requiringContext: Record<string, (context: unknown) => unknown> = {
+    "isContext()": context => isContext(context as any),
+    "vm.runInContext()": context => runInContext("1 + 1;", context as any),
+    "Script#runInContext()": context => script.runInContext(context as any),
+  };
+
+  function invalidArgType(received: string | RegExp) {
+    return expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message:
+        typeof received === "string"
+          ? `The "object" argument must be of type object. Received ${received}`
+          : expect.stringMatching(received),
+    });
+  }
+
+  const rejected: [description: string, context: unknown, received: string | RegExp][] = [
+    ["a function", function foo() {}, "function foo"],
+    ["an anonymous function", function () {}, "function "],
+    ["an arrow function", () => {}, "function "],
+    ["an async function", async function foo() {}, "function foo"],
+    ["a class", class Foo {}, "function Foo"],
+    // How these two are named differs from Node today; only the type matters here.
+    [
+      "a bound function",
+      function foo() {}.bind(null),
+      /^The "object" argument must be of type object\. Received function /,
+    ],
+    [
+      "a callable Proxy",
+      new Proxy(function foo() {}, {}),
+      /^The "object" argument must be of type object\. Received function /,
+    ],
+    ["null", null, "null"],
+    ["a number", 1, "type number (1)"],
+    ["a string", "sandbox", "type string ('sandbox')"],
+    ["a boolean", true, "type boolean (true)"],
+    ["a symbol", Symbol("sandbox"), "type symbol (Symbol(sandbox))"],
+  ];
+
+  describe.each(Object.entries({ ...contextifying, ...requiringContext }))("%s", (_, run) => {
+    test.each(rejected)("rejects %s", (_, context, received) => {
+      expect(() => run(context)).toThrow(invalidArgType(received));
+    });
+  });
+
+  describe.each(Object.entries(contextifying))("%s", (_, run) => {
+    test.each([
+      ["an array", []],
+      ["undefined", undefined],
+      ["vm.constants.DONT_CONTEXTIFY", constants.DONT_CONTEXTIFY],
+    ])("still contextifies %s", (_, context) => {
+      expect(run(context)).toBe(2);
+    });
+  });
+
+  describe.each(Object.entries(requiringContext))("%s", (_, run) => {
+    test("rejects undefined", () => {
+      expect(() => run(undefined)).toThrow(invalidArgType("undefined"));
+    });
+  });
+
+  test("a contextified array is a context everywhere", () => {
+    const sandbox: unknown[] = [];
+    expect(isContext(sandbox)).toBe(false);
+    expect(createContext(sandbox)).toBe(sandbox);
+    expect(isContext(sandbox)).toBe(true);
+    expect(runInContext("1 + 1;", sandbox)).toBe(2);
+    expect(script.runInContext(sandbox)).toBe(2);
+  });
+
+  test("an object that is not a context fails the vm.Context check, not the type check", () => {
+    const notAContext = expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: expect.stringContaining('The "contextifiedObject" argument must be an vm.Context'),
+    });
+    expect(isContext({})).toBe(false);
+    expect(isContext([])).toBe(false);
+    expect(() => runInContext("1 + 1;", {})).toThrow(notAContext);
+    expect(() => runInContext("1 + 1;", [])).toThrow(notAContext);
+    expect(() => script.runInContext({})).toThrow(notAContext);
+    expect(() => script.runInContext([])).toThrow(notAContext);
+  });
 });
 
 test("node:vm native Module prototype methods reject non-module receivers", async () => {


### PR DESCRIPTION
### Problem
- `vm.isContext(function () {})` returns `false`, `vm.createContext(fn)` contextifies the function, and `new vm.Script("1").runInNewContext(fn)` runs. Node throws `TypeError [ERR_INVALID_ARG_TYPE]: The "object" argument must be of type object. Received function ` from all of them.
- `vm.runInContext()`, `vm.runInNewContext()` and `Script#runInContext()` do reject a function, but with the second-tier error (`The "contextifiedObject" argument must be an vm.Context`) instead of the type error above.
- Cause: the native checks use `JSValue::isObject()`, which is true for functions: `vmModule_isContext` (src/jsc/bindings/NodeVM.cpp:1718), `vmModule_createContext` (NodeVM.cpp:1657), `scriptRunInNewContext` (src/jsc/bindings/NodeVMScript.cpp:636) and `getGlobalObjectFromContext` (NodeVM.cpp:759, used by `Script#runInContext`). `src/js/node/vm.ts` does not need changes: its `validateContext()` delegates to the native `isContext`.
- The same sites also differ from Node for non-objects: `createContext(1)` and `script.runInContext(1)` name the argument `"context"` (Node: `"object"`), and `script.runInNewContext(1)` throws a plain `TypeError: Context must be an object` with no `code`.

### Fix
- Adds `NodeVM::validateContextArg()`: rejects anything that is not an object or that is callable, with `ERR_INVALID_ARG_TYPE` for `"object"`, and uses it at the four sites. `getGlobalObjectFromContext()` applies it on its throwing path (`Script#runInContext`); its non-throwing callers (the Module classes, which pass an already validated context or the main global) keep returning null for non-objects as before.
- Matches Node: `lib/vm.js` `isContext()` validates with `validateObject(object, 'object', kValidateObjectAllowArray)`, and `createContext()`, `runInContext()`, `runInNewContext()` and `Script#runInContext()`/`runInNewContext()` all validate the context through `isContext()`. `isObject() && !isCallable()` is `typeof x === "object" && x !== null`, which is exactly what that validator accepts: arrays still pass, functions, null and primitives do not.
- `vm.constants.DONT_CONTEXTIFY` and `undefined` are still turned into a fresh sandbox by `getContextArg()` before the check runs, so those paths are unchanged (covered by the new tests and the existing `DONT_CONTEXTIFY` block).
- The native `vmModuleRunInNewContext` has the same `isObject()` check but is not reachable (`vm.ts` implements `runInNewContext` itself) and is removed by #38326, so it is left alone.
- Tests: `test/js/node/vm/vm.test.ts`, "the context argument": for each of the six entry points, rejection of function declarations, anonymous/arrow/async functions, classes, bound functions and callable Proxies plus null and primitives with Node's exact message (checked against node v26.3.0), arrays/undefined/`DONT_CONTEXTIFY` still contextifying, a contextified array being accepted everywhere, and non-context objects still getting the `vm.Context` error. 58 of the new cases fail on the released binary, all pass with the fix.
- Also run with the debug build: the rest of `test/js/node/vm/`, all 97 `test/js/node/test/parallel/test-vm-*` files (97 pass), and the new block plus `test-vm-context.js`/`test-vm-is-context.js`/`test-vm-create-context-arg.js`/`test-vm-basic.js` under `BUN_JSC_validateExceptionChecks=1`.

### Background
- A vm "context" is an ordinary object (the sandbox) that `createContext()` has associated with its own `NodeVMGlobalObject` realm; Bun records the association in a WeakMap on the main global, and `isContext()` is a lookup in that map. Contextifying a function would therefore "work" mechanically, which is why nothing crashed; it is simply an input Node rejects.
- Node's `validateObject` flags: the default rejects null, arrays and functions; `kValidateObjectAllowArray` (used by `isContext`) additionally lets arrays through, so `createContext([])` is valid and must stay valid.
- `getContextArg()` is the shared pre-step for `createContext()`/`Script#runInNewContext()`: it replaces `undefined` and the `DONT_CONTEXTIFY` symbol with a fresh object, which is why the new check runs after it.
- Two related cosmetic differences are intentionally not touched here and are tracked separately: how a bound function's name is rendered in the `Received ...` suffix (the new tests use a prefix match for those cases), and the missing `Received ...` suffix on the `vm.Context` error.
