### PR TITLE
bundler: emit the JS chunk for an import()ed stylesheet that is also an entry point

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -272,6 +272,27 @@ impl Chunk {
         self.entry_point.is_entry_point()
     }
 
+    /// The entry point kind this chunk is named and classified by.
+    ///
+    /// A stylesheet only gets a JS chunk because it is `import()`ed (see `compute_chunks`), so
+    /// that chunk is a dynamic import chunk even when the user also passed the stylesheet as an
+    /// entry point: the entry point name and kind belong to its CSS chunk.
+    pub(crate) fn entry_point_kind(
+        &self,
+        linker_graph: &LinkerGraph<'_>,
+    ) -> crate::entry_point::Kind {
+        if !self.entry_point.is_entry_point() {
+            return crate::entry_point::Kind::None;
+        }
+        let source_index = self.entry_point.source_index() as usize;
+        if matches!(self.content, Content::Javascript(_))
+            && linker_graph.ast.items_css()[source_index].is_some()
+        {
+            return crate::entry_point::Kind::DynamicImport;
+        }
+        linker_graph.files.items_entry_point_kind()[source_index]
+    }
+
     /// Returns the HTML closing tag that must be escaped when this chunk's content
     /// is inlined into a standalone HTML file (e.g. "</script" for JS, "</style" for CSS).
     pub(crate) fn closing_tag_for_content(&self) -> &'static [u8] {

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -272,11 +272,7 @@ impl Chunk {
         self.entry_point.is_entry_point()
     }
 
-    /// The entry point kind this chunk is named and classified by.
-    ///
-    /// A stylesheet only gets a JS chunk because it is `import()`ed (see `compute_chunks`), so
-    /// that chunk is a dynamic import chunk even when the user also passed the stylesheet as an
-    /// entry point: the entry point name and kind belong to its CSS chunk.
+    /// Kind used to name and classify the chunk; a stylesheet's JS chunk is always `DynamicImport`.
     pub(crate) fn entry_point_kind(
         &self,
         linker_graph: &LinkerGraph<'_>,

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -288,6 +288,7 @@ impl Chunk {
         if matches!(self.content, Content::Javascript(_))
             && linker_graph.ast.items_css()[source_index].is_some()
         {
+            debug_assert!(linker_graph.dynamically_imported_files.is_set(source_index));
             return crate::entry_point::Kind::DynamicImport;
         }
         linker_graph.files.items_entry_point_kind()[source_index]

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2738,7 +2738,11 @@ impl<'a> LinkerContext<'a> {
             }
 
             // An import()ed stylesheet has its own JS chunk; walk its parts like an entry point's.
-            if ctx.entry_point_kinds[source_index as usize] != EntryPoint::Kind::DynamicImport {
+            if !self
+                .graph
+                .dynamically_imported_files
+                .is_set(source_index as usize)
+            {
                 return;
             }
         }

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -212,9 +212,7 @@ pub struct LinkerGraph<'a> {
 
     pub(crate) is_scb_bitset: BitSet,
 
-    /// Every target of an `import()` (only populated with code splitting). Unlike
-    /// `File.entry_point_kind`, this also covers files the user passed as entry points, which
-    /// stay `UserSpecified`; a stylesheet in this set needs a JS chunk for the `import()` to load.
+    /// Every `import()` target, including files that are also user-specified entry points.
     pub(crate) dynamically_imported_files: BitSet,
 
     /// This is for cross-module inlining of detected inlinable constants
@@ -986,8 +984,7 @@ pub struct File {
     /// This file is an entry point if and only if this is not ".none".
     /// Note that dynamically-imported files are allowed to also be specified by
     /// the user as top-level entry points, so some dynamically-imported files
-    /// may be ".user_specified" instead of ".dynamic_import"; see
-    /// `LinkerGraph.dynamically_imported_files` for the complete set.
+    /// may be ".user_specified" instead of ".dynamic_import" (see `dynamically_imported_files`).
     pub entry_point_kind: EntryPoint::Kind,
 
     /// If "entry_point_kind" is not ".none", this is the index of the

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -212,6 +212,11 @@ pub struct LinkerGraph<'a> {
 
     pub(crate) is_scb_bitset: BitSet,
 
+    /// Every target of an `import()` (only populated with code splitting). Unlike
+    /// `File.entry_point_kind`, this also covers files the user passed as entry points, which
+    /// stay `UserSpecified`; a stylesheet in this set needs a JS chunk for the `import()` to load.
+    pub(crate) dynamically_imported_files: BitSet,
+
     /// This is for cross-module inlining of detected inlinable constants
     // const_values: bun_ast::Ast::ConstValuesMap,
     /// This is for cross-module inlining of TypeScript enum constants
@@ -225,9 +230,9 @@ pub struct LinkerGraph<'a> {
 // - `bump: *const Arena` is a backref into `BundleV2`; the arena is frozen
 //   (no new allocations) for the duration of any worker-pool fan-out that
 //   holds `&LinkerGraph`.
-// - `files_live` / `parts_live` / `is_scb_bitset` / `reachable_files` /
-//   `stable_source_indices` / `code_splitting` / `ts_enums` are populated
-//   before fan-out and only read by workers.
+// - `files_live` / `parts_live` / `is_scb_bitset` / `dynamically_imported_files` /
+//   `reachable_files` / `stable_source_indices` / `code_splitting` / `ts_enums` are
+//   populated before fan-out and only read by workers.
 // - `ast` / `meta` / `files` columns that workers mutate are split out via
 //   `split_mut()` into disjoint `&mut [_]` *before* the pool runs (see
 //   `compute_cross_chunk_dependencies`); workers never reach those columns
@@ -275,6 +280,7 @@ impl Default for LinkerGraph<'_> {
             reachable_files: Vec::new(),
             stable_source_indices: Vec::new(),
             is_scb_bitset: BitSet::default(),
+            dynamically_imported_files: BitSet::default(),
             ts_enums: bun_ast::ast_result::TsEnumsMap::default(),
         }
     }
@@ -625,6 +631,7 @@ impl<'a> LinkerGraph<'a> {
         self.files.set_capacity(sources.len())?;
         self.files.zero();
         self.files_live = BitSet::init_empty(sources.len())?;
+        self.dynamically_imported_files = BitSet::init_empty(sources.len())?;
         // SAFETY: capacity reserved above; columns zeroed by `zero()`.
         unsafe { self.files.set_len(sources.len()) };
 
@@ -681,6 +688,7 @@ impl<'a> LinkerGraph<'a> {
 
             for &id in dynamic_import_entry_points {
                 debug_assert!(self.code_splitting); // this should never be a thing without code splitting
+                self.dynamically_imported_files.set(id as usize);
 
                 if entry_point_kinds[id as usize] != entry_point::Kind::None {
                     // You could dynamic import a file that is already an entry point
@@ -978,7 +986,8 @@ pub struct File {
     /// This file is an entry point if and only if this is not ".none".
     /// Note that dynamically-imported files are allowed to also be specified by
     /// the user as top-level entry points, so some dynamically-imported files
-    /// may be ".user_specified" instead of ".dynamic_import".
+    /// may be ".user_specified" instead of ".dynamic_import"; see
+    /// `LinkerGraph.dynamically_imported_files` for the complete set.
     pub entry_point_kind: EntryPoint::Kind,
 
     /// If "entry_point_kind" is not ".none", this is the index of the

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -187,9 +187,12 @@ pub(crate) fn compute_chunks(
                 };
             }
 
-            // An import()ed stylesheet is loaded as a JS module, so it also needs a JS chunk.
-            if this.graph.files.items_entry_point_kind()[source_index as usize]
-                != crate::EntryPoint::Kind::DynamicImport
+            // An import()ed stylesheet is loaded as a JS module, so it also needs a JS chunk
+            // (whether or not the user also passed the stylesheet as an entry point).
+            if !this
+                .graph
+                .dynamically_imported_files
+                .is_set(source_index as usize)
             {
                 continue;
             }
@@ -567,7 +570,6 @@ pub(crate) fn compute_chunks(
     // Derived from `this_ptr` (raw) so it does not reborrow `*this` here — the column
     // slices below hold disjoint immutable borrows into `this.graph`.
     let bv2: &mut BundleV2 = unsafe { &mut *LinkerContext::bundle_v2_ptr(this_ptr) };
-    let kinds = this.graph.files.items_entry_point_kind();
     let output_paths = this.graph.entry_points.items_output_path();
     // re-borrow after `find_all_imported_parts_in_js_order` released `&mut this`.
     let ast_targets = this.graph.ast.items_target();
@@ -597,8 +599,7 @@ pub(crate) fn compute_chunks(
 
         if chunk.entry_point.is_entry_point()
             && (matches!(chunk.content, chunk::Content::Html)
-                || (kinds[chunk.entry_point.source_index() as usize]
-                    == crate::EntryPoint::Kind::UserSpecified
+                || (chunk.entry_point_kind(&this.graph) == crate::EntryPoint::Kind::UserSpecified
                     && !chunk.flags.contains(chunk::Flags::HAS_HTML_CHUNK)))
         {
             // Use fileWithTarget template if there are HTML imports and user hasn't manually set naming

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -187,8 +187,7 @@ pub(crate) fn compute_chunks(
                 };
             }
 
-            // An import()ed stylesheet is loaded as a JS module, so it also needs a JS chunk
-            // (whether or not the user also passed the stylesheet as an entry point).
+            // An import()ed stylesheet is loaded as a JS module, so it also needs a JS chunk.
             if !this
                 .graph
                 .dynamically_imported_files

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -436,8 +436,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             writeln!(&mut msg, "Multiple files share the same output path")?;
 
-            let kinds = c.graph.files.items_entry_point_kind();
-
             for (key, dup) in duplicates_map
                 .keys()
                 .iter()
@@ -446,9 +444,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 writeln!(&mut msg, "  {}:", bstr::BStr::new(key))?;
                 for chunk in dup.sources.iter() {
                     if chunk.entry_point.is_entry_point() {
-                        if kinds[chunk.entry_point.source_index() as usize]
-                            == EntryPoint::Kind::UserSpecified
-                        {
+                        if chunk.entry_point_kind(&c.graph) == EntryPoint::Kind::UserSpecified {
                             entry_naming = Some(&chunk.template.data);
                         } else {
                             chunk_naming = Some(&chunk.template.data);
@@ -1219,11 +1215,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             let output_kind = if matches!(chunk.content, crate::chunk::Content::Css(_)) {
                 options::OutputKind::Asset
-            } else if chunk.entry_point.is_entry_point() {
-                c.graph.files.items_entry_point_kind()[chunk.entry_point.source_index() as usize]
-                    .output_kind()
             } else {
-                options::OutputKind::Chunk
+                chunk.entry_point_kind(&c.graph).output_kind()
             };
 
             let chunk_index =

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -540,11 +540,8 @@ pub(crate) fn write_output_files_to_disk(
 
         let output_kind = if matches!(chunk.content, Content::Css(_)) {
             options::OutputKind::Asset
-        } else if chunk.entry_point.is_entry_point() {
-            c.graph.files.items_entry_point_kind()[chunk.entry_point.source_index() as usize]
-                .output_kind()
         } else {
-            options::OutputKind::Chunk
+            chunk.entry_point_kind(&c.graph).output_kind()
         };
 
         let chunk_index = output_files.insert_for_chunk(OutputFile::init(OutputFileInit {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -1,7 +1,8 @@
+import type { BuildArtifact } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { itBundled } from "./expectBundled";
 
 const env = {
@@ -9,6 +10,12 @@ const env = {
   // Deflake these tests that check import evaluation order is consistent.
   BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1",
 };
+
+function outputKinds(outputs: BuildArtifact[]) {
+  return outputs
+    .map(output => ({ file: basename(output.path), kind: output.kind }))
+    .sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
+}
 
 describe("bundler", () => {
   itBundled("splitting/DynamicImportCSSFile", {
@@ -414,12 +421,12 @@ describe("bundler", () => {
     ],
   });
 
-  // A stylesheet that is both a user-specified entry point and import()ed only
-  // gets its CSS output (entry point kinds are exclusive), so the import() is
-  // still rewritten to the .css output (or, with --css-chunking, to whatever
-  // chunk is at index 0) instead of a JS chunk exporting the class map.
+  // A stylesheet that is both a user-specified entry point and import()ed keeps
+  // its entry-point-named CSS output and additionally gets the same hashed JS
+  // chunk an import()-only stylesheet gets, which is what the import() resolves
+  // to. Previously the stylesheet's entry point kind alone decided whether the
+  // JS chunk exists, so the import() was rewritten to the .css output.
   itBundled("splitting/DynamicImportOfUserSpecifiedCSSEntryPoint", {
-    todo: true,
     files: {
       "/entry.js": `
         const mod = await import('./styles.module.css');
@@ -430,8 +437,30 @@ describe("bundler", () => {
     entryPoints: ["/entry.js", "/styles.module.css"],
     splitting: true,
     outdir: "/out",
+    metafile: true,
+    onAfterApiBundle(build) {
+      expect(outputKinds(build.outputs)).toEqual([
+        { file: "entry.css", kind: "asset" },
+        { file: "entry.js", kind: "entry-point" },
+        { file: expect.stringMatching(/^styles\.module-[a-z0-9]+\.js$/), kind: "chunk" },
+        { file: "styles.module.css", kind: "asset" },
+      ]);
+    },
     onAfterBundle(api) {
-      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/styles\.module[^"]*\.js"\)/);
+      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
+      expect(api.readFile("/out/styles.module.css")).toContain("color: red");
+
+      const { outputs } = JSON.parse(api.readFile("/metafile.json"));
+      const stylesheetOutputs = Object.keys(outputs).filter(file => outputs[file].entryPoint === "styles.module.css");
+      expect(stylesheetOutputs.map(file => basename(file)).sort()).toEqual([
+        expect.stringMatching(/^styles\.module-[a-z0-9]+\.js$/),
+        "styles.module.css",
+      ]);
+      const chunk = stylesheetOutputs.find(file => file.endsWith(".js"))!;
+      expect(outputs[chunk]).toMatchObject({
+        exports: ["default", "foo"],
+        cssBundle: stylesheetOutputs.find(file => file.endsWith(".css")),
+      });
     },
     run: {
       file: "/out/entry.js",
@@ -440,7 +469,34 @@ describe("bundler", () => {
     },
   });
 
-  // A stylesheet the user passes as an entry point still only produces CSS.
+  // The same build with the stylesheet listed first (so it has entry point id 0)
+  // and kept in memory, which classifies the outputs on a separate code path.
+  test("splitting/DynamicImportOfUserSpecifiedCSSEntryPointInMemory", async () => {
+    using dir = tempDir("splitting-user-css-entry-in-memory", {
+      "entry.js": `import('./styles.module.css').then(mod => console.log(mod.foo));`,
+      "styles.module.css": `.foo { color: red; }`,
+    });
+    const root = String(dir);
+
+    const build = await Bun.build({
+      entrypoints: [join(root, "styles.module.css"), join(root, "entry.js")],
+      splitting: true,
+      naming: { chunk: "[name]-[hash].[ext]" },
+    });
+    expect(build.logs).toEqual([]);
+    expect(outputKinds(build.outputs)).toEqual([
+      { file: "entry.css", kind: "asset" },
+      { file: "entry.js", kind: "entry-point" },
+      { file: expect.stringMatching(/^styles\.module-[a-z0-9]+\.js$/), kind: "chunk" },
+      { file: "styles.module.css", kind: "asset" },
+    ]);
+
+    const entry = build.outputs.find(output => output.kind === "entry-point")!;
+    expect(await entry.text()).toMatch(/import\("\.\/styles\.module-[a-z0-9]+\.js"\)/);
+  });
+
+  // A stylesheet the user passes as an entry point without import()ing it
+  // anywhere still only produces CSS.
   itBundled("splitting/UserSpecifiedCSSEntryPointHasNoJSChunk", {
     files: {
       "/entry.js": `console.log('entry')`,
@@ -503,6 +559,60 @@ describe("bundler", () => {
     expect(runOut).toBe("default,foo true\n");
     expect(runExit).toBe(0);
   });
+
+  // The user-specified variant of the above: the stylesheet's own CSS chunk is
+  // the one shared with the importing entry point (named after whichever entry
+  // point comes first), and the import() must point at the stylesheet's JS chunk.
+  // It used to be rewritten to the shared CSS output when the stylesheet came
+  // first, and to the importing entry point itself (chunk 0) when it came second.
+  const stylesheetChunk = expect.stringMatching(/^styles\.module-[a-z0-9]+\.js$/);
+  test.each([
+    { entryPoints: ["./entry.js", "./styles.module.css"], outputs: ["entry.css", "entry.js", stylesheetChunk] },
+    { entryPoints: ["./styles.module.css", "./entry.js"], outputs: ["entry.js", stylesheetChunk, "styles.module.css"] },
+  ])(
+    "splitting/DynamicImportOfUserSpecifiedCSSEntryPointWithCSSChunking $entryPoints",
+    async ({ entryPoints, outputs }) => {
+      using dir = tempDir("splitting-css-chunking-user-css-entry", {
+        "entry.js": `
+          import('./styles.module.css').then(mod => console.log(Object.keys(mod).join(','), /^foo_/.test(mod.foo)));
+        `,
+        "styles.module.css": `.foo { color: red; }`,
+      });
+      const root = String(dir);
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--splitting", "--css-chunking", "--outdir", "out", ...entryPoints],
+        env: bunEnv,
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [buildOut, buildErr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect(buildErr).toBe("");
+      expect(buildOut).toMatch(/styles\.module-[a-z0-9]+\.js\s+\S+ bytes\s+\(chunk\)/);
+      expect(buildExit).toBe(0);
+
+      expect(readdirSync(join(root, "out")).sort()).toEqual(outputs);
+      expect(readFileSync(join(root, "out", "entry.js"), "utf8")).toMatch(
+        /import\("\.\/styles\.module-[a-z0-9]+\.js"\)/,
+      );
+
+      await using run = Bun.spawn({
+        cmd: [bunExe(), join(root, "out", "entry.js")],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect(runErr).toBe("");
+      expect(runOut).toBe("default,foo true\n");
+      expect(runExit).toBe(0);
+    },
+  );
 
   itBundled("splitting/CircularDynamicImportsWithCSS", {
     files: {


### PR DESCRIPTION
Stacked on #38319 (this PR's base is its branch); only the commits after it are this PR. #38319 adds the JS chunk for an import()ed stylesheet and leaves the case below as a `todo` test, which this PR turns into a passing one. Like #38319, the case was found by reading the code rather than reported by a user; it needs `--splitting`, the stylesheet in the entry point list and an `import()` of it. Everything here is `--splitting` only; `import()` of a stylesheet without splitting is #38307's.

### Problem
- With `--splitting`, a stylesheet that the user passes as an entry point and that is also `import()`ed gets no JS chunk, so the `import()` is rewritten to the stylesheet's `.css` output (`import("./styles.module.css")`), and with `--css-chunking` to chunk 0, which is the importing entry point itself (`entry.js` ends up with `import("./entry.js")`).
- Cause: entry point kinds are exclusive. `LinkerGraph::load` (`src/bundler/LinkerGraph.rs`, loop over `dynamic_import_entry_points`) skips a file that is already `UserSpecified`, so such a stylesheet never becomes a `DynamicImport` entry point, and both places #38319 added are keyed on that kind: the JS chunk creation in `compute_chunks` (`src/bundler/linker_context/computeChunks.rs`, CSS branch of the entry point loop) and the walk of the stylesheet's parts in `mark_file_live_step` (`src/bundler/LinkerContext.rs`). The stylesheet therefore keeps only its CSS chunk, which is what `entry_point_chunk_index` names and what `compute_cross_chunk_dependencies` rewrites the `import()` to. With `--css-chunking` that CSS chunk is shared with the importer's CSS (same content hash) and so skipped by the "entry point also has a JS chunk" rule, leaving `entry_point_chunk_index` at the 0 `LinkerGraph::load` zero-fills it with.

### Fix
- `LinkerGraph` gets a `dynamically_imported_files` bitset, filled in `load` from every `import()` target before the `UserSpecified` skip. The two sites above test it instead of `kind == DynamicImport`; for a stylesheet that is not a user entry point the two conditions are identical, so #38319's case is unchanged, and a user-specified stylesheet that is not `import()`ed stays CSS-only (pinned by the existing `UserSpecifiedCSSEntryPointHasNoJSChunk`).
- Because the stylesheet now has a JS chunk, the existing `compute_chunks` rule already links `entry_point_chunk_index` to it and the `import()` is rewritten to that chunk; `find_imported_parts_in_js_order` from #38319 fills the chunk for any stylesheet entry point, so nothing else is needed there.
- New `Chunk::entry_point_kind` (`src/bundler/Chunk.rs`) returns `DynamicImport` for the JS chunk of a stylesheet (asserting in debug builds that the stylesheet is in the bitset, which is the only way such a chunk gets created) and the file's kind otherwise, and replaces the four per-chunk reads of the file's kind: the naming template choice in `compute_chunks`, the output kind in `generate_chunks_in_parallel` (in-memory builds) and `write_output_files_to_disk` (outdir builds), and the naming hint in the duplicate output path error. So the chunk is `styles.module-<hash>.js` with kind `chunk` whether or not the stylesheet is also a user entry point, while the stylesheet's CSS output keeps its entry point name (`styles.module.css`) and its existing kind. For every other chunk the helper returns what the sites read before.
- Why this shape: esbuild gives the same input `styles.module.css` (entry point name) plus a `styles.module-<hash>.js` chunk exporting `default` and the class names, with the `import()` pointing at the chunk; in esbuild the JS side of a stylesheet is a separate file that becomes a `DynamicImport` entry point on its own, and the bitset plus `Chunk::entry_point_kind` is how Bun, where both sides share one source index, reaches the same result. Classifying the chunk as `chunk` rather than `entry-point` also keeps `Bun.build`'s `outputs.filter(o => o.kind === "entry-point")` and the `compile` path, which takes the first `entry-point` output as the executable's entry, from picking up a hashed chunk.
- Tests, in `test/bundler/bundler_splitting.test.ts`: `DynamicImportOfUserSpecifiedCSSEntryPoint` (the `todo` from #38319 made real: the rewrite, the CSS output, output kinds on the outdir path, the chunk's `exports` and `cssBundle` in the metafile, and the entry runs), `DynamicImportOfUserSpecifiedCSSEntryPointInMemory` (stylesheet listed first, in-memory `Bun.build`, output kinds on the other path and the chunk named by the chunk template), and `DynamicImportOfUserSpecifiedCSSEntryPointWithCSSChunking` in both entry point orders through the CLI (the `.css` and the chunk 0 rewrites from the report; also checks the summary lists the chunk as a chunk). All four fail on the base branch (no JS chunk is produced) and pass with this change.
- Also run with this change, all passing: `bundler_splitting`, `css/css-modules`, `bundler_loader`, `html-import-manifest`, `metafile`, `bundler_html`, `bundler_compile_splitting`, `esbuild/splitting`, `esbuild/css`, `bundler_naming`, `bun-build-api`, `bundler_edgecase`, `esbuild/loader`, `bundler_regressions` (486 tests). `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` are clean.
- Sequencing: #38307 replaces the same `return` in `mark_file_live_step` with a `wrap != Cjs` check; whichever lands second combines the two conditions (`wrap != Cjs && !dynamically_imported_files.is_set(..)`), as #38319 already notes. #38341 adds a line to the CSS chunk creation a few lines above the changed condition in `compute_chunks`; the two merge cleanly. The metafile assertions compare keys to each other instead of spelling out the `././` prefix that #38366 is removing.
- Verified together with #38286 and #38307 (both merged into this branch locally, with that one hunk resolved as above): `bundler_splitting`, `bundler_loader` and `css/css-modules` pass (91 tests), and a `--splitting` build whose stylesheet is an entry point that one entry `import()`s and another `require()`s works in both entry point orders, with and without `--css-chunking`: the stylesheet's chunk becomes `var require_styles_module = __commonJS(...)` plus `export default require_styles_module()`, importing `__commonJS` from the shared runtime chunk, and the importer gets the usual `.then(m => __toESM(m.default, 1))`. #38307's rule that a stylesheet entry point's bit stays off the runtime therefore still holds with the new chunk, which imports what it needs across chunks instead. That combined case is not a test here because it only passes once the whole family has landed; it belongs in whichever PR lands last.

### Background
- Entry points and kinds: with `--splitting`, every user entry point and every `import()` target is an entry point and gets its own chunk; `File.entry_point_kind` records `UserSpecified` or `DynamicImport`, one per file, and a file the user passed that is also `import()`ed stays `UserSpecified`. `entry_point_chunk_index` maps an entry point file to the chunk an `import()` of it is rewritten to.
- A stylesheet's JS side: a stylesheet imported from JS is parsed into a CSS AST plus a small JS AST (`export default {class map}` and one export per class) under the same source index. esbuild keeps that JS in a separate file; Bun does not, which is why chunking and tree shaking have stylesheet-specific branches and why one file can need both a CSS chunk and a JS chunk.
- Naming and kinds of chunks: an entry point's chunks are named with the entry naming template and reported as `entry-point`; other chunks use the chunk naming template and are reported as `chunk`. CSS chunks are always reported as `asset`, and the secondary JS and CSS chunks of an HTML entry point already use the chunk template (the `HAS_HTML_CHUNK` flag); the JS chunk of a stylesheet is the same situation.

<details>
<summary>Repro, before and after</summary>

```sh
printf '.foo { color: red }\n' > styles.module.css
printf 'import("./styles.module.css").then(m => console.log(Object.keys(m).join(",")));\n' > entry.js
bun build entry.js styles.module.css --outdir out --splitting --target bun && bun out/entry.js
bun build entry.js styles.module.css --outdir out2 --splitting --css-chunking --target bun && bun out2/entry.js
```

Before (on #38319, and on the release), `out/entry.js` contains `import("./styles.module.css")` and prints `__esModule,default` (bun's runtime loads the `.css` file as a module without the class map; a browser fails to load a stylesheet as a module); `out2/entry.js` contains `import("./entry.js")` and prints an empty line, the keys of its own empty namespace.

After, both builds contain `import("./styles.module-<hash>.js")` and print `default,foo`. The first build writes `entry.js`, `styles.module-<hash>.js` (listed as a chunk), `entry.css` and `styles.module.css`; the second writes `entry.js`, `styles.module-<hash>.js` and the single shared CSS output, which `--css-chunking` already named after the first entry point before this change.

For comparison, esbuild writes `entry.js`, `styles.module-<hash>.js`, `entry.css`, `styles.module.css` (and a second, hashed copy of the CSS for the chunk, which Bun points at the entry-named output instead), with the same `import()` rewrite.
</details>

