### PR TITLE
test(bunx): install fixture packages from a local registry instead of real ones

### DIFF
--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -217,14 +217,17 @@ it.concurrent("should choose the tagged versions instead of the PATH versions wh
     semverVersions = semverVersions.slice(0, 2);
   }
 
-  // Every version depends on the same package, so the simultaneous installs
-  // below (one shared install cache) also race to extract that one dependency,
-  // the way the real semver versions all shared lru-cache.
+  // Like the real 7.5+ versions (which share lru-cache), every version depends
+  // on one shared package, so the simultaneous installs below also race to
+  // extract the same dependency into the shared install cache. Not on Windows:
+  // two installs extracting the same package there fail with "ENOENT: failed
+  // opening cache/package/version dir" roughly half the time, and the real
+  // 7.0.0 and 7.1.0 that Windows runs have no dependencies either.
   using registry = localRegistry(
     { name: "lru-cache", version: "1.0.0", files: { "index.js": "" } },
     ...semverVersions.map(version => ({
       ...fixturePackage("semver", version, "semver"),
-      dependencies: { "lru-cache": "1.0.0" },
+      ...(!isWindows && { dependencies: { "lru-cache": "1.0.0" } }),
     })),
   );
 
@@ -253,11 +256,23 @@ it.concurrent("should choose the tagged versions instead of the PATH versions wh
   });
 
   const results = await Promise.all(
-    processes.map(p => Promise.all([p.stdout.text(), p.stderr.text(), p.exited] as const)),
+    processes.map(async (subprocess, i) => {
+      const [stdout, stderr, exitCode] = await Promise.all([
+        subprocess.stdout.text(),
+        subprocess.stderr.text(),
+        subprocess.exited,
+      ]);
+      return { version: semverVersions[i], stdout: stdout.trim(), stderr, exitCode };
+    }),
   );
-  for (const [, stderr] of results) expect(stderr).not.toContain("error:");
-  expect(results.map(([stdout]) => stdout.trim())).toEqual(semverVersions.map(v => `semver ${v} --help`));
-  expect(results.map(([, , exitCode]) => exitCode)).toEqual(semverVersions.map(() => 0));
+  expect(results).toEqual(
+    semverVersions.map(version => ({
+      version,
+      stdout: `semver ${version} --help`,
+      stderr: expect.not.stringContaining("error:"),
+      exitCode: 0,
+    })),
+  );
 });
 
 it.concurrent("should install and run default (latest) version", async () => {

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -41,19 +41,21 @@ function pathWithout(name: string, PATH: string | undefined): string {
 }
 
 // Cases that need bunx to install something get a per-test in-process registry
-// serving throwaway packages. What they assert is bunx's own behavior (name ->
-// bin resolution, the bunx cache, argument passthrough); installing real
+// serving throwaway packages: what they assert is bunx's own behavior (name ->
+// bin resolution, the bunx cache, argument passthrough), and installing real
 // packages made the file's cost scale with their dependency trees instead
 // (@angular/cli alone was ~21k files per run to extract and, once the CI runner
-// removes TMPDIR, delete again). Per-test servers also work under it.concurrent,
-// unlike dummy.registry's module-level handler, and `requests` lets a case prove
-// that a second run came from the bunx cache.
+// removes TMPDIR, delete again). dummy.registry's per-test contexts only serve
+// the .tgz files checked in next to it, answer every package name with the same
+// version list, and have no GitHub shape; these generate the tarballs instead,
+// and `requests` lets a case prove that a second run came from the bunx cache.
 
 type FixturePackage = {
   name: string;
   version: string;
   bin?: Record<string, string>;
   dependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
   /** Contents of the package besides its generated package.json. */
   files: Record<string, string>;
 };
@@ -63,51 +65,24 @@ function echoBin(label: string): string {
   return `#!/usr/bin/env node\nconsole.log(${JSON.stringify(label)}, ...process.argv.slice(2));\n`;
 }
 
-function fixturePackage(name: string, version: string, binName: string): FixturePackage {
-  return {
-    name,
-    version,
-    bin: { [binName]: "cli.js" },
-    files: { "cli.js": echoBin(`${binName} ${version}`) },
-  };
-}
-
-function ustarHeader(name: string, size: number, type: "0" | "5"): Buffer {
-  if (Buffer.byteLength(name) >= 100) throw new Error(`tar entry name too long for a ustar header: ${name}`);
-  const header = Buffer.alloc(512);
-  header.write(name, 0);
-  header.write("0000755\0", 100); // mode
-  header.write("0000000\0", 108); // uid
-  header.write("0000000\0", 116); // gid
-  header.write(size.toString(8).padStart(11, "0") + "\0", 124);
-  header.write("00000000000\0", 136); // mtime
-  header.write("        ", 148); // checksum is computed over spaces
-  header.write(type, 156);
-  header.write("ustar\0", 257);
-  header.write("00", 263);
-  let checksum = 0;
-  for (const byte of header) checksum += byte;
-  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
-  return header;
+function fixturePackage(
+  name: string,
+  version: string,
+  binName: string,
+  binScript: string = echoBin(`${binName} ${version}`),
+): FixturePackage {
+  return { name, version, bin: { [binName]: "cli.js" }, files: { "cli.js": binScript } };
 }
 
 /**
- * A .tgz with every entry under `root/`, the layout of both npm tarballs
- * (`package/`) and GitHub's tarballs (`<owner>-<repo>-<commit>/`, which bun
- * install reads back as the resolved commit).
+ * A .tgz with every entry under `root/`: `package/` for npm tarballs,
+ * `<owner>-<repo>-<commit>/` for GitHub's. The directory entry comes first
+ * because bun install reads a GitHub tarball's first entry as that root.
  */
-function tarball(root: string, files: Record<string, string>): Uint8Array<ArrayBuffer> {
-  const blocks = [ustarHeader(`${root}/`, 0, "5")];
-  for (const [path, contents] of Object.entries(files)) {
-    const body = Buffer.from(contents);
-    blocks.push(
-      ustarHeader(`${root}/${path}`, body.length, "0"),
-      body,
-      Buffer.alloc((512 - (body.length % 512)) % 512),
-    );
-  }
-  blocks.push(Buffer.alloc(1024));
-  return Bun.gzipSync(Buffer.concat(blocks));
+function tarball(root: string, files: Record<string, string>): Promise<Uint8Array<ArrayBuffer>> {
+  const entries: Record<string, string> = { [`${root}/`]: "" };
+  for (const [path, contents] of Object.entries(files)) entries[`${root}/${path}`] = contents;
+  return new Bun.Archive(entries, { compress: "gzip" }).bytes();
 }
 
 function fixtureServer(handler: (pathname: string) => Uint8Array<ArrayBuffer> | object | undefined) {
@@ -136,7 +111,7 @@ function fixtureServer(handler: (pathname: string) => Uint8Array<ArrayBuffer> | 
  * An npm registry serving `packages` (the last version listed for a name is its
  * `latest`); point bunx at it with `npm_config_registry: registry.url`.
  */
-function localRegistry(...packages: FixturePackage[]) {
+async function localRegistry(...packages: FixturePackage[]) {
   const manifests = new Map<
     string,
     { name: string; versions: Record<string, object>; "dist-tags": { latest: string } }
@@ -145,10 +120,10 @@ function localRegistry(...packages: FixturePackage[]) {
   const registry = fixtureServer(
     pathname => tarballs.get(pathname) ?? manifests.get(decodeURIComponent(pathname.slice(1))),
   );
-  for (const { name, version, bin, dependencies, files } of packages) {
+  for (const { name, version, bin, dependencies, scripts, files } of packages) {
     const tarballPath = `/${name}/-/${name.slice(name.lastIndexOf("/") + 1)}-${version}.tgz`;
-    const packageJson = { name, version, bin, dependencies };
-    tarballs.set(tarballPath, tarball("package", { "package.json": JSON.stringify(packageJson), ...files }));
+    const packageJson = { name, version, bin, dependencies, scripts };
+    tarballs.set(tarballPath, await tarball("package", { "package.json": JSON.stringify(packageJson), ...files }));
     const manifest = manifests.get(name) ?? { name, versions: {}, "dist-tags": { latest: version } };
     manifest.versions[version] = { ...packageJson, dist: { tarball: `${registry.url}${tarballPath}` } };
     manifest["dist-tags"].latest = version;
@@ -161,8 +136,8 @@ function localRegistry(...packages: FixturePackage[]) {
  * Stands in for api.github.com (bun install honors `GITHUB_API_URL`): every
  * `/repos/<owner>/<repo>/tarball/<ref>` request gets the one fixture repository.
  */
-function localGithub(owner: string, repo: string, files: Record<string, string>) {
-  const bytes = tarball(`${owner}-${repo}-0123abc`, files);
+async function localGithub(owner: string, repo: string, files: Record<string, string>) {
+  const bytes = await tarball(`${owner}-${repo}-0123abc`, files);
   return fixtureServer(pathname => (pathname.startsWith(`/repos/${owner}/${repo}/tarball/`) ? bytes : undefined));
 }
 
@@ -223,7 +198,7 @@ it.concurrent("should choose the tagged versions instead of the PATH versions wh
   // two installs extracting the same package there fail with "ENOENT: failed
   // opening cache/package/version dir" roughly half the time, and the real
   // 7.0.0 and 7.1.0 that Windows runs have no dependencies either.
-  using registry = localRegistry(
+  using registry = await localRegistry(
     { name: "lru-cache", version: "1.0.0", files: { "index.js": "" } },
     ...semverVersions.map(version => ({
       ...fixturePackage("semver", version, "semver"),
@@ -275,38 +250,54 @@ it.concurrent("should choose the tagged versions instead of the PATH versions wh
   );
 });
 
+// Two versions of a package whose bin (`uglifyjs`, as in the real uglify-js) is
+// not named after the package, so bunx has to read the installed package.json to
+// find it. 3.19.3 is `latest`; `latestBin` replaces its bin script.
+function uglifyJs(latestBin?: string): FixturePackage[] {
+  return [
+    fixturePackage("uglify-js", "3.14.1", "uglifyjs"),
+    fixturePackage("uglify-js", "3.19.3", "uglifyjs", latestBin),
+  ];
+}
+
 it.concurrent("should install and run default (latest) version", async () => {
   const { x_dir, env } = setup();
+  using registry = await localRegistry(
+    ...uglifyJs(
+      `#!/usr/bin/env node\nconsole.log("uglifyjs 3.19.3", ...process.argv.slice(2), "stdin:", require("fs").readFileSync(0, "utf8"));\n`,
+    ),
+  );
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "x", "uglify-js", "--compress"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: new TextEncoder().encode("console.log(6 * 7);"),
     stderr: "pipe",
-    env,
+    env: { ...env, npm_config_registry: registry.url },
   });
-  const err = await stderr.text();
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
   expect(err).not.toContain("error:");
-  const out = await stdout.text();
-  expect(out.split(/\r?\n/)).toEqual(["console.log(42);", ""]);
-  expect(await exited).toBe(0);
+  expect(out.trim()).toBe("uglifyjs 3.19.3 --compress stdin: console.log(6 * 7);");
+  expect(registry.requests).toEqual(["/uglify-js", "/uglify-js/-/uglify-js-3.19.3.tgz"]);
+  expect(exitCode).toBe(0);
 });
 
 it.concurrent("should install and run specified version", async () => {
   const { x_dir, env } = setup();
+  using registry = await localRegistry(...uglifyJs());
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "x", "uglify-js@3.14.1", "-v"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: "inherit",
     stderr: "pipe",
-    env,
+    env: { ...env, npm_config_registry: registry.url },
   });
-  const err = await stderr.text();
+  const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
   expect(err).not.toContain("error:");
-  const out = await stdout.text();
-  expect(out.split(/\r?\n/)).toEqual(["uglify-js 3.14.1", ""]);
-  expect(await exited).toBe(0);
+  expect(out.trim()).toBe("uglifyjs 3.14.1 -v");
+  expect(registry.requests).toEqual(["/uglify-js", "/uglify-js/-/uglify-js-3.14.1.tgz"]);
+  expect(exitCode).toBe(0);
 });
 
 it.concurrent("should output usage if no arguments are passed", async () => {
@@ -332,7 +323,7 @@ it.concurrent("should work for @scoped packages", async () => {
   const { x_dir, env } = setup();
   // Like @babel/cli -> `babel`: the bin is named after neither the scope nor the
   // package, so bunx has to read the installed package.json to find it.
-  using registry = localRegistry(fixturePackage("@bunx-fixture/cli", "1.2.3", "scoped-cli"));
+  using registry = await localRegistry(fixturePackage("@bunx-fixture/cli", "1.2.3", "scoped-cli"));
   const run = () => {
     const subprocess = spawn({
       cmd: [bunExe(), "--bun", "x", "@bunx-fixture/cli", "--help"],
@@ -375,18 +366,25 @@ console.log(
 7
 )`,
   );
+  // The bin resolves its argument against the directory it was started in.
+  using registry = await localRegistry(
+    ...uglifyJs(
+      `#!/usr/bin/env node\nconsole.log("uglifyjs 3.19.3 read", process.argv[2] + ":", require("fs").readFileSync(process.argv[2], "utf8").replace(/\\s+/g, ""));\n`,
+    ),
+  );
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "--bun", "x", "uglify-js", "test.js", "--compress"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: "inherit",
     stderr: "pipe",
-    env,
+    env: { ...env, npm_config_registry: registry.url },
   });
   const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
   expect(err).not.toContain("error:");
+  // bunx installed into its cache dir, not into the directory it was run from
   expect(await readdirSorted(x_dir)).toEqual(["test.js"]);
-  expect(out.split(/\r?\n/)).toEqual(["console.log(42);", ""]);
+  expect(out.trim()).toBe("uglifyjs 3.19.3 read test.js: console.log(6*7)");
   expect(exitCode).toBe(0);
 });
 
@@ -399,7 +397,7 @@ const cowsayRepo = {
 
 it.concurrent("should work for github repository", async () => {
   const { x_dir, env } = setup();
-  using github = localGithub("bunx-fixture", "cowsay", cowsayRepo);
+  using github = await localGithub("bunx-fixture", "cowsay", cowsayRepo);
   const run = () => {
     const subprocess = spawn({
       cmd: [bunExe(), "x", "github:bunx-fixture/cowsay", "--help"],
@@ -433,7 +431,7 @@ it.concurrent("should work for github repository", async () => {
 
 it.concurrent("should work for github repository with committish", async () => {
   const { x_dir, env } = setup();
-  using github = localGithub("bunx-fixture", "cowsay", cowsayRepo);
+  using github = await localGithub("bunx-fixture", "cowsay", cowsayRepo);
   const run = (...flags: string[]) => {
     const subprocess = spawn({
       cmd: [bunExe(), "x", ...flags, "github:bunx-fixture/cowsay#HEAD", "hello bun!"],
@@ -503,21 +501,26 @@ it.concurrent("should print the revision and exit", async () => {
 
 it.concurrent("should pass --version to the package if specified", async () => {
   const { x_dir, env } = setup();
+  using registry = await localRegistry(fixturePackage("esbuild", "0.28.2", "esbuild"));
   const subprocess = spawn({
     cmd: [bunExe(), "x", "esbuild", "--version"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: "inherit",
     stderr: "pipe",
-    env,
+    env: {
+      ...env,
+      npm_config_registry: registry.url,
+      // unversioned, so an esbuild already on PATH would be run instead of the fixture
+      PATH: pathWithout("esbuild", env.PATH ?? process.env.PATH),
+    },
   });
 
   let [err, out, exited] = await Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited]);
 
   expect(err).not.toContain("error:");
-  // esbuild's own version, not bunx's
-  expect(out.trim()).toMatch(/^\d+\.\d+\.\d+$/);
-  expect(out.trim()).not.toBe(Bun.version);
+  // the flag reached the package instead of being taken as bunx's own --version
+  expect(out.trim()).toBe("esbuild 0.28.2 --version");
   expect(exited).toBe(0);
 });
 
@@ -593,7 +596,7 @@ describe("bunx --no-install", () => {
     "`bunx --no-install %s` should find cached packages",
     async pkg => {
       const bin = pkg === "typescript" ? "tsc" : pkg;
-      using registry = localRegistry(fixturePackage(pkg, "1.0.0", bin));
+      using registry = await localRegistry(fixturePackage(pkg, "1.0.0", bin));
       const ctx = setup();
       ctx.env.npm_config_registry = registry.url;
       // An unversioned `bunx <pkg>` runs a matching bin from PATH before it looks
@@ -623,7 +626,7 @@ describe("bunx --no-install", () => {
   );
 
   it.concurrent("when an exact version match is found, should find cached packages", async () => {
-    using registry = localRegistry(fixturePackage("http-server", "14.0.0", "http-server"));
+    using registry = await localRegistry(fixturePackage("http-server", "14.0.0", "http-server"));
     const ctx = setup();
     ctx.env.npm_config_registry = registry.url;
 
@@ -649,9 +652,24 @@ describe("bunx --no-install", () => {
 
 it.concurrent("should handle postinstall scripts correctly with symlinked bunx", async () => {
   const { x_dir, env } = setup();
-  // Create a symlink to bun called "bunx"
+  // Copies rather than symlinks: bun re-runs its own executable path for the
+  // install (`bunx add`) and for lifecycle scripts (`bunx exec`), and #17076 was
+  // those being taken for packages named "add"/"exec" when that path ends in bunx.
   copyFileSync(bunExe(), join(x_dir, isWindows ? "bun.exe" : "bun"));
   copyFileSync(bunExe(), join(x_dir, isWindows ? "bunx.exe" : "bunx"));
+
+  // esbuild is in bun's default trusted dependencies, so its postinstall runs.
+  // The bin reports whether it did.
+  using registry = await localRegistry({
+    name: "esbuild",
+    version: "0.28.2",
+    bin: { esbuild: "cli.js" },
+    scripts: { postinstall: "node postinstall.js" },
+    files: {
+      "postinstall.js": `require("fs").writeFileSync("postinstall-ran", "");\n`,
+      "cli.js": `#!/usr/bin/env node\nconsole.log("esbuild 0.28.2", require("fs").existsSync(__dirname + "/postinstall-ran") ? "after postinstall" : "without postinstall", ...process.argv.slice(2));\n`,
+    },
+  });
 
   const subprocess = spawn({
     cmd: ["bunx", "esbuild@latest", "--version"],
@@ -661,7 +679,8 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
     stderr: "pipe",
     env: {
       ...env,
-      PATH: `${x_dir}${isWindows ? ";" : ":"}${env.PATH || ""}`,
+      npm_config_registry: registry.url,
+      PATH: `${x_dir}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
     },
   });
 
@@ -669,9 +688,8 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
 
   expect(err).not.toContain("error:");
   expect(err).not.toContain("Cannot find module 'exec'");
-  // esbuild's own version, not bunx's
-  expect(out.trim()).toMatch(/^\d+\.\d+\.\d+$/);
-  expect(out.trim()).not.toBe(Bun.version);
+  expect(out.trim()).toBe("esbuild 0.28.2 after postinstall --version");
+  expect(registry.requests).toEqual(["/esbuild", "/esbuild/-/esbuild-0.28.2.tgz"]);
   expect(exited).toBe(0);
 });
 
@@ -682,7 +700,7 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
 // engines range moved under us twice.
 it.concurrent("should handle package that requires node 24", async () => {
   const { x_dir, env } = setup();
-  using registry = localRegistry({
+  using registry = await localRegistry({
     name: "@bunx-fixture/requires-node-24",
     version: "1.0.0",
     bin: { ng: "cli.js" },
@@ -1371,7 +1389,7 @@ describe("package name aliases", () => {
 it.skipIf(!isWindows)("should not crash on corrupted .bunx file with missing quote", async () => {
   // Installing any package with a bin creates the tsc.exe + tsc.bunx pair; the
   // .bunx contents are overwritten below, so a fixture is as good as the real thing.
-  using registry = localRegistry(fixturePackage("typescript", "5.0.0", "tsc"));
+  using registry = await localRegistry(fixturePackage("typescript", "5.0.0", "tsc"));
   await writeFile(join(x_dir, "package.json"), "{}");
   const subprocess1 = spawn({
     cmd: [bunExe(), "add", "typescript@5.0.0"],

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -40,6 +40,132 @@ function pathWithout(name: string, PATH: string | undefined): string {
     .join(delimiter);
 }
 
+// Cases that need bunx to install something get a per-test in-process registry
+// serving throwaway packages. What they assert is bunx's own behavior (name ->
+// bin resolution, the bunx cache, argument passthrough); installing real
+// packages made the file's cost scale with their dependency trees instead
+// (@angular/cli alone was ~21k files per run to extract and, once the CI runner
+// removes TMPDIR, delete again). Per-test servers also work under it.concurrent,
+// unlike dummy.registry's module-level handler, and `requests` lets a case prove
+// that a second run came from the bunx cache.
+
+type FixturePackage = {
+  name: string;
+  version: string;
+  bin?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  /** Contents of the package besides its generated package.json. */
+  files: Record<string, string>;
+};
+
+/** A bin script that prints `<label>` followed by the arguments it was invoked with. */
+function echoBin(label: string): string {
+  return `#!/usr/bin/env node\nconsole.log(${JSON.stringify(label)}, ...process.argv.slice(2));\n`;
+}
+
+function fixturePackage(name: string, version: string, binName: string): FixturePackage {
+  return {
+    name,
+    version,
+    bin: { [binName]: "cli.js" },
+    files: { "cli.js": echoBin(`${binName} ${version}`) },
+  };
+}
+
+function ustarHeader(name: string, size: number, type: "0" | "5"): Buffer {
+  if (Buffer.byteLength(name) >= 100) throw new Error(`tar entry name too long for a ustar header: ${name}`);
+  const header = Buffer.alloc(512);
+  header.write(name, 0);
+  header.write("0000755\0", 100); // mode
+  header.write("0000000\0", 108); // uid
+  header.write("0000000\0", 116); // gid
+  header.write(size.toString(8).padStart(11, "0") + "\0", 124);
+  header.write("00000000000\0", 136); // mtime
+  header.write("        ", 148); // checksum is computed over spaces
+  header.write(type, 156);
+  header.write("ustar\0", 257);
+  header.write("00", 263);
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+  return header;
+}
+
+/**
+ * A .tgz with every entry under `root/`, the layout of both npm tarballs
+ * (`package/`) and GitHub's tarballs (`<owner>-<repo>-<commit>/`, which bun
+ * install reads back as the resolved commit).
+ */
+function tarball(root: string, files: Record<string, string>): Uint8Array<ArrayBuffer> {
+  const blocks = [ustarHeader(`${root}/`, 0, "5")];
+  for (const [path, contents] of Object.entries(files)) {
+    const body = Buffer.from(contents);
+    blocks.push(
+      ustarHeader(`${root}/${path}`, body.length, "0"),
+      body,
+      Buffer.alloc((512 - (body.length % 512)) % 512),
+    );
+  }
+  blocks.push(Buffer.alloc(1024));
+  return Bun.gzipSync(Buffer.concat(blocks));
+}
+
+function fixtureServer(handler: (pathname: string) => Uint8Array<ArrayBuffer> | object | undefined) {
+  const requests: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const { pathname } = new URL(request.url);
+      requests.push(pathname);
+      const body = handler(pathname);
+      if (body === undefined) return new Response(`no fixture for ${pathname}`, { status: 404 });
+      return body instanceof Uint8Array ? new Response(body) : Response.json(body);
+    },
+  });
+  return {
+    /** Every request path received so far, in order. */
+    requests,
+    url: server.url.origin,
+    [Symbol.dispose]() {
+      server.stop(true);
+    },
+  };
+}
+
+/**
+ * An npm registry serving `packages` (the last version listed for a name is its
+ * `latest`); point bunx at it with `npm_config_registry: registry.url`.
+ */
+function localRegistry(...packages: FixturePackage[]) {
+  const manifests = new Map<
+    string,
+    { name: string; versions: Record<string, object>; "dist-tags": { latest: string } }
+  >();
+  const tarballs = new Map<string, Uint8Array<ArrayBuffer>>();
+  const registry = fixtureServer(
+    pathname => tarballs.get(pathname) ?? manifests.get(decodeURIComponent(pathname.slice(1))),
+  );
+  for (const { name, version, bin, dependencies, files } of packages) {
+    const tarballPath = `/${name}/-/${name.slice(name.lastIndexOf("/") + 1)}-${version}.tgz`;
+    const packageJson = { name, version, bin, dependencies };
+    tarballs.set(tarballPath, tarball("package", { "package.json": JSON.stringify(packageJson), ...files }));
+    const manifest = manifests.get(name) ?? { name, versions: {}, "dist-tags": { latest: version } };
+    manifest.versions[version] = { ...packageJson, dist: { tarball: `${registry.url}${tarballPath}` } };
+    manifest["dist-tags"].latest = version;
+    manifests.set(name, manifest);
+  }
+  return registry;
+}
+
+/**
+ * Stands in for api.github.com (bun install honors `GITHUB_API_URL`): every
+ * `/repos/<owner>/<repo>/tarball/<ref>` request gets the one fixture repository.
+ */
+function localGithub(owner: string, repo: string, files: Record<string, string>) {
+  const bytes = tarball(`${owner}-${repo}-0123abc`, files);
+  return fixtureServer(pathname => (pathname.startsWith(`/repos/${owner}/${repo}/tarball/`) ? bytes : undefined));
+}
+
 beforeAll(async () => {
   // Clean stale bunx cache dirs from previous runs once up front instead of before every test.
   const tmp = isWindows ? tmpdir() : "/tmp";
@@ -91,27 +217,47 @@ it.concurrent("should choose the tagged versions instead of the PATH versions wh
     semverVersions = semverVersions.slice(0, 2);
   }
 
-  const processes = semverVersions.map((version, i) => {
+  // Every version depends on the same package, so the simultaneous installs
+  // below (one shared install cache) also race to extract that one dependency,
+  // the way the real semver versions all shared lru-cache.
+  using registry = localRegistry(
+    { name: "lru-cache", version: "1.0.0", files: { "index.js": "" } },
+    ...semverVersions.map(version => ({
+      ...fixturePackage("semver", version, "semver"),
+      dependencies: { "lru-cache": "1.0.0" },
+    })),
+  );
+
+  // A `semver` that is first in PATH must lose to the explicitly requested versions.
+  const decoyBinDir = tmpdirSync();
+  if (isWindows) {
+    await writeFile(join(decoyBinDir, "semver.cmd"), "@echo semver from PATH\r\n");
+  } else {
+    await writeFile(join(decoyBinDir, "semver"), '#!/bin/sh\necho "semver from PATH"\n');
+    chmodSync(join(decoyBinDir, "semver"), 0o755);
+  }
+
+  const processes = semverVersions.map(version => {
     return spawn({
       cmd: [bunExe(), "x", "semver@" + version, "--help"],
       cwd: x_dir,
       stdout: "pipe",
       stdin: "ignore",
-      stderr: "ignore",
+      stderr: "pipe",
       env: {
         ...env,
-        // BUN_DEBUG_QUIET_LOGS: undefined,
-        // BUN_DEBUG: "/tmp/bun-debug.txt." + i,
+        npm_config_registry: registry.url,
+        PATH: `${decoyBinDir}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
       },
     });
   });
 
-  const results = await Promise.all(processes.map(p => p.exited));
-  expect(results).toEqual(semverVersions.map(() => 0));
-  const outputs = (await Promise.all(processes.map(p => new Response(p.stdout).text()))).map(a =>
-    a.substring(0, a.indexOf("\n")),
+  const results = await Promise.all(
+    processes.map(p => Promise.all([p.stdout.text(), p.stderr.text(), p.exited] as const)),
   );
-  expect(outputs).toEqual(semverVersions.map(v => "SemVer " + v));
+  for (const [, stderr] of results) expect(stderr).not.toContain("error:");
+  expect(results.map(([stdout]) => stdout.trim())).toEqual(semverVersions.map(v => `semver ${v} --help`));
+  expect(results.map(([, , exitCode]) => exitCode)).toEqual(semverVersions.map(() => 0));
 });
 
 it.concurrent("should install and run default (latest) version", async () => {
@@ -169,44 +315,38 @@ it.concurrent("should output usage if no arguments are passed", async () => {
 
 it.concurrent("should work for @scoped packages", async () => {
   const { x_dir, env } = setup();
-  let exited: number, err: string, out: string;
+  // Like @babel/cli -> `babel`: the bin is named after neither the scope nor the
+  // package, so bunx has to read the installed package.json to find it.
+  using registry = localRegistry(fixturePackage("@bunx-fixture/cli", "1.2.3", "scoped-cli"));
+  const run = () => {
+    const subprocess = spawn({
+      cmd: [bunExe(), "--bun", "x", "@bunx-fixture/cli", "--help"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: { ...env, npm_config_registry: registry.url },
+    });
+    return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+  };
+
   // without cache
-  const withoutCache = spawn({
-    cmd: [bunExe(), "--bun", "x", "@babel/cli", "--help"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stdin: "inherit",
-    stderr: "pipe",
-    env,
-  });
+  {
+    const [err, out, exited] = await run();
+    expect(err).not.toContain("error:");
+    expect(out.trim()).toBe("scoped-cli 1.2.3 --help");
+    expect(exited).toBe(0);
+  }
+  expect(registry.requests).toEqual(["/@bunx-fixture%2fcli", "/@bunx-fixture/cli/-/cli-1.2.3.tgz"]);
 
-  [err, out, exited] = await Promise.all([
-    new Response(withoutCache.stderr).text(),
-    new Response(withoutCache.stdout).text(),
-    withoutCache.exited,
-  ]);
-  expect(err).not.toContain("error:");
-  expect(out.trim()).toContain("Usage: babel [options]");
-  expect(exited).toBe(0);
-  // cached
-  const cached = spawn({
-    cmd: [bunExe(), "--bun", "x", "@babel/cli", "--help"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stdin: "inherit",
-    stderr: "pipe",
-    env,
-  });
-
-  [err, out, exited] = await Promise.all([
-    new Response(cached.stderr).text(),
-    new Response(cached.stdout).text(),
-    cached.exited,
-  ]);
-
-  expect(err).not.toContain("error:");
-
-  expect(out.trim()).toContain("Usage: babel [options]");
+  // cached: the second run must come from the bunx cache without touching the registry
+  {
+    const [err, out, exited] = await run();
+    expect(err).toBe("");
+    expect(out.trim()).toBe("scoped-cli 1.2.3 --help");
+    expect(exited).toBe(0);
+  }
+  expect(registry.requests).toHaveLength(2);
 });
 
 it.concurrent("should execute from current working directory", async () => {
@@ -235,89 +375,78 @@ console.log(
   expect(exitCode).toBe(0);
 });
 
+// `bunx github:<owner>/<repo>` guesses the bin from the repository name, so the
+// fixture repository is named after its bin, like piuccio/cowsay -> `cowsay`.
+const cowsayRepo = {
+  "package.json": JSON.stringify({ name: "cowsay", version: "1.0.0", bin: { cowsay: "cli.js" } }),
+  "cli.js": echoBin("cowsay from github"),
+};
+
 it.concurrent("should work for github repository", async () => {
   const { x_dir, env } = setup();
+  using github = localGithub("bunx-fixture", "cowsay", cowsayRepo);
+  const run = () => {
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", "github:bunx-fixture/cowsay", "--help"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: { ...env, GITHUB_API_URL: github.url },
+    });
+    return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+  };
+
   // without cache
-  const withoutCache = spawn({
-    cmd: [bunExe(), "x", "github:piuccio/cowsay", "--help"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stdin: "inherit",
-    stderr: "pipe",
-    env,
-  });
-
-  let [err, out, exited] = await Promise.all([
-    new Response(withoutCache.stderr).text(),
-    new Response(withoutCache.stdout).text(),
-    withoutCache.exited,
-  ]);
-
-  expect(err).not.toContain("error:");
-  expect(out.trim()).toContain("Usage: " + (isWindows ? "cli.js" : "cowsay"));
-  expect(exited).toBe(0);
+  {
+    const [err, out, exited] = await run();
+    expect(err).not.toContain("error:");
+    expect(out.trim()).toBe("cowsay from github --help");
+    expect(exited).toBe(0);
+  }
+  expect(github.requests).toEqual(["/repos/bunx-fixture/cowsay/tarball/"]);
 
   // cached
-  const cached = spawn({
-    cmd: [bunExe(), "x", "github:piuccio/cowsay", "--help"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stdin: "inherit",
-    stderr: "pipe",
-    env,
-  });
-
-  [err, out, exited] = await Promise.all([
-    new Response(cached.stderr).text(),
-    new Response(cached.stdout).text(),
-    cached.exited,
-  ]);
-
-  expect(err).not.toContain("error:");
-  expect(out.trim()).toContain("Usage: " + (isWindows ? "cli.js" : "cowsay"));
-  expect(exited).toBe(0);
+  {
+    const [err, out, exited] = await run();
+    expect(err).toBe("");
+    expect(out.trim()).toBe("cowsay from github --help");
+    expect(exited).toBe(0);
+  }
+  expect(github.requests).toHaveLength(1);
 });
 
 it.concurrent("should work for github repository with committish", async () => {
   const { x_dir, env } = setup();
-  const withoutCache = spawn({
-    cmd: [bunExe(), "x", "github:piuccio/cowsay#HEAD", "hello bun!"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stdin: "inherit",
-    stderr: "pipe",
-    env,
-  });
+  using github = localGithub("bunx-fixture", "cowsay", cowsayRepo);
+  const run = (...flags: string[]) => {
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", ...flags, "github:bunx-fixture/cowsay#HEAD", "hello bun!"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: { ...env, GITHUB_API_URL: github.url },
+    });
+    return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+  };
 
-  let [err, out, exited] = await Promise.all([
-    new Response(withoutCache.stderr).text(),
-    new Response(withoutCache.stdout).text(),
-    withoutCache.exited,
-  ]);
-
-  expect(err).not.toContain("error:");
-  expect(out.trim()).toContain("hello bun!");
-  expect(exited).toBe(0);
+  {
+    const [err, out, exited] = await run();
+    expect(err).not.toContain("error:");
+    expect(out.trim()).toBe("cowsay from github hello bun!");
+    expect(exited).toBe(0);
+  }
+  expect(github.requests).toEqual(["/repos/bunx-fixture/cowsay/tarball/HEAD"]);
 
   // cached
-  const cached = spawn({
-    cmd: [bunExe(), "x", "--no-install", "github:piuccio/cowsay#HEAD", "hello bun!"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stdin: "inherit",
-    stderr: "pipe",
-    env,
-  });
-
-  [err, out, exited] = await Promise.all([
-    new Response(cached.stderr).text(),
-    new Response(cached.stdout).text(),
-    cached.exited,
-  ]);
-
-  expect(err).not.toContain("error:");
-  expect(out.trim()).toContain("hello bun!");
-  expect(exited).toBe(0);
+  {
+    const [err, out, exited] = await run("--no-install");
+    expect(err).toBe("");
+    expect(out.trim()).toBe("cowsay from github hello bun!");
+    expect(exited).toBe(0);
+  }
+  expect(github.requests).toHaveLength(1);
 });
 
 it.concurrent.each(["--version", "-v"])("should print the version using %s and exit", async flag => {
@@ -371,7 +500,9 @@ it.concurrent("should pass --version to the package if specified", async () => {
   let [err, out, exited] = await Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited]);
 
   expect(err).not.toContain("error:");
-  expect(out.trim()).not.toContain(Bun.version);
+  // esbuild's own version, not bunx's
+  expect(out.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  expect(out.trim()).not.toBe(Bun.version);
   expect(exited).toBe(0);
 });
 
@@ -446,42 +577,58 @@ describe("bunx --no-install", () => {
   it.concurrent.each(["typescript", "http-server", "eslint"])(
     "`bunx --no-install %s` should find cached packages",
     async pkg => {
+      const bin = pkg === "typescript" ? "tsc" : pkg;
+      using registry = localRegistry(fixturePackage(pkg, "1.0.0", bin));
       const ctx = setup();
+      ctx.env.npm_config_registry = registry.url;
+      // An unversioned `bunx <pkg>` runs a matching bin from PATH before it looks
+      // at its cache, so a tsc/eslint/http-server installed on this machine
+      // would satisfy both runs without the cache ever being consulted.
+      // (bunEnv spreads process.env, whose key is `Path` on Windows.)
+      ctx.env.PATH = pathWithout(bin, ctx.env.PATH ?? process.env.PATH);
+
       // not cached
       {
         const [err, out, code] = await run(ctx, pkg, "--version");
         expect(err).not.toContain("error:");
-        expect(out).not.toBeEmpty();
+        expect(out.trim()).toBe(`${bin} 1.0.0 --version`);
         expect(code).toBe(0);
       }
+      expect(registry.requests).toEqual([`/${pkg}`, `/${pkg}/-/${pkg}-1.0.0.tgz`]);
 
       // cached
       {
         const [err, out, code] = await run(ctx, "--no-install", pkg, "--version");
-        expect(err).not.toContain("error:");
-        expect(out).not.toBeEmpty();
+        expect(err).toBe("");
+        expect(out.trim()).toBe(`${bin} 1.0.0 --version`);
         expect(code).toBe(0);
       }
+      expect(registry.requests).toHaveLength(2);
     },
   );
 
   it.concurrent("when an exact version match is found, should find cached packages", async () => {
+    using registry = localRegistry(fixturePackage("http-server", "14.0.0", "http-server"));
     const ctx = setup();
+    ctx.env.npm_config_registry = registry.url;
+
     // not cached
     {
       const [err, out, code] = await run(ctx, "http-server@14.0.0", "--version");
       expect(err).not.toContain("error:");
-      expect(out).not.toBeEmpty();
+      expect(out.trim()).toBe("http-server 14.0.0 --version");
       expect(code).toBe(0);
     }
+    expect(registry.requests).toEqual(["/http-server", "/http-server/-/http-server-14.0.0.tgz"]);
 
     // cached
     {
       const [err, out, code] = await run(ctx, "--no-install", "http-server@14.0.0", "--version");
-      expect(err).not.toContain("error:");
-      expect(out).not.toBeEmpty();
+      expect(err).toBe("");
+      expect(out.trim()).toBe("http-server 14.0.0 --version");
       expect(code).toBe(0);
     }
+    expect(registry.requests).toHaveLength(2);
   });
 });
 
@@ -507,27 +654,47 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
 
   expect(err).not.toContain("error:");
   expect(err).not.toContain("Cannot find module 'exec'");
-  expect(out.trim()).not.toContain(Bun.version);
+  // esbuild's own version, not bunx's
+  expect(out.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  expect(out.trim()).not.toBe(Bun.version);
   expect(exited).toBe(0);
 });
 
-// Pinned to 20: its engines are "^20.19.0 || ^22.12.0 || >=24.0.0", so the node-24
-// requirement this test exercises holds no matter what Node.js version Bun reports.
-// @latest tracks Angular's engines upward and breaks whenever they outrun us.
+// Stands in for `bunx --bun @angular/cli`, whose `ng` refuses to start on a
+// Node.js older than its engines range (Bun used to self-report 22.6.0 and
+// fail it). The fixture applies the same gate to the version Bun reports under
+// --bun; installing the real CLI pulled in ~250 packages per run, and its
+// engines range moved under us twice.
 it.concurrent("should handle package that requires node 24", async () => {
   const { x_dir, env } = setup();
+  using registry = localRegistry({
+    name: "@bunx-fixture/requires-node-24",
+    version: "1.0.0",
+    bin: { ng: "cli.js" },
+    files: {
+      "cli.js": `#!/usr/bin/env node
+const [major] = process.versions.node.split(".").map(Number);
+if (major < 24) {
+  console.error("error: Node.js v" + process.versions.node + " is not supported, v24 or newer is required");
+  process.exit(3);
+}
+console.log("node v" + process.versions.node + " running in " + (typeof Bun === "undefined" ? "node" : "bun"));
+`,
+    },
+  });
   const subprocess = spawn({
-    cmd: [bunExe(), "x", "--bun", "@angular/cli@20", "--help"],
+    cmd: [bunExe(), "x", "--bun", "@bunx-fixture/requires-node-24", "--help"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: "inherit",
     stderr: "pipe",
-    env,
+    env: { ...env, npm_config_registry: registry.url },
   });
 
   let [err, out, exited] = await Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited]);
   expect(err).not.toContain("error:");
-  expect(out.trim()).not.toContain(Bun.version);
+  // --bun ran the bin with this same Bun, so it saw the version Bun reports as Node.js
+  expect(out.trim()).toBe(`node v${process.versions.node} running in bun`);
   expect(exited).toBe(0);
 });
 
@@ -1187,30 +1354,25 @@ describe("package name aliases", () => {
 // When the .bunx metadata file is corrupted (e.g., missing quote terminator in bin_path),
 // bunx should gracefully fall back to the slow path instead of panicking.
 it.skipIf(!isWindows)("should not crash on corrupted .bunx file with missing quote", async () => {
-  // First, install a package to create a valid .bunx file
-  // Use typescript which creates both .exe and .bunx files
-  // Need to init first to create package.json
-  const initProc = spawn({
-    cmd: [bunExe(), "init", "-y"],
-    cwd: x_dir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  await initProc.exited;
-
+  // Installing any package with a bin creates the tsc.exe + tsc.bunx pair; the
+  // .bunx contents are overwritten below, so a fixture is as good as the real thing.
+  using registry = localRegistry(fixturePackage("typescript", "5.0.0", "tsc"));
+  await writeFile(join(x_dir, "package.json"), "{}");
   const subprocess1 = spawn({
     cmd: [bunExe(), "add", "typescript@5.0.0"],
     cwd: x_dir,
     stdout: "pipe",
     stderr: "pipe",
-    env,
+    env: { ...env, npm_config_registry: registry.url },
   });
   const [err1, out1, exitCode1] = await Promise.all([
     subprocess1.stderr.text(),
     subprocess1.stdout.text(),
     subprocess1.exited,
   ]);
+  expect(err1).not.toContain("error:");
+  expect(out1).toContain("installed typescript@5.0.0");
+  expect(exitCode1).toBe(0);
 
   // Find the .bunx file
   const binDir = join(x_dir, "node_modules", ".bin");
@@ -1237,8 +1399,10 @@ it.skipIf(!isWindows)("should not crash on corrupted .bunx file with missing quo
   const corruptedData = Buffer.concat([binPath, corruptedQuote, nullChar, shebang, binLen, argsLen, flags]);
   await writeFile(bunxFile, corruptedData);
 
-  // Now run bunx - it should NOT crash, but may fail gracefully
-  // Using bun run to invoke tsc.exe, which triggers the BunXFastPath
+  // `bun run tsc` first tries to launch the bin in-process from the .bunx
+  // metadata (the BunXFastPath). On corrupt metadata it must fall through to
+  // spawning tsc.exe, whose standalone copy of the same parser reports the
+  // corruption and exits 255; bun then reports that exit like any other bin's.
   const subprocess2 = spawn({
     cmd: [bunExe(), "run", "tsc", "--version"],
     cwd: x_dir,
@@ -1253,9 +1417,10 @@ it.skipIf(!isWindows)("should not crash on corrupted .bunx file with missing quo
     subprocess2.exited,
   ]);
 
-  // The key assertion: we should NOT see a panic
-  expect(stderr).not.toContain("panic");
-  expect(stderr).not.toContain("reached unreachable code");
+  expect(stderr).toContain("bin metadata is corrupt");
+  expect(stderr).toContain('"tsc.exe" exited with code');
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(255);
 });
 
 // The bunx cache root lives at a predictable path inside the shared temp dir


### PR DESCRIPTION
### Problem

- `test/cli/install/bunx.test.ts` is a serial-phase file that takes 23-26s on the alpine lanes and 30s on windows 11 aarch64 (builds 95391 / 95331), against 3s on debian and ubuntu.
- The time is disk volume, not a network wait: the file installs real packages (`@angular/cli@20`, `@babel/cli`, `eslint`, `typescript`, `http-server` twice, `github:piuccio/cowsay` twice, 25 versions of `semver`, and `bun init` + `typescript@5.0.0` in the Windows-only case; `uglify-js` x3 and `esbuild` x2 are small but also live) and leaves ~35k files / 400-680MB in TMPDIR per run. `scripts/runner.node.mjs` (`spawnBun`) gives each file a fresh TMPDIR and `rmSync`s it afterwards, so every lane pays to extract those files and then to delete them. In the alpine logs that deletion is the 11-13s gap between `Ran 35 tests` and the next file's header; the remaining time is the extraction inside the tests.
- The single dominant case is `should handle package that requires node 24`: `@angular/cli@20` is ~250 packages, 21.6k files / 300MB per run. Measured alone on windows-aarch64 it takes 25.4s plus 4.9s to delete, which is the whole 30s the CI lane reports for the file. Next are `@babel/cli` (3.2k files), `http-server` x2 (2.9k), `semver` x25 (2.8k), `eslint` (2.4k), `cowsay` x2 (1.9k), `typescript` (1k files, 62MB), and on Windows `bun init`'s `@types/bun` + `typescript@5.0.0` (1.3k, in a sequential test).
- `test/cli/init/init.test.ts` shows the same alpine/Windows-slow signature; `bun init` installs `@types/bun` into TMPDIR per test, so it is very likely the same mechanism (files written to TMPDIR, then deleted by the runner), and the helpers here can be lifted for it.

### Fix

- Adds small helpers at the top of the file: `tarball()` (a `Bun.Archive` gzip tarball with everything under one root directory), `localRegistry(...packages)` (a per-test `Bun.serve` on port 0 serving manifests and tarballs for fixture packages, reached through `npm_config_registry`) and `localGithub()` (a stand-in for the GitHub tarball API, reached through the `GITHUB_API_URL` override that `alloc_github_url` in `src/install/PackageManager/runTasks.rs` already honors). Both servers record the request paths they receive. `dummy.registry`'s per-test contexts were not usable for this because they only serve the `.tgz` files checked in next to it, answer every package name with the same version list, and have no GitHub shape; the comment in the file says so.
- Every case in the file that installs something now installs a fixture, so the file no longer contacts npm or GitHub at all (the hermeticity rule in `REVIEW.md`); the real-registry install path itself is covered by the install suites against the local registry. The fixtures keep the shape each real package exercised: a scoped package whose bin is named like neither the scope nor the package (`@angular/cli` -> `ng`, `@babel/cli` -> `babel`), packages literally named `typescript` (bin `tsc`), `http-server` and `eslint` so the name special-casing in `bunx_command.rs` is still what gets exercised, `uglify-js` with its bin named `uglifyjs` (found by reading the installed package.json) in two versions, `esbuild` with a postinstall script (it is in the default trusted dependencies, which is why the real one's script ran), a GitHub repo named after its bin like `cowsay`, and 25 `semver` versions sharing one dependency so the simultaneous installs still race to extract the same package into the shared cache (what #9738 grew this case to 25 versions for). Not on Windows: the two versions it runs there are dependency-free like the real `7.0.0`/`7.1.0`, because two concurrent installs extracting the same package fail about half the time on Windows (details below). The `requires node 24` fixture applies the same `process.versions.node` gate Angular's `ng` applies.
- This is correct to do because these cases assert bunx's behavior (name -> bin resolution, the bunx cache dir, argument and stdin passthrough, re-executing itself as `bunx add`/`bunx exec`, the `.bunx` fast-path fallback), none of which depends on what the installed package contains. The pinned real `@angular/cli` also broke twice when its engines range moved (#32042, #33948, which took the whole file out of CI for 3.5 weeks); the fixtures cannot.
- Assertions tightened while converting:
  - every converted case checks the exact line its bin printed (was `toContain("Usage: ...")`, `not.toBeEmpty()`, `not.toContain(Bun.version)`, or, for `uglify-js`, output that any version produces);
  - install runs assert the request paths: the scoped name requested as `/@scope%2fname`, `github:owner/repo` / `#HEAD` becoming `/repos/owner/repo/tarball/` and `/tarball/HEAD`, and for `uglify-js` that the bare name fetched the `latest` tarball while `@3.14.1` fetched that one (the registry also serves a newer version, so these can fail);
  - the cached runs (`--no-install`, and the second plain run in the `@scoped` and `github` cases) assert `stderr === ""` and that the registry received no further requests, so they fail if bunx re-installs instead of using its cache (before, a re-install passed them);
  - `default (latest) version` asserts stdin reached the bin; `current working directory` asserts the bin resolved its relative argument against the caller's directory (plus the existing check that bunx wrote nothing there);
  - `requires node 24` asserts the bin ran under Bun and saw `process.versions.node` of the Bun under test (the old version passed even if `--bun` was ignored and a system node ran `ng`);
  - the `semver` case plants a decoy `semver` first in PATH, which its title claimed to test but nothing checked, and compares one `{stdout, stderr, exitCode}` record per version (stderr used to be ignored);
  - `--version` passthrough asserts the package received `--version`; the postinstall case asserts the script actually ran (its bin reports a marker the script writes) and that the install went through the `bunx`-named copy, which is the #17076 path; removing the script from the fixture flips the output, so the assertion is live;
  - the unversioned `--no-install` and `esbuild --version` cases strip PATH entries that provide the bin (as the `bunx claude` case already does), so a binary installed on the machine cannot satisfy them;
  - the Windows corrupted-`.bunx` case writes `package.json` instead of running `bun init` (which installed `@types/bun`), checks that `bun add` succeeded, and asserts the documented fallback (`bin metadata is corrupt` from the spawned `tsc.exe`, `"tsc.exe" exited with code`, exit 255) instead of `not.toContain("panic")`.
- `setDefaultTimeout` is left alone: the `semver` case still starts 25 bunx processes that each spawn an install, which is several seconds under the ASAN build, so the 5s default would flake and per-test timeouts are discouraged in `test/CLAUDE.md`. Test names and order are unchanged so the open PRs that add cases to this file stay rebasable. The helpers stay in this file for now: `dummy.registry.ts` is being extended by #35149 (GitHub fixtures) and #37150/#37283 (context tarball dirs) at the same time, and a second consumer (`init.test.ts`, which would import from `harness.ts`) does not exist yet; moving them is mechanical when it does, or now if preferred.
- Verification:
  - `bun bd test test/cli/install/bunx.test.ts` (debug build, linux): 68.0s before, 13.7s after the first revision, which removed the large installs; the later revisions only remove the remaining network calls. TMPDIR left behind 34,927 files before, ~420 after. (`should set "npm_config_user_agent" to bun` fails under `bun bd test` both before and after; that is the env inheritance #31928 fixes in the harness, and it passes in CI.)
  - Same file with the release system bun: 4.45s -> 1.3-1.7s on an idle host; 36,059 files / 402MB -> 409 files; the `rm -rf` of TMPDIR 2.5s -> 0.1s.
  - windows-aarch64 (same VM, canary build, runner-style TEMP): 42.1s run + 7.6s to delete 34,843 files before; 5.0-5.2s run + 0.2s to delete 249 files now (two runs; what is left is ~3s of process-spawn contention in the concurrent batch plus the sequential `dummy.registry` cases). 33 pass / 2 skip each time; the `semver` case passed 30/30 looped runs after the Windows change.
  - The request paths, stderr contents and the `.bunx` fallback messages asserted above were captured from the release bun first (the `.bunx` one on Windows) and then written into the assertions. A files-only GitHub tarball is refused by bun install (`tarball root directory ... is not a valid folder name`), which is why `tarball()` emits the directory entry first.

### Background

- `bunx <pkg>` looks for a bin on PATH (only when no version is given), then in its cache dir `$TMPDIR/bunx-<uid>-<pkg>@<version>/node_modules/.bin/`, and otherwise spawns `bun add <pkg>` into that dir and runs the result (`src/runtime/cli/bunx_command.rs`). A second run within 24h is served from that dir, which is what the "cached" halves of these cases test; `--no-install` skips the install step and errors if nothing is cached.
- For a scoped package bunx first guesses the bin from the unscoped name, and on a miss reads the installed `package.json` to find the real bin; for `github:owner/repo` it guesses the repo name. The fixtures keep those shapes.
- `bun install` fetches `github:` dependencies as tarballs from `$GITHUB_API_URL/repos/<owner>/<repo>/tarball/<ref>` (default `https://api.github.com`) and reads the tarball's single root directory, `<owner>-<repo>-<commit>/`, as the resolved commit, so the fixture tarball uses that layout. npm tarballs use a `package/` root.
- On Windows a bin link is a `<bin>.exe` shim plus a `<bin>.bunx` metadata file. `bun run <bin>` parses the metadata in-process (the BunXFastPath); on corrupt metadata it is supposed to fall through to spawning the `.exe`, whose standalone copy of the parser reports `bin metadata is corrupt` and exits 255 (`src/install/windows-shim/bun_shim_impl.rs`). That fall-through is what the corrupted-`.bunx` case now asserts.
- The CI runner (`scripts/runner.node.mjs`, `spawnBun`) points `TMPDIR`, `BUN_TMPDIR` and `BUN_INSTALL_CACHE_DIR` of each test file at a fresh directory and removes it synchronously after the file exits, so everything a file installs is written once and deleted once per lane, inside the file's measured wall time.

<details>
<summary>Per-test timings on windows-aarch64 before the change</summary>

```
(pass) should handle package that requires node 24 [34348.48ms]
(pass) bunx --no-install > `bunx --no-install eslint` should find cached packages [14812.56ms]
(pass) should work for @scoped packages [14037.16ms]
(pass) bunx --no-install > `bunx --no-install http-server` should find cached packages [11149.93ms]
(pass) bunx --no-install > when an exact version match is found, should find cached packages [11002.09ms]
(pass) should work for github repository [10139.45ms]
(pass) should work for github repository with committish [10116.88ms]
(pass) should handle postinstall scripts correctly with symlinked bunx [5203.44ms]
(pass) bunx --no-install > `bunx --no-install typescript` should find cached packages [4435.24ms]
(pass) should not crash on corrupted .bunx file with missing quote [1641.53ms]
...
Ran 35 tests across 1 file. [42.07s]
TMPDIR afterwards: 34843 files, 677MB, Remove-Item 7.6s
```

`-t "requires node 24"` alone: 25.4s, 21,602 files / 3,529 dirs / 300MB, 4.9s to delete.

After: every converted case is 0.1-0.6s on linux; the file's concurrent batch on the Windows VM is bounded by the remaining `uglify-js`/`esbuild` downloads (~3s).

</details>

<details>
<summary>Concurrent installs sharing one package are not race-free on Windows (why the Windows semver fixtures have no dependency)</summary>

The first revision gave the two Windows `semver` fixtures the same shared dependency as the other platforms and flaked on the windows 11 aarch64 lane: one of the two processes printed nothing. Looping the case on a windows-aarch64 VM reproduced it 10/25 times. A standalone probe spawning two `bun x semver@<v> --help` against a local registry, 20 runs each:

```
with a shared dependency:    13 failing processes / 20 runs
   exit=1, stdout="", stderr="Resolving dependencies
                              Resolved, downloaded and extracted [8]
                              ENOENT: failed opening cache/package/version dir for package lru-cache
                              Saved lockfile"
without a shared dependency:  0 failing processes / 20 runs
```

The message is the `Step::OpeningCacheDir` failure from `src/install/PackageInstaller.rs`; the `bun add` child exits 1 and bunx propagates the exit code without printing anything itself (`bunx_command.rs`, after the install spawn). That is the existing "Windows does not support race-free installs" limitation this case already works around by running only two versions there, and those two real versions (`7.0.0`, `7.1.0`) have no dependencies, so the fixtures now do not either. The bun-side race is tracked separately; it is not changed by this PR.

</details>

<details>
<summary>Earlier revisions of this PR</summary>

- Revision 1 converted the large installs but kept `uglify-js` x3 and `esbuild` x2 on the live registry and built tarballs with a hand-written ustar writer; revision 3 replaced the writer with `Bun.Archive` (the only thing the writer did that `Bun.Archive` does not do by default is emit the leading directory entry, which is now passed explicitly) and converted the five remaining cases.
- Revision 1 also gave the two Windows `semver` fixtures the shared dependency and flaked on the windows 11 aarch64 lane; see the Windows block above.

</details>

<details>
<summary>Left as is</summary>

- The 13 sequential cases that use `dummy.registry`'s module-level handler (`--package flag`, scoped-collision and alias suites) are 10-90ms each on release builds; converting them to per-test servers would touch the areas several open PRs add cases to.
- `should handle postinstall scripts correctly with symlinked bunx` still copies the bun binary twice (the copy named `bunx` is the point of that regression test, #17076); on debug builds that is two copies of a large binary, but it is one sequential file copy each, not the file-count problem above.
- `setDefaultTimeout`, see above.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->