### PR TITLE
bun:test: fix crash when spyOn targets an indexed property that is not a function

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1570,8 +1570,6 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             if (hasValue)
                 attributes = slot.attributes();
 
-            attributes |= PropertyAttribute::Accessor;
-
             if (JSModuleNamespaceObject* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(object)) {
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
@@ -1579,7 +1577,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 // For indexed properties, set the mock directly instead of wrapping in GetterSetter
                 object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
             } else {
-                object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
+                object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes | PropertyAttribute::Accessor);
             }
 
             // mock->setName(propertyKey.publicName());

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1090,6 +1090,38 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // The mock used to be stored at the index with the Accessor attribute set even though it is
+    // a plain value, so reading the index tripped an engine assertion and assigning to it
+    // segfaulted (the mock was invoked as if it were a getter/setter pair).
+    test("spyOn works with indexed properties that are not functions", () => {
+      const obj = {};
+      obj[213] = obj;
+      const fn = spyOn(obj, 213);
+      expect(obj[213]).toBe(fn);
+      expect(Object.getOwnPropertyDescriptor(obj, 213)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(obj[213]()).toBe(obj);
+      expect(fn).toHaveBeenCalledTimes(1);
+      obj[213] = 5;
+      expect(obj[213]).toBe(5);
+      fn.mockRestore();
+      expect(obj[213]).toBe(obj);
+
+      const arr = [];
+      arr[0] = 42;
+      const fn2 = spyOn(arr, 0);
+      expect(arr[0]).toBe(fn2);
+      expect(arr[0]()).toBe(42);
+      arr[0] = 7;
+      expect(arr[0]).toBe(7);
+      fn2.mockRestore();
+      expect(arr[0]).toBe(42);
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {


### PR DESCRIPTION
### What does this PR do?

`spyOn(target, key)` has two ways of installing the spy when the current value is not a function. For a named key it wraps the mock in a `GetterSetter` and installs it as an accessor. For an index (`spyOn(obj, 213)`, `spyOn(arr, 0)`) it stores the mock itself at the index with `putDirectIndex`, but it still passed the `Accessor` attribute along. The resulting sparse entry claimed to be an accessor while holding a plain function:

- debug builds fail the `!(attributes & Accessor)` assertion in `PropertySlot::setValue` as soon as the index is read
- release builds segfault when the index is assigned to, because `SparseArrayEntry::put` casts the stored value to `GetterSetter` and calls its setter

```js
import { spyOn } from "bun:test";
const obj = {};
obj[213] = obj;
spyOn(obj, 213);
obj[213] = 5; // panic(main thread): Segmentation fault at address 0x38
```

Array literals did not show the problem because copy-on-write arrays take the `defineOwnProperty` route in `putDirectIndex`, which rebuilds the attributes from the descriptor. Plain objects and arrays that were filled in after creation go through the sparse map directly and keep the bogus attribute.

The fix only applies the `Accessor` attribute on the named property path, where the value really is a `GetterSetter`. The indexed path now stores the mock as a regular data property, which is what the function case already does and what release builds already returned on read.

Context: this came out of a Fuzzilli report (fingerprint `e9e695f80b733103`) whose program stores an indexed property on the `bun:test` module object and then calls `spyOn` on it. The report itself was flagged flaky (SIGABRT with no output), and I could not get that program to crash again in roughly 900 runs, in a single process and across fresh processes, with and without a Redis server listening. Going through the `spyOn` path it exercises turned up the deterministic crash above, which is what this PR fixes.

### How did you verify your code works?

Added a test to `test/js/bun/test/mock-fn.test.js` next to the other indexed `spyOn` tests. It segfaults on the current release build (`USE_SYSTEM_BUN=1 bun test ... -t "not functions"` dies with the crash above), and the read alone trips the assertion on an unpatched debug build. With this change, `bun bd test test/js/bun/test/mock-fn.test.js` passes (81 tests), as do `mock-disposable.test.ts` and `spyMatchers.test.ts`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (bc0e12089)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [3.44ms]
(pass) mock() > mock [10.57ms]
(pass) mock() > checks the this value > mock [12.01ms]
(pass) mock() > checks the this value > _protoImpl [1.36ms]
(pass) mock() > checks the this value > getMockImplementation [2.75ms]
(pass) mock() > checks the this value > getMockName [1.25ms]
(pass) mock() > checks the this value > mockClear [1.06ms]
(pass) mock() > checks the this value > mockReset [1.08ms]
(pass) mock() > checks the this value > mockRestore [0.91ms]
(pass) mock() > checks the this value > mockImplementation [1.08ms]
(pass) mock() > checks the this value > mockImplementationOnce [1.45ms]
(pass) mock() > checks the this value > withImplementation [0.97ms]
(pass) mock() > checks the this value > mockName [1.06ms]
(pass) mock() > checks the this value > mockReturnThis [0.88ms]
(pass) mock() > checks the this value > mockReturnValue [0.72ms]
(pass) mock() > checks the this val
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.04ms]
(pass) mock() > mock [0.18ms]
(pass) mock() > checks the this value > mock [0.20ms]
(pass) mock() > checks the this value > _protoImpl [0.02ms]
(pass) mock() > checks the this value > getMockImplementation [0.03ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.02ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce [0.04ms]
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (bc0e12089)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.35ms]
(pass) mock() > mock [6.59ms]
(pass) mock() > checks the this value > mock [7.29ms]
(pass) mock() > checks the this value > _protoImpl [0.87ms]
(pass) mock() > checks the this value > getMockImplementation [1.53ms]
(pass) mock() > checks the this value > getMockName [0.83ms]
(pass) mock() > checks the this value > mockClear [0.68ms]
(pass) mock() > checks the this value > mockReset [0.70ms]
(pass) mock() > checks the this value > mockRestore [0.61ms]
(pass) mock() > checks the this value > mockImplementation [0.69ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.87ms]
(pass) mock() > checks the this value > withImplementation [0.58ms]
(pass) mock() > checks the this value > mockName [0.64ms]
(pass) mock() > checks the this value > mockReturnThis [0.59ms]
(pass) mock() > checks the this value > mockReturnValue [0.52ms]
(pass) mock() > checks the this value
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 809ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp |  4 +---
 test/js/bun/test/mock-fn.test.js    | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 33 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp      4      1      0
test/js/bun/test/mock-fn.test.js         1      1      0
```

</details>

<!-- robobun:evidence:end -->