### PR TITLE
test(shell): make leak.test.ts measure what it claims and cut its runtime

### DIFF
--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -1,9 +1,9 @@
 import { $ } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, isASAN, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isPosix, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "path";
-import { bunExe } from "./test_builder";
 import { createTestBuilder } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
 type TestBuilder = InstanceType<typeof TestBuilder>;
@@ -12,11 +12,24 @@ $.env(bunEnv);
 $.cwd(process.cwd());
 $.nothrow();
 
-// ASAN's quarantine retains freed allocations (default 256 MB) so per-iteration
-// RSS jumps run far higher under bun-asan; widen the threshold there.
+// Bound on RSS growth over a whole run. ASAN's quarantine retains freed
+// allocations (default 256 MB), so RSS grows far more under bun-asan even
+// without a leak; widen the threshold there. (Measured growth over 100 runs is
+// 11-56 MB under ASAN, much less without it.)
 const DEFAULT_THRESHOLD = (isASAN ? 350 : process.platform === "darwin" ? 100 : 150) * (1 << 20);
 
-const TESTS: [name: string, builder: () => TestBuilder, runs?: number][] = [
+// Every leak these tests guard against costs at least one unit (fd, JS object,
+// protected object) per run, so a leak puts `runs` units on the detector. The
+// bounds below allow for legitimate residue: the last run's interpreter and
+// script can stay conservatively rooted through Bun.gc(true), and an interpreter
+// that has not been finalized yet can still hold an fd or two. 100 runs puts a
+// one-unit-per-run leak at 20x the fd bound and 33x the object bound.
+const RUNS = 100;
+const WARMUP_RUNS = 1;
+const FD_LEAK_BOUND = 5;
+const MAX_SHELL_OBJECTS = 3;
+
+const TESTS: [name: string, builder: () => TestBuilder][] = [
   ["redirect_file", () => TestBuilder.command`echo hello > test.txt`.fileEquals("test.txt", "hello\n")],
   ["change_cwd", () => TestBuilder.command`cd ${TestBuilder.tmpdir()} && cd -`],
   ["pipeline", () => TestBuilder.command`echo hi | cat`.stdout("hi\n")],
@@ -34,7 +47,6 @@ const TESTS: [name: string, builder: () => TestBuilder, runs?: number][] = [
               .sort(),
           ).toEqual(["lmao", "lol", "nice", "foo/bar:", "bar", "great", "wow"].sort()),
         ),
-    500,
   ],
   [
     "rm",
@@ -49,121 +61,138 @@ const TESTS: [name: string, builder: () => TestBuilder, runs?: number][] = [
               .sort(),
           ).toEqual(["foo/", "foo/bar", "foo/bar/great", "foo/bar/wow", "foo/lmao", "foo/lol", "foo/nice"].sort()),
         ),
-    100,
   ],
 ];
 
-describe.concurrent("fd leak", () => {
-  function fdLeakTest(name: string, builder: () => TestBuilder, runs: number = 1000, threshold: number = 5) {
-    test(`fdleak_${name}`, async () => {
-      const testcode = await Bun.file(join(import.meta.dirname, "./test_builder.ts")).text();
+const testBuilderSource = readFileSync(join(import.meta.dirname, "test_builder.ts"), "utf8");
 
-      const impl = /* ts */ `
-              import { openSync, closeSync, readdirSync } from "node:fs";
-              import { devNull } from "os";
-              const TestBuilder = createTestBuilder(import.meta.path);
+/** The builders above are never called here; their source text becomes the body of a child process. */
+function snippet(builder: () => TestBuilder): string {
+  return builder.toString().slice("() =>".length);
+}
 
-              const runs = ${runs};
-              const threshold = ${threshold};
+/**
+ * Spawns a bun that runs `once` (source of an expression evaluating to a
+ * promise) WARMUP_RUNS times, so lazily-initialized state is not attributed to
+ * the measured runs, and then hands `measure` (source of an async function) a
+ * `run` callback that performs the `runs` measured executions. Whatever
+ * `measure` returns is printed as JSON and returned here.
+ *
+ * Helpers available to `measure`: fdCount(), shellObjectCounts(),
+ * protectedObjectCounts() and settle(sample, ok), which samples after a full GC
+ * on successive event loop turns until `ok` accepts the sample (or 50 turns
+ * pass) and returns the last sample: a dead interpreter can stay visible to
+ * heapStats for a turn, a real leak never goes away.
+ */
+async function runChild(
+  name: string,
+  { once, measure, runs }: { once: string; measure: string; runs: number },
+): Promise<{ result: any; exitCode: number }> {
+  const script = /* ts */ `
+    ${testBuilderSource}
+    import { heapStats } from "bun:jsc";
+    import { closeSync, openSync, readdirSync } from "node:fs";
+    import { devNull } from "node:os";
+    const { expect } = Bun.jest(import.meta.path);
+    const TestBuilder = createTestBuilder(import.meta.path);
 
-              function getFDCount(): number {
-                if (process.platform === "darwin" || process.platform === "linux") {
-                  return readdirSync(process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd").length;
-                }
-                const maxFD = openSync(devNull, "r");
-                closeSync(maxFD);
-                return maxFD;
-              }
-
-              Bun.gc(true);
-              const baseline = getFDCount();
-
-              for (let i = 0; i < runs; i++) {
-                await ${builder.toString().slice("() =>".length)}.quiet().run();
-              }
-              // Run the GC, because the interpreter closes file descriptors when it
-              // deinitializes when its finalizer is called
-              Bun.gc(true);
-              const after = getFDCount();
-              if (after - baseline > threshold) {
-                console.error('FD leak detected:', after - baseline, 'leaked (threshold:', threshold, ')');
-                process.exit(1);
-              }
-            `;
-
-      using dir = tempDir("fdleak", {
-        "script.ts": testcode + impl,
-      });
-
-      const { exited, stderr: stream } = Bun.spawn([process.argv0, "--smol", "test", join(dir, "script.ts")], {
-        env: bunEnv,
-        stderr: "pipe",
-      });
-      const [exitCode, stderr] = await Promise.all([exited, stream.text()]);
-      if (exitCode != 0) {
-        console.log("\n\nSTDERR:", stderr);
+    function fdCount(): number {
+      if (process.platform === "darwin" || process.platform === "linux") {
+        return readdirSync(process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd").length;
       }
+      const fd = openSync(devNull, "r");
+      closeSync(fd);
+      return fd;
+    }
+    function shellObjectCounts() {
+      const counts = heapStats().objectTypeCounts;
+      return { ShellInterpreter: counts.ShellInterpreter ?? 0, ParsedShellScript: counts.ParsedShellScript ?? 0 };
+    }
+    function protectedObjectCounts(): Record<string, number> {
+      return heapStats().protectedObjectTypeCounts;
+    }
+    async function settle<T>(sample: () => T, ok: (value: T) => boolean): Promise<T> {
+      for (let turn = 0; ; turn++) {
+        Bun.gc(true);
+        const value = sample();
+        if (ok(value) || turn === 50) return value;
+        await new Promise(resolve => setImmediate(resolve));
+      }
+    }
+    async function runTimes(n: number) {
+      for (let i = 0; i < n; i++) await (${once});
+    }
+
+    await runTimes(${WARMUP_RUNS});
+    Bun.gc(true);
+    const result = await (${measure})(() => runTimes(${runs}));
+    console.log(JSON.stringify(result));
+  `;
+  // The child's cwd and tmpdir both point here, so whatever the snippets create
+  // (TestBuilder.tmpdir() makes a fresh directory per run) is removed with it.
+  using dir = tempDir(`shell-leak-${name}`, { "child.ts": script });
+  const cwd = String(dir);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "run", "child.ts"],
+    cwd,
+    env: { ...bunEnv, TMPDIR: cwd, TMP: cwd, TEMP: cwd },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^\{.*\}\n$/);
+  return { result: JSON.parse(stdout), exitCode };
+}
+
+describe.concurrent("fd leak", () => {
+  function fdLeakTest(name: string, builder: () => TestBuilder, runs: number = RUNS) {
+    test(`fdleak_${name}`, async () => {
+      const { result, exitCode } = await runChild(`fd-${name}`, {
+        once: `${snippet(builder)}.quiet().run()`,
+        runs,
+        measure: /* ts */ `async (run) => {
+          const baseline = fdCount();
+          await run();
+          // An interpreter closes the fds it still owns when it is finalized.
+          const leakedFds = await settle(() => fdCount() - baseline, leaked => leaked <= ${FD_LEAK_BOUND});
+          return { leakedFds };
+        }`,
+      });
+      expect(result.leakedFds).toBeLessThanOrEqual(FD_LEAK_BOUND);
       expect(exitCode).toBe(0);
-    }, 100_000);
+    });
   }
 
   function memLeakTest(
     name: string,
     builder: () => TestBuilder,
-    runs: number = 500,
+    runs: number = RUNS,
     threshold: number = DEFAULT_THRESHOLD,
   ) {
     test(`memleak_${name}`, async () => {
-      const testcode = await Bun.file(join(import.meta.dirname, "./test_builder.ts")).text();
-
-      const impl = /* ts */ `
-              import { heapStats } from "bun:jsc";
-              const TestBuilder = createTestBuilder(import.meta.path);
-              const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
-
-              const threshold = ${threshold}
-              let prev: number | undefined = undefined;
-              let prevprev: number | undefined = undefined;
-              for (let i = 0; i < ${runs}; i++) {
-                Bun.gc(true);
-                await (async function() {
-                  await ${builder.toString().slice("() =>".length)}.quiet().runAsTest('iter:', i)
-                })()
-                Bun.gc(true);
-                Bun.gc(true);
-
-                const objectTypeCounts = heapStats().objectTypeCounts;
-                if (objectTypeCounts.ParsedShellScript > 3 || objectTypeCounts.ShellInterpreter > 3) {
-                  console.error('TOO many ParsedShellScript or ShellInterpreter objects', objectTypeCounts.ParsedShellScript, objectTypeCounts.ShellInterpreter)
-                  process.exit(1);
-                }
-
-                const val = rss();
-                if (prev === undefined) {
-                  prev = val;
-                  prevprev = val;
-                } else {
-                  // Growth from the baseline is a leak; a drop is the allocator
-                  // handing memory back (the idle sweep does this on purpose).
-                  if (!(val - prev < threshold)) process.exit(1);
-                }
-              }
-            `;
-
-      using dir = tempDir("memleak", {
-        "script.ts": testcode + impl,
+      const { result, exitCode } = await runChild(`mem-${name}`, {
+        once: `${snippet(builder)}.quiet().run()`,
+        runs,
+        measure: /* ts */ `async (run) => {
+          const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rssBefore = rss();
+          await run();
+          const counts = await settle(
+            shellObjectCounts,
+            ({ ShellInterpreter, ParsedShellScript }) =>
+              ShellInterpreter <= ${MAX_SHELL_OBJECTS} && ParsedShellScript <= ${MAX_SHELL_OBJECTS},
+          );
+          // Growth from the baseline is a leak; a drop is the allocator handing
+          // memory back (the idle sweep does this on purpose).
+          return { rssGrowth: rss() - rssBefore, ...counts };
+        }`,
       });
-
-      const { exited, stderr: stream } = Bun.spawn([process.argv0, "--smol", "test", join(dir, "script.ts")], {
-        env: bunEnv,
-        stderr: "pipe",
-      });
-      const [exitCode, stderr] = await Promise.all([exited, stream.text()]);
-      if (exitCode != 0) {
-        console.log("\n\nSTDERR:", stderr);
-      }
+      expect(result.ShellInterpreter).toBeLessThanOrEqual(MAX_SHELL_OBJECTS);
+      expect(result.ParsedShellScript).toBeLessThanOrEqual(MAX_SHELL_OBJECTS);
+      expect(result.rssGrowth).toBeLessThan(threshold);
       expect(exitCode).toBe(0);
-    }, 100_000);
+    });
   }
 
   TESTS.forEach(args => {
@@ -171,272 +200,214 @@ describe.concurrent("fd leak", () => {
     memLeakTest(...args);
   });
 
-  // Use text of this file so its big enough to cause a leak
-  memLeakTest("ArrayBuffer", () => TestBuilder.command`cat ${import.meta.filename} > ${new ArrayBuffer(128)}`, 100);
-  memLeakTest("Buffer", () => TestBuilder.command`cat ${import.meta.filename} > ${Buffer.alloc(128)}`, 100);
-  memLeakTest(
-    "Blob_something",
-    () =>
-      TestBuilder.command`cat < ${new Blob([
-        Array(128 * 1024)
-          .fill("a")
-          .join(""),
-      ])}`.stdout(str =>
-        expect(str).toEqual(
-          Array(128 * 1024)
-            .fill("a")
-            .join(""),
-        ),
-      ),
-    100,
+  // The child script (test_builder.ts plus the harness above) is far bigger than
+  // the 128 byte redirect targets.
+  memLeakTest("ArrayBuffer", () => TestBuilder.command`cat ${import.meta.filename} > ${new ArrayBuffer(128)}`);
+  memLeakTest("Buffer", () => TestBuilder.command`cat ${import.meta.filename} > ${Buffer.alloc(128)}`);
+  memLeakTest("Blob_something", () =>
+    TestBuilder.command`cat < ${new Blob([Buffer.alloc(128 * 1024, "a").toString()])}`.stdout(str =>
+      expect(str).toEqual(Buffer.alloc(128 * 1024, "a").toString()),
+    ),
   );
-  memLeakTest(
-    "Blob_nothing",
-    () =>
-      TestBuilder.command`echo hi < ${new Blob([
-        Array(128 * 1024)
-          .fill("a")
-          .join(""),
-      ])}`.stdout("hi\n"),
-    100,
+  memLeakTest("Blob_nothing", () =>
+    TestBuilder.command`echo hi < ${new Blob([Buffer.alloc(128 * 1024, "a").toString()])}`.stdout("hi\n"),
   );
-  memLeakTest("String", () => TestBuilder.command`echo ${Array(4096).fill("a").join("")}`.stdout(() => {}), 100);
+  memLeakTest("String", () => TestBuilder.command`echo ${Buffer.alloc(4096, "a").toString()}`.stdout(() => {}));
 
+  /**
+   * The shell pins a redirect target (`> ${buffer}`) for as long as the command
+   * runs. heapStats() reports the pinned objects in protectedObjectTypeCounts
+   * under their JSC class name (a Buffer is a Uint8Array there; a string is
+   * copied and never appears), so the whole table is compared before and after
+   * instead of looking up one class. Output redirected into `val` leaves stdout
+   * empty, which is what TestBuilder expects unless a snippet says otherwise.
+   */
   function memLeakTestProtect(
     name: string,
-    className: string,
     constructStmt: string,
     builder: string,
     posixOnly: boolean = false,
     runs: number = 5,
   ) {
-    const runTheTest = !posixOnly ? true : isPosix;
-    test.if(runTheTest)(
-      `memleak_protect_${name}`,
-      async () => {
-        const testcode = await Bun.file(join(import.meta.dirname, "./test_builder.ts")).text();
-
-        const impl = /* ts */ `
-              import { heapStats } from "bun:jsc";
-              const TestBuilder = createTestBuilder(import.meta.path);
-
-              Bun.gc(true);
-              const startValue = heapStats().protectedObjectTypeCounts.${className} ?? 0;
-              for (let i = 0; i < ${runs}; i++) {
-                await (async function() {
-                  let val = ${constructStmt}
-                  await ${builder}
-                })()
-                Bun.gc(true);
-
-                let value = heapStats().protectedObjectTypeCounts.${className} ?? 0;
-
-                if (value > startValue) {
-                  console.error('Leaked ${className} objects')
-                  process.exit(1);
-                }
-              }
-            `;
-
-        using dir = tempDir("memleak_protect", {
-          "script.ts": testcode + impl,
-        });
-
-        const { stderr: stream, exited } = Bun.spawn([process.argv0, "--smol", "test", join(dir, "script.ts")], {
-          env: bunEnv,
-          stdout: "ignore",
-          stderr: "pipe",
-        });
-        const [exitCode, stderr] = await Promise.all([exited, stream.text()]);
-        if (exitCode != 0) {
-          console.log("\n\nSTDERR:", stderr);
-        }
-        expect(exitCode).toBe(0);
-      },
-      100_000,
-    );
+    test.if(!posixOnly || isPosix)(`memleak_protect_${name}`, async () => {
+      const { result, exitCode } = await runChild(`protect-${name}`, {
+        once: /* ts */ `(async () => {
+          const val = ${constructStmt};
+          await ${builder}.quiet().run();
+        })()`,
+        runs,
+        measure: /* ts */ `async (run) => {
+          const before = protectedObjectCounts();
+          await run();
+          const after = await settle(protectedObjectCounts, after => Bun.deepEquals(after, before));
+          return { before, after };
+        }`,
+      });
+      expect(result.after).toEqual(result.before);
+      expect(exitCode).toBe(0);
+    });
   }
 
-  memLeakTestProtect(
-    "ArrayBuffer",
-    "ArrayBuffer",
-    "new ArrayBuffer(64)",
-    "TestBuilder.command`cat ${import.meta.filename} > ${val}`",
-  );
-  memLeakTestProtect(
-    "Buffer",
-    "Buffer",
-    "Buffer.alloc(64)",
-    "TestBuilder.command`cat ${import.meta.filename} > ${val}`",
-  );
+  // The child script is far bigger than these 64 byte targets.
+  memLeakTestProtect("ArrayBuffer", "new ArrayBuffer(64)", "TestBuilder.command`cat ${import.meta.filename} > ${val}`");
+  memLeakTestProtect("Buffer", "Buffer.alloc(64)", "TestBuilder.command`cat ${import.meta.filename} > ${val}`");
   memLeakTestProtect(
     "ArrayBuffer_builtin",
-    "ArrayBuffer",
     "new ArrayBuffer(64)",
     "TestBuilder.command`echo ${import.meta.filename} > ${val}`",
   );
   memLeakTestProtect(
     "Buffer_builtin",
-    "Buffer",
     "Buffer.alloc(64)",
     "TestBuilder.command`echo ${import.meta.filename} > ${val}`",
   );
 
-  memLeakTestProtect(
-    "Uint8Array",
-    "Uint8Array",
-    "new Uint8Array(64)",
-    "TestBuilder.command`cat ${import.meta.filename} > ${val}`",
-  );
+  memLeakTestProtect("Uint8Array", "new Uint8Array(64)", "TestBuilder.command`cat ${import.meta.filename} > ${val}`");
   memLeakTestProtect(
     "Uint8Array_builtin",
-    "Uint8Array",
     "new Uint8Array(64)",
     "TestBuilder.command`echo ${import.meta.filename} > ${val}`",
   );
 
   memLeakTestProtect(
-    "DataView",
     "DataView",
     "new DataView(new ArrayBuffer(64))",
     "TestBuilder.command`cat ${import.meta.filename} > ${val}`",
   );
   memLeakTestProtect(
     "DataView_builtin",
-    "DataView",
     "new DataView(new ArrayBuffer(64))",
     "TestBuilder.command`echo ${import.meta.filename} > ${val}`",
   );
 
   memLeakTestProtect(
     "String_large_input",
-    "String",
-    "Array(4096).fill('test').join('')",
-    "TestBuilder.command`echo ${val}`",
+    "Buffer.alloc(4 * 4096, 'test').toString()",
+    "TestBuilder.command`echo ${val}`.stdout(val + '\\n')",
   );
   memLeakTestProtect(
     "String_pipeline",
-    "String",
-    "Array(1024).fill('data').join('')",
-    "TestBuilder.command`echo ${val} | cat`",
+    "Buffer.alloc(4 * 1024, 'data').toString()",
+    "TestBuilder.command`echo ${val} | cat`.stdout(val + '\\n')",
   );
 
   // Complex nested pipelines
   memLeakTestProtect(
     "ArrayBuffer_nested_pipeline",
-    "ArrayBuffer",
     "new ArrayBuffer(256)",
-    "TestBuilder.command`echo ${val} | head -n 10 | tail -n 5 | wc -l`",
+    "TestBuilder.command`echo hello | head -n 10 | tail -n 5 | wc -l > ${val}`",
     true,
   );
   memLeakTestProtect(
     "Buffer_triple_pipeline",
-    "Buffer",
     "Buffer.alloc(256)",
-    "TestBuilder.command`echo ${val} | cat | grep -v nonexistent | wc -c`",
+    "TestBuilder.command`echo hello | cat | grep -v nonexistent | wc -c > ${val}`",
     true,
   );
   memLeakTestProtect(
     "String_complex_pipeline",
-    "String",
     "Array(512).fill('pipeline').join('\\n')",
-    "TestBuilder.command`echo ${val} | sort | uniq | head -n 3`",
+    "TestBuilder.command`echo ${val} | sort | uniq | head -n 3`.stdout('pipeline\\n')",
     true,
   );
 
   // Subshells with JS objects
   memLeakTestProtect(
     "ArrayBuffer_subshell",
-    "ArrayBuffer",
     "new ArrayBuffer(128)",
-    "TestBuilder.command`echo $(echo ${val} | wc -c)`",
+    "TestBuilder.command`echo $(echo hello | wc -c) > ${val}`",
     true,
   );
   memLeakTestProtect(
     "Buffer_nested_subshell",
-    "Buffer",
     "Buffer.alloc(128)",
-    "TestBuilder.command`echo $(echo ${val} | head -c 10) done`",
+    "TestBuilder.command`echo $(echo hello | head -c 3) done > ${val}`",
     true,
   );
   memLeakTestProtect(
     "String_subshell_pipeline",
-    "String",
-    "Array(256).fill('sub').join('')",
-    "TestBuilder.command`echo start $(echo ${val} | wc -c | cat) end`",
+    "Buffer.alloc(3 * 256, 'sub').toString()",
+    "TestBuilder.command`echo start $(echo ${val} | cat) end`.stdout('start ' + val + ' end\\n')",
     true,
   );
 
   // Mixed builtin and subprocess commands
   memLeakTestProtect(
     "ArrayBuffer_mixed_commands",
-    "ArrayBuffer",
     "new ArrayBuffer(192)",
-    "TestBuilder.command`mkdir -p tmp && echo ${val} > tmp/test.txt && cat tmp/test.txt && rm -rf tmp`",
+    "TestBuilder.command`mkdir -p tmp && echo hello > tmp/test.txt && cat tmp/test.txt > ${val} && rm -rf tmp`",
   );
+  // Every run here spawns a bun (about 0.3s each in a debug build). The check is
+  // exact, so two measured runs detect a leak as surely as five.
   memLeakTestProtect(
     "Buffer_builtin_external_mix",
-    "Buffer",
     "Buffer.alloc(192)",
-    "TestBuilder.command`echo ${val} | ${bunExe()} -e 'process.stdin.on(\"data\", d => process.stdout.write(d))' | head -c 50`",
+    "TestBuilder.command`echo hello | ${bunExe()} -e 'Bun.stdin.text().then(text => Bun.write(Bun.stdout, text))' > ${val}`",
+    false,
+    2,
   );
   memLeakTestProtect(
     "String_cd_operations",
-    "String",
-    "Array(128).fill('dir').join('')",
-    "TestBuilder.command`mkdir -p testdir && cd testdir && echo ${val} > file.txt && cd .. && cat testdir/file.txt && rm -rf testdir`",
+    "Buffer.alloc(3 * 128, 'dir').toString()",
+    "TestBuilder.command`mkdir -p testdir && cd testdir && echo ${val} > file.txt && cd .. && cat testdir/file.txt && rm -rf testdir`.stdout(val + '\\n')",
   );
 
   // Conditional execution
   memLeakTestProtect(
     "ArrayBuffer_conditional",
-    "ArrayBuffer",
     "new ArrayBuffer(64)",
-    "TestBuilder.command`echo ${val} && echo success || echo failure`",
+    "TestBuilder.command`echo hello > ${val} && echo success || echo failure`.stdout('success\\n')",
   );
   memLeakTestProtect(
     "Buffer_test_conditional",
-    "Buffer",
     "Buffer.alloc(64)",
-    "TestBuilder.command`test -n ${val} && echo 'has content' || echo 'empty'`",
+    "TestBuilder.command`test -n hello && echo 'has content' > ${val} || echo 'empty'`",
     true,
   );
 
-  describe.serial("#11816", async () => {
+  // The rest measures this process's own heap, so it runs alone, after the
+  // child-spawning tests above. #11816 leaked one ShellInterpreter per command;
+  // 30 commands against a bound of 3 keep a 10x margin.
+  const BATCHES = 3;
+  const BATCH_SIZE = 10;
+
+  function shellCommand(builtin: boolean, dir: string): $.ShellPromise {
+    return builtin
+      ? $`cat ${dir}/input.txt`
+      : $`${bunExe()} -e ${/* ts */ `console.log(Buffer.alloc(1024, 'a').toString())`}`.env(bunEnv);
+  }
+
+  // Same settle loop as the children: the last batch can stay conservatively
+  // rooted until the stack unwinds for an event loop turn.
+  async function expectShellObjectsCollected() {
+    let counts = { ShellInterpreter: 0, ParsedShellScript: 0 };
+    for (let turn = 0; turn <= 50; turn++) {
+      if (turn > 0) await new Promise(resolve => setImmediate(resolve));
+      Bun.gc(true);
+      const { ShellInterpreter = 0, ParsedShellScript = 0 } = heapStats().objectTypeCounts;
+      counts = { ShellInterpreter, ParsedShellScript };
+      if (ShellInterpreter <= MAX_SHELL_OBJECTS && ParsedShellScript <= MAX_SHELL_OBJECTS) break;
+    }
+    expect(counts.ShellInterpreter).toBeLessThanOrEqual(MAX_SHELL_OBJECTS);
+    expect(counts.ParsedShellScript).toBeLessThanOrEqual(MAX_SHELL_OBJECTS);
+  }
+
+  describe.serial("#11816", () => {
     function doit(builtin: boolean) {
       test(builtin ? "builtin" : "external", async () => {
         await using files = tempDir("hi", {
-          "input.txt": Array(2048).fill("a").join(""),
+          "input.txt": Buffer.alloc(2048, "a").toString(),
         });
-        for (let j = 0; j < 10; j++) {
-          const promises = [];
-          for (let i = 0; i < 10; i++) {
-            if (builtin) {
-              promises.push($`cat ${files}/input.txt`.quiet());
-            } else {
-              promises.push(
-                $`${bunExe()} -e ${/* ts */ `console.log(Array(1024).fill('a').join(''))`}`.env(bunEnv).quiet(),
-              );
-            }
+        for (let j = 0; j < BATCHES; j++) {
+          const promises: $.ShellPromise[] = [];
+          for (let i = 0; i < BATCH_SIZE; i++) {
+            promises.push(shellCommand(builtin, String(files)).quiet());
           }
-
-          await Promise.all(promises);
-          Bun.gc(true);
+          const outputs = await Promise.all(promises);
+          expect(outputs.map(output => output.exitCode)).toEqual(Array(BATCH_SIZE).fill(0));
         }
 
-        // Same GC-settle window as the sibling test below: a dead interpreter can
-        // stay visible to heapStats for a tick; a real leak stays high forever.
-        for (let k = 0; k < 50; k++) {
-          const c = heapStats().objectTypeCounts;
-          if ((c.ShellInterpreter ?? 0) <= 3 && (c.ParsedShellScript ?? 0) <= 3) break;
-          await Bun.sleep(20);
-          Bun.gc(true);
-        }
-        const { ShellInterpreter, ParsedShellScript } = heapStats().objectTypeCounts;
-        if (ShellInterpreter > 3 || ParsedShellScript > 3) {
-          console.error("TOO many ParsedShellScript or ShellInterpreter objects", ParsedShellScript, ShellInterpreter);
-          throw new Error("TOO many ParsedShellScript or ShellInterpreter objects");
-        }
+        await expectShellObjectsCollected();
       });
     }
     doit(false);
@@ -447,46 +418,25 @@ describe.concurrent("fd leak", () => {
     function doit(builtin: boolean) {
       test(builtin ? "builtin" : "external", async () => {
         await using files = tempDir("hi", {
-          "input.txt": Array(2048).fill("a").join(""),
+          "input.txt": Buffer.alloc(2048, "a").toString(),
         });
         // wrapping in a function
         // because of an optimization
         // which will hoist the `promise` array to the top (to avoid creating it in every iteration)
         // this causes the array to be kept alive for the scope
         function run() {
-          for (let j = 0; j < 10; j++) {
-            const promises = [];
-            for (let i = 0; i < 10; i++) {
-              if (builtin) {
-                promises.push($`cat ${files}/input.txt`);
-              } else {
-                promises.push($`${bunExe()} -e ${/* ts */ `console.log(Array(1024).fill('a').join(''))`}`.env(bunEnv));
-              }
+          for (let j = 0; j < BATCHES; j++) {
+            const promises: $.ShellPromise[] = [];
+            for (let i = 0; i < BATCH_SIZE; i++) {
+              promises.push(shellCommand(builtin, String(files)));
             }
-
-            Bun.gc(true);
           }
         }
         run();
-        Bun.gc(true);
 
-        // The newer module loader can keep the last inner-loop batch reachable
-        // via a conservative stack root for one extra tick; give GC a brief
-        // retry window before asserting (mirrors expectMaxObjectTypeCount).
-        for (let k = 0; k < 50; k++) {
-          const c = heapStats().objectTypeCounts;
-          if ((c.ShellInterpreter ?? 0) <= 3 && (c.ParsedShellScript ?? 0) <= 3) break;
-          await Bun.sleep(20);
-          Bun.gc(true);
-        }
-        const { ShellInterpreter, ParsedShellScript } = heapStats().objectTypeCounts;
-        if (ShellInterpreter > 3 || ParsedShellScript > 3) {
-          console.error("TOO many ParsedShellScript or ShellInterpreter objects", ParsedShellScript, ShellInterpreter);
-          throw new Error("TOO many ParsedShellScript or ShellInterpreter objects");
-        }
+        await expectShellObjectsCollected();
       });
     }
-
     doit(false);
     doit(true);
   });

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -14,10 +14,12 @@ $.nothrow();
 
 // Every leak these tests guard against costs at least one unit (fd, JS object,
 // protected object) per run, so a leak puts RUNS units on the detector. The
-// bounds below allow for legitimate residue: the last run's interpreter and
-// script can stay conservatively rooted through Bun.gc(true), and an interpreter
-// that has not been finalized yet can still hold an fd or two. 100 runs puts a
-// one-unit-per-run leak at 20x the fd bound and 33x the object bound.
+// bounds below allow for legitimate residue: heapStats() counts each class's
+// prototype (so ShellInterpreter and ParsedShellScript read 1 each once a script
+// has run, and never less), the last run's objects can stay conservatively
+// rooted through Bun.gc(true), and an interpreter that has not been finalized
+// yet can still hold an fd or two. 100 runs puts a one-unit-per-run leak at 20x
+// the fd bound and 33x the object bound.
 const RUNS = 100;
 const WARMUP_RUNS = 1;
 const FD_LEAK_BOUND = 5;
@@ -81,6 +83,11 @@ function snippet(builder: () => TestBuilder): string {
  * on successive event loop turns until `ok` accepts the sample (or 50 turns
  * pass) and returns the last sample: a dead interpreter can stay visible to
  * heapStats for a turn, a real leak never goes away.
+ *
+ * Every child also reports how many ShellInterpreter cells exist when it is
+ * done. The class prototype is created the first time a script executes, so
+ * this is 0 exactly when the snippet never reached the shell, which is how an
+ * earlier version of this file passed while its children ran nothing.
  */
 async function runChild(
   name: string,
@@ -124,7 +131,7 @@ async function runChild(
     await runTimes(${WARMUP_RUNS});
     Bun.gc(true);
     const result = await (${measure})(() => runTimes(${runs}));
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify({ result, shellInterpreters: shellObjectCounts().ShellInterpreter }));
   `;
   // The child's cwd and tmpdir both point here, so whatever the snippets create
   // (TestBuilder.tmpdir() makes a fresh directory per run) is removed with it.
@@ -140,7 +147,9 @@ async function runChild(
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout).toMatch(/^\{.*\}\n$/);
-  return { result: JSON.parse(stdout), exitCode };
+  const { result, shellInterpreters } = JSON.parse(stdout);
+  expect(shellInterpreters).toBeGreaterThanOrEqual(1);
+  return { result, exitCode };
 }
 
 describe.concurrent("fd leak", () => {
@@ -208,12 +217,19 @@ describe.concurrent("fd leak", () => {
   memLeakTest("String", () => TestBuilder.command`echo ${Buffer.alloc(4096, "a").toString()}`.stdout(() => {}));
 
   /**
-   * The shell pins a redirect target (`> ${buffer}`) for as long as the command
-   * runs. heapStats() reports the pinned objects in protectedObjectTypeCounts
-   * under their JSC class name (a Buffer is a Uint8Array there; a string is
-   * copied and never appears), so the whole table is compared before and after
-   * instead of looking up one class. Output redirected into `val` leaves stdout
-   * empty, which is what TestBuilder expects unless a snippet says otherwise.
+   * The shell pins a JS redirect target for as long as the command runs: one
+   * reference per redirected stream (`&>` takes two) for both builtins and
+   * subprocesses, and a builtin also pins a `< ${buffer}` stdin (a subprocess
+   * copies it). heapStats() reports the pinned objects in
+   * protectedObjectTypeCounts under their JSC class name (a Buffer is a
+   * Uint8Array there; a string argument is copied and never appears), so the
+   * whole table is compared before and after instead of looking up one class.
+   *
+   * `echo` and `cd` are builtins everywhere; `cat` is the system binary on
+   * POSIX and the builtin on Windows, so the `cat` snippets cover the
+   * subprocess paths on the POSIX lanes and the builtin paths on Windows.
+   * Output redirected into `val` leaves stdout empty, which is what TestBuilder
+   * expects unless a snippet says otherwise.
    */
   function memLeakTestProtect(
     name: string,
@@ -271,6 +287,41 @@ describe.concurrent("fd leak", () => {
     "DataView_builtin",
     "new DataView(new ArrayBuffer(64))",
     "TestBuilder.command`echo ${import.meta.filename} > ${val}`",
+  );
+
+  // Both streams pinned at once (#29531 leaked one of the two references).
+  memLeakTestProtect(
+    "ArrayBuffer_builtin_both_streams",
+    "new ArrayBuffer(64)",
+    "TestBuilder.command`echo hi &> ${val}`",
+  );
+  memLeakTestProtect(
+    "Buffer_subprocess_both_streams",
+    "Buffer.alloc(64)",
+    "TestBuilder.command`${bunExe()} -e 'console.log(1); console.error(2)' &> ${val}`",
+    false,
+    2,
+  );
+
+  // stderr pinned by a command that fails, so the references are released on
+  // the error path.
+  memLeakTestProtect(
+    "Uint8Array_missing_file_stderr",
+    "new Uint8Array(128)",
+    "TestBuilder.command`cat missing.txt 2> ${val}`.exitCode(1)",
+  );
+  memLeakTestProtect(
+    "ArrayBuffer_failed_cd_stderr",
+    "new ArrayBuffer(128)",
+    "TestBuilder.command`cd missing-dir 2> ${val}`.exitCode(1)",
+  );
+
+  // stdin from a JS object.
+  memLeakTestProtect("Buffer_stdin", "Buffer.from('hi\\n')", "TestBuilder.command`cat < ${val}`.stdout('hi\\n')");
+  memLeakTestProtect(
+    "Buffer_builtin_stdin",
+    "Buffer.alloc(64)",
+    "TestBuilder.command`echo hi < ${val}`.stdout('hi\\n')",
   );
 
   memLeakTestProtect(

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -12,14 +12,8 @@ $.env(bunEnv);
 $.cwd(process.cwd());
 $.nothrow();
 
-// Bound on RSS growth over a whole run. ASAN's quarantine retains freed
-// allocations (default 256 MB), so RSS grows far more under bun-asan even
-// without a leak; widen the threshold there. (Measured growth over 100 runs is
-// 11-56 MB under ASAN, much less without it.)
-const DEFAULT_THRESHOLD = (isASAN ? 350 : process.platform === "darwin" ? 100 : 150) * (1 << 20);
-
 // Every leak these tests guard against costs at least one unit (fd, JS object,
-// protected object) per run, so a leak puts `runs` units on the detector. The
+// protected object) per run, so a leak puts RUNS units on the detector. The
 // bounds below allow for legitimate residue: the last run's interpreter and
 // script can stay conservatively rooted through Bun.gc(true), and an interpreter
 // that has not been finalized yet can still hold an fd or two. 100 runs puts a
@@ -28,6 +22,10 @@ const RUNS = 100;
 const WARMUP_RUNS = 1;
 const FD_LEAK_BOUND = 5;
 const MAX_SHELL_OBJECTS = 3;
+// Bound on RSS growth across the measured runs (11-56 MB measured under ASAN,
+// less without it). ASAN's quarantine keeps freed allocations resident
+// (256 MB by default), so the bound is wider under bun-asan.
+const MAX_RSS_GROWTH = (isASAN ? 350 : process.platform === "darwin" ? 100 : 150) * (1 << 20);
 
 const TESTS: [name: string, builder: () => TestBuilder][] = [
   ["redirect_file", () => TestBuilder.command`echo hello > test.txt`.fileEquals("test.txt", "hello\n")],
@@ -146,11 +144,11 @@ async function runChild(
 }
 
 describe.concurrent("fd leak", () => {
-  function fdLeakTest(name: string, builder: () => TestBuilder, runs: number = RUNS) {
+  function fdLeakTest(name: string, builder: () => TestBuilder) {
     test(`fdleak_${name}`, async () => {
       const { result, exitCode } = await runChild(`fd-${name}`, {
         once: `${snippet(builder)}.quiet().run()`,
-        runs,
+        runs: RUNS,
         measure: /* ts */ `async (run) => {
           const baseline = fdCount();
           await run();
@@ -164,16 +162,11 @@ describe.concurrent("fd leak", () => {
     });
   }
 
-  function memLeakTest(
-    name: string,
-    builder: () => TestBuilder,
-    runs: number = RUNS,
-    threshold: number = DEFAULT_THRESHOLD,
-  ) {
+  function memLeakTest(name: string, builder: () => TestBuilder) {
     test(`memleak_${name}`, async () => {
       const { result, exitCode } = await runChild(`mem-${name}`, {
         once: `${snippet(builder)}.quiet().run()`,
-        runs,
+        runs: RUNS,
         measure: /* ts */ `async (run) => {
           const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
           const rssBefore = rss();
@@ -190,7 +183,7 @@ describe.concurrent("fd leak", () => {
       });
       expect(result.ShellInterpreter).toBeLessThanOrEqual(MAX_SHELL_OBJECTS);
       expect(result.ParsedShellScript).toBeLessThanOrEqual(MAX_SHELL_OBJECTS);
-      expect(result.rssGrowth).toBeLessThan(threshold);
+      expect(result.rssGrowth).toBeLessThan(MAX_RSS_GROWTH);
       expect(exitCode).toBe(0);
     });
   }


### PR DESCRIPTION
### Problem
- `test/js/bun/shell/leak.test.ts` is a serial-phase file that takes 23-24s on the x64 ASAN lane and 7-17s on the others (Buildkite 95391, 95331). Locally on a debug build it takes 230s and three tests (`memleak_ls`, `memleak_Blob_something`, `memleak_Blob_nothing`) hit their 100s timeout.
- The cost is 1000/500 executions per snippet, plus three `Bun.gc(true)` and one `heapStats()` heap walk per iteration in the memleak children, plus `Array(128 * 1024).fill("a").join("")` twice per run in the Blob fixtures (2.9s per call in a debug build).
- While reading it, most of the file turned out not to measure anything:
  - memleak block (11 tests): the child calls `.runAsTest()` inside the measuring loop (since #10199). That registers a test and returns, so the GC, RSS and object-count checks all ran during test registration, before a single command had executed. The commands ran afterwards with no measurement.
  - protect block (21 tests): the child does `await TestBuilder.command\`...\`` with no `.run()`, so no command ever executed. On top of that the `Buffer` cases read `protectedObjectTypeCounts.Buffer`, a key that never exists (a Buffer is reported under its JSC class, `Uint8Array`), and 8 of the snippets interpolate a buffer as a command argument, which the shell rejects with `expected a command or assignment but got: "JSObjRef"` as soon as they actually run.
  - Two protect snippets run `mkdir -p tmp ... rm -rf tmp` / `rm -rf testdir` in the inherited cwd, i.e. the repo root when they are made to run.
- Each test asserted only the child's exit code (38 `expect()` calls for 42 tests), so a failure printed nothing about what leaked.

### Fix
- One `runChild()` helper generates every child: `test_builder.ts` + the snippet, run with plain `bun --smol run` (TestBuilder only needs `Bun.jest()`, which works outside the test runner). The child runs the snippet once as warmup, takes its baseline, runs it `runs` times via `.run()`, measures once at the end and prints the numbers as one JSON line. The parent asserts `stderr === ""`, then the numbers, then the exit code:
  - fd: `leakedFds <= 5`
  - memleak: `ShellInterpreter <= 3`, `ParsedShellScript <= 3`, `rssGrowth < threshold` (threshold unchanged: 350 MB ASAN / 100 MB darwin / 150 MB)
  - protect: the whole `protectedObjectTypeCounts` table before `toEqual` after, so every pinned class is covered without naming it and a failure prints e.g. `Uint8Array: 1 -> 6`
  - the two in-process blocks: `#11816` now also checks that all 30 commands exited 0; both assert the counts with `expect` instead of `console.error` + `throw`
  - positive control, applied to all 44 children by `runChild()`: the child also reports its `ShellInterpreter` cell count and the parent requires `>= 1`. `heapStats()` counts the class prototype, which is only created once a script has executed (fresh process 0; after any run 1, and it stays 1 through further GCs, verified on debug and release), so a snippet that stops reaching `.run()`, i.e. exactly how this file went quiet before, now fails with `Expected: >= 1, Received: 0` (verified by removing `.run()` from a copy).
- Measuring once at the end is the same detector as the old per-iteration check (a leak of N objects is visible at the end just as it was after 4 iterations), minus the per-iteration GC + heap walk that was the bulk of the cost. The bounds stay upper bounds rather than exact values because the residue is 1 per class for the prototype plus whatever the last run left conservatively rooted (1, occasionally 2, in 10/10 probes); protected counts have no such residue and are asserted exactly.
- `settle()` re-samples after a full GC on successive event loop turns (`setImmediate`) until the bound holds, at most 50 turns, and returns the last sample. Replaces the `Bun.sleep(20)` loops; the fast path is zero extra turns. A real leak never settles, so the reported value is the leak.
- Loop counts, each with the detection arithmetic for a leak of one unit per run:
  - fd: 1000 (ls 500, rm 100) -> 100 runs. Leak lands at 100 against a bound of 5: 20x. Measured residue is exactly 0 for all six snippets.
  - memleak: 500 (ls 500, rm 100, fixtures 100) -> 100 runs. Leak lands at 100+ against a bound of 3: 33x. Measured residue is 1-2 interpreters, 1 script. RSS growth over 100 runs measures 11-17 MB (56 MB for `Blob_something`) under ASAN against 350 MB. The fixture payloads (128 B buffers since #20476, 128 KB blobs, 4 KB strings) never came close to tripping the RSS bound at 100 or 500 runs, so the RSS check is a gross-leak guard at either count; the object-count checks are the per-fixture detectors.
  - protect: still 5 runs (2 for the two cases that spawn a bun per run); the check is exact, so any count of measured runs detects a one-per-run leak and prints it.
  - in-process blocks: 10x10 -> 3x10 commands. #11816 leaked one interpreter per command, so 30 against a bound of 3: 10x.
- Protect snippets now put the buffer where the shell pins it, the redirect target (`... > ${val}`), keeping each snippet's shape (pipeline, subshell, builtin + external, `&&`/`||`, `test`). Probed with a slow external command: `> ${val}` shows up as `ArrayBuffer` / `Uint8Array` / `DataView: 1` in the table mid-run and is gone after the run; string arguments are copied and never pinned, so the `String_*` cases assert their stdout and that the table is unchanged. A JS-object redirect inside `$(...)` does not parse at all (`... got: "CmdSubstEnd"`, reported separately), so the subshell cases redirect the outer command.
- Six protect cases are added for the pinning sites the original table did not reach, one line each: `&>` for a builtin and for a subprocess (two references to the same buffer; #29531 fixed a leak of one of them on both paths), `2> ${val}` on a command that fails (`cat missing.txt`, `cd missing-dir`, both `.exitCode(1)`) so release on the error path is covered, and stdin from a buffer for a builtin (pinned) and for `cat` (copied by a subprocess). Note `cat` is the system binary on POSIX and the builtin on Windows (`posix_disabled: [Cat, Cp]` in `Builtin.rs`), so every `cat` case exercises the subprocess paths on the POSIX lanes and the builtin paths on Windows; this is now documented next to the table. All six release their references today (probed on both paths), and a wrong `.exitCode()` on the failing cases does fail the test (TestBuilder reports it on the child's stderr).
- Children get `cwd` and `TMPDIR`/`TMP`/`TEMP` set to the test's own temp dir, so the directory `TestBuilder.tmpdir()` creates per run (previously ~4000 per file run, never removed) goes away with the test, and the `rm -rf tmp` snippets no longer touch the process cwd.
- Fixture strings use `Buffer.alloc(n, fill).toString()` (same contents); the external helper in `Buffer_builtin_external_mix` uses `Bun.stdin`/`Bun.write` instead of `process.stdin`, whose initialization alone costs ~0.9s per spawn in a debug build. The explicit 100s timeouts are gone; the slowest test is ~2.3s on the debug build (5s default).
- Also typed the two `promises` arrays (`$.ShellPromise[]`), which were `never[]` under tsc before.
- Verification, all on this branch:
  - `bun bd test test/js/bun/shell/leak.test.ts` (debug + ASAN): before 229.9s with 3 timeouts, after 17.1-21.3s across 6 runs of the 42-test version, all passing. Under ASAN `bun test` caps concurrency at 5, so the remaining time is mostly child process startups (~1.3s each on a debug build) in waves of 5 plus ~2.6s loading the file. The 48-test version passes as well (26.7s, measured on a heavily loaded host, so not comparable).
  - `USE_SYSTEM_BUN=1 bun test` (release 1.4.0): before 4.56s wall / 27.9s user CPU, after 0.74s wall / 1.75s user CPU for the 42-test version (1.1s / 2.0s for the 48-test version on the loaded host). The CI lanes are 4-8 vCPUs, so CPU is the number that predicts their wall time.
  - `expect()` calls per file run: 38 -> 188 (42 tests), now 48 tests.
  - CI, this PR's first build (serial-phase time of the file, `Ran 42 tests` line; before = the 95391/95331 numbers this was filed with): debian 13 x64 ASAN 23-24s -> 4.3s, windows 11 aarch64 17s -> 3.2s, windows 2019 x64 13s -> 2.6s, alpine x64 13s -> 2.9s, alpine aarch64 11s -> 2.7s, debian/ubuntu x64 7-9s -> 1.7s, debian/ubuntu aarch64 -> 0.9-1.2s. 42 pass on every lane that ran (35 + the 7 posix-only protect cases skipped on Windows); the darwin shards of that build never got an agent. The six added cases are in the build for a0f7863.
  - Deliberate-leak experiment (temporary copy of the file injecting one leak per run in the child loop, output below): every reduced loop still fails, with the value in the message.

<details>
<summary>Deliberate leak output</summary>

Injected into `runTimes()` of a temporary copy, one per run, then run with the matching test filter:

```
openSync(devNull)                      fdleak_pipeline:        expect(leakedFds).toBeLessThanOrEqual   Expected: <= 5   Received: 100
keep.push(Bun.$`true`)                 memleak_pipeline:       expect(ParsedShellScript)...            Expected: <= 3   Received: 102
keep.push(Buffer.alloc(4 << 20))       memleak_String:         expect(rssGrowth).toBeLessThan          Expected: < 367001600   Received: 437534720
unawaited `bun -e setTimeout > ${val}` memleak_protect_Buffer: expect(after).toEqual(before)
                                         -   "Uint8Array": 1,
                                         +   "Uint8Array": 6,
```

(102 = 100 runs + the warmup run + the usual one lingering script; the protect baseline already holds the warmup run's pin.)
</details>

<details>
<summary>Residue probes behind the bounds</summary>

30 `echo hi` runs followed by `Bun.gc(true)`, then up to 10 more turns of `setImmediate` + GC, 10 trials: `ShellInterpreter` stayed at 1 and `ParsedShellScript` at 1 (2 in one trial) through every turn, so exact-zero assertions on these counts would fail; the bound of 3 is the existing one.

`protectedObjectTypeCounts` diff relative to a post-GC baseline, sampled while `bun -e 'setTimeout(()=>{},300)'` runs and again after it: `> ${new ArrayBuffer(64)}` -> `{ArrayBuffer: 1}` then `{}`; `> ${Buffer.alloc(64)}` -> `{Uint8Array: 1}` then `{}`; `> ${new Uint8Array(64)}` -> `{Uint8Array: 1}`; `> ${new DataView(...)}` -> `{DataView: 1}`; `< ${buffer}` and a string argument -> `{}` both times.
</details>

### Background
- `heapStats()` (from `bun:jsc`) walks the JS heap. `objectTypeCounts` counts live cells per class; `ShellInterpreter` and `ParsedShellScript` are the wrapper objects for a running shell and a parsed `$` template (#11816 / #11830 leaked them). `protectedObjectTypeCounts` counts objects kept alive by native strong references; bun's `Strong` handles are merged into it, and the shell holds one for a JS redirect target while the command runs. Both tables count cells by class name, so a class's prototype object counts as one instance of that class once it has been created.
- JSC scans the stack conservatively: any word on the stack that looks like a pointer to an object keeps it alive through `Bun.gc(true)`. That is why the most recent run's objects can survive a GC and why the checks are upper bounds plus a retry across event loop turns, which unwinds the stack in between.
- `TestBuilder` (`test_builder.ts`) is the shell test DSL: `.command\`...\`` records a template, `.stdout()`/`.fileEquals()` record expectations, `.run()` executes and checks them via `Bun.jest(path).expect`, while `.runAsTest()` only registers a `test()` to be executed later. The children embed the builders' source text, which is why the snippets in this file are never invoked in the parent.
- Under ASAN, freed memory sits in a quarantine (256 MB by default) and still counts toward RSS, which is why the RSS bound is 350 MB there and why RSS can only catch gross leaks. ASAN builds of `bun test` also default `--max-concurrency` to 5 instead of 20 (`options_types/context.rs`), so on the ASAN lane this file's wall time is roughly (child processes / 5) x child duration.

