### PR TITLE
shell: stop emitting a stray delimiter at the end of a command substitution

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1390,6 +1390,10 @@ impl<'bump> Parser<'bump> {
                     let Token::JSObjRef(obj_ref) = self.prev() else {
                         unreachable!()
                     };
+                    // The lexer emits a Delimit before the `)` / backtick that closes a
+                    // command substitution; consume it like parse_atom does for a file
+                    // target, or it gets parsed as the start of a second command.
+                    let _ = self.r#match(TokenTag::Delimit);
                     break 'redirect_file Some(ast::Redirect::JsBuf(ast::JSBuf::new(obj_ref)));
                 }
 

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1390,8 +1390,6 @@ impl<'bump> Parser<'bump> {
                     let Token::JSObjRef(obj_ref) = self.prev() else {
                         unreachable!()
                     };
-                    // The lexer delimits the target before a closing `)`/backtick.
-                    let _ = self.r#match(TokenTag::Delimit);
                     break 'redirect_file Some(ast::Redirect::JsBuf(ast::JSBuf::new(obj_ref)));
                 }
 
@@ -2347,13 +2345,6 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
         self.delimit_quote = snap.delimit_quote;
     }
 
-    fn last_tok_tag(&self) -> Option<TokenTag> {
-        if self.tokens.is_empty() {
-            return None;
-        }
-        Some(self.tokens[self.tokens.len() - 1].tag())
-    }
-
     pub fn lex(&mut self) -> Result<(), LexerError> {
         loop {
             // Fast path: bulk-consume runs of non-special bytes in Normal state.
@@ -2646,11 +2637,6 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             }
                             if self.in_subshell == Some(SubShellKind::Backtick) {
                                 self.break_word_operator()?;
-                                if let Some(toktag) = self.last_tok_tag() {
-                                    if toktag != TokenTag::Delimit {
-                                        self.tokens.push(Token::Delimit);
-                                    }
-                                }
                                 self.tokens.push(Token::CmdSubstEnd);
                                 return Ok(());
                             } else {
@@ -2726,25 +2712,12 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 break 'escaped;
                             }
 
-                            self.break_word(true)?;
-                            // Command substitution can be put in a word so need to add delimiter
                             if self.in_subshell == Some(SubShellKind::Dollar) {
-                                if let Some(toktag) = self.last_tok_tag() {
-                                    match toktag {
-                                        TokenTag::Delimit
-                                        | TokenTag::Semicolon
-                                        | TokenTag::Eof
-                                        | TokenTag::Newline => {}
-                                        _ => {
-                                            self.tokens.push(Token::Delimit);
-                                        }
-                                    }
-                                }
-                            }
-
-                            if self.in_subshell == Some(SubShellKind::Dollar) {
+                                // A trailing word like the `$x` in `$(echo $x)` still needs its Delimit.
+                                self.break_word_operator()?;
                                 self.tokens.push(Token::CmdSubstEnd);
-                            } else if self.in_subshell == Some(SubShellKind::Normal) {
+                            } else {
+                                self.break_word(true)?;
                                 self.tokens.push(Token::CloseParen);
                             }
                             return Ok(());

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1390,9 +1390,7 @@ impl<'bump> Parser<'bump> {
                     let Token::JSObjRef(obj_ref) = self.prev() else {
                         unreachable!()
                     };
-                    // The lexer emits a Delimit before the `)` / backtick that closes a
-                    // command substitution; consume it like parse_atom does for a file
-                    // target, or it gets parsed as the start of a second command.
+                    // The lexer delimits the target before a closing `)`/backtick.
                     let _ = self.r#match(TokenTag::Delimit);
                     break 'redirect_file Some(ast::Redirect::JsBuf(ast::JSBuf::new(obj_ref)));
                 }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -522,6 +522,84 @@ describe("bunshell", () => {
     );
   });
 
+  describe("redirect to a JS object inside a command substitution", () => {
+    // Used to fail to parse with: expected a command or assignment but got: "CmdSubstEnd"
+    const BACKTICK = { raw: "`" };
+
+    test.concurrent("$(cmd > buffer)", async () => {
+      const buffer = Buffer.alloc(64);
+      const { stdout } = await $`echo a $(echo hi > ${buffer}) b`;
+      expect({ stdout: stdout.toString(), buffer: stringifyBuffer(buffer) }).toEqual({
+        stdout: "a b\n",
+        buffer: "hi\n",
+      });
+    });
+
+    test.concurrent("$(cmd > buffer ) with whitespace before the closing paren", async () => {
+      const buffer = Buffer.alloc(64);
+      const { stdout } = await $`echo a $(echo hi > ${buffer} ) b`;
+      expect({ stdout: stdout.toString(), buffer: stringifyBuffer(buffer) }).toEqual({
+        stdout: "a b\n",
+        buffer: "hi\n",
+      });
+    });
+
+    test.concurrent("$(cmd 2> buffer)", async () => {
+      const buffer = Buffer.alloc(128);
+      const { stdout } = await $`echo $(${BUN} -e ${"console.log('out'); console.error('err')"} 2> ${buffer})`.env(
+        bunEnv,
+      );
+      expect({ stdout: stdout.toString(), buffer: stringifyBuffer(buffer) }).toEqual({
+        stdout: "out\n",
+        buffer: "err\n",
+      });
+    });
+
+    test.concurrent("$(cmd < buffer)", async () => {
+      const input = Buffer.from("from buffer\n");
+      const { stdout } = await $`echo got: $(cat < ${input})`;
+      expect(stdout.toString()).toEqual("got: from buffer\n");
+    });
+
+    test.concurrent('"$(cmd > buffer)" inside double quotes', async () => {
+      const buffer = new Uint8Array(64);
+      const { stdout } = await $`echo "[$(echo hi > ${buffer})]"`;
+      expect({ stdout: stdout.toString(), buffer: stringifyBuffer(buffer) }).toEqual({
+        stdout: "[]\n",
+        buffer: "hi\n",
+      });
+    });
+
+    test.concurrent("`cmd > buffer`", async () => {
+      const buffer = Buffer.alloc(64);
+      const { stdout } = await $`echo a ${BACKTICK}echo hi > ${buffer}${BACKTICK} b`;
+      expect({ stdout: stdout.toString(), buffer: stringifyBuffer(buffer) }).toEqual({
+        stdout: "a b\n",
+        buffer: "hi\n",
+      });
+    });
+
+    test.concurrent("nested: $(cmd $(cmd > buffer))", async () => {
+      const buffer = Buffer.alloc(64);
+      const { stdout } = await $`echo $(echo outer $(echo inner > ${buffer}))`;
+      expect({ stdout: stdout.toString(), buffer: stringifyBuffer(buffer) }).toEqual({
+        stdout: "outer\n",
+        buffer: "inner\n",
+      });
+    });
+
+    test.concurrent("the rest of the outer command still runs", async () => {
+      const first = Buffer.alloc(64);
+      const second = Buffer.alloc(64);
+      const { stdout } = await $`echo $(echo one > ${first}) && echo two > ${second} && echo three`;
+      expect({ stdout: stdout.toString(), first: stringifyBuffer(first), second: stringifyBuffer(second) }).toEqual({
+        stdout: "\nthree\n",
+        first: "one\n",
+        second: "two\n",
+      });
+    });
+  });
+
   test("pipeline", async () => {
     const { stdout } = await $`echo "LMAO" | cat`;
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -522,9 +522,34 @@ describe("bunshell", () => {
     );
   });
 
-  describe("redirect to a JS object inside a command substitution", () => {
-    // Used to fail to parse with: expected a command or assignment but got: "CmdSubstEnd"
+  describe("command substitution ending in something other than a word", () => {
+    // Each of these used to fail to parse with: expected a command or assignment but got: "CmdSubstEnd"
     const BACKTICK = { raw: "`" };
+
+    test.concurrent("$( (subshell) )", async () => {
+      const { stdout } = await $`echo $( (echo hi) ) $( (echo there) )`;
+      expect(stdout.toString()).toEqual("hi there\n");
+    });
+
+    test.concurrent("`(subshell)`", async () => {
+      const { stdout } = await $`echo ${BACKTICK}(echo hi)${BACKTICK}`;
+      expect(stdout.toString()).toEqual("hi\n");
+    });
+
+    test.concurrent("$([[ cond ]] )", async () => {
+      const { stdout } = await $`echo $([[ -n x ]] ) && echo yes`;
+      expect(stdout.toString()).toEqual("\nyes\n");
+    });
+
+    test.concurrent("`cmd;` with a trailing semicolon", async () => {
+      const { stdout } = await $`echo ${BACKTICK}echo hi;${BACKTICK}`;
+      expect(stdout.toString()).toEqual("hi\n");
+    });
+
+    test.concurrent("empty $() and ``", async () => {
+      const { stdout } = await $`echo "[$()]" a $() b ${BACKTICK}${BACKTICK} c`;
+      expect(stdout.toString()).toEqual("[] a b c\n");
+    });
 
     test.concurrent("$(cmd > buffer)", async () => {
       const buffer = Buffer.alloc(64);

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -706,6 +706,79 @@ describe("lex shell", () => {
     expect(JSON.parse(result)).toEqual(expected);
   });
 
+  describe("end of cmd subst", () => {
+    // Closing a `$(...)` or backtick substitution used to always push a Delimit,
+    // even after tokens that do not end a word (JSObjRef, CloseParen, `;`, or
+    // nothing at all); the parser then took that Delimit as the start of another
+    // command and failed with `expected a command or assignment but got: "CmdSubstEnd"`.
+    const BACKTICK = { raw: "`" };
+    const buffer = new Uint8Array(8);
+    const echoTo = (tail: object[]) => [
+      { Text: "echo" },
+      { Delimit: {} },
+      { CmdSubstBegin: {} },
+      { Text: "echo" },
+      { Delimit: {} },
+      { Text: "hi" },
+      { Delimit: {} },
+      ...tail,
+      { CmdSubstEnd: {} },
+      { Eof: {} },
+    ];
+
+    test("js obj redirect target", () => {
+      const expected = echoTo([{ Redirect: redirect({ stdout: true }) }, { JSObjRef: 0 }]);
+      expect(JSON.parse(lex`echo $(echo hi > ${buffer})`)).toEqual(expected);
+      expect(JSON.parse(lex`echo ${BACKTICK}echo hi > ${buffer}${BACKTICK}`)).toEqual(expected);
+    });
+
+    test("subshell", () => {
+      const expected = [
+        { Text: "echo" },
+        { Delimit: {} },
+        { CmdSubstBegin: {} },
+        { OpenParen: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Text: "hi" },
+        { Delimit: {} },
+        { CloseParen: {} },
+        { CmdSubstEnd: {} },
+        { Eof: {} },
+      ];
+      expect(JSON.parse(lex`echo $( (echo hi) )`)).toEqual(expected);
+      expect(JSON.parse(lex`echo ${BACKTICK}(echo hi)${BACKTICK}`)).toEqual(expected);
+    });
+
+    test("semicolon", () => {
+      const expected = echoTo([{ Semicolon: {} }]);
+      expect(JSON.parse(lex`echo $(echo hi;)`)).toEqual(expected);
+      expect(JSON.parse(lex`echo ${BACKTICK}echo hi;${BACKTICK}`)).toEqual(expected);
+    });
+
+    test("empty", () => {
+      const expected = [{ Text: "echo" }, { Delimit: {} }, { CmdSubstBegin: {} }, { CmdSubstEnd: {} }, { Eof: {} }];
+      expect(JSON.parse(lex`echo $()`)).toEqual(expected);
+      expect(JSON.parse(lex`echo ${BACKTICK}${BACKTICK}`)).toEqual(expected);
+    });
+
+    test("a trailing word is still delimited", () => {
+      const expected = [
+        { Text: "echo" },
+        { Delimit: {} },
+        { CmdSubstBegin: {} },
+        { Text: "echo" },
+        { Delimit: {} },
+        { Var: "FOO" },
+        { Delimit: {} },
+        { CmdSubstEnd: {} },
+        { Eof: {} },
+      ];
+      expect(JSON.parse(lex`echo $(echo $FOO)`)).toEqual(expected);
+      expect(JSON.parse(lex`echo ${BACKTICK}echo $FOO${BACKTICK}`)).toEqual(expected);
+    });
+  });
+
   describe("errors", async () => {
     // This is disallowed because the js object references get turned into special vars: $__bun_0, $__bun_1, etc.
     // this will break things inside of a quote.

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -350,48 +350,23 @@ describe("parse shell", () => {
     expect(result).toEqual(expected);
   });
 
-  describe("redirect js obj inside command substitution", () => {
-    // The lexer ends a `$(...)` / backtick body with a Delimit token after the
-    // JSObjRef, which the parser has to consume as part of the redirect instead
-    // of treating it as the start of a second command.
+  describe("end of cmd subst", () => {
+    // Closing a `$(...)` or backtick substitution used to push a Delimit even when
+    // the last token was not a word (a JS object redirect target, a subshell's `)`,
+    // a `;`, or an empty body); the parser then read that Delimit as the start of
+    // another command and failed with `expected a command or assignment but got: "CmdSubstEnd"`.
     const BACKTICK = { raw: "`" };
     const buffer = new Uint8Array(64);
 
-    // `echo <cmd_subst>` where the substituted script is a single command
-    // redirected to jsbuf #0.
-    const echoOfSubst = (inner: { name_and_args: unknown[]; redirect: unknown }, quoted = false) => ({
+    // `echo <cmd_subst>` whose substituted script has the given statements.
+    const echoOfSubst = (stmts: unknown[], quoted = false) => ({
       stmts: [
         {
           exprs: [
             {
               cmd: {
                 assigns: [],
-                name_and_args: [
-                  { simple: { Text: "echo" } },
-                  {
-                    simple: {
-                      cmd_subst: {
-                        script: {
-                          stmts: [
-                            {
-                              exprs: [
-                                {
-                                  cmd: {
-                                    assigns: [],
-                                    name_and_args: inner.name_and_args,
-                                    redirect: inner.redirect,
-                                    redirect_file: { jsbuf: { idx: 0 } },
-                                  },
-                                },
-                              ],
-                            },
-                          ],
-                        },
-                        quoted,
-                      },
-                    },
-                  },
-                ],
+                name_and_args: [{ simple: { Text: "echo" } }, { simple: { cmd_subst: { script: { stmts }, quoted } } }],
                 redirect: redirect({}),
                 redirect_file: null,
               },
@@ -401,63 +376,115 @@ describe("parse shell", () => {
       ],
     });
 
-    const echoFooToBuffer = {
-      name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "foo" } }],
-      redirect: redirect({ stdout: true }),
+    const echoHi = {
+      cmd: {
+        assigns: [],
+        name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "hi" } }],
+        redirect: redirect({}),
+        redirect_file: null,
+      },
     };
 
-    test("$(cmd > buf)", () => {
-      expect(JSON.parse(parse`echo $(echo foo > ${buffer})`)).toEqual(echoOfSubst(echoFooToBuffer));
+    // A single command redirected to jsbuf #0.
+    const redirectedToBuffer = (name_and_args: unknown[], flags: Parameters<typeof redirect>[0]) => [
+      {
+        exprs: [
+          { cmd: { assigns: [], name_and_args, redirect: redirect(flags), redirect_file: { jsbuf: { idx: 0 } } } },
+        ],
+      },
+    ];
+    const echoFooToBuffer = redirectedToBuffer([{ simple: { Text: "echo" } }, { simple: { Text: "foo" } }], {
+      stdout: true,
     });
 
-    test("$(cmd > buf ) with whitespace before the closing paren", () => {
-      expect(JSON.parse(parse`echo $(echo foo > ${buffer} )`)).toEqual(echoOfSubst(echoFooToBuffer));
-    });
+    describe("redirect to a js obj", () => {
+      test("$(cmd > buf)", () => {
+        expect(JSON.parse(parse`echo $(echo foo > ${buffer})`)).toEqual(echoOfSubst(echoFooToBuffer));
+      });
 
-    test('"$(cmd > buf)" quoted', () => {
-      expect(JSON.parse(parse`echo "$(echo foo > ${buffer})"`)).toEqual(echoOfSubst(echoFooToBuffer, true));
-    });
+      test("$(cmd > buf ) with whitespace before the closing paren", () => {
+        expect(JSON.parse(parse`echo $(echo foo > ${buffer} )`)).toEqual(echoOfSubst(echoFooToBuffer));
+      });
 
-    test("$(cmd 2> buf)", () => {
-      expect(JSON.parse(parse`echo $(echo foo 2> ${buffer})`)).toEqual(
-        echoOfSubst({ ...echoFooToBuffer, redirect: redirect({ stderr: true }) }),
-      );
-    });
+      test('"$(cmd > buf)" quoted', () => {
+        expect(JSON.parse(parse`echo "$(echo foo > ${buffer})"`)).toEqual(echoOfSubst(echoFooToBuffer, true));
+      });
 
-    test("$(cmd < buf)", () => {
-      expect(JSON.parse(parse`echo $(cat < ${buffer})`)).toEqual(
-        echoOfSubst({ name_and_args: [{ simple: { Text: "cat" } }], redirect: redirect({ stdin: true }) }),
-      );
-    });
+      test("$(cmd 2> buf)", () => {
+        expect(JSON.parse(parse`echo $(echo foo 2> ${buffer})`)).toEqual(
+          echoOfSubst(
+            redirectedToBuffer([{ simple: { Text: "echo" } }, { simple: { Text: "foo" } }], { stderr: true }),
+          ),
+        );
+      });
 
-    test("`cmd > buf`", () => {
-      expect(JSON.parse(parse`echo ${BACKTICK}echo foo > ${buffer}${BACKTICK}`)).toEqual(echoOfSubst(echoFooToBuffer));
-    });
+      test("$(cmd < buf)", () => {
+        expect(JSON.parse(parse`echo $(cat < ${buffer})`)).toEqual(
+          echoOfSubst(redirectedToBuffer([{ simple: { Text: "cat" } }], { stdin: true })),
+        );
+      });
 
-    test("$(cmd > buf) followed by more of the outer command", () => {
-      const expected = {
-        stmts: [
-          {
-            exprs: [
-              {
-                binary: {
-                  op: "And",
-                  left: echoOfSubst(echoFooToBuffer).stmts[0].exprs[0],
-                  right: {
-                    cmd: {
-                      assigns: [],
-                      name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "bar" } }],
-                      redirect: redirect({ stdout: true }),
-                      redirect_file: { jsbuf: { idx: 1 } },
+      test("`cmd > buf`", () => {
+        expect(JSON.parse(parse`echo ${BACKTICK}echo foo > ${buffer}${BACKTICK}`)).toEqual(
+          echoOfSubst(echoFooToBuffer),
+        );
+      });
+
+      test("$(cmd > buf) followed by more of the outer command", () => {
+        const expected = {
+          stmts: [
+            {
+              exprs: [
+                {
+                  binary: {
+                    op: "And",
+                    left: echoOfSubst(echoFooToBuffer).stmts[0].exprs[0],
+                    right: {
+                      cmd: {
+                        assigns: [],
+                        name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "bar" } }],
+                        redirect: redirect({ stdout: true }),
+                        redirect_file: { jsbuf: { idx: 1 } },
+                      },
                     },
                   },
                 },
+              ],
+            },
+          ],
+        };
+        expect(JSON.parse(parse`echo $(echo foo > ${buffer}) && echo bar > ${buffer}`)).toEqual(expected);
+      });
+    });
+
+    test("subshell", () => {
+      const expected = echoOfSubst([
+        {
+          exprs: [
+            {
+              subshell: {
+                script: { stmts: [{ exprs: [echoHi] }] },
+                redirect: null,
+                redirect_flags: redirect({}),
               },
-            ],
-          },
-        ],
-      };
-      expect(JSON.parse(parse`echo $(echo foo > ${buffer}) && echo bar > ${buffer}`)).toEqual(expected);
+            },
+          ],
+        },
+      ]);
+      expect(JSON.parse(parse`echo $( (echo hi) )`)).toEqual(expected);
+      expect(JSON.parse(parse`echo ${BACKTICK}(echo hi)${BACKTICK}`)).toEqual(expected);
+    });
+
+    test("trailing semicolon", () => {
+      const expected = echoOfSubst([{ exprs: [echoHi] }]);
+      expect(JSON.parse(parse`echo $(echo hi;)`)).toEqual(expected);
+      expect(JSON.parse(parse`echo ${BACKTICK}echo hi;${BACKTICK}`)).toEqual(expected);
+    });
+
+    test("empty", () => {
+      expect(JSON.parse(parse`echo $()`)).toEqual(echoOfSubst([]));
+      expect(JSON.parse(parse`echo "$()"`)).toEqual(echoOfSubst([], true));
+      expect(JSON.parse(parse`echo ${BACKTICK}${BACKTICK}`)).toEqual(echoOfSubst([]));
     });
   });
 

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -350,6 +350,117 @@ describe("parse shell", () => {
     expect(result).toEqual(expected);
   });
 
+  describe("redirect js obj inside command substitution", () => {
+    // The lexer ends a `$(...)` / backtick body with a Delimit token after the
+    // JSObjRef, which the parser has to consume as part of the redirect instead
+    // of treating it as the start of a second command.
+    const BACKTICK = { raw: "`" };
+    const buffer = new Uint8Array(64);
+
+    // `echo <cmd_subst>` where the substituted script is a single command
+    // redirected to jsbuf #0.
+    const echoOfSubst = (inner: { name_and_args: unknown[]; redirect: unknown }, quoted = false) => ({
+      stmts: [
+        {
+          exprs: [
+            {
+              cmd: {
+                assigns: [],
+                name_and_args: [
+                  { simple: { Text: "echo" } },
+                  {
+                    simple: {
+                      cmd_subst: {
+                        script: {
+                          stmts: [
+                            {
+                              exprs: [
+                                {
+                                  cmd: {
+                                    assigns: [],
+                                    name_and_args: inner.name_and_args,
+                                    redirect: inner.redirect,
+                                    redirect_file: { jsbuf: { idx: 0 } },
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        quoted,
+                      },
+                    },
+                  },
+                ],
+                redirect: redirect({}),
+                redirect_file: null,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const echoFooToBuffer = {
+      name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "foo" } }],
+      redirect: redirect({ stdout: true }),
+    };
+
+    test("$(cmd > buf)", () => {
+      expect(JSON.parse(parse`echo $(echo foo > ${buffer})`)).toEqual(echoOfSubst(echoFooToBuffer));
+    });
+
+    test("$(cmd > buf ) with whitespace before the closing paren", () => {
+      expect(JSON.parse(parse`echo $(echo foo > ${buffer} )`)).toEqual(echoOfSubst(echoFooToBuffer));
+    });
+
+    test('"$(cmd > buf)" quoted', () => {
+      expect(JSON.parse(parse`echo "$(echo foo > ${buffer})"`)).toEqual(echoOfSubst(echoFooToBuffer, true));
+    });
+
+    test("$(cmd 2> buf)", () => {
+      expect(JSON.parse(parse`echo $(echo foo 2> ${buffer})`)).toEqual(
+        echoOfSubst({ ...echoFooToBuffer, redirect: redirect({ stderr: true }) }),
+      );
+    });
+
+    test("$(cmd < buf)", () => {
+      expect(JSON.parse(parse`echo $(cat < ${buffer})`)).toEqual(
+        echoOfSubst({ name_and_args: [{ simple: { Text: "cat" } }], redirect: redirect({ stdin: true }) }),
+      );
+    });
+
+    test("`cmd > buf`", () => {
+      expect(JSON.parse(parse`echo ${BACKTICK}echo foo > ${buffer}${BACKTICK}`)).toEqual(echoOfSubst(echoFooToBuffer));
+    });
+
+    test("$(cmd > buf) followed by more of the outer command", () => {
+      const expected = {
+        stmts: [
+          {
+            exprs: [
+              {
+                binary: {
+                  op: "And",
+                  left: echoOfSubst(echoFooToBuffer).stmts[0].exprs[0],
+                  right: {
+                    cmd: {
+                      assigns: [],
+                      name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "bar" } }],
+                      redirect: redirect({ stdout: true }),
+                      redirect_file: { jsbuf: { idx: 1 } },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(JSON.parse(parse`echo $(echo foo > ${buffer}) && echo bar > ${buffer}`)).toEqual(expected);
+    });
+  });
+
   test("cmd subst", () => {
     const expected = {
       stmts: [


### PR DESCRIPTION
### Problem
- A command substitution whose body ends in anything other than a plain word fails to parse, in both the `$(...)` and the backtick form, with `expected a command or assignment but got: "CmdSubstEnd"`:
  ```ts
  const buf = Buffer.alloc(64);
  await $`echo $(echo hi > ${buf})`;   // redirect to a JS object (the case this was reported for)
  await $`echo $( (echo hi) )`;        // body ends in a subshell
  await $`echo $([[ -n x ]] )`;        // body ends in a conditional
  await $`echo $()`;                   // empty body (bash prints an empty line)
  await $`echo ${BT}echo hi;${BT}`;    // backticks with a trailing `;` ($(echo hi;) works)
  await $`echo ${BT}${BT}`;            // empty backticks
  ```
  Each of these works at top level or inside `( ... )`; only command substitutions are affected.
- Cause: when the lexer reaches the `)` or backtick that closes a substitution it unconditionally pushes a `Delimit` token unless the previous token is already a delimiter (`src/shell_parser/parse.rs`, the `)` arm and the closing-backtick arm of the lexer; the backtick arm skipped only `Delimit`, the `)` arm also `;`/newline/EOF). So the body ends in `JSObjRef, Delimit, CmdSubstEnd`, `CloseParen, Delimit, CmdSubstEnd`, `CmdSubstBegin, Delimit, CmdSubstEnd`, and so on.
- A `Delimit` only means something after a word, and the word consumer (`parse_atom`) is the only thing that eats it. `parse_redirect` (JS object target), `parse_subshell`, `parse_cond_expr`, the `;` handling in `parse_stmt`, and an empty body all leave it behind, and the substitution's statement loop then tries to parse it as the start of another command. Everywhere else in the lexer (`break_word_impl`) a `Delimit` is only emitted after a word-ending token, which is why the same constructs parse fine outside substitutions.
- Same behavior in the original Zig parser; not a regression.

### Fix
- Both closing arms now just call `break_word_operator()`, the same routine every other word boundary uses: it flushes a pending word and emits a `Delimit` only when the previous token ends a word (`Var`, text, `}`/`,`, a nested `CmdSubstEnd`, `*`), so the token stream for a substitution now ends the way the rest of the lexer would end it. The forced `Delimit` push and the now-unused `last_tok_tag` helper are deleted; the `$(...)`-specific comment explains why that arm differs from the `( ... )` arm next to it, which keeps `break_word(true)`.
- This is the layer that owns the invariant (the lexer decides where delimiters go), so none of the parser's consumers need to learn to skip a token that should not be there, and the two arms can no longer drift apart. The parser is unchanged.
- Token streams for substitutions ending in a word are unchanged (`$(ls)`, `$(echo $x)`, `$(echo {a,b})`, nested `$(..)`; the existing `lex.test.ts` cases cover these and the new control case pins the `$x` shape in both syntaxes). Endings that lose the `Delimit` are either the fixed cases above or inputs that were already parse errors (`$(x |)`), plus `2>&1` and `**`, which `parse_atom` already handles because the closing token counts as a delimiter for it (covered by the new `bunshell.test.ts` cases and the existing redirect tests).
- Verified:
  - `test/js/bun/shell/lex.test.ts` ("end of cmd subst"): the token stream for each ending (JS object target, subshell, `;`, empty) in both syntaxes, plus the unchanged trailing-word shape. 4 of 5 fail on the released bun.
  - `test/js/bun/shell/parse.test.ts` ("end of cmd subst"): the AST for the same endings, including `>`/`<`/`2>` JS object targets, quoted and unquoted, and a `&&` continuation after the substitution. All 10 fail on the released bun.
  - `test/js/bun/shell/bunshell.test.ts` ("command substitution ending in something other than a word"): end to end, checking the buffer contents or the substituted output for each ending. All 13 fail on the released bun.
  - `bun bd test` on `bunshell.test.ts`, `lex.test.ts`, `parse.test.ts`, `bunshell-instance.test.ts`, `file-io.test.ts`, `shell-cmdsub-crash.test.ts`, `brace.test.ts`, `shell-seq-condexpr.test.ts`: no failures.
- Related open PRs, both compatible with this one: #33547 (the opening backtick does not flush the preceding word, a separate bug in the arm next to this one; `"[${BT}${BT}]"` still misbehaves for that reason and is not asserted here) and #34901 (redirect parsing).
- `$([[ -n x ]])` with no space before the `)` still fails, for a different reason (`]]` directly followed by `)` is lexed as text); that is tracked separately.

### Background
- The shell lexer produces a flat token stream. `Delimit` is a marker meaning "the word being built ends here"; the parser's word consumer `parse_atom` glues consecutive tokens into one word until it sees a `Delimit` (or a structural token such as `;` or the substitution's closing token), and consumes the `Delimit` itself. Tokens that are not words (`JSObjRef` for an interpolated Buffer/Blob/Response, `CloseParen`, `]]`, `;`) are consumed directly by the construct that owns them and never expect a `Delimit` to follow.
- `break_word_impl` is the lexer's single routine for ending a word: it flushes pending text as a `Text` token and decides, based on the previous token, whether a `Delimit` is due. `break_word_operator()` is the variant used at operators and other hard boundaries.
- A command substitution is lexed by a sub-lexer that emits `CmdSubstBegin ... CmdSubstEnd` into the same stream, and parsed by a subparser whose statement loop runs until it sees `CmdSubstEnd`; any token left between the last statement and `CmdSubstEnd` is treated as the start of a new command.

<details>
<summary>Earlier version of this PR</summary>

The first revision only made <code>parse_redirect</code> consume the stray <code>Delimit</code> after a <code>JSObjRef</code>, which fixed the reported case but left the other endings listed above broken. Review pointed out the siblings; the fix was moved into the lexer so that the whole class is handled in one place and the parser is left untouched.
</details>
