### PR TITLE
Copy a byte path out of the caller's buffer when creating a file or S3 store

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3674,7 +3674,6 @@ impl BlobExt for Blob {
                     }
                 }
 
-                path_or_fd.to_thread_safe();
                 core::mem::replace(
                     path_or_fd,
                     PathOrFileDescriptor::Path(crate::webcore::node_types::PathLike::String(

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -18,7 +18,7 @@ use crate::webcore::s3::client::{
     S3Credentials, S3CredentialsWithOptions, S3DeleteResult, S3ListObjectsOptions,
     S3ListObjectsResult,
 };
-use bun_core::{ZigString, strings};
+use bun_core::{ZigString, ZigStringSlice, strings};
 use bun_http_types::MimeType::MimeType;
 use bun_url::URL;
 
@@ -110,6 +110,21 @@ fn mime_from_path_ext(sliced: &[u8]) -> Option<MimeType> {
     bun_http_types::MimeType::by_extension_no_default(ext)
 }
 
+/// A store outlives the call that made it and is read (and released) from other
+/// threads, so a byte path is copied out of the caller's ArrayBuffer (as
+/// `Bun.file(bytes)` documents) rather than kept as a view into it: the view would
+/// follow later writes to the buffer, and the `protect()` that `to_thread_safe`
+/// takes on a `Buffer` has no release on the store side.
+fn own_path(path: &mut PathLike) {
+    if let PathLike::Buffer(buffer) = &*path {
+        // Assigning over the `Buffer` drops it, which unpins it here on the JS thread.
+        let copy = bun_core::handle_oom(ZigStringSlice::init_dupe(buffer.slice()));
+        *path = PathLike::EncodedSlice(copy);
+        return;
+    }
+    path.to_thread_safe();
+}
+
 impl StoreExt for Store {
     /// Caller is responsible for derefing the Store.
     fn to_any_blob(&mut self) -> Option<super::Any> {
@@ -128,8 +143,7 @@ impl StoreExt for Store {
         credentials: S3Credentials,
     ) -> Result<Box<Store>, crate::Error> {
         let mut path = pathlike;
-        // this actually protects/refs the pathlike
-        path.to_thread_safe();
+        own_path(&mut path);
 
         // Compute the extension-derived fallback before moving `path` into the
         // Store so we don't need to clone the owned PathLike.
@@ -144,9 +158,13 @@ impl StoreExt for Store {
     }
 
     fn init_file(
-        pathlike: PathOrFileDescriptor,
+        mut pathlike: PathOrFileDescriptor,
         mime_type: Option<MimeType>,
     ) -> Result<Box<Store>, crate::Error> {
+        if let PathOrFileDescriptor::Path(path) = &mut pathlike {
+            own_path(path);
+        }
+
         // Compute the extension-derived fallback before moving `pathlike` into
         // the Store so we don't need to clone the owned PathOrFileDescriptor.
         let mime_type = mime_type.or_else(|| match &pathlike {

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -155,3 +155,39 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   });
   expect(exitCode).toBe(0);
 });
+
+// The store behind a file blob is read (and may be released) on pool threads
+// after the call that made it returns, so it has to own its path: a byte path is
+// copied out of the caller's buffer, as documented, not read through it later.
+test.each([
+  ["Uint8Array", (bytes: Uint8Array<ArrayBuffer>) => bytes],
+  ["ArrayBuffer", (bytes: Uint8Array<ArrayBuffer>) => bytes.buffer],
+])("Bun.file() and Bun.write() copy a %s path out of the buffer", async (_, asArgument) => {
+  await using dir = tempDir("bun-file-byte-path", { "a.txt": "from a", "z.txt": "from z" });
+  const encode = (name: string) => new TextEncoder().encode(join(String(dir), name));
+  // "<x>.txt" -> "z.txt", in place.
+  const retarget = (bytes: Uint8Array) => void (bytes[bytes.length - 5] = "z".charCodeAt(0));
+
+  const source = encode("a.txt");
+  const file = Bun.file(asArgument(source));
+  retarget(source);
+  expect(file.name).toBe(join(String(dir), "a.txt"));
+  expect(await file.text()).toBe("from a");
+
+  const destination = encode("c.txt");
+  const written = Bun.write(asArgument(destination), file);
+  retarget(destination);
+  // The resolved byte count is not asserted: the Windows file-to-file copy
+  // reports 0 (#33715); where the bytes went is what this test is about.
+  await written;
+  expect(await Bun.file(join(String(dir), "c.txt")).text()).toBe("from a");
+  expect(await Bun.file(join(String(dir), "z.txt")).text()).toBe("from z");
+});
+
+// An s3:// byte path goes through the S3 store constructor instead; same contract.
+test("Bun.file() copies an s3:// byte path out of the buffer", () => {
+  const key = new TextEncoder().encode("s3://bucket/a.txt");
+  const file = Bun.file(key);
+  key[key.length - 5] = "z".charCodeAt(0);
+  expect(file.name).toBe("bucket/a.txt");
+});


### PR DESCRIPTION
### Problem
- `Bun.file(bytes)`, `Bun.write(bytes, ...)` and the same calls with an `s3://` byte path keep the caller's buffer as the store's path: the `PathLike::Buffer` parsed from the argument goes into the `Store` as is (`Blob::find_or_create_file_from_path`, `src/runtime/webcore/Blob.rs:3677`, and `Store::init_s3`, `src/runtime/webcore/blob/Store.rs:132`).
- So the path is a view into the caller's ArrayBuffer: writing to the buffer after the call changes the file the blob points at (`file.name` and every later read/write follow it), although the docs for this overload say the buffer is copied.
- The `protect()` that `PathLike::to_thread_safe()` takes on a `Buffer` path is never released: `Store`'s drop goes through `PathLike::drop`, which unpins but does not unprotect (`src/jsc/node_path.rs:159`), so the ArrayBuffer is kept alive for the rest of the process. The unpin also happens on whichever thread drops the store's last ref, which for a file or S3 store can be a pool or HTTP thread.
- Split out of #38312, whose remaining part (whether teardown should wait for such jobs) is a separate question; this part stands on its own.

### Fix
- `Store::init_file` and `Store::init_s3` run the path through `own_path()`: a `Buffer` path is copied into an owned `PathLike::EncodedSlice` on the JS thread (dropping the `Buffer` there unpins it; no protect is taken), and string paths are promoted with `to_thread_safe()` as before. The `to_thread_safe()` call in `find_or_create_file_from_path` moves into `init_file`, so every file and S3 store is built the same way; the other `init_file` callers (`Bun.build` artifacts, `fetch("file://")`, structured clone) already pass owned paths, for which this is a no-op. The only two stores built without `init_file` (`build_store` in `BunObject.rs`, `__bun_stdio_blob_store_new` in `jsc_hooks.rs`) are the fd-backed stdio stores, and all three S3 constructors go through `init_s3`, so every path-carrying store takes this route.
- `EncodedSlice` is what `fetch("file://")` and the build artifacts already use for a store path, and the store code that reads paths (`get_path`, `serialize`, `File::unlink`, the `File` clone the file jobs take) handles it.
- Verified with `test/js/bun/util/bun-file.test.ts`: three new cases (`Uint8Array` and `ArrayBuffer` paths for `Bun.file()` + `Bun.write()`, and an `s3://` byte path) that mutate the buffer after the call and check the blob still names and reads/writes the original path. All three fail on main (the name comes back as the mutated path) and pass with this change.
- `bun-write.test.js`, `blob.test.ts`, `blob-file-name-ownership.test.ts`, `bun-file-read.test.ts`, `bun-file-exists.test.js`, `s3-argument-validation.test.ts` and `bunstring-tothreadsafe.test.ts` pass with the debug build, apart from five `bun-write` cases that time out identically with main's `src/` in this container (large copies under the debug build).

### Background
- A `Store` is the refcounted backing of a `Blob`; for `Bun.file()` it holds a path (or fd) rather than bytes. Blobs share it, and the read/write/copy jobs hold a ref to it while they run on the thread pool, so whichever thread drops the last ref frees it.
- `PathLike` is the parsed form of a path argument. Its `Buffer` variant does not own anything: it points into the JS ArrayBuffer the caller passed and pins it (so it cannot be detached or moved) until the `PathLike` is dropped. `to_thread_safe()` additionally `protect()`s the JS value so a thread-pool job may read it; the caller is expected to `unprotect()` afterwards (`node:fs` does this through `ThreadSafe<T>`), which a `Store` has no hook for.
- `EncodedSlice` is the `PathLike` variant that owns a plain byte buffer; nothing about it refers to the JS heap, so it can be read and dropped on any thread.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (04426ac05)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [98.23ms]
(pass) writer.end() should not close the fd if it does not own the fd [184.36ms]
(pass) Bun.file() read errors include async stack frames [27.37ms]
(pass) Bun.write() errors include async stack frames [44.63ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [15.08ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [437.24ms]
169 |   const retarget = (bytes: Uint8Array) => void (bytes[bytes.length - 5] = "z".charCodeAt(0));
170 | 
171 |   const source = encode("a.txt");
172 |   const file = Bun.file(asArgument(source));
173 |   retarget(source);
174 |   expect(file.name).toBe(join(String(dir), "a.txt"));
                          ^
error: expect(received).toBe(expected)

Expected: "/tmp/bun-file-byte-path_HiQwn1/a.txt"
Received: "/tmp/bun-file-byte-path_HiQwn1/z.txt"

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-file
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [2.20ms]
(pass) writer.end() should not close the fd if it does not own the fd [4.44ms]
(pass) Bun.file() read errors include async stack frames [0.45ms]
(pass) Bun.write() errors include async stack frames [1.67ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [0.28ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [16.19ms]
169 |   const retarget = (bytes: Uint8Array) => void (bytes[bytes.length - 5] = "z".charCodeAt(0));
170 | 
171 |   const source = encode("a.txt");
172 |   const file = Bun.file(asArgument(source));
173 |   retarget(source);
174 |   expect(file.name).toBe(join(String(dir), "a.txt"));
                          ^
error: expect(received).toBe(expected)

Expected: "/tmp/bun-file-byte-path_bnmPA3/a.txt"
Received: "/tmp/bun-file-byte-path_bnmPA3/z.txt"

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-file.test.ts:174:21)
(fail) Bun.file() and Bun.write() copy a Uint8Array path out of the buffer [1.34ms]
169 |   const retarget = (bytes: Uint8Array) => void (bytes[byte
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (04426ac05)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [69.53ms]
(pass) writer.end() should not close the fd if it does not own the fd [122.86ms]
(pass) Bun.file() read errors include async stack frames [16.48ms]
(pass) Bun.write() errors include async stack frames [35.33ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [19.56ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [474.23ms]
(pass) Bun.file() and Bun.write() copy a Uint8Array path out of the buffer [32.35ms]
(pass) Bun.file() and Bun.write() copy a ArrayBuffer path out of the buffer [12.14ms]
(pass) Bun.file() copies an s3:// byte path out of the buffer [3.85ms]

 9 pass
 0 fail
 58 expect() calls
Ran 9 tests across 1 file. [3.23s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     04426ac052
  features     baseline

22 deps, 123 codegen, 1176 objects in 728ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [13.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [9.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [17.00ms]
[8/1237] fetch zlib
[zlib] up to date
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs       |  1 -
 src/runtime/webcore/blob/Store.rs | 26 ++++++++++++++++++++++----
 test/js/bun/util/bun-file.test.ts | 36 ++++++++++++++++++++++++++++++++++++
 3 files changed, 58 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/Blob.rs            3      0      0
src/runtime/webcore/blob/Store.rs      2      2      0
test/js/bun/util/bun-file.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->