### PR TITLE
test(init): initialize each react template once and skip the npm bun package's postinstall

### DIFF
--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -1,31 +1,127 @@
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fs, { readdirSync } from "fs";
-import { bunEnv, bunExe, isWindows, nodeExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, nodeExe, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
+
+// The `bun install` that `bun init` runs reads this global bunfig. The
+// tailwind and shadcn templates depend on bun-plugin-tailwind, whose `bun` peer
+// dependency pulls in the npm `bun` package, and that package's postinstall
+// costs several seconds per install on some CI machines (it shells out to
+// `npm install` on musl and to PowerShell on Windows x64). Nothing in this file
+// asserts on lifecycle scripts.
+const globalConfigDir = tempDirWithFiles("bun-init-global-config", {
+  ".bunfig.toml": "[install]\nignoreScripts = true\n",
+});
 
 // Whether `bun init` emits CLAUDE.md depends on a `claude` binary being on
 // PATH, which varies by CI machine — disable the detection so the directory
 // snapshots are stable everywhere.
-const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
+const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1", XDG_CONFIG_HOME: globalConfigDir };
 
-(isWindows ? describe : describe.concurrent)("bun init", () => {
-  // Every test's `bun init` runs a real `bun install`. bun dedupes downloads
-  // within a process but not across them, so on a cold CI cache the concurrent
-  // inits each re-fetch the same tarballs. Prime the shared install cache once,
-  // serially: `--react=shadcn`'s lockfile is a superset of the other react
-  // templates', and `-y` covers the blank template (typescript + @types/bun).
-  beforeAll(async () => {
-    for (const flag of ["-y", "--react=shadcn"]) {
-      const temp = tempDirWithFiles("bun-init-cache-prime", {});
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "init", flag],
-        cwd: temp,
-        stdio: ["ignore", "ignore", "ignore"],
-        env: initEnv,
-      });
-      await proc.exited;
+// `src/cli` is a symlink to `src/runtime/cli`, which Windows checkouts may
+// materialize as a plain file, so go through the real path.
+const templateSourceDir = path.join(import.meta.dir, "../../../src/runtime/cli/init");
+
+interface InitResult {
+  dir: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  /** Everything `bun init` left in `dir`, captured before any test builds into it. */
+  files: string[];
+}
+
+// Relative paths of everything under `dir`, sorted, with node_modules listed
+// as a single entry: the installed packages are asserted on separately.
+function listFiles(dir: string, prefix = ""): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(path.join(dir, prefix), { withFileTypes: true })) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory() && entry.name !== "node_modules") {
+      files.push(...listFiles(dir, rel));
+    } else {
+      files.push(rel);
     }
+  }
+  return files.sort();
+}
+
+describe.concurrent("bun init", () => {
+  // `bun init <template>` scaffolds the template and runs a real `bun install`
+  // against the registry. Each template is initialized at most once per run
+  // and the cases below share the result: the react templates are the
+  // expensive installs (shadcn is ~60 packages), and the assertions only read
+  // from the directory, apart from `bun run build`, which writes `dist/`.
+  const templateInits = new Map<string, Promise<InitResult>>();
+
+  function initTemplate(flag: string): Promise<InitResult> {
+    let init = templateInits.get(flag);
+    if (!init) {
+      init = (async () => {
+        const dir = tempDirWithFiles(`bun-init${flag.replace(/[^a-z]+/g, "-")}`, {});
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "init", flag],
+          cwd: dir,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: initEnv,
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { dir, stdout, stderr, exitCode, files: listFiles(dir) };
+      })();
+      templateInits.set(flag, init);
+    }
+    return init;
+  }
+
+  // bun dedupes downloads within one `bun install`, not across processes, so
+  // on a cold CI cache concurrent inits would each fetch the same tarballs.
+  // shadcn's dependency closure is a superset of every other template's
+  // (including the blank one: @types/bun + typescript), so initializing it
+  // first, alone, leaves every other install in this file fully cached.
+  beforeAll(async () => {
+    await initTemplate("--react=shadcn");
   }, 240_000);
+
+  afterAll(async () => {
+    const dirs = [globalConfigDir];
+    for (const init of await Promise.allSettled(templateInits.values())) {
+      if (init.status === "fulfilled") dirs.push(init.value.dir);
+    }
+    await Promise.all(dirs.map(dir => fs.promises.rm(dir, { recursive: true, force: true })));
+  });
+
+  // The scaffolding `bun init` does for a react template is fully determined
+  // by the template's source directory plus the generated README/.gitignore,
+  // and `bun init` exits 0 even when the nested `bun install` fails, so the
+  // evidence that the install ran is the lockfile and node_modules.
+  function expectReactTemplate(init: InitResult, source: string, readmeTitle: string) {
+    const { dir, stdout, stderr, exitCode } = init;
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    expect(stderr).not.toMatch(/^(error|warn)/m);
+
+    // Line endings are normalized because the checkout that built the binary
+    // and the one running the tests need not agree on them.
+    const lf = (file: string) => fs.readFileSync(file, "utf8").replaceAll("\r\n", "\n");
+    const sourceDir = path.join(templateSourceDir, source);
+    // The template directory's own bun.lock (and the node_modules a local
+    // `bun install` in there leaves behind) are not part of the scaffold;
+    // `bun init` writes a fresh bun.lock.
+    const templateFiles = listFiles(sourceDir).filter(file => file !== "bun.lock" && file !== "node_modules");
+    expect(templateFiles.length).toBeGreaterThan(0);
+    for (const file of templateFiles) {
+      expect(lf(path.join(dir, file)), file).toBe(lf(path.join(sourceDir, file)));
+    }
+
+    const readme = fs.readFileSync(path.join(dir, "README.md"), "utf8");
+    expect(readme).toStartWith(`# ${readmeTitle}\n`);
+    expect(readme).toInclude("bun v" + Bun.version.replaceAll("-debug", ""));
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+    const declared = Object.keys({ ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies }).sort();
+    expect(declared).toContain("typescript");
+    const installed = declared.filter(name => fs.existsSync(path.join(dir, "node_modules", name, "package.json")));
+    expect(installed).toEqual(declared);
+  }
 
   test("bun init works", async () => {
     await using temp = tempDir("bun-init-works", {});
@@ -57,10 +153,15 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(readme).toInclude("v" + Bun.version.replaceAll("-debug", ""));
     expect(readme).toInclude("index.ts");
 
-    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(readdirSync(temp).sort()).toEqual([
+      ".gitignore",
+      "README.md",
+      "bun.lock",
+      "index.ts",
+      "node_modules",
+      "package.json",
+      "tsconfig.json",
+    ]);
   }, 30_000);
 
   test("bun init falls back to --yes when stdin is not a TTY", async () => {
@@ -85,9 +186,16 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(stderr).not.toContain("\x1b[");
     expect(exitCode).toBe(0);
 
-    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    // The blank template was scaffolded and installed, exactly as with -y.
+    expect(readdirSync(temp).sort()).toEqual([
+      ".gitignore",
+      "README.md",
+      "bun.lock",
+      "index.ts",
+      "node_modules",
+      "package.json",
+      "tsconfig.json",
+    ]);
   }, 30_000);
 
   test("bun init in folder", async () => {
@@ -125,13 +233,19 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     await using temp = tempDir("bun-init-error-rather-than-overwriting-file", {
       "mydir": "don't delete me!!!",
     });
-    const { exited } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "init", "-y", "mydir"],
       cwd: temp,
       stdio: ["ignore", "pipe", "pipe"],
       env: initEnv,
     });
-    expect(await exited).not.toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toMatchInlineSnapshot(`
+      "Failed to change directory to mydir: ENOTDIR
+      "
+    `);
+    expect(exitCode).toBe(1);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
     expect(await Bun.file(path.join(temp, "mydir")).text()).toBe("don't delete me!!!");
   });
@@ -238,78 +352,89 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   });
 
   test("bun init --react works", async () => {
-    await using temp = tempDir("bun-init--react-works", {});
-
-    const { exited } = Bun.spawn({
-      cmd: [bunExe(), "init", "--react"],
-      cwd: temp,
-      stdio: ["ignore", "inherit", "inherit"],
-      env: initEnv,
-    });
-
-    expect(await exited).toBe(0);
-
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
-    expect(pkg).toHaveProperty("dependencies.react");
-    expect(pkg).toHaveProperty("dependencies.react-dom");
-    expect(pkg).toHaveProperty("devDependencies.@types/react");
-    expect(pkg).toHaveProperty("devDependencies.@types/react-dom");
-    expect(pkg.peerDependencies).toEqual({ typescript: "^6" });
-
-    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    const init = await initTemplate("--react");
+    expect(init.files).toMatchInlineSnapshot(`
+      [
+        ".gitignore",
+        "README.md",
+        "bun-env.d.ts",
+        "bun.lock",
+        "bunfig.toml",
+        "node_modules",
+        "package.json",
+        "src/APITester.tsx",
+        "src/App.tsx",
+        "src/frontend.tsx",
+        "src/index.css",
+        "src/index.html",
+        "src/index.ts",
+        "src/logo.svg",
+        "src/react.svg",
+        "tsconfig.json",
+      ]
+    `);
+    expectReactTemplate(init, "react-app", "bun-react-template");
   }, 30_000);
 
   test("bun init --react=tailwind works", async () => {
-    await using temp = tempDir("bun-init--react=tailwind-works", {});
-
-    const { exited } = Bun.spawn({
-      cmd: [bunExe(), "init", "--react=tailwind"],
-      cwd: temp,
-      stdio: ["ignore", "inherit", "inherit"],
-      env: initEnv,
-    });
-
-    expect(await exited).toBe(0);
-
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
-    expect(pkg).toHaveProperty("dependencies.react");
-    expect(pkg).toHaveProperty("dependencies.react-dom");
-    expect(pkg).toHaveProperty("devDependencies.@types/react");
-    expect(pkg).toHaveProperty("devDependencies.@types/react-dom");
-    expect(pkg).toHaveProperty("dependencies.bun-plugin-tailwind");
-    expect(pkg.peerDependencies).toEqual({ typescript: "^6" });
-
-    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/index.ts"))).toBe(true);
+    const init = await initTemplate("--react=tailwind");
+    expect(init.files).toMatchInlineSnapshot(`
+      [
+        ".gitignore",
+        "README.md",
+        "build.ts",
+        "bun-env.d.ts",
+        "bun.lock",
+        "bunfig.toml",
+        "node_modules",
+        "package.json",
+        "src/APITester.tsx",
+        "src/App.tsx",
+        "src/frontend.tsx",
+        "src/index.css",
+        "src/index.html",
+        "src/index.ts",
+        "src/logo.svg",
+        "src/react.svg",
+        "tsconfig.json",
+      ]
+    `);
+    expectReactTemplate(init, "react-tailwind", "bun-react-tailwind-template");
   }, 30_000);
 
   test("bun init --react=shadcn works", async () => {
-    await using temp = tempDir("bun-init--react=shadcn-works", {});
-
-    const { exited } = Bun.spawn({
-      cmd: [bunExe(), "init", "--react=shadcn"],
-      cwd: temp,
-      stdio: ["ignore", "inherit", "inherit"],
-      env: initEnv,
-    });
-
-    expect(await exited).toBe(0);
-
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
-    expect(pkg).toHaveProperty("dependencies.react");
-    expect(pkg).toHaveProperty("dependencies.react-dom");
-    expect(pkg).toHaveProperty("dependencies.@radix-ui/react-slot");
-    expect(pkg).toHaveProperty("dependencies.class-variance-authority");
-    expect(pkg).toHaveProperty("dependencies.clsx");
-    expect(pkg).toHaveProperty("dependencies.bun-plugin-tailwind");
-    expect(pkg.peerDependencies).toEqual({ typescript: "^6" });
-
-    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/components"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/components/ui"))).toBe(true);
+    const init = await initTemplate("--react=shadcn");
+    expect(init.files).toMatchInlineSnapshot(`
+      [
+        ".gitignore",
+        "README.md",
+        "build.ts",
+        "bun-env.d.ts",
+        "bun.lock",
+        "bunfig.toml",
+        "components.json",
+        "node_modules",
+        "package.json",
+        "src/APITester.tsx",
+        "src/App.tsx",
+        "src/components/ui/button.tsx",
+        "src/components/ui/card.tsx",
+        "src/components/ui/input.tsx",
+        "src/components/ui/label.tsx",
+        "src/components/ui/select.tsx",
+        "src/components/ui/textarea.tsx",
+        "src/frontend.tsx",
+        "src/index.css",
+        "src/index.html",
+        "src/index.ts",
+        "src/lib/utils.ts",
+        "src/logo.svg",
+        "src/react.svg",
+        "styles/globals.css",
+        "tsconfig.json",
+      ]
+    `);
+    expectReactTemplate(init, "react-shadcn", "bun-react-tailwind-shadcn-template");
   }, 30_000);
 
   // Every template declares `typescript: "^6"`, so the `bun install` that
@@ -318,54 +443,48 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
   test.each(["-y", "--react", "--react=tailwind", "--react=shadcn"])(
     "bun init %s installs TypeScript 6, typechecks, and builds",
     async flag => {
-      await using temp = tempDir(`bun-init-ts6${flag.replace(/[^a-z]+/g, "-")}`, {});
+      const { dir, stdout, stderr, exitCode } = await initTemplate(flag);
+      expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
 
-      await using init = Bun.spawn({
-        cmd: [bunExe(), "init", flag],
-        cwd: temp,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: initEnv,
-      });
-      const [initStdout, initStderr, initExited] = await Promise.all([
-        init.stdout.text(),
-        init.stderr.text(),
-        init.exited,
-      ]);
-      expect({ initStdout, initStderr, initExited }).toMatchObject({ initExited: 0 });
-
-      const tsPkg = JSON.parse(fs.readFileSync(path.join(temp, "node_modules/typescript/package.json"), "utf8"));
+      const tsPkg = JSON.parse(fs.readFileSync(path.join(dir, "node_modules/typescript/package.json"), "utf8"));
       expect(tsPkg.version).toStartWith("6.");
 
       // What matters is that the template typechecks, not which runtime runs
       // the compiler, and tsc under a debug+ASAN bun is 10-50x slower.
       await using tsc = Bun.spawn({
         cmd: [nodeExe() ?? bunExe(), "node_modules/typescript/bin/tsc", "--noEmit"],
-        cwd: temp,
+        cwd: dir,
         stdio: ["ignore", "pipe", "pipe"],
         env: bunEnv,
       });
       const [tscStdout, tscStderr, tscExited] = await Promise.all([tsc.stdout.text(), tsc.stderr.text(), tsc.exited]);
       expect({ tscStdout, tscStderr, tscExited }).toMatchObject({ tscExited: 0 });
 
-      // The blank template has no `build` script; the react templates do.
-      // bun-plugin-tailwind's `bun` peer dep links a node_modules/.bin/bun that
-      // would otherwise shadow bunExe() in the nested `bun run build.ts`, so
-      // pass --bun.
-      const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
-      if (pkg.scripts?.build) {
-        await using build = Bun.spawn({
-          cmd: [bunExe(), "--bun", "run", "build"],
-          cwd: temp,
-          stdio: ["ignore", "pipe", "pipe"],
-          env: bunEnv,
-        });
-        const [buildStdout, buildStderr, buildExited] = await Promise.all([
-          build.stdout.text(),
-          build.stderr.text(),
-          build.exited,
-        ]);
-        expect({ buildStdout, buildStderr, buildExited }).toMatchObject({ buildExited: 0 });
+      // The blank template has no `build` script; the react templates build
+      // src/index.html into dist/. bun-plugin-tailwind's `bun` peer dep puts a
+      // node_modules/.bin/bun ahead of bunExe() on the script's PATH (with
+      // scripts ignored it is the npm package's placeholder, which only prints
+      // an error), so pass --bun to run the script's `bun` as the bun under test.
+      const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+      if (flag === "-y") {
+        expect(pkg.scripts).toBeUndefined();
+        return;
       }
+      expect(pkg.scripts).toHaveProperty("build");
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "--bun", "run", "build"],
+        cwd: dir,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: bunEnv,
+      });
+      const [buildStdout, buildStderr, buildExited] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect({ buildStdout, buildStderr, buildExited }).toMatchObject({ buildExited: 0 });
+      expect(readdirSync(path.join(dir, "dist"))).toContain("index.html");
     },
     180_000,
   );

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -90,15 +90,25 @@ describe.concurrent("bun init", () => {
     await Promise.all(dirs.map(dir => fs.promises.rm(dir, { recursive: true, force: true })));
   });
 
+  // Every consumer of an init runs this before looking at anything the nested
+  // `bun install` should have produced. `bun init` exits 0 even when that
+  // install fails (#38474), and the install's errors are in the captured
+  // stderr, so a failed install has to be reported together with that output
+  // rather than as a missing file further down.
+  function expectInstalled({ dir, stdout, stderr, exitCode }: InitResult, packages: string[]) {
+    const missing = packages.filter(name => !fs.existsSync(path.join(dir, "node_modules", name, "package.json")));
+    expect({ missing, exitCode, stdout, stderr }).toMatchObject({ missing: [], exitCode: 0 });
+  }
+
   // A react template's scaffold is fully determined by its source directory
-  // plus the generated README.md and .gitignore. Whether the nested
-  // `bun install` did its job is checked through what it leaves behind
-  // (the lockfile is in the file listing, node_modules is checked here)
-  // rather than through `bun init`'s exit code.
+  // plus the generated README.md and .gitignore; `bun install` then adds
+  // bun.lock (part of the file listing the callers snapshot) and node_modules.
   function expectReactTemplate(init: InitResult, source: string, readmeTitle: string) {
-    const { dir, stdout, stderr, exitCode } = init;
-    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
-    expect(stderr).not.toMatch(/^(error|warn)/m);
+    const { dir } = init;
+    const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+    const declared = Object.keys({ ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies });
+    expect(declared).toContain("typescript");
+    expectInstalled(init, declared);
 
     // Line endings are normalized because the checkout that built the binary
     // and the one running the tests need not agree on them.
@@ -116,12 +126,6 @@ describe.concurrent("bun init", () => {
     const readme = fs.readFileSync(path.join(dir, "README.md"), "utf8");
     expect(readme).toStartWith(`# ${readmeTitle}\n`);
     expect(readme).toInclude("bun v" + Bun.version.replaceAll("-debug", ""));
-
-    const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
-    const declared = Object.keys({ ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies }).sort();
-    expect(declared).toContain("typescript");
-    const installed = declared.filter(name => fs.existsSync(path.join(dir, "node_modules", name, "package.json")));
-    expect(installed).toEqual(declared);
   }
 
   test("bun init works", async () => {
@@ -354,6 +358,7 @@ describe.concurrent("bun init", () => {
 
   test("bun init --react works", async () => {
     const init = await initTemplate("--react");
+    expectReactTemplate(init, "react-app", "bun-react-template");
     expect(init.files).toMatchInlineSnapshot(`
       [
         ".gitignore",
@@ -374,11 +379,11 @@ describe.concurrent("bun init", () => {
         "tsconfig.json",
       ]
     `);
-    expectReactTemplate(init, "react-app", "bun-react-template");
   }, 30_000);
 
   test("bun init --react=tailwind works", async () => {
     const init = await initTemplate("--react=tailwind");
+    expectReactTemplate(init, "react-tailwind", "bun-react-tailwind-template");
     expect(init.files).toMatchInlineSnapshot(`
       [
         ".gitignore",
@@ -400,11 +405,11 @@ describe.concurrent("bun init", () => {
         "tsconfig.json",
       ]
     `);
-    expectReactTemplate(init, "react-tailwind", "bun-react-tailwind-template");
   }, 30_000);
 
   test("bun init --react=shadcn works", async () => {
     const init = await initTemplate("--react=shadcn");
+    expectReactTemplate(init, "react-shadcn", "bun-react-tailwind-shadcn-template");
     expect(init.files).toMatchInlineSnapshot(`
       [
         ".gitignore",
@@ -435,7 +440,6 @@ describe.concurrent("bun init", () => {
         "tsconfig.json",
       ]
     `);
-    expectReactTemplate(init, "react-shadcn", "bun-react-tailwind-shadcn-template");
   }, 30_000);
 
   // Every template declares `typescript: "^6"`, so the `bun install` that
@@ -444,8 +448,9 @@ describe.concurrent("bun init", () => {
   test.each(["-y", "--react", "--react=tailwind", "--react=shadcn"])(
     "bun init %s installs TypeScript 6, typechecks, and builds",
     async flag => {
-      const { dir, stdout, stderr, exitCode } = await initTemplate(flag);
-      expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+      const init = await initTemplate(flag);
+      const { dir } = init;
+      expectInstalled(init, ["typescript"]);
 
       const tsPkg = JSON.parse(fs.readFileSync(path.join(dir, "node_modules/typescript/package.json"), "utf8"));
       expect(tsPkg.version).toStartWith("6.");

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -90,10 +90,11 @@ describe.concurrent("bun init", () => {
     await Promise.all(dirs.map(dir => fs.promises.rm(dir, { recursive: true, force: true })));
   });
 
-  // The scaffolding `bun init` does for a react template is fully determined
-  // by the template's source directory plus the generated README/.gitignore,
-  // and `bun init` exits 0 even when the nested `bun install` fails, so the
-  // evidence that the install ran is the lockfile and node_modules.
+  // A react template's scaffold is fully determined by its source directory
+  // plus the generated README.md and .gitignore. Whether the nested
+  // `bun install` did its job is checked through what it leaves behind
+  // (the lockfile is in the file listing, node_modules is checked here)
+  // rather than through `bun init`'s exit code.
   function expectReactTemplate(init: InitResult, source: string, readmeTitle: string) {
     const { dir, stdout, stderr, exitCode } = init;
     expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });


### PR DESCRIPTION
### Problem
- `test/cli/init/init.test.ts` is a serial-phase file that took 25s on alpine x64, 20s on alpine aarch64, 23s on windows x64 and 29s on windows aarch64 in build 95391, against 3.5-6s on the debian, ubuntu and darwin lanes.
- The alpine and windows x64 time is the postinstall of the npm `bun` package. `--react=tailwind` and `--react=shadcn` depend on `bun-plugin-tailwind`, whose `bun` peer dependency installs that package, and `bun` is in `src/install/default-trusted-dependencies.txt`, so every init of those templates ran its `install.js`. The file ran it five times per run (cache prime, two `works` cases, two typecheck/build cases).
  - On musl, the published `bun@1.3.14` postinstall tries the glibc build first (`@oven/bun-linux-x64`), fails to execute it, runs `npm install` of that same package against registry.npmjs.org, fails again, and only then tries the musl build. In the alpine x64 log the tailwind and shadcn installs took 5.9s and 7.4s after the cache was primed, against 0.2s for the blank template on the same lane and 0.17s / 0.65s for the same two installs on debian; the prime itself took 13.4s against 2.0s on debian.
  - On windows x64 the same postinstall probes for AVX2 by having PowerShell compile a C# snippet. (Both behaviors are already gone from `packages/bun-release` since #36283, but the test installs whatever is published, and nothing in the file asserts on lifecycle scripts.)
- The windows aarch64 time is structural: the describe block was `describe` instead of `describe.concurrent` on Windows, and the shadcn template (60 packages, 5555 files, 4090 of them in lucide-react) was installed three times per run at about 6s per warm install on that lane.

### Fix
- `initEnv` points `XDG_CONFIG_HOME` at a global bunfig with `[install] ignoreScripts = true`, so the `bun install` that `bun init` spawns skips the `bun` package's postinstall. `peer = false` was tried first and rejected: it still downloads the `@oven/*` tarballs and it also drops the project's own `typescript` peer dependency, which the TypeScript 6 cases exist to check.
- Each template is initialized at most once per run (`initTemplate`, memoized per flag). The `works` case and the "installs TypeScript 6, typechecks, and builds" case for a template share the result; the file listing is captured right after init, before the build case writes `dist/`. Shared directories are removed in `afterAll`.
- The `beforeAll` prime is now the shadcn init itself rather than two throwaway installs. shadcn's closure is a superset of every other template's, including the blank one: after a shadcn-only init into a fresh cache, `-y`, `--react`, `--react=tailwind` and `--react=shadcn` each report `Resolved, downloaded and extracted [0]`.
- `describe.concurrent` on every platform. The Windows exemption came from the bulk `test.concurrent` conversion in #22823 with no recorded reason; 7 runs on a windows aarch64 machine (one cold cache, six warm) were all green.
- Assertions, while in there:
  - the three react `works` cases now snapshot the exact set of files `bun init` created, compare every file from `src/runtime/cli/init/<template>/` against what was written, check the per-template README title and bun version, and check that every dependency, devDependency and peerDependency declared in the written package.json is present in node_modules. This replaces the `toHaveProperty` and `existsSync` checks.
  - every consumer of an init checks the installed packages first, in one assertion that also carries the captured stdout/stderr (`expectInstalled`): the react inits now use pipes instead of inherited stdio, and `bun init` exits 0 when the nested install fails (#38474), so this is what puts the install's error lines in the failure output instead of a bare listing diff or ENOENT. Verified with a dead registry (`BUN_CONFIG_REGISTRY=http://127.0.0.1:1/`): all seven template cases fail at that assertion with the `error: ConnectionRefused ...` lines shown. There is deliberately no blanket "stderr has no error/warn lines" check, since `warn:` lines there depend on registry state (peer ranges during a publish window, optional dependency fetch failures).
  - the typecheck/build cases assert that the blank template has no scripts and the react templates have a `build` script, so the build branch cannot silently stop running, and that the build produced `dist/index.html`.
  - "error rather than overwriting file" asserts the exact message (`Failed to change directory to mydir: ENOTDIR`, identical on Windows), empty stdout and exit code 1 instead of `not.toBe(0)`.
  - "bun init works" and the no-TTY case assert the exact directory listing instead of three or four `existsSync` calls.
- Timings, cold install cache in every run:
  - CI, this PR's build 95949 against build 95391 (same file, all 15 cases passing on every lane): alpine x64 24.9s to 13.1s, alpine aarch64 19.6s to 9.4s, windows x64 23.0s to 8.0s, windows aarch64 29.0s to 10.6s, debian x64 6.1s to 4.9s, debian x64-asan 6.2s to 4.9s, debian aarch64 3.5s to 4.3s. On alpine x64 the remaining time is 6.0s for the one cold shadcn install in `beforeAll` and about 7s for the concurrent phase (four `tsc` runs and three builds).
  - windows aarch64 machine, release canary, `bun test`: 43.9s before, 16.6s after (11.2-12.7s with a warm cache). Of the 16.6s, about 11s is the one cold shadcn install in `beforeAll`.
  - linux x64 glibc (this container), `bun bd test test/cli/init/init.test.ts`: 35.2s before, 34.4s and 34.9s after. Flat as expected: glibc never took the postinstall detour, and under a debug+ASAN binary the file is dominated by the three template `bun run build` steps (5-24s each), which are unchanged. Release binary on the same box: 4.9s before, 4.4-5.0s after.
  - What remains per run is one real install of each template; the `bun` package still pulls one to four `@oven/bun-*` platform tarballs into the cache once per run (four on x64 linux, since bun install does not filter optional dependencies by libc yet, #31123). The only way to avoid that is `peer = false`, rejected above.
- Not a shared cause with `test/cli/install/bunx.test.ts` (#38467): that file does not install `bun-plugin-tailwind`. One observation from the same logs that does apply to any install-heavy file: even fully cached, the 5-package blank installs took 200-250ms on alpine and windows aarch64 against 14-30ms on debian.
- Rebase notes for the open PRs touching this file: #36607, #35164, #38419 and #38474 add cases or edit the blank-template cases, which this PR leaves in place (#35164 inserts right after the `--react works` case, whose body changed). #35445's edits to the three react `works` cases are superseded, since those now compare package.json against the template source.

### Background
- `bun init` writes the template files and then spawns `bun install` in the new directory; `bun install` reads `$XDG_CONFIG_HOME/.bunfig.toml` (falling back to `$HOME/.bunfig.toml`) on every platform before the project's bunfig, which is how a test can configure the nested install without adding files to the scaffold it is asserting on. `test/cli/install/minimum-release-age.test.ts` uses the same mechanism.
- bun only runs lifecycle scripts of packages listed in `trustedDependencies` or in bun's built-in default trusted list; `bun` is on that list. `ignoreScripts` disables them for the whole install.
- In CI each test file gets a fresh `BUN_INSTALL_CACHE_DIR` (`scripts/runner.node.mjs`), so every run of this file starts from a cold cache; bun dedupes downloads within one install but not across concurrently running installs, which is why one install has to run alone before the rest start.

<details>
<summary>Per-lane timeline of the file in build 95391 (from the raw job logs)</summary>

```
alpine x64        prime 13.4s | post-prime installs: blank 0.20-0.26s, tailwind 5.88s, shadcn 7.39s | total 24.9s
alpine aarch64    prime 12.2s | blank 0.01-0.05s, tailwind 3.93s, shadcn 5.27s                      | total 19.6s
windows x64       prime  6.2s | blank 0.05s, tailwind 2.35s, shadcn 2.67s, then 10.3s serial tsc/builds | total 23.0s
windows aarch64   prime  9.3s | blank 0.25s, tailwind 0.79s, shadcn 3.03s, then 11.4s serial tsc/builds | total 29.0s
debian x64        prime  2.0s | blank 0.01-0.03s, tailwind 0.17s, shadcn 0.65s                      | total  6.1s
debian x64-asan   prime  2.6s | blank 0.08-0.10s, tailwind 0.13s, shadcn 0.21s                      | total  6.2s
debian aarch64    prime  1.2s | blank 0.01-0.03s, tailwind 0.05s, shadcn 0.15s                      | total  3.5s
```
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/init/init.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/init/init.test.ts
bun test v1.4.0 (7f8f5d3cf)

test/cli/init/init.test.ts:
 + .gitignore
 + index.ts
 + tsconfig.json (for editor autocomplete)
 + README.md

To get started, run:

    bun run index.ts

 + .gitignore
 + index.ts
 + tsconfig.json (for editor autocomplete)
 + README.md

To get started, run:

    bun run index.ts

bun install v1.4.0 (7f8f5d3cf)
Resolving dependencies
Resolved, downloaded and extracted [0]
(pass) bun init > bun init error rather than overwriting file [281.57ms]
Saved lockfile

+ @types/bun@1.3.14
+ typescript@6.0.3 (v7.0.2 available)

5 packages installed [220.00ms]
bun install v1.4.0 (7f8f5d3cf)

bun install v1.4.0 (7f8f5d3cf)
Resolving dependencies
Resolved, downloaded and extracted [0]
Resolving dependencies
Resolved, downloaded and extracted [0]
 + .gitignore
 + index.ts
 + tsconfig.json (for editor autocomplete)
 + README.md

To get started, run:

    bun run index.ts

Saved lockfile

+ @types/bun@1.3.14
+ typescript@6.0.3 (v7.0.2 available)

5 packages installed [222.00ms]
(pass) bun init > bun init works [518.17ms]
Saved lockfile

+ @types/bun@1.3.14
+ typescript@6.0.3 (v7.0.2 available)

5 packages installed [295.00ms]


(pass) bun init > bun init falls back to --yes when stdin is not a TTY [574.10ms]
bun install v1.4.0 (7f8f5d3cf)
(pass) bun init > bun init in folder [582.93ms]
Resolving dependencies
Resolved, downloaded and extracted [0]
(pass) bun init > bun init --react=shadcn works [83.02ms]
Saved lockfile

+ @types/bun@1.3.14
+ typescript@6.0.3 (v7.0.2 available)

5 packages installed [211.00ms]
(pass) bun init > bun init utf-8 [657.96ms]

(pass) bun init > bun init --react works [666.40ms]
(pass) bun init > bun init twice [835.71ms]
(pass) bun init > bun init --react=tailwind works [636.62ms]
(pass) bun init > nested `bun install` output is inherited [636.34ms]
 + tsconfig.json (for editor autocomplete)
bun install v1.4.0 (7
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/init/init.test.ts | 383 ++++++++++++++++++++++++++++++---------------
 1 file changed, 254 insertions(+), 129 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                        reads  edits  tests
test/cli/init/init.test.ts      7     20      0
```

</details>

<!-- robobun:evidence:end -->