### PR TITLE
worker: wake the loop when a worker stops itself from an immediate (process.exit() / uncaught error)

### DIFF
--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -382,12 +382,9 @@ impl VmHandle {
     }
 
     /// [`stop`](Self::stop), raise a JSC `TerminationException` in the VM at
-    /// its next safepoint, and wake its loop. Any thread: a parent's
-    /// `worker.terminate()`, or the worker's own thread on `process.exit()` /
-    /// an uncaught error, where the wake still matters because the request
-    /// may be made from the part of a loop turn that runs before the poll
-    /// (an immediate), and the run loop only re-checks after the poll
-    /// returns. No-op once the VM is closed.
+    /// its next safepoint, and wake its loop. Any thread (a parent's
+    /// `worker.terminate()`, the worker's own `process.exit()` / uncaught
+    /// error); no-op once the VM is closed.
     pub fn request_termination(&self) {
         self.stop();
         if let Some(_a) = self.enter() {

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -383,8 +383,7 @@ impl VmHandle {
 
     /// [`stop`](Self::stop), raise a JSC `TerminationException` in the VM at
     /// its next safepoint, and wake its loop. Any thread (a parent's
-    /// `worker.terminate()`, the worker's own `process.exit()` / uncaught
-    /// error); no-op once the VM is closed.
+    /// `worker.terminate()`); no-op once the VM is closed.
     pub fn request_termination(&self) {
         self.stop();
         if let Some(_a) = self.enter() {

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -382,8 +382,12 @@ impl VmHandle {
     }
 
     /// [`stop`](Self::stop), raise a JSC `TerminationException` in the VM at
-    /// its next safepoint, and wake its loop. Any thread (a parent's
-    /// `worker.terminate()`); no-op once the VM is closed.
+    /// its next safepoint, and wake its loop. Any thread: a parent's
+    /// `worker.terminate()`, or the worker's own thread on `process.exit()` /
+    /// an uncaught error, where the wake still matters because the request
+    /// may be made from the part of a loop turn that runs before the poll
+    /// (an immediate), and the run loop only re-checks after the poll
+    /// returns. No-op once the VM is closed.
     pub fn request_termination(&self) {
         self.stop();
         if let Some(_a) = self.enter() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1093,13 +1093,14 @@ impl WebWorker {
         // process.exit() from an exit handler does not re-arm the trap.
         let vm_ptr = self.vm_ptr();
         if !vm_ptr.is_null() {
+            // Same request as a parent's terminate(): nothing more enters script
+            // (Node's `Stop(env)` on the worker's own exit), and the loop is
+            // woken. The wake matters on the loop's own thread too: called from
+            // an immediate we are inside `auto_tick_active` ahead of its poll,
+            // and `spin()` re-reads `requested_terminate` only after that poll
+            // returns, which nothing else may ever make it do.
             // SAFETY: this thread's live VM.
-            unsafe {
-                // As for a parent's terminate(): nothing more may enter script
-                // (Node's `Stop(env)` on the worker's own exit).
-                (*vm_ptr).handle_ref().stop();
-                (*vm_ptr).jsc_vm().notify_need_termination();
-            }
+            unsafe { (*vm_ptr).handle_ref().request_termination() };
         }
     }
 
@@ -1266,20 +1267,17 @@ fn on_unhandled_rejection(
     // second time (a second `workerGlobalScopeDestroyed` → double deref of
     // the proxy's thread-held reference).
     //
-    // Instead, arm the JSC termination trap so any further JS halts at the
-    // next safepoint, and let the stack unwind normally back to `spin()`,
-    // whose loop observes `requested_terminate` and reaches the single
-    // `shutdown()` call at its bottom with no live JSC frames above it. The
-    // promise-rejection path in `spin()` (line ~1044) gets there even sooner:
-    // `uncaught_exception` returns `handled == false`, so `spin()` calls
-    // `return self.shutdown()` directly — same observable ordering.
-    // `vm.jsc_vm` is the worker's live `JSC::VM*` (we just used it via
-    // `global_object`); `notify_need_termination` is documented thread-safe
-    // (VMTraps). The gate closes with it, as for exit()/terminate(): the
-    // native→JS entries still reached this tick refuse rather than run into
-    // the pending termination.
-    vm.handle_ref().stop();
-    vm.jsc_vm().notify_need_termination();
+    // Instead, make the same request as exit()/terminate(): close the gate
+    // (native→JS entries still reached this tick refuse), arm the JSC
+    // termination trap so any further JS halts at the next safepoint, and
+    // wake the loop, since an immediate throws ahead of the poll. Then let
+    // the stack unwind normally back to `spin()`, whose loop observes
+    // `requested_terminate` and reaches the single `shutdown()` call at its
+    // bottom with no live JSC frames above it. The promise-rejection path in
+    // `spin()` (line ~1044) gets there even sooner: `uncaught_exception`
+    // returns `handled == false`, so `spin()` calls `return self.shutdown()`
+    // directly — same observable ordering.
+    vm.handle_ref().request_termination();
 }
 
 /// Resolve a worker entry-point specifier to a path the module loader can

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1093,9 +1093,7 @@ impl WebWorker {
         // process.exit() from an exit handler does not re-arm the trap.
         let vm_ptr = self.vm_ptr();
         if !vm_ptr.is_null() {
-            // The wake is needed even on the loop's own thread: from an
-            // immediate this runs ahead of the turn's poll, which `spin()`
-            // waits out before it re-reads `requested_terminate`.
+            // From an immediate this runs before the turn's poll; the wake is what ends it.
             // SAFETY: this thread's live VM.
             unsafe { (*vm_ptr).handle_ref().request_termination() };
         }
@@ -1249,8 +1247,7 @@ fn on_unhandled_rejection(
     // second time (a second `workerGlobalScopeDestroyed` → double deref of
     // the proxy's thread-held reference).
     //
-    // Instead, request the stop as `exit()` does and unwind back to `spin()`,
-    // which reaches the single `shutdown()` call with no live JSC frames above it.
+    // Instead, request the stop as `exit()` does and unwind to `spin()`'s `shutdown()`.
     vm.handle_ref().request_termination();
 }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1093,12 +1093,9 @@ impl WebWorker {
         // process.exit() from an exit handler does not re-arm the trap.
         let vm_ptr = self.vm_ptr();
         if !vm_ptr.is_null() {
-            // Same request as a parent's terminate(): nothing more enters script
-            // (Node's `Stop(env)` on the worker's own exit), and the loop is
-            // woken. The wake matters on the loop's own thread too: called from
-            // an immediate we are inside `auto_tick_active` ahead of its poll,
-            // and `spin()` re-reads `requested_terminate` only after that poll
-            // returns, which nothing else may ever make it do.
+            // The wake is needed even on the loop's own thread: from an
+            // immediate this runs ahead of the turn's poll, which `spin()`
+            // waits out before it re-reads `requested_terminate`.
             // SAFETY: this thread's live VM.
             unsafe { (*vm_ptr).handle_ref().request_termination() };
         }
@@ -1252,16 +1249,8 @@ fn on_unhandled_rejection(
     // second time (a second `workerGlobalScopeDestroyed` → double deref of
     // the proxy's thread-held reference).
     //
-    // Instead, make the same request as exit()/terminate(): close the gate
-    // (native→JS entries still reached this tick refuse), arm the JSC
-    // termination trap so any further JS halts at the next safepoint, and
-    // wake the loop, since an immediate throws ahead of the poll. Then let
-    // the stack unwind normally back to `spin()`, whose loop observes
-    // `requested_terminate` and reaches the single `shutdown()` call at its
-    // bottom with no live JSC frames above it. The promise-rejection path in
-    // `spin()` (line ~1044) gets there even sooner: `uncaught_exception`
-    // returns `handled == false`, so `spin()` calls `return self.shutdown()`
-    // directly — same observable ordering.
+    // Instead, request the stop as `exit()` does and unwind back to `spin()`,
+    // which reaches the single `shutdown()` call with no live JSC frames above it.
     vm.handle_ref().request_termination();
 }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2307,6 +2307,51 @@ test("closing the only ref'd port from setImmediate lets the process exit", asyn
   expect(exitCode).toBe(0);
 });
 
+// A worker's own stop requests (process.exit(), an uncaught error) have to wake
+// its loop the way the parent's terminate() does: made from an immediate they
+// land after the turn's tick and before its poll, and the run loop only looks
+// for them again once the poll returns. With a parentPort listener keeping the
+// loop alive, nothing else ends that poll: the exit used to wait for the idle GC
+// timer (about a second), and without it (disabled here) never happened.
+describe("a worker that stops itself from an immediate exits right away", () => {
+  test.concurrent.each([
+    ["process.exit()", "process.exit(7);", { errors: [], code: 7 }],
+    [
+      "process.exit() from a nextTick the immediate queued",
+      "process.nextTick(() => process.exit(7));",
+      { errors: [], code: 7 },
+    ],
+    ["an uncaught exception", 'throw new Error("boom");', { errors: ["boom"], code: 1 }],
+  ])("%s", async (_label, stop, expected) => {
+    const workerSrc = `const { parentPort } = require("node:worker_threads");
+      parentPort.on("message", () => {});
+      // Scheduled a little after startup so the worker's startup GC timers have
+      // fired by then and nothing is left that would end the poll on its own.
+      setTimeout(() => setImmediate(() => { parentPort.postMessage("stopping"); ${stop} }), 300);`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true });
+         const seen = { messages: [], errors: [] };
+         w.on("message", m => seen.messages.push(m));
+         w.on("error", e => seen.errors.push(e.message));
+         w.on("exit", code => console.log(JSON.stringify({ ...seen, code })));`,
+      ],
+      env: { ...bunEnv, BUN_GC_TIMER_DISABLE: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ messages: ["stopping"], ...expected }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 // Node's setupPortReferencing: the parent side of parentPort keeps the parent
 // alive while the Worker has 'message' listeners, independently of unref().
 test("an unref'ed worker with a 'message' listener still delivers to the parent", async () => {


### PR DESCRIPTION
### Problem
- In a `worker_threads` Worker (or Web `Worker`) whose loop is kept alive by something like a `parentPort` `'message'` listener, `process.exit()` called from a `setImmediate` callback (or from a `nextTick`/microtask that callback queued), and likewise an uncaught exception thrown from one, does not end the worker promptly. The parent's `'exit'` event arrives about 680ms later on 1.4.0 release (about 900ms on a debug build); the same exit from a `setTimeout` callback or a message listener takes ~3ms.
- The delay is "until something unrelated wakes the worker's loop": by default that is the idle GC timer (1s period, 30s once it has backed off after 30 idle fires). With `BUN_GC_TIMER_DISABLE=1` the worker never exits at all; the parent process hangs.
- Cause: the worker's two self-stop sites, `WebWorker::exit()` (`src/jsc/web_worker.rs:1088`, reached from `Bun__Process__exit`) and the uncaught-error hook `on_unhandled_rejection` (`src/jsc/web_worker.rs:1282`), set `requested_terminate`, stop the VM handle and arm the JSC termination trap, but do not wake the loop. A parent's `worker.terminate()` goes through `VmHandle::request_termination()` (`src/jsc/VmHandle.rs:387`), which does the same three things plus `wakeup()`.
- Why only immediates: `spin()` (`web_worker.rs:933`) checks `requested_terminate` after `tick()` and after `auto_tick_active()`. Immediates run at the top of `auto_tick_active()` (`src/runtime/jsc_hooks.rs:1134`), which then computes the poll timeout from the timer heaps and blocks in `tick_with_timeout()`; the flag is only re-read once that poll returns. Timer and I/O callbacks run after the poll, so their exits are seen right away. With a keep-alive and an empty timer heap, `get_timeout()` asks for an unbounded wait.

### Fix
- Both self-stop sites call `handle_ref().request_termination()`, the same request a parent's `terminate()` makes: stop the handle, arm the trap, wake the loop. The wake is a write to the loop's wakeup fd (eventfd / mach port / `uv_async_send`), so the poll that follows returns at once and `spin()` sees the flag. Nothing else about the stop changes: `stop()` and `notify_need_termination()` are what these sites already did, in the same order.
- Correct because the wake goes through the mechanism the parent-side stop has always used (the worker's loop is already woken from another thread on `terminate()`); waking the loop from its own thread is the same eventfd write, and a wake that turns out to be unnecessary (no keep-alive, so the poll was non-blocking anyway) is harmless, exactly as it is today for a `terminate()` that lands while the worker is idle.
- Debug build, `BUN_GC_TIMER_DISABLE=1`: exit from an immediate went from never exiting to ~165ms (the same as an exit from a timer callback, i.e. plain teardown cost); with the GC timer on, ~900ms to ~165ms. Release numbers in the details below.
- Verified:
  - `test/js/node/worker_threads/worker_threads.test.ts`, new `describe` "a worker that stops itself from an immediate exits right away" (3 rows: `process.exit()`, `process.exit()` from a `nextTick` the immediate queued, an uncaught exception). Each runs with `BUN_GC_TIMER_DISABLE=1`, so without the `src/` change the worker never exits and all three rows time out (confirmed on a build without it); with it they pass. Whole file: 132 pass.
  - `test/js/web/workers/worker.test.ts`, `worker-terminate-lifetime.test.ts`, `worker-terminate-funnels.test.ts`, `worker-late-completion.test.ts`, `worker_destruction.test.ts`, `worker-top-level-await.test.ts`, `worker-async-dispose.test.ts`, `worker-shutdown-post-leak.test.ts`: the only failures are identical on a build without this change (the fs `Binding` LSan report that #35159 addresses, and 5s timeouts of tests that boot many workers on a debug/ASAN build).
  - 24 upstream `test-worker-*` exit / uncaught / terminate tests under `test/js/node/test/parallel`: all pass.
- Not covered here: a promise rejected (not thrown) inside an immediate is still only reported after the next loop wakeup, on the main thread as well. That has a different cause (rejections are not examined between the immediate phase and the poll) and is tracked separately; #37981 is adjacent to it.
- #38016 edits the same two sites for a different bug (discarding queued work after the stop); the two changes compose, whichever lands second just calls both.

### Background
- Worker run loop: `WebWorker::spin()` loops `tick()` (runs queued tasks and microtasks) then `auto_tick_active()` (runs the immediates queued for this turn, computes how long the loop may sleep from the timer heaps, blocks in the uSockets/libuv poll, then runs due timers). It breaks out and tears the VM down when `requested_terminate` is set; that flag is checked between those two calls, never inside them.
- `requested_terminate` and `VmHandle`: a worker is stopped by setting the `WebWorker`'s `requested_terminate` flag (what `spin()` polls) and making the VM stop running script: `VmHandle::stop()` closes the gate every native-to-JS entry consults, and `notify_need_termination()` arms JSC's trap so script already on the stack unwinds with a `TerminationException`. `VmHandle::request_termination()` bundles those two with a loop wakeup, and is what the parent thread's `terminate()` calls; this PR makes the worker's own exit paths call it too.
- Loop wakeup: every uSockets loop has an async handle (an eventfd on Linux, a mach port on macOS, a `uv_async_t` on Windows) registered in its poll set. `wakeup()` signals it, so a blocked poll returns immediately and a poll entered afterwards returns without blocking. It works the same whether signalled from another thread or from the loop's own thread before it polls.
- Idle GC timer (`GarbageCollectionController`): a per-VM repeating timer that runs a GC every 1s (30s after the heap has been stable for 30 fires); `BUN_GC_TIMER_DISABLE=1` turns it off. It is normally what bounded this bug at about a second, which is why the new tests disable it: without it a worker stuck in the poll stays stuck, so the tests hang rather than pass slowly on a build without the fix.

<details>
<summary>Measurements (time from the worker's postMessage right before the stop to the parent's 'exit' event)</summary>

Release 1.4.0, linux x64, worker kept alive by a `parentPort` listener, before this change:

| shape | default | `BUN_GC_TIMER_DISABLE=1` |
|---|---|---|
| `process.exit()` from an immediate scheduled 300ms in | 679ms | never exits |
| `throw` from that immediate | 679ms (code 1) | never exits |
| `process.exit()` from a nextTick queued by that immediate | 680ms | never exits |
| `process.exit()` from a microtask queued by that immediate | 682ms | never exits |
| `process.exit()` from a `setTimeout` callback | 4ms | 3ms |
| `throw` from a `setTimeout` callback | 4ms | 5ms |
| `process.exit()` from a `parentPort` message listener | 4ms | 4ms |
| immediate scheduled synchronously at startup | ~104ms | ~103ms (a JSC startup timer happens to fire then) |

Scanning the immediate's scheduling delay with the GC timer disabled (release): 0ms to 100ms after startup the exit piggybacks on a one-shot startup timer (106ms, 79ms, 54ms, 32ms, 4ms), from 150ms on it never exits. The debug build behaves the same (last startup timer at about 150ms), which is what the 300ms in the new tests is sized against.

Debug build after this change, all immediate shapes: 162ms to 195ms, the same as the timer shapes (161ms to 168ms) on that build. The `Promise.reject` shape is unchanged (910ms / never), see the last Fix bullet.
</details>
