### PR TITLE
test/bundler: make the itBundled duplicate-id check work and fix the 26 ids it finds

### DIFF
--- a/test/bundler/bundler_comments.test.ts
+++ b/test/bundler/bundler_comments.test.ts
@@ -175,12 +175,12 @@ describe("single-line comments", () => {
         stdout: "",
       },
     });
-    itBundled("only a comment", {
+    itBundled(`only a comment ${minify ? "with minification" : "without minification"}`, {
       files: {
         "/entry.js": `// This is a comment`,
       },
-      minifyWhitespace: true,
-      minifySyntax: true,
+      minifyWhitespace: minify,
+      minifySyntax: minify,
       run: {
         stdout: "",
       },

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1260,7 +1260,7 @@ describe("bundler", () => {
   });
   // chunk-concat forgets to de-duplicate source indicies
   // chunk-concat ignores all but the first instance of a chunk
-  itBundled("edgecase/EmitInvalidSourceMap2", {
+  itBundled("edgecase/EmitInvalidSourceMap3", {
     files: {
       "/entry.js": `
         const a = new TextEncoder();
@@ -3174,7 +3174,7 @@ describe("bundler", () => {
 
 for (const backend of ["api", "cli"] as const) {
   describe(`bundler_edgecase/${backend}`, () => {
-    itBundled("edgecase/ProcessEnvArbitrary", {
+    itBundled(`edgecase/${backend}/ProcessEnvArbitrary`, {
       files: {
         "/entry.js": /* js */ `
         capture(process.env.ARBITRARY);

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -27,7 +27,7 @@ for (let backend of ["api", "cli"] as const) {
         },
       });
 
-    itBundled("env/inline system", {
+    itBundled(`env/${backend}/inline system`, {
       env: {
         PATH: process.env.PATH,
       },
@@ -47,7 +47,7 @@ for (let backend of ["api", "cli"] as const) {
     });
 
     // Test disable mode - no env vars are inlined
-    itBundled("env/disable", {
+    itBundled(`env/${backend}/disable`, {
       env: {
         FOO: "bar",
         BAZ: "123",

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -4,9 +4,9 @@ import fs, { readdirSync } from "node:fs";
 import { join } from "path";
 import { itBundled } from "./expectBundled";
 
-describe("bundler", async () => {
+describe("bundler", () => {
   for (let target of ["bun", "node"] as const) {
-    describe(`${target} loader`, async () => {
+    describe(`${target} loader`, () => {
       itBundled(`${target}/loader-yaml-file`, {
         target,
         files: {
@@ -340,9 +340,10 @@ describe("bundler", async () => {
     },
   });
 
-  const moon = await Bun.file(
+  const moon = fs.readFileSync(
     fileURLToPath(import.meta.resolve("../js/bun/util/text-loader-fixture-text-file.backslashes.txt")),
-  ).text();
+    "utf8",
+  );
 
   // https://github.com/oven-sh/bun/issues/3449
   itBundled("bun/loader-text-file-#3449", {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -7,7 +7,7 @@ import { itBundled } from "./expectBundled";
 describe("bundler", async () => {
   for (let target of ["bun", "node"] as const) {
     describe(`${target} loader`, async () => {
-      itBundled("bun/loader-yaml-file", {
+      itBundled(`${target}/loader-yaml-file`, {
         target,
         files: {
           "/entry.ts": /* js */ `
@@ -18,7 +18,7 @@ describe("bundler", async () => {
         },
         run: { stdout: '{"hello":"world"}' },
       });
-      itBundled("bun/loader-text-file", {
+      itBundled(`${target}/loader-text-file`, {
         target,
         outfile: "",
         outdir: "/out",
@@ -32,7 +32,7 @@ describe("bundler", async () => {
         },
         run: { stdout: "Hello, world!" },
       });
-      itBundled("bun/loader-json-file", {
+      itBundled(`${target}/loader-json-file`, {
         target,
         files: {
           "/entry.ts": /* js */ `
@@ -43,7 +43,7 @@ describe("bundler", async () => {
         },
         run: { stdout: '{"hello":"world"}' },
       });
-      itBundled("bun/loader-toml-file", {
+      itBundled(`${target}/loader-toml-file`, {
         target,
         files: {
           "/entry.ts": /* js */ `
@@ -54,7 +54,7 @@ describe("bundler", async () => {
         },
         run: { stdout: '{"hello":"world"}' },
       });
-      itBundled("bun/loader-text-file", {
+      itBundled(`${target}/loader-text-file-with-json-extension`, {
         target,
         files: {
           "/entry.ts": /* js */ `
@@ -65,7 +65,7 @@ describe("bundler", async () => {
         },
         run: { stdout: '{"hello":"world"}' },
       });
-      itBundled("bun/loader-xml-file", {
+      itBundled(`${target}/loader-xml-file`, {
         target,
         files: {
           "/entry.ts": /* js */ `
@@ -84,7 +84,7 @@ describe("bundler", async () => {
     });
   }
 
-  itBundled("bun/loader-text-file", {
+  itBundled("bun/loader-text-file-with-backticks", {
     target: "bun",
     outfile: "",
     outdir: "/out",

--- a/test/bundler/css/wpt/color-computed-rgb.test.ts
+++ b/test/bundler/css/wpt/color-computed-rgb.test.ts
@@ -2,8 +2,8 @@ import { describe } from "bun:test";
 import { itBundled } from "../../expectBundled";
 
 const runTest = (testTitle: string, input: string, expected: string) => {
-  testTitle = testTitle.length === 0 ? input : testTitle;
-  itBundled(testTitle, {
+  // Several WPT cases share a title, so the input is what makes the id unique.
+  itBundled(testTitle.length === 0 ? input : `${input} (${testTitle})`, {
     files: {
       "/a.css": /* css */ `
 h1 {

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -786,24 +786,6 @@ describe("bundler", () => {
 });
 
 describe("esbuild-bundler", () => {
-  itBundled("css/CSSEntryPoint", {
-    // GENERATED
-    files: {
-      "/entry.css": /* css */ `
-        body {
-          background: white;
-          color: black }
-      `,
-    },
-  });
-  itBundled("css/CSSAtImportMissing", {
-    files: {
-      "/entry.css": `@import "./missing.css";`,
-    },
-    bundleErrors: {
-      "/entry.css": ['Could not resolve: "./missing.css"'],
-    },
-  });
   itBundled("css/CSSAtImportExternal", {
     external: ["./external1.css", "./external2.css", "./external3.css", "./external4.css", "./external5.css"],
     // GENERATED

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -486,7 +486,7 @@ describe("bundler", () => {
     },
     run: true,
   });
-  itBundled("extra/PrototypeChain2", {
+  itBundled("extra/PrototypeChain3", {
     files: {
       "in.js": `
         import * as star from './cjs-proto'
@@ -977,7 +977,7 @@ describe("bundler", () => {
           catch (e) { if (e === 'fail') throw e }
         `,
       });
-      add(22, {
+      add(23, {
         "in.js": `
           let x = 1;
           ({ set a(y) { x = y } }${access} = 2);

--- a/test/bundler/expectBundled.test.ts
+++ b/test/bundler/expectBundled.test.ts
@@ -1,26 +1,106 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import path from "node:path";
+import { bunEnv, bunExe, isCI } from "harness";
+import { itBundled } from "./expectBundled";
 
-// Each test writes a small bundler test file into a temp directory and runs `bun test` on it, so
-// what is asserted is what a contributor sees when a test file registers an itBundled() id twice.
+// itBundled registrations belong in files under test/bundler/, and the ones under test here must not
+// land in this file's own run, so this file doubles as its own fixture: spawned with
+// EXPECT_BUNDLED_TEST_CASE set it registers that case and nothing else, and the tests below spawn it
+// that way and assert on what the child printed.
+const CASE = "EXPECT_BUNDLED_TEST_CASE";
+const files = { "/entry.js": /* js */ `console.log("hi");` };
+// Each child loads expectBundled.ts, which alone takes a few seconds in a debug build. In CI the
+// runner's --timeout applies, as it does to the itBundled tests themselves.
+const childTimeout = isCI ? undefined : 30_000;
 
-const fixturePrelude = /* ts */ `
-  import { describe } from "bun:test";
-  import { itBundled } from ${JSON.stringify(path.join(import.meta.dir, "expectBundled.ts"))};
-  const files = { "/entry.js": 'console.log("hi");' };
-`;
+switch (process.env[CASE]) {
+  case "duplicate ids":
+    describe("copy+pasted in one describe block", () => {
+      itBundled("harness/CopyPasted", { files });
+      itBundled("harness/CopyPasted", { files });
+    });
+    for (const backend of ["api", "cli"] as const) {
+      describe(`registered once per ${backend}`, () => {
+        itBundled("harness/NotParameterized", { files, backend });
+      });
+    }
+    describe("registered through a helper", () => {
+      const add = (n: number) => itBundled(`harness/Case${n}`, { files });
+      add(1);
+      add(2);
+      add(2);
+    });
+    describe("itBundled.skip then itBundled", () => {
+      itBundled.skip("harness/Skipped", { files });
+      itBundled("harness/Skipped", { files });
+    });
+    describe("itBundled then itBundled.only", () => {
+      itBundled("harness/Focused", { files });
+      itBundled.only("harness/Focused", { files });
+    });
+    describe("on both sides of an await that does not need the event loop", async () => {
+      itBundled("harness/AroundAwait", { files });
+      await Promise.resolve();
+      itBundled("harness/AroundAwait", { files });
+    });
+    break;
 
-async function runFixture(body: string, ...args: string[]) {
-  using dir = tempDir("expect-bundled-ids", { "ids.test.ts": fixturePrelude + body });
+  case "unique ids":
+    describe("bundler", () => {
+      itBundled("harness/Unique", { files });
+      itBundled.skip("harness/UniqueSkipped", { files });
+      console.log("collected the ids");
+    });
+    break;
+
+  default:
+    describe("itBundled ids must be unique within a test file", () => {
+      test.concurrent(
+        "every id registered twice fails the file, however it was registered",
+        async () => {
+          // The errors are raised while the file is collected; nothing needs to run.
+          const { output, exitCode } = await runBunTest([import.meta.path, "-t", "^$"], { [CASE]: "duplicate ids" });
+          const reported = [...output.matchAll(/^error: itBundled\("(.*?)", \.\.\.\) was registered twice\./gm)].map(
+            m => m[1],
+          );
+          expect(reported).toEqual([
+            "harness/CopyPasted",
+            "harness/NotParameterized",
+            "harness/Case2",
+            "harness/Skipped",
+            "harness/Focused",
+            "harness/AroundAwait",
+          ]);
+          expect(exitCode).toBe(1);
+        },
+        childTimeout,
+      );
+
+      test.concurrent(
+        "--rerun-each registers the same ids again without tripping the check",
+        async () => {
+          const { output, exitCode } = await runBunTest([import.meta.path, "--rerun-each", "3"], {
+            [CASE]: "unique ids",
+          });
+          expect(output).not.toContain("was registered twice");
+          expect(output.match(/collected the ids/g)).toHaveLength(3);
+          expect(exitCode).toBe(0);
+        },
+        childTimeout,
+      );
+    });
+}
+
+async function runBunTest(args: string[], env: Record<string, string>) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "ids.test.ts", ...args],
-    cwd: String(dir),
+    cmd: [bunExe(), "test", ...args],
+    cwd: import.meta.dir,
     env: {
       ...bunEnv,
+      // A developer's shell may carry these; they would change what the child registers.
       BUN_BUNDLER_TEST_FILTER: undefined,
       BUN_BUNDLER_TEST_USE_ESBUILD: undefined,
       BUN_BUNDLER_TEST_DEBUG: undefined,
+      ...env,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -28,82 +108,3 @@ async function runFixture(body: string, ...args: string[]) {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { output: stdout + stderr, exitCode };
 }
-
-const registeredTwice = (id: string) => `itBundled("${id}", ...) was registered twice`;
-
-describe("itBundled ids must be unique within a test file", () => {
-  test.concurrent("the same id twice in one describe block fails the file", async () => {
-    const { output, exitCode } = await runFixture(/* ts */ `
-      describe("bundler", () => {
-        itBundled("harness/CopyPasted", { files });
-        itBundled("harness/CopyPasted", { files });
-      });
-    `);
-    expect(output).toContain(registeredTwice("harness/CopyPasted"));
-    expect(exitCode).toBe(1);
-  });
-
-  test.concurrent("the same id from two describe blocks fails the file", async () => {
-    const { output, exitCode } = await runFixture(/* ts */ `
-      for (const backend of ["api", "cli"] as const) {
-        describe(\`bundler/\${backend}\`, () => {
-          itBundled("harness/NotParameterized", { files, backend });
-        });
-      }
-    `);
-    expect(output).toContain(registeredTwice("harness/NotParameterized"));
-    expect(exitCode).toBe(1);
-  });
-
-  test.concurrent("the same id registered through a helper fails the file", async () => {
-    const { output, exitCode } = await runFixture(/* ts */ `
-      const add = (n: number) => itBundled(\`harness/Case\${n}\`, { files });
-      describe("bundler", () => {
-        add(1);
-        add(2);
-        add(2);
-      });
-    `);
-    expect(output).toContain(registeredTwice("harness/Case2"));
-    expect(exitCode).toBe(1);
-  });
-
-  test.concurrent("itBundled.skip takes part in the check", async () => {
-    const { output, exitCode } = await runFixture(/* ts */ `
-      describe("bundler", () => {
-        itBundled.skip("harness/Skipped", { files });
-        itBundled("harness/Skipped", { files });
-      });
-    `);
-    expect(output).toContain(registeredTwice("harness/Skipped"));
-    expect(exitCode).toBe(1);
-  });
-
-  test.concurrent("itBundled.only takes part in the check", async () => {
-    const { output, exitCode } = await runFixture(/* ts */ `
-      describe("bundler", () => {
-        itBundled("harness/Focused", { files });
-        itBundled.only("harness/Focused", { files });
-      });
-    `);
-    expect(output).toContain(registeredTwice("harness/Focused"));
-    expect(exitCode).toBe(1);
-  });
-
-  test.concurrent("--rerun-each re-registers the same ids without tripping the check", async () => {
-    const { output, exitCode } = await runFixture(
-      /* ts */ `
-        describe("bundler", () => {
-          itBundled("harness/First", { files });
-          itBundled.skip("harness/Second", { files });
-          console.log("collected ids");
-        });
-      `,
-      "--rerun-each",
-      "3",
-    );
-    expect(output).not.toContain("was registered twice");
-    expect(output.split("collected ids").length - 1).toBe(3);
-    expect(exitCode).toBe(0);
-  });
-});

--- a/test/bundler/expectBundled.test.ts
+++ b/test/bundler/expectBundled.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+// Each test writes a small bundler test file into a temp directory and runs `bun test` on it, so
+// what is asserted is what a contributor sees when a test file registers an itBundled() id twice.
+
+const fixturePrelude = /* ts */ `
+  import { describe } from "bun:test";
+  import { itBundled } from ${JSON.stringify(path.join(import.meta.dir, "expectBundled.ts"))};
+  const files = { "/entry.js": 'console.log("hi");' };
+`;
+
+async function runFixture(body: string, ...args: string[]) {
+  using dir = tempDir("expect-bundled-ids", { "ids.test.ts": fixturePrelude + body });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "ids.test.ts", ...args],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_BUNDLER_TEST_FILTER: undefined,
+      BUN_BUNDLER_TEST_USE_ESBUILD: undefined,
+      BUN_BUNDLER_TEST_DEBUG: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { output: stdout + stderr, exitCode };
+}
+
+const registeredTwice = (id: string) => `itBundled("${id}", ...) was registered twice`;
+
+describe("itBundled ids must be unique within a test file", () => {
+  test.concurrent("the same id twice in one describe block fails the file", async () => {
+    const { output, exitCode } = await runFixture(/* ts */ `
+      describe("bundler", () => {
+        itBundled("harness/CopyPasted", { files });
+        itBundled("harness/CopyPasted", { files });
+      });
+    `);
+    expect(output).toContain(registeredTwice("harness/CopyPasted"));
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("the same id from two describe blocks fails the file", async () => {
+    const { output, exitCode } = await runFixture(/* ts */ `
+      for (const backend of ["api", "cli"] as const) {
+        describe(\`bundler/\${backend}\`, () => {
+          itBundled("harness/NotParameterized", { files, backend });
+        });
+      }
+    `);
+    expect(output).toContain(registeredTwice("harness/NotParameterized"));
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("the same id registered through a helper fails the file", async () => {
+    const { output, exitCode } = await runFixture(/* ts */ `
+      const add = (n: number) => itBundled(\`harness/Case\${n}\`, { files });
+      describe("bundler", () => {
+        add(1);
+        add(2);
+        add(2);
+      });
+    `);
+    expect(output).toContain(registeredTwice("harness/Case2"));
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("itBundled.skip takes part in the check", async () => {
+    const { output, exitCode } = await runFixture(/* ts */ `
+      describe("bundler", () => {
+        itBundled.skip("harness/Skipped", { files });
+        itBundled("harness/Skipped", { files });
+      });
+    `);
+    expect(output).toContain(registeredTwice("harness/Skipped"));
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("itBundled.only takes part in the check", async () => {
+    const { output, exitCode } = await runFixture(/* ts */ `
+      describe("bundler", () => {
+        itBundled("harness/Focused", { files });
+        itBundled.only("harness/Focused", { files });
+      });
+    `);
+    expect(output).toContain(registeredTwice("harness/Focused"));
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("--rerun-each re-registers the same ids without tripping the check", async () => {
+    const { output, exitCode } = await runFixture(
+      /* ts */ `
+        describe("bundler", () => {
+          itBundled("harness/First", { files });
+          itBundled.skip("harness/Second", { files });
+          console.log("collected ids");
+        });
+      `,
+      "--rerun-each",
+      "3",
+    );
+    expect(output).not.toContain("was registered twice");
+    expect(output.split("collected ids").length - 1).toBe(3);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -151,7 +151,30 @@ const tempDirectoryTemplate = path.join(realpathSync(tmpdir()), "bun-build-tests
 if (!existsSync(path.dirname(tempDirectoryTemplate)))
   mkdirSync(path.dirname(tempDirectoryTemplate), { recursive: true });
 const tempDirectory = mkdtempSync(tempDirectoryTemplate);
-const testsRan = new Set();
+
+/**
+ * Ids registered while the current test file is being collected. An id names the test and is also
+ * its directory under `tempDirectory`, so one registered twice is a copy+paste mistake.
+ *
+ * Scoped to one collection pass rather than to the process: this module stays loaded across test
+ * files and across `bun test --rerun-each` re-evaluating a file. bun collects a file's describe
+ * callbacks without returning to the event loop and evaluates the next file (or the same one again)
+ * only after it has, so the setImmediate clears the set between passes.
+ */
+let registeredIds: Set<string> | undefined;
+
+function registerTestId(id: string) {
+  if (!registeredIds) {
+    registeredIds = new Set();
+    setImmediate(() => {
+      registeredIds = undefined;
+    });
+  }
+  if (registeredIds.has(id)) {
+    throw new Error(`itBundled("${id}", ...) was registered twice. Check your tests for bad copy+pasting.`);
+  }
+  registeredIds.add(id);
+}
 
 const originalCwd = process.cwd();
 
@@ -563,11 +586,6 @@ function expectBundled(
   // TODO: Remove this check once all options have been implemented
   if (Object.keys(unknownProps).length > 0) {
     throw new Error("expectBundled received unexpected options: " + Object.keys(unknownProps).join(", "));
-  }
-
-  // This is a sanity check that protects against bad copy pasting.
-  if (testsRan.has(id)) {
-    throw new Error(`expectBundled("${id}", ...) was called twice. Check your tests for bad copy+pasting.`);
   }
 
   // Resolve defaults for options and some related things
@@ -1883,6 +1901,7 @@ export function itBundled(
   id: string,
   opts: BundlerTestInput | ((metadata: BundlerTestWrappedAPI) => BundlerTestInput),
 ): BundlerTestRef {
+  registerTestId(id);
   if (typeof opts === "function") {
     const fn = opts;
     opts = opts({ root: path.join(tempDirectory, id), getConfigRef });
@@ -1920,6 +1939,7 @@ export function itBundled(
 }
 
 itBundled.only = (id: string, opts: BundlerTestInput) => {
+  registerTestId(id);
   const { it } = testForFile(currentFile ?? callerSourceOrigin());
 
   it.only(
@@ -1931,6 +1951,7 @@ itBundled.only = (id: string, opts: BundlerTestInput) => {
 };
 
 itBundled.skip = (id: string, opts: BundlerTestInput) => {
+  registerTestId(id);
   if (FILTER && !filterMatches(id)) {
     return testRef(id, opts);
   }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -156,10 +156,12 @@ const tempDirectory = mkdtempSync(tempDirectoryTemplate);
  * Ids registered while the current test file is being collected. An id names the test and is also
  * its directory under `tempDirectory`, so one registered twice is a copy+paste mistake.
  *
- * Scoped to one collection pass rather than to the process: this module stays loaded across test
- * files and across `bun test --rerun-each` re-evaluating a file. bun collects a file's describe
- * callbacks without returning to the event loop and evaluates the next file (or the same one again)
- * only after it has, so the setImmediate clears the set between passes.
+ * Cleared by a setImmediate rather than kept for the process: this module stays loaded across test
+ * files and across the re-evaluations `bun test --rerun-each` does, and the runner runs immediates
+ * after each file before evaluating the next one (or the same one again), so every file starts
+ * with an empty set. A file's synchronous describe callbacks (all of them, in test/bundler) are
+ * collected before the immediate fires. A describe callback that awaits the event loop lets it fire
+ * mid-file, and ids registered after that await are only compared with each other.
  */
 let registeredIds: Set<string> | undefined;
 


### PR DESCRIPTION
### Problem
- `expectBundled()` throws `expectBundled("<id>", ...) was called twice. Check your tests for bad copy+pasting.` when `testsRan.has(id)`, but nothing ever adds to `testsRan` (test/bundler/expectBundled.ts:154 and :569 on main). The check has been dead since the set was introduced in #2312.
- An id names the test and is also the directory the test bundles into (`expectBundled.ts:648`, `path.join(tempDirectory, id)`), so two tests with one id share a name and a working directory.
- With the check made live, `bun test test/bundler` finds 26 ids registered more than once, in 7 files (full list below). `edgecase/EmitInvalidSourceMap2` is registered twice in bundler_edgecase.test.ts; the second one (added in #11509) tests something different and was meant to be a new name.

### Fix
- `registerTestId(id)` is called at the top of `itBundled()`, `itBundled.only` and `itBundled.skip`, and the dead check and `testsRan` are removed from `expectBundled()`. A duplicate throws out of the `describe` callback that registered it, so the file fails with the id and the line of the second registration; it does not go through the dry run in `itBundled`, whose `try/catch` would otherwise swallow it and silently drop the test.
- The set is created by the first registration and cleared by a `setImmediate`. It cannot live for the process: `bun test --rerun-each N` re-evaluates the test file while `expectBundled.ts` stays cached (test_command.rs deletes only the test file's own registry entry), so a process-wide set would report every id on the second run. The runner runs immediates after each file, before it evaluates the next one or the same one again (`test_command.rs`, the `tick_immediate_tasks` call after the file's run loop), so every pass starts empty: no false positives by construction. Within a pass, all of a file's synchronous describe callbacks (nested and loop-generated ones included) are collected before the immediate fires, which is every itBundled file after this PR. Verified against the runner for plain runs, `--rerun-each`, `-t` matching nothing, files whose tests are all todo/skip, files registering no tests, several files in one process, and `--parallel`.
- The check runs before the `BUN_BUNDLER_TEST_FILTER` early return so a duplicate fails the file the same way whether or not a filter is set.
- Scope of the check, stated in the comment on the set: a describe callback that awaits something needing the event loop (a file read, a timer) can let the immediate fire mid-file, and whether a duplicate across that await is reported then depends on whether the await completes before the immediate phase, so it is best effort; an await that only needs microtasks is fine. `bundler_loader.test.ts` was the only itBundled file with such an await (it read a fixture with `await Bun.file().text()` between registrations); it now reads it with `readFileSync`, like the wasm fixture a few lines above, and its describe callbacks are no longer `async`, so no file in the suite has this shape.
- The 26 existing duplicates are fixed so the suite still loads:
  - `bundler_edgecase.test.ts`: second `edgecase/EmitInvalidSourceMap2` becomes `EmitInvalidSourceMap3`; `edgecase/ProcessEnvArbitrary`, registered once per backend, becomes `edgecase/${backend}/ProcessEnvArbitrary`.
  - `bundler_env.test.ts`: `env/inline system` and `env/disable` are registered once per backend; the backend is added to the id.
  - `bundler_loader.test.ts`: the six tests registered once per target used a fixed `bun/` prefix; they now use `${target}/` (as `${target}/loader-empty-text-file` further down already does). `bun/loader-text-file` was additionally used by three different tests; the other two become `loader-text-file-with-json-extension` and `loader-text-file-with-backticks`. The fixture read is made synchronous (previous bullet).
  - `bundler_comments.test.ts`: `only a comment` sits in the `for (const minify ...)` loop next to three tests that put the variant in their name and use `minify`, but hardcoded `true` and a fixed name, so it registered the same test twice. It now follows its siblings; both variants pass.
  - `esbuild/extra.test.ts`: the third `PrototypeChain` test was named `PrototypeChain2`; the last `add(22, ...)` is `add(23, ...)`. The `add` helper makes this the case where both registrations come from the same `itBundled` call site.
  - `esbuild/css.test.ts`: the `esbuild-bundler` block's `css/CSSEntryPoint` and `css/CSSAtImportMissing` are the un-asserted esbuild ports that the `bundler` block above re-implements with the same input and assertions added (the block was `describe.todo` until #16486). They are deleted; the byte-identical `CSSAtImportMissing` and the assertion-free `CSSEntryPoint` add nothing over the ones that stay.
  - `css/wpt/color-computed-rgb.test.ts`: `runTest` used the WPT title as the id, and titles such as "Capitalization should not affect parsing" are shared by up to ten cases (nine titles, 41 registrations). The id is now the input, with the title appended, which is how the sibling wpt files already key their tests.
- No snapshot file references any of the renamed tests, and nothing outside test/bundler does.
- #38499 (location check) adds its own one-line call at the top of the same three functions and also creates `test/bundler/expectBundled.test.ts`; whichever lands second rebases by adding its line next to the other's and its `describe` into the same file. The self-test here is already shaped so that #38499's check accepts it.
- Verification:
  - `test/bundler/expectBundled.test.ts` (new). The cases have to be registered from a file under `test/bundler/` (#38499 makes the harness enforce that), so the file is its own fixture: spawned with `EXPECT_BUNDLED_TEST_CASE="duplicate ids"` it registers six describe blocks, one per shape (copy+paste in one block, one block per backend in a loop, through a helper, `.skip` then `itBundled`, `itBundled` then `.only`, and on both sides of a microtask await in an async describe), and the parent asserts the child reports exactly those six ids, in order, and exits 1. Spawned with `"unique ids"` under `--rerun-each 3` it must collect three times, report nothing and exit 0. With main's `expectBundled.ts` in place the first test fails (the child reports no ids and exits 0) and the second still passes; with this branch both pass.
  - `bun bd test` on the seven edited files: all pass (bundler_edgecase 134 pass / 13 todo, the rest 0 fail); bundler_comments and bundler_env also pass under `--rerun-each 2`.
  - `bun test test/bundler -t __nomatch__` (registration only) before the renames fails exactly the seven files listed above with the new error; after them it loads every file with no error.

### Background
- `itBundled(id, opts)` is the bundler test helper: at collection time it dry-runs `expectBundled` to validate the options, then registers `it(id, () => expectBundled(id, opts))`. `expectBundled` writes `opts.files` under `$TMPDIR/bun-build-tests/<run>/<id>`, bundles them, and checks the output. Errors thrown by the dry run are swallowed and the test is skipped silently, which is why the duplicate check has to live outside it.
- Collection pass: `bun test` evaluates a test file, then invokes its describe callbacks, which is when `it()`/`itBundled()` calls register tests; the tests run afterwards. `--rerun-each N` repeats evaluation, collection and execution N times in the same process, re-importing only the test file itself; modules it imports, such as `expectBundled.ts`, keep their module-level state.
- `setImmediate` callbacks run on the event loop's immediate phase, i.e. only once the runner has returned to the loop. Synchronous describe callbacks are all invoked before that happens; an `async` describe callback that awaits the loop hands control back to it, and bun resumes collection from an enqueued task afterwards.

<details>
<summary>The 26 duplicated ids found by the live check (before this change)</summary>

```
bundler_comments.test.ts        only a comment                              x2 (loop, id not parameterized)
bundler_edgecase.test.ts        edgecase/EmitInvalidSourceMap2              x2
bundler_edgecase.test.ts        edgecase/ProcessEnvArbitrary                x2 (one describe per backend)
bundler_env.test.ts             env/inline system, env/disable              x2 each (one describe per backend)
bundler_loader.test.ts          bun/loader-{yaml,json,toml,xml}-file        x2 each (one describe per target)
bundler_loader.test.ts          bun/loader-text-file                        x5 (3 call sites, 2 of them per target)
esbuild/css.test.ts             css/CSSEntryPoint, css/CSSAtImportMissing   x2 each
esbuild/extra.test.ts           extra/PrototypeChain2                       x2
esbuild/extra.test.ts           extra/{Minify,}{Dot,Bracket}Access22        x2 each (add(22) twice)
css/wpt/color-computed-rgb.test.ts   9 WPT titles, 41 registrations in total
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->