### PR TITLE
Bump mordant to 3bcf116

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "18a573447ab447acc0f52796188c601b9726b1bc" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "3bcf1165e57b7a0e266df661f62781ad368340e7" },
 ]
 
 [workspace.package]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,65 +1,23 @@
 [bun_bundler]
-"pub_invariant_fields:src/bundler/options.rs" = 3
+"defaulted_failure:src/bundler/bundle_v2.rs" = 2
 
 [bun_core]
-"pub_invariant_fields:src/bun_core/string/mod.rs" = 1
-
-[bun_css]
-"pub_invariant_fields:src/css/properties/css_modules.rs" = 1
-"pub_invariant_fields:src/css/properties/display.rs" = 1
-"pub_invariant_fields:src/css/rules/container.rs" = 1
-"pub_invariant_fields:src/css/rules/font_face.rs" = 2
-"pub_invariant_fields:src/css/rules/page.rs" = 2
-"pub_invariant_fields:src/css/rules/property.rs" = 1
+"defaulted_failure:src/bun_core/string/immutable.rs" = 1
 
 [bun_install]
+"defaulted_failure:src/install/npm.rs" = 1
 "unread_none:src/install/PackageInstall.rs" = 1
 
-[bun_js_parser]
-"pub_invariant_fields:src/js_parser/parser.rs" = 1
-"pub_invariant_fields:src/js_parser/scan/scan_imports.rs" = 1
-
-[bun_options_types]
-"pub_invariant_fields:src/options_types/compile_target.rs" = 3
-
-[bun_picohttp]
-"pub_invariant_fields:src/picohttp/lib.rs" = 1
-
-[bun_resolver]
-"pub_invariant_fields:src/resolver/fs.rs" = 1
-"pub_invariant_fields:src/resolver/package_json.rs" = 1
-
-[bun_router]
-"pub_invariant_fields:src/router/lib.rs" = 1
+[bun_jsc]
+"defaulted_failure:src/jsc/ConsoleObject.rs" = 4
 
 [bun_runtime]
+"bypassed_validator:src/runtime/api/js_bundle_completion_task.rs" = 1
 "bypassed_validator:src/runtime/cli/pack_command.rs" = 2
-"pub_invariant_fields:src/runtime/api/JSBundler.rs" = 7
-"pub_invariant_fields:src/runtime/api/bun/Terminal.rs" = 1
-"pub_invariant_fields:src/runtime/bake/bake_body.rs" = 1
-"pub_invariant_fields:src/runtime/bake/production.rs" = 2
-"pub_invariant_fields:src/runtime/cli/publish_command.rs" = 3
-"pub_invariant_fields:src/runtime/crypto/EVP.rs" = 1
-"pub_invariant_fields:src/runtime/crypto/PBKDF2.rs" = 1
-"pub_invariant_fields:src/runtime/node/node_fs.rs" = 6
-"pub_invariant_fields:src/runtime/node/node_fs_stat_watcher.rs" = 1
-"pub_invariant_fields:src/runtime/node/node_fs_watcher.rs" = 2
-"pub_invariant_fields:src/runtime/node/types.rs" = 1
-"pub_invariant_fields:src/runtime/server/ServerConfig.rs" = 13
-"pub_invariant_fields:src/runtime/socket/Handlers.rs" = 2
-"pub_invariant_fields:src/runtime/socket/udp_socket.rs" = 1
-"pub_invariant_fields:src/runtime/webcore/Request.rs" = 4
+"bypassed_validator:src/runtime/server/HTMLBundle.rs" = 2
+"bypassed_validator:src/runtime/server/mod.rs" = 1
+"bypassed_validator:src/runtime/server/server_body.rs" = 5
+"defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
+"defaulted_failure:src/runtime/server/RequestContext.rs" = 1
+"defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "stored_projection:src/runtime/test_runner/bun_test.rs" = 1
-
-[bun_sql_jsc]
-"pub_invariant_fields:src/sql_jsc/mysql/MySQLValue.rs" = 2
-"pub_invariant_fields:src/sql_jsc/shared/QueryCtorArgs.rs" = 4
-
-[bun_standalone_graph]
-"pub_invariant_fields:src/standalone_graph/StandaloneModuleGraph.rs" = 1
-
-[bun_uws_sys]
-"pub_invariant_fields:src/uws_sys/socket.rs" = 1
-
-[bun_watcher]
-"pub_invariant_fields:src/watcher/KEventWatcher.rs" = 1


### PR DESCRIPTION
Picks up the new mordant: pub_invariant_fields is gone (its 76 baseline entries with it), bypassed_validator now also covers writes (2 -> 11 entries here), and defaulted_failure is new (14 entries). All 25 new entries are baselined; the ones that are real bugs rather than noise get their own PRs, starting with the shasum one in npm.rs and the server.reload() ones in server_body.rs.