### PR TITLE
Bun.serve: hand the plugin loader a &mut DevServer and store it as BackRef<_, Mut>

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1990,10 +1990,10 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
                                 };
                                 dev.has_tailwind_plugin_hack = has_tailwind;
 
-                                let load_result: crate::server::GetOrStartLoadResult = dev
-                                    .server
-                                    .as_ref()
-                                    .expect("infallible: server bound")
+                                // Copy the `AnyServer` handle out first: `dev` itself is
+                                // lent to the loader below.
+                                let server = dev.server.expect("infallible: server bound");
+                                let load_result: crate::server::GetOrStartLoadResult = server
                                     .get_or_load_plugins(
                                         crate::server::ServePluginsCallback::DevServer(dev),
                                     );

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -903,13 +903,14 @@ pub enum ServePluginsState {
         plugin: Box<JSBundler::Plugin>,
         promise: jsc::JSPromiseStrong,
         html_bundle_routes: Vec<*mut html_bundle::Route>,
-        // LIFETIMES.tsv classifies this BORROW_PARAM (`Option<&'a DevServer>`),
-        // but `ServePlugins` is a refcounted heap object handed across FFI as
-        // a raw promise-context pointer with dynamic lifetime, so a borrowed
-        // `&'a DevServer` cannot be expressed here. Back-reference invariant:
-        // the DevServer outlives the pending plugin load (see the SAFETY
-        // comments at the deref sites in `on_plugins_resolved`/`_rejected`).
-        dev_server: Option<NonNull<DevServer>>,
+        /// BACKREF: `ServePlugins` is a refcounted heap object handed across
+        /// FFI as a raw promise-context pointer, so the borrow handed to
+        /// `get_or_start_load` cannot be carried here; the DevServer outlives
+        /// the pending load. `Mut` because `handle_on_resolve`/`handle_on_reject`
+        /// write through it (`DevServer::on_plugins_resolved`/`_rejected` take
+        /// `&mut self`), so it has to be minted from the caller's `&mut`, not
+        /// from a shared reference.
+        dev_server: Option<bun_ptr::BackRef<DevServer, bun_ptr::Mut>>,
     },
     Loaded(Box<JSBundler::Plugin>),
     /// Error information is not stored as it is already reported.
@@ -923,7 +924,6 @@ pub enum GetOrStartLoadResult<'a> {
     Err,
 }
 
-#[derive(Clone, Copy)]
 pub enum ServePluginsCallback<'a> {
     /// Raw `*mut` because the route is stored in
     /// `ServePluginsState::Pending.html_bundle_routes` and later resolved via
@@ -931,7 +931,10 @@ pub enum ServePluginsCallback<'a> {
     /// (mutation goes through `Cell`/`JsCell`), so the `*mut` spelling is
     /// signature-only; callers pass `Route::as_ctx_ptr(&self)`.
     HtmlBundleRoute(*mut html_bundle::Route),
-    DevServer(&'a DevServer),
+    /// `&mut` because, unlike the route, the DevServer is mutated when the
+    /// load settles: it is stored in `ServePluginsState::Pending.dev_server`
+    /// as a `BackRef<_, Mut>`, which needs a pointer with write provenance.
+    DevServer(&'a mut DevServer),
 }
 
 impl ServePlugins {
@@ -1007,12 +1010,9 @@ impl ServePlugins {
                             html_bundle_routes.push(route);
                         }
                         ServePluginsCallback::DevServer(server) => {
-                            debug_assert!(
-                                dev_server.is_none()
-                                    || dev_server.map(|p| p.as_ptr().cast_const())
-                                        == Some(std::ptr::from_ref(server))
-                            ); // one dev server per server
-                            *dev_server = Some(NonNull::from(server));
+                            let server = bun_ptr::BackRef::new_mut(server);
+                            debug_assert!(dev_server.is_none_or(|existing| existing == server)); // one dev server per server
+                            *dev_server = Some(server);
                         }
                     }
                     return Ok(GetOrStartLoadResult::Pending);
@@ -1155,10 +1155,12 @@ impl ServePlugins {
             unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
         }
         if let Some(mut server) = dev_server {
-            // SAFETY: dev_server outlives plugin load (stored as a back-reference
-            // by `get_or_start_load`; the owning Box<DevServer> is held by the
-            // server instance, which itself holds a counted ref on `self`).
-            bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_resolved(Some(
+            // SAFETY: liveness is the BACKREF invariant on `Pending::dev_server`
+            // (`Mut` records that it was minted from a `&mut DevServer`).
+            // Exclusivity: the load settles from the promise reaction, or
+            // synchronously inside `load_and_resolve_plugins` before any dev
+            // server has registered, so no borrow of the DevServer is live here.
+            bun_core::handle_oom(unsafe { server.get_mut() }.on_plugins_resolved(Some(
                 std::ptr::from_ref::<JSBundler::Plugin>(plugin_ref).cast_mut(),
             )));
         }
@@ -1187,8 +1189,8 @@ impl ServePlugins {
             unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
         }
         if let Some(mut server) = dev_server {
-            // SAFETY: dev_server outlives plugin load
-            bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_rejected());
+            // SAFETY: same as the `dev_server` arm of `handle_on_resolve`.
+            bun_core::handle_oom(unsafe { server.get_mut() }.on_plugins_rejected());
         }
 
         Output::err_generic("Failed to load plugins for Bun.serve:", ());


### PR DESCRIPTION
### Problem

- `ServePluginsCallback::DevServer(&'a DevServer)` (`src/runtime/server/server_body.rs:934`) takes a shared reference, and `get_or_start_load` stores it as `NonNull::from(server)` (`:1015`), so the pointer kept in `ServePluginsState::Pending.dev_server` is derived from a `&T`.
- When the load settles, `handle_on_resolve` / `handle_on_reject` (`:1161`, `:1191`) call `server.as_mut()` and run `DevServer::on_plugins_resolved` / `on_plugins_rejected` (`src/runtime/bake/DevServer.rs:6127`, `:6137`), which take `&mut self` and write `plugin_state` and `bundler_options.plugin` and drain `next_bundle`.
- Writing through a pointer minted from a shared reference is undefined behaviour under both aliasing models (Tree Borrows, which `bun run rust:miri` uses, and Stacked Borrows), regardless of whether the original `&T` is still alive. It is the class `test/internal/source-lints/frozen-nonnull-reborrow.test.ts` bans; this instance is invisible to that lint because the downgrade happens at the variant's type (the only caller, `ensure_route_is_bundled` at `DevServer.rs:1998`, holds a `&mut DevServer` and coerces it), not in a `NonNull::from(&*x)` expression.
- Not known to miscompile today. Surfaced by review on #32078, which type-erases this variant and intentionally keeps its shape, so the pointer type is fixed on main separately.

### Fix

- The variant takes `&'a mut DevServer`. `Pending.dev_server` becomes `Option<bun_ptr::BackRef<DevServer, bun_ptr::Mut>>`, built with `BackRef::new_mut` where it is stored, and both dispatch sites go through `BackRef::get_mut`. The callback enum loses `#[derive(Clone, Copy)]`; nothing copied it.
- The caller copies the `AnyServer` handle out of `dev.server` before the call so `dev` itself can be lent; the previous `.as_ref()` receiver chain kept `dev` shared-borrowed for the duration of the call.
- Why this is right: the loader mutates the DevServer through the stored pointer, so the pointer has to be minted from a `&mut`. `BackRef<_, Mut>` is the type `bun_ptr` provides for exactly that, and it is what the other DevServer back-references already use (`HmrSocket::new`, `ErrorReportRequest::run`). `ensure_route_is_bundled` holds `&mut DevServer` for its whole body, so lending it here claims no exclusivity that was not already claimed. The writes performed and their order are unchanged.
- Out of scope: whether the DevServer can be freed while the load is pending is a separate liveness bug with its own PR (#37838). The `HtmlBundleRoute` arm is unaffected; its callbacks take `&self` and it already dispatches through a shared `BackRef`.
- Also out of scope: the caller keeps using `dev` after the back-reference is stored (`dev.plugin_state = Pending` on the next line), and other requests re-derive `&mut DevServer` from the owning `Box` before the load settles. That ordering is unchanged by this PR and is the same shape as every other `BackRef<DevServer, Mut>` in bake (`HmrSocket::new`, `ErrorReportRequest::run` are both followed by further use of the DevServer before the back-reference is used). Giving stored DevServer pointers a provenance that survives those later accesses means minting all of them from the `Box` itself, which is a change to how the DevServer is owned, not to this variant. This PR only fixes the one site whose pointer never had write permission to begin with.
- Verification: this changes pointer provenance only, so there is no test that fails before and passes after. Existing coverage of every affected path was run against the debug build:
  - `test/bake/serve-plugins-dev-server.test.ts` (DevServer resolve and reject arms)
  - `test/js/bun/http/bun-serve-html.test.ts -t "serve plugins"` (HTML route arm, including concurrent consumers of one pending load)
  - `test/bake/dev/plugins.test.ts`
  - `cargo clippy -p bun_runtime --no-deps` and `cargo fmt --all -- --check` are clean.

### Background

- Pointer provenance: in Rust's aliasing models every pointer carries a permission inherited from the reference it was created from. A pointer created from `&T` is read-only for its entire life, so a later `as_mut()` on it is UB even after the `&T` is gone; a pointer created from `&mut T` may be written through. Miri checks this; the compiler does not, which is why the code works today.
- `bun_ptr::BackRef<T, P>`: a non-owning pointer to an object that outlives its holder. `BackRef<T, Shared>` is built from `&T` and only hands out `&T`. `BackRef<T, Mut>` is built from `&mut T` (`new_mut`) and hands out `&mut T` through `unsafe fn get_mut`, whose remaining obligation at each call site is that no other borrow of the pointee is live.
- `ServePlugins`: per-server state machine that loads the `[serve.static]` plugins once. Consumers that ask while the load is in flight are recorded in `Pending` (any number of HTML routes, at most one DevServer) and notified from the plugin promise's reaction when it settles; the DevServer's notification is what releases the requests it deferred while waiting.
