### PR TITLE
shell: free the cp builtin's task when its fs.cp completion is released unrun

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1502,10 +1502,24 @@ mod _async_tasks {
             bun_event_loop::task_tag::AsyncCpTask
         };
         /// A finished fs.cp whose completion will not run: destroy releases
-        /// its promise handle, protected arguments and keep-alive.
+        /// its promise handle, protected arguments and keep-alive. The shell's
+        /// variant is also the completion of the `ShellCpTask` that handed it
+        /// the copy (`run_from_js_thread` → `cp_on_finish`), so that task is
+        /// released unrun here too; nothing else frees it.
         unsafe fn release_unrun(this: *mut Self) {
-            // SAFETY: fn contract — posted by `on_subtask_done` with the count at zero.
-            unsafe { Self::destroy(this) }
+            // SAFETY: fn contract — posted by `on_subtask_done` with the count
+            // at zero, so nothing on the pool still reads this task or the
+            // shell task it points at. The shell task is released after this
+            // one: `args` borrows its absolute paths.
+            unsafe {
+                let shelltask = (*this).shelltask;
+                Self::destroy(this);
+                if let Some(shelltask) = shelltask {
+                    <ShellCpTask as bun_event_loop::Taskable>::release_unrun(
+                        shelltask.as_mut_ptr(),
+                    );
+                }
+            }
         }
     }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1502,15 +1502,13 @@ mod _async_tasks {
             bun_event_loop::task_tag::AsyncCpTask
         };
         /// A finished fs.cp whose completion will not run: destroy releases
-        /// its promise handle, protected arguments and keep-alive. The shell's
-        /// variant is also the completion of the `ShellCpTask` that handed it
-        /// the copy (`run_from_js_thread` → `cp_on_finish`), so that task is
-        /// released unrun here too; nothing else frees it.
+        /// its promise handle, protected arguments and keep-alive. For the
+        /// shell this completion is also what frees the `ShellCpTask`
+        /// (`cp_on_finish`), so that is released unrun here as well.
         unsafe fn release_unrun(this: *mut Self) {
             // SAFETY: fn contract — posted by `on_subtask_done` with the count
-            // at zero, so nothing on the pool still reads this task or the
-            // shell task it points at. The shell task is released after this
-            // one: `args` borrows its absolute paths.
+            // at zero, so the pool is done with both tasks. `args` borrows the
+            // shell task's paths, hence the order.
             unsafe {
                 let shelltask = (*this).shelltask;
                 Self::destroy(this);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1502,13 +1502,13 @@ mod _async_tasks {
             bun_event_loop::task_tag::AsyncCpTask
         };
         /// A finished fs.cp whose completion will not run: destroy releases
-        /// its promise handle, protected arguments and keep-alive. For the
-        /// shell this completion is also what frees the `ShellCpTask`
-        /// (`cp_on_finish`), so that is released unrun here as well.
+        /// its promise handle, protected arguments and keep-alive.
         unsafe fn release_unrun(this: *mut Self) {
             // SAFETY: fn contract — posted by `on_subtask_done` with the count
-            // at zero, so the pool is done with both tasks. `args` borrows the
-            // shell task's paths, hence the order.
+            // at zero, so the pool is done with this task and with the shell
+            // task whose completion it carries (running it, `cp_on_finish`
+            // would have freed that task); `args` borrows that task's paths,
+            // hence the order.
             unsafe {
                 let shelltask = (*this).shelltask;
                 Self::destroy(this);

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -232,13 +232,22 @@ const ROWS: Row[] = [
 // the worker waits for (with the gate armed, a parent→worker post is itself a
 // cross-thread post that waits for the worker's teardown). Rows with a parent
 // side post in response to "armed".
+//
+// The work is started from an immediate, not from the module body: a `leak:`
+// suppression matches any frame of an allocation's recorded stack, and
+// test/leaksan.supp suppresses module evaluation (evaluateCommonJSModuleOnce),
+// which on the release ASAN build is still inside the 30 frames recorded for
+// what a row's work allocates. Started from the module body, a leaking
+// release path went unreported there.
 function host(row: Row, dir: string) {
   const worker = `
     const { parentPort, workerData } = require("node:worker_threads");
     parentPort.on("message", () => {});
-    ${row.worker}
-    parentPort.postMessage("armed");
-    setImmediate(() => setImmediate(() => process.exit(0)));
+    setImmediate(() => {
+      ${row.worker}
+      parentPort.postMessage("armed");
+      setImmediate(() => setImmediate(() => process.exit(0)));
+    });
   `;
   return `
     const { Worker, MessageChannel } = require("node:worker_threads");

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -13,13 +13,21 @@
 // the wait, and the runtime names it on stderr. A row passes only if the named
 // line appeared (the work really was on another thread, really came back
 // during teardown, and — for ticketed work — was taken through the door at
-// the expected site) and the process exited cleanly; on the ASAN build the
-// release paths are also checked for use-after-free and leaks. Builds with
-// debug assertions only (debug, ASAN): the gate does not exist in release.
-import { describe, expect, test } from "bun:test";
+// the expected site) and the process exited cleanly; on the ASAN build a
+// release path that frees too much crashes the host, and one that frees too
+// little fails under the LeakSanitizer the host is run with here, whatever
+// environment the test runner supplies. Builds with debug assertions only
+// (debug, ASAN): the gate does not exist in release.
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isAndroid, isASAN, isDebug, isLinux, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
+
+// Every test here starts a debug/ASAN bun plus a worker (the last one also
+// sits out the 2s outstanding-ticket report), and a failing row's leak report
+// takes LeakSanitizer seconds more to symbolize: none of that fits the 5s
+// default.
+setDefaultTimeout(90_000);
 
 type Row = {
   name: string;
@@ -147,7 +155,9 @@ const ROWS: Row[] = [
   },
   {
     // The builtin's pool task hands the copy to an fs.cp task carrying a
-    // clone of its poster; that task's last subtask posts the completion.
+    // clone of its poster; that task's last subtask posts the completion, so
+    // releasing it unrun has to free the builtin's task as well (it used to
+    // leak, which LeakSanitizer reports on this row).
     name: "$ cp -R",
     worker: `Bun.$\`cp -R \${workerData.dir}/src \${workerData.dir}/dst\`.quiet().catch(() => {});`,
     ticket: "cp.rs",
@@ -242,13 +252,24 @@ function host(row: Row, dir: string) {
   `;
 }
 
+// LeakSanitizer on the host (ASAN build): a release path that leaks exits it
+// non-zero with the report on stderr. The main VM is destroyed at exit as well
+// (as under the CI runner), or whatever it still owned would be reported too.
+const leakCheckEnv = isASAN
+  ? {
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+      LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
+    }
+  : {};
+
 describe.skipIf(!isDebug && !isASAN)("work that comes back after its worker began tearing down", () => {
   for (const row of ROWS) {
     test.concurrent.skipIf(!!row.skip)(row.name, async () => {
       using dir = tempDir("worker-late-completion", row.files ?? {});
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", host(row, String(dir))],
-        env: { ...bunEnv, ...row.env, BUN_DEBUG_TEST_WORKER_TEARDOWN_GATE: "1" },
+        env: { ...bunEnv, ...leakCheckEnv, ...row.env, BUN_DEBUG_TEST_WORKER_TEARDOWN_GATE: "1" },
         stdout: "pipe",
         stderr: "pipe",
       });


### PR DESCRIPTION
### Problem
- A `cp -R` run through the shell's `cp` builtin in a worker, with the copy still in flight when the worker exits, leaks the builtin's task. LeakSanitizer on the `$ cp -R` row of `test/js/web/workers/worker-late-completion.test.ts`: `Direct leak of 440 byte(s) in 1 object(s)` allocated at `<bun_runtime::shell::builtins::cp::ShellCpTask>::create src/runtime/shell/builtin/cp.rs:422` (via `Cp::next` cp.rs:174, `Builtin::start`). Reproduces 6/6 on a debug build of main (032b8dbf13).
- On the success path the `ShellCpTask` hands the copy to a `ShellAsyncCpTask` (`cp.rs:730`, `run_from_thread_pool_impl`) and drops its own poster. The `ShellAsyncCpTask`'s completion is then the only thing that reaches the `ShellCpTask` again: `run_from_js_thread` (`node_fs.rs:1690`) calls `cp_on_finish`, which continues the builtin and frees the task.
- When that completion is released unrun instead (the worker is tearing down), `<ShellAsyncCpTask as Taskable>::release_unrun` (`node_fs.rs:1506`) only destroyed the fs task. The `ShellCpTask` it pointed at, and the keep-alive `ShellCpTask::schedule` took, were never released.
- The builtin's error path is unaffected: there the `ShellCpTask` is posted itself and `<ShellCpTask as Taskable>::release_unrun` frees it. The other pool builtins (`ls`, `rm`, `mv`, `mkdir`, `touch`, glob) post their own task and their `release_unrun` impls mirror their run paths; `cp` is the one whose completion is carried by another type.

### Fix
- `release_unrun` of `NewAsyncCpTask` now also releases the shell task it carries the completion for (`Some` only in the `IS_SHELL` instantiation), through `<ShellCpTask as Taskable>::release_unrun`: unref the keep-alive, drop the box. The fs task is destroyed first because its `args` borrow the shell task's absolute paths.
- Correct because the release happens at the same point the run path would have used the shell task, with nothing else left to touch it: `on_subtask_done` posts only after the last pool subtask is done with both tasks (the `cp_on_copy` callers), the builtin's own pool callback never touches the task after handing the copy over, and nothing else holds a pointer to it on POSIX (the Windows EBUSY list is only filled by the run path). `release_unrun` runs on the task's own JS thread with the loop alive, which is what `ShellCpTask::release_unrun` already assumes on the error path.
- Test: `test/js/web/workers/worker-late-completion.test.ts`. Its rows now run the host under LeakSanitizer themselves on ASAN builds (`detect_leaks=1`, `test/leaksan.supp`, `BUN_DESTRUCT_VM_ON_EXIT=1`, the same environment the CI runner supplies on the ASAN lane), so a release path that leaks fails its row under a plain `bun bd test` too. Every test in the file starts a debug bun plus a worker and the last one waits out the 2s ticket report, so the file's default timeout is raised to 90s (passing rows take about 3s on a debug build here, and the failing row about 7s once LeakSanitizer has symbolized its report, past the 5s default; CI already ran the file with a 90s/270s timeout).
- `bun bd test test/js/web/workers/worker-late-completion.test.ts`: with `src/` stashed, only `$ cp -R` fails, with the report above; with the fix, 33/33 pass (twice).
- `bun bd test test/js/node/fs/cp.test.ts`: passes; a manual `cp -Rv`/missing-source run with the builtin enabled under LeakSanitizer exits clean.

### Background
- Shell `cp` builtin: `Cp::next` heap-allocates one `ShellCpTask` per source operand and schedules it on the work pool. On the pool it resolves paths and hands the actual copying to node:fs's async cp implementation, `ShellAsyncCpTask` (`NewAsyncCpTask<true>` in `node_fs.rs`), which keeps a back-pointer (`shelltask`) to it. The fs task's subtasks report each copied file to the shell task (`cp_on_copy`), and its completion continues the builtin (`cp_on_finish`).
- Completion / `Taskable::release_unrun`: pool work posts a completion task into its VM's queue to run on the JS thread. Since #38299 a VM being torn down (a worker exiting or being terminated) waits for everything it sent off-thread to come back, and completions arriving during that wait are not run; they are handed to their type's `release_unrun`, which has to free whatever running them would have freed.
- Keep-alive: `ShellCpTask::schedule` refs the event loop's keep-alive so the loop stays alive while the task is out; the run path unrefs it in `ShellTask::run_from_main_thread`, the release path in `ShellTask::unref_unrun`.
- `BUN_DEBUG_TEST_WORKER_TEARDOWN_GATE` (debug-assertion builds): holds a cross-thread post until the worker's teardown is already waiting, so each row of the test exercises its release path deterministically. With `detect_leaks=1`, LeakSanitizer makes the host exit non-zero with a report if that path leaks; `BUN_DESTRUCT_VM_ON_EXIT=1` destroys the main VM at exit so what it still owns is not reported as well.
