### PR TITLE
bundler: count a CR-terminated banner as one line break in source maps

### DIFF
--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -317,16 +317,17 @@ pub(crate) fn post_process_js_chunk(
                 break 'brk (source_hashbang.slice(), c.options.banner);
             }
 
-            // Otherwise check if banner starts with hashbang
+            // Otherwise check if banner starts with hashbang. As in the lexer, the
+            // hashbang ends at the first '\r' or '\n', so a CRLF banner does not
+            // leave a '\r' on it that advance() would count as its own line break.
             if !c.options.banner.is_empty() && c.options.banner.starts_with(b"#!") {
-                let newline_pos = strings::index_of_char(c.options.banner, b'\n')
-                    .map(|n| n as usize)
+                let hashbang_end = strings::index_of_any(c.options.banner, b"\r\n")
                     .unwrap_or(c.options.banner.len());
-                let banner_hashbang = &c.options.banner[..newline_pos];
+                let banner_hashbang = &c.options.banner[..hashbang_end];
 
                 break 'brk (
                     banner_hashbang,
-                    strings::trim_left(&c.options.banner[newline_pos..], b"\r\n"),
+                    strings::trim_left(&c.options.banner[hashbang_end..], b"\r\n"),
                 );
             }
 
@@ -374,9 +375,16 @@ pub(crate) fn post_process_js_chunk(
     if !banner.is_empty() {
         j.push_static(banner);
         line_offset.advance(banner);
-        if !strings::ends_with_char(banner, b'\n') {
-            j.push_static(b"\n");
-            line_offset.advance(b"\n");
+        match banner[banner.len() - 1] {
+            b'\n' => {}
+            // advance() already counted a trailing bare '\r' as a line break. The
+            // '\n' pushed here merges with it into a single CRLF in the output,
+            // so counting it too would shift every mapping down by one line.
+            b'\r' => j.push_static(b"\n"),
+            _ => {
+                j.push_static(b"\n");
+                line_offset.advance(b"\n");
+            }
         }
         newline_before_comment = true;
     }

--- a/test/bundler/bundler_banner.test.ts
+++ b/test/bundler/bundler_banner.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect } from "bun:test";
-import { itBundled } from "./expectBundled";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { BundlerTestBundleAPI, itBundled } from "./expectBundled";
+
+// api.readFile() normalizes CRLF to LF, so read the raw bytes instead.
+function readRawOutput(api: BundlerTestBundleAPI, name: string): string {
+  return readFileSync(path.join(api.outdir, name), "utf8");
+}
+
+// Asserts that the first generated line with a mapping in `name`.map is the
+// line of `name` that `console.log(` is on. Line breaks are counted the way a
+// JS parser (and a source map consumer) counts them: a CRLF is one line break.
+function expectFirstMappingOnConsoleLogLine(api: BundlerTestBundleAPI, name: string) {
+  const outputLines = readRawOutput(api, name).split(/\r\n|\r|\n/);
+  const consoleLogLine = outputLines.findIndex(line => line.startsWith("console.log("));
+  expect(consoleLogLine).toBeGreaterThan(0);
+
+  const { mappings } = JSON.parse(api.readFile(`/out/${name}.map`));
+  const firstMappedLine = mappings.split(";").findIndex((line: string) => line.length > 0);
+  expect(firstMappedLine).toBe(consoleLogLine);
+}
 
 describe("bundler", () => {
   itBundled("banner/CommentBanner", {
@@ -232,4 +252,31 @@ console.log("bun!");`,
       stdout: "bun!\n",
     },
   });
+
+  // `--banner "$(cat banner.txt)"` with a CRLF banner.txt gives a banner whose
+  // lines end in "\r\n" and whose last line ends in a bare "\r" (the shell strips
+  // the final "\n"). The "\n" the bundler appends completes that "\r\n", which is
+  // one line break in the output, and the source map has to be placed accordingly.
+  // The hashbang line itself is emitted without the "\r", like a source hashbang.
+  for (const [name, banner, expectedOutputPrefix] of [
+    ["LFBanner", "#!/usr/bin/env bun\n// banner", "#!/usr/bin/env bun\n// banner\n"],
+    ["HashbangEndingInCR", "#!/usr/bin/env bun\r", "#!/usr/bin/env bun\n"],
+    ["CRLFHashbangBanner", "#!/usr/bin/env bun\r\n// banner\r\n", "#!/usr/bin/env bun\n// banner\r\n"],
+    ["CRLFHashbangBannerEndingInCR", "#!/usr/bin/env bun\r\n// banner\r", "#!/usr/bin/env bun\n// banner\r\n"],
+    ["CRLFBannerEndingInCR", "// line one\r\n// line two\r", "// line one\r\n// line two\r\n"],
+  ] as const) {
+    itBundled(`banner/SourceMapWith${name}`, {
+      banner,
+      backend: "api",
+      outdir: "/out",
+      sourceMap: "external",
+      files: {
+        "/a.js": `console.log("Hello, world!");`,
+      },
+      onAfterBundle(api) {
+        expectFirstMappingOnConsoleLogLine(api, "a.js");
+        expect(readRawOutput(api, "a.js")).toStartWith(expectedOutputPrefix);
+      },
+    });
+  }
 });


### PR DESCRIPTION
### Problem
- `bun build --sourcemap` with a banner whose last byte is a bare `\r` produces a source map in which every mapping is one generated line too low. This is what `--banner "$(cat banner.txt)"` passes when `banner.txt` has CRLF line endings: the shell strips the final `\n` and leaves `"#!/usr/bin/env bun\r\n...\r"`. A banner whose hashbang line ends in CRLF shifts the map even when the banner itself ends in `\n`; when both the hashbang and the last line end in `\r`, the map is off by two.
- `src/bundler/linker_context/postProcessJSChunk.rs:322` split the banner's hashbang at the first `\n`, so the hashbang kept its trailing `\r`. Lines 345-346 then advanced the line offset over the hashbang (the bare `\r` at its end counts as a line break) and over the `\n` pushed after it (a second line break), although those two bytes form one CRLF in the output file.
- Lines 376-379 did the same for a non-hashbang banner ending in `\r`: `advance(banner)` followed by `advance("\n")`.
- The emitted hashbang line also kept the `\r` (`#!/usr/bin/env bun\r\n`), unlike a hashbang taken from a CRLF source file, which the lexer ends before the `\r`.

### Fix
- The banner's hashbang now ends at the first `\r` or `\n` (`strings::index_of_any`), matching how the lexer delimits a source file's hashbang; it is emitted as `hashbang + "\n"` and so never contains a `\r`. The rest of the banner is still trimmed of leading `\r\n` as before.
- When the banner body ends in a bare `\r`, the `\n` that completes it into a CRLF is pushed without advancing the line offset: `advance(banner)` already counted that `\r` as a line break, and in the output the `\r\n` pair is a single line break. The banner bytes themselves are emitted unchanged, so a CRLF banner stays CRLF.
- This is correct because `generated_offset` for each file's source map chunk is derived from `line_offset`, which has to equal the number of line terminators (in the JS sense, where CRLF is one) actually written to the chunk before that file's code. Both changes make the count match the bytes written; a banner with LF line endings, or one that already ends in `\n`, takes exactly the same path as before.
- Out of scope on purpose: `target_from_hashbang` in `src/bundler/bundle_v2.rs` (the entry-file shebang that switches the default target to bun) also only recognizes an LF-terminated shebang. That is a separate behavior whose semantics are being changed by #33859 and #33862, so it is left alone here and tracked separately.
- Verified with `test/bundler/bundler_banner.test.ts` (`banner/SourceMapWith*`): the four CR cases fail on the current release (first mapped line is 4 instead of 3, 5 instead of 4, 6 instead of 4, 5 instead of 4) and pass with this change; the LF case passes both ways as a control. Also re-ran `test/bundler/esbuild/default.test.ts -t Hashbang` and `test/bundler/bundler_edgecase.test.ts -t SourceMap`, plus manual builds with `--target=bun`, `--format=cjs`, `--splitting` (non-entry chunks receive the whole banner) and a source-file hashbang combined with a CR-terminated banner.

### Background
- `post_process_js_chunk` assembles a chunk by pushing byte slices into a `StringJoiner`; next to every push it calls `line_offset.advance(slice)` so that when it reaches a file's printed code it can record where in the chunk that code starts (`generated_offset`). The chunk's source map is built by shifting each file's mappings by that offset.
- `LineColumnOffset::advance` (`src/sourcemap/lib.rs`) counts `\n`, `\r`, U+2028 and U+2029 as line breaks and a `\r\n` pair inside the slice as one. It is stateless across calls, so a `\r` at the end of one slice and a `\n` at the start of the next are counted as two line breaks even though the file contains a single CRLF.
- The hashbang is split off the banner because for `--target=bun` the `// @bun` pragma and the CommonJS wrapper have to be emitted between the hashbang and the rest of the banner.

<details>
<summary>Repro on the current release</summary>

```sh
printf 'console.log(1);\n' > in.js
bun build ./in.js --outdir out --sourcemap=external --banner "$(printf '#!/usr/bin/env bun\r')"
```

`out/in.js` is `#!/usr/bin/env bun\r\n`, `\n`, `// in.js\n`, `console.log(1);\n`, so `console.log` is on generated line 3 (0-based). `out/in.js.map` has `mappings: ";;;;AAAA,QAAQ,IAAI,CAAC;"`, i.e. line 4. With `--banner '#!/usr/bin/env bun'` the mappings are `";;;AAAA,..."`, which is correct.

</details>
