### PR TITLE
Clear exceptions thrown by property lookups during inspect's property walk

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5605,10 +5605,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property builders.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5680,7 +5681,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,82 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Run in a child: a regression here segfaults the process instead of throwing.
+describe("property lookup throws while formatting an object", () => {
+  it.concurrent("Proxy traps in the prototype chain", async () => {
+    const fixture = `
+      {
+        // Only "a" throws, so the walk has to carry on past it without the
+        // exception still pending when "b" and "c" are looked up.
+        const proto = new Proxy(
+          { a: 1, b: 2, c: 3 },
+          {
+            get(target, key, receiver) {
+              if (key === "a") throw new Error("get trap");
+              return Reflect.get(target, key, receiver);
+            },
+          },
+        );
+        console.log(Bun.inspect(Object.create(proto)));
+      }
+      {
+        const proto = new Proxy(
+          { a: 1 },
+          {
+            getPrototypeOf() {
+              throw new Error("getPrototypeOf trap");
+            },
+          },
+        );
+        const obj = Object.create(proto);
+        obj.x = 1;
+        console.log(Bun.inspect(obj));
+        console.log(obj);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        b: 2,
+        c: 3,
+      }
+      {
+        x: 1,
+        a: 1,
+      }
+      {
+        x: 1,
+        a: 1,
+      }
+      "
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("lazy property of the Bun object", async () => {
+    // Bun.redis builds the default client the first time it is read, and an
+    // invalid REDIS_URL makes that throw. Only that property may be left out;
+    // the properties visited after it must still be printed.
+    const fixture = `
+      const keys = Object.keys(Bun);
+      const out = Bun.inspect(Bun);
+      console.log(JSON.stringify(keys.filter(key => !out.includes("\\n  " + key + ":"))));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, REDIS_URL: "http://not-a-redis-url" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe('["redis"]\n');
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -968,7 +968,8 @@ describe("property lookup throws while formatting an object", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toMatchInlineSnapshot(`
       "{
         b: 2,
@@ -1002,7 +1003,8 @@ describe("property lookup throws while formatting an object", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout).toBe('["redis"]\n');
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### What does this PR do?

Found by fuzzing. The fuzzer's script replaced the global `Symbol` with a number and then called `new CompressionStream(globalThis)`. The error message for the bad `format` argument inspects `globalThis`, which walks the `Bun` object, and `Bun.$` is a lazy static property whose builder runs `shell.ts`, which calls `Symbol("cwd")` and throws. In debug builds the process died with

```
ASSERTION FAILED: Unexpected exception observed ...
Error Exception: Symbol is not a function. (In 'Symbol("cwd")', 'Symbol' is NaN)
void JSC::ExceptionScope::releaseAssertNoException()
```

Root cause is in `JSC__JSValue__forEachPropertyImpl` (bindings.cpp), the property walk used by `Bun.inspect` / `console.log`:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
CLEAR_IF_EXCEPTION(scope);
```

When the lookup throws (a Proxy `get` trap, or a lazy static property builder; `setUpStaticFunctionSlot` reports the property as not found in that case), `getPropertySlot` returns false and the loop continued with the exception still pending on the VM. Consequences:

* Every later lookup on that object fails too, because `setUpStaticFunctionSlot` checks for a pending exception after reifying. In release builds this silently drops the rest of the object from the output: `REDIS_URL=http://x bun -e 'console.log(Bun)'` prints nothing after `redis` (`secrets`, `write`, `zstd*` are all missing).
* The next lazy builder that returns a value with an exception already pending trips the exception scope assertion in debug builds (the fuzzer's crash).
* When the object being walked is a Proxy, the `getPrototype` call at the end of the loop returns an empty `JSValue` because of the pending exception, and `.getObject()` on it dereferences null. Release builds segfault at address 0x5 on `Bun.inspect(Object.create(new Proxy({a: 1, b: 2}, { get(t, k) { if (k === "a") throw 1; return t[k]; } })))`.

The fix is to clear the exception before looking at the result of `getPropertySlot`, which is what `JSC__JSValue__forEachPropertyOrdered` already does. The second hunk in the same function handles `getPrototype` itself throwing (a Proxy `getPrototypeOf` trap on an object in the prototype chain), which segfaulted the same way independently of the first bug; the walk now stops there, matching how the fast path in this function already treats that trap.

The `BunObject.cpp` hunk removes the debug-only `reportUncaughtExceptionAtEventLoop` calls in the two `Bun.sql` builders. They ran the uncaught exception handler while the module load error was still pending on the VM, and the `process._fatalException` lookup inside that handler then hits JSC's `storedPrototype` / `JSObject::get` assertions. With the `Symbol` tampering above, `Bun.inspect(Bun)` reaches these builders right after the first fix, so debug builds still crashed on the fuzzer's script without this. The error is propagated to the caller on the next line anyway, so `Bun.sql` now just throws the load error in debug builds like it does in release.

### How did you verify your code works?

Two tests added to `test/js/bun/util/inspect.test.js`, both running the scenario in a child process since a regression is a crash rather than a thrown error:

* `Proxy traps in the prototype chain`: the `get` trap and `getPrototypeOf` trap cases above. On the unfixed build the child segfaults and prints nothing.
* `lazy property of the Bun object`: `REDIS_URL` set to an invalid URL so the `Bun.redis` builder throws, then checks which keys of `Object.keys(Bun)` are missing from `Bun.inspect(Bun)`. Unfixed release prints `["redis","secrets","write","zstdCompressSync","zstdDecompressSync","zstdCompress","zstdDecompress"]`, unfixed debug crashes, fixed prints `["redis"]`.

Both fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. The rest of `inspect.test.js`, `BunObject.test.ts`, `bun-inspect.test.ts`, `custom-inspect.test.js` and `console-table.test.ts` pass on the debug build. The original fuzzer script (evaluated in the global scope the way the REPRL harness runs it) crashes the unfixed debug build with the assertion above and runs to completion on the fixed one, also with `BUN_JSC_validateExceptionChecks=1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->