### PR TITLE
test: fix crash when spyOn targets a non-function indexed property

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1592,9 +1592,6 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             if (JSModuleNamespaceObject* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(object)) {
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
-            } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1249,6 +1249,30 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // Making one index an accessor moves the whole array out of contiguous storage.
+    // The other elements and the length must survive that move.
+    test("spyOn on one array element keeps the other elements and the length", () => {
+      const arr = [1, 2, 3];
+
+      const fn = spyOn(arr, 1);
+      expect(arr[1]).toBe(2);
+      arr[1] = 20;
+      expect(arr[1]).toBe(2);
+      expect(fn.mock.calls).toEqual([[], [20], []]);
+      expect(arr.length).toBe(3);
+      expect([arr[0], arr[2]]).toEqual([1, 3]);
+
+      fn.mockRestore();
+      expect(arr).toEqual([1, 2, 3]);
+      expect(Object.getOwnPropertyDescriptor(arr, 1)).toEqual({
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     test("spyOn works with missing indexed properties", () => {
       const arr = [];
 
@@ -1281,6 +1305,13 @@ describe("spyOn", () => {
       expect(fn.mock.calls).toEqual([[], ["x"], []]);
 
       fn.mockRestore();
+      // Same as a missing named key: restore writes the original `undefined` back as a data property.
+      expect(Object.getOwnPropertyDescriptor(obj, 169)).toEqual({
+        value: undefined,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
       expect(obj[169]).toBeUndefined();
       expect(fn).not.toHaveBeenCalled();
     });

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1344,6 +1344,12 @@ describe("spyOn", () => {
       expect(arr[3]).toBeUndefined();
 
       fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(arr, 3)).toEqual({
+        value: undefined,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
       expect(arr[3]).toBeUndefined();
       expect(fn).not.toHaveBeenCalled();
     });

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1219,6 +1219,37 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // An index this large never gets vector storage. It lives in the sparse map from the
+    // start, which is where the malformed accessor entry used to crash reads and writes.
+    test("spyOn works with a large sparse index that is not a function", () => {
+      const obj = {};
+      const original = [1.5];
+      obj[3221225473] = original;
+
+      const fn = spyOn(obj, 3221225473);
+      expect(Object.getOwnPropertyDescriptor(obj, 3221225473)).toEqual({
+        get: fn,
+        set: fn,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(obj[3221225473]).toBe(original);
+      obj[3221225473] = 5;
+      expect(obj[3221225473]).toBe(original);
+      expect(fn.mock.calls).toEqual([[], [5], []]);
+
+      fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(obj, 3221225473)).toEqual({
+        value: original,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      obj[3221225473] = 6;
+      expect(obj[3221225473]).toBe(6);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     // An array filled after creation is not copy-on-write, so it takes a different
     // storage path than an array literal when the index becomes an accessor.
     test("spyOn installs a getter/setter on an indexed property that is not a function", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1219,6 +1219,35 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // An int32 at an index of an object literal is in Int32 storage. The plain object
+    // above has Contiguous storage, because its value is an object.
+    test("spyOn works with an index key of an object literal", () => {
+      const obj = { 0: 42 };
+
+      const fn = spyOn(obj, 0);
+      expect(Object.getOwnPropertyDescriptor(obj, 0)).toEqual({
+        get: fn,
+        set: fn,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(obj[0]).toBe(42);
+      obj[0] = 7;
+      expect(obj[0]).toBe(42);
+      expect(fn.mock.calls).toEqual([[], [7], []]);
+
+      fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(obj, 0)).toEqual({
+        value: 42,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      obj[0] = 8;
+      expect(obj[0]).toBe(8);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     // An index this large never gets vector storage. It lives in the sparse map from the
     // start, which is where the malformed accessor entry used to crash reads and writes.
     test("spyOn works with a large sparse index that is not a function", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1211,6 +1211,9 @@ describe("spyOn", () => {
       expect(obj[213]).toBe(obj);
       expect(fn).toHaveBeenCalledTimes(2);
 
+      // Same as named keys: the index is an accessor now, so it cannot be spied again.
+      expect(() => spyOn(obj, 213)).toThrow("does not support accessor properties");
+
       fn.mockRestore();
       expect(obj[213]).toBe(obj);
       expect(fn).not.toHaveBeenCalled();

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1174,6 +1174,63 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // Like named properties, a non-function indexed property gets a getter/setter spy.
+    // This used to store the mock itself flagged as an accessor, and the next write to
+    // the index crashed the process.
+    test("spyOn works with indexed properties that are not functions", () => {
+      const arr = [42];
+
+      const fn = spyOn(arr, 0);
+      expect(fn).not.toHaveBeenCalled();
+      expect(arr[0]).toBe(42);
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      arr[0] = 7;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls[1]).toEqual([7]);
+      expect(arr[0]).toBe(42);
+
+      fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(arr, 0)).toEqual({
+        value: 42,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(arr[0]).toBe(42);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("spyOn works with indexed properties on plain objects", () => {
+      const obj = {};
+      obj[213] = obj;
+
+      const fn = spyOn(obj, 213);
+      obj[213] = 1;
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(obj[213]).toBe(obj);
+      expect(fn).toHaveBeenCalledTimes(2);
+
+      fn.mockRestore();
+      expect(obj[213]).toBe(obj);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("spyOn works with missing indexed properties", () => {
+      const arr = [];
+
+      const fn = spyOn(arr, 3);
+      expect(arr[3]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(1);
+      arr[3] = "x";
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(arr[3]).toBeUndefined();
+
+      fn.mockRestore();
+      expect(arr[3]).toBeUndefined();
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1216,6 +1216,36 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // An array filled after creation is not copy-on-write, so it takes a different
+    // storage path than an array literal when the index becomes an accessor.
+    test("spyOn installs a getter/setter on an indexed property that is not a function", () => {
+      const arr = [];
+      arr[0] = 42;
+
+      const fn = spyOn(arr, 0);
+      expect(Object.getOwnPropertyDescriptor(arr, 0)).toEqual({
+        get: fn,
+        set: fn,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(arr[0]).toBe(42);
+      arr[0] = 7;
+      expect(arr[0]).toBe(42);
+      expect(fn.mock.calls).toEqual([[], [7], []]);
+
+      fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(arr, 0)).toEqual({
+        value: 42,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      arr[0] = 8;
+      expect(arr[0]).toBe(8);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     test("spyOn works with missing indexed properties", () => {
       const arr = [];
 

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1264,6 +1264,27 @@ describe("spyOn", () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    // A plain object has no indexed storage at all, so the spy creates it.
+    test("spyOn works with a missing indexed property on a plain object", () => {
+      const obj = {};
+
+      const fn = spyOn(obj, 169);
+      expect(Object.getOwnPropertyDescriptor(obj, 169)).toEqual({
+        get: fn,
+        set: fn,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(obj[169]).toBeUndefined();
+      obj[169] = "x";
+      expect(obj[169]).toBeUndefined();
+      expect(fn.mock.calls).toEqual([[], ["x"], []]);
+
+      fn.mockRestore();
+      expect(obj[169]).toBeUndefined();
+      expect(fn).not.toHaveBeenCalled();
+    });
+
     // The engine serves a function's `prototype` property specially, so it cannot be
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {


### PR DESCRIPTION
### What does this PR do?

`spyOn(obj, index)` breaks the property when `obj[index]` is not a function:

```js
const obj = { 0: 42 };
spyOn(obj, 0);
obj[0]; // the mock function, not 42 (debug builds assert)
obj[0] = 1; // Segmentation fault at address 0x38
```

For a non-function property, `spyOn` sets `PropertyAttribute::Accessor` and installs a `GetterSetter`. #25020 put a branch for index keys in front of that call. The branch stores the bare mock under the `Accessor` attribute. JSC expects a `GetterSetter` in an accessor slot. The next write downcasts the mock to `GetterSetter` and calls through it.

This PR deletes that branch. The fuzzer found the crash.

### Why is a deletion the right fix?

The branch is wrong for every input. It always runs after `attributes |= PropertyAttribute::Accessor`, and it never stores a `GetterSetter`.

Nothing has to replace it. `JSObject::putDirectAccessor`, the call below the branch, already routes index keys:

```cpp
if (std::optional<uint32_t> index = parseIndex(propertyName))
    return putDirectIndex(globalObject, index.value(), accessor, attributes, PutDirectIndexLikePutDirect);
```

So an index key now gets the same getter/setter spy as a named key.

The deletion is a revert of one hunk of #25020. That PR added the same guard in three places. Two of them protect `putDirect`, which asserts on index keys, and they stay. The third protected `putDirectAccessor`, which needs no guard. The tests of #25020 only spy on functions, so they never ran the third hunk. After this PR, the non-function branch is identical to the code before #25020.

### How did you verify your code works?

New tests in `mock-fn.test.js` spy on a non-function index of arrays and plain objects. The shapes are an array literal, an array filled later, an object literal, a large sparse index, and a missing index. The tests check the installed descriptor, reads, writes, and the descriptor after `mockRestore()`.

With `USE_SYSTEM_BUN=1` the new tests fail or segfault. With `bun bd test`, `mock-fn.test.js`, `mock-disposable.test.ts`, `spyMatchers.test.ts` and `mock/mock-module.test.ts` pass.

### Related PRs

- Supersedes #31628, #37021, #38466, #40609, #40724, #40867 and #41283 (all closed). Their test shapes are in this PR.
- #36395 (open) still has the deleted branch and must drop it when it rebases. It also makes `spyOn` throw on a missing property, which changes the two missing-index tests here.
