### PR TITLE
sql(mysql): explain the remedy when public key retrieval is refused

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -141,6 +141,25 @@ MySQL databases support:
 
 </Accordion>
 
+<Accordion title="MySQL 8 authentication over plain TCP (allowPublicKeyRetrieval)">
+
+MySQL 8 accounts default to the `caching_sha2_password` plugin. The first connection for a user requires full authentication: over an unencrypted connection the client has to download the server's RSA public key to encrypt the password. Bun refuses that by default (the same default as mysql2 and Connector/J), because an attacker on the network path could substitute their own key and recover the password. The connection fails with `ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED`.
+
+Connect with TLS, or opt in explicitly if you trust the network (for example a local development database):
+
+```ts
+const mysql = new SQL({
+  adapter: "mysql",
+  hostname: "localhost",
+  username: "root",
+  password: "secret",
+  database: "myapp",
+  allowPublicKeyRetrieval: true, // permit RSA public key retrieval without TLS
+});
+```
+
+</Accordion>
+
 ### SQLite
 
 SQLite support is built into `Bun.SQL`, with the same tagged template literal interface:

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -857,7 +857,15 @@ impl JSMySQLConnection {
             if let Some(err_) = self.global_object.try_take_exception() {
                 self.fail_with_js_value(err_);
             } else {
-                self.fail(b"Connection closed", err);
+                let message: &[u8] = match err {
+                    AnyMySQLErrorT::PublicKeyRetrievalNotAllowed => {
+                        b"The server requested RSA public key retrieval to complete \
+                          authentication, which is not allowed over an insecure connection. \
+                          Enable TLS or set allowPublicKeyRetrieval: true"
+                    }
+                    _ => b"Connection closed",
+                };
+                self.fail(message, err);
             }
         }
     }

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -218,3 +218,39 @@ test("caching_sha2_password scramble hashes the double-SHA256 before the nonce",
     server.close();
   }
 });
+
+// AuthMoreData 0x04 (perform_full_authentication) over plain TCP makes the client
+// fetch the server's RSA public key, which is refused unless allowPublicKeyRetrieval
+// is set. Every MySQL 8 first connection for a user looks like this by default, so
+// the refusal must name the cause and the remedies, not just say "Connection closed".
+test("public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies", async () => {
+  const PERFORM_FULL_AUTH = 0x04;
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10({ authPlugin: "caching_sha2_password" }));
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
+        if (!authed) {
+          // HandshakeResponse41 -> demand full authentication.
+          authed = true;
+          socket.write(mysqlAuthMoreData(seq + 1, Buffer.from([PERFORM_FULL_AUTH])));
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
+    const err = await sql.connect().then(
+      () => null,
+      e => e,
+    );
+    expect(err?.code).toBe("ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED");
+    expect(err?.message).toContain("allowPublicKeyRetrieval: true");
+    expect(err?.message).toContain("TLS");
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
### Problem

- Connecting to MySQL 8.x over plain TCP fails with code `ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED` but message "Connection closed", which says nothing about the cause or the remedy (#38446).
- The refusal itself is intentional and stays: over plain TCP an on-path attacker can answer the public key request with their own key and recover the password, so bun (like mysql2 and Connector/J) requires an explicit `allowPublicKeyRetrieval: true` opt-in. The existing negative test in `test/js/sql/sql-mysql.auth.test.ts` pins that default.
- The useless message comes from `on_error` in `src/sql_jsc/mysql/JSMySQLConnection.rs`, which hardcodes "Connection closed" for every connection-level error regardless of the variant.

### Fix

- `on_error` now gives `PublicKeyRetrievalNotAllowed` an actionable message: "The server requested RSA public key retrieval to complete authentication, which is not allowed over an insecure connection. Enable TLS or set allowPublicKeyRetrieval: true". All other variants keep the previous message.
- Documented `allowPublicKeyRetrieval` in `docs/runtime/sql.mdx` (it was only in the type declarations before).
- Test: scripted MySQL server in `test/js/sql/sql-mysql.auth.test.ts` sends AuthMoreData `0x04` (perform_full_authentication); asserts the error code and that the message names both remedies. Fails on current bun (message is "Connection closed"), passes with this change. Full file passes under `bun bd test`.

### Background

- MySQL 8 accounts default to the `caching_sha2_password` auth plugin. A user's first connection (cold server-side auth cache) takes the "full authentication" path: the server sends AuthMoreData `0x04`, and over an unencrypted connection the client must download the server's RSA public key to encrypt the password. Later connections take a fast path that needs no key, which makes the failure look intermittent to users.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql.auth.test.ts
bun test v1.4.0 (72072bc46)

test/js/sql/sql-mysql.auth.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [526.51ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [111.48ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [73.09ms]
246 |     const err = await sql.connect().then(
247 |       () => null,
248 |       e => e,
249 |     );
250 |     expect(err?.code).toBe("ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED");
251 |     expect(err?.message).toContain("allowPublicKeyRetrieval: true");
                               ^
error: expect(received).toContain(expected)

Expected to contain: "allowPublicKeyRetrieval: true"
Received: "Connection closed"

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql.auth.test.ts:251:26)
(
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/sql/sql-mysql.auth.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [10.12ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [2.05ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [2.53ms]
246 |     const err = await sql.connect().then(
247 |       () => null,
248 |       e => e,
249 |     );
250 |     expect(err?.code).toBe("ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED");
251 |     expect(err?.message).toContain("allowPublicKeyRetrieval: true");
                               ^
error: expect(received).toContain(expected)

Expected to contain: "allowPublicKeyRetrieval: true"
Received: "Connection closed"

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql.auth.test.ts:251:26)
(fail) public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies [2.15ms]

 3 pass
 1 fail
 6 expect() calls
Ran 4 tests across 1 file. [234.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql.auth.test.ts
bun test v1.4.0 (72072bc46)

test/js/sql/sql-mysql.auth.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [630.05ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [116.31ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [76.86ms]
(pass) public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies [54.01ms]

 4 pass
 0 fail
 7 expect() calls
Ran 4 tests across 1 file. [4.17s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 746ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[2/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[3/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[4/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[5/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[6/11] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[7/11] gen cpp.rs (cppbind)
[7/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx                   | 19 ++++++++++++++++++
 src/sql_jsc/mysql/JSMySQLConnection.rs | 10 +++++++++-
 test/js/sql/sql-mysql.auth.test.ts     | 36 ++++++++++++++++++++++++++++++++++
 3 files changed, 64 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
docs/runtime/sql.mdx                        1      2      0
src/sql_jsc/mysql/JSMySQLConnection.rs      3      1      0
test/js/sql/sql-mysql.auth.test.ts          1      2      0
```

</details>

**root cause** · written by the author bot

When connecting to MySQL 8 over plain TCP with the default caching_sha2_password plugin, the server requests full authentication and the client must fetch the server's RSA public key, which Bun refuses by default unless allowPublicKeyRetrieval is enabled; the connection-level error path then collapsed this refusal into a generic "Connection closed" message that gave users no indication of the cause. The fix adds a dedicated match arm for the PublicKeyRetrievalNotAllowed error variant so the raised error now explains the refusal and names both remedies, enabling TLS or setting allowPublicKey…

<!-- robobun:evidence:end -->