### PR TITLE
sql(sqlite): lift the ~640k row ceiling on result sets

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -85,8 +85,16 @@ class SQLResultArray<T> extends PublicArray<T> {
 
   static [Symbol.toStringTag] = "SQLResults";
 
-  constructor(values: T[] = []) {
-    super(...values);
+  constructor(values?: T[]) {
+    super();
+
+    // Not super(...values): spreading puts every row on the JS stack, which overflows
+    // once a result set has a few hundred thousand rows.
+    if (values) {
+      for (let i = 0, length = values.length; i < length; i++) {
+        $putByValDirect(this, i, values[i]);
+      }
+    }
 
     // match postgres's result array, in this way for in will not list the
     // properties and .map will not return undefined command and count

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2030,6 +2030,35 @@ describe("Performance & Edge Cases", () => {
     await sql.close();
   });
 
+  test(
+    "returns result sets with more rows than a call can take as arguments",
+    async () => {
+      await using sql = new SQL("sqlite://:memory:");
+
+      // JavaScriptCore refuses to spread more than 0x100000 arguments into one call, so a result
+      // set this size fails no matter how much stack is free if the rows are spread into the result.
+      const rowCount = 0x100000 + 1;
+      const rows = await sql`
+        WITH RECURSIVE counter(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM counter WHERE n < ${rowCount})
+        SELECT n FROM counter
+      `;
+
+      expect({
+        length: rows.length,
+        count: rows.count,
+        first: rows[0],
+        last: rows[rowCount - 1],
+      }).toEqual({
+        length: rowCount,
+        count: rowCount,
+        first: { n: 1 },
+        last: { n: rowCount },
+      });
+    },
+    // bun:sqlite needs several seconds to build a million row objects in a debug build.
+    isDebug ? 60_000 : 10_000,
+  );
+
   test("handles many columns", async () => {
     const sql = new SQL(":memory:");
 


### PR DESCRIPTION
### Problem
- With the sqlite adapter, any `Bun.SQL` query whose result has more than about 640k rows rejects with `RangeError: Maximum call stack size exceeded` (`at new SQLResultArray (internal:sql/shared)`), in every result mode (objects, `.values()`, `.raw()`). `bun:sqlite` returns the same rows fine, and the error is thrown after SQLite has already produced all of them.
- Cause: `SQLResultArray`'s constructor was `super(...values)` (`src/js/internal/sql/shared.ts:89`), and the sqlite adapter builds the result as `new SQLResultArray(rows)` (`src/js/internal/sql/sqlite.ts:261`), so every row became an argument of one call. JavaScriptCore limits a call to the JS stack budget (5 MB by default, 8 bytes per argument, so roughly 640k arguments once the frames already in use are subtracted) and additionally to 0x100000 (1,048,576) arguments outright.
- The postgres and mysql adapters call `new SQLResultArray()` and have native code append rows afterwards, so they were not affected.

### Fix
- `SQLResultArray` now calls `super()` and fills itself by index with `$putByValDirect`, so the row count is only bounded by memory. `$putByValDirect` defines each element directly, as the `Array` constructor did with the spread arguments, so accessors installed on `Array.prototype` are bypassed exactly as before (a plain `this[i] = row` would run them).
- `new SQLResultArray()` with no argument (the postgres and mysql path) behaves exactly as before: `super()` is what `super(...[])` already did.
- The copy is one store per row; on a debug build it takes about 0.25 s for a million rows, compared with about 8 s for `bun:sqlite` to produce those rows in the first place.
- Verified with `test/js/sql/sqlite-sql.test.ts` ("returns result sets with more rows than a call can take as arguments"): it selects 0x100000 + 1 rows, which fails with the RangeError above on the current release and passes with this change. Using the hard 0x100000 argument cap rather than a count just above the stack budget means the test proves the bug independently of how much stack happens to be free. It gets a per-test timeout because building that many row objects takes about 10 s on a debug build (about 0.3 s in release).
- The rest of `test/js/sql/sqlite-sql.test.ts` (240 tests) passes, and a postgres query against a local server still returns a result array with `count`, `command`, `.values()`, and `Array` results from `.map()` as before.

### Background
- `Bun.SQL` returns query results as a `SQLResultArray`, an `Array` subclass defined in `src/js/internal/sql/shared.ts` that carries `count`, `command`, `lastInsertRowid`, and `affectedRows` alongside the rows. The sqlite adapter gets the complete row array back from `bun:sqlite` (`stmt.all()` / `.values()` / `.raw()`) and wraps it in a `SQLResultArray`; the network adapters create an empty one and push rows into it from native code as they arrive.
- `$putByValDirect` is the intrinsic available to Bun's built-in JavaScript that defines an own indexed property on an object directly, without running setters found on the prototype chain. It is the same helper the other built-ins use to fill arrays (for example `src/js/internal/fifo.ts`).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sqlite-sql.test.ts
bun test v1.4.0 (093342fa7)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [116.45ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [12.47ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [38.50ms]
(pass) Connection & Initialization > should handle connection with options object [104.40ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [17.15ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [27.46ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [43.94ms]
(pass) Connection & Initialization > should work with relative paths [40.66ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [49.41ms]
(pass) Connection & Initialization 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [2.29ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [0.29ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [1.55ms]
(pass) Connection & Initialization > should handle connection with options object [2.00ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [0.34ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [2.89ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [24.26ms]
(pass) Connection & Initialization > should work with relative paths [32.33ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [31.76ms]
(pass) Connection & Initialization > Environment Variable Handling > should handle DATABASE_URL with :memory: [0.65ms]
(pass) Connection & Initialization > Environment Variable Handling > should han
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sqlite-sql.test.ts
bun test v1.4.0 (093342fa7)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [116.04ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [12.52ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [41.15ms]
(pass) Connection & Initialization > should handle connection with options object [108.20ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [17.36ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [28.64ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [52.33ms]
(pass) Connection & Initialization > should work with relative paths [52.24ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [52.32ms]
(pass) Connection & Initialization 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     093342fa7e
  features     baseline

22 deps, 123 codegen, 1176 objects in 641ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [13.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [8.00ms]
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] fetch zlib
[zlib] up to date
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/shared.ts  | 12 ++++++++++--
 test/js/sql/sqlite-sql.test.ts | 29 +++++++++++++++++++++++++++++
 2 files changed, 39 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/internal/sql/shared.ts       2      1      0
test/js/sql/sqlite-sql.test.ts      2      2      0
```

</details>

**root cause** · written by the author bot

The failure came from `SQLResultArray` constructing itself with `super(...values)`, so the sqlite adapter, which builds the result from the fully materialized `stmt.all()` array, spread every row as a separate constructor argument and hit the JS argument and stack limit once a result set exceeded roughly 637k rows. The constructor now calls `super()` and copies rows in by index with `$putByValDirect`, so result size is bounded only by memory as it is with `bun:sqlite`, while the pg and mysql paths, which fill results natively, are unchanged.

<!-- robobun:evidence:end -->