### PR TITLE
css: use the right-hand operand when folding math functions over mixed length units

### DIFF
--- a/src/css/values/length.rs
+++ b/src/css/values/length.rs
@@ -690,9 +690,7 @@ impl protocol::TryOp for LengthValue {
             let v = f(ctx, self.value(), rhs.value());
             return Some(self.map_value(|_| v));
         }
-        // Intentionally calls `self.to_px()` for BOTH operands (sic) — kept
-        // for behavioral compatibility.
-        if let (Some(a), Some(b)) = (self.to_px(), self.to_px()) {
+        if let (Some(a), Some(b)) = (self.to_px(), rhs.to_px()) {
             return Some(LengthValue::Px(f(ctx, a, b)));
         }
         None
@@ -704,9 +702,7 @@ impl protocol::TryOpTo for LengthValue {
         if core::mem::discriminant(self) == core::mem::discriminant(rhs) {
             return Some(f(ctx, self.value(), rhs.value()));
         }
-        // Intentionally calls `self.to_px()` for BOTH operands (sic) — kept
-        // for behavioral compatibility.
-        if let (Some(a), Some(b)) = (self.to_px(), self.to_px()) {
+        if let (Some(a), Some(b)) = (self.to_px(), rhs.to_px()) {
             return Some(f(ctx, a, b));
         }
         None

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -191,6 +191,40 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("math functions with mixed length units", () => {
+    // Operands with different absolute units are both converted to px before the
+    // function is evaluated. Expected values match lightningcss. 1in = 96px, 1pc = 16px.
+    minify_test(`a { width: round(1in, 10px) }`, `a{width:100px}`);
+    minify_test(`a { width: round(10px, 1in) }`, `a{width:0}`);
+    minify_test(`a { width: round(1pc, 1in) }`, `a{width:0}`);
+    minify_test(`a { width: round(up, 1in, 50px) }`, `a{width:100px}`);
+    minify_test(`a { width: round(down, 1in, 50px) }`, `a{width:50px}`);
+    minify_test(`a { width: round(to-zero, 100px, 1in) }`, `a{width:96px}`);
+    minify_test(`a { width: rem(1in, 10px) }`, `a{width:6px}`);
+    minify_test(`a { width: rem(10px, 1in) }`, `a{width:10px}`);
+    minify_test(`a { width: mod(1in, 10px) }`, `a{width:6px}`);
+    minify_test(`a { width: mod(10px, 1in) }`, `a{width:10px}`);
+    minify_test(`a { width: mod(1in, 25px) }`, `a{width:21px}`);
+    minify_test(`a { width: hypot(1in, 10px) }`, `a{width:96.5194px}`);
+    minify_test(`a { width: hypot(1in, 1pc) }`, `a{width:97.3242px}`);
+    // <length> (not <length-percentage>) properties go through the same conversion.
+    minify_test(`a { border-spacing: round(1in, 10px) }`, `a{border-spacing:100px}`);
+    minify_test(`a { border-spacing: rem(1in, 10px) mod(1in, 10px) }`, `a{border-spacing:6px}`);
+    minify_test(`a { border-spacing: hypot(1in, 10px) }`, `a{border-spacing:96.5194px}`);
+    // atan2() of two lengths converts both to px too. (The angle is printed in
+    // whichever of deg/rad is shorter; 1.467rad is 84.0531deg.)
+    minify_test(`a { transform: rotate(atan2(1in, 0px)) }`, `a{transform:rotate(90deg)}`);
+    minify_test(`a { transform: rotate(atan2(0px, -1in)) }`, `a{transform:rotate(180deg)}`);
+    minify_test(`a { transform: rotate(atan2(1in, 10px)) }`, `a{transform:rotate(1.467rad)}`);
+    // A second operand in a unit that cannot be converted to px (em) leaves the
+    // function unevaluated, the same as when the first operand cannot be converted.
+    minify_test(`a { width: round(1in, 1em) }`, `a{width:round(1in,1em)}`);
+    minify_test(`a { width: round(1em, 1in) }`, `a{width:round(1em,1in)}`);
+    minify_test(`a { width: rem(1in, 1em) }`, `a{width:rem(1in,1em)}`);
+    minify_test(`a { width: mod(1in, 1em) }`, `a{width:mod(1in,1em)}`);
+    minify_test(`a { width: hypot(1in, 1em) }`, `a{width:hypot(1in,1em)}`);
+    minify_test(`a { transform: rotate(atan2(1in, 1em)) }`, `a{transform:rotate(atan2(1in,1em))}`);
+  });
   describe("border_spacing", () => {
     minify_test(
       `


### PR DESCRIPTION
### Problem
- The CSS minifier folds two-operand math functions whose length operands have different units using the first operand twice: `round(1in, 10px)` becomes `96px` (should be `100px`), `rem(1in, 10px)` and `mod(1in, 10px)` become `0` (should be `6px`), `hypot(1in, 10px)` becomes `135.764px` (should be `96.5194px`), `atan2(1in, 10px)` becomes `45deg` (should be 84.0531deg).
- When only the second operand has a unit that cannot be converted to px, the function is still folded: `round(1in, 1em)` becomes `96px` instead of staying `round(1in,1em)`.
- Cause: `impl protocol::TryOp for LengthValue` and `impl protocol::TryOpTo for LengthValue` in `src/css/values/length.rs` (the different-units branch, previously lines 695 and 709) read `(self.to_px(), self.to_px())` instead of `(self.to_px(), rhs.to_px())`. Both impls carried a comment calling this intentional; it is a copy/paste slip inherited from the original port (`tryOp`/`tryOpTo` in the old `length.zig` had the same two `this.toPx()` lines, while its `tryAdd` and `partialCmp` used the other operand).
- Same-unit operands and `calc()` addition of mixed units were unaffected, which is why this went unnoticed.
- Reproduces with bun 1.4.0 and main; affects `bun build` on CSS, `Bun.build`, and anything else that goes through the CSS minifier.

### Fix
- Use `rhs.to_px()` for the second operand in both impls and drop the two comments.
- Correct because the same-unit branch two lines above already passes `rhs.value()` as the second argument, the inherent `LengthValue::try_add` and `LengthValue::partial_cmp` already convert `rhs` in their different-units branch, and lightningcss (which this code is ported from) does the same. With the change, every folded value in the new tests matches lightningcss 1.30.2's output for the same input.
- Returning `None` when `rhs` is not convertible (for example `1em`) is what leaves the function unevaluated, which is the existing behavior when the first operand is not convertible.
- Test: `test/js/bun/css/css.test.ts`, new `math functions with mixed length units` block. It covers `round()` (including rounding strategies and the operand order both ways), `rem()`, `mod()`, two-argument `hypot()` and `atan2()`, a `<length>` property (`border-spacing`) as well as a `<length-percentage>` one (`width`), and the non-convertible second operand for each function. 24 of the 25 cases fail on the unfixed binary (`USE_SYSTEM_BUN=1`); all 25 pass with the fix. The rest of `css.test.ts` (1167 tests) still passes.
- Not changed here: `hypot()` with three or more arguments in mixed units is still wrong (it squares values in their original unit and then converts the sum to px linearly; lightningcss has the same bug), and `clamp()` with a center above the max is covered by #32290. Both have different causes and are tracked separately.

### Background
- The CSS parser evaluates math functions at parse time when all operands are concrete values. `Calc::apply_op` (used by `round()`/`rem()`/`mod()`/`hypot()`) calls the value type's `try_op`, and `atan2()` calls `try_op_to`; both `Length` and `LengthPercentage` forward to the `LengthValue` impls changed here. A `None` result leaves the function in the output as written.
- `LengthValue::to_px()` returns `Some` only for absolute units (`px`, `in`, `cm`, `mm`, `Q`, `pt`, `pc`); relative units such as `em` return `None`, so functions mixing those cannot be folded and must be preserved.
- Angles computed by `atan2()` are printed in whichever of `deg`/`rad` is shorter, which is why one test expects `1.467rad` (84.0531deg); the two other `atan2()` cases use operands whose result is a whole number of degrees.

<details>
<summary>Before/after for the cases in the test, next to lightningcss 1.30.2</summary>

```
input                                bun 1.4.0          this PR              lightningcss 1.30.2
width: round(1in, 10px)              96px               100px                100px
width: round(10px, 1in)              10px               0                    0
width: round(up, 1in, 50px)          96px               100px                100px
width: round(down, 1in, 50px)        96px               50px                 50px
width: rem(1in, 10px)                0                  6px                  6px
width: rem(10px, 1in)                0                  10px                 10px
width: mod(1in, 10px)                0                  6px                  6px
width: mod(1in, 25px)                0                  21px                 21px
width: hypot(1in, 10px)              135.764px          96.5194px            96.5194px
width: hypot(1in, 1pc)               135.764px          97.3242px            97.3242px
transform: rotate(atan2(1in, 0px))   rotate(45deg)      rotate(90deg)        rotate(90deg)
transform: rotate(atan2(0px, -1in))  rotate(0)          rotate(180deg)       rotate(180deg)
transform: rotate(atan2(1in, 10px))  rotate(45deg)      rotate(1.467rad)     rotate(84.0531deg)
width: round(1in, 1em)               96px               round(1in,1em)       round(1in,1em)
width: hypot(1in, 1em)               135.764px          hypot(1in,1em)       hypot(1in,1em)
```
</details>
