### PR TITLE
process: validate cpuUsage()/threadCpuUsage() prevValue in Node's order

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3823,6 +3823,62 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionResourceUsage, (JSC::JSGlobalObject * g
     return JSValue::encode(result);
 }
 
+// Results of cpuUsage()/threadCpuUsage() share cpuUsageStructure: user is at
+// offset 0 and system at offset 1.
+static JSValue getPrevCpuUsageField(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSC::JSObject* prevValue, Structure* cpuUsageStructure, PropertyOffset offset, ASCIILiteral name)
+{
+    JSValue value;
+    if (prevValue->structureID() == cpuUsageStructure->id()) [[likely]] {
+        value = prevValue->getDirect(offset);
+    } else {
+        value = prevValue->getIfPropertyExists(globalObject, JSC::Identifier::fromString(JSC::getVM(globalObject), name));
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    return value.isEmpty() ? jsUndefined() : value;
+}
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L209-L213
+static bool isValidPrevCpuUsageField(JSValue value)
+{
+    return value.isNumber() && value.asNumber() >= 0 && value.asNumber() <= JSC::maxSafeInteger();
+}
+
+// Same check order as Node: prevValue.user is read before prevValue itself is
+// validated, so an array or function is only rejected as "prevValue" when its
+// user field is unusable, and system is not read until user has passed.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L129-L143
+static void getPrevCpuUsage(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject, JSValue prevValue, Structure* cpuUsageStructure, double* user, double* system)
+{
+    JSC::JSObject* prevObject = prevValue.getObject();
+    if (!prevObject) [[unlikely]] {
+        Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "prevValue"_s, "object"_s, prevValue);
+        return;
+    }
+
+    JSValue userValue = getPrevCpuUsageField(throwScope, globalObject, prevObject, cpuUsageStructure, 0, "user"_s);
+    RETURN_IF_EXCEPTION(throwScope, );
+    if (!isValidPrevCpuUsageField(userValue)) [[unlikely]] {
+        Bun::V::validateObject(throwScope, globalObject, prevValue, "prevValue"_s);
+        RETURN_IF_EXCEPTION(throwScope, );
+        Bun::V::validateNumber(throwScope, globalObject, userValue, "prevValue.user"_s, jsUndefined(), jsUndefined());
+        RETURN_IF_EXCEPTION(throwScope, );
+        Bun::ERR::INVALID_ARG_VALUE_RangeError(throwScope, globalObject, "prevValue.user"_s, userValue);
+        return;
+    }
+
+    JSValue systemValue = getPrevCpuUsageField(throwScope, globalObject, prevObject, cpuUsageStructure, 1, "system"_s);
+    RETURN_IF_EXCEPTION(throwScope, );
+    if (!isValidPrevCpuUsageField(systemValue)) [[unlikely]] {
+        Bun::V::validateNumber(throwScope, globalObject, systemValue, "prevValue.system"_s, jsUndefined(), jsUndefined());
+        RETURN_IF_EXCEPTION(throwScope, );
+        Bun::ERR::INVALID_ARG_VALUE_RangeError(throwScope, globalObject, "prevValue.system"_s, systemValue);
+        return;
+    }
+
+    *user = userValue.asNumber();
+    *system = systemValue.asNumber();
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionCpuUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -3852,45 +3908,10 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionCpuUsage, (JSC::JSGlobalObject * global
     if (callFrame->argumentCount() > 0) {
         JSValue comparatorValue = callFrame->argument(0);
         if (!comparatorValue.isUndefined()) {
-            JSC::JSObject* comparator = comparatorValue.getObject();
-            if (!comparator) [[unlikely]] {
-                return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "prevValue"_s, "object"_s, comparatorValue);
-            }
-
-            JSValue userValue;
-            JSValue systemValue;
-
-            if (comparator->structureID() == cpuUsageStructure->id()) [[likely]] {
-                userValue = comparator->getDirect(0);
-                systemValue = comparator->getDirect(1);
-            } else {
-                userValue = comparator->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "user"_s));
-                RETURN_IF_EXCEPTION(throwScope, {});
-                if (userValue.isEmpty()) userValue = jsUndefined();
-
-                systemValue = comparator->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "system"_s));
-                RETURN_IF_EXCEPTION(throwScope, {});
-                if (systemValue.isEmpty()) systemValue = jsUndefined();
-            }
-
-            Bun::V::validateNumber(throwScope, globalObject, userValue, "prevValue.user"_s, jsUndefined(), jsUndefined());
+            double userComparator = 0;
+            double systemComparator = 0;
+            getPrevCpuUsage(throwScope, globalObject, comparatorValue, cpuUsageStructure, &userComparator, &systemComparator);
             RETURN_IF_EXCEPTION(throwScope, {});
-
-            Bun::V::validateNumber(throwScope, globalObject, systemValue, "prevValue.system"_s, jsUndefined(), jsUndefined());
-            RETURN_IF_EXCEPTION(throwScope, {});
-
-            double userComparator = userValue.toNumber(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            double systemComparator = systemValue.toNumber(globalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-
-            if (!(userComparator >= 0 && userComparator <= JSC::maxSafeInteger())) {
-                return Bun::ERR::INVALID_ARG_VALUE_RangeError(throwScope, globalObject, "prevValue.user"_s, userValue, "is invalid"_s);
-            }
-
-            if (!(systemComparator >= 0 && systemComparator <= JSC::maxSafeInteger())) {
-                return Bun::ERR::INVALID_ARG_VALUE_RangeError(throwScope, globalObject, "prevValue.system"_s, systemValue, "is invalid"_s);
-            }
 
             user -= userComparator;
             system -= systemComparator;
@@ -3911,33 +3932,15 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionThreadCpuUsage, (JSC::JSGlobalObject * 
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
+    auto* process = getProcessObject(globalObject, callFrame->thisValue());
+    Structure* cpuUsageStructure = process->cpuUsageStructure();
+
     double userComparator = 0;
     double systemComparator = 0;
     JSValue prevValue = callFrame->argument(0);
     if (!prevValue.isUndefined()) {
-        Bun::V::validateObject(throwScope, globalObject, prevValue, "prevValue"_s);
+        getPrevCpuUsage(throwScope, globalObject, prevValue, cpuUsageStructure, &userComparator, &systemComparator);
         RETURN_IF_EXCEPTION(throwScope, {});
-        JSC::JSObject* comparator = prevValue.getObject();
-
-        JSValue userValue = comparator->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "user"_s));
-        RETURN_IF_EXCEPTION(throwScope, {});
-        if (userValue.isEmpty()) userValue = jsUndefined();
-        JSValue systemValue = comparator->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "system"_s));
-        RETURN_IF_EXCEPTION(throwScope, {});
-        if (systemValue.isEmpty()) systemValue = jsUndefined();
-
-        if (!(userValue.isNumber() && userValue.asNumber() >= 0 && userValue.asNumber() <= JSC::maxSafeInteger())) {
-            if (!userValue.isNumber())
-                return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "prevValue.user"_s, "number"_s, userValue);
-            return Bun::ERR::INVALID_ARG_VALUE_RangeError(throwScope, globalObject, "prevValue.user"_s, userValue, "is invalid"_s);
-        }
-        if (!(systemValue.isNumber() && systemValue.asNumber() >= 0 && systemValue.asNumber() <= JSC::maxSafeInteger())) {
-            if (!systemValue.isNumber())
-                return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "prevValue.system"_s, "number"_s, systemValue);
-            return Bun::ERR::INVALID_ARG_VALUE_RangeError(throwScope, globalObject, "prevValue.system"_s, systemValue, "is invalid"_s);
-        }
-        userComparator = userValue.asNumber();
-        systemComparator = systemValue.asNumber();
     }
 
     double user = 0;
@@ -3979,8 +3982,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionThreadCpuUsage, (JSC::JSGlobalObject * 
     user -= userComparator;
     system -= systemComparator;
 
-    auto* process = getProcessObject(globalObject, callFrame->thisValue());
-    Structure* cpuUsageStructure = process->cpuUsageStructure();
     JSC::JSObject* result = JSC::constructEmptyObject(vm, cpuUsageStructure);
     RETURN_IF_EXCEPTION(throwScope, {});
     result->putDirectOffset(vm, 0, JSC::jsNumber(user));

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1088,6 +1088,133 @@ describe.concurrent(() => {
     });
   });
 
+  // Node (lib/internal/process/per_thread.js) reads prevValue.user first and only
+  // runs validateObject(prevValue), which is what rejects arrays and functions, when
+  // user is not a valid number. prevValue.system is only read once user passed.
+  describe.each(["cpuUsage", "threadCpuUsage"])("process.%s prevValue check order", name => {
+    const prevValueTypeError = received =>
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "prevValue" argument must be of type object. ${received}`,
+      });
+
+    it.each([
+      ["[]", () => [], "Received an instance of Array"],
+      ["() => {}", () => () => {}, "Received function "],
+      ["function named() {}", () => function named() {}, "Received function named"],
+      [
+        "array with non-number user",
+        () => Object.assign([], { user: "x", system: 1 }),
+        "Received an instance of Array",
+      ],
+      ["function with negative user", () => Object.assign(() => {}, { user: -1, system: 1 }), "Received function "],
+      ["array with NaN user", () => Object.assign([], { user: NaN, system: 1 }), "Received an instance of Array"],
+      ["Proxy of an array", () => new Proxy([], {}), "Received an instance of Array"],
+    ])("rejects %s as prevValue, not prevValue.user", (_, makePrevValue, received) => {
+      expect(() => process[name](makePrevValue())).toThrow(prevValueTypeError(received));
+    });
+
+    it.each([
+      ["array", () => Object.assign([], { user: Number.MAX_SAFE_INTEGER, system: Number.MAX_SAFE_INTEGER })],
+      ["function", () => Object.assign(() => {}, { user: Number.MAX_SAFE_INTEGER, system: Number.MAX_SAFE_INTEGER })],
+      [
+        "Proxy of an array",
+        () => new Proxy(Object.assign([], { user: Number.MAX_SAFE_INTEGER, system: Number.MAX_SAFE_INTEGER }), {}),
+      ],
+    ])("accepts %s carrying valid user and system", (_, makePrevValue) => {
+      const usage = process[name](makePrevValue());
+      expect(usage).toEqual({ user: expect.any(Number), system: expect.any(Number) });
+      // Negative results prove the fields were subtracted rather than ignored.
+      expect(usage.user).toBeLessThan(0);
+      expect(usage.system).toBeLessThan(0);
+    });
+
+    it.each([
+      [
+        "array without system",
+        () => Object.assign([], { user: 1 }),
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        'The "prevValue.system" property must be of type number. Received undefined',
+      ],
+      [
+        "function with non-number system",
+        () => Object.assign(() => {}, { user: 1, system: "x" }),
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        `The "prevValue.system" property must be of type number. Received type string ('x')`,
+      ],
+      [
+        "array with negative system",
+        () => Object.assign([], { user: 1, system: -1 }),
+        "RangeError",
+        "ERR_INVALID_ARG_VALUE",
+        "The property 'prevValue.system' is invalid. Received -1",
+      ],
+    ])("reports prevValue.system for %s once user is valid", (_, makePrevValue, errorName, code, message) => {
+      expect(() => process[name](makePrevValue())).toThrow(expect.objectContaining({ name: errorName, code, message }));
+    });
+
+    it("reads user before validating prevValue itself", () => {
+      const prevValue = Object.defineProperty([], "user", {
+        get() {
+          throw new Error("user getter");
+        },
+      });
+      expect(() => process[name](prevValue)).toThrow(new Error("user getter"));
+    });
+
+    it.each([
+      [
+        "non-number",
+        "x",
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        `The "prevValue.user" property must be of type number. Received type string ('x')`,
+      ],
+      ["negative", -1, "RangeError", "ERR_INVALID_ARG_VALUE", "The property 'prevValue.user' is invalid. Received -1"],
+    ])("does not read system when user is %s", (_, user, errorName, code, message) => {
+      let systemReads = 0;
+      const prevValue = {
+        user,
+        get system() {
+          systemReads++;
+          return 0;
+        },
+      };
+      expect(() => process[name](prevValue)).toThrow(expect.objectContaining({ name: errorName, code, message }));
+      expect(systemReads).toBe(0);
+    });
+
+    it.each([
+      ["cpuUsage", () => process.cpuUsage()],
+      ["threadCpuUsage", () => process.threadCpuUsage()],
+    ])("still validates the fields of a %s() result", (_, makePrevValue) => {
+      const negativeUser = makePrevValue();
+      negativeUser.user = -1;
+      expect(() => process[name](negativeUser)).toThrow(
+        expect.objectContaining({
+          name: "RangeError",
+          code: "ERR_INVALID_ARG_VALUE",
+          message: "The property 'prevValue.user' is invalid. Received -1",
+        }),
+      );
+
+      const stringSystem = makePrevValue();
+      stringSystem.system = "x";
+      expect(() => process[name](stringSystem)).toThrow(
+        expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "prevValue.system" property must be of type number. Received type string ('x')`,
+        }),
+      );
+
+      expect(process[name](makePrevValue())).toEqual({ user: expect.any(Number), system: expect.any(Number) });
+    });
+  });
+
   if (process.platform !== "win32") {
     it("process.getegid", () => {
       expect(typeof process.getegid()).toBe("number");


### PR DESCRIPTION
### Problem
- `process.cpuUsage([])` and `process.cpuUsage(() => {})` throw `ERR_INVALID_ARG_TYPE` for `"prevValue.user"` (`Received undefined`); Node throws it for `"prevValue"` (`Received an instance of Array` / `Received function `).
- `process.threadCpuUsage(prev)` throws `ERR_INVALID_ARG_TYPE` for `"prevValue"` when `prev` is an array or function that does carry valid `user` and `system` fields; Node returns the diff. When such a value has a valid `user` but a bad `system`, Node reports `"prevValue.system"` and Bun still reports `"prevValue"`.
- Both functions read `prevValue.system` before validating `user`, so `{ user: "x", get system() { throw e } }` throws `e` in Bun and the `"prevValue.user"` error in Node.
- Cause: `Process_functionCpuUsage` and `Process_functionThreadCpuUsage` (`src/jsc/bindings/BunProcess.cpp`) each had their own copy of the checks. `cpuUsage` gated on `getObject()` (which accepts arrays and functions) and then validated the fields; `threadCpuUsage` ran `validateObject` (which rejects arrays and functions) before looking at the fields. Node does neither: it reads `user` first and only runs `validateObject` when `user` is not a valid number ([per_thread.js#L129-L143](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/per_thread.js#L129-L143), same code in both functions).

### Fix
- Replace the two copies with one helper, `getPrevCpuUsage`, that follows Node's sequence: read `user`; if it is not a valid number, `validateObject(prevValue)`, then `validateNumber(user)`, then the `ERR_INVALID_ARG_VALUE` RangeError; only then read `system` and apply the same number checks to it. The valid-number predicate is Node's `previousValueIsValid` (`typeof === "number"`, `>= 0`, `<= MAX_SAFE_INTEGER`).
- This is correct because it makes both functions evaluate the same checks in the same order as Node, so which error wins for any `prevValue` (array, function, plain object, throwing getter) is decided the same way. Truthy primitives short-circuit to the `"prevValue"` type error before the read, which is the same error Node's `validateObject` produces for them.
- The `if (prevValue is undefined)` gates are untouched; #38398 changes those to Node's truthiness test and the two changes are independent (they will need a trivial rebase against each other).
- The fast path that reads `user`/`system` straight out of objects created with `cpuUsageStructure` is kept and now also applies to `threadCpuUsage()`, whose result objects use the same structure.
- Test: `test/js/node/process/process.test.js`, new `describe.each(["cpuUsage", "threadCpuUsage"])("process.%s prevValue check order")` block. On the unfixed build 18 of its 36 cases fail (the `"prevValue"` and system-not-read cases for `cpuUsage`, the accept / `"prevValue.system"` / user-read-first / system-not-read cases for `threadCpuUsage`); all pass with this change. Every asserted message was taken from Node v26.3.0 output.
- Also run with this change: the whole `process.test.js` (201 pass), the upstream `test-process-cpuUsage.js`, `test-process-threadCpuUsage-main-thread.js` (asserts `threadCpuUsage([])` still reports `"prevValue"`), `test-process-threadCpuUsage-worker-threads.js` and `test-worker-cpu-usage.js` (all exit 0), and the matrix below under `BUN_JSC_validateExceptionChecks=1`.

### Background
- `prevValue` is the optional previous reading passed to `process.cpuUsage()` / `process.threadCpuUsage()`; when present the functions return the difference between the current reading and its `user` / `system` fields (microseconds).
- Node implements both functions in JS; the validation is the literal sequence of property reads and validator calls in `per_thread.js`, and that sequence is observable through which error is thrown and which getters run. Bun implements them as C++ host functions, so matching Node means performing the same reads and checks in the same order.
- `validateObject` (Node's `lib/internal/validators.js`, Bun's `Bun::V::validateObject` in `NodeValidator.cpp`) rejects `null`, arrays and functions as well as non-objects. `validateNumber` without bounds only rejects non-numbers; the range part of the check is the separate `ERR_INVALID_ARG_VALUE` RangeError.
- `cpuUsageStructure` is the JSC Structure (property layout) that both functions use for the objects they return, with `user` at inline offset 0 and `system` at offset 1; an incoming object with that exact structure can be read by offset without a property lookup.

<details>
<summary>Repro: Node v26.3.0 vs Bun 1.4.0 vs this branch</summary>

```js
const fnWithProps = Object.assign(() => {}, { user: 1, system: 1 });
const arrWithProps = Object.assign([], { user: 1, system: 1 });
for (const name of ["cpuUsage", "threadCpuUsage"]) {
  for (const prev of [[], () => {}, arrWithProps, fnWithProps, Object.assign([], { user: 1, system: "x" }),
                      { user: "x", get system() { throw new Error("system getter"); } }]) {
    try { process[name](prev); console.log(name, "ok"); }
    catch (e) { console.log(name, e.code ?? e.name, e.message); }
  }
}
```

Node v26.3.0 and this branch print, for each function:

```
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received an instance of Array
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received function 
ok
ok
ERR_INVALID_ARG_TYPE The "prevValue.system" property must be of type number. Received type string ('x')
ERR_INVALID_ARG_TYPE The "prevValue.user" property must be of type number. Received type string ('x')
```

Bun 1.4.0, `cpuUsage`:

```
ERR_INVALID_ARG_TYPE The "prevValue.user" property must be of type number. Received undefined
ERR_INVALID_ARG_TYPE The "prevValue.user" property must be of type number. Received undefined
ok
ok
ERR_INVALID_ARG_TYPE The "prevValue.system" property must be of type number. Received type string ('x')
Error system getter
```

Bun 1.4.0, `threadCpuUsage`:

```
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received an instance of Array
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received function 
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received an instance of Array
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received function 
ERR_INVALID_ARG_TYPE The "prevValue" argument must be of type object. Received an instance of Array
Error system getter
```

A wider 49-input matrix per function (primitives, plain objects with every invalid field combination, NaN / Infinity / MAX_SAFE_INTEGER boundaries, -0, Proxies, throwing getters, mutated result objects) produces byte-identical output under Node v26.3.0 and this branch, except for the engine's own TypeError wording when `prevValue` is a revoked Proxy (both now fail at the same step, the `user` read). Bun 1.4.0 differs from Node on 26 of those 98 lines.
</details>
