### PR TITLE
fetch: ignore http_proxy/https_proxy when the request uses a unix socket

### DIFF
--- a/docs/runtime/networking/fetch.mdx
+++ b/docs/runtime/networking/fetch.mdx
@@ -203,6 +203,8 @@ const response = await fetch("https://hostname/a/path", {
 });
 ```
 
+The URL still determines the scheme (`https:` speaks TLS over the socket), the `Host` header and the path. A request made over a Unix domain socket is never sent through a proxy: the `http_proxy` / `https_proxy` environment variables are ignored, and passing the `proxy` option together with `unix` rejects with a `TypeError`.
+
 ### TLS
 
 To use a client certificate, use the `tls` option:

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1990,7 +1990,12 @@ interface BunFetchRequestInit extends RequestInit {
   s3?: Bun.S3Options;
 
   /**
-   * Make the request over a Unix socket
+   * Make the request over a Unix socket. The URL still supplies the scheme
+   * (`https:` speaks TLS over the socket), `Host` header and path.
+   *
+   * A request over a Unix socket never goes through a proxy: the
+   * `http_proxy` / `https_proxy` environment variables are ignored, and
+   * combining this with the `proxy` option rejects with a `TypeError`.
    *
    * @example
    * ```js

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1969,8 +1969,16 @@ impl FetchTasklet {
         // hop (`HTTPClient::reevaluate_proxy_for_redirect`). `ProxySettings`
         // owns copies of the env values, so a later `process.env.HTTP_PROXY =
         // ...` on the JS thread cannot invalidate them mid-request.
+        //
+        // `unix` is the transport for this request, so neither the proxy env nor
+        // the per-hop re-resolution may apply to it (otherwise the daemon would
+        // be sent an absolute-form request or a CONNECT, with the proxy's
+        // credentials); fetch() already rejects an explicit `proxy` with `unix`.
         let proxy_settings: Option<Box<http::ProxySettings>> =
-            if let Some(proxy_opt) = &fetch_options.proxy {
+            if !fetch_options.unix_socket_path.slice().is_empty() {
+                debug_assert!(fetch_options.proxy.is_none());
+                None
+            } else if let Some(proxy_opt) = &fetch_options.proxy {
                 if !proxy_opt.is_empty() {
                     http::ProxySettings::from_explicit(proxy_opt.href, env)
                 } else {

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -1,7 +1,7 @@
 import { serve, ServeOptions, Server } from "bun";
-import { afterAll, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync } from "fs";
-import { isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tls as tlsCert, tmpdirSync } from "harness";
 import { request } from "http";
 import { join } from "path";
 const tmp_dir = tmpdirSync();
@@ -272,4 +272,143 @@ it("does not pool the unix-socket connection whose redirect is being followed", 
     results.push(`${response.status} ${response.redirected} ${await response.text()}`);
   }
   expect(results).toEqual(Array(5).fill("200 true tcp /world"));
+});
+
+// `unix` names the transport, so http_proxy / https_proxy in the environment
+// must not apply to the request (an explicit `proxy` alongside `unix` is
+// rejected). If they did, the daemon would be sent the proxy flavour of the
+// request: absolute-form for an http:// URL, a plaintext CONNECT for an
+// https:// URL, either one carrying the proxy URL's credentials in
+// Proxy-Authorization; and a redirect would be followed through the proxy.
+describe("http_proxy / https_proxy in the environment are ignored when `unix` is given", () => {
+  const plainSock = join(tmp_dir, "plain.sock");
+  const tlsSock = join(tmp_dir, "tls.sock");
+  // What the unix daemons received: request line, and whether a
+  // Proxy-Authorization header came with it.
+  const daemonLog: { line: string; proxyAuth: boolean }[] = [];
+  // Request lines that reached the proxy named by the env.
+  const proxyLog: string[] = [];
+  let origin: Server;
+  let proxy: ReturnType<typeof Bun.listen>;
+  let plainDaemon: ReturnType<typeof Bun.listen>;
+  let tlsDaemon: ReturnType<typeof Bun.listen>;
+
+  // Raw HTTP/1.1 server that answers each connection's first request with
+  // whatever `respond` returns for its header block.
+  function recording(respond: (head: string[]) => string) {
+    return {
+      open(socket: Bun.Socket<{ buf: string }>) {
+        socket.data = { buf: "" };
+      },
+      data(socket: Bun.Socket<{ buf: string }>, chunk: Uint8Array) {
+        const buf = (socket.data.buf += new TextDecoder("latin1").decode(chunk));
+        const end = buf.indexOf("\r\n\r\n");
+        if (end < 0) return;
+        socket.end(respond(buf.slice(0, end).split("\r\n")));
+      },
+      error() {},
+    };
+  }
+
+  function daemon(head: string[]) {
+    daemonLog.push({ line: head[0], proxyAuth: head.some(h => /^proxy-authorization:/i.test(h)) });
+    // Matched in both origin-form and absolute-form so the redirect hop is
+    // exercised either way.
+    if (/^GET \S*\/redirect /.test(head[0])) {
+      return `HTTP/1.1 302 Found\r\nLocation: ${origin.url.origin}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`;
+    }
+    return "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\ndaemon";
+  }
+
+  beforeAll(() => {
+    origin = serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("origin") });
+    proxy = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: recording(head => {
+        proxyLog.push(head[0]);
+        return "HTTP/1.1 200 OK\r\nContent-Length: 9\r\nConnection: close\r\n\r\nvia-proxy";
+      }),
+    });
+    plainDaemon = Bun.listen({ unix: plainSock, socket: recording(daemon) });
+    tlsDaemon = Bun.listen({ unix: tlsSock, tls: tlsCert, socket: recording(daemon) });
+  });
+
+  afterAll(() => {
+    origin.stop(true);
+    proxy.stop(true);
+    plainDaemon.stop(true);
+    tlsDaemon.stop(true);
+  });
+
+  async function fetchInChild(url: string, unix?: string) {
+    daemonLog.length = 0;
+    proxyLog.length = 0;
+    const env = { ...bunEnv };
+    for (const key of ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY", "no_proxy", "NO_PROXY"])
+      delete env[key];
+    env.http_proxy = env.https_proxy = `http://user:pass@127.0.0.1:${proxy.port}`;
+    env.URL_TO_FETCH = url;
+    if (unix !== undefined) env.UNIX_SOCKET = unix;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { URL_TO_FETCH, UNIX_SOCKET } = process.env;
+         const res = await fetch(URL_TO_FETCH, UNIX_SOCKET ? { unix: UNIX_SOCKET, tls: { rejectUnauthorized: false } } : {});
+         console.log(res.status, await res.text());`,
+      ],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode,
+      daemonLog: [...daemonLog],
+      proxyLog: [...proxyLog],
+    };
+  }
+
+  it("control: the same environment does route a TCP fetch through the proxy", async () => {
+    expect(await fetchInChild(`${origin.url.origin}/final`)).toEqual({
+      stdout: "200 via-proxy",
+      stderr: "",
+      exitCode: 0,
+      daemonLog: [],
+      proxyLog: [`GET http://127.0.0.1:${origin.port}/final HTTP/1.1`],
+    });
+  });
+
+  it("http:// URL: the daemon gets an origin-form request without the proxy credentials", async () => {
+    expect(await fetchInChild("http://daemon.invalid/v1/x", plainSock)).toEqual({
+      stdout: "200 daemon",
+      stderr: "",
+      exitCode: 0,
+      daemonLog: [{ line: "GET /v1/x HTTP/1.1", proxyAuth: false }],
+      proxyLog: [],
+    });
+  });
+
+  it("https:// URL: TLS is spoken to the daemon itself instead of sending it a CONNECT", async () => {
+    expect(await fetchInChild("https://daemon.invalid/v1/y", tlsSock)).toEqual({
+      stdout: "200 daemon",
+      stderr: "",
+      exitCode: 0,
+      daemonLog: [{ line: "GET /v1/y HTTP/1.1", proxyAuth: false }],
+      proxyLog: [],
+    });
+  });
+
+  it("a redirect off the unix socket is followed directly, not through the proxy", async () => {
+    expect(await fetchInChild("http://daemon.invalid/redirect", plainSock)).toEqual({
+      stdout: "200 origin",
+      stderr: "",
+      exitCode: 0,
+      daemonLog: [{ line: "GET /redirect HTTP/1.1", proxyAuth: false }],
+      proxyLog: [],
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- With `http_proxy` / `https_proxy` set in the environment (and the URL's host not covered by `no_proxy`), `fetch(url, { unix })` still connects to the unix socket but writes the proxy form of the request to it: `GET http://host/path HTTP/1.1` (absolute-form) for an `http://` URL, and a plaintext `CONNECT host:443 HTTP/1.1` for an `https://` URL, which a daemon answers with garbage or a close (`ECONNRESET` on bun 1.4.0).
- Either form also carries the proxy URL's credentials to the daemon as `Proxy-Authorization`, and a redirect served by the daemon is followed through the proxy.
- Cause: `FetchTasklet::get` (src/runtime/webcore/fetch/FetchTasklet.rs:1978) builds `ProxySettings::from_env` without looking at `unix_socket_path`. `HTTPClient` then takes every proxy branch (`send_initial_request_payload` writing `write_proxy_request` / `write_proxy_connect`, `is_https()` picking the proxy's scheme, `reevaluate_proxy_for_redirect` on each hop) while `HttpThread::connect` dials the unix socket regardless.
- Present since `unix` was added (#9097); only `unix` + an explicit `proxy` option was handled (rejected).

### Fix
- `FetchTasklet::get` leaves `proxy_settings` `None` when `unix_socket_path` is set. `proxy_settings` is the only source of the hop-0 proxy and of the per-redirect re-resolution, so this is one check covering every consumer instead of a transport check in each of them. A `debug_assert!` records that fetch.rs already rejects an explicit `proxy` here.
- Why it is right: the unix socket is the transport for the whole request, and a proxy is another transport, so there is nothing for the proxy settings to apply to. This is already how the rest of bun treats it: fetch.rs rejects `proxy` + `unix` ("fetch() cannot use a proxy with a unix socket."), node:http skips the proxy env when `socketPath` is set (src/js/internal/http.ts `checkShouldUseProxy`, same as Node), and the WebSocket client drops the proxy for `ws+unix:` URLs (WebSocket.cpp). A redirect that leaves the socket goes direct for the same reason there is no way to opt a unix request into a proxy explicitly.
- With and without the proxy variables, a unix request now produces the same bytes on the socket.
- Docs and the `unix` option's JSDoc state the rule.
- Verified:
  - `test/js/web/fetch/fetch.unix.test.ts`, new `describe` "http_proxy / https_proxy in the environment are ignored when `unix` is given": recording plain and TLS daemons on unix sockets plus a recording TCP proxy named by a credentialed `http_proxy`/`https_proxy` in a child's env. Asserts the daemon receives `GET /v1/x HTTP/1.1` with no `Proxy-Authorization` (http), that TLS is spoken to the daemon and it receives `GET /v1/y HTTP/1.1` (https), and that a 302 off the socket is followed directly with nothing reaching the proxy. A control test shows the same environment does route a plain TCP fetch through the proxy. The three unix tests fail on the unfixed build (received `GET http://daemon.invalid/v1/x HTTP/1.1` + `proxyAuth: true`; `ECONNRESET`; hop 2 logged by the proxy), on Linux and on Windows; all pass with the fix.
  - `test/js/bun/http/proxy.test.ts` (68 tests) still passes with the fix.
  - `test/integration/bun-types/bun-types.test.ts` passes with the JSDoc change.

### Background
- `fetch(url, { unix })`: the URL supplies the scheme (`https:` means TLS over the socket), `Host` and path; the socket path replaces host:port as the thing to connect to (`HttpThread::connect` checks it before anything else).
- HTTP proxying in bun's client: for an `http://` target the request is sent to the proxy in absolute-form (`GET http://host/path`), for an `https://` target a `CONNECT host:port` is sent first and TLS is run inside the resulting tunnel; in both cases proxy credentials go in a `Proxy-Authorization` header. Which applies is decided by `HTTPClient::http_proxy` being set.
- `ProxySettings` (src/http/lib.rs): owned copies of `http_proxy` / `https_proxy` / `no_proxy` captured on the JS thread when the request is created. `FetchTasklet::get` resolves hop 0's `http_proxy` from it, and `HTTPClient::reevaluate_proxy_for_redirect` re-resolves it against each redirect target (#33651).
