### PR TITLE
css: keep rotate: 0deg out of none, and keep the origin alpha in relative colors

### DIFF
--- a/src/css/properties/transform.rs
+++ b/src/css/properties/transform.rs
@@ -746,16 +746,25 @@ impl Translate {
 }
 
 /// A value for the [rotate](https://drafts.csswg.org/css-transforms-2/#propdef-rotate) property.
+///
+/// `none` is not the same as a zero angle: like a non-`none` `transform`, any
+/// rotation (even `0deg`) creates a stacking context and containing block.
 #[derive(Copy, Clone, PartialEq)]
-pub struct Rotate {
-    /// Rotation around the x axis.
-    pub(crate) x: f32,
-    /// Rotation around the y axis.
-    pub(crate) y: f32,
-    /// Rotation around the z axis.
-    pub(crate) z: f32,
-    /// The angle of rotation.
-    pub(crate) angle: Angle,
+pub enum Rotate {
+    /// The "none" keyword.
+    None,
+
+    /// A rotation of `angle` around the `x y z` axis.
+    Xyz {
+        /// The x component of the axis.
+        x: f32,
+        /// The y component of the axis.
+        y: f32,
+        /// The z component of the axis.
+        z: f32,
+        /// The angle of rotation.
+        angle: Angle,
+    },
 }
 
 impl Rotate {
@@ -764,41 +773,36 @@ impl Rotate {
             .try_parse(|i| i.expect_ident_matching(b"none"))
             .is_ok()
         {
-            return Ok(Rotate {
-                x: 0.0,
-                y: 0.0,
-                z: 1.0,
-                angle: Angle::Deg(0.0),
-            });
+            return Ok(Rotate::None);
         }
 
         let angle = input.try_parse(Angle::parse);
 
-        struct Xyz {
+        struct Axis {
             x: f32,
             y: f32,
             z: f32,
         }
 
-        let xyz = match input.try_parse(|i| -> Result<Xyz> {
+        let axis = match input.try_parse(|i| -> Result<Axis> {
             let location = i.current_source_location();
             let ident = i.expect_ident_cloned()?;
             crate::match_ignore_ascii_case! { ident, {
-                b"x" => Ok(Xyz { x: 1.0, y: 0.0, z: 0.0 }),
-                b"y" => Ok(Xyz { x: 0.0, y: 1.0, z: 0.0 }),
-                b"z" => Ok(Xyz { x: 0.0, y: 0.0, z: 1.0 }),
+                b"x" => Ok(Axis { x: 1.0, y: 0.0, z: 0.0 }),
+                b"y" => Ok(Axis { x: 0.0, y: 1.0, z: 0.0 }),
+                b"z" => Ok(Axis { x: 0.0, y: 0.0, z: 1.0 }),
                 _ => Err(location.new_unexpected_token_error(Token::Ident(ident))),
             }}
         }) {
             Ok(v) => v,
             Err(_) => input
-                .try_parse(|i| -> Result<Xyz> {
+                .try_parse(|i| -> Result<Axis> {
                     let x = CSSNumberFns::parse(i)?;
                     let y = CSSNumberFns::parse(i)?;
                     let z = CSSNumberFns::parse(i)?;
-                    Ok(Xyz { x, y, z })
+                    Ok(Axis { x, y, z })
                 })
-                .unwrap_or(Xyz {
+                .unwrap_or(Axis {
                     x: 0.0,
                     y: 0.0,
                     z: 1.0,
@@ -810,34 +814,34 @@ impl Rotate {
             Err(_) => Angle::parse(input)?,
         };
 
-        Ok(Rotate {
-            x: xyz.x,
-            y: xyz.y,
-            z: xyz.z,
+        Ok(Rotate::Xyz {
+            x: axis.x,
+            y: axis.y,
+            z: axis.z,
             angle: final_angle,
         })
     }
 
     pub(crate) fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
-        if self.x == 0.0 && self.y == 0.0 && self.z == 1.0 && self.angle.is_zero() {
-            dest.write_str("none")?;
-            return Ok(());
-        }
+        let (x, y, z, angle) = match self {
+            Rotate::None => return dest.write_str("none"),
+            Rotate::Xyz { x, y, z, angle } => (*x, *y, *z, angle),
+        };
 
-        if self.x == 1.0 && self.y == 0.0 && self.z == 0.0 {
+        if x == 1.0 && y == 0.0 && z == 0.0 {
             dest.write_str("x ")?;
-        } else if self.x == 0.0 && self.y == 1.0 && self.z == 0.0 {
+        } else if x == 0.0 && y == 1.0 && z == 0.0 {
             dest.write_str("y ")?;
-        } else if !(self.x == 0.0 && self.y == 0.0 && self.z == 1.0) {
-            CSSNumberFns::to_css(self.x, dest)?;
+        } else if !(x == 0.0 && y == 0.0 && z == 1.0) {
+            CSSNumberFns::to_css(x, dest)?;
             dest.write_char(b' ')?;
-            CSSNumberFns::to_css(self.y, dest)?;
+            CSSNumberFns::to_css(y, dest)?;
             dest.write_char(b' ')?;
-            CSSNumberFns::to_css(self.z, dest)?;
+            CSSNumberFns::to_css(z, dest)?;
             dest.write_char(b' ')?;
         }
 
-        self.angle.to_css(dest)
+        angle.to_css(dest)
     }
 }
 
@@ -846,11 +850,14 @@ impl Rotate {
 impl Rotate {
     /// Converts the rotation to a transform function.
     fn to_transform(&self, _bump: &Bump) -> Transform {
-        Transform::Rotate3d {
-            x: self.x,
-            y: self.y,
-            z: self.z,
-            angle: self.angle,
+        match *self {
+            Rotate::None => Transform::Rotate3d {
+                x: 0.0,
+                y: 0.0,
+                z: 1.0,
+                angle: Angle::Deg(0.0),
+            },
+            Rotate::Xyz { x, y, z, angle } => Transform::Rotate3d { x, y, z, angle },
         }
     }
 

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1457,13 +1457,17 @@ fn parse_legacy_alpha(input: &mut css::Parser, parser: &ComponentParser) -> CssR
 }
 
 fn parse_alpha(input: &mut css::Parser, parser: &ComponentParser) -> CssResult<f32> {
-    let res = if input.try_parse(|i| i.expect_delim(b'/')).is_ok() {
-        parse_number_or_percentage(input, parser)?.clamp(0.0, 1.0)
-    } else {
-        1.0
-    };
+    if input.try_parse(|i| i.expect_delim(b'/')).is_ok() {
+        return Ok(parse_number_or_percentage(input, parser)?.clamp(0.0, 1.0));
+    }
 
-    Ok(res)
+    // In the relative color syntax an omitted alpha defaults to the origin
+    // color's alpha, not to 100%.
+    // https://drafts.csswg.org/css-color-5/#relative-colors
+    Ok(match &parser.from {
+        Some(from) => from.components.3,
+        None => 1.0,
+    })
 }
 
 pub(crate) fn parse_number_or_percentage(

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -649,3 +649,26 @@ describe("color-mix() percentage range", () => {
     expect(color(input, "css")).toBe(expected);
   });
 });
+
+// https://drafts.csswg.org/css-color-5/#relative-colors
+// An omitted alpha defaults to the origin color's alpha, not to 100%.
+describe("relative color syntax", () => {
+  test.each([
+    ["rgb(from #0008 r g b)", "#0008"],
+    ["rgb(from #0008 r g b / alpha)", "#0008"],
+    ["rgb(from #0008 r g b / 1)", "#000"],
+    ["rgb(from #000 r g b)", "#000"],
+    ["hsl(from #0008 h s l)", "#0008"],
+    ["hwb(from #0008 h w b)", "#0008"],
+    ["oklch(from oklch(50% 0 0 / 50%) l c h)", "oklch(50% 0 0 / .5)"],
+    ["oklch(from oklch(50% 0 0 / 50%) l c h / 1)", "oklch(50% 0 0)"],
+  ])("%s keeps the origin alpha", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test("the origin alpha is converted along with the channels", () => {
+    expect(color("rgb(from rgb(1 2 3 / 50%) r g b)", "[rgba]")).toEqual([1, 2, 3, 128]);
+    expect(color("hsl(from rgb(1 2 3 / 50%) calc(h + 180) s l)", "[rgba]")).toEqual([3, 2, 1, 128]);
+    expect(color("rgb(from rgb(1 2 3 / 50%) r g b / 1)", "[rgba]")).toEqual([1, 2, 3, 255]);
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7331,6 +7331,34 @@ describe("css tests", () => {
     );
   });
 
+  describe("relative colors", () => {
+    // https://drafts.csswg.org/css-color-5/#relative-colors
+    // An omitted alpha defaults to the origin color's alpha, not to 100%.
+    minify_test(".foo { color: rgb(from #0008 r g b) }", ".foo{color:#0008}");
+    minify_test(".foo { color: rgb(from #0008 r g b / alpha) }", ".foo{color:#0008}");
+    minify_test(".foo { color: rgb(from #0008 r g b / calc(alpha / 2)) }", ".foo{color:#0004}");
+    minify_test(".foo { color: rgb(from #0008 r g b / 1) }", ".foo{color:#000}");
+    minify_test(".foo { color: rgb(from #0008 r g b / 0) }", ".foo{color:#0000}");
+    minify_test(".foo { color: rgb(from #000 r g b) }", ".foo{color:#000}");
+    minify_test(".foo { color: rgb(from rgb(0 0 0 / none) r g b) }", ".foo{color:#0000}");
+    minify_test(".foo { color: rgb(from rgb(1 2 3 / 50%) b g r) }", ".foo{color:#03020180}");
+    minify_test(".foo { color: hsl(from #0008 h s l) }", ".foo{color:#0008}");
+    minify_test(".foo { color: hsl(from rgb(1 2 3 / 50%) calc(h + 180) s l) }", ".foo{color:#03020180}");
+    minify_test(".foo { color: hwb(from #0008 h w b) }", ".foo{color:#0008}");
+    minify_test(".foo { color: lab(from lab(50% 0 0 / 50%) l a b) }", ".foo{color:lab(50% 0 0/.5)}");
+    minify_test(".foo { color: lch(from lch(50% 0 0 / 50%) l c h) }", ".foo{color:lch(50% 0 0/.5)}");
+    minify_test(".foo { color: oklab(from oklab(50% 0 0 / 50%) l a b) }", ".foo{color:oklab(50% 0 0/.5)}");
+    minify_test(".foo { color: oklch(from oklch(50% 0 0 / 50%) l c h) }", ".foo{color:oklch(50% 0 0/.5)}");
+    minify_test(".foo { color: oklch(from oklch(50% 0 0 / 50%) l c h / 1) }", ".foo{color:oklch(50% 0 0)}");
+    minify_test(".foo { color: color(from color(srgb 0 0 0 / 50%) srgb r g b) }", ".foo{color:color(srgb 0 0 0/.5)}");
+    minify_test(
+      ".foo { color: color(from color(srgb 0 0 0 / 50%) display-p3 r g b) }",
+      ".foo{color:color(display-p3 0 0 0/.5)}",
+    );
+    minify_test(".foo { color: rgb(from light-dark(#ff08, #f008) r g b) }", ".foo{color:light-dark(#ff08,#f008)}");
+    minify_test(".foo { color: rgb(from rgb(from #0008 r g b) r g b) }", ".foo{color:#0008}");
+  });
+
   describe("color-scheme", () => {
     minify_test(".foo { color-scheme: normal; }", ".foo{color-scheme:normal}");
     minify_test(".foo { color-scheme: light; }", ".foo{color-scheme:light}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7242,8 +7242,20 @@ describe("css tests", () => {
     minify_test(".foo { rotate: y 10deg }", ".foo{rotate:y 10deg}");
     minify_test(".foo { rotate: 0 1 0 10deg }", ".foo{rotate:y 10deg}");
     minify_test(".foo { rotate: 1 1 1 10deg }", ".foo{rotate:1 1 1 10deg}");
-    minify_test(".foo { rotate: 0 0 1 0deg }", ".foo{rotate:none}");
+    // A zero rotation is not `none`: unlike `none` it still creates a stacking
+    // context and a containing block, the same as `transform: rotate(0)`.
+    minify_test(".foo { rotate: 0deg }", ".foo{rotate:0deg}");
+    minify_test(".foo { rotate: 0turn }", ".foo{rotate:0turn}");
+    minify_test(".foo { rotate: z 0deg }", ".foo{rotate:0deg}");
+    minify_test(".foo { rotate: 0 0 1 0deg }", ".foo{rotate:0deg}");
+    minify_test(".foo { rotate: x 0deg }", ".foo{rotate:x 0deg}");
     minify_test(".foo { rotate: none }", ".foo{rotate:none}");
+    minify_test(".foo { rotate: NONE }", ".foo{rotate:none}");
+    minify_test(".foo { rotate: none; rotate: 0deg }", ".foo{rotate:0deg}");
+    minify_test(".foo { rotate: 0deg; rotate: none }", ".foo{rotate:none}");
+    // When folded into a preceding `transform`, `none` and `0deg` are both the identity rotation.
+    minify_test(".foo { transform: translate(1px); rotate: none }", ".foo{transform:translate(1px)rotate(0)}");
+    minify_test(".foo { transform: translate(1px); rotate: 0deg }", ".foo{transform:translate(1px)rotate(0)}");
     minify_test(".foo { scale: 1 }", ".foo{scale:1}");
     minify_test(".foo { scale: 1 1 }", ".foo{scale:1}");
     minify_test(".foo { scale: 1 1 1 }", ".foo{scale:1}");


### PR DESCRIPTION
Two CSS minifier value folds that change the meaning of the input. Both came out of a fuzzing round against lightningcss; the third finding from that round, `rem()` folding with the divisor's sign, already has an open fix in #32286 and is not repeated here.

### Problem

- `rotate: 0deg` is minified to `rotate: none`. The two are not equivalent: a `rotate` value other than `none` creates a stacking context and a containing block for fixed/absolute descendants, exactly like a non-`none` `transform`, so the fold can change layout. lightningcss keeps `0deg`.
  - Cause: `Rotate` in `src/css/properties/transform.rs` was a plain struct and parsed `none` as `{x: 0, y: 0, z: 1, angle: 0deg}`; `to_css` printed every value matching that pattern as `none`, so a literal `0deg`, `z 0deg` or `0 0 1 0deg` became `none` too.
- A relative color with no `/ alpha` is folded fully opaque: `rgb(from #0008 r g b)` becomes `#000`, `hsl(from rgb(1 2 3 / .5) calc(h + 180) s l)` becomes `#030201`. CSS Color 5 says an omitted alpha in the relative syntax defaults to the origin color's alpha (not to 100% as in the absolute syntax), so these should be `#0008` and `#03020180`. lightningcss has the same bug; this follows the spec and browsers.
  - Cause: `parse_alpha` in `src/css/values/color.rs` returns `1.0` whenever there is no `/`, without looking at `parser.from`, which already holds the resolved origin color (it is what the `alpha` keyword reads).
  - `Bun.color()` uses the same parser, so `Bun.color("rgb(from #0008 r g b)", "css")` also returned `"#000"`.

### Fix

- `Rotate` becomes an enum with a `None` variant and an `Xyz { x, y, z, angle }` variant, the same shape as `Translate` and `Scale` (and as current upstream lightningcss). `none` round-trips to `none`, everything else prints its angle; the `x`/`y` keyword and z-axis shortenings are unchanged. `to_transform` still maps `None` to the identity `rotate3d(0, 0, 1, 0deg)`, so merging into a preceding `transform` is unchanged.
- `parse_alpha` returns the origin's alpha when a `from` color is set and no `/` was written. Every relative-capable function (`rgb`, `hsl`, `hwb`, `lab`, `lch`, `oklab`, `oklch`, `color()`) goes through this one helper. The origin alpha is already resolved (`none` becomes 0, same as the explicit `alpha` keyword), so the explicit `/ alpha` and the omitted form now agree. The token-list path for `rgb(... / var(--a))` requires an explicit `/` and is not affected.
- Verified:
  - `test/js/bun/css/css.test.ts` (`transform` block, new `relative colors` block): 5 rotate cases and 14 relative color cases fail on the released build and pass with this change; full file passes.
  - `test/js/bun/css/color.test.ts` (new `relative color syntax` block): fails on the released build, passes with this change; full file passes.
  - `test/bundler/css/` (including the WPT relative color file, whose origins are all opaque) passes.

### Background

- Individual transform properties: `translate`, `rotate` and `scale` are separate properties that compose with `transform`. Their initial value `none` is special in CSS Transforms 2: it is the only value that does not establish a stacking context / containing block, which is why a minifier may not rewrite an identity rotation to `none` even though both render the same.
- Relative color syntax: `rgb(from <origin> r g b / alpha)` parses the origin color, converts it into the function's color space, and exposes its channels as keywords. In this codebase `ComponentParser::from` holds those resolved channels (`components.3` is alpha) while the arguments are parsed; `RelativeComponentParser::get_ident` is how the `alpha` keyword reads it.
- The CSS parser and minifier live in `src/css/` and are a port of lightningcss; `minify_test` in `test/js/bun/css/` runs a stylesheet through the minifier in-process and compares the output string.

<details>
<summary>Repro</summary>

```css
a{rotate:0deg}
c{color:rgb(from #0008 r g b); background:hsl(from rgb(1 2 3 / .5) calc(h + 180) s l)}
```

`bun build --minify` before: `a{rotate:none}c{color:#000;background:#030201}`

after: `a{rotate:0deg}c{color:#0008;background:#03020180}`

lightningcss 1.33.0 on the same input: `a{rotate:0deg}` and `c{color:#000;...}` (it shares the alpha bug).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 24 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (ab00a59ba)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.96ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.66ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.54ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.85ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [16.19ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.53ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [2.28ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.43ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.27ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.24ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.59ms]
(pass) color({"r":0,"g":25
... (truncated)

release without fix: 24 failed, 67 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.08ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.02ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.01ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.05ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.54ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.01ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit"))
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.01ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ansi-24bit")
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (ab00a59ba)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.39ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.53ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.52ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.71ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [14.29ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.70ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.72ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.34ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.27ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.26ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.56ms]
(pass) color({"r":0,"g":25
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ab00a59ba5
  features     baseline

22 deps, 123 codegen, 1176 objects in 846ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [15.00ms]
[3/1238] gen bindgenv2
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[6/1237] fetch zlib
[zlib] up to date
[7/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[10/1237] gen ProcessBindingHTTPParser.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/transform.rs | 93 ++++++++++++++++++++++-------------------
 src/css/values/color.rs         | 16 ++++---
 test/js/bun/css/color.test.ts   | 23 ++++++++++
 test/js/bun/css/css.test.ts     | 42 ++++++++++++++++++-
 4 files changed, 124 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/css/properties/transform.rs      2      3      0
src/css/values/color.rs              3      1      0
test/js/bun/css/color.test.ts        1      2      0
test/js/bun/css/css.test.ts          3      4      0
```

</details>

<!-- robobun:evidence:end -->