### PR TITLE
css: fold hypot() with three or more arguments pairwise

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -511,11 +511,8 @@ impl<V: CalcValue> Calc<V> {
             CalcUnit::Exp => Self::parse_numeric_fn(input, NumericFnOp::Exp, ctx, parse_ident),
             CalcUnit::Hypot => input.parse_nested_block(|i| {
                 let mut args = i.parse_comma_separated(|i| Self::parse_sum(i, ctx, parse_ident))?;
-                let val = Self::parse_hypot(&mut args)?;
-                if let Some(v) = val {
-                    return Ok(v);
-                }
-                Ok(Calc::Function(Box::new(MathFunction::Hypot(args))))
+                Ok(Self::parse_hypot(&mut args)
+                    .unwrap_or_else(|| Calc::Function(Box::new(MathFunction::Hypot(args)))))
             }),
             CalcUnit::Abs => input.parse_nested_block(|i| {
                 let v = Self::parse_sum(i, ctx, parse_ident)?;
@@ -918,38 +915,18 @@ impl<V: CalcValue> Calc<V> {
         Ok(val)
     }
 
-    pub(crate) fn parse_hypot(args: &mut [Self]) -> CssResult<Option<Self>> {
+    pub(crate) fn parse_hypot(args: &mut [Self]) -> Option<Self> {
         if args.len() == 1 {
             let v = core::mem::replace(&mut args[0], Calc::Number(0.0));
-            return Ok(Some(v));
+            return Some(v);
         }
 
-        if args.len() == 2 {
-            return Ok(Self::apply_op(&args[0], &args[1], (), |_, a, b| {
-                hypot((), a, b)
-            }));
+        // Not a sum of squares: `try_op` converts units linearly, wrong for squared values.
+        let mut acc = Self::apply_op(&args[0], &args[1], (), hypot)?;
+        for arg in &args[2..] {
+            acc = Self::apply_op(&acc, arg, (), hypot)?;
         }
-
-        let mut i: usize = 0;
-        let Some(first) = Self::apply_map(&args[0], powi2) else {
-            return Ok(None);
-        };
-        i += 1;
-        let mut errored = false;
-        let mut sum = first;
-        for arg in &args[i..] {
-            let Some(next) = Self::apply_op(&sum, arg, (), |_, a, b| a + b.powf(2.0)) else {
-                errored = true;
-                break;
-            };
-            sum = next;
-        }
-
-        if errored {
-            return Ok(None);
-        }
-
-        Ok(Self::apply_map(&sum, sqrtf32))
+        Some(acc)
     }
 
     pub(crate) fn apply_op<OC: Copy>(
@@ -1533,14 +1510,6 @@ fn round(_: (), value: f32, to: f32, strategy: RoundingStrategy) -> f32 {
 
 fn hypot(_: (), a: f32, b: f32) -> f32 {
     a.hypot(b)
-}
-
-fn powi2(v: f32) -> f32 {
-    v.powf(2.0)
-}
-
-fn sqrtf32(v: f32) -> f32 {
-    v.sqrt()
 }
 
 /// Returns -1.0, 0.0, or 1.0 (NOT Rust's `f32::signum`, which

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -225,6 +225,46 @@ describe("css tests", () => {
     minify_test(`a { width: hypot(1in, 1em) }`, `a{width:hypot(1in,1em)}`);
     minify_test(`a { transform: rotate(atan2(1in, 1em)) }`, `a{transform:rotate(atan2(1in,1em))}`);
   });
+  describe("hypot() with three or more arguments", () => {
+    // hypot(a, b, c) is folded as hypot(hypot(a, b), c), so a unit conversion can
+    // happen at any step and the result is in px (or deg) once one has happened.
+    // 1pc = 16px, 1in = 96px, 100grad = 0.25turn = 90deg. The inputs are scaled
+    // Pythagorean triples/quadruples so the exact results are easy to check by hand:
+    // hypot(2, 3, 6) = 7, hypot(1, 2, 2) = 3, hypot(3, 4, 12) = 13, hypot(1, 2, 2, 4) = 5.
+    minify_test(`a { width: hypot(2pc, 3pc, 1in) }`, `a{width:112px}`);
+    minify_test(`a { width: hypot(1in, 2pc, 3pc) }`, `a{width:112px}`);
+    minify_test(`a { width: hypot(32px, 48px, 1in) }`, `a{width:112px}`);
+    minify_test(`a { width: hypot(3pc, 4pc, 0px) }`, `a{width:80px}`);
+    minify_test(`a { width: hypot(1pc, 2pc, 2pc, 64px) }`, `a{width:80px}`);
+    minify_test(`a { width: hypot(3in, 4in, 10px) }`, `a{width:480.104px}`); // sqrt(288² + 384² + 10²)
+    minify_test(`a { border-spacing: hypot(2pc, 3pc, 1in) }`, `a{border-spacing:112px}`);
+    // No conversion needed: the unit is kept.
+    minify_test(`a { width: hypot(2in, 3in, 6in) }`, `a{width:7in}`);
+    minify_test(`a { width: hypot(3em, 4em, 12em) }`, `a{width:13em}`);
+    // An argument that cannot be converted to px leaves the function unevaluated.
+    minify_test(`a { width: hypot(3in, 4in, 1em) }`, `a{width:hypot(3in,4in,1em)}`);
+    minify_test(`a { width: hypot(1em, 3in, 4in) }`, `a{width:hypot(1em,3in,4in)}`);
+    minify_test(`a { width: hypot(30%, 40%, 1px) }`, `a{width:hypot(30%,40%,1px)}`);
+    // Two or more percentages fold through the same binary step that round()/mod() of
+    // percentages use, whatever the argument count. This holds for a bare <percentage>
+    // context (opacity) as well as for <length-percentage>.
+    minify_test(`a { width: hypot(30%, 40%) }`, `a{width:50%}`);
+    minify_test(`a { width: hypot(20%, 30%, 60%) }`, `a{width:70%}`);
+    minify_test(`a { opacity: hypot(20%, 30%, 60%) }`, `a{opacity:.7}`);
+    minify_test(`a { opacity: calc(10% + hypot(20%, 30%, 60%)) }`, `a{opacity:.8}`);
+    // Angles convert to deg.
+    minify_test(`a { rotate: hypot(0.25turn, 135deg, 270deg) }`, `a{rotate:315deg}`);
+    minify_test(`a { rotate: hypot(50grad, 100grad, 90deg) }`, `a{rotate:135deg}`);
+    minify_test(`a { rotate: hypot(20grad, 30grad, 60grad) }`, `a{rotate:70grad}`);
+    minify_test(
+      `a { background: conic-gradient(red hypot(50grad, 100grad, 90deg), blue) }`,
+      `a{background:conic-gradient(red 135deg,#00f)}`,
+    );
+    // Times convert the later arguments into the first one's unit, numbers have no unit.
+    minify_test(`a { transition-duration: hypot(2s, 3s, 6000ms) }`, `a{transition-duration:7s}`);
+    minify_test(`a { transition-duration: hypot(2000ms, 3s, 6s) }`, `a{transition-duration:7s}`);
+    minify_test(`a { line-height: hypot(2, 3, 6) }`, `a{line-height:7}`);
+  });
   describe("border_spacing", () => {
     minify_test(
       `


### PR DESCRIPTION
Stacked on #38489 (this PR's base is that branch, so the diff shown here is only the `hypot()` change and its tests). The mixed-unit length cases below need both fixes; the angle and percentage cases only need this one. Once #38489 lands this gets rebased onto main.

### Problem
- The CSS minifier (`bun build` on CSS, `Bun.build`) folds `hypot()` with three or more arguments to a wrong value whenever the arguments are not all in the same unit:
  - `width: hypot(3in, 4in, 10px)` becomes `50px` (should be `480.104px`, sqrt(288² + 384² + 10²))
  - `width: hypot(2pc, 3pc, 1in)` becomes `97.0773px` (should be `112px`)
  - `rotate: hypot(.25turn, 135deg, 270deg)` becomes `301.906deg` (should be `315deg`)
  - `conic-gradient(red hypot(50grad, 100grad, 90deg), blue)` gets `139.104deg` (should be `135deg`)
- Cause: `Calc::parse_hypot` in `src/css/values/calc.rs` (lines 933-952 before this change) squares the first argument in place with `apply_map`, then folds the rest with `apply_op(sum, arg, |a, b| a + b²)`, then takes `sqrt`. The accumulator is a squared quantity that still carries a linear unit (`3in` becomes `9in`). When a later argument has a different unit, `LengthValue::try_op` / `Angle::try_op` convert the accumulator to px / deg by the linear factor (96 for `in`, 0.9 for `grad`), but a squared quantity would need the squared factor, so the sum is wrong from that step on.
- It only shows when a conversion happens while the accumulator is in a non-canonical unit, which is why same-unit arguments, px-first / deg-first argument orders, and `Time` (whose `try_op` converts the right operand into the left operand's unit instead) were already right.
- Without #38489 the same inputs print `2400.5px` / `208.499px` (bun 1.4.0): `try_op` also ignored the right operand. That is a separate bug in `length.rs`; this PR is the `parse_hypot` half.
- lightningcss 1.30.2, which this code is ported from, prints the same wrong values (`50px`, `97.0773px`, `301.906deg`), so matching upstream is not the target here; the CSS Values 4 definition `hypot(A, B, ...) = sqrt(A² + B² + ...)` with all arguments in one unit is.

### Fix
- Fold the arguments pairwise with the existing two-argument `hypot` op: `hypot(a, b, c) == hypot(hypot(a, b), c)`, so every value `try_op` converts is a plain length or angle and its linear conversion is the right one. The two-argument case is the same `apply_op` call as before; the one-argument case is untouched (see the note at the end). `powi2` / `sqrtf32` had no other users and are removed, and `parse_hypot` returns the `Option` directly since it never produced an error.
- A step that cannot be folded (`1em` among absolute units, a percentage among lengths, a non-value argument) still returns `None` without modifying `args`, so the function is still emitted unevaluated exactly as written (`hypot(3in,4in,1em)`), same as before.
- One visible side effect, pinned in the tests: `hypot()` of three or more percentages now folds (`hypot(20%, 30%, 60%)` becomes `70%`, `opacity: calc(10% + hypot(20%, 30%, 60%))` becomes `.8`). It was left unevaluated only because the old first step was `try_map`, which refuses percentages; the two-argument `hypot(30%, 40%)` has always folded to `50%` through `try_op`, like `round()` / `mod()` of percentages do. In a bare `<percentage>` context the old result was worse than merely unevaluated: `opacity: calc(10% + hypot(20%, 30%, 60%))` printed `opacity:0` on 1.4.0, because `Percentage::from_calc` turns a non-value calc into NaN (upstream has an `unreachable!()` there instead; the sink itself is fixed separately in #38513). Folding moves these inputs out of it.
- Results for the already-correct cases are unchanged: all 1188 pre-existing tests in `css.test.ts` still pass.
- Test: `test/js/bun/css/css.test.ts`, new `hypot() with three or more arguments` block (23 cases): mixed absolute lengths with the conversion at the first, middle and last step and with 4 arguments, a `<length>` property (`border-spacing`) as well as `<length-percentage>` (`width`), same-unit absolute and relative lengths, non-convertible arguments in first and last position, percentages in `<length-percentage>` and bare `<percentage>` (`opacity`) contexts, mixed angles (`rotate`) and `<angle-percentage>` (`conic-gradient`), same-unit angles, mixed times and plain numbers. Inputs are scaled Pythagorean triples so the expected values are exact.
  - on the base branch (#38489 without this change): 12 of the 23 fail with the values listed above; on bun 1.4.0: 14 fail
  - with this change: all 23 pass; full `css.test.ts`: 1190 pass, 0 fail; `doesnt_crash.test.ts`: 61 pass
  - `cargo clippy -p bun_css` and `cargo fmt --check` are clean
- Not changed here: the one-argument form still returns its argument as parsed, so `hypot(-3px)` still prints `-3px` (spec: `3px`) and `hypot(1px + 10%)` still prints the bare sum. Folding it through `abs()`'s `apply_map` is the obvious fix, but until #38513 lands it would route `hypot(50%)` into the `Percentage::from_calc` NaN sink and turn the currently correct `opacity: calc(10% + hypot(50%))` (`.6`) into `0`; an earlier revision of this PR did exactly that and was reverted. It is tracked separately, to land on top of #38513.

### Background
- Math functions such as `round()`, `mod()`, `hypot()` are evaluated at parse time when all of their arguments are concrete values. `Calc::apply_op(a, b, op)` does one binary step by calling the value type's `try_op`; `Calc::apply_map(a, op)` does one unary step through `try_map`. A `None` from either makes the parser keep the function in the output as written.
- `try_op` for `LengthValue` applies `op` to the raw numbers when both operands have the same unit, and otherwise converts both to px (`LengthValue::to_px`, absolute units only) and returns a px value; `Angle::try_op` does the same with degrees. Both conversions are linear in the stored number, which is only right when that number is a length or angle to the first power.
- `Percentage::try_op` folds (so binary functions of percentages fold), while `Percentage::try_map` returns `None` because a percentage's sign is unknown until it is resolved (this is what keeps `abs()` / `sign()` of a percentage unevaluated).
- `Percentage::from_calc` is how a `calc()` sum in a bare `<percentage>` property (`opacity`, color alpha) turns a folded calc back into a value; for anything that is not a plain value it currently produces NaN, which the serializer prints as `0`.

<details>
<summary>Before/after for the inputs in the test, next to lightningcss 1.30.2</summary>

```
input                                          base (#38489)            bun 1.4.0                lightningcss 1.30.2      this PR
width: hypot(3in,4in,10px)                     50px                     2400.5px                 50px                     480.104px
width: hypot(2pc,3pc,1in)                      97.0773px                208.499px                97.0773px                112px
width: hypot(1in,2pc,3pc)                      58.515px                 9312.5px                 58.515px                 112px
width: hypot(32px,48px,1in)                    112px                    3328.5px                 112px                    112px
width: hypot(3pc,4pc,0px)                      20px                     400.5px                  20px                     80px
width: hypot(1pc,2pc,2pc,64px)                 65.1153px                144.499px                65.1153px                80px
rotate: hypot(.25turn,135deg,270deg)           301.906deg               301.906deg               301.906deg               315deg
rotate: hypot(50grad,100grad,90deg)            139.104deg               139.104deg               139.104deg               135deg
width: hypot(20%,30%,60%)                      hypot(20%,30%,60%)       hypot(20%,30%,60%)       hypot(20%,30%,60%)       70%
opacity: hypot(20%,30%,60%)                    hypot(20%,30%,60%)       hypot(20%,30%,60%)       panics (unreachable!)    .7
opacity: calc(10% + hypot(20%,30%,60%))        0                        0                        panics (unreachable!)    .8
width: hypot(3in,4in,1em)                      hypot(3in,4in,1em)       2400.5px                 hypot(3in,4in,1em)       hypot(3in,4in,1em)
width: hypot(2in,3in,6in)                      7in                      7in                      7in                      7in
transition-duration: hypot(2s,3s,6000ms)       7s                       7s                       7s                       7s
```
</details>

<details>
<summary>Earlier revision (reverted): one-argument hypot() folded like abs()</summary>

Commit ed7d689ab3 in this PR's history made the one-argument branch `apply_map(arg, absf)`, which fixed `hypot(-3px)` -> `3px` and stopped `hypot(1px + 10%)` from printing a bare sum, but also made `hypot(50%)` return a `MathFunction` instead of the percentage. In a bare `<percentage>` property that hits `Percentage::from_calc`'s NaN fallback, so `opacity: calc(10% + hypot(50%))` went from `.6` to `0` and `rgb(255 0 0 / calc(hypot(50%) + 10%))` from `#f009` to `#f000`. #38513 changes that fallback to a parse error (which preserves the declaration); the one-argument fold is deferred until it lands.
</details>
