### PR TITLE
css: print integer tokens from their i32 instead of a 6 digit float

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5784,7 +5784,27 @@ pub mod serializer {
         unit: &'static [u8],
         dest: &mut Printer,
     ) -> Result<(), PrintErr> {
-        let int_value: Option<i32> = if fract(value) == 0.0 {
+        let num = Num {
+            has_sign: false,
+            value,
+            int_value: None,
+        };
+        serialize_dimension_num(&num, unit, dest)
+    }
+
+    /// Minified dimension printing: a redundant `+` and the `.0` of an integral
+    /// value are dropped. An `<integer-token>` is printed from its own integer
+    /// (`16777217fr` is stored as the f32 16777216); any other integral value
+    /// is printed from the f32.
+    pub(crate) fn serialize_dimension_num(
+        num: &Num,
+        unit: &'static [u8],
+        dest: &mut Printer,
+    ) -> Result<(), PrintErr> {
+        let value = num.value;
+        let int_value: Option<i32> = if let Some(int) = num.exact_int() {
+            Some(int)
+        } else if fract(value) == 0.0 {
             Some(value as i32) // saturating cast
         } else {
             None

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5411,11 +5411,8 @@ impl Num {
         generic::implement_hash(self, hasher)
     }
 
-    /// The integer an `<integer-token>` was written as. `value` is an f32 and
-    /// cannot hold every i32 (`2147483647` is stored as `2147483648.0`), so
-    /// printing goes through this instead of `value`. `None` for a fractional
-    /// token, or when `int_value` saturated at the i32 range and no longer
-    /// describes `value`.
+    /// `int_value` unless it saturated and no longer describes `value`. Print
+    /// from this, not `value`: an f32 cannot hold every i32.
     pub(crate) fn exact_int(&self) -> Option<i32> {
         self.int_value.filter(|&int| int as f32 == self.value)
     }
@@ -5792,10 +5789,8 @@ pub mod serializer {
         serialize_dimension_num(&num, unit, dest)
     }
 
-    /// Minified dimension printing: a redundant `+` and the `.0` of an integral
-    /// value are dropped. An `<integer-token>` is printed from its own integer
-    /// (`16777217fr` is stored as the f32 16777216); any other integral value
-    /// is printed from the f32.
+    /// Prints `num` without a redundant `+` or `.0`, from its own integer when
+    /// it has one (see `Num::exact_int`).
     pub(crate) fn serialize_dimension_num(
         num: &Num,
         unit: &'static [u8],
@@ -5909,8 +5904,7 @@ pub mod serializer {
                 scientific: false,
             }
         } else if let Some(int) = num.exact_int() {
-            // `dtoa_short` below keeps 6 significant digits, which would turn
-            // `z-index: 2147483647` into `2147480000`.
+            // `dtoa_short` rounds to 6 significant digits.
             let mut buf = bun_core::fmt::ItoaBuf::new();
             return writer.write_all(bun_core::fmt::itoa(&mut buf, int));
         } else {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5411,8 +5411,7 @@ impl Num {
         generic::implement_hash(self, hasher)
     }
 
-    /// `int_value` unless it saturated and no longer describes `value`. Print
-    /// from this, not `value`: an f32 cannot hold every i32.
+    /// `int_value`, unless it saturated and no longer describes `value`.
     pub(crate) fn exact_int(&self) -> Option<i32> {
         self.int_value.filter(|&int| int as f32 == self.value)
     }
@@ -5789,8 +5788,6 @@ pub mod serializer {
         serialize_dimension_num(&num, unit, dest)
     }
 
-    /// Prints `num` without a redundant `+` or `.0`, from its own integer when
-    /// it has one (see `Num::exact_int`).
     pub(crate) fn serialize_dimension_num(
         num: &Num,
         unit: &'static [u8],

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5304,17 +5304,22 @@ impl Token {
                 debug_assert!(*x <= 0x7F);
                 writer.write_byte(*x as u8)
             }
-            Token::Number(n) => serializer::write_numeric(n.value, n.int_value, n.has_sign, writer),
+            Token::Number(n) => serializer::write_numeric(n, writer),
             Token::Percentage {
                 unit_value,
                 int_value,
                 has_sign,
             } => {
-                serializer::write_numeric(*unit_value * 100.0, *int_value, *has_sign, writer)?;
+                let num = Num {
+                    has_sign: *has_sign,
+                    value: *unit_value * 100.0,
+                    int_value: *int_value,
+                };
+                serializer::write_numeric(&num, writer)?;
                 writer.write_all(b"%")
             }
             Token::Dimension(d) => {
-                serializer::write_numeric(d.num.value, d.num.int_value, d.num.has_sign, writer)?;
+                serializer::write_numeric(&d.num, writer)?;
                 // Disambiguate with scientific notation.
                 let unit = d.unit;
                 if (unit.len() == 1 && unit[0] == b'e')
@@ -5404,6 +5409,15 @@ pub use crate::{Dimension, Num};
 impl Num {
     pub(crate) fn hash(&self, hasher: &mut bun_wyhash::Wyhash) {
         generic::implement_hash(self, hasher)
+    }
+
+    /// The integer an `<integer-token>` was written as. `value` is an f32 and
+    /// cannot hold every i32 (`2147483647` is stored as `2147483648.0`), so
+    /// printing goes through this instead of `value`. `None` for a fractional
+    /// token, or when `int_value` saturated at the i32 range and no longer
+    /// describes `value`.
+    pub(crate) fn exact_int(&self) -> Option<i32> {
+        self.int_value.filter(|&int| int as f32 == self.value)
     }
 }
 
@@ -5853,11 +5867,15 @@ pub mod serializer {
     }
 
     pub(crate) fn write_numeric<W: WriteAll + ?Sized>(
-        value: f32,
-        int_value: Option<i32>,
-        has_sign: bool,
+        num: &Num,
         writer: &mut W,
     ) -> bun_io::Result<()> {
+        let Num {
+            has_sign,
+            value,
+            int_value,
+        } = *num;
+
         // `value >= 0` is true for negative 0.
         if has_sign && !value.is_sign_negative() {
             writer.write_all(b"+")?;
@@ -5870,6 +5888,11 @@ pub mod serializer {
                 decimal_point: false,
                 scientific: false,
             }
+        } else if let Some(int) = num.exact_int() {
+            // `dtoa_short` below keeps 6 significant digits, which would turn
+            // `z-index: 2147483647` into `2147480000`.
+            let mut buf = bun_core::fmt::ItoaBuf::new();
+            return writer.write_all(bun_core::fmt::itoa(&mut buf, int));
         } else {
             let mut buf = [0u8; 129];
             let (str, maybe_notation) = dtoa_short(&mut buf, value, 6);

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -418,7 +418,10 @@ impl TokenList {
                         has_whitespace = false;
                     }
                     Token::Number(v) => {
-                        CSSNumberFns::to_css(v.value, dest)?;
+                        match v.exact_int() {
+                            Some(int) => CSSIntegerFns::to_css(int, dest)?,
+                            None => CSSNumberFns::to_css(v.value, dest)?,
+                        }
                         has_whitespace = false;
                     }
                     _ => {

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -414,7 +414,7 @@ impl TokenList {
                         has_whitespace = self.write_whitespace_if_needed(i, dest)?;
                     }
                     Token::Dimension(dim) => {
-                        css_parser::serializer::serialize_dimension(dim.num.value, dim.unit, dest)?;
+                        css_parser::serializer::serialize_dimension_num(&dim.num, dim.unit, dest)?;
                         has_whitespace = false;
                     }
                     Token::Number(v) => {

--- a/src/css/values/percentage.rs
+++ b/src/css/values/percentage.rs
@@ -30,7 +30,7 @@ impl Percentage {
     pub(crate) fn to_css(self, dest: &mut Printer) -> Result<(), PrintErr> {
         let x = self.v * 100.0;
         let int_value: Option<i32> = if (x - x.trunc()) == 0.0 {
-            Some(self.v as i32)
+            Some(x as i32)
         } else {
             None
         };

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7747,6 +7747,8 @@ describe("css tests", () => {
     minify_test(".foo{width:1234567px}", ".foo{width:1234567px}");
     minify_test(".foo{height:1234567%}", ".foo{height:1234567%}");
     minify_test(".foo{grid-template-columns:1234567fr}", ".foo{grid-template-columns:1234567fr}");
+    minify_test(".foo{grid-template-columns:16777217fr}", ".foo{grid-template-columns:16777217fr}");
+    minify_test(".foo{grid-template-columns:+2fr 2.0fr}", ".foo{grid-template-columns:2fr 2fr}");
     // An integer outside the i32 range saturates the token's integer. 2147483648 rounds to the
     // same f32 as i32::MAX, so the saturated integer is still what gets printed (browsers clamp
     // an <integer> to the same bound); further out it no longer matches the float, which is

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7701,6 +7701,63 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  describe("integer tokens", () => {
+    // Properties that are not in the typed property table (z-index, orphans, counter-*, grid
+    // lines, custom properties) round-trip their <integer> values as tokens. These used to be
+    // printed from the token's f32 with 6 significant digits, so 2147483647 and 2147483646
+    // both came out as 2147480000 and the two stacking levels collapsed into one.
+    minify_test(".foo{z-index:2147483647}", ".foo{z-index:2147483647}");
+    minify_test(".foo{z-index:2147483646}", ".foo{z-index:2147483646}");
+    minify_test(".foo{z-index:-2147483648}", ".foo{z-index:-2147483648}");
+    minify_test(".foo{z-index:999999999}", ".foo{z-index:999999999}");
+    minify_test(".foo{z-index:100000001}", ".foo{z-index:100000001}");
+    cssTest(
+      indoc`
+        .a { z-index: 2147483647 }
+        .b { z-index: 2147483646 }
+      `,
+      indoc`
+        .a {
+          z-index: 2147483647;
+        }
+
+        .b {
+          z-index: 2147483646;
+        }
+      `,
+    );
+    // Above 2^24 the f32 itself is already rounded (16777217 is stored as 16777216); the
+    // token still carries the integer that was written.
+    minify_test(".foo{orphans:16777217}", ".foo{orphans:16777217}");
+    minify_test(".foo{counter-set:n 2147483647}", ".foo{counter-set:n 2147483647}");
+    minify_test(".foo{grid-row:2147483647}", ".foo{grid-row:2147483647}");
+    minify_test(":root{--z:2147483647}", ":root{--z:2147483647}");
+    minify_test(":root{--z:calc(2147483647 - 1)}", ":root{--z:calc(2147483647 - 1)}");
+    minify_test(".foo{z-index:var(--z,2147483647)}", ".foo{z-index:var(--z,2147483647)}");
+    // Token lists still drop a redundant sign.
+    minify_test(".foo{z-index:+2147483647}", ".foo{z-index:2147483647}");
+    minify_test(".foo{z-index:-0}", ".foo{z-index:0}");
+    // Arguments of unknown functional pseudo-classes are printed verbatim.
+    minify_test(
+      ".foo:-x-level(+2147483647 16777217 -0 1.0){color:red}",
+      ".foo:-x-level(+2147483647 16777217 -0 1.0){color:red}",
+    );
+    // Integral percentages and dimensions are printed in full as well.
+    minify_test(":root{--p:1234567%}", ":root{--p:1234567%}");
+    minify_test(".foo{width:1234567px}", ".foo{width:1234567px}");
+    minify_test(".foo{height:1234567%}", ".foo{height:1234567%}");
+    minify_test(".foo{grid-template-columns:1234567fr}", ".foo{grid-template-columns:1234567fr}");
+    // An integer outside the i32 range saturates the token's integer. 2147483648 rounds to the
+    // same f32 as i32::MAX, so the saturated integer is still what gets printed (browsers clamp
+    // an <integer> to the same bound); further out it no longer matches the float, which is
+    // printed as before.
+    minify_test(".foo{z-index:2147483648}", ".foo{z-index:2147483647}");
+    minify_test(".foo{z-index:3000000000}", ".foo{z-index:3000000000}");
+    // Non-integer tokens keep the 6 significant digit float output.
+    minify_test(":root{--n:1234567.0}", ":root{--n:1234570}");
+    minify_test(":root{--n:1234567.5}", ":root{--n:1234570}");
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(

--- a/test/regression/issue/21907.test.ts
+++ b/test/regression/issue/21907.test.ts
@@ -86,8 +86,8 @@ test("CSS parser should handle extremely large floating-point values without cra
     "/* [path] */
     .test-rounded-full {
       border-radius: 3.40282e+38px;
-      width: 2147480000px;
-      height: -2147480000px;
+      width: 2147483647px;
+      height: -2147483648px;
     }
 
     .test-negative {
@@ -109,8 +109,8 @@ test("CSS parser should handle extremely large floating-point values without cra
     }
 
     .test-boundaries {
-      margin: 2147480000px;
-      padding: -2147480000px;
+      margin: 2147483647px;
+      padding: -2147483648px;
       left: 4294970000px;
     }
 


### PR DESCRIPTION
### Problem
- `bun build` rewrites large CSS `<integer>` values: `a{z-index:2147483647} b{z-index:2147483646}` comes out as `z-index:2147480000` for both, so two distinct stacking levels become the same one and DOM order decides which is on top. Same for `--z:2147483647`, `orphans:16777217` (printed `16777200`), `counter-set:n 2147483647`, `grid-row:2147483647`. Happens with and without `--minify`.
- A number token stores the value twice: `value: f32` and, for an `<integer-token>`, the exact `int_value: i32` (`src/css/css_parser.rs` `consume_numeric`). Both printers ignore `int_value` and format the f32 with 6 significant digits:
  - `TokenList::to_css` (`src/css/properties/custom.rs:420`) prints `Token::Number` through `CSSNumberFns::to_css(v.value)`. This is the path for every property bun has no typed entry for (z-index included) and for custom properties.
  - `serializer::write_numeric` (`src/css/css_parser.rs`) prints raw tokens (percentage tokens in token lists, unknown pseudo-class arguments, and the `serialize_dimension` helper used by typed lengths) with `dtoa_short(value, 6)`.
- lightningcss has the same token printers but avoids the z-index case with a typed i32 `z-index` property, which bun's port does not have; it has the same loss for custom properties.

### Fix
- `Num::exact_int()` returns `int_value` when `int_value as f32 == value`, i.e. when the integer still describes the float. `write_numeric` and the `Token::Number` arm of `TokenList::to_css` print that integer with itoa and fall back to the existing float path otherwise.
- The `Token::Dimension` arm of `TokenList::to_css` goes through `serialize_dimension_num`, which takes the token's `Num` and prefers its exact integer (`16777217fr` used to come back as `16777216fr` once the f32 had rounded it); `serialize_dimension` is now a wrapper over it for the typed callers that only have an f32.
- The comparison is what keeps the existing producers safe: the tokenizer saturates `int_value` at the i32 range (`3000000000` keeps printing from the float), and `serialize_dimension` synthesizes `int_value` with a saturating cast. `Percentage::to_css` used to fill `int_value` with the unit value (`0` for `50%`) purely as an "is integral" flag; it now stores the percentage's integer so integral percentages print in full too.
- Output only changes for integral values with more than 6 significant digits; for 6 or fewer, itoa and the float path print the same digits. Fractional values, typed `<number>` properties (`opacity`, `line-height`, ...) and the `.0` / `+` / `-0` round-trip rules are untouched.
- Verified:
  - `test/js/bun/css/css.test.ts` ("integer tokens"): 20 of the 25 new cases fail on the released build (the other 5 pin behavior that must not change), all 25 pass with the fix.
  - `test/regression/issue/21907.test.ts`: snapshot updated. `margin:2147483647px` / `padding:-2147483648px` now print exactly; `width:2147483648px` / `height:-2147483649px` print as the i32 bounds, which parse back to the same f32 as before (the old `2147480000px` did not).
  - `test/js/bun/css/` (minus the local-only fuzz file) and `test/bundler/css/` pass with the debug build.

### Background
- CSS `<integer>` values such as `z-index` are i32 in browsers. f32 has a 24 bit mantissa, so it holds every integer only up to 16777216; `2147483647` is stored as `2147483648.0`. cssparser (and bun's port) therefore keep the exact integer next to the float in the token.
- `dtoa_short(value, 6)` is the float formatter lightningcss uses everywhere: shortest representation, then rounded to 6 significant digits (`0.30000001` prints as `.3`). Applied to an integer it zero-fills the remaining digits, which is where `2147480000` comes from.
- `TokenList` is the representation for custom properties and for any declaration bun cannot parse into a typed property; it is printed token by token, with numbers and dimensions going through the minifying number printers rather than the verbatim token printer.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts "test/regression/issue/21907.test.ts"
bun test v1.4.1 (65362b53b)

test/regression/issue/21907.test.ts:
80 |       .trim();
81 |   }
82 | 
83 |   // Test the actual output with inline snapshot - this ensures all intFromFloat
84 |   // conversions work correctly and captures any changes in output format
85 |   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
                                                 ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* [path] */
  .test-rounded-full {
    border-radius: 3.40282e+38px;
-   width: 2147483647px;
-   height: -2147483648px;
+   width: 2147480000px;
+   height: -2147480000px;
  }
  
  .test-negative {
    border-radius: -3.40282e+38px;
  }
  
  .test-very-large, .test-large-integer {
    border-radius: 3.40282e38px;
  }
  
  .test-colors {
    color: #f0f;
    background: red;
  }
  
  .test-percentages {
    width: 1000000000000000000%;
    height: -1000000000000000000%;
  }
  
  .test-boundaries {
-   margin: 2147483647px;
- 
... (truncated)

release without fix: 21 failed, 67 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/regression/issue/21907.test.ts:
80 |       .trim();
81 |   }
82 | 
83 |   // Test the actual output with inline snapshot - this ensures all intFromFloat
84 |   // conversions work correctly and captures any changes in output format
85 |   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
                                                 ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* [path] */
  .test-rounded-full {
    border-radius: 3.40282e+38px;
-   width: 2147483647px;
-   height: -2147483648px;
+   width: 2147480000px;
+   height: -2147480000px;
  }
  
  .test-negative {
    border-radius: -3.40282e+38px;
  }
  
  .test-very-large, .test-large-integer {
    border-radius: 3.40282e38px;
  }
  
  .test-colors {
    color: #f0f;
    background: red;
  }
  
  .test-percentages {
    width: 1000000000000000000%;
    height: -1000000000000000000%;
  }
  
  .test-boundaries {
-   margin: 2147483647px;
-   padding: -2147483648px;
+   margin: 2147480000px;
+   padding: -2147480000px;
    left: 4294970000px;
  }
  
  .test-normal {
    width: 10px;
    height: 20.5px;
    margin: 0;
  }"
  

-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts "test/regression/issue/21907.test.ts"
bun test v1.4.1 (65362b53b)

test/regression/issue/21907.test.ts:
(pass) CSS parser should handle extremely large floating-point values without crashing [362.63ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.70ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.17ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1498bea1a5
  features     baseline

23 deps, 131 codegen, 1172 objects in 847ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [46.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] gen ErrorCode+*.h
[6/1217] fetch tinycc
[tinycc] up to date
[7/1216] gen .bind.ts → GeneratedBindings.cpp
[8/1216] fetch zlib
[zlib] up to date
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [59.00ms]
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ..
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/css_parser.rs               | 48 +++++++++++++++++++++++++-----
 src/css/properties/custom.rs        |  7 +++--
 src/css/values/percentage.rs        |  2 +-
 test/js/bun/css/css.test.ts         | 59 +++++++++++++++++++++++++++++++++++++
 test/regression/issue/21907.test.ts |  8 ++---
 5 files changed, 110 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/css/css_parser.rs                    9     12      0
src/css/properties/custom.rs             4      2      0
src/css/values/percentage.rs             1      1      0
test/js/bun/css/css.test.ts              2      5      0
test/regression/issue/21907.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->