### PR TITLE
fix(install): resolve sibling workspaces for bun link

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -35,6 +35,7 @@ use bun_url::URL;
 use bun_spawn::process::WaiterThread;
 
 use crate::RunCommand;
+use crate::dependency::TagExt;
 
 /// `Command::Context` shim — the option-carrying `ContextData` shape was lifted
 /// into `bun_options_types::context` so install can reference it without the CLI
@@ -486,11 +487,32 @@ impl Subcommand {
     pub(crate) fn supports_json_output(self) -> bool {
         matches!(self, Self::Audit | Self::Pm | Self::Info)
     }
+}
 
-    // TODO: make all subcommands find root and chdir
-    pub(crate) fn should_chdir_to_root(self) -> bool {
-        !matches!(self, Self::Link)
-    }
+fn has_workspace_dependencies(root: &bun_ast::Expr) -> bool {
+    const DEPENDENCY_GROUPS: [&[u8]; 4] = [
+        b"dependencies",
+        b"devDependencies",
+        b"optionalDependencies",
+        b"peerDependencies",
+    ];
+
+    DEPENDENCY_GROUPS.iter().any(|group| {
+        root.get(group)
+            .and_then(|dependencies| dependencies.data.e_object())
+            .is_some_and(|dependencies| {
+                dependencies.properties.iter().any(|dependency| {
+                    dependency
+                        .value
+                        .as_ref()
+                        .and_then(|value| value.as_utf8_string_literal())
+                        .is_some_and(|version| {
+                            crate::dependency::Tag::infer(version)
+                                == crate::dependency::Tag::Workspace
+                        })
+                })
+            })
+    })
 }
 
 pub enum WorkspaceFilter {
@@ -1631,8 +1653,23 @@ pub fn init(
             ZStr::from_buf(&original_package_json_path_buf[..], new_path_len);
         let child_cwd = &original_package_json_path.as_bytes()[..this_cwd.len()];
 
+        let link_has_workspace_dependencies = subcommand == Subcommand::Link
+            && cli.positionals.len() > 1
+            && match workspace_package_json_cache.get_with_path(
+                // SAFETY: `ctx.log` is the process-lifetime CLI log initialized before `init`.
+                unsafe { &mut *ctx.log },
+                original_package_json_path.as_bytes(),
+                Default::default(),
+            ) {
+                workspace_package_json_cache::GetResult::Entry(entry) => {
+                    has_workspace_dependencies(&entry.root)
+                }
+                workspace_package_json_cache::GetResult::ParseErr(_)
+                | workspace_package_json_cache::GetResult::ReadErr(_) => false,
+            };
+
         // Check if this is a workspace; if so, use root package
-        if subcommand.should_chdir_to_root() {
+        if subcommand != Subcommand::Link || link_has_workspace_dependencies {
             if !created_package_json {
                 while let Some(parent) = bun_core::dirname(this_cwd) {
                     let parent_without_trailing_slash = strings::without_trailing_slash(parent);

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -32,6 +32,70 @@ afterEach(async () => {
   await dummyAfterEach();
 });
 
+const workspaceDependencyGroups = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+] as const;
+
+async function createLinkWorkspace(rootDir: string, dependencyGroup: (typeof workspaceDependencyGroups)[number]) {
+  const workspacePackageDir = join(rootDir, "foo");
+  const rootManifest = { workspaces: ["foo", "bar"] };
+  const workspaceManifest = {
+    name: "foo",
+    [dependencyGroup]: {
+      bar: "workspace:*",
+    },
+  };
+
+  await mkdir(workspacePackageDir, { recursive: true });
+  await mkdir(join(rootDir, "bar"), { recursive: true });
+  await Promise.all([
+    writeFile(join(rootDir, "package.json"), JSON.stringify(rootManifest)),
+    writeFile(join(workspacePackageDir, "package.json"), JSON.stringify(workspaceManifest)),
+    writeFile(
+      join(rootDir, "bar", "package.json"),
+      JSON.stringify({
+        name: "bar",
+        version: "1.0.0",
+      }),
+    ),
+  ]);
+
+  return { rootManifest, workspaceManifest, workspacePackageDir };
+}
+
+async function runLink(cwd: string, args: string[], processEnv: NodeJS.Dict<string>) {
+  await using proc = spawn({
+    cmd: [bunExe(), "link", ...args],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: processEnv,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+async function registerLinkedPackage(linkName: string, processEnv: NodeJS.Dict<string>) {
+  await writeFile(
+    join(link_dir, "package.json"),
+    JSON.stringify({
+      name: linkName,
+      version: "1.0.0",
+    }),
+  );
+
+  const { stdout, stderr, exitCode } = await runLink(link_dir, [], processEnv);
+  expect({ stdout: stdout.includes(`Success! Registered "${linkName}"`), stderr, exitCode }).toEqual({
+    stdout: true,
+    stderr: "",
+    exitCode: 0,
+  });
+}
+
 it("should link and unlink workspace package", async () => {
   await writeFile(
     join(link_dir, "package.json"),
@@ -170,6 +234,79 @@ it("should link and unlink workspace package", async () => {
   expect(err.split(/\r?\n/)).toEqual([""]);
   expect(await stdout.text()).toContain(`success: unlinked package "foo"`);
   expect(await exited).toBe(0);
+});
+
+for (const dependencyGroup of workspaceDependencyGroups) {
+  it(`should link a package from a workspace with sibling ${dependencyGroup}`, async () => {
+    const linkName = basename(link_dir).slice("bun-link.".length);
+    const testEnv = { ...env, BUN_INSTALL_GLOBAL_DIR: join(link_dir, "global") };
+    const { rootManifest, workspaceManifest, workspacePackageDir } = await createLinkWorkspace(
+      package_dir,
+      dependencyGroup,
+    );
+    await registerLinkedPackage(linkName, testEnv);
+
+    const { stdout, stderr, exitCode } = await runLink(workspacePackageDir, [linkName, "--linker=hoisted"], testEnv);
+
+    expect({ stdout: stdout.replace(/\s*\[[0-9.]+ms\]\s*$/, "").split(/\r?\n/), stderr, exitCode }).toEqual({
+      stdout: [
+        expect.stringContaining("bun link v1."),
+        "",
+        "+ bar@workspace:bar",
+        "",
+        `installed ${linkName}@link:${linkName}`,
+        "",
+        "3 packages installed",
+      ],
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await file(join(package_dir, "package.json")).json()).toEqual(rootManifest);
+    expect(await file(join(workspacePackageDir, "package.json")).json()).toEqual(workspaceManifest);
+    expect(await file(join(package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
+      name: "bar",
+      version: "1.0.0",
+    });
+    expect(await file(join(package_dir, "node_modules", linkName, "package.json")).json()).toEqual({
+      name: linkName,
+      version: "1.0.0",
+    });
+  });
+}
+
+it("should save a linked package only to the child workspace manifest", async () => {
+  const linkName = basename(link_dir).slice("bun-link.".length);
+  const testEnv = { ...env, BUN_INSTALL_GLOBAL_DIR: join(link_dir, "global") };
+  const { rootManifest, workspacePackageDir } = await createLinkWorkspace(package_dir, "dependencies");
+  await registerLinkedPackage(linkName, testEnv);
+
+  const { stdout, stderr, exitCode } = await runLink(
+    workspacePackageDir,
+    [linkName, "--linker=hoisted", "--save"],
+    testEnv,
+  );
+
+  expect({ stdout: stdout.replace(/\s*\[[0-9.]+ms\]\s*$/, "").split(/\r?\n/), stderr, exitCode }).toEqual({
+    stdout: [
+      expect.stringContaining("bun link v1."),
+      "",
+      "+ bar@workspace:bar",
+      "",
+      `installed ${linkName}@link:${linkName}`,
+      "",
+      "3 packages installed",
+    ],
+    stderr: "Saved lockfile\n",
+    exitCode: 0,
+  });
+  expect(await file(join(package_dir, "package.json")).json()).toEqual(rootManifest);
+  expect(await file(join(workspacePackageDir, "package.json")).json()).toEqual({
+    name: "foo",
+    dependencies: {
+      bar: "workspace:*",
+      [linkName]: `link:${linkName}`,
+    },
+  });
 });
 
 it("should link package", async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #24190.

`bun link <package>` now discovers the workspace root when the current package
has a `workspace:` dependency, allowing sibling workspaces to resolve during
the link install.

The current manifest is read through the existing parsed package JSON cache.
Root discovery remains disabled for bare `bun link` and for targeted links
without workspace dependencies, preserving their current child-local install
behavior. This avoids the broad behavior change from the closed #24198 and
#26279 approaches.

The regression covers all four dependency groups, default no-save behavior,
and a fresh-state `--save` run. It verifies sibling installation, linked
package installation, an unchanged root manifest, and writing only the child
workspace manifest when requested.

### How did you verify your code works?

- Confirmed the released Bun 1.3.14 reproduces the exact sibling workspace
  resolution failure.
- Confirmed the new regression fails on unmodified current `main` with
  `Workspace dependency "bar" not found`.
- `bun bd test test/cli/install/bun-link.test.ts` (9 passed)
- `cargo check -p bun_install`
- `cargo clippy -p bun_install -- -D warnings`
- `cargo fmt --all -- --check`
- `bun x prettier --check test/cli/install/bun-link.test.ts`

The repository-wide `bun run typecheck` baseline currently reports unrelated
fixture and project-configuration diagnostics. Its references to
`bun-link.test.ts` are the pre-existing custom matcher declarations and calls,
outside this change.
