### PR TITLE
napi: treat finalizers fired by VM destruction as running from GC

### DIFF
--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -387,9 +387,15 @@ public:
         delete handle;
     }
 
+    // True when a finalizer running right now would be running from the garbage collector.
+    // ~VM (a Worker exiting, or BUN_DESTRUCT_VM_ON_EXIT) is the second such context besides a
+    // collection: Heap::lastChanceToFinalize fires every finalizer still registered, but runs
+    // the weak-handle ones, and the destructors of precise allocations (the first few cells of
+    // every IsoSubspace), without the Sweeping mutator state isCollectorBusyOnCurrentThread()
+    // keys on. It sets isShuttingDown() first.
     bool inGC() const
     {
-        return this->vm().isCollectorBusyOnCurrentThread();
+        return this->vm().isCollectorBusyOnCurrentThread() || this->vm().heap.isShuttingDown();
     }
 
     void checkGC() const
@@ -490,11 +496,12 @@ public:
         // The deferred path (NapiFinalizerTask::schedule) is responsible for the
         // shutdown case: once is_shutting_down() it either pushes a cleanup hook
         // (if those haven't run yet) or drops the task (if they have). Running a
-        // non-EXPERIMENTAL finalizer immediately during the final collectNow() is
-        // never safe — by then on_exit() has already run cleanup hooks (including
-        // the napi_set_instance_data finalizer that frees per-addon state the
-        // object finalizer reads), the heap is sweeping (no allocation, no handle
-        // scope), and napi_call_function returns the termination exception.
+        // non-EXPERIMENTAL finalizer immediately during the final collectNow(), or
+        // during the ~VM that follows it (inGC() reports both), is never safe: by
+        // then on_exit() has already run cleanup hooks (including the
+        // napi_set_instance_data finalizer that frees per-addon state the object
+        // finalizer reads), the heap is sweeping (no allocation, no handle scope),
+        // and napi_call_function returns the termination exception.
         return m_napiModule.nm_version != NAPI_VERSION_EXPERIMENTAL;
     }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -387,8 +387,7 @@ public:
         delete handle;
     }
 
-    // isShuttingDown(): ~VM's Heap::lastChanceToFinalize fires the remaining weak-handle
-    // finalizers and precise-allocation destructors without entering the Sweeping mutator state.
+    // isShuttingDown(): ~VM (Heap::lastChanceToFinalize) runs finalizers without the Sweeping mutator state.
     bool inGC() const
     {
         return this->vm().isCollectorBusyOnCurrentThread() || this->vm().heap.isShuttingDown();

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -387,12 +387,8 @@ public:
         delete handle;
     }
 
-    // True when a finalizer running right now would be running from the garbage collector.
-    // ~VM (a Worker exiting, or BUN_DESTRUCT_VM_ON_EXIT) is the second such context besides a
-    // collection: Heap::lastChanceToFinalize fires every finalizer still registered, but runs
-    // the weak-handle ones, and the destructors of precise allocations (the first few cells of
-    // every IsoSubspace), without the Sweeping mutator state isCollectorBusyOnCurrentThread()
-    // keys on. It sets isShuttingDown() first.
+    // isShuttingDown(): ~VM's Heap::lastChanceToFinalize fires the remaining weak-handle
+    // finalizers and precise-allocation destructors without entering the Sweeping mutator state.
     bool inGC() const
     {
         return this->vm().isCollectorBusyOnCurrentThread() || this->vm().heap.isShuttingDown();
@@ -496,12 +492,11 @@ public:
         // The deferred path (NapiFinalizerTask::schedule) is responsible for the
         // shutdown case: once is_shutting_down() it either pushes a cleanup hook
         // (if those haven't run yet) or drops the task (if they have). Running a
-        // non-EXPERIMENTAL finalizer immediately during the final collectNow(), or
-        // during the ~VM that follows it (inGC() reports both), is never safe: by
-        // then on_exit() has already run cleanup hooks (including the
-        // napi_set_instance_data finalizer that frees per-addon state the object
-        // finalizer reads), the heap is sweeping (no allocation, no handle scope),
-        // and napi_call_function returns the termination exception.
+        // non-EXPERIMENTAL finalizer immediately during the final collectNow() is
+        // never safe — by then on_exit() has already run cleanup hooks (including
+        // the napi_set_instance_data finalizer that frees per-addon state the
+        // object finalizer reads), the heap is sweeping (no allocation, no handle
+        // scope), and napi_call_function returns the termination exception.
         return m_napiModule.nm_version != NAPI_VERSION_EXPERIMENTAL;
     }
 

--- a/src/jsc/bindings/napi_handle_scope.cpp
+++ b/src/jsc/bindings/napi_handle_scope.cpp
@@ -103,7 +103,10 @@ NapiHandleScopeImpl* NapiHandleScope::open(Zig::GlobalObject* globalObject, bool
     // 2. Do an allocation in a hot code path
     // 3. the napi_ref finalizer is called while the constructor is running
     // 4. The finalizer creates a new handle scope (yes, it should not do that. No, we can't change that.)
-    if (vm.heap.mutatorState() == JSC::MutatorState::Sweeping) {
+    //
+    // Same for a finalizer fired by ~VM (Heap::lastChanceToFinalize): the allocators are
+    // already stopped, but mutatorState() does not say Sweeping there (see NapiEnv::inGC()).
+    if (vm.heap.mutatorState() == JSC::MutatorState::Sweeping || vm.heap.isShuttingDown()) {
         return nullptr;
     }
 

--- a/src/jsc/bindings/napi_handle_scope.cpp
+++ b/src/jsc/bindings/napi_handle_scope.cpp
@@ -103,9 +103,7 @@ NapiHandleScopeImpl* NapiHandleScope::open(Zig::GlobalObject* globalObject, bool
     // 2. Do an allocation in a hot code path
     // 3. the napi_ref finalizer is called while the constructor is running
     // 4. The finalizer creates a new handle scope (yes, it should not do that. No, we can't change that.)
-    //
-    // Same for a finalizer fired by ~VM (Heap::lastChanceToFinalize): the allocators are
-    // already stopped, but mutatorState() does not say Sweeping there (see NapiEnv::inGC()).
+    // isShuttingDown(): same thing from ~VM's finalizers, which do not set Sweeping (see NapiEnv::inGC()).
     if (vm.heap.mutatorState() == JSC::MutatorState::Sweeping || vm.heap.isShuttingDown()) {
         return nullptr;
     }

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -297,5 +297,28 @@
                 "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
             ],
         },
+        {
+            "target_name": "test_vm_teardown_finalizers",
+            "sources": ["test_vm_teardown_finalizers.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
+        {
+            "target_name": "test_vm_teardown_finalizers_experimental",
+            "sources": ["test_vm_teardown_finalizers.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+                "TEST_EXPERIMENTAL=1",
+            ],
+        },
     ]
 }

--- a/test/napi/napi-app/test_vm_teardown_finalizers.c
+++ b/test/napi/napi-app/test_vm_teardown_finalizers.c
@@ -1,0 +1,157 @@
+// Finalizers that only the destruction of the JSC VM can reach.
+//
+// setup(kind) registers one finalizer of the given kind and then pins its
+// object with a strong napi_ref that is never released, so no garbage
+// collection can run the finalizer while the env is alive. Env teardown
+// (NapiEnv::cleanup, whose last step is the instance data finalizer below)
+// does not run these kinds either, so the finalizer is still registered when
+// the JSC VM is destroyed afterwards: a worker_threads Worker exiting, or the
+// main thread exiting under BUN_DESTRUCT_VM_ON_EXIT=1. JSC's
+// Heap::lastChanceToFinalize then fires every remaining finalizer, without
+// the bookkeeping a collection has (MutatorState::Sweeping), so Bun must
+// recognize that state on its own.
+//
+// Built twice (binding.gyp): as a regular module, and with TEST_EXPERIMENTAL
+// as a NAPI_EXPERIMENTAL module. Whatever the finalizer reports on stderr
+// starts with "FAIL:".
+//   - Regular module: a finalizer may call any Node-API function, which cannot
+//     be honored while the heap is being destroyed, so it must not be invoked
+//     from there at all.
+//   - Experimental module: finalizers run synchronously from whatever frees
+//     their object and must not call functions that may affect GC state (Node
+//     aborts with "FATAL ERROR" when they do). The finalizer calls one such
+//     function, napi_get_undefined; Bun has to abort rather than let it through.
+
+#ifdef TEST_EXPERIMENTAL
+#define NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_NO_WARNING
+#endif
+
+#include <js_native_api.h>
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NODE_API_CALL(env, call)                                               \
+  do {                                                                         \
+    if ((call) != napi_ok) {                                                   \
+      napi_throw_error((env), NULL, #call " failed");                          \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
+
+static int env_torn_down = 0;
+static int pending_finalizers = 0;
+static int instance_data;
+
+static void instance_data_finalizer(napi_env env, void *data, void *hint) {
+  (void)env;
+  (void)data;
+  (void)hint;
+  env_torn_down = 1;
+  printf("env teardown: %d finalizer(s) still pending\n", pending_finalizers);
+  fflush(stdout);
+}
+
+// Registered as the finalize callback of every kind; `hint` is the kind name.
+static void finalizer(napi_env env, void *data, void *hint) {
+  const char *kind = hint;
+  (void)data;
+  pending_finalizers--;
+
+  if (!env_torn_down) {
+    printf("finalizer: %s\n", kind);
+    fflush(stdout);
+    return;
+  }
+
+  // Only VM destruction gets here.
+#ifdef TEST_EXPERIMENTAL
+  // Bun has to refuse this (it aborts, as during a collection); returning from
+  // it means the call went through.
+  napi_value undefined;
+  napi_status status = napi_get_undefined(env, &undefined);
+  fprintf(stderr,
+          "FAIL: %s finalizer called napi_get_undefined during VM destruction "
+          "and got status %d\n",
+          kind, (int)status);
+#else
+  fprintf(stderr, "FAIL: %s finalizer ran after env teardown\n", kind);
+  // What node-addon-api's finalizer wrapper does before anything else; here it
+  // allocates a JSC cell in the heap being destroyed.
+  napi_handle_scope scope;
+  if (napi_open_handle_scope(env, &scope) == napi_ok) {
+    napi_close_handle_scope(env, scope);
+  }
+#endif
+}
+
+static char *dup_kind(const char *kind) {
+  // Leaked on purpose: it is the finalize hint, read whenever the finalizer
+  // runs, including from VM destruction.
+  char *copy = malloc(strlen(kind) + 1);
+  strcpy(copy, kind);
+  return copy;
+}
+
+static napi_value setup(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  char kind[64];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  if (argc < 1) {
+    napi_throw_error(env, NULL, "setup(kind) needs a kind");
+    return NULL;
+  }
+  NODE_API_CALL(env, napi_get_value_string_utf8(env, argv[0], kind,
+                                                sizeof(kind), NULL));
+
+  napi_value pinned;
+  if (strcmp(kind, "add_finalizer") == 0) {
+    // No napi_ref asked for: registered straight on the JSC heap
+    // (Heap::addFinalizer).
+    NODE_API_CALL(env, napi_create_object(env, &pinned));
+    NODE_API_CALL(env, napi_add_finalizer(env, pinned, NULL, finalizer,
+                                          dup_kind(kind), NULL));
+  } else if (strcmp(kind, "add_finalizer_ref") == 0) {
+    // Registered through a weak NapiRef (the napi_ref variant).
+    napi_ref weak;
+    NODE_API_CALL(env, napi_create_object(env, &pinned));
+    NODE_API_CALL(env, napi_add_finalizer(env, pinned, NULL, finalizer,
+                                          dup_kind(kind), &weak));
+  } else if (strcmp(kind, "external") == 0) {
+    // Runs from the NapiExternal cell's destructor.
+    NODE_API_CALL(env, napi_create_external(env, NULL, finalizer,
+                                            dup_kind(kind), &pinned));
+  } else if (strcmp(kind, "empty_external_buffer") == 0) {
+    // A zero-length external buffer has no contents to hang the finalizer
+    // on, so it too is registered straight on the JSC heap.
+    NODE_API_CALL(env, napi_create_external_buffer(env, 0, NULL, finalizer,
+                                                   dup_kind(kind), &pinned));
+  } else {
+    napi_throw_error(env, NULL, "unknown kind");
+    return NULL;
+  }
+  pending_finalizers++;
+
+  // Never deleted: the object stays reachable until the VM is destroyed.
+  napi_ref pin;
+  NODE_API_CALL(env, napi_create_reference(env, pinned, 1, &pin));
+
+  napi_value undefined;
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
+  return undefined;
+}
+
+static napi_value init(napi_env env, napi_value exports) {
+  NODE_API_CALL(env, napi_set_instance_data(env, &instance_data,
+                                            instance_data_finalizer, NULL));
+  napi_value setup_fn;
+  NODE_API_CALL(env, napi_create_function(env, "setup", NAPI_AUTO_LENGTH,
+                                          setup, NULL, &setup_fn));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "setup", setup_fn));
+  return exports;
+}
+
+NAPI_MODULE(test_vm_teardown_finalizers, init)

--- a/test/napi/napi-app/vm-teardown-finalizers.js
+++ b/test/napi/napi-app/vm-teardown-finalizers.js
@@ -1,0 +1,27 @@
+// Usage: bun vm-teardown-finalizers.js <addon target> <kind>[,<kind>...] [--main-thread]
+//
+// Loads build/Debug/<addon target>.node (see test_vm_teardown_finalizers.c)
+// and registers one pinned finalizer per kind, in a worker_threads Worker
+// that then exits, or on the main thread with --main-thread (run under
+// BUN_DESTRUCT_VM_ON_EXIT=1 so that the main thread's VM is destroyed too).
+// Any other argument is ignored.
+const { Worker, isMainThread, workerData } = require("node:worker_threads");
+const path = require("node:path");
+
+function setup({ addon, kinds }) {
+  const { setup } = require(path.join(__dirname, "build/Debug", addon + ".node"));
+  for (const kind of kinds) setup(kind);
+  console.log("registered:", kinds.join(","));
+}
+
+if (!isMainThread) {
+  setup(workerData);
+} else {
+  const [addon, kindList] = process.argv.slice(2);
+  const args = { addon, kinds: kindList.split(",") };
+  if (process.argv.includes("--main-thread")) {
+    setup(args);
+  } else {
+    new Worker(__filename, { workerData: args }).on("exit", code => console.log("worker exited:", code));
+  }
+}

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1459,6 +1459,18 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     const fixture = join(__dirname, "napi-app/vm-teardown-finalizers.js");
     const kinds = ["add_finalizer", "add_finalizer_ref", "external", "empty_external_buffer"];
 
+    // The ASAN lanes export BUN_DESTRUCT_VM_ON_EXIT and LSan settings that the
+    // children would inherit. The variants below choose which VM is destroyed
+    // themselves, and the fixture's pins are never deleted (nothing of the
+    // addon's runs after the point they have to survive), so they keep its
+    // NapiEnv and the VM handle ref it holds alive, which LSan reports once the
+    // Worker is gone.
+    const { BUN_DESTRUCT_VM_ON_EXIT: _destruct, BUN_INSPECT_CONNECT_TO: _inspect, ...inheritedEnv } = bunEnv;
+    const fixtureEnv = (...asanOptions: string[]) => ({
+      ...inheritedEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0", ...asanOptions].filter(Boolean).join(":"),
+    });
+
     const vms = [
       { vm: "a worker_threads Worker", flags: [] as string[], extraEnv: {} as Record<string, string> },
       { vm: "the main thread", flags: ["--main-thread"], extraEnv: { BUN_DESTRUCT_VM_ON_EXIT: "1" } },
@@ -1468,7 +1480,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       async ({ flags, extraEnv }) => {
         await using proc = spawn({
           cmd: [bunExe(), fixture, "test_vm_teardown_finalizers", kinds.join(","), ...flags],
-          env: { ...bunEnv, ...extraEnv },
+          env: { ...fixtureEnv(), ...extraEnv },
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -1494,7 +1506,6 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it.each(["external", "add_finalizer"])(
       "an experimental module's %s finalizer is told it is running from GC",
       async kind => {
-        const { BUN_INSPECT_CONNECT_TO: _, ...env } = bunEnv;
         await using proc = spawn({
           // The trailing flag makes a debug build's crash handler skip its slow
           // symbolized backtrace; the fixture ignores it.
@@ -1505,11 +1516,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
             kind,
             "--debug-crash-handler-use-trace-string",
           ],
-          env: {
-            ...env,
-            BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1",
-            ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
-          },
+          env: { ...fixtureEnv("disable_coredump=1", "symbolize=0"), BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1" },
           stdout: "pipe",
           stderr: "pipe",
         });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1457,6 +1457,10 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   // were all still registered when env teardown finished.
   describe("finalizers still registered when the VM is destroyed", () => {
     const fixture = join(__dirname, "napi-app/vm-teardown-finalizers.js");
+    // The registration kinds env teardown (NapiEnv::cleanup) leaves registered,
+    // unlike napi_wrap and non-empty external buffers. If one of them starts
+    // being run at env teardown too, the "still pending" count below drops and
+    // the kind belongs in that path's tests instead of this list.
     const kinds = ["add_finalizer", "add_finalizer_ref", "external", "empty_external_buffer"];
 
     // The ASAN lanes export BUN_DESTRUCT_VM_ON_EXIT and LSan settings that the

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1126,12 +1126,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       await checkSameOutput("bigint_to_i64", testsString);
       await checkSameOutput("bigint_to_u64", testsString);
     });
+    // Three serial node + bun runs: over 5s on a debug ASAN build.
     it("returns the right error code", async () => {
       const badTypes = '[null, undefined, 5, "123", "abc"]';
       await checkSameOutput("bigint_to_i64", badTypes);
       await checkSameOutput("bigint_to_u64", badTypes);
       await checkSameOutput("bigint_to_64_null", []);
-    });
+    }, 10_000);
   });
 
   describe("create_bigint_words", () => {
@@ -1445,6 +1446,83 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     },
     25_000,
   );
+
+  // Destroying a JSC VM (a Worker exiting; the main thread under
+  // BUN_DESTRUCT_VM_ON_EXIT) fires every finalizer still registered. That
+  // happens after env teardown and without the "sweeping" mutator state a
+  // collection has, which Bun used to mistake for an ordinary non-GC context:
+  // it ran the addon's callbacks inline, inside the heap being destroyed. The
+  // fixture pins its objects with strong refs, so VM destruction is the only
+  // thing that can reach these finalizers; the "still pending" count shows they
+  // were all still registered when env teardown finished.
+  describe("finalizers still registered when the VM is destroyed", () => {
+    const fixture = join(__dirname, "napi-app/vm-teardown-finalizers.js");
+    const kinds = ["add_finalizer", "add_finalizer_ref", "external", "empty_external_buffer"];
+
+    const vms = [
+      { vm: "a worker_threads Worker", flags: [] as string[], extraEnv: {} as Record<string, string> },
+      { vm: "the main thread", flags: ["--main-thread"], extraEnv: { BUN_DESTRUCT_VM_ON_EXIT: "1" } },
+    ];
+    it.each(vms)(
+      "a regular module's finalizers are not invoked from the dying heap of $vm",
+      async ({ flags, extraEnv }) => {
+        await using proc = spawn({
+          cmd: [bunExe(), fixture, "test_vm_teardown_finalizers", kinds.join(","), ...flags],
+          env: { ...bunEnv, ...extraEnv },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        // Before the fix: one "FAIL: <kind> finalizer ran after env teardown" line
+        // per kind, then (debug builds) an assertion failure in JSCell::JSCell
+        // when the finalizer's handle scope allocates in the heap being destroyed.
+        expect(stderr).toBe("");
+        expect(stdout).toContain(`env teardown: ${kinds.length} finalizer(s) still pending`);
+        if (flags.length === 0) expect(stdout).toContain("worker exited: 0");
+        expect(exitCode).toBe(0);
+      },
+    );
+
+    // Experimental modules have their finalizers run synchronously by whatever
+    // frees the object, VM destruction included; what has to hold is that a
+    // GC-affecting call made from there is refused the same way it is during a
+    // collection. One kind per path JSC fires them from: the fixture's
+    // NapiExternal is destroyed as an individually allocated cell
+    // (PreciseAllocation::sweep), a napi_add_finalizer callback is a weak-handle
+    // finalizer (WeakBlock::lastChanceToFinalize). The first finalizer to run
+    // aborts the process, so each kind gets its own run.
+    it.each(["external", "add_finalizer"])(
+      "an experimental module's %s finalizer is told it is running from GC",
+      async kind => {
+        const { BUN_INSPECT_CONNECT_TO: _, ...env } = bunEnv;
+        await using proc = spawn({
+          // The trailing flag makes a debug build's crash handler skip its slow
+          // symbolized backtrace; the fixture ignores it.
+          cmd: [
+            bunExe(),
+            fixture,
+            "test_vm_teardown_finalizers_experimental",
+            kind,
+            "--debug-crash-handler-use-trace-string",
+          ],
+          env: {
+            ...env,
+            BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1",
+            ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stdout).toContain("env teardown: 1 finalizer(s) still pending");
+        // Before the fix: "FAIL: <kind> finalizer called napi_get_undefined
+        // during VM destruction and got status 0" and a clean exit.
+        expect(stderr).not.toContain("FAIL:");
+        expect(stderr).toContain("FATAL ERROR: Finalizer is calling a function that may affect GC state.");
+        expect(exitCode).not.toBe(0);
+      },
+    );
+  });
 });
 
 // Kept outside describe.concurrent("napi") so RSS measurement isn't skewed by


### PR DESCRIPTION
### Problem

- When a JSC VM is destroyed (a `worker_threads` Worker exiting; the main thread under `BUN_DESTRUCT_VM_ON_EXIT=1`), `Heap::lastChanceToFinalize` fires every Node-API finalizer that is still registered. Bun did not recognize that as a GC context, so:
  - a regular (non-experimental) module's `napi_add_finalizer` callbacks (both the `napi_ref` and the `result == NULL` variants) and zero-length `napi_create_external_buffer` callbacks ran inline, after `NapiEnv::cleanup()` had already run the addon's cleanup hooks and instance-data finalizer. `NapiEnv::mustDeferFinalizers()` documents why that is never safe; the same callbacks are deferred and dropped when the final collection reaches them instead.
  - a node-addon-api style finalizer that opens a handle scope from there allocates a cell in a heap whose allocators are already stopped. Debug build: `ASSERTION FAILED: m_cellState == CellState::DefinitelyWhite` in `JSC::JSCell::JSCell`, from `NapiHandleScopeImpl::create <- NapiHandleScope::open <- ... <- Heap::lastChanceToFinalize <- JSC::VM::~VM <- destroyVM`.
  - an experimental module's finalizers got GC-affecting calls through (`napi_get_undefined` returns `napi_ok` from inside `PreciseAllocation::sweep <- Heap::lastChanceToFinalize <- ~VM`) instead of the `FATAL ERROR` the same call gets during a collection.
- Cause: `NapiEnv::inGC()` (`src/jsc/bindings/napi.h`) is `vm().isCollectorBusyOnCurrentThread()`, i.e. `mayBeGCThread() || mutatorState() != Running`, and `NapiHandleScope::open` (`src/jsc/bindings/napi_handle_scope.cpp`) checks `mutatorState() == Sweeping`. `lastChanceToFinalize` runs on the mutator thread and leaves the state `Running` on two of its three paths: `WeakSet::lastChanceToFinalize` (weak-handle finalizers: `Heap::addFinalizer` lambdas and `NapiRef` owners) runs before the block sweep that installs a `SweepingScope`, and `PreciseAllocation::sweep` (destructors such as `~NapiExternal`) never installs one. Only cells swept through `MarkedBlock::Handle::sweep` were detected.

### Fix

- `inGC()` also returns true while `vm().heap.isShuttingDown()`, and `NapiHandleScope::open` returns null in that state too. `lastChanceToFinalize` sets that flag before it fires anything, so every finalizer it fires now takes the path it takes from the final `collectNow()`: `doFinalizer` / `NapiRef::callFinalizer` defer a regular module's callback (which `NapiFinalizerTask::schedule` then drops, cleanup hooks having run), `checkGC()` refuses an experimental module's GC-affecting calls, and no handle scope cell is allocated. `inGC()` is the one predicate every Node-API GC check goes through (`doFinalizer`, `callFinalizer`, `checkGC()` behind `NAPI_CHECK_ENV_NOT_IN_GC` and `napi_internal_check_gc`); the handle scope check is the only one outside it.
- Correct because a finalizer reached in that state is being run by the heap tearing itself down, which is the situation these checks exist for, and `isShuttingDown()` is set nowhere else: `NapiEnv::cleanup()`, `wrap_cleanup` and everything before `destroyVM` are unchanged. Experimental modules keep running their finalizers synchronously, as they do from a collection, so native memory they free at Worker exit is still freed.
- Behaviour change to be aware of: for a regular module, the kinds listed under Problem (`napi_add_finalizer` either way, zero-length external buffers) used to have their callback run at Worker exit, unsafely; with this PR it is not run at all, exactly as already happens to the same callbacks when the final collection gets to the object first (the usual case: those objects are unreachable once the global is released; only objects still rooted, e.g. by a `napi_ref`, survive into `~VM`). Running them at env teardown instead, as Node does and as Bun already does for `napi_wrap` and non-empty external buffers, is separate work: #32912 does it for `napi_add_finalizer` and `napi_create_external` but predates #37075 and currently conflicts; nothing covers zero-length external buffers or external strings (whose callbacks a JSString cell swept by `~VM` already had dropped, via the detected `MarkedBlock` path) yet. Whatever is left unbound still ends up in `lastChanceToFinalize`, so this check is needed in every one of those shapes.
- Verified with `test/napi/napi.test.ts` ("finalizers still registered when the VM is destroyed"): new addon `test_vm_teardown_finalizers.c`, built as a regular and as an experimental module, registers one finalizer per kind and pins each object with a strong ref so only `~VM` can reach it, in a Worker and on the main thread; the instance-data finalizer reports how many are still registered when env teardown finishes (4), which is what ties the test to the `~VM` path (a change that starts running one of these kinds at env teardown fails that line and should drop the kind from the list). Before: one `FAIL:` line per kind (and the `JSCell` assertion on the debug build) for the regular module, `status 0` and a clean exit for the experimental one; after: the regular module runs none of them, the experimental module aborts with the `FATAL ERROR`. Also reproduced on the current release canary with the fixture.
- The fixture children run with LSan off: the pins are never deleted (nothing of the addon runs after the point they have to survive), and they keep the addon's `NapiEnv`, and the VM handle ref it holds, alive past the Worker's exit, which LSan otherwise reports on the ASAN lanes.
- The rest of `test/napi/napi.test.ts`, `napi-finalizer-delete-ref.test.ts`, and the finalizer / reference / env-teardown / worker node-napi-tests pass on the debug ASAN build. One unrelated test in `napi.test.ts` (bigint error codes: three serial node + bun runs) takes ~5.4s on a debug ASAN build and gets the same 10s budget its neighbours have.

### Background

- Node-API finalizers come in two flavours. A regular module's finalizer may call any Node-API function, so Bun never runs it from inside the collector: `doFinalizer` / `NapiRef::callFinalizer` enqueue it as a `NapiFinalizerTask` when `inGC()` is true. An experimental (`NAPI_EXPERIMENTAL`) module's finalizer runs synchronously from the collector and may only call functions that do not affect GC state; `checkGC()` aborts the process with a `FATAL ERROR` otherwise, as Node does.
- Env teardown is `NapiEnv::cleanup()`, a VM cleanup hook that runs with the exit handlers, before `destroyVM`: it runs the addon's cleanup hooks, the finalizers bound to the env (`napi_wrap`, non-empty external buffers) and finally the instance-data finalizer. Finalizers registered any other way stay on the JSC heap and are only reached by a collection or by `~VM`.
- `Heap::mutatorState()` is JSC's record of what the JS thread is doing; `MutatorState::Sweeping` is installed by a `SweepingScope` while a `MarkedBlock` is swept (destructors and weak finalizers run from there during a collection). `Heap::finalize()` installs one around the precise-allocation sweep too, so during a collection every finalizer is covered; `lastChanceToFinalize` is the one caller that is not.
- A `PreciseAllocation` is a cell JSC allocates and sweeps individually rather than inside a `MarkedBlock`; the first few cells of every `IsoSubspace` (such as `NapiExternal`'s) are allocated that way.
- `Heap::isShuttingDown()` is the flag `lastChanceToFinalize` sets on entry; JSC itself uses it (`CodeBlock`, `JSLock`) to detect work happening during heap destruction.
- `destroyVM` (`src/jsc/bindings/ZigGlobalObject.cpp`) releases the global, runs a final `collectNow()`, then the `~VM` that calls `lastChanceToFinalize`. Workers always go through it; the main thread only with `BUN_DESTRUCT_VM_ON_EXIT=1`.
