### PR TITLE
compile: do not abort on import()/require() of a relative specifier longer than the path buffer

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -102,6 +102,18 @@ mod bun_paths {
             |P| ::bun_paths::resolve_path::join_abs_string_buf::<P>(cwd, buf, parts)
         )
     }
+    /// Like `join_abs_string_buf`, but returns `None` when the normalized
+    /// result does not fit in `buf`. Use it when `parts` may be arbitrarily long.
+    pub(super) fn join_abs_string_buf_checked<'b>(
+        cwd: &'b [u8],
+        buf: &'b mut [u8],
+        parts: &[&[u8]],
+        platform: Platform,
+    ) -> Option<&'b [u8]> {
+        dispatch_platform!(platform, |P| {
+            ::bun_paths::resolve_path::join_abs_string_buf_checked::<P>(cwd, buf, parts)
+        })
+    }
     pub(super) fn join_abs(cwd: &[u8], platform: Platform, part: &[u8]) -> &'static [u8] {
         // NOTE: `resolve_path::join_abs` ties the result lifetime to `cwd`, but the
         // returned slice always points into the threadlocal `PARSER_JOIN_INPUT_BUFFER`
@@ -1318,7 +1330,9 @@ impl<'a> Resolver<'a> {
                 ) {
                     if import_path.len() > 2 && is_dot_slash(&import_path[0..2]) {
                         let buf = bufs!(import_path_for_standalone_module_graph);
-                        let joined = bun_paths::join_abs_string_buf(
+                        // `import_path` comes from user code (`import()` / `require()`),
+                        // so it may not fit; a path that long is never in the graph.
+                        let joined = bun_paths::join_abs_string_buf_checked(
                             source_dir,
                             buf,
                             &[import_path],
@@ -1326,7 +1340,9 @@ impl<'a> Resolver<'a> {
                         );
 
                         // Support relative paths in the graph
-                        if let Some(file_name) = graph.find_assume_standalone_path(joined) {
+                        if let Some(file_name) =
+                            joined.and_then(|joined| graph.find_assume_standalone_path(joined))
+                        {
                             // Intern: trait borrows into the graph; `Path::init`
                             // needs `'static` (DirnameStore-backed).
                             let file_name = Fs::file_system::DirnameStore::instance()

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -785,6 +785,46 @@ describe("bundler", () => {
     },
     compile: true,
   });
+  // A "./" specifier imported at runtime from an embedded module is first
+  // joined onto /$bunfs/root/ and looked up in the standalone module graph.
+  // That join used to write into a fixed PATH_MAX-sized buffer unchecked, so a
+  // specifier longer than PATH_MAX (1024 on macOS, 4096 on Linux, 98302 on
+  // Windows) aborted the whole binary. Specifiers longer than 1.5x PATH_MAX are
+  // rejected before resolution even starts, so the lengths below sit between
+  // the two bounds. Both probes must report "not found" exactly like a
+  // non-compiled `bun run` does, and the graph must still serve a "./"
+  // specifier of normal length afterwards.
+  itBundled("compile/RelativeSpecifierLongerThanPathMax", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        const req = (x) => require(x);
+        const imp = (x) => import(x);
+        const len = process.platform === "win32" ? 100_000 : process.platform === "linux" ? 5000 : 1200;
+        const tooLong = "./" + Buffer.alloc(len, "w").toString();
+        const out = [];
+        try { req(tooLong); out.push("require resolved"); } catch (e) { out.push("require: " + e.code); }
+        try { await imp(tooLong); out.push("import resolved"); } catch (e) { out.push("import: " + e.code); }
+        out.push(req("./embedded-sibling.js").value);
+        out.push((await imp("./embedded-sibling.js")).value);
+        console.log(out.join("\\n"));
+      `,
+      "/embedded-sibling.ts": /* js */ `
+        export const value = "embedded sibling resolved from the graph";
+      `,
+    },
+    entryPointsRaw: ["./entry.ts", "./embedded-sibling.ts"],
+    outfile: "dist/out",
+    run: {
+      file: "dist/out",
+      stdout: [
+        "require: MODULE_NOT_FOUND",
+        "import: ERR_MODULE_NOT_FOUND",
+        "embedded sibling resolved from the graph",
+        "embedded sibling resolved from the graph",
+      ].join("\n"),
+    },
+  });
   for (const minify of [true, false] as const) {
     itBundled("compile/platform-specific-binary" + (minify ? "-minify" : ""), {
       minifySyntax: minify,


### PR DESCRIPTION
### Problem

- Inside a `bun build --compile` executable, `await import("./" + "w".repeat(5000))` or `require("./" + ...)` aborts the whole process: `panic: range end index 5012 out of range for slice of length 4095` (exit 134). The same file run with plain `bun` rejects with `Cannot find module`.
- Cause: when the importing module lives in the embedded filesystem, `Resolver::resolve_and_auto_install` (`src/resolver/resolver.rs:1321` on main) joins a `./` specifier onto the module's `/$bunfs/root/` directory with `join_abs_string_buf` into a fixed `PathBuffer` so it can look the result up in the standalone module graph. The join does not check that the normalized result fits, and the specifier is user input of any length up to the 1.5x `PATH_MAX` cap that `VirtualMachine::resolve` applies first (so on Linux every specifier between about 4083 and 6144 bytes aborts; the windows are 1024..1536 on macOS and 98302..147453 on Windows).

### Fix

- Join with `join_abs_string_buf_checked` and treat `None` like a graph miss, so resolution falls through to the regular resolver exactly as it does for any `./` specifier that is not embedded.
- This is correct because the graph lookup is a pure optimization for embedded files: every embedded name fits in a `PathBuffer` by construction, so a specifier whose joined form does not fit can never match, and skipping the lookup changes nothing for specifiers that do fit (`join_abs_string_buf_checked` calls the same `join_abs_string_buf` on that path). The fallthrough, `check_relative_path`, already uses the checked join against the cwd and returns `NotFound`, which is where plain `bun`'s `Cannot find module` comes from today, so the compiled binary now matches the non-compiled behavior (`MODULE_NOT_FOUND` / `ERR_MODULE_NOT_FOUND`).
- The checked variant is added to the resolver's existing value-dispatched `bun_paths` shim next to the unchecked one, which still has one other caller (tsconfig `extends`, lengths from a config file, not touched here).
- Verified:
  - `test/bundler/bundler_compile.test.ts`, `compile/RelativeSpecifierLongerThanPathMax`: a two-entry compiled binary tries `require()` and `import()` of an over-long `./` specifier (length picked per platform to land between `PATH_MAX` and the 1.5x cap), then requires and imports a sibling embedded module through the same `./` branch. Fails on the released build with `Runtime failed with SIGABRT` / the panic above; passes with this change.
  - `bun bd test test/bundler/bundler_compile.test.ts`: 68 pass, the 1 failure (`compile/HelloWorldWithProcessVersionsBun`) is a debug-build-only test bug already fixed in a separate PR.
  - `bun bd test test/js/bun/resolve/resolve-error.test.ts` (the existing long-specifier suite for non-compiled runs): 22 pass.
  - `cargo fmt --all -- --check` clean.

### Background

- Standalone module graph: the table of modules and assets embedded in a `bun build --compile` executable. They are addressed by virtual paths under `/$bunfs/root/` (`B:/~BUN/root/` on Windows); `is_bun_standalone_file_path` tests for that prefix.
- Relative specifiers from an embedded module: the resolver first joins them onto the embedded directory and checks the graph (this lets a second entry point be `require("./other.js")`'d at runtime). On a miss it resolves them against the process cwd instead, like any other import; `check_relative_path` is that fallthrough.
- `PathBuffer`: a fixed `MAX_PATH_BYTES` byte array (1024 on macOS, 4096 on Linux, 98302 on Windows). `join_abs_string_buf` normalizes into it with plain slice indexing; `join_abs_string_buf_checked` (already used by `check_relative_path`, `node:fs`, the install code) returns `None` instead when the normalized result would not fit.

<details>
<summary>Repro on the released build</summary>

```sh
cat > main.js <<'EOF'
const spec = "./" + "w".repeat(parseInt(process.env.N || "5000"));
try { if (process.env.MODE === "require") require(spec); else await import(spec); }
catch (e) { console.log("caught:", e.code); }
EOF
bun build --compile ./main.js --outfile ./app
N=5000 ./app                # panic: range end index 5012 out of range for slice of length 4095 (exit 134)
N=5000 MODE=require ./app   # same panic
N=200 ./app                 # caught: ERR_MODULE_NOT_FOUND
N=7000 ./app                # caught (ENAMETOOLONG from the 1.5x cap in VirtualMachine::resolve)
N=5000 bun main.js          # caught: ERR_MODULE_NOT_FOUND
```

Two neighboring overflows found while probing this are separate bugs and are tracked separately: the regular resolver's extension probe (`load_extension`) still overflows when cwd + specifier lands within a few bytes under `PATH_MAX`, in compiled and non-compiled runs alike; and on Windows the absolute `B:/~BUN/...` branch just above this one normalizes the specifier into a `PathBuffer` inside the graph lookup. The Worker constructor's own standalone join is fixed in #38422.
</details>
