### PR TITLE
test/bundler: make the three dead source map checks in expectBundled assert

### DIFF
--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -378,6 +378,9 @@ export type MappingSnapshot = [
   // If column is quoted text, find the token and use the column of it
   //    "index.ts:5:'abc'"
   source_code: string,
+  // The generated position the source map maps that to, plus the text the
+  // generated file must contain there. Line is 1-based, column is 0-based:
+  //    "3:2:return"
   generated_mapping: string,
 ];
 
@@ -1673,23 +1676,24 @@ for (const [key, blob] of build.outputs) {
                 expect(sourcemap_content).toBe(actual_content);
               }
 
-              const generated_code = await Bun.file(path.join(outdir!, file.replace(".map", ""))).text();
+              const generated_lines = (await Bun.file(path.join(outdir!, file.replace(".map", ""))).text()).split("\n");
 
               if (map_tests.mappings)
-                for (const mapping of map_tests.mappings) {
-                  const src = parseSourceMapStrSource(outdir!, parsed, mapping[0]);
-                  const dest = parseSourceMapStrGenerated(generated_code, mapping[1]);
+                for (const [source_str, generated_str] of map_tests.mappings) {
+                  const src = parseSourceMapStrSource(outdir!, parsed, source_str);
+                  const expected_text = parseSourceMapStrGenerated(generated_str);
                   const pos = map.generatedPositionFor(src);
-                  if (!dest.matched) {
-                    const real_generated = generated_code
-                      .split("\n")
-                      [pos.line! - 1].slice(pos.column!)
-                      .slice(0, dest.expected!.length);
-                    expect(`${pos.line}:${pos.column}:${real_generated}`).toBe(mapping[1]);
-                    throw new Error("Not matched");
+                  // Format what the map says in the same "line:col:text" shape as the
+                  // snapshot so a failure can be pasted back into the test.
+                  let actual = "unmapped";
+                  if (pos.line !== null && pos.column !== null) {
+                    const text = (generated_lines[pos.line - 1] ?? "").slice(
+                      pos.column,
+                      pos.column + expected_text.length,
+                    );
+                    actual = `${pos.line}:${pos.column}:${text}`;
                   }
-                  expect(pos.line === dest.line);
-                  expect(pos.column === dest.column);
+                  expect(actual, `${file}: generated position of ${source_str}`).toBe(generated_str);
                 }
               if (map_tests.mappingsExactMatch) {
                 expect(parsed.mappings).toBe(map_tests.mappingsExactMatch);
@@ -1998,21 +2002,20 @@ function parseSourceMapStrSource(root: string, source_map: SourceMap, string: st
   return { line, column: col, source: source_map.sources[source_id] };
 }
 
-function parseSourceMapStrGenerated(source_code: string, string: string) {
+/** Validates a "line:col:text" generated location and returns its `text` part. */
+function parseSourceMapStrGenerated(string: string) {
   const split = string.split(":");
   if (split.length != 3)
     throw new Error("Test is invalid; Invalid generated location. See MappingSnapshot typedef for more info.");
-  const [line_raw, col_raw, ...match] = split;
-  const line = Number(line_raw);
-  if (!Number.isInteger(line))
+  const [line_raw, col_raw, text] = split;
+  if (!Number.isInteger(Number(line_raw)))
     throw new Error(
       "Test is invalid; Invalid generated line " +
         JSON.stringify(line_raw) +
         ". See MappingSnapshot typedef for more info.",
     );
 
-  let column = Number(col_raw);
-  if (!Number.isInteger(column)) {
+  if (!Number.isInteger(Number(col_raw))) {
     throw new Error(
       "Test is invalid; Invalid generated column " +
         JSON.stringify(col_raw) +
@@ -2020,14 +2023,5 @@ function parseSourceMapStrGenerated(source_code: string, string: string) {
     );
   }
 
-  if (match.length > 0) {
-    let str = match.join(":");
-    const text = source_code.split("\n")[line - 1];
-    const actual = text.slice(column, column + str.length);
-    if (actual !== str) {
-      return { matched: false, line, column, actual, expected: str };
-    }
-  }
-
-  return { matched: true, line, column };
+  return text;
 }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1669,11 +1669,11 @@ for (const [key, blob] of build.outputs) {
             const map_tests = snapshotSourceMap?.[path.basename(file)];
             if (map_tests) {
               expect(parsed.sources.map((a: string) => a.replaceAll("\\", "/"))).toEqual(map_tests.files);
-              for (let i = 0; i < parsed.sources; i++) {
+              const map_dir = path.dirname(path.join(outdir!, file));
+              for (let i = 0; i < parsed.sources.length; i++) {
                 const source = parsed.sources[i];
-                const sourcemap_content = parsed.sourceContent[i];
-                const actual_content = readFileSync(path.resolve(path.join(outdir!, file), source), "utf-8");
-                expect(sourcemap_content).toBe(actual_content);
+                const actual_content = readFileSync(path.resolve(map_dir, source), "utf-8");
+                expect(parsed.sourcesContent[i], `${file}: sourcesContent of ${source}`).toBe(actual_content);
               }
 
               const generated_lines = (await Bun.file(path.join(outdir!, file.replace(".map", ""))).text()).split("\n");

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -466,7 +466,7 @@ function testRef(id: string, options: BundlerTestInput): BundlerTestRef {
   return { id, options };
 }
 
-function expectBundled(
+export function expectBundled(
   id: string,
   opts: BundlerTestInput,
   dryRun = false,
@@ -1654,8 +1654,8 @@ for (const [key, blob] of build.outputs) {
 
               const loc_key = `${m.generatedLine}:${m.generatedColumn}`;
               if (mappedLocations.has(loc_key)) {
-                const fmtLoc = (loc: any) =>
-                  `${loc.generatedLine}:${m.generatedColumn} -> ${m.originalLine}:${m.originalColumn} [${m.source.replaceAll(/^(\.\.\/)+/g, "/").replace(root, "")}]`;
+                const fmtLoc = (loc: typeof m) =>
+                  `${loc.generatedLine}:${loc.generatedColumn} -> ${loc.originalLine}:${loc.originalColumn} [${loc.source.replaceAll(/^(\.\.\/)+/g, "/").replace(root, "")}]`;
 
                 const a = fmtLoc(mappedLocations.get(loc_key));
                 const b = fmtLoc(m);

--- a/test/bundler/itBundled-snapshotSourceMap.test.ts
+++ b/test/bundler/itBundled-snapshotSourceMap.test.ts
@@ -31,32 +31,63 @@ const bundle = {
 } satisfies BundlerTestInput;
 const files = ["../greet.ts", "../entry.ts"];
 
-// Mappings that disagree with the source map, and what the map really says.
-// The quoted text does exist at each claimed generated position, which used to
-// be the only thing `mappings` checked.
-const rejected: Record<string, { mapping: MappingSnapshot; received: string }> = {
+function withMapping(mapping: MappingSnapshot): Partial<BundlerTestInput> {
+  return { snapshotSourceMap: { "entry.js.map": { files, mappings: [mapping] } } };
+}
+
+// Snapshots that disagree with the emitted source map, and what their failure
+// has to say. The quoted text does exist at each claimed generated position,
+// which used to be the only thing `mappings` checked.
+const rejected: Record<string, { opts: Partial<BundlerTestInput>; output: string[] }> = {
   // Generated line 8 also starts with `console`, but entry.ts:2 maps to line 7.
-  WrongLine: { mapping: ["entry.ts:2:'console'", "8:0:console"], received: "7:0:console" },
-  WrongText: { mapping: ["entry.ts:2:'console'", "7:0:nope"], received: "7:0:cons" },
+  WrongLine: {
+    opts: withMapping(["entry.ts:2:'console'", "8:0:console"]),
+    output: [
+      "entry.js.map: generated position of entry.ts:2:'console'",
+      'Expected: "8:0:console"',
+      'Received: "7:0:console"',
+    ],
+  },
+  WrongText: {
+    opts: withMapping(["entry.ts:2:'console'", "7:0:nope"]),
+    output: [
+      "entry.js.map: generated position of entry.ts:2:'console'",
+      'Expected: "7:0:nope"',
+      'Received: "7:0:cons"',
+    ],
+  },
   // Generated line 1 is the `// greet.ts` comment; nothing in greet.ts:1 (also
   // a comment) is mapped at all.
-  Unmapped: { mapping: ["greet.ts:1:'greets'", "1:3:greet"], received: "unmapped" },
+  Unmapped: {
+    opts: withMapping(["greet.ts:1:'greets'", "1:3:greet"]),
+    output: [
+      "entry.js.map: generated position of greet.ts:1:'greets'",
+      'Expected: "1:3:greet"',
+      'Received: "unmapped"',
+    ],
+  },
+  // runtimeFiles are written after bundling, so the map's sourcesContent no
+  // longer matches greet.ts on disk.
+  StaleSourcesContent: {
+    opts: {
+      snapshotSourceMap: { "entry.js.map": { files } },
+      runtimeFiles: { "/greet.ts": `export function greet() {}` },
+    },
+    output: ["entry.js.map: sourcesContent of ../greet.ts"],
+  },
 };
-const CHILD_ENV = "BUN_BUNDLER_TEST_REJECTED_MAPPINGS";
+const CHILD_ENV = "BUN_BUNDLER_TEST_REJECTED_SNAPSHOTS";
 
 describe("bundler", () => {
   if (process.env[CHILD_ENV]) {
     // Spawned by the test below: only register the cases that have to fail.
-    for (const [name, { mapping }] of Object.entries(rejected)) {
-      itBundled(`harness/SnapshotSourceMap${name}`, {
-        ...bundle,
-        snapshotSourceMap: { "entry.js.map": { files, mappings: [mapping] } },
-      });
+    for (const [name, { opts }] of Object.entries(rejected)) {
+      itBundled(`harness/SnapshotSourceMap${name}`, { ...bundle, ...opts });
     }
     return;
   }
 
-  itBundled("harness/SnapshotSourceMapMappings", {
+  itBundled("harness/SnapshotSourceMap", {
     ...bundle,
     snapshotSourceMap: {
       "entry.js.map": {
@@ -74,7 +105,7 @@ describe("bundler", () => {
   // itBundled() registers nothing on Windows yet: expectBundled's "test/bundler/"
   // stack check never matches backslash paths, so the child would have nothing to fail.
   test.skipIf(isWindows)(
-    "snapshotSourceMap.mappings rejects positions the source map disagrees with",
+    "snapshotSourceMap rejects snapshots the emitted source map disagrees with",
     async () => {
       const env: Record<string, string | undefined> = { ...bunEnv, [CHILD_ENV]: "1" };
       // bunEnv spreads process.env; an ambient filter would keep the child from registering its cases.
@@ -88,11 +119,9 @@ describe("bundler", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       const output = stdout + stderr;
 
-      for (const [name, { mapping, received }] of Object.entries(rejected)) {
+      for (const [name, { output: lines }] of Object.entries(rejected)) {
         expect(output).toContain(`(fail) bundler > harness/SnapshotSourceMap${name}`);
-        expect(output).toContain(`entry.js.map: generated position of ${mapping[0]}`);
-        expect(output).toContain(`Expected: "${mapping[1]}"`);
-        expect(output).toContain(`Received: "${received}"`);
+        for (const line of lines) expect(output).toContain(line);
       }
       expect(output).toContain(" 0 pass\n");
       expect(output).toContain(` ${Object.keys(rejected).length} fail\n`);

--- a/test/bundler/itBundled-snapshotSourceMap.test.ts
+++ b/test/bundler/itBundled-snapshotSourceMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows } from "harness";
 import { BundlerTestInput, itBundled, MappingSnapshot } from "./expectBundled";
 
 // Every case in this file bundles the same two files. out/entry.js is:
@@ -73,27 +73,32 @@ describe("bundler", () => {
 
   // itBundled() registers nothing on Windows yet: expectBundled's "test/bundler/"
   // stack check never matches backslash paths, so the child would have nothing to fail.
-  test.skipIf(isWindows)("snapshotSourceMap.mappings rejects positions the source map disagrees with", async () => {
-    const env: Record<string, string | undefined> = { ...bunEnv, [CHILD_ENV]: "1" };
-    // bunEnv spreads process.env; an ambient filter would keep the child from registering its cases.
-    delete env.BUN_BUNDLER_TEST_FILTER;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", import.meta.path],
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const output = stdout + stderr;
+  test.skipIf(isWindows)(
+    "snapshotSourceMap.mappings rejects positions the source map disagrees with",
+    async () => {
+      const env: Record<string, string | undefined> = { ...bunEnv, [CHILD_ENV]: "1" };
+      // bunEnv spreads process.env; an ambient filter would keep the child from registering its cases.
+      delete env.BUN_BUNDLER_TEST_FILTER;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--timeout=60000", import.meta.path],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const output = stdout + stderr;
 
-    for (const [name, { mapping, received }] of Object.entries(rejected)) {
-      expect(output).toContain(`(fail) bundler > harness/SnapshotSourceMap${name}`);
-      expect(output).toContain(`entry.js.map: generated position of ${mapping[0]}`);
-      expect(output).toContain(`Expected: "${mapping[1]}"`);
-      expect(output).toContain(`Received: "${received}"`);
-    }
-    expect(output).toContain(" 0 pass\n");
-    expect(output).toContain(` ${Object.keys(rejected).length} fail\n`);
-    expect(exitCode).toBe(1);
-  });
+      for (const [name, { mapping, received }] of Object.entries(rejected)) {
+        expect(output).toContain(`(fail) bundler > harness/SnapshotSourceMap${name}`);
+        expect(output).toContain(`entry.js.map: generated position of ${mapping[0]}`);
+        expect(output).toContain(`Expected: "${mapping[1]}"`);
+        expect(output).toContain(`Received: "${received}"`);
+      }
+      expect(output).toContain(" 0 pass\n");
+      expect(output).toContain(` ${Object.keys(rejected).length} fail\n`);
+      expect(exitCode).toBe(1);
+    },
+    // A debug build spends a few seconds just starting the child and importing the harness in it.
+    isDebug ? 60_000 : undefined,
+  );
 });

--- a/test/bundler/itBundled-snapshotSourceMap.test.ts
+++ b/test/bundler/itBundled-snapshotSourceMap.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import { BundlerTestInput, itBundled, MappingSnapshot } from "./expectBundled";
+
+// Every case in this file bundles the same two files. out/entry.js is:
+//
+//   1 | // greet.ts
+//   2 | function greet(name) {
+//   3 |   return "hello " + name;
+//   4 | }
+//   5 |
+//   6 | // entry.ts
+//   7 | console.log(greet("world"));
+//   8 | console.log(greet("bun"));
+const bundle = {
+  files: {
+    "/entry.ts": /* ts */ `
+      import { greet } from "./greet";
+      console.log(greet("world"));
+      console.log(greet("bun"));
+    `,
+    "/greet.ts": /* ts */ `
+      // greets someone
+      export function greet(name: string) {
+        return "hello " + name;
+      }
+    `,
+  },
+  outdir: "/out",
+  sourceMap: "external",
+} satisfies BundlerTestInput;
+const files = ["../greet.ts", "../entry.ts"];
+
+// Mappings that disagree with the source map, and what the map really says.
+// The quoted text does exist at each claimed generated position, which used to
+// be the only thing `mappings` checked.
+const rejected: Record<string, { mapping: MappingSnapshot; received: string }> = {
+  // Generated line 8 also starts with `console`, but entry.ts:2 maps to line 7.
+  WrongLine: { mapping: ["entry.ts:2:'console'", "8:0:console"], received: "7:0:console" },
+  WrongText: { mapping: ["entry.ts:2:'console'", "7:0:nope"], received: "7:0:cons" },
+  // Generated line 1 is the `// greet.ts` comment; nothing in greet.ts:1 (also
+  // a comment) is mapped at all.
+  Unmapped: { mapping: ["greet.ts:1:'greets'", "1:3:greet"], received: "unmapped" },
+};
+const CHILD_ENV = "BUN_BUNDLER_TEST_REJECTED_MAPPINGS";
+
+describe("bundler", () => {
+  if (process.env[CHILD_ENV]) {
+    // Spawned by the test below: only register the cases that have to fail.
+    for (const [name, { mapping }] of Object.entries(rejected)) {
+      itBundled(`harness/SnapshotSourceMap${name}`, {
+        ...bundle,
+        snapshotSourceMap: { "entry.js.map": { files, mappings: [mapping] } },
+      });
+    }
+    return;
+  }
+
+  itBundled("harness/SnapshotSourceMapMappings", {
+    ...bundle,
+    snapshotSourceMap: {
+      "entry.js.map": {
+        files,
+        mappings: [
+          ["greet.ts:2:'greet'", "2:9:greet"],
+          ["greet.ts:3:'return'", "3:2:return"],
+          ["entry.ts:2:'console'", "7:0:console"],
+          ["entry.ts:3:'\"bun\"'", '8:18:"bun"'],
+        ],
+      },
+    },
+  });
+
+  // itBundled() registers nothing on Windows yet: expectBundled's "test/bundler/"
+  // stack check never matches backslash paths, so the child would have nothing to fail.
+  test.skipIf(isWindows)("snapshotSourceMap.mappings rejects positions the source map disagrees with", async () => {
+    const env: Record<string, string | undefined> = { ...bunEnv, [CHILD_ENV]: "1" };
+    // bunEnv spreads process.env; an ambient filter would keep the child from registering its cases.
+    delete env.BUN_BUNDLER_TEST_FILTER;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", import.meta.path],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdout + stderr;
+
+    for (const [name, { mapping, received }] of Object.entries(rejected)) {
+      expect(output).toContain(`(fail) bundler > harness/SnapshotSourceMap${name}`);
+      expect(output).toContain(`entry.js.map: generated position of ${mapping[0]}`);
+      expect(output).toContain(`Expected: "${mapping[1]}"`);
+      expect(output).toContain(`Received: "${received}"`);
+    }
+    expect(output).toContain(" 0 pass\n");
+    expect(output).toContain(` ${Object.keys(rejected).length} fail\n`);
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/bundler/itBundled-snapshotSourceMap.test.ts
+++ b/test/bundler/itBundled-snapshotSourceMap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isWindows } from "harness";
-import { BundlerTestInput, itBundled, MappingSnapshot } from "./expectBundled";
+import { isWindows } from "harness";
+import { BundlerTestInput, expectBundled, itBundled, MappingSnapshot } from "./expectBundled";
 
 // Every case in this file bundles the same two files. out/entry.js is:
 //
@@ -35,36 +35,24 @@ function withMapping(mapping: MappingSnapshot): Partial<BundlerTestInput> {
   return { snapshotSourceMap: { "entry.js.map": { files, mappings: [mapping] } } };
 }
 
-// Snapshots that disagree with the emitted source map, and what their failure
-// has to say. The quoted text does exist at each claimed generated position,
-// which used to be the only thing `mappings` checked.
-const rejected: Record<string, { opts: Partial<BundlerTestInput>; output: string[] }> = {
+// Source map checks that have to fail, and how each failure has to start. The
+// quoted text does exist at each claimed generated position, which used to be
+// the only thing `mappings` checked.
+const rejected: Record<string, { opts: Partial<BundlerTestInput>; error: string }> = {
   // Generated line 8 also starts with `console`, but entry.ts:2 maps to line 7.
   WrongLine: {
     opts: withMapping(["entry.ts:2:'console'", "8:0:console"]),
-    output: [
-      "entry.js.map: generated position of entry.ts:2:'console'",
-      'Expected: "8:0:console"',
-      'Received: "7:0:console"',
-    ],
+    error: `entry.js.map: generated position of entry.ts:2:'console'\n\nExpected: "8:0:console"\nReceived: "7:0:console"`,
   },
   WrongText: {
     opts: withMapping(["entry.ts:2:'console'", "7:0:nope"]),
-    output: [
-      "entry.js.map: generated position of entry.ts:2:'console'",
-      'Expected: "7:0:nope"',
-      'Received: "7:0:cons"',
-    ],
+    error: `entry.js.map: generated position of entry.ts:2:'console'\n\nExpected: "7:0:nope"\nReceived: "7:0:cons"`,
   },
   // Generated line 1 is the `// greet.ts` comment; nothing in greet.ts:1 (also
   // a comment) is mapped at all.
   Unmapped: {
     opts: withMapping(["greet.ts:1:'greets'", "1:3:greet"]),
-    output: [
-      "entry.js.map: generated position of greet.ts:1:'greets'",
-      'Expected: "1:3:greet"',
-      'Received: "unmapped"',
-    ],
+    error: `entry.js.map: generated position of greet.ts:1:'greets'\n\nExpected: "1:3:greet"\nReceived: "unmapped"`,
   },
   // runtimeFiles are written after bundling, so the map's sourcesContent no
   // longer matches greet.ts on disk.
@@ -73,20 +61,24 @@ const rejected: Record<string, { opts: Partial<BundlerTestInput>; output: string
       snapshotSourceMap: { "entry.js.map": { files } },
       runtimeFiles: { "/greet.ts": `export function greet() {}` },
     },
-    output: ["entry.js.map: sourcesContent of ../greet.ts"],
+    error: "entry.js.map: sourcesContent of ../greet.ts\n",
+  },
+  // Every external source map is checked for one generated position that maps
+  // to two source positions. "AACA" adds a segment at the column of the last
+  // segment on generated line 8 that points one source line further down.
+  DuplicateMapping: {
+    opts: {
+      onAfterBundle(api) {
+        const map = JSON.parse(api.readFile("out/entry.js.map"));
+        map.mappings = map.mappings.replace(/;*$/, ",AACA");
+        api.writeFile("out/entry.js.map", JSON.stringify(map));
+      },
+    },
+    error: "Duplicate mapping in source-map for 8:24\n8:24 -> 3:24 [/entry.ts]\n8:24 -> 4:24 [/entry.ts]",
   },
 };
-const CHILD_ENV = "BUN_BUNDLER_TEST_REJECTED_SNAPSHOTS";
 
 describe("bundler", () => {
-  if (process.env[CHILD_ENV]) {
-    // Spawned by the test below: only register the cases that have to fail.
-    for (const [name, { opts }] of Object.entries(rejected)) {
-      itBundled(`harness/SnapshotSourceMap${name}`, { ...bundle, ...opts });
-    }
-    return;
-  }
-
   itBundled("harness/SnapshotSourceMap", {
     ...bundle,
     snapshotSourceMap: {
@@ -102,32 +94,23 @@ describe("bundler", () => {
     },
   });
 
-  // itBundled() registers nothing on Windows yet: expectBundled's "test/bundler/"
-  // stack check never matches backslash paths, so the child would have nothing to fail.
-  test.skipIf(isWindows)(
-    "snapshotSourceMap rejects snapshots the emitted source map disagrees with",
-    async () => {
-      const env: Record<string, string | undefined> = { ...bunEnv, [CHILD_ENV]: "1" };
-      // bunEnv spreads process.env; an ambient filter would keep the child from registering its cases.
-      delete env.BUN_BUNDLER_TEST_FILTER;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", "--timeout=60000", import.meta.path],
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
+  // expectBundled's "test/bundler/" stack check never matches backslash paths, so
+  // it throws before bundling anything on Windows (the itBundled case above is
+  // silently dropped there for the same reason).
+  describe.skipIf(isWindows)("rejects", () => {
+    for (const [name, { opts, error }] of Object.entries(rejected)) {
+      const id = `harness/SnapshotSourceMap${name}`;
+      test(id, async () => {
+        let message = "<expectBundled() passed>";
+        try {
+          // ignoreFilter: an ambient BUN_BUNDLER_TEST_FILTER must not turn these into no-ops.
+          await expectBundled(id, { ...bundle, ...opts }, false, true);
+        } catch (e: any) {
+          // Expected/Received are colored when running in a terminal.
+          message = Bun.stripANSI(e.message);
+        }
+        expect(message).toStartWith(error);
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      const output = stdout + stderr;
-
-      for (const [name, { output: lines }] of Object.entries(rejected)) {
-        expect(output).toContain(`(fail) bundler > harness/SnapshotSourceMap${name}`);
-        for (const line of lines) expect(output).toContain(line);
-      }
-      expect(output).toContain(" 0 pass\n");
-      expect(output).toContain(` ${Object.keys(rejected).length} fail\n`);
-      expect(exitCode).toBe(1);
-    },
-    // A debug build spends a few seconds just starting the child and importing the harness in it.
-    isDebug ? 60_000 : undefined,
-  );
+    }
+  });
 });


### PR DESCRIPTION
### Problem

Three checks in the external source map validation block of `test/bundler/expectBundled.ts` (the `SourceMapConsumer.with` callback, all three added together in #11344) cannot fail:

- `snapshotSourceMap[...].mappings` ends with `expect(pos.line === dest.line); expect(pos.column === dest.column);` (lines 1691-1692 on main). `expect(boolean)` with no matcher asserts nothing, so `pos`, the position the map actually produces for the entry, is never compared with anything. What an entry did verify is that its expected text exists at its expected `line:col` of the generated file, which only reads the generated file: a map that sends every token to the wrong place passes as long as the hard-coded position contains the quoted text, and a source position the map does not cover at all (`generatedPositionFor` returning `null`) passes too.
- The `sourcesContent` loop (lines 1669-1674) has the bound `i < parsed.sources`, a number compared with an array, so it never iterates. Had it iterated it would have read `parsed.sourceContent` (the field is `sourcesContent`) and resolved each source against the `.map` file path instead of the map's directory.
- The duplicate-mapping check (lines 1654-1662) runs for every external map, not only `snapshotSourceMap` users. Its `fmtLoc` reads every field except `generatedLine` from the mapping being visited (`m`) instead of from its argument, and `generatedLine` is part of the key the two mappings were matched on, so the two strings are always equal and the `Duplicate mapping in source-map` throw is unreachable.
- Users today: `bundler_npm.test.ts` (`npm/ReactSSR`) is the only `mappings` user; it and two tests in `bundler_edgecase.test.ts` set `snapshotSourceMap`; every external-map test with an outdir goes through the duplicate check. `mappingsExactMatch` is unaffected. The remaining dead check in this file, the never-populated `testsRan` duplicate-id set, is a different check and is fixed in #38471, which does not overlap with this diff.

### Fix

- `mappings`: format what the map says for the entry's source position in the snapshot's own `line:col:text` shape (text sliced from the generated file at that position, `"unmapped"` when the map has no position for it) and `toBe` it against the entry. One string comparison covers position and text: equal strings mean the map's position is the expected one and the generated file has the expected text there, which is what the old text check established once the position agrees, so nothing that passed for the right reason changes. `parseSourceMapStrGenerated` now only validates the entry's format and returns its text. The assertion is labelled with the map file and entry, so a failure reads `Expected: "8:0:console"` / `Received: "7:0:console"` and the received value can be pasted back into the test; this also replaces the old text-mismatch path, which asserted and then threw a second `Not matched` error.
- `sourcesContent`: iterate `sources.length`, read `sourcesContent`, resolve against the map's directory, label the assertion with the map file and source.
- Duplicate check: `fmtLoc` formats its argument. Nothing else changes, so a map is rejected exactly when one generated position carries two different source positions, which is what the check's comment says it is for.
- `expectBundled` is exported again (it was exported until #2740; `expectBundled.md` still documents calling it directly) so the test below can call it without registering anything.
- Every existing user holds under the live checks, so this is a harness fix only, no bundler change: `bundler_npm.test.ts` goes from 179563 to 179575 `expect()` calls (6 mappings entries, 6 sources) and passes; `bundler_edgecase.test.ts` (whole file), `bundler_comments.test.ts`, `esbuild/loader.test.ts` and `esbuild/default.test.ts -t SourceMap` pass with the duplicate check live, so no current output has a duplicate generated position. The odd-looking `npm/ReactSSR` entries are fine: `at` and `or` in `"1:5623:at"` / `"23:4082:or++"` are the minified names, and `'<html>' -> "100:19062:void"` is the last of the three generated ranges that position maps to, which is what `generatedPositionFor` returns for a multiply-mapped position, as before this change.
- Test: `test/bundler/itBundled-snapshotSourceMap.test.ts`. One `itBundled` case with correct `mappings` on a two-file bundle (this also runs the live `sourcesContent` loop on both sources), plus five cases that call `expectBundled()` directly and pin how the rejection starts: a position whose text is present but whose line the map disagrees with, a text mismatch, an unmapped position, a source rewritten after bundling via `runtimeFiles` so `sourcesContent` no longer matches disk, and a map rewritten in `onAfterBundle` to put two source positions on one generated position. Each case takes 0.2 to 0.6 s on a debug build. Against main's `expectBundled.ts` (plus the `export`), four of the five are accepted (`Received: "<expectBundled() passed>"`) and the text mismatch fails only on the old unlabelled message; with this change all six pass.
- The fix lives under `test/`, so a fail-before check that only stashes `src/` cannot observe it; the before/after above was run by swapping in main's `expectBundled.ts` under the debug build.
- Windows: the direct `expectBundled()` cases are `describe.skipIf(isWindows)` because its `test/bundler/` stack check never matches backslash paths there, which is also why the `itBundled` case is silently not registered on Windows today (#34552 fixes the check; the skip can go when it lands). Verified on Windows with the earlier spawn-based revision of this file that the harness registers nothing there, and that with #34552's one-line fix applied the positive case passes un-skipped.

### Background

- `snapshotSourceMap` is an `itBundled` option for source maps too large to snapshot whole. `files` pins the map's `sources` (and, through the loop fixed here, their `sourcesContent`); `mappings` is a list of `[source position, generated position]` samples, where the source side is `"file:line:'token'"` and the generated side is `"line:col:text"`. Independently of that option, every external map produced by a test is decoded and checked for a generated position mapped to two different source positions.
- `SourceMapConsumer.generatedPositionFor` (the `source-map` package) answers "where did this source position end up in the output"; it returns `{ line: null, column: null }` when the map has nothing at or before that position in that source.
- `itBundled(id, opts)` registers a test whose body is `expectBundled(id, opts)`; `expectBundled` itself only bundles and runs the checks, returning a promise that rejects on the first failed check. `runtimeFiles` are written, and `onAfterBundle` runs, after bundling and before these checks, which is how the test makes a source file or the map disagree with the bundle.
- `"AACA"` is one VLQ segment: generated column +0, same source, source line +1, source column +0. Appended to the last mapped line it duplicates that line's last generated position with a different source line.
- `expect(value, message)` is bun:test's labelled form: the label replaces the matcher headline in the error message and Expected/Received are still appended (colored when attached to a terminal, hence the `Bun.stripANSI` in the test).

<details>
<summary>Error messages the test pins (debug build)</summary>

```
harness/SnapshotSourceMapWrongLine
  entry.js.map: generated position of entry.ts:2:'console'
  Expected: "8:0:console"
  Received: "7:0:console"
harness/SnapshotSourceMapWrongText
  Expected: "7:0:nope"
  Received: "7:0:cons"
harness/SnapshotSourceMapUnmapped
  entry.js.map: generated position of greet.ts:1:'greets'
  Expected: "1:3:greet"
  Received: "unmapped"
harness/SnapshotSourceMapStaleSourcesContent
  entry.js.map: sourcesContent of ../greet.ts
  (followed by the diff of the two contents)
harness/SnapshotSourceMapDuplicateMapping
  Duplicate mapping in source-map for 8:24
  8:24 -> 3:24 [/entry.ts]
  8:24 -> 4:24 [/entry.ts]
```

</details>

<details>
<summary>Earlier revisions of this PR</summary>

- First push: fixed only the `mappings` assertion; the test spawned a child `bun test` with the must-fail cases and grepped its reporter output, which took about 4 s on a debug build and needed a debug-only timeout.
- Second push: folded in the `sourcesContent` loop after review pointed out it is the same kind of dead check in the same block.
- Current: folded in the duplicate-mapping check for the same reason, and replaced the spawn with direct `expectBundled()` calls, which removed the child process, the env-var switch, the timeout and the dependence on reporter output.

</details>
