### PR TITLE
perf_hooks: record nodeTiming milestones and resolve their names in performance.measure()

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -59,31 +59,64 @@ var constants = {
   NODE_PERFORMANCE_MILESTONE_V8_START: 4,
 };
 
-// PerformanceEntry is not a valid constructor, so we have to fake it.
+// Milliseconds since timeOrigin, or -1 until the milestone is reached. Same
+// table performance.measure() resolves these names against.
+const getNodeTimingMilestone = $newCppFunction("JSPerformance.cpp", "jsPerformance_getNodeTimingMilestone", 1) as (
+  name: string,
+) => number;
+
+function milestoneDescriptor(name: string): PropertyDescriptor {
+  return {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      return getNodeTimingMilestone(name);
+    },
+  };
+}
+
+// Ported from node's lib/internal/perf/nodetiming.js: every property is an own
+// enumerable slot (so `{ ...performance.nodeTiming }` copies them), and the
+// milestones are getters because loopStart/loopExit are stamped after this
+// module has loaded. PerformanceEntry is not constructible, so the prototype
+// chain is linked below instead of with `extends`.
 class PerformanceNodeTiming {
-  bootstrapComplete: number = 0;
-  environment: number = 0;
-  idleTime: number = 0;
-  loopExit: number = 0;
-  loopStart: number = 0;
-  nodeStart: number = 0;
-  v8Start: number = 0;
+  declare readonly name: string;
+  declare readonly entryType: string;
+  declare readonly startTime: number;
+  declare readonly duration: number;
+  declare readonly nodeStart: number;
+  declare readonly v8Start: number;
+  declare readonly environment: number;
+  declare readonly loopStart: number;
+  declare readonly loopExit: number;
+  declare readonly bootstrapComplete: number;
+  declare readonly idleTime: number;
 
-  // we have to fake the properties since it's not real
-  get name() {
-    return "node";
-  }
-
-  get entryType() {
-    return "node";
-  }
-
-  get startTime() {
-    return this.nodeStart;
-  }
-
-  get duration() {
-    return performance.now();
+  constructor() {
+    Object.defineProperties(this, {
+      name: { __proto__: null, enumerable: true, configurable: true, value: "node" },
+      entryType: { __proto__: null, enumerable: true, configurable: true, value: "node" },
+      startTime: { __proto__: null, enumerable: true, configurable: true, value: 0 },
+      duration: {
+        __proto__: null,
+        enumerable: true,
+        configurable: true,
+        get() {
+          return performance.now();
+        },
+      },
+      nodeStart: milestoneDescriptor("nodeStart"),
+      v8Start: milestoneDescriptor("v8Start"),
+      environment: milestoneDescriptor("environment"),
+      loopStart: milestoneDescriptor("loopStart"),
+      loopExit: milestoneDescriptor("loopExit"),
+      bootstrapComplete: milestoneDescriptor("bootstrapComplete"),
+      // Bun does not track time parked in the poll, matching the zeros
+      // eventLoopUtilization() reports.
+      idleTime: { __proto__: null, enumerable: true, configurable: true, value: 0 },
+    });
   }
 
   toJSON() {
@@ -92,28 +125,19 @@ class PerformanceNodeTiming {
       entryType: this.entryType,
       startTime: this.startTime,
       duration: this.duration,
-      bootstrapComplete: this.bootstrapComplete,
-      environment: this.environment,
-      idleTime: this.idleTime,
-      loopExit: this.loopExit,
-      loopStart: this.loopStart,
       nodeStart: this.nodeStart,
       v8Start: this.v8Start,
+      bootstrapComplete: this.bootstrapComplete,
+      environment: this.environment,
+      loopStart: this.loopStart,
+      loopExit: this.loopExit,
+      idleTime: this.idleTime,
     };
   }
 }
 if (PerformanceEntry) {
   Object.setPrototypeOf(PerformanceNodeTiming.prototype, PerformanceEntry.prototype);
   Object.setPrototypeOf(PerformanceNodeTiming, PerformanceEntry);
-}
-
-function createPerformanceNodeTiming() {
-  const object = Object.create(PerformanceNodeTiming.prototype);
-
-  object.bootstrapComplete = object.environment = object.nodeStart = object.v8Start = performance.timeOrigin;
-  object.loopStart = object.idleTime = 1;
-  object.loopExit = -1;
-  return object;
 }
 
 function eventLoopUtilization(_utilization1, _utilization2) {
@@ -320,7 +344,7 @@ function processTimerifyComplete(name, start, args, histogram) {
   }
 }
 
-const nodeTiming = createPerformanceNodeTiming();
+const nodeTiming = new PerformanceNodeTiming();
 
 // Node augments the real `performance` object (not a forwarding shim), so
 // timerify/eventLoopUtilization/nodeTiming go on Performance.prototype,

--- a/src/jsc/JSErrorCode.rs
+++ b/src/jsc/JSErrorCode.rs
@@ -68,4 +68,6 @@ pub enum DOMExceptionCode {
     InvalidThisError,
     InvalidURLError,
     CryptoOperationFailedError,
+    EventRecursion,
+    InvalidArgValueError,
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -133,6 +133,32 @@ impl Default for InitOptions {
     }
 }
 
+/// The `performance.nodeTiming` milestones, stamped at Bun's equivalent of each
+/// Node startup phase. The discriminants index
+/// [`VirtualMachine::node_timing_milestones`] and are shared with the name
+/// table in `src/jsc/bindings/webcore/PerformanceUserTiming.cpp`.
+#[derive(Clone, Copy)]
+#[repr(u32)]
+pub(crate) enum NodeTimingMilestone {
+    /// The runtime started building this VM (a hair after `timeOrigin`).
+    NodeStart = 0,
+    /// Bun's own per-VM state exists; the JavaScriptCore VM is about to be created.
+    V8Start = 1,
+    /// The JSC VM and global object exist (`init` is done).
+    Environment = 2,
+    /// Pre-execution bootstrap is done; preloads and the entry point are about to run.
+    BootstrapComplete = 3,
+    /// The event loop polled for the first time, i.e. the entry point's
+    /// synchronous evaluation (and its microtasks) finished.
+    LoopStart = 4,
+    /// The event loop drained and 'exit' is about to be emitted.
+    LoopExit = 5,
+}
+
+impl NodeTimingMilestone {
+    pub(crate) const COUNT: usize = 6;
+}
+
 pub struct VirtualMachine {
     pub global: *mut JSGlobalObject,
     // allocator dropped per §Allocators (global mimalloc)
@@ -281,6 +307,9 @@ pub struct VirtualMachine {
 
     pub origin_timer: std::time::Instant,
     pub(crate) origin_timestamp: u64,
+    /// Nanoseconds since `origin_timer` at which each [`NodeTimingMilestone`]
+    /// was reached; `-1` until it is. Read by `Bun__getNodeTimingMilestone`.
+    pub(crate) node_timing_milestones: [i64; NodeTimingMilestone::COUNT],
     /// For fake timers: override performance.now() with a specific value (in nanoseconds).
     pub overridden_performance_now: Option<u64>,
     pub(crate) macro_event_loop: EventLoop,
@@ -1590,6 +1619,9 @@ impl VirtualMachine {
             self.exit_on_uncaught_exception = true;
             return;
         }
+        // A script with no async work never polled the loop; Node still
+        // reports it as having started (and, below, exited) around now.
+        self.record_node_timing_milestone(NodeTimingMilestone::LoopStart);
         ExitHandler::dispatch_on_before_exit(self);
         let mut dispatch = false;
         loop {
@@ -1612,6 +1644,11 @@ impl VirtualMachine {
             }
 
             break;
+        }
+        // Only a cleanly drained loop stamps this: `process.exit()` and a
+        // fatal exception leave it at -1 for the 'exit' listeners, as in Node.
+        if self.unhandled_error_counter == 0 {
+            self.record_node_timing_milestone(NodeTimingMilestone::LoopExit);
         }
     }
 
@@ -2443,6 +2480,8 @@ impl VirtualMachine {
                 .write(VirtualMachine::default_on_unhandled_rejection);
             addr_of_mut!((*vm).origin_timer).write(std::time::Instant::now());
             addr_of_mut!((*vm).origin_timestamp).write(get_origin_timestamp());
+            addr_of_mut!((*vm).node_timing_milestones).write([-1; NodeTimingMilestone::COUNT]);
+            Self::record_node_timing_milestone_raw(vm, NodeTimingMilestone::NodeStart);
             addr_of_mut!((*vm).smol).write(opts.smol);
             // `Option<{CPU,Heap}ProfilerConfig>` are NOT zero-valid: each
             // payload contains a `bool`, and rustc picks that field's invalid
@@ -2523,6 +2562,10 @@ impl VirtualMachine {
             unsafe { (*vm).runtime_state = (hooks.init_runtime_state)(vm, &mut opts)? };
         }
 
+        // SAFETY: `origin_timer` and `node_timing_milestones` were written in
+        // the block above.
+        unsafe { Self::record_node_timing_milestone_raw(vm, NodeTimingMilestone::V8Start) };
+
         // JSGlobalObject creation. `ensure_waker()` must run before the FFI.
         // SAFETY: `vm` is the unique live VM on this thread; raw-ptr deref so
         // no `&mut` is held across the FFI re-entry (`Bun__getVM()` —
@@ -2579,6 +2622,9 @@ impl VirtualMachine {
             IS_SMOL_MODE.store(true, core::sync::atomic::Ordering::Relaxed);
         }
 
+        // SAFETY: see the `V8Start` stamp above.
+        unsafe { Self::record_node_timing_milestone_raw(vm, NodeTimingMilestone::Environment) };
+
         Ok(vm)
     }
 
@@ -2610,10 +2656,40 @@ impl VirtualMachine {
         self.event_loop_mut().wait_for_promise(promise)
     }
 
+    /// First write wins: `LoopStart` is recorded on every tick and
+    /// `BootstrapComplete` on every hot reload, and both mean the first time.
+    ///
+    /// # Safety
+    /// `(*vm).origin_timer` and `(*vm).node_timing_milestones` must be
+    /// initialized. Nothing else is touched and no `&mut VirtualMachine` is
+    /// formed, which lets [`init`](Self::init) stamp a partially built VM (see
+    /// the validity note there).
+    unsafe fn record_node_timing_milestone_raw(
+        vm: *mut VirtualMachine,
+        milestone: NodeTimingMilestone,
+    ) {
+        // SAFETY: per the contract above; only the two fields are projected.
+        unsafe {
+            let slots = core::ptr::addr_of_mut!((*vm).node_timing_milestones);
+            if (*slots)[milestone as usize] >= 0 {
+                return;
+            }
+            let elapsed = (*core::ptr::addr_of!((*vm).origin_timer)).elapsed();
+            (*slots)[milestone as usize] = elapsed.as_nanos() as i64;
+        }
+    }
+
+    #[inline]
+    pub(crate) fn record_node_timing_milestone(&mut self, milestone: NodeTimingMilestone) {
+        // SAFETY: a `&mut self` is a fully initialized VM.
+        unsafe { Self::record_node_timing_milestone_raw(self, milestone) }
+    }
+
     /// `eventLoop().autoTick()` — dispatched through the runtime hook
     /// (needs `Timer::All` for the poll timeout).
     #[inline]
     pub fn auto_tick(&mut self) {
+        self.record_node_timing_milestone(NodeTimingMilestone::LoopStart);
         if let Some(hooks) = runtime_hooks() {
             // SAFETY: hook contract — `self` is the live per-thread VM.
             unsafe { (hooks.auto_tick)(self) };
@@ -2631,6 +2707,7 @@ impl VirtualMachine {
     /// `on_before_exit` / `bun_main` still make forward progress.
     #[inline]
     pub fn auto_tick_active(&mut self) {
+        self.record_node_timing_milestone(NodeTimingMilestone::LoopStart);
         if let Some(hooks) = runtime_hooks() {
             // SAFETY: `self` is the live per-thread VM (hook contract).
             unsafe { (hooks.auto_tick_active)(self) };
@@ -2692,6 +2769,7 @@ impl VirtualMachine {
             // evaluating `internal/process/pre_execution`.
             crate::cpp::Bun__preExecutionBootstrap(self.global());
         }
+        self.record_node_timing_milestone(NodeTimingMilestone::BootstrapComplete);
 
         if !self.main_is_html_entrypoint {
             if let Some(hooks) = hooks {
@@ -4821,6 +4899,7 @@ impl VirtualMachine {
         self.event_loop_mut().ensure_waker();
 
         let _ = self.ensure_debugger(true);
+        self.record_node_timing_milestone(NodeTimingMilestone::BootstrapComplete);
 
         if !self.transpiler.options.disable_transpilation {
             if let Some(hooks) = runtime_hooks() {

--- a/src/jsc/bindings/ExceptionCode.h
+++ b/src/jsc/bindings/ExceptionCode.h
@@ -78,6 +78,8 @@ enum ExceptionCode : uint8_t {
     InvalidURLError,
     CryptoOperationFailedError,
     EVENT_RECURSION,
+    // ERR_INVALID_ARG_VALUE with the message supplied by the thrower.
+    InvalidArgValueError,
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -175,6 +175,9 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
     case ExceptionCode::EVENT_RECURSION:
         return Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_EVENT_RECURSION, message);
 
+    case ExceptionCode::InvalidArgValueError:
+        return Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_ARG_VALUE, message);
+
     default: {
         // FIXME: All callers to createDOMException need to pass in the correct global object.
         // For now, we're going to assume the lexicalGlobalObject. Which is wrong in cases like this:

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -51,6 +51,7 @@
 #include "JSPerformanceMeasureOptions.h"
 // #include "JSPerformanceNavigation.h"
 #include "JSPerformanceTiming.h"
+#include "PerformanceUserTiming.h"
 
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
@@ -138,6 +139,18 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformancePrototypeFunction_markResourceTiming, (JSG
 {
     // TODO:
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsPerformance_getNodeTimingMilestone, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto name = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto milestone = PerformanceUserTiming::nodeTimingMilestone(vm, name);
+    if (!milestone)
+        return JSValue::encode(jsUndefined());
+    return JSValue::encode(jsNumber(*milestone));
 }
 
 // -- end copied --

--- a/src/jsc/bindings/webcore/JSPerformance.h
+++ b/src/jsc/bindings/webcore/JSPerformance.h
@@ -100,4 +100,7 @@ template<> struct JSDOMWrapperConverterTraits<Performance> {
     using ToWrappedReturnType = Performance*;
 };
 
+// (milestoneName) => the value performance.nodeTiming reports for it; backs node/perf_hooks.ts.
+JSC_DECLARE_HOST_FUNCTION(jsPerformance_getNodeTimingMilestone);
+
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/Performance.cpp
+++ b/src/jsc/bindings/webcore/Performance.cpp
@@ -221,11 +221,11 @@ ExceptionOr<Ref<PerformanceMark>> Performance::mark(JSC::JSGlobalObject& globalO
     return mark.releaseReturnValue();
 }
 
-void Performance::clearMarks(const String& markName)
+ExceptionOr<void> Performance::clearMarks(const String& markName)
 {
     if (!m_userTiming)
         m_userTiming = makeUnique<PerformanceUserTiming>(*this);
-    m_userTiming->clearMarks(markName);
+    return m_userTiming->clearMarks(markName);
 }
 
 ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& globalObject, const String& measureName, std::optional<StartOrMeasureOptions>&& startOrMeasureOptions, const String& endMark)

--- a/src/jsc/bindings/webcore/Performance.h
+++ b/src/jsc/bindings/webcore/Performance.h
@@ -95,7 +95,7 @@ public:
     void setResourceTimingBufferSize(unsigned);
 
     ExceptionOr<Ref<PerformanceMark>> mark(JSC::JSGlobalObject&, const String& markName, std::optional<PerformanceMarkOptions>&&);
-    void clearMarks(const String& markName);
+    ExceptionOr<void> clearMarks(const String& markName);
 
     using StartOrMeasureOptions = std::variant<String, PerformanceMeasureOptions>;
     ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, std::optional<StartOrMeasureOptions>&&, const String& endMark);

--- a/src/jsc/bindings/webcore/PerformanceMark.cpp
+++ b/src/jsc/bindings/webcore/PerformanceMark.cpp
@@ -46,6 +46,9 @@ static double performanceNow(ScriptExecutionContext& scriptExecutionContext)
 
 ExceptionOr<Ref<PerformanceMark>> PerformanceMark::create(JSC::JSGlobalObject& globalObject, ScriptExecutionContext& scriptExecutionContext, const String& name, std::optional<PerformanceMarkOptions>&& markOptions)
 {
+    if (PerformanceUserTiming::isRestrictedMarkName(name))
+        return PerformanceUserTiming::restrictedMarkNameException(name);
+
     double startTime;
     JSC::JSValue detail;
     if (markOptions) {

--- a/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
@@ -27,17 +27,51 @@
 #include "config.h"
 #include "PerformanceUserTiming.h"
 
+#include "BunClientData.h"
 #include "MessagePort.h"
 #include "PerformanceMarkOptions.h"
 #include "PerformanceMeasureOptions.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <wtf/SortedArrayMap.h>
+
+// Defined in src/jsc/virtual_machine_exports.rs.
+extern "C" double Bun__getNodeTimingMilestone(void* bunVM, uint32_t milestone);
 
 namespace WebCore {
+
+// Values are `NodeTimingMilestone` discriminants from src/jsc/VirtualMachine.rs.
+static constexpr SortedArrayMap nodeTimingMilestoneIndices { std::to_array<std::pair<ComparableASCIILiteral, uint32_t>>({
+    { "bootstrapComplete"_s, 3 },
+    { "environment"_s, 2 },
+    { "loopExit"_s, 5 },
+    { "loopStart"_s, 4 },
+    { "nodeStart"_s, 0 },
+    { "v8Start"_s, 1 },
+}) };
 
 PerformanceUserTiming::PerformanceUserTiming(Performance& performance)
     : m_performance(performance)
 {
+}
+
+bool PerformanceUserTiming::isRestrictedMarkName(const String& markName)
+{
+    return nodeTimingMilestoneIndices.contains(markName);
+}
+
+Exception PerformanceUserTiming::restrictedMarkNameException(const String& markName)
+{
+    // lib/internal/perf/usertiming.js: `throw new ERR_INVALID_ARG_VALUE('name', name)`.
+    return Exception { InvalidArgValueError, makeString("The argument 'name' is invalid. Received '"_s, markName, '\'') };
+}
+
+std::optional<double> PerformanceUserTiming::nodeTimingMilestone(JSC::VM& vm, const String& name)
+{
+    auto* index = nodeTimingMilestoneIndices.tryGet(name);
+    if (!index)
+        return std::nullopt;
+    return Bun__getNodeTimingMilestone(bunVM(vm), *index);
 }
 
 size_t PerformanceUserTiming::memoryCost() const
@@ -96,10 +130,13 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
     return mark.releaseReturnValue();
 }
 
-void PerformanceUserTiming::clearMarks(const String& markName)
+ExceptionOr<void> PerformanceUserTiming::clearMarks(const String& markName)
 {
+    if (isRestrictedMarkName(markName))
+        return restrictedMarkNameException(markName);
     clearPerformanceEntries(m_marksMap, markName);
     m_markCounter = 0;
+    return {};
 }
 
 ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const std::variant<String, double>& mark) const
@@ -112,6 +149,10 @@ ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const std::var
 
 ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const String& mark) const
 {
+    // Node hands back the milestone even while it is still -1 (loopStart before the loop runs).
+    if (auto milestone = nodeTimingMilestone(m_performance.scriptExecutionContext()->vm(), mark))
+        return *milestone;
+
     auto iterator = m_marksMap.find(mark);
     if (iterator != m_marksMap.end())
         return iterator->value.last()->startTime();

--- a/src/jsc/bindings/webcore/PerformanceUserTiming.h
+++ b/src/jsc/bindings/webcore/PerformanceUserTiming.h
@@ -33,6 +33,7 @@
 
 namespace JSC {
 class JSGlobalObject;
+class VM;
 }
 
 namespace WebCore {
@@ -47,8 +48,18 @@ class PerformanceUserTiming {
 public:
     explicit PerformanceUserTiming(Performance&);
 
+    // Node reserves the PerformanceNodeTiming milestone names (nodeStart, v8Start, environment,
+    // loopStart, loopExit, bootstrapComplete): mark() and clearMarks() reject them, and measure()
+    // resolves them to performance.nodeTiming's values. Upstream WebKit does the same with the
+    // PerformanceTiming attribute names.
+    static bool isRestrictedMarkName(const String&);
+    static Exception restrictedMarkNameException(const String&);
+    // The milestone's value as performance.nodeTiming reports it (ms since timeOrigin, -1 until
+    // reached), or nullopt when `name` is not a milestone.
+    static std::optional<double> nodeTimingMilestone(JSC::VM&, const String& name);
+
     ExceptionOr<Ref<PerformanceMark>> mark(JSC::JSGlobalObject&, const String& markName, std::optional<PerformanceMarkOptions>&&);
-    void clearMarks(const String& markName);
+    ExceptionOr<void> clearMarks(const String& markName);
 
     using StartOrMeasureOptions = std::variant<String, PerformanceMeasureOptions>;
     ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, std::optional<StartOrMeasureOptions>&&, const String& endMark);

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -57,6 +57,16 @@ pub fn read_origin_timer_start(vm: &VirtualMachine) -> f64 {
         / 1_000_000.0
 }
 
+/// `performance.nodeTiming` milestone `index` (a `NodeTimingMilestone`
+/// discriminant) in milliseconds since `timeOrigin`, or -1 until it is reached.
+// HOST_EXPORT(Bun__getNodeTimingMilestone, c)
+pub fn get_node_timing_milestone(vm: &VirtualMachine, index: u32) -> f64 {
+    match vm.node_timing_milestones.get(index as usize) {
+        Some(&nanos) if nanos >= 0 => nanos as f64 / 1_000_000.0,
+        _ => -1.0,
+    }
+}
+
 // HOST_EXPORT(Bun__VirtualMachine__exitDuringUncaughtException, c)
 pub fn exit_during_uncaught_exception(this: &mut VirtualMachine) {
     this.exit_on_uncaught_exception = true;

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import net from "net";
 import perf, { PerformanceObserver } from "perf_hooks";
@@ -188,4 +188,236 @@ test("net entries are instanceof PerformanceEntry", async () => {
   expect(entry).toBeInstanceOf(PerformanceEntry);
   expect(entry.constructor.name).toBe("PerformanceNodeEntry");
   expect(entry.entryType).toBe("net");
+});
+
+// performance.nodeTiming reports each startup phase in ms since timeOrigin
+// (-1 until reached), and Node reserves the six milestone names in the User
+// Timing API: mark()/clearMarks() reject them and measure() resolves them to
+// nodeTiming's values. Behaviour verified against Node v26.3.0.
+describe("nodeTiming milestones", () => {
+  const milestones = ["nodeStart", "v8Start", "environment", "bootstrapComplete", "loopStart", "loopExit"] as const;
+
+  function thrown(fn: () => unknown) {
+    try {
+      fn();
+    } catch (e: any) {
+      return { isTypeError: e instanceof TypeError, code: e.code, message: e.message };
+    }
+    return "did not throw";
+  }
+
+  test("nodeTiming has Node's shape and its values are offsets from timeOrigin", () => {
+    const nodeTiming = perf.performance.nodeTiming;
+    expect(nodeTiming).toBeInstanceOf(PerformanceEntry);
+    expect(Object.keys(nodeTiming)).toEqual([
+      "name",
+      "entryType",
+      "startTime",
+      "duration",
+      "nodeStart",
+      "v8Start",
+      "environment",
+      "loopStart",
+      "loopExit",
+      "bootstrapComplete",
+      "idleTime",
+    ]);
+    for (const name of milestones) {
+      expect(Object.getOwnPropertyDescriptor(nodeTiming, name)).toEqual({
+        get: expect.any(Function),
+        set: undefined,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+
+    const { nodeStart, v8Start, environment, bootstrapComplete, loopStart } = nodeTiming;
+    expect(nodeStart).toBeGreaterThanOrEqual(0);
+    expect(v8Start).toBeGreaterThan(nodeStart);
+    expect(environment).toBeGreaterThan(v8Start);
+    expect(bootstrapComplete).toBeGreaterThan(environment);
+    expect(bootstrapComplete).toBeLessThanOrEqual(performance.now());
+    // The test runner entered the event loop before running this test body,
+    // and will not leave it until the file is done.
+    expect(loopStart).toBeGreaterThanOrEqual(0);
+    expect(nodeTiming.toJSON()).toEqual({
+      name: "node",
+      entryType: "node",
+      startTime: 0,
+      duration: expect.any(Number),
+      nodeStart,
+      v8Start,
+      bootstrapComplete,
+      environment,
+      loopStart,
+      loopExit: -1,
+      idleTime: 0,
+    });
+    expect(nodeTiming.duration).toBeLessThanOrEqual(performance.now());
+  });
+
+  test("measure() resolves the milestone names to nodeTiming's values", () => {
+    const nodeTiming = perf.performance.nodeTiming;
+    const timing = (entry: PerformanceMeasure) => ({ startTime: entry.startTime, duration: entry.duration });
+
+    // Like Node, an unreached milestone (loopExit) resolves to -1 rather than throwing.
+    for (const name of milestones) {
+      expect(performance.measure(`since ${name}`, name).startTime).toBe(nodeTiming[name]);
+    }
+    expect(timing(performance.measure("boot", "nodeStart", "bootstrapComplete"))).toEqual({
+      startTime: nodeTiming.nodeStart,
+      duration: nodeTiming.bootstrapComplete - nodeTiming.nodeStart,
+    });
+    expect(timing(performance.measure("jsc", { start: "v8Start", end: "environment" }))).toEqual({
+      startTime: nodeTiming.v8Start,
+      duration: nodeTiming.environment - nodeTiming.v8Start,
+    });
+    expect(timing(performance.measure("until bootstrap", undefined, "bootstrapComplete"))).toEqual({
+      startTime: 0,
+      duration: nodeTiming.bootstrapComplete,
+    });
+    const fromStart = performance.measure("after nodeStart", { start: "nodeStart", duration: 5 });
+    expect(fromStart.startTime).toBe(nodeTiming.nodeStart);
+    expect(fromStart.duration).toBeCloseTo(5, 6);
+    const untilEnd = performance.measure("before bootstrap", { end: "bootstrapComplete", duration: 5 });
+    expect(untilEnd.startTime).toBe(nodeTiming.bootstrapComplete - 5);
+    expect(untilEnd.duration).toBeCloseTo(5, 6);
+
+    // Only marks are looked up this way: a measure may be named after a
+    // milestone, and unknown mark names still throw.
+    expect(performance.measure("nodeStart").entryType).toBe("measure");
+    expect(() => performance.measure("m", "noSuchMark")).toThrow();
+    expect(() => performance.measure("m", { start: "nodeStart", end: "noSuchMark" })).toThrow();
+    performance.clearMeasures();
+  });
+
+  test("mark(), new PerformanceMark() and clearMarks() reject the milestone names", () => {
+    for (const name of milestones) {
+      const expected = {
+        isTypeError: true,
+        code: "ERR_INVALID_ARG_VALUE",
+        message: `The argument 'name' is invalid. Received '${name}'`,
+      };
+      expect(thrown(() => performance.mark(name))).toEqual(expected);
+      expect(thrown(() => new PerformanceMark(name))).toEqual(expected);
+      expect(thrown(() => performance.clearMarks(name))).toEqual(expected);
+      expect(performance.getEntriesByName(name, "mark")).toEqual([]);
+    }
+    // Only the six milestones are reserved; other nodeTiming property names are ordinary marks.
+    expect(performance.mark("idleTime").entryType).toBe("mark");
+    performance.clearMarks("idleTime");
+    expect(performance.getEntriesByName("idleTime", "mark")).toEqual([]);
+  });
+
+  test.concurrent("loopStart and loopExit follow the main script's lifecycle", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { performance } = require("perf_hooks");
+         const nodeTiming = performance.nodeTiming;
+         const seen = { topLevel: { loopStart: nodeTiming.loopStart, loopExit: nodeTiming.loopExit } };
+         setImmediate(() => {
+           seen.inLoop = {
+             loopStartAfterBootstrap: nodeTiming.loopStart >= nodeTiming.bootstrapComplete,
+             measureStartsAtLoopStart: performance.measure("loop", "loopStart").startTime === nodeTiming.loopStart,
+             loopExit: nodeTiming.loopExit,
+           };
+         });
+         process.on("beforeExit", () => {
+           seen.beforeExit = { loopExit: nodeTiming.loopExit };
+         });
+         process.on("exit", () => {
+           seen.exit = {
+             loopExitAfterLoopStart: nodeTiming.loopExit >= nodeTiming.loopStart,
+             measureStartsAtLoopExit: performance.measure("exit", "loopExit").startTime === nodeTiming.loopExit,
+           };
+           console.log(JSON.stringify(seen));
+         });`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      topLevel: { loopStart: -1, loopExit: -1 },
+      inLoop: { loopStartAfterBootstrap: true, measureStartsAtLoopStart: true, loopExit: -1 },
+      beforeExit: { loopExit: -1 },
+      exit: { loopExitAfterLoopStart: true, measureStartsAtLoopExit: true },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("process.exit() does not count as the loop exiting", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { performance } = require("perf_hooks");
+         process.on("exit", () => console.log(performance.nodeTiming.loopStart >= 0, performance.nodeTiming.loopExit));
+         setImmediate(() => process.exit(0));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true -1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a script with no async work still gets loopStart and loopExit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { nodeTiming } = require("perf_hooks").performance;
+         process.on("beforeExit", () => console.log("beforeExit", nodeTiming.loopStart >= nodeTiming.bootstrapComplete, nodeTiming.loopExit));
+         process.on("exit", () => console.log("exit", nodeTiming.loopExit >= nodeTiming.loopStart));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("beforeExit true -1\nexit true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Workers boot through the same VM setup, so a worker's performance object
+  // gets a complete set of milestones of its own.
+  test.concurrent("worker threads report their own startup milestones", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("worker_threads");
+         const worker = new Worker(
+           \`const { parentPort } = require("worker_threads");
+            const { performance } = require("perf_hooks");
+            const { nodeStart, v8Start, environment, bootstrapComplete } = performance.nodeTiming;
+            let markRejected;
+            try { performance.mark("nodeStart"); } catch (e) { markRejected = e.code; }
+            parentPort.postMessage({
+              ordered: 0 <= nodeStart && nodeStart < v8Start && v8Start < environment && environment < bootstrapComplete,
+              bootMeasure: performance.measure("boot", "nodeStart", "bootstrapComplete").duration === bootstrapComplete - nodeStart,
+              markRejected,
+            });\`,
+           { eval: true },
+         );
+         worker.on("message", message => console.log(JSON.stringify(message)));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ ordered: true, bootMeasure: true, markRejected: "ERR_INVALID_ARG_VALUE" });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/test/parallel/test-performance-nodetiming.js
+++ b/test/js/node/test/parallel/test-performance-nodetiming.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { performance } = require('perf_hooks');
+const { isMainThread } = require('worker_threads');
+
+const { nodeTiming } = performance;
+assert.strictEqual(nodeTiming.name, 'node');
+assert.strictEqual(nodeTiming.entryType, 'node');
+
+assert.strictEqual(nodeTiming.startTime, 0);
+const now = performance.now();
+assert.ok(nodeTiming.duration >= now);
+
+// Check that the nodeTiming milestone values are in the correct order and greater than 0.
+const keys = ['nodeStart', 'v8Start', 'environment', 'bootstrapComplete'];
+for (let idx = 0; idx < keys.length; idx++) {
+  if (idx === 0) {
+    assert.ok(nodeTiming[keys[idx]] >= 0);
+    continue;
+  }
+  assert.ok(nodeTiming[keys[idx]] > nodeTiming[keys[idx - 1]], `expect nodeTiming['${keys[idx]}'] > nodeTiming['${keys[idx - 1]}']`);
+}
+
+// loop milestones.
+assert.strictEqual(nodeTiming.idleTime, 0);
+if (isMainThread) {
+  // Main thread does not start loop until the first tick is finished.
+  assert.strictEqual(nodeTiming.loopStart, -1);
+} else {
+  // Worker threads run the user script after loop is started.
+  assert.ok(nodeTiming.loopStart >= nodeTiming.bootstrapComplete);
+}
+assert.strictEqual(nodeTiming.loopExit, -1);
+
+setTimeout(common.mustCall(() => {
+  assert.ok(nodeTiming.idleTime >= 0);
+  assert.ok(nodeTiming.idleTime + nodeTiming.loopExit <= nodeTiming.duration);
+  assert.ok(nodeTiming.loopStart >= nodeTiming.bootstrapComplete);
+}, 1), 1);
+
+// Can not be wrapped in common.mustCall().
+process.on('exit', () => {
+  assert.ok(nodeTiming.loopExit > 0);
+});


### PR DESCRIPTION
### Problem
- `performance.measure("boot", "nodeStart", "bootstrapComplete")` (and the other five `nodeTiming` names, in any of measure's argument shapes) throws `SyntaxError: No mark named 'bootstrapComplete' exists`. Node documents that measure() accepts these names and resolves them to `performance.nodeTiming`.
- `performance.mark("nodeStart")`, `new PerformanceMark("nodeStart")` and `performance.clearMarks("nodeStart")` succeed; Node rejects the six names with `ERR_INVALID_ARG_VALUE` (`The argument 'name' is invalid. Received 'nodeStart'`).
- `performance.nodeTiming` itself was fake: `nodeStart`/`v8Start`/`environment`/`bootstrapComplete` were all `performance.timeOrigin` (an epoch timestamp, ~1.78e12), `loopStart` and `idleTime` were `1`, `startTime` was the epoch value, and the values were data properties frozen at module load (src/js/node/perf_hooks.ts `createPerformanceNodeTiming`). Node reports milliseconds since `timeOrigin`, `-1` for unreached milestones, and `startTime: 0`.
- Cause: mark/measure are WebKit's User Timing code. `PerformanceUserTiming::convertMarkToTimestamp` (src/jsc/bindings/webcore/PerformanceUserTiming.cpp) only consulted the user marks map; the browser version's restricted-name table had been removed in the port, and nothing in the runtime recorded startup milestones for it to resolve against.

### Fix
- `VirtualMachine` (src/jsc/VirtualMachine.rs) records six milestones as nanoseconds since `origin_timer` (the same clock `performance.now()` uses), first write wins: `nodeStart` right after `origin_timer` is taken, `v8Start` just before the JSC VM and global object are created, `environment` at the end of `init`, `bootstrapComplete` in `reload_entry_point` (main entry, workers, `-e`) and in the test runner's equivalent, `loopStart` in `auto_tick`/`auto_tick_active` (plus `on_before_exit`, for scripts that never poll the loop), `loopExit` at the end of `on_before_exit`. `process.exit()` and a fatal uncaught exception never reach that point, so `loopExit` stays `-1` for `'exit'` listeners, as in Node. `Bun__getNodeTimingMilestone(vm, index)` (src/jsc/virtual_machine_exports.rs) returns a milestone in ms or `-1`.
- `PerformanceUserTiming` gets WebKit's restricted-mark-name mechanism back, with the six names mapped to milestone indices: `convertMarkToTimestamp` returns the milestone for them (including `-1`, which is what Node returns for an unreached `loopStart`/`loopExit`), `PerformanceMark::create` (covers `mark()` and the constructor) and `clearMarks()` reject them. The rejection is a new `ExceptionCode::InvalidArgValueError`, mapped to `ERR_INVALID_ARG_VALUE` in `createDOMException` the same way `EVENT_RECURSION` is; `clearMarks` now returns `ExceptionOr<void>`, which the existing binding already handles.
- perf_hooks.ts's `PerformanceNodeTiming` is ported from Node's nodetiming.js: own enumerable properties, `startTime` 0, milestones as getters backed by a small host function (`jsPerformance_getNodeTimingMilestone`, which goes through the same name table), so `measure("x", name).startTime === nodeTiming[name]` holds at every point in the process lifetime. `idleTime` is 0, consistent with the `eventLoopUtilization()` stub.
- Per-VM storage means workers get their own milestones, like Node's per-thread `nodeTiming`.
- Verified: `test/js/node/perf_hooks/perf_hooks.test.ts` (new `nodeTiming milestones` block: 6 of 7 tests fail on main, all pass with the fix); Node's `test/parallel/test-performance-nodetiming.js` vendored verbatim from v26.3.0 (fails on main at its first `startTime` assertion, passes with the fix); the existing vendored `test-performance-*`/`test-perf-hooks-*` files, `test/js/web/timers/performance*.test.*` and `test/js/deno/performance/performance.test.ts` still pass. Expected values in the new tests were checked against node v26.3.0.
- Overlap with open PRs: #32481 rewrites the same `nodeTiming` values in JS only (this supersedes it); #36069 adds the `mark()` rejection as part of a wider validation change (it explicitly leaves measure() resolution out); the nodeTiming part of the #35390 draft uses the same milestone indices and export name as this PR, so rebasing it onto this should be a matter of dropping its copy.

### Background
- `performance.nodeTiming` (node:perf_hooks) is a `PerformanceEntry` whose properties are timestamps of the process's startup phases, in milliseconds relative to `performance.timeOrigin`, like every other User Timing value. Node also lets `performance.measure()`'s start/end arguments name one of those properties instead of a user mark, and reserves the names so a user mark cannot shadow them.
- In Bun, `performance.timeOrigin` is the moment the thread's `VirtualMachine` was set up (`origin_timer`), and `performance.now()` is `Bun__readOriginTimer` = elapsed time on that clock; the milestones are stored on the same clock so they are directly comparable with marks and `now()`.
- `ExceptionOr`/`Exception` is how the ported WebCore code reports errors without touching JS; `createDOMException` (src/jsc/bindings/JSDOMExceptionHandling.cpp) turns the `ExceptionCode` into the JS error when the binding returns. A few codes there already produce Node-style errors with a `.code` property instead of a DOMException; `InvalidArgValueError` is one more of those.
- `// HOST_EXPORT(Name, c)` on a Rust function makes the build emit an `extern "C"` thunk of that name, which is how C++ reaches `Bun__getNodeTimingMilestone`; `$newCppFunction` in a builtin module wraps a C++ host function as a JS function, which is how perf_hooks.ts reads the values.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (f8a07b31e)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [7.37ms]
(pass) doesn't throw [22.48ms]
(pass) Symbol name argument throws V8 wording [11.60ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [7.75ms]
(pass) timerify entry shape [73.72ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.43ms]
(pass) export surface matches Node v26.3.0 [7.31ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [446.66ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [566.26ms]
(pass) net entries are instanceof PerformanceEntry [470.90ms]
207 |   }
208 | 
209 |   test("nodeTiming has Node's shape and its values are offsets from timeOrigin", () => {
210 |     const nodeTiming = perf.performance.nodeTiming;
211 |     expect(nodeTiming).toBeInstanceOf(PerformanceEntry);
212 |     expect(Object.keys(nodeTiming)).toEqual([
                     
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.05ms]
(pass) doesn't throw [0.13ms]
(pass) Symbol name argument throws V8 wording [0.11ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [0.13ms]
(pass) timerify entry shape [0.87ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [0.02ms]
(pass) export surface matches Node v26.3.0 [0.08ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [10.98ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [10.17ms]
(pass) net entries are instanceof PerformanceEntry [8.02ms]
207 |   }
208 | 
209 |   test("nodeTiming has Node's shape and its values are offsets from timeOrigin", () => {
210 |     const nodeTiming = perf.performance.nodeTiming;
211 |     expect(nodeTiming).toBeInstanceOf(PerformanceEntry);
212 |     expect(Object.keys(nodeTiming)).toEqual([
                                          ^
error: expect(received).toEqual(expected)

  [
-   "name",
-   "entryType",
-   "startTime",
-   "duration",
-   "nodeStart",
    "v8Start",
+   "nodeS
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.0 (f8a07b31e)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [5.45ms]
(pass) doesn't throw [15.36ms]
(pass) Symbol name argument throws V8 wording [7.06ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.27ms]
(pass) timerify entry shape [52.61ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.43ms]
(pass) export surface matches Node v26.3.0 [9.05ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [442.72ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [506.47ms]
(pass) net entries are instanceof PerformanceEntry [396.51ms]
(pass) nodeTiming milestones > nodeTiming has Node's shape and its values are offsets from timeOrigin [13.42ms]
(pass) nodeTiming milestones > measure() resolves the milestone names to nodeTiming's values [15.55ms]
(pass) nodeTiming milestones > mark(), new PerformanceMark() and clearMarks() reject the mil
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f8a07b31e4
  features     baseline

22 deps, 123 codegen, 1176 objects in 688ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [30.00ms]
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [8.00ms]
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[7/1237] fetch zlib
[zlib] up to date
[8/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] gen .bind.ts → GeneratedBindings.cpp

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/perf_hooks.ts                          |  98 +++++----
 src/jsc/JSErrorCode.rs                             |   2 +
 src/jsc/VirtualMachine.rs                          |  79 +++++++
 src/jsc/bindings/ExceptionCode.h                   |   2 +
 src/jsc/bindings/JSDOMExceptionHandling.cpp        |   3 +
 src/jsc/bindings/webcore/JSPerformance.cpp         |  13 ++
 src/jsc/bindings/webcore/JSPerformance.h           |   3 +
 src/jsc/bindings/webcore/Performance.cpp           |   4 +-
 src/jsc/bindings/webcore/Performance.h             |   2 +-
 src/jsc/bindings/webcore/PerformanceMark.cpp       |   3 +
 src/jsc/bindings/webcore/PerformanceUserTiming.cpp |  43 +++-
 src/jsc/bindings/webcore/PerformanceUserTiming.h   |  13 +-
 src/jsc/virtual_machine_exports.rs                 |  10 +
 test/js/node/perf_hooks/perf_hooks.test.ts         | 234 ++++++++++++++++++++-
 .../test/parallel/test-performance-nodetiming.js   |  46 ++++
 15 files changed, 512 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/perf_hooks.ts                                     2      6      0
src/jsc/JSErrorCode.rs                                        1      1      0
src/jsc/VirtualMachine.rs                                    11     15      0
src/jsc/bindings/ExceptionCode.h                              1      2      0
src/jsc/bindings/JSDOMExceptionHandling.cpp                   1      2      0
src/jsc/bindings/webcore/JSPerformance.cpp                    2      2      0
src/jsc/bindings/webcore/JSPerformance.h                      2      2      0
src/jsc/bindings/webcore/Performance.cpp                      2      1      0
src/jsc/bindings/webcore/Performance.h                        1      1      0
src/jsc/bindings/webcore/PerformanceMark.cpp                  1      1      0
src/jsc/bindings/webcore/PerformanceUserTiming.cpp            1      4      0
src/jsc/bindings/webcore/PerformanceUserTiming.h              1      2      0
src/jsc/virtual_machine_exports.rs                            1      1      0
test/js/node/perf_hooks/perf_hooks.test.ts                    2      4      0
…st/js/node/test/parallel/test-performance-nodetiming.js      0      0      0
```

</details>

<!-- robobun:evidence:end -->