### PR TITLE
sql(sqlite): honor options.url with adapter: "sqlite" and keep "?" in plain filenames

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1442,6 +1442,13 @@ function parseDefinitelySqliteUrl(value: string | URL | null): string | null {
   return null;
 }
 
+function hasSqliteProtocol(str: string): boolean {
+  for (const { prefix } of sqliteProtocols) {
+    if (str.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
 function parseSQLiteOptions(
   filenameOrUrl: string | URL | null | undefined,
   options: Bun.SQL.__internal.OptionsWithDefinedAdapter,
@@ -1453,24 +1460,16 @@ function parseSQLiteOptions(
     filename: ":memory:",
   };
 
-  let filename = filenameOrUrl || ":memory:";
-  let originalUrl = filename; // Keep the original URL for query parsing
-
-  if (filename instanceof URL) {
-    originalUrl = filename.toString();
-    filename = filename.toString();
-  }
+  let filename = filenameOrUrl instanceof URL ? filenameOrUrl.toString() : filenameOrUrl || ":memory:";
 
   let queryString: string | null = null;
-  // Parse query string from the original URL before processing
-  if (typeof originalUrl === "string") {
-    const queryIndex = originalUrl.indexOf("?");
+  // Only a URL carries a query string. A plain path is passed to SQLite as-is,
+  // so "what?.db" opens the file named "what?.db" just like bun:sqlite does.
+  if (filenameOrUrl instanceof URL || hasSqliteProtocol(filename)) {
+    const queryIndex = filename.indexOf("?");
     if (queryIndex !== -1) {
-      queryString = originalUrl.slice(queryIndex + 1);
-      // Strip query from filename for processing
-      if (typeof filename === "string") {
-        filename = filename.slice(0, queryIndex);
-      }
+      queryString = filename.slice(queryIndex + 1);
+      filename = filename.slice(0, queryIndex);
     }
   }
 
@@ -1623,21 +1622,17 @@ function parseConnectionDetailsFromOptionsOrEnvironment(
 
   let optionsFilename;
   let optionsUrl;
-  if (options.adapter === "sqlite") {
-    // SQLite adapter - only check filename (not url)
-    if ("filename" in options && (optionsFilename = options.filename)) {
-      resolvedUrl = optionsFilename;
-    }
-  } else if (!options.adapter) {
-    // Unknown adapter - check both, filename first (more specific)
-    if ("filename" in options && (optionsFilename = options.filename)) {
-      resolvedUrl = optionsFilename;
-    } else if ("url" in options && (optionsUrl = options.url)) {
+  if (options.adapter && options.adapter !== "sqlite") {
+    // Known non-SQLite adapter - only check url (not filename)
+    if ("url" in options && (optionsUrl = options.url)) {
       resolvedUrl = optionsUrl;
     }
   } else {
-    // Known non-SQLite adapter - only check url (not filename)
-    if ("url" in options && (optionsUrl = options.url)) {
+    // SQLite or unknown adapter - check both, filename first (more specific).
+    // { adapter: "sqlite", url } must open the same database that { url } alone does.
+    if ("filename" in options && (optionsFilename = options.filename)) {
+      resolvedUrl = optionsFilename;
+    } else if ("url" in options && (optionsUrl = options.url)) {
       resolvedUrl = optionsUrl;
     }
   }

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, SQL } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { isDebug, tempDir } from "harness";
+import { isDebug, isWindows, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -489,6 +489,40 @@ describe("Connection & Initialization", () => {
       await sql.close();
       await rm(dir, { recursive: true });
     });
+
+    // A plain path is not a URL, so a "?" in it belongs to the filename, the same as in bun:sqlite.
+    // Only sqlite:, file: and URL inputs carry a ?mode= query string.
+    test("should keep ? in a plain filename", async () => {
+      using dir = tempDir("question-mark-filename", {});
+      const dbPath = path.join(dir, "what?.db");
+
+      await using fromOptions = new SQL({ adapter: "sqlite", filename: dbPath });
+      await using fromArgument = new SQL(dbPath, { adapter: "sqlite" });
+
+      expect(fromOptions.options.filename).toBe(dbPath);
+      expect(fromArgument.options.filename).toBe(dbPath);
+    });
+
+    test.skipIf(isWindows)("should open the file named by a plain filename containing ?", async () => {
+      using dir = tempDir("question-mark-open", {});
+      const dbPath = path.join(dir, "what?.db");
+
+      {
+        await using sql = new SQL({ adapter: "sqlite", filename: dbPath });
+        await sql`CREATE TABLE test (id INTEGER)`;
+        await sql`INSERT INTO test VALUES (1)`;
+      }
+
+      expect(existsSync(dbPath)).toBe(true);
+      expect(existsSync(path.join(dir, "what"))).toBe(false);
+
+      // In URL form the "?" has to be percent-encoded, and the query string is still honored.
+      await using sql = new SQL({ adapter: "sqlite", filename: `${Bun.pathToFileURL(dbPath).href}?mode=ro` });
+      expect(sql.options.filename).toBe(dbPath);
+      expect(sql.options.readonly).toBe(true);
+      const rows = await sql`SELECT id FROM test`;
+      expect(rows).toEqual([{ id: 1 }]);
+    });
   });
 
   describe("Path Handling", () => {
@@ -681,6 +715,58 @@ describe("Connection & Initialization", () => {
 
       await sql.close();
       await rm(dir, { recursive: true });
+    });
+
+    test("should open options.url when adapter is sqlite", async () => {
+      using dir = tempDir("url-with-adapter", {});
+      const dbPath = path.join(dir, "url.db");
+      const options = { adapter: "sqlite" as const, url: `sqlite://${dbPath}` };
+
+      {
+        await using sql = new SQL(options);
+        expect(sql.options.filename).toBe(dbPath);
+        await sql`CREATE TABLE test (id INTEGER)`;
+        await sql`INSERT INTO test VALUES (1)`;
+      }
+
+      expect(existsSync(dbPath)).toBe(true);
+
+      await using sql = new SQL(options);
+      const rows = await sql`SELECT id FROM test`;
+      expect(rows).toEqual([{ id: 1 }]);
+    });
+
+    test("should accept the same url shapes with adapter: sqlite as without it", async () => {
+      using dir = tempDir("url-shapes-with-adapter", {});
+      const dbPath = path.join(dir, "shapes.db");
+
+      const urls = [`sqlite://${dbPath}`, Bun.pathToFileURL(dbPath), dbPath];
+      const filenames: unknown[] = [];
+      for (const url of urls) {
+        const options = { adapter: "sqlite" as const, url };
+        await using sql = new SQL(options);
+        filenames.push(sql.options.filename);
+      }
+      expect(filenames).toEqual([dbPath, dbPath, dbPath]);
+
+      const readonlyOptions = { adapter: "sqlite" as const, url: `sqlite://${dbPath}?mode=ro` };
+      await using readonly = new SQL(readonlyOptions);
+      expect(readonly.options.filename).toBe(dbPath);
+      expect(readonly.options.readonly).toBe(true);
+    });
+
+    test("should prefer options.filename over options.url", async () => {
+      using dir = tempDir("filename-over-url", {});
+      const filenamePath = path.join(dir, "filename.db");
+      const urlPath = path.join(dir, "url.db");
+
+      const options = { adapter: "sqlite" as const, filename: filenamePath, url: `sqlite://${urlPath}` };
+      await using sql = new SQL(options);
+      expect(sql.options.filename).toBe(filenamePath);
+
+      await sql`CREATE TABLE test (id INTEGER)`;
+      expect(existsSync(filenamePath)).toBe(true);
+      expect(existsSync(urlPath)).toBe(false);
     });
   });
 


### PR DESCRIPTION
### Problem
- `new SQL({ adapter: "sqlite", url: "sqlite://a.db" })` opens `:memory:` (`sql.options.filename === ":memory:"`), so everything written is gone at close and `a.db` is never created. The same object without `adapter`, and `{ adapter: "sqlite" }` plus `DATABASE_URL=sqlite://a.db`, both open `a.db`. A `URL` instance or a bare path in `url` is dropped the same way.
- Cause: `parseConnectionDetailsFromOptionsOrEnvironment` (src/js/internal/sql/shared.ts:1626) only reads `options.filename` when the adapter is sqlite, so `url` is never looked at and the filename falls through to the `:memory:` default.
- `new SQL({ adapter: "sqlite", filename: "what?.db" })` opens a file named `what` (`sql.options.filename === "what"`); `new SQL("what?.db", { adapter: "sqlite" })` does the same. `bun:sqlite`'s `new Database("what?.db")` opens `what?.db`.
- Cause: `parseSQLiteOptions` (shared.ts:1467) cuts every input at the first `?` to pull out `?mode=`, whether or not the input is a URL. Before #22260 only protocol-prefixed strings were cut.

### Fix
- The sqlite branch of the adapter check now resolves `filename`, then `url`, which is exactly what the adapter-less branch already did (the two branches are merged). Non-sqlite adapters are unchanged and still read only `url`. `filename` still wins when both are given, and `url` overrides the first constructor argument the same way it does for postgres/mysql/mariadb.
- `parseSQLiteOptions` only splits off a query string when the input is a `URL` instance or starts with `sqlite://`, `sqlite:`, `file://` or `file:`. Plain paths reach SQLite unchanged. `?mode=` handling for URL-shaped input is the same as before (the 28-case query matrix in sqlite-url-parsing.test.ts still passes).
- Types and docs are left as they are: `filename` stays the documented sqlite option; this change stops `url` from being silently discarded when it is passed anyway.
- Verified:
  - test/js/sql/sqlite-sql.test.ts: new tests `should open options.url when adapter is sqlite`, `should accept the same url shapes with adapter: sqlite as without it`, `should keep ? in a plain filename`, `should open the file named by a plain filename containing ?` (skipped on Windows, where `?` is not a legal filename character), plus `should prefer options.filename over options.url` pinning the precedence. The four fail on the released bun (`:memory:` / file not created) and pass with this change; the whole file passes (244).
  - test/js/sql/sqlite-url-parsing.test.ts, adapter-env-var-precedence.test.ts, adapter-override.test.ts: 272 pass.

### Background
- `Bun.SQL` accepts a connection string, a `URL`, or an options object, and `parseOptions` in shared.ts picks an adapter (postgres, mysql, mariadb or sqlite) and normalizes the input into that adapter's options. `parseConnectionDetailsFromOptionsOrEnvironment` decides which option (`filename`, `url`, the first argument, or an env var) is the connection target; `parseSQLiteOptions` then turns that target into a `bun:sqlite` filename plus `readonly`/`create` flags.
- For sqlite the target can be a URL (`sqlite://data.db?mode=ro`, `file:///data.db`) or a plain path (`./data.db`). Only the URL form has a query string; `?mode=ro|rw|rwc` maps onto the open flags. A plain path is handed to SQLite verbatim, and `?` is an ordinary character in a path.
- Related but separate: #38417 changes what `?mode=rw` maps to; it edits a different part of `parseSQLiteOptions`.

<details>
<summary>Before/after on the original report</summary>

```
// released bun 1.4.0
(a) { adapter: "sqlite", url: "sqlite://a.db" }        -> filename ":memory:"
(a) { adapter: "sqlite", url: new URL("sqlite://a.db") } -> filename ":memory:"
(a) { adapter: "sqlite", url: "a.db" }                 -> filename ":memory:"
(b) { adapter: "sqlite", filename: "what?.db" }        -> filename "what"
(b) new SQL("what?.db", { adapter: "sqlite" })         -> filename "what"

// with this change
(a) all three                                           -> filename "a.db", file created
(b) both                                                -> filename "what?.db", file created
{ url: "sqlite://d.db?mode=rwc" }                        -> "d.db", create: true   (unchanged)
{ adapter: "sqlite", filename: "sqlite://e.db?mode=ro" } -> "e.db", readonly: true (unchanged)
{ adapter: "sqlite", filename: "file:f.db?mode=ro" }     -> "f.db", readonly: true (unchanged)
{ adapter: "sqlite", filename: "g-file.db", url: "sqlite://g-url.db" } -> "g-file.db" (unchanged)
```

Not changed here: `{ filename: "./dev.db" }` with no adapter still resolves to postgres; `sqlite://` paths are still not percent-decoded and keep `#`, as the existing url-parsing tests require.
</details>
