### PR TITLE
sql: make result array metadata properties non-enumerable

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -78,9 +78,7 @@ class SQLArrayParameter {
 }
 
 class SQLResultArray<T> extends PublicArray<T> {
-  // `declare` so these are only types. A real class field would define each of
-  // them as an enumerable own property as soon as super() returns, which the
-  // defineProperties call below would then have to redefine.
+  // Types only: real class fields would be defined (enumerable) after super() and redefined below.
   declare count: number | null;
   declare command: string | null;
   declare lastInsertRowid: number | bigint | null;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -78,9 +78,9 @@ class SQLArrayParameter {
 }
 
 class SQLResultArray<T> extends PublicArray<T> {
-  // `declare` so these are only types. A real class field would be defined as
-  // an enumerable own property as soon as super() returns, and the
-  // defineProperties call below would then leave it enumerable.
+  // `declare` so these are only types. A real class field would define each of
+  // them as an enumerable own property as soon as super() returns, which the
+  // defineProperties call below would then have to redefine.
   declare count: number | null;
   declare command: string | null;
   declare lastInsertRowid: number | bigint | null;
@@ -94,10 +94,10 @@ class SQLResultArray<T> extends PublicArray<T> {
     // match postgres's result array, in this way for in will not list the
     // properties and .map will not return undefined command and count
     Object.defineProperties(this, {
-      count: { value: null, writable: true, configurable: true },
-      command: { value: null, writable: true, configurable: true },
-      lastInsertRowid: { value: null, writable: true, configurable: true },
-      affectedRows: { value: null, writable: true, configurable: true },
+      count: { value: null, writable: true, enumerable: false, configurable: true },
+      command: { value: null, writable: true, enumerable: false, configurable: true },
+      lastInsertRowid: { value: null, writable: true, enumerable: false, configurable: true },
+      affectedRows: { value: null, writable: true, enumerable: false, configurable: true },
     });
   }
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -78,10 +78,13 @@ class SQLArrayParameter {
 }
 
 class SQLResultArray<T> extends PublicArray<T> {
-  public count!: number | null;
-  public command!: string | null;
-  public lastInsertRowid!: number | bigint | null;
-  public affectedRows!: number | bigint | null;
+  // `declare` so these are only types. A real class field would be defined as
+  // an enumerable own property as soon as super() returns, and the
+  // defineProperties call below would then leave it enumerable.
+  declare count: number | null;
+  declare command: string | null;
+  declare lastInsertRowid: number | bigint | null;
+  declare affectedRows: number | bigint | null;
 
   static [Symbol.toStringTag] = "SQLResults";
 
@@ -91,10 +94,10 @@ class SQLResultArray<T> extends PublicArray<T> {
     // match postgres's result array, in this way for in will not list the
     // properties and .map will not return undefined command and count
     Object.defineProperties(this, {
-      count: { value: null, writable: true },
-      command: { value: null, writable: true },
-      lastInsertRowid: { value: null, writable: true },
-      affectedRows: { value: null, writable: true },
+      count: { value: null, writable: true, configurable: true },
+      command: { value: null, writable: true, configurable: true },
+      lastInsertRowid: { value: null, writable: true, configurable: true },
+      affectedRows: { value: null, writable: true, configurable: true },
     });
   }
 

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -176,6 +176,31 @@ if (isDockerEnabled()) {
             await sql`UPDATE ${sql(random_name)} SET name = "test2" WHERE id = ${lastInsertRowid}`;
           expect(affectedRows).toBe(1);
         });
+        test("result metadata properties are not enumerable", async () => {
+          await using db = new SQL({ ...getOptions(), max: 1, idleTimeout: 5 });
+          using sql = await db.reserve();
+          const t = "meta_" + randomUUIDv7("hex").replaceAll("-", "");
+          await sql`CREATE TEMPORARY TABLE ${sql(t)} (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, name text)`;
+
+          const inserted = await sql`INSERT INTO ${sql(t)} (name) VALUES (${"test"})`;
+          expect(Object.keys(inserted)).toEqual([]);
+          expect(
+            ["lastInsertRowid", "affectedRows"].map(key => Object.getOwnPropertyDescriptor(inserted, key)),
+          ).toEqual([
+            { value: 1, writable: true, enumerable: false, configurable: true },
+            { value: 1, writable: true, enumerable: false, configurable: true },
+          ]);
+
+          const selected = await sql`SELECT id, name FROM ${sql(t)}`;
+          expect(selected).toEqual([{ id: 1, name: "test" }]);
+          expect(Object.keys(selected)).toEqual(["0"]);
+          expect(Object.getOwnPropertyDescriptor(selected, "count")).toEqual({
+            value: 1,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+          });
+        });
         test("MEDIUMINT not in the last column reads following columns correctly", async () => {
           // MySQL's binary protocol sends MYSQL_TYPE_INT24 as a fixed 4-byte
           // field. Reading only 3 left the cursor 1 byte behind, silently

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -976,6 +976,18 @@ if (isDockerEnabled()) {
       expect((await sql`select 1`).command).toBe("SELECT");
     });
 
+    test("Result metadata is not enumerable", async () => {
+      const result = await sql`select 1 as x`;
+      expect(Object.keys(result)).toEqual(["0"]);
+      const metadata = ["count", "command", "lastInsertRowid", "affectedRows"];
+      expect(metadata.map(key => Object.getOwnPropertyDescriptor(result, key))).toEqual([
+        { value: 1, writable: true, enumerable: false, configurable: true },
+        { value: "SELECT", writable: true, enumerable: false, configurable: true },
+        { value: null, writable: true, enumerable: false, configurable: true },
+        { value: null, writable: true, enumerable: false, configurable: true },
+      ]);
+    });
+
     test("Create table", async () => {
       await sql`create table test(int int)`;
       await sql`drop table test`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -872,6 +872,38 @@ describe("Query Execution", () => {
     expect(result.command).toBe("DELETE");
   });
 
+  test("result metadata properties are not enumerable", async () => {
+    await sql`CREATE TABLE result_metadata (id INTEGER PRIMARY KEY, name TEXT)`;
+    const inserted = await sql`INSERT INTO result_metadata (name) VALUES (${"a"}), (${"b"})`;
+    const selected = await sql`SELECT * FROM result_metadata ORDER BY id`;
+
+    // Like postgres.js, the metadata hangs off the array without showing up
+    // when the rows are enumerated.
+    expect(Object.keys(selected)).toEqual(["0", "1"]);
+    expect(Object.keys(inserted)).toEqual([]);
+    const forIn: string[] = [];
+    for (const key in selected) forIn.push(key);
+    expect(forIn).toEqual(["0", "1"]);
+    expect({ ...selected }).toEqual({
+      "0": { id: 1, name: "a" },
+      "1": { id: 2, name: "b" },
+    });
+
+    const metadata = ["count", "command", "lastInsertRowid", "affectedRows"];
+    expect(metadata.map(key => Object.getOwnPropertyDescriptor(selected, key))).toEqual([
+      { value: 2, writable: true, enumerable: false, configurable: true },
+      { value: "SELECT", writable: true, enumerable: false, configurable: true },
+      { value: null, writable: true, enumerable: false, configurable: true },
+      { value: null, writable: true, enumerable: false, configurable: true },
+    ]);
+    expect(metadata.map(key => Object.getOwnPropertyDescriptor(inserted, key))).toEqual([
+      { value: 2, writable: true, enumerable: false, configurable: true },
+      { value: "INSERT", writable: true, enumerable: false, configurable: true },
+      { value: 2, writable: true, enumerable: false, configurable: true },
+      { value: null, writable: true, enumerable: false, configurable: true },
+    ]);
+  });
+
   test("SELECT with various clauses", async () => {
     await sql`CREATE TABLE scores (id INTEGER, player TEXT, score INTEGER, team TEXT)`;
     await sql`INSERT INTO scores VALUES


### PR DESCRIPTION
### Problem
- The arrays returned by `Bun.SQL` queries carry `count`, `command`, `lastInsertRowid` and `affectedRows` as enumerable own properties, so `Object.keys(rows)`, `for (const k in rows)` and `{ ...rows }` list them next to the row indexes:
  ```ts
  const rows = await new SQL(":memory:")`select 1 as a union all select 2 as a`;
  Object.keys(rows); // [ "0", "1", "count", "command", "lastInsertRowid", "affectedRows" ]
  ```
- Same on every adapter (sqlite, postgres, mysql), since the properties are created in the shared `SQLResultArray` constructor. Reproduces on bun 1.4.0 and on main.
- Cause: `src/js/internal/sql/shared.ts:81-84` declares the four names as class fields (`public count!: ...`). The builtins bundle emits them as real class fields, so every instance gets them as enumerable, configurable properties as soon as `super()` returns. The `Object.defineProperties` call right below (`shared.ts:93`), whose comment says it exists so that `for in` does not list them, then finds properties that already exist, and a descriptor applied to an existing property only changes the attributes it names (`value`, `writable`); `enumerable` stays `true`.
- This is a regression. 09ab840114 (#17635, bun 1.2.4) fixed exactly this by removing the `command; count;` class fields and adding the `defineProperties` call. 784271f85e (#21640, bun 1.2.21) moved the class into `shared.ts` and re-added the names as typed class fields, which undid the fix. Nothing caught it because `toEqual` on arrays ignores non-index properties, and no test looked at `Object.keys` of a result.

### Fix
- The four fields become `declare` fields, so nothing is emitted for them and `Object.defineProperties` is what creates the properties, as in postgres.js's `Result` (the model for this class) and as in the 1.2.4 fix. This also removes the define-then-redefine of every property on every result array.
- The descriptors now spell out `enumerable: false`. With `declare` fields the creation default already gives that, but the 1.2.21 regression happened precisely because the intent lived only in that default; stated explicitly, the descriptor map is correct even if a real class field is ever reintroduced (see #30037 below).
- The descriptors also pass `configurable: true`. Creating the properties would otherwise make them non-configurable; the bug is the enumerable flag, and `delete rows.count` / redefining a property has worked in every shipped release, so that is left as is. The final descriptor is `{ writable: true, enumerable: false, configurable: true }`, i.e. today's descriptor with only `enumerable` changed.
- Reading and assigning the metadata is unchanged: the adapters set it with plain assignment (`sqlite.ts:263`, `postgres.ts:270`, `mysql.ts:33`), which keeps the attributes of an existing writable property. `JSON.stringify`, `.map()` (`Symbol.species` is `Array`) and `expect().toEqual()` against a plain array behave as before. `structuredClone(rows)` and object spread now drop the metadata, since they only copy enumerable properties; `console.log(rows)` still shows it because Bun's inspect currently prints non-enumerable properties too.
- Tests (each fails on the unfixed build at its `Object.keys` assertion, passes with the fix):
  - `test/js/sql/sqlite-sql.test.ts` "result metadata properties are not enumerable": both constructor paths (a SELECT with rows and an INSERT without), `Object.keys`, `for...in`, spread, and the full descriptors of all four properties. Whole file: 240 pass. The `Object.keys` pin also catches any metadata name added enumerably in the future.
  - `test/js/sql/sql.test.ts` "Result metadata is not enumerable": postgres, after the resolve callback has filled in `command`/`count`.
  - `test/js/sql/sql-mysql.test.ts` "result metadata properties are not enumerable": mysql, after the resolve callback has filled in `count`/`lastInsertRowid`/`affectedRows`. Both server tests were also run against local postgres and MariaDB services with a copy of the test bodies (the files themselves are docker-gated locally).
- Related: #32872 carries the same descriptor change as a side effect of making `toEqual` stricter and needs it to land. #30037 adds `columns`/`statement` to this class with the pre-fix `public x!:` pattern; after this lands they should be `declare` fields too (its copied descriptors will now carry `enumerable: false` either way). #38438 changes the `super(...values)` line of the same constructor and does not overlap with these hunks.

### Background
- `SQLResultArray` (`src/js/internal/sql/shared.ts`) is the `Array` subclass every `Bun.SQL` query resolves to. Rows are the array elements; query metadata hangs off the array as extra own properties, mirroring postgres.js's `Result` class, whose constructor is `super(); Object.defineProperties(this, { count: { value: null, writable: true }, ... })`.
- A TypeScript class field (`count!: T;`) is not type-only: it compiles to an ES class field, which runs `[[DefineOwnProperty]]` on the instance with `enumerable: true, configurable: true, writable: true` right after `super()` returns. A `declare` field is the type-only form and emits nothing.
- `Object.defineProperty`/`defineProperties` on a property that does not exist yet creates it with every unspecified attribute set to `false`; on a property that already exists, it only changes the attributes that the descriptor mentions.
