### PR TITLE
sql(mysql): give every error variant a descriptive default message

### DIFF
--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -21,7 +21,7 @@ use bun_sql::mysql::ssl_mode::SSLMode;
 use bun_uws::{self as uws, AnySocket, NewSocketHandler, SocketTCP};
 
 use super::js_mysql_query::JSMySQLQuery;
-use crate::mysql::protocol::any_mysql_error_jsc::{mysql_error_to_js, MaybeBytes};
+use crate::mysql::protocol::any_mysql_error_jsc::{MaybeBytes, mysql_error_to_js};
 use crate::mysql::protocol::error_packet_jsc::ErrorPacketJsc;
 // `my_sql_connection::MySQLConnection` (the protocol-layer struct)
 // is intentionally NOT imported by name — that ident is taken in this module's

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -857,8 +857,6 @@ impl JSMySQLConnection {
             if let Some(err_) = self.global_object.try_take_exception() {
                 self.fail_with_js_value(err_);
             } else {
-                // No server-provided message: `mysql_error_to_js` supplies the
-                // per-variant default.
                 self.fail(None::<&[u8]>, err);
             }
         }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -21,7 +21,7 @@ use bun_sql::mysql::ssl_mode::SSLMode;
 use bun_uws::{self as uws, AnySocket, NewSocketHandler, SocketTCP};
 
 use super::js_mysql_query::JSMySQLQuery;
-use crate::mysql::protocol::any_mysql_error_jsc::mysql_error_to_js;
+use crate::mysql::protocol::any_mysql_error_jsc::{mysql_error_to_js, MaybeBytes};
 use crate::mysql::protocol::error_packet_jsc::ErrorPacketJsc;
 // `my_sql_connection::MySQLConnection` (the protocol-layer struct)
 // is intentionally NOT imported by name — that ident is taken in this module's
@@ -746,7 +746,7 @@ impl JSMySQLConnection {
         );
     }
 
-    fn fail(&self, message: &[u8], err: AnyMySQLErrorT) {
+    fn fail(&self, message: impl MaybeBytes, err: AnyMySQLErrorT) {
         let instance = mysql_error_to_js(&self.global_object, message, err);
         self.fail_with_js_value(instance);
     }
@@ -857,15 +857,9 @@ impl JSMySQLConnection {
             if let Some(err_) = self.global_object.try_take_exception() {
                 self.fail_with_js_value(err_);
             } else {
-                let message: &[u8] = match err {
-                    AnyMySQLErrorT::PublicKeyRetrievalNotAllowed => {
-                        b"The server requested RSA public key retrieval to complete \
-                          authentication, which is not allowed over an insecure connection. \
-                          Enable TLS or set allowPublicKeyRetrieval: true"
-                    }
-                    _ => b"Connection closed",
-                };
-                self.fail(message, err);
+                // No server-provided message: `mysql_error_to_js` supplies the
+                // per-variant default.
+                self.fail(None::<&[u8]>, err);
             }
         }
     }

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -317,9 +317,6 @@ impl JSMySQLQuery {
         if let Some(err_) = self.global_object().try_take_exception() {
             self.reject_with_js_value(queries_array, err_);
         } else {
-            // Per-variant default message: the errors that reach here
-            // (binding, encoding, protocol limits) each have a more specific
-            // default than a blanket "Failed to bind query".
             let instance = mysql_error_to_js(self.global_object(), None::<&[u8]>, err);
             instance.ensure_still_alive();
             self.reject_with_js_value(queries_array, instance);

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -317,7 +317,10 @@ impl JSMySQLQuery {
         if let Some(err_) = self.global_object().try_take_exception() {
             self.reject_with_js_value(queries_array, err_);
         } else {
-            let instance = mysql_error_to_js(self.global_object(), "Failed to bind query", err);
+            // Per-variant default message: the errors that reach here
+            // (binding, encoding, protocol limits) each have a more specific
+            // default than a blanket "Failed to bind query".
+            let instance = mysql_error_to_js(self.global_object(), None::<&[u8]>, err);
             instance.ensure_still_alive();
             self.reject_with_js_value(queries_array, instance);
         }

--- a/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
+++ b/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
@@ -77,44 +77,120 @@ impl<T: MaybeBytes> MaybeBytes for Option<T> {
 
 pub(crate) fn mysql_error_to_js(
     global_object: &JSGlobalObject,
-    // Falls back to the error name when no message is given.
+    // Falls back to the per-variant default message when no message is given.
     message: impl MaybeBytes,
     err: impl IntoAnyMySQLError,
 ) -> JSValue {
     let name = err.mysql_error_name();
-    let msg: &[u8] = message.as_maybe_bytes().unwrap_or(name.as_bytes());
 
-    let code: &'static [u8] = match name {
-        "ConnectionClosed" => b"ERR_MYSQL_CONNECTION_CLOSED",
-        "ConnectionFailed" => b"ERR_MYSQL_CONNECTION_FAILED",
-        "ConnectionRefused" => b"ERR_MYSQL_CONNECTION_REFUSED",
-        "Overflow" => b"ERR_MYSQL_OVERFLOW",
-        "AuthenticationFailed" => b"ERR_MYSQL_AUTHENTICATION_FAILED",
-        "UnsupportedAuthPlugin" => b"ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN",
-        "UnsupportedProtocolVersion" => b"ERR_MYSQL_UNSUPPORTED_PROTOCOL_VERSION",
-        "LocalInfileNotSupported" => b"ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED",
-        "WrongNumberOfParametersProvided" => b"ERR_MYSQL_WRONG_NUMBER_OF_PARAMETERS_PROVIDED",
-        "UnsupportedColumnType" => b"ERR_MYSQL_UNSUPPORTED_COLUMN_TYPE",
-        "InvalidLocalInfileRequest" => b"ERR_MYSQL_INVALID_LOCAL_INFILE_REQUEST",
-        "InvalidAuthSwitchRequest" => b"ERR_MYSQL_INVALID_AUTH_SWITCH_REQUEST",
-        "InvalidQueryBinding" => b"ERR_MYSQL_INVALID_QUERY_BINDING",
-        "InvalidResultRow" => b"ERR_MYSQL_INVALID_RESULT_ROW",
-        "InvalidBinaryValue" => b"ERR_MYSQL_INVALID_BINARY_VALUE",
-        "InvalidEncodedInteger" => b"ERR_MYSQL_INVALID_ENCODED_INTEGER",
-        "InvalidEncodedLength" => b"ERR_MYSQL_INVALID_ENCODED_LENGTH",
-        "InvalidPrepareOKPacket" => b"ERR_MYSQL_INVALID_PREPARE_OK_PACKET",
-        "InvalidOKPacket" => b"ERR_MYSQL_INVALID_OK_PACKET",
-        "InvalidEOFPacket" => b"ERR_MYSQL_INVALID_EOF_PACKET",
-        "InvalidErrorPacket" => b"ERR_MYSQL_INVALID_ERROR_PACKET",
-        "UnexpectedPacket" => b"ERR_MYSQL_UNEXPECTED_PACKET",
-        "ConnectionTimedOut" => b"ERR_MYSQL_CONNECTION_TIMEOUT",
-        "IdleTimeout" => b"ERR_MYSQL_IDLE_TIMEOUT",
-        "LifetimeTimeout" => b"ERR_MYSQL_LIFETIME_TIMEOUT",
-        "PasswordRequired" => b"ERR_MYSQL_PASSWORD_REQUIRED",
-        "MissingAuthData" => b"ERR_MYSQL_MISSING_AUTH_DATA",
-        "FailedToEncryptPassword" => b"ERR_MYSQL_FAILED_TO_ENCRYPT_PASSWORD",
-        "InvalidPublicKey" => b"ERR_MYSQL_INVALID_PUBLIC_KEY",
-        "PublicKeyRetrievalNotAllowed" => b"ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED",
+    let (code, default_message): (&'static [u8], &'static [u8]) = match name {
+        "ConnectionClosed" => (b"ERR_MYSQL_CONNECTION_CLOSED", b"Connection closed"),
+        "ConnectionFailed" => (b"ERR_MYSQL_CONNECTION_FAILED", b"Connection failed"),
+        "ConnectionRefused" => (b"ERR_MYSQL_CONNECTION_REFUSED", b"Connection refused"),
+        "Overflow" => (
+            b"ERR_MYSQL_OVERFLOW",
+            b"Packet exceeds the maximum payload length",
+        ),
+        "AuthenticationFailed" => (b"ERR_MYSQL_AUTHENTICATION_FAILED", b"Authentication failed"),
+        "UnsupportedAuthPlugin" => (
+            b"ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN",
+            b"Server requested an unsupported authentication plugin",
+        ),
+        "UnsupportedProtocolVersion" => (
+            b"ERR_MYSQL_UNSUPPORTED_PROTOCOL_VERSION",
+            b"Server is using an unsupported protocol version",
+        ),
+        "LocalInfileNotSupported" => (
+            b"ERR_MYSQL_LOCAL_INFILE_NOT_SUPPORTED",
+            b"LOCAL INFILE is not supported",
+        ),
+        "WrongNumberOfParametersProvided" => (
+            b"ERR_MYSQL_WRONG_NUMBER_OF_PARAMETERS_PROVIDED",
+            b"Wrong number of parameters provided",
+        ),
+        "UnsupportedColumnType" => (
+            b"ERR_MYSQL_UNSUPPORTED_COLUMN_TYPE",
+            b"Unsupported column type",
+        ),
+        "InvalidLocalInfileRequest" => (
+            b"ERR_MYSQL_INVALID_LOCAL_INFILE_REQUEST",
+            b"Invalid LOCAL INFILE request received from the server",
+        ),
+        "InvalidAuthSwitchRequest" => (
+            b"ERR_MYSQL_INVALID_AUTH_SWITCH_REQUEST",
+            b"Invalid AuthSwitchRequest packet received from the server",
+        ),
+        "InvalidQueryBinding" => (
+            b"ERR_MYSQL_INVALID_QUERY_BINDING",
+            b"Failed to bind query parameters",
+        ),
+        "InvalidResultRow" => (
+            b"ERR_MYSQL_INVALID_RESULT_ROW",
+            b"Invalid result row received from the server",
+        ),
+        "InvalidBinaryValue" => (
+            b"ERR_MYSQL_INVALID_BINARY_VALUE",
+            b"Invalid binary value received from the server",
+        ),
+        "InvalidEncodedInteger" => (
+            b"ERR_MYSQL_INVALID_ENCODED_INTEGER",
+            b"Invalid length-encoded integer received from the server",
+        ),
+        "InvalidEncodedLength" => (
+            b"ERR_MYSQL_INVALID_ENCODED_LENGTH",
+            b"Invalid length-encoded value received from the server",
+        ),
+        "InvalidPrepareOKPacket" => (
+            b"ERR_MYSQL_INVALID_PREPARE_OK_PACKET",
+            b"Invalid prepared statement OK packet received from the server",
+        ),
+        "InvalidOKPacket" => (
+            b"ERR_MYSQL_INVALID_OK_PACKET",
+            b"Invalid OK packet received from the server",
+        ),
+        "InvalidEOFPacket" => (
+            b"ERR_MYSQL_INVALID_EOF_PACKET",
+            b"Invalid EOF packet received from the server",
+        ),
+        "InvalidErrorPacket" => (
+            b"ERR_MYSQL_INVALID_ERROR_PACKET",
+            b"Invalid error packet received from the server",
+        ),
+        "UnexpectedPacket" => (
+            b"ERR_MYSQL_UNEXPECTED_PACKET",
+            b"Unexpected packet received from the server",
+        ),
+        "ConnectionTimedOut" => (b"ERR_MYSQL_CONNECTION_TIMEOUT", b"Connection timed out"),
+        "IdleTimeout" => (
+            b"ERR_MYSQL_IDLE_TIMEOUT",
+            b"Connection closed due to idle timeout",
+        ),
+        "LifetimeTimeout" => (
+            b"ERR_MYSQL_LIFETIME_TIMEOUT",
+            b"Connection closed after exceeding its maximum lifetime",
+        ),
+        "PasswordRequired" => (
+            b"ERR_MYSQL_PASSWORD_REQUIRED",
+            b"Server requires a password, but none was provided",
+        ),
+        "MissingAuthData" => (
+            b"ERR_MYSQL_MISSING_AUTH_DATA",
+            b"Server did not send authentication data during the handshake",
+        ),
+        "FailedToEncryptPassword" => (
+            b"ERR_MYSQL_FAILED_TO_ENCRYPT_PASSWORD",
+            b"Failed to encrypt password with the server's RSA public key",
+        ),
+        "InvalidPublicKey" => (
+            b"ERR_MYSQL_INVALID_PUBLIC_KEY",
+            b"Server sent an invalid RSA public key",
+        ),
+        "PublicKeyRetrievalNotAllowed" => (
+            b"ERR_MYSQL_PUBLIC_KEY_RETRIEVAL_NOT_ALLOWED",
+            b"The server requested RSA public key retrieval to complete authentication, \
+              which is not allowed over an insecure connection. Enable TLS or set \
+              allowPublicKeyRetrieval: true",
+        ),
         "JSError" => {
             return global_object.take_exception(JsError::Thrown);
         }
@@ -129,8 +205,9 @@ pub(crate) fn mysql_error_to_js(
         }
         // "UnknownError" + any name not in the AnyMySQLError set (possible when
         // the caller hands us a raw `crate::Error`).
-        _ => b"ERR_MYSQL_UNKNOWN_ERROR",
+        _ => (b"ERR_MYSQL_UNKNOWN_ERROR", name.as_bytes()),
     };
+    let msg: &[u8] = message.as_maybe_bytes().unwrap_or(default_message);
 
     create_mysql_error(
         global_object,

--- a/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
+++ b/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
@@ -108,6 +108,11 @@ pub(crate) fn mysql_error_to_js(
             b"ERR_MYSQL_WRONG_NUMBER_OF_PARAMETERS_PROVIDED",
             b"Wrong number of parameters provided",
         ),
+        "TooManyParameters" => (
+            b"ERR_MYSQL_TOO_MANY_PARAMETERS",
+            b"Query has too many parameters - the MySQL wire protocol supports a maximum \
+              of 65535 parameters per query. Try reducing your batch size",
+        ),
         "UnsupportedColumnType" => (
             b"ERR_MYSQL_UNSUPPORTED_COLUMN_TYPE",
             b"Unsupported column type",

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -254,3 +254,25 @@ test("public key retrieval refusal names allowPublicKeyRetrieval and TLS as reme
     server.close();
   }
 });
+
+// Connection-level failures used to surface as "Connection closed" whatever their
+// code; each variant now carries its own default message. An unknown auth plugin
+// in the handshake exercises a second variant through the same path.
+test("unsupported auth plugin error says so instead of Connection closed", async () => {
+  const { server, port } = await listeningServer(socket => {
+    socket.write(mysqlHandshakeV10({ authPlugin: "definitely_not_a_plugin" }));
+    socket.on("error", () => {});
+  });
+
+  try {
+    await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
+    const err = await sql.connect().then(
+      () => null,
+      e => e,
+    );
+    expect(err?.code).toBe("ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN");
+    expect(err?.message).toBe("Server requested an unsupported authentication plugin");
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
### Problem

- Follow-up to #38451, which fixed the message for one variant. Every other connection-level MySQL error still surfaces as "Connection closed" regardless of its code: unsupported auth plugin, invalid RSA public key, protocol decode errors, all of them.
- Query-level bind and encode failures all say "Failed to bind query", including errors that are not binding errors.
- Cause: `on_error` in `src/sql_jsc/mysql/JSMySQLConnection.rs` and `reject` in `src/sql_jsc/mysql/JSMySQLQuery.rs` hardcode one fallback message each, and `mysql_error_to_js` falls back to the bare variant name.

### Fix

- `mysql_error_to_js` (`src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs`) now keeps a per-variant default message next to the existing per-variant code table, used whenever the caller has no more specific message.
- `on_error` and `reject` pass no message so each variant gets its default; `fail` accepts an optional message. Call sites that do have a specific message (server error packets, timeout formatting with the configured duration, "Connection closed before the connection was established") are unchanged. Error codes are unchanged with one exception: `TooManyParameters` previously fell through to `ERR_MYSQL_UNKNOWN_ERROR` and now gets `ERR_MYSQL_TOO_MANY_PARAMETERS` (mirroring postgres); nothing on the MySQL path constructs that variant today.
- The #38451 message for `PublicKeyRetrievalNotAllowed` moves into the table unchanged.
- Test: scripted server in `test/js/sql/sql-mysql.auth.test.ts` advertises an unknown auth plugin; asserts code `ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN` and the new message. Fails on current main (message is "Connection closed"), passes with this change. Also ran `sql-mysql.auth`, `sql-connect-error-reporting`, `sql-mysql`, `sql-mysql-bind-oob`, `sql-mysql-duplicate-auth-switch`, `sql-mysql-prepare-ok-zero-statement-id`, `sql-mysql-auth-short-nonce`, `sql-mysql-bigint-out-of-range` under `bun bd test`: all pass. No existing test asserts the replaced fallback strings.

### Background

- MySQL errors are represented by the `AnyMySQLError` enum (`src/sql/mysql/protocol/AnyMySQLError.rs`); `mysql_error_to_js` maps a variant to a JS `MySQLError` with a `code` property. The code was always specific; only the human-readable message was lost at the two generic call sites.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql.auth.test.ts
bun test v1.4.0 (58ed706a9)

test/js/sql/sql-mysql.auth.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [693.98ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [137.00ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [90.78ms]
(pass) public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies [60.12ms]
269 |     const err = await sql.connect().then(
270 |       () => null,
271 |       e => e,
272 |     );
273 |     expect(err?.code).toBe("ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN");
274 |     expect(err?.message).toBe("Server requested an unsupported authentication plugin");
                               ^
error: expect(received).toBe(expected)

Expected: "Server requested an unsupported authentication plugin
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (72072bc46)

test/js/sql/sql-mysql.auth.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [15.70ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [2.95ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [3.47ms]
(pass) public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies [2.66ms]
269 |     const err = await sql.connect().then(
270 |       () => null,
271 |       e => e,
272 |     );
273 |     expect(err?.code).toBe("ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN");
274 |     expect(err?.message).toBe("Server requested an unsupported authentication plugin");
                               ^
error: expect(received).toBe(expected)

Expected: "Server requested an unsupported authentication plugin"
Received: "Connection closed"

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql.auth.test.ts:274:26)
(fail) unsupported auth plugin error says so instea
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql.auth.test.ts
bun test v1.4.0 (58ed706a9)

test/js/sql/sql-mysql.auth.test.ts:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [532.58ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [113.10ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [74.63ms]
(pass) public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies [48.18ms]
(pass) unsupported auth plugin error says so instead of Connection closed [36.67ms]

 5 pass
 0 fail
 9 expect() calls
Ran 5 tests across 1 file. [3.73s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 735ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/mysql/JSMySQLConnection.rs            |  14 +-
 src/sql_jsc/mysql/JSMySQLQuery.rs                 |   2 +-
 src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs | 150 +++++++++++++++++-----
 test/js/sql/sql-mysql.auth.test.ts                |  22 ++++
 4 files changed, 142 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/sql_jsc/mysql/JSMySQLConnection.rs                 7      5      0
src/sql_jsc/mysql/JSMySQLQuery.rs                      2      2      0
src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs      2      3      0
test/js/sql/sql-mysql.auth.test.ts                     1      3      0
```

</details>

<!-- robobun:evidence:end -->