### PR TITLE
test(fetch): speed up fetch.test.ts (~30s to ~12s release) and tighten its assertions

### DIFF
--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -19,7 +19,6 @@ import {
   tempDir,
   tls,
   tmpdirSync,
-  withoutAggressiveGC,
 } from "harness";
 
 import { once } from "events";
@@ -967,14 +966,7 @@ function testBlobInterface(blobbyConstructor: { (..._: any[]): any }, hasBlobFn?
         const compare = new Uint8Array(await response.arrayBuffer());
         if (withGC) gc();
 
-        withoutAggressiveGC(() => {
-          for (let i = 0; i < compare.length; i++) {
-            if (withGC) gc();
-
-            expect(compare[i]).toBe(bytes[i]);
-            if (withGC) gc();
-          }
-        });
+        expect(compare).toEqual(bytes);
         if (withGC) gc();
       });
 
@@ -990,14 +982,8 @@ function testBlobInterface(blobbyConstructor: { (..._: any[]): any }, hasBlobFn?
         const compare = await response.bytes();
         if (withGC) gc();
 
-        withoutAggressiveGC(() => {
-          for (let i = 0; i < compare.length; i++) {
-            if (withGC) gc();
-
-            expect(compare[i]).toBe(bytes[i]);
-            if (withGC) gc();
-          }
-        });
+        expect(compare).toBeInstanceOf(Uint8Array);
+        expect(compare).toEqual(bytes);
         if (withGC) gc();
       });
 
@@ -1015,14 +1001,7 @@ function testBlobInterface(blobbyConstructor: { (..._: any[]): any }, hasBlobFn?
         const compare = new Uint8Array(await response.arrayBuffer());
         if (withGC) gc();
 
-        withoutAggressiveGC(() => {
-          for (let i = 0; i < compare.length; i++) {
-            if (withGC) gc();
-
-            expect(compare[i]).toBe(bytes[i]);
-            if (withGC) gc();
-          }
-        });
+        expect(compare).toEqual(bytes);
         if (withGC) gc();
       });
 
@@ -1040,14 +1019,8 @@ function testBlobInterface(blobbyConstructor: { (..._: any[]): any }, hasBlobFn?
         const compare = await response.bytes();
         if (withGC) gc();
 
-        withoutAggressiveGC(() => {
-          for (let i = 0; i < compare.length; i++) {
-            if (withGC) gc();
-
-            expect(compare[i]).toBe(bytes[i]);
-            if (withGC) gc();
-          }
-        });
+        expect(compare).toBeInstanceOf(Uint8Array);
+        expect(compare).toEqual(bytes);
         if (withGC) gc();
       });
 
@@ -1744,18 +1717,29 @@ it("#2794", () => {
   expect(typeof Bun.fetch.bind).toBe("function");
 });
 
-it("#3545", () => {
-  expect(() => fetch("http://example.com?a=b")).not.toThrow();
+it("#3545", async () => {
+  // A query directly after the host, with no path, used to fail to open the socket.
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname, search } = new URL(req.url);
+      return Response.json({ pathname, search });
+    },
+  });
+  const response = await fetch(`${server.url.origin}?a=b`);
+  expect(await response.json()).toEqual({ pathname: "/", search: "?a=b" });
+  expect(response.url).toBe(`${server.url.origin}/?a=b`);
+  expect(response.status).toBe(200);
 });
 
-it("invalid header doesnt crash", () => {
-  expect(() =>
-    fetch("http://example.com", {
-      headers: {
-        ["lol!!!!!" + "emoji" + "😀"]: "hello",
-      },
-    }),
-  ).toThrow();
+it("invalid header doesnt crash", async () => {
+  const promise = fetch("http://127.0.0.1:1/", {
+    headers: {
+      ["lol!!!!!" + "emoji" + "😀"]: "hello",
+    },
+  });
+  await expect(promise).rejects.toBeInstanceOf(TypeError);
+  await expect(promise).rejects.toThrow("Invalid header name: 'lol!!!!!emoji😀'");
 });
 
 it("new Request(https://example.com, otherRequest) uses url from left instead of right", () => {
@@ -1833,7 +1817,7 @@ it("should work with http 100 continue", async () => {
     });
 
     const { promise: start, resolve } = Promise.withResolvers();
-    server.listen(8080, resolve);
+    server.listen(0, resolve);
 
     await start;
 
@@ -1863,7 +1847,7 @@ it("should work with http 100 continue on the same buffer", async () => {
     });
 
     const { promise: start, resolve } = Promise.withResolvers();
-    server.listen(8080, resolve);
+    server.listen(0, resolve);
 
     await start;
 
@@ -2121,11 +2105,14 @@ it.concurrent("should allow very long redirect URLS", async () => {
       });
     },
   });
-  // run it more times to check Malformed_HTTP_Response errors
-  for (let i = 0; i < 100; i++) {
-    const { url, status } = await fetch(`${server.url.origin}/redirect`);
-    expect(url).toBe(`${server.url.origin}${Location}`);
-    expect(status).toBe(404);
+  // Sequential iterations reuse the pooled keep-alive connections, so a redirect body left
+  // undrained (#8874) surfaces as Malformed_HTTP_Response on a following request.
+  for (let i = 0; i < 20; i++) {
+    const response = await fetch(`${server.url.origin}/redirect`);
+    expect(response.url).toBe(`${server.url.origin}${Location}`);
+    expect(response.redirected).toBe(true);
+    expect(await response.text()).toBe("Not Found");
+    expect(response.status).toBe(404);
   }
 });
 
@@ -2344,9 +2331,8 @@ describe("fetch Response life cycle", () => {
 
     await using serverProcess = Bun.spawn({
       cmd: [bunExe(), "--smol", fetchFixture3],
-      stderr: "inherit",
-      stdout: "inherit",
-      stdin: "inherit",
+      stderr: "pipe",
+      stdout: "pipe",
       env: bunEnv,
       ipc(message) {
         deferred.resolve(message);
@@ -2356,12 +2342,24 @@ describe("fetch Response life cycle", () => {
     const serverUrl = await deferred.promise;
     await using clientProcess = Bun.spawn({
       cmd: [bunExe(), "--smol", fetchFixture4, serverUrl],
-      stderr: "inherit",
-      stdout: "inherit",
-      stdin: "inherit",
+      stderr: "pipe",
+      stdout: "pipe",
       env: bunEnv,
     });
-    expect(await clientProcess.exited).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([
+      clientProcess.stdout.text(),
+      clientProcess.stderr.text(),
+      clientProcess.exited,
+    ]);
+    // The fixture asserts the post-GC Response/Promise counts itself and reports a
+    // violation on stderr; it logs one heap summary per iteration on stdout.
+    expect(stderr).toBe("");
+    expect(stdout.match(/Response: \d+/g)).toHaveLength(10);
+    expect(exitCode).toBe(0);
+
+    serverProcess.kill();
+    const [serverStdout, serverStderr] = await Promise.all([serverProcess.stdout.text(), serverProcess.stderr.text()]);
+    expect({ serverStdout, serverStderr }).toEqual({ serverStdout: "", serverStderr: "" });
   });
   it("should allow to get promise result after response is GC'd", async () => {
     using server = Bun.serve({
@@ -2622,12 +2620,15 @@ describe("fetch should allow duplex", () => {
     }).not.toThrow();
   });
 
+  // The remaining cases each spend their time waiting on their own child process or
+  // servers, so they run concurrently with each other.
+
   // When the download source is faster than the upload target, the response-
   // body ByteStream must pause the source socket instead of buffering the
   // rate difference in-process. Before the fix, a chunk arriving before the
   // upload sink attached flipped the source to BufferAll and RSS grew at the
   // line rate (several GB in seconds on localhost).
-  it("bounds memory when the upload target is slower than the download source", async () => {
+  it.concurrent("bounds memory when the upload target is slower than the download source", async () => {
     const fixture = `
       const net = require("node:net");
       const chunk = Buffer.alloc(64 * 1024, 0x47);
@@ -2678,7 +2679,7 @@ describe("fetch should allow duplex", () => {
   // A type:"direct" stream body where pull does `await controller.write(chunk)`
   // in a loop must suspend when the sink is backpressured: write() returns a
   // pending Promise once the stream buffer is over the high-water mark.
-  it("suspends a type:'direct' body's controller.write() when the upload target is backpressured", async () => {
+  it.concurrent("suspends a type:'direct' body's controller.write() when the upload target is stalled", async () => {
     const fixture = `
       const net = require("node:net");
       const sink = net.createServer(sock => sock.pause());
@@ -2729,7 +2730,7 @@ describe("fetch should allow duplex", () => {
   // Passing a response body as a request body attaches it to a native sink;
   // the source stream must be marked locked + disturbed so a second consumer
   // errors instead of hanging on data that will never be delivered to it.
-  it("locks the response body when it is used as a request body", async () => {
+  it.concurrent("locks the response body when it is used as a request body", async () => {
     await using source = Bun.serve({
       port: 0,
       fetch: () => new Response(new ReadableStream({ pull: c => c.enqueue(new Uint8Array(64 * 1024)) })),
@@ -2771,7 +2772,7 @@ describe("fetch should allow duplex", () => {
   // back-pressure the uploading client rather than buffering the difference:
   // the request-body ByteStream stops reading from the inbound socket while
   // the outbound sink is over its high-water mark.
-  it("bounds memory when a handler forwards req.body to a stalled target", async () => {
+  it.concurrent("bounds memory when a handler forwards req.body to a stalled target", async () => {
     const fixture = `
       const net = require("node:net");
       const CHUNK = Buffer.alloc(64 * 1024, 0x47), COUNT = 2048; // 128 MB
@@ -3385,134 +3386,152 @@ it("does not reuse a keep-alive connection whose response carried more bytes tha
 });
 
 // https://github.com/oven-sh/bun/issues/16682
-it("an explicit numeric `timeout` extends the socket idle deadline past the default", async () => {
-  // The child runs with a 1s idle default (BUN_CONFIG_HTTP_IDLE_TIMEOUT=1) and
-  // talks to an in-process server whose handler holds every request idle for
-  // 10s (longer than the worst-case firing window of the 1s idle timer, which
-  // is swept on uSockets' 4s tick) before responding.
-  //
-  //   - `timeout: 60_000` must override the 1s idle default and resolve.
-  //   - `timeout: 0` must keep meaning "no timeout" and resolve.
-  //   - no `timeout` at all must still hit the 1s idle default (control that
-  //     proves the env override and the stall are both real).
-  const script = /* js */ `
-    const HOLD_MS = 10_000;
+it.concurrent(
+  "an explicit numeric `timeout` extends the socket idle deadline past the default",
+  async () => {
+    // The child runs with a 1s idle default (BUN_CONFIG_HTTP_IDLE_TIMEOUT=1) and
+    // talks to an in-process server that holds every request idle (no bytes in
+    // either direction) until a control request carrying no `timeout` has been
+    // aborted by that default. The idle timer is swept on uSockets' 4s tick, so
+    // the control fires at the first tick after it is armed (~4s into the test).
+    //
+    //   - `timeout: 60_000` must override the 1s idle default and resolve.
+    //   - `timeout: 0` / `timeout: Infinity` must keep meaning "no timeout" and resolve.
+    //   - the control must still hit the 1s idle default (proves the env override
+    //     and the stall are both real). It is sent only after the server has seen
+    //     the three explicit requests, so their idle timers were armed no later
+    //     than the control's: a build that ignored the explicit `timeout` would
+    //     have aborted them by the sweep that aborts the control, i.e. before the
+    //     server releases the held responses.
+    const script = /* js */ `
+    const explicitArrived = Promise.withResolvers();
+    const release = Promise.withResolvers();
+    let arrived = 0;
     using server = Bun.serve({
       port: 0,
       // Disable Bun.serve's own request idle timeout; only the client-side
       // idle timer under test may abort anything here.
       idleTimeout: 0,
       async fetch(req) {
-        const arrived = Date.now();
-        // Hold the connection idle (no bytes in either direction) until the
-        // hold window has really elapsed on the server's clock.
-        while (Date.now() - arrived < HOLD_MS) {
-          await Bun.sleep(HOLD_MS - (Date.now() - arrived));
-        }
+        if (++arrived === 3) explicitArrived.resolve();
+        await release.promise;
         return new Response("hello");
       },
     });
-    const get = init => fetch(server.url, init).then(r => r.text(), e => "ERR:" + (e?.code ?? e?.name ?? e));
-    const [withTimeout, withZero, withInfinity, withDefault] = await Promise.all([
-      get({ timeout: 60_000 }),
-      get({ timeout: 0 }),
-      get({ timeout: Infinity }),
-      get(undefined),
-    ]);
+    const get = init => fetch(server.url, init).then(r => r.text(), e => e?.name + ": " + e?.message);
+    const explicit = Promise.all([get({ timeout: 60_000 }), get({ timeout: 0 }), get({ timeout: Infinity })]);
+    await explicitArrived.promise;
+    const withDefault = await get(undefined);
+    release.resolve();
+    const [withTimeout, withZero, withInfinity] = await explicit;
     console.log(JSON.stringify({ withTimeout, withZero, withInfinity, withDefault }));
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const out = JSON.parse(stdout.trim().split("\n").pop()!) as Record<string, string>;
-  expect({ withTimeout: out.withTimeout, withZero: out.withZero, withInfinity: out.withInfinity }).toEqual({
-    withTimeout: "hello",
-    withZero: "hello",
-    withInfinity: "hello",
-  });
-  // Control: without an explicit `timeout`, the 1s idle default still aborts
-  // the stalled request.
-  expect(out.withDefault).toStartWith("ERR:");
-  expect(exitCode).toBe(0);
-}, 60_000);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      withTimeout: "hello",
+      withZero: "hello",
+      withInfinity: "hello",
+      withDefault: "TimeoutError: The operation timed out.",
+    });
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
 
-it("the idle timer is an absolute deadline for the response header block (not re-armed by a byte drip)", async () => {
-  // A server that trickles one response-header byte at a time, each interval
-  // shorter than the request's idle timeout, must not be able to keep the
-  // request alive indefinitely. The idle timer is armed when the request is
-  // written and is not re-armed on partial header reads, so it bounds how long
-  // the header block may take to arrive in total (undici `headersTimeout`
-  // semantics). Once the header block completes the body path re-arms per
-  // chunk, so a slow-but-steady body is still accepted.
-  const BODY = "abc";
-  const HEAD = `HTTP/1.1 200 OK\r\nContent-Length: ${BODY.length}\r\n\r\n`;
-  const DRIP_MS = 2_000;
-  const DRIP_N = 10; // header drip sends this many single bytes, then the rest at once
-  const IDLE_MS = 5_000;
+it.concurrent(
+  "the idle timer is an absolute deadline for the response header block (not re-armed by a byte drip)",
+  async () => {
+    // A server that trickles one response-header byte at a time, each interval
+    // shorter than the request's idle timeout, must not be able to keep the
+    // request alive indefinitely. The idle timer is armed when the request is
+    // written and is not re-armed on partial header reads, so it bounds how long
+    // the header block may take to arrive in total (undici `headersTimeout`
+    // semantics). Once the header block completes the body path re-arms per
+    // chunk, so a slow-but-steady body is still accepted.
+    //
+    // IDLE_MS is 2 ticks of uSockets' 4s timeout sweep, so an armed timer fires
+    // 4-8s later, at the second sweep after it was (re-)armed.
+    const BODY = "body bytes that trickle in one at a time";
+    const HEAD = `HTTP/1.1 200 OK\r\nContent-Length: ${BODY.length}\r\n\r\n`;
+    const DRIP_MS = 1_000;
+    const DRIP_N = 20; // header drip sends this many single bytes, then the rest at once
+    const IDLE_MS = 5_000;
 
-  const sockets = new Set<net.Socket>();
-  const intervals = new Set<ReturnType<typeof setInterval>>();
-  const server = net.createServer(sock => {
-    sockets.add(sock);
-    sock.on("close", () => sockets.delete(sock));
-    sock.on("error", () => {});
-    sock.once("data", chunk => {
-      // /h drips DRIP_N header bytes then bursts the rest + body.
-      // /b bursts the header block then drips the body byte-by-byte.
-      const headerDrip = chunk.includes("/h ");
-      if (!headerDrip) sock.write(HEAD);
-      const dripped = headerDrip ? HEAD.slice(0, DRIP_N) : BODY;
-      const tail = headerDrip ? HEAD.slice(DRIP_N) + BODY : "";
-      let i = 0;
-      const iv = setInterval(() => {
-        if (sock.destroyed) {
+    const sockets = new Set<net.Socket>();
+    const intervals = new Set<ReturnType<typeof setInterval>>();
+    // Resolves, once /b has been requested, with a function that ends /b's body.
+    const bodyDrip = Promise.withResolvers<() => void>();
+    const server = net.createServer(sock => {
+      sockets.add(sock);
+      sock.on("close", () => sockets.delete(sock));
+      sock.on("error", () => {});
+      sock.once("data", chunk => {
+        // /h drips DRIP_N header bytes, then bursts the rest of the head + body.
+        // /b bursts the head, then drips body bytes until the test ends the body.
+        const headerDrip = chunk.includes("/h ");
+        if (!headerDrip) sock.write(HEAD);
+        const dripped = headerDrip ? HEAD.slice(0, DRIP_N) : BODY.slice(0, -1);
+        let i = 0;
+        let finished = false;
+        const finish = () => {
+          if (finished) return;
+          finished = true;
           clearInterval(iv);
           intervals.delete(iv);
-          return;
-        }
-        if (i < dripped.length) {
+          if (!sock.destroyed) sock.end(headerDrip ? HEAD.slice(DRIP_N) + BODY : BODY.slice(i));
+        };
+        const iv = setInterval(() => {
+          if (sock.destroyed || i === dripped.length) {
+            finish();
+            return;
+          }
           sock.write(dripped[i++]);
-        } else {
-          clearInterval(iv);
-          intervals.delete(iv);
-          sock.end(tail);
-        }
-      }, DRIP_MS);
-      intervals.add(iv);
+        }, DRIP_MS);
+        intervals.add(iv);
+        if (!headerDrip) bodyDrip.resolve(finish);
+      });
     });
-  });
-  await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
-  const port = (server.address() as AddressInfo).port;
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+    const port = (server.address() as AddressInfo).port;
 
-  try {
-    const settle = (path: string) =>
-      fetch(`http://127.0.0.1:${port}${path}`, { timeout: IDLE_MS }).then(
-        async r => ({ ok: true as const, status: r.status, body: await r.text() }),
-        e => ({ ok: false as const, name: e?.name as string, message: String(e?.message ?? e) }),
-      );
+    try {
+      const settle = (path: string) =>
+        fetch(`http://127.0.0.1:${port}${path}`, { timeout: IDLE_MS }).then(
+          async r => ({ ok: true as const, status: r.status, body: await r.text() }),
+          e => ({ ok: false as const, name: e?.name as string, message: String(e?.message ?? e) }),
+        );
 
-    // /h: DRIP_N bytes * DRIP_MS = ~20s of drip before the response would
-    // complete; the 5s idle deadline (uSockets 4s-tick sweep, so ~5-9s) must
-    // fire first. A build that re-arms on every partial header read resolves
-    // 200 after the full drip instead.
-    // /b: headers arrive in one write, then the 3-byte body trickles at
-    // DRIP_MS/byte (~8s). Each body chunk re-arms the idle timer, so this
-    // resolves despite taking longer than IDLE_MS overall.
-    const [hdr, bod] = await Promise.all([settle("/h"), settle("/b")]);
-    expect({ hdr, bod }).toEqual({
-      hdr: { ok: false, name: "TimeoutError", message: "The operation timed out." },
-      bod: { ok: true, status: 200, body: BODY },
-    });
-  } finally {
-    for (const iv of intervals) clearInterval(iv);
-    for (const s of sockets) s.destroy();
-    await new Promise<void>(r => server.close(() => r()));
-  }
-}, 60_000);
+      // /b goes first, and /h is only sent once the server has /b's request, so
+      // /b's idle timer was armed no later than /h's. /h's header drip (DRIP_N *
+      // DRIP_MS = 20s) outlasts the deadline, so /h is aborted by the second sweep
+      // after it was armed; a build that re-armed on partial header reads would
+      // resolve it with a 200 after the full drip instead. That sweep (or an
+      // earlier one) would also have aborted /b had its body bytes not re-armed
+      // the timer, so /b still being there to receive the rest of its body once
+      // /h has failed is what proves the body path re-arms.
+      const bod = settle("/b");
+      const finishBody = await bodyDrip.promise;
+      const hdr = await settle("/h");
+      finishBody();
+      expect({ hdr, bod: await bod }).toEqual({
+        hdr: { ok: false, name: "TimeoutError", message: "The operation timed out." },
+        bod: { ok: true, status: 200, body: BODY },
+      });
+    } finally {
+      for (const iv of intervals) clearInterval(iv);
+      for (const s of sockets) s.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  },
+  60_000,
+);
 
 it.skipIf(isWindows)("sends the exact Content-Length for a file body of 100 GB", async () => {
   using dir = tempDir("fetch-large-file-body", { "large.bin": "" });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2105,9 +2105,10 @@ it.concurrent("should allow very long redirect URLS", async () => {
       });
     },
   });
-  // Sequential iterations reuse the pooled keep-alive connections, so a redirect body left
-  // undrained (#8874) surfaces as Malformed_HTTP_Response on a following request.
-  for (let i = 0; i < 20; i++) {
+  // Twice: the second round's /redirect rides the connection pooled by the first round's
+  // final response. (The 302's own connection is closed because it carries a body; which
+  // redirect responses get pooled is pinned by connection count in fetch-keepalive.test.ts.)
+  for (let i = 0; i < 2; i++) {
     const response = await fetch(`${server.url.origin}/redirect`);
     expect(response.url).toBe(`${server.url.origin}${Location}`);
     expect(response.redirected).toBe(true);

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3473,40 +3473,43 @@ it.concurrent(
       sock.on("close", () => sockets.delete(sock));
       sock.on("error", () => {});
       sock.once("data", chunk => {
-        // /h drips DRIP_N header bytes, then bursts the rest of the head + body.
-        // /b bursts the head, then drips body bytes until the test ends the body.
+        // /h drips DRIP_N header bytes, then bursts the rest of the head + body so
+        // that a build which keeps re-arming gets a 200 instead of hanging.
+        // /b bursts the head, then drips body bytes; only the test ends its body.
         const headerDrip = chunk.includes("/h ");
         if (!headerDrip) sock.write(HEAD);
         const dripped = headerDrip ? HEAD.slice(0, DRIP_N) : BODY.slice(0, -1);
         let i = 0;
-        let finished = false;
-        const finish = () => {
-          if (finished) return;
-          finished = true;
-          clearInterval(iv);
-          intervals.delete(iv);
-          if (!sock.destroyed) sock.end(headerDrip ? HEAD.slice(DRIP_N) + BODY : BODY.slice(i));
-        };
         const iv = setInterval(() => {
-          if (sock.destroyed || i === dripped.length) {
-            finish();
+          if (!sock.destroyed && i < dripped.length) {
+            sock.write(dripped[i++]);
             return;
           }
-          sock.write(dripped[i++]);
+          clearInterval(iv);
+          intervals.delete(iv);
+          if (headerDrip && !sock.destroyed) sock.end(HEAD.slice(DRIP_N) + BODY);
         }, DRIP_MS);
         intervals.add(iv);
-        if (!headerDrip) bodyDrip.resolve(finish);
+        if (!headerDrip) {
+          bodyDrip.resolve(() => {
+            clearInterval(iv);
+            intervals.delete(iv);
+            if (!sock.destroyed) sock.end(BODY.slice(i));
+          });
+        }
       });
     });
     await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
     const port = (server.address() as AddressInfo).port;
 
     try {
+      // fetch() resolves once the head is in, so /b's timeout would surface from
+      // text(); catch() rather than a rejection handler on the same then() so it
+      // ends up in the assertion below instead of being thrown out of the test.
       const settle = (path: string) =>
-        fetch(`http://127.0.0.1:${port}${path}`, { timeout: IDLE_MS }).then(
-          async r => ({ ok: true as const, status: r.status, body: await r.text() }),
-          e => ({ ok: false as const, name: e?.name as string, message: String(e?.message ?? e) }),
-        );
+        fetch(`http://127.0.0.1:${port}${path}`, { timeout: IDLE_MS })
+          .then(async r => ({ ok: true as const, status: r.status, body: await r.text() }))
+          .catch(e => ({ ok: false as const, name: e?.name as string, message: String(e?.message ?? e) }));
 
       // /b goes first, and /h is only sent once the server has /b's request, so
       // /b's idle timer was armed no later than /h's. /h's header drip (DRIP_N *


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/fetch.test.ts` is a serial-phase file that takes ~29s on every CI lane (41s on debian x64 ASAN), and a release build is barely faster than a debug one, so the time is spent waiting rather than running.
- Locally the time splits into: a fixed 10s server hold in the explicit `timeout` idle test, 6-8s in the absolute-deadline idle test, ~7s of `Bun.gc(true)` calls in `testBlobInterface` (two forced GCs per compared byte, ~6,300 calls in total), and ~4s of independent RSS cases in `fetch should allow duplex` running one after another.
- The `testBlobInterface` GC loops are synchronous and run inside `describe.concurrent("Bun.file")`, so they also stall the HTTPS cases that share that concurrent batch (on a slow machine those time out).
- A few cases nearby are weak: `#3545` fires an unawaited `fetch()` at example.com and only asserts that nothing throws synchronously, the 100-continue tests listen on a hardcoded port 8080, and the explicit `timeout` test asserts `toStartWith("ERR:")` on what is actually the DOMException legacy code (`ERR:23`).

### Fix
- Explicit `timeout` idle test (10.0s to 4.0s): the child's server holds every request until the control request (no `timeout`) has been aborted by the 1s default, instead of for a fixed 10s. The three explicit requests are sent first and the control only once the server has seen them, so their idle timers are armed no later than the control's: a build that ignored the explicit `timeout` would have aborted them by the sweep that aborts the control, before the server releases anything, so the check stays deterministic. The control fires at the first sweep tick, ~4s in.
- Absolute-deadline idle test: `/b` now drips body bytes until `/h` has timed out and is only then completed. Before, `/b` completed after a fixed 6s, inside the 4-8s window in which `/h`'s deadline fires, so a body path that stopped re-arming was only caught when the sweep phase happened to fall under 6s; now `/b` has to survive the very sweep that killed `/h`. `/b` is sent first and `/h` only after the server has `/b`'s request, for the same ordering argument as above. Its duration is `/h`'s deadline: two sweep ticks, which is ~8s in practice because this test's own sockets are what start the sweep timer (4-8s only when earlier sockets left it running).
- Both idle tests are `it.concurrent`, so together they cost ~8s instead of 16-18s. Because `it.concurrent(name, fn, timeout)` is not one of prettier's test-call shapes, prettier wraps both calls and re-indents their bodies; `git diff -w` shows the real changes.
- `testBlobInterface` (~7s to ~0.2s in release): the `arrayBuffer` / `bytes` / `arrayBuffer -> arrayBuffer` / `arrayBuffer -> bytes` cases compare the whole array with `toEqual` after one GC instead of calling `gc()` before and after every byte; that is the same check (the buffer is read after a full GC), and the `bytes()` cases additionally assert the result is a `Uint8Array`. `withoutAggressiveGC` had no other users. This is where most of the drop in the `expect()` count (7,438 to ~1,000) comes from.
- The four RSS cases at the end of `fetch should allow duplex` are `it.concurrent` (4.2s to 2.0s); they each spawn their own child or servers. One name is shortened by a few characters (`... is backpressured` to `... is stalled`, matching its sibling) so that prettier keeps the call on one line instead of re-indenting the test. Their RSS observation windows are unchanged.
- `should allow very long redirect URLS` runs its round trip twice instead of 100 times (each round is two requests plus a forced GC in the handler; 5s+ in this container's debug build, 0.3s now). The loop dates from #8874, when a redirect response's body was drained and its connection pooled; since #33613 a 3xx that carries a body has its connection closed instead (`src/http/lib.rs`, the `is_redirect_pending` branch of the body-length check), so repeating the round trip cannot surface an undrained redirect body. What a second round does add is the next `/redirect` riding the connection pooled by the previous round's final response (checked with a raw server: two rounds use three connections, and the second connection serves round 1's final response and then round 2's `/redirect`); the comment now says exactly that, and which redirect responses get pooled is already pinned by connection count in `fetch-keepalive.test.ts` ("302 carrying a body" and friends). The test also asserts `redirected` and the final body now.
- Assertions: the idle tests assert the exact JSON the child prints (including `TimeoutError: The operation timed out.` for the control) and an empty stderr; the Response life cycle test pipes both children and asserts the client's stderr is empty, that it logged all 10 iterations, and that the server printed nothing; `#3545` fetches `http://host:port?a=b` from a local server and asserts the request target it received (`/` + `?a=b`), `response.url` and the status; the invalid header test asserts a `TypeError` with `Invalid header name: ...` (on current main `fetch()` returns a rejected promise here rather than throwing; older releases threw); the 100-continue tests listen on port 0.
- Both rewritten idle tests were checked against the regressions they guard by simulating those from the test side (the explicit requests sent without a `timeout`, which is what a client that ignored the option would do; `/b`'s body bytes withheld, which is what the client sees if body reads stop re-arming). On release and debug builds both tests then fail through their `toEqual` diff: the three explicit requests come back `TimeoutError` at the same ~4s sweep as the control, and `/b` is already a `TimeoutError` when `/h` fails (output in the details below). The second commit makes a `/b` body timeout land in that diff instead of being thrown out of the test (`fetch()` resolves on the head, so it surfaces from `text()`), and only lets the test complete `/b`'s body.
- Verified: `bun bd test test/js/web/fetch/fetch.test.ts` (debug + ASAN, same binary) 225.5s before, 41.0s after; `USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch.test.ts` (release) 29.9s before, 12.3s after. On this PR's CI run (build 95959) the file took 12.1-12.2s on the linux release lanes and 12.5s on debian x64 ASAN, against the 28-30s / 41s it took on the builds quoted above. The set of failing cases in this container is identical before and after (see details); everything this PR touches passes on both builds.
- What is left (release): ~8s is the absolute-deadline test's two-tick deadline (the explicit `timeout` test runs inside it), ~2s the duplex RSS windows, ~0.8s the Response life cycle fixtures. The 8s is a floor set by uSockets' fixed 4s sweep; the two idle tests are written so they do not depend on the tick length, so a test-only override of the sweep period in bun-usockets (serve.test.ts and fetch-http2-client.test.ts pay the same floor) would be the next step and would let these two tests shed their ordering comments. Not attempted here.
- Not touched: the test rewritten by #37913, and none of the hunks here are adjacent to the insertion points of the other open PRs against this file (the seven currently mergeable ones still merge cleanly on top of this branch).

### Background
- Idle timeouts on the fetch client are uSockets socket timeouts. uSockets sweeps sockets every 4s (`LIBUS_TIMEOUT_GRANULARITY`), and `us_socket_timeout(s, seconds)` arms the socket for `ceil(seconds / 4)` sweeps, so a 1s timeout fires at the next sweep (0-4s later) and a 5s timeout at the second one (4-8s later). The sweep timer only runs while the HTTP thread's loop has sockets and starts when the first one is created, which is why the child in the explicit `timeout` test fires at almost exactly 4s, why the absolute-deadline test usually lands at 8s, and why that test needs a 2-sweep timeout at all: a 1-sweep timeout fires at the next sweep whether or not it was re-armed in between.
- `BUN_CONFIG_HTTP_IDLE_TIMEOUT` sets the default idle timeout (seconds) when the HTTP thread starts, which is why that test runs in a child process; `fetch(url, { timeout: ms })` overrides it per request.
- `it.concurrent` cases run together with the `it.concurrent` cases declared directly before and after them; a plain `it` in between is a barrier. That is why only the adjacent groups above were converted, and why the two idle tests had to both become concurrent to overlap.

<details>
<summary>Local failure set (unchanged by this PR)</summary>

In this container 25 cases fail identically before and after: `localhost` resolves to `::1` first here, so listeners bound to the name `localhost` are unreachable from the client (the situation #37442 addresses), and the `bad permissions throws` cases do not apply when running as root. Before this change the debug run additionally timed out in the 12 `utf16 ... (with gc)` cases, in the HTTPS cases that share their concurrent batch, and in the long redirect test; those all pass now.

Simulated regressions against the rewritten idle tests (release build; the debug build fails the same way). Explicit requests sent without a `timeout`:

```
-   "withInfinity": "hello",
-   "withTimeout": "hello",
-   "withZero": "hello",
+   "withInfinity": "TimeoutError: The operation timed out.",
+   "withTimeout": "TimeoutError: The operation timed out.",
+   "withZero": "TimeoutError: The operation timed out.",
(fail) an explicit numeric `timeout` extends the socket idle deadline past the default [4014.19ms]
```

`/b`'s body bytes withheld (what the client sees if body reads stop re-arming the timer); `/b` had already failed at the same sweep as `/h` (both at 8007ms in a standalone process, where the sweep starts with the first socket):

```
-     "body": "body bytes that trickle in one at a time",
-     "ok": true,
-     "status": 200,
+     "message": "The operation timed out.",
+     "name": "TimeoutError",
+     "ok": false,
(fail) the idle timer is an absolute deadline for the response header block (not re-armed by a byte drip) [8009.14ms]
```

Release per-case profile before: explicit `timeout` test 10.0s, absolute-deadline test 6.0s, `bounds memory when the upload target is slower` 2.0s, `suspends a type:'direct' body` 1.5s, `Bun.file` concurrent batch ~1.75s (dominated by its GC loops), `Response`/`Request`/`Blob` `utf16 ... (with gc)` cases 0.3-0.6s each (16 cases), `should not keep Response alive` 0.65s, `bounds memory when a handler forwards` 0.63s.
</details>
