### PR TITLE
docs: update Vercel guide for Bun.serve() deployments

### DIFF
--- a/docs/guides/deployment/vercel.mdx
+++ b/docs/guides/deployment/vercel.mdx
@@ -4,23 +4,19 @@ sidebarTitle: Deploy on Vercel
 mode: center
 ---
 
-[Vercel](https://vercel.com/) is a cloud platform for building, deploying, and scaling apps.
+[Vercel](https://vercel.com/) is a cloud platform for building, deploying, and scaling apps. Vercel Functions can run on the Bun runtime, either behind a framework that Vercel supports or as a [`Bun.serve()`](/runtime/http/server) server.
 
 <Warning>
-  The Bun runtime is in Beta. Some features are not yet supported — for example, automatic source maps, byte-code
-  caching, and metrics on `node:http/https`.
+  The Bun runtime on Vercel is in Beta. Automatic source maps, bytecode caching, and request metrics for `node:http` and
+  `node:https` are not supported yet (request metrics for `fetch` are). See [feature
+  support](https://vercel.com/docs/functions/runtimes/bun#feature-support) in the Vercel documentation.
 </Warning>
-
-<Note>
-  `Bun.serve` is not supported on Vercel Functions. Use Bun with frameworks supported by Vercel, like Next.js, Express,
-  Hono, or Nitro.
-</Note>
 
 ---
 
 <Steps>
 	<Step title="Configure Bun in vercel.json">
-		To enable the Bun runtime for your Functions, add a `bunVersion` field in your `vercel.json` file:
+		To run your Functions on Bun, add a [`bunVersion`](https://vercel.com/docs/project-configuration/vercel-json#bunversion) field to your `vercel.json` file:
 
     	```json vercel.json icon="file-json"
     	{
@@ -28,28 +24,83 @@ mode: center
     	}
     	```
 
-    	Vercel automatically detects this configuration and runs your application on Bun. The value must be `"1.x"`; Vercel handles the minor version internally.
+    	The value must be `"1.x"`; Vercel manages the minor and patch versions.
 
     	For best results, match your local Bun version with the version used by Vercel.
     </Step>
 
-    <Step title="Next.js configuration">
-    	If you’re deploying a **Next.js** project (including ISR), update your `package.json` scripts to use the Bun runtime:
+    <Step title="Add a server">
+    	Choose how requests reach your code.
 
-    	```json package.json icon="file-json"
-    	{
-    		"scripts": {
-    			"dev": "bun --bun next dev", // [!code ++]
-    			"build": "bun --bun next build" // [!code ++]
-    		}
-    	}
-    	```
+    	<Tabs>
+    		<Tab title="Bun.serve() for the whole app">
+    			Vercel's Bun framework preset sends every request for the deployment to a single `Bun.serve()` server. Vercel uses the preset when the project sets `bunVersion`, has a `bun.lock` file, and has a server entrypoint at one of these paths:
 
-    	<Note>
-    		The `--bun` flag runs the Next.js CLI under Bun. Bundling (with Turbopack or Webpack) is unchanged.
-    	</Note>
+    			- `server.{js,cjs,mjs,ts,cts,mts}`
+    			- `src/server.{js,cjs,mjs,ts,cts,mts}`
 
-    	With these scripts, both local development and builds use Bun.
+    			`bun install` creates `bun.lock` on Bun 1.2 or later. On older versions, run `bun install --save-text-lockfile`. The preset does not detect the binary `bun.lockb` format.
+
+    			Call `Bun.serve()` once while the module loads. Vercel detects that call and routes incoming requests to it. The `fetch`, [`routes`](/runtime/http/routing), `error`, and `websocket` options are supported:
+
+    			```ts server.ts icon="/icons/typescript.svg"
+    			Bun.serve({
+    				routes: {
+    					"/health": () => Response.json({ status: "ok" }),
+    				},
+    				fetch() {
+    					return new Response("Hello from Bun on Vercel");
+    				},
+    			});
+    			```
+
+    			A minimal project is `package.json`, `bun.lock`, `server.ts`, and the `vercel.json` from the previous step. It doesn't need an `api/` directory or any routing configuration.
+
+    			<Note>
+    				`port` and `hostname` only apply when you run the server locally; they don't configure the deployed endpoint. Unix sockets and [HTML imports](/runtime/http/server#html-imports) in `routes` are not supported on Vercel.
+
+    				To serve WebSocket connections, see the [Bun example in Vercel's WebSockets documentation](https://vercel.com/docs/functions/websockets#bun).
+    			</Note>
+    		</Tab>
+
+    		<Tab title="Bun.serve() under /api">
+    			To add a Bun server to a project that also has a frontend, create `api/server.ts` and call `Bun.serve()` once while the module loads. Vercel deploys it as a single Function at `/api/server`. Unlike the framework preset, only requests for `/api/server` reach this server.
+
+    			```ts api/server.ts icon="/icons/typescript.svg"
+    			Bun.serve({
+    				fetch(request) {
+    					const url = new URL(request.url);
+
+    					return Response.json({
+    						message: "Hello from Bun on Vercel",
+    						pathname: url.pathname,
+    					});
+    				},
+    			});
+    			```
+
+    			This only needs the `bunVersion` setting from the previous step; it doesn't use the framework preset or require a `bun.lock` file. To send other paths to this server, add route overrides to `vercel.json`. Each override must use the full request path, including the `/api/server` prefix. See [the Vercel Bun runtime documentation](https://vercel.com/docs/functions/runtimes/bun) for details.
+    		</Tab>
+
+    		<Tab title="Next.js or another framework">
+    			Frameworks that Vercel supports, such as Next.js, Express, Hono, and Nitro, run on Bun once `bunVersion` is set.
+
+    			If you're deploying a **Next.js** project (including ISR), also update the `package.json` scripts so the Next.js CLI runs under Bun:
+
+    			```json package.json icon="file-json"
+    			{
+    				"scripts": {
+    					"dev": "bun --bun next dev", // [!code ++]
+    					"build": "bun --bun next build" // [!code ++]
+    				}
+    			}
+    			```
+
+    			<Note>
+    				The `--bun` flag runs the Next.js CLI under Bun. Bundling (with Turbopack or Webpack) is unchanged.
+    			</Note>
+    		</Tab>
+    	</Tabs>
     </Step>
 
     <Step title="Deploy your app">
@@ -79,7 +130,7 @@ mode: center
     	console.log("runtime", process.versions.bun);
     	```
     	```txt
-    	runtime 1.3.3
+    	runtime 1.3.14
     	```
 
     	[See the Vercel Bun Runtime documentation for feature support →](https://vercel.com/docs/functions/runtimes/bun#feature-support)


### PR DESCRIPTION
### Problem
- `docs/guides/deployment/vercel.mdx` says `Bun.serve` is not supported on Vercel Functions and tells readers to use a framework instead.
- Vercel's Bun runtime docs (https://vercel.com/docs/functions/runtimes/bun) now document two ways to deploy a `Bun.serve()` server: the Bun framework preset (`server.ts` or `src/server.ts` plus a `bun.lock`), and a single function at `api/server.ts`.
- The beta warning used Vercel's old wording (`byte-code caching`, `metrics on node:http/https`).

### Fix
- Drop the "not supported" note. Replace the Next.js step with an "Add a server" step that has three tabs: `Bun.serve()` for the whole app (preset requirements, entrypoint paths, `bun.lock` vs `bun.lockb`, supported options, the `port`/`hostname`, Unix socket and HTML import caveats, WebSockets link), `Bun.serve()` under `/api`, and the existing Next.js/framework instructions.
- Beta warning now lists the unsupported features as Vercel's feature table does, and links to it. The `bunVersion` step links to the `vercel.json` reference.
- Sample `process.versions.bun` output bumped from 1.3.3 to the current release, as earlier version bumps did.
- Everything the new text claims about Vercel's behavior is taken from the Vercel page above; nothing is added beyond it.
- Verified: both `Bun.serve()` snippets run as written (`/health` returns `{"status":"ok"}`, `/api/server` echoes its pathname); the file compiles with `@mdx-js/mdx` with every component (`Steps`, `Step`, `Tabs`, `Tab`, `Note`, `Warning`), all 9 code blocks and both lists recognized; `prettier --check` passes; the three internal links (`/runtime/http/server`, `/runtime/http/server#html-imports`, `/runtime/http/routing`) resolve to existing pages and headings. The vercel.com links are copied from that page and the previous version of this guide; I could not fetch them from the environment this was written in.

### Background
- Vercel Functions: Vercel's serverless functions. Setting `"bunVersion": "1.x"` in `vercel.json` makes them run on Bun instead of Node.js (beta).
- Bun framework preset: a Vercel project type that detects a `Bun.serve()` call in a root `server.*` entrypoint and sends every request for the deployment to it. It requires the text `bun.lock` lockfile (default since Bun 1.2).
- `api/server.ts`: the alternative layout. Vercel deploys that file as one function at `/api/server`, so it can sit next to a frontend in the same project; only that path reaches it unless routes are overridden in `vercel.json`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->