### PR TITLE
Worker teardown: fixes from fuzzing terminate()/process.exit() lifetimes

### DIFF
--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -556,6 +556,8 @@ mod test_gate {
     static SAY: bun_threading::Mutex = bun_threading::Mutex::new();
     fn say(what: core::fmt::Arguments<'_>) {
         let _g = SAY.lock_guard();
+        // The poster can be a thread Bun never set up for output (a JSC helper).
+        bun_core::output::Source::configure_thread();
         let w = bun_core::output::error_writer();
         let _ = writeln!(w, "[vm] {what}");
         let _ = w.flush();

--- a/src/jsc/bindings/ActiveDOMCallback.cpp
+++ b/src/jsc/bindings/ActiveDOMCallback.cpp
@@ -44,8 +44,12 @@ ActiveDOMCallback::~ActiveDOMCallback() = default;
 
 bool ActiveDOMCallback::canInvokeCallback() const
 {
+    // WebCore only asks whether the context's active DOM objects are stopped, because a
+    // terminating worker's WorkerRunLoop runs no more tasks. Bun's event loop keeps draining
+    // its task queue for the rest of the tick after the VM's stop was requested, so the same
+    // gate the event-listener boundary uses (isJSExecutionForbidden) applies here too.
     ScriptExecutionContext* context = scriptExecutionContext();
-    return context && !context->activeDOMObjectsAreStopped();
+    return context && !context->activeDOMObjectsAreStopped() && !context->isJSExecutionForbidden();
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -136,6 +136,7 @@ KeyObject prepareKey(JSGlobalObject* globalObject, ThrowScope& scope, JSValue ke
 
         BufferEncodingType encoding = BufferEncodingType::utf8;
         JSValue buffer = JSValue::decode(WebCore::constructFromEncoding(globalObject, keyView, encoding));
+        RETURN_IF_EXCEPTION(scope, {});
         auto* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
 
         Vector<uint8_t> copy;

--- a/src/jsc/bindings/webcore/JSCallbackData.cpp
+++ b/src/jsc/bindings/webcore/JSCallbackData.cpp
@@ -50,6 +50,13 @@ JSValue JSCallbackData::invokeCallback(VM& vm, JSObject* callback, JSValue thisV
     JSGlobalObject* lexicalGlobalObject = callback->globalObject();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    ScriptExecutionContext* context = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject)->scriptExecutionContext();
+    // We will fail to get the context if the frame has been detached. Once the VM's stop was
+    // requested this is a silent no-op, as at the other native→JS boundaries
+    // (JSEventListener::handleEvent, Bun__JSValue__call).
+    if (!context || context->isJSExecutionForbidden())
+        return JSValue();
+
     JSValue function;
     CallData callData;
 
@@ -82,11 +89,6 @@ JSValue JSCallbackData::invokeCallback(VM& vm, JSObject* callback, JSValue thisV
 
     ASSERT(!function.isEmpty());
     ASSERT(callData.type != CallData::Type::None);
-
-    ScriptExecutionContext* context = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject)->scriptExecutionContext();
-    // We will fail to get the context if the frame has been detached.
-    if (!context)
-        return JSValue();
 
     // JSExecState::instrumentFunction(context, callData);
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -690,13 +690,24 @@ JSC_DEFINE_HOST_FUNCTION(jsWorkerPrototypeFunction_unref, (JSGlobalObject * lexi
     return IDLOperation<JSWorker>::call<jsWorkerPrototypeFunction_unrefBody>(*lexicalGlobalObject, *callFrame, "unref");
 }
 
-// Resolve/reject a cross-VM introspection promise on the parent thread. The
-// promise lives in WorkerMessagingProxy::m_pendingCrossVMRequests keyed by reqId; if it was
-// already drained by workerGlobalScopeDestroyedInternal's rejectAllCrossVMRequests, this is a no-op.
-static void resolveCrossVMRequest(WorkerMessagingProxy& proxy, uint64_t reqId, ScriptExecutionContext& parentCtx, JSValue value)
+// Resolve a cross-VM introspection promise on the parent thread. The promise lives in
+// WorkerMessagingProxy::m_pendingCrossVMRequests keyed by reqId. Nothing is built or settled if it
+// was already drained by workerGlobalScopeDestroyedInternal's rejectAllCrossVMRequests, or if the
+// parent's own VM is being stopped meanwhile (the Strong just drops).
+// createError() comes back empty only with a termination pending on this VM: nothing to settle then.
+static void rejectWorkerNotRunning(VM& vm, Zig::GlobalObject* globalObject, JSPromise* promise)
 {
-    if (auto handle = proxy.takeCrossVMRequest(reqId))
-        handle->resolve(parentCtx.globalObject(), parentCtx.vm(), value);
+    if (auto* error = Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s))
+        promise->reject(vm, error);
+}
+
+template<typename BuildValue>
+static void resolveCrossVMRequest(WorkerMessagingProxy& proxy, uint64_t reqId, ScriptExecutionContext& parentCtx, const BuildValue& buildValue)
+{
+    auto handle = proxy.takeCrossVMRequest(reqId);
+    if (!handle || parentCtx.isJSExecutionForbidden())
+        return;
+    handle->resolve(parentCtx.globalObject(), parentCtx.vm(), buildValue(parentCtx.vm(), parentCtx.globalObject()));
 }
 
 static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSWorker>::ClassParameter castedThis)
@@ -750,13 +761,13 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
 
         ScriptExecutionContext::postTaskTo(parentId,
             [reqId, protectedProxy = WTF::move(protectedProxy), snapshot = snapshot.isolatedCopy()](ScriptExecutionContext& parentCtx) {
-                resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, jsString(parentCtx.vm(), snapshot));
+                resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& vm, JSGlobalObject*) -> JSValue { return jsString(vm, snapshot); });
             });
     });
     if (!accepted) {
         // postTaskToWorkerGlobalScope returns false only for Closing/Closed.
         worker.contextProxy().takeCrossVMRequest(reqId);
-        promise->reject(vm, Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s));
+        rejectWorkerNotRunning(vm, globalObject, promise);
     }
     return JSValue::encode(promise);
 }
@@ -776,32 +787,32 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapStatisticsBod
         double capacity = static_cast<double>(wvm.heap.capacity());
         double extra = static_cast<double>(wvm.heap.extraMemorySize());
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedProxy = WTF::move(protectedProxy), heapSize, capacity, extra](ScriptExecutionContext& parentCtx) {
-            auto& pvm = parentCtx.vm();
-            auto* go = parentCtx.globalObject();
-            JSObject* o = constructEmptyObject(go);
-            auto set = [&](ASCIILiteral k, double v) { o->putDirect(pvm, Identifier::fromString(pvm, k), jsNumber(v)); };
-            double avail = capacity > heapSize ? capacity - heapSize : 0;
-            set("total_heap_size"_s, heapSize);
-            set("total_heap_size_executable"_s, heapSize / 2.0);
-            set("total_physical_size"_s, capacity);
-            set("total_available_size"_s, avail);
-            set("used_heap_size"_s, heapSize);
-            set("heap_size_limit"_s, capacity * 10.0);
-            set("malloced_memory"_s, heapSize);
-            set("peak_malloced_memory"_s, capacity);
-            o->putDirect(pvm, Identifier::fromString(pvm, "does_zap_garbage"_s), jsBoolean(false));
-            set("number_of_native_contexts"_s, 1);
-            set("number_of_detached_contexts"_s, 0);
-            set("total_global_handles_size"_s, 8192);
-            set("used_global_handles_size"_s, 2208);
-            set("external_memory"_s, extra);
-            set("total_allocated_bytes"_s, heapSize);
-            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, o);
+            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& pvm, JSGlobalObject* go) -> JSValue {
+                JSObject* o = constructEmptyObject(go);
+                auto set = [&](ASCIILiteral k, double v) { o->putDirect(pvm, Identifier::fromString(pvm, k), jsNumber(v)); };
+                double avail = capacity > heapSize ? capacity - heapSize : 0;
+                set("total_heap_size"_s, heapSize);
+                set("total_heap_size_executable"_s, heapSize / 2.0);
+                set("total_physical_size"_s, capacity);
+                set("total_available_size"_s, avail);
+                set("used_heap_size"_s, heapSize);
+                set("heap_size_limit"_s, capacity * 10.0);
+                set("malloced_memory"_s, heapSize);
+                set("peak_malloced_memory"_s, capacity);
+                o->putDirect(pvm, Identifier::fromString(pvm, "does_zap_garbage"_s), jsBoolean(false));
+                set("number_of_native_contexts"_s, 1);
+                set("number_of_detached_contexts"_s, 0);
+                set("total_global_handles_size"_s, 8192);
+                set("used_global_handles_size"_s, 2208);
+                set("external_memory"_s, extra);
+                set("total_allocated_bytes"_s, heapSize);
+                return o;
+            });
         });
     });
     if (!accepted) {
         worker.contextProxy().takeCrossVMRequest(reqId);
-        promise->reject(vm, Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s));
+        rejectWorkerNotRunning(vm, globalObject, promise);
     }
     return JSValue::encode(promise);
 }
@@ -818,12 +829,12 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_startCpuProfileInter
         if (!Bun::isCPUProfilerRunning())
             Bun::startCPUProfiler(workerCtx.vm());
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedProxy = WTF::move(protectedProxy)](ScriptExecutionContext& parentCtx) {
-            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, jsUndefined());
+            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [](VM&, JSGlobalObject*) -> JSValue { return jsUndefined(); });
         });
     });
     if (!accepted) {
         worker.contextProxy().takeCrossVMRequest(reqId);
-        promise->reject(vm, Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s));
+        rejectWorkerNotRunning(vm, globalObject, promise);
     }
     return JSValue::encode(promise);
 }
@@ -845,7 +856,7 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_stopCpuProfileIntern
         if (result.isEmpty())
             result = kEmptyCpuProfileJSON;
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedProxy = WTF::move(protectedProxy), result = result.isolatedCopy()](ScriptExecutionContext& parentCtx) {
-            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, jsString(parentCtx.vm(), result));
+            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& vm, JSGlobalObject*) -> JSValue { return jsString(vm, result); });
         });
     });
     if (!accepted) {
@@ -897,17 +908,17 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_cpuUsageInternalBody
         sys = static_cast<double>(ru.ru_stime.tv_sec) * 1e6 + static_cast<double>(ru.ru_stime.tv_usec);
 #endif
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedProxy = WTF::move(protectedProxy), user, sys](ScriptExecutionContext& parentCtx) {
-            auto& pvm = parentCtx.vm();
-            auto* go = parentCtx.globalObject();
-            JSObject* o = constructEmptyObject(go);
-            o->putDirect(pvm, Identifier::fromString(pvm, "user"_s), jsNumber(user));
-            o->putDirect(pvm, Identifier::fromString(pvm, "system"_s), jsNumber(sys));
-            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, o);
+            resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& pvm, JSGlobalObject* go) -> JSValue {
+                JSObject* o = constructEmptyObject(go);
+                o->putDirect(pvm, Identifier::fromString(pvm, "user"_s), jsNumber(user));
+                o->putDirect(pvm, Identifier::fromString(pvm, "system"_s), jsNumber(sys));
+                return o;
+            });
         });
     });
     if (!accepted) {
         worker.contextProxy().takeCrossVMRequest(reqId);
-        promise->reject(vm, Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s));
+        rejectWorkerNotRunning(vm, globalObject, promise);
     }
     return JSValue::encode(promise);
 }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -254,12 +254,19 @@ void WorkerMessagingProxy::rejectAllCrossVMRequests()
         Locker lock { m_pendingTasksLock };
         pending = std::exchange(m_pendingCrossVMRequests, {});
     }
-    if (pending.isEmpty() || !m_scriptExecutionContext)
+    // A parent whose own VM is being stopped settles nothing more (and could not build the error:
+    // its termination is pending); the Strong handles just drop.
+    if (pending.isEmpty() || !m_scriptExecutionContext || m_scriptExecutionContext->isJSExecutionForbidden())
         return;
     auto* globalObject = defaultGlobalObject(m_scriptExecutionContext->globalObject());
     auto& vm = JSC::getVM(globalObject);
-    for (auto& entry : pending)
-        entry.value->reject(vm, Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s));
+    for (auto& entry : pending) {
+        // Empty only if a (recoverable, e.g. test-timeout) termination is pending on this VM.
+        auto* error = Bun::createError(globalObject, Bun::ErrorCode::ERR_WORKER_NOT_RUNNING, "Worker instance not running"_s);
+        if (!error)
+            return;
+        entry.value->reject(vm, error);
+    }
 }
 
 // ---- Inbox drain (both directions) ---------------------------------------------------------------

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -379,8 +379,9 @@ impl ServerWebSocket {
         // Both callers route through `on_upgrade`'s `handler.server.is_none()`
         // refusal, so this is normally `Some`; keep the `and_then` as
         // defense-in-depth (option getters between that guard and here can
-        // re-enter JS and `stop(true)`, and `js_value_for_dispatch` still
-        // returns `None` on `Finalized`).
+        // re-enter JS and `stop(true)`, and `js_value_for_dispatch` returns
+        // `None` once the wrapper is `Finalized` or the VM's script gate has
+        // closed).
         if let Some(server_js) = handler.server.and_then(|s| s.js_value_for_dispatch()) {
             js::server_set_cached(this_value, global_object, server_js);
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -932,11 +932,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         callback: JSValue,
         extra_args: [JSValue; ARG_COUNT],
     ) {
-        // Same Finalized-only gate as the network trampolines. Unreachable
-        // today — the saved request's `pending_requests` increment keeps the
-        // wrapper `Strong`, so `finalize()` cannot run — but explicit so a
-        // future accounting bug 503s instead of dispatching with a stale
-        // handler shadow.
+        // Same gate as the network trampolines: the saved request's
+        // `pending_requests` increment keeps the wrapper `Strong` (so it is
+        // never `Finalized` here), but the VM's script gate can have closed
+        // while the bundle was being built.
         // SAFETY: `this` is the live server backref for this request.
         let Some(server_js) = unsafe { &*this }.js_value_for_dispatch() else {
             server_body::respond_stopped_503(bun_opaque::opaque_deref_mut(resp));
@@ -1886,9 +1885,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             && !self.has_active_connections()
         {
             // Make the wrapper collectible. Dispatch still works while it is
-            // `Weak` (its WriteBarrier slots still root the handlers); the
-            // `js_value_for_dispatch` gate only trips once the wrapper is
-            // actually finalized.
+            // `Weak` (its WriteBarrier slots still root the handlers);
+            // `js_value_for_dispatch` refuses only once the wrapper is
+            // actually finalized (or the VM's script gate has closed).
             self.js_value.downgrade();
             if let Some(ws) = self.config.websocket.as_mut() {
                 ws.handler.app = None;

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -586,12 +586,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.js_value.try_get().expect("js_value alive")
     }
 
-    /// Returns the wrapper while it is alive (`Strong` or `Weak`), or `None`
-    /// once `finalize()` has set `Finalized`. `Weak` means the wrapper cell is
+    /// Returns the wrapper while it is alive (`Strong` or `Weak`) and its VM
+    /// may still run script, else `None`. `Weak` means the wrapper cell is
     /// still live (its WriteBarrier slots still root the handlers); only
     /// `Finalized` means the slots are gone and the `config` shadows may point
-    /// at freed cells. Dispatch trampolines answer 503+close on `None`.
+    /// at freed cells. A VM whose script gate has closed (a worker that called
+    /// `process.exit()` or was asked to terminate, still draining the current
+    /// loop tick before its stop phase closes the listener) must not have a
+    /// request built for it either: uWS requires every dispatched request to
+    /// be answered or adopted, so dispatch trampolines answer 503+close on
+    /// `None`.
     pub(crate) fn js_value_for_dispatch(&self) -> Option<JSValue> {
+        if !self.vm().script_allowed() {
+            return None;
+        }
         self.js_value.try_get()
     }
 }
@@ -1244,13 +1252,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         use bun_http_jsc::method_jsc::MethodJsc as _;
         use node_http_response::Flags as NhrFlags;
 
-        // A stopped server, or a VM whose script gate has closed (a worker asked
-        // to terminate, still draining its loop): uWS requires every dispatched
-        // request to be answered or adopted, so answer natively.
         // SAFETY: `this` is the live server backref registered as the uws
         // userdata; only one borrow derived from it is alive at a time.
         let this_ref = unsafe { &*this };
-        if this_ref.js_value_for_dispatch().is_none() || !this_ref.vm().script_allowed() {
+        if this_ref.js_value_for_dispatch().is_none() {
             server_body::respond_stopped_503(resp);
             return;
         }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -574,3 +574,57 @@ test.skipIf(!isDebug)(
   },
   timeout,
 );
+
+// Regression: WebCore-style callbacks (PerformanceObserver, abort algorithms)
+// were still invoked from the task queue after terminate() had stopped the
+// worker's VM mid-tick, entering JS with the TerminationException a previous
+// task left pending and tripping executeCallImpl's assertNoException(). They
+// now refuse once script is forbidden, like event listeners already did.
+test.skipIf(!isDebug)(
+  "terminate() while PerformanceObserver deliveries are queued does not invoke the observer on a stopped VM",
+  async () => {
+    const workers = slow ? 24 : 60;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const src =
+          "const { PerformanceObserver, performance } = require('node:perf_hooks');" +
+          "new PerformanceObserver(() => {}).observe({ entryTypes: ['mark', 'measure'] });" +
+          "self.onmessage = () => { performance.mark('x'); performance.measure('mx', 'x'); };" +
+          "for (let i = 0; i < 50; i++) { performance.mark('a' + i); performance.measure('m' + i, 'a' + i); }" +
+          "postMessage('go');" +
+          "Bun.sleepSync(20);";
+        const url = URL.createObjectURL(new Blob([src], { type: "text/javascript" }));
+        let started = 0, closed = 0;
+        function again() {
+          if (started >= ${workers}) {
+            if (closed === ${workers}) console.log("PASS");
+            return;
+          }
+          started++;
+          const w = new Worker(url, { smol: true });
+          for (let i = 0; i < 500; i++) {
+            const ab = new ArrayBuffer(64);
+            w.postMessage({ i, ab }, [ab]);
+          }
+          w.onmessage = () => w.terminate();
+          w.onerror = () => {};
+          w.addEventListener("close", () => { closed++; again(); });
+        }
+        again(); again(); again();
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -521,3 +521,56 @@ test(
   },
   timeout,
 );
+
+// Regression: a worker's own Bun.serve() listener kept dispatching requests
+// into the fetch handler for the rest of the loop tick after process.exit()
+// had stopped the VM. Building the Request for a VM whose termination had
+// already unwound script initialised JSRequestStructure under a pending
+// TerminationException, tripping VMTraps::deferTerminationSlow's
+// ASSERT(vm.hasTerminationRequest()). A stopped VM's server now answers 503
+// natively, as it already did for node:http.
+test.skipIf(!isDebug)(
+  "process.exit() with requests arriving at the worker's own Bun.serve() does not build them for a stopped VM",
+  async () => {
+    const workers = slow ? 8 : 24;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src =
+          "const s = Bun.serve({ port: 0, fetch: () => new Response('x') });" +
+          "for (let i = 0; i < 8; i++) fetch(s.url).then(r => r.text()).catch(() => {});" +
+          "setImmediate(() => process.exit(0));";
+        let started = 0, exited = 0;
+        function again() {
+          if (started >= ${workers}) {
+            if (exited === ${workers}) console.log("PASS");
+            return;
+          }
+          started++;
+          const w = new Worker(src, { eval: true });
+          w.on("error", (e) => { console.error(e); process.exit(1); });
+          w.on("exit", (code) => {
+            if (code !== 0) { console.error("worker exited " + code); process.exit(1); }
+            exited++;
+            again();
+          });
+        }
+        again();
+        again();
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -522,7 +522,7 @@ test(
   timeout,
 );
 
-// Regression: a worker's own Bun.serve() listener kept dispatching requests
+// A worker's own Bun.serve() listener kept dispatching requests
 // into the fetch handler for the rest of the loop tick after process.exit()
 // had stopped the VM. Building the Request for a VM whose termination had
 // already unwound script initialised JSRequestStructure under a pending
@@ -575,7 +575,7 @@ test.skipIf(!isDebug)(
   timeout,
 );
 
-// Regression: WebCore-style callbacks (PerformanceObserver, abort algorithms)
+// WebCore-style callbacks (PerformanceObserver, abort algorithms)
 // were still invoked from the task queue after terminate() had stopped the
 // worker's VM mid-tick, entering JS with the TerminationException a previous
 // task left pending and tripping executeCallImpl's assertNoException(). They
@@ -629,7 +629,7 @@ test.skipIf(!isDebug)(
   timeout,
 );
 
-// Regression: a nested worker's parent that is itself being terminated still
+// A nested worker's parent that is itself being terminated still
 // tried to settle the getHeapSnapshot()/getHeapStatistics() promises it had
 // pending against its child when the child's exit was processed in the same
 // tick, building the ERR_WORKER_NOT_RUNNING error under its own pending

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -628,3 +628,58 @@ test.skipIf(!isDebug)(
   },
   timeout,
 );
+
+// Regression: a nested worker's parent that is itself being terminated still
+// tried to settle the getHeapSnapshot()/getHeapStatistics() promises it had
+// pending against its child when the child's exit was processed in the same
+// tick, building the ERR_WORKER_NOT_RUNNING error under its own pending
+// TerminationException — which yields no object — and rejecting with a null
+// cell (UBSan null member call in debug, SEGV in JSCell::validateIsNotSweeping
+// under ASAN). A stopped parent VM now settles nothing and just drops them.
+test(
+  "terminate() of a worker with cross-VM requests pending against its own child does not settle them on the stopped VM",
+  async () => {
+    const workers = slow ? 12 : 60;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const inner = "setImmediate(() => process.exit(0)); require('node:worker_threads').parentPort.postMessage('x');";
+        const middle =
+          "const { Worker, parentPort } = require('node:worker_threads');" +
+          "const w2 = new Worker(" + JSON.stringify(inner) + ", { eval: true });" +
+          "w2.on('error', () => {});" +
+          "w2.getHeapSnapshot().then(() => {}, () => {});" +
+          "const iv = setInterval(() => { w2.getHeapSnapshot().then(() => {}, () => {}); w2.getHeapStatistics().then(() => {}, () => {}); }, 1);" +
+          "w2.on('exit', () => clearInterval(iv));" +
+          "w2.terminate(); w2.terminate();" +
+          "parentPort.postMessage('up');";
+        let started = 0, exited = 0;
+        function again() {
+          if (started >= ${workers}) {
+            if (exited === ${workers}) console.log("PASS");
+            return;
+          }
+          started++;
+          const w1 = new Worker(middle, { eval: true });
+          w1.on("online", () => w1.terminate());
+          w1.on("error", () => {});
+          w1.on("exit", () => { exited++; again(); });
+        }
+        again(); again();
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);


### PR DESCRIPTION
### What does this PR do?

Fixes for crashes when a worker's VM is stopped (`worker.terminate()`, or `process.exit()` inside the worker) while native work is still landing in the same event-loop tick. A stopped worker keeps draining the current tick before its stop phase closes listeners and tears the VM down; every native→JS boundary reached in that window has to refuse rather than run into the TerminationException that already unwound script.

**Bun.serve answers 503 natively once its VM has been stopped.** The worker's own `Bun.serve()` listener still dispatched requests arriving in that window into the fetch/routes/upgrade handlers, building a `Request` for the stopped VM — in debug this trips JSC's `ASSERT(vm.hasTerminationRequest())` in `VMTraps::deferTerminationSlow` when `JSRequestStructure` is first initialised under the pending TerminationException. node:http's trampoline already answered 503+close for a stopped VM; that gate now lives in `NewServer::js_value_for_dispatch()` so every uWS dispatch trampoline (fetch handler, user routes, upgrade, node:http, h3) refuses the same way.

**WebCore callbacks (PerformanceObserver, abort algorithms) are not invoked on a stopped VM.** `JSCallbackData::invokeCallback` / `ActiveDOMCallback::canInvokeCallback` only asked whether the context's active DOM objects were stopped, which in WebCore suffices because a terminating worker's run loop executes no more tasks. Bun's task queue keeps draining, so a queued `PerformanceObserver` delivery entered JS with the TerminationException an earlier task had left pending, tripping `Interpreter::executeCallImpl`'s `assertNoException()`. Both now use the `isJSExecutionForbidden()` gate that `JSEventListener::handleEvent` and `Bun__JSValue__call` already apply.

**A stopped parent does not settle its cross-VM introspection promises.** `worker.getHeapSnapshot()` / `getHeapStatistics()` / `cpuUsage()` / `startCpuProfile()` park a promise in the parent's `WorkerMessagingProxy` and settle it when the child answers or exits. When the parent is a worker that is itself being terminated, that can happen in the same tick after the parent's termination unwound script: `Bun::createError()` then yields no object and `JSPromise::reject` was called with a null cell (UBSan null member call in debug, SEGV under ASAN). A parent whose script is forbidden now builds and settles nothing for these (the `Strong` handles just drop, as `parentContextWillDestroy` already does), the resolve paths build their result only behind the same check, and the reject sites tolerate `createError()` coming back empty under a recoverable termination.

**`crypto.hkdf` checks for an exception after converting a string key.** `prepareKey()` dereferenced `constructFromEncoding()`'s result without the `RETURN_IF_EXCEPTION` every other caller has; with a worker's termination landing in that call the result is empty and a null `JSArrayBufferView` was dereferenced.

Also: the debug-only `BUN_DEBUG_TEST_WORKER_TEARDOWN_GATE` hook sets up output on the posting thread before logging (it can be a JSC helper thread that never initialised it).

### How did you verify your code works?

New tests in `test/js/web/workers/worker-terminate-lifetime.test.ts` — workers that `Bun.serve()` and `process.exit()` with requests to themselves in flight; workers terminated with hundreds of queued messages feeding a `PerformanceObserver`; a terminated worker with `getHeapSnapshot()`/`getHeapStatistics()` pending against its own child — each fails with the corresponding assertion / UBSan error on a debug build without the change and passes with it. The hkdf change has no dedicated test (the window is only reachable by termination timing); `test-crypto-hkdf.js` still passes.
