### PR TITLE
css: keep empty named @layer blocks as @layer statements

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2425,6 +2425,7 @@ mod stylesheet_impl {
                 err: None,
                 selector_expansion_multiplier: 1,
                 selector_expansion_total: 0,
+                in_style_rule: false,
             };
 
             if self.rules.minify(&mut minify_ctx, false).is_err() {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -550,7 +550,23 @@ impl<R> CssRuleList<R> {
                     CssRule::LayerBlock(lay) => {
                         lay.rules.minify(context, parent_is_unused)?;
                         if lay.rules.v.is_empty() {
-                            break 'arm;
+                            // An empty block still declares the layer, and a layer's
+                            // first declaration fixes its place in the cascade order,
+                            // so `@layer a {}` becomes `@layer a;` rather than
+                            // disappearing. An empty anonymous layer can never be
+                            // referenced again, so it has no effect.
+                            let Some(name) = lay.name.take() else {
+                                break 'arm;
+                            };
+                            if let Some(CssRule::LayerStatement(last_rule)) = rules.last_mut() {
+                                last_rule.names.append(name);
+                                break 'arm;
+                            }
+                            let loc = lay.loc;
+                            *rule = CssRule::LayerStatement(layer::LayerStatementRule {
+                                names: css::SmallList::with_one(name),
+                                loc,
+                            });
                         }
                     }
                     CssRule::LayerStatement(_lay) => {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -550,11 +550,8 @@ impl<R> CssRuleList<R> {
                     CssRule::LayerBlock(lay) => {
                         lay.rules.minify(context, parent_is_unused)?;
                         if lay.rules.v.is_empty() {
-                            // An empty block still declares the layer, and a layer's
-                            // first declaration fixes its place in the cascade order,
-                            // so `@layer a {}` becomes `@layer a;` rather than
-                            // disappearing. An empty anonymous layer can never be
-                            // referenced again, so it has no effect.
+                            // An empty named block still fixes the layer's position in the
+                            // cascade order, so it is kept as `@layer a;`.
                             let Some(name) = lay.name.take() else {
                                 break 'arm;
                             };

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -550,8 +550,6 @@ impl<R> CssRuleList<R> {
                     CssRule::LayerBlock(lay) => {
                         lay.rules.minify(context, parent_is_unused)?;
                         if lay.rules.v.is_empty() {
-                            // An empty named block still fixes the layer's position in the
-                            // cascade order, so it is kept as `@layer a;`.
                             let Some(name) = lay.name.take() else {
                                 break 'arm;
                             };

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -550,18 +550,22 @@ impl<R> CssRuleList<R> {
                     CssRule::LayerBlock(lay) => {
                         lay.rules.minify(context, parent_is_unused)?;
                         if lay.rules.v.is_empty() {
-                            let Some(name) = lay.name.take() else {
-                                break 'arm;
-                            };
-                            if let Some(CssRule::LayerStatement(last_rule)) = rules.last_mut() {
-                                last_rule.names.append(name);
+                            if lay.name.is_none() {
                                 break 'arm;
                             }
-                            let loc = lay.loc;
-                            *rule = CssRule::LayerStatement(layer::LayerStatementRule {
-                                names: css::SmallList::with_one(name),
-                                loc,
-                            });
+                            if !context.in_style_rule
+                                && let Some(name) = lay.name.take()
+                            {
+                                if let Some(CssRule::LayerStatement(last_rule)) = rules.last_mut() {
+                                    last_rule.names.append(name);
+                                    break 'arm;
+                                }
+                                let loc = lay.loc;
+                                *rule = CssRule::LayerStatement(layer::LayerStatementRule {
+                                    names: css::SmallList::with_one(name),
+                                    loc,
+                                });
+                            }
                         }
                     }
                     CssRule::LayerStatement(_lay) => {
@@ -1258,4 +1262,9 @@ pub struct MinifyContext<'a, 'bump> {
     /// Running total of selectors that compiling nested rules for the targets
     /// will expand to, checked against [`MAX_SELECTOR_EXPANSION`].
     pub(crate) selector_expansion_total: u32,
+    /// Set while minifying the rules nested inside a style rule. A `@layer`
+    /// statement is not a nested group rule (browsers ignore one nested in a
+    /// style rule, see WPT css/css-nesting/nesting-layer.html), so an empty
+    /// `@layer` block must stay a block there instead of becoming a statement.
+    pub(crate) in_style_rule: bool,
 }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -450,7 +450,9 @@ impl<R> StyleRule<R> {
             &mut context.handler_context,
             &mut handler_context,
         );
+        let saved_in_style_rule = core::mem::replace(&mut context.in_style_rule, true);
         let result = self.rules.minify(context, parent_is_unused);
+        context.in_style_rule = saved_in_style_rule;
         core::mem::swap::<PropertyHandlerContext<'_>>(
             &mut context.handler_context,
             &mut handler_context,

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -2098,6 +2098,49 @@ c {
     },
   });
 
+  // A layer's position in the cascade order is fixed by its first declaration,
+  // so the empty blocks in order.css decide that `b` beats `a` in entry.css.
+  // They must come out as `@layer` statements instead of being removed as
+  // empty rules.
+  itBundled("css/CSSAtLayerEmptyBlockKeepsLayerOrder", {
+    files: {
+      "/entry.css": /* css */ `
+        @import "./order.css";
+        @layer b { .x { color: red } }
+        @layer a { .x { color: blue } }
+      `,
+      "/order.css": /* css */ `
+        @layer a {}
+        @layer b {}
+        @media print { @layer c {} }
+        @layer {}
+      `,
+    },
+    outfile: "/out.css",
+    onAfterBundle(api) {
+      api.expectFile("/out.css").toEqualIgnoringWhitespace(/* css */ `
+        /* order.css */
+        @layer a, b;
+        @media print {
+          @layer c;
+        }
+
+        /* entry.css */
+        @layer b {
+          .x {
+            color: red;
+          }
+        }
+
+        @layer a {
+          .x {
+            color: #00f;
+          }
+        }
+      `);
+    },
+  });
+
   itBundled("css/CSSAtImportConditionsChainExternal", {
     files: {
       "/entry.css": /* css */ `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7559,6 +7559,33 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
+  describe("layer", () => {
+    // The first declaration of a layer fixes its position in the cascade
+    // order, so an empty `@layer x {}` block is not dead: it has to survive as
+    // an `@layer x;` statement. Here the source order is (a, b), so `b` wins.
+    minify_test(
+      "@layer a {} @layer b { .x { color: red } } @layer a { .x { color: blue } }",
+      "@layer a;@layer b{.x{color:red}}@layer a{.x{color:#00f}}",
+    );
+    minify_test("@layer a {}", "@layer a;");
+    minify_test("@layer a.b {}", "@layer a.b;");
+    minify_test("@layer a {} @layer b {} .x { color: red }", "@layer a,b;.x{color:red}");
+    minify_test("@layer a, b; @layer c {}", "@layer a,b,c;");
+    minify_test("@layer a {} @layer b;", "@layer a;@layer b;");
+    minify_test("@layer a {} .x { color: red } @layer b {}", "@layer a;.x{color:red}@layer b;");
+    // A block whose contents are minified away still declares its layer.
+    minify_test("@layer a { @media not all { .x { color: red } } }", "@layer a;");
+    // Layers declared inside a conditional rule only join the order when the
+    // condition matches, so the statement has to stay inside it.
+    minify_test("@media screen { @layer a {} }", "@media screen{@layer a;}");
+    minify_test("@supports (display: grid) { @layer a {} }", "@supports (display: grid){@layer a;}");
+    minify_test("@layer a { @layer b {} @layer c {} }", "@layer a{@layer b,c;}");
+    // An anonymous layer can never be referenced again, so an empty one has no
+    // effect on anything and can go.
+    minify_test("@layer {} .x { color: red }", ".x{color:red}");
+    minify_test("@layer a, b; @layer a { .x { color: red } }", "@layer a,b;@layer a{.x{color:red}}");
+  });
+
   describe("container", () => {
     minify_test("@container (width > 100px) { a { color: red } }", "@container (width>100px){a{color:red}}");
     minify_test("@container not (width > 100px) { a { color: red } }", "@container not (width>100px){a{color:red}}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7584,6 +7584,18 @@ describe("css tests", () => {
     // effect on anything and can go.
     minify_test("@layer {} .x { color: red }", ".x{color:red}");
     minify_test("@layer a, b; @layer a { .x { color: red } }", "@layer a,b;@layer a{.x{color:red}}");
+    // Nested in a style rule, only the block form is a valid nested group rule
+    // (browsers ignore a nested `@layer a;`, see WPT css/css-nesting/nesting-layer.html
+    // and Bun's own parser rejects it), so there the empty block stays a block.
+    minify_test(".foo { color: red; @layer a {} }", ".foo{color:red;@layer a{}}");
+    minify_test(".foo { color: red; @media screen { @layer a {} } }", ".foo{color:red;@media screen{@layer a{}}}");
+    minify_test(".foo { color: red; @layer {} }", ".foo{color:red}");
+    // The style rule's own nesting does not leak into the rules after it.
+    minify_test(".foo { color: red; .bar { color: blue } } @layer a {}", ".foo{color:red;& .bar{color:#00f}}@layer a;");
+    minify_test(
+      "@layer a { .foo { color: red; @layer b {} } @layer c {} }",
+      "@layer a{.foo{color:red;@layer b{}}@layer c;}",
+    );
   });
 
   describe("container", () => {


### PR DESCRIPTION
### Problem

- `bun build` (with or without `--minify`) deletes empty named `@layer x {}` blocks, which changes the cascade layer order of the output:
  ```css
  @layer a {}
  @layer b { .x { color: red } }
  @layer a { .x { color: blue } }
  ```
  comes out as `@layer b{.x{color:red}}@layer a{.x{color:#00f}}`. In the source the layer order is (a, b), so `b` wins and `.x` is red; in the output the first appearance order is (b, a), so `.x` is blue. `@layer a {} @layer b {} .x {...}` loses both declarations, and blocks nested in `@media` / `@supports` are dropped too.
- Cause: `CssRuleList::minify` in `src/css/rules/mod.rs:550` removes a `LayerBlock` whose rule list is empty after minifying, as if it were an empty `@media` block. The minify pass runs on every CSS file the bundler parses (`src/bundler/ParseTask.rs:1246`), so this is not limited to `--minify`. This has been the behavior since the CSS minifier was first written; it never worked.
- `@layer a, b;` statements were never affected, only the block form.

### Fix

- When a named layer block is empty after minifying, emit it as an `@layer a;` statement instead of removing it. If the rule emitted just before it is already a layer statement, the name is appended to that statement, so `@layer a {} @layer b {}` prints as `@layer a, b;`. This matches what lightningcss emits for these inputs.
- `@layer a {}` and `@layer a;` have the same meaning (both declare `a` at that point in the order), and outside style rules (see below) a statement is valid wherever a block is, including inside conditional rules, where the declaration must stay conditional (`@media screen { @layer a {} }` becomes `@media screen { @layer a; }`).
- Empty anonymous blocks (`@layer {}`) are still removed: an anonymous layer cannot be referenced again, so an empty one affects nothing. This is also what the bundler's `@import ... layer` wrapping in `prepareCssAstsForChunk.rs` already does for empty imported files.
- Appending to the previous statement touches only `rules.last_mut()`, like the existing `@media` merge in the same function, so the style-rule dedup state does not need updating. Existing statements are otherwise left alone, so output for stylesheets without empty blocks is unchanged.
- Inside a style rule the rewrite is skipped and an empty named block is kept as a block (`.foo { color: red; @layer a {} }` becomes `.foo{color:red;@layer a{}}`; compiling nesting away for older targets hoists it as a top-level `@layer a {}`). A `@layer` statement is not a valid nested group rule: browsers ignore one nested in a style rule (WPT `css/css-nesting/nesting-layer.html`) and Bun's parser rejects it, so the statement form would both lose the declaration and fail to re-parse. `StyleRule::minify_nested_rules` sets `MinifyContext::in_style_rule` around the nested list for this. (lightningcss emits the nested statement and then rejects its own output, so this is a deliberate difference from it.)
- Not ported: lightningcss also merges same-named layer blocks that are not adjacent. That is not order-preserving when sublayers are involved (`@layer a {} @layer a.x {...} @layer a { @layer y {...} }` comes out with `y` declared before `x`), so this change does not do it.
- Verified:
  - `test/js/bun/css/css.test.ts` (new `layer` describe block): the top-level cases, the conditional-rule cases, the style-rule-nested cases and the flag restore after a style rule. 15 of the 18 cases fail on the current release (`USE_SYSTEM_BUN=1`); all pass with this change, and every expected output re-parses to itself. Whole file passes.
  - `test/bundler/esbuild/css.test.ts` `css/CSSAtLayerEmptyBlockKeepsLayerOrder`: an imported file that only declares the layer order used to bundle to nothing; fails before, passes after. The rest of the file and `test/bundler/css/` pass with no snapshot changes.
  - `test/regression/issue/28914.test.ts` and `20546.test.ts` (existing `@layer` bundling coverage) pass.

### Background

- Cascade layers (`@layer`) group rules so that the layer, rather than specificity or source order, decides which rule wins. The layers are ordered by the point at which each layer name is first declared; later declarations of the same name add rules to the existing layer but do not move it. Both `@layer a;` (statement) and `@layer a { ... }` (block, even an empty one) count as declarations. A layer declared inside `@media` / `@supports` only enters the order if the condition matches.
- `CssRule::LayerBlock` and `CssRule::LayerStatement` are the two AST forms in `src/css/rules/layer.rs`; the statement form holds a list of names because `@layer a, b;` declares several at once.
- `CssRuleList::minify` rebuilds each rule list into `rules`, recursing into nested at-rules and removing rules that can have no effect. Bun runs it on every stylesheet it bundles, independent of the `--minify` flag, which only controls how the result is printed.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/css.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (c65a608ed)

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [618.23ms]
(pass) bundler > css/CSSEntryPointEmpty [105.86ms]
(pass) bundler > css/CSSNesting [99.49ms]
(pass) bundler > css/CSSAtImportMissing [119.23ms]
(pass) bundler > css/CSSAtImportSimple [99.27ms]
(pass) bundler > css/CSSAtImportDiamond [115.56ms]
(pass) bundler > css/CSSAtImportCycle [114.63ms]
(pass) bundler > css/CSSUrlImport [107.26ms]
(pass) bundler > css/ImportCSSFromJSComposes [137.51ms]
(pass) bundler > css/ImportCSSFromJSComposesFromMissingImport [292.49ms]
(pass) bundler > css/ImportCSSFromJSComposesFromNotCSS [100.13ms]
(pass) bundler > css/ImportCSSFromJSComposesCircular [116.00ms]
(pass) bundler > css/ImportCSSFromJSComposesFromCircular [116.56ms]
(pass) bundler > css/ImportCSSFromJSComposesIDSelector [101.34ms]
(pass) bundler > css/ImportCSSFromJSComposesElementSelector [103.16ms]
(pass) bundler > css/ImportCSSFromJSComposesCompoundSelector [105.51ms]
(pass) 
... (truncated)

release without fix: 12 failed, 67 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [13.81ms]
(pass) bundler > css/CSSEntryPointEmpty [3.34ms]
(pass) bundler > css/CSSNesting [3.18ms]
(pass) bundler > css/CSSAtImportMissing [2.95ms]
(pass) bundler > css/CSSAtImportSimple [3.54ms]
(pass) bundler > css/CSSAtImportDiamond [3.19ms]
(pass) bundler > css/CSSAtImportCycle [3.40ms]
(pass) bundler > css/CSSUrlImport [3.26ms]
(pass) bundler > css/ImportCSSFromJSComposes [3.32ms]
(pass) bundler > css/ImportCSSFromJSComposesFromMissingImport [6.20ms]
(pass) bundler > css/ImportCSSFromJSComposesFromNotCSS [2.98ms]
(pass) bundler > css/ImportCSSFromJSComposesCircular [3.45ms]
(pass) bundler > css/ImportCSSFromJSComposesFromCircular [3.41ms]
(pass) bundler > css/ImportCSSFromJSComposesIDSelector [2.77ms]
(pass) bundler > css/ImportCSSFromJSComposesElementSelector [3.18ms]
(pass) bundler > css/ImportCSSFromJSComposesCompoundSelector [2.93ms]
(pass) bundler > css/ImportCSSFromJSComposesComplexSelector [3.09ms]
(pass) bundler > css/ImportCSSFromJSComposesPseudoClass [3.27ms]
(pass) bundler > css/ImportCSSFromJSComposesAttributeSelector [3.20ms]
(pass) bundler >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/css.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (c65a608ed)

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [598.96ms]
(pass) bundler > css/CSSEntryPointEmpty [125.60ms]
(pass) bundler > css/CSSNesting [131.89ms]
(pass) bundler > css/CSSAtImportMissing [125.10ms]
(pass) bundler > css/CSSAtImportSimple [109.16ms]
(pass) bundler > css/CSSAtImportDiamond [120.90ms]
(pass) bundler > css/CSSAtImportCycle [136.46ms]
(pass) bundler > css/CSSUrlImport [133.13ms]
(pass) bundler > css/ImportCSSFromJSComposes [210.67ms]
(pass) bundler > css/ImportCSSFromJSComposesFromMissingImport [317.27ms]
(pass) bundler > css/ImportCSSFromJSComposesFromNotCSS [117.59ms]
(pass) bundler > css/ImportCSSFromJSComposesCircular [138.59ms]
(pass) bundler > css/ImportCSSFromJSComposesFromCircular [185.83ms]
(pass) bundler > css/ImportCSSFromJSComposesIDSelector [180.68ms]
(pass) bundler > css/ImportCSSFromJSComposesElementSelector [180.31ms]
(pass) bundler > css/ImportCSSFromJSComposesCompoundSelector [140.32ms]
(pass
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c65a608ed1
  features     baseline

22 deps, 123 codegen, 1176 objects in 721ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [22.00ms]
[2/1238] gen bindgenv2
[3/1238] gen ErrorCode+*.h
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] gen .bind.ts → GeneratedBindings.cpp
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1237] inst
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/rules/mod.rs             | 18 ++++++++++++++++-
 test/bundler/esbuild/css.test.ts | 43 ++++++++++++++++++++++++++++++++++++++++
 test/js/bun/css/css.test.ts      | 27 +++++++++++++++++++++++++
 3 files changed, 87 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/css/rules/mod.rs                  4      4      0
test/bundler/esbuild/css.test.ts      3      1      0
test/js/bun/css/css.test.ts           5      3      0
```

</details>

<!-- robobun:evidence:end -->
