### PR TITLE
bun-types: declare the bun:ffi type names the runtime accepts

### DIFF
--- a/packages/bun-types/ffi.d.ts
+++ b/packages/bun-types/ffi.d.ts
@@ -189,6 +189,12 @@ declare module "bun:ffi" {
      * ```
      */
     int = 5,
+    /**
+     * 32-bit signed integer
+     *
+     * The same as `int` in C. Alias of {@link FFIType.int32_t}
+     */
+    c_int = 5,
 
     /**
      * 32-bit unsigned integer
@@ -211,6 +217,12 @@ declare module "bun:ffi" {
      * Alias of {@link FFIType.uint32_t}
      */
     u32 = 6,
+    /**
+     * 32-bit unsigned integer
+     *
+     * The same as `unsigned int` in C. Alias of {@link FFIType.uint32_t}
+     */
+    c_uint = 6,
 
     /**
      * 64-bit signed integer
@@ -222,6 +234,12 @@ declare module "bun:ffi" {
      * Alias of {@link FFIType.int64_t}
      */
     i64 = 7,
+    /**
+     * Pointer-sized signed integer (`intptr_t` / `ssize_t`)
+     *
+     * Bun only runs on 64-bit platforms, so this is an alias of {@link FFIType.int64_t}
+     */
+    isize = 7,
 
     /**
      * 64-bit unsigned integer
@@ -231,6 +249,12 @@ declare module "bun:ffi" {
      * 64-bit unsigned integer
      */
     u64 = 8,
+    /**
+     * Pointer-sized unsigned integer (`uintptr_t` / `size_t`)
+     *
+     * Bun only runs on 64-bit platforms, so this is an alias of {@link FFIType.uint64_t}
+     */
+    usize = 8,
 
     /**
      * IEEE-754 double precision float
@@ -328,7 +352,30 @@ declare module "bun:ffi" {
      * In C, this always becomes `uint64_t`
      */
     u64_fast = 16,
+
+    /**
+     * Function pointer
+     *
+     * In `args`, pass a {@link JSCallback} or its `ptr`.
+     *
+     * In C:
+     * ```c
+     * void (*)()
+     * ```
+     */
     function = 17,
+    /**
+     * Function pointer
+     *
+     * Alias of {@link FFIType.function}
+     */
+    callback = 17,
+    /**
+     * Function pointer
+     *
+     * Alias of {@link FFIType.function}
+     */
+    fn = 17,
 
     napi_env = 18,
     napi_value = 19,
@@ -341,6 +388,10 @@ declare module "bun:ffi" {
      * Engine-native only; not supported inside `cc()`.
      */
     buffer_length = 21,
+    /**
+     * Alias of {@link FFIType.buffer_length}
+     */
+    buffer_bytelength = 21,
   }
 
   type Pointer = number & { __pointer__: null };
@@ -412,12 +463,17 @@ declare module "bun:ffi" {
     ["int32_t"]: FFIType.int32_t;
     ["i32"]: FFIType.i32;
     ["int"]: FFIType.int;
+    ["c_int"]: FFIType.c_int;
     ["uint32_t"]: FFIType.uint32_t;
     ["u32"]: FFIType.u32;
+    ["c_uint"]: FFIType.c_uint;
     ["int64_t"]: FFIType.int64_t;
     ["i64"]: FFIType.i64;
+    ["isize"]: FFIType.isize;
     ["uint64_t"]: FFIType.uint64_t;
     ["u64"]: FFIType.u64;
+    ["usize"]: FFIType.usize;
+    ["size_t"]: FFIType.uint64_t;
     ["double"]: FFIType.double;
     ["f64"]: FFIType.f64;
     ["float"]: FFIType.float;
@@ -425,16 +481,20 @@ declare module "bun:ffi" {
     ["bool"]: FFIType.bool;
     ["ptr"]: FFIType.ptr;
     ["pointer"]: FFIType.pointer;
+    ["void*"]: FFIType.ptr;
+    ["char*"]: FFIType.ptr;
     ["void"]: FFIType.void;
     ["cstring"]: FFIType.cstring;
+    ["i64_fast"]: FFIType.i64_fast;
+    ["u64_fast"]: FFIType.u64_fast;
     ["function"]: FFIType.pointer; // for now
-    ["usize"]: FFIType.uint64_t; // for now
     ["callback"]: FFIType.pointer; // for now
+    ["fn"]: FFIType.pointer; // for now
     ["napi_env"]: FFIType.napi_env;
     ["napi_value"]: FFIType.napi_value;
     ["buffer"]: FFIType.buffer;
     ["buffer_length"]: FFIType.buffer_length;
-    ["buffer_bytelength"]: FFIType.buffer_length;
+    ["buffer_bytelength"]: FFIType.buffer_bytelength;
   }
 
   type FFITypeOrString = FFIType | keyof FFITypeStringToType;
@@ -710,7 +770,7 @@ declare module "bun:ffi" {
    * ```js
    * import {CFunction} from 'bun:ffi';
    *
-   * const getVersion = new CFunction({
+   * const getVersion = CFunction({
    *   returns: "cstring",
    *   args: [],
    *   ptr: myNativeLibraryGetVersion,

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -367,36 +367,48 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
+  // These run on debug builds too: spawning tsc over a file or two is cheap,
   // unlike the in-process LanguageService runs above.
+  async function tscCheck(name: string, files: string[], extraFiles: Record<string, string> = {}) {
+    const checkDir = join(TEMP_DIR, name);
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.files = files;
+    tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, {
+      ...extraFiles,
+      "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      await tscCheck("mmap-options-check", ["mmap-options.ts"], {
         "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
            view satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
       });
+    });
+  });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+  describe("bun:ffi", () => {
+    test("fixture/ffi.ts type-checks (declares every type name the runtime accepts)", async () => {
+      await tscCheck("ffi-check", [join(BASE_FIXTURE_DIR, "ffi.ts")]);
     });
   });
 

--- a/test/integration/bun-types/fixture/ffi.ts
+++ b/test/integration/bun-types/fixture/ffi.ts
@@ -1,4 +1,15 @@
-import { dlopen, FFIType, JSCallback, read, suffix, type CString, type Pointer } from "bun:ffi";
+import {
+  cc,
+  dlopen,
+  FFIType,
+  JSCallback,
+  linkSymbols,
+  read,
+  suffix,
+  viewSource,
+  type CString,
+  type Pointer,
+} from "bun:ffi";
 import * as tsd from "./utilities";
 
 // `suffix` is either "dylib", "so", or "dll" depending on the platform
@@ -181,3 +192,81 @@ tsd.expectType<number>(read.f32(ptr, 0));
 tsd.expectType<number>(read.f64(ptr, 0));
 tsd.expectType<number>(read.ptr(ptr, 0));
 tsd.expectType<number>(read.intptr(ptr, 0));
+
+// Every name the runtime accepts in `args`/`returns` is declared: the keys of the FFIType
+// object in src/js/bun/ffi.ts as enum members, and the table in src/runtime/ffi/abi_type.rs
+// as strings.
+declare const callback: JSCallback;
+declare const view: Uint8Array;
+
+const aliases = dlopen(path, {
+  c_ints: { args: [FFIType.c_int, FFIType.c_uint, "c_int", "c_uint"], returns: "c_int" },
+  returns_c_uint: { args: [], returns: FFIType.c_uint },
+  sizes: { args: [FFIType.isize, FFIType.usize, "isize", "usize", "size_t"], returns: "isize" },
+  returns_usize: { args: [], returns: FFIType.usize },
+  returns_size_t: { args: [], returns: "size_t" },
+  fast: { args: ["i64_fast", "u64_fast"], returns: "i64_fast" },
+  returns_u64_fast: { args: [], returns: "u64_fast" },
+  c_pointers: { args: ["char*", "void*"], returns: "char*" },
+  returns_void_pointer: { args: [], returns: "void*" },
+  function_members: { args: [FFIType.callback, FFIType.fn], returns: FFIType.fn },
+  function_names: { args: ["function", "callback", "fn"], returns: "fn" },
+  buffers: { args: [FFIType.buffer, FFIType.buffer_bytelength, "buffer", "buffer_bytelength"] },
+} as const);
+
+type AliasParams<K extends keyof (typeof aliases)["symbols"]> = Parameters<(typeof aliases)["symbols"][K]>;
+type Int64Arg = number | bigint;
+type PointerArg = NodeJS.TypedArray | Pointer | bigint | null;
+type PointerReturn = Pointer | bigint | null;
+type BufferArg = NodeJS.TypedArray | DataView;
+
+tsd.expectType<AliasParams<"c_ints">>().is<[number, number, number, number]>();
+tsd.expectType(aliases.symbols.c_ints(1, 2, 3, 4)).is<number>();
+tsd.expectType(aliases.symbols.returns_c_uint()).is<number>();
+
+tsd.expectType<AliasParams<"sizes">>().is<[Int64Arg, Int64Arg, Int64Arg, Int64Arg, Int64Arg]>();
+tsd.expectType(aliases.symbols.sizes(-1, 1n, -1n, 1, 1)).is<bigint>();
+tsd.expectType(aliases.symbols.returns_usize()).is<bigint>();
+tsd.expectType(aliases.symbols.returns_size_t()).is<bigint>();
+
+tsd.expectType<AliasParams<"fast">>().is<[Int64Arg, Int64Arg]>();
+tsd.expectType(aliases.symbols.fast(1, 1n)).is<Int64Arg>();
+tsd.expectType(aliases.symbols.returns_u64_fast()).is<Int64Arg>();
+
+tsd.expectType<AliasParams<"c_pointers">>().is<[PointerArg, PointerArg]>();
+tsd.expectType(aliases.symbols.c_pointers(view, null)).is<PointerReturn>();
+tsd.expectType(aliases.symbols.returns_void_pointer()).is<PointerReturn>();
+
+tsd.expectType<AliasParams<"function_members">>().is<[Pointer | JSCallback, Pointer | JSCallback]>();
+tsd.expectType(aliases.symbols.function_members(callback, ptr)).is<PointerReturn>();
+// The string spellings resolve like "function" and "callback" always have (to the pointer
+// argument type), so `fn(callback.ptr)` keeps compiling.
+tsd.expectType<AliasParams<"function_names">>().is<[PointerArg, PointerArg, PointerArg]>();
+tsd.expectType(aliases.symbols.function_names(callback.ptr, ptr, 1n)).is<PointerReturn>();
+
+tsd.expectType<AliasParams<"buffers">>().is<[BufferArg, BufferArg, BufferArg, BufferArg]>();
+tsd.expectType(aliases.symbols.buffers(view, view, view, view)).is<undefined>();
+
+// Names the runtime does not accept stay undeclared.
+// @ts-expect-error the runtime FFIType object has no `size_t` key (only the string is accepted)
+FFIType.size_t;
+// @ts-expect-error "jsvalue" is not accepted by bun:ffi
+viewSource({ f: { args: ["jsvalue"] } });
+
+// The same FFIFunction declaration type is shared by every entry point.
+const linked = linkSymbols({
+  strlen: { args: ["char*"], returns: "size_t", ptr },
+  labs: { args: ["isize"], returns: FFIType.isize, ptr },
+} as const);
+tsd.expectType(linked.symbols.strlen(view)).is<bigint>();
+tsd.expectType(linked.symbols.labs(-1n)).is<bigint>();
+
+const compiled = cc({
+  source: "add.c",
+  symbols: { add: { args: ["c_int", FFIType.c_uint], returns: "u64_fast" } } as const,
+});
+tsd.expectType(compiled.symbols.add(1, 2)).is<number | bigint>();
+
+new JSCallback(() => 0n, { args: ["void*", "size_t", FFIType.usize], returns: "isize" });
+viewSource({ f: { args: ["i64_fast", "fn", FFIType.buffer_bytelength], returns: "c_uint" } });
+viewSource({ args: [FFIType.callback], returns: FFIType.c_int }, true);


### PR DESCRIPTION
### Problem
- `packages/bun-types/ffi.d.ts` does not declare several `bun:ffi` type names the runtime accepts, so programs that work fail to type-check, e.g. `dlopen(lib, { strlen: { args: ["cstring"], returns: "usize" } })` works but `returns: FFIType.usize` or `args: ["isize"]` is a type error.
- `enum FFIType` lacks `c_int`, `c_uint`, `isize`, `usize`, `callback`, `fn` and `buffer_bytelength`, all of which are keys of the `FFIType` object exported by `src/js/bun/ffi.ts`.
- `FFITypeStringToType` (which `args`/`returns` accept strings from, via `FFITypeOrString`) lacks `c_int`, `c_uint`, `isize`, `size_t`, `char*`, `void*`, `i64_fast`, `u64_fast` and `fn`, all of which are in the runtime's name table `ABI_TYPE_LABEL` (`src/runtime/ffi/abi_type.rs`). `i64_fast`/`u64_fast` are documented `FFIType` rows, yet the string spelling was rejected.
- The `CFunction` JSDoc example uses `new CFunction(...)`, which does not type-check against the `function CFunction(...)` declaration right below it.

### Fix
- Add the missing enum members (each with the same value as the member it aliases) and the missing string-map entries, so that every name in `ABI_TYPE_LABEL` is accepted and resolves to the same `FFIType` value the runtime maps it to (`isize` to `int64_t`, `size_t`/`usize` to `uint64_t`, `c_int` to `int32_t`, `c_uint` to `uint32_t`, `char*`/`void*` to `ptr`, `buffer_bytelength` to `buffer_length`). Argument and return types therefore come out of the existing `FFITypeToArgsType`/`FFITypeToReturnsType` tables unchanged; those tables are not touched (see the comment above them about alias keys and tsgo).
- `"fn"` is declared the way `"function"` and `"callback"` already are (resolving to the pointer argument type), so the three spellings agree with each other and `fn(callback.ptr)` keeps compiling. Pointing the three at `FFIType.function` (`Pointer | JSCallback`) would start rejecting `callback.ptr` (`Pointer | null`) in existing string-declared signatures, so that is deliberately left as it was.
- `FFIType.size_t` is deliberately not declared: the runtime only accepts `"size_t"` as a string (the JS `FFIType` object has no such key), and the fixture pins that with a `@ts-expect-error`.
- Change the `CFunction` example to call `CFunction(...)`, matching the declaration (the `.mdx` examples are updated separately in #38386).
- Verified: `test/integration/bun-types/fixture/ffi.ts` now declares symbols with every new name and asserts the inferred parameter/return types for `dlopen`, `linkSymbols`, `cc`, `JSCallback` and `viewSource`. `test/integration/bun-types/bun-types.test.ts` gains a `tsc` run over that fixture that also executes on debug builds (the in-process LanguageService cases are `skipIf(isDebug)`). Without the `.d.ts` change it fails with 87 diagnostics, 23 of them directly on the names used in the `dlopen` declaration (`Property 'isize' does not exist on type 'typeof FFIType'`, `Type '"size_t"' is not assignable to type 'FFITypeOrString'`, ...); with it, all 16 cases of `bun test test/integration/bun-types/bun-types.test.ts` pass (tsc with and without lib.dom, and tsgo), and `bun bd test` runs the new case on the debug build.
- Runtime truth was checked against bun 1.4.0 (FFI sources identical to main): `viewSource` accepts every name added here as both an argument and a return type and rejects `"jsvalue"`, which stays undeclared.

Not changed here: `cc()`'s `source` option also accepts an array of files at runtime, but that form is untested, undocumented and panics on an empty array (handed off separately), so its declaration is left alone until that is sorted out. The `c_int`/`c_uint`/`size_t` spellings are accepted but absent from the docs tables, which #38386 is currently editing.

### Background
- `bun:ffi` symbol declarations (`{ args, returns }`) name C types either with an `FFIType` enum value or with a string. At runtime both are parsed in `src/runtime/ffi/ffi_body.rs`: numbers directly, strings through the `ABI_TYPE_LABEL` table in `abi_type.rs`, which has several spellings per type (`"u64"`, `"uint64_t"`, `"usize"`, `"size_t"` all mean the same 64-bit unsigned integer).
- In the declarations, `FFITypeStringToType` maps each accepted string to an `FFIType` member, and `FFITypeToArgsType`/`FFITypeToReturnsType` map the `FFIType` value to the JavaScript types of the generated wrapper's parameters and return value. Adding a spelling therefore only requires an entry in the string map (plus an enum member when the runtime `FFIType` object also has that key); the argument/return typing is inherited from the canonical member because alias members share its numeric value.
