### PR TITLE
css: dedupe font-family names in linear time

### DIFF
--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -998,22 +998,9 @@ impl FontHandler {
 
         if let Some(f) = family.as_mut() {
             if f.len() > 1 {
-                // Dedupe
+                // Dedupe, keeping the first occurrence of each family.
                 let mut seen: FontFamilyHashMap<()> = Default::default();
-
-                let mut i: usize = 0;
-                while i < f.len() {
-                    use bun_collections::array_hash_map::MapEntry;
-                    match seen.entry(f.at(i).clone()) {
-                        MapEntry::Occupied(_) => {
-                            let _ = f.ordered_remove(i);
-                        }
-                        MapEntry::Vacant(v) => {
-                            v.insert(());
-                            i += 1;
-                        }
-                    }
-                }
+                f.retain(|family| seen.insert(family.clone(), ()).is_none());
             }
         }
 

--- a/test/js/bun/css/font-family-dedupe-quadratic.test.ts
+++ b/test/js/bun/css/font-family-dedupe-quadratic.test.ts
@@ -1,0 +1,57 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The font handler removes repeated family names from a `font-family` /
+// `font` value when minifying. It used to do so with an ordered remove per
+// duplicate, shifting the rest of the list down each time, so a value made
+// of n copies of the same name took O(n^2) to minify: 40k copies (80 KB of
+// CSS) kept a release build busy for several seconds, and the time
+// quadrupled with every doubling of the input. Dedupe is now a single
+// compaction pass.
+//
+// The size below is chosen so the old quadratic dedupe cannot finish before
+// the spawn timeout kills the child (it needs minutes even in a release
+// build) while the linear version finishes in a few seconds in a debug
+// build.
+test("font-family with many duplicate names minifies in linear time", async () => {
+  const n = 1_000_000;
+  const script = `
+    const { minifyTest } = require("bun:internal-for-testing").cssInternals;
+    const css = "a{font-family:" + Buffer.alloc(${n} * 2, "f,").toString() + "serif}";
+    console.log(minifyTest(css, ""));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+    killSignal: "SIGKILL",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({
+    stdout,
+    stderr: /error|panic|assert|crash|abort/i.test(stderr) ? stderr : "",
+    exitCode,
+    signalCode: proc.signalCode,
+  }).toEqual({
+    stdout: "a{font-family:f,serif}\n",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+}, 90_000);
+
+test("font-family dedupe keeps the first occurrence of each family in order", () => {
+  expect(
+    [
+      `a{font-family:Foo,serif,Foo,"Bar",serif,Bar,"serif"}`,
+      `a{font-family:serif,f,serif,f,sans-serif,f,serif}`,
+      `a{font:12px Foo,Foo,serif}`,
+    ].map(css => cssInternals.minifyTest(css, "")),
+  ).toEqual([`a{font-family:Foo,serif,Bar,"serif"}`, `a{font-family:serif,f,sans-serif}`, `a{font:12px Foo,serif}`]);
+});


### PR DESCRIPTION
### Problem
- Minifying a `font-family` (or `font`) value that repeats the same family name many times is O(n^2) in the number of names: 40k copies of one name (80 KB of CSS) take 5 to 10 seconds in a release build, and every doubling of the input quadruples the time. Distinct names are linear, only the duplicate removal is quadratic.
- Cause: the dedupe loop in `FontHandler::finalize` (`src/css/properties/font.rs:1004-1016` before this change) calls `ordered_remove(i)` (`Vec::remove`) for every duplicate, and each call shifts the rest of the list down by one.

### Fix
- Replace the remove-in-a-loop with `Vec::retain` over the same seen set, so the list is compacted in one pass.
- Output is unchanged: `retain` visits names in order and the seen set still keeps the first occurrence of each, which is what the old loop did (this is also how lightningcss implements the same step).
- Verified with `test/js/bun/css/font-family-dedupe-quadratic.test.ts`:
  - minifies 1M copies of one name in a child with a 60 s kill switch; takes about 5 s in a debug build with the fix, and gets killed at 60 s without it (checked against both a release build and a debug build of the unfixed code; the unfixed debug build needs several minutes at this size)
  - pins the first-occurrence ordering for `font-family` and the `font` shorthand, including the generic `serif` keyword versus the quoted `"serif"` family name, which stay distinct
- Existing `font` tests in `test/js/bun/css/css.test.ts` still pass, including the system-ui fallback expansion that relies on this dedupe.

### Background
- `FontHandler` is the property handler that collects the `font-*` longhands of a rule while minifying and emits them again (merged into a `font` shorthand when possible) in `finalize`. Deduping the family list happens there, so it applies to both `font-family` and the family list inside `font`.
- `FontFamily` hashes and compares by the family name's bytes (or by the generic keyword), so the seen set treats `Foo` and `"Foo"` as the same family but keeps the `serif` keyword and the quoted `"serif"` name apart.

<details>
<summary>Timings</summary>

Release build, `Bun.build({ minify: true })` on `a{font-family:` + `f,` x n + `serif}`:

```
n=5000    88ms
n=10000   360ms
n=20000   1469ms
n=40000   5712ms
```

Debug build with the fix, `cssInternals.minifyTest` on the same input:

```
n=40000     181ms
n=200000    989ms
n=800000    2979ms
n=1000000   3736ms
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/font-family-dedupe-quadratic.test.ts
bun test v1.4.0 (ed65b29c6)

test/js/bun/css/font-family-dedupe-quadratic.test.ts:
36 |   expect({
37 |     stdout,
38 |     stderr: /error|panic|assert|crash|abort/i.test(stderr) ? stderr : "",
39 |     exitCode,
40 |     signalCode: proc.signalCode,
41 |   }).toEqual({
          ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "signalCode": null,
+   "exitCode": 137,
+   "signalCode": "SIGKILL",
    "stderr": "",
-   "stdout": 
- "a{font-family:f,serif}
- "
- ,
+   "stdout": "",
  }

- Expected  - 6
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/css/font-family-dedupe-quadratic.test.ts:41:6)
(fail) font-family with many duplicate names minifies in linear time [60092.65ms]
(pass) font-family dedupe keeps the first occurrence of each family in order [8.33ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [62.62s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/font-family-dedupe-quadratic.test.ts:
36 |   expect({
37 |     stdout,
38 |     stderr: /error|panic|assert|crash|abort/i.test(stderr) ? stderr : "",
39 |     exitCode,
40 |     signalCode: proc.signalCode,
41 |   }).toEqual({
          ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "signalCode": null,
+   "exitCode": 137,
+   "signalCode": "SIGKILL",
    "stderr": "",
-   "stdout": 
- "a{font-family:f,serif}
- "
- ,
+   "stdout": "",
  }

- Expected  - 6
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/css/font-family-dedupe-quadratic.test.ts:41:6)
(fail) font-family with many duplicate names minifies in linear time [60016.22ms]
(pass) font-family dedupe keeps the first occurrence of each family in order [0.53ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [60.18s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/font-family-dedupe-quadratic.test.ts
bun test v1.4.0 (ed65b29c6)

test/js/bun/css/font-family-dedupe-quadratic.test.ts:
(pass) font-family with many duplicate names minifies in linear time [5616.91ms]
(pass) font-family dedupe keeps the first occurrence of each family in order [6.61ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [8.52s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 749ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/font.rs                         | 17 +------
 .../bun/css/font-family-dedupe-quadratic.test.ts   | 57 ++++++++++++++++++++++
 2 files changed, 59 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/css/properties/font.rs                                2      1      0
test/js/bun/css/font-family-dedupe-quadratic.test.ts      0      1      0
```

</details>

**root cause** · written by the author bot

When the CSS minifier flushed a `font-family` value, it removed duplicate names by calling an ordered remove on the vector for each duplicate, and since every removal shifts the remaining tail, a value with n repeated names cost O(n²) time, so roughly 80 KB of hostile CSS took about ten seconds to bundle. The fix replaces that loop with a single `retain` pass that keeps a name only when inserting it into the seen set reports it as new, compacting the vector in one linear sweep. Because `retain` walks front to back and the seen set is unchanged, the first occurrence of each name is kept in …

<!-- robobun:evidence:end -->