### PR TITLE
bun test: only run process.on('exit') listeners when node:test APIs were used

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1628,8 +1628,6 @@ const fileGeneration = $newRustFunction("jest.rs", "jsFileGeneration", 0);
 // `done` binds the intended sequence so a late call after the bun:test watchdog
 // moved on cannot write onto the currently-running test.
 const markCurrentResult = $newRustFunction("jest.rs", "jsNodeTestMarkResult", 2);
-// Makes `bun test` dispatch process.on('exit') listeners when the run ends; node's tests assert from them.
-$rust("jest.rs", "jsNodeTestLoaded");
 
 let rootNode: TestNode | undefined;
 let rootGeneration = -1;

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1628,6 +1628,8 @@ const fileGeneration = $newRustFunction("jest.rs", "jsFileGeneration", 0);
 // `done` binds the intended sequence so a late call after the bun:test watchdog
 // moved on cannot write onto the currently-running test.
 const markCurrentResult = $newRustFunction("jest.rs", "jsNodeTestMarkResult", 2);
+// Makes `bun test` dispatch process.on('exit') listeners when the run ends; node's tests assert from them.
+$rust("jest.rs", "jsNodeTestLoaded");
 
 let rootNode: TestNode | undefined;
 let rootGeneration = -1;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -551,6 +551,8 @@ pub fn is_smol_mode() -> bool {
 #[derive(Default)]
 pub struct ExitHandler {
     pub exit_code: u8,
+    /// `bun test` sets this at the end of a run unless `node:test` was loaded: jest and vitest never fire a test file's `process.on('exit')` listeners.
+    pub skip_exit_listeners: bool,
 }
 
 impl ExitHandler {
@@ -599,7 +601,7 @@ impl ExitHandler {
     pub(crate) fn dispatch_on_exit(vm: &VirtualMachine) {
         let exit_code = vm.exit_handler.exit_code;
         // `process.on('exit')` handlers are user script (see `on_exit`).
-        if vm.script_allowed() {
+        if vm.script_allowed() && !vm.exit_handler.skip_exit_listeners {
             Process__dispatchOnExit(vm.global(), exit_code);
         }
         if vm.worker.is_none() {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -551,7 +551,7 @@ pub fn is_smol_mode() -> bool {
 #[derive(Default)]
 pub struct ExitHandler {
     pub exit_code: u8,
-    /// `bun test` sets this at the end of a run unless `node:test` was loaded: jest and vitest never fire a test file's `process.on('exit')` listeners.
+    /// `bun test` sets this at the end of a run unless `node:test` APIs were used: jest and vitest never fire a test file's `process.on('exit')` listeners.
     pub skip_exit_listeners: bool,
 }
 

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -682,10 +682,13 @@ pub(crate) fn run_as_worker(
     // Mirror TestCommand::exec's exit path so BUN_DESTRUCT_VM_ON_EXIT teardown
     // (lastChanceToFinalize) runs; bypassing it leaks JSC-owned native state.
     vm_ref.exit_handler.exit_code = 0;
-    vm_ref.is_shutting_down = true;
+    vm_ref.exit_handler.skip_exit_listeners = test_command::skip_exit_listeners(wloop.reporter);
     vm_ref.run_with_api_lock(|| {
         // SAFETY: caller guarantees `vm` is a valid live VM pointer for the worker's lifetime.
-        unsafe { (*vm).global_exit() }
+        unsafe {
+            (*vm).on_exit();
+            (*vm).global_exit()
+        }
     });
     {
         Global::exit(0);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -920,6 +920,11 @@ fn should_drain_event_loop() -> bool {
     env_var::BUN_TEST_DRAIN_EVENT_LOOP.get().unwrap_or(false)
 }
 
+/// jest and vitest never run a test file's `process.on('exit')` listeners; node's test harness asserts from them.
+pub(crate) fn skip_exit_listeners(reporter: &CommandLineReporter) -> bool {
+    !(reporter.jest.node_test_used || should_drain_event_loop())
+}
+
 pub struct CommandLineReporter {
     // `TestRunner<'a>` borrows `TestOptions`/regex from the CLI ctx; the
     // reporter is held in a `Box` local to `TestCommand::exec` which never
@@ -3031,8 +3036,7 @@ impl TestCommand {
         {
             vm.exit_handler.exit_code = 1;
         }
-        // Node's test harness verifies mustCall() counts from an 'exit' listener; jest and vitest never run a test file's.
-        vm.exit_handler.skip_exit_listeners = !reporter.jest.node_test_used;
+        vm.exit_handler.skip_exit_listeners = skip_exit_listeners(&reporter);
         // Must precede the GC-root release below: exit listeners are user JS and may touch still-live state.
         {
             let vm_ptr: *mut VirtualMachine = vm;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2217,6 +2217,7 @@ impl TestCommand {
                 test_options: unsafe { bun_ptr::detach_lifetime_ref(&ctx.test_options) },
                 unhandled_errors_between_tests: 0,
                 summary: Summary::default(),
+                node_test_loaded: false,
             },
             repeat_count: 1,
             last_printed_dot: core::cell::Cell::new(false),
@@ -3030,10 +3031,9 @@ impl TestCommand {
         {
             vm.exit_handler.exit_code = 1;
         }
-        // Run `process.on('exit')` handlers like `bun run` does. Node's test
-        // harness verifies mustCall() counts from one, so skipping them made
-        // those assertions silently pass. Must precede the GC-root release
-        // below: handlers are user JS and may touch still-live state.
+        // Node's test harness verifies mustCall() counts from an 'exit' listener; jest and vitest never run a test file's.
+        vm.exit_handler.skip_exit_listeners = !reporter.jest.node_test_loaded;
+        // Must precede the GC-root release below: exit listeners are user JS and may touch still-live state.
         {
             let vm_ptr: *mut VirtualMachine = vm;
             // SAFETY: `vm_ptr` reborrows the live `&mut VirtualMachine`;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2217,7 +2217,7 @@ impl TestCommand {
                 test_options: unsafe { bun_ptr::detach_lifetime_ref(&ctx.test_options) },
                 unhandled_errors_between_tests: 0,
                 summary: Summary::default(),
-                node_test_loaded: false,
+                node_test_used: false,
             },
             repeat_count: 1,
             last_printed_dot: core::cell::Cell::new(false),
@@ -3032,7 +3032,7 @@ impl TestCommand {
             vm.exit_handler.exit_code = 1;
         }
         // Node's test harness verifies mustCall() counts from an 'exit' listener; jest and vitest never run a test file's.
-        vm.exit_handler.skip_exit_listeners = !reporter.jest.node_test_loaded;
+        vm.exit_handler.skip_exit_listeners = !reporter.jest.node_test_used;
         // Must precede the GC-root release below: exit listeners are user JS and may touch still-live state.
         {
             let vm_ptr: *mut VirtualMachine = vm;

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -518,7 +518,7 @@ pub mod Jest {
 /// Reached only from `node:test`, through `$newRustFunction` rather than the
 /// public `bun:test` module object, whenever a node:test API registers something. Returns 0 outside `bun test`.
 pub(crate) fn js_file_generation(
-    _global: &JSGlobalObject,
+    global: &JSGlobalObject,
     _callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     // `runner_ptr()` rather than `runner()`: node:test calls this on every test
@@ -526,7 +526,9 @@ pub(crate) fn js_file_generation(
     // `bun_test_root` pointer `test_command.rs` keeps live across the file run.
     // SAFETY: same invariant as `runner()` — RUNNER is only read on the JS thread.
     let generation = Jest::runner_ptr().map_or(0, |p| unsafe {
-        (*p.as_ptr()).node_test_used = true;
+        if global.bun_vm().worker_ref().is_none() {
+            (*p.as_ptr()).node_test_used = true;
+        }
         (*p.as_ptr()).bun_test_root.file_generation
     });
     Ok(JSValue::from(generation))

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -145,8 +145,8 @@ pub struct TestRunner<'a> {
     pub(crate) unhandled_errors_between_tests: u32,
     pub(crate) summary: Summary,
 
-    /// Set when `node:test` is evaluated; gates `process.on('exit')` dispatch at the end of the run.
-    pub(crate) node_test_loaded: bool,
+    /// Set once any `node:test` registration API is called; gates `process.on('exit')` dispatch at the end of the run.
+    pub(crate) node_test_used: bool,
 
     pub(crate) bun_test_root: bun_test::BunTestRoot,
 }
@@ -516,7 +516,7 @@ pub mod Jest {
 }
 
 /// Reached only from `node:test`, through `$newRustFunction` rather than the
-/// public `bun:test` module object. Returns 0 outside `bun test`.
+/// public `bun:test` module object, whenever a node:test API registers something. Returns 0 outside `bun test`.
 pub(crate) fn js_file_generation(
     _global: &JSGlobalObject,
     _callframe: &CallFrame,
@@ -525,18 +525,11 @@ pub(crate) fn js_file_generation(
     // registration, and an exclusive `&mut TestRunner` would invalidate the
     // `bun_test_root` pointer `test_command.rs` keeps live across the file run.
     // SAFETY: same invariant as `runner()` — RUNNER is only read on the JS thread.
-    let generation =
-        Jest::runner_ptr().map_or(0, |p| unsafe { (*p.as_ptr()).bun_test_root.file_generation });
+    let generation = Jest::runner_ptr().map_or(0, |p| unsafe {
+        (*p.as_ptr()).node_test_used = true;
+        (*p.as_ptr()).bun_test_root.file_generation
+    });
     Ok(JSValue::from(generation))
-}
-
-/// `$rust()` call evaluated by `node:test`'s module body; a no-op outside `bun test`.
-pub(crate) fn js_node_test_loaded(_global: &JSGlobalObject) -> JsResult<JSValue> {
-    if let Some(p) = Jest::runner_ptr() {
-        // SAFETY: same invariant as `js_file_generation` — RUNNER is only touched on the JS thread.
-        unsafe { (*p.as_ptr()).node_test_loaded = true };
-    }
-    Ok(JSValue::UNDEFINED)
 }
 
 /// Reached only from `node:test` (`t.skip()` / `t.todo()` at runtime): overrides

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -145,6 +145,9 @@ pub struct TestRunner<'a> {
     pub(crate) unhandled_errors_between_tests: u32,
     pub(crate) summary: Summary,
 
+    /// Set when `node:test` is evaluated; gates `process.on('exit')` dispatch at the end of the run.
+    pub(crate) node_test_loaded: bool,
+
     pub(crate) bun_test_root: bun_test::BunTestRoot,
 }
 
@@ -525,6 +528,15 @@ pub(crate) fn js_file_generation(
     let generation =
         Jest::runner_ptr().map_or(0, |p| unsafe { (*p.as_ptr()).bun_test_root.file_generation });
     Ok(JSValue::from(generation))
+}
+
+/// `$rust()` call evaluated by `node:test`'s module body; a no-op outside `bun test`.
+pub(crate) fn js_node_test_loaded(_global: &JSGlobalObject) -> JsResult<JSValue> {
+    if let Some(p) = Jest::runner_ptr() {
+        // SAFETY: same invariant as `js_file_generation` — RUNNER is only touched on the JS thread.
+        unsafe { (*p.as_ptr()).node_test_loaded = true };
+    }
+    Ok(JSValue::UNDEFINED)
 }
 
 /// Reached only from `node:test` (`t.skip()` / `t.todo()` at runtime): overrides

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1572,10 +1572,10 @@ describe("bun test", () => {
 
   // jest and vitest never run a test file's process.on('exit') listeners; node's test harness asserts from them.
   describe.concurrent("process.on('exit') listeners", () => {
-    async function runFile(name: string, contents: string) {
-      using dir = tempDir("bun-test-exit-listener", { [name]: contents });
+    async function runFiles(files: Record<string, string>, ...args: string[]) {
+      using dir = tempDir("bun-test-exit-listener", files);
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", name],
+        cmd: [bunExe(), "test", ...args],
         env: bunEnv,
         cwd: String(dir),
         stderr: "pipe",
@@ -1584,19 +1584,27 @@ describe("bun test", () => {
       return { stdout, stderr, exitCode };
     }
 
+    function runFile(name: string, contents: string) {
+      return runFiles({ [name]: contents }, name);
+    }
+
+    const bunTestFile = (n: number) => `
+      import { test } from "bun:test";
+      process.on("exit", () => {
+        console.log("exit listener ${n} ran");
+        process.exit(1);
+      });
+      test("test ${n}", () => {});
+    `;
+    const nodeTestFile = (n: number) => `
+      import { test } from "node:test";
+      process.on("exit", () => process.exit(1));
+      test("test ${n}", () => {});
+    `;
+
     test("are not run for a bun:test file", async () => {
-      const { stdout, stderr, exitCode } = await runFile(
-        "exit.test.ts",
-        `
-          import { test } from "bun:test";
-          process.on("exit", () => {
-            console.log("exit listener ran");
-            process.exit(1);
-          });
-          test("a passing test", () => {});
-        `,
-      );
-      expect(stdout).not.toContain("exit listener ran");
+      const { stdout, stderr, exitCode } = await runFile("exit.test.ts", bunTestFile(1));
+      expect(stdout).not.toContain("exit listener");
       expect(stderr).toContain("1 pass");
       expect(exitCode).toBe(0);
     });
@@ -1664,16 +1672,46 @@ describe("bun test", () => {
     });
 
     test("can fail the run once node:test registered a test, like node's common.mustCall()", async () => {
-      const { stderr, exitCode } = await runFile(
-        "node-exit-code.test.ts",
-        `
-          import { test } from "node:test";
-          process.on("exit", () => process.exit(1));
-          test("a passing test", () => {});
-        `,
-      );
+      const { stderr, exitCode } = await runFile("node-exit-code.test.ts", nodeTestFile(1));
       expect(stderr).toContain("1 pass");
       expect(exitCode).toBe(1);
+    });
+
+    test("run for a bun:test file under BUN_TEST_DRAIN_EVENT_LOOP, which the vendored node tests set", async () => {
+      using dir = tempDir("bun-test-exit-listener", { "drain.test.ts": bunTestFile(1) });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "drain.test.ts"],
+        env: { ...bunEnv, BUN_TEST_DRAIN_EVENT_LOOP: "1" },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toContain("exit listener 1 ran");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(1);
+    });
+
+    test("are not run in --parallel workers for bun:test files", async () => {
+      const { stdout, stderr, exitCode } = await runFiles(
+        { "a.test.ts": bunTestFile(1), "b.test.ts": bunTestFile(2) },
+        "--parallel=2",
+        "a.test.ts",
+        "b.test.ts",
+      );
+      expect(stdout).not.toContain("exit listener");
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("--parallel workers exit cleanly after node:test files", async () => {
+      const { stderr } = await runFiles(
+        { "a.test.ts": nodeTestFile(1), "b.test.ts": nodeTestFile(2) },
+        "--parallel=2",
+        "a.test.ts",
+        "b.test.ts",
+      );
+      expect(stderr).not.toContain("worker crashed");
+      expect(stderr).toContain("2 pass");
     });
   });
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1570,49 +1570,92 @@ describe("bun test", () => {
     expect(output).toContain("app message");
   });
 
-  test("runs process.on('exit') handlers", async () => {
-    using dir = tempDir("bun-test-exit-handler", {
-      "exit.test.ts": `
-        import { test } from "bun:test";
-        process.on("exit", () => console.log("exit handler ran"));
-        test("a test", () => {});
-      `,
+  // jest and vitest never run a test file's process.on('exit') listeners; node's test harness asserts from them.
+  describe.concurrent("process.on('exit') listeners", () => {
+    async function runFile(name: string, contents: string) {
+      using dir = tempDir("bun-test-exit-listener", { [name]: contents });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", name],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test("are not run for a bun:test file", async () => {
+      const { stdout, stderr, exitCode } = await runFile(
+        "exit.test.ts",
+        `
+          import { test } from "bun:test";
+          process.on("exit", () => {
+            console.log("exit listener ran");
+            process.exit(1);
+          });
+          test("a passing test", () => {});
+        `,
+      );
+      expect(stdout).not.toContain("exit listener ran");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
     });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "exit.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
+    test("are not run for a file that registers globals-style tests", async () => {
+      const { stdout, stderr, exitCode } = await runFile(
+        "globals.test.ts",
+        `
+          process.on("exit", () => {
+            console.log("exit listener ran");
+            process.exit(1);
+          });
+          test("a passing test", () => {});
+        `,
+      );
+      expect(stdout).not.toContain("exit listener ran");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toContain("exit handler ran");
-    expect(stderr).toContain("1 pass");
-    expect(exitCode).toBe(0);
-  });
-
-  test("an exit handler can fail the run, like node's common.mustCall()", async () => {
-    using dir = tempDir("bun-test-exit-handler-code", {
-      "exit-code.test.ts": `
-        import { test } from "bun:test";
-        process.on("exit", () => process.exit(1));
-        test("a passing test", () => {});
-      `,
+    test("still run when the file itself calls process.exit()", async () => {
+      const { stdout, exitCode } = await runFile(
+        "explicit-exit.test.ts",
+        `
+          import { test } from "bun:test";
+          process.on("exit", code => console.log("exit listener ran with", code));
+          test("exits", () => process.exit(3));
+        `,
+      );
+      expect(stdout).toContain("exit listener ran with 3");
+      expect(exitCode).toBe(3);
     });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "exit-code.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
+    test("run once node:test is loaded", async () => {
+      const { stdout, stderr, exitCode } = await runFile(
+        "node.test.ts",
+        `
+          import { test } from "node:test";
+          process.on("exit", code => console.log("exit listener ran with", code));
+          test("a passing test", () => {});
+        `,
+      );
+      expect(stdout).toContain("exit listener ran with 0");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Windows prints the banner to stdout; only assert nothing test-shaped leaks.
-    expect(stdout).not.toContain("pass");
-    expect(stderr).toContain("1 pass");
-    expect(exitCode).toBe(1);
+    test("can fail the run once node:test is loaded, like node's common.mustCall()", async () => {
+      const { stderr, exitCode } = await runFile(
+        "node-exit-code.test.ts",
+        `
+          import { test } from "node:test";
+          process.on("exit", () => process.exit(1));
+          test("a passing test", () => {});
+        `,
+      );
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(1);
+    });
   });
 });
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1726,13 +1726,15 @@ describe("bun test", () => {
         "a.test.ts",
         "b.test.ts",
       );
-      expect(stdout).not.toContain("exit listener");
+      // Worker output is relayed on the coordinator's stderr.
+      expect(stdout + stderr).not.toContain("exit listener");
       expect(stderr).toContain("2 pass");
       expect(exitCode).toBe(0);
     });
 
-    test("--parallel workers exit cleanly after node:test files", async () => {
-      const { stderr } = await runFiles(
+    // --parallel implies --isolate, and a file's listeners are torn down with its global before the worker exits.
+    test("--parallel workers exit cleanly after node:test files; listeners do not reach the run's exit code", async () => {
+      const { stderr, exitCode } = await runFiles(
         { "a.test.ts": nodeTestFile(1), "b.test.ts": nodeTestFile(2) },
         "--parallel=2",
         "a.test.ts",
@@ -1740,6 +1742,7 @@ describe("bun test", () => {
       );
       expect(stderr).not.toContain("worker crashed");
       expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
     });
   });
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1617,6 +1617,25 @@ describe("bun test", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("are not run when node:test is only imported", async () => {
+      const { stdout, stderr, exitCode } = await runFile(
+        "node-import-only.test.ts",
+        `
+          import { test } from "bun:test";
+          import { mock } from "node:test";
+          void mock;
+          process.on("exit", () => {
+            console.log("exit listener ran");
+            process.exit(1);
+          });
+          test("a passing test", () => {});
+        `,
+      );
+      expect(stdout).not.toContain("exit listener ran");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+    });
+
     test("still run when the file itself calls process.exit()", async () => {
       const { stdout, exitCode } = await runFile(
         "explicit-exit.test.ts",
@@ -1630,7 +1649,7 @@ describe("bun test", () => {
       expect(exitCode).toBe(3);
     });
 
-    test("run once node:test is loaded", async () => {
+    test("run once a node:test API registers a test", async () => {
       const { stdout, stderr, exitCode } = await runFile(
         "node.test.ts",
         `
@@ -1644,7 +1663,7 @@ describe("bun test", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("can fail the run once node:test is loaded, like node's common.mustCall()", async () => {
+    test("can fail the run once node:test registered a test, like node's common.mustCall()", async () => {
       const { stderr, exitCode } = await runFile(
         "node-exit-code.test.ts",
         `

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1655,7 +1655,10 @@ describe("bun test", () => {
             });
             test("a Worker uses node:test", async () => {
               const worker = new Worker(new URL("./worker.ts", import.meta.url));
-              await new Promise(resolve => worker.addEventListener("message", resolve, { once: true }));
+              await new Promise((resolve, reject) => {
+                worker.addEventListener("message", resolve, { once: true });
+                worker.addEventListener("error", e => reject(e.error ?? new Error(e.message)), { once: true });
+              });
               worker.terminate();
             });
           `,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1644,6 +1644,34 @@ describe("bun test", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("are not run when only a Worker uses node:test", async () => {
+      const { stdout, stderr, exitCode } = await runFiles(
+        {
+          "worker-uses-node-test.test.ts": `
+            import { test } from "bun:test";
+            process.on("exit", () => {
+              console.log("exit listener ran");
+              process.exit(1);
+            });
+            test("a Worker uses node:test", async () => {
+              const worker = new Worker(new URL("./worker.ts", import.meta.url));
+              await new Promise(resolve => worker.addEventListener("message", resolve, { once: true }));
+              worker.terminate();
+            });
+          `,
+          "worker.ts": `
+            import { mock } from "node:test";
+            mock.fn(() => {});
+            postMessage("used");
+          `,
+        },
+        "worker-uses-node-test.test.ts",
+      );
+      expect(stdout).not.toContain("exit listener ran");
+      expect(stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+    });
+
     test("still run when the file itself calls process.exit()", async () => {
       const { stdout, exitCode } = await runFile(
         "explicit-exit.test.ts",

--- a/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js
@@ -3187,9 +3187,7 @@ test("no assertion failures 3", () => {
 });
 
 // Utility functions
-function runCallChecks(exitCode) {
-  if (exitCode !== 0) return;
-
+afterAll(function runCallChecks() {
   const failed = mustCallChecks.filter(function (context) {
     if ("minimum" in context) {
       context.messageSegment = `at least ${context.minimum}`;
@@ -3199,21 +3197,17 @@ function runCallChecks(exitCode) {
     return context.actual !== context.exact;
   });
 
-  failed.forEach(function (context) {
-    console.log(
-      "Mismatched %s function calls. Expected %s, actual %d.",
-      context.name,
-      context.messageSegment,
-      context.actual,
-    );
-    console.log(context.stack.split("\n").slice(2).join("\n"));
-  });
-
-  if (failed.length) process.exit(1);
-}
+  assert.deepStrictEqual(
+    failed.map(
+      context =>
+        `Mismatched ${context.name} function calls. Expected ${context.messageSegment}, actual ${context.actual}.\n` +
+        context.stack.split("\n").slice(2).join("\n"),
+    ),
+    [],
+  );
+});
 
 function mustCall(fn, criteria = 1) {
-  if (process._exiting) throw new Error("Cannot use mustCall() in process exit handler");
   if (typeof fn === "number") {
     criteria = fn;
     fn = noop;
@@ -3229,8 +3223,6 @@ function mustCall(fn, criteria = 1) {
     name: fn.name || "<anonymous>",
   };
 
-  // Add the exit listener only once to avoid listener leak warnings
-  if (mustCallChecks.length === 0) process.on("exit", runCallChecks);
   mustCallChecks.push(context);
 
   const _return = function () {


### PR DESCRIPTION
### What does this PR do?

Reverts the user-visible half of #34444's exit-listener change. Since that PR, `bun test` dispatched every test file's `process.on('exit')` listeners once the last file finished, so a listener calling `process.exit(1)` failed the run even though the summary reported everything passing (this was slated to be a documented breaking change in the 1.4 notes).

Checked jest 30 and vitest 4.1 with a passing test whose file registers `process.on("exit", () => process.exit(1))`:

| runner | listener ran | exit code |
|---|---|---|
| jest (workers and `-i`) | no | 0 |
| vitest (`forks`, `threads`, `vmForks`, `vmThreads`) | no | 0 |
| bun 1.4 canary before this PR | yes | 1 |

jest gives test files a copy of `process`; vitest tears its workers down itself. Since `bun test` runs every file in one process, one file's listener also affected the whole run.

Now the end-of-run `on_exit()` still runs (profilers, deferred flushes, cleanup hooks) but skips the listener dispatch unless one of these opted in:

- a `node:test` API was called on the main thread — `test`/`describe`/hooks/`mock.*`/`assert.register` all reach `jsFileGeneration`, which marks the runner. Merely importing `node:test`, or a Worker using it, doesn't count.
- `BUN_TEST_DRAIN_EVENT_LOOP=1`, the existing opt-in `scripts/runner.node.mjs` sets for vendored node tests (a few of those run under `bun test` without `node:test` and check `common.mustCall()` counts from an exit listener).

Both keep the vendored node tests and `node:test`'s `run()` children working. A test that calls `process.exit()` itself still runs listeners, as before. `--parallel` workers now go through the same gated `on_exit()` instead of straight to `global_exit()`.

`test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js` verified its own `mustCall()` wrappers from an exit listener; that check is now an `afterAll`.

### How did you verify your code works?

- `test/cli/test/bun-test.test.ts` — replaced the two tests from #34444 with eleven covering: bun:test file, globals-style file, import-only `node:test`, and Worker-only `node:test` don't run listeners and exit 0 even when the listener calls `process.exit(1)`; explicit `process.exit(3)` from a test still runs them; a file registering a `node:test` test runs them and can fail the run; `BUN_TEST_DRAIN_EVENT_LOOP=1` runs them for a bun:test file; `--parallel` runs for both kinds. The "not run" cases fail on the current canary and pass with this branch; the Worker case was also checked against a build with the main-thread guard removed.
- `util-inspect.test.js` passes, and fails when a `mustCall()` wrapper is never invoked.
- `test/js/node/test_runner/node-test.test.ts` passes (45/45); the vendored `test-events-add-abort-listener`, `test-file-write-stream5`, `test-worker-arraybuffer-zerofill`, `test-runner-mocking` still pass with `BUN_TEST_DRAIN_EVENT_LOOP=1`.
- `test/cli/test/parallel.test.ts`: 34/35 locally; the one failure (`unique JEST_WORKER_ID`) reproduces on this debug build without the worker change and passes on the release canary — debug-build timing, unrelated.
