### PR TITLE
install: warn when a registry manifest advertises an integrity hash bun cannot use

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -5,7 +5,6 @@
 "defaulted_failure:src/bun_core/string/immutable.rs" = 1
 
 [bun_install]
-"defaulted_failure:src/install/npm.rs" = 1
 "unread_none:src/install/PackageInstall.rs" = 1
 
 [bun_jsc]

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2607,8 +2607,18 @@ impl PackageManifest {
                         }
 
                         if let Some(shasum_str) = dist.get(b"shasum").and_then(|v| v.as_str()) {
-                            package_version.integrity =
-                                Integrity::parse_sha_sum(shasum_str).unwrap_or_default();
+                            match Integrity::parse_sha_sum(shasum_str) {
+                                Ok(integrity) => package_version.integrity = integrity,
+                                Err(_) => log.add_warning_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "Malformed shasum in registry metadata for {}@{}; its tarball will not be verified",
+                                        bstr::BStr::new(expected_name),
+                                        bstr::BStr::new(version_name),
+                                    ),
+                                ),
+                            }
                         }
                     }
                 }

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2623,9 +2623,6 @@ impl PackageManifest {
                             }
                         }
 
-                        // A registry that advertises no hash at all stays quiet; one
-                        // that advertises a hash we cannot use gets a warning, since
-                        // the version will install unverified either way.
                         if !integrity_str.is_empty() || malformed_shasum {
                             log.add_warning_fmt(
                                 None,

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -2599,26 +2599,43 @@ impl PackageManifest {
                             package_version.unpacked_size = n.value() as u32;
                         }
 
-                        if let Some(shasum_str) = dist.get(b"integrity").and_then(|v| v.as_str()) {
-                            package_version.integrity = Integrity::parse(shasum_str);
+                        let integrity_str = dist
+                            .get(b"integrity")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(b"");
+                        if !integrity_str.is_empty() {
+                            package_version.integrity = Integrity::parse(integrity_str);
                             if package_version.integrity.tag.is_supported() {
                                 break 'integrity;
                             }
                         }
 
+                        let mut malformed_shasum = false;
                         if let Some(shasum_str) = dist.get(b"shasum").and_then(|v| v.as_str()) {
                             match Integrity::parse_sha_sum(shasum_str) {
-                                Ok(integrity) => package_version.integrity = integrity,
-                                Err(_) => log.add_warning_fmt(
-                                    None,
-                                    bun_ast::Loc::EMPTY,
-                                    format_args!(
-                                        "Malformed shasum in registry metadata for {}@{}; its tarball will not be verified",
-                                        bstr::BStr::new(expected_name),
-                                        bstr::BStr::new(version_name),
-                                    ),
-                                ),
+                                Ok(integrity) => {
+                                    package_version.integrity = integrity;
+                                    if integrity.tag.is_supported() {
+                                        break 'integrity;
+                                    }
+                                }
+                                Err(_) => malformed_shasum = true,
                             }
+                        }
+
+                        // A registry that advertises no hash at all stays quiet; one
+                        // that advertises a hash we cannot use gets a warning, since
+                        // the version will install unverified either way.
+                        if !integrity_str.is_empty() || malformed_shasum {
+                            log.add_warning_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!(
+                                    "Unsupported or malformed integrity hash in registry metadata for {}@{}; its tarball will not be verified",
+                                    bstr::BStr::new(expected_name),
+                                    bstr::BStr::new(version_name),
+                                ),
+                            );
                         }
                     }
                 }

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -649,9 +649,10 @@ describe.concurrent("tarball integrity metadata forms", () => {
       tgz,
       sha512: "sha512-" + createHash("sha512").update(tgz).digest("base64"),
       sha384: "sha384-" + createHash("sha384").update(tgz).digest("base64"),
+      shasum: createHash("sha1").update(tgz).digest("hex"),
     };
   }
-  function serveManifest(integrity: string, tgz: Buffer) {
+  function serveManifest(dist: { integrity?: string; shasum?: string }, tgz: Buffer) {
     const server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
@@ -666,7 +667,7 @@ describe.concurrent("tarball integrity metadata forms", () => {
                 name: "pkg",
                 version: "1.0.0",
                 dist: {
-                  integrity,
+                  ...dist,
                   tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz`,
                 },
               },
@@ -700,7 +701,7 @@ describe.concurrent("tarball integrity metadata forms", () => {
     const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
     const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
 
-    await using server = serveManifest(`${other.sha512} ${real.sha384}`, real.tgz);
+    await using server = serveManifest({ integrity: `${other.sha512} ${real.sha384}` }, real.tgz);
     using dir = projectDir("integrity-multi-hash", server.port);
 
     await using proc = spawn({
@@ -720,7 +721,7 @@ describe.concurrent("tarball integrity metadata forms", () => {
     const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
     const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
 
-    await using server = serveManifest(`${real.sha512} ${other.sha384}`, real.tgz);
+    await using server = serveManifest({ integrity: `${real.sha512} ${other.sha384}` }, real.tgz);
     using dir = projectDir("integrity-multi-hash-lock", server.port);
 
     await using proc = spawn({
@@ -743,7 +744,7 @@ describe.concurrent("tarball integrity metadata forms", () => {
     const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
     const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
 
-    await using server = serveManifest(`${other.sha512}?vcs=git`, real.tgz);
+    await using server = serveManifest({ integrity: `${other.sha512}?vcs=git` }, real.tgz);
     using dir = projectDir("integrity-option-suffix", server.port);
 
     await using proc = spawn({
@@ -757,6 +758,51 @@ describe.concurrent("tarball integrity metadata forms", () => {
     expect(stderr + stdout).toContain("Integrity check failed");
     expect(stdout).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
+  });
+
+  it("verifies the tarball against the manifest shasum when there is no integrity field", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const other = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
+
+    await using server = serveManifest({ shasum: other.shasum }, real.tgz);
+    using dir = projectDir("integrity-shasum-mismatch", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr).not.toContain("Malformed shasum");
+    expect(stderr + stdout).toContain("Integrity check failed");
+    expect(stdout).not.toContain("1 package installed");
+    expect(exitCode).not.toBe(0);
+  });
+
+  it("warns when the manifest shasum is malformed instead of silently skipping verification", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+
+    // Same length as a sha1 hex digest, but not hex.
+    await using server = serveManifest({ shasum: Buffer.alloc(40, "x").toString() }, real.tgz);
+    using dir = projectDir("integrity-shasum-malformed", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr).toContain(
+      "warn: Malformed shasum in registry metadata for pkg@1.0.0; its tarball will not be verified",
+    );
+    expect(stdout).toContain("1 package installed");
+    // Nothing usable was advertised, so the lockfile carries no pin for it.
+    expect(await file(join(String(dir), "bun.lock")).text()).not.toMatch(/sha\d+-/);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -649,6 +649,7 @@ describe.concurrent("tarball integrity metadata forms", () => {
       tgz,
       sha512: "sha512-" + createHash("sha512").update(tgz).digest("base64"),
       sha384: "sha384-" + createHash("sha384").update(tgz).digest("base64"),
+      sha1: "sha1-" + createHash("sha1").update(tgz).digest("base64"),
       shasum: createHash("sha1").update(tgz).digest("hex"),
     };
   }
@@ -775,18 +776,42 @@ describe.concurrent("tarball integrity metadata forms", () => {
       stderr: "pipe",
     });
     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
-    expect(stderr).not.toContain("Malformed shasum");
+    expect(stderr).not.toContain("Unsupported or malformed integrity hash");
     expect(stderr + stdout).toContain("Integrity check failed");
     expect(stdout).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
   });
 
-  it("warns when the manifest shasum is malformed instead of silently skipping verification", async () => {
+  it("falls back to the manifest shasum when the integrity field is unusable, without warning", async () => {
     const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
 
+    await using server = serveManifest({ integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==", shasum: real.shasum }, real.tgz);
+    using dir = projectDir("integrity-shasum-fallback", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--save-text-lockfile"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr).not.toContain("Unsupported or malformed integrity hash");
+    expect(stdout).toContain("1 package installed");
+    expect(await file(join(String(dir), "bun.lock")).text()).toContain(real.sha1);
+    expect(exitCode).toBe(0);
+  });
+
+  it.each([
     // Same length as a sha1 hex digest, but not hex.
-    await using server = serveManifest({ shasum: Buffer.alloc(40, "x").toString() }, real.tgz);
-    using dir = projectDir("integrity-shasum-malformed", server.port);
+    ["malformed shasum", { shasum: Buffer.alloc(40, "x").toString() }],
+    ["unsupported integrity algorithm", { integrity: "md5-AAAAAAAAAAAAAAAAAAAAAA==" }],
+    ["malformed integrity and empty shasum", { integrity: "sha512-!!!", shasum: "" }],
+  ] as const)("warns instead of silently skipping verification: %s", async (_label, dist) => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+
+    await using server = serveManifest(dist, real.tgz);
+    using dir = projectDir("integrity-unusable", server.port);
 
     await using proc = spawn({
       cmd: [bunExe(), "install", "--save-text-lockfile"],
@@ -797,11 +822,30 @@ describe.concurrent("tarball integrity metadata forms", () => {
     });
     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
     expect(stderr).toContain(
-      "warn: Malformed shasum in registry metadata for pkg@1.0.0; its tarball will not be verified",
+      "warn: Unsupported or malformed integrity hash in registry metadata for pkg@1.0.0; its tarball will not be verified",
     );
     expect(stdout).toContain("1 package installed");
     // Nothing usable was advertised, so the lockfile carries no pin for it.
     expect(await file(join(String(dir), "bun.lock")).text()).not.toMatch(/sha\d+-/);
+    expect(exitCode).toBe(0);
+  });
+
+  it("stays quiet when the manifest advertises no hash at all", async () => {
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+
+    await using server = serveManifest({}, real.tgz);
+    using dir = projectDir("integrity-absent", server.port);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr).not.toContain("Unsupported or malformed integrity hash");
+    expect(stdout).toContain("1 package installed");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- Flagged by the new `defaulted_failure` lint in the mordant bump (#38460): `src/install/npm.rs` built a version's integrity with `Integrity::parse_sha_sum(shasum_str).unwrap_or_default()`.
- `parse_sha_sum` rejects a `dist.shasum` that is not hex or has an odd length (`src/install/integrity.rs:51`). The `unwrap_or_default()` turned that rejection into an `Integrity` with `Tag::UNKNOWN`, which every verification path reads as "nothing to verify" (`Streaming::verify` returns true for an unsupported tag).
- The `dist.integrity` field six lines above had the same outcome by a different route: `Integrity::parse` reports a malformed value or an unsupported algorithm as `Tag::UNKNOWN` rather than an error, so with no `shasum` to fall back on it went equally quiet.
- Net effect: a manifest that advertised a hash bun could not use installed that version unverified and wrote `""` into `bun.lock`, with nothing on stderr. A well-formed hash that does not match the bytes already fails the install, so the unusable case was the only one that went quiet.

### Fix
- `PackageManifest::parse` now tries `dist.integrity`, then `dist.shasum` (matching on the `Result`), and breaks out as soon as one yields a supported hash. If it reaches the end having been given a non-empty `integrity` or a malformed `shasum`, it adds one warning for that version to the manifest task's log, which `run_tasks` prints when the task resolves: `warn: Unsupported or malformed integrity hash in registry metadata for pkg@1.0.0; its tarball will not be verified`. A manifest that advertises no hash at all stays silent, as before.
- The stored value is unchanged in every case (an unusable hash still ends up as the zeroed `UNKNOWN` value), so the binary manifest cache and lockfile output are byte-identical to before; the only new behavior is the warning.
- A warning rather than an error matches how `bun.lock.rs` already treats an unparseable integrity string in the lockfile. Propagating the error would fail the whole manifest and make every version of the package uninstallable because one version's metadata is bad. The warning is per version, at manifest parse time, so it names the offending versions even when a different version ends up installed. The public registry always serves sha512 SRI or 40 hex chars, so it never fires there; in this repo only `minimum-release-age.test.ts` serves placeholder values (`sha512-fake1==`), and it still passes (49 tests) since it does not assert on the absence of warnings.
- Removes the `defaulted_failure:src/install/npm.rs` entry from `mordant-baseline.toml`; it was the only finding of that lint in the file.
- Verified with `test/cli/install/bun-install-tarball-integrity.test.ts` ("tarball integrity metadata forms"). Three new cases (malformed shasum, unsupported integrity algorithm, malformed integrity plus empty shasum) fail on the released build, where stderr is just the progress lines, and pass with this change. Three guards pin the surrounding behavior: a mismatching well-formed shasum still fails the install with no warning, an unusable integrity backed by a valid shasum installs with a `sha1-` pin and no warning, and a manifest with no hash installs silently. The whole file (22 tests), `minimum-release-age.test.ts`, and `bun-install-streaming-extract.test.ts` pass on the debug build.
- #31327 proposes the broader fail-closed policy (refuse unparseable manifest hashes, pin a computed sha512 when none is advertised). This change only makes the existing behavior visible and does not conflict with that direction.

### Background
- `PackageManifest::parse` (`src/install/npm.rs`) turns a registry packument into bun's binary manifest. For each version it reads `dist.integrity` (an SRI string such as `sha512-...`) and, when that is absent or unsupported, falls back to `dist.shasum`, the legacy 40 character hex sha1 that older packages carry instead.
- `Integrity` is a tag plus digest bytes; `Tag::UNKNOWN` means "no hash available". Every verification path skips versions tagged UNKNOWN, which is why a silent parse failure is equivalent to switching verification off for that version.
- Manifest parsing runs on a thread pool worker with a per-task `Log`; `run_tasks` prints that log on the main thread when the task completes, so warnings added during parsing show up in the normal `bun install` output and respect the usual log level flags.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records how many findings of each lint per file are accepted as pre-existing, and CI fails a PR only when a file exceeds its count. Removing an entry means CI now requires the file to have zero findings of that lint.

<details>
<summary>Earlier shape of this PR</summary>

The first revision only matched on `parse_sha_sum` and warned about a malformed `shasum` ("Malformed shasum in registry metadata for ..."). Review pointed out that an unusable `dist.integrity` with no `shasum` reached the same silent outcome, so the warning now covers both fields with one message per version.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
bun test v1.4.0 (0f7781825)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [312.40ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [394.64ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [392.90ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [204.44ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [564.00ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [731.83ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [259.59ms]
(pass) tarball integrity mismatch (hoisted) > should fail (not hang) when tarball bytes don't match manifest SHA-512 [351.51m
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (12fba92bf)

test/cli/install/bun-install-tarball-integrity.test.ts:
819 |       env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
820 |       stdout: "pipe",
821 |       stderr: "pipe",
822 |     });
823 |     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
824 |     expect(stderr).toContain(
                         ^
error: expect(received).toContain(expected)

Expected to contain: "warn: Unsupported or malformed integrity hash in registry metadata for pkg@1.0.0; its tarball will not be verified"
Received: "Resolving dependencies\nResolved, downloaded and extracted [4]\nSaved lockfile\n"

      at <anonymous> (/workspace/bun/test/cli/install/bun-install-tarball-integrity.test.ts:824:20)
819 |       env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
820 |       stdout: "pipe",
821 |       stderr: "pipe",
822 |     });
823 |     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
824 |     expect(stderr).toContain(
                         ^
error: expect(received).toContain(expected)

Ex
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-tarball-integrity.test.ts
bun test v1.4.0 (0f7781825)

test/cli/install/bun-install-tarball-integrity.test.ts:
(pass) tarball integrity > should store integrity hash for local tarball in text lockfile [370.93ms]
(pass) tarball integrity > should store integrity hash for tarball URL in text lockfile [457.74ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash (backward compat) [444.85ms]
(pass) tarball integrity > should add integrity hash to lockfile when re-resolving tarball dep [173.98ms]
(pass) tarball integrity > should store consistent integrity hash for tarball URL across reinstalls [609.39ms]
(pass) tarball integrity > should fail integrity check when tarball URL content changes [795.46ms]
(pass) tarball integrity > should install successfully from text lockfile without integrity hash for local tarball (backward compat) [314.29ms]
(pass) tarball integrity > should store consistent integrity hash for local tarball across reinstalls [506.56ms]
(pass) tarba
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 696ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
mordant-baseline.toml                              |   1 -
 src/install/npm.rs                                 |  32 ++++++-
 .../install/bun-install-tarball-integrity.test.ts  | 100 +++++++++++++++++++--
 3 files changed, 123 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
mordant-baseline.toml                                       1      1      0
src/install/npm.rs                                          9      4      0
test/cli/install/bun-install-tarball-integrity.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->