### PR TITLE
test(css): stop css-fuzz.test.ts from writing invalid.css into the cwd

### DIFF
--- a/test/js/bun/css/css-fuzz.test.ts
+++ b/test/js/bun/css/css-fuzz.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { isCI, isDebug } from "harness";
+import { isCI, isDebug, tempDir } from "harness";
+import { join } from "node:path";
 
 interface InvalidFuzzOptions {
   maxLength: number;
@@ -121,6 +122,8 @@ if (!isCI) {
   )(
     "CSS Parser Invalid Input Fuzzing - %s (%d iterations)",
     async (strategy, iterations) => {
+      using dir = tempDir("css-fuzz", {});
+      const entrypoint = join(String(dir), "invalid.css");
       const options: InvalidFuzzOptions = {
         maxLength: 10000,
         strategy: strategy as any,
@@ -177,11 +180,11 @@ if (!isCI) {
         log("--- CSS Fuzz ---");
         invalidCSS = invalidCSS + "";
         log(JSON.stringify(invalidCSS, null, 2));
-        await Bun.write("invalid.css", invalidCSS);
+        await Bun.write(entrypoint, invalidCSS);
 
         try {
           const result = await Bun.build({
-            entrypoints: ["invalid.css"],
+            entrypoints: [entrypoint],
           });
 
           // We expect the parser to either throw an error or return a valid result
@@ -228,6 +231,8 @@ if (!isCI) {
 
   // Additional test for mixed valid/invalid input
   test("CSS Parser Mixed Input Fuzzing", async () => {
+    using dir = tempDir("css-fuzz-mixed", {});
+    const entrypoint = join(String(dir), "invalid.css");
     const validCSS = ".test{color:red}";
 
     for (let i = 0; i < 100; i++) {
@@ -239,11 +244,11 @@ if (!isCI) {
 
       console.log("--- Mixed CSS ---");
       console.log(JSON.stringify(mixedCSS, null, 2));
-      await Bun.write("invalid.css", mixedCSS);
+      await Bun.write(entrypoint, mixedCSS);
 
       try {
         await Bun.build({
-          entrypoints: ["invalid.css"],
+          entrypoints: [entrypoint],
         });
       } catch (error) {
         // Expected to throw, but shouldn't crash

--- a/test/js/bun/css/css-fuzz.test.ts
+++ b/test/js/bun/css/css-fuzz.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "bun:test";
-import { isCI, isDebug, tempDir } from "harness";
-import { join } from "node:path";
+import { isCI, isDebug } from "harness";
 
 interface InvalidFuzzOptions {
   maxLength: number;
@@ -10,6 +9,10 @@ interface InvalidFuzzOptions {
 
 const shutup = process.env.CSS_FUZZ_SHUTUP === "1";
 const log = shutup ? () => {} : console.log;
+
+// Virtual path of the fuzzed stylesheet, handed to Bun.build through `files` instead of being
+// written to disk. It has to be absolute: the bundler asserts that entry points are absolute paths.
+const entrypoint = "/css-fuzz/invalid.css";
 
 // Collection of invalid CSS generation strategies
 const invalidGenerators = {
@@ -122,8 +125,6 @@ if (!isCI) {
   )(
     "CSS Parser Invalid Input Fuzzing - %s (%d iterations)",
     async (strategy, iterations) => {
-      using dir = tempDir("css-fuzz", {});
-      const entrypoint = join(String(dir), "invalid.css");
       const options: InvalidFuzzOptions = {
         maxLength: 10000,
         strategy: strategy as any,
@@ -180,11 +181,11 @@ if (!isCI) {
         log("--- CSS Fuzz ---");
         invalidCSS = invalidCSS + "";
         log(JSON.stringify(invalidCSS, null, 2));
-        await Bun.write(entrypoint, invalidCSS);
 
         try {
           const result = await Bun.build({
             entrypoints: [entrypoint],
+            files: { [entrypoint]: invalidCSS },
           });
 
           // We expect the parser to either throw an error or return a valid result
@@ -231,8 +232,6 @@ if (!isCI) {
 
   // Additional test for mixed valid/invalid input
   test("CSS Parser Mixed Input Fuzzing", async () => {
-    using dir = tempDir("css-fuzz-mixed", {});
-    const entrypoint = join(String(dir), "invalid.css");
     const validCSS = ".test{color:red}";
 
     for (let i = 0; i < 100; i++) {
@@ -244,11 +243,11 @@ if (!isCI) {
 
       console.log("--- Mixed CSS ---");
       console.log(JSON.stringify(mixedCSS, null, 2));
-      await Bun.write(entrypoint, mixedCSS);
 
       try {
         await Bun.build({
           entrypoints: [entrypoint],
+          files: { [entrypoint]: mixedCSS },
         });
       } catch (error) {
         // Expected to throw, but shouldn't crash


### PR DESCRIPTION
### Problem
- Running `test/js/bun/css/css-fuzz.test.ts` (for example via `bun bd test test/js/bun/css/` from the repo root) leaves an untracked `invalid.css` in the checkout; `git status` shows `?? invalid.css` afterwards.
- Cause: every iteration does `Bun.write("invalid.css", ...)` followed by `Bun.build({ entrypoints: ["invalid.css"] })` (css-fuzz.test.ts:180 and :242 on main). Both resolve against `process.cwd()`, which for `bun test` is wherever the command was started, and nothing removes the file.
- The stray file has been swept into commits by `git add -A` on branches before (a1e904a36a and 5c2d1e0d53 both add a root-level `invalid.css`); it never reached main.

### Fix
- The stylesheet is handed to `Bun.build` through its `files` option under a fixed virtual path (`/css-fuzz/invalid.css`), which is also the entrypoint. The two `Bun.write` calls are gone, so the test writes nothing anywhere: not in the cwd, and not in a temp dir either. The diff is one file, +8/-4.
- Same thing is exercised: a `files` entry that matches an entrypoint skips disk resolution (`src/bundler/bundle_v2.rs:3065-3075`) and is then parsed like any other input, with the loader picked from the extension (`bundle_v2.rs:2714-2716`) and the bytes coming from the map instead of a read (`src/bundler/ParseTask.rs:1393-1403`). No `outdir` is set, so the build output stays in memory as before. `test/js/bun/css/doesnt_crash.test.ts:39-44` already drives the CSS parser this way.
- The key is absolute on purpose: `enqueue_entry_item` asserts that entry points are absolute (`bundle_v2.rs:2702`), so a bare `"invalid.css"` key panics debug and ASAN builds. A POSIX-rooted key is what `test/bundler/bundler_files.test.ts` uses too, and that file runs on the Windows lanes, so this works for local runs on every platform. (Relative `files` keys never getting resolved is a separate bug in the option itself, tracked separately.)
- Why in memory rather than a per-test `tempDir`: this file's tests time out on debug builds (see below), and a timed-out test never reaches its `using` disposal, so the tempDir shape still left one directory per test in the OS temp dir in exactly the mode `bun bd test` runs in. The `files` shape has nothing to clean up.
- Test-only change, so there is no new assertion that fails on an unfixed build; the proof is the checkout state before and after running the file:
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/css/css-fuzz.test.ts` on main: 5 pass, `git status --short` afterwards shows `?? invalid.css`.
  - Same command with this change: 5 pass (expected-error counts in the same range as before: 462/811/139/21 vs 486/807/114/22 on main), `git status --short` shows nothing extra, and the file runs in about 4s instead of 8 to 10s because it no longer does ~2,700 writes.
  - `bun bd test test/js/bun/css/css-fuzz.test.ts`: the checkout is clean afterwards and no `css-fuzz*` entries are created under the OS temp dir. The four tests that run on a debug build still time out before and after this change (roughly 40ms per `Bun.build` against the file's 10s and 5s budgets); that is pre-existing and #38500 addresses it. The two PRs touch neighbouring lines of the mixed-input test, so whichever lands second needs a trivial rebase.

### Background
- `Bun.build({ files })` is an in-memory file map: keys are file paths, values are their contents. An entrypoint or import whose path matches a key is bundled from the map instead of from disk (`packages/bun-types/bun.d.ts`, `files` on `BuildConfig`).
- `bun test` runs test files with the cwd left as the directory the command was started from, not the test file's directory, so a cwd-relative path written by a test lands in the checkout when tests are run from the repo root.

<details>
<summary>Earlier shape of this PR (superseded)</summary>

The first revision kept the disk write but moved it into a per-test `using dir = tempDir(...)` and passed the absolute path to `Bun.build`. That fixed the checkout, but on debug builds, where every test in this file currently times out, the disposal never ran and each run left one `css-fuzz*` directory per test in the OS temp dir. Self-review pointed out that `files` removes the write entirely, which is what the PR now does.

</details>
