### PR TITLE
Bun.color: convert color() inputs instead of returning them as a CSS string

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -86,18 +86,6 @@ impl RGBA {
         }
     }
 
-    /// Routes RGBA → SRGB → HSL.
-    #[inline]
-    pub fn into_hsl(self) -> HSL {
-        HSL::from_rgba(self)
-    }
-
-    /// Routes RGBA → SRGB → LAB.
-    #[inline]
-    pub fn into_lab(self) -> LAB {
-        LAB::from_rgba(self)
-    }
-
     /// Convert any `CssColor` into `RGBA` by routing through `SRGB`.
     #[inline]
     pub(crate) fn try_from_css_color(color: &CssColor) -> Option<RGBA> {
@@ -1475,39 +1463,6 @@ pub(crate) fn parse_number_or_percentage(
         NumberOrPercentage::Number { value } => value,
         NumberOrPercentage::Percentage { unit_value } => unit_value,
     })
-}
-
-impl LABColor {
-    pub fn into_hsl(&self) -> HSL {
-        HSL::from_lab_color(self)
-    }
-
-    pub fn into_lab(&self) -> LAB {
-        LAB::from_lab_color(self)
-    }
-
-    /// Project a LAB-space color into sRGB. Routes through the
-    /// `From<{LAB,LCH,OKLAB,OKLCH}>` lattice (LAB/LCH → XYZd50 → XYZd65 →
-    /// SRGBLinear → SRGB; OKLAB/OKLCH → XYZd65 → SRGBLinear → SRGB).
-    pub fn into_srgb(&self) -> SRGB {
-        SRGB::from_lab_color(self)
-    }
-}
-
-impl FloatColor {
-    pub fn into_hsl(&self) -> HSL {
-        HSL::from_float_color(self)
-    }
-
-    pub fn into_lab(&self) -> LAB {
-        LAB::from_float_color(self)
-    }
-
-    /// Project any float-color variant into sRGB.
-    #[inline]
-    pub fn into_srgb(&self) -> SRGB {
-        SRGB::from_float_color(self)
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -214,7 +214,7 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
     use bun_core::ZigStringSlice;
     use bun_css as css;
     use bun_css::CssColor;
-    use bun_css::values::color::{HSL, LAB, RGBA, SRGB};
+    use bun_css::values::color::{Colorspace as _, HSL, LAB, RGBA, SRGB};
     use bun_jsc::StringJsc as _;
 
     let args = frame.arguments_as_array::<2>();
@@ -388,14 +388,10 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
                         | OutputColorFormat::RgbObject
                         | OutputColorFormat::RgbaArray
                         | OutputColorFormat::RgbArray) => {
-                            let srgba: SRGB = match &result {
-                                CssColor::Float(float) => match &**float {
-                                    css::FloatColor::Rgb(rgb) => *rgb,
-                                    other => other.into_srgb(),
-                                },
-                                CssColor::Rgba(rgba) => rgba.into_srgb(),
-                                CssColor::Lab(lab) => lab.into_srgb(),
-                                _ => break 'formatted,
+                            // None is currentColor, a system color or light-dark():
+                            // there are no channels to convert, so print the CSS.
+                            let Some(srgba) = SRGB::try_from_css_color(&result) else {
+                                break 'formatted;
                             };
                             let rgba = srgba.into_rgba();
                             match tag {
@@ -554,14 +550,8 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
                         }
 
                         OutputColorFormat::Hsl => {
-                            let hsl: HSL = match &result {
-                                CssColor::Float(float) => match &**float {
-                                    css::FloatColor::Hsl(hsl) => *hsl,
-                                    other => other.into_hsl(),
-                                },
-                                CssColor::Rgba(rgba) => rgba.into_hsl(),
-                                CssColor::Lab(lab) => lab.into_hsl(),
-                                _ => break 'formatted,
+                            let Some(hsl) = HSL::try_from_css_color(&result) else {
+                                break 'formatted;
                             };
 
                             // Saturation and lightness are stored as 0..1 but hsl()
@@ -575,14 +565,8 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
                             ));
                         }
                         OutputColorFormat::Lab => {
-                            let lab: LAB = match &result {
-                                CssColor::Float(float) => float.into_lab(),
-                                CssColor::Lab(lab) => match &**lab {
-                                    css::LabColor::Lab(lab_) => *lab_,
-                                    other => other.into_lab(),
-                                },
-                                CssColor::Rgba(rgba) => rgba.into_lab(),
-                                _ => break 'formatted,
+                            let Some(lab) = LAB::try_from_css_color(&result) else {
+                                break 'formatted;
                             };
 
                             // lab() is space-separated and takes lightness as a

--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -388,8 +388,8 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
                         | OutputColorFormat::RgbObject
                         | OutputColorFormat::RgbaArray
                         | OutputColorFormat::RgbArray) => {
-                            // None is currentColor, a system color or light-dark():
-                            // there are no channels to convert, so print the CSS.
+                            // None: currentColor, a system color or light-dark(), which
+                            // have no channel values.
                             let Some(srgba) = SRGB::try_from_css_color(&result) else {
                                 break 'formatted;
                             };

--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -388,8 +388,6 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
                         | OutputColorFormat::RgbObject
                         | OutputColorFormat::RgbaArray
                         | OutputColorFormat::RgbArray) => {
-                            // None: currentColor, a system color or light-dark(), which
-                            // have no channel values.
                             let Some(srgba) = SRGB::try_from_css_color(&result) else {
                                 break 'formatted;
                             };

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -559,6 +559,10 @@ describe("input forms", () => {
     ["rgb()", "rgb(255, 0, 0)"],
     ["rgba()", "rgba(255, 0, 0, 1)"],
     ["hsl() with percentages", "hsl(0, 100%, 50%)"],
+    ["color(srgb)", "color(srgb 1 0 0)"],
+    ["color(srgb-linear)", "color(srgb-linear 1 0 0)"],
+    ["color() in relative color syntax", "color(from red xyz x y z)"],
+    ["color-mix() in a color() space", "color-mix(in srgb-linear, red, red)"],
     ["a number", 0xff0000],
     ["an object", { r: 255, g: 0, b: 0 }],
     ["an array", [255, 0, 0]],
@@ -601,6 +605,127 @@ describe("input forms", () => {
   test("in-range object alpha is unchanged", () => {
     expect(color({ r: 10, g: 20, b: 30, a: 1 }, "{rgba}")).toEqual({ r: 10, g: 20, b: 30, a: 1 });
     expect(color({ r: 10, g: 20, b: 30, a: 0.5 }, "[rgba]")).toEqual([10, 20, 30, 127]);
+  });
+});
+
+// The color() function (CSS Color 4 predefined color spaces) used to be the one
+// parseable input that every output format other than "css" echoed back as a
+// string, so "{rgba}" returned "color(srgb 1 0 0)" instead of an object.
+describe("color() inputs convert to every output format", () => {
+  const conversionFormats = [
+    "hex",
+    "HEX",
+    "rgb",
+    "rgba",
+    "number",
+    "{rgb}",
+    "{rgba}",
+    "[rgb]",
+    "[rgba]",
+    "ansi-16",
+    "ansi-256",
+    "ansi-16m",
+    "hsl",
+    "lab",
+  ] as const;
+
+  test.each(conversionFormats)("color(srgb 1 0 0) formats as %s exactly like #ff0000", format => {
+    expect(color("color(srgb 1 0 0)", format)).toEqual(color("#ff0000", format));
+  });
+
+  test("non-string formats return their documented types", () => {
+    expect(color("color(srgb 1 0 0)", "{rgba}")).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+    expect(color("color(srgb 1 0 0)", "[rgba]")).toEqual([255, 0, 0, 255]);
+    expect(color("color(srgb 1 0 0)", "number")).toBe(0xff0000);
+    expect(color("color(srgb 1 0 0)", "ansi-16m")).toBe("\x1b[38;2;255;0;0m");
+  });
+
+  test("channels are 0..1 fractions of the space, not 0..255", () => {
+    expect(color("color(srgb 0.2 0.4 0.6)", "hex")).toBe("#336699");
+    // #336699 in linear light: ((c + 0.055) / 1.055) ** 2.4 for each channel.
+    expect(color("color(srgb-linear 0.0331048 0.132868 0.318547)", "hex")).toBe("#336699");
+    // Greys are the same in every D65 space that shares the sRGB transfer curve.
+    expect(color("color(display-p3 0.2 0.2 0.2)", "hex")).toBe("#333333");
+  });
+
+  // Relative color syntax converts #336699 into the named space and hands the
+  // result back as a color() value, so converting it again must be the identity.
+  // (a98-rgb and srgb-linear are missing because their relative forms do not parse yet.)
+  test.each([
+    "color(from #336699 srgb r g b)",
+    "color(from #336699 display-p3 r g b)",
+    "color(from #336699 prophoto-rgb r g b)",
+    "color(from #336699 rec2020 r g b)",
+    "color(from #336699 xyz x y z)",
+    "color(from #336699 xyz-d50 x y z)",
+    "color(from #336699 xyz-d65 x y z)",
+    "color-mix(in srgb-linear, #336699, #336699)",
+    "color-mix(in xyz, #336699, #336699)",
+  ])("%s round-trips to #336699", input => {
+    expect(color(input, "css")).toStartWith("color(");
+    expect(color(input, "hex")).toBe("#336699");
+    expect(color(input, "{rgb}")).toEqual({ r: 51, g: 102, b: 153 });
+  });
+
+  // The trip through the other space perturbs the last float digit, so the hsl and
+  // lab strings are compared numerically instead of byte for byte.
+  test.each(["color(from #336699 display-p3 r g b)", "color(from #336699 xyz-d50 x y z)"])(
+    "%s formats as the hsl and lab of #336699",
+    input => {
+      for (const format of ["hsl", "lab"] as const) {
+        const actual = color(input, format) as string;
+        expect(actual).toStartWith(`${format}(`);
+        const components = actual.match(/-?[\d.]+/g)!.map(Number);
+        const expected = (color("#336699", format) as string).match(/-?[\d.]+/g)!.map(Number);
+        expect(components).toHaveLength(expected.length);
+        for (let i = 0; i < expected.length; i++) {
+          expect(components[i]).toBeCloseTo(expected[i], 2);
+        }
+      }
+    },
+  );
+
+  test("alpha and `none` are handled like the rgb() forms", () => {
+    expect(color("color(srgb 1 0 0 / 0.5)", "[rgba]")).toEqual([255, 0, 0, 128]);
+    expect(color("color(srgb 1 0 0 / 0.5)", "{rgba}")).toEqual(color("rgba(255, 0, 0, 0.5)", "{rgba}"));
+    expect(color("color(display-p3 0.2 0.2 0.2 / 0.5)", "[rgba]")).toEqual([51, 51, 51, 128]);
+    expect(color("color(srgb none 0 1)", "hex")).toBe(color("rgb(none 0 255)", "hex"));
+    expect(color("color(srgb none 0 1)", "hex")).toBe("#0000ff");
+  });
+
+  // These primaries lie outside the sRGB gamut. Like lab()/oklch() inputs they are
+  // gamut mapped, and the results are the `#rrggbb` fallbacks `bun build` emits
+  // for the same declarations, because both go through the same conversion.
+  test.each([
+    ["color(display-p3 1 0 0)", "#ff0f0e"],
+    ["color(display-p3 0 1 0)", "#00f942"],
+    ["color(rec2020 1 0 0)", "#ff5758"],
+    ["color(prophoto-rgb 1 0 0)", "#ff5d6a"],
+  ])("%s is gamut mapped to %s", (input, expected) => {
+    expect(color(input, "hex")).toBe(expected);
+  });
+
+  test("out-of-range channels are mapped into 0..255 rather than echoed", () => {
+    expect(color("color(srgb 2 -1 0.5)", "hex")).toMatch(/^#[0-9a-f]{6}$/);
+    expect(color("color(display-p3 1 1 1)", "hex")).toBe("#ffffff");
+    expect(color("color(rec2020 1 1 1)", "hex")).toBe("#ffffff");
+    expect(color("color(prophoto-rgb 1 1 1)", "hex")).toBe("#ffffff");
+  });
+
+  // "css" keeps the authored color space; only the converting formats changed.
+  test("the css format still serializes the color() value as written", () => {
+    expect(color("color(srgb 1 0 0)", "css")).toBe("color(srgb 1 0 0)");
+    expect(color("color(display-p3 1 0 0)", "css")).toBe("color(display-p3 1 0 0)");
+  });
+
+  // These have no channel values to convert, so every format still falls back to
+  // serializing them as CSS, exactly as before.
+  test.each(["currentColor", "Canvas", "light-dark(red, blue)"])("%s still falls back to its css form", input => {
+    const css = color(input, "css");
+    expect(css).toBeString();
+    for (const format of ["hex", "{rgba}", "hsl", "lab"] as const) {
+      expect(color(input, format)).toBe(css);
+    }
   });
 });
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -608,9 +608,9 @@ describe("input forms", () => {
   });
 });
 
-// The color() function (CSS Color 4 predefined color spaces) used to be the one
-// parseable input that every output format other than "css" echoed back as a
-// string, so "{rgba}" returned "color(srgb 1 0 0)" instead of an object.
+// The color() function (CSS Color 4 predefined color spaces) has channel values
+// like any rgb()/lab() color, but every output format other than "css" used to
+// echo it back as a string, so "{rgba}" returned "color(srgb 1 0 0)" instead of an object.
 describe("color() inputs convert to every output format", () => {
   const conversionFormats = [
     "hex",
@@ -650,7 +650,7 @@ describe("color() inputs convert to every output format", () => {
 
   // Relative color syntax converts #336699 into the named space and hands the
   // result back as a color() value, so converting it again must be the identity.
-  // (a98-rgb and srgb-linear are missing because their relative forms do not parse yet.)
+  // The a98-rgb and srgb-linear relative forms are parser bugs, fixed in #38487.
   test.each([
     "color(from #336699 srgb r g b)",
     "color(from #336699 display-p3 r g b)",
@@ -716,16 +716,6 @@ describe("color() inputs convert to every output format", () => {
   test("the css format still serializes the color() value as written", () => {
     expect(color("color(srgb 1 0 0)", "css")).toBe("color(srgb 1 0 0)");
     expect(color("color(display-p3 1 0 0)", "css")).toBe("color(display-p3 1 0 0)");
-  });
-
-  // These have no channel values to convert, so every format still falls back to
-  // serializing them as CSS, exactly as before.
-  test.each(["currentColor", "Canvas", "light-dark(red, blue)"])("%s still falls back to its css form", input => {
-    const css = color(input, "css");
-    expect(css).toBeString();
-    for (const format of ["hex", "{rgba}", "hsl", "lab"] as const) {
-      expect(color(input, format)).toBe(css);
-    }
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.color()` returns the input serialized as CSS for every `color()` input, whatever output format is asked for: `Bun.color("color(srgb 1 0 0)", "hex")` is `"color(srgb 1 0 0)"`, and `"{rgba}"`, `"[rgba]"`, `"number"`, `"ansi-16m"`, `"hsl"` and `"lab"` all return that same string. `"{rgba}"` and `"number"` are typed and documented as returning an object and a number.
- Same for anything else the parser resolves into a predefined space: `color-mix(in srgb-linear, ...)`, `color-mix(in xyz, ...)` and `color(from red display-p3 r g b)`.
- `lab()`, `oklch()`, `hwb()` and friends convert fine. Cause: the formatters in `src/css_jsc/color_js.rs` (the sRGB family at line 391, `"hsl"` at 557, `"lab"` at 578) match `CssColor::Rgba | Float | Lab` by hand and send everything else to the CSS printer with `_ => break 'formatted`, which also catches `CssColor::Predefined`, the variant `color()` parses into.
- Not a regression: the match has never had an arm for this variant.

### Fix
- The three formatters now resolve the parsed color with `Colorspace::try_from_css_color` (`SRGB::`, `HSL::`, `LAB::`), and only fall through to the CSS printer when it returns `None`.
- Correct because `try_from_css_color` is the exhaustive conversion `bun_css` already owns: for `Rgba`, `Float` and `Lab` it calls the same `from_rgba` / `from_float_color` / `from_lab_color` functions the removed arms called (they were one-line wrappers around it, so output for those inputs is unchanged, which the existing 1000 or so cases in the file cover), it converts `Predefined` through the same conversion graph, and it returns `None` only for `currentColor`, system colors and `light-dark()`, which have no channel values.
- It is also the function `CssColor::to_rgb()` uses to compute the sRGB fallbacks `bun build` emits, so `Bun.color("color(display-p3 1 0 0)", "hex")` now returns `#ff0f0e`, the same fallback the bundler writes for that declaration, and out of gamut values get the same gamut mapping `lab()` inputs already get (it happens in `SRGB::into_rgba()`, which the sRGB formats were already calling).
- `RGBA::into_hsl/into_lab` and the `LABColor` / `FloatColor` `into_*` helpers in `src/css/values/color.rs` had no callers other than the removed arms, so they are removed.
- Intentionally excluded: the `None` case. Those three keywords still fall through to the CSS string exactly as before (`Bun.color("currentColor", "hex")` is still `"currentColor"`). The docs and `bun.d.ts` say the converting formats return the converted value or `null`, so returning `null` there is the consistent end state, but it changes an existing result and is already proposed in #33047 (its `color_js.rs` hunk is this PR's hunk with `break 'formatted` replaced by `return Ok(JSValue::NULL)` at the three sites), so this PR neither changes nor tests that behavior. Happy to fold it in here if that is preferred; it is those three lines plus a sentence in `docs/runtime/color.mdx`.
- Tests: `test/js/bun/css/color.test.ts`, new `color() inputs convert to every output format` block plus four entries in `input forms`. 37 of the new cases fail on the unfixed build (the four `input forms` entries, every converting format for `color(srgb 1 0 0)`, the object/array/number shapes, fractional channels, identity round trips through 7 spaces and two `color-mix()` spaces, alpha and `none`, and the gamut mapped primaries); the one case that passes on both builds pins that `"css"` output is unchanged. Whole file: 1031 pass with `bun bd test`, 995 pass / 37 fail with the released 1.4.0.
- Also ran `test/bundler/css/wpt/color-computed.test.ts` and `relative_color_out_of_gamut.test.ts` (bundler users of the same conversion code), and `cargo clippy -p bun_css -p bun_css_jsc`.
- Related PRs: #38487 fixes the three parser bugs found while writing these tests (`color(a98-rgb ...)` not parsing, `color(from ... srgb-linear r g b)` not parsing, `color-mix(in xyz-d50)` interpolating in xyz-d65), which is why the round trip table here covers 7 of the 9 space idents (the `srgb-linear` literal and `color-mix(in srgb-linear)` forms are covered, and A98 goes through the same conversion graph as the rest); it touches different lines of `color.rs` and a different region of `color.test.ts`, so the two merge in either order, and whichever lands second adds the `a98-rgb` and `srgb-linear` rows to that table. #33047 is the older, larger `Bun.color` PR mentioned above (conflicting, idle since early July); after this lands, only its `null` and parser/bundler pieces remain.

### Background
- `color()` is the CSS Color 4 function for the predefined color spaces (`srgb`, `srgb-linear`, `display-p3`, `a98-rgb`, `prophoto-rgb`, `rec2020`, `xyz`, `xyz-d50`, `xyz-d65`), with channels as 0..1 fractions. bun's CSS parser (`bun_css`, a lightningcss port) parses it into `CssColor::Predefined`, a separate variant from `Rgba` (8-bit colors), `Float` (rgb/hsl/hwb with `none` components) and `Lab`.
- `Colorspace` is the trait every concrete space type (`SRGB`, `HSL`, `LAB`, `P3`, ...) implements. `T::try_from_css_color(&color)` converts any `CssColor` to `T` through the conversion graph in `color_generated.rs`, and returns `None` for the variants that are keywords rather than colors.
- Gamut mapping: a color outside sRGB (display-p3 red, for example) has no exact 8-bit representation. `SRGB::into_rgba()` runs the CSS Color 4 mapping (reduce chroma in Oklch until the color fits), which is how both the bundler's fallbacks and `Bun.color`'s `lab()` handling already behave.

<details>
<summary>Before / after</summary>

```console
$ bun -e 'for (const f of ["hex","{rgba}","[rgba]","number","ansi-16m","hsl","lab"]) console.log(f, JSON.stringify(Bun.color("color(srgb 1 0 0)", f)))'
# bun 1.4.0
hex "color(srgb 1 0 0)"
{rgba} "color(srgb 1 0 0)"
[rgba] "color(srgb 1 0 0)"
number "color(srgb 1 0 0)"
ansi-16m "color(srgb 1 0 0)"
hsl "color(srgb 1 0 0)"
lab "color(srgb 1 0 0)"

# this branch
hex "#ff0000"
{rgba} {"r":255,"g":0,"b":0,"a":1}
[rgba] [255,0,0,255]
number 16711680
ansi-16m "\^[[38;2;255;0;0m"
hsl "hsl(0, 100%, 50%)"
lab "lab(54.290546% 80.80492 69.89099)"
```

Out of gamut inputs now agree with the fallbacks `bun build` emits for the same declarations:

```
color(display-p3 1 0 0)    Bun.color -> #ff0f0e    bun build fallback -> #ff0f0e
color(display-p3 0 1 0)    Bun.color -> #00f942    bun build fallback -> #00f942
color(rec2020 1 0 0)       Bun.color -> #ff5758    bun build fallback -> #ff5758
color(prophoto-rgb 1 0 0)  Bun.color -> #ff5d6a    bun build fallback -> #ff5d6a
```

`USE_SYSTEM_BUN=1 bun test test/js/bun/css/color.test.ts` (bun 1.4.0): 995 pass, 37 fail (the new cases). `bun bd test test/js/bun/css/color.test.ts`: 1031 pass, 0 fail.
</details>


