### PR TITLE
test/bundler: reject api paths that name an input file, fix the four tests that did

### DIFF
--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -897,12 +897,10 @@ describe("bundler", () => {
       });
     },
     onAfterBundle(api) {
-      // Verify the build succeeded and files were created
-      api.assertFileExists("index.html");
-      // The image should be copied with a hashed name
-      const html = api.readFile("index.html");
-      expect(html).toContain('src="');
-      expect(html).toContain('.jpeg"');
+      // The image is emitted under a hashed name, with the contents the plugin returned.
+      const [, image] = api.readFile("out/index.html").match(/src="\.\/(image-[a-z0-9]+\.jpeg)"/) ?? [];
+      expect(image).toBeDefined();
+      expect(api.readFile(join("out", image!))).toBe("custom image contents");
     },
   });
 
@@ -929,15 +927,16 @@ describe("bundler", () => {
       });
     },
     run: {
-      stdout: /\.(png|wasm)/,
+      stdout: /^\.\/image-[a-z0-9]+\.png \.\/module-[a-z0-9]+\.wasm$/,
     },
     onAfterBundle(api) {
-      // Verify the build succeeded and files were created
-      api.assertFileExists("index.js");
-      const js = api.readFile("index.js");
-      // Should contain references to the copied files
-      expect(js).toContain('.png"');
-      expect(js).toContain('.wasm"');
+      const js = api.readFile("out/index.js");
+      const [, image] = js.match(/"\.\/(image-[a-z0-9]+\.png)"/) ?? [];
+      const [, wasm] = js.match(/"\.\/(module-[a-z0-9]+\.wasm)"/) ?? [];
+      expect(image).toBeDefined();
+      expect(wasm).toBeDefined();
+      expect(api.readFile(join("out", image!))).toBe("custom png contents");
+      expect(api.readFile(join("out", wasm!))).toBe("custom wasm contents");
     },
   });
 

--- a/test/bundler/esbuild/__snapshots__/css.test.ts.snap
+++ b/test/bundler/esbuild/__snapshots__/css.test.ts.snap
@@ -1,6 +1,31 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/001/default/style.css 1`] = `
+exports[`bundler css/ComposesWithSharedPropertiesError 1`] = `
+"// styles.module.css
+var styles_module_default = {
+  button: "otherButton_NlEjJA button_-MSaAA"
+};
+
+// entry.js
+console.log(styles_module_default);
+"
+`;
+
+exports[`bundler css/ComposesWithSharedPropertiesError 2`] = `
+"/* other.module.css */
+.otherButton_NlEjJA {
+  color: red;
+  font-size: 16px;
+}
+
+/* styles.module.css */
+.button_-MSaAA {
+  color: #00f;
+}
+"
+`;
+
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /001/default/style.css 1`] = `
 "/* 001/default/a.css */
 .box {
   background-color: green;
@@ -11,7 +36,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/001/def
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/001/relative-url/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /001/relative-url/style.css 1`] = `
 "/* 001/relative-url/a.css */
 .box {
   background-color: green;
@@ -22,10 +47,8 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/001/rel
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-charset/001/style.css 1`] = `
-"@charset "UTF-8";
-
-/* at-charset/001/a.css */
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-charset/001/style.css 1`] = `
+"/* at-charset/001/a.css */
 .box {
   background-color: red;
 }
@@ -40,7 +63,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-char
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-keyframes/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-keyframes/001/style.css 1`] = `
 "/* at-keyframes/001/a.css */
 @media screen {
   .box {
@@ -48,6 +71,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-keyf
     animation-duration: 0s;
     animation-fill-mode: both;
   }
+
   @keyframes BOX {
     0%, 100% {
       background-color: green;
@@ -62,6 +86,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-keyf
     animation-duration: 0s;
     animation-fill-mode: both;
   }
+
   @keyframes BOX {
     0%, 100% {
       background-color: red;
@@ -74,7 +99,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-keyf
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/001/style.css 1`] = `
 "@layer a;
 
 /* at-layer/001/b.css */
@@ -96,7 +121,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/002/style.css 1`] = `
 "@media print {
   @layer a;
 }
@@ -120,7 +145,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/003/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/003/style.css 1`] = `
 "@layer a;
 
 /* at-layer/003/b.css */
@@ -142,7 +167,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/004/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/004/style.css 1`] = `
 "/* at-layer/004/b.css */
 @layer {
   .box {
@@ -162,7 +187,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/005/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/005/style.css 1`] = `
 "/* at-layer/005/b.css */
 @media (min-width: 1px) {
   @layer a {
@@ -187,6 +212,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
     background-color: red;
   }
 }
+
 @layer a.b {
   .box {
     background-color: green;
@@ -195,7 +221,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/006/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/006/style.css 1`] = `
 "/* at-layer/006/b.css */
 @media (min-width: 1px) {
   @layer a {
@@ -220,6 +246,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
     background-color: green;
   }
 }
+
 @layer a.b {
   .box {
     background-color: red;
@@ -228,17 +255,14 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/007/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/007/style.css 1`] = `
 "/* at-layer/007/style.css */
-@layer foo {
-}
-@layer bar {
-}
 @layer bar {
   .box {
     background-color: green;
   }
 }
+
 @layer foo {
   .box {
     background-color: red;
@@ -247,7 +271,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-layer/008/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/008/style.css 1`] = `
 "/* at-layer/008/b.css */
 @layer {
   @layer {
@@ -269,7 +293,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-laye
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/001/default/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/001/default/style.css 1`] = `
 "/* at-media/001/default/a.css */
 @media screen {
   .box {
@@ -282,7 +306,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/002/style.css 1`] = `
 "/* at-media/002/a.css */
 @media screen {
   .box {
@@ -302,7 +326,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/003/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/003/style.css 1`] = `
 "/* at-media/003/b.css */
 @media screen {
   @media (min-width: 1px) {
@@ -314,12 +338,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 
 /* at-media/003/a.css */
 
+
 /* at-media/003/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/004/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/004/style.css 1`] = `
 "/* at-media/004/c.css */
 .box {
   background-color: green;
@@ -336,12 +361,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 
 /* at-media/004/a.css */
 
+
 /* at-media/004/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/005/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/005/style.css 1`] = `
 "/* at-media/005/c.css */
 .box {
   background-color: green;
@@ -358,12 +384,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 
 /* at-media/005/a.css */
 
+
 /* at-media/005/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/006/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/006/style.css 1`] = `
 "/* at-media/006/b.css */
 @media (min-height: 1px) {
   @media (min-width: 1px) {
@@ -375,12 +402,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 
 /* at-media/006/a.css */
 
+
 /* at-media/006/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/007/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/007/style.css 1`] = `
 "/* at-media/007/b.css */
 @media all {
   @media screen {
@@ -392,12 +420,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 
 /* at-media/007/a.css */
 
+
 /* at-media/007/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-media/008/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/008/style.css 1`] = `
 "/* at-media/008/green.css */
 @media all {
   @layer alpha {
@@ -440,6 +469,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
     background-color: green;
   }
 }
+
 @layer alpha {
   .box {
     background-color: red;
@@ -448,7 +478,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-medi
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supports/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/001/style.css 1`] = `
 "/* at-supports/001/a.css */
 @supports (display: block) {
   .box {
@@ -461,7 +491,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supp
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supports/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/002/style.css 1`] = `
 "/* at-supports/002/b.css */
 @supports (display: block) {
   @supports (width: 10px) {
@@ -473,14 +503,15 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supp
 
 /* at-supports/002/a.css */
 
+
 /* at-supports/002/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supports/003/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/003/style.css 1`] = `
 "/* at-supports/003/b.css */
-@supports ((display: block) or (display: inline)) {
+@supports (display: block) or (display: inline) {
   @supports (width: 10px) {
     .box {
       background-color: green;
@@ -490,12 +521,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supp
 
 /* at-supports/003/a.css */
 
+
 /* at-supports/003/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supports/004/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/004/style.css 1`] = `
 "/* at-supports/004/b.css */
 @supports (display: block) {
   @layer a {
@@ -519,7 +551,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supp
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supports/005/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/005/style.css 1`] = `
 "/* at-supports/005/green.css */
 @supports (display: block) {
   @layer alpha {
@@ -562,6 +594,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supp
     background-color: green;
   }
 }
+
 @layer alpha {
   .box {
     background-color: red;
@@ -570,7 +603,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/at-supp
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/001/style.css 1`] = `
 "/* cycles/001/style.css */
 .box {
   background-color: green;
@@ -578,7 +611,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/002/style.css 1`] = `
 "/* cycles/002/red.css */
 .box {
   background-color: red;
@@ -591,14 +624,16 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 
 /* cycles/002/b.css */
 
+
 /* cycles/002/a.css */
+
 
 /* cycles/002/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/003/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/003/style.css 1`] = `
 "/* cycles/003/b.css */
 .box {
   background-color: red;
@@ -614,7 +649,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/004/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/004/style.css 1`] = `
 "/* cycles/004/a.css */
 .box {
   background-color: red;
@@ -630,7 +665,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/005/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/005/style.css 1`] = `
 "/* cycles/005/b.css */
 .box {
   background-color: red;
@@ -646,7 +681,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/006/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/006/style.css 1`] = `
 "/* cycles/006/red.css */
 .box {
   background-color: red;
@@ -659,16 +694,19 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 
 /* cycles/006/b.css */
 
+
 /* cycles/006/a.css */
 
+
 /* cycles/006/c.css */
+
 
 /* cycles/006/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/007/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/007/style.css 1`] = `
 "/* cycles/007/green.css */
 .box {
   background-color: green;
@@ -683,7 +721,9 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 
 /* cycles/007/a.css */
 
+
 /* cycles/007/b.css */
+
 
 /* cycles/007/red.css */
 @media not print {
@@ -703,16 +743,19 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 
 /* cycles/007/b.css */
 
+
 /* cycles/007/a.css */
 
+
 /* cycles/007/c.css */
+
 
 /* cycles/007/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/008/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/008/style.css 1`] = `
 "/* cycles/008/green.css */
 @layer {
   .box {
@@ -729,7 +772,9 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 
 /* cycles/008/a.css */
 
+
 /* cycles/008/b.css */
+
 
 /* cycles/008/red.css */
 @layer {
@@ -751,17 +796,20 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/cycles/
 
 /* cycles/008/b.css */
 
+
 /* cycles/008/a.css */
 
+
 /* cycles/008/c.css */
+
 
 /* cycles/008/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/data-urls/002/style.css 1`] = `
-"/* <data:text/css;plain,.box%20%7B%0A%09background-color%3A%20green%...> */
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /data-urls/002/style.css 1`] = `
+"/* dataurl:data:text/css;plain,.box%20%7B%0A%09background-color%3A%20green%3B%0A%7D%0A */
 .box {
   background-color: green;
 }
@@ -771,8 +819,8 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/data-ur
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/data-urls/003/style.css 1`] = `
-"/* <data:text/css,.box%20%7B%0A%09background-color%3A%20green%3B%0A%...> */
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /data-urls/003/style.css 1`] = `
+"/* dataurl:data:text/css,.box%20%7B%0A%09background-color%3A%20green%3B%0A%7D%0A */
 .box {
   background-color: green;
 }
@@ -782,7 +830,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/data-ur
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/duplicates/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /duplicates/001/style.css 1`] = `
 "/* duplicates/001/b.css */
 .box {
   background-color: red;
@@ -798,7 +846,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/duplica
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/duplicates/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /duplicates/002/style.css 1`] = `
 "/* duplicates/002/b.css */
 .box {
   background-color: red;
@@ -814,8 +862,9 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/duplica
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/empty/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /empty/001/style.css 1`] = `
 "/* empty/001/empty.css */
+
 
 /* empty/001/style.css */
 .box {
@@ -824,7 +873,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/empty/0
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/relative-paths/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /relative-paths/001/style.css 1`] = `
 "/* relative-paths/001/b/b.css */
 .box {
   background-color: green;
@@ -832,12 +881,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/relativ
 
 /* relative-paths/001/a/a.css */
 
+
 /* relative-paths/001/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/relative-paths/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /relative-paths/002/style.css 1`] = `
 "/* relative-paths/002/b/b.css */
 .box {
   background-color: green;
@@ -845,15 +895,16 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/relativ
 
 /* relative-paths/002/a/a.css */
 
+
 /* relative-paths/002/style.css */
 
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subresource/001/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/001/style.css 1`] = `
 "/* subresource/001/something/styles/green.css */
 .box {
-  background-image: url(data:image/png;base64,Li4u);
+  background-image: url("data:image/png;base64,Li4u");
 }
 
 /* subresource/001/style.css */
@@ -861,10 +912,10 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subreso
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subresource/002/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/002/style.css 1`] = `
 "/* subresource/002/styles/green.css */
 .box {
-  background-image: url(data:image/png;base64,Li4u);
+  background-image: url("data:image/png;base64,Li4u");
 }
 
 /* subresource/002/style.css */
@@ -872,10 +923,10 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subreso
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subresource/004/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/004/style.css 1`] = `
 "/* subresource/004/styles/green.css */
 .box {
-  background-image: url(data:image/png;base64,Li4u);
+  background-image: url("data:image/png;base64,Li4u");
 }
 
 /* subresource/004/style.css */
@@ -883,10 +934,10 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subreso
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subresource/005/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/005/style.css 1`] = `
 "/* subresource/005/styles/green.css */
 .box {
-  background-image: url(data:image/png;base64,Li4u);
+  background-image: url("data:image/png;base64,Li4u");
 }
 
 /* subresource/005/style.css */
@@ -894,15 +945,15 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subreso
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/subresource/007/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/007/style.css 1`] = `
 "/* subresource/007/style.css */
 .box {
-  background-image: url(data:image/png;base64,Li4u);
+  background-image: url("data:image/png;base64,Li4u");
 }
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-format/001/default/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/001/default/style.css 1`] = `
 "/* url-format/001/default/a.css */
 .box {
   background-color: green;
@@ -913,7 +964,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-for
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-format/001/relative-url/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/001/relative-url/style.css 1`] = `
 "/* url-format/001/relative-url/a.css */
 .box {
   background-color: green;
@@ -924,7 +975,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-for
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-format/002/default/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/002/default/style.css 1`] = `
 "/* url-format/002/default/a.css */
 .box {
   background-color: green;
@@ -935,7 +986,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-for
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-format/002/relative-url/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/002/relative-url/style.css 1`] = `
 "/* url-format/002/relative-url/a.css */
 .box {
   background-color: green;
@@ -946,7 +997,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-for
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-format/003/default/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/003/default/style.css 1`] = `
 "/* url-format/003/default/a.css */
 .box {
   background-color: green;
@@ -957,7 +1008,7 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-for
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-format/003/relative-url/style.css 1`] = `
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/003/relative-url/style.css 1`] = `
 "/* url-format/003/relative-url/a.css */
 .box {
   background-color: green;
@@ -968,8 +1019,8 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-for
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-fragments/001/style.css 1`] = `
-"/* url-fragments/001/a.css#foo */
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-fragments/001/style.css 1`] = `
+"/* url-fragments/001/a.css */
 .box {
   background-color: green;
 }
@@ -979,18 +1030,13 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-fra
 "
 `;
 
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-fragments/002/style.css 1`] = `
-"/* url-fragments/002/a.css#1 */
-.box {
-  background-color: green;
-}
-
-/* url-fragments/002/b.css#2 */
+exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-fragments/002/style.css 1`] = `
+"/* url-fragments/002/b.css */
 .box {
   background-color: red;
 }
 
-/* url-fragments/002/a.css#3 */
+/* url-fragments/002/a.css */
 .box {
   background-color: green;
 }
@@ -999,142 +1045,6 @@ exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /out/url-fra
 
 "
 `;
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /001/default/style.css 1`] = `"@import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /001/relative-url/style.css 1`] = `"@import url("./a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-charset/001/style.css 1`] = `"@charset "utf-8"; @import url("a.css"); @import url("b.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-keyframes/001/style.css 1`] = `"@import url("a.css") screen; @import url("b.css") print;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/001/style.css 1`] = `
-"@import url("a.css") layer(a);
-@import url("b.css") layer(b);
-@import url("a.css") layer(a);"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/002/style.css 1`] = `
-"@import url("a.css") layer(a) print;
-@import url("b.css") layer(b);
-@import url("a.css") layer(a);"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/003/style.css 1`] = `"@import url("a.css"); @import url("b.css"); @import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/004/style.css 1`] = `"@import url("a.css"); @import url("b.css"); @import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/005/style.css 1`] = `
-"@import url("a.css") layer(a) (min-width: 1px);
-@layer a.c { .box { background-color: red; } }
-@layer a.b { .box { background-color: green; } }"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/006/style.css 1`] = `
-"@import url("a.css") layer(a) (min-width: 1px);
-@layer a.c { .box { background-color: green; } }
-@layer a.b { .box { background-color: red; } }"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/007/style.css 1`] = `
-"@layer foo {}
-@layer bar {}
-@layer bar { .box { background-color: green; } }
-@layer foo { .box { background-color: red; } }"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-layer/008/style.css 1`] = `"@import url("a.css") layer;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/001/default/style.css 1`] = `"@import url("a.css") screen;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/002/style.css 1`] = `"@import url("a.css") screen; @import url("b.css") print;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/003/style.css 1`] = `"@import url("a.css") screen;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/004/style.css 1`] = `"@import url("c.css"); @import url("a.css") print;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/005/style.css 1`] = `"@import url("c.css"); @import url("a.css") (max-width: 1px);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/006/style.css 1`] = `"@import url("a.css") (min-height: 1px);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/007/style.css 1`] = `"@import url("a.css") all;"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-media/008/style.css 1`] = `
-"@import url("a.css") layer(alpha) all;
-@import url("b.css") layer(beta) all;
-@layer beta { .box { background-color: green; } }
-@layer alpha { .box { background-color: red; } }"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/001/style.css 1`] = `"@import url("a.css") supports(display: block);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/002/style.css 1`] = `"@import url("a.css") supports(display: block);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/003/style.css 1`] = `"@import url("a.css") supports((display: block) or (display: inline));"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/004/style.css 1`] = `"@import url("a.css") layer(a) supports(display: block);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /at-supports/005/style.css 1`] = `
-"@import url("a.css") layer(alpha) supports(display: block);
-@import url("b.css") layer(beta) supports(display: block);
-@layer beta { .box { background-color: green; } }
-@layer alpha { .box { background-color: red; } }"
-`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/001/style.css 1`] = `"@import url("style.css"); .box { background-color: green; }"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/002/style.css 1`] = `"@import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/003/style.css 1`] = `"@import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/004/style.css 1`] = `"@import url("a.css"); @import url("b.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/005/style.css 1`] = `"@import url("a.css"); @import url("b.css"); @import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/006/style.css 1`] = `"@import url("b.css"); @import url("c.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/007/style.css 1`] = `"@import url("b.css"); @import url("c.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /cycles/008/style.css 1`] = `"@import url("b.css"); @import url("c.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /data-urls/002/style.css 1`] = `"@import url('data:text/css;plain,.box%20%7B%0A%09background-color%3A%20green%3B%0A%7D%0A');"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /data-urls/003/style.css 1`] = `"@import url('data:text/css,.box%20%7B%0A%09background-color%3A%20green%3B%0A%7D%0A');"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /duplicates/001/style.css 1`] = `"@import url("a.css"); @import url("b.css"); @import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /duplicates/002/style.css 1`] = `"@import url("a.css"); @import url("b.css"); @import url("a.css"); @import url("b.css"); @import url("a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /empty/001/style.css 1`] = `"@import url("./empty.css"); .box { background-color: green; }"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /relative-paths/001/style.css 1`] = `"@import url("./a/a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /relative-paths/002/style.css 1`] = `"@import url("./a/a.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/001/style.css 1`] = `"@import url("./something/styles/green.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/002/style.css 1`] = `"@import url("./styles/green.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/004/style.css 1`] = `"@import url("./styles/green.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/005/style.css 1`] = `"@import url("./styles/green.css");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /subresource/007/style.css 1`] = `".box { background-image: url("./green.png"); }"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/001/default/style.css 1`] = `"@import url(a.css);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/001/relative-url/style.css 1`] = `"@import url(./a.css);"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/002/default/style.css 1`] = `"@import "a.css";"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/002/relative-url/style.css 1`] = `"@import "./a.css";"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/003/default/style.css 1`] = `"@import url("a.css""`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-format/003/relative-url/style.css 1`] = `"@import url("./a.css""`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-fragments/001/style.css 1`] = `"@import url("./a.css#foo");"`;
-
-exports[`esbuild-bundler css/CSSAtImportConditionsFromExternalRepo: /url-fragments/002/style.css 1`] = `"@import url("./a.css#1"); @import url("./b.css#2"); @import url("./a.css#3");"`;
 
 exports[`esbuild-bundler css/CSSAtImportConditionsAtLayerBundle: case1.css 1`] = `
 "@layer first.one;
@@ -1416,45 +1326,56 @@ exports[`esbuild-bundler css/CSSAtImportConditionsAtLayerBundleAlternatingLayerI
 `;
 
 exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /a.js 1`] = `
-"import shared from './shared.js'
-console.log(shared() + 1)"
-`;
+"import {
+  shared_default
+} from "./chunk.js";
 
-exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /b.js 1`] = `
-"import shared from './shared.js'
-console.log(shared() + 2)"
-`;
-
-exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /c.css 1`] = `
-"@import "./shared.css";
-body { color: red }"
-`;
-
-exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /d.css 1`] = `
-"@import "./shared.css";
-body { color: blue }"
-`;
-
-exports[`bundler css/ComposesWithSharedPropertiesError 1`] = `
-"// styles.module.css
-var styles_module_default = {
-  button: "otherButton_NlEjJA button_-MSaAA"
-};
-
-// entry.js
-console.log(styles_module_default);
+// a.js
+console.log(shared_default() + 1);
 "
 `;
 
-exports[`bundler css/ComposesWithSharedPropertiesError 2`] = `
-"/* other.module.css */
-.otherButton_NlEjJA {
-  color: red;
-  font-size: 16px;
+exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /b.js 1`] = `
+"import {
+  shared_default
+} from "./chunk.js";
+
+// b.js
+console.log(shared_default() + 2);
+"
+`;
+
+exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /chunk.js 1`] = `
+"// shared.js
+function shared_default() {
+  return 3;
 }
 
-/* styles.module.css */
-.button_-MSaAA {
+export { shared_default };
+"
+`;
+
+exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /c.css 1`] = `
+"/* shared.css */
+body {
+  background: #000;
+}
+
+/* c.css */
+body {
+  color: red;
+}
+"
+`;
+
+exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /d.css 1`] = `
+"/* shared.css */
+body {
+  background: #000;
+}
+
+/* d.css */
+body {
   color: #00f;
 }
 "

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1969,12 +1969,12 @@ c {
       "/url-fragments/002/style.css": `@import url("./a.css#1"); @import url("./b.css#2"); @import url("./a.css#3");`,
     },
     entryPoints: files,
-    outputPaths: files,
+    outputPaths: files.map(file => join("/out", file)),
     outdir: "/out",
     onAfterBundle(api) {
       for (const file of files) {
         console.log("Checking snapshot:", file);
-        api.expectFile(join(file)).toMatchSnapshot(file);
+        api.expectFile(join("/out", file)).toMatchSnapshot(file);
       }
     },
   });
@@ -2141,10 +2141,11 @@ c {
     entryPoints: ["/a.js", "/b.js", "/c.css", "/d.css"],
     format: "esm",
     splitting: true,
+    chunkNaming: "chunk.[ext]",
     onAfterBundle(api) {
-      const files = ["/a.js", "/b.js", "/c.css", "/d.css"];
+      const files = ["/a.js", "/b.js", "/chunk.js", "/c.css", "/d.css"];
       for (const file of files) {
-        api.expectFile(file).toMatchSnapshot(file);
+        api.expectFile(join("/out", file)).toMatchSnapshot(file);
       }
     },
   });

--- a/test/bundler/expectBundled.md
+++ b/test/bundler/expectBundled.md
@@ -156,6 +156,8 @@ itBundled("default/ThisOutsideFunctionRenamedToExports", {
 
 Check the `BundlerTestBundleAPI` typedef for all available methods. Note that `api.readFile` is cached so you can call it multiple times without worrying about anything.
 
+Paths passed to the `api` methods (and to `outputPaths`) are resolved from the test's root directory, the same place `files` are written to, so outputs are `"/out.js"`, `"/out/entry.js"`, and so on. Passing the path of one of the test's own `files` throws, because the assertion would otherwise be checking the fixture instead of the bundle.
+
 This callback is run before `run`, so you can use tricks like `appendFile` to add extra data, useful when testing IIFE bundles in combination with `globalName`
 
 ```ts

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -195,7 +195,10 @@ export interface BundlerTestInput {
   bundling?: boolean;
   /** Used for `default/ErrorMessageCrashStdinESBuildIssue2913`. */
   stdin?: { contents: string; cwd: string };
-  /** Use when doing something weird with entryPoints and you need to check other output paths. */
+  /**
+   * Use when doing something weird with entryPoints and you need to check other output paths.
+   * Resolved from the test root like `files`, so entries look like `/out/pages/a/entry.js`.
+   */
   outputPaths?: string[];
   /** Use --compile */
 
@@ -387,6 +390,11 @@ export interface BundlerTestBundleAPI {
   outdir: string;
 
   join(subPath: string): string;
+  /**
+   * File paths given to the methods below resolve from the test root, where `files` are written, so
+   * outputs are addressed as `/out.js`, `/out/entry.js`, etc. Naming one of the test's own input
+   * files throws instead of reading the fixture back.
+   */
   readFile(file: string): string;
   writeFile(file: string, contents: string): void;
   prependFile(file: string, contents: string): void;
@@ -463,7 +471,7 @@ function testRef(id: string, options: BundlerTestInput): BundlerTestRef {
   return { id, options };
 }
 
-function expectBundled(
+export function expectBundled(
   id: string,
   opts: BundlerTestInput,
   dryRun = false,
@@ -676,6 +684,23 @@ function expectBundled(
     outfile = useOutFile ? path.join(root, outfile ?? (compile ? "/out" : "/out.js")) : undefined;
     outdir = !useOutFile && generateOutput ? path.join(root, outdir ?? "/out") : undefined;
     metafile = metafile ? path.join(root, metafile) : undefined;
+
+    // `files` are the bundler's inputs, and `api` paths resolve from the same root the inputs are
+    // written to, so a test that names one of them where it means an output silently checks its
+    // own fixture.
+    const inputFiles = new Set(Object.keys(files).map(file => path.join(root, file)));
+    const rejectInputFile = (file: string, what: string) => {
+      if (!inputFiles.has(path.join(root, file))) return;
+      const outputLocation = outfile ?? outdir;
+      throw new Error(
+        `${what} refers to one of the test's input files, not to bundle output. Paths resolve from the test root` +
+          (outputLocation
+            ? `; the bundle is written to ${JSON.stringify("/" + path.relative(root, outputLocation).replaceAll("\\", "/"))}.`
+            : "."),
+      );
+    };
+    for (const file of outputPaths ?? []) rejectInputFile(file, `outputPaths entry ${JSON.stringify(file)}`);
+
     outputPaths = (
       outputPaths
         ? outputPaths.map(file => path.join(root, file))
@@ -1380,8 +1405,10 @@ for (const [key, blob] of build.outputs) {
     }
 
     const readCache: Record<string, string> = {};
-    const readFile = (file: string) =>
-      readCache[file] || (readCache[file] = readFileSync(path.join(root, file)).toUnixString());
+    const readFile = (file: string, method = "readFile") => {
+      rejectInputFile(file, `api.${method}(${JSON.stringify(file)})`);
+      return readCache[file] || (readCache[file] = readFileSync(path.join(root, file)).toUnixString());
+    };
     const writeFile = (file: string, contents: string) => {
       readCache[file] = contents;
       writeFileSync(path.join(root, file), contents);
@@ -1391,12 +1418,13 @@ for (const [key, blob] of build.outputs) {
       outfile: outfile!,
       outdir: outdir!,
       join: (...paths: string[]) => path.join(root, ...paths),
-      readFile,
+      readFile: file => readFile(file),
       writeFile,
-      expectFile: file => expect(readFile(file)),
-      prependFile: (file, contents) => writeFile(file, dedent(contents) + "\n" + readFile(file)),
-      appendFile: (file, contents) => writeFile(file, readFile(file) + "\n" + dedent(contents)),
+      expectFile: file => expect(readFile(file, "expectFile")),
+      prependFile: (file, contents) => writeFile(file, dedent(contents) + "\n" + readFile(file, "prependFile")),
+      appendFile: (file, contents) => writeFile(file, readFile(file, "appendFile") + "\n" + dedent(contents)),
       assertFileExists: file => {
+        rejectInputFile(file, `api.assertFileExists(${JSON.stringify(file)})`);
         if (!existsSync(path.join(root, file))) {
           throw new Error("Expected file to be written: " + file);
         }
@@ -1404,7 +1432,7 @@ for (const [key, blob] of build.outputs) {
       warnings: warningReference,
       options: opts,
       captureFile: (file, fnName = "capture") => {
-        const fileContents = readFile(file);
+        const fileContents = readFile(file, "captureFile");
         let i = 0;
         const length = fileContents.length;
         const matches = [];

--- a/test/bundler/itBundled-inputFiles.test.ts
+++ b/test/bundler/itBundled-inputFiles.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
+import { BundlerTestInput, expectBundled, itBundled } from "./expectBundled";
+
+// `api` paths and `outputPaths` resolve from the test root, which is also where `files` are
+// written, so a test naming an input file where it means an output would silently check its own
+// fixture. expectBundled rejects such paths. Every case here bundles the same input to /out/entry.js.
+const bundle = {
+  files: {
+    "/entry.js": /* js */ `
+      import { greeting } from "./lib/greeting";
+      console.log(greeting);
+    `,
+    "lib/greeting.js": `export const greeting = "hi";`,
+  },
+  outdir: "/out",
+} satisfies BundlerTestInput;
+
+function refersToInput(what: string, writtenTo = "/out") {
+  return `${what} refers to one of the test's input files, not to bundle output. Paths resolve from the test root; the bundle is written to ${JSON.stringify(writtenTo)}.`;
+}
+
+const rejected: Record<string, { opts: Partial<BundlerTestInput>; error: string }> = {
+  OutputPaths: {
+    opts: { outputPaths: ["/out/entry.js", "/entry.js"] },
+    error: refersToInput('outputPaths entry "/entry.js"'),
+  },
+  ExpectFile: {
+    opts: { onAfterBundle: api => api.expectFile("/entry.js") },
+    error: refersToInput('api.expectFile("/entry.js")'),
+  },
+  // The remaining cases spell the path differently from the `files` key; they resolve to the same file.
+  ReadFile: {
+    opts: { onAfterBundle: api => api.readFile("entry.js") },
+    error: refersToInput('api.readFile("entry.js")'),
+  },
+  AssertFileExists: {
+    opts: { onAfterBundle: api => api.assertFileExists("./lib/greeting.js") },
+    error: refersToInput('api.assertFileExists("./lib/greeting.js")'),
+  },
+  CaptureFile: {
+    opts: { onAfterBundle: api => api.captureFile("/lib/greeting.js") },
+    error: refersToInput('api.captureFile("/lib/greeting.js")'),
+  },
+  Outfile: {
+    opts: { outdir: undefined, outfile: "/bundle.js", onAfterBundle: api => api.readFile("/entry.js") },
+    error: refersToInput('api.readFile("/entry.js")', "/bundle.js"),
+  },
+};
+
+describe("bundler", () => {
+  itBundled("harness/InputFilesOutputsStayReadable", {
+    ...bundle,
+    outputPaths: ["/out/entry.js"],
+    // runtimeFiles are written into the root after bundling; they are not inputs.
+    runtimeFiles: { "/run.js": `import "./out/entry.js";` },
+    onAfterBundle(api) {
+      api.assertFileExists("/out/entry.js");
+      api.expectFile("/out/entry.js").toContain('"hi"');
+      expect(api.readFile("out/entry.js")).toBe(api.readFile("/out/entry.js"));
+      expect(api.readFile("/run.js")).toBe(`import "./out/entry.js";`);
+    },
+  });
+
+  // On Windows, expectBundled's `stack.includes("test/bundler/")` check fails on the backslash paths
+  // and throws before any of this runs (itBundled swallows that throw, so the case above is dropped
+  // there too).
+  describe.skipIf(isWindows)("rejects paths that name an input file", () => {
+    for (const [name, { opts, error }] of Object.entries(rejected)) {
+      const id = `harness/InputFiles${name}`;
+      test(id, async () => {
+        let message = "<expectBundled() passed>";
+        try {
+          // ignoreFilter: an ambient BUN_BUNDLER_TEST_FILTER must not turn these into no-ops.
+          await expectBundled(id, { ...bundle, ...opts }, false, true);
+        } catch (e: any) {
+          message = e.message;
+        }
+        expect(message).toBe(error);
+      });
+    }
+  });
+});


### PR DESCRIPTION
### Problem

- In `itBundled`, the paths given to `api.readFile` / `expectFile` / `assertFileExists` / `captureFile` and to `outputPaths` resolve from the test root (`test/bundler/expectBundled.ts`, `readFile` and the `outputPaths` mapping), which is also where `files` are written. A test that names one of its inputs there passes no matter what the bundler emits, and nothing reports it.
- Four tests do this, introduced independently twice:
  - `css/CSSAtImportConditionsFromExternalRepo` (`test/bundler/esbuild/css.test.ts`, the 53 cases ported from css-import-tests) snapshots `join(file)` and passes `outputPaths: files`, so every snapshot holds the fixture text (`"@import url("a.css");"`) and the 53 hand-written `... /out/<case>/style.css` entries in the `.snap` were never referenced by anything. Case `at-layer/007` is bun dropping empty `@layer` blocks and flipping the layer order (#38480), unnoticed since #16486.
  - `css/CSSAndJavaScriptCodeSplittingESBuildIssue1064` (same file) snapshots `/a.js`, `/b.js`, `/c.css`, `/d.css`, the inputs.
  - `plugin/FileLoaderWithCustomContents` and `plugin/FileLoaderMultipleAssets` (`test/bundler/bundler_plugin.test.ts`) read `index.html` / `index.js`; their `toContain('.jpeg"')` / `toContain('.png"')` checks are satisfied by the fixtures' own `<img src>` and `import` lines.

### Fix

- `expectBundled` now collects the resolved paths of `files` and throws when an `api` read, `assertFileExists`, or an `outputPaths` entry resolves to one of them. The message names the call and the path and says where the bundle went: `api.expectFile("/a.js") refers to one of the test's input files, not to bundle output. Paths resolve from the test root; the bundle is written to "/out".` The `outputPaths` check runs before bundling; the `api` checks run when the path is used. `expectBundled` is exported so the new test can call it directly.
- This is safe to enforce because nothing in the suite reads a bundle written over an input: the only tests that bundle over their inputs (`edgecase/OverwriteInput*`, todo) have neither `outputPaths` nor `onAfterBundle`, and the check only looks at user-supplied `outputPaths` and `api` calls, not at the output paths the harness derives itself. Every `api` read, `outputPaths` entry, `assertNotPresent` key, `expectExactFilesize` key, and `capture` / `cjs2esm` read in `test/bundler` names an output apart from the four tests above.
- `run.file` is intentionally not checked: running a script from `files` (or `runtimeFiles`) that imports the bundle is a normal pattern. `runtimeFiles` are not inputs and are not checked either.
- The four tests are pointed at `/out`. The css tests snapshot their outputs (the splitting test gets `chunkNaming: "chunk.[ext]"` so `a.js` / `b.js` import a stable name, and the chunk is snapshotted as well); the plugin tests pick the hashed asset name out of the emitted `index.html` / `index.js` and check the asset's contents are what the `onLoad` plugin returned, and the second one's `run.stdout` now matches the two emitted names exactly. The snapshot keys stay `toMatchSnapshot(file)`, so they are separator independent.
- `css.test.ts.snap`: the 57 input-text entries are replaced by bun's output, the 53 orphaned `/out/...` entries are removed, `chunk.js` is added; the 14 entries of other tests are byte-identical (the file was rewritten by `-u`, which moved two entries).
- The regenerated css output was reviewed case by case (details below): 52 of the 53 css-import-tests cases still render `.box` green. The exception is `at-layer/007`, whose snapshot now records the current wrong output; #38480 changes it, so whichever PR lands second regenerates that one entry. Against the hand-written entries, 41 cases match modulo whitespace; the other differences are cosmetic (no `@charset`, quoted `url()` data, `@supports (a) or (b)` without outer parentheses, `a.css#1` / `a.css#3` emitted once).
- `test/bundler/itBundled-inputFiles.test.ts` covers the check: one `itBundled` case reading outputs in the forms tests use (plus a `runtimeFiles` entry) and six `expectBundled` calls that must throw: `outputPaths`, `expectFile`, `readFile`, `assertFileExists` and `captureFile` (the last three spelling the path differently from the `files` key), and the message for an `outfile` build. The throwing cases are skipped on Windows, where `expectBundled`'s existing `stack.includes("test/bundler/")` check throws first (that is #34552's problem; with it patched out locally, all seven cases and the two plugin tests pass on Windows as well).
- Verified:
  - `bun bd test test/bundler/bundler_plugin.test.ts test/bundler/esbuild/css.test.ts test/bundler/itBundled-inputFiles.test.ts`: 118 pass, 3 pre-existing todo.
  - With the harness change but the four tests as they were, each fails with the new message (first ones: `outputPaths entry "/001/default/style.css" refers to ...`, `api.expectFile("/a.js") refers to ...`, `api.assertFileExists("index.html") refers to ...`). With the css assertions fixed but the old snapshot entries, both css tests fail on content, so the new assertions read the bundle.
  - Found because #38480 changes the `at-layer/007` output and produced no snapshot diff in this file.

### Background

- `itBundled(id, opts)` writes `opts.files` into a fresh root directory, runs `bun build` with the entry points into `<root>/out` (or `<root>/<outfile>`), checks that the expected outputs exist, then calls `opts.onAfterBundle(api)`. `api.readFile(p)` and friends are thin wrappers around `readFileSync(path.join(root, p))`, so an output has to be spelled `/out/...` or `/out.js`; `outputPaths` is the list of files the existence check looks for and is resolved the same way. `runtimeFiles` are extra files written into the root after bundling, typically a script that `run` executes against the bundle.
- A cascade layer's position is fixed by the first declaration of its name, including an empty `@layer x {}` block; later blocks with the same name add rules without moving it, and later layers win. That is why removing the empty blocks in `at-layer/007` changes which rule applies.
- `chunkNaming` is the naming template for the non-entry files code splitting produces; the harness default is `[name]-[hash].[ext]`.

<details>
<summary>Per-case review of the regenerated css-import-tests output</summary>

Viewport assumptions are the upstream suite's: screen media, width larger than 1px, `display: block` supported, `foo: bar` not supported.

- `001/*`, `at-media/001`, `at-supports/001`, `data-urls/*`, `empty/001`, `relative-paths/*`, `url-format/*`, `url-fragments/001`: one green rule, possibly wrapped in the import's `@media` / `@supports`.
- `at-charset/001`: red then green, green wins. Bun omits the `@charset` rule.
- `at-keyframes/001`: the green `@keyframes BOX` ends up inside `@media screen`, the red one inside `@media print`.
- `at-layer/001`, `003`: `@layer a;` is emitted before the `b` block, so the order is `a, b` and `b` (green) wins even though its block is printed first.
- `at-layer/002`: the first import's `@layer a;` is inside `@media print`, so on screen the order is `b, a` and `a` (green) wins.
- `at-layer/004`: two anonymous layers, green last.
- `at-layer/005`: `a.b` is only declared inside `@media (width: 1px)`, so the order inside `a` is `c, b` and `a.b` (green) wins.
- `at-layer/006`: `a.b` (red) is declared first, then `a.c` (green), so `a.c` wins.
- `at-layer/007`: bun prints `bar` then `foo`, so `foo` (red) wins. Wrong; this is #38480.
- `at-layer/008`: the nested anonymous layer holding red comes before the anonymous layer holding green.
- `at-media/002` to `007`, `at-supports/002` to `004`: red is wrapped in a non-matching query or comes before green; the nested imports are emitted as nested `@media` / `@supports` blocks.
- `at-media/008`, `at-supports/005`: `alpha` is declared before `beta`, the nested red/green imports are inside a non-matching `print` / `(foo: bar)` condition, so the trailing `@layer beta` block (green) wins.
- `cycles/001`: the self import is dropped.
- `cycles/002` to `006`: each file is emitted once, at its last position, and the last rule is green, which is also what a browser computes for these import graphs.
- `cycles/007`, `008`: files imported under different conditions are emitted once per condition; the last emitted rule is green (inside `@media not print { @media screen }` for 007, in the last anonymous layer for 008).
- `duplicates/*`, `url-fragments/002`: `a.css` (green) is emitted once, after `b.css`.
- `subresource/*`: the 3-byte `green.png` fixtures are inlined as `url("data:image/png;base64,Li4u")`, resolved relative to the importing file in every case.
- `CSSAndJavaScriptCodeSplittingESBuildIssue1064`: `a.js` / `b.js` import `shared_default` from `./chunk.js`; `c.css` / `d.css` each contain `shared.css` followed by their own rule. This matches esbuild's expected output for that issue.

</details>

<details>
<summary>Earlier shape of this PR</summary>

The first push only fixed the two css tests. Review pointed out that the same mistake exists in `bundler_plugin.test.ts` and that the harness could refuse it outright, which is what the second commit adds.

</details>
