### PR TITLE
css: fix color(a98-rgb), srgb-linear relative colors and color-mix(in xyz-d50)

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -194,7 +194,7 @@ The `color()` function specifies colors in predefined color spaces beyond tradit
 }
 ```
 
-For browsers that don't support these color spaces, Bun's CSS bundler adds fallbacks in more widely supported ones:
+For browsers that don't support these color spaces, Bun's CSS bundler adds RGB fallbacks:
 
 ```css title="styles.css" icon="file-code"
 .vivid-element {
@@ -204,8 +204,6 @@ For browsers that don't support these color spaces, Bun's CSS bundler adds fallb
   color: color(display-p3 1 0.1 0.3);
 
   background-color: #6a815c;
-  /* display-p3 is more widely supported than the other color() spaces */
-  background-color: color(display-p3 0.431961 0.501334 0.375499);
   background-color: color(a98-rgb 0.44 0.5 0.37);
 }
 ```

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -194,16 +194,18 @@ The `color()` function specifies colors in predefined color spaces beyond tradit
 }
 ```
 
-For browsers that don't support these color spaces, Bun's CSS bundler adds RGB fallbacks:
+For browsers that don't support these color spaces, Bun's CSS bundler adds fallbacks in more widely supported ones:
 
 ```css title="styles.css" icon="file-code"
 .vivid-element {
   /* RGB fallback first for maximum compatibility */
-  color: #fa1a4c;
+  color: #ff1f51;
   /* Keep original for browsers that support it */
   color: color(display-p3 1 0.1 0.3);
 
-  background-color: #6a805d;
+  background-color: #6a815c;
+  /* display-p3 is more widely supported than the other color() spaces */
+  background-color: color(display-p3 0.431961 0.501334 0.375499);
   background-color: color(a98-rgb 0.44 0.5 0.37);
 }
 ```

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2455,9 +2455,8 @@ pub(crate) fn parse_color_mix(input: &mut css::Parser) -> CssResult<CssColor> {
         ColorSpaceName::Xyz | ColorSpaceName::XyzD65 => {
             first_color.interpolate::<XYZd65>(p1, &second_color, p2, hue_method)
         }
-        // Intentionally XYZd65 for xyz-d50 too (sic) — kept for behavioral compatibility.
         ColorSpaceName::XyzD50 => {
-            first_color.interpolate::<XYZd65>(p1, &second_color, p2, hue_method)
+            first_color.interpolate::<XYZd50>(p1, &second_color, p2, hue_method)
         }
     };
 

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1778,9 +1778,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`sRGB-linear`](https://www.w3.org/TR/css-color-4/#predefined-sRGB-linear) color space.
     SRGBLinear { r, g, b }
-    // `r` intentionally uses the angle channel type (sic) — kept for
-    // behavioral compatibility.
-    types = (CT_ANG, CT_PCT, CT_PCT);
+    types = (CT_PCT, CT_PCT, CT_PCT);
     gamut = bounded;
     premultiply = rectangular;
     powerless = none;
@@ -2352,8 +2350,7 @@ pub(crate) fn parse_predefined_relative(
         b"srgb" => PredefinedColor::Srgb(SRGB { r: a, g: b, b: c, alpha }),
         b"srgb-linear" => PredefinedColor::SrgbLinear(SRGBLinear { r: a, g: b, b: c, alpha }),
         b"display-p3" => PredefinedColor::DisplayP3(P3 { r: a, g: b, b: c, alpha }),
-        // "a99-rgb" (sic) — kept for behavioral compatibility.
-        b"a99-rgb" => PredefinedColor::A98(A98 { r: a, g: b, b: c, alpha }),
+        b"a98-rgb" => PredefinedColor::A98(A98 { r: a, g: b, b: c, alpha }),
         b"prophoto-rgb" => PredefinedColor::Prophoto(ProPhoto { r: a, g: b, b: c, alpha }),
         b"rec2020" => PredefinedColor::Rec2020(Rec2020 { r: a, g: b, b: c, alpha }),
         b"xyz-d50" => PredefinedColor::XyzD50(XYZd50 { x: a, y: b, z: c, alpha }),

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -380,6 +380,16 @@ describe("color() predefined color spaces", () => {
     expect(color("color(from red srgb-linear r g b)", "css")).toBe("color(srgb-linear 1 0 0)");
     expect(color("color(from red srgb-linear g g r)", "css")).toBe("color(srgb-linear 0 0 1)");
   });
+
+  test("color-mix(in xyz-d50) stays in xyz-d50", () => {
+    expect(color("color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .3 .2 .1))", "css")).toBe(
+      "color(xyz-d50 .2 .2 .2)",
+    );
+    expect(color("color-mix(in xyz-d50, color(xyz-d50 none .2 .3), color(xyz-d50 .3 .2 .1))", "css")).toBe(
+      "color(xyz-d50 .3 .2 .2)",
+    );
+    expect(color("color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .3 .2 .1))", "css")).toBe("color(xyz .2 .2 .2)");
+  });
 });
 
 // 2^24 color() calls take minutes on debug builds (past the per-test timeout) and dominate

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -382,6 +382,10 @@ describe("color() predefined color spaces", () => {
     expect(color("color(from #c86432 a98-rgb r g b)", "css")).toBe("color(a98-rgb .695066 .391898 .220089)");
   });
 
+  test("a98-rgb channels accept percentages", () => {
+    expect(color("color(A98-RGB 100% 50% 0%)", "css")).toBe("color(a98-rgb 1 .5 0)");
+  });
+
   test("srgb-linear relative colors can reference r", () => {
     expect(color("color(from red srgb-linear r g b)", "css")).toBe("color(srgb-linear 1 0 0)");
     expect(color("color(from red srgb-linear g g r)", "css")).toBe("color(srgb-linear 0 0 1)");
@@ -810,6 +814,24 @@ describe("conversions between color spaces", () => {
     const g = linear(0.5);
     const b = linear(0.002);
     const out = same("xyz", "color(display-p3 1 0.5 0.002)");
+    expect(out).toStartWith("color(xyz ");
+    expectChannels(
+      out,
+      [0, 1, 2].map(i => red[i] + g * green[i] + b * blue[i]),
+      4,
+    );
+  });
+
+  test("a98-rgb to xyz applies the 563/256 gamma before the matrix", () => {
+    // XYZ of the a98-rgb primaries, i.e. the columns of the matrix in
+    // https://www.w3.org/TR/css-color-4/#color-conversion-code. a98-rgb uses a
+    // pure power curve instead of the sRGB piecewise transfer function.
+    const red = [0.576669, 0.297345, 0.027031];
+    const green = [0.185558, 0.627364, 0.070689];
+    const blue = [0.188229, 0.075291, 0.991338];
+    const g = 0.5 ** (563 / 256);
+    const b = 0.002 ** (563 / 256);
+    const out = same("xyz", "color(a98-rgb 1 0.5 0.002)");
     expect(out).toStartWith("color(xyz ");
     expectChannels(
       out,

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -347,6 +347,41 @@ describe("lab()/oklab() sRGB fallback for boundary colors (#33331)", () => {
   });
 });
 
+describe("color() predefined color spaces", () => {
+  const spaces: [space: string, channels: string, printed?: string][] = [
+    ["srgb", "b g r"],
+    ["srgb-linear", "b g r"],
+    ["display-p3", "b g r"],
+    ["a98-rgb", "b g r"],
+    ["prophoto-rgb", "b g r"],
+    ["rec2020", "b g r"],
+    ["xyz-d50", "z y x"],
+    ["xyz-d65", "z y x", "xyz"],
+    ["xyz", "z y x"],
+  ];
+
+  test.each(spaces)("color(%s ...) parses", (space, channels, printed = space) => {
+    expect(color(`color(${space.toUpperCase()} 0 1 0 / 50%)`, "css")).toBe(`color(${printed} 0 1 0 / .5)`);
+    expect(color(`color(from color(${space} .5 .25 .125) ${space} ${channels})`, "css")).toBe(
+      `color(${printed} .125 .25 .5)`,
+    );
+  });
+
+  test("a98-rgb converts to sRGB", () => {
+    expect(color("rgb(from color(a98-rgb .5 .25 .125) r g b)", "hex")).toBe("#923e17");
+    expect(color("color-mix(in srgb, color(a98-rgb .5 .25 .125), white)", "hex")).toBe("#c89e8b");
+  });
+
+  test("a98-rgb is a relative color target", () => {
+    expect(color("color(from #c86432 a98-rgb r g b)", "css")).toBe("color(a98-rgb .695066 .391898 .220089)");
+  });
+
+  test("srgb-linear relative colors can reference r", () => {
+    expect(color("color(from red srgb-linear r g b)", "css")).toBe("color(srgb-linear 1 0 0)");
+    expect(color("color(from red srgb-linear g g r)", "css")).toBe("color(srgb-linear 0 0 1)");
+  });
+});
+
 // 2^24 color() calls take minutes on debug builds (past the per-test timeout) and dominate
 // the ASAN lane, so those sweep the ansi256 equivalence classes (~13k deterministic inputs):
 // each single channel, the grey diagonal, the sub-8 cube, and a coarse 17-step cube.

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -379,6 +379,9 @@ describe("color() predefined color spaces", () => {
   test("srgb-linear relative colors can reference r", () => {
     expect(color("color(from red srgb-linear r g b)", "css")).toBe("color(srgb-linear 1 0 0)");
     expect(color("color(from red srgb-linear g g r)", "css")).toBe("color(srgb-linear 0 0 1)");
+    expect(color("color(from #808080 srgb-linear r g b / r)", "css")).toBe(
+      "color(srgb-linear .215861 .215861 .215861 / .215861)",
+    );
   });
 
   test("color-mix(in xyz-d50) stays in xyz-d50", () => {

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -367,6 +367,12 @@ describe("color() predefined color spaces", () => {
     );
   });
 
+  test("an unknown color space is not a color", () => {
+    // a99-rgb is the misspelling the parser used to accept in place of a98-rgb.
+    expect(color("color(a99-rgb 1 0 0)", "css")).toBeNull();
+    expect(color("color(a98rgb 1 0 0)", "css")).toBeNull();
+  });
+
   test("a98-rgb converts to sRGB", () => {
     expect(color("rgb(from color(a98-rgb .5 .25 .125) r g b)", "hex")).toBe("#923e17");
     expect(color("color-mix(in srgb, color(a98-rgb .5 .25 .125), white)", "hex")).toBe("#c89e8b");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7810,6 +7810,29 @@ describe("css tests", () => {
     });
   });
 
+  describe("color-mix()", () => {
+    // `in xyz-d50` interpolates in, and yields a color in, xyz-d50; it used to be
+    // routed through xyz-d65. Expected values are lightningcss output.
+    minify_test(
+      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .3 .2 .1)) }",
+      ".foo{color:color(xyz-d50 .2 .2 .2)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 none .2 .3), color(xyz-d50 .3 .2 .1)) }",
+      ".foo{color:color(xyz-d50 .3 .2 .2)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in xyz-d50, red, blue) }",
+      ".foo{color:color(xyz-d50 .289572 .141556 .364012)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in xyz-d50, rgb(255 0 0 / .5), blue) }",
+      ".foo{color:color(xyz-d50 .240996 .114718 .480098/.75098)}",
+    );
+    minify_test(".foo { color: color-mix(in xyz-d65, red, blue) }", ".foo{color:color(xyz .296436 .142416 .484931)}");
+    minify_test(".foo { color: color-mix(in xyz, red, blue) }", ".foo{color:color(xyz .296436 .142416 .484931)}");
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7703,10 +7703,9 @@ describe("css tests", () => {
 
   describe("color()", () => {
     // Every predefined color space, in the absolute form and as the target of a
-    // relative color that references all three channels. Expected values are
-    // lightningcss output. A color() that fails to parse is kept as an unparsed
-    // token stream, so the alpha percentage and the channel keywords would be
-    // printed verbatim instead of being folded.
+    // relative color that references all three channels. A color() that fails to
+    // parse is kept as an unparsed token stream, so the alpha percentage and the
+    // channel keywords would be printed verbatim instead of being folded.
     const predefined: [space: string, channels: string, printed?: string][] = [
       ["srgb", "b g r"],
       ["srgb-linear", "b g r"],
@@ -7725,6 +7724,108 @@ describe("css tests", () => {
         `.foo{color:color(${printed} .125 .25 .5)}`,
       );
     }
+
+    // lightningcss 1.30.2 `test_relative_color`, the loop over the RGB-like predefined
+    // spaces (src/lib.rs, `for color_space in &["srgb", "srgb-linear", "a98-rgb", "rec2020",
+    // "prophoto-rgb"]`). `{}` stands for the color space. Like the upstream `test()` helper,
+    // the expected color literal is normalized through the printer before the comparison.
+    describe("relative colors in the RGB-like predefined spaces", () => {
+      function relative_color_test(input: string, expected: string) {
+        const source = `.foo { color: ${input} }`;
+        test(source, () => {
+          const normalized = minify_test_with_options(`.foo { color: ${expected} }`, "");
+          expect(minify_test_with_options(source, "")).toBe(normalized);
+        });
+      }
+
+      const cases: [input: string, expected: string][] = [
+        // No modifications.
+        ["color(from color({} 0.7 0.5 0.3) {} r g b)", "color({} 0.7 0.5 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g b / alpha)", "color({} 0.7 0.5 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g b)", "color({} 0.7 0.5 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g b / alpha)", "color({} 0.7 0.5 0.3 / 0.4)"],
+        // Nested relative colors.
+        ["color(from color(from color({} 0.7 0.5 0.3) {} r g b) {} r g b)", "color({} 0.7 0.5 0.3)"],
+        // Replacement with 0.
+        ["color(from color({} 0.7 0.5 0.3) {} 0 0 0)", "color({} 0 0 0)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 0 0 0 / 0)", "color({} 0 0 0 / 0)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 0 g b / alpha)", "color({} 0 0.5 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r 0 b / alpha)", "color({} 0.7 0 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g 0 / alpha)", "color({} 0.7 0.5 0)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g b / 0)", "color({} 0.7 0.5 0.3 / 0)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} 0 g b / alpha)", "color({} 0 0.5 0.3 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r 0 b / alpha)", "color({} 0.7 0 0.3 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g 0 / alpha)", "color({} 0.7 0.5 0 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g b / 0)", "color({} 0.7 0.5 0.3 / 0)"],
+        // Replacement with a constant.
+        ["color(from color({} 0.7 0.5 0.3) {} 0.2 g b / alpha)", "color({} 0.2 0.5 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 20% g b / alpha)", "color({} 0.2 0.5 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r 0.2 b / alpha)", "color({} 0.7 0.2 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r 20% b / alpha)", "color({} 0.7 0.2 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g 0.2 / alpha)", "color({} 0.7 0.5 0.2)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g 20% / alpha)", "color({} 0.7 0.5 0.2)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g b / 0.2)", "color({} 0.7 0.5 0.3 / 0.2)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g b / 20%)", "color({} 0.7 0.5 0.3 / 0.2)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} 0.2 g b / alpha)", "color({} 0.2 0.5 0.3 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} 20% g b / alpha)", "color({} 0.2 0.5 0.3 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r 0.2 b / alpha)", "color({} 0.7 0.2 0.3 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r 20% b / alpha)", "color({} 0.7 0.2 0.3 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g 0.2 / alpha)", "color({} 0.7 0.5 0.2 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g 20% / alpha)", "color({} 0.7 0.5 0.2 / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g b / 0.2)", "color({} 0.7 0.5 0.3 / 0.2)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g b / 20%)", "color({} 0.7 0.5 0.3 / 0.2)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 2 3 4)", "color({} 2 3 4)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 2 3 4 / 5)", "color({} 2 3 4)"],
+        ["color(from color({} 0.7 0.5 0.3) {} -2 -3 -4)", "color({} -2 -3 -4)"],
+        ["color(from color({} 0.7 0.5 0.3) {} -2 -3 -4 / -5)", "color({} -2 -3 -4 / 0)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 200% 300% 400%)", "color({} 2 3 4)"],
+        ["color(from color({} 0.7 0.5 0.3) {} 200% 300% 400% / 500%)", "color({} 2 3 4)"],
+        ["color(from color({} 0.7 0.5 0.3) {} -200% -300% -400%)", "color({} -2 -3 -4)"],
+        ["color(from color({} 0.7 0.5 0.3) {} -200% -300% -400% / -500%)", "color({} -2 -3 -4 / 0)"],
+        // Valid permutations (the types match).
+        ["color(from color({} 0.7 0.5 0.3) {} g b r)", "color({} 0.5 0.3 0.7)"],
+        ["color(from color({} 0.7 0.5 0.3) {} b alpha r / g)", "color({} 0.3 1 0.7 / 0.5)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r r r / r)", "color({} 0.7 0.7 0.7 / 0.7)"],
+        ["color(from color({} 0.7 0.5 0.3) {} alpha alpha alpha / alpha)", "color({} 1 1 1)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} g b r)", "color({} 0.5 0.3 0.7)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} b alpha r / g)", "color({} 0.3 0.4 0.7 / 0.5)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r r r / r)", "color({} 0.7 0.7 0.7 / 0.7)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} alpha alpha alpha / alpha)", "color({} 0.4 0.4 0.4 / 0.4)"],
+        // Out of gamut components.
+        ["color(from color({} 1.7 1.5 1.3) {} r g b)", "color({} 1.7 1.5 1.3)"],
+        ["color(from color({} 1.7 1.5 1.3) {} r g b / alpha)", "color({} 1.7 1.5 1.3)"],
+        ["color(from color({} 1.7 1.5 1.3 / 140%) {} r g b)", "color({} 1.7 1.5 1.3)"],
+        ["color(from color({} 1.7 1.5 1.3 / 140%) {} r g b / alpha)", "color({} 1.7 1.5 1.3)"],
+        ["color(from color({} -0.7 -0.5 -0.3) {} r g b)", "color({} -0.7 -0.5 -0.3)"],
+        ["color(from color({} -0.7 -0.5 -0.3) {} r g b / alpha)", "color({} -0.7 -0.5 -0.3)"],
+        ["color(from color({} -0.7 -0.5 -0.3 / -40%) {} r g b)", "color({} -0.7 -0.5 -0.3)"],
+        ["color(from color({} -0.7 -0.5 -0.3 / -40%) {} r g b / alpha)", "color({} -0.7 -0.5 -0.3 / 0)"],
+        // calc().
+        ["color(from color({} 0.7 0.5 0.3) {} calc(r) calc(g) calc(b))", "color({} 0.7 0.5 0.3)"],
+        [
+          "color(from color({} 0.7 0.5 0.3 / 40%) {} calc(r) calc(g) calc(b) / calc(alpha))",
+          "color({} 0.7 0.5 0.3 / 0.4)",
+        ],
+        // none.
+        ["color(from color({} 0.7 0.5 0.3) {} none none none)", "color({} none none none)"],
+        ["color(from color({} 0.7 0.5 0.3) {} none none none / none)", "color({} none none none / none)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g none)", "color({} 0.7 0.5 none)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g none / alpha)", "color({} 0.7 0.5 none)"],
+        ["color(from color({} 0.7 0.5 0.3) {} r g b / none)", "color({} 0.7 0.5 0.3 / none)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g none / alpha)", "color({} 0.7 0.5 none / 0.4)"],
+        ["color(from color({} 0.7 0.5 0.3 / 40%) {} r g b / none)", "color({} 0.7 0.5 0.3 / none)"],
+        // A none channel of the origin is 0 when a keyword references it.
+        ["color(from color({} none none none) {} r g b)", "color({} 0 0 0)"],
+        ["color(from color({} none none none / none) {} r g b / alpha)", "color({} 0 0 0 / 0)"],
+        ["color(from color({} 0.7 none 0.3) {} r g b)", "color({} 0.7 0 0.3)"],
+        ["color(from color({} 0.7 0.5 0.3 / none) {} r g b / alpha)", "color({} 0.7 0.5 0.3 / 0)"],
+      ];
+      for (const space of ["srgb", "srgb-linear", "a98-rgb", "rec2020", "prophoto-rgb"]) {
+        for (const [input, expected] of cases) {
+          relative_color_test(input.replaceAll("{}", space), expected.replaceAll("{}", space));
+        }
+      }
+    });
 
     describe("a98-rgb", () => {
       minify_test(".foo { color: color(A98-RGB 0 1 0 / 50%) }", ".foo{color:color(a98-rgb 0 1 0/.5)}");
@@ -7813,16 +7914,13 @@ describe("css tests", () => {
     });
 
     describe("srgb-linear", () => {
-      // The `r` channel keyword of an srgb-linear relative color.
+      // The `r` channel keyword of an srgb-linear relative color, with an origin
+      // that has to be converted into srgb-linear first.
       minify_test(".foo { color: color(from red srgb-linear r g b) }", ".foo{color:color(srgb-linear 1 0 0)}");
       minify_test(".foo { color: color(from red srgb-linear g g r) }", ".foo{color:color(srgb-linear 0 0 1)}");
       minify_test(
         ".foo { color: color(from color(srgb-linear .5 .25 .125) srgb-linear calc(r / 2) g b) }",
         ".foo{color:color(srgb-linear .25 .25 .125)}",
-      );
-      minify_test(
-        ".foo { color: color(from color(srgb-linear .5 .25 .125) srgb-linear r g b / 50%) }",
-        ".foo{color:color(srgb-linear .5 .25 .125/.5)}",
       );
       minify_test(
         ".foo { color: color(from #808080 srgb-linear r g b) }",
@@ -7861,28 +7959,129 @@ describe("css tests", () => {
   });
 
   describe("color-mix()", () => {
-    // `in xyz-d50` interpolates in, and yields a color in, xyz-d50; it used to be
-    // routed through xyz-d65. Expected values are lightningcss output.
-    minify_test(
-      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .3 .2 .1)) }",
-      ".foo{color:color(xyz-d50 .2 .2 .2)}",
-    );
-    minify_test(
-      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 none .2 .3), color(xyz-d50 .3 .2 .1)) }",
-      ".foo{color:color(xyz-d50 .3 .2 .2)}",
-    );
-    minify_test(
-      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 none .2 .1)) }",
-      ".foo{color:color(xyz-d50 .1 .2 .2)}",
-    );
-    minify_test(
-      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 none .2 .3), color(xyz-d50 none .2 .1)) }",
-      ".foo{color:color(xyz-d50 none .2 .2)}",
-    );
-    minify_test(
-      ".foo { color: color-mix(in xyz, color(xyz .1 .2 .3), color(xyz none .2 .1)) }",
-      ".foo{color:color(xyz .1 .2 .2)}",
-    );
+    // lightningcss 1.30.2 `test_color_mix`, the loop over the XYZ spaces (src/lib.rs,
+    // `for color_space in [/*"srgb", */ "srgb-linear", "xyz", "xyz-d50", "xyz-d65"]`, itself
+    // converted from the web platform tests). `{}` stands for the interpolation space in
+    // the input and for the result space in the output: `in xyz-d65` yields `color(xyz ...)`.
+    // `in xyz-d50` interpolates in, and yields a color in, xyz-d50; it used to be routed
+    // through xyz-d65. srgb-linear is left out: 8 of its cases mix `none` or out-of-range
+    // channels, and `CssColor::interpolate` gamut-maps and drops the powerless components
+    // of the wrong operand (its `converted_*` flags are inverted), which #38508 fixes.
+    const cases: [input: string, expected: string][] = [
+      [".foo { color: color-mix(in {}, color({} .1 .2 .3), color({} .5 .6 .7)) }", ".foo{color:color({} .3 .4 .5)}"],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3) 25%, color({} .5 .6 .7)) }",
+        ".foo{color:color({} .4 .5 .6)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, 25% color({} .1 .2 .3), color({} .5 .6 .7)) }",
+        ".foo{color:color({} .4 .5 .6)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3), color({} .5 .6 .7) 25%) }",
+        ".foo{color:color({} .2 .3 .4)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3), 25% color({} .5 .6 .7)) }",
+        ".foo{color:color({} .2 .3 .4)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3) 25%, color({} .5 .6 .7) 75%) }",
+        ".foo{color:color({} .4 .5 .6)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3) 30%, color({} .5 .6 .7) 90%) }",
+        ".foo{color:color({} .4 .5 .6)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3) 12.5%, color({} .5 .6 .7) 37.5%) }",
+        ".foo{color:color({} .4 .5 .6/.5)}",
+      ],
+      [".foo { color: color-mix(in {}, color({} .1 .2 .3) 0%, color({} .5 .6 .7)) }", ".foo{color:color({} .5 .6 .7)}"],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .5), color({} .5 .6 .7 / .8)) }",
+        ".foo{color:color({} .346154 .446154 .546154/.65)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4) 25%, color({} .5 .6 .7 / .8)) }",
+        ".foo{color:color({} .442857 .542857 .642857/.7)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, 25% color({} .1 .2 .3 / .4), color({} .5 .6 .7 / .8)) }",
+        ".foo{color:color({} .442857 .542857 .642857/.7)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4), color({} .5 .6 .7 / .8) 25%) }",
+        ".foo{color:color({} .26 .36 .46/.5)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4), 25% color({} .5 .6 .7 / .8)) }",
+        ".foo{color:color({} .26 .36 .46/.5)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4) 25%, color({} .5 .6 .7 / .8) 75%) }",
+        ".foo{color:color({} .442857 .542857 .642857/.7)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4) 30%, color({} .5 .6 .7 / .8) 90%) }",
+        ".foo{color:color({} .442857 .542857 .642857/.7)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4) 12.5%, color({} .5 .6 .7 / .8) 37.5%) }",
+        ".foo{color:color({} .442857 .542857 .642857/.35)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / .4) 0%, color({} .5 .6 .7 / .8)) }",
+        ".foo{color:color({} .5 .6 .7/.8)}",
+      ],
+      [".foo { color: color-mix(in {}, color({} 2 3 4 / 5), color({} 4 6 8 / 10)) }", ".foo{color:color({} 3 4.5 6)}"],
+      [".foo { color: color-mix(in {}, color({} -2 -3 -4), color({} -4 -6 -8)) }", ".foo{color:color({} -3 -4.5 -6)}"],
+      [
+        ".foo { color: color-mix(in {}, color({} -2 -3 -4 / -5), color({} -4 -6 -8 / -10)) }",
+        ".foo{color:color({} 0 0 0/0)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} none none none), color({} none none none)) }",
+        ".foo{color:color({} none none none)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} none none none), color({} .5 .6 .7)) }",
+        ".foo{color:color({} .5 .6 .7)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3), color({} none none none)) }",
+        ".foo{color:color({} .1 .2 .3)}",
+      ],
+      [".foo { color: color-mix(in {}, color({} .1 .2 none), color({} .5 .6 .7)) }", ".foo{color:color({} .3 .4 .7)}"],
+      [".foo { color: color-mix(in {}, color({} .1 .2 .3), color({} .5 .6 none)) }", ".foo{color:color({} .3 .4 .3)}"],
+      [
+        ".foo { color: color-mix(in {}, color({} none .2 .3), color({} .5 none .7)) }",
+        ".foo{color:color({} .5 .2 .5)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / none), color({} .5 .6 .7)) }",
+        ".foo{color:color({} .3 .4 .5)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / none), color({} .5 .6 .7 / 0.5)) }",
+        ".foo{color:color({} .3 .4 .5/.5)}",
+      ],
+      [
+        ".foo { color: color-mix(in {}, color({} .1 .2 .3 / none), color({} .5 .6 .7 / none)) }",
+        ".foo{color:color({} .3 .4 .5/none)}",
+      ],
+    ];
+    for (const [space, result] of [
+      ["xyz", "xyz"],
+      ["xyz-d50", "xyz-d50"],
+      ["xyz-d65", "xyz"],
+    ]) {
+      for (const [input, expected] of cases) {
+        minify_test(input.replaceAll("{}", space), expected.replaceAll("{}", result));
+      }
+    }
+
+    // Operands that have to be converted into the interpolation space first.
     minify_test(
       ".foo { color: color-mix(in xyz-d50, red, blue) }",
       ".foo{color:color(xyz-d50 .289572 .141556 .364012)}",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7701,6 +7701,115 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  describe("color()", () => {
+    // Every predefined color space, in the absolute form and as the target of a
+    // relative color that references all three channels. Expected values are
+    // lightningcss output. A color() that fails to parse is kept as an unparsed
+    // token stream, so the alpha percentage and the channel keywords would be
+    // printed verbatim instead of being folded.
+    const predefined: [space: string, channels: string, printed?: string][] = [
+      ["srgb", "b g r"],
+      ["srgb-linear", "b g r"],
+      ["display-p3", "b g r"],
+      ["a98-rgb", "b g r"],
+      ["prophoto-rgb", "b g r"],
+      ["rec2020", "b g r"],
+      ["xyz-d50", "z y x"],
+      ["xyz-d65", "z y x", "xyz"],
+      ["xyz", "z y x"],
+    ];
+    for (const [space, channels, printed = space] of predefined) {
+      minify_test(`.foo { color: color(${space} 0 1 0 / 50%) }`, `.foo{color:color(${printed} 0 1 0/.5)}`);
+      minify_test(
+        `.foo { color: color(from color(${space} .5 .25 .125) ${space} ${channels}) }`,
+        `.foo{color:color(${printed} .125 .25 .5)}`,
+      );
+    }
+
+    describe("a98-rgb", () => {
+      minify_test(".foo { color: color(A98-RGB 0 1 0 / 50%) }", ".foo{color:color(a98-rgb 0 1 0/.5)}");
+      minify_test(".foo { color: color(a98-rgb 100% 50% 0%) }", ".foo{color:color(a98-rgb 1 .5 0)}");
+      minify_test(
+        ".foo { color: color(from #c86432 a98-rgb r g b) }",
+        ".foo{color:color(a98-rgb .695066 .391898 .220089)}",
+      );
+      minify_test(
+        ".foo { color: color(from #c86432 a98-rgb r g b / 50%) }",
+        ".foo{color:color(a98-rgb .695066 .391898 .220089/.5)}",
+      );
+      minify_test(".foo { color: rgb(from color(a98-rgb .5 .25 .125) r g b) }", ".foo{color:#923e17}");
+      minify_test(
+        ".foo { color: color(from color(a98-rgb .5 .25 .125) srgb r g b) }",
+        ".foo{color:color(srgb .570881 .241183 .0913544)}",
+      );
+      minify_test(
+        ".foo { color: color(from color(a98-rgb .5 .25 .125) display-p3 r g b) }",
+        ".foo{color:color(display-p3 .530457 .26084 .134638)}",
+      );
+      minify_test(".foo { color: color-mix(in srgb, color(a98-rgb .5 .25 .125), white) }", ".foo{color:#c89e8b}");
+
+      prefix_test(
+        ".foo { color: color(a98-rgb 1 0 0) }",
+        indoc`
+          .foo {
+            color: #ff6251;
+            color: color(a98-rgb 1 0 0);
+          }
+        `,
+        { chrome: 90 << 16 },
+      );
+      prefix_test(
+        ".foo { color: color(a98-rgb 1 0 0) }",
+        indoc`
+          .foo {
+            color: #ff6251;
+            color: color(display-p3 1.0633 .238564 .167582);
+            color: color(a98-rgb 1 0 0);
+          }
+        `,
+        { chrome: 87 << 16, safari: 14 << 16 },
+      );
+      prefix_test(
+        ".foo { color: color(from #c86432 a98-rgb r g b / 50%) }",
+        indoc`
+          .foo {
+            color: #c8643280;
+            color: color(a98-rgb .695066 .391898 .220089 / .5);
+          }
+        `,
+        { chrome: 90 << 16 },
+      );
+      prefix_test(
+        ".foo { background: linear-gradient(color(a98-rgb .5 .25 .125), color(a98-rgb .4 .5 .6)) }",
+        indoc`
+          .foo {
+            background: linear-gradient(#923e17, #59819b);
+            background: linear-gradient(color(a98-rgb .5 .25 .125), color(a98-rgb .4 .5 .6));
+          }
+        `,
+        { chrome: 90 << 16 },
+      );
+    });
+
+    describe("srgb-linear", () => {
+      // The `r` channel keyword of an srgb-linear relative color.
+      minify_test(".foo { color: color(from red srgb-linear r g b) }", ".foo{color:color(srgb-linear 1 0 0)}");
+      minify_test(".foo { color: color(from red srgb-linear g g r) }", ".foo{color:color(srgb-linear 0 0 1)}");
+      minify_test(
+        ".foo { color: color(from color(srgb-linear .5 .25 .125) srgb-linear calc(r / 2) g b) }",
+        ".foo{color:color(srgb-linear .25 .25 .125)}",
+      );
+      minify_test(
+        ".foo { color: color(from color(srgb-linear .5 .25 .125) srgb-linear r g b / 50%) }",
+        ".foo{color:color(srgb-linear .5 .25 .125/.5)}",
+      );
+      minify_test(
+        ".foo { color: color(from #808080 srgb-linear r g b) }",
+        ".foo{color:color(srgb-linear .215861 .215861 .215861)}",
+      );
+    });
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7729,6 +7729,9 @@ describe("css tests", () => {
     describe("a98-rgb", () => {
       minify_test(".foo { color: color(A98-RGB 0 1 0 / 50%) }", ".foo{color:color(a98-rgb 0 1 0/.5)}");
       minify_test(".foo { color: color(a98-rgb 100% 50% 0%) }", ".foo{color:color(a98-rgb 1 .5 0)}");
+      // The misspelling the parser used to accept (and rewrite to a98-rgb) is an
+      // unknown color space like any other.
+      minify_test(".foo { color: color(a99-rgb 1 0 0) }", ".foo{color:color(a99-rgb 1 0 0)}");
       minify_test(
         ".foo { color: color(from #c86432 a98-rgb r g b) }",
         ".foo{color:color(a98-rgb .695066 .391898 .220089)}",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7859,6 +7859,18 @@ describe("css tests", () => {
       ".foo{color:color(xyz-d50 .3 .2 .2)}",
     );
     minify_test(
+      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 none .2 .1)) }",
+      ".foo{color:color(xyz-d50 .1 .2 .2)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in xyz-d50, color(xyz-d50 none .2 .3), color(xyz-d50 none .2 .1)) }",
+      ".foo{color:color(xyz-d50 none .2 .2)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in xyz, color(xyz .1 .2 .3), color(xyz none .2 .1)) }",
+      ".foo{color:color(xyz .1 .2 .2)}",
+    );
+    minify_test(
       ".foo { color: color-mix(in xyz-d50, red, blue) }",
       ".foo{color:color(xyz-d50 .289572 .141556 .364012)}",
     );

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7780,6 +7780,16 @@ describe("css tests", () => {
         `,
         { chrome: 87 << 16, safari: 14 << 16 },
       );
+      // A target that supports color() gets no fallback.
+      prefix_test(
+        ".foo { color: color(a98-rgb 1 0 0) }",
+        indoc`
+          .foo {
+            color: color(a98-rgb 1 0 0);
+          }
+        `,
+        { chrome: 111 << 16 },
+      );
       prefix_test(
         ".foo { color: color(from #c86432 a98-rgb r g b / 50%) }",
         indoc`

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7737,6 +7737,14 @@ describe("css tests", () => {
         ".foo { color: color(from #c86432 a98-rgb r g b / 50%) }",
         ".foo{color:color(a98-rgb .695066 .391898 .220089/.5)}",
       );
+      minify_test(
+        ".foo { color: color(from #c86432 a98-rgb r g b / g) }",
+        ".foo{color:color(a98-rgb .695066 .391898 .220089/.391898)}",
+      );
+      minify_test(
+        ".foo { color: color(from light-dark(color(a98-rgb .5 .25 .125), color(a98-rgb .1 .2 .3)) a98-rgb b g r) }",
+        ".foo{color:light-dark(color(a98-rgb .125 .25 .5),color(a98-rgb .3 .2 .1))}",
+      );
       minify_test(".foo { color: rgb(from color(a98-rgb .5 .25 .125) r g b) }", ".foo{color:#923e17}");
       minify_test(
         ".foo { color: color(from color(a98-rgb .5 .25 .125) srgb r g b) }",
@@ -7806,6 +7814,35 @@ describe("css tests", () => {
       minify_test(
         ".foo { color: color(from #808080 srgb-linear r g b) }",
         ".foo{color:color(srgb-linear .215861 .215861 .215861)}",
+      );
+      minify_test(
+        ".foo { color: color(from #808080 srgb-linear r g b / r) }",
+        ".foo{color:color(srgb-linear .215861 .215861 .215861/.215861)}",
+      );
+      minify_test(
+        ".foo { color: color(from light-dark(red, blue) srgb-linear r g b) }",
+        ".foo{color:light-dark(color(srgb-linear 1 0 0),color(srgb-linear 0 0 1))}",
+      );
+
+      prefix_test(
+        ".foo { color: color(from red srgb-linear r g b) }",
+        indoc`
+          .foo {
+            color: red;
+            color: color(srgb-linear 1 0 0);
+          }
+        `,
+        { chrome: 90 << 16 },
+      );
+      prefix_test(
+        ".foo { color: color(from #808080 srgb-linear r g b) }",
+        indoc`
+          .foo {
+            color: gray;
+            color: color(srgb-linear .215861 .215861 .215861);
+          }
+        `,
+        { chrome: 90 << 16 },
       );
     });
   });


### PR DESCRIPTION
### Problem
- `color(a98-rgb 1 0 0)` never parses: `bun build` emits no fallback for it and `Bun.color("color(a98-rgb 1 0 0)", "css")` returns `null`. Cause: the second color space match in `parse_predefined_relative` (`src/css/values/color.rs:2356`) spells the ident `a99-rgb`.
- `color(from <color> srgb-linear r g b)` never parses. `SRGBLinear` declares `r` as an angle channel (`color.rs:1783`), so the `r` keyword is rejected where a number is expected.
- `color-mix(in xyz-d50, ...)` interpolates in xyz-d65 (`color.rs:2462`). It returns `color(xyz ...)`, and the d50 to d65 matrix turns a `none` channel of an xyz-d50 operand into 0 before the mix.

### Fix
- `a99-rgb` becomes `a98-rgb`. `r` of `SRGBLinear` becomes a percentage channel like `g` and `b`. The `XyzD50` arm of `parse_color_mix` interpolates in `XYZd50`, a type that already existed unused.
- Correct because lightningcss, which this parser ports, does all three. All three lines came from the original `color.zig` with "(sic)" comments.
- Nothing else reads the changed values: the ident only reaches this match, `CHANNEL_TYPES` is only read by `RelativeComponentParser`, and the xyz-d50 arm is only reached by `color-mix(in xyz-d50, ...)`.
- Verified: `test/js/bun/css/css.test.ts` ports the two lightningcss 1.30.2 test loops that cover these spaces, `test_relative_color` over the five RGB-like spaces and `test_color_mix` over the XYZ spaces, plus the fallback and `Bun.color()` cases. 174 cases in `css.test.ts` and 9 in `color.test.ts` fail before. Also `test/bundler/css/` and the other css suites.

### Background
- `color()` (CSS Color 4) takes a predefined color space ident and three channels. `parse_predefined_relative` matches the ident twice: once to convert an optional `from` origin into the target space, once to build the `PredefinedColor`.
- In the relative form, `color(from <origin> <space> r g b)`, a channel can be a keyword that names an origin channel. `RelativeComponentParser` resolves it by name and by declared channel type.
- `color-mix(in <space>, a, b)` converts both operands into the named space, fills `none` channels from the other operand, and interpolates there. xyz-d50 and xyz-d65 are XYZ under two white points.
- A value that fails to parse is kept as an unparsed token list and printed back. That is why the first two bugs look like missing fallbacks, not errors.

<details><summary>Notes</summary>

Repro without the test suite, on bun 1.4.0 and main:

```
$ printf 'a{color:color(a98-rgb 1 0 0)}\nb{color:color(from #c86432 srgb-linear r g b)}\nc{color:color-mix(in xyz-d50,color(xyz-d50 none .2 .3),color(xyz-d50 .3 .2 .1))}\n' > x.css && bun build --minify x.css
a{color:color(a98-rgb 1 0 0)}b{color:color(from #c86432 srgb-linear r g b)}c{color:#3e8788;color:color(display-p3 .319112 .523724 .529618);color:color(xyz .151353 .201952 .263819)}
```

`a` and `b` pass through unparsed. `c` is folded to the wrong color: the `none` channel became 0 on the way through xyz-d65. lightningcss gives `color(xyz-d50 .3 .2 .2)` for `c`. With this PR:

```
a{color:#ff6251;color:color(display-p3 1.0633 .238564 .167582);color:color(a98-rgb 1 0 0)}b{color:#c86432;color:color(display-p3 .733816 .413298 .243042);color:color(srgb-linear .577581 .127438 .031896)}c{color:#bf578b;color:color(display-p3 .696946 .366074 .536818);color:color(xyz-d50 .3 .2 .2)}
```

Why the angle type could never have mattered before: `CHANNEL_TYPES` is only consumed by `RelativeComponentParser`, and its callers for predefined spaces only ever ask for number or percentage channels. So `r` declared as an angle matched nothing. The conversion code, serialization and fallback logic for A98 and srgb-linear were already in place and are unchanged.

Tests. The two upstream loops are ported as data tables with `{}` for the color space, the rows copied from lightningcss 1.30.2 `src/lib.rs`. `test_relative_color`: 68 rows over `srgb`, `srgb-linear`, `a98-rgb`, `rec2020`, `prophoto-rgb` (340 cases, the expected literal normalized through the printer like the upstream `test()` helper). `test_color_mix`: 30 rows over `xyz`, `xyz-d50`, `xyz-d65` (90 cases). Every row was also checked against the lightningcss 1.30.2 binary. The upstream color-mix loop also runs over `srgb-linear`. Those rows are left out: 8 of them mix `none` or out-of-range channels and hit the inverted `converted_*` flags in `CssColor::interpolate`, which #38508 fixes. The rest of `css.test.ts`: every predefined space in the absolute and relative form, a98-rgb fallbacks per target (`chrome: 90`, `chrome: 87` + `safari: 14`, `chrome: 111` which gets none), the alpha slot and `light-dark()` origins, cross-space origins into and out of a98-rgb and srgb-linear, `a99-rgb` staying unparsed, and sRGB operands mixed `in xyz-d50`. `color.test.ts`: the same through `Bun.color()`, plus the a98-rgb to xyz conversion (563/256 power curve) and percentage channels.

The rest of the upstream color corpus (`test_color`, the other loops of `test_relative_color` and `test_color_mix`) is not in the tree: the 2024 port of `test_color` was removed in #16486 and the other two were never ported. Porting them is separate work, since many of their cases depend on other open color fixes.

On the released bun: 174 of the `css.test.ts` cases fail (68 a98-rgb and 48 srgb-linear rows of the relative loop, all 30 xyz-d50 rows of the color-mix loop, and the targeted cases), 9 in `color.test.ts`. The srgb, rec2020, prophoto-rgb, xyz and xyz-d65 rows pass before and after.

#40725 fixed the a98-rgb part alone. It is closed in favor of this PR. Its cases that were not already here (the `chrome: 111` target, the a98-rgb gamma conversion, percentage channels through `Bun.color()`) are folded in (c4b9e4def9).

`docs/bundler/css.mdx` already documents the a98-rgb fallback this makes work. Its two hex values are corrected to what `bun build` emits for that input. The old hex values were not produced by any version. With the current default browser targets (Safari 14) `bun build` also emits a `display-p3` intermediate for the a98-rgb color. The example does not show it: it depends on the default targets, which #40369 changes.

Cross-reference: #38488 makes `Bun.color()` convert `color()` values for the non-`css` output formats. Its round trip table covers 7 of the 9 space idents because `a98-rgb` and the `srgb-linear` relative form only parse with this PR. The two PRs touch different lines and merge in either order. Whichever lands second should add the `a98-rgb` and `srgb-linear` rows to that table.

Suites run with the debug build after the rebase onto d578a8c70d: `test/js/bun/css/css.test.ts` (1657 pass, 67 skip), `test/js/bun/css/color.test.ts` (1038 pass, 1 skip), `test/bundler/css/` (235 pass), `test/js/bun/css/css-loader.test.ts`, `test/js/bun/css/doesnt_crash.test.ts`, and the css regression tests under `test/regression/issue/` (11 pass).

</details>
