### PR TITLE
test/bundler: make the itBundled location check look at the calling file

### DIFF
--- a/test/bundler/compile-html-asset-urls.test.ts
+++ b/test/bundler/compile-html-asset-urls.test.ts
@@ -1,5 +1,5 @@
 import { describe } from "bun:test";
-import { itBundled } from "../../bundler/expectBundled";
+import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
   // Test that `bun build --compile` produces absolute asset URLs in HTML,

--- a/test/bundler/expectBundled.test.ts
+++ b/test/bundler/expectBundled.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import path from "node:path";
+import { itBundled } from "./expectBundled";
+
+// This file is inside test/bundler/, so this registers; the spawned run below asserts that it did.
+describe("bundler", () => {
+  itBundled("harness/RegisteredFromBundlerDir", {
+    files: {
+      "/entry.js": /* js */ `console.log("registered");`,
+    },
+    run: { stdout: "registered" },
+  });
+});
+
+async function runBunTest(cwd: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args],
+    cwd,
+    env: {
+      ...bunEnv,
+      // A developer's shell may carry these; they would change what the child registers.
+      BUN_BUNDLER_TEST_FILTER: undefined,
+      BUN_BUNDLER_TEST_USE_ESBUILD: undefined,
+      BUN_BUNDLER_TEST_DEBUG: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { output: stdout + stderr, exitCode };
+}
+
+describe("itBundled must be called from a test file in test/bundler/", () => {
+  // itBundled() registers nothing on Windows until #34552 lands (see the isWindows return in itBundled).
+  test.skipIf(isWindows).concurrent("a test file in test/bundler/ registers its tests", async () => {
+    const { output, exitCode } = await runBunTest(
+      import.meta.dir,
+      import.meta.path,
+      "-t",
+      "harness/RegisteredFromBundlerDir",
+    );
+    expect(output).toMatch(/^ 1 pass$/m);
+    expect(output).toMatch(/^ 0 fail$/m);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent.each(["itBundled", "itBundled.skip", "itBundled.only"])(
+    "%s in a test file outside test/bundler/ fails the file instead of registering nothing",
+    async register => {
+      using dir = tempDir("expect-bundled-location", {
+        "misplaced.test.ts": /* ts */ `
+          import { itBundled } from ${JSON.stringify(path.join(import.meta.dir, "expectBundled.ts"))};
+          ${register}("harness/Misplaced", { files: { "/entry.js": "" } });
+        `,
+      });
+      const { output, exitCode } = await runBunTest(String(dir), "misplaced.test.ts");
+      expect(output).toContain(
+        `itBundled("harness/Misplaced") was called from ${path.join(String(dir), "misplaced.test.ts")}. ` +
+          "All bundler tests must be placed in test/bundler/",
+      );
+      expect(output).toMatch(/^ 0 pass$/m);
+      expect(exitCode).toBe(1);
+    },
+  );
+});

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -16,10 +16,11 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
-import { bunEnv, bunExe, isCI, isDebug } from "harness";
+import { bunEnv, bunExe, isCI, isDebug, isWindows } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 import { SourceMapConsumer } from "source-map";
+import { getCallSites } from "util";
 
 /** Dedent module does a bit too much with their stuff. we will be much simpler */
 export function dedent(str: string | TemplateStringsArray, ...args: any[]) {
@@ -469,12 +470,6 @@ function expectBundled(
   dryRun = false,
   ignoreFilter = false,
 ): Promise<BundlerTestRef> | BundlerTestRef {
-  if (!new Error().stack!.includes("test/bundler/")) {
-    throw new Error(
-      `All bundler tests must be placed in ./test/bundler/ so that regressions can be quickly detected locally via the 'bun test bundler' command`,
-    );
-  }
-
   var { expect, it, test } = testForFile(currentFile ?? callerSourceOrigin());
   if (!ignoreFilter && FILTER && !filterMatches(id)) return testRef(id, opts);
 
@@ -1877,12 +1872,32 @@ for (const [key, blob] of build.outputs) {
   })();
 }
 
+/**
+ * Bundler tests live in test/bundler/ so that `bun test bundler` runs all of them. Throws out of
+ * the registration call (never from inside the dry run, which `itBundled` swallows to skip tests
+ * whose options the current backend does not implement) so a misplaced file fails to load instead
+ * of silently registering nothing.
+ */
+function assertCalledFromBundlerTestDir(id: string) {
+  // The nearest frame that is not this file is the test file registering the test.
+  const caller = getCallSites().find(site => site.scriptName && site.scriptName !== import.meta.path)?.scriptName;
+  if (caller) {
+    const relative = path.relative(import.meta.dir, caller);
+    if (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)) return;
+  }
+  throw new Error(
+    `itBundled("${id}") was called from ${caller ?? "an unknown file"}. All bundler tests must be placed in ` +
+      `test/bundler/ so that regressions can be quickly detected locally via the 'bun test bundler' command`,
+  );
+}
+
 /** Shorthand for test and expectBundled. See `expectBundled` for what this does.
  */
 export function itBundled(
   id: string,
   opts: BundlerTestInput | ((metadata: BundlerTestWrappedAPI) => BundlerTestInput),
 ): BundlerTestRef {
+  assertCalledFromBundlerTestDir(id);
   if (typeof opts === "function") {
     const fn = opts;
     opts = opts({ root: path.join(tempDirectory, id), getConfigRef });
@@ -1890,6 +1905,11 @@ export function itBundled(
     opts._referenceFn = fn;
   }
   const ref = testRef(id, opts);
+  // itBundled has not registered anything on Windows since the location check was added (#15181): it
+  // ran inside the dry run below and failed on every backslash path. Registering the ~1950 tests again
+  // adds 55 failures today (bundleErrors keys built with backslashes, posix-only assertions,
+  // sideEffects globs, [dir] naming); #34552 removes this line and fixes those.
+  if (isWindows) return ref;
   const { it } = testForFile(currentFile ?? callerSourceOrigin()) as any;
 
   if (FILTER && !filterMatches(id)) {
@@ -1920,6 +1940,7 @@ export function itBundled(
 }
 
 itBundled.only = (id: string, opts: BundlerTestInput) => {
+  assertCalledFromBundlerTestDir(id);
   const { it } = testForFile(currentFile ?? callerSourceOrigin());
 
   it.only(
@@ -1931,6 +1952,7 @@ itBundled.only = (id: string, opts: BundlerTestInput) => {
 };
 
 itBundled.skip = (id: string, opts: BundlerTestInput) => {
+  assertCalledFromBundlerTestDir(id);
   if (FILTER && !filterMatches(id)) {
     return testRef(id, opts);
   }

--- a/test/bundler/plugin-onresolve-entrypoint.test.ts
+++ b/test/bundler/plugin-onresolve-entrypoint.test.ts
@@ -1,6 +1,6 @@
 import { describe } from "bun:test";
 import path from "node:path";
-import { itBundled } from "../../bundler/expectBundled";
+import { itBundled } from "./expectBundled";
 
 describe("bundler plugin onResolve entry point", () => {
   itBundled("onResolve-entrypoint-modification", {

--- a/test/expected-durations.json
+++ b/test/expected-durations.json
@@ -399,6 +399,12 @@
     "musl": 27320,
     "windows": 31130
   },
+  "bundler/compile-html-asset-urls.test.ts": {
+    "default": 1710,
+    "asan": 3560,
+    "musl": 1250,
+    "windows": 0
+  },
   "bundler/compile-process-execargv.test.ts": {
     "default": 1500,
     "asan": 4070,
@@ -565,6 +571,12 @@
     "asan": 440,
     "musl": 30,
     "windows": 90
+  },
+  "bundler/plugin-onresolve-entrypoint.test.ts": {
+    "default": 70,
+    "asan": 900,
+    "musl": 360,
+    "windows": 0
   },
   "bundler/plugin-sync-exception-fallback.test.ts": {
     "default": 20,
@@ -32856,12 +32868,6 @@
     "musl": 30,
     "windows": 80
   },
-  "regression/issue/27465.test.ts": {
-    "default": 1710,
-    "asan": 3560,
-    "musl": 1250,
-    "windows": 0
-  },
   "regression/issue/27478.test.ts": {
     "default": 30,
     "asan": 210,
@@ -33365,12 +33371,6 @@
     "asan": 130,
     "musl": 60,
     "windows": 20
-  },
-  "regression/issue/bundler-plugin-onresolve-entrypoint.test.ts": {
-    "default": 70,
-    "asan": 900,
-    "musl": 360,
-    "windows": 0
   },
   "regression/issue/circular-error-stack-edge-cases.test.ts": {
     "default": 50,


### PR DESCRIPTION
### Problem
- `expectBundled()` opens with `if (!new Error().stack!.includes("test/bundler/")) throw new Error("All bundler tests must be placed in ./test/bundler/ ...")` (`test/bundler/expectBundled.ts:472`).
- The Error is created inside `expectBundled.ts`, which is itself in `test/bundler/`, so on posix the stack always contains the substring and the check never fires. A test in `/tmp` that imports `itBundled` registers and passes, and two files have drifted out of the directory since the check was added in #15181: `test/regression/issue/27465.test.ts` and `test/regression/issue/bundler-plugin-onresolve-entrypoint.test.ts`.
- On Windows the stack uses backslashes, so the same line always throws. It throws inside the dry run that `itBundled()` wraps in `try { } catch { return ref }`, so every `itBundled` test is silently dropped there: `bun test test/bundler/bundler_banner.test.ts` on main reports `Ran 0 tests across 1 file` on Windows (11 on Linux), and 36 of the 99 `bundler/` files in `test/expected-durations.json` have `"windows": 0`.

### Fix
- `assertCalledFromBundlerTestDir(id)` runs at the top of `itBundled`, `itBundled.only` and `itBundled.skip`. It takes the nearest `util.getCallSites()` frame whose file is not `expectBundled.ts` (the test file doing the registering) and throws, naming that file, unless it is under `import.meta.dir`. The check in `expectBundled()` is removed; `expectBundled` is module-private and only reachable through those three entry points.
- It runs outside the dry run on purpose: the dry run's catch exists to skip tests whose options the current backend (esbuild) does not implement, and a convention check that lands in that catch turns into silently dropped tests, which is exactly what happened on Windows. Throwing from the registration call makes the file fail to load with the offending path in the message.
- `path.relative` against `import.meta.dir` is what makes the check correct on both platforms: `getCallSites()` returns native paths, so this works on Windows as well (verified below), unlike substring matching on a rendered stack.
- Made real rather than deleted because the convention is still the documented one (#15181 added the check while moving stray bundler tests into `test/bundler/`, `bundler_regressions.test.ts` is the home for issue-driven bundler tests, and the error message's reason, `bun test bundler` running everything, still holds); the two files that got through only got through because the check was dead. They move to `test/bundler/compile-html-asset-urls.test.ts` and `test/bundler/plugin-onresolve-entrypoint.test.ts` with only the import path changed (`expected-durations.json` keys renamed to match).
- Windows registration is left exactly as it is today, now as an explicit `if (isWindows) return ref;` in `itBundled()` with the reason next to it. With the location check fixed, Windows would otherwise start registering ~1950 tests, 55 of which fail on main today (measured below); fixing and gating those is #34552, which would then delete this line instead of normalizing backslashes in the stack string. The location check itself does run on Windows, so a misplaced file fails there too.
- Test: `test/bundler/expectBundled.test.ts`. Three cases write a file into a temp dir that calls `itBundled` / `itBundled.skip` / `itBundled.only` from `expectBundled.ts` and assert the spawned `bun test` prints `itBundled("harness/Misplaced") was called from <that file>. All bundler tests must be placed in test/bundler/`, registers nothing and exits 1; with the harness change stashed they fail (the misplaced file passes, is skipped, or hits the `.only` CI guard instead). One case registers an `itBundled` from inside `test/bundler/` and asserts a spawned `bun test` of this file reports `1 pass` (skipped on Windows, pointing at the return above). The change is entirely under `test/`, so the automatic stash-`src/` check cannot show the before state; the stash runs above are the equivalent.
- Other runs: `bun bd test` on the new file, both moved files, `bundler_regressions.test.ts`, `esbuild/loader.test.ts` and `css/css-modules.test.ts` (files in subdirectories of `test/bundler/` go through the `path.relative` branch); `bun test test/bundler` with the released bun before and after registers the same tests plus exactly the new file's (6494 tests / 100 files before, 6499 / 101 after, identical skip and todo counts, same failures); `test/internal/parallel-allowlist.test.ts`.

### Background
- `itBundled(id, opts)` is the bundler test harness entry point. At collection time it calls `expectBundled(id, opts, /* dryRun */ true)` to validate the options, and if that throws it returns without calling `it()`, which is how tests whose options the esbuild backend cannot run get skipped. Anything else that throws in there disappears the same way.
- `util.getCallSites()` (Node 22.9+, implemented in `src/js/node/util.ts`) returns the current stack as objects with a `scriptName` path per frame, without rendering a string or touching a user-installed `Error.prepareStackTrace`. `callerSourceOrigin()` from `bun:jsc`, which the harness already uses, was not usable for this: called from inside `expectBundled.ts` it reports `expectBundled.ts` itself (`Bun.jest()` only needs some absolute path, so that existing use is unaffected).
- #38471 adds a self-test for the harness that drives `itBundled` from a temp dir, which this check rejects by design; whichever lands second needs its fixtures registered from a file inside `test/bundler/` (the same-file `-t` pattern used here works for that).

<details>
<summary>Windows measurement (Windows Server 2019 x64, released bun at 032b8dbf13, <code>bun test test/bundler</code>)</summary>

| harness | tests | pass | todo | fail |
|---|---:|---:|---:|---:|
| main | 4443 | 3220 | 22 | 44 + 1 error |
| location check fixed, no `isWindows` return | 6395 | 4976 | 163 | 99 + 1 error |
| this PR | 4447 | 3223 | 22 | 44 + 1 error |

The 55 failures that appear in the middle row are all newly registered `itBundled` tests: most are `bundleErrors` keys the API backend builds with backslashes (`/node_modules\normallib\Bar.js` vs the expected `/node_modules/normallib/Bar.js`, `packagejson/*`, `tsconfig/*`, `barrel/*`, `html/*`), plus `compile-argv` asserting a `bunfs` path, `plugin/ResolvePrefix` and `ResolveTwoImportsSeparateFiles` building importer paths with `/`, and the `dce/PackageJsonSideEffects*`, `naming/AssetNamingDir` and `html-import/*` cases #34552 gates. The +4 in the last row is `expectBundled.test.ts` (3 pass, 1 skip); `bundler_banner.test.ts` still reports `Ran 0 tests`.

Misplaced file on Windows with this PR:

```
error: itBundled("onResolve-entrypoint-modification") was called from C:\workspace\bun\test\regression\issue\bundler-plugin-onresolve-entrypoint.test.ts. All bundler tests must be placed in test/bundler/ so that regressions can be quickly detected locally via the 'bun test bundler' command
Ran 0 tests across 1 file.
```
</details>
