### PR TITLE
spawn: throw synchronously when the stdin ReadableStream is locked

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -401,6 +401,14 @@ impl Stdio {
                         )
                         .throw());
                 }
+                if stream.is_locked(global) {
+                    return Err(global
+                        .err(
+                            jsc::ErrorCode::INVALID_STATE,
+                            format_args!("ReadableStream is locked"),
+                        )
+                        .throw());
+                }
 
                 *out_stdio = Stdio::ReadableStream(stream);
             }
@@ -549,6 +557,14 @@ impl Stdio {
                             "'{}' ReadableStream has already been used",
                             bstr::BStr::new(name),
                         ),
+                    )
+                    .throw());
+            }
+            if stream.is_locked(global) {
+                return Err(global
+                    .err(
+                        jsc::ErrorCode::INVALID_STATE,
+                        format_args!("'{}' ReadableStream is locked", bstr::BStr::new(name)),
                     )
                     .throw());
             }

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -543,6 +543,99 @@ describe("spawn stdin ReadableStream", () => {
     }).toThrow("'stdin' ReadableStream has already been used");
   });
 
+  // A locked stream can never be pumped into the child (the pump's reader
+  // acquisition throws), so spawn has to reject it before forking. Previously it
+  // forked, and the pump failure surfaced as an unhandled rejection instead.
+  test.each([
+    {
+      how: "getReader()",
+      lock(stream: ReadableStream<string>) {
+        const reader = stream.getReader();
+        return () => reader.read();
+      },
+    },
+    {
+      how: "tee()",
+      lock(stream: ReadableStream<string>) {
+        const [branch] = stream.tee();
+        return () => branch.getReader().read();
+      },
+    },
+  ])("ReadableStream locked by $how throws synchronously instead of spawning", async ({ lock }) => {
+    const stream = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue("still readable by the lock holder");
+        controller.close();
+      },
+    });
+    const readFirstChunk = lock(stream);
+    expect(stream.locked).toBe(true);
+
+    const locked = expect.objectContaining({ code: "ERR_INVALID_STATE", message: "'stdin' ReadableStream is locked" });
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdin: stream, env: bunEnv })).toThrow(locked);
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdio: [stream, "ignore", "ignore"], env: bunEnv })).toThrow(
+      locked,
+    );
+
+    // The rejected spawn must not have cancelled the stream out from under whoever holds the lock.
+    expect(await readFirstChunk()).toEqual({ done: false, value: "still readable by the lock holder" });
+  });
+
+  test.each([
+    { kind: "Response", wrap: (body: ReadableStream) => new Response(body) },
+    { kind: "Request", wrap: (body: ReadableStream) => new Request("http://localhost/", { method: "POST", body }) },
+  ])("$kind whose body stream is locked throws synchronously instead of spawning", ({ wrap }) => {
+    const wrapper = wrap(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue("body");
+          controller.close();
+        },
+      }),
+    );
+    wrapper.body!.getReader();
+
+    expect(() => spawn({ cmd: [bunExe(), "-e", ""], stdin: wrapper, env: bunEnv })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_STATE", message: "ReadableStream is locked" }),
+    );
+  });
+
+  test("rejecting a locked stdin stream is catchable and does not fail the process", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue("data");
+            controller.close();
+          },
+        });
+        stream.getReader();
+        try {
+          Bun.spawn({
+            cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+            stdin: stream,
+            stdout: "ignore",
+          });
+          console.log("spawned");
+        } catch (e) {
+          console.log(e.code + ": " + e.message);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("ERR_INVALID_STATE: 'stdin' ReadableStream is locked");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("ReadableStream with abort signal calls cancel", async () => {
     const controller = new AbortController();
     const cancel = mock();


### PR DESCRIPTION
### Problem
- `Bun.spawn({ stdin: stream })` with a stream that is locked (after `stream.getReader()` or `stream.tee()`) does not throw: it forks the child and returns a `Subprocess`.
- The stdin pump then fails to acquire its reader and its result promise is rejected with `TypeError: Invalid state: ReadableStream is locked` (`ERR_INVALID_STATE`). Nothing handles that promise, so the error is reported as an unhandled rejection and the process exits with code 1 even though a `try/catch` around `Bun.spawn` ran to completion.
- The failed pump's teardown also cancels the caller's stream (`FileSink::handle_reject_stream` -> `abort`), so whoever holds the lock reads `{ done: true }` instead of the data, and a second spawn with the same stream reports `'stdin' ReadableStream has already been used`.
- Cause: the stdin validation in `Stdio::extract` (src/runtime/api/bun/spawn/stdio.rs:544) and `Stdio::extract_body_value` (stdio.rs:396, the `Request`/`Response` body path) only checks `is_disturbed`. Locking a stream does not disturb it, so a locked stream passes validation and the failure is only discovered after the child exists, in `Writable::init` -> `FileSink::assign_to_stream`, where there is no longer anything to throw to.

### Fix
- Add an `is_locked` check next to the existing `is_disturbed` check at both validation sites. `Bun.spawn` now throws `ERR_INVALID_STATE` (`'stdin' ReadableStream is locked`, or `ReadableStream is locked` for a `Request`/`Response` body) before the child is spawned, and the caller's stream is left untouched.
- Correct because a locked stream can never be consumed by spawn: the pump's `acquireReadableStreamDefaultReader` throws on exactly the predicate `is_locked` reports (`isReadableStreamLocked`), so failing up front rejects only inputs that were guaranteed to fail later. Native-backed streams (Blob, file, fetch body) already hit the `is_disturbed` check because materializing them marks them disturbed; JS-sourced streams were the gap.
- Separate message for the locked case mirrors the stream consumers (`createLockedError` vs `createAlreadyUsedError` in BunStreamConsumers.cpp); the disturbed check runs first so a stream that is being actively consumed keeps its existing message.
- A stream that is already errored when passed to spawn still reaches the pump and is reported through its producer-error path; surfacing producer errors is what #36236 changes and is not touched here.
- Tests: `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`, five new cases: `getReader()` and `tee()` (both `stdin:` and `stdio:` forms, plus the lock holder still receiving the data afterwards), `Response` and `Request` with a locked body stream, and a child process asserting the error is catchable and the exit code stays 0. All five fail on the current release build (`spawn` returns a `Subprocess`, child prints `spawned`, exit code 1) and pass with `bun bd test`.
- Also ran `spawn-stdin-readable-stream*.test.ts`, `spawn-streaming-stdin.test.ts`, `spawn.test.ts` and `spawnSync.test.ts` with the debug build: no failures.

### Background
- Locked vs disturbed: a `ReadableStream` is locked while a reader is attached (`getReader()`, `tee()`, `pipeTo`) and becomes disturbed once something has read from or cancelled it. `getReader()` alone locks without disturbing, which is the state this PR starts rejecting.
- Stdin pump: for a `ReadableStream` stdin, spawn creates a `FileSink` on the child's stdin pipe and `FileSink::assign_to_stream` starts `readStreamIntoSink` (BunStreamSource.cpp), which acquires a reader and copies chunks into the sink. It reports failures by rejecting a promise, which is fine for errors that happen while streaming but has no way to make `Bun.spawn` itself throw.
