### PR TITLE
worker: do not abort a compiled executable on a relative specifier longer than the path buffer

### DIFF
--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1320,11 +1320,15 @@ unsafe fn resolve_entry_point_specifier<'s>(
             'try_from_extension: {
                 let mut pathbuf = bun_paths::path_buffer_pool::get();
                 let base_path = graph.base_public_path_with_default_suffix();
-                let base = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Loose>(
-                    base_path,
-                    &mut pathbuf[..],
-                    &[str],
-                );
+                // `str` is user input of any length. If it does not fit in the
+                // buffer (with room for the `.js` appended below), skip the
+                // remap and let the resolver below report it as not found.
+                let usable_len = pathbuf.len() - b".js".len();
+                let Some(base) = bun_paths::resolve_path::join_abs_string_buf_checked::<
+                    bun_paths::platform::Loose,
+                >(base_path, &mut pathbuf[..usable_len], &[str]) else {
+                    break 'try_from_extension;
+                };
                 let base_len = base.len();
                 let extname_len = bun_paths::extension(base).len();
                 // `extname` cannot be held as a sub-slice of `pathbuf` while

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -452,6 +452,67 @@ describe("bundler", () => {
       },
     },
   });
+  // The extension remap above ("./worker" -> "/$bunfs/root/worker.js") joins
+  // the specifier into a fixed-size path buffer. A specifier that does not fit
+  // used to abort the whole process instead of firing the worker's error event.
+  itBundled("compile/WorkerRelativePathLongerThanPathBuffer", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        const w = (length) => Buffer.alloc(length, "w").toString();
+        // The specifier is joined onto import.meta.dir ("/$bunfs/root") plus a slash.
+        const joinedPrefixLength = import.meta.dir.length + 1;
+        const specifiers = [
+          ["./ past the buffer", "./" + w(100_000)],
+          ["../ past the buffer", "../" + w(100_000)],
+          // Path buffer sizes on macOS, Linux and Windows. The joined path
+          // stops one byte short of filling the buffer, so the join fits and
+          // only the ".js" appended by the remap does not.
+          ...[1024, 4096, 98302].map(size => [
+            "./ one byte short of a " + size + " byte buffer",
+            "./" + w(size - 1 - joinedPrefixLength),
+          ]),
+        ];
+        for (const [label, specifier] of specifiers) {
+          const { promise, resolve } = Promise.withResolvers();
+          const worker = new Worker(specifier);
+          worker.onerror = resolve;
+          await promise;
+          console.log(label + ": error event");
+        }
+      `,
+    },
+    run: {
+      stdout: `
+        ./ past the buffer: error event
+        ../ past the buffer: error event
+        ./ one byte short of a 1024 byte buffer: error event
+        ./ one byte short of a 4096 byte buffer: error event
+        ./ one byte short of a 98302 byte buffer: error event
+      `,
+      setCwd: true,
+    },
+  });
+  // Preloads go through the same remap, on the parent thread.
+  itBundled("compile/WorkerPreloadLongerThanPathBuffer", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        try {
+          new Worker("./worker.ts", { preload: ["./" + Buffer.alloc(100_000, "p").toString()] });
+          console.log("constructed");
+        } catch (e) {
+          console.log("constructor threw an Error:", e instanceof Error);
+        }
+      `,
+      "/worker.ts": /* js */ `
+        console.log("Worker loaded!");
+      `.trim(),
+    },
+    entryPointsRaw: ["./entry.ts", "./worker.ts"],
+    outfile: "dist/out",
+    run: { stdout: "constructor threw an Error: true", file: "dist/out", setCwd: true },
+  });
   itBundled("compile/Bun.embeddedFiles", {
     compile: true,
     // TODO: this shouldn't be necessary, or we should add a map aliasing files.


### PR DESCRIPTION
### Problem

- In a `bun build --compile` executable, `new Worker("./" + "w".repeat(5000))` aborts the whole process: `panic: range end index 5012 out of range for slice of length 4095`. The same script run with plain `bun` fires the worker's `error` event and keeps going.
- `../` specifiers and the `preload` option of `Worker` take the same path, so they abort the same way.
- Cause: the standalone branch of `resolve_entry_point_specifier` remaps `./foo` to `/$bunfs/root/foo.js` by joining the specifier into a pooled `PathBuffer` with `join_abs_string_buf` (`src/jsc/web_worker.rs:1323` on main), which does not check that the normalized result fits, and then writes `.js` at `pathbuf[base_len..base_len + 3]` (`web_worker.rs:1337`), which is not checked either. The specifier is user input of any length.
- The second write has its own window: a specifier whose joined form is 1 to 3 bytes short of filling the buffer survives the join and panics on the `.js` append (`range end index 4098 out of range for slice of length 4096`).

### Fix

- Join with `join_abs_string_buf_checked` into `pathbuf[..len - 3]`, so a successful join always leaves room for the `.js` append, and skip the remap (`break 'try_from_extension`) when it returns `None`.
- This is correct because the remap is only an optimization for finding embedded files: a specifier that does not fit in a path buffer is not remapped and falls through to the resolver, which already handles over-long specifiers and reports them the way it reports any other missing module. The result is the behavior plain `bun` has today: the worker fires `error` (or, for a preload, the constructor throws) and the process continues. Specifiers that fit take exactly the path they took before (`join_abs_string_buf_checked` calls `join_abs_string_buf` when the input fits).
- Both call sites of `resolve_entry_point_specifier` are covered: the entry point (resolved on the worker thread) and preloads (resolved on the parent thread in `create`).
- Tests: `test/bundler/bundler_compile.test.ts`, `compile/WorkerRelativePathLongerThanPathBuffer` (a compiled binary creates workers for `./` and `../` specifiers of 100,000 bytes, plus one `./` specifier per platform path buffer size (1024, 4096, 98302) whose joined form is one byte short of the buffer, so that on each platform one of them hits the `.js` append window; every one must fire `error` and the binary must exit 0) and `compile/WorkerPreloadLongerThanPathBuffer` (a valid embedded worker with a 100,000 byte preload; the constructor must throw and the binary must exit 0).
- `USE_SYSTEM_BUN=1 bun test test/bundler/bundler_compile.test.ts -t LongerThanPathBuffer`: both fail with `Runtime failed with SIGABRT` / `panic: range end index 100012 out of range for slice of length 4095`.
- `bun bd test test/bundler/bundler_compile.test.ts`: 69 of 70 pass; the one failure, `compile/HelloWorldWithProcessVersionsBun`, fails on any debug build independently of this change and is already covered by #37373.

### Background

- A compiled executable embeds its modules in a standalone module graph, keyed by virtual absolute paths under `/$bunfs/root/` (`B:/~BUN/root/` on Windows). The bundler renames every embedded module to `.js`, so `new Worker("./foo")` or `new Worker("./foo.ts")` has to be remapped to `/$bunfs/root/foo.js` before it can be looked up in the graph; that remap is what this branch does. When the lookup fails, the specifier falls through to the normal resolver, which resolves it against the working directory.
- `PathBuffer` is a fixed `MAX_PATH_BYTES` scratch buffer (4096 bytes on Linux, 1024 on macOS, 98302 on Windows), handed out from a pool. `join_abs_string_buf` normalizes the joined path straight into the caller's buffer; `join_abs_string_buf_checked` is the variant that returns `None` when the normalized result would not fit, and is what the other user-input call sites (`Bun.mmap`, `fs.watch`, the resolver's relative path check) already use.
- The earlier attempt at this, #33219, bundled this change with an unrelated resolver panic; it was closed when #35349 fixed the resolver half, and this part never landed.

<details>
<summary>Probes against the unfixed binary (bun 1.4.0, Linux x64), one worker per run</summary>

`main.js` creates `new Worker(PREFIX + "w".repeat(N))` with an `onerror` handler, compiled with `bun build --compile`. The joined prefix `/$bunfs/root/` is 13 bytes.

```
./  N=200    -> error event: BuildMessage: ModuleNotFound resolving "./www..."
./  N=4080   -> error event                                   (joined 4093 bytes, .js fits exactly)
./  N=4081   -> panic: range end index 4097 out of range for slice of length 4096   (.js append)
./  N=4082   -> panic: range end index 4098 out of range for slice of length 4096   (.js append)
./  N=4083   -> panic: range end index 4099 out of range for slice of length 4096   (.js append)
./  N=4084   -> panic: range end index 4096 out of range for slice of length 4095   (join)
./  N=5000   -> panic: range end index 5012 out of range for slice of length 4095   (join)
../ N=5000   -> panic: range end index 5007 out of range for slice of length 4095   (join)
./  N=98288  -> panic: range end index 98300 out of range for slice of length 4095  (join)
preload ./ N=5000 -> panic: range end index 5012 out of range for slice of length 4095 (parent thread, in create)
```

With this change, the same binary prints an error event (or the constructor throws, for the preload) and exits 0 for every row.

The same family has one more face that this PR does not touch: a `./` specifier this long passed to `import()` / `require()` from inside a compiled executable hits an unchecked join in `src/resolver/resolver.rs` (the standalone relative-import branch). That is a separate code path and is being handled separately.
</details>
