### PR TITLE
sql(sqlite): make ?mode=rw open without creating the database

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1485,13 +1485,15 @@ function parseSQLiteOptions(
 
   // Parse query parameters if present
   if (queryString) {
-    const params = new URLSearchParams(queryString);
-    const mode = params.get("mode");
+    // SQLite URI semantics: when mode= is repeated, the last one wins.
+    const modes = new URLSearchParams(queryString).getAll("mode");
+    const mode = modes[modes.length - 1];
 
     if (mode === "ro") {
       sqliteOptions.readonly = true;
     } else if (mode === "rw") {
       sqliteOptions.readonly = false;
+      sqliteOptions.create = false;
     } else if (mode === "rwc") {
       sqliteOptions.readonly = false;
       sqliteOptions.create = true;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -366,6 +366,7 @@ describe("Connection & Initialization", () => {
       const sql = new SQL(`sqlite://${dbPath}?mode=rw`);
       expect(sql.options.adapter).toBe("sqlite");
       expect(sql.options.readonly).toBe(false);
+      expect(sql.options.create).toBe(false);
 
       await sql`INSERT INTO test VALUES (1)`;
       const result = await sql`SELECT * FROM test`;
@@ -373,6 +374,56 @@ describe("Connection & Initialization", () => {
 
       await sql.close();
       await rm(dir, { recursive: true });
+    });
+
+    test("mode=rw should not create a missing database file", async () => {
+      await using dir = tempDir("rw-missing-test", {});
+      const dbPath = path.join(dir, "missing.db");
+
+      const sql = new SQL(`sqlite://${dbPath}?mode=rw`);
+
+      await expect(sql`CREATE TABLE test (id INTEGER)`.execute()).rejects.toMatchObject({
+        name: "SQLiteError",
+        code: "SQLITE_CANTOPEN",
+      });
+      expect(existsSync(dbPath)).toBe(false);
+      expect(sql.options.readonly).toBe(false);
+      expect(sql.options.create).toBe(false);
+
+      await sql.close();
+    });
+
+    test("explicit create option should override mode=rw", async () => {
+      await using dir = tempDir("rw-create-override-test", {});
+      const dbPath = path.join(dir, "created.db");
+
+      const sql = new SQL(`sqlite://${dbPath}?mode=rw`, { create: true });
+      expect(sql.options.create).toBe(true);
+
+      await sql`CREATE TABLE test (id INTEGER)`;
+      expect(existsSync(dbPath)).toBe(true);
+
+      await sql.close();
+    });
+
+    test("repeated mode= should use the last value, like SQLite URIs", async () => {
+      await using dir = tempDir("repeated-mode-test", {});
+      const dbPath = path.join(dir, "repeated.db");
+
+      const roLast = new SQL(`sqlite://${dbPath}?mode=rw&mode=ro`);
+      expect(roLast.options.readonly).toBe(true);
+      await expect(roLast`CREATE TABLE test (id INTEGER)`.execute()).rejects.toMatchObject({
+        code: "SQLITE_CANTOPEN",
+      });
+      expect(existsSync(dbPath)).toBe(false);
+      await roLast.close();
+
+      const rwcLast = new SQL(`sqlite://${dbPath}?mode=ro&mode=rwc`);
+      expect(rwcLast.options.readonly).toBe(false);
+      expect(rwcLast.options.create).toBe(true);
+      await rwcLast`CREATE TABLE test (id INTEGER)`;
+      expect(existsSync(dbPath)).toBe(true);
+      await rwcLast.close();
     });
 
     test("should handle mode=rwc (read-write-create)", async () => {

--- a/test/js/sql/sqlite-url-parsing.test.ts
+++ b/test/js/sql/sqlite-url-parsing.test.ts
@@ -84,11 +84,14 @@ describe("SQLite URL Parsing Matrix", () => {
     const queryParams = [
       { query: "", readonly: undefined, create: undefined, name: "no params" },
       { query: "?mode=ro", readonly: true, create: undefined, name: "readonly" },
-      { query: "?mode=rw", readonly: false, create: undefined, name: "read-write" },
+      { query: "?mode=rw", readonly: false, create: false, name: "read-write" },
       { query: "?mode=rwc", readonly: false, create: true, name: "read-write-create" },
       { query: "?mode=invalid", readonly: undefined, create: undefined, name: "invalid mode" },
       { query: "?other=param", readonly: undefined, create: undefined, name: "other param" },
       { query: "?mode=ro&cache=shared", readonly: true, create: undefined, name: "multiple params" },
+      // Repeated mode= follows SQLite URI semantics: the last one wins.
+      { query: "?mode=rw&mode=ro", readonly: true, create: undefined, name: "repeated mode, ro last" },
+      { query: "?mode=ro&mode=rw", readonly: false, create: false, name: "repeated mode, rw last" },
     ];
 
     const queryMatrix = protocolsWithQuery.flatMap(base =>


### PR DESCRIPTION
### Problem
- `new SQL("sqlite://missing.db?mode=rw")` creates `missing.db` and the first query succeeds. The docs (docs/runtime/sql.mdx) say `?mode=rw` means `readonly: false, create: false` ("Read-write mode (no create)").
- `parseSQLiteOptions` (src/js/internal/sql/shared.ts:1493) maps `mode=rw` to `readonly = false` only and never sets `create`.
- `SQLiteAdapter` (src/js/internal/sql/sqlite.ts:318) then computes `create = connectionInfo.create !== false`, which is `true` when `create` is undefined, so the file is created.
- `mode=rw` exists so that a mistyped or unmounted path fails instead of silently starting on an empty database. `new SQL({ adapter: "sqlite", filename, create: false })` already fails with `SQLITE_CANTOPEN` on the same path; only the URL form was broken.
- Related: a repeated `mode=` parameter (`?mode=rw&mode=ro`) used the first value (`URLSearchParams.get`). SQLite's own URI parsing applies the last one.

### Fix
- `mode=rw` now sets `create = false` in addition to `readonly = false`, so the adapter opens with `{ readwrite: true, create: false }` and a missing file rejects with `SQLITE_CANTOPEN` without being created. `mode=rwc` (create) and `mode=ro` are unchanged.
- An explicit `create` option passed alongside the URL still wins, because explicit options are applied after the query string (unchanged code path).
- When `mode=` is repeated, the last value is used (`getAll`), matching SQLite.
- Verified:
  - test/js/sql/sqlite-sql.test.ts: new tests `mode=rw should not create a missing database file`, `explicit create option should override mode=rw`, `repeated mode= should use the last value`; the existing `mode=rw` test now also checks `options.create`. The missing-file test fails on the released bun (`Received promise that resolved`) and passes with this change; full file 242 pass.
  - test/js/sql/sqlite-url-parsing.test.ts: `?mode=rw` now expects `create: false`, plus two repeated-`mode=` entries; 12 matrix cases fail on the released bun, 184 pass with this change.
  - test/js/sql/adapter-env-var-precedence.test.ts and adapter-override.test.ts still pass.

### Background
- `Bun.SQL` with a `sqlite:` / `file:` URL is backed by `bun:sqlite`. `parseSQLiteOptions` in shared.ts turns the URL plus options object into the adapter's `connectionInfo`; `SQLiteAdapter` in sqlite.ts translates that into `bun:sqlite` `Database` open flags (`readonly`, or `readwrite` + `create`).
- In SQLite URI filenames, `mode=ro` / `mode=rw` / `mode=rwc` select `SQLITE_OPEN_READONLY`, `SQLITE_OPEN_READWRITE`, or `READWRITE | CREATE`. Without `CREATE`, opening a path that does not exist fails with `SQLITE_CANTOPEN`. `rwc` is the default when no mode is given.
- The adapter opens the database in the `SQL` constructor but stores any open error and reports it when the first query runs, which is why the tests assert on the query rejecting rather than on the constructor throwing (the existing `mode=ro` missing-file test does the same).
