### PR TITLE
bundler: drop import attributes from import() calls that code splitting points at a chunk

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -75,8 +75,9 @@ bitflags::bitflags! {
         /// Code splitting repointed this `import()` from the file it named at
         /// the JavaScript chunk built for that file. The options object written
         /// on the `import()` described the original file, so the printer
-        /// leaves it out.
-        const POINTS_TO_CHUNK = 1 << 10;
+        /// leaves it out. Not set when the chunk is the file's own CSS or HTML
+        /// output, which the options still describe.
+        const POINTS_TO_JS_CHUNK = 1 << 10;
 
         /// If true, this import can be removed if it's unused
         const IS_EXTERNAL_WITHOUT_SIDE_EFFECTS = 1 << 11;

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -72,11 +72,10 @@ bitflags::bitflags! {
 
         const WAS_ORIGINALLY_REQUIRE = 1 << 9;
 
-        /// Code splitting repointed this `import()` from the file it named at
-        /// the JavaScript chunk built for that file. The options object written
-        /// on the `import()` described the original file, so the printer
-        /// leaves it out. Not set when the chunk is the file's own CSS or HTML
-        /// output, which the options still describe.
+        /// Code splitting repointed this `import()` at the JavaScript chunk built
+        /// for the imported file, so the printer omits the options object written
+        /// on the `import()`: it described that file, not the chunk. Not set when
+        /// the chunk is the file's own CSS or HTML output.
         const POINTS_TO_JS_CHUNK = 1 << 10;
 
         /// If true, this import can be removed if it's unused

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -72,10 +72,8 @@ bitflags::bitflags! {
 
         const WAS_ORIGINALLY_REQUIRE = 1 << 9;
 
-        /// Code splitting repointed this `import()` at the JavaScript chunk built
-        /// for the imported file, so the printer omits the options object written
-        /// on the `import()`: it described that file, not the chunk. Not set when
-        /// the chunk is the file's own CSS or HTML output.
+        /// Code splitting repointed this `import()` at a JavaScript chunk; the printer
+        /// drops its options object, which described the file originally imported.
         const POINTS_TO_JS_CHUNK = 1 << 10;
 
         /// If true, this import can be removed if it's unused

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -72,6 +72,12 @@ bitflags::bitflags! {
 
         const WAS_ORIGINALLY_REQUIRE = 1 << 9;
 
+        /// Code splitting repointed this `import()` from the file it named at
+        /// the JavaScript chunk built for that file. The options object written
+        /// on the `import()` described the original file, so the printer
+        /// leaves it out.
+        const POINTS_TO_CHUNK = 1 << 10;
+
         /// If true, this import can be removed if it's unused
         const IS_EXTERNAL_WITHOUT_SIDE_EFFECTS = 1 << 11;
 

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -178,8 +178,6 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                         // which outlives the link pass.
                         import_record.path.text = other_chunk.unique_key;
                         import_record.source_index = Index::INVALID;
-                        // A CSS or HTML entry point's chunk is the .css/.html output
-                        // itself, which the import's attributes still describe.
                         if other_chunk.content.is_javascript() {
                             import_record.loader = None;
                             import_record

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -1,6 +1,7 @@
 use crate::bun_renamer as renamer;
 use crate::mal_prelude::*;
 use bun_alloc::ArenaVecExt as _;
+use bun_ast::ImportRecordFlags;
 use bun_collections::{ArrayHashMap, VecExt};
 
 use crate::LinkerContext;
@@ -117,8 +118,8 @@ struct CrossChunkDependencies<'a, 'bump> {
 impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
     // Called once per chunk from the sequential loop above. Writes:
     // `self.chunk_meta[chunk_index]` (per-chunk disjoint),
-    // `self.import_records[source_index][rec].{path,source_index}` (per-chunk
-    // disjoint via `chunk.files_with_parts_in_chunk`),
+    // `self.import_records[source_index][rec].{path,source_index,loader,flags}`
+    // (per-chunk disjoint via `chunk.files_with_parts_in_chunk`),
     // `symbols.assign_chunk_index(ref)` (Relaxed atomic store to
     // `Symbol.chunk_index: AtomicU32`; per-symbol-ref disjoint by chunk
     // membership — debug-asserted in `assign_chunk_index`).
@@ -176,6 +177,10 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                         // which outlives the link pass.
                         import_record.path.text = _chunks[other_chunk_index as usize].unique_key;
                         import_record.source_index = Index::INVALID;
+                        import_record.loader = None;
+                        import_record
+                            .flags
+                            .insert(ImportRecordFlags::POINTS_TO_CHUNK);
 
                         // Track this cross-chunk dynamic import so we make sure to
                         // include its hash when we're calculating the hashes of all

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -87,9 +87,9 @@ pub(crate) fn compute_cross_chunk_dependencies(
 struct CrossChunkDependencies<'a, 'bump> {
     chunk_meta: &'a mut [ChunkMeta],
     // `BackRef` — the same `[Chunk]` slice is also iterated mutably by
-    // the caller's sequential `walk` loop; `walk` only reads `chunks[other].unique_key`
-    // (disjoint from the per-iteration `&mut Chunk`). The slice outlives the struct
-    // (caller stack frame).
+    // the caller's sequential `walk` loop; `walk` only reads
+    // `chunks[other].{unique_key,content}` (disjoint from the per-iteration
+    // `&mut Chunk`). The slice outlives the struct (caller stack frame).
     chunks: bun_ptr::BackRef<[Chunk]>,
     parts: &'a [bun_ast::PartList<'bump>],
     import_records: &'a mut [bun_ast::import_record::List<'bump>],
@@ -171,16 +171,21 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                     {
                         let other_chunk_index =
                             entry_point_chunk_indices[import_record.source_index.get() as usize];
+                        let other_chunk = &_chunks[other_chunk_index as usize];
                         // Slice copy (fat pointer):
                         // `path.text` borrows the chunk's
                         // `unique_key` backing buffer (`LinkerContext.unique_key_buf`),
                         // which outlives the link pass.
-                        import_record.path.text = _chunks[other_chunk_index as usize].unique_key;
+                        import_record.path.text = other_chunk.unique_key;
                         import_record.source_index = Index::INVALID;
-                        import_record.loader = None;
-                        import_record
-                            .flags
-                            .insert(ImportRecordFlags::POINTS_TO_CHUNK);
+                        // A CSS or HTML entry point's chunk is the .css/.html output
+                        // itself, which the import's attributes still describe.
+                        if other_chunk.content.is_javascript() {
+                            import_record.loader = None;
+                            import_record
+                                .flags
+                                .insert(ImportRecordFlags::POINTS_TO_JS_CHUNK);
+                        }
 
                         // Track this cross-chunk dynamic import so we make sure to
                         // include its hash when we're calculating the hashes of all

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2712,7 +2712,7 @@ pub(crate) mod __gated_printer {
             }
 
             if !import_options.is_missing()
-                && !record.flags.contains(ImportRecordFlags::POINTS_TO_CHUNK)
+                && !record.flags.contains(ImportRecordFlags::POINTS_TO_JS_CHUNK)
             {
                 self.print_whitespacer(ws!(b", "));
                 self.print_expr(import_options, Level::Comma, ExprFlagSet::empty());

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2711,7 +2711,9 @@ pub(crate) mod __gated_printer {
                 self.print_string_literal_utf8(path.pretty, false);
             }
 
-            if !import_options.is_missing() {
+            if !import_options.is_missing()
+                && !record.flags.contains(ImportRecordFlags::POINTS_TO_CHUNK)
+            {
                 self.print_whitespacer(ws!(b", "));
                 self.print_expr(import_options, Level::Comma, ExprFlagSet::empty());
             }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -328,9 +328,9 @@ describe("bundler", () => {
     },
   });
 
-  // A dynamic import the linker points at a chunk must not keep the import
-  // attributes the user wrote for the original file: the chunk is JavaScript,
-  // and the runtime would otherwise try to load it with the attribute's loader.
+  // A dynamic import the linker points at a JavaScript chunk must not keep the
+  // import attributes the user wrote for the original file: the runtime would
+  // otherwise try to load the chunk with the attribute's loader.
   itBundled("splitting/DynamicImportWithAttributeToChunk", {
     files: {
       "/entry.ts": `
@@ -351,17 +351,27 @@ describe("bundler", () => {
     },
   });
 
+  // The attribute is what selects the loader for these files (the extension
+  // does not), so each chunk holds the file parsed with that loader, and the
+  // attribute has nothing left to do at runtime.
   itBundled("splitting/DynamicImportAttributesToChunkAllLoaders", {
     files: {
       "/entry.ts": `
-        const json = await import("./data.json", { assert: { type: "json" } });
-        const text = await import("./note.txt", { with: { type: "text" } });
-        const toml = await import("./config.toml", { with: { type: "toml" } });
-        console.log(json.default.answer, JSON.stringify(text.default), toml.default.name);
+        const json = await import("./data.notjson", { assert: { type: "json" } });
+        const text = await import("./note.md", { with: { type: "text" } });
+        const toml = await import("./config", { with: { type: "toml" } });
+        const file = await import("./asset.bin", { with: { type: "file" } });
+        console.log(
+          json.default.answer,
+          JSON.stringify(text.default),
+          toml.default.name,
+          /^\\.\\/asset-[a-z0-9]+\\.bin$/.test(file.default),
+        );
       `,
-      "/data.json": `{ "answer": 42 }`,
-      "/note.txt": `hello`,
-      "/config.toml": `name = "from toml"`,
+      "/data.notjson": `{ "answer": 42 }`,
+      "/note.md": `# hello`,
+      "/config": `name = "from toml"`,
+      "/asset.bin": `binary`,
     },
     splitting: true,
     outdir: "/out",
@@ -370,11 +380,92 @@ describe("bundler", () => {
       expect(entry).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
       expect(entry).toMatch(/import\("\.\/note-[a-z0-9]+\.js"\)/);
       expect(entry).toMatch(/import\("\.\/config-[a-z0-9]+\.js"\)/);
+      expect(entry).toMatch(/import\("\.\/asset-[a-z0-9]+\.js"\)/);
       expect(entry).not.toContain("type:");
     },
     run: {
       file: "/out/entry.js",
-      stdout: '42 "hello" from toml',
+      stdout: '42 "# hello" from toml true',
+    },
+  });
+
+  // The options do not have to be an object literal at the import() site.
+  itBundled("splitting/DynamicImportOptionsVariableToChunk", {
+    files: {
+      "/entry.ts": `
+        const options = { with: { type: "json" } };
+        const { default: data } = await import("./data.json", options);
+        console.log(data.answer);
+      `,
+      "/data.json": `{ "answer": 42 }`,
+    },
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "42",
+    },
+  });
+
+  // The import() lives in a module shared by two entry points, so the rewrite
+  // happens in a shared chunk rather than in an entry point's chunk.
+  itBundled("splitting/DynamicImportAttributesToChunkFromSharedChunk", {
+    files: {
+      "/a.ts": `
+        import { load } from "./shared";
+        console.log("a", await load());
+      `,
+      "/b.ts": `
+        import { load } from "./shared";
+        console.log("b", await load());
+      `,
+      "/shared.ts": `
+        export async function load() {
+          const { default: data } = await import("./data.json", { with: { type: "json" } });
+          return data.answer;
+        }
+      `,
+      "/data.json": `{ "answer": 42 }`,
+    },
+    entryPoints: ["/a.ts", "/b.ts"],
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      const outputs = readdirSync(api.outdir).map(name => readFileSync(join(api.outdir, name), "utf8"));
+      expect(outputs.filter(code => /import\("\.\/data-[a-z0-9]+\.js"\)/.test(code))).toHaveLength(1);
+      expect(outputs.filter(code => code.includes("type:"))).toHaveLength(0);
+    },
+    run: [
+      { file: "/out/a.js", stdout: "a 42" },
+      { file: "/out/b.js", stdout: "b 42" },
+    ],
+  });
+
+  // One options object is shared by both arms of a conditional import(). The
+  // arm that stays external keeps it; the arm pointed at a chunk drops it.
+  itBundled("splitting/ConditionalDynamicImportExternalAndChunk", {
+    files: {
+      "/entry.ts": `
+        const useExternal = process.argv.length > 100;
+        const { default: data } = await import(useExternal ? "external-data" : "./data.json", { with: { type: "json" } });
+        console.log(data.answer);
+      `,
+      "/data.json": `{ "answer": 42 }`,
+    },
+    external: ["external-data"],
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(
+        /import\("external-data", \{ with: \{ type: "json" \} \}\) : import\("\.\/data-[a-z0-9]+\.js"\)/,
+      );
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "42",
     },
   });
 
@@ -420,6 +511,25 @@ describe("bundler", () => {
     run: {
       file: "/out/entry.js",
       stdout: "42",
+    },
+  });
+
+  // A dynamically imported stylesheet is pointed at its CSS output, not at a
+  // JavaScript chunk, so the attribute still describes what gets loaded.
+  itBundled("splitting/DynamicImportToCssChunkKeepsAttribute", {
+    files: {
+      "/entry.ts": `
+        export const sheet = import("./styles.css", { with: { type: "css" } });
+      `,
+      "/styles.css": `.a { color: red; }`,
+    },
+    splitting: true,
+    outdir: "/out",
+    target: "browser",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(
+        /import\("\.\/styles-[a-z0-9]+\.css", \{ with: \{ type: "css" \} \}\)/,
+      );
     },
   });
 

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -328,6 +328,101 @@ describe("bundler", () => {
     },
   });
 
+  // A dynamic import the linker points at a chunk must not keep the import
+  // attributes the user wrote for the original file: the chunk is JavaScript,
+  // and the runtime would otherwise try to load it with the attribute's loader.
+  itBundled("splitting/DynamicImportWithAttributeToChunk", {
+    files: {
+      "/entry.ts": `
+        const { default: data } = await import("./data.json", { with: { type: "json" } });
+        console.log(data.answer);
+      `,
+      "/data.json": `{ "answer": 42 }`,
+    },
+    splitting: true,
+    outdir: "/out",
+    target: "bun",
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "42",
+    },
+  });
+
+  itBundled("splitting/DynamicImportAttributesToChunkAllLoaders", {
+    files: {
+      "/entry.ts": `
+        const json = await import("./data.json", { assert: { type: "json" } });
+        const text = await import("./note.txt", { with: { type: "text" } });
+        const toml = await import("./config.toml", { with: { type: "toml" } });
+        console.log(json.default.answer, JSON.stringify(text.default), toml.default.name);
+      `,
+      "/data.json": `{ "answer": 42 }`,
+      "/note.txt": `hello`,
+      "/config.toml": `name = "from toml"`,
+    },
+    splitting: true,
+    outdir: "/out",
+    onAfterBundle(api) {
+      const entry = api.readFile("/out/entry.js");
+      expect(entry).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
+      expect(entry).toMatch(/import\("\.\/note-[a-z0-9]+\.js"\)/);
+      expect(entry).toMatch(/import\("\.\/config-[a-z0-9]+\.js"\)/);
+      expect(entry).not.toContain("type:");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: '42 "hello" from toml',
+    },
+  });
+
+  itBundled("splitting/DynamicImportAttributesToChunkMinified", {
+    files: {
+      "/entry.ts": `
+        const { default: data } = await import("./data.json", { with: { type: "json" } });
+        console.log(data.answer);
+      `,
+      "/data.json": `{ "answer": 42 }`,
+    },
+    splitting: true,
+    outdir: "/out",
+    minifyWhitespace: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "42",
+    },
+  });
+
+  // The attributes still belong on an import() that stays external: it loads
+  // the file the user named, not a chunk.
+  itBundled("splitting/ExternalDynamicImportKeepsAttributes", {
+    files: {
+      "/entry.ts": `
+        const { default: data } = await import("./data.json", { with: { type: "json" } });
+        console.log(data.answer);
+      `,
+    },
+    external: ["*.json"],
+    splitting: true,
+    outdir: "/out",
+    runtimeFiles: {
+      "/out/data.json": `{ "answer": 42 }`,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toContain('import("./data.json", { with: { type: "json" } })');
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "42",
+    },
+  });
+
   // N same-named cross-chunk exports must get unique aliases in O(N) total
   // (ExportRenamer::next_renamed_name). Debug/ASAN builds blow past the 15s
   // cap with far fewer files than release, hence the scaled N.


### PR DESCRIPTION
### Problem
- `bun build --splitting` keeps the import attributes a user wrote on a dynamic import when it rewrites that import to point at a JavaScript chunk:
  ```ts
  // entry.ts
  const { default: data } = await import("./data.json", { with: { type: "json" } });
  ```
  ```js
  // out/entry.js
  var { default: data } = await import("./data-jn2krqnp.js", { with: { type: "json" } });
  ```
  The chunk is JavaScript, so loading the bundle fails: `SyntaxError: JSON parse error: Unrecognized token '/'` under bun (any `--target`), `ERR_IMPORT_ATTRIBUTE_TYPE_INCOMPATIBLE` under node. Same for `type: "text"`, `"toml"`, `"file"`, the legacy `assert:` form, and options passed as a variable (`import("./data.json", options)` prints `import("./data-HASH.js", options)`). Without the attribute the same program builds to `import("./data-jn2krqnp.js")` and works. Reproduces on 1.4.0 and main; esbuild drops the attribute in this situation.
- Cause: `computeCrossChunkDependencies.rs` (`walk`, the "Rewrite external dynamic imports" loop) repoints the import record at the chunk by replacing `path.text` and invalidating `source_index`, but the options object lives on the `E::Import` AST node, not on the record (`transpose_import` in `src/js_parser/p.rs` stores it there). The printer's external `import()` branch in `print_require_or_import_expr` (`src/js_printer/lib.rs`) then prints that object after whatever path the record holds.

### Fix
- New `ImportRecordFlags::POINTS_TO_JS_CHUNK` (bit 10 was unused). The linker sets it where it repoints the record, when the target chunk's content is JavaScript; the printer's external `import()` branch skips the options object when it is set.
- The gate matters because the target is not always a JavaScript chunk: a dynamically imported `.css` or `.html` file is an entry point whose chunk is the `.css`/`.html` output itself (`computeChunks.rs`, the `entry_point_chunk_indices` loop), so the rewrite produces `import("./styles-HASH.css", ...)`. A `with { type: "css" }` written on that import still describes what is loaded (in browsers it is what makes importing a stylesheet work), so those records are left exactly as on main. If such an import is later given a JavaScript chunk, the gate strips the attribute there automatically.
- The linker also clears `record.loader` for the records it flags. It held the loader for the original file (from the attribute, or from resolution), and the record now names a JavaScript chunk. Nothing reads it for an `import()` record on main today; #38275 adds a printer branch that would, and import statements already print `with { type }` from this field, so the record should not carry a stale value.
- Why this is correct: the options described the file the user imported. The bundler has already applied that loader when it built the chunk (the chunk exports the parsed JSON/text/TOML, or the asset path for `type: "file"`, as an ES module), so re-applying it to the chunk is never right, and the printer cannot tell a chunk import from a genuinely external `import()` without the flag. The flag is set only on this rewrite, so external dynamic imports keep their options (they still load the file the user named), and non-splitting builds are untouched (an inlined `import()` never reaches this branch). Dropping the object cannot drop side effects: the parser only attaches an import record to an `import()` whose options expression is side-effect free (`e_import` in `src/js_parser/visit/visit_expr.rs`).
- Not changed: one file imported with two different attribute loaders (`type: "text"` and `type: "json"` on the same path) is still bundled once and both imports now receive that one chunk; that is #37476's subject. The metafile's `inputs` entry for a cross-chunk `import()` is also unchanged.
- Tests in `test/bundler/bundler_splitting.test.ts`. Fail on the released binary, pass with this change:
  - `DynamicImportWithAttributeToChunk` (target bun, the report's repro), `DynamicImportAttributesToChunkMinified`
  - `DynamicImportAttributesToChunkAllLoaders`: attributes that select the loader on their own (`assert` json on a `.notjson` file, text on a `.md` file, toml on an extensionless file, `file`)
  - `DynamicImportOptionsVariableToChunk`: options held in a variable
  - `DynamicImportAttributesToChunkFromSharedChunk`: the `import()` sits in a module shared by two entry points, so the rewrite runs in a shared chunk
  - `ConditionalDynamicImportExternalAndChunk`: one options object shared by both arms of `import(cond ? "external-data" : "./data.json", ...)`; printed as `import("external-data", { with: ... }) : import("./data-HASH.js")`
- Guards that pass before and after: `ExternalDynamicImportKeepsAttributes` (`--external` import keeps its options) and `DynamicImportToCssChunkKeepsAttribute` (`import("./styles.css", { with: { type: "css" } })` still prints the attribute with the `.css` path; fails without the content gate).
- Also run with the debug build: `esbuild/splitting`, `bundler_compile_splitting`, `bundler_bun`, `bundler_html`, `esbuild/default`, `bundler_edgecase`, `transpiler/transpiler.test.js`, `test/js/bun/import-attributes`; `cargo fmt --all`. Manually: the report's repro under bun and, built with `--target node`, under node; `--compile --splitting` (the embedded `import()` loses the attribute too; the standalone loader ignored it, so that case already ran); a file imported both statically and dynamically still yields one module instance.

### Background
- Import record: the bundler's entry for one import site. During linking, `source_index` points at the bundled module it resolved to; a record without one is printed back out as an import of its `path`. Under `--splitting`, every dynamically imported file becomes an entry point with its own chunk, and `computeCrossChunkDependencies` repoints each cross-chunk `import()` record at that chunk (its `path.text` becomes the chunk's placeholder key, replaced with the final file name when chunks are written) so the printer emits it through the external `import()` path. This PR adds one more piece of state to that rewrite.
- Chunk content: each output chunk is `Content::Javascript`, `Content::Css` or `Content::Html`. A JavaScript entry point gets a JavaScript chunk (plus a secondary CSS chunk for any stylesheets it imports); a `.css` or `.html` entry point's primary chunk is the stylesheet or document itself, and that is the chunk a dynamic import of such a file is pointed at.
- Import attributes: the `{ with: { type: "json" } }` second argument of `import()`. At runtime, bun, node and browsers use it to pick how the target file is loaded (bun accepts its loader names there, such as `text` and `toml`). At build time, the parser uses it to set the loader the bundler parses that file with; the file then becomes an ordinary ES module in the graph.
- `ImportRecord::loader`: the loader attached to an import site. The printer uses it to re-emit `with { type }` on import statements that stay external for `--target bun`, so the runtime loads the file the way the build intended.

<details>
<summary>Earlier version of this PR</summary>

The first push set the flag (then named `POINTS_TO_CHUNK`) on every rewritten record, which also stripped `with { type: "css" }` from an `import()` pointed at a `.css` output. Review caught that; the second push gates the flag on the target chunk being JavaScript, renames it, and adds the loader, variable, shared chunk, conditional and stylesheet tests.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
bun test v1.4.0 (55d788c4f)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [1021.44ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [663.84ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [667.79ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [771.66ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [680.02ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [626.21ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [619.09ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [877.56ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [606.00ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [687.96ms]
341 |     },
342 |     splitting: true,
343 |     outdir: "/out",
344 |     target: "bun",
345 |     onAfterBundle(api) {
346 |       expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
                                                  ^
error: expe
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [45.23ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [44.51ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [37.15ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [41.38ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [46.47ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [45.79ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [34.38ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [41.76ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [28.79ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [36.94ms]
341 |     },
342 |     splitting: true,
343 |     outdir: "/out",
344 |     target: "bun",
345 |     onAfterBundle(api) {
346 |       expect(api.readFile("/out/entry.js")).toMatch(/import\("\.\/data-[a-z0-9]+\.js"\)/);
                                                  ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /import\("\.\/data-[a-z0-9]+\.js"\)/
Received: "// @bun\nimport {\n  __require\n} from \"./entry-2k8z266m.js\";
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_splitting.test.ts
bun test v1.4.0 (55d788c4f)

test/bundler/bundler_splitting.test.ts:
(pass) bundler > splitting/DynamicImportCSSFile [1344.40ms]
(pass) bundler > splitting/DynamicImportMultipleCSSImports [750.83ms]
(pass) bundler > splitting/StaticAndDynamicCSSImports [646.47ms]
(pass) bundler > splitting/NestedDynamicImportWithCSS [694.21ms]
(pass) bundler > splitting/SharedCSSBetweenChunks [657.40ms]
(pass) bundler > splitting/DynamicImportChainWithCSS [826.98ms]
(pass) bundler > splitting/ConditionalDynamicImportWithCSS [732.57ms]
(pass) bundler > splitting/MultipleEntryPointsWithSharedCSS [906.33ms]
(pass) bundler > splitting/DynamicImportWithOnlyCSSNoJS [656.95ms]
(pass) bundler > splitting/CircularDynamicImportsWithCSS [731.20ms]
(pass) bundler > splitting/DynamicImportWithAttributeToChunk [616.08ms]
(pass) bundler > splitting/DynamicImportAttributesToChunkAllLoaders [910.99ms]
(pass) bundler > splitting/DynamicImportOptionsVariableToChunk [459.60ms]
(pass) bundler > splitting/DynamicImportAttributesToChunk
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     55d788c4fb
  features     baseline

22 deps, 123 codegen, 1176 objects in 877ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [28.00ms]
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] gen bindgenv2
[6/1237] fetch zlib
[zlib] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [20.00ms]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/import_record.rs                           |   4 +
 .../computeCrossChunkDependencies.rs               |  20 +-
 src/js_printer/lib.rs                              |   4 +-
 test/bundler/bundler_splitting.test.ts             | 205 +++++++++++++++++++++
 4 files changed, 226 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/ast/import_record.rs                                      3      4      0
…bundler/linker_context/computeCrossChunkDependencies.rs      4      8      0
src/js_printer/lib.rs                                         4      1      0
test/bundler/bundler_splitting.test.ts                        2      4      0
```

</details>

<!-- robobun:evidence:end -->