### PR TITLE
test(css): replace the random css-fuzz loops with a deterministic table

### DIFF
--- a/test/js/bun/css/css-fuzz.test.ts
+++ b/test/js/bun/css/css-fuzz.test.ts
@@ -114,10 +114,18 @@ function corruptCSS(css: string): string {
 // TODO:
 if (!isCI) {
   // Main fuzzing test suite for invalid inputs
+  //
+  // Every iteration is one Bun.build call: ~1ms on a release build, ~50ms on a
+  // debug build, where the release counts run past the test timeout. Only ~23%
+  // of "encoding" iterations are rejected by the parser (the randomly corrupted
+  // ones), so debug still needs about 50 of them for `errorCount > 0` to hold.
   test.each(
-    [["syntax", 1000], ["structure", 1000], ["encoding", 500], !isDebug ? ["memory", 100] : []].filter(
-      xs => xs.length > 0,
-    ),
+    [
+      ["syntax", isDebug ? 50 : 1000],
+      ["structure", isDebug ? 50 : 1000],
+      ["encoding", isDebug ? 50 : 500],
+      !isDebug ? ["memory", 100] : [],
+    ].filter(xs => xs.length > 0),
   )(
     "CSS Parser Invalid Input Fuzzing - %s (%d iterations)",
     async (strategy, iterations) => {
@@ -230,15 +238,15 @@ if (!isCI) {
   test("CSS Parser Mixed Input Fuzzing", async () => {
     const validCSS = ".test{color:red}";
 
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < (isDebug ? 10 : 100); i++) {
       const mixedCSS = `
       ${validCSS}
       ${corruptCSS(validCSS)}
       ${validCSS}
     `;
 
-      console.log("--- Mixed CSS ---");
-      console.log(JSON.stringify(mixedCSS, null, 2));
+      log("--- Mixed CSS ---");
+      log(JSON.stringify(mixedCSS, null, 2));
       await Bun.write("invalid.css", mixedCSS);
 
       try {

--- a/test/js/bun/css/css-fuzz.test.ts
+++ b/test/js/bun/css/css-fuzz.test.ts
@@ -1,262 +1,126 @@
-import { expect, test } from "bun:test";
-import { isCI, isDebug } from "harness";
+import { describe, expect, test } from "bun:test";
 
-interface InvalidFuzzOptions {
-  maxLength: number;
-  strategy: "syntax" | "structure" | "encoding" | "memory" | "all";
-  iterations: number;
+// Malformed stylesheets the CSS parser has to get through. Each one is bundled
+// from memory as written and again after every corruption below. The build may
+// succeed or report errors; the assertions only check that it came back with a
+// well-formed result, the process surviving is the point.
+
+const invalid: Record<string, string[]> = {
+  selectors: [
+    "}{color:red}",
+    "&*#@.class{color:red}",
+    "..double.dot{color:red}",
+    ".{color:red}",
+    "#{color:red}",
+    ".outer { .inner { color: red } }",
+  ],
+  declarations: [".test{color:}", ".test{:red}", ".test{color::red}", ".test{;color:red}", ".test{color:red;;;}"],
+  "unclosed blocks and comments": [
+    ".test { color: red\n.another { padding: 10px }",
+    "/* unclosed comment .test{color:red}",
+    ".test{color:red} /* unclosed",
+    "/**//**//* .test{color:red}",
+    "@media screen { @media print { } ",
+  ],
+  "at-rules": [
+    "@media ;",
+    "@{color:red}",
+    "@media screen and and {color:red}",
+    "@keyframes { @keyframes { } }",
+    "@import url('test.css'",
+    "@import 'file' 'screen';",
+    "@import url(;",
+    "@import url('test.css') print",
+  ],
+  "null bytes": [".test{color:red\0;}", ".te\0st{color:red}", "\0.test{color:red}"],
+};
+
+const corruptions: ((css: string) => string)[] = [
+  css => css.replaceAll("{", "}"),
+  css => css.replaceAll("}", "{"),
+  css => css.replaceAll(":", ";"),
+  css => css.replaceAll(";", ":"),
+  css => css.slice(0, css.length >> 1),
+  css => css + "}}}}",
+  css => Array.from(css).reverse().join(""),
+];
+
+const invalidUtf8: Record<string, number[]> = {
+  "overlong two byte NUL": [0xc0, 0x80],
+  "overlong three byte NUL": [0xe0, 0x80, 0x80],
+  "overlong four byte NUL": [0xf0, 0x80, 0x80, 0x80],
+  "truncated three byte sequence": [0xe2],
+};
+
+function splice(before: string, bytes: number[], after: string): Uint8Array {
+  return new Uint8Array([...Buffer.from(before), ...bytes, ...Buffer.from(after)]);
 }
 
-const shutup = process.env.CSS_FUZZ_SHUTUP === "1";
-const log = shutup ? () => {} : console.log;
+// The sources only exist inside the `files` option; nothing is written to disk.
+const virtualDir = import.meta.dir.replaceAll("\\", "/") + "/css-fuzz-input";
 
-// Collection of invalid CSS generation strategies
-const invalidGenerators = {
-  // Syntax errors
-  syntax: {
-    unclosedRules: () => `
-      .test { color: red
-      .another { padding: 10px }`,
-    invalidSelectors: () => [
-      "}{color:red}",
-      "&*#@.class{color:red}",
-      "..double.dot{color:red}",
-      ".{color:red}",
-      "#{color:red}",
-    ],
-    malformedProperties: () => [
-      ".test{color:}",
-      ".test{:red}",
-      ".test{color::red}",
-      ".test{;color:red}",
-      ".test{color:red;;;}",
-    ],
-    unclosedComments: () => [
-      "/* unclosed comment .test{color:red}",
-      ".test{color:red} /* unclosed",
-      "/**//**//* .test{color:red}",
-    ],
-  } as const,
+// Builds every source in one Bun.build call. A batch produces no output once any
+// of its sources is rejected, so a source that should also reach the printer has
+// to be built on its own.
+async function build(sources: (string | Uint8Array)[]) {
+  const files: Record<string, string | Uint8Array> = {};
+  sources.forEach((source, i) => {
+    files[`${virtualDir}/${i}.css`] = source;
+  });
+  const entrypoints = Object.keys(files);
 
-  // Structural errors
-  structure: {
-    nestedRules: () => [
-      ".outer { .inner { color: red } }", // Invalid nesting without @rules
-      "@media screen { @media print { } ", // Unclosed nested at-rule
-      "@keyframes { @keyframes { } }", // Invalid nesting of @keyframes
-    ],
-    malformedAtRules: () => ["@media ;", "@import url('test.css'", "@{color:red}", "@media screen and and {color:red}"],
-    invalidImports: () => ["@import 'file' 'screen';", "@import url(;", "@import url('test.css') print"],
-  } as const,
+  const result = await Bun.build({ entrypoints, files, throw: false });
 
-  // Encoding and character issues
-  encoding: {
-    invalidUTF8: () => [
-      `.test{content:"${Buffer.from([0xc0, 0x80]).toString()}"}`,
-      `.test{content:"${Buffer.from([0xe0, 0x80, 0x80]).toString()}"}`,
-      `.test{content:"${Buffer.from([0xf0, 0x80, 0x80, 0x80]).toString()}"}`,
-    ],
-    nullBytes: () => [`.test{color:red${"\0"};}`, `.te${"\0"}st{color:red}`, `${"\0"}.test{color:red}`],
-    controlCharacters: () => {
-      const controls = Array.from({ length: 32 }, (_, i) => String.fromCharCode(i));
-      return controls.map(char => `.test{color:${char}red}`);
-    },
-  } as const,
-
-  // Memory and resource stress
-  memory: {
-    deepNesting: (depth: number = 300) => {
-      let css = "";
-      for (let i = 0; i < depth; i++) {
-        css += "@media screen {";
-      }
-      css += ".test{color:red}";
-      for (let i = 0; i < depth; i++) {
-        css += "}";
-      }
-      return css;
-    },
-    longSelectors: (length: number = 100000) => {
-      const selector = ".test".repeat(length);
-      return `${selector}{color:red}`;
-    },
-    manyProperties: (count: number = 10000) => {
-      const properties = Array(count).fill("color:red;").join("\n");
-      return `.test{${properties}}`;
-    },
-  } as const,
-} as const;
-
-// Helper to randomly corrupt CSS
-function corruptCSS(css: string): string {
-  const corruptions = [
-    (s: string) => (s + "").replace(/{/g, "}"),
-    (s: string) => (s + "").replace(/}/g, "{"),
-    (s: string) => (s + "").replace(/:/g, ";"),
-    (s: string) => (s + "").replace(/;/g, ":"),
-    (s: string) => (s + "").slice(Math.floor(Math.random() * (s + "").length)),
-    (s: string) => s + "" + "}}".repeat(Math.floor(Math.random() * 5)),
-    (s: string) => (s + "").split("").reverse().join(""),
-    (s: string) => (s + "").replace(/[a-z]/g, c => String.fromCharCode(97 + Math.floor(Math.random() * 26))),
-  ];
-
-  const numCorruptions = Math.floor(Math.random() * 3) + 1;
-  let corrupted = css;
-
-  for (let i = 0; i < numCorruptions; i++) {
-    const corruption = corruptions[Math.floor(Math.random() * corruptions.length)];
-    corrupted = corruption(corrupted);
+  for (const log of result.logs) {
+    expect(log.message).toBeString();
   }
-
-  return corrupted;
+  if (result.success) {
+    expect(result.outputs).toHaveLength(entrypoints.length);
+  } else {
+    expect(result.logs.length).toBeGreaterThan(0);
+  }
+  return result;
 }
 
-// TODO:
-if (!isCI) {
-  // Main fuzzing test suite for invalid inputs
-  //
-  // Every iteration is one Bun.build call: ~1ms on a release build, ~50ms on a
-  // debug build, where the release counts run past the test timeout. Only ~23%
-  // of "encoding" iterations are rejected by the parser (the randomly corrupted
-  // ones), so debug still needs about 50 of them for `errorCount > 0` to hold.
-  test.each(
-    [
-      ["syntax", isDebug ? 50 : 1000],
-      ["structure", isDebug ? 50 : 1000],
-      ["encoding", isDebug ? 50 : 500],
-      !isDebug ? ["memory", 100] : [],
-    ].filter(xs => xs.length > 0),
-  )(
-    "CSS Parser Invalid Input Fuzzing - %s (%d iterations)",
-    async (strategy, iterations) => {
-      const options: InvalidFuzzOptions = {
-        maxLength: 10000,
-        strategy: strategy as any,
-        iterations,
-      };
+test("a valid stylesheet builds through the same path", async () => {
+  const result = await build([".test{color:red}"]);
+  expect(result.success).toBe(true);
+  expect(await result.outputs[0].text()).toContain("color: red");
+});
 
-      let crashCount = 0;
-      let errorCount = 0;
-      const startTime = performance.now();
-
-      for (let i = 0; i < options.iterations; i++) {
-        let invalidCSS = "";
-
-        switch (strategy) {
-          case "syntax":
-            invalidCSS =
-              invalidGenerators.syntax[
-                Object.keys(invalidGenerators.syntax)[
-                  Math.floor(Math.random() * Object.keys(invalidGenerators.syntax).length)
-                ]
-              ]()[Math.floor(Math.random() * 5)];
-            break;
-
-          case "structure":
-            invalidCSS =
-              invalidGenerators.structure[
-                Object.keys(invalidGenerators.structure)[
-                  Math.floor(Math.random() * Object.keys(invalidGenerators.structure).length)
-                ]
-              ]()[Math.floor(Math.random() * 3)];
-            break;
-
-          case "encoding":
-            invalidCSS =
-              invalidGenerators.encoding[
-                Object.keys(invalidGenerators.encoding)[
-                  Math.floor(Math.random() * Object.keys(invalidGenerators.encoding).length)
-                ]
-              ]()[0];
-            break;
-
-          case "memory":
-            const memoryFuncs = Object.keys(invalidGenerators.memory);
-            const selectedFunc = memoryFuncs[Math.floor(Math.random() * memoryFuncs.length)];
-            invalidCSS = invalidGenerators.memory[selectedFunc]();
-            break;
-        }
-
-        // Further corrupt the CSS randomly
-        if (Math.random() < 0.3) {
-          invalidCSS = corruptCSS(invalidCSS);
-        }
-
-        log("--- CSS Fuzz ---");
-        invalidCSS = invalidCSS + "";
-        log(JSON.stringify(invalidCSS, null, 2));
-        await Bun.write("invalid.css", invalidCSS);
-
-        try {
-          const result = await Bun.build({
-            entrypoints: ["invalid.css"],
-          });
-
-          // We expect the parser to either throw an error or return a valid result
-          // If it returns undefined/null, that's a potential issue
-          if (result === undefined || result === null) {
-            crashCount++;
-            console.error(`Parser returned ${result} for input:\n${invalidCSS.slice(0, 100)}...`);
-          }
-        } catch (error) {
-          // Expected behavior for invalid CSS
-          errorCount++;
-
-          // Check for specific error types we want to track
-          if (error instanceof RangeError || error instanceof TypeError) {
-            console.warn(`Unexpected error type: ${error.constructor.name} for input:\n${invalidCSS.slice(0, 100)}...`);
-          }
-        }
-
-        // Memory check every 100 iterations
-        if (i % 100 === 0) {
-          const heapUsed = process.memoryUsage().heapUsed / 1024 / 1024;
-          expect(heapUsed).toBeLessThan(500); // Alert if memory usage exceeds 500MB
-        }
-      }
-
-      const endTime = performance.now();
-      const duration = endTime - startTime;
-
-      console.log(`
-    Strategy: ${strategy}
-    Total iterations: ${iterations}
-    Crashes: ${crashCount}
-    Expected errors: ${errorCount}
-    Duration: ${duration.toFixed(2)}ms
-    Average time per test: ${(duration / iterations).toFixed(2)}ms
-  `);
-
-      // We expect some errors for invalid input, but no crashes
-      expect(crashCount).toBe(0);
-      expect(errorCount).toBeGreaterThan(0);
-    },
-    10 * 1000,
-  );
-
-  // Additional test for mixed valid/invalid input
-  test("CSS Parser Mixed Input Fuzzing", async () => {
-    const validCSS = ".test{color:red}";
-
-    for (let i = 0; i < (isDebug ? 10 : 100); i++) {
-      const mixedCSS = `
-      ${validCSS}
-      ${corruptCSS(validCSS)}
-      ${validCSS}
-    `;
-
-      log("--- Mixed CSS ---");
-      log(JSON.stringify(mixedCSS, null, 2));
-      await Bun.write("invalid.css", mixedCSS);
-
-      try {
-        await Bun.build({
-          entrypoints: ["invalid.css"],
-        });
-      } catch (error) {
-        // Expected to throw, but shouldn't crash
-        expect(error).toBeDefined();
-      }
+for (const [family, stylesheets] of Object.entries(invalid)) {
+  describe(family, () => {
+    for (const css of stylesheets) {
+      test(JSON.stringify(css), async () => {
+        await build([css]);
+        await build(corruptions.map(corrupt => corrupt(css)));
+      });
     }
   });
 }
+
+test("every control character inside a declaration value", async () => {
+  await build(Array.from({ length: 32 }, (_, i) => `.test{color:${String.fromCharCode(i)}red}`));
+});
+
+describe("invalid UTF-8", () => {
+  for (const [name, bytes] of Object.entries(invalidUtf8)) {
+    test(`${name} inside a string`, async () => {
+      await build([splice('.test{content:"', bytes, '"}')]);
+    });
+
+    test(`${name} inside an identifier`, async () => {
+      await build([splice(".te", bytes, "st{color:red}")]);
+    });
+  }
+});
+
+describe("oversized input", () => {
+  test("a selector with 100000 compound parts", async () => {
+    await build([Buffer.alloc(".test".length * 100_000, ".test").toString() + "{color:red}"]);
+  });
+
+  test("a rule with 10000 declarations", async () => {
+    await build([".test{" + Buffer.alloc("color:red;\n".length * 10_000, "color:red;\n").toString() + "}"]);
+  });
+});

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -58,7 +58,6 @@ test/integration/next-pages/test/dev-server-ssr-100.test.ts
 test/integration/next-pages/test/dev-server.test.ts
 test/integration/next-pages/test/next-build.test.ts
 test/integration/vite-build/vite-build.test.ts
-test/js/bun/css/css-fuzz.test.ts
 test/js/bun/ffi/cc.test.ts
 test/js/bun/http/bun-serve-html-manifest.test.ts
 test/js/bun/http/bun-server.test.ts


### PR DESCRIPTION
### Problem
- `bun bd test test/js/bun/css/css-fuzz.test.ts` fails 4/4 on a debug build: the syntax, structure and encoding strategies hit `this test timed out after 10000ms` and "CSS Parser Mixed Input Fuzzing" hits `timed out after 5000ms` (main 032b8dbf13; the release binary passes). Several recent CSS PRs list these timeouts as pre-existing noise from `bun bd test test/js/bun/css/`.
- Cause: each strategy builds 1000 (encoding: 500) randomly picked strings, one `Bun.build` call per string, and a `Bun.build` call costs 40-60ms on a debug build against the 10s timeout the file passes to `test.each` (css-fuzz.test.ts:226 on main).
- The random sampling is also what makes the file weak: the whole file is wrapped in `if (!isCI)` (css-fuzz.test.ts:115), so it registers no tests in CI, and the way the loop indexes its tables (`[Math.floor(Math.random() * 5)]` on every syntax generator at :144, `* 3` at :153, `[0]` at :162) means 1000 iterations can only ever reach 28 of the 62 strings the tables define, three of them by accident (`"\n"`, `" "` from indexing into the `unclosedRules` string, and the literal `"undefined"` from indexing past the 3-element `unclosedComments` array). The `invalidUTF8` entries build the strings through `Buffer#toString`, which replaces the bytes with U+FFFD, so they were valid UTF-8 by the time the parser saw them.

### Fix
- The file becomes a deterministic table: every string the old tables defined is built once as written and once more as a batch of the old `corruptCSS` transforms with the randomness removed (brace and colon/semicolon swaps, truncation, extra closing braces, reversal), the 32 control characters are built as one batch, the invalid UTF-8 sequences are passed as real bytes (spliced into a string token and into an identifier), and the two oversized generators (`longSelectors`, `manyProperties`) are fixed cases. 39 tests, 66 `Bun.build` calls.
- Each build asserts only that it came back well formed: every log has a string message, a successful build has one output per source, a failed one has at least one log. Which inputs the parser rejects is not asserted, since that changes on purpose as recovery improves; the file is a crash corpus, like `doesnt_crash.test.ts` next to it. A first test builds a valid stylesheet through the same helper so a broken `files` mapping fails loudly instead of turning the table into 66 resolution errors.
- Sources go through `Bun.build({ files })`, the in-memory input `doesnt_crash.test.ts` already uses, so the file no longer writes `invalid.css` into the cwd (#38491 fixes that write on the old loops; with this change there is nothing left to move, whichever lands first the other is a trivial rebase or becomes unnecessary).
- This removes the `!isCI` wrapper, the `10 * 1000` timeout, the iteration counts and the debug/release split, so there is nothing left to tune per build type: the tests take about 0.3s total on release and about 6s on a debug ASAN build (5.5s of that is the `Bun.build` calls, 0.7s the 500 KB selector), under the default per-test timeout by 5x or more for every test. Same approach as the `fuzz ansi256` change in #33622: sweep the inputs the old loop was sampling instead of sampling them.
- `test/no-validate-leaksan.txt` loses its `css-fuzz.test.ts` line. The entry dates from when LSAN was wired up (45760cd53c), while the file registered no tests in CI; the rewritten file runs clean with the runner's LSAN settings (`detect_leaks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `test/leaksan.supp`) and with `BUN_JSC_validateExceptionChecks=1` on the debug build.
- Dropped on purpose: the old `memory.deepNesting` generator (300 nested `@media`). It overflows the 4 MB pool-thread stack on debug/ASAN builds before `MAX_NESTING_DEPTH` applies, which is a parser bug with its own fix and test in #38481; the old file skipped the whole `memory` strategy on debug builds for this reason. Also left out: a stray continuation byte after a rule, which trips a char-boundary `debug_assert` in the tokenizer on debug builds; that is reported separately and gets its own test with its fix.
- Verified:
  - `bun bd test test/js/bun/css/css-fuzz.test.ts`: 39 pass (main: 0 pass, 4 fail, all by timeout).
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/css/css-fuzz.test.ts`: 39 pass in 0.6s.
  - Debug build with the runner's LSAN and exception-check environment: 39 pass, exit 0, no sanitizer output.
  - On the release binary: 12 of the 27 strings are accepted as written (so they reach the printer) and 15 are rejected, all 27 corruption batches contain a rejected variant, and the control-character batch builds 32 outputs, so both branches of the helper's assertion run on every pass.
- Test-only change, so there is no src diff to stash for a before/after on the same test; the before is the current file timing out 4/4 under `bun bd test`, the after is the same command passing.

### Background
- `Bun.build({ files })` takes a map of path to contents and resolves entrypoints (and imports) against it before touching the disk, so a build can run entirely from memory; keys are normalized to forward slashes, which is why the test derives its virtual paths from `import.meta.dir` the same way `doesnt_crash.test.ts` does.
- `throw: false` makes `Bun.build` return `{ success, logs, outputs }` for a failed build instead of throwing an `AggregateError`.
- When one source in a multi-entrypoint build is rejected, the bundler still parses every other source but stops before linking and printing, so the batch produces no outputs. That is why each string is also built alone: an accepted stylesheet then reaches the printer as well.
- `test/no-validate-leaksan.txt` lists test files the CI runner (`scripts/runner.node.mjs`) runs without LeakSanitizer on the ASAN lanes; everything else runs with `detect_leaks=1` and the suppressions in `test/leaksan.supp`.

<details>
<summary>Runs</summary>

Main, debug build:

```
(fail) CSS Parser Invalid Input Fuzzing - syntax (1000 iterations) [10000.22ms]
(fail) CSS Parser Invalid Input Fuzzing - structure (1000 iterations) [10000.21ms]
(fail) CSS Parser Invalid Input Fuzzing - encoding (500 iterations) [10000.16ms]
(fail) CSS Parser Mixed Input Fuzzing [5000.15ms]
 0 pass, 4 fail
Ran 4 tests across 1 file. [37.82s]
```

This branch, debug build (`bun bd test`): 39 pass, 0 fail. Test bodies sum to 5.5s (median 115ms for the built-alone-plus-batch tests, 731ms for the 100000-part selector); a one-test file reports 3.7s on the same binary, which is the fixed startup cost.

This branch, release binary: 39 pass, 0 fail, `Ran 39 tests across 1 file. [611.00ms]`.

Per-call cost measured with a standalone loop of `Bun.build` on a one-rule stylesheet, 100 iterations: release 1.2ms, debug 53-58ms.

<details>
<summary>Superseded first version of this PR</summary>

The first push kept the random loops and ran 50 iterations per strategy (10 for the mixed test) when `isDebug`, with a flake-rate argument for 50 (only ~23% of encoding iterations were rejected, so `errorCount > 0` needed about 50 samples). Reviewing it showed the iteration count was the wrong knob: the coverage of the loops is bounded by their tables regardless of the count, the file was not running in CI at all, and enumerating the tables is both faster on a debug build than the tuned counts and removes the need for the split, so that version was replaced by the current one.

</details>
</details>
