### PR TITLE
Index console.table columns by name once a row gets wide

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -10,7 +10,7 @@ use core::ffi::c_void;
 use crate as jsc;
 use crate::virtual_machine::VirtualMachine;
 use crate::{EventType, JSGlobalObject, JSPromise, JSValue, JsResult};
-use bun_collections::HashMap;
+use bun_collections::{HashContext, HashMap};
 use bun_core::{EncodedSlice, String as BunString, strings};
 use bun_core::{Output, StackCheck};
 
@@ -587,6 +587,87 @@ struct Column {
     width: u32,
 }
 
+/// Hashes the way [`BunString::eql`] compares: by text, whatever the encoding.
+struct ColumnNameContext;
+
+impl HashContext<BunString> for ColumnNameContext {
+    fn ctx_hash(name: &BunString) -> u64 {
+        if !name.is_utf16() {
+            return bun_wyhash::hash(name.byte_slice());
+        }
+        let utf16 = name.utf16();
+        match utf16
+            .iter()
+            .map(|&unit| u8::try_from(unit).ok())
+            .collect::<Option<Vec<u8>>>()
+        {
+            Some(latin1) => bun_wyhash::hash(&latin1),
+            // A unit above 0xFF rules out equality with any 8-bit name.
+            None => bun_wyhash::hash(bytemuck::cast_slice(utf16)),
+        }
+    }
+
+    fn ctx_eql(a: &BunString, b: &BunString) -> bool {
+        a.eql(b)
+    }
+}
+
+/// Scanning this many names costs about as much as one hash lookup.
+const MAX_SCANNED_COLUMNS: usize = 8;
+
+/// The columns in print order, plus an index by name once a row gets wide.
+struct Columns {
+    list: Vec<Column>,
+    /// Built past [`MAX_SCANNED_COLUMNS`] columns.
+    by_name: Option<HashMap<BunString, usize, ColumnNameContext>>,
+}
+
+impl Columns {
+    /// Tables that look names up have only the index column before these.
+    const FIRST_PROPERTY_COLUMN: usize = 1;
+
+    /// Per cell; `create` is per column and stays out of line so this inlines.
+    #[inline]
+    fn find_or_create(&mut self, name: &BunString) -> usize {
+        let found = match &self.by_name {
+            None => self.list[Self::FIRST_PROPERTY_COLUMN..]
+                .iter()
+                .position(|col| col.name.eql(name))
+                .map(|i| Self::FIRST_PROPERTY_COLUMN + i),
+            Some(by_name) => by_name.get(name).copied(),
+        };
+        found.unwrap_or_else(|| self.create(name))
+    }
+
+    #[inline(never)]
+    fn create(&mut self, name: &BunString) -> usize {
+        let index = self.list.len();
+        self.list.push(Column {
+            name: name.clone(),
+            width: 1,
+        });
+        if let Some(by_name) = &mut self.by_name {
+            by_name
+                .put_no_clobber(name.clone(), index)
+                .expect("unreachable");
+        } else if self.list.len() - Self::FIRST_PROPERTY_COLUMN > MAX_SCANNED_COLUMNS {
+            let mut by_name = HashMap::default();
+            for (i, col) in self
+                .list
+                .iter()
+                .enumerate()
+                .skip(Self::FIRST_PROPERTY_COLUMN)
+            {
+                by_name
+                    .put_no_clobber(col.name.clone(), i)
+                    .expect("unreachable");
+            }
+            self.by_name = Some(by_name);
+        }
+        index
+    }
+}
+
 enum RowKey {
     /// Property-name UTF-8 bytes + visible width (plain-object tabular data).
     Str {
@@ -706,11 +787,11 @@ impl<'a> TablePrinter<'a> {
     fn collect_row<const ENABLE_ANSI_COLORS: bool>(
         &mut self,
         cell_text: &mut Vec<u8>,
-        columns: &mut Vec<Column>,
+        columns: &mut Columns,
         row_key: RowKey,
         row_value: JSValue,
     ) -> JsResult<CollectedRow> {
-        columns[0].width = columns[0].width.max(row_key.width());
+        columns.list[0].width = columns.list[0].width.max(row_key.width());
 
         let mut row = CollectedRow {
             key: row_key,
@@ -728,7 +809,7 @@ impl<'a> TablePrinter<'a> {
                 cell_text,
                 row_value.get_index(self.global_object, 1)?,
             )?;
-            columns[1].width = columns[1].width.max(key_cell.width);
+            columns.list[1].width = columns.list[1].width.max(key_cell.width);
             self.values_col_width = Some(self.values_col_width.unwrap_or(0).max(value_cell.width));
             row.cells.push(Some(key_cell));
             row.values_cell = Some(value_cell);
@@ -742,7 +823,7 @@ impl<'a> TablePrinter<'a> {
             //  - otherwise: iterate the object properties, and create the
             //    columns on-demand
             if !self.properties.is_undefined() {
-                for column in columns[1..].iter_mut() {
+                for column in columns.list[1..].iter_mut() {
                     if let Some(value) = row_value.get_own(self.global_object, &column.name)? {
                         let cell = self.format_cell::<ENABLE_ANSI_COLORS>(cell_text, value)?;
                         column.width = column.width.max(cell.width);
@@ -762,24 +843,11 @@ impl<'a> TablePrinter<'a> {
                 )?;
 
                 while let Some((col_key, value)) = cols_iter.next()? {
-                    // find or create the column for the property
-                    let col_idx: usize = 'brk: {
-                        // reshaped for borrowck — split find/append.
-                        if let Some(idx) =
-                            columns[1..].iter().position(|col| col.name.eql(&col_key))
-                        {
-                            break 'brk 1 + idx;
-                        }
-
-                        columns.push(Column {
-                            name: (*col_key).clone(),
-                            width: 1,
-                        });
-                        break 'brk columns.len() - 1;
-                    };
+                    let col_idx = columns.find_or_create(&col_key);
 
                     let cell = self.format_cell::<ENABLE_ANSI_COLORS>(cell_text, value)?;
-                    columns[col_idx].width = columns[col_idx].width.max(cell.width);
+                    let column = &mut columns.list[col_idx];
+                    column.width = column.width.max(cell.width);
                     let slot = col_idx - 1;
                     if row.cells.len() <= slot {
                         row.cells.resize(slot + 1, None);
@@ -866,17 +934,20 @@ impl<'a> TablePrinter<'a> {
     ) -> JsResult<()> {
         let global_object = self.global_object;
 
-        let mut columns: Vec<Column> = Vec::with_capacity(16);
+        let mut columns = Columns {
+            list: Vec::with_capacity(16),
+            by_name: None,
+        };
 
         // create the first column " " which is always present
-        columns.push(Column {
+        columns.list.push(Column {
             name: BunString::static_("\u{0020}"),
             width: 1,
         });
 
         // special case for Map: create the special "Key" column at index 1
         if self.jstype.is_map() {
-            columns.push(Column {
+            columns.list.push(Column {
                 name: BunString::static_("Key"),
                 width: 1,
             });
@@ -886,7 +957,7 @@ impl<'a> TablePrinter<'a> {
         if !self.properties.is_undefined() {
             let mut properties_iter = jsc::JSArrayIterator::init(self.properties, global_object)?;
             while let Some(value) = properties_iter.next()? {
-                columns.push(Column {
+                columns.list.push(Column {
                     name: value.to_bun_string(global_object)?,
                     width: 1,
                 });
@@ -903,7 +974,7 @@ impl<'a> TablePrinter<'a> {
                 struct Ctx<'c, 'a> {
                     this: &'c mut TablePrinter<'a>,
                     cell_text: &'c mut Vec<u8>,
-                    columns: &'c mut Vec<Column>,
+                    columns: &'c mut Columns,
                     rows: &'c mut Vec<CollectedRow>,
                     idx: u32,
                     err: Option<jsc::JsError>,
@@ -975,6 +1046,9 @@ impl<'a> TablePrinter<'a> {
             }
         }
 
+        // No more lookups by name; the remaining passes only need the print order.
+        let columns = &mut columns.list;
+
         // append the special "Values" column as the last one, if it is present
         if let Some(width) = self.values_col_width {
             self.values_col_idx = columns.len();
@@ -1041,7 +1115,7 @@ impl<'a> TablePrinter<'a> {
 
         // render pass: replay each row's pre-formatted cell bytes
         for row in rows.iter() {
-            self.print_row(writer, &columns, row, &cell_text);
+            self.print_row(writer, columns, row, &cell_text);
         }
 
         // print the table bottom border

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 
 // `console.table` and `Bun.inspect.table` share the same native TablePrinter,
 // so we can render in-process instead of spawning a subprocess per case.
@@ -361,5 +361,142 @@ console.log("calls=" + calls);`,
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: box("1") + "calls=1\n", stderr: "", exitCode: 0 });
+  });
+});
+
+// A cell's column is found by name: by scanning the column list while it is
+// short, and through a name index once a row has more properties than that
+// (MAX_SCANNED_COLUMNS in ConsoleObject.rs). Both have to agree on which names
+// are the same column, and neither may hand out the index or Values column.
+describe("console.table column lookup", () => {
+  // Two rows with the same 7-character keys, each cell holding its own key, so
+  // the header and both rows render as the same line of 7-wide cells and the
+  // whole table can be spelled out. The second row lists the keys in the
+  // opposite order: each of its cells has to be found in the column the first
+  // row created, not in the column at the same position.
+  function wideTable(columns: number) {
+    const keys = Array.from({ length: columns }, (_, i) => "c" + (100000 + i));
+    const first: Record<string, string> = {};
+    for (const key of keys) first[key] = key;
+    const second: Record<string, string> = {};
+    for (let i = keys.length - 1; i >= 0; i--) second[keys[i]] = keys[i];
+
+    const rule = (left: string, mid: string, right: string) =>
+      left + "───" + (mid + "─────────").repeat(columns) + right + "\n";
+    const body = "│ " + keys.join(" │ ") + " │\n";
+    const expected =
+      rule("┌", "┬", "┐") + "│   " + body + rule("├", "┼", "┤") + "│ 0 " + body + "│ 1 " + body + rule("└", "┴", "┘");
+    return { rows: [first, second], expected };
+  }
+
+  test("cells land in the column their name was first seen in", () => {
+    const { rows, expected } = wideTable(300);
+    expect(Bun.inspect.table(rows)).toBe(expected);
+  });
+
+  test("rendering is linear in the number of columns", () => {
+    // When every cell scanned the columns created so far, these sizes took
+    // ~25 s in a release build and ~22 s in a debug build. Indexed they take
+    // ~80 ms and ~0.4 s, so the budget has over 10x of headroom either way.
+    const columns = isDebug ? 10_000 : 64_000;
+    const budgetMs = 5_000;
+    const { rows, expected } = wideTable(columns);
+
+    const start = performance.now();
+    const out = Bun.inspect.table(rows);
+    const elapsed = performance.now() - start;
+
+    // toBe(expected) would print megabytes on a mismatch; the 300-column test
+    // above is the one that gives a readable diff.
+    expect({ matches: out === expected, length: out.length }).toEqual({ matches: true, length: expected.length });
+    expect(elapsed).toBeLessThan(budgetMs);
+  });
+
+  // The column names and the cells of each row, trimmed, without the row-index
+  // column.
+  function shape(table: string) {
+    const cellsOf = (line: string) =>
+      line
+        .split("│")
+        .slice(2, -1)
+        .map(cell => cell.trim());
+    const [, header, , ...lines] = table.split("\n");
+    return { columns: cellsOf(header), cells: lines.slice(0, -2).map(cellsOf) };
+  }
+
+  // Enough columns to leave the scan behind; keep it above MAX_SCANNED_COLUMNS.
+  const fillerNames = Array.from({ length: 10 }, (_, i) => "f" + i);
+  const filler = Object.fromEntries(fillerNames.map(name => [name, 0]));
+
+  // `rows` on their own are narrow enough to be scanned; behind a row of
+  // filler columns, every one of their names goes through the index.
+  function expectColumns(rows: unknown[], columns: string[], cells: string[][]) {
+    expect(shape(Bun.inspect.table(rows))).toEqual({ columns, cells });
+
+    const blank = (names: unknown[]) => names.map(() => "");
+    expect(shape(Bun.inspect.table([filler, ...rows]))).toEqual({
+      columns: [...fillerNames, ...columns],
+      cells: [[...fillerNames.map(() => "0"), ...blank(columns)], ...cells.map(row => [...blank(fillerNames), ...row])],
+    });
+  }
+
+  test("a name stored as Latin-1 by one row and as UTF-16 by another is one column", () => {
+    // String keys are atomized, so equal text shares one storage; a symbol's
+    // description keeps the storage of the string it was made from, and a
+    // slice of a 16-bit string keeps sharing its 16-bit storage once it is
+    // longer than the few characters WTF would rather copy.
+    const name = "crème brûlée, à la carte";
+    const wide = Array.from(name + "\u65e5")
+      .join("")
+      .slice(0, name.length);
+    expect(wide).toBe(name);
+    expectColumns([{ [Symbol(name)]: 1 }, { [Symbol(wide)]: 2 }], [name], [["1"], ["2"]]);
+    expectColumns([{ [Symbol(wide)]: 1 }, { [Symbol(name)]: 2 }], [name], [["1"], ["2"]]);
+  });
+
+  test("names with non-ASCII characters are matched across rows", () => {
+    // 日本 is stored as UTF-16, é as Latin-1.
+    expectColumns(
+      [
+        { 日本: 1, é: 2 },
+        { é: 3, 日本: 4 },
+      ],
+      ["日本", "é"],
+      [
+        ["1", "2"],
+        ["4", "3"],
+      ],
+    );
+  });
+
+  test("the empty name is a column like any other", () => {
+    expectColumns(
+      [
+        { "": 1, "a": 2 },
+        { "a": 3, "": 4 },
+      ],
+      ["", "a"],
+      [
+        ["1", "2"],
+        ["4", "3"],
+      ],
+    );
+  });
+
+  test("a property named like the index column gets its own column", () => {
+    // The name " " trims to "" here; the point is the extra column.
+    expectColumns([{ " ": 1 }, { " ": 2 }], [""], [["1"], ["2"]]);
+  });
+
+  test("a property named Values is separate from the Values column", () => {
+    expectColumns(
+      [{ Values: 1 }, 2, { Values: 3 }],
+      ["Values", "Values"],
+      [
+        ["1", ""],
+        ["", "2"],
+        ["3", ""],
+      ],
+    );
   });
 });


### PR DESCRIPTION
### Problem
- `console.table` and `Bun.inspect.table` are quadratic in the number of columns: one row with 40k keys takes ~4 s here (5.7 s in the report), 1000x1000 takes ~3 s. Node prints the same tables in 92 ms and 0.87 s; Bun's own JS `new Console(stream).table` is also linear.
- Cause: `TablePrinter::collect_row` (`src/jsc/ConsoleObject.rs`) resolved every property of every row with `columns[1..].iter().position(|col| col.name.eql(..))`, a scan of every column created so far, so a row with N keys costs N^2/2 string comparisons. Output was correct; only the time was wrong.

### Fix
- The column list is wrapped in a `Columns` struct whose `find_or_create` keeps scanning while there are at most 8 property columns (`MAX_SCANNED_COLUMNS`, the shape of almost every table, so that path does the same work as before) and switches to a name -> index `bun_collections::HashMap` once a row grows past that. The map is built from the existing columns at the crossover and kept in sync by `create`.
- The map's context (`ColumnNameContext`) hashes names by content the same way the existing `BunString::eql` compares them: 8-bit names hash their bytes, UTF-16 names whose units all fit in Latin-1 hash as those bytes, and only names with a unit above 0xFF hash their UTF-16 bytes. Equality is still `eql`, so both lookup strategies agree on which names share a column. Each key is a clone of the column's name (one more ref on the same `WTF::StringImpl`), so the list and the map each release their own refs when they drop.
- The index column, Map's "Key" column, the trailing "Values" column and `properties`-argument columns were never looked up by name (the scan started at 1 and the `properties` branch iterates columns directly); they stay out of the map.
- Release build of this tree, with and without the change (`Bun.inspect.table`, best of 3): 1 row x 5k cols 68 ms -> 2.8 ms, 10k 281 ms -> 5.7 ms, 20k 0.97 s -> 16 ms, 40k 4.14 s -> 33 ms (doubling the columns now doubles the time), 200 rows x 2000 cols 2.03 s -> 96 ms, 1000x1000 2.98 s -> 0.24 s, 10k rows x 50 cols 165 ms -> 110 ms. Full table, including UTF-16 and 64-character names and the untouched `properties` path, in the details below.
- Narrow tables (1 to 8 columns, the scan path) measure 0 to 8% apart, in either direction depending on the run, on a shared host whose unchanged binary itself moves 5 to 15% between runs. The disassembly of `collect_row` is the same scan loop as before (one out-of-line `String::eql` per compared column) plus one check of whether the map exists, and the functions on the per-cell path (`format_cell`, `String::eql`, `JSPropertyIterator::next`, even the C++ `getNameAndValue`) land at different addresses and cache-line offsets in the two binaries, so I attribute the remaining spread to layout rather than to the lookup.
- Tests, in `test/js/bun/console/console-table.test.ts` (`console.table column lookup`): a 2-row table whose second row lists the keys in reverse order, rendered exactly at 300 columns and under a 5 s budget at 64k columns (10k in debug builds). Without the fix those sizes take ~25 s release / ~22 s debug+ASAN (the budget test fails with `Received: 22248`); with it ~80 ms / ~0.4 s. The remaining cases pin the semantics both strategies must share, each run once narrow (scanned) and once behind a row of 10 filler columns (indexed): a name stored as Latin-1 by one row and as UTF-16 by another is one column (symbol keys are the only way to get that today, since string keys are atomized; #34241 proposes dropping symbol columns, which would make that case unreachable and retire that test), non-ASCII names match across rows, the empty name is a column, and properties named `" "` or `Values` do not get folded into the index or Values columns. All of those pass before and after the change; the existing console table snapshots are unchanged.

### Background
- `TablePrinter` renders a table in two passes: `collect_row` reads and formats every cell once while sizing the columns (creating columns on demand as new property names appear), then the render pass writes the rows out. This change only touches how `collect_row` maps a property name to a column index.
- Property names reach the printer as `StringView`s borrowed from a `JSPropertyIterator`. Since #40238 `bun_core::String` owns its WTF ref (`Clone` refs, `Drop` derefs), so a column keeps its name with `clone()` and nothing has to deref by hand; the map's keys are clones too.
- JSC stores strings either as 8-bit Latin-1 or as UTF-16, and `BunString::eql` compares by content regardless of which is used. A hash used alongside that equality has to give equal content the same hash in both storages, which is why UTF-16 names are narrowed before hashing when they can be.
- `bun_collections::HashMap` is the repo's open-addressing map; `HashContext` is how a caller supplies the hash and equality functions for a key type that does not implement `Hash`/`Eq` itself, which `BunString` does not.

<details>
<summary>Benchmark (release builds of this tree without and with the change, node v26.3.0 on the same machine, best of 3)</summary>

| shape | before | after | node |
| --- | ---: | ---: | ---: |
| 1 row x 5000 cols | 68 ms | 2.8 ms | 9.8 ms |
| 1 row x 10000 cols | 281 ms | 5.7 ms | 17.5 ms |
| 1 row x 20000 cols | 0.97 s | 16 ms | 41.5 ms |
| 1 row x 40000 cols | 4.14 s | 33 ms | 92 ms |
| 200 rows x 2000 cols | 2.03 s | 96 ms | 0.39 s |
| 1000 rows x 1000 cols | 2.98 s | 0.24 s | 0.87 s |
| 1 row x 10k cols, Latin-1 names (`é` + i) | 0.28 s | 5.7 ms | |
| 1 row x 10k cols, UTF-16 names (`列` + i) | 0.27 s | 6.2 ms | |
| 1 row x 10k cols, 64-char names | 0.35 s | 25 ms | |
| 10k rows x 50 cols | 165 ms | 110 ms | |
| 10k rows x 50 cols, UTF-16 names | 170 ms | 120 ms | |
| 3 rows x 3 cols (per table) | 3.5 us | 3.6 us | |
| 20 rows x 6 cols (per table) | 26.2 us | 27.9 us | |
| 100 rows x 8 cols | 160 us | 172 us | |
| 1000 rows x 2 cols | 466 us | 498 us | |
| 80k rows x 2 cols | 40.9 ms | 44.7 ms | |
| 1 row x 5k cols, `properties` argument | 2.3 ms | 2.4 ms | |
| 1000 rows x 20 cols, `properties` argument | 3.3 ms | 3.4 ms | |

The last seven rows do not use the index (too narrow, or the `properties` path); see the note on layout in the Fix section. Load average on the host was 45 to 55 during all of these runs, and the same binary moves 5 to 15% between runs at these sizes.

Debug + ASAN build, 1 row: 8000 columns 7.4 s -> 0.19 s; 16000 columns (extrapolated ~30 s before) 0.38 s after.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [100.55ms]
(pass) console.table > expected output for: not object (number) [16.04ms]
(pass) console.table > expected output for: not object (string) [2.82ms]
(pass) console.table > expected output for: object - empty [2.27ms]
(pass) console.table > expected output for: object [4.07ms]
(pass) console.table > expected output for: array - empty [2.16ms]
(pass) console.table > expected output for: array - plain [1.69ms]
(pass) console.table > expected output for: array - object [2.20ms]
(pass) console.table > expected output for: array - objects with diff props [4.76ms]
(pass) console.table > expected output for: array - mixed [1.98ms]
(pass) console.table > expected output for: set [2.33ms]
(pass) console.table > expected output for: map [3.88ms]
(pass) con
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [0.16ms]
(pass) console.table > expected output for: not object (number) [0.51ms]
(pass) console.table > expected output for: not object (string) [0.03ms]
(pass) console.table > expected output for: object - empty [0.03ms]
(pass) console.table > expected output for: object [0.02ms]
(pass) console.table > expected output for: array - empty [0.01ms]
(pass) console.table > expected output for: array - plain [0.02ms]
(pass) console.table > expected output for: array - object [0.01ms]
(pass) console.table > expected output for: array - objects with diff props [0.02ms]
(pass) console.table > expected output for: array - mixed [0.02ms]
(pass) console.table > expected output for: set [0.02ms]
(pass) console.table > expected output for: map [0.03ms]
(pass) console.table > expected output for: properties [0.02ms]
(pass) console.table > expected output for: properties - empty [0.01ms]
(pass) console.table > expected output for:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-table.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/console/console-table.test.ts:
┌───┐
│   │
├───┤
└───┘
┌───┐
│   │
├───┤
└───┘
(pass) console.table > throws when second arg is invalid [7.76ms]
(pass) console.table > expected output for: not object (number) [9.66ms]
(pass) console.table > expected output for: not object (string) [1.56ms]
(pass) console.table > expected output for: object - empty [2.01ms]
(pass) console.table > expected output for: object [1.70ms]
(pass) console.table > expected output for: array - empty [1.52ms]
(pass) console.table > expected output for: array - plain [1.61ms]
(pass) console.table > expected output for: array - object [2.28ms]
(pass) console.table > expected output for: array - objects with diff props [2.79ms]
(pass) console.table > expected output for: array - mixed [1.92ms]
(pass) console.table > expected output for: set [2.32ms]
(pass) console.table > expected output for: map [2.33ms]
(pass) consol
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 769ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                  | 128 +++++++++++++++++++++------
 test/js/bun/console/console-table.test.ts | 139 +++++++++++++++++++++++++++++-
 2 files changed, 239 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/ConsoleObject.rs                      13     38      0
test/js/bun/console/console-table.test.ts      7      8      0
```

</details>

<!-- robobun:evidence:end -->
