### PR TITLE
sourcemap: fix the CRLF peek when counting generated lines

### DIFF
--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -568,12 +568,9 @@ impl NewBuilder<'_, VLQSourceMap> {
                 }
                 // '\r', '\n', U+2028, U+2029
                 0x0D | 0x0A | 0x2028 | 0x2029 => {
-                    // windows newline
-                    if c == 0x0D {
-                        let newline_check = self.last_generated_update as usize + i + 1;
-                        if newline_check < output.len() && output[newline_check] == b'\n' {
-                            continue;
-                        }
+                    // windows newline: `i` already points at the byte after the '\r'
+                    if c == 0x0D && i < n && slice[i] == b'\n' {
+                        continue;
                     }
 
                     // If we're about to move to the next line and the previous line didn't have

--- a/test/bundler/bundler_comments.test.ts
+++ b/test/bundler/bundler_comments.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { readFileSync } from "node:fs";
 import { SourceMap } from "node:module";
 import { itBundled } from "./expectBundled";
 
@@ -390,6 +391,57 @@ describe("multi-line comments", () => {
       expect(entry.originalLine).toBeGreaterThanOrEqual(0);
     },
   });
+
+  // JS engines count a lone "\r" as a line terminator and "\r\n" as a single
+  // one, so the generated lines in the map have to be counted the same way for
+  // stack traces to remap. A legal comment is printed verbatim apart from its
+  // "\r\n"s becoming "\n", and an inlined enum member is followed by a comment
+  // holding its name; those are how these terminators end up in the output.
+  function lineOf(code: string, needle: string) {
+    const index = code.split(/\r\n|\r|\n/).findIndex(line => line.includes(needle));
+    expect(index).toBeGreaterThanOrEqual(0);
+    return index;
+  }
+  const terminatorCases = [
+    {
+      name: "lone CR in a legal comment starts a new generated line in the sourcemap",
+      file: "/entry.js",
+      // One character between the "\r" and the "\n" is the shape the builder used to miss.
+      entry: '/*! a\rb\nc */\nconsole.log("after comment");\nconsole.log("next line");\n',
+      printed: "/*! a\rb\nc */",
+      needles: ['"after comment"', '"next line"'],
+    },
+    {
+      name: "CRLF left in a legal comment counts as one generated line in the sourcemap",
+      file: "/entry.js",
+      entry: '/*! a\r\r\nb */\nconsole.log("after comment");\nconsole.log("next line");\n',
+      printed: "/*! a\r\nb */",
+      needles: ['"after comment"', '"next line"'],
+    },
+    {
+      name: "CRLF in an inlined enum member comment counts as one generated line in the sourcemap",
+      file: "/entry.ts",
+      entry: 'enum E { "a\\r\\nb" = 1 }\nconsole.log(E["a\\r\\nb"]);\nconsole.log("next line");\n',
+      printed: "1 /* a\r\nb */",
+      needles: ['"next line"'],
+    },
+  ];
+  for (const { name, file, entry, printed, needles } of terminatorCases) {
+    itBundled(name, {
+      files: { [file]: entry },
+      sourceMap: "external",
+      onAfterBundle(api) {
+        // api.readFile() normalizes CRLF, so read the output directly.
+        const output = readFileSync(api.outfile, "utf8");
+        expect(output).toContain(printed);
+        const map = new SourceMap(JSON.parse(readFileSync(api.outfile + ".map", "utf8")));
+        // The generated line each needle ends up on must map back to the line it is on in the entry.
+        expect(needles.map(needle => [needle, map.findEntry(lineOf(output, needle), 0).originalLine])).toEqual(
+          needles.map(needle => [needle, lineOf(entry, needle)]),
+        );
+      },
+    });
+  }
 
   // The lexer skips >=512-byte block comment bodies with SIMD; these verify
   // large comments end-to-end (legal comment preservation, ASI, output code).

--- a/test/js/bun/sourcemap/internal-sourcemap.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap.test.ts
@@ -191,6 +191,31 @@ describe("InternalSourceMap", () => {
     expect(exited).toBe(0);
   });
 
+  // The generated lines counted while building the map have to agree with what
+  // JSC reports: a lone "\r" is a line terminator and "\r\n" is a single one. A
+  // legal comment is printed verbatim apart from its "\r\n"s becoming "\n", so
+  // it is how either reaches the transpiled code ("\r\r\n" comes out as "\r\n").
+  describe("line terminators inside a legal comment", () => {
+    async function remappedLines(index: string) {
+      const { stdout, stderr, exited } = await run({ "index.ts": index });
+      expect(stderr).toBe("");
+      expect(exited).toBe(0);
+      return [...stdout.matchAll(/index\.ts:(\d+):\d+/g)].map(m => Number(m[1]));
+    }
+
+    test("a lone CR starts a new line", async () => {
+      // Lines: 1 "/*! a", 2 "b", 3 "c */", 4 the Error, 5 console.log.
+      const index = '/*! a\rb\nc */\nconst err = new Error("x");\nconsole.log(err.stack);\n';
+      expect(await remappedLines(index)).toEqual([4]);
+    });
+
+    test("a CRLF is a single line break", async () => {
+      // Lines: 1 "/*! a", 2 "", 3 "b */", 4 console.log("before"), 5 the Error, 6 console.log.
+      const index = '/*! a\r\r\nb */\nconsole.log("before");\nconst err = new Error("x");\nconsole.log(err.stack);\n';
+      expect(await remappedLines(index)).toEqual([5]);
+    });
+  });
+
   test("FindCache eviction (>16 distinct windows in one stack)", async () => {
     // 20 functions spread ~125 lines apart in a single file. With ~6 mappings
     // per padding line that's ~750 mappings between calls -> each frame lands


### PR DESCRIPTION
### Problem

- Every mapping that follows a carriage return in the printed output lands on the wrong generated line, in both `bun build --sourcemap` output and the maps the runtime uses to remap `error.stack`: a lone `\r` followed by a one-character line is not counted as a line break, and an actual `\r\n` is counted as two.
- Repro: bundle `/*! a\rb\nc */\nconsole.log(1);\nthrow new Error("x");\n` with `--sourcemap=external`. The output puts `console.log` on its 5th line (the `\r` ends a line, as it does for every JS engine), but `mappings` is `;AAGA;AAAA;AAAA,QAAQ,IAAI,CAAC;...`, with `console.log` in the 4th line group. Running a file with that comment reports a `new Error()` created on line 4 as line 5.
- Cause: `update_generated_line_and_column_slow` in `src/sourcemap/Chunk.rs` advances `i` past the decoded character before matching on it, but the `\r` arm peeked at `last_generated_update + i + 1`, which is two bytes past the CR. (The `+ 1` is from esbuild's version of this loop, where `i` is the index of the rune itself.) So `\rX\n` skips the CR because the byte two ahead is a `\n`, and `\r\nX` counts the CR and then the `\n` again.

### Fix

- The `\r` arm peeks at `slice[i]`, the byte directly after the CR. That condition is the whole change; the rest of the hunk is the comment.
- This is the line terminator rule JSC uses for the positions that get looked up in these maps (`\r`, `\n`, U+2028 and U+2029 each end a line, `\r\n` ends one), and it is the rule `LineOffsetTable::generate` already applies to the original side of every mapping, so the two sides of a mapping now count lines the same way.
- This miscount is what #18814 ran into (CRLF legal comments in tabster's dist shifted every later mapping in the bundle, one line per comment line); #23871 fixed that report by rewriting `\r\n` to `\n` inside legal comments in the printer, which left the builder wrong for the CRs that still get through (the shapes tested here). Fixing the peek where the count happens covers those without more printer-side normalization.
- Tests, all of which fail on the unfixed build:
  - `test/bundler/bundler_comments.test.ts`: three bundles (lone CR in a legal comment, CRLF left in a legal comment, CRLF in an inlined enum member comment) check that the generated line holding each statement after the comment maps back to that statement's line in the entry point. Unfixed, the statement after the lone CR maps to the line below it and the one after the CRLF maps to the line above it.
  - `test/js/bun/sourcemap/internal-sourcemap.test.ts`: the same two shapes through `bun run` and `error.stack`, which go through the same builder but the runtime's internal map format. Unfixed, they report line 5 instead of 4 and line 4 instead of 5.
- Also ran `test/js/bun/sourcemap/`, `bundler_edgecase`, the compile source map tests and the `node:module` source map tests against the debug build.

### Background

- The printer calls the source map builder once per token it maps. `update_generated_line_and_column` scans whatever was printed since the previous call to advance the generated line and column, emitting one line separator (a `;` in VLQ maps, a separator entry in the runtime's internal format) per line break it sees. `bun build` maps and the runtime's stack trace maps both come out of this one loop.
- A raw CR reaches the printed output in two ways. Legal comments (`/*! ... */`) are copied verbatim except that a `\r\n` inside them becomes `\n`, so a lone `\r` survives and `\r\r\n` comes out as a real `\r\n`. Accessing an inlined enum member prints `1 /* member name */` with the name verbatim. Strings and template literals escape or normalize CRs, so the tests use those two shapes.
- The runtime CRLF test uses the legal comment shape rather than the enum one because the runtime prints a single-member enum as an arrow function ending in a multi-line template literal, and JSC reports wrong line numbers after that construct regardless of source maps (tracked separately).
- Not changed here: the same loop (and `LineOffsetTable::generate`) steps over the declared width of an invalid UTF-8 lead byte, so a Latin-1 byte directly before a newline still swallows that line break. Different cause, tracked separately.

<details>
<summary>Repro output before and after</summary>

```
$ printf '/*! a\rb\nc */\nconsole.log(1);\nthrow new Error("x");\n' > in.js
$ bun build ./in.js --outdir out --sourcemap=external

# out/in.js (cat -A)
// in.js$
/*! a^Mb$
c */$
console.log(1);$
throw new Error("x");$

# mappings before (6 groups, console.log in group 4, it is on line 5 of the file)
;AAGA;AAAA;AAAA,QAAQ,IAAI,CAAC;AACb,MAAM,IAAI,MAAM,GAAG;
# mappings after (7 groups)
;AAGA;AAAA;AAAA;AAAA,QAAQ,IAAI,CAAC;AACb,MAAM,IAAI,MAAM,GAAG;

$ printf 'enum E { "a\\r\\nb" = 1 }\nconsole.log(E["a\\r\\nb"]);\nthrow new Error("x");\n' > in.ts
$ bun build ./in.ts --outdir out --sourcemap=external
# out/in.js contains `console.log(1 /* a<CR><LF>b */);` (3 lines of code after the path comment)
# before (6 groups, the CRLF counted twice)
;AACA,QAAQ,IAAI;AAAA;AAAA,IAAW;AACvB,MAAM,IAAI,MAAM,GAAG;
# after (5 groups)
;AACA,QAAQ,IAAI;AAAA,IAAW;AACvB,MAAM,IAAI,MAAM,GAAG;

$ printf '/*! a\rb\nc */\nconst err = new Error("x");\nconsole.log(err.stack.split("\\n")[1]);\n' > rt.js
$ bun rt.js
    at /tmp/rt.js:5:17      # before (the Error is on line 4)
    at /tmp/rt.js:4:17      # after
```

</details>
