### PR TITLE
bundler: shift source maps past the spliced HTML import manifest

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -921,13 +921,16 @@ impl IntermediateOutput {
                                         &mut cursor,
                                     )
                                     .expect("unreachable");
-                                    let pos = before_len - cursor.len();
-                                    remain = &mut remain[pos..];
+                                    let written = before_len - cursor.len();
 
                                     if ENABLE_SOURCE_MAP_SHIFTS {
+                                        // The placeholder was an HtmlImport unique key, which has
+                                        // the same UNIQUE_KEY_LEN as this chunk's own key.
                                         shift.before.advance(chunk.unique_key);
+                                        shift.after.advance(&remain[..written]);
                                         shifts.push(shift);
                                     }
+                                    remain = &mut remain[written..];
                                     continue;
                                 }
                                 _ => unreachable!(),

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { SourceMapConsumer } from "source-map";
 import { itBundled } from "./expectBundled";
 
 describe.concurrent("bundler", () => {
@@ -393,6 +394,64 @@ console.log("About manifest:", aboutHtml);
     expect(jsA.path).not.toBe(jsB.path);
     expect(htmlA.path).toBe(htmlB.path);
     expect(htmlA.headers.etag).not.toBe(htmlB.headers.etag);
+  });
+
+  // The manifest JSON is spliced into the chunk in place of a 25-byte
+  // placeholder after the source map was generated, so the map has to be
+  // shifted by the size difference. With whitespace minified, the rest of the
+  // chunk shares the manifest's line, so every mapping after it depends on
+  // that shift accounting for the full length of each spliced manifest.
+  test("html-import/source-map-columns-after-manifest", async () => {
+    const source = [
+      `import home from "./home.html";`,
+      `import about from "./about.html";`,
+      `function manifests() { return [home, about]; }`,
+      `console.log(manifests());`,
+      ``,
+    ].join("\n");
+    await using dir = tempDir("html-import-sourcemap", {
+      "server.ts": source,
+      "home.html": `<!doctype html><script type="module" src="./home.ts"></script>`,
+      "about.html": `<!doctype html><script type="module" src="./about.ts"></script>`,
+      "home.ts": `console.log("home");`,
+      "about.ts": `console.log("about");`,
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "server.ts")],
+      outdir: join(dir, "out"),
+      target: "bun",
+      sourcemap: "external",
+      minify: { whitespace: true },
+    });
+    expect(build.logs).toBeEmpty();
+
+    const generated = await build.outputs.find(o => o.path.endsWith("server.js"))!.text();
+    const map = await build.outputs.find(o => o.path.endsWith("server.js.map"))!.json();
+
+    // 1-based line, 0-based column, as `source-map` reports positions.
+    const lineColumn = (text: string, index: number) => {
+      expect(index).not.toBe(-1);
+      const before = text.slice(0, index);
+      return { line: before.split("\n").length, column: index - (before.lastIndexOf("\n") + 1) };
+    };
+
+    // Both manifests and the user code end up on one generated line.
+    const manifestLine = lineColumn(generated, generated.indexOf("__jsonParse(")).line;
+    expect(lineColumn(generated, generated.lastIndexOf("__jsonParse(")).line).toBe(manifestLine);
+    expect(lineColumn(generated, generated.indexOf("function manifests(")).line).toBe(manifestLine);
+
+    await SourceMapConsumer.with(map, null, consumer => {
+      const positions = ["function manifests(", "return[", "console.log("].map(token => {
+        const mapped = consumer.originalPositionFor(lineColumn(generated, generated.indexOf(token)));
+        return { token, source: mapped.source?.split(/[\\/]/).pop(), line: mapped.line, column: mapped.column };
+      });
+      expect(positions).toEqual([
+        { token: "function manifests(", source: "server.ts", ...lineColumn(source, source.indexOf("function ")) },
+        { token: "return[", source: "server.ts", ...lineColumn(source, source.indexOf("return ")) },
+        { token: "console.log(", source: "server.ts", ...lineColumn(source, source.indexOf("console.")) },
+      ]);
+    });
   });
 
   // Test that import with {type: 'file'} still works as a file import


### PR DESCRIPTION
### Problem
- In a server build that imports an HTML file (`import index from "./index.html"` with `--target=bun --sourcemap`), every source map mapping that follows the embedded manifest on the same generated line points `json.len()` columns too far left. With `--minify` (or `--minify-whitespace`) that is the rest of the chunk, so stack traces and debuggers for the whole entry point land on the wrong token.
- Chunk assembly (`IntermediateOutput::code_with_source_map_shifts`, `src/bundler/Chunk.rs`) replaces each 25-byte placeholder in the printed chunk and records a shift per substitution. The Chunk/Asset/Scb arms advance `shift.before` by the placeholder and `shift.after` by the bytes actually written. The HtmlImport arm (`src/bundler/Chunk.rs:913`) wrote the escaped manifest JSON into the buffer but only advanced `shift.before` before pushing the shift, so the recorded shift says the manifest is 0 bytes wide.
- The sizing pass (`src/bundler/Chunk.rs:752`) counts the JSON correctly, so the emitted code is fine; only the shift bookkeeping is off.

### Fix
- Advance `shift.after` by the bytes `write_escaped_json` just wrote before pushing the shift, mirroring the other substitution kinds.
- Correct because `shift.after` is by definition the position in the final output, and the manifest JSON is part of that output; `shift.before` was already being advanced by the right amount, since every unique key (the HtmlImport placeholder included) is `UNIQUE_KEY_LEN` bytes, which is what the existing `chunk.unique_key` advance measures. `LineColumnOffset::advance` is used rather than adding a byte count so the column math matches the rest of the shift code (UTF-16 units, and newlines should the payload ever contain them).
- Test: `test/bundler/html-import-manifest.test.ts` (`html-import/source-map-columns-after-manifest`) builds an entry point with two HTML imports and whitespace minification, then resolves the tokens after the manifests through the map back to the source. Fails on the current release (all three tokens resolve to `server.ts:4:23`), passes with this change.
- Also ran with the debug build: the rest of `html-import-manifest.test.ts`, the `EmitInvalidSourceMap*` cases in `bundler_edgecase.test.ts`, `bundler_html.test.ts`, `bundler_html_server.test.ts`, `bun-build-compile-sourcemap.test.ts`.

### Background
- Placeholders and pieces: the JS printer does not know final output paths or the manifest contents, so it prints a fixed 25-byte unique key where each of them goes, and the source map is generated against that placeholder text. `break_output_into_pieces` then splits the chunk at those keys, and chunk assembly writes the real content (a path, or here the manifest JSON) in their place.
- Source map shifts: each substitution changes the width of the line, so assembly records a `SourceMapShifts { before, after }` pair after each one, where `before` is the line/column reached in the placeholder version of the output and `after` is the line/column reached in the final output. `SourceMapPieces::finalize` re-encodes the generated column of every mapping using `after - before` of the latest shift preceding it, so a shift whose `after` is short by N bytes moves every later mapping on that line N columns left.
- HTML import manifest: for `import x from "./index.html"` in a `--target=bun` build, the bundler synthesizes a module whose body is `__jsonParse("<placeholder>")`, and at assembly the placeholder becomes the JSON-escaped manifest describing the browser build's output files. It is a single line of a few hundred bytes to many KB, which is the size of the drift.

<details>
<summary>Repro on the current release</summary>

```
index.html: <script src="./app.ts"></script>
server.ts:
  import index from "./index.html";
  function afterManifest() { return index; }
  console.log(afterManifest(), "MARKER");

$ bun build --target=bun --outdir=dist --sourcemap=external --minify server.ts
```

In `dist/server.js` the escaped manifest is 399 bytes, `function` starts at column 436 and `console.log` at column 458. `dist/server.js.map` maps `server.ts:2:0` to column 37 and `server.ts:3:0` to column 59, each exactly 399 columns short. The same build without the HTML import maps correctly, and an unminified build hides the bug because the user code lands on later lines.
</details>
