### PR TITLE
Read BUN_FEATURE_FLAG_NO_LIBDEFLATE and BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE from the environment

### DIFF
--- a/src/bun_core/feature_flags.rs
+++ b/src/bun_core/feature_flags.rs
@@ -2,7 +2,7 @@
 //! instead.
 
 use crate::env;
-use crate::feature_flag;
+use crate::env_var::feature_flag;
 
 /// Store and reuse file descriptors during module resolution
 /// This was a ~5% performance improvement
@@ -120,14 +120,20 @@ pub fn is_libdeflate_enabled() -> bool {
         return false;
     }
 
-    !feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE.get()
+    !feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE
+        .get()
+        .unwrap_or(false)
 }
 
 /// Enable the "app" option in Bun.serve. This option will likely be removed
 /// in favor of HTML loaders and configuring framework options in bunfig.toml
 pub fn bake() -> bool {
     // In canary or if an environment variable is specified.
-    env::IS_CANARY || env::IS_DEBUG || feature_flag::BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE.get()
+    env::IS_CANARY
+        || env::IS_DEBUG
+        || feature_flag::BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE
+            .get()
+            .unwrap_or(false)
 }
 
 /// Additional debugging features for bake.DevServer, such as the incremental visualizer.

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2278,19 +2278,6 @@ pub(crate) mod debug_allocator_data {
     }
 }
 
-/// `bun.feature_flag.*` runtime env-var getters. The canonical typed
-/// accessors live in `env_var::feature_flag`; this stub provides the
-/// `.get()` accessor surface for flags not yet wired there.
-pub mod feature_flag {
-    macro_rules! flag { ($($name:ident),* $(,)?) => { $(
-        #[allow(non_camel_case_types)] pub struct $name;
-        impl $name { #[inline] pub fn get(&self) -> bool { false } }
-    )* } }
-    flag!(
-        BUN_FEATURE_FLAG_NO_LIBDEFLATE,
-        BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE
-    );
-}
 /// `bun.linuxKernelVersion()`. Lives in T1 because `bun_sys` calls it from feature probes (copy_file_range,
 /// ioctl_ficlone, RWF_NONBLOCK) and cannot depend on `bun_analytics`. Parses
 /// `uname(2).release` major.minor.patch directly; the full Semver parse with

--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -2,9 +2,11 @@
 
 use core::ffi::c_int;
 
-use bun_core::feature_flag;
+use bun_core::env_var::feature_flag;
 use bun_libdeflate_sys::libdeflate as libdeflate_sys;
 use bun_zlib as zlib;
+
+bun_core::define_scoped_log!(log, crate::websocket_client::WebSocketClient);
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -131,7 +133,10 @@ impl PerMessageDeflate {
     }
 
     fn can_use_libdeflate(len: usize) -> bool {
-        if feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE.get() {
+        if feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE
+            .get()
+            .unwrap_or(false)
+        {
             return false;
         }
 
@@ -147,6 +152,7 @@ impl PerMessageDeflate {
 
         // First we try with libdeflate, which is both faster and doesn't need the trailing deflate bytes
         if Self::can_use_libdeflate(in_buf.len()) {
+            log!("Decompressing {} bytes with libdeflate", in_buf.len());
             if let Some(decompressor) = self.rare_data.decompressor() {
                 let result =
                     decompressor.decompress_to_vec(in_buf, out, libdeflate_sys::Encoding::Deflate);

--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -2,11 +2,8 @@
 
 use core::ffi::c_int;
 
-use bun_core::env_var::feature_flag;
 use bun_libdeflate_sys::libdeflate as libdeflate_sys;
 use bun_zlib as zlib;
-
-bun_core::define_scoped_log!(log, crate::websocket_client::WebSocketClient);
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -133,14 +130,7 @@ impl PerMessageDeflate {
     }
 
     fn can_use_libdeflate(len: usize) -> bool {
-        if feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE
-            .get()
-            .unwrap_or(false)
-        {
-            return false;
-        }
-
-        len < RareData::STACK_BUFFER_SIZE
+        bun_core::feature_flags::is_libdeflate_enabled() && len < RareData::STACK_BUFFER_SIZE
     }
 
     pub(crate) fn decompress(
@@ -152,7 +142,6 @@ impl PerMessageDeflate {
 
         // First we try with libdeflate, which is both faster and doesn't need the trailing deflate bytes
         if Self::can_use_libdeflate(in_buf.len()) {
-            log!("Decompressing {} bytes with libdeflate", in_buf.len());
             if let Some(decompressor) = self.rare_data.decompressor() {
                 let result =
                     decompressor.decompress_to_vec(in_buf, out, libdeflate_sys::Encoding::Deflate);

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -575,6 +575,8 @@ export const decodeURIComponentSIMD = $newCppFunction(
 
 export const getDevServerDeinitCount = $bindgenFn("DevServer.bind.ts", "getDeinitCountForTesting");
 export const getCounters = $newRustFunction("Counters.rs", "createCountersObject", 0);
+/** What fetch(), bun install and the WebSocket client consult before trying libdeflate; false under BUN_FEATURE_FLAG_NO_LIBDEFLATE. */
+export const isLibdeflateEnabled = $newRustFunction("bun.rs", "isLibdeflateEnabled", 0) as () => boolean;
 export const linearFifoOrderedRemoveProbe = $newRustFunction(
   "collections/linear_fifo.rs",
   "TestingAPIs.orderedRemoveProbe",

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -74,6 +74,17 @@ pub(crate) fn bun_get_use_system_ca(
     Ok(JSValue::js_boolean(v))
 }
 
+/// `bun:internal-for-testing`'s `isLibdeflateEnabled()`. The accessor itself is
+/// in `bun_core`, which cannot depend on `bun_jsc`, so the JS wrapper lives here.
+pub(crate) fn bun_is_libdeflate_enabled(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_boolean(
+        bun_core::feature_flags::is_libdeflate_enabled(),
+    ))
+}
+
 mod css {
     pub use bun_css_jsc::css_internals::{
         _test, attr_test, minify_error_test_with_options, minify_test, minify_test_with_options,

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -74,8 +74,7 @@ pub(crate) fn bun_get_use_system_ca(
     Ok(JSValue::js_boolean(v))
 }
 
-/// `bun:internal-for-testing`'s `isLibdeflateEnabled()`. The accessor itself is
-/// in `bun_core`, which cannot depend on `bun_jsc`, so the JS wrapper lives here.
+/// `isLibdeflateEnabled()` in `bun:internal-for-testing`.
 pub(crate) fn bun_is_libdeflate_enabled(
     _global: &JSGlobalObject,
     _frame: &CallFrame,

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -1,6 +1,6 @@
 import { Socket } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gcTick, isDebug } from "harness";
+import { bunEnv, bunExe, gcTick } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
@@ -962,43 +962,31 @@ describe("empty compressed responses", () => {
   }
 });
 
-// The NO_LIBDEFLATE cases above expect the same bytes either way, so they pass
-// even when the flag is ignored. Only debug builds say which decoder ran
-// (the HTTPInternalState scoped log), so that is what this checks.
-describe.skipIf(!isDebug)("BUN_FEATURE_FLAG_NO_LIBDEFLATE selects the decoder", () => {
-  const expected = Buffer.alloc(1024, "hello libdeflate ").toString();
-  const compressed = gzipSync(expected);
-
+// The NO_LIBDEFLATE=1 cases above decode to the same bytes as the =0 cases, so
+// they also pass when the variable is ignored. This checks the switch itself:
+// isLibdeflateEnabled() is what fetch(), bun install and the WebSocket client
+// consult before trying libdeflate.
+describe("BUN_FEATURE_FLAG_NO_LIBDEFLATE is read from the environment", () => {
   it.concurrent.each([
-    ["0", ["[httpinternalstate] Decompressing N bytes with libdeflate"]],
-    ["1", ["[httpinternalstate] Decompressing N bytes"]],
-  ])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", async (noLibdeflate, decoderLines) => {
-    // Content-Length and a buffered read: the whole body is in hand when it is
-    // decoded, which is the only case the libdeflate fast path is eligible for.
-    using server = Bun.serve({
-      port: 0,
-      fetch: () => new Response(compressed, { headers: { "Content-Encoding": "gzip" } }),
-    });
+    ["unset", undefined, "true"],
+    ["0", "0", "true"],
+    ["1", "1", "false"],
+  ])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", async (_label, value, enabled) => {
+    const env = { ...bunEnv };
+    delete env.BUN_FEATURE_FLAG_NO_LIBDEFLATE;
+    if (value !== undefined) env.BUN_FEATURE_FLAG_NO_LIBDEFLATE = value;
+
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `const text = await (await fetch(process.argv[1])).text();
-         if (text !== process.argv[2]) throw new Error("decoded " + text.length + " bytes, expected " + process.argv[2].length);`,
-        String(server.url),
-        expected,
+        `import { isLibdeflateEnabled } from "bun:internal-for-testing";
+         console.log(isLibdeflateEnabled());`,
       ],
-      env: { ...bunEnv, BUN_FEATURE_FLAG_NO_LIBDEFLATE: noLibdeflate, BUN_DEBUG_HTTPInternalState: "1" },
+      env,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({
-      decoderLines: stdout
-        .split(/\r?\n/)
-        .filter(line => line.startsWith("[httpinternalstate] Decompressing "))
-        .map(line => line.replace(/\d+ bytes/, "N bytes")),
-      stderr,
-      exitCode,
-    }).toEqual({ decoderLines, stderr: expect.not.stringContaining("error"), exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: `${enabled}\n`, stderr: "", exitCode: 0 });
   });
 });

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -1,6 +1,6 @@
 import { Socket } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gcTick } from "harness";
+import { bunEnv, bunExe, gcTick, isDebug } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
@@ -960,4 +960,45 @@ describe("empty compressed responses", () => {
       }
     });
   }
+});
+
+// The NO_LIBDEFLATE cases above expect the same bytes either way, so they pass
+// even when the flag is ignored. Only debug builds say which decoder ran
+// (the HTTPInternalState scoped log), so that is what this checks.
+describe.skipIf(!isDebug)("BUN_FEATURE_FLAG_NO_LIBDEFLATE selects the decoder", () => {
+  const expected = Buffer.alloc(1024, "hello libdeflate ").toString();
+  const compressed = gzipSync(expected);
+
+  it.concurrent.each([
+    ["0", ["[httpinternalstate] Decompressing N bytes with libdeflate"]],
+    ["1", ["[httpinternalstate] Decompressing N bytes"]],
+  ])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", async (noLibdeflate, decoderLines) => {
+    // Content-Length and a buffered read: the whole body is in hand when it is
+    // decoded, which is the only case the libdeflate fast path is eligible for.
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(compressed, { headers: { "Content-Encoding": "gzip" } }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const text = await (await fetch(process.argv[1])).text();
+         if (text !== process.argv[2]) throw new Error("decoded " + text.length + " bytes, expected " + process.argv[2].length);`,
+        String(server.url),
+        expected,
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_NO_LIBDEFLATE: noLibdeflate, BUN_DEBUG_HTTPInternalState: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      decoderLines: stdout
+        .split(/\r?\n/)
+        .filter(line => line.startsWith("[httpinternalstate] Decompressing "))
+        .map(line => line.replace(/\d+ bytes/, "N bytes")),
+      stderr,
+      exitCode,
+    }).toEqual({ decoderLines, stderr: expect.not.stringContaining("error"), exitCode: 0 });
+  });
 });

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -1,6 +1,5 @@
 import { serve } from "bun";
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug } from "harness";
+import { expect, test } from "bun:test";
 
 test("WebSocket client negotiates permessage-deflate", async () => {
   let serverReceivedExtensions = "";
@@ -391,60 +390,4 @@ test("server enforces maxPayloadLength on compressed messages inflated through t
   expect(events[1]).toBe("close");
 
   expect(serverReceived).toEqual([900]);
-});
-
-// The client offers every compressed message to libdeflate before its zlib
-// stream unless BUN_FEATURE_FLAG_NO_LIBDEFLATE is set. Both decoders yield the
-// same bytes, so only the debug log (WebSocketClient scope) shows which ran.
-describe.skipIf(!isDebug)("BUN_FEATURE_FLAG_NO_LIBDEFLATE disables the client's libdeflate fast path", () => {
-  const message = Buffer.alloc(1024, "compress me ").toString();
-
-  test.concurrent.each([
-    ["0", ["[websocketclient] Decompressing N bytes with libdeflate"]],
-    ["1", []],
-  ])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", async (noLibdeflate, libdeflateLines) => {
-    using server = serve({
-      port: 0,
-      fetch(req, server) {
-        if (server.upgrade(req)) {
-          return;
-        }
-        return new Response("Not found", { status: 404 });
-      },
-      websocket: {
-        perMessageDeflate: true,
-        open(ws) {
-          ws.send(message, true);
-        },
-        message() {},
-      },
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const ws = new WebSocket(process.argv[1]);
-         const { promise, resolve, reject } = Promise.withResolvers();
-         ws.onmessage = event => resolve(event.data);
-         ws.onclose = event => reject(new Error("closed before a message arrived: " + event.code + " " + event.reason));
-         const received = await promise;
-         ws.close();
-         if (received !== process.argv[2]) throw new Error("received " + received.length + " bytes, expected " + process.argv[2].length);`,
-        `ws://localhost:${server.port}`,
-        message,
-      ],
-      env: { ...bunEnv, BUN_FEATURE_FLAG_NO_LIBDEFLATE: noLibdeflate, BUN_DEBUG_WebSocketClient: "1" },
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({
-      libdeflateLines: stdout
-        .split(/\r?\n/)
-        .filter(line => line.startsWith("[websocketclient] Decompressing "))
-        .map(line => line.replace(/\d+ bytes/, "N bytes")),
-      stderr,
-      exitCode,
-    }).toEqual({ libdeflateLines, stderr: expect.not.stringContaining("error"), exitCode: 0 });
-  });
 });

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -1,5 +1,6 @@
 import { serve } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
 
 test("WebSocket client negotiates permessage-deflate", async () => {
   let serverReceivedExtensions = "";
@@ -390,4 +391,60 @@ test("server enforces maxPayloadLength on compressed messages inflated through t
   expect(events[1]).toBe("close");
 
   expect(serverReceived).toEqual([900]);
+});
+
+// The client offers every compressed message to libdeflate before its zlib
+// stream unless BUN_FEATURE_FLAG_NO_LIBDEFLATE is set. Both decoders yield the
+// same bytes, so only the debug log (WebSocketClient scope) shows which ran.
+describe.skipIf(!isDebug)("BUN_FEATURE_FLAG_NO_LIBDEFLATE disables the client's libdeflate fast path", () => {
+  const message = Buffer.alloc(1024, "compress me ").toString();
+
+  test.concurrent.each([
+    ["0", ["[websocketclient] Decompressing N bytes with libdeflate"]],
+    ["1", []],
+  ])("BUN_FEATURE_FLAG_NO_LIBDEFLATE=%s", async (noLibdeflate, libdeflateLines) => {
+    using server = serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) {
+          return;
+        }
+        return new Response("Not found", { status: 404 });
+      },
+      websocket: {
+        perMessageDeflate: true,
+        open(ws) {
+          ws.send(message, true);
+        },
+        message() {},
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const ws = new WebSocket(process.argv[1]);
+         const { promise, resolve, reject } = Promise.withResolvers();
+         ws.onmessage = event => resolve(event.data);
+         ws.onclose = event => reject(new Error("closed before a message arrived: " + event.code + " " + event.reason));
+         const received = await promise;
+         ws.close();
+         if (received !== process.argv[2]) throw new Error("received " + received.length + " bytes, expected " + process.argv[2].length);`,
+        `ws://localhost:${server.port}`,
+        message,
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_NO_LIBDEFLATE: noLibdeflate, BUN_DEBUG_WebSocketClient: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      libdeflateLines: stdout
+        .split(/\r?\n/)
+        .filter(line => line.startsWith("[websocketclient] Decompressing "))
+        .map(line => line.replace(/\d+ bytes/, "N bytes")),
+      stderr,
+      exitCode,
+    }).toEqual({ libdeflateLines, stderr: expect.not.stringContaining("error"), exitCode: 0 });
+  });
 });


### PR DESCRIPTION
### Problem
- `BUN_FEATURE_FLAG_NO_LIBDEFLATE=1` and `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1` have no effect. An unfixed debug build run with `BUN_FEATURE_FLAG_NO_LIBDEFLATE=1 BUN_DEBUG_HTTPInternalState=1` on a gzip `fetch()` still prints `[httpinternalstate] Decompressing 81 bytes with libdeflate`.
- Cause: `src/bun_core/lib.rs:2284` defined `pub mod feature_flag` as a stub whose `get()` is hardcoded to `false` for exactly these two flags, and the three readers imported that stub instead of the real accessors:
  - `src/bun_core/feature_flags.rs:123`, `is_libdeflate_enabled()`, used by the fetch body decoder (`src/http/InternalState.rs:264`) and tarball extraction (`src/install/extract_tarball.rs:297`)
  - `src/bun_core/feature_flags.rs:130`, `bake()`, which gates `bun build --app` and the `app` option of `Bun.serve` on non-canary release builds
  - `src/http_jsc/websocket_client/WebSocketDeflate.rs:134`, the WebSocket client's libdeflate fast path
- The real accessors already exist, `env_var::feature_flag::BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE` (`src/bun_core/env_var.rs:260`) and `BUN_FEATURE_FLAG_NO_LIBDEFLATE` (`env_var.rs:285`), and nothing referenced them.
- Before the Rust port, `bun.feature_flag` was an alias of `env_var.feature_flag` (`src/bun.zig`), so both variables used to work. The `BUN_FEATURE_FLAG_NO_LIBDEFLATE=1` rows in `test/js/web/fetch/fetch-gzip.test.ts` and the `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1` in `test/harness.ts`'s `bunEnv` were written against that behavior; with the stub, the `=1` rows silently re-ran the libdeflate path.

### Fix
- `is_libdeflate_enabled()` and `bake()` read `env_var::feature_flag::*` with the `.get().unwrap_or(false)` form every other flag reader uses; the stub module is deleted.
- The WebSocket client calls `feature_flags::is_libdeflate_enabled()` instead of reading the variable itself, so the HTTP client, `bun install` and the WebSocket client share one accessor.
- Correct because it restores the pre-port behavior, and the `env_var` declarations are the canonical definition of these flags (`feature_flags.rs` itself says new flags belong in `env_var.rs`). Both flags still default to `false`, so nothing changes unless the variable is set.
- Test: `bun:internal-for-testing` gains `isLibdeflateEnabled()` (`src/runtime/dispatch_js2native.rs`, next to `getUseSystemCA`; `bun_core` cannot depend on `bun_jsc`, so the JS wrapper lives there). The new block at the end of `fetch-gzip.test.ts` spawns bun with the variable unset, `0` and `1` and expects `true`, `true`, `false`. It runs on release builds. With the stub still in place and only the getter added, the `=1` row fails (prints `true`); against main as-is the import fails, so all three rows fail.
- Because all three consumers go through that one accessor, this covers the thing that broke. The decoders themselves produce identical bytes (the flag is an escape hatch), and the existing `=1` rows in this file now exercise the zlib fallback for real on every lane, so I did not add per-consumer "which decoder ran" instrumentation.
- `bake()` is verified by reading only: on debug and canary builds (everything CI tests) it is `true` regardless of the variable.
- Other runs: `fetch-gzip.test.ts` (83 pass), the three `websocket-permessage-deflate*` files with the variable unset and with `BUN_FEATURE_FLAG_NO_LIBDEFLATE=1` exported (21 pass each way), `test/cli/install/bun-install-streaming-extract.test.ts` with it exported (11 pass, exercising the libarchive fallback), `cargo clippy` on `bun_core`, `bun_http_jsc`, `bun_runtime` clean.

### Background
- `bun_core::env_var` is the typed, cached environment variable layer. `new_feature_flag!(NAME, "NAME", {})` expands to a module plus an `Accessor` whose `get()` returns `Option<bool>`, `Some(false)` when unset; call sites spell it `FLAG.get().unwrap_or(false)`.
- libdeflate is a one-shot decompressor bun tries first for whole gzip/deflate bodies, buffered `.tgz` files and complete WebSocket messages; zlib (fetch, WebSocket) or libarchive (`bun install`) is the streaming fallback it drops to when libdeflate cannot decode the input. `BUN_FEATURE_FLAG_NO_LIBDEFLATE` skips the first attempt.
- `bun:internal-for-testing` is the module the test suite uses to reach internal state; it is only importable when `bunEnv` sets `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING`. `$newRustFunction("bun.rs", name, 0)` binds an export to `dispatch_js2native::bun_<snake_name>`.

<details>
<summary>Earlier revision</summary>

The first push kept the WebSocket client reading the variable directly, added a `WebSocketClient` debug log line there, and tested both the fetch and WebSocket paths by scraping `BUN_DEBUG_*` scoped logs from a child process. Those tests were `skipIf(!isDebug)`, which means no default CI lane ran them, and the log line existed only to make the test writable. Self-review flagged both, so the log and the two tests were replaced by the shared accessor plus the `bun:internal-for-testing` getter above.

</details>
