### PR TITLE
Blob: stop a prefix slice's text() (or a stripped BOM) from marking the shared store all-ASCII

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2557,15 +2557,13 @@ impl BlobExt for Blob {
     }
 
     fn set_is_ascii_flag(&self, is_all_ascii: bool) {
-        // The callers scanned the bytes after any stripped UTF-8 BOM, but this
-        // flag describes the raw bytes (slices and the store share them), and
-        // the BOM itself is non-ASCII.
+        // The callers scanned the bytes after a stripped UTF-8 BOM, which is itself non-ASCII.
         let is_all_ascii =
             is_all_ascii && !self.shared_view().starts_with(&strings::BOM::UTF8_BYTES);
         self.charset
             .set(strings::AsciiStatus::from_bool(Some(is_all_ascii)));
-        // Every Blob sharing the store reads the store's flag, so only a Blob
-        // whose window spans the whole store may set it.
+        // if this Blob represents the entire binary data
+        // we can update the store's is_all_ascii flag
         if self.size.get() > 0 && self.offset.get() == 0 {
             if let Some(store_ref) = self.store() {
                 let store = store_ref.as_ptr();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2557,23 +2557,27 @@ impl BlobExt for Blob {
     }
 
     fn set_is_ascii_flag(&self, is_all_ascii: bool) {
+        // The callers scanned the bytes after any stripped UTF-8 BOM, but this
+        // flag describes the raw bytes (slices and the store share them), and
+        // the BOM itself is non-ASCII.
+        let is_all_ascii =
+            is_all_ascii && !self.shared_view().starts_with(&strings::BOM::UTF8_BYTES);
         self.charset
             .set(strings::AsciiStatus::from_bool(Some(is_all_ascii)));
-        // The store's flag is consulted by every Blob sharing the store (the
-        // parent of a slice, sibling slices, a Response wrapping the Blob), so
-        // only a Blob whose window spans all of the store's bytes may set it.
-        let Some(store_ref) = self.store() else {
-            return;
-        };
-        let store = store_ref.as_ptr();
-        // SAFETY: `store` is live (we hold a `StoreRef`); single-threaded
-        // JS execution means no concurrent &Store borrow is outstanding.
-        unsafe {
-            let store::Data::Bytes(bytes) = &(*store).data else {
-                return;
-            };
-            if self.offset.get() == 0 && self.size.get() >= bytes.len() {
-                (*store).is_all_ascii = Some(is_all_ascii);
+        // Every Blob sharing the store reads the store's flag, so only a Blob
+        // whose window spans the whole store may set it.
+        if self.size.get() > 0 && self.offset.get() == 0 {
+            if let Some(store_ref) = self.store() {
+                let store = store_ref.as_ptr();
+                // SAFETY: `store` is live (we hold a `StoreRef`); single-threaded
+                // JS execution means no concurrent &Store borrow is outstanding.
+                unsafe {
+                    if let store::Data::Bytes(bytes) = &(*store).data
+                        && self.size.get() >= bytes.len()
+                    {
+                        (*store).is_all_ascii = Some(is_all_ascii);
+                    }
+                }
             }
         }
     }
@@ -2670,9 +2674,7 @@ impl BlobExt for Blob {
             }
 
             if LIFETIME != Lifetime::Temporary {
-                // The flag describes the raw bytes (which slices and the store
-                // share), and a stripped BOM is itself non-ASCII.
-                self.set_is_ascii_flag(bom.is_none());
+                self.set_is_ascii_flag(true);
             }
         }
 
@@ -2895,8 +2897,7 @@ impl BlobExt for Blob {
             }
 
             if LIFETIME != Lifetime::Temporary {
-                // See to_string_with_bytes: a stripped BOM is itself non-ASCII.
-                self.set_is_ascii_flag(bom.is_none());
+                self.set_is_ascii_flag(true);
             }
         }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2559,18 +2559,21 @@ impl BlobExt for Blob {
     fn set_is_ascii_flag(&self, is_all_ascii: bool) {
         self.charset
             .set(strings::AsciiStatus::from_bool(Some(is_all_ascii)));
-        // if this Blob represents the entire binary data
-        // we can update the store's is_all_ascii flag
-        if self.size.get() > 0 && self.offset.get() == 0 {
-            if let Some(store_ref) = self.store() {
-                let store = store_ref.as_ptr();
-                // SAFETY: `store` is live (we hold a `StoreRef`); single-threaded
-                // JS execution means no concurrent &Store borrow is outstanding.
-                unsafe {
-                    if matches!((*store).data, store::Data::Bytes(_)) {
-                        (*store).is_all_ascii = Some(is_all_ascii);
-                    }
-                }
+        // The store's flag is consulted by every Blob sharing the store (the
+        // parent of a slice, sibling slices, a Response wrapping the Blob), so
+        // only a Blob whose window spans all of the store's bytes may set it.
+        let Some(store_ref) = self.store() else {
+            return;
+        };
+        let store = store_ref.as_ptr();
+        // SAFETY: `store` is live (we hold a `StoreRef`); single-threaded
+        // JS execution means no concurrent &Store borrow is outstanding.
+        unsafe {
+            let store::Data::Bytes(bytes) = &(*store).data else {
+                return;
+            };
+            if self.offset.get() == 0 && self.size.get() >= bytes.len() {
+                (*store).is_all_ascii = Some(is_all_ascii);
             }
         }
     }
@@ -2667,7 +2670,9 @@ impl BlobExt for Blob {
             }
 
             if LIFETIME != Lifetime::Temporary {
-                self.set_is_ascii_flag(true);
+                // The flag describes the raw bytes (which slices and the store
+                // share), and a stripped BOM is itself non-ASCII.
+                self.set_is_ascii_flag(bom.is_none());
             }
         }
 
@@ -2890,7 +2895,8 @@ impl BlobExt for Blob {
             }
 
             if LIFETIME != Lifetime::Temporary {
-                self.set_is_ascii_flag(true);
+                // See to_string_with_bytes: a stripped BOM is itself non-ASCII.
+                self.set_is_ascii_flag(bom.is_none());
             }
         }
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -93,6 +93,77 @@ for (const info of [
   });
 }
 
+// text()/json() cache whether the bytes they decoded were all ASCII, and Blobs
+// sharing one backing store read each other's cache. The cache must only ever
+// describe bytes the reader is actually going to decode.
+describe("Blob text()/json() decoding does not depend on what was read before", () => {
+  const utf8 = "héllo wörld ✓";
+  const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+
+  test("parent after an ASCII prefix slice", async () => {
+    const blob = new Blob(["abc", utf8]);
+    expect(await blob.slice(0, 3).text()).toBe("abc");
+    expect(await blob.text()).toBe("abc" + utf8);
+  });
+
+  test("sibling slice after an ASCII prefix slice", async () => {
+    const blob = new Blob(["abc", utf8]);
+    const rest = blob.slice(3);
+    expect(await blob.slice(0, 3).text()).toBe("abc");
+    expect(await rest.text()).toBe(utf8);
+  });
+
+  test("Response wrapping the Blob after an ASCII prefix slice", async () => {
+    const blob = new Blob(["abc", utf8]);
+    expect(await blob.slice(0, 3).text()).toBe("abc");
+    expect(await new Response(blob).text()).toBe("abc" + utf8);
+  });
+
+  test("parent json() after an ASCII prefix slice text()", async () => {
+    const blob = new Blob(['"', utf8, '"']);
+    expect(await blob.slice(0, 1).text()).toBe('"');
+    expect(await blob.json()).toBe(utf8);
+  });
+
+  test("parent text() after an ASCII prefix slice json()", async () => {
+    const blob = new Blob(["123", utf8]);
+    expect(await blob.slice(0, 3).json()).toBe(123);
+    expect(await blob.text()).toBe("123" + utf8);
+  });
+
+  test("slice(0) spans the whole Blob and decodes the same as the parent", async () => {
+    const blob = new Blob(["abc", utf8]);
+    expect(await blob.slice(0).text()).toBe("abc" + utf8);
+    expect(await blob.text()).toBe("abc" + utf8);
+    expect(await blob.slice(0, 3).text()).toBe("abc");
+    expect(await blob.slice(3).text()).toBe(utf8);
+  });
+
+  test("slice into a UTF-8 BOM after the parent's text() stripped it", async () => {
+    const blob = new Blob([bom, "abc"]);
+    const sliceMadeBefore = blob.slice(1);
+    expect(await blob.text()).toBe("abc");
+    expect(await sliceMadeBefore.text()).toBe("\ufffd\ufffdabc");
+    expect(await blob.slice(1).text()).toBe("\ufffd\ufffdabc");
+  });
+
+  test("slice into a UTF-8 BOM after the parent's json() stripped it", async () => {
+    const blob = new Blob([bom, '{"a":1}']);
+    const sliceMadeBefore = blob.slice(1);
+    expect(await blob.json()).toEqual({ a: 1 });
+    expect(await sliceMadeBefore.text()).toBe('\ufffd\ufffd{"a":1}');
+    expect(await blob.slice(1).text()).toBe('\ufffd\ufffd{"a":1}');
+  });
+
+  test("Blob built from a BOM-prefixed Blob part that was already read", async () => {
+    const part = new Blob([bom, "abc"]);
+    expect(await part.text()).toBe("abc");
+    // The BOM is no longer at the start, so it decodes as U+FEFF.
+    expect(await new Blob(["x", part]).text()).toBe("x\ufeffabc");
+    expect(await new Blob([part]).text()).toBe("abc");
+  });
+});
+
 test("new Blob", () => {
   var blob = new Blob(["Bun", "Foo"], { type: "text/foo" });
   expect(blob.size).toBe(6);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -119,6 +119,18 @@ describe("Blob text()/json() decoding does not depend on what was read before", 
     expect(await new Response(blob).text()).toBe("abc" + utf8);
   });
 
+  test("parent after a Response body made from an ASCII prefix slice", async () => {
+    const blob = new Blob(["abc", utf8]);
+    expect(await new Response(blob.slice(0, 3)).text()).toBe("abc");
+    expect(await blob.text()).toBe("abc" + utf8);
+  });
+
+  test("parent after a Response body made from an ASCII prefix slice was read as json()", async () => {
+    const blob = new Blob(["123", utf8]);
+    expect(await new Response(blob.slice(0, 3)).json()).toBe(123);
+    expect(await blob.text()).toBe("123" + utf8);
+  });
+
   test("parent json() after an ASCII prefix slice text()", async () => {
     const blob = new Blob(['"', utf8, '"']);
     expect(await blob.slice(0, 1).text()).toBe('"');
@@ -142,6 +154,7 @@ describe("Blob text()/json() decoding does not depend on what was read before", 
   test("slice into a UTF-8 BOM after the parent's text() stripped it", async () => {
     const blob = new Blob([bom, "abc"]);
     const sliceMadeBefore = blob.slice(1);
+    expect(await blob.text()).toBe("abc");
     expect(await blob.text()).toBe("abc");
     expect(await sliceMadeBefore.text()).toBe("\ufffd\ufffdabc");
     expect(await blob.slice(1).text()).toBe("\ufffd\ufffdabc");


### PR DESCRIPTION
### Problem

- `const b = new Blob(["abc", "héllo wörld ✓"])`: after `await b.slice(0, 3).text()`, `await b.text()` returns `"abchÃ©llo wÃ¶rld â"` (the UTF-8 bytes decoded as Latin-1). Without the slice read first it returns the right string. Node and browsers return the right string in both orders.
- The same read-order dependence shows up for a sibling slice made earlier (`b.slice(3).text()`), for `new Response(b).text()`, for a Response whose body is the prefix slice, and for `.json()` in either role. Reproduces on the released 1.4.0; the condition is unchanged from the pre-port Zig.
- Cause: `set_is_ascii_flag` (src/runtime/webcore/Blob.rs:2559) caches the scan result on the shared store for any Blob with `offset == 0`, without checking that the Blob's `size` covers the store. The 3-byte prefix slice scans `abc` and writes `store.is_all_ascii = Some(true)`. `to_string_with_bytes` / `to_json_with_bytes` (Blob.rs:2632, :2878) fall back to that store flag whenever the reading Blob's own charset is still unknown, and `Some(true)` takes the Latin-1 zero-copy path.
- A second route to the same bad cache: text()/json() scan the bytes left after stripping a leading UTF-8 BOM, so `new Blob([BOM, "abc"]).text()` records "all ASCII" for a byte range that contains the (non-ASCII) BOM. That reaches `blob.slice(1).text()` (through the store flag, or through the charset `slice()` copies from its parent) and `new Blob(["x", blob]).text()`, whose constructor trusts the part's charset and skips its own scan: `"xï»¿abc"` instead of `"x\uFEFFabc"`.

### Fix

- All of the change is inside `set_is_ascii_flag`, the one place both caches are written; the text()/json() call sites are untouched.
- The store flag is written only when the Blob's window spans the store (the existing `offset == 0` check plus `size >= store byte length`). The per-Blob charset is still set unconditionally; it describes exactly the bytes that Blob decodes.
- `true` is downgraded to `false` when the Blob's own bytes start with a UTF-8 BOM, so the recorded value describes the raw bytes. Such a Blob's later text()/json() calls still decode correctly (that state means "scan", which is what produced the result the first time); it only loses the skip-the-scan shortcut. Doing this in the callee rather than at the call sites means any future caller recording an ASCII scan gets the same semantics, and it does not depend on how the callers detect the BOM.
- Why this is correct: `Some(true)` on the store is read as "every window of this store can skip UTF-8 decoding", so it may only come from a scan that covered every byte of the store. The pessimistic states (unknown, not ASCII) both mean "scan", so a value that is too pessimistic costs a scan and cannot change output. Once `AllAscii` describes a Blob's raw bytes, the existing copy of charset into `slice()` results and the constructor's trust in parts' charset are both sound: any sub-range of all-ASCII bytes is all-ASCII.
- Only other reader of the per-Blob bit: the text/plain vs octet-stream fallback for untyped Response bodies (`Any::was_string`). A BOM-prefixed ASCII Blob that has been read through text() is now treated there like any other non-ASCII body.
- Verified with test/js/web/fetch/blob.test.ts, `describe("Blob text()/json() decoding does not depend on what was read before")`: 10 of the 11 new tests fail on the released 1.4.0 (`USE_SYSTEM_BUN=1`; the eleventh is a control), all pass with this build. Also run: the rest of blob.test.ts, utf8-bom, blob-cow, blob-array-fast-path, body, body-clone, structured-clone-blob-file (pass); the 19-case read-order probe below matches node on every line.
- A related but separate bug turned up while reviewing this one (consuming a slice's `.stream()` after the Blob wrappers are collected returns the whole store's bytes, via `Any::to_internal_blob_if_possible`); it is a different code path with a different symptom and is being fixed separately.

### Background

- A Blob's bytes live in a refcounted `Blob.Store`. `slice()` does not copy: it creates a Blob with a new `offset`/`size` into the same store, and `dupe()` (used by `new Response(blob)`, `new Blob([blob])`) shares the store the same way.
- `Blob.charset` (per Blob) and `Store.is_all_ascii` (per store) are a tri-state cache filled in by text()/json(): unknown, all ASCII, not all ASCII. "All ASCII" lets text() hand the bytes to JSC as a Latin-1 string with no scan and no transcoding, which is exact because ASCII bytes mean the same thing in Latin-1 and UTF-8. The other two states make text() run the UTF-8 scan, which either transcodes to UTF-16 or finds the bytes were ASCII after all. The store copy exists so that other Blobs over the same store can also skip the scan.
- text()/json() strip a leading `EF BB BF` (UTF-8 BOM) before decoding, as the File API's UTF-8 decode does. `slice()` works on raw bytes and knows nothing about it, so a slice can start inside the BOM.

<details>
<summary>Probe: 19 read-order cases, released 1.4.0 vs this build (node agrees with every expected value)</summary>

```
1.4.0:
ok   1 prefix slice text(): "abc"
FAIL 1 parent text() after prefix slice: "abchÃ©llo wÃ¶rld â" expected "abchéllo wörld ✓"
FAIL 2 parent json() after prefix slice text(): "abchÃ©llo wÃ¶rld â" expected "abchéllo wörld ✓"
ok   3 prefix slice json(): 123
FAIL 3 parent text() after prefix slice json(): "123hÃ©llo wÃ¶rld â" expected "123héllo wörld ✓"
FAIL 4 sibling slice text() after prefix slice text(): "hÃ©llo wÃ¶rld â" expected "héllo wörld ✓"
ok   5 control parent text(): "abchéllo wörld ✓"
ok   6 suffix slice text(): "abc"
ok   6 parent text() after suffix slice: "héllo wörld ✓abc"
ok   7 full slice text(): "abchéllo wörld ✓"
ok   7 parent text() after full slice: "abchéllo wörld ✓"
ok   8 ascii prefix: "abc"
ok   8 ascii parent: "abcdef"
ok   9a bom blob text(): "abc"
FAIL 9b bom blob slice(1).text() after parent text(): "»¿abc" expected "\ufffd\ufffdabc"
FAIL 9c new Blob(['x', bomBlob]).text(): "xï»¿abc" expected "x\ufeffabc"
ok   9d bom blob slice(1).text() fresh: "\ufffd\ufffdabc"
FAIL 9e bom blob: slice(1) created before parent text(), read after: "»¿abc" expected "\ufffd\ufffdabc"
FAIL 10 new Response(blob).text() after prefix slice: "abchÃ©llo wÃ¶rld â" expected "abchéllo wörld ✓"

this build: all 19 ok
```

</details>

<details>
<summary>Earlier shape of this PR</summary>

The first revision passed `bom.is_none()` from the two call sites in `to_string_with_bytes` / `to_json_with_bytes` and restructured the body of `set_is_ascii_flag`. Review pointed out that the call-site form depends on how those functions compute `bom` (an open change to the UTF-16 BOM sniffing would have turned it back into `true` without a conflict) and that the restructuring collided with other pending edits to the same function, so the BOM downgrade moved into `set_is_ascii_flag` and the body kept its original shape. Behavior is the same; the tests did not change except for two added cases.

</details>
