### PR TITLE
docs: IPC does not carry Blob, Bun.file() or net.BlockList across processes

### DIFF
--- a/docs/guides/process/ipc.mdx
+++ b/docs/guides/process/ipc.mdx
@@ -54,7 +54,7 @@ process.on("message", message => {
 
 ---
 
-By default, messages are serialized with the JSC `serialize` API, which supports everything [`structuredClone` supports](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), including strings, typed arrays, and objects. This does not support transferring ownership of objects.
+By default, messages are serialized with the JSC `serialize` API, which handles the JavaScript values that [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) handles: strings, numbers, plain objects and arrays, `Date`, `RegExp`, `Map`, `Set`, `Error`, typed arrays, and `ArrayBuffer`. Platform objects such as `Blob`, `Bun.file()`, and `net.BlockList` are not sent across the process boundary: the other process receives an empty object (`{}`) in their place, as it does in Node.js. This does not support transferring ownership of objects.
 
 ```ts child.ts icon="/icons/typescript.svg"
 // send a string

--- a/docs/guides/process/ipc.mdx
+++ b/docs/guides/process/ipc.mdx
@@ -54,7 +54,7 @@ process.on("message", message => {
 
 ---
 
-By default, messages are serialized with the JSC `serialize` API, which handles the JavaScript values that [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) handles: strings, numbers, plain objects and arrays, `Date`, `RegExp`, `Map`, `Set`, `Error`, typed arrays, and `ArrayBuffer`. Platform objects such as `Blob`, `Bun.file()`, and `net.BlockList` are not sent across the process boundary: the other process receives an empty object (`{}`) in their place, as it does in Node.js. This does not support transferring ownership of objects.
+By default, messages are serialized with the same serializer as [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm): the values it accepts (strings, numbers, plain objects and arrays, `Date`, `RegExp`, `Map`, `Set`, `Error`, typed arrays, `ArrayBuffer`) arrive with their types intact, and the values it rejects (a `URL`, a `Headers`, a function, ...) make `send()` throw a `DataCloneError`. Unlike `structuredClone`, a `Blob` (including `File` and `Bun.file()`) or a `net.BlockList` inside a message is not cloned: the other process receives an empty object (`{}`) in its place, as it would in Node.js. This does not support transferring ownership of objects.
 
 ```ts child.ts icon="/icons/typescript.svg"
 // send a string

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -301,7 +301,7 @@ process.send({ message: "Hello from child as object" });
 
 The `serialization` option controls the underlying communication format between the two processes:
 
-- `advanced`: (default) Messages are serialized using the JSC `serialize` API, which supports cloning [everything `structuredClone` supports](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). This does not support transferring ownership of objects.
+- `advanced`: (default) Messages are serialized using the JSC `serialize` API, which handles the JavaScript values that [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) handles: strings, numbers, plain objects and arrays, `Date`, `RegExp`, `Map`, `Set`, `Error`, typed arrays, and `ArrayBuffer`. Platform objects such as `Blob`, `Bun.file()`, and `net.BlockList` are not sent across the process boundary: the other process receives an empty object (`{}`) in their place, as it does in Node.js. This does not support transferring ownership of objects.
 - `json`: Messages are serialized using `JSON.stringify` and `JSON.parse`, which does not support as many object types as `advanced` does.
 
 To disconnect the IPC channel from the parent process, call:

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -301,7 +301,7 @@ process.send({ message: "Hello from child as object" });
 
 The `serialization` option controls the underlying communication format between the two processes:
 
-- `advanced`: (default) Messages are serialized using the JSC `serialize` API, which handles the JavaScript values that [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) handles: strings, numbers, plain objects and arrays, `Date`, `RegExp`, `Map`, `Set`, `Error`, typed arrays, and `ArrayBuffer`. Platform objects such as `Blob`, `Bun.file()`, and `net.BlockList` are not sent across the process boundary: the other process receives an empty object (`{}`) in their place, as it does in Node.js. This does not support transferring ownership of objects.
+- `advanced`: (default) Messages are serialized with the same serializer as [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm): the values it accepts (strings, numbers, plain objects and arrays, `Date`, `RegExp`, `Map`, `Set`, `Error`, typed arrays, `ArrayBuffer`) arrive with their types intact, and the values it rejects (a `URL`, a `Headers`, a function, ...) make `send()` throw a `DataCloneError`. Unlike `structuredClone`, a `Blob` (including `File` and `Bun.file()`) or a `net.BlockList` inside a message is not cloned: the other process receives an empty object (`{}`) in its place, as it would in Node.js. This does not support transferring ownership of objects.
 - `json`: Messages are serialized using `JSON.stringify` and `JSON.parse`, which does not support as many object types as `advanced` does.
 
 To disconnect the IPC channel from the parent process, call:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7142,7 +7142,10 @@ declare module "bun" {
       /**
        * When specified, Bun opens an IPC channel to the subprocess. The passed callback is called for
        * incoming messages, and `subprocess.send` can send messages to the subprocess. Messages are serialized
-       * using the JSC serialize API, which allows the same types that `postMessage`/`structuredClone` supports.
+       * using the JSC serialize API, which handles the JavaScript values that `structuredClone` handles (plain
+       * objects and arrays, `Date`, `Map`, `Set`, `Error`, typed arrays, ...). Platform objects such as `Blob`,
+       * `Bun.file()`, and `net.BlockList` are not sent across the process boundary; the other process receives
+       * an empty object (`{}`) in their place, as it does in Node.js.
        *
        * The subprocess can send and receive messages with `process.send` and `process.on("message")`,
        * respectively. This is the same API that Node.js exposes when `child_process.fork()` is used.
@@ -7543,7 +7546,10 @@ declare module "bun" {
      * Send a message to the subprocess. This is only supported if the subprocess
      * was created with the `ipc` option, and is another instance of `bun`.
      *
-     * Messages are serialized using the JSC serialize API, which allows for the same types that `postMessage`/`structuredClone` supports.
+     * Messages are serialized using the JSC serialize API, which handles the JavaScript values that
+     * `structuredClone` handles (plain objects and arrays, `Date`, `Map`, `Set`, `Error`, typed arrays, ...).
+     * Platform objects such as `Blob`, `Bun.file()`, and `net.BlockList` are not sent across the process
+     * boundary; the subprocess receives an empty object (`{}`) in their place, as it does in Node.js.
      */
     send(message: any): void;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7141,16 +7141,18 @@ declare module "bun" {
 
       /**
        * When specified, Bun opens an IPC channel to the subprocess. The passed callback is called for
-       * incoming messages, and `subprocess.send` can send messages to the subprocess. Messages are serialized
-       * using the JSC serialize API, which handles the JavaScript values that `structuredClone` handles (plain
-       * objects and arrays, `Date`, `Map`, `Set`, `Error`, typed arrays, ...). Platform objects such as `Blob`,
-       * `Bun.file()`, and `net.BlockList` are not sent across the process boundary; the other process receives
-       * an empty object (`{}`) in their place, as it does in Node.js.
+       * incoming messages, and `subprocess.send` can send messages to the subprocess. Messages go through the
+       * same serializer as `structuredClone`: the values it accepts (plain objects and arrays, `Date`, `Map`,
+       * `Set`, `Error`, typed arrays, ...) arrive with their types intact, and the values it rejects make
+       * `send()` throw a `DataCloneError`. Unlike `structuredClone`, a `Blob` (including `Bun.file()`) or a
+       * `net.BlockList` inside a message is not cloned; the other process receives an empty object (`{}`) in
+       * its place, as it would in Node.js.
        *
        * The subprocess can send and receive messages with `process.send` and `process.on("message")`,
        * respectively. This is the same API that Node.js exposes when `child_process.fork()` is used.
        *
-       * This is only compatible with processes that are other `bun` instances.
+       * The default `"advanced"` {@link serialization} can only be read by another `bun` process. To talk to
+       * a Node.js process, set `serialization` to `"json"`.
        */
       ipc?(
         message: any,
@@ -7544,12 +7546,13 @@ declare module "bun" {
 
     /**
      * Send a message to the subprocess. This is only supported if the subprocess
-     * was created with the `ipc` option, and is another instance of `bun`.
+     * was created with the `ipc` option.
      *
-     * Messages are serialized using the JSC serialize API, which handles the JavaScript values that
-     * `structuredClone` handles (plain objects and arrays, `Date`, `Map`, `Set`, `Error`, typed arrays, ...).
-     * Platform objects such as `Blob`, `Bun.file()`, and `net.BlockList` are not sent across the process
-     * boundary; the subprocess receives an empty object (`{}`) in their place, as it does in Node.js.
+     * Messages go through the same serializer as `structuredClone`: the values it accepts (plain objects and
+     * arrays, `Date`, `Map`, `Set`, `Error`, typed arrays, ...) arrive with their types intact, and the values
+     * it rejects make this throw a `DataCloneError`. Unlike `structuredClone`, a `Blob` (including
+     * `Bun.file()`) or a `net.BlockList` inside a message is not cloned; the subprocess receives an empty
+     * object (`{}`) in its place, as it would in Node.js.
      */
     send(message: any): void;
 

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -88,6 +88,95 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
 });
 
 describe("ipc mode advanced", () => {
+  it("follows structuredClone, except that Blob and net.BlockList arrive as empty objects", async () => {
+    // This is the contract documented in docs/runtime/child-process.mdx and the
+    // `ipc` / `send()` JSDoc: values structuredClone clones keep their types,
+    // values it rejects make send() throw, and the two non-transferable Bun
+    // classes degrade to {} (the same thing Node.js delivers for them).
+    const childSource = [
+      `const net = require("node:net");`,
+      `const blockList = new net.BlockList();`,
+      `blockList.addAddress("1.2.3.4");`,
+      `const rejected = {};`,
+      `for (const [name, value] of Object.entries({ url: new URL("http://example.com/"), fn: { f() {} } })) {`,
+      `  try { process.send({ value }); rejected[name] = "sent"; } catch (e) { rejected[name] = e.name; }`,
+      `}`,
+      `process.send({`,
+      `  kind: "from-child",`,
+      `  blob: new Blob(["hi"]),`,
+      `  file: Bun.file(process.execPath),`,
+      `  blockList,`,
+      `  nested: { blob: new Blob(["hi"]) },`,
+      `  date: new Date(0),`,
+      `  map: new Map([["k", 1]]),`,
+      `  bytes: new Uint8Array([1, 2, 3]),`,
+      `  rejected,`,
+      `});`,
+      `process.on("message", message => {`,
+      `  if (message === "bye") process.exit(0);`,
+      `  process.send({`,
+      `    kind: "from-parent",`,
+      `    blobConstructor: message.blob.constructor.name,`,
+      `    blobKeys: Object.keys(message.blob),`,
+      `    bytes: message.bytes,`,
+      `  });`,
+      `});`,
+    ].join("\n");
+
+    let onMessage: (message: any) => void = () => {};
+    const nextMessage = () => new Promise<any>(resolve => (onMessage = resolve));
+    const { promise: exitedEarly, reject } = Promise.withResolvers<never>();
+    exitedEarly.catch(() => {});
+
+    const fromChild = nextMessage();
+    await using child = spawn([bunExe(), "-e", childSource], {
+      env: bunEnv,
+      stdio: ["ignore", "inherit", "inherit"],
+      serialization: "advanced",
+      ipc(message) {
+        onMessage(message);
+      },
+      onExit(_subprocess, exitCode, signalCode) {
+        reject(new Error(`child exited (${exitCode}, ${signalCode}) before the test finished`));
+      },
+    });
+
+    const received = await Promise.race([fromChild, exitedEarly]);
+    expect(received).toEqual({
+      kind: "from-child",
+      blob: {},
+      file: {},
+      blockList: {},
+      nested: { blob: {} },
+      date: new Date(0),
+      map: new Map([["k", 1]]),
+      bytes: new Uint8Array([1, 2, 3]),
+      rejected: { url: "DataCloneError", fn: "DataCloneError" },
+    });
+    expect([received.blob, received.file, received.blockList, received.nested.blob].map(v => v.constructor)).toEqual([
+      Object,
+      Object,
+      Object,
+      Object,
+    ]);
+
+    expect(() => child.send({ url: new URL("http://example.com/") })).toThrow(
+      expect.objectContaining({ name: "DataCloneError" }),
+    );
+
+    const fromParent = nextMessage();
+    child.send({ blob: new Blob(["hi"]), bytes: new Uint8Array([4, 5]) });
+    expect(await Promise.race([fromParent, exitedEarly])).toEqual({
+      kind: "from-parent",
+      blobConstructor: "Object",
+      blobKeys: [],
+      bytes: new Uint8Array([4, 5]),
+    });
+
+    child.send("bye");
+    expect(await child.exited).toBe(0);
+  });
+
   it("unwraps the Buffer envelope before cmd dispatch", async () => {
     // A cmd-bearing message whose payload holds a Buffer travels as the
     // [message, buffers] envelope. The receiver's cmd fast-path reads


### PR DESCRIPTION
### Problem
- `docs/guides/process/ipc.mdx:57`, `docs/runtime/child-process.mdx:304` and the `ipc` / `Subprocess.send` JSDoc in `packages/bun-types/bun.d.ts` say advanced-mode IPC supports everything `structuredClone` supports.
- It does not: a `Blob` (including `File` and `Bun.file()`) or a `net.BlockList` inside a message arrives in the other process as `{}`, while `structuredClone` of the same value returns a working clone. This came up while auditing the IPC guide.
- The runtime behavior is deliberate, so the docs are the part that is wrong:
  - `CloneSerializer` writes `ObjectTag` + `TerminatorTag` (an empty object) for any Bun class not marked `transferable` when serializing for a cross-process transfer (`src/jsc/bindings/webcore/SerializedScriptValue.cpp:1405-1411`); `Blob` and `BlockList` are the two such classes (`src/runtime/webcore/response.classes.ts`, `src/runtime/socket/sockets.classes.ts`). Introduced on purpose in #19351.
  - `test/js/node/cluster.test.ts` ("cloneable and non-transferable not-equals", BunFile and BlockList) and `test/js/web/workers/structuredClone-classes.test.ts` assert the empty object.
  - Node.js v26.3.0 does the same for these values: `Blob`, `File` and `net.BlockList` sent through `child_process` IPC arrive as `{}` in both `json` and `advanced` mode (probe below).
- The same two JSDoc blocks also still say IPC only works with other `bun` processes. That has been false since `serialization: "json"` landed: the `serialization` JSDoc a few lines below, the "IPC between Bun & Node.js" section of `child-process.mdx`, and `test/js/bun/spawn/spawn.ipc.bun-node.test.ts` all have Bun talking to a Node child.

### Fix
- Reword the four places to describe IPC in terms of `structuredClone` and name the Blob/BlockList deviation from it: the values `structuredClone` accepts arrive with their types intact, the values it rejects make `send()` throw a `DataCloneError` (verified for `URL`, `Headers`, `Response`, `FormData`, `AbortSignal`, `MessagePort` and a nested function, from both `process.send` and `subprocess.send`), and a `Blob` / `Bun.file()` / `net.BlockList` inside a message arrives as `{}`, as in Node.js.
  - The sentence is scoped to values inside a message on purpose: `net.Server` / `net.Socket` handles are passed through the separate handle argument (#31829), which this text does not describe.
  - Types that are in flux on other open PRs (`SharedArrayBuffer`, `KeyObject`) are deliberately not listed either way.
- Replace the "only other `bun` instances" sentence in the `ipc` JSDoc with the real constraint (the default `"advanced"` format can only be read by another `bun` process; use `"json"` for Node.js) and drop the same clause from `send()`, matching the neighbouring `disconnect()` JSDoc.
- Add a test to `test/js/bun/spawn/spawn.ipc.test.ts` that pins the documented contract through `Bun.spawn({ ipc })` in both directions: `Date` / `Map` / `Uint8Array` keep their types, `URL` and a nested function make `process.send` and `subprocess.send` throw `DataCloneError`, and `Blob`, `Bun.file()`, `net.BlockList` and a nested `Blob` arrive as plain empty objects. Existing coverage only checked `Bun.file()` through `node:cluster`. Since this PR changes no runtime code, the test passes before and after it; it exists so a later change to the serializer (for example one of the open PRs that touch cross-process serialization) fails this test and updates the docs along with it.
- Every value named in the new text was sent through Bun 1.4.0 IPC; the same probes under Node v26.3.0 back the "as in Node.js" claim for the Blob and BlockList rows only, which is the only row it is attached to (Node delivers `{}` for `URL`/`Headers` where Bun throws, so the text does not claim Node parity for those).
- No runtime change. `bun bd test test/js/bun/spawn/spawn.ipc.test.ts` passes (14 tests, including the new one); `bun test test/integration/bun-types/bun-types.test.ts` passes with the JSDoc edits.

### Background
- Bun has two IPC serialization modes. `json` uses `JSON.stringify`; `advanced` (the default for `Bun.spawn({ ipc })` and for `child_process` with `serialization: "advanced"`) uses the structured clone serializer with a cross-process flag set.
- The structured clone serializer handles Bun's own classes through a per-class hook declared in the `.classes.ts` files. That declaration also says whether the class may cross a process boundary (`transferable`). A file-backed Blob serializes as the sending process's path or raw file descriptor number (`src/runtime/webcore/blob/Store.rs:177`) and a BlockList serializes as a handle to the native object inside the sending process (`src/runtime/node/net/BlockList.rs:411`), so neither is marked transferable; in-process `structuredClone`, `postMessage` and `bun:jsc` serialization do not set the cross-process flag and still clone them.
- Everything else in the message takes the same code path as `structuredClone`, which is why unsupported values throw the same `DataCloneError` over IPC that they throw in-process.
- The empty object (rather than a `DataCloneError`) for the two Bun classes mirrors what V8's serializer produces for these values in Node's `child_process` IPC.

<details>
<summary>Probe 1: round-trips. A child sends each value with <code>process.send</code>, the parent prints what it received</summary>

Same two files run under both runtimes (`bun probe-parent.mjs advanced` / `node probe-parent.mjs advanced`); `bunFile` is only sent under Bun. Bun 1.4.0 and Node v26.3.0 print the same lines.

```
string       [object String] "s"
number       [object Number] 1.5
bigint       [object BigInt] 10
nested       [object Object] {"a":[1,{"b":"c"}],"d":null}
date         [object Date] 1970-01-01T00:00:00.000Z
regexp       [object RegExp] /a+/gi
map          [object Map] [["k",1]]
set          [object Set] [1,2]
error        [object Error] boom
typedArray   [object Uint8Array] {"0":1,"1":2}
arrayBuffer  [object ArrayBuffer] [3,4]
blob         [object Object] {}
file         [object Object] {}
blockList    [object Object] {}
nestedBlob   [object Object] {"x":{}}
bunFile      [object Object] {}          (Bun only)
```
</details>

<details>
<summary>Probe 2: structuredClone vs IPC for platform objects (advanced mode)</summary>

```
Bun 1.4.0
name           structuredClone            ipc send                  received as
blob           [object Blob]              sent                      [object Object] {}
file           [object Blob]              sent                      [object Object] {}
blockList      [object BlockList]         sent                      [object Object] {}
bunFile        [object Blob]              sent                      [object Object] {}
url            throws DataCloneError      throws DataCloneError
headers        throws DataCloneError      throws DataCloneError
response       throws DataCloneError      throws DataCloneError
formData       throws DataCloneError      throws DataCloneError
abortSignal    throws DataCloneError      throws DataCloneError
messagePort    throws DataCloneError      throws DataCloneError
domException   [object DOMException]      sent                      [object DOMException]

Node v26.3.0
blob / file / blockList                   sent                      [object Object] {}
url / headers / response / formData       sent                      [object Object] {}
```

`subprocess.send()` from a `Bun.spawn({ ipc })` parent behaves the same as `process.send()` above: `URL` and a nested function throw `DataCloneError`, a nested `Blob` is delivered as `{"b":{}}`.
</details>
