### PR TITLE
node:fs: match node's ERR_INVALID_ARG_VALUE message for an invalid encoding

### DIFF
--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -743,16 +743,22 @@ impl Encoding {
         Ok(Self::from(str.to_utf8().slice()))
     }
 
+    /// Node's `assertEncoding` (lib/internal/fs/utils.js):
+    /// `ERR_INVALID_ARG_VALUE('encoding', value, 'is invalid encoding')`.
     pub(crate) fn throw_encoding_error(
         global_object: &JSGlobalObject,
         value: JSValue,
     ) -> jsc::JsError {
+        let actual = match JSGlobalObject::inspect_for_error_message(global_object, value) {
+            Ok(actual) => actual,
+            Err(err) => return err,
+        };
         global_object
             .err(
                 jsc::ErrorCode::INVALID_ARG_VALUE,
                 format_args!(
-                    "encoding '{}' is an invalid encoding",
-                    value.fmt_string(global_object)
+                    "The argument 'encoding' is invalid encoding. Received {}",
+                    actual
                 ),
             )
             .throw()

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -171,6 +171,7 @@ describe("test-fs-assert-encoding-error", () => {
   const expectedError = expect.objectContaining({
     code: "ERR_INVALID_ARG_VALUE",
     name: "TypeError",
+    message: "The argument 'encoding' is invalid encoding. Received 'test'",
   });
 
   it("readFile throws on invalid encoding", () => {
@@ -273,6 +274,83 @@ describe("test-fs-assert-encoding-error", () => {
     expect(() => {
       fs.WriteStream(testPath, options);
     }).toThrow(expectedError);
+  });
+});
+
+describe("invalid encoding error renders the received value like node", () => {
+  const testPath = join(tmpdirSync(), "assert-encoding-received");
+  const invalidEncoding = (received: string) =>
+    expect.objectContaining({
+      code: "ERR_INVALID_ARG_VALUE",
+      name: "TypeError",
+      message: `The argument 'encoding' is invalid encoding. Received ${received}`,
+    });
+
+  // [how node's util.inspect renders the value, the value passed as options.encoding]
+  const values: [string, unknown][] = [
+    ["'nope'", "nope"],
+    [`"it's"`, "it's"],
+    ["[ 1 ]", [1]],
+    ["{ a: 1 }", { a: 1 }],
+    ["1", 1],
+    ["true", true],
+    ["10n", 10n],
+    ["Symbol(nope)", Symbol("nope")],
+  ];
+
+  it.each(values)("readFileSync(path, { encoding: %s })", (received, encoding) => {
+    expect(() => fs.readFileSync(testPath, { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it.each(values)("fs.promises.readFile(path, { encoding: %s })", async (received, encoding) => {
+    await expect(promises.readFile(testPath, { encoding } as any)).rejects.toThrow(invalidEncoding(received));
+  });
+
+  const encoding = [1];
+  const received = "[ 1 ]";
+
+  it("readFile callback form", () => {
+    expect(() => fs.readFile(testPath, { encoding } as any, () => {})).toThrow(invalidEncoding(received));
+  });
+
+  it("writeFileSync", () => {
+    expect(() => fs.writeFileSync(testPath, "data", { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("appendFileSync", () => {
+    expect(() => fs.appendFileSync(testPath, "data", { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("readdirSync", () => {
+    expect(() => fs.readdirSync(testPath, { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("readlinkSync", () => {
+    expect(() => fs.readlinkSync(testPath, { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("realpathSync", () => {
+    expect(() => fs.realpathSync(testPath, { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("realpathSync.native", () => {
+    expect(() => fs.realpathSync.native(testPath, { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("mkdtempSync", () => {
+    expect(() => fs.mkdtempSync(testPath, { encoding } as any)).toThrow(invalidEncoding(received));
+  });
+
+  it("watch", () => {
+    expect(() => fs.watch(testPath, { encoding } as any, () => {})).toThrow(invalidEncoding(received));
+  });
+
+  it("fs.promises.readdir", async () => {
+    await expect(promises.readdir(testPath, { encoding } as any)).rejects.toThrow(invalidEncoding(received));
+  });
+
+  it("fs.promises.mkdtemp", async () => {
+    await expect(promises.mkdtemp(testPath, { encoding } as any)).rejects.toThrow(invalidEncoding(received));
   });
 });
 


### PR DESCRIPTION
### Problem
- The native `node:fs` entry points reject an unknown encoding with the right code (`ERR_INVALID_ARG_VALUE`) but not node's message. `fs.readFileSync(file, { encoding: "nope" })` throws `encoding 'nope' is an invalid encoding`; node v26.3.0 throws `The argument 'encoding' is invalid encoding. Received 'nope'`.
- The received value is rendered with `toString()` instead of `util.inspect`: `{ encoding: ["a"] }` reports `encoding 'a'`, `{ encoding: { a: 1 } }` reports `encoding '[object Object]'`, and `{ encoding: Symbol("x") }` throws a plain `TypeError: Cannot convert a symbol to a string` with no `code` at all.
- Cause: `Encoding::throw_encoding_error` (`src/runtime/node/types.rs:746`) builds its own message around `value.fmt_string()`. Every native encoding check goes through it: `readFile`, `writeFile`, `appendFile`, `readdir`, `readlink`, `realpath`, `mkdtemp`, `fs.watch`, and their sync, callback and `fs.promises` forms (`Encoding::assert` in `node_fs.rs` and `node_fs_watcher.rs`, plus `jsAssertEncodingValid` used by the Windows `realpath` port). The JS-side checks (`opendir`, `createReadStream`, `createWriteStream`) already use `$ERR_INVALID_ARG_VALUE("encoding", value, "is invalid encoding")` and match node.

### Fix
- `throw_encoding_error` now uses node's wording and renders the value with `JSGlobalObject::inspect_for_error_message`, the same helper the `flags` and `mode` errors in this file already use.
- Matches node: the text is what `assertEncoding` in `lib/internal/fs/utils.js` produces (`ERR_INVALID_ARG_VALUE('encoding', value, 'is invalid encoding')`), and `inspect_for_error_message` is the formatter behind Bun's other `ERR_INVALID_ARG_VALUE` messages, so the `Received` part is rendered the same way as the rest of them (strings quoted like inspect, arrays and objects inline, symbols as `Symbol(x)`). The code, error type, which values are accepted, and throw-vs-reject behaviour are unchanged.
- Test: `test/js/node/fs/fs.test.ts`. The existing `test-fs-assert-encoding-error` block now asserts the message for all 17 entry points, and a new block checks the rendering of non-string values (`[ 1 ]`, `{ a: 1 }`, `1`, `true`, `10n`, `Symbol(nope)`, a string containing a quote) through `readFileSync` and `fs.promises.readFile`, plus an array value through each other native entry point. 42 of the assertions fail on the unfixed build, all pass with the fix; the whole file passes (538 pass, 6 skip).
- Also run: `test/js/node/test/parallel/test-fs-assert-encoding-error.js` and `test-fs-internal-assertencoding.js` pass; the repro below runs clean under `BUN_JSC_validateExceptionChecks=1`.
- Not changed, tracked separately: strings nested inside an array or object still render with double quotes (`[ "a" ]`, node prints `[ 'a' ]`) and values longer than 128 characters are not cut (#38402 adds the cut inside `inspect_for_error_message`, so this path picks it up). `fs.write(fd, string, position, encoding)` keeps rejecting an unknown encoding (node silently writes utf8 there); only its message changes.

### Background
- `ERR_INVALID_ARG_VALUE` messages in node have the shape `The argument '<name>' <reason>. Received <value>`, where `<value>` is `util.inspect(value)`.
- Bun has one formatter for that `<value>` part, `JSValueToStringSafe(..., quotesLikeInspect)` in `src/jsc/bindings/ErrorCode.cpp`. C++ reaches it through the `Bun::ERR::INVALID_ARG_VALUE` overloads, JS builtins through `$ERR_INVALID_ARG_VALUE`, and Rust through `JSGlobalObject::inspect_for_error_message`, which wraps `Bun__ErrorCode__inspectForErrorMessage`.
- `Encoding::assert` is the Rust counterpart of node's `assertEncoding`: falsy values mean "use the default", anything else must name a known encoding, otherwise `throw_encoding_error` is called with the original JS value.

<details>
<summary>node v26.3.0 vs this branch across 43 fs calls</summary>

Probe: every sync, callback and promise form of readFile, writeFile, appendFile, readdir, readlink, realpath, realpathSync.native, mkdtemp, opendir, watch, createReadStream, createWriteStream and write with an invalid encoding, printing `code` and `message`. Before the change 37 of the 43 lines differed; after it the only differences are:

```
readFileSync array    node: Received [ 'a' ]        bun: Received [ "a" ]          (nested quote style, shared renderer)
readFileSync long     node: cuts at 128 chars + ... bun: full value                (#38402)
writeSync string      node: no throw                bun: ERR_INVALID_ARG_VALUE     (pre-existing, message text only changed)
```

</details>
