### PR TITLE
node:crypto: render prepareAsymmetricKey ERR_INVALID_ARG_TYPE lists like Node

### DIFF
--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -1788,7 +1788,7 @@ KeyObject::PrepareAsymmetricKeyResult KeyObject::prepareAsymmetricKey(JSC::JSGlo
 
     auto checkKeyObject = [globalObject, &scope, mode](const KeyObject& keyObject, JSValue keyValue) -> void {
         if (mode == PrepareAsymmetricKeyMode::CreatePrivate) {
-            ERR::INVALID_ARG_TYPE(scope, globalObject, "key"_s, "string, ArrayBuffer, Buffer, TypedArray, or DataView"_s, keyValue);
+            ERR::INVALID_ARG_TYPE(scope, globalObject, "key"_s, "string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView"_s, keyValue);
             return;
         }
 
@@ -1806,7 +1806,7 @@ KeyObject::PrepareAsymmetricKeyResult KeyObject::prepareAsymmetricKey(JSC::JSGlo
 
     auto checkCryptoKey = [globalObject, &scope, mode](const CryptoKey& cryptoKey, JSValue keyValue) -> void {
         if (mode == PrepareAsymmetricKeyMode::CreatePrivate) {
-            ERR::INVALID_ARG_TYPE(scope, globalObject, "key"_s, "string, ArrayBuffer, Buffer, TypedArray, or DataView"_s, keyValue);
+            ERR::INVALID_ARG_TYPE(scope, globalObject, "key"_s, "string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView"_s, keyValue);
             return;
         }
 
@@ -1938,7 +1938,7 @@ KeyObject::PrepareAsymmetricKeyResult KeyObject::prepareAsymmetricKey(JSC::JSGlo
             }
 
             if (!dynamicDowncast<JSArrayBufferView>(dataValue) && !dynamicDowncast<JSArrayBuffer>(dataValue)) {
-                ERR::INVALID_ARG_TYPE(scope, globalObject, "key.key"_s, "ArrayBuffer, Buffer, TypedArray, or DataView"_s, dataValue);
+                ERR::INVALID_ARG_INSTANCE(scope, globalObject, "key.key"_s, "ArrayBuffer, Buffer, TypedArray, or DataView"_s, dataValue);
                 return {};
             }
 

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -20,6 +20,7 @@ import {
   publicEncrypt,
   randomBytes,
   sign,
+  subtle,
   verify,
 } from "crypto";
 import fs from "fs";
@@ -142,6 +143,27 @@ describe("crypto.KeyObjects", () => {
     // should throw.
     const privateKey = createPrivateKey(privatePem);
     expect(() => createPrivateKey(privateKey)).toThrow();
+  });
+
+  test("createPrivateKey rejects KeyObject and CryptoKey input with Node's message", async () => {
+    // Node lists "string" (a type) and the rest (classes), so the message reads
+    // "of type string or an instance of ...".
+    const expected = (received: object) =>
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message:
+          'The "key" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. ' +
+          `Received an instance of ${received.constructor.name}`,
+      });
+
+    const { privateKey: cryptoKey } = (await subtle.generateKey("Ed25519", true, ["sign", "verify"])) as CryptoKeyPair;
+    expect(cryptoKey.constructor.name).toBe("CryptoKey");
+
+    for (const key of [createPrivateKey(privatePem), createPublicKey(privatePem), cryptoKey]) {
+      expect(() => createPrivateKey(key)).toThrow(expected(key));
+      expect(() => createPrivateKey({ key })).toThrow(expected(key));
+    }
   });
 
   test("basics should work", async () => {

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1158,6 +1158,37 @@ describe("KeyObject raw-public / raw-private / raw-seed formats", () => {
     ).toThrow(expect.objectContaining({ code: "ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS" }));
   });
 
+  // Node lists the accepted types as class names, so the message reads "an instance of", not "of type".
+  it("raw key import reports a non-buffer key.key with Node's message", () => {
+    const expected = received =>
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "key.key" property must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received ${received}`,
+      });
+    const ed25519 = { asymmetricKeyType: "ed25519" };
+
+    expect(() => crypto.createPrivateKey({ key: "abc", format: "raw-private", ...ed25519 })).toThrow(
+      expected("type string ('abc')"),
+    );
+    expect(() => crypto.createPrivateKey({ key: {}, format: "raw-seed", ...ed25519 })).toThrow(
+      expected("an instance of Object"),
+    );
+    expect(() => crypto.createPublicKey({ key: 123, format: "raw-public", ...ed25519 })).toThrow(
+      expected("type number (123)"),
+    );
+    expect(() => crypto.createPublicKey({ format: "raw-private", ...ed25519 })).toThrow(expected("undefined"));
+
+    // The same check runs when a raw key is passed to a consumer instead of createPublicKey/createPrivateKey.
+    const data = Buffer.from("data");
+    expect(() => crypto.sign(null, data, { key: "abc", format: "raw-private", ...ed25519 })).toThrow(
+      expected("type string ('abc')"),
+    );
+    expect(() => crypto.verify(null, data, { key: null, format: "raw-public", ...ed25519 }, Buffer.alloc(64))).toThrow(
+      expected("null"),
+    );
+  });
+
   it("publicEncrypt is not confused by a buffer detached from an oaepLabel getter", () => {
     const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
     const label = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);


### PR DESCRIPTION
### Problem
- `createPrivateKey({ key: "abc", format: "raw-private", asymmetricKeyType: "ed25519" })` (and the `raw-public` / `raw-seed` formats, through `createPublicKey`, `sign`, `verify`, ...) throws `ERR_INVALID_ARG_TYPE` with `The "key.key" property must be of type ArrayBuffer, Buffer, TypedArray, or DataView. Received type string ('abc')`.
- Node v26.3.0 throws `The "key.key" property must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received type string ('abc')`. Its `prepareAsymmetricKey` passes `['ArrayBuffer', 'Buffer', 'TypedArray', 'DataView']`, and a list made only of class names renders as "an instance of".
- Cause: the raw-* branch of `KeyObject::prepareAsymmetricKey` (`src/jsc/bindings/node/crypto/KeyObject.cpp:1941`) passes the already flattened list to `ERR::INVALID_ARG_TYPE`, whose single-string overload always prefixes "of type".
- Two lines up in the same function (`KeyObject.cpp:1791` and `:1809`), `createPrivateKey()` given a KeyObject or CryptoKey throws `must be of type string, ArrayBuffer, Buffer, TypedArray, or DataView`. Node's `validateAsymmetricKeyType` passes `['string', 'ArrayBuffer', 'Buffer', 'TypedArray', 'DataView']`, which renders as `must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView`.
- Only the wording differs. The error code, error class and the accepted inputs are the same as Node's.

### Fix
- The raw-* branch now throws through `ERR::INVALID_ARG_INSTANCE`, which renders "an instance of" and still picks "property" for the dotted `key.key` name. This is the helper `prepareSecretKey` already uses for the same list a few lines below.
- The two `CreatePrivate` sites pass the same `string or an instance of ...` text the other `prepareAsymmetricKey` rejections in this function already use.
- Why this is correct: matches Node. With the change, the messages for every raw-* format, every consumer (`createPublicKey`, `createPrivateKey`, `sign`, `verify`) and every rejected value shape (string, number, object, undefined, null, KeyObject, CryptoKey) are byte-identical to Node v26.3.0's; the one remaining difference is the constructor name in "Received an instance of KeyObject", which #37019 covers.
- Tests:
  - `test/js/node/crypto/node-crypto.test.js`: raw-private / raw-public / raw-seed through `createPrivateKey`, `createPublicKey`, `sign` and `verify`, asserting the full message for several rejected values.
  - `test/js/node/crypto/crypto.key-objects.test.ts`: `createPrivateKey()` given a private KeyObject, a public KeyObject and a CryptoKey, both directly and as `{ key }`, asserting the full message.
  - Both new tests fail on the current release with the old wording and pass with this change; both files pass in full.
  - Vendored `test-crypto-key-objects.js`, `test-crypto-keygen-raw.js`, `test-crypto-keygen-key-objects.js` and the two PQC key-object tests still pass.

### Background
- `ERR_INVALID_ARG_TYPE` in Node takes a list of expected types and groups it when rendering: primitive type names become "of type a or b", class names become "an instance of X, Y, or Z", and the two groups are joined with "or" (`lib/internal/errors.js`). The name gets "property" instead of "argument" when it contains a dot.
- Bun's native error helpers in `src/jsc/bindings/ErrorCode.cpp` take that list pre-rendered as one string: `ERR::INVALID_ARG_TYPE(name, types, value)` prefixes it with "of type", `ERR::INVALID_ARG_INSTANCE(name, classes, value)` prefixes it with "an instance of". Picking the wrong helper, or flattening a mixed list as plain commas, is what produced the wording differences here.
- `prepareAsymmetricKey` is the shared entry point that turns whatever the user passed as a key (string, buffer, KeyObject, CryptoKey, or an options object with `key`/`format`/...) into key material. `createPublicKey`, `createPrivateKey`, `sign`, `verify`, `privateEncrypt` and friends all go through it, which is why one site covers all of those callers.
