### PR TITLE
init: exit 1 when the nested bun install fails

### DIFF
--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -787,7 +787,7 @@ impl InitCommand {
             template.write_to_package_json(&mut fields, &bump)?;
         }
 
-        'write_package_json: {
+        {
             let (fd, created_close): (Fd, Option<bun_sys::CloseOnDrop>) = match package_json_file
                 .as_ref()
             {
@@ -820,8 +820,7 @@ impl InitCommand {
                     "package.json failed to write due to error {}",
                     err.name(),
                 );
-                package_json_file = None;
-                break 'write_package_json;
+                Global::exit(1);
             }
             let written = package_json_writer.ctx.get_written();
             if let Err(err) = bun_sys::File::borrow(&fd).write_all(written) {
@@ -829,8 +828,7 @@ impl InitCommand {
                     "package.json failed to write due to error {}",
                     bstr::BStr::new(err.name()),
                 );
-                package_json_file = None;
-                break 'write_package_json;
+                Global::exit(1);
             }
             if let Err(err) =
                 bun_sys::ftruncate(fd, i64::try_from(written.len()).expect("int cast"))
@@ -839,8 +837,7 @@ impl InitCommand {
                     "package.json failed to write due to error {}",
                     bstr::BStr::new(err.name()),
                 );
-                package_json_file = None;
-                break 'write_package_json;
+                Global::exit(1);
             }
         }
 

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -937,7 +937,9 @@ impl InitCommand {
                 if exists_z(b"package.json") && need_run_bun_install {
                     bun_core::prettyln!("");
                     let self_exe = bun::self_exe_path()?;
-                    let _ = bun::spawn_sync_inherit(&[self_exe.as_bytes(), b"install"])?;
+                    if !bun::spawn_sync_inherit(&[self_exe.as_bytes(), b"install"])?.is_ok() {
+                        Global::exit(1);
+                    }
                 }
             }
             _ => {}
@@ -1674,7 +1676,9 @@ impl Template {
         Output::flush();
 
         let self_exe = bun::self_exe_path()?;
-        let _ = bun::spawn_sync_inherit_no_stdin(&[self_exe.as_bytes(), b"install"])?;
+        if !bun::spawn_sync_inherit_no_stdin(&[self_exe.as_bytes(), b"install"])?.is_ok() {
+            Global::exit(1);
+        }
 
         bun_core::prettyln!(
             "\n\

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -425,4 +425,35 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
     expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
   });
+
+  // The blank template and the react templates spawn the nested `bun install`
+  // from different places; both used to drop its exit status, so `bun init`
+  // exited 0 (and the react templates printed the success banner) after the
+  // install had failed.
+  test.each(["-y", "--react"])("bun init %s exits non-zero when the nested `bun install` fails", async flag => {
+    using registry = Bun.serve({
+      port: 0,
+      fetch: () => new Response("not found", { status: 404 }),
+    });
+    await using temp = tempDir(`bun-init-install-fails${flag.replace(/[^a-z]+/g, "-")}`, {});
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "init", flag],
+      cwd: temp,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...initEnv,
+        BUN_CONFIG_REGISTRY: String(registry.url),
+        BUN_INSTALL_CACHE_DIR: path.join(temp, ".bun-cache"),
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The scaffold is written before the install runs and stays on disk.
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(false);
+    expect(stderr).toContain("failed to resolve");
+    expect(stdout).not.toContain("New project configured!");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -456,4 +456,28 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(stdout).not.toContain("New project configured!");
     expect(exitCode).toBe(1);
   });
+
+  // Failing to write package.json itself was also reported and then ignored:
+  // init went on to scaffold the rest of the project around it and exited 0.
+  // `ulimit -f 0` makes every regular-file write fail with EFBIG (bun ignores
+  // SIGXFSZ), and the existing package.json already lists everything the blank
+  // template would add, so no `bun install` runs and the exit code is init's
+  // own.
+  test.skipIf(isWindows)("bun init exits non-zero when package.json cannot be written", async () => {
+    const pkg = { name: "already-here", devDependencies: { "@types/bun": "latest", typescript: "^6" } };
+    await using temp = tempDir("bun-init-package-json-write-fails", { "package.json": JSON.stringify(pkg) });
+
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", 'ulimit -f 0 && exec "$0" init -y', bunExe()],
+      cwd: temp,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: initEnv,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("package.json failed to write due to error EFBIG");
+    // Nothing else gets scaffolded once package.json has failed.
+    expect(readdirSync(temp).sort()).toEqual(["package.json"]);
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun init` exits 0 when the `bun install` it spawns fails. With a dead registry, `bun init -y` prints `error: @types/bun@latest failed to resolve` and exits 0; `bun init --react` prints the same kind of errors and then the `New project configured! ... Happy bunning!` banner, and also exits 0. No `node_modules` or `bun.lock` exists in either case, so `bun init --react && bun run build` goes on to build a broken tree.
- Both install sites in `src/runtime/cli/init_command.rs` throw the child's status away: the blank template does `let _ = bun::spawn_sync_inherit(...)?;` and `Template::write_files_and_run_bun_dev` does `let _ = bun::spawn_sync_inherit_no_stdin(...)?;` and then prints the banner unconditionally. The `?` only covers a failed spawn; the `SpawnStatus` it returns is what carries the exit code.
- The blank template's own package.json write has the same shape of bug: when printing, writing, or truncating package.json fails, the three failure arms print `package.json failed to write due to error ...` and then `break` out of the block, so init goes on to create .gitignore, tsconfig.json and README.md next to the broken package.json, runs `bun install` against it, and exits 0. The react path already treats a failed template file as fatal (`Global::crash()`, which is `exit(1)`).
- Nothing that reads the exit code can tell a working scaffold from a broken one: scripted `bun init -y` users, and the test suite, which checks for `node_modules` instead (the comment in #38476's `expectInstalled` helper describes exactly this workaround).

### Fix
- Check `SpawnStatus::is_ok()` at both install sites and `Global::exit(1)` when the install exited non-zero. The react path exits before the banner, so a failed install is no longer reported as success. The scaffold stays on disk: it was written correctly and the user only needs to rerun `bun install`. The install's own errors are the last thing on the terminal (its stdio is inherited), so nothing extra is printed.
- The three package.json failure arms keep their message and `Global::exit(1)` instead of continuing; the `'write_package_json` label and the `package_json_file = None` bookkeeping only existed to support the continuation, so they go. `package_json_file` is still assigned in the read path, which is why it stays `mut`.
- Exiting 1 rather than forwarding the child's code is what `pm version` does for its git children (`!result.is_ok()` then `Global::exit(1)`); `SpawnStatus` only exposes `is_ok()`, and a child killed by a signal has no exit code to forward anyway.
- A spawn failure (the `?` path) and a failed `File::create` of a new package.json already exit 1 through `handle_root_error`; unchanged.
- `bun create` drops its nested install's status the same way (`create_command.rs`, `let _ = process?;`); that is a separate command and is left for a separate change.
- Tests, all in `test/cli/init/init.test.ts`:
  - one failing-install case per install site (`-y` for the blank template, `--react` for the react templates; the three react templates share the one function), with `BUN_CONFIG_REGISTRY` pointed at a local `Bun.serve` answering 404 and a fresh `BUN_INSTALL_CACHE_DIR`. On the current release `-y` exits 0 and `--react` prints the banner.
  - one package.json write failure case (POSIX): an existing package.json that already lists `@types/bun` and `typescript`, so no install runs, with `bun init -y` started under `ulimit -f 0`. bun ignores SIGXFSZ at startup, so the write fails with EFBIG. On the current release the directory ends up with .gitignore, README.md, index.ts and tsconfig.json next to it and init exits 0; now it exits 1 with only package.json there.
  - the rest of the file (the successful installs) still passes with the debug build, so a passing init still exits 0. The file's `beforeAll` cache primer ignores `bun init`'s exit code, so the new non-zero exit cannot fail the suite when the primer's install hits a flaky network.

### Background
- `bun init` writes the scaffold and then runs `bun install` as a child process using `bun_core::spawn_sync_inherit` (blank template, stdin inherited) or `spawn_sync_inherit_no_stdin` (react templates, stdin ignored). Both return `Result<SpawnStatus, _>`: the `Err` side is "could not spawn or wait", the `SpawnStatus` is the child's exit code (`is_ok()` is `code == 0`; a signaled child reports as not ok).
- `Global::exit(n)` flushes stdout/stderr and exits the process; it is how the commands in `src/runtime/cli/` report a failed step. `InitCommand::exec` returning an `Err` also ends in exit 1, but via a generic `error:` line, so the arms that already print a specific message exit directly.
- `RLIMIT_FSIZE` (`ulimit -f`) caps the size of files a process may write; a write past it raises SIGXFSZ and, when that signal is ignored, fails with EFBIG. It is the portable way to make a write to an ordinary file fail from a test.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/init/init.test.ts

<!-- robobun:evidence:end -->