### PR TITLE
node errors: quote and escape ERR_INVALID_ARG_VALUE string values like util.inspect

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -16,6 +16,7 @@
 #include "JavaScriptCore/JSType.h"
 #include "JavaScriptCore/Symbol.h"
 #include "wtf/Assertions.h"
+#include "wtf/HexNumber.h"
 #include "wtf/Vector.h"
 #include "wtf/text/ASCIIFastPath.h"
 #include "wtf/text/ASCIILiteral.h"
@@ -264,8 +265,6 @@ JSObject* createError(Zig::JSGlobalObject* globalObject, ErrorCode code, JSC::JS
 // on one line ("Received { abc: 123 }") the way Node does.
 extern "C" BunString Bun__inspect_singleline(JSC::JSGlobalObject* globalObject, JSValue value);
 
-// util.inspect's quoted-string escaping (https://github.com/nodejs/node/blob/main/lib/internal/util/inspect.js
-// strEscape). Bun.inspect double-quotes; Node's messages use single quotes.
 template<typename CharType>
 static void appendEscapedQuotedChar(WTF::StringBuilder& builder, CharType c, char quote)
 {
@@ -295,16 +294,54 @@ static void appendEscapedQuotedChar(WTF::StringBuilder& builder, CharType c, cha
             return;
         }
         // Node escapes C0 (0x00-0x1F), DEL, and the C1 range (0x80-0x9F);
-        // its meta table runs through index 0x9F.
+        // its meta table runs through index 0x9F and spells the hex digits in uppercase.
         if (c < 0x20 || (c >= 0x7f && c <= 0x9f)) {
-            static constexpr char hex[] = "0123456789abcdef";
             builder.append("\\x"_s);
-            builder.append(hex[(c >> 4) & 0xf]);
-            builder.append(hex[c & 0xf]);
+            builder.append(hex(static_cast<uint8_t>(c), 2));
             return;
         }
         builder.append(c);
     }
+}
+
+// util.inspect's strEscape (https://github.com/nodejs/node/blob/v26.3.0/lib/internal/util/inspect.js#L787),
+// which is how Node renders the value in ERR_INVALID_ARG_VALUE messages. Bun.inspect double-quotes instead.
+static void appendQuotedLikeInspect(WTF::StringBuilder& builder, WTF::StringView str)
+{
+    // Single quotes, unless the string contains one: then double quotes, then backticks, and if
+    // the string contains all three (or a "${"), single quotes with \' escaped. Only the chosen
+    // quote gets escaped, and the first two fallbacks are only chosen when it does not occur.
+    char quote = '\'';
+    if (str.contains('\'')) {
+        if (!str.contains('"'))
+            quote = '"';
+        else if (!str.contains('`') && !str.contains("${"_s))
+            quote = '`';
+    }
+
+    builder.append(quote);
+    if (str.is8Bit()) {
+        for (const auto c : str.span<Latin1Character>())
+            appendEscapedQuotedChar(builder, c, quote);
+    } else {
+        const auto span = str.span<char16_t>();
+        for (size_t i = 0; i < span.size(); i++) {
+            const char16_t c = span[i];
+            if (!U16_IS_SURROGATE(c)) {
+                appendEscapedQuotedChar(builder, c, quote);
+                continue;
+            }
+            if (U16_IS_LEAD(c) && i + 1 < span.size() && U16_IS_TRAIL(span[i + 1])) {
+                builder.append(c);
+                builder.append(span[++i]);
+                continue;
+            }
+            // A lone surrogate becomes \uXXXX; node formats it with Number#toString(16), hence lowercase.
+            builder.append("\\u"_s);
+            builder.append(hex(static_cast<uint16_t>(c), 4, Lowercase));
+        }
+    }
+    builder.append(quote);
 }
 
 void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue arg, bool quotesLikeInspect = false)
@@ -324,16 +361,7 @@ void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& 
         auto str = jsString->view(globalObject);
         RETURN_IF_EXCEPTION(scope, );
         if (quotesLikeInspect) {
-            const char quote = str->contains('\'') ? '"' : '\'';
-            builder.append(quote);
-            if (str->is8Bit()) {
-                for (const auto c : str->span<Latin1Character>())
-                    appendEscapedQuotedChar(builder, c, quote);
-            } else {
-                for (const auto c : str->span<char16_t>())
-                    appendEscapedQuotedChar(builder, c, quote);
-            }
-            builder.append(quote);
+            appendQuotedLikeInspect(builder, str);
             return;
         }
         builder.append(str);

--- a/test/js/node/errors/invalid-arg-value-string-escape.test.ts
+++ b/test/js/node/errors/invalid-arg-value-string-escape.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+
+// ERR_INVALID_ARG_VALUE renders a string value the way util.inspect does (Node's strEscape in
+// lib/internal/util/inspect.js). Every builder of that message shares one renderer in
+// src/jsc/bindings/ErrorCode.cpp; the entry points below reach it from C++, from the JS builtins'
+// $ERR_INVALID_ARG_VALUE, and from Rust's inspect_for_error_message. The expected strings are
+// what node v26.3.0 prints for the same calls.
+const cases: [input: string, rendered: string][] = [
+  ["plain", "'plain'"],
+  ["it's", `"it's"`],
+  ["a'\"b", "`a'\"b`"],
+  ["a'\"`b", "'a\\'\"`b'"],
+  ["a'\"${b}", "'a\\'\"${b}'"],
+  ["a\x1b\0b", "'a\\x1B\\x00b'"],
+  ["\x0b\x0e\x0f\x1a\x1f\x7f", "'\\x0B\\x0E\\x0F\\x1A\\x1F\\x7F'"],
+  ["\x8a\x9f\x80", "'\\x8A\\x9F\\x80'"],
+  ["tab\there\nnl\\bs", "'tab\\there\\nnl\\\\bs'"],
+  // Non-latin1 content makes JSC store the string as UTF-16, which is a separate code path.
+  ["a\x1b\u4e2d", "'a\\x1B\u4e2d'"],
+  ["it's \u4e2d", `"it's \u4e2d"`],
+  ["a'\"\u4e2d", "`a'\"\u4e2d`"],
+  ["a'\"${\u4e2d}", "'a\\'\"${\u4e2d}'"],
+  ["\ud800x", "'\\ud800x'"],
+  ["x\udc00", "'x\\udc00'"],
+  ["\udc00\ud800", "'\\udc00\\ud800'"],
+  ["\ud83d\ude00", "'\ud83d\ude00'"],
+  ["\ud800\ud83d\ude00", "'\\ud800\ud83d\ude00'"],
+  ["it's \ud800", `"it's \\ud800"`],
+];
+
+function receivedValue(fn: () => unknown): string {
+  let error: any;
+  try {
+    fn();
+  } catch (e) {
+    error = e;
+  }
+  expect(error?.code).toBe("ERR_INVALID_ARG_VALUE");
+  const marker = ". Received ";
+  const message: string = error.message;
+  expect(message).toContain(marker);
+  return message.slice(message.indexOf(marker) + marker.length);
+}
+
+describe("ERR_INVALID_ARG_VALUE quotes and escapes a string value like util.inspect", () => {
+  test("Bun::ERR::INVALID_ARG_VALUE (Buffer#fill)", () => {
+    const rendered = cases.map(([input]) => receivedValue(() => Buffer.alloc(4).fill(input, "hex")));
+    expect(rendered).toEqual(cases.map(([, expected]) => expected));
+  });
+
+  test("inspect_for_error_message (fs.openSync flags)", () => {
+    const rendered = cases.map(([input]) => receivedValue(() => fs.openSync(import.meta.path, input)));
+    expect(rendered).toEqual(cases.map(([, expected]) => expected));
+  });
+
+  test("$ERR_INVALID_ARG_VALUE (fs.cpSync path with a null byte)", () => {
+    const prefix = "The argument 'src' must be a string, Uint8Array, or URL without null bytes. Received ";
+    const messages = ["a'\"\0b", "a\x1b\0b", "a'\"`\0"].map(src => {
+      let error: any;
+      try {
+        fs.cpSync(src, "never-created");
+      } catch (e) {
+        error = e;
+      }
+      return `${error?.code}: ${error?.message}`;
+    });
+    expect(messages).toEqual([
+      "ERR_INVALID_ARG_VALUE: " + prefix + "`a'\"\\x00b`",
+      "ERR_INVALID_ARG_VALUE: " + prefix + "'a\\x1B\\x00b'",
+      "ERR_INVALID_ARG_VALUE: " + prefix + "'a\\'\"`\\x00'",
+    ]);
+  });
+});


### PR DESCRIPTION
### Problem
- `ERR_INVALID_ARG_VALUE` messages render a string value differently from node in three ways. `fs.cpSync("a'\"\0b", "c")` throws `... Received "a'\"\x00b"` where node v26.3.0 throws `` ... Received `a'"\x00b` ``; `fs.openSync(f, "a\x1b")` throws `... Received 'a\x1b'` where node throws `... Received 'a\x1B'`; a lone surrogate in the value is copied into the message raw (or as U+FFFD on the Rust paths) where node prints `'\ud800x'`.
- Node builds the `Received` part with `util.inspect`, whose `strEscape` picks single quotes, then double quotes if the string has a `'`, then backticks if it also has a `"` (unless it has a backtick or `${` too, in which case single quotes with `\'`), writes `\xNN` escapes from a table with uppercase digits, and writes lone surrogates as `\uXXXX`. Bun's `util.inspect` already does all of this.
- Cause: the quoting in `JSValueToStringSafe(..., quotesLikeInspect)` in `src/jsc/bindings/ErrorCode.cpp` only implemented the first fallback (`contains('\'') ? '"' : '\''`, escaping whichever quote it picked), `appendEscapedQuotedChar` used a lowercase hex table, and nothing looked at surrogates. This renderer is shared by every `Bun::ERR::INVALID_ARG_VALUE` overload, the JS builtins' `$ERR_INVALID_ARG_VALUE`, and `Bun__ErrorCode__inspectForErrorMessage` (Rust's `JSGlobalObject::inspect_for_error_message`), so every module's `ERR_INVALID_ARG_VALUE` was affected; the message text around the value was already right.

### Fix
- Move the string case into `appendQuotedLikeInspect()`, a port of `strEscape`: the three step quote selection, `\xNN` through WTF's `hex()` (uppercase), and in the UTF-16 loop a surrogate pair is copied through while a lone surrogate becomes `\u` plus four lowercase hex digits, which is what node's `toString(16)` produces. `appendEscapedQuotedChar` is otherwise unchanged; since only the single quote is ever chosen while also present in the string, its existing "escape the chosen quote" rule is exactly node's `\'` rule.
- Why this is right: matches node. It is the same algorithm node runs on the same input, so every `ERR_INVALID_ARG_VALUE` with a string value now carries the same `Received ...` text as node; the two probe scripts below produce output identical to node v26.3.0 on the fixed build. Strings that node renders with plain single quotes and no letter-bearing escapes (the overwhelmingly common case) render exactly as before.
- Not changed: strings nested inside objects and arrays (rendered by `Bun__inspect_singleline`, which double-quotes), `determineSpecificType` for `ERR_INVALID_ARG_TYPE` (node uses a different rule there), and the 128 character cut from #38402, which wraps this renderer and is unaffected by it.
- Test: `test/js/node/errors/invalid-arg-value-string-escape.test.ts` (new file next to the one #38402 adds; no existing file covers this renderer, which has no module of its own). One table of 19 strings with node's rendering for each, run through `Buffer#fill` (C++ overload) and `fs.openSync` flags (Rust `inspect_for_error_message`), plus three full messages from `fs.cpSync` (JS `$ERR_INVALID_ARG_VALUE`). The table covers each quote choice, the `${` exception, C0, DEL and C1 escapes, named escapes, both the Latin-1 and UTF-16 string paths, lone lead and trail surrogates, a lead followed by a pair, and a pair that must stay intact.
- Verified: all 3 tests fail on `USE_SYSTEM_BUN=1` (14 of the 19 table rows differ), pass with `bun bd test`, also under `BUN_JSC_validateExceptionChecks=1`. The vendored node tests that assert quoted `Received` values (`test-process-execve-validation`, `test-buffer-fill`, `test-fs-open*`, `test-http-agent-scheduling`, `test-internal-validators-validateoneof`, `test-crypto-key-objects`, `test-streams-highwatermark`, `test-stream-readable-async-iterators`, `test-dgram-sendto`, `test-c-ares`, `test-buffer-arraybuffer`, and the `test-fs-cp-*` set) still pass. No in-tree test asserted the old spellings.

### Background
- `ERR_INVALID_ARG_VALUE` messages look like `The argument 'flags' is invalid. Received <value>`. Node renders `<value>` with `util.inspect`; in Bun the C++ `JSValueToStringSafe(..., quotesLikeInspect = true)` in `ErrorCode.cpp` plays that role for the top level value, quoting strings itself and handing objects to Bun's inspector.
- `strEscape` is the function inside node's `util.inspect` that quotes a string: it chooses the quote character so that, where possible, nothing in the string has to be escaped, and escapes control characters (0x00-0x1F, 0x7F-0x9F), backslashes, and lone surrogates (UTF-16 code units in 0xD800-0xDFFF that do not form a pair and so do not encode a character).
- JSC stores a string either as Latin-1 bytes or as UTF-16 code units (`StringView::is8Bit()`); surrogates can only occur in the UTF-16 form, which is why only that loop looks for them.

<details>
<summary>Probe output, node v26.3.0 vs fixed build (identical)</summary>

Each line is `util.inspect(value)`, which also equals the `Received` text from `Buffer#fill` and `fs.openSync` on both runtimes. On bun 1.4.0 the lines marked with a `*` differed.

```
  "plain"                => 'plain'
  "it's"                 => "it's"
* "a'\"b"                => `a'"b`                        (was "a'\"b")
* "a'\"`b"               => 'a\'"`b'                      (was "a'\"`b")
* "a'\"${b}"             => 'a\'"${b}'                    (was "a'\"${b}")
* "a\u001b\u0000b"       => 'a\x1B\x00b'                  (was 'a\x1b\x00b')
* "\v\u000e\u000f\u001a\u001f\u007f" => '\x0B\x0E\x0F\x1A\x1F\x7F'   (was lowercase)
* "\u008a\u009f\u0080"   => '\x8A\x9F\x80'                (was lowercase)
  "tab\there\nnl\\bs"    => 'tab\there\nnl\\bs'
* "a\u001b中"            => 'a\x1B中'                     (was 'a\x1b中')
  "it's 中"              => "it's 中"
* "a'\"中"               => `a'"中`                       (was "a'\"中")
* "\ud800x"              => '\ud800x'                     (was the raw code unit)
* "x\udc00"              => 'x\udc00'                     (was the raw code unit)
* "\udc00\ud800"         => '\udc00\ud800'                (was the raw code units)
  "😀"                   => '😀'
* "it's \ud800"          => "it's \ud800"                 (was the raw code unit)
```

Second probe (also identical to node): `'` alone, `"` alone, a backtick alone, `'"`, `` '` ``, `${'}`, `ÿ'"` (Latin-1 backtick case), `\x7F`/`\x9F` in UTF-16 strings, a lone lead, a lone trail, lead + pair, pair + lone trail, `a\'b`, and U+2028/U+2029/U+00A0 (left unescaped, as in node).

</details>
