### PR TITLE
node errors: render a callable's name in determineSpecificType like node

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -428,8 +428,7 @@ void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::
         return;
     }
     if (cell->isCallable()) {
-        // Node: `function ${value.name}`. Not Zig::functionName(), which is the
-        // stack-trace heuristic and returns "" for a callable Proxy.
+        // node: `function ${value.name}` (lib/internal/errors.js determineSpecificType)
         auto name = value.get(globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, void());
         auto* nameString = name.toString(globalObject);

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -428,12 +428,18 @@ void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::
         return;
     }
     if (cell->isCallable()) {
+        // Node renders `function ${value.name}`, i.e. an ordinary [[Get]]: a callable
+        // Proxy yields its target's (or trap's) name, a bound function "bound f", and a
+        // throwing getter/trap propagates. Zig::functionName() is the stack-trace
+        // heuristic (returns "" for proxies, never runs user code) and does not match.
+        auto name = value.get(globalObject, vm.propertyNames->name);
+        RETURN_IF_EXCEPTION(scope, void());
+        auto* nameString = name.toString(globalObject);
+        RETURN_IF_EXCEPTION(scope, void());
+        auto nameView = nameString->view(globalObject);
+        RETURN_IF_EXCEPTION(scope, void());
         builder.append("function "_s);
-        auto name = Zig::functionName(vm, globalObject, cell->getObject());
-
-        if (!name.isEmpty()) {
-            builder.append(name);
-        }
+        builder.append(nameView);
         return;
     }
     if (cell->isString()) {

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -428,10 +428,8 @@ void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::
         return;
     }
     if (cell->isCallable()) {
-        // Node renders `function ${value.name}`, i.e. an ordinary [[Get]]: a callable
-        // Proxy yields its target's (or trap's) name, a bound function "bound f", and a
-        // throwing getter/trap propagates. Zig::functionName() is the stack-trace
-        // heuristic (returns "" for proxies, never runs user code) and does not match.
+        // Node: `function ${value.name}`. Not Zig::functionName(), which is the
+        // stack-trace heuristic and returns "" for a callable Proxy.
         auto name = value.get(globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, void());
         auto* nameString = name.toString(globalObject);

--- a/test/js/node/errors/invalid-arg-type-received-function.test.ts
+++ b/test/js/node/errors/invalid-arg-type-received-function.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import url from "node:url";
+import zlib from "node:zlib";
+
+// The "Received ..." suffix of ERR_INVALID_ARG_TYPE comes from determineSpecificType() in
+// src/jsc/bindings/ErrorCode.cpp. For a callable, Node renders `function ${value.name}`, i.e. a
+// plain property read, so a callable Proxy reports its target's name (or whatever its get trap
+// returns), a bound function reports "bound f", and `name` overrides and getters are honored.
+// The entry points below reach the renderer from a C++ validator, from the JS builtins'
+// $ERR_INVALID_ARG_TYPE, from Rust's determine_specific_type, and from the ERR_INVALID_THIS message
+// that native classes build with it. The ERR_INVALID_ARG_TYPE renderings are what node v26.3.0 prints
+// for the same values.
+const entryPoints: [label: string, code: string, prefix: string, throwWith: (value: unknown) => unknown][] = [
+  [
+    "C++ validator (process.umask)",
+    "ERR_INVALID_ARG_TYPE",
+    'The "mask" argument must be of type number. Received ',
+    value => process.umask(value as any),
+  ],
+  [
+    "$ERR_INVALID_ARG_TYPE (url.format)",
+    "ERR_INVALID_ARG_TYPE",
+    'The "urlObject" argument must be one of type object or string. Received ',
+    value => url.format(value as any),
+  ],
+  [
+    "Rust determine_specific_type (zlib.crc32)",
+    "ERR_INVALID_ARG_TYPE",
+    'The "value" argument must be of type number. Received ',
+    value => zlib.crc32("x", value as any),
+  ],
+  [
+    "createInvalidThisError (CryptoHasher#update)",
+    "ERR_INVALID_THIS",
+    "Expected this to be instanceof CryptoHasher, but received ",
+    value => Bun.CryptoHasher.prototype.update.call(value, "x"),
+  ],
+];
+
+// Each case builds a fresh value so that nothing has read `.name` before the error is rendered
+// (JSC materializes a function's `name` property lazily).
+const cases: [label: string, make: () => unknown, rendered: string][] = [
+  ["proxy of a named function", () => new Proxy(function codegen() {}, {}), "function codegen"],
+  ["proxy of a class", () => new Proxy(class Bar {}, {}), "function Bar"],
+  ["proxy of a builtin", () => new Proxy(Array.prototype.push, {}), "function push"],
+  ["proxy of a proxy", () => new Proxy(new Proxy(function inner() {}, {}), {}), "function inner"],
+  ["proxy of an anonymous function", () => new Proxy((0, function () {}), {}), "function "],
+  [
+    "proxy whose get trap renames it",
+    () =>
+      new Proxy(function target() {}, { get: (t, key, r) => (key === "name" ? "trapped" : Reflect.get(t, key, r)) }),
+    "function trapped",
+  ],
+  [
+    "proxy whose get trap returns a non-string name",
+    () => new Proxy(function target() {}, { get: (t, key, r) => (key === "name" ? 7 : Reflect.get(t, key, r)) }),
+    "function 7",
+  ],
+  ["bound function", () => function f() {}.bind(null), "function bound f"],
+  ["name redefined as a number", () => Object.defineProperty(function f() {}, "name", { value: 42 }), "function 42"],
+  ["name redefined as empty", () => Object.defineProperty(function f() {}, "name", { value: "" }), "function "],
+  [
+    "name redefined as a getter",
+    () => Object.defineProperty(function f() {}, "name", { get: () => "fromGetter" }),
+    "function fromGetter",
+  ],
+  [
+    "name deleted (falls back to Function.prototype.name)",
+    () => {
+      function f() {}
+      delete (f as any).name;
+      return f;
+    },
+    "function ",
+  ],
+  // Unchanged renderings, pinned so the rewrite of the callable branch cannot regress them.
+  ["named function", () => function named() {}, "function named"],
+  ["class", () => class Foo {}, "function Foo"],
+  ["builtin", () => Array.prototype.push, "function push"],
+  ["anonymous arrow", () => (0, () => {}), "function "],
+];
+
+function thrownBy(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the call to throw");
+}
+
+describe.each(entryPoints)(
+  "determineSpecificType renders a callable like node: %s",
+  (_label, code, prefix, throwWith) => {
+    test("reads the callable's name through [[Get]]", () => {
+      const messages = cases.map(([label, make]) => {
+        const error = thrownBy(() => throwWith(make()));
+        return [label, error.code, error.message];
+      });
+      expect(messages).toEqual(cases.map(([label, , rendered]) => [label, code, prefix + rendered]));
+    });
+
+    test("an exception thrown while reading the name replaces the error being built", () => {
+      const trapBoom = new RangeError("trap boom");
+      const getterBoom = new RangeError("getter boom");
+      const revocable = Proxy.revocable(function f() {}, {});
+      revocable.revoke();
+
+      const trapProxy = new Proxy(function f() {}, {
+        get() {
+          throw trapBoom;
+        },
+      });
+      const getterFunction = Object.defineProperty(function f() {}, "name", {
+        get() {
+          throw getterBoom;
+        },
+      });
+
+      expect(thrownBy(() => throwWith(trapProxy))).toBe(trapBoom);
+      expect(thrownBy(() => throwWith(getterFunction))).toBe(getterBoom);
+      const revokedError = thrownBy(() => throwWith(revocable.proxy));
+      expect(revokedError).toBeInstanceOf(TypeError);
+      expect(revokedError.code).toBeUndefined();
+    });
+  },
+);
+
+test("a non-callable Proxy still renders through the object branch", () => {
+  const messages = [new Proxy([], {}), new Proxy({}, {})].map(
+    value => thrownBy(() => process.umask(value as any)).message,
+  );
+  expect(messages).toEqual([
+    'The "mask" argument must be of type number. Received an instance of Array',
+    'The "mask" argument must be of type number. Received an instance of Object',
+  ]);
+});


### PR DESCRIPTION
### Problem

- The `Received ...` suffix of `ERR_INVALID_ARG_TYPE` renders a callable `Proxy` as `function ` with no name. Node prints the target's name:

  ```js
  try { process.umask(new Proxy(function codegen() {}, {})); } catch (e) { console.log(e.message); }
  // bun:  The "mask" argument must be of type number. Received function
  // node: The "mask" argument must be of type number. Received function codegen
  ```

- Every Node-style validator shares this rendering (74 of the ~100 entry points I tried, across `process`, `Buffer`, `crypto`, `zlib`, `url`, `fs`, `events`, `child_process`, ...), as does the `ERR_INVALID_THIS` message native classes build for a wrong `this`.
- Cause: the callable branch of `determineSpecificType()` (`src/jsc/bindings/ErrorCode.cpp:430`) gets the name from `Zig::functionName()` (`src/jsc/bindings/ErrorStackTrace.cpp:547`), which returns an empty string for `ProxyObjectType` by design and otherwise only looks at internal function state. Node's `determineSpecificType` (`lib/internal/errors.js`) is `function ${value.name}`.
- The same shortcut produces other divergences from node: a bound function renders as `function f` instead of `function bound f` unless something happened to read `.name` first (JSC materializes it lazily), and a redefined `name` (data value or getter) is ignored.

### Fix

- The callable branch now does what node does: `[[Get]]` of `name` on the value, `ToString` it, append. Exceptions are checked after each step and left pending for the caller, which is the contract the object branch (`.constructor` lookup a few lines below) already has. The C++ message builders and `JSBuffer.cpp` check right after the call, the Rust FFI entry is checked by `determine_specific_type` in `src/jsc/JSGlobalObject.rs`, and `createInvalidThisError` does not check but hands the message to `ErrorCodeCache::createError`, which returns the pending exception's value in place of the new error, so its callers end up throwing the user's exception (the test covers this path).
- Why this is correct: it is node's algorithm, so a callable Proxy reports whatever its `get` trap (or, without one, its target) says, `bound f` and `class Foo` come out as in node, and a throwing `name` getter or trap propagates instead of being swallowed, which node also does. Renderings that were already right are unchanged: named functions, builtins, classes, anonymous functions (`function `, as before, which the existing `process.umask` assertion in `test/js/node/process/process.test.js` pins), and non-callable Proxies still go through the object branch.
- User code can now run while rendering a callable (a `name` getter or a Proxy trap). The object branch has always done this for `.constructor`, so callers are already written for it; the exception-check lane (`BUN_JSC_validateExceptionChecks=1`) is clean on the new test.
- Verified with `test/js/node/errors/invalid-arg-type-received-function.test.ts`: 9 pass with the fix, 8 fail on the released binary (`USE_SYSTEM_BUN=1`). It drives one table of values through a C++ validator (`process.umask`), the JS builtins' `$ERR_INVALID_ARG_TYPE` (`url.format`), Rust's `determine_specific_type` (`zlib.crc32`) and `createInvalidThisError` (`Bun.CryptoHasher#update`), and checks that a throwing getter, trap, or revoked proxy surfaces the user's error. Expected strings were taken from node v26.3.0.
- Also ran: the 59 vendored node tests in `test/js/node/test/parallel` that use `common.invalidArgTypeHelper` (which expects node's `function ${input.name}`); no new failures. `process.test.js` and `util-promisify.test.js` pass apart from a pre-existing `$USER`-dependent test.
- Not changed, handled as separate fixes so this one stays a single rendering: the other `Zig::functionName` use in this file, the `[Function: x]` arm of `JSValueToStringSafe` behind `ERR_INVALID_ARG_VALUE` (bound functions, classes and async functions render as `[Function: b]`, `[Function: Foo]`, `[Function: af]` where node's `util.inspect` form is `[Function: bound b]`, `[class Foo]`, `[AsyncFunction: af]`), and two unrelated branches of `determineSpecificType` itself (`-0` renders as `type number (0)`; a `constructor` without a `name` property renders as `an instance of undefined`). #38401, #38402 and #38435 edit other parts of this file and do not overlap with this hunk.

### Background

- `determineSpecificType` is bun's port of node's helper of the same name. It appends the `Received ...` description of a value (`type number (5)`, `an instance of Array`, `function foo`) and is reached from the C++ `ERR::INVALID_ARG_TYPE` family and native validators, from the JS builtins via `$ERR_INVALID_ARG_TYPE`, from Rust via `Bun__ErrorCode__determineSpecificType`, and from `createInvalidThisError`.
- `Zig::functionName()` is the helper stack-trace formatting uses to name a frame's callee. It deliberately never runs user code, so it skips Proxies and accessors and otherwise reads JSC's internal name fields, which is why it is the wrong source for a message whose node definition is a property read.
- A callable `Proxy` is an object of JSC type `ProxyObjectType` wrapping a callable target; `typeof` reports `"function"` and property reads go through its `get` trap, or straight to the target when there is none.
- JSC creates a function's `name` own property lazily, on first access. That is why the old rendering of a bound function depended on whether `.name` had been read before the error was built.

