### PR TITLE
Fix require() of an embedded CommonJS entry point in compiled executables

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -726,6 +726,16 @@ JSValue fetchCommonJSModule(
     RETURN_IF_EXCEPTION(scope, {});
     if (builtin) {
         if (!res->success) {
+            // A file embedded in a standalone executable is served by the builtin probe.
+            // A CommonJS one is evaluated right here like any require()d CJS file (the
+            // module loader path would find `target` already in the require map and
+            // never give it its source); only ES modules go through the loader.
+            if (res->result.value.isCommonJSModule) {
+                res->success = true;
+                target->evaluate(globalObject, specifierWtfString, res->result.value);
+                RETURN_IF_EXCEPTION(scope, {});
+                RELEASE_AND_RETURN(scope, target);
+            }
             RELEASE_AND_RETURN(scope, builtin);
         }
         target->setExportsObject(builtin);

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -353,6 +353,40 @@ describe("bundler", () => {
       setCwd: true,
     },
   });
+  // A second CommonJS entry point that is only reached through a runtime
+  // require() must load from the embedded module graph (with its bytecode,
+  // when built with --bytecode) rather than the filesystem.
+  for (const bytecode of [false, true]) {
+    itBundled("compile/RuntimeRequireEmbeddedCJS" + (bytecode ? "+bytecode" : ""), {
+      backend: "cli",
+      compile: true,
+      bytecode,
+      format: "cjs",
+      files: {
+        "/entry.js": /* js */ `
+          const { rmSync } = require("fs");
+          rmSync("./second.js", { force: true });
+          const specifier = "./second" + ".js";
+          const second = require(specifier);
+          console.log(second.greeting, require(specifier) === second);
+        `,
+        "/second.js": /* js */ `
+          module.exports = { greeting: "hello from second" };
+        `,
+      },
+      entryPointsRaw: ["./entry.js", "./second.js"],
+      outfile: "dist/out",
+      run: {
+        stdout: "hello from second true",
+        stderr: bytecode
+          ? "[Disk Cache] Cache hit for sourceCode\n[Disk Cache] Cache hit for sourceCode\n[Disk Cache] Cache miss for sourceCode\n"
+          : undefined,
+        env: bytecode ? { BUN_JSC_verboseDiskCache: "1" } : undefined,
+        file: "dist/out",
+        setCwd: true,
+      },
+    });
+  }
   // https://github.com/oven-sh/bun/issues/8697
   itBundled("compile/EmbeddedFileOutfile", {
     compile: true,


### PR DESCRIPTION
### What does this PR do?

In a `bun build --compile` executable built with more than one CommonJS entry point, a runtime `require()` of one of the other embedded entry points (a specifier the bundler could not resolve statically, e.g. `require("./second" + ".js")`) threw `error: Failed to evaluate module`.

`require()` registers the module object first, then asks the embedded-file probe for the file. The probe answered "hand this to the module loader", and that path found the already-registered module object in the require map and never gave it its source, so evaluation failed with an empty source. `fetchCommonJSModule` now evaluates embedded CommonJS files directly, the same way any other required CommonJS file is evaluated, so the embedded copy (and its bytecode when built with `--bytecode`) is used instead of erroring. Embedded ES modules still go through the module loader as before.

### How did you verify your code works?

New tests `compile/RuntimeRequireEmbeddedCJS` and `compile/RuntimeRequireEmbeddedCJS+bytecode` in `test/bundler/bundler_compile.test.ts`: two CommonJS entry points, the on-disk copy of the second is deleted before it is required at runtime, and the bytecode variant asserts a bytecode cache hit for it via `BUN_JSC_verboseDiskCache=1`. Both fail on the current release with the `Failed to evaluate module` error and pass with this change (`bun bd test test/bundler/bundler_compile.test.ts -t RuntimeRequireEmbeddedCJS`). Also drove a debug build by hand with `bun build --compile --format=cjs [--bytecode] a.js b.js` where `a.js` does `require(String("./b.js"))`, and re-ran the neighboring `compile/DynamicRequire`, `DynamicImport`, `CanRequireLocalPackages`, `NoAutoInstall` and `WorkerBytecodeESM` tests.