### PR TITLE
node:vm: stop validating `timeout` in the Script constructor

### DIFF
--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -19,6 +19,9 @@
 namespace Bun {
 using namespace NodeVM;
 
+// As in Node's lib/vm.js, timeout / displayErrors / breakOnSigint are not
+// constructor options: RunningScriptOptions reads them on each runIn*Context
+// call, and vm.runIn*Context() passes one options object through both parsers.
 bool ScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::ThrowScope& scope, JSC::JSValue optionsArg, JSValue* importer)
 {
     if (importer) {
@@ -49,11 +52,6 @@ bool ScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm, JSC::
                 ERR::INVALID_ARG_TYPE(scope, globalObject, "options.contextOrigin"_s, "string"_s, contextOriginOpt);
                 return false;
             }
-            any = true;
-        }
-
-        if (validateTimeout(globalObject, vm, scope, options, this->timeout)) {
-            RETURN_IF_EXCEPTION(scope, false);
             any = true;
         }
 
@@ -732,6 +730,13 @@ bool RunningScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm
     if (!optionsArg.isUndefined() && !optionsArg.isString()) {
         JSObject* options = asObject(optionsArg);
 
+        // Same order as Node's getRunInContextArgs (lib/vm.js): timeout,
+        // displayErrors, breakOnSigint. Observable when several are invalid.
+        if (validateTimeout(globalObject, vm, scope, options, this->timeout)) {
+            any = true;
+        }
+        RETURN_IF_EXCEPTION(scope, false);
+
         auto displayErrorsOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "displayErrors"_s));
         RETURN_IF_EXCEPTION(scope, false);
         if (displayErrorsOpt) {
@@ -744,11 +749,6 @@ bool RunningScriptOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& vm
                 any = true;
             }
         }
-
-        if (validateTimeout(globalObject, vm, scope, options, this->timeout)) {
-            any = true;
-        }
-        RETURN_IF_EXCEPTION(scope, {});
 
         auto breakOnSigintOpt = options->getIfPropertyExists(globalObject, Identifier::fromString(vm, "breakOnSigint"_s));
         RETURN_IF_EXCEPTION(scope, false);

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -9,7 +9,6 @@ namespace Bun {
 class ScriptOptions : public BaseVMOptions {
 public:
     WTF::Vector<uint8_t> cachedData;
-    std::optional<int64_t> timeout = std::nullopt;
     bool produceCachedData = false;
 
     using BaseVMOptions::BaseVMOptions;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -309,6 +309,104 @@ describe("Script", () => {
     });
   });
 
+  describe("timeout is a run option, not a constructor option", () => {
+    // Node's Script constructor (lib/vm.js) never looks at options.timeout; the
+    // runIn*Context methods validate it. The vm.runIn*Context() wrappers hand the
+    // same options object to both, so a bad timeout still surfaces there, but
+    // only after the constructor's own checks.
+    const invalidTimeouts: [timeout: unknown, code: string][] = [
+      ["x", "ERR_INVALID_ARG_TYPE"],
+      [null, "ERR_INVALID_ARG_TYPE"],
+      [{}, "ERR_INVALID_ARG_TYPE"],
+      [0, "ERR_OUT_OF_RANGE"],
+      [-1, "ERR_OUT_OF_RANGE"],
+      [NaN, "ERR_OUT_OF_RANGE"],
+    ];
+    // "<code> <option>" for a node-style error, the error name otherwise.
+    const thrown = (fn: () => unknown) => {
+      try {
+        fn();
+        return "no error";
+      } catch (e: any) {
+        return e.code ? `${e.code} ${e.message.match(/"(options\.\w+)"/)?.[1] ?? e.message}` : e.name;
+      }
+    };
+
+    test("new Script() accepts an invalid timeout and the script runs without one", () => {
+      const context = createContext({});
+      for (const [timeout] of invalidTimeouts) {
+        const script = new Script("1", { timeout } as any);
+        expect(script.runInThisContext()).toBe(1);
+        expect(script.runInContext(context)).toBe(1);
+        expect(script.runInNewContext({})).toBe(1);
+      }
+    });
+
+    test("new Script() does not read options.timeout, runInThisContext() does", () => {
+      let reads = 0;
+      const options = {
+        get timeout() {
+          reads++;
+          return 10_000;
+        },
+      };
+      const script = new Script("1", options);
+      expect(reads).toBe(0);
+      expect(script.runInThisContext(options)).toBe(1);
+      expect(reads).toBe(1);
+    });
+
+    test("every run entry point still rejects an invalid timeout", () => {
+      const script = new Script("1");
+      const context = createContext({});
+      const entryPoints: Record<string, (options: any) => unknown> = {
+        "script.runInThisContext": options => script.runInThisContext(options),
+        "script.runInContext": options => script.runInContext(context, options),
+        "script.runInNewContext": options => script.runInNewContext({}, options),
+        "vm.runInThisContext": options => runInThisContext("1", options),
+        "vm.runInContext": options => runInContext("1", context, options),
+        "vm.runInNewContext": options => runInNewContext("1", {}, options),
+      };
+      const actual: Record<string, Record<string, string>> = {};
+      const expected: Record<string, Record<string, string>> = {};
+      for (const [timeout, code] of invalidTimeouts) {
+        const key = `timeout: ${Bun.inspect(timeout)}`;
+        actual[key] = {};
+        expected[key] = {};
+        for (const [name, run] of Object.entries(entryPoints)) {
+          actual[key][name] = thrown(() => run({ timeout }));
+          expected[key][name] = `${code} options.timeout`;
+        }
+      }
+      expect(actual).toEqual(expected);
+    });
+
+    test("vm.runIn*Context() report constructor problems before an invalid timeout, like Node", () => {
+      const context = createContext({});
+      const options = (o: Record<string, unknown>) => o as any;
+      expect({
+        syntaxError: thrown(() => runInThisContext("%%", options({ timeout: "x" }))),
+        produceCachedData: thrown(() => runInThisContext("1", options({ timeout: "x", produceCachedData: "y" }))),
+        cachedData: thrown(() => runInNewContext("1", {}, options({ timeout: "x", cachedData: 1 }))),
+        importModuleDynamically: thrown(() =>
+          runInContext("1", context, options({ timeout: "x", importModuleDynamically: 1 })),
+        ),
+        // Among the run options, Node's getRunInContextArgs checks timeout first.
+        displayErrors: thrown(() => runInThisContext("1", options({ timeout: "x", displayErrors: 1 }))),
+        displayErrorsOnScript: thrown(() =>
+          new Script("1").runInThisContext(options({ timeout: "x", displayErrors: 1, breakOnSigint: 1 })),
+        ),
+      }).toEqual({
+        syntaxError: "SyntaxError",
+        produceCachedData: "ERR_INVALID_ARG_TYPE options.produceCachedData",
+        cachedData: "ERR_INVALID_ARG_TYPE options.cachedData",
+        importModuleDynamically: "ERR_INVALID_ARG_TYPE options.importModuleDynamically",
+        displayErrors: "ERR_INVALID_ARG_TYPE options.timeout",
+        displayErrorsOnScript: "ERR_INVALID_ARG_TYPE options.timeout",
+      });
+    });
+  });
+
   test("can specify displayErrors", () => {
     const src = 'throw new Error("boom")';
     // displayErrors: false — no source-line/caret decoration on the stack.


### PR DESCRIPTION
### Problem
- `new vm.Script("1", { timeout: "x" })` throws `ERR_INVALID_ARG_TYPE: The "options.timeout" property must be of type number`, and `{ timeout: 0 }` throws `ERR_OUT_OF_RANGE`. Node constructs the script in both cases: `timeout` is not a Script constructor option (lib/vm.js only reads filename, lineOffset, columnOffset, cachedData, produceCachedData, importModuleDynamically).
- The constructor also reads the property (a `timeout` getter runs); Node never touches it there.
- Because `vm.runInThisContext()` / `runInContext()` / `runInNewContext()` are `new Script(code, options).runIn*Context(..., options)`, a bad `timeout` was reported before anything the constructor finds. Node reports the constructor's problem first: `vm.runInThisContext("%%", { timeout: "x" })` is a SyntaxError in Node, `ERR_INVALID_ARG_TYPE options.timeout` in Bun; same for a bad `produceCachedData`, `cachedData` or `importModuleDynamically` alongside a bad `timeout`.
- Cause: `ScriptOptions::fromJS` (src/jsc/bindings/NodeVMScript.cpp:55) calls `validateTimeout()` into `ScriptOptions::timeout` (NodeVMScript.h:12), and nothing reads that field. The value that is actually used comes from `RunningScriptOptions::fromJS`, which each run method parses.

### Fix
- Drop the `validateTimeout()` call and the unused `ScriptOptions::timeout` field. `RunningScriptOptions` keeps validating `timeout` on every run entry point, so `script.runIn*Context({ timeout: "x" })` and the `vm.runIn*Context()` wrappers still throw; the wrappers now just do it after the constructor's checks, like Node.
- In `RunningScriptOptions::fromJS`, check `timeout` before `displayErrors` (the order of Node's `getRunInContextArgs`: timeout, displayErrors, breakOnSigint). Without this, removing the constructor check would have flipped `vm.runInThisContext(code, { timeout: "x", displayErrors: 1 })` from Node's answer (timeout) to displayErrors; with it, `script.runInThisContext({ timeout: "x", displayErrors: 1 })` matches Node too.
- Why this is right: matches Node (every expectation in the new tests was run against node v26.3.0 first).
- Verified: `test/js/node/vm/vm.test.ts` (new `describe("timeout is a run option, not a constructor option")`, 3 of its 4 tests fail on bun 1.4.0, all pass with this build; the whole file passes).
- Also ran against this build: `test/js/node/vm/` (only `script-leak.test.ts` fails, a 25s debug-build timeout unrelated to this change) and all `test/js/node/test/parallel/test-vm-*.js`, including `test-vm-options-validation.js`, `test-vm-api-handles-getter-errors.js` and `test-vm-timeout.js` (all exit 0).
- #38409 removes the contextName/contextOrigin block directly above the lines removed here; whichever lands second needs a trivial rebase of `ScriptOptions::fromJS`.

### Background
- `ScriptOptions` is the native parser for the options object of `new vm.Script(code, options)`; `RunningScriptOptions` is the parser for the options object of `Script#runInThisContext/runInContext/runInNewContext`. Node splits the same way: the Script constructor and `getRunInContextArgs()` in lib/vm.js.
- The `vm.runInThisContext()` / `runInContext()` / `runInNewContext()` functions (src/js/node/vm.ts) pass one options object to both the constructor and the run method, so which parser rejects a key first decides which error the user sees when several keys are invalid.
- `timeout` is applied per run (it arms the JSC watchdog around one evaluation), which is why only the run-side parser has any use for it.

<details>
<summary>Before / after, vs node v26.3.0</summary>

```
new Script("1", { timeout: "x" })                          node: ok          bun 1.4.0: ERR_INVALID_ARG_TYPE   fixed: ok
new Script("1", { timeout: 0 })                            node: ok          bun 1.4.0: ERR_OUT_OF_RANGE       fixed: ok
new Script("1", { get timeout() { throw } })               node: ok          bun 1.4.0: getter throws          fixed: ok
new Script("1").runInThisContext({ timeout: "x" })         node: ERR_INVALID_ARG_TYPE   bun 1.4.0: same        fixed: same
vm.runInThisContext("%%", { timeout: "x" })                node: SyntaxError            bun 1.4.0: ERR_INVALID_ARG_TYPE (timeout)   fixed: SyntaxError
vm.runInThisContext("1", { timeout: "x", produceCachedData: "y" })
                                                           node: produceCachedData      bun 1.4.0: timeout     fixed: produceCachedData
script.runInThisContext({ timeout: "x", displayErrors: 1 }) node: timeout               bun 1.4.0: displayErrors   fixed: timeout
```

Still different after this PR, handed off separately: the run-side upper bound is int64 max where Node's is 2**32 - 1, and the run methods validate filename/lineOffset/columnOffset, which Node's run methods ignore.
</details>
