### PR TITLE
bundler: report a split dynamic import as its input file in the metafile

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3982,10 +3982,7 @@ pub mod bv2_impl {
 
                 // Generate metafile if requested (the CLI build command writes the files)
                 let metafile: Option<Box<[u8]>> = if this.linker.options.metafile {
-                    match crate::linker_context::metafile_builder::generate(
-                        &mut this.linker,
-                        &mut chunks,
-                    ) {
+                    match crate::linker_context::metafile_builder::generate(&this.linker, &chunks) {
                         Ok(m) => Some(m),
                         Err(err) => {
                             bun_core::warn!("Failed to generate metafile: {}", err);
@@ -5097,10 +5094,7 @@ pub mod bv2_impl {
 
             // Generate metafile if requested
             let metafile: Option<Box<[u8]>> = if self.linker.options.metafile {
-                match crate::linker_context::metafile_builder::generate(
-                    &mut self.linker,
-                    &mut chunks,
-                ) {
+                match crate::linker_context::metafile_builder::generate(&self.linker, &chunks) {
                     Ok(m) => Some(m),
                     Err(err) => {
                         bun_core::warn!("Failed to generate metafile: {}", err.name());

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3982,7 +3982,10 @@ pub mod bv2_impl {
 
                 // Generate metafile if requested (the CLI build command writes the files)
                 let metafile: Option<Box<[u8]>> = if this.linker.options.metafile {
-                    match crate::linker_context::metafile_builder::generate(&this.linker, &chunks) {
+                    match crate::linker_context::metafile_builder::generate(
+                        &mut this.linker,
+                        &mut chunks,
+                    ) {
                         Ok(m) => Some(m),
                         Err(err) => {
                             bun_core::warn!("Failed to generate metafile: {}", err);
@@ -5094,7 +5097,10 @@ pub mod bv2_impl {
 
             // Generate metafile if requested
             let metafile: Option<Box<[u8]>> = if self.linker.options.metafile {
-                match crate::linker_context::metafile_builder::generate(&self.linker, &chunks) {
+                match crate::linker_context::metafile_builder::generate(
+                    &mut self.linker,
+                    &mut chunks,
+                ) {
                     Ok(m) => Some(m),
                     Err(err) => {
                         bun_core::warn!("Failed to generate metafile: {}", err.name());

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -215,9 +215,6 @@ pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box
     // Iterate through all files in chunks to collect unique source indices
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
 
-    // Resolves the import records that `compute_cross_chunk_dependencies` pointed at a
-    // chunk (`path.text` = the chunk's unique key, no `source_index`) back to the
-    // imported file: the chunk's entry point.
     let mut entry_point_by_chunk_key: StringHashMap<u32> = StringHashMap::default();
 
     // Mark all files that appear in chunks
@@ -299,6 +296,7 @@ pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box
                 let target_source_index: Option<u32> = if record.source_index.is_valid() {
                     Some(record.source_index.get())
                 } else {
+                    // A chunk's unique key, see `compute_cross_chunk_dependencies`.
                     entry_point_by_chunk_key.get(record.path.text).copied()
                 };
 

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -200,12 +200,8 @@ pub(crate) fn generate_chunk_json(
 
 /// Assembles the final metafile JSON from pre-built chunk fragments.
 /// Called after all chunks have been generated in parallel.
-/// Chunk references (unique_keys) are resolved to their final output paths.
-/// The caller is responsible for freeing the returned slice.
-pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Result<Box<[u8]>> {
-    // Use StringJoiner so we can use breakOutputIntoPieces to resolve chunk references
+pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box<[u8]>> {
     let mut j = StringJoiner::default();
-    // errdefer j.deinit() — handled by Drop
 
     j.push_static(b"{\n  \"inputs\": {");
 
@@ -218,7 +214,13 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
 
     // Iterate through all files in chunks to collect unique source indices
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
-    // defer seen_sources.deinit() — handled by Drop
+
+    // With code splitting, `compute_cross_chunk_dependencies` rewrites a dynamic
+    // import of another entry point so the printer emits an import of that entry
+    // point's chunk: `path.text` becomes the chunk's unique key and `source_index`
+    // is cleared. The inputs graph describes source files, so such a record is
+    // reported as an import of the chunk's entry point, the file the source imports.
+    let mut entry_point_by_chunk_key: StringHashMap<u32> = StringHashMap::default();
 
     // Mark all files that appear in chunks
     for chunk in chunks.iter() {
@@ -226,6 +228,10 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
             if (source_index as usize) < sources.len() {
                 seen_sources.set(source_index as usize);
             }
+        }
+        if chunk.entry_point.is_entry_point() && !chunk.unique_key.is_empty() {
+            entry_point_by_chunk_key
+                .put_static_key(chunk.unique_key, chunk.entry_point.source_index())?;
         }
     }
 
@@ -292,17 +298,20 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                 }
                 first_import = false;
 
+                let target_source_index: Option<u32> = if record.source_index.is_valid() {
+                    Some(record.source_index.get())
+                } else {
+                    entry_point_by_chunk_key.get(record.path.text).copied()
+                };
+
                 j.push_static(b"\n        {\n          \"path\": ");
                 // Bundled imports use the target source's pretty path (same string as the
                 // "inputs" key). `record.path.text` is unreliable here: dedup can set
-                // `source_index` without rewriting the path. Externals/chunk refs fall through.
+                // `source_index` without rewriting the path. Externals fall through.
                 let import_path: &[u8] = 'path: {
-                    if record.source_index.is_valid()
-                        && record.source_index.get() != Index::RUNTIME.get()
-                    {
-                        let idx = record.source_index.get() as usize;
-                        if idx < sources.len() {
-                            let pretty = sources[idx].path.pretty;
+                    if let Some(idx) = target_source_index {
+                        if idx != Index::RUNTIME.get() && (idx as usize) < sources.len() {
+                            let pretty = sources[idx as usize].path.pretty;
                             if !pretty.is_empty() {
                                 break 'path pretty;
                             }
@@ -339,16 +348,15 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                 if record
                     .flags
                     .contains(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS)
-                    || !record.source_index.is_valid()
+                    || target_source_index.is_none()
                 {
                     j.push_static(b",\n          \"external\": true");
                 }
 
                 // Add "with" for import attributes (json, toml, text loaders)
-                if record.source_index.is_valid()
-                    && (record.source_index.get() as usize) < loaders.len()
+                if let Some(loader) =
+                    target_source_index.and_then(|idx| loaders.get(idx as usize).copied())
                 {
-                    let loader = loaders[record.source_index.get() as usize];
                     let with_type: Option<&'static [u8]> = match loader {
                         Loader::Json => Some(b"json"),
                         Loader::Toml => Some(b"toml"),
@@ -418,40 +426,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
 
     j.push_static(b"\n  }\n}\n");
 
-    // If no chunks, there are no chunk references to resolve, so just return the joined string
-    if chunks.is_empty() {
-        return Ok(j.done()?);
-    }
-
-    // Break output into pieces and resolve chunk references to final paths
-    let alloc = c.arena();
-    // SAFETY: every borrowed node in `j` points into `chunk.metafile_chunk_json`,
-    // parse-graph data (import-record kind labels), or `'static` literals, all of
-    // which outlive `intermediate` — it is consumed by `code()` below while `chunks`
-    // and `c` are still alive.
-    let mut j = unsafe { j.detach_lifetime() };
-    let mut intermediate = c.break_output_into_pieces(
-        alloc,
-        &mut j,
-        u32::try_from(chunks.len()).expect("int cast"),
-    )?;
-
-    // Get final output with all chunk references resolved.
-    // `code()` takes the dummy chunk and the full slice as `&`, so pass
-    // `&chunks[0]` directly — overlapping shared borrows are fine.
-    let code_result = intermediate.code(
-        None,
-        parse_graph,
-        &c.graph,
-        b"", // no import prefix for metafile
-        &chunks[0],
-        chunks,
-        None,  // no display size
-        false, // not force absolute path
-        false, // no source map shifts
-    )?;
-
-    Ok(code_result.buffer)
+    Ok(j.done()?)
 }
 
 fn write_json_string(writer: &mut impl Write, str: &[u8]) -> std::io::Result<()> {

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -215,11 +215,9 @@ pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box
     // Iterate through all files in chunks to collect unique source indices
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
 
-    // With code splitting, `compute_cross_chunk_dependencies` rewrites a dynamic
-    // import of another entry point so the printer emits an import of that entry
-    // point's chunk: `path.text` becomes the chunk's unique key and `source_index`
-    // is cleared. The inputs graph describes source files, so such a record is
-    // reported as an import of the chunk's entry point, the file the source imports.
+    // Resolves the import records that `compute_cross_chunk_dependencies` pointed at a
+    // chunk (`path.text` = the chunk's unique key, no `source_index`) back to the
+    // imported file: the chunk's entry point.
     let mut entry_point_by_chunk_key: StringHashMap<u32> = StringHashMap::default();
 
     // Mark all files that appear in chunks

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -200,8 +200,12 @@ pub(crate) fn generate_chunk_json(
 
 /// Assembles the final metafile JSON from pre-built chunk fragments.
 /// Called after all chunks have been generated in parallel.
-pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box<[u8]>> {
+/// Chunk references (unique_keys) left in the output are resolved to their final output paths.
+/// The caller is responsible for freeing the returned slice.
+pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Result<Box<[u8]>> {
+    // Use StringJoiner so we can use breakOutputIntoPieces to resolve chunk references
     let mut j = StringJoiner::default();
+    // errdefer j.deinit() — handled by Drop
 
     j.push_static(b"{\n  \"inputs\": {");
 
@@ -214,6 +218,7 @@ pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box
 
     // Iterate through all files in chunks to collect unique source indices
     let mut seen_sources = DynamicBitSet::init_empty(sources.len())?;
+    // defer seen_sources.deinit() — handled by Drop
 
     let mut entry_point_by_chunk_key: StringHashMap<u32> = StringHashMap::default();
 
@@ -303,7 +308,7 @@ pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box
                 j.push_static(b"\n        {\n          \"path\": ");
                 // Bundled imports use the target source's pretty path (same string as the
                 // "inputs" key). `record.path.text` is unreliable here: dedup can set
-                // `source_index` without rewriting the path. Externals fall through.
+                // `source_index` without rewriting the path. Externals/chunk refs fall through.
                 let import_path: &[u8] = 'path: {
                     if let Some(idx) = target_source_index {
                         if idx != Index::RUNTIME.get() && (idx as usize) < sources.len() {
@@ -422,7 +427,40 @@ pub(crate) fn generate(c: &LinkerContext, chunks: &[Chunk]) -> crate::Result<Box
 
     j.push_static(b"\n  }\n}\n");
 
-    Ok(j.done()?)
+    // If no chunks, there are no chunk references to resolve, so just return the joined string
+    if chunks.is_empty() {
+        return Ok(j.done()?);
+    }
+
+    // Break output into pieces and resolve chunk references to final paths
+    let alloc = c.arena();
+    // SAFETY: every borrowed node in `j` points into `chunk.metafile_chunk_json`,
+    // parse-graph data (import-record kind labels), or `'static` literals, all of
+    // which outlive `intermediate` — it is consumed by `code()` below while `chunks`
+    // and `c` are still alive.
+    let mut j = unsafe { j.detach_lifetime() };
+    let mut intermediate = c.break_output_into_pieces(
+        alloc,
+        &mut j,
+        u32::try_from(chunks.len()).expect("int cast"),
+    )?;
+
+    // Get final output with all chunk references resolved.
+    // `code()` takes the dummy chunk and the full slice as `&`, so pass
+    // `&chunks[0]` directly — overlapping shared borrows are fine.
+    let code_result = intermediate.code(
+        None,
+        parse_graph,
+        &c.graph,
+        b"", // no import prefix for metafile
+        &chunks[0],
+        chunks,
+        None,  // no display size
+        false, // not force absolute path
+        false, // no source map shifts
+    )?;
+
+    Ok(code_result.buffer)
 }
 
 fn write_json_string(writer: &mut impl Write, str: &[u8]) -> std::io::Result<()> {

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -470,7 +470,7 @@ describe("bundler metafile", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
       return await Bun.file(`${dir}/meta.json`).json();
@@ -1148,7 +1148,7 @@ describe("bun build --metafile-md", () => {
       stdout: "pipe",
     });
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -418,8 +418,9 @@ describe("bundler metafile", () => {
 
   test("metafile tracks dynamic-import imports with code splitting", async () => {
     using dir = tempDir("metafile-dynamic-import-test", {
-      "entry.js": `import("./dynamic.js").then(m => console.log(m));`,
+      "entry.js": `import("./dynamic.js").then(m => console.log(m)); import("./styles.css");`,
       "dynamic.js": `export const value = 123;`,
+      "styles.css": `.dynamic { color: red; }`,
     });
 
     const result = await Bun.build({
@@ -433,12 +434,15 @@ describe("bundler metafile", () => {
     const inputKeys = Object.keys(metafile.inputs);
     const entryKey = inputKeys.find(k => k.endsWith("entry.js"))!;
     const dynamicKey = inputKeys.find(k => k.endsWith("dynamic.js"))!;
+    const stylesKey = entryKey.replace(/entry\.js$/, "styles.css");
 
-    // Splitting turns dynamic.js into its own chunk, but the inputs graph still links
-    // source files to source files: the import resolves to the "inputs" key of the
-    // imported file and is not external (esbuild reports it the same way).
+    // Splitting gives each import() target a chunk of its own (a JS chunk for dynamic.js,
+    // a CSS chunk for styles.css), but the inputs graph still links source files to
+    // source files: the import resolves to the "inputs" key of the imported file and is
+    // not external (esbuild reports it the same way).
     expect(metafile.inputs[entryKey].imports).toEqual([
       { path: dynamicKey, kind: "dynamic-import", original: "./dynamic.js" },
+      { path: stylesKey, kind: "dynamic-import", original: "./styles.css" },
     ]);
 
     // The chunk itself is what the outputs graph links to.
@@ -486,7 +490,8 @@ describe("bundler metafile", () => {
     ]);
     expect(withSplitting.inputs).toEqual(withoutSplitting.inputs);
 
-    // Every import edge in the inputs graph points at another input.
+    // Everything this fixture imports ends up in the bundle, so every import edge in the
+    // inputs graph points at another input, splitting or not.
     const inputKeys = Object.keys(withSplitting.inputs);
     for (const input of Object.values(withSplitting.inputs)) {
       for (const imp of input.imports) {

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Type definitions for metafile structure
 interface MetafileImport {
@@ -416,7 +416,7 @@ describe("bundler metafile", () => {
     expect(requireImport!.kind).toBe("require-call");
   });
 
-  test("metafile tracks dynamic-import imports", async () => {
+  test("metafile tracks dynamic-import imports with code splitting", async () => {
     using dir = tempDir("metafile-dynamic-import-test", {
       "entry.js": `import("./dynamic.js").then(m => console.log(m));`,
       "dynamic.js": `export const value = 123;`,
@@ -429,33 +429,81 @@ describe("bundler metafile", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(result.metafile).toBeDefined();
+    const metafile = result.metafile as Metafile;
+    const inputKeys = Object.keys(metafile.inputs);
+    const entryKey = inputKeys.find(k => k.endsWith("entry.js"))!;
+    const dynamicKey = inputKeys.find(k => k.endsWith("dynamic.js"))!;
 
-    // Find the entry file in inputs
-    const inputs = (result.metafile as Metafile).inputs as Record<string, MetafileInput>;
-    let dynamicImport: MetafileImport | null = null;
-    for (const [path, input] of Object.entries(inputs)) {
-      if (path.includes("entry.js")) {
-        for (const imp of input.imports) {
-          if (imp.kind === "dynamic-import" && imp.original === "./dynamic.js") {
-            dynamicImport = imp;
-            break;
-          }
-        }
-        break;
+    // Splitting turns dynamic.js into its own chunk, but the inputs graph still links
+    // source files to source files: the import resolves to the "inputs" key of the
+    // imported file and is not external (esbuild reports it the same way).
+    expect(metafile.inputs[entryKey].imports).toEqual([
+      { path: dynamicKey, kind: "dynamic-import", original: "./dynamic.js" },
+    ]);
+
+    // The chunk itself is what the outputs graph links to.
+    const [dynamicChunkPath] = Object.entries(metafile.outputs).find(([, output]) => output.entryPoint === dynamicKey)!;
+    const entryOutput = Object.values(metafile.outputs).find(output => output.entryPoint === entryKey)!;
+    expect(entryOutput.imports).toContainEqual({ path: dynamicChunkPath, kind: "dynamic-import" });
+  });
+
+  test("metafile inputs are the same with and without --splitting", async () => {
+    const files = {
+      "entry.js": `
+        import { shared } from "./shared.js";
+        console.log(shared, import("./data.json"), import("./other.js"), import("./lazy.js"));
+      `,
+      // A second user entry point that entry.js also import()s.
+      "other.js": `export const other = "other";`,
+      // Only reachable through import(), so splitting makes it an entry point of its own.
+      "lazy.js": `import { shared } from "./shared.js"; export const lazy = shared + "!";`,
+      "shared.js": `export const shared = "shared";`,
+      "data.json": `{ "answer": 42 }`,
+    };
+
+    async function buildMetafile(...extraArgs: string[]): Promise<Metafile> {
+      using dir = tempDir("metafile-splitting-inputs", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "entry.js", "other.js", "--outdir=out", "--metafile=meta.json", ...extraArgs],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return await Bun.file(`${dir}/meta.json`).json();
+    }
+
+    const [withSplitting, withoutSplitting] = await Promise.all([buildMetafile("--splitting"), buildMetafile()]);
+
+    expect(withSplitting.inputs["entry.js"].imports).toEqual([
+      { path: "shared.js", kind: "import-statement", original: "./shared.js" },
+      { path: "data.json", kind: "dynamic-import", original: "./data.json", with: { type: "json" } },
+      { path: "other.js", kind: "dynamic-import", original: "./other.js" },
+      { path: "lazy.js", kind: "dynamic-import", original: "./lazy.js" },
+    ]);
+    expect(withSplitting.inputs).toEqual(withoutSplitting.inputs);
+
+    // Every import edge in the inputs graph points at another input.
+    const inputKeys = Object.keys(withSplitting.inputs);
+    for (const input of Object.values(withSplitting.inputs)) {
+      for (const imp of input.imports) {
+        expect(inputKeys).toContain(imp.path);
       }
     }
 
-    expect(dynamicImport).not.toBeNull();
-    expect(dynamicImport!.kind).toBe("dynamic-import");
-    expect(dynamicImport!.original).toBe("./dynamic.js");
-    // The path should be the final chunk path (e.g., "./chunk-xxx.js"), not the internal unique_key
-    expect(dynamicImport!.path).toMatch(/^\.\/chunk-[a-z0-9]+\.js$/);
-
-    // Verify the path corresponds to an actual output chunk
-    const outputs = (result.metafile as Metafile).outputs as Record<string, MetafileOutput>;
-    const outputPaths = Object.keys(outputs);
-    expect(outputPaths).toContain(dynamicImport!.path);
+    // The chunks the dynamic imports load are listed in the outputs graph.
+    const outputPathOf = (entryPoint: string) =>
+      Object.entries(withSplitting.outputs).find(([, output]) => output.entryPoint === entryPoint)![0];
+    expect(withSplitting.outputs[outputPathOf("entry.js")].imports).toEqual(
+      expect.arrayContaining([
+        { path: outputPathOf("data.json"), kind: "dynamic-import" },
+        { path: outputPathOf("other.js"), kind: "dynamic-import" },
+        { path: outputPathOf("lazy.js"), kind: "dynamic-import" },
+      ]),
+    );
   });
 
   test("metafile includes cssBundle for CSS outputs", async () => {
@@ -800,8 +848,6 @@ describe("Bun.build metafile option variants", () => {
 });
 
 // CLI tests for --metafile-md
-import { bunEnv, bunExe } from "harness";
-
 describe("bun build --metafile-md", () => {
   test("generates markdown metafile with default name", async () => {
     using dir = tempDir("metafile-md-test", {
@@ -1086,6 +1132,31 @@ describe("bun build --metafile-md", () => {
     expect(content).toContain("import-statement");
     expect(content).toContain("dynamic-import");
     expect(content).toContain("require-call");
+  });
+
+  test("markdown links dynamically imported modules to their importers with --splitting", async () => {
+    using dir = tempDir("metafile-md-splitting-dynamic-import", {
+      "entry.js": `import("./dynamic.js").then(m => console.log(m));`,
+      "dynamic.js": `export const dynamic_value = 2;`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.js", "--metafile-md", "--outdir=dist", "--splitting"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const content = await Bun.file(`${dir}/meta.md`).text();
+    expect(content).toContain("[IMPORT: entry.js -> dynamic.js]");
+    expect(content).toContain("[IMPORTED_BY: dynamic.js <- entry.js]");
+    expect(content).not.toContain("[EXTERNAL: entry.js");
+    expect(content).not.toContain("| External imports |");
   });
 
   test("markdown shows commonly imported modules", async () => {


### PR DESCRIPTION
### Problem
- With `--splitting`, the metafile's `inputs` section reports a dynamic import of a bundled file as the chunk's output path and marks it external:
  ```json
  "entry.ts": { "imports": [ { "path": "./data-jn2krqnp.js", "kind": "dynamic-import", "original": "./data.json", "external": true } ] }
  ```
  Without `--splitting` (and in esbuild, with or without splitting) the same import is `{ "path": "data.json", "kind": "dynamic-import", "original": "./data.json", "with": { "type": "json" } }`.
- Consumers that walk `inputs` edges (esbuild's analyzer, `--metafile-md`) lose every dynamic-import edge under splitting: the markdown report counts them as "External imports" and lists the imported module as "(entry point or orphan)".
- Cause: `compute_cross_chunk_dependencies` (src/bundler/linker_context/computeCrossChunkDependencies.rs:177) rewrites every dynamic import of another entry point so the printer emits an import of that entry point's chunk: `record.path.text` becomes the chunk's unique key and `record.source_index` is cleared. `metafile_builder::generate` runs after linking and reads the same records, so the import fell through to `path.text` (the unique key, which the `break_output_into_pieces` pass at the end of `generate` then turned into the chunk's output path), the cleared source index produced `"external": true`, and the `with` lookup was skipped. #34534 fixed the static-import half of this (emit the `inputs` key for bundled imports) and left this case as the fall-through.

### Fix
- `generate` builds a map from each entry point chunk's unique key to the chunk's entry point source index. A record with no source index whose path is one of those keys resolves to that source and is then emitted exactly like any other bundled import: `path` is the target's pretty path (its `inputs` key), no `external`, `with` derived from the target's loader.
- This is the edge the source expresses: the redirect targets `entry_point_chunk_index[target]`, and computeChunks.rs:505-518 sets that to the chunk whose `entry_point.source_index()` is the target, so the chunk's entry point is the file that was imported. This holds for JS, JSON, and asset targets, and for an `import()`ed stylesheet (whose entry chunk is a CSS chunk today and gains a JS chunk with the same entry point under #38319 / #38455, so the edge is unchanged when those land). Which output file serves the import stays in `outputs[].imports`, which this change does not touch.
- The `break_output_into_pieces` pass at the end of `generate` is kept. `entry_point_chunk_index` is 0 for an entry point that never received a chunk of its own (today: an `import()`ed stylesheet deduplicated by `--css-chunking`), so the linker redirects such an import at chunk 0, which may not be an entry chunk; the map has no entry for it and the pass keeps reporting what it reports today (chunk 0's output path, external) instead of leaking the raw placeholder. Fixing the redirect itself is the business of #38319 / #38455 (own chunk for an `import()`ed stylesheet) and #38341 (CSS entries in the metafile); this PR touches none of the code they change and does not depend on their order.
- Everything else is unchanged: externals have no source index and no matching key (keys carry a random per-build prefix), so they keep `"external": true`; records pointing at the runtime still fall through to `path.text`.
- Verified with test/bundler/metafile.test.ts (the three new or updated cases fail on the released build and pass with this change; 46/46 in the file pass):
  - `metafile tracks dynamic-import imports with code splitting` (Bun.build API): an `import()` of a JS file and of a stylesheet both resolve to the imported file's key; previously asserted the chunk path. Also checks `outputs` still points at the JS chunk.
  - `metafile inputs are the same with and without --splitting` (CLI): a JSON target (`with`), a second user entry point that is also `import()`ed, and a file only reachable through `import()`; `inputs` is identical between the two builds, every edge points at an input, and the entry's output lists the three chunks.
  - `markdown links dynamically imported modules to their importers with --splitting` (`--metafile-md`).
  - Also ran test/bundler/esbuild/metafile.test.ts (12/12) and test/bundler/bundler_splitting.test.ts (11/11), and checked by hand that `--splitting --css-chunking` with an `import()`ed stylesheet produces the same metafile as 1.4.0.

### Background
- Metafile: the esbuild-format build report. `inputs` maps each source file to the imports found in it (edges between source files, plus externals); `outputs` maps each emitted file to the files it contains and the other outputs it imports. Bun emits `outputs` per chunk during chunk generation and assembles `inputs` afterwards in `metafile_builder::generate` from the import records left in the graph.
- Import record: the bundler's per-import entry (`src/ast/import_record.rs`). `source_index` identifies the bundled file it resolved to; when it is invalid the printer prints `path.text` verbatim as an external import. That is why the splitting redirect both clears `source_index` and replaces `path.text`: it is how the linker asks the printer for `import("<chunk>")`.
- Unique key: a placeholder string (`{random 64-bit hex}{kind}{index}`) each chunk and asset gets before its output path is known; code is printed with the placeholder and `break_output_into_pieces` substitutes the final path at the end. `chunk.unique_key` is a chunk's placeholder, and an entry point's chunk records that entry point in `chunk.entry_point`.

<details>
<summary>Repro</summary>

```sh
printf 'const m = await import("./data.json");\nconsole.log(m.default.answer);\n' > entry.ts
printf '{ "answer": 42 }\n' > data.json
bun build ./entry.ts --target bun --splitting --outdir out --metafile=meta.json
```

Before (bun 1.4.0 and main), `inputs["entry.ts"].imports`:

```json
[{ "path": "./data-jn2krqnp.js", "kind": "dynamic-import", "original": "./data.json", "external": true }]
```

After:

```json
[{ "path": "data.json", "kind": "dynamic-import", "original": "./data.json", "with": { "type": "json" } }]
```

`outputs["./entry.js"].imports` still contains `{ "path": "./data-jn2krqnp.js", "kind": "dynamic-import" }` in both cases.
</details>

<details>
<summary>Earlier revision</summary>

The first revision of this PR also deleted the `break_output_into_pieces` pass at the end of `generate`, on the grounds that the inputs loop now resolves every redirected record. Review turned up the `--css-chunking` case above, where the redirect points at a chunk that is not an entry chunk and the deleted pass was what kept the raw placeholder (`...C00000000`) out of the metafile, so the pass is back and `generate`'s signature and its callers in bundle_v2.rs are unchanged from main.
</details>
