### PR TITLE
test(bundler): run the bundle in the #12734 entry point test, pin plugin asset hashes to plugin contents

### DIFF
--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1627,10 +1627,11 @@ describe("bundler", () => {
     },
     root: "/src",
     entryPointsRaw: ["src/entry.ts"],
+    outputPaths: ["/out/entry.js"],
     packages: "external",
     target: "bun",
     run: {
-      file: "/src/entry.ts",
+      file: "/out/entry.js",
       stdout: `
         Hello World
       `,

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -897,12 +897,12 @@ describe("bundler", () => {
       });
     },
     onAfterBundle(api) {
-      // The HTML must point at the hashed copy of the image, and that copy must
-      // hold what the plugin returned rather than the contents of image.jpeg on disk.
-      const html = api.readFile("out/index.html");
-      const imgSrc = /<img src="\.\/(image-[a-z0-9]+\.jpeg)"/;
-      expect(html).toMatch(imgSrc);
-      api.expectFile(join("out", imgSrc.exec(html)![1])).toBe("custom image contents");
+      // Verify the build succeeded and files were created
+      api.assertFileExists("index.html");
+      // The image should be copied with a hashed name
+      const html = api.readFile("index.html");
+      expect(html).toContain('src="');
+      expect(html).toContain('.jpeg"');
     },
   });
 
@@ -929,20 +929,43 @@ describe("bundler", () => {
       });
     },
     run: {
-      stdout: /^\.\/image-[a-z0-9]+\.png \.\/module-[a-z0-9]+\.wasm$/,
+      stdout: /\.(png|wasm)/,
+    },
+    onAfterBundle(api) {
+      // Verify the build succeeded and files were created
+      api.assertFileExists("index.js");
+      const js = api.readFile("index.js");
+      // Should contain references to the copied files
+      expect(js).toContain('.png"');
+      expect(js).toContain('.wasm"');
+    },
+  });
+
+  // The hash in an asset's output name is computed from the bytes the plugin returned, not from the
+  // file on disk, so it has to match the hash of an asset that has those same bytes on disk.
+  itBundled("plugin/FileLoaderHashComesFromPluginContents", {
+    files: {
+      "index.js": /* js */ `
+        import fromPlugin from "./image.png";
+        import fromDisk from "./copy.txt";
+        console.log(fromPlugin, fromDisk);
+      `,
+      "image.png": "png data on disk",
+      "copy.txt": "contents returned by the plugin",
+    },
+    entryPoints: ["./index.js"],
+    outdir: "/out",
+    loader: { ".txt": "file" },
+    plugins(build) {
+      build.onLoad({ filter: /\.png$/ }, () => ({ loader: "file", contents: "contents returned by the plugin" }));
     },
     onAfterBundle(api) {
       const js = api.readFile("out/index.js");
-      const assets = [...js.matchAll(/"\.\/((?:image|module)-[a-z0-9]+\.(png|wasm))"/g)];
-      expect(assets.map(match => match[1]).sort()).toEqual([
-        expect.stringMatching(/^image-[a-z0-9]+\.png$/),
-        expect.stringMatching(/^module-[a-z0-9]+\.wasm$/),
-      ]);
-      // Each emitted asset must hold what the plugin returned rather than the
-      // contents of the file on disk.
-      for (const [, asset, ext] of assets) {
-        api.expectFile(join("out", asset)).toBe(`custom ${ext} contents`);
-      }
+      const fromPlugin = /"\.\/image-([a-z0-9]+)\.png"/;
+      const fromDisk = /"\.\/copy-([a-z0-9]+)\.txt"/;
+      expect(js).toMatch(fromPlugin);
+      expect(js).toMatch(fromDisk);
+      expect(fromPlugin.exec(js)![1]).toBe(fromDisk.exec(js)![1]);
     },
   });
 

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -897,12 +897,12 @@ describe("bundler", () => {
       });
     },
     onAfterBundle(api) {
-      // Verify the build succeeded and files were created
-      api.assertFileExists("index.html");
-      // The image should be copied with a hashed name
-      const html = api.readFile("index.html");
-      expect(html).toContain('src="');
-      expect(html).toContain('.jpeg"');
+      // The HTML must point at the hashed copy of the image, and that copy must
+      // hold what the plugin returned rather than the contents of image.jpeg on disk.
+      const html = api.readFile("out/index.html");
+      const imgSrc = /<img src="\.\/(image-[a-z0-9]+\.jpeg)"/;
+      expect(html).toMatch(imgSrc);
+      api.expectFile(join("out", imgSrc.exec(html)![1])).toBe("custom image contents");
     },
   });
 
@@ -929,15 +929,20 @@ describe("bundler", () => {
       });
     },
     run: {
-      stdout: /\.(png|wasm)/,
+      stdout: /^\.\/image-[a-z0-9]+\.png \.\/module-[a-z0-9]+\.wasm$/,
     },
     onAfterBundle(api) {
-      // Verify the build succeeded and files were created
-      api.assertFileExists("index.js");
-      const js = api.readFile("index.js");
-      // Should contain references to the copied files
-      expect(js).toContain('.png"');
-      expect(js).toContain('.wasm"');
+      const js = api.readFile("out/index.js");
+      const assets = [...js.matchAll(/"\.\/((?:image|module)-[a-z0-9]+\.(png|wasm))"/g)];
+      expect(assets.map(match => match[1]).sort()).toEqual([
+        expect.stringMatching(/^image-[a-z0-9]+\.png$/),
+        expect.stringMatching(/^module-[a-z0-9]+\.wasm$/),
+      ]);
+      // Each emitted asset must hold what the plugin returned rather than the
+      // contents of the file on disk.
+      for (const [, asset, ext] of assets) {
+        api.expectFile(join("out", asset)).toBe(`custom ${ext} contents`);
+      }
     },
   });
 


### PR DESCRIPTION
### Problem

- `edgecase/EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal#12734` in `test/bundler/bundler_edgecase.test.ts` never looks at its bundle. `run.file` is joined with the test root (`test/bundler/expectBundled.ts`, the `run` loop), and the test names `/src/entry.ts`, which is the input, so the `Hello World` stdout check runs the source file. The test uses `entryPointsRaw`, so the harness derives no output path either: nothing checked that `/out/entry.js` was written at all.
- #12734 was the resolver marking an entry point given as `src/entry.ts` (no `./`) as external under `packages: "external"`; the only thing this test can check is that the bundle came out, and that is the part it skipped.
- The two file loader plugin tests next to this (`plugin/FileLoaderWithCustomContents`, `plugin/FileLoaderMultipleAssets`) have the same input-path problem. Those two are fixed in #38497 together with a harness check that rejects input paths in `api.*` calls and `outputPaths`; that check deliberately does not cover `run.file`, because ~15 tests run a driver script from `files` on purpose, so the #12734 case has to be fixed by hand. This PR no longer touches those two tests (it did in its first push; see the details block).
- After #38497, the emitted bytes of a plugin-provided `loader: "file"` asset are covered, but the hash in the asset's name is not: the bytes and the hash travel on different paths (`on_load` in `src/bundler/bundle_v2.rs` parks the plugin bytes in `source.contents` for `process_files_to_copy`; the parse task hashes its own copy of the contents in `src/bundler/ParseTask.rs`, `Loader::File` arm), and those two tests are the only ones in the suite where plugin bytes differ from the bytes on disk. A bundler that hashed the wrong bytes, which means stale cache-busting names after a plugin changes an asset, would pass them.

### Fix

- `#12734` test: run `/out/entry.js` and list it in `outputPaths`, so the harness checks the bundle was written and the stdout check executes it. Running the bundle also proves `second.ts` was bundled in: there is no `second.ts` next to the output, so a left-over import would fail to load.
- New `plugin/FileLoaderHashComesFromPluginContents` in `test/bundler/bundler_plugin.test.ts`: `image.png` is intercepted by an `onLoad` plugin returning `loader: "file"` with some contents, and `copy.txt` (`loader: { ".txt": "file" }`) has exactly those contents on disk. The hash segment of `image-<hash>.png` in the bundle must equal the one of `copy-<hash>.txt`. The hash is a pure function of the bytes (`ContentHasher::run`, length plus contents), so this holds exactly when the plugin asset was hashed from the plugin's bytes; the asset emitted from disk is the oracle, so the test does not depend on the hash algorithm or encoding.
- Merges cleanly with #38497 (checked with `git merge-tree` against its current head): the new test sits after the two tests that PR rewrites, and it reads `out/index.js`, so it passes that PR's input-path check too.
- Verified:
  - `bun bd test test/bundler/bundler_plugin.test.ts` (56 pass, 3 todo) and `bun bd test test/bundler/bundler_edgecase.test.ts` (134 pass, 13 todo).
  - With `ParseTask.rs` temporarily hashing the path instead of the contents, only the new test fails (`Expected: "qzwtg50h", Received: "3py5q516"`); the byte-level assertions on the neighbouring tests still pass, which is the gap it closes. That change is not part of the PR.
  - Re-introducing the bug the `#12734` test is for (dropping the entry point exemption in `src/resolver/resolver.rs`) makes the debug build fail an assertion while enqueueing the entry point, so on debug builds the old and new versions of the test both fail there; the new version additionally fails whenever `/out/entry.js` is missing or does not run, which the old one did not check.

### Background

- `itBundled` writes the `files` fixtures into a fresh root directory, bundles into `<root>/out` (or an `outfile`), checks that `outputPaths` exist, runs `onAfterBundle(api)`, and finally executes `run.file`. `api.readFile` and friends, `outputPaths`, and `run.file` are all resolved from that root, so outputs have to be spelled `out/...`; a bare fixture name reads or runs the input. `entryPointsRaw` passes entry point strings to the bundler verbatim instead of resolving them against the root, which is how this test reproduces the `src/entry.ts` shape from #12734, and it is also why the harness cannot derive an output path for it.
- `loader: "file"` copies a module into the output directory as an asset named by the asset template (`[name]-[hash].[ext]` by default, `[hash]` being a hash of the asset's bytes) and replaces imports of it with the asset's path. An `onLoad` plugin returning that loader with `contents` substitutes those bytes for the file on disk; both the copied bytes and the hash are supposed to come from them.

<details>
<summary>First push of this PR</summary>

The first push also rewrote `plugin/FileLoaderWithCustomContents` and `plugin/FileLoaderMultipleAssets` to read `out/index.html` / `out/index.js` and check the emitted assets' bytes. #38497 has since picked up the same two fixes (its harness check requires them to land together), so they were dropped here to avoid two PRs editing the same lines; the hash test was added in their place after a review pass pointed out that the byte assertions leave the hash unpinned.

</details>
