### PR TITLE
bun:ffi: throw on an empty cc() source array instead of panicking

### DIFF
--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -275,6 +275,8 @@ impl Default for CompileC {
 
 enum Source {
     File(ZBox),
+    /// Never empty: `bun_ffi_cc` rejects an empty `source` array, and `first()`
+    /// relies on that.
     Files(Vec<ZBox>),
 }
 
@@ -1142,7 +1144,7 @@ impl FFI {
             object.get_own(global_this, &bun_core::String::borrow_utf8(b"source"))?
         {
             if source_value.is_array() {
-                compile_c.source = Source::Files(Vec::new());
+                let mut files: Vec<ZBox> = Vec::new();
                 let mut iter = source_value.array_iterator(global_this)?;
                 while let Some(value) = iter.next()? {
                     if !value.is_string() {
@@ -1152,10 +1154,19 @@ impl FFI {
                             value,
                         ));
                     }
-                    if let Source::Files(files) = &mut compile_c.source {
-                        files.push(value.get_zig_string(global_this)?.to_owned_slice_z());
-                    }
+                    files.push(value.get_zig_string(global_this)?.to_owned_slice_z());
                 }
+                if files.is_empty() {
+                    return Err(global_this
+                        .err(
+                            jsc::ErrorCode::INVALID_ARG_VALUE,
+                            format_args!(
+                                "The argument 'source' must be a non-empty array of file paths. Received []"
+                            ),
+                        )
+                        .throw());
+                }
+                compile_c.source = Source::Files(files);
             } else if !source_value.is_string() {
                 return Err(global_this.throw_invalid_argument_type_value(
                     b"source",

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -101,6 +101,79 @@ describe.skipIf(isASAN)("given an add(a, b) function", () => {
   });
 }); // </given add(a, b) function>
 
+// `source` also accepts an array of files. Both tests spawn bun: an empty
+// array used to crash the process (the native side indexed the first source
+// file while building the "symbol is missing" error), which would take the
+// test runner down with it.
+describe.concurrent("given an array of source files", () => {
+  const symbols = {
+    add: { args: ["int", "int"], returns: "int" },
+    sub: { args: ["int", "int"], returns: "int" },
+  };
+
+  it("when the array is empty, throws instead of crashing", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          import { cc } from "bun:ffi";
+          try {
+            cc({ source: [], symbols: ${JSON.stringify(symbols)} });
+            console.log(JSON.stringify("cc() did not throw"));
+          } catch (error) {
+            console.log(JSON.stringify({ name: error.name, code: error.code, message: error.message }));
+          }
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is only included so a crashed child shows why; debug builds may
+    // print benign warnings to it.
+    const thrown = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ thrown, stderr, exitCode }).toMatchObject({
+      thrown: {
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_VALUE",
+        message: "The argument 'source' must be a non-empty array of file paths. Received []",
+      },
+      exitCode: 0,
+    });
+  });
+
+  it("compiles every file in the array", async () => {
+    using dir = tempDir("bun-ffi-cc-source-array", {
+      "add.c": /* c */ `int add(int a, int b) { return a + b; }`,
+      "sub.c": /* c */ `int sub(int a, int b) { return a - b; }`,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: [path.join(import.meta.dir, "add.c"), path.join(import.meta.dir, "sub.c")],
+          symbols: ${JSON.stringify(symbols)},
+        });
+        console.log(JSON.stringify([symbols.add(1, 2), symbols.sub(1, 2)]));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({ stdout: "[3,-1]", exitCode: 0 });
+  });
+}); // </given an array of source files>
+
 describe("given a source file with syntax errors", () => {
   const source = /* c */ `
     int add(int a, int b) {


### PR DESCRIPTION
### Problem
- `cc({ source: [], symbols: { ... } })` kills the process instead of throwing:
  `panic: index out of bounds: the len is 0 but the index is 0` (exit 134), from `Source::first` at `src/runtime/ffi/ffi_body.rs:285`.
- `bun_ffi_cc` turns an array `source` into `Source::Files(Vec)` without checking that it has any entries (`ffi_body.rs:1145`). The JS wrapper in `src/js/bun/ffi.ts` only rejects a falsy `source`, and `[]` is truthy.
- With no files, nothing is added to the TinyCC state and relocation succeeds, so the first symbol lookup fails and `CompileC::compile` formats its "is missing from" error with `self.source.first()` (`ffi_body.rs:873`), which indexes `files[0]` of the empty Vec. The deferred-errors path at `ffi_body.rs:1184` formats the same way.

### Fix
- Collect the array into a local Vec first; if it ends up empty, throw `ERR_INVALID_ARG_VALUE` (`TypeError: The argument 'source' must be a non-empty array of file paths. Received []`) and only then construct `Source::Files`, so it is never built empty and both `first()` callers are covered.
- Correct because the empty array is caller input, and this is the one place it enters native code: it is rejected next to the existing `source` type checks (the `ERR_INVALID_ARG_TYPE` throws for a non-string element or non-array value), with the same error family Bun uses for other invalid argument values. A non-empty array is still compiled file by file, unchanged.
- `Received []` is spelled out rather than rendered from the value: reaching the check means every element was consumed and none was kept, so the array's length is 0.
- Verified with `test/js/bun/ffi/cc.test.ts` ("given an array of source files"): the empty-array test exits 134 with the panic above on the unfixed build and passes with the fix; the second test compiles two files through the array form and passes before and after (it guards the rewritten collection loop, which had no coverage).
- The rest of `cc.test.ts`, `ffi-error-messages.test.ts` and `ffi.test.js` pass on the debug build, except for `ffi.test.js`'s "integer identities work for all possible values" cases, which hit their 5s timeout on the debug build here regardless of this change (dlopen path, not `cc()`).

### Background
- `cc()` (`bun:ffi`) compiles C source at runtime with TinyCC and exposes the listed `symbols` as JS functions. `source` is documented as a single path, but the implementation also accepts an array of paths, each of which is added to the same TinyCC state and linked together.
- `Source` (`ffi_body.rs`) is `File(path)` or `Files(Vec<path>)`. `Source::first()` is only used for error messages: it names the source file in "symbol X is missing from <file>" and in the "N errors while compiling <file>" header.
- `ERR_INVALID_ARG_VALUE` is the Node-style error code (a `TypeError` with `.code`) Bun throws for an argument of the right type but an unusable value; `ERR_INVALID_ARG_TYPE` is what the surrounding `source` checks already throw for the wrong type.

Found while working on #38423, which leaves the array form out of the type declarations until this is fixed.
