### PR TITLE
Bun.write(file, file): wait for a non-blocking fd instead of rejecting with EAGAIN

### DIFF
--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -383,7 +383,6 @@ impl CopyFile {
         }
 
         loop {
-            // TODO: this should use non-blocking I/O.
             let written: isize = match USE {
                 TryWith::CopyFileRange => {
                     // SAFETY: raw copy_file_range(2); both fds owned by caller, null offsets.
@@ -426,6 +425,20 @@ impl CopyFile {
 
             match bun_sys::get_errno(written) {
                 bun_sys::E::SUCCESS => {}
+
+                // One of the fds is O_NONBLOCK (`Bun.stdout` is, once
+                // `process.stdout` has been touched). A pipe-to-pipe splice is
+                // non-blocking as a whole if either end is, so EAGAIN does not
+                // say which side would have blocked: wait for both, then retry.
+                bun_sys::E::EAGAIN => {
+                    if let Err(err) = bun_sys::block_until_readable(src_fd)
+                        .and_then(|()| bun_sys::block_until_writable(dest_fd))
+                    {
+                        self.system_error = Some(err.to_system_error());
+                        return Err(bun_errno::from_errno(err.errno as i32).into());
+                    }
+                    continue;
+                }
 
                 // XDEV: cross-device copy not supported
                 // NOSYS: syscall not available
@@ -992,19 +1005,30 @@ fn read_write_loop_capped(
     let mut remaining = cap;
     while remaining > 0 {
         let want = (buf.len() as SizeType).min(remaining) as usize;
-        let amt = bun_sys::read(src_fd, &mut buf[..want])?;
+        // Either fd may be O_NONBLOCK (`Bun.stdout` is once `process.stdout` has
+        // been touched); wait for it and retry instead of failing the copy.
+        let amt = match bun_sys::read(src_fd, &mut buf[..want]) {
+            Ok(amt) => amt,
+            Err(err) if err.is_retry() => {
+                bun_sys::block_until_readable(src_fd)?;
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
         if amt == 0 {
             break;
         }
         remaining -= amt as SizeType;
         let mut slice = &buf[..amt];
         while !slice.is_empty() {
-            match bun_sys::write(dest_fd, slice)? {
-                0 => return Ok(()),
-                n => {
+            match bun_sys::write(dest_fd, slice) {
+                Ok(0) => return Ok(()),
+                Ok(n) => {
                     *total += n as u64;
                     slice = &slice[n..];
                 }
+                Err(err) if err.is_retry() => bun_sys::block_until_writable(dest_fd)?,
+                Err(err) => return Err(err),
             }
         }
     }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -426,10 +426,8 @@ impl CopyFile {
             match bun_sys::get_errno(written) {
                 bun_sys::E::SUCCESS => {}
 
-                // One of the fds is O_NONBLOCK (`Bun.stdout` is, once
-                // `process.stdout` has been touched). A pipe-to-pipe splice is
-                // non-blocking as a whole if either end is, so EAGAIN does not
-                // say which side would have blocked: wait for both, then retry.
+                // A pipe-to-pipe splice is non-blocking if either pipe is, so
+                // EAGAIN does not say which side would have blocked.
                 bun_sys::E::EAGAIN => {
                     if let Err(err) = bun_sys::block_until_readable(src_fd)
                         .and_then(|()| bun_sys::block_until_writable(dest_fd))
@@ -1005,8 +1003,6 @@ fn read_write_loop_capped(
     let mut remaining = cap;
     while remaining > 0 {
         let want = (buf.len() as SizeType).min(remaining) as usize;
-        // Either fd may be O_NONBLOCK (`Bun.stdout` is once `process.stdout` has
-        // been touched); wait for it and retry instead of failing the copy.
         let amt = match bun_sys::read(src_fd, &mut buf[..want]) {
             Ok(amt) => amt,
             Err(err) if err.is_retry() => {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -426,8 +426,7 @@ impl CopyFile {
             match bun_sys::get_errno(written) {
                 bun_sys::E::SUCCESS => {}
 
-                // A pipe-to-pipe splice is non-blocking if either pipe is, so
-                // EAGAIN does not say which side would have blocked.
+                // A pipe-to-pipe splice is non-blocking if either pipe is, so wait on both sides.
                 bun_sys::E::EAGAIN => {
                     if let Err(err) = bun_sys::block_until_readable(src_fd)
                         .and_then(|()| bun_sys::block_until_writable(dest_fd))

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7642,15 +7642,13 @@ pub fn kevent(
     }
 }
 
-/// Blocks until a read-side syscall on `fd` would not return EAGAIN; the
-/// retried syscall reports whatever is pending (data, EOF or the error).
+/// Blocks until a read from `fd` would not return EAGAIN (there is data, EOF or an error).
 #[cfg(all(unix, not(target_os = "macos")))]
 pub fn block_until_readable(fd: Fd) -> Maybe<()> {
     block_until(fd, posix::POLL_IN)
 }
 
-/// Blocks until a write-side syscall on `fd` would not return EAGAIN; the
-/// retried syscall reports whatever is pending (room or the error, e.g. EPIPE).
+/// Blocks until a write to `fd` would not return EAGAIN (there is room, or an error like EPIPE).
 #[cfg(all(unix, not(target_os = "macos")))]
 pub fn block_until_writable(fd: Fd) -> Maybe<()> {
     block_until(fd, posix::POLL_OUT)
@@ -7671,15 +7669,13 @@ fn block_until(fd: Fd, events: i16) -> Maybe<()> {
     }
 }
 
-/// Blocks until a read-side syscall on `fd` would not return EAGAIN; the
-/// retried syscall reports whatever is pending (data, EOF or the error).
+/// Blocks until a read from `fd` would not return EAGAIN (there is data, EOF or an error).
 #[cfg(target_os = "macos")]
 pub fn block_until_readable(fd: Fd) -> Maybe<()> {
     select_one(fd, SelectFor::Read)
 }
 
-/// Blocks until a write-side syscall on `fd` would not return EAGAIN; the
-/// retried syscall reports whatever is pending (room or the error, e.g. EPIPE).
+/// Blocks until a write to `fd` would not return EAGAIN (there is room, or an error like EPIPE).
 #[cfg(target_os = "macos")]
 pub fn block_until_writable(fd: Fd) -> Maybe<()> {
     select_one(fd, SelectFor::Write)
@@ -7692,9 +7688,7 @@ enum SelectFor {
     Write,
 }
 
-/// `select(2)`, not `poll(2)`: XNU's poll is the kqueue vnode filter, which for
-/// a named pipe never fires when the other end closes; `fifo_select` goes
-/// through the FIFO's socket and does. EINTR is retried.
+/// On XNU, poll(2) on a named pipe never wakes for the other end closing; select(2) does.
 #[cfg(target_os = "macos")]
 fn select_one(fd: Fd, what: SelectFor) -> Maybe<()> {
     debug_assert!(fd.is_valid());

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1411,6 +1411,8 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    #[cfg(target_os = "macos")]
+    pub(crate) const select: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1418,7 +1420,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1528,6 +1530,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "select",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -1708,6 +1711,16 @@ mod nocancel {
         ) -> isize;
         #[link_name = "poll$NOCANCEL"]
         pub(crate) fn poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int) -> c_int;
+        // `_DARWIN_UNLIMITED_SELECT` select(2): no FD_SETSIZE limit; a set is
+        // ceil(nfds / 32) 32-bit words rather than a `libc::fd_set`.
+        #[link_name = "select$DARWIN_EXTSN$NOCANCEL"]
+        pub(crate) fn select(
+            nfds: c_int,
+            readfds: *mut u32,
+            writefds: *mut u32,
+            errorfds: *mut u32,
+            timeout: *mut libc::timeval,
+        ) -> c_int;
         // Remaining `$NOCANCEL` variants Bun links against.
         // safe: by-value `c_int` fd; bad fd → -1/EBADF, no UB.
         #[link_name = "close$NOCANCEL"]
@@ -7626,6 +7639,101 @@ pub fn kevent(
             E::SUCCESS => return Ok(rc as usize),
             E::EINTR => continue,
             e => return Err(Error::from_code(e, Tag::kevent).with_fd(fd)),
+        }
+    }
+}
+
+// ── block_until_readable / block_until_writable ──
+//
+// For loops that copy blocking-style on a pool thread but may be handed an fd
+// whose open file description is in O_NONBLOCK mode (`process.stdout` puts the
+// inherited stdio descriptions there, and the flag travels with a description
+// into child processes). On EAGAIN the loop waits here and retries, which is
+// what a blocking description would have done inside the syscall. Both return
+// as soon as the retried syscall will not block again, including when what it
+// is going to report is EOF or an error such as EPIPE: the retry reports it.
+
+/// Blocks until a `read`-side syscall on `fd` would make progress. EINTR is retried.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub fn block_until_readable(fd: Fd) -> Maybe<()> {
+    block_until(fd, posix::POLL_IN)
+}
+
+/// Blocks until a `write`-side syscall on `fd` would make progress. EINTR is retried.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub fn block_until_writable(fd: Fd) -> Maybe<()> {
+    block_until(fd, posix::POLL_OUT)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn block_until(fd: Fd, events: i16) -> Maybe<()> {
+    debug_assert!(fd.is_valid());
+    let mut fds = [posix::PollFd {
+        fd: fd.native(),
+        events,
+        revents: 0,
+    }];
+    // POLLHUP / POLLERR / POLLNVAL are reported without being requested, so
+    // any return means the caller's retry settles the matter.
+    match posix::poll(&mut fds, -1) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(err.with_fd(fd)),
+    }
+}
+
+/// Blocks until a `read`-side syscall on `fd` would make progress. EINTR is retried.
+#[cfg(target_os = "macos")]
+pub fn block_until_readable(fd: Fd) -> Maybe<()> {
+    select_one(fd, SelectFor::Read)
+}
+
+/// Blocks until a `write`-side syscall on `fd` would make progress. EINTR is retried.
+#[cfg(target_os = "macos")]
+pub fn block_until_writable(fd: Fd) -> Maybe<()> {
+    select_one(fd, SelectFor::Write)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+enum SelectFor {
+    Read,
+    Write,
+}
+
+/// `select(2)` rather than `poll(2)`: XNU implements poll on the kqueue vnode
+/// filter, which for a named pipe (FIFO) fires only while bytes (or space) are
+/// available and never for the other end closing, so a poll would outlive the
+/// peer. `fifo_select` consults the FIFO's socket, which does report the close.
+/// `pipe(2)` pipes, sockets and ttys behave under select exactly as under poll.
+#[cfg(target_os = "macos")]
+fn select_one(fd: Fd, what: SelectFor) -> Maybe<()> {
+    debug_assert!(fd.is_valid());
+    let index = fd.native() as usize;
+    let word = index / 32;
+    let mut set = vec![0u32; word + 1];
+    loop {
+        set.fill(0);
+        set[word] = 1 << (index % 32);
+        let (read_set, write_set) = match what {
+            SelectFor::Read => (set.as_mut_ptr(), core::ptr::null_mut()),
+            SelectFor::Write => (core::ptr::null_mut(), set.as_mut_ptr()),
+        };
+        // SAFETY: `set` holds the ceil(nfds / 32) words the kernel reads and
+        // writes back for `nfds = fd + 1`; the other sets and the timeout
+        // (wait indefinitely) may be null.
+        let rc = unsafe {
+            nocancel::select(
+                fd.native() + 1,
+                read_set,
+                write_set,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            )
+        };
+        match get_errno(rc) {
+            E::SUCCESS => return Ok(()),
+            E::EINTR => continue,
+            e => return Err(Error::from_code(e, Tag::select).with_fd(fd)),
         }
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1711,8 +1711,7 @@ mod nocancel {
         ) -> isize;
         #[link_name = "poll$NOCANCEL"]
         pub(crate) fn poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int) -> c_int;
-        // `_DARWIN_UNLIMITED_SELECT` select(2): no FD_SETSIZE limit; a set is
-        // ceil(nfds / 32) 32-bit words rather than a `libc::fd_set`.
+        // `_DARWIN_UNLIMITED_SELECT`: no FD_SETSIZE cap; a set is ceil(nfds / 32) `u32`s.
         #[link_name = "select$DARWIN_EXTSN$NOCANCEL"]
         pub(crate) fn select(
             nfds: c_int,
@@ -7643,28 +7642,21 @@ pub fn kevent(
     }
 }
 
-// ── block_until_readable / block_until_writable ──
-//
-// For loops that copy blocking-style on a pool thread but may be handed an fd
-// whose open file description is in O_NONBLOCK mode (`process.stdout` puts the
-// inherited stdio descriptions there, and the flag travels with a description
-// into child processes). On EAGAIN the loop waits here and retries, which is
-// what a blocking description would have done inside the syscall. Both return
-// as soon as the retried syscall will not block again, including when what it
-// is going to report is EOF or an error such as EPIPE: the retry reports it.
-
-/// Blocks until a `read`-side syscall on `fd` would make progress. EINTR is retried.
+/// Blocks until a read-side syscall on `fd` would not return EAGAIN; the
+/// retried syscall reports whatever is pending (data, EOF or the error).
 #[cfg(all(unix, not(target_os = "macos")))]
 pub fn block_until_readable(fd: Fd) -> Maybe<()> {
     block_until(fd, posix::POLL_IN)
 }
 
-/// Blocks until a `write`-side syscall on `fd` would make progress. EINTR is retried.
+/// Blocks until a write-side syscall on `fd` would not return EAGAIN; the
+/// retried syscall reports whatever is pending (room or the error, e.g. EPIPE).
 #[cfg(all(unix, not(target_os = "macos")))]
 pub fn block_until_writable(fd: Fd) -> Maybe<()> {
     block_until(fd, posix::POLL_OUT)
 }
 
+/// POLLHUP / POLLERR / POLLNVAL wake this without being requested; EINTR is retried.
 #[cfg(all(unix, not(target_os = "macos")))]
 fn block_until(fd: Fd, events: i16) -> Maybe<()> {
     debug_assert!(fd.is_valid());
@@ -7673,21 +7665,21 @@ fn block_until(fd: Fd, events: i16) -> Maybe<()> {
         events,
         revents: 0,
     }];
-    // POLLHUP / POLLERR / POLLNVAL are reported without being requested, so
-    // any return means the caller's retry settles the matter.
     match posix::poll(&mut fds, -1) {
         Ok(_) => Ok(()),
         Err(err) => Err(err.with_fd(fd)),
     }
 }
 
-/// Blocks until a `read`-side syscall on `fd` would make progress. EINTR is retried.
+/// Blocks until a read-side syscall on `fd` would not return EAGAIN; the
+/// retried syscall reports whatever is pending (data, EOF or the error).
 #[cfg(target_os = "macos")]
 pub fn block_until_readable(fd: Fd) -> Maybe<()> {
     select_one(fd, SelectFor::Read)
 }
 
-/// Blocks until a `write`-side syscall on `fd` would make progress. EINTR is retried.
+/// Blocks until a write-side syscall on `fd` would not return EAGAIN; the
+/// retried syscall reports whatever is pending (room or the error, e.g. EPIPE).
 #[cfg(target_os = "macos")]
 pub fn block_until_writable(fd: Fd) -> Maybe<()> {
     select_one(fd, SelectFor::Write)
@@ -7700,11 +7692,9 @@ enum SelectFor {
     Write,
 }
 
-/// `select(2)` rather than `poll(2)`: XNU implements poll on the kqueue vnode
-/// filter, which for a named pipe (FIFO) fires only while bytes (or space) are
-/// available and never for the other end closing, so a poll would outlive the
-/// peer. `fifo_select` consults the FIFO's socket, which does report the close.
-/// `pipe(2)` pipes, sockets and ttys behave under select exactly as under poll.
+/// `select(2)`, not `poll(2)`: XNU's poll is the kqueue vnode filter, which for
+/// a named pipe never fires when the other end closes; `fifo_select` goes
+/// through the FIFO's socket and does. EINTR is retried.
 #[cfg(target_os = "macos")]
 fn select_one(fd: Fd, what: SelectFor) -> Maybe<()> {
     debug_assert!(fd.is_valid());

--- a/test/js/bun/io/bun-write-nonblocking-stdio.test.ts
+++ b/test/js/bun/io/bun-write-nonblocking-stdio.test.ts
@@ -1,0 +1,230 @@
+// O_NONBLOCK lives on the open file description, so once process.stdout has
+// been used (a Worker does that while starting up) fd 1 is non-blocking for
+// everything that writes to it, Bun.write(Bun.stdout, file) included; a child
+// process inherits the state too. The file-to-file copy behind Bun.write is a
+// blocking-style loop on a pool thread. It used to report the EAGAIN such an fd
+// produces as the copy's failure instead of waiting for the fd.
+//
+// Bun.spawn's stdio are socketpairs, so the children run under sh to get real
+// pipes on fd 0/1. Each child reports on stderr as JSON lines: {ready: <bytes
+// prefilled>} as soon as Bun.write() has been called, then the promise's
+// outcome; the test supplies the input or the reader only after "ready".
+import { describe, expect, it } from "bun:test";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// On Linux the copy is a splice(2)/sendfile(2) loop; the env var sends it down
+// the read(2)/write(2) loop that macOS and FreeBSD always use for an fd
+// destination, so the Linux lanes cover both.
+const loops: [string, Record<string, string>][] = [
+  ["kernel copy", {}],
+  ["read/write loop", { BUN_CONFIG_DISABLE_COPY_FILE_RANGE: "1" }],
+];
+
+const copyScript = (setup: string, source: string) => `
+  let prefilled = 0;
+  ${setup}
+  const copy = Bun.write(Bun.stdout, ${source});
+  process.stderr.write(JSON.stringify({ ready: prefilled }) + "\\n");
+  copy
+    .then(n => ({ resolved: n }), e => ({ rejected: e.code + " " + e.syscall }))
+    .then(outcome => process.stderr.write(JSON.stringify(outcome) + "\\n"));
+`;
+
+// Makes fd 1 non-blocking the way any process.stdout use does, then fills the
+// pipe behind it until the kernel refuses more: nothing can be written to it
+// until the reader drains it.
+const fillStdout = `
+  process.stdout.write("");
+  const fs = require("fs");
+  const zeros = Buffer.alloc(4096);
+  for (;;) {
+    try {
+      prefilled += fs.writeSync(1, zeros);
+    } catch (e) {
+      if (e.code !== "EAGAIN") throw e;
+      break;
+    }
+  }
+`;
+
+const shell = (pipeline: string, script: string, env: Record<string, string> = {}) =>
+  ({
+    cmd: ["sh", "-c", pipeline],
+    env: { ...bunEnv, ...env, BUN: bunExe(), SCRIPT: script },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  }) as const;
+
+// Accumulates a stream. `until` resolves once the text so far satisfies the
+// predicate, or the stream ends; `all` once the stream ends. Both resolve with
+// the text so far. Concurrent waiters share one in-flight read.
+function collect(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  let pending: Promise<boolean> | undefined;
+  const more = () =>
+    (pending ??= reader.read().then(({ value, done }) => {
+      pending = undefined;
+      if (!done) text += decoder.decode(value, { stream: true });
+      return !done;
+    }));
+  return {
+    async until(predicate: (text: string) => boolean) {
+      while (!predicate(text)) if (!(await more())) break;
+      return text;
+    },
+    async all() {
+      while (await more()) {}
+      return text;
+    },
+  };
+}
+type Collected = ReturnType<typeof collect>;
+
+const parseLines = (text: string) =>
+  text
+    .trim()
+    .split("\n")
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return line;
+      }
+    });
+const reported = (count: number) => (text: string) => text.endsWith("\n") && parseLines(text).length >= count;
+
+async function ready(stderr: Collected): Promise<number> {
+  const text = await stderr.until(reported(1));
+  if (!reported(1)(text)) throw new Error("child exited before reporting ready: " + text);
+  return parseLines(text)[0].ready;
+}
+
+// The source has to be found empty, writer still attached, while the copy is
+// under way. Two pieces do that: the second is sent only after the first has
+// come back out of the child, so the copy's next syscall met an empty source
+// and had to wait. (The broken copy reports EAGAIN instead, possibly before
+// even the first piece; the second piece then just lets the pipeline finish.)
+async function feedInTwoPieces(stdout: Collected, stderr: Collected, send: (piece: string) => Promise<unknown>) {
+  await send("hel");
+  await Promise.race([stdout.until(text => text.includes("hel")), stderr.until(reported(2))]);
+  await send("lo\n");
+}
+
+// Stage 1 turns two lines from sh's stdin (this test) into the two pieces.
+const lateStdin = `{ read -r a; printf '%s' "$a"; read -r b; printf '%s\\n' "$b"; } | "$BUN" -e "$SCRIPT" | cat`;
+const sendLine = (proc: Bun.Subprocess<"pipe", "pipe", "pipe">) => async (piece: string) => {
+  proc.stdin.write(piece.trimEnd() + "\n");
+  await proc.stdin.flush();
+};
+
+async function expectCopied(proc: Bun.Subprocess, stdout: Collected, stderr: Collected) {
+  const [out, err, exitCode] = await Promise.all([stdout.all(), stderr.all(), proc.exited]);
+  expect({ stdout: out, reports: parseLines(err) }).toEqual({
+    stdout: "hello\n",
+    reports: [{ ready: 0 }, { resolved: 6 }],
+  });
+  expect(exitCode).toBe(0);
+}
+
+(isWindows ? describe.skip : describe.concurrent)("Bun.write(Bun.stdout, file) with a non-blocking stdio fd", () => {
+  it("waits for stdin once process.stdout has made fd 1 non-blocking", async () => {
+    // A pipe-to-pipe splice is non-blocking as soon as either pipe is, so it is
+    // the empty (blocking) stdin that used to fail the copy here.
+    await using proc = Bun.spawn(shell(lateStdin, copyScript(`process.stdout.write("");`, "Bun.stdin")));
+    const [stdout, stderr] = [collect(proc.stdout), collect(proc.stderr)];
+    await ready(stderr);
+    await feedInTwoPieces(stdout, stderr, sendLine(proc));
+    await expectCopied(proc, stdout, stderr);
+  });
+
+  it("waits for stdin inside a Worker, where fd 1 is non-blocking from the start", async () => {
+    const script = `
+        const { Worker } = require("node:worker_threads");
+        new Worker(
+          'const { parentPort } = require("node:worker_threads");' +
+            'const copy = Bun.write(Bun.stdout, Bun.stdin);' +
+            'parentPort.postMessage({ ready: 0 });' +
+            'copy.then(n => ({ resolved: n }), e => ({ rejected: e.code + " " + e.syscall })).then(o => parentPort.postMessage(o));',
+          { eval: true },
+        ).on("message", report => process.stderr.write(JSON.stringify(report) + "\\n"));
+      `;
+    await using proc = Bun.spawn(shell(lateStdin, script));
+    const [stdout, stderr] = [collect(proc.stdout), collect(proc.stderr)];
+    await ready(stderr);
+    await feedInTwoPieces(stdout, stderr, sendLine(proc));
+    await expectCopied(proc, stdout, stderr);
+  }, // Boots a second runtime inside the child; a few seconds under ASAN.
+  30_000);
+
+  for (const [name, env] of loops) {
+    // The reader of the child's stdout does not start until this test sends it
+    // a line over fd 3 (sh's own stdin), so the pipe the child filled up stays
+    // full until then; wc then counts prefill + copy.
+    const gatedReader = `{ read -r go <&3; exec wc -c; }`;
+    const size = 256 * 1024;
+
+    async function expectDrained(proc: Bun.Subprocess<"pipe", "pipe", "pipe">, stderr: Collected, prefilled: number) {
+      expect(prefilled).toBeGreaterThan(0);
+      proc.stdin.write("go\n");
+      await proc.stdin.flush();
+      const [stdout, err, exitCode] = await Promise.all([proc.stdout.text(), stderr.all(), proc.exited]);
+      expect({ piped: Number(stdout), reports: parseLines(err) }).toEqual({
+        piped: prefilled + size,
+        reports: [{ ready: prefilled }, { resolved: size }],
+      });
+      expect(exitCode).toBe(0);
+    }
+
+    it(`${name}: a pipe source waits for the reader of a full non-blocking stdout`, async () => {
+      await using proc = Bun.spawn(
+        shell(
+          `exec 3<&0; head -c ${size} /dev/zero | "$BUN" -e "$SCRIPT" | ${gatedReader}`,
+          copyScript(fillStdout, "Bun.stdin"),
+          env,
+        ),
+      );
+      const stderr = collect(proc.stderr);
+      await expectDrained(proc, stderr, await ready(stderr));
+    });
+
+    it(`${name}: a regular file source waits for the reader of a full non-blocking stdout`, async () => {
+      using dir = tempDir("bun-write-nonblocking-stdout", { "src.bin": Buffer.alloc(size, "S").toString() });
+      const source = `Bun.file(${JSON.stringify(join(String(dir), "src.bin"))})`;
+      await using proc = Bun.spawn(
+        shell(`exec 3<&0; "$BUN" -e "$SCRIPT" | ${gatedReader}`, copyScript(fillStdout, source), env),
+      );
+      const stderr = collect(proc.stderr);
+      await expectDrained(proc, stderr, await ready(stderr));
+    });
+
+    it(`${name}: a non-blocking source waits for its writer`, async () => {
+      // The child's stdin is a FIFO read end this test opened with O_NONBLOCK;
+      // the description is shared, so fd 0 is non-blocking in the child
+      // whatever the child does. The writer is attached before the child starts.
+      using dir = tempDir("bun-write-nonblocking-stdin", {});
+      const fifo = join(String(dir), "fifo");
+      execFileSync("mkfifo", [fifo]);
+      const readEnd = fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+      const writeEnd = fs.openSync(fifo, "w");
+      await using proc = Bun.spawn({
+        ...shell(`"$BUN" -e "$SCRIPT" | cat`, copyScript("", "Bun.stdin"), env),
+        stdin: readEnd,
+      });
+      fs.closeSync(readEnd);
+      const [stdout, stderr] = [collect(proc.stdout), collect(proc.stderr)];
+      try {
+        await ready(stderr);
+        await feedInTwoPieces(stdout, stderr, async piece => fs.writeSync(writeEnd, piece));
+      } finally {
+        fs.closeSync(writeEnd);
+      }
+      await expectCopied(proc, stdout, stderr);
+    });
+  }
+});

--- a/test/js/bun/io/bun-write-nonblocking-stdio.test.ts
+++ b/test/js/bun/io/bun-write-nonblocking-stdio.test.ts
@@ -159,8 +159,7 @@ async function expectCopied(proc: Bun.Subprocess, stdout: Collected, stderr: Col
     await ready(stderr);
     await feedInTwoPieces(stdout, stderr, sendLine(proc));
     await expectCopied(proc, stdout, stderr);
-  }, // Boots a second runtime inside the child; a few seconds under ASAN.
-  30_000);
+  }, 30_000); // Boots a second runtime inside the child; a few seconds under ASAN.
 
   for (const [name, env] of loops) {
     // The reader of the child's stdout does not start until this test sends it


### PR DESCRIPTION
### Problem

- `await Bun.write(Bun.stdout, Bun.stdin)` (the documented way to copy stdin to stdout) rejects with `EAGAIN`, `syscall: "splice"`, as soon as fd 1 is in O_NONBLOCK mode and stdin has no data yet. `process.stdout` puts the inherited stdio open file description into that mode the first time it is used, and a Worker does that while starting up, so inside a `worker_threads` Worker the idiom fails every time the data is not already sitting in the pipe. Reproduces on 1.4.0 and on main, Linux.
- The same thing happens on the other side and on the other copy strategies: `Bun.write(Bun.stdout, Bun.stdin)` or `Bun.write(Bun.stdout, Bun.file(path))` into a non-blocking stdout whose reader is slower than the copy rejects with `EAGAIN` from `splice` or `sendfile` once the pipe is full, and the read/write fallback (what macOS and FreeBSD always use for an fd destination, and Linux with `BUN_CONFIG_DISABLE_COPY_FILE_RANGE=1`) rejects with `EAGAIN` from `read` or `write`. A copy that started fine fails the same way as soon as its source is momentarily empty.
- Cause: the file-to-file path of `Bun.write` is `CopyFile` (`src/runtime/webcore/blob/copy_file.rs`), which copies on a pool thread with loops written for blocking fds. `do_copy_file_range` (the `splice`/`sendfile`/`copy_file_range` loop, errno match at line 427) and `read_write_loop_capped` (the `?` on `read` and `write` at lines 995 and 1002) treat EAGAIN like any other errno and fail the copy. O_NONBLOCK is a property of the open file description, so the flag set by `process.stdout` is visible to every user of fd 1, and is inherited by child processes as well.

### Fix

- `bun_sys::block_until_readable(fd)` / `block_until_writable(fd)`: block until a read-side or write-side syscall on the fd would make progress. `poll(2)` (via the existing EINTR-retrying `posix::poll`) everywhere except macOS; on macOS `select(2)`, because XNU's poll is built on the kqueue vnode filter, which for a named pipe never fires for the peer closing, so a poll-based wait on a non-blocking FIFO would turn today's EAGAIN into a hang at EOF. `select$DARWIN_EXTSN$NOCANCEL` is the variant without the FD_SETSIZE limit. This is the same helper (same import, same `Tag::select`) that #37823 and #37852 add for their macOS-only FIFO cases; it is defined in the same spot so whichever lands second gets a textual conflict rather than a duplicate definition.
- `do_copy_file_range`: on EAGAIN, wait for the source to be readable and the destination to be writable, then retry. Both, because a pipe-to-pipe `splice` is non-blocking as a whole when either pipe is, so the errno does not say which side would have blocked (in the repro it is the blocking, empty stdin that produces the EAGAIN). On a regular file either wait returns at once.
- `read_write_loop_capped`: EAGAIN from `read` waits for the source and re-reads; EAGAIN from `write` waits for the destination and retries the same slice, so nothing read is lost.
- Why this is the right shape: this job already blocks a pool thread for the whole copy when the fds are blocking (`splice` on an empty blocking stdin sits in the kernel until data arrives). Waiting in `poll`/`select` on the same thread gives a non-blocking description exactly the behaviour a blocking one already has, without touching the flag, which is shared with `process.stdout` and must stay set for it. Both waits return on HUP/ERR too, and the retried syscall then reports the real outcome (0 for EOF, EPIPE for a vanished reader), so error semantics are unchanged. The interaction with `worker.terminate()` is the same as for a blocked `splice` today and is handled separately by #38312. Moving the wait to the io thread instead (what the `TODO: this should use non-blocking I/O` notes in this function ask for) would be a rewrite of the job into a state machine; this PR does not attempt it, and only drops the one copy of that note that sat directly above the arm which now handles the non-blocking case, the ones on the fallback arms still stand.
- Not changed: the fallback for a destination `CopyFile` opened itself from a path (`copy_file_using_read_write_loop`, shared with `fs.copyFile`). Its destination is always blocking; a non-blocking source only reaches it through the cases #36692 is adding (FIFO source with a path destination) or on kernels where `sendfile` rejects the source, and it is being reshaped by #36692 and #33715, so it is left for those to pick the helpers up.
- Verification:
  - `test/js/bun/io/bun-write-nonblocking-stdio.test.ts` (new, POSIX): the reported case (stdin late, stdout made non-blocking by `process.stdout`), the same inside a Worker, and for both the kernel-copy loop and the read/write loop: a pipe source and a regular-file source into a stdout the child has filled up, and a source that is non-blocking by construction (a FIFO opened with O_NONBLOCK handed to the child as stdin). The source-side tests feed the input in two pieces and send the second only once the first has come back out, so the copy is guaranteed to meet an empty source mid-way. Against the released 1.4.0 all 8 fail, 60 of 60 runs, each with its own errno site: `EAGAIN splice` (4), `EAGAIN sendfile`, `EAGAIN write` (2), `EAGAIN read`. With this change on the debug (ASAN) build: 8 of 8 pass, 15 of 15 runs, about 6 s per run for the file.
  - The tests live in a sibling of `bun-write.test.js` because that file is one `describe.concurrent` of subprocess tests that already runs close to its timeouts under ASAN (see #37792); adding eight more there pushed both old and new tests over 5 s in this environment, while on their own they take 1.2 to 1.5 s (3.5 s for the Worker one, which has an explicit timeout).
  - `bun-write.test.js` behaves the same before and after (the one failure here is the pre-existing `copyFileRange is not available > on large files` timeout under ASAN).
  - `cargo check` / `cargo clippy` of `bun_sys` and `bun_runtime` natively and for `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-freebsd`, `aarch64-linux-android`, `x86_64-pc-windows-msvc` (`bun_sys`); `cargo fmt`; `test/internal/source-lints`. There is no macOS machine here; the macOS `select` arm is exercised by the new tests on the darwin lanes (the same code passed #37823's and #37852's darwin lanes).

### Background

- An open file description is the kernel object an fd refers to; `dup`, `fork`/`spawn` and stdio inheritance make several fds share one. O_NONBLOCK is stored on the description, so setting it through any one fd changes the behaviour of every fd sharing it, in this process and in children. That is how `process.stdout` (which dups fd 1 and sets O_NONBLOCK for its own writer) ends up changing what `Bun.write(Bun.stdout, ...)` sees on fd 1.
- With O_NONBLOCK, a syscall that would have to wait (read from an empty pipe, write to a full one) returns EAGAIN instead; the normal response is to wait for readiness with `poll`/`select` and retry. `splice(2)` between two pipes uses the flags of both pipes, so it behaves non-blocking towards both ends if either one is non-blocking.
- `CopyFile` is the off-thread half of `Bun.write(fileA, fileB)`: it opens what it needs, picks `copy_file_range`, `splice` or `sendfile` on Linux (read/write loop otherwise or as fallback), runs the whole copy on a work-pool thread, and resolves the promise with the byte count when done.
- On macOS, `poll(2)` is implemented on kqueue. For a FIFO created with `mkfifo`, XNU's vnode filter reports only "bytes/space available", not "the other end went away", while `select(2)` goes through the FIFO's underlying socket, which reports both. `pipe(2)` pipes (what shell pipelines and subprocess stdio use) report both under either call.
