### PR TITLE
error: report default class constructor frames at the class definition

### DIFF
--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -29,6 +29,10 @@ ZigStackFramePosition classSourceStartPosition(const SourceCode& classSource)
     auto* provider = classSource.provider();
     int start = classSource.startOffset();
     WTF::StringView source = provider->source();
+    // node:vm lineOffset/columnOffset: JSC applies them (the column to the first line only) but clamps negative ones away; V8 does not.
+    TextPosition providerStart = provider->startPosition();
+
+    int line = classSource.firstLine().zeroBasedInt() + std::min(providerStart.m_line.zeroBasedInt(), 0);
 
     // startColumn() is only a fallback: on the first line of a lazily parsed function it counts from the function.
     int column = classSource.startColumn().zeroBasedInt();
@@ -37,13 +41,12 @@ ZigStackFramePosition classSourceStartPosition(const SourceCode& classSource)
         while (lineStart > 0 && !isLineTerminator(source[lineStart - 1]))
             lineStart--;
         column = start - lineStart;
-        // JSC's columns on the first line of a source include its start column (node:vm columnOffset).
         if (lineStart == 0)
-            column += provider->startPosition().m_column.zeroBasedInt();
+            column += providerStart.m_column.zeroBasedInt();
     }
 
     return ZigStackFramePosition {
-        .line_zero_based = classSource.firstLine().zeroBasedInt(),
+        .line_zero_based = line,
         .column_zero_based = column,
         .byte_position = start,
     };

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -30,9 +30,7 @@ ZigStackFramePosition classSourceStartPosition(const SourceCode& classSource)
     int start = classSource.startOffset();
     WTF::StringView source = provider->source();
 
-    // classSource.startColumn() is counted from wherever the lexer started, which for a class on
-    // the first line of a lazily parsed function body is that function, not the line. Count from
-    // the line start instead; the column is only taken as-is when the source text is unavailable.
+    // startColumn() is only a fallback: on the first line of a lazily parsed function it counts from the function.
     int column = classSource.startColumn().zeroBasedInt();
     if (static_cast<unsigned>(start) <= source.length()) {
         int lineStart = start;

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -1,12 +1,69 @@
 #include "root.h"
+#include "ErrorStackFrame.h"
 #include "JavaScriptCore/CodeBlock.h"
-#include "headers-handwritten.h"
-#include "JavaScriptCore/BytecodeIndex.h"
+#include "JavaScriptCore/FunctionExecutable.h"
+#include "JavaScriptCore/SourceProvider.h"
+#include "JavaScriptCore/StackFrame.h"
+#include "JavaScriptCore/UnlinkedFunctionExecutable.h"
 #include "wtf/Assertions.h"
 #include "wtf/text/OrdinalNumber.h"
 
 namespace Bun {
 using namespace JSC;
+
+SourceCode defaultClassConstructorClassSource(ScriptExecutable* executable)
+{
+    auto* function = dynamicDowncast<FunctionExecutable>(executable);
+    if (!function || !function->unlinkedExecutable()->isBuiltinDefaultClassConstructor())
+        return {};
+    return function->classSource();
+}
+
+static bool isLineTerminator(char16_t c)
+{
+    return c == '\n' || c == '\r' || c == 0x2028 || c == 0x2029;
+}
+
+ZigStackFramePosition classSourceStartPosition(const SourceCode& classSource)
+{
+    auto* provider = classSource.provider();
+    int start = classSource.startOffset();
+    WTF::StringView source = provider->source();
+
+    // classSource.startColumn() is counted from wherever the lexer started, which for a class on
+    // the first line of a lazily parsed function body is that function, not the line. Count from
+    // the line start instead; the column is only taken as-is when the source text is unavailable.
+    int column = classSource.startColumn().zeroBasedInt();
+    if (static_cast<unsigned>(start) <= source.length()) {
+        int lineStart = start;
+        while (lineStart > 0 && !isLineTerminator(source[lineStart - 1]))
+            lineStart--;
+        column = start - lineStart;
+        // JSC's columns on the first line of a source include its start column (node:vm columnOffset).
+        if (lineStart == 0)
+            column += provider->startPosition().m_column.zeroBasedInt();
+    }
+
+    return ZigStackFramePosition {
+        .line_zero_based = classSource.firstLine().zeroBasedInt(),
+        .column_zero_based = column,
+        .byte_position = start,
+    };
+}
+
+LineColumn computeLineAndColumn(const StackFrame& frame)
+{
+    auto* codeBlock = frame.codeBlock();
+    auto classSource = codeBlock ? defaultClassConstructorClassSource(codeBlock->ownerExecutable()) : SourceCode();
+    if (!classSource.isNull()) {
+        auto position = classSourceStartPosition(classSource);
+        return LineColumn {
+            .line = static_cast<unsigned>(position.line().oneBasedInt()),
+            .column = static_cast<unsigned>(position.column().oneBasedInt()),
+        };
+    }
+    return frame.computeLineAndColumn();
+}
 
 /// Adjust a `ZigStackFramePosition` by a number of bytes. This accounts for when the adjustment
 /// crosses line boundaries, and thus requires the source code in order to properly compute
@@ -64,6 +121,10 @@ void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* 
 
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
 {
+    auto classSource = defaultClassConstructorClassSource(code->ownerExecutable());
+    if (!classSource.isNull())
+        return classSourceStartPosition(classSource);
+
     auto expr = code->expressionInfoForBytecodeIndex(bc);
 
     ZigStackFramePosition pos {

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -14,8 +14,7 @@ class StackFrame;
 
 namespace Bun {
 
-/// The class whose constructor JSC synthesized because it declared none (that constructor's own
-/// source() is the URL-less "(function () { })" template), or null for any other executable.
+/// The class of a constructor JSC synthesized (its own source() is the URL-less "(function () { })" template), else null.
 JSC::SourceCode defaultClassConstructorClassSource(JSC::ScriptExecutable* executable);
 
 /// Position of the `class` keyword `classSource` starts at; frames of its default constructor go there, as in V8.

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -1,9 +1,33 @@
+#pragma once
+
 #include "root.h"
 #include "headers-handwritten.h"
 #include "JavaScriptCore/BytecodeIndex.h"
+#include "JavaScriptCore/LineColumn.h"
+#include "JavaScriptCore/SourceCode.h"
+
+namespace JSC {
+class CodeBlock;
+class ScriptExecutable;
+class StackFrame;
+}
 
 namespace Bun {
 
+/// JSC compiles the constructor of a class that declares none from
+/// BuiltinExecutables::defaultConstructorSourceCode(), a fixed one-line string with no URL, so that
+/// executable's source() and bytecode positions only describe that string. For such an executable
+/// this returns the SourceCode of the class itself (its file, starting at the `class` keyword), which
+/// is where V8 reports these frames. Null for every other executable.
+JSC::SourceCode defaultClassConstructorClassSource(JSC::ScriptExecutable* executable);
+
+/// Position of the `class` keyword a class SourceCode starts at, in the same coordinates JSC reports
+/// bytecode positions of that file in.
+ZigStackFramePosition classSourceStartPosition(const JSC::SourceCode& classSource);
+
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
+
+/// frame.computeLineAndColumn(), except that a default class constructor frame is placed at its class.
+JSC::LineColumn computeLineAndColumn(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -14,20 +14,16 @@ class StackFrame;
 
 namespace Bun {
 
-/// JSC compiles the constructor of a class that declares none from
-/// BuiltinExecutables::defaultConstructorSourceCode(), a fixed one-line string with no URL, so that
-/// executable's source() and bytecode positions only describe that string. For such an executable
-/// this returns the SourceCode of the class itself (its file, starting at the `class` keyword), which
-/// is where V8 reports these frames. Null for every other executable.
+/// The class whose constructor JSC synthesized because it declared none (that constructor's own
+/// source() is the URL-less "(function () { })" template), or null for any other executable.
 JSC::SourceCode defaultClassConstructorClassSource(JSC::ScriptExecutable* executable);
 
-/// Position of the `class` keyword a class SourceCode starts at, in the same coordinates JSC reports
-/// bytecode positions of that file in.
+/// Position of the `class` keyword `classSource` starts at; frames of its default constructor go there, as in V8.
 ZigStackFramePosition classSourceStartPosition(const JSC::SourceCode& classSource);
 
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// frame.computeLineAndColumn(), except that a default class constructor frame is placed at its class.
+/// frame.computeLineAndColumn(), with default class constructor frames placed at their class.
 JSC::LineColumn computeLineAndColumn(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -304,7 +304,16 @@ JSCStackFrame::JSCStackFrame(JSC::VM& vm, const JSC::StackFrame& frame)
 
 intptr_t JSCStackFrame::sourceID() const
 {
-    return m_codeBlock ? m_codeBlock->ownerExecutable()->sourceID() : JSC::noSourceID;
+    if (!m_codeBlock) {
+        return JSC::noSourceID;
+    }
+
+    auto classSource = Bun::defaultClassConstructorClassSource(m_codeBlock->ownerExecutable());
+    if (!classSource.isNull()) {
+        return classSource.providerID();
+    }
+
+    return m_codeBlock->ownerExecutable()->sourceID();
 }
 
 JSC::JSString* JSCStackFrame::sourceURL()
@@ -371,12 +380,9 @@ ALWAYS_INLINE String JSCStackFrame::retrieveSourceURL()
     // Instead, try to get some identifying information for this frame
 
     // Try to use sourceID if available
-    if (m_codeBlock) {
-        auto sourceID = m_codeBlock->ownerExecutable()->sourceID();
-        if (sourceID != JSC::noSourceID) {
-            // Use a placeholder that includes the sourceID to make frames distinguishable
-            return makeString("[source:"_s, sourceID, "]"_s);
-        }
+    if (auto sourceID = this->sourceID(); sourceID != JSC::noSourceID) {
+        // Use a placeholder that includes the sourceID to make frames distinguishable
+        return makeString("[source:"_s, sourceID, "]"_s);
     }
 
     // Last resort: return a distinguishable placeholder instead of empty string
@@ -468,6 +474,11 @@ String sourceURL(JSC::CodeBlock& codeBlock)
 {
     if (!codeBlock.ownerExecutable()) {
         return String();
+    }
+
+    auto classSource = Bun::defaultClassConstructorClassSource(codeBlock.ownerExecutable());
+    if (!classSource.isNull()) {
+        return sourceURL(classSource);
     }
 
     const auto& source = codeBlock.source();

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -21,6 +21,7 @@
 
 #include "BunClientData.h"
 #include "CallSite.h"
+#include "ErrorStackFrame.h"
 #include "ErrorStackTrace.h"
 #include "headers-handwritten.h"
 
@@ -264,7 +265,7 @@ WTF::String formatStackTrace(
 
         if (!frame.hasLineAndColumnInfo()) continue;
 
-        originalLineColumns[i] = frame.computeLineAndColumn();
+        originalLineColumns[i] = Bun::computeLineAndColumn(frame);
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
         if (auto* callee = frame.callee()) {

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -135,7 +135,10 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
     if (!code)
         return;
 
-    auto* provider = code->source().provider();
+    // The position below is in the class's source for a default class constructor, so the
+    // source lines have to come from it as well.
+    auto classSource = Bun::defaultClassConstructorClassSource(code->ownerExecutable());
+    auto* provider = classSource.isNull() ? code->source().provider() : classSource.provider();
     if (!provider) [[unlikely]]
         return;
     // Make sure the range is valid:
@@ -146,7 +149,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
 
     if (!stackFrame.hasBytecodeIndex()) {
         if (stackFrame.hasLineAndColumnInfo()) {
-            auto lineColumn = stackFrame.computeLineAndColumn();
+            auto lineColumn = Bun::computeLineAndColumn(stackFrame);
             position.line_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.line).zeroBasedInt();
             position.column_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.column).zeroBasedInt();
         }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -135,8 +135,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
     if (!code)
         return;
 
-    // The position below is in the class's source for a default class constructor, so the
-    // source lines have to come from it as well.
+    // Same source getAdjustedPositionForBytecode() positions the frame in.
     auto classSource = Bun::defaultClassConstructorClassSource(code->ownerExecutable());
     auto* provider = classSource.isNull() ? code->source().provider() : classSource.provider();
     if (!provider) [[unlikely]]

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -261,8 +261,9 @@ console.log(JSON.stringify({ derived: frame(new Derived().err, "Derived"), later
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    expect(stdout).toBe("");
     expect(stderr).toContain("1 | class Nullary extends null {}\n    ^\n");
     expect(stderr).toMatch(/^\s+at new Nullary \(.*fixture\.js:1:1\)/m);
     expect(exitCode).toBe(1);

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -2,6 +2,7 @@ import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
+import vm from "node:vm";
 
 test("name property is used for function calls in Error.stack", () => {
   function WRONG() {
@@ -267,5 +268,47 @@ console.log(JSON.stringify({ derived: frame(new Derived().err, "Derived"), later
     expect(stderr).toContain("1 | class Nullary extends null {}\n    ^\n");
     expect(stderr).toMatch(/^\s+at new Nullary \(.*fixture\.js:1:1\)/m);
     expect(exitCode).toBe(1);
+  });
+
+  test("node:vm lineOffset and columnOffset are applied to the class position", () => {
+    class Thrower {
+      err: Error;
+      constructor() {
+        this.err = new Error("T");
+      }
+    }
+    const context = vm.createContext({ Thrower });
+    const run = (code: string, options: vm.ScriptOptions) =>
+      new vm.Script(code, options).runInContext(context) as Error;
+    const frame = (err: Error, name: string) =>
+      err
+        .stack!.split("\n")
+        .map(line => line.trim())
+        .find(line => line.startsWith(`at new ${name} `));
+    const offsets = { filename: "offsets.vm.js", lineOffset: 10, columnOffset: 5 };
+
+    // The expected positions are what node prints for the same scripts.
+    expect({
+      firstLine: frame(run("class First extends Thrower {} new First().err;", offsets), "First"),
+      laterLine: frame(run("\n\n    class Later extends Thrower {}\nnew Later().err;", offsets), "Later"),
+      negativeColumn: frame(
+        run("         class NegCol extends Thrower {} new NegCol().err;", { filename: "neg.vm.js", columnOffset: -3 }),
+        "NegCol",
+      ),
+      negativeLine: frame(
+        run("\n\n\n  class NegLine extends Thrower {}\n  new NegLine().err;", {
+          filename: "neg.vm.js",
+          lineOffset: -2,
+        }),
+        "NegLine",
+      ),
+    }).toEqual({
+      // The column offset only applies to the first line.
+      firstLine: "at new First (offsets.vm.js:11:6)",
+      laterLine: "at new Later (offsets.vm.js:13:5)",
+      // JSC clamps negative offsets away for the positions it reports itself.
+      negativeColumn: "at new NegCol (neg.vm.js:1:7)",
+      negativeLine: "at new NegLine (neg.vm.js:2:3)",
+    });
   });
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -148,4 +148,123 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// JSC compiles the constructor of a class that declares none from a fixed source string, so these
+// frames used to render as "new X (unknown:1:17)". Like V8, they should point at the `class` keyword.
+describe("frames of a class without an explicit constructor", () => {
+  test.concurrent("error.stack, error.sourceURL and error.line point at the class", async () => {
+    using dir = tempDir("default-ctor-stack", {
+      // Every position below is asserted on, so the lines are laid out deliberately. `// @bun` makes
+      // bun load the file as-is: these are JSC's own positions, with no source map involved.
+      "fixture.js": `// @bun
+class Thrower { constructor() { this.err = new Error("T"); } }
+export class Derived extends Thrower {}
+export class Fields { err = new Error("F"); }
+function later() {
+    class Later extends Thrower {}
+    return new Later().err;
+}
+function sameLine() { class SameLine extends Thrower {} return new SameLine().err; }
+const Anon = class extends Thrower {};
+class Nullary extends null {}
+let nullary;
+try { new Nullary(); } catch (e) { nullary = e; }
+const norm = s => String(s).replaceAll(import.meta.path, "<fixture>");
+const frame = (err, name) => norm(err.stack.split("\\n").map(l => l.trim()).find(l => l.startsWith("at new " + name + " ")));
+console.log(JSON.stringify({
+  derived: frame(new Derived().err, "Derived"),
+  fields: frame(new Fields().err, "Fields"),
+  later: frame(later(), "Later"),
+  sameLine: frame(sameLine(), "SameLine"),
+  anon: frame(new Anon().err, "Anon"),
+  nullary: { sourceURL: norm(nullary.sourceURL), line: nullary.line, column: nullary.column },
+}));
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      // The `class` keyword, not `export`, like V8.
+      derived: "at new Derived (<fixture>:3:8)",
+      // A base class: its default constructor is what runs the field initializer.
+      fields: "at new Fields (<fixture>:4:8)",
+      later: "at new Later (<fixture>:6:5)",
+      // On the first line of a function body, JSC's own column for the class counts from the
+      // function rather than from the line (it would give 9:6).
+      sameLine: "at new SameLine (<fixture>:9:23)",
+      anon: "at new Anon (<fixture>:10:14)",
+      // The default constructor of `Nullary` is the top frame: `super()` is what throws.
+      nullary: { sourceURL: "<fixture>", line: 11, column: 1 },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the class position is source mapped back to the original file", async () => {
+    using dir = tempDir("default-ctor-stack-sourcemap", {
+      // The interface and the type alias are removed by the transpiler, so the positions JSC reports
+      // differ from the ones in this file.
+      "fixture.ts": `interface Shape {
+  width: number;
+}
+class Thrower {
+  err: Error;
+  constructor() {
+    this.err = new Error("T");
+  }
+}
+export class Derived extends Thrower {}
+function later(): Error {
+  type Unused = Shape;
+  class Later extends Thrower {}
+  return new Later().err;
+}
+const norm = (s: string | undefined) => String(s).replaceAll(import.meta.path, "<fixture>");
+const frame = (err: Error, name: string) =>
+  norm(err.stack!.split("\\n").map(l => l.trim()).find(l => l.startsWith("at new " + name + " ")));
+console.log(JSON.stringify({ derived: frame(new Derived().err, "Derived"), later: frame(later(), "Later") }));
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      derived: "at new Derived (<fixture>:10:8)",
+      later: "at new Later (<fixture>:13:3)",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an uncaught error thrown by the default constructor is printed at the class", async () => {
+    using dir = tempDir("default-ctor-stack-uncaught", {
+      "fixture.js": "class Nullary extends null {}\nnew Nullary();\n",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("1 | class Nullary extends null {}\n    ^\n");
+    expect(stderr).toMatch(/^\s+at new Nullary \(.*fixture\.js:1:1\)/m);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -2,6 +2,7 @@ import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
 import { afterEach, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { readFileSync } from "node:fs";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -574,13 +575,17 @@ test("CallSites of a class without a constructor point at the class definition",
     isConstructor: site.isConstructor(),
     fileName: site.getFileName(),
     lineNumber: site.getLineNumber(),
+    columnNumber: site.getColumnNumber(),
     scriptId: site.getScriptId(),
   });
+  const sourceLines = readFileSync(import.meta.path, "utf8").split("\n");
   const expectedAt = (classSite, functionName) => ({
     functionName,
     isConstructor: true,
     fileName: classSite.getFileName(),
     lineNumber: classSite.getLineNumber(),
+    // getColumnNumber() is zero-based; this is the column of the `class` keyword on that line.
+    columnNumber: sourceLines[classSite.getLineNumber() - 1].indexOf(`class ${functionName} `),
     scriptId: classSite.getScriptId(),
   });
 
@@ -588,9 +593,6 @@ test("CallSites of a class without a constructor point at the class definition",
   expect(innerClassSite.getLineNumber()).not.toBe(derivedClassSite.getLineNumber());
   expect(describeSite(derivedSite)).toEqual(expectedAt(derivedClassSite, "Derived"));
   expect(describeSite(innerSite)).toEqual(expectedAt(innerClassSite, "Inner"));
-  // The `class` keyword comes before the `extends` clause on each line.
-  expect(derivedSite.getColumnNumber()).toBeLessThan(derivedClassSite.getColumnNumber());
-  expect(innerSite.getColumnNumber()).toBeLessThan(innerClassSite.getColumnNumber());
 });
 
 test("CallFrame.p.isNative", () => {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -535,6 +535,64 @@ test("CallFrame.p.isConstructor", () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 });
 
+test("CallSites of a class without a constructor point at the class definition", () => {
+  Error.prepareStackTrace = (err, callSites) => callSites;
+
+  let fromBase;
+  class Base {
+    constructor() {
+      fromBase = new Error();
+    }
+  }
+  // JSC compiles the constructor of a class that declares none from an internal one-line source, and
+  // its frames used to report that source: no file, line 1. V8 reports the line of the `class`
+  // keyword, which is also where each `marked(Base)` below is called from.
+  const markers = [];
+  function marked(Super) {
+    markers.push(new Error());
+    return Super;
+  }
+  class Derived extends marked(Base) {}
+  function makeInner() {
+    class Inner extends marked(Base) {}
+    new Inner();
+  }
+
+  new Derived();
+  const derivedError = fromBase;
+  makeInner();
+  const innerError = fromBase;
+  // In the markers, [0] is `marked` and [1] the `extends` clause; in the errors from Base, [0] is
+  // `new Base` and [1] the synthesized constructor of the subclass.
+  const [derivedClassSite, innerClassSite] = markers.map(marker => marker.stack[1]);
+  const derivedSite = derivedError.stack[1];
+  const innerSite = innerError.stack[1];
+  Error.prepareStackTrace = origPrepareStackTrace;
+
+  const describeSite = site => ({
+    functionName: site.getFunctionName(),
+    isConstructor: site.isConstructor(),
+    fileName: site.getFileName(),
+    lineNumber: site.getLineNumber(),
+    scriptId: site.getScriptId(),
+  });
+  const expectedAt = (classSite, functionName) => ({
+    functionName,
+    isConstructor: true,
+    fileName: classSite.getFileName(),
+    lineNumber: classSite.getLineNumber(),
+    scriptId: classSite.getScriptId(),
+  });
+
+  expect(derivedClassSite.getFileName()).toBe(import.meta.path);
+  expect(innerClassSite.getLineNumber()).not.toBe(derivedClassSite.getLineNumber());
+  expect(describeSite(derivedSite)).toEqual(expectedAt(derivedClassSite, "Derived"));
+  expect(describeSite(innerSite)).toEqual(expectedAt(innerClassSite, "Inner"));
+  // The `class` keyword comes before the `extends` clause on each line.
+  expect(derivedSite.getColumnNumber()).toBeLessThan(derivedClassSite.getColumnNumber());
+  expect(innerSite.getColumnNumber()).toBeLessThan(innerClassSite.getColumnNumber());
+});
+
 test("CallFrame.p.isNative", () => {
   let prevPrepareStackTrace = Error.prepareStackTrace;
   Error.prepareStackTrace = (e, s) => {


### PR DESCRIPTION
### Problem
- A class with no explicit constructor produces a stack frame with no file and a meaningless position whenever something below its constructor captures a stack: `at new E (unknown:1:28)` for a derived class, `at new B (unknown:1:17)` for a base class (e.g. a class with field initializers). Node prints `at new E (/tmp/e.js:2:1)`, the position of the `class` keyword.
  ```js
  class Thrower { constructor() { this.err = new Error("T"); } }
  class E extends Thrower {}
  console.log(new E().err.stack);
  ```
- Same frame in every renderer: `error.stack`, `Error.prepareStackTrace` CallSites (`getFileName()` is `[source:3]`, `getLineNumber()` is 1, `getScriptId()` is a different script per class), and the uncaught error printer. When such a frame is on top (`class E extends null {}; new E()`, where the synthesized `super(...args)` throws) the printer shows `at new E (1:23)` with the caret under the wrong line, and `err.sourceURL` / `err.line` are unset / 1.
- Cause: JSC compiles the constructor of a class that declares none from `BuiltinExecutables::defaultConstructorSourceCode()` (`"(function () { })"` / `"(function (...args) { super(...args); })"`), and `UnlinkedFunctionExecutable::linkedSourceCode()` makes that string the executable's source. Bun reads the URL and position straight off that code block: `Zig::sourceURL(CodeBlock&)` (src/jsc/bindings/ErrorStackTrace.cpp), `getAdjustedPositionForBytecode()` (src/jsc/bindings/ErrorStackFrame.cpp), `frame.computeLineAndColumn()` in `formatStackTrace` (src/jsc/bindings/FormatStackTraceForJS.cpp) and the provider used for the source excerpt in `populateStackFramePosition` (src/jsc/bindings/ZigException.cpp).

### Fix
- `Bun::defaultClassConstructorClassSource(executable)` (ErrorStackFrame.cpp) returns `FunctionExecutable::classSource()` when the executable's `UnlinkedFunctionExecutable::isBuiltinDefaultClassConstructor()` is set, and a null SourceCode otherwise. `isBuiltinDefaultClassConstructor` is the flag `linkedSourceCode()` itself keys the source swap on, and `classSource()` is the class's real SourceCode: the user's provider, starting at the `class` keyword.
- `Bun::classSourceStartPosition()` turns that into a position: the class source's `firstLine()`, the column counted back to the line start in the provider's text, `byte_position` = the class start offset. `classSource.startColumn()` is not used because JSC's lexer counts columns from wherever it started, so for a class on the first line of a lazily parsed function body it is relative to the function (the `sameLine` test case reports `9:6` with it, `9:23` with this). node:vm `lineOffset`/`columnOffset` are taken from the provider's `startPosition()` the way V8 applies them: the column offset on the first line only, and both signs (JSC itself clamps negative offsets away in `SourceCode`, so `firstLine()` only carries a positive line offset and the negative part is added back). The vm test case asserts the positions node prints for the same scripts, both signs of both offsets.
- The four readers above consult it: `Zig::sourceURL(CodeBlock&)` returns the class source's URL (this also covers `JSCStackFrame::retrieveSourceURL`, `Zig::sourceURL(StackVisitor&)` and the two `StackFrame` overloads, which all funnel through it), `getAdjustedPositionForBytecode()` returns the class position (CallSites via `calculateSourcePositions`, and the error printer), `formatStackTrace` pass 1 uses a `Bun::computeLineAndColumn(frame)` wrapper that does the same on top of `StackFrame::computeLineAndColumn()` (error.stack's columns for other frames are unchanged), and `populateStackFramePosition` takes the excerpt lines from the class source's provider so they match the position it just computed. `JSCStackFrame::sourceID()` (CallSite `getScriptId()` and the `[source:N]` placeholder) reports the class's provider for the same reason.
- Why this is the right place: the frame really is executing in the class's file, JSC just compiles it from a template. Reporting it at the class definition is what V8 does (`at new E (file:2:1)`, `export class` reports the `class` keyword, a class expression reports its `class` keyword), and giving the frame a real URL and position is also what lets `Bun__remapStackFramePositions` source-map it for transpiled files, so TypeScript classes now report their original line.
- Not changed: `Bun__CallFrame__getCallerSrcLoc`, `Bun__CallFrame__getLineNumber` and `InspectorTestReporterAgent::reportTestFound` still pair `Zig::sourceURL(visitor)` with `visitor->computeLineAndColumn()`. They locate the JS caller of a non-constructor native function, which a synthesized constructor (whose body is only `super(...args)`) can never be, so only their URL half is affected, and it now agrees with the other renderers. The arrow header node:vm prepends to an error escaping a vm script (`NodeVM.cpp`, JSC's own `sourceURL()` / `computeLineAndColumn()` on the top frame) still shows the template source when that top frame is a default constructor; several open node:vm PRs are editing that function, so it is left for a follow-up. The frames in that error's `.stack` are fixed by this PR.
- Open PRs on the same lines: #37396 (error.stack positions move onto a new `getAdjustedLineColumnForBytecode`), #38248 (negative vm offsets for the frames JSC positions itself), #38344 (vm sources and source maps). This PR is deliberately not stacked on them: it is a different bug and can land in any order. Its position rule is one early return at the top of `getAdjustedPositionForBytecode` plus the `Bun::computeLineAndColumn` wrapper for error.stack, and whichever of #37396 / #38248 lands second adds that same early return to its per-frame position function and drops the wrapper (a few lines; the error.stack tests here fail if it is missed). #38248's `applyNegativeSourceStart` must not run on these frames and does not need to: the class position already includes both offsets, which is what the negative cases in the vm test pin down.
- Verified with `bun bd test test/js/bun/test/stack.test.ts` (new: error.stack for a `// @bun` file with derived / base-with-fields / class in a function / class on a function's first line / class expression, `err.sourceURL`+`err.line` for `extends null` on top; the same through a source map for a `.ts` file; the uncaught printer's frame line and caret; `vm.Script` with positive and negative `lineOffset`/`columnOffset`) and `bun bd test test/js/node/v8/capture-stack-trace.test.js` (new: CallSite `getFileName`/`getLineNumber`/`getColumnNumber`/`getScriptId`/`isConstructor` for a top-level and an in-function class; the expected file and line come from a frame captured in each class's `extends` clause, the expected column from the `class` keyword's offset in that line). All five new tests fail on the released binary with the output quoted above.
- Also ran with the fix: the rest of those two files, `inspect-error.test.js`, `reportError.test.ts`, `vm.test.ts`, `vm-sourceUrl.test.ts`, `internal-sourcemap.test.ts`, `coverage.test.ts`. The only failures (`inspect-error` "Error inside minified file", `error-gc-test`, `diffexample` "no color") fail identically on main with a debug build and are tracked separately.

### Background
- Default class constructor: for `class E extends B {}` JSC does not parse a constructor; `BytecodeGenerator::emitNewDefaultConstructor` creates an `UnlinkedFunctionExecutable` from a fixed source string (`BuiltinExecutables.cpp`), marks it `isBuiltinDefaultClassConstructor`, and stores the class's own source range on it via `setClassSource()`. It is a normal (not builtin-visibility) function, so it shows up in stacks like any user function.
- `SourceCode` / `SourceProvider`: a provider holds one file's text and URL; a `SourceCode` is a range in it (`startOffset`, `firstLine`, `startColumn`). `classSource()` is the range from the `class` keyword to the closing brace; it is also what `Function.prototype.toString` prints for a class.
- node:vm `lineOffset`/`columnOffset`: stored on the script's SourceProvider as `startPosition()`. JSC adds a positive line offset to every line and a positive column offset to the first line when it reports positions; V8 does the same but also honors negative offsets.
- `ZigStackFramePosition`: zero-based line/column plus a byte offset into the provider's text, shared with the Rust error printer; the offset is what the printer's source excerpt is cut around, which is why the excerpt provider has to match it.
- Bun has three stack renderers reading the same JSC frames: `formatStackTrace` builds the `error.stack` string (and sets `err.line`/`err.sourceURL`), `JSCStackFrame`/`CallSite` back `Error.prepareStackTrace`, and `ZigException` feeds the uncaught error / `Bun.inspect` printer. All three hand positions to `Bun__remapStackFramePositions`, which applies the transpiler's source map when the frame has a URL.

