### PR TITLE
create: report a failed nested bun install and exit with its status

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use std::cell::Cell;
 use std::io::Write as _;
 
+use crate::api::bun_process::Status;
 use crate::api::bun_process::sync as spawn_sync;
 use bun_clap as clap;
 use bun_core::Progress::{Node as ProgressNode, Progress};
@@ -1107,7 +1108,7 @@ impl CreateCommand {
             }
         }
 
-        let mut install_ok = true;
+        let mut failed_install: Option<Status> = None;
         if let Some(ref npm_client) = npm_client_ {
             let start_time = bun_core::time::nano_timestamp();
             let install_args: &[&[u8]] = &[npm_client.bin, b"install"];
@@ -1158,10 +1159,13 @@ impl CreateCommand {
                 windows: (),
                 ..Default::default()
             })?;
-            install_ok = process?.status.is_ok();
+            let status = process?.status;
+            if !status.is_ok() {
+                failed_install = Some(status);
+            }
         }
 
-        if install_ok && !user_skipped_install && !postinstall_tasks.is_empty() {
+        if failed_install.is_none() && !user_skipped_install && !postinstall_tasks.is_empty() {
             for task in &postinstall_tasks {
                 exec_task(task, destination, path_env, npm_client_);
             }
@@ -1172,8 +1176,19 @@ impl CreateCommand {
         }
 
         // Only after the git thread is joined: exiting earlier would abandon git mid-commit.
-        if !install_ok {
-            Global::exit(1);
+        if let Some(status) = failed_install {
+            pretty_errorln!(
+                "<r><red>error<r><d>:<r> <b>bun install<r> failed in \"{}\" ({})\n<blue>note<r><d>:<r> the template files were written; run <b>bun install<r> there once the error above is fixed",
+                bstr::BStr::new(destination),
+                status,
+            );
+            Global::exit(match status {
+                Status::Exited(exited) => u32::from(exited.code),
+                Status::Signaled(signal) => {
+                    u32::from(bun_sys::SignalCode(signal).to_exit_code().unwrap_or(1))
+                }
+                _ => 1,
+            });
         }
 
         Output::print_error("\n");

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1165,7 +1165,7 @@ impl CreateCommand {
             }
         }
 
-        if failed_install.is_none() && !user_skipped_install && !postinstall_tasks.is_empty() {
+        if !user_skipped_install && !postinstall_tasks.is_empty() {
             for task in &postinstall_tasks {
                 exec_task(task, destination, path_env, npm_client_);
             }
@@ -1178,8 +1178,8 @@ impl CreateCommand {
         // Only after the git thread is joined: exiting earlier would abandon git mid-commit.
         if let Some(status) = failed_install {
             pretty_errorln!(
-                "<r><red>error<r><d>:<r> <b>bun install<r> failed in \"{}\" ({})\n<blue>note<r><d>:<r> the template files were written; run <b>bun install<r> there once the error above is fixed",
-                bstr::BStr::new(destination),
+                "<r><red>error<r><d>:<r> <b>bun install<r> failed in {} ({})\n<blue>note<r><d>:<r> the template files were written; run <b>bun install<r> in that directory once the error is fixed",
+                bun_core::fmt::quote(destination),
                 status,
             );
             Global::exit(match status {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1107,6 +1107,7 @@ impl CreateCommand {
             }
         }
 
+        let mut install_ok = true;
         if let Some(ref npm_client) = npm_client_ {
             let start_time = bun_core::time::nano_timestamp();
             let install_args: &[&[u8]] = &[npm_client.bin, b"install"];
@@ -1157,10 +1158,10 @@ impl CreateCommand {
                 windows: (),
                 ..Default::default()
             })?;
-            let _ = process?;
+            install_ok = process?.status.is_ok();
         }
 
-        if !user_skipped_install && !postinstall_tasks.is_empty() {
+        if install_ok && !user_skipped_install && !postinstall_tasks.is_empty() {
             for task in &postinstall_tasks {
                 exec_task(task, destination, path_env, npm_client_);
             }
@@ -1168,6 +1169,12 @@ impl CreateCommand {
 
         if !create_options.skip_install && !create_options.skip_git {
             create_options.skip_git = !GitHandler::wait();
+        }
+
+        // Checked only after the git thread is joined so a failed install does
+        // not exit while `git commit` is still writing the repository.
+        if !install_ok {
+            Global::exit(1);
         }
 
         Output::print_error("\n");

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1171,8 +1171,7 @@ impl CreateCommand {
             create_options.skip_git = !GitHandler::wait();
         }
 
-        // Checked only after the git thread is joined so a failed install does
-        // not exit while `git commit` is still writing the repository.
+        // Only after the git thread is joined: exiting earlier would abandon git mid-commit.
         if !install_ok {
             Global::exit(1);
         }

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -319,8 +319,8 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
 });
 
 // The exit status of the nested `bun install` used to be dropped: when it
-// failed, `bun create` still ran the postinstall tasks, printed "dependencies
-// were installed automatically" / "Created ... successfully" and exited 0.
+// failed, `bun create` still printed "dependencies were installed
+// automatically" / "Created ... successfully" and exited 0.
 //
 // Ways to make that install fail, and what `bun create` must then exit with: a
 // dependency the registry (a local server answering 404) cannot provide makes
@@ -413,9 +413,13 @@ async function createWithFailingInstall(
   // The template files were copied before the install ran and stay on disk.
   expect(await exists(join(dest, "index.js"))).toBe(true);
   expect(err).toMatch(new RegExp(`error: bun install failed in "[^"]*dest" \\(code: ${failure.exitCode}\\)`));
-  expect(err).toContain("note: the template files were written; run bun install there once the error above is fixed");
+  expect(err).toContain(
+    "note: the template files were written; run bun install in that directory once the error is fixed",
+  );
   expect(out).toContain("$ bun install");
-  expect(out).not.toContain("postinstall-task-ran");
+  // The template's own `bun-create` tasks still run (they are not written to
+  // the project, so this is the only chance to see them); the banner does not.
+  expect(out).toContain("postinstall-task-ran");
   expect(out).not.toContain("installed automatically");
   expect(out).not.toContain("successfully");
   expect(out).not.toContain("To get started");

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -321,28 +321,65 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
 // The exit status of the nested `bun install` used to be dropped: when it
 // failed, `bun create` still ran the postinstall tasks, printed "dependencies
 // were installed automatically" / "Created ... successfully" and exited 0.
-// Creates a local template whose only dependency cannot be resolved (the
-// registry answers 404) and returns bun create's stderr. `onStderr` is called
-// with everything written to stderr so far each time more of it arrives.
-async function createWithFailingInstall({
-  args = [],
-  extraEnv = {},
-  onStderr,
-}: {
-  args?: string[];
-  extraEnv?: Record<string, string>;
-  onStderr?: (stderrSoFar: string) => void;
-}) {
+//
+// Ways to make that install fail, and what `bun create` must then exit with: a
+// dependency the registry (a local server answering 404) cannot provide makes
+// `bun install` exit 1; a failing root postinstall script makes it exit with
+// the script's own code; a root postinstall script killed by a signal makes
+// `bun install` re-raise that signal on itself, which is reported the way
+// shells do, as 128 + the signal number.
+const installFailures = [
+  {
+    name: "an unresolvable dependency",
+    packageJson: { dependencies: { "bun-create-missing-dep": "1.0.0" } },
+    exitCode: 1,
+  },
+  {
+    name: "a failing postinstall script",
+    packageJson: { dependencies: { localdep: "file:./localdep" }, scripts: { postinstall: "exit 3" } },
+    exitCode: 3,
+  },
+  ...(isPosix
+    ? [
+        {
+          name: "a postinstall script killed by SIGKILL",
+          packageJson: {
+            dependencies: { localdep: "file:./localdep" },
+            scripts: { postinstall: "sh -c 'kill -9 $$'" },
+          },
+          exitCode: 128 + 9,
+        },
+      ]
+    : []),
+];
+
+// Runs `bun create` on a local template whose install fails as described by
+// `failure`, checks everything the failure must and must not produce, and
+// returns bun create's stderr. `onStderr` is called with everything written to
+// stderr so far each time more of it arrives.
+async function createWithFailingInstall(
+  failure: (typeof installFailures)[number],
+  {
+    args = [],
+    extraEnv = {},
+    onStderr,
+  }: {
+    args?: string[];
+    extraEnv?: Record<string, string>;
+    onStderr?: (stderrSoFar: string) => void;
+  } = {},
+) {
   using registry = Bun.serve({
     port: 0,
     fetch: () => new Response("not found", { status: 404 }),
   });
   using dir = tempDir("create-install-fails", {
     "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
     "bun-create/tmpl/package.json": JSON.stringify({
       name: "tmpl",
       version: "1.0.0",
-      dependencies: { "bun-create-missing-dep": "1.0.0" },
+      ...failure.packageJson,
       "bun-create": { postinstall: "echo postinstall-task-ran" },
     }),
   });
@@ -375,20 +412,24 @@ async function createWithFailingInstall({
 
   // The template files were copied before the install ran and stay on disk.
   expect(await exists(join(dest, "index.js"))).toBe(true);
-  expect(err).toContain("bun-create-missing-dep@1.0.0 failed to resolve");
+  expect(err).toMatch(new RegExp(`error: bun install failed in "[^"]*dest" \\(code: ${failure.exitCode}\\)`));
+  expect(err).toContain("note: the template files were written; run bun install there once the error above is fixed");
   expect(out).toContain("$ bun install");
   expect(out).not.toContain("postinstall-task-ran");
   expect(out).not.toContain("installed automatically");
   expect(out).not.toContain("successfully");
   expect(out).not.toContain("To get started");
   expect(proc.signalCode).toBeNull();
-  expect(exitCode).toBe(1);
+  expect(exitCode).toBe(failure.exitCode);
   return err;
 }
 
-it("exits 1 without running postinstall tasks or printing the success banner when the nested `bun install` fails", async () => {
-  await createWithFailingInstall({ args: ["--no-git"] });
-});
+it.each(installFailures)(
+  "reports the failure and exits with the install's code when the nested `bun install` fails because of $name",
+  async failure => {
+    await createWithFailingInstall(failure, { args: ["--no-git"] });
+  },
+);
 
 // Without --no-git the git commands run on a second thread while the install
 // runs, and the thread prints its "[..ms] git" line once they are all done. A
@@ -416,7 +457,7 @@ exit 0
   );
 
   let stderrAtRelease: string | undefined;
-  const err = await createWithFailingInstall({
+  const err = await createWithFailingInstall(installFailures[0], {
     extraEnv: { PATH: `${bin}:${env.PATH}` },
     onStderr(stderrSoFar) {
       if (stderrAtRelease === undefined && stderrSoFar.includes("] bun install")) {
@@ -426,8 +467,11 @@ exit 0
     },
   });
 
+  // Neither the git timing line nor bun create's own error had been printed
+  // while git was still blocked; both were once git had been released.
   expect(stderrAtRelease).toBeDefined();
   expect(stderrAtRelease).not.toContain("] git");
+  expect(stderrAtRelease).not.toContain("error: bun install failed");
   expect(err).toContain("] git");
 });
 

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -318,6 +318,73 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
   expect(proc.resourceUsage!.contextSwitches.voluntary).toBeLessThan(2000);
 });
 
+// The exit status of the nested `bun install` used to be dropped: when it
+// failed, `bun create` still ran the postinstall tasks, printed "dependencies
+// were installed automatically" / "Created ... successfully" and exited 0.
+// Creates a local template whose only dependency cannot be resolved (the
+// registry answers 404) and returns bun create's stderr.
+async function createWithFailingInstall(args: string[], extraEnv: Record<string, string> = {}) {
+  using registry = Bun.serve({
+    port: 0,
+    fetch: () => new Response("not found", { status: 404 }),
+  });
+  using dir = tempDir("create-install-fails", {
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({
+      name: "tmpl",
+      version: "1.0.0",
+      dependencies: { "bun-create-missing-dep": "1.0.0" },
+      "bun-create": { postinstall: "echo postinstall-task-ran" },
+    }),
+  });
+  const dest = join(String(dir), "dest");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", dest, ...args],
+    cwd: String(dir),
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env: {
+      ...env,
+      ...extraEnv,
+      BUN_CREATE_DIR: join(String(dir), "bun-create"),
+      BUN_CONFIG_REGISTRY: String(registry.url),
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    },
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The template files were copied before the install ran and stay on disk.
+  expect(await exists(join(dest, "index.js"))).toBe(true);
+  expect(err).toContain("bun-create-missing-dep@1.0.0 failed to resolve");
+  expect(out).toContain("$ bun install");
+  expect(out).not.toContain("postinstall-task-ran");
+  expect(out).not.toContain("installed automatically");
+  expect(out).not.toContain("successfully");
+  expect(out).not.toContain("To get started");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(1);
+  return err;
+}
+
+it("exits 1 without running postinstall tasks or printing the success banner when the nested `bun install` fails", async () => {
+  await createWithFailingInstall(["--no-git"]);
+});
+
+// Without --no-git the git commands run on a second thread while the install
+// runs. The failed install must still wait for that thread (which prints the
+// "[..ms] git" line when it is done) rather than exit while git is writing the
+// repository; the stub git is slow enough to still be running when the install
+// has already failed. POSIX-only: the stub is a shell script.
+it.skipIf(!isPosix)("still waits for the git thread when the nested `bun install` fails", async () => {
+  using bin = tempDir("create-install-fails-git", { git: "#!/bin/sh\nsleep 0.3\nexit 0\n" });
+  chmodSync(join(String(bin), "git"), 0o755);
+
+  const err = await createWithFailingInstall([], { PATH: `${bin}:${env.PATH}` });
+  expect(err).toContain("] git");
+});
+
 it("should create template from local folder", async () => {
   const bunCreateDir = join(x_dir, "bun-create");
   const testTemplate = "test-template";

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { beforeEach, describe, expect, it } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, mkdirSync, writeFileSync } from "fs";
 import { exists, stat } from "fs/promises";
 import { bunExe, bunEnv as env, isPosix, tempDir, tls, tmpdirSync } from "harness";
 import { once } from "node:events";
@@ -322,8 +322,17 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
 // failed, `bun create` still ran the postinstall tasks, printed "dependencies
 // were installed automatically" / "Created ... successfully" and exited 0.
 // Creates a local template whose only dependency cannot be resolved (the
-// registry answers 404) and returns bun create's stderr.
-async function createWithFailingInstall(args: string[], extraEnv: Record<string, string> = {}) {
+// registry answers 404) and returns bun create's stderr. `onStderr` is called
+// with everything written to stderr so far each time more of it arrives.
+async function createWithFailingInstall({
+  args = [],
+  extraEnv = {},
+  onStderr,
+}: {
+  args?: string[];
+  extraEnv?: Record<string, string>;
+  onStderr?: (stderrSoFar: string) => void;
+}) {
   using registry = Bun.serve({
     port: 0,
     fetch: () => new Response("not found", { status: 404 }),
@@ -353,7 +362,16 @@ async function createWithFailingInstall(args: string[], extraEnv: Record<string,
       BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
     },
   });
-  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const readStderr = async () => {
+    const decoder = new TextDecoder();
+    let text = "";
+    for await (const chunk of proc.stderr) {
+      text += decoder.decode(chunk, { stream: true });
+      onStderr?.(text);
+    }
+    return text + decoder.decode();
+  };
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), readStderr(), proc.exited]);
 
   // The template files were copied before the install ran and stay on disk.
   expect(await exists(join(dest, "index.js"))).toBe(true);
@@ -369,19 +387,47 @@ async function createWithFailingInstall(args: string[], extraEnv: Record<string,
 }
 
 it("exits 1 without running postinstall tasks or printing the success banner when the nested `bun install` fails", async () => {
-  await createWithFailingInstall(["--no-git"]);
+  await createWithFailingInstall({ args: ["--no-git"] });
 });
 
 // Without --no-git the git commands run on a second thread while the install
-// runs. The failed install must still wait for that thread (which prints the
-// "[..ms] git" line when it is done) rather than exit while git is writing the
-// repository; the stub git is slow enough to still be running when the install
-// has already failed. POSIX-only: the stub is a shell script.
+// runs, and the thread prints its "[..ms] git" line once they are all done. A
+// failed install must still wait for that thread rather than exit while git is
+// writing the repository. The stub git blocks until the test releases it, and
+// the test only does that after bun create has printed the "[..ms] bun install"
+// line, i.e. after the install's failure is known: "] git" can then only show up
+// in stderr if bun create waited. POSIX-only: the stub is a shell script.
 it.skipIf(!isPosix)("still waits for the git thread when the nested `bun install` fails", async () => {
-  using bin = tempDir("create-install-fails-git", { git: "#!/bin/sh\nsleep 0.3\nexit 0\n" });
-  chmodSync(join(String(bin), "git"), 0o755);
+  using bin = tempDir("create-install-fails-git", {});
+  const release = join(String(bin), "release");
+  writeFileSync(
+    join(String(bin), "git"),
+    `#!/bin/sh
+# Blocks until the test creates the release file; gives up after ~5s so a
+# broken run cannot leave it spinning forever.
+i=0
+while [ ! -e "${release}" ] && [ $i -lt 500 ]; do
+  sleep 0.01
+  i=$((i + 1))
+done
+exit 0
+`,
+    { mode: 0o755 },
+  );
 
-  const err = await createWithFailingInstall([], { PATH: `${bin}:${env.PATH}` });
+  let stderrAtRelease: string | undefined;
+  const err = await createWithFailingInstall({
+    extraEnv: { PATH: `${bin}:${env.PATH}` },
+    onStderr(stderrSoFar) {
+      if (stderrAtRelease === undefined && stderrSoFar.includes("] bun install")) {
+        stderrAtRelease = stderrSoFar;
+        writeFileSync(release, "");
+      }
+    },
+  });
+
+  expect(stderrAtRelease).toBeDefined();
+  expect(stderrAtRelease).not.toContain("] git");
   expect(err).toContain("] git");
 });
 


### PR DESCRIPTION
### Problem
- `bun create <template>` exits 0 when the `bun install` it spawns fails. With an unreachable registry it prints `error: left-pad@1.0.0 failed to resolve`, then `A local git repository was created for you and dependencies were installed automatically.` and `Created tpl project successfully`, and exits 0. Nothing was installed, and anything chained after it (`bun create tpl app && cd app && bun run build`) goes on with an empty tree.
- `CreateCommand::exec` drops the child's status (src/runtime/cli/create_command.rs:1160 on main, `let _ = process?;`). The two `?` only cover "could not spawn"; the exit status is in the `sync::Result` being discarded. The Zig version had the same `_ = try process.unwrap();`, so this is not a regression.
- This is the template branch of `bun create`: local templates (`.bun-create/<name>`, `~/.bun-create/<name>`, `BUN_CREATE_DIR`), GitHub repositories, and the hardcoded non-bunx names (`elysia`, `stric`, ...). The other two branches already get this right: `bun create <name>` for an npm `create-<name>` package runs it through `bunx` and exits with its code, and `bun create ./App.tsx` (`create/SourceFileProjectGenerator.rs`, `run_install`) forwards its nested install's code or 128 + signal.

### Fix
- Keep the install child's `Status`. When it is not a clean exit, the template's `bun-create` postinstall tasks and the git join run exactly as before, and then, instead of the timing line, banner and "To get started" text, bun create prints
  ```
  error: bun install failed in "/tmp/x/app" (code: 3)
  note: the template files were written; run bun install in that directory once the error is fixed
  ```
  and exits with the child's status: its exit code, 128 + signal when it was killed by a signal, 1 if waiting for it failed. That is the mapping `filter_run.rs` / `multi_run.rs` use and the one the `./App.tsx` branch already applies to the same nested install, so a given failing install now exits the same way whichever way the template was spelled.
- The error line exists because the child's own output is followed by bun create's `[..ms] bun install` footer and any postinstall task output, and because a child killed by a signal or a wait error prints nothing itself; `Status`'s `Display` covers all three shapes in one line. The `note:` names the remedy, since the copied template is left in place (it is complete, the destination may be `.`, and running `bun install` there is the fix). The path goes through `bun_core::fmt::quote` like the other CLI error messages.
- The `bun-create` postinstall tasks still run after a failed install on purpose: that section is stripped from the package.json written into the project, so skipping them would drop them without a trace, while running them at least shows the user what the template wanted to do. Whether the tasks' own exit codes should matter is left alone (they never have, and #37589 is restructuring how the tasks, the install and git are run).
- The exit happens after `GitHandler::wait()` on purpose: the git commands run on a second thread while the install runs, and a failing install usually finishes first (4ms vs 23ms in the repro). Exiting immediately would abandon `git add`/`git commit` mid-write. The join was already unconditional; only the exit sits behind it.
- Deliberately unchanged: the statuses of the git commands (ignored today; #35253 is about those) and of the `bun-create` tasks. A spawn failure of the install (the `?` path) was already reported and exited 1 before and still is. #37589, which reworks this block onto the event loop, currently still discards the install's status, so whichever of the two lands second has to carry this over.
- The successful path is unchanged: nothing is recorded when no install runs (`--no-install`, or a template without dependencies) or when it exits 0, so the banner and exit code are as before.
- Tests in `test/cli/install/bun-create.test.ts`, all on a local template with a `bun-create` postinstall task and a local `Bun.serve` as the registry:
  - `it.each` over three ways the install fails: an unresolvable dependency (`bun install` exits 1), a root `scripts.postinstall` doing `exit 3` (exits 3) and, POSIX only, one killed by SIGKILL (`bun install` re-raises it; bun create exits 137). Each case checks that the template file is still on disk, the error and note lines, that the `bun-create` task still ran, that the banner and "To get started" text are absent, that bun create itself was not signaled, and the exit code.
  - A POSIX test with a stub `git` on PATH that blocks until the test releases it, which the test does only once the `[..ms] bun install` footer has shown up in the streamed stderr. At that point neither `[..ms] git` nor the new error line had been printed; both are in the final stderr, so the error and exit only happen after the git thread was joined. Moving the exit ahead of the join makes this test fail on the `] git` line (checked with a temporary build).
  - All four fail on the release binary (exit 0, banner printed) and pass with the debug build; the rest of the file (25 tests total, including the GitHub template installs that must still exit 0) passes.
- `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.

### Background
- `bun_spawn::process::sync::spawn` returns `Result<Maybe<sync::Result>, Error>`: the outer `Err` is an allocation failure, the `Maybe` `Err` is a failed `posix_spawn`/`uv_spawn`, and `sync::Result.status` is the child's `Status`: `Exited { code }`, `Signaled(signal)`, or `Err` when waiting for the child failed. `Status::is_ok()` is `Exited` with code 0; its `Display` prints `code: N` (128 + N for a signal that has a shell exit code), `signal: N`, or the wait error.
- `bun_sys::SignalCode(n).to_exit_code()` is the shell convention of 128 + signal number for signals 1..=31 and `None` otherwise.
- `GitHandler::spawn` starts a thread that runs `git init`, `git add`, `git commit` in the destination while the main thread installs; `GitHandler::wait()` blocks on a futex until that thread has finished (it prints its `[..ms] git` timing line just before signalling) and joins it.
- `bun-create.preinstall` / `bun-create.postinstall` in the template's package.json are commands `bun create` runs around the install and removes from the package.json it writes. They are unrelated to npm `scripts.postinstall`, which `bun install` itself runs and whose failure `bun install` reports by exiting with the script's code or re-raising the signal that killed it; the tests use the latter to make the install fail with a chosen status.
- #38474 fixes the same dropped status in `bun init`; it exits 1 there because the `bun_core::SpawnStatus` helper it uses only exposes `is_ok()`.

<details>
<summary>Earlier shapes of this PR</summary>

The first version exited 1 unconditionally, printed nothing and skipped the postinstall tasks. Review pointed out that the other two `bun create` branches forward the child's status, that a signaled child or a wait error would fail silently, and that skipping the tasks loses them because the `bun-create` section is not written into the project; the current version prints the lines above, forwards the status and leaves the tasks alone. The git-thread test originally kept the stub git busy with a fixed sleep; it now blocks until released so the ordering is checked without timing.
</details>
