### PR TITLE
css: interpolate color-mix() operands as css-color-4 specifies

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -801,7 +801,8 @@ impl CssColor {
             });
         }
 
-        fn check_converted<T: 'static>(color: &CssColor) -> Option<bool> {
+        /// Whether `color` is already specified in the interpolation color space `T`.
+        fn is_in_space<T: 'static>(color: &CssColor) -> Option<bool> {
             use core::any::TypeId;
             debug_assert!(!matches!(
                 color,
@@ -819,8 +820,11 @@ impl CssColor {
             }
         }
 
-        let converted_first = check_converted::<T>(self)?;
-        let converted_second = check_converted::<T>(other)?;
+        // Only operands converted into the interpolation space are gamut mapped and have
+        // their powerless components treated as missing; a color specified directly in
+        // that space is interpolated as written (https://www.w3.org/TR/css-color-4/#interpolation-space).
+        let converted_first = !is_in_space::<T>(self)?;
+        let converted_second = !is_in_space::<T>(other)?;
 
         // https://drafts.csswg.org/css-color-5/#color-mix-result
         let mut first_color = T::try_from_css_color(self)?;

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -818,15 +818,11 @@ impl CssColor {
         let converted_second = !is_in_space::<T>(other)?;
 
         // https://drafts.csswg.org/css-color-5/#color-mix-result
-        // Operands outside the gamut of the interpolation space are interpolated as-is
-        // (https://www.w3.org/TR/css-color-4/#interpolation-space); gamut mapping only
-        // happens when the result is converted to rgb for output.
+        // Out-of-gamut operands stay as-is: https://www.w3.org/TR/css-color-4/#interpolation-space
         let mut first_color = T::try_from_css_color(self)?;
         let mut second_color = T::try_from_css_color(other)?;
 
         // https://www.w3.org/TR/css-color-4/#powerless
-        // Components made powerless by the conversion become missing. A color specified
-        // directly in the interpolation space keeps them as written.
         if converted_first {
             first_color.adjust_powerless_components();
         }
@@ -1645,11 +1641,7 @@ macro_rules! define_colorspace {
     };
     (@interp none $pow:ident $(($eps:literal))? $name:ident { $a:ident, $b:ident, $c:ident }) => {};
 
-    // Only hues are powerless (https://www.w3.org/TR/css-color-4/#powerless): a hue produced
-    // by converting a color into a polar space is powerless when the color is achromatic,
-    // i.e. its colorfulness is within the "powerless hue ε" css-color-4 lists for that
-    // space. The ε is given in this file's units (chroma as written, saturation, white and
-    // black as fractions of 1).
+    // $eps is the space's "powerless hue ε" (https://www.w3.org/TR/css-color-4/#powerless).
     (@powerless none $name:ident { $a:ident, $b:ident, $c:ident }) => {};
     (@powerless lch($eps:literal) $name:ident { $l:ident, $c:ident, $h:ident }) => {
         fn adjust_powerless_components(&mut self) {

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -763,13 +763,7 @@ impl CssColor {
         method: HueInterpolationMethod,
     ) -> Option<CssColor>
     where
-        T: Colorspace
-            + ColorGamut
-            + Interpolate
-            + Into<OKLCH>
-            + From<OKLCH>
-            + Into<OKLAB>
-            + 'static,
+        T: Interpolate + 'static,
     {
         if matches!(self, CssColor::CurrentColor) || matches!(other, CssColor::CurrentColor) {
             return None;
@@ -820,25 +814,19 @@ impl CssColor {
             }
         }
 
-        // Only operands converted into the interpolation space are gamut mapped and have
-        // their powerless components treated as missing; a color specified directly in
-        // that space is interpolated as written (https://www.w3.org/TR/css-color-4/#interpolation-space).
         let converted_first = !is_in_space::<T>(self)?;
         let converted_second = !is_in_space::<T>(other)?;
 
         // https://drafts.csswg.org/css-color-5/#color-mix-result
+        // Operands outside the gamut of the interpolation space are interpolated as-is
+        // (https://www.w3.org/TR/css-color-4/#interpolation-space); gamut mapping only
+        // happens when the result is converted to rgb for output.
         let mut first_color = T::try_from_css_color(self)?;
         let mut second_color = T::try_from_css_color(other)?;
 
-        if converted_first && !first_color.in_gamut() {
-            first_color = map_gamut(first_color);
-        }
-
-        if converted_second && !second_color.in_gamut() {
-            second_color = map_gamut(second_color);
-        }
-
         // https://www.w3.org/TR/css-color-4/#powerless
+        // Components made powerless by the conversion become missing. A color specified
+        // directly in the interpolation space keeps them as written.
         if converted_first {
             first_color.adjust_powerless_components();
         }
@@ -1529,7 +1517,7 @@ macro_rules! define_colorspace {
         types = ($ta:expr, $tb:expr, $tc:expr);
         gamut = $gamut:ident;
         premultiply = $pre:ident;
-        powerless = $pow:ident;
+        powerless = $pow:ident $(($eps:literal))?;
         into_css = $into_css:expr;
     ) => {
         $(#[$meta])*
@@ -1561,7 +1549,7 @@ macro_rules! define_colorspace {
         }
 
         define_colorspace!(@gamut $gamut $name { $a, $b, $c });
-        define_colorspace!(@interp $pre $pow $name { $a, $b, $c });
+        define_colorspace!(@interp $pre $pow $(($eps))? $name { $a, $b, $c });
     };
 
     // Gamut variants
@@ -1606,7 +1594,7 @@ macro_rules! define_colorspace {
     (@gamut none $name:ident { $a:ident, $b:ident, $c:ident }) => {};
 
     // Interpolate / premultiply / powerless variants
-    (@interp rectangular $pow:ident $name:ident { $a:ident, $b:ident, $c:ident }) => {
+    (@interp rectangular $pow:ident $(($eps:literal))? $name:ident { $a:ident, $b:ident, $c:ident }) => {
         impl Interpolate for $name {
             fn interpolate(&self, p1: f32, other: &Self, p2: f32) -> Self {
                 let (a, b, c, alpha) = lerp_components(self, p1, other, p2);
@@ -1628,10 +1616,10 @@ macro_rules! define_colorspace {
                     self.alpha *= alpha_multiplier;
                 }
             }
-            define_colorspace!(@powerless $pow $name { $a, $b, $c });
+            define_colorspace!(@powerless $pow $(($eps))? $name { $a, $b, $c });
         }
     };
-    (@interp polar $pow:ident $name:ident { $h:ident, $a:ident, $b:ident }) => {
+    (@interp polar $pow:ident $(($eps:literal))? $name:ident { $h:ident, $a:ident, $b:ident }) => {
         impl Interpolate for $name {
             fn interpolate(&self, p1: f32, other: &Self, p2: f32) -> Self {
                 let (a, b, c, alpha) = lerp_components(self, p1, other, p2);
@@ -1652,30 +1640,20 @@ macro_rules! define_colorspace {
                     self.alpha *= alpha_multiplier;
                 }
             }
-            define_colorspace!(@powerless $pow $name { $h, $a, $b });
+            define_colorspace!(@powerless $pow $(($eps))? $name { $h, $a, $b });
         }
     };
-    (@interp none $pow:ident $name:ident { $a:ident, $b:ident, $c:ident }) => {};
+    (@interp none $pow:ident $(($eps:literal))? $name:ident { $a:ident, $b:ident, $c:ident }) => {};
 
+    // Only hues are powerless (https://www.w3.org/TR/css-color-4/#powerless): a hue produced
+    // by converting a color into a polar space is powerless when the color is achromatic,
+    // i.e. its colorfulness is within the "powerless hue ε" css-color-4 lists for that
+    // space. The ε is given in this file's units (chroma as written, saturation, white and
+    // black as fractions of 1).
     (@powerless none $name:ident { $a:ident, $b:ident, $c:ident }) => {};
-    (@powerless lab $name:ident { $l:ident, $a:ident, $b:ident }) => {
+    (@powerless lch($eps:literal) $name:ident { $l:ident, $c:ident, $h:ident }) => {
         fn adjust_powerless_components(&mut self) {
-            // If the lightness of a LAB color is 0%, both the a and b components are powerless.
-            if self.$l.abs() < f32::EPSILON {
-                self.$a = f32::NAN;
-                self.$b = f32::NAN;
-            }
-        }
-    };
-    (@powerless lch $name:ident { $l:ident, $c:ident, $h:ident }) => {
-        fn adjust_powerless_components(&mut self) {
-            // If the chroma of an LCH color is 0%, the hue component is powerless.
-            // If the lightness of an LCH color is 0%, both the hue and chroma components are powerless.
-            if self.$c.abs() < f32::EPSILON {
-                self.$h = f32::NAN;
-            }
-            if self.$l.abs() < f32::EPSILON {
-                self.$c = f32::NAN;
+            if self.$c <= $eps {
                 self.$h = f32::NAN;
             }
         }
@@ -1683,27 +1661,19 @@ macro_rules! define_colorspace {
             method.interpolate(&mut self.$h, &mut other.$h);
         }
     };
-    (@powerless hsl $name:ident { $h:ident, $s:ident, $l:ident }) => {
+    (@powerless hsl($eps:literal) $name:ident { $h:ident, $s:ident, $l:ident }) => {
         fn adjust_powerless_components(&mut self) {
-            // If the saturation of an HSL color is 0%, then the hue component is powerless.
-            // If the lightness of an HSL color is 0% or 100%, both the saturation and hue components are powerless.
-            if self.$s.abs() < f32::EPSILON {
+            if self.$s <= $eps {
                 self.$h = f32::NAN;
-            }
-            if self.$l.abs() < f32::EPSILON || (self.$l - 1.0).abs() < f32::EPSILON {
-                self.$h = f32::NAN;
-                self.$s = f32::NAN;
             }
         }
         fn adjust_hue(&mut self, other: &mut Self, method: HueInterpolationMethod) {
             method.interpolate(&mut self.$h, &mut other.$h);
         }
     };
-    (@powerless hwb $name:ident { $h:ident, $w:ident, $b:ident }) => {
+    (@powerless hwb($eps:literal) $name:ident { $h:ident, $w:ident, $b:ident }) => {
         fn adjust_powerless_components(&mut self) {
-            // If white+black is equal to 100% (after normalization), it defines an achromatic color,
-            // i.e. some shade of gray, without any hint of the chosen hue. In this case, the hue component is powerless.
-            if (self.$w + self.$b - 1.0).abs() < f32::EPSILON {
+            if self.$w + self.$b >= 1.0 - $eps {
                 self.$h = f32::NAN;
             }
         }
@@ -1723,7 +1693,7 @@ define_colorspace! {
     types = (CT_PCT, CT_NUM, CT_NUM);
     gamut = unbounded;
     premultiply = rectangular;
-    powerless = lab;
+    powerless = none;
     into_css = |c: &LAB| CssColor::Lab(Box::new(LABColor::Lab(*c)));
 }
 
@@ -1754,7 +1724,8 @@ define_colorspace! {
     types = (CT_ANG, CT_PCT, CT_PCT);
     gamut = hsl_hwb;
     premultiply = polar;
-    powerless = hsl;
+    // css-color-4: S <= 0.001 (of 100)
+    powerless = hsl(0.00001);
     into_css = |c: &HSL| CssColor::Rgba(RGBA::from(*c));
 }
 
@@ -1764,7 +1735,8 @@ define_colorspace! {
     types = (CT_ANG, CT_PCT, CT_PCT);
     gamut = hsl_hwb;
     premultiply = polar;
-    powerless = hwb;
+    // css-color-4: W + B >= 99.999 (of 100)
+    powerless = hwb(0.00001);
     into_css = |c: &HWB| CssColor::Rgba(RGBA::from(*c));
 }
 
@@ -1846,7 +1818,8 @@ define_colorspace! {
     types = (CT_PCT, CT_NUM, CT_ANG);
     gamut = unbounded;
     premultiply = rectangular;
-    powerless = lch;
+    // css-color-4: C <= 0.0015
+    powerless = lch(0.0015);
     into_css = |c: &LCH| CssColor::Lab(Box::new(LABColor::Lch(*c)));
 }
 
@@ -1856,7 +1829,7 @@ define_colorspace! {
     types = (CT_PCT, CT_NUM, CT_NUM);
     gamut = unbounded;
     premultiply = rectangular;
-    powerless = lab;
+    powerless = none;
     into_css = |c: &OKLAB| CssColor::Lab(Box::new(LABColor::Oklab(*c)));
 }
 
@@ -1866,7 +1839,8 @@ define_colorspace! {
     types = (CT_PCT, CT_NUM, CT_ANG);
     gamut = unbounded;
     premultiply = rectangular;
-    powerless = lch;
+    // css-color-4: C <= 0.000004
+    powerless = lch(0.000004);
     into_css = |c: &OKLCH| CssColor::Lab(Box::new(LABColor::Oklch(*c)));
 }
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -650,41 +650,74 @@ describe("color-mix() percentage range", () => {
   });
 });
 
-// https://www.w3.org/TR/css-color-4/#interpolation-space: only an operand that is
-// converted into the interpolation space is gamut mapped and has its powerless
-// components treated as missing; an operand authored in that space is mixed as
-// written. Expected values are lightningcss output.
-describe("color-mix() converted operands", () => {
+// css-color-4 #interpolation-space and #powerless: converting an operand into the
+// interpolation space leaves its channels alone (out-of-gamut values are interpolated
+// as-is); a hue the conversion makes powerless becomes missing and is taken from the
+// other operand. An operand written in that space is mixed as written.
+describe("color-mix() operand conversion", () => {
   test.each([
-    // Authored in the interpolation space: mixed as written.
+    // color(display-p3 0 1 0) is color(srgb -0.511605 1.01827 -0.310675); these used to come
+    // out as each other's result (#4d9654 and #0b9b0b).
     ["color-mix(in srgb, color(srgb -0.51 1.018 -0.31), color(srgb 0.6 0.2 0.4))", "#0b9b0b"],
+    ["color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))", "#0b9b0b"],
     ["color-mix(in srgb, color(srgb -0.5 1.5 -0.5), color(srgb 0.5 0.5 0.5))", "#0f0"],
-    ["color-mix(in srgb, color(srgb 1.13 0 0), white)", "#ff8886"],
+    ["color-mix(in srgb-linear, color(srgb-linear 1.5 0 0), white)", "color(srgb-linear 1.25 .5 .5)"],
+    // Hue made powerless by the conversion.
+    ["color-mix(in lch, lab(50% 0 0), lch(50% 50 120))", "lch(50% 25 120)"],
+    ["color-mix(in lch, black, lch(50% 50 120))", "lch(25% 25 120)"],
+    ["color-mix(in oklch, white, oklch(50% 0.2 120))", "oklch(75% .1 120)"],
+    ["color-mix(in oklch, oklab(50% 0 0), black)", "oklch(25% 0 none)"],
+    // Powerless components written out stay in effect.
+    ["color-mix(in lch, lch(50% 0 200), lch(50% 50 120))", "lch(50% 25 160)"],
+    ["color-mix(in oklch, oklch(50% 0 200), oklch(50% 0.2 120))", "oklch(50% .1 160)"],
     ["color-mix(in hsl, hsl(120 none 50%), hsl(200 100% 50%))", "#0fa"],
     ["color-mix(in hwb, hwb(120 50% none), hwb(200 0% 40%))", "#40997b"],
     ["color-mix(in lab, lab(0% 30 40), lab(50% 50 -20))", "lab(25% 40 10)"],
-    ["color-mix(in lch, lch(50% 0 200), lch(50% 50 120))", "lch(50% 25 160)"],
-    ["color-mix(in oklch, oklch(50% 0 200), oklch(50% 0.2 120))", "oklch(50% .1 160)"],
-    ["color-mix(in srgb-linear, color(srgb-linear 1.5 0 0), white)", "color(srgb-linear 1.25 .5 .5)"],
-    // Converted into it: gamut mapped first, powerless components taken from the other side.
-    // color(display-p3 0 1 0) converts to the color(srgb -0.51 1.018 -0.31) used above.
-    ["color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))", "#4d9654"],
-    ["color-mix(in srgb, color(display-p3 0 1 0), white)", "#80fca0"],
-    ["color-mix(in srgb, white, color(display-p3 0 1 0))", "#80fca0"],
-    ["color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 0 1 0))", "#808428"],
-    ["color-mix(in hsl, white, red)", "#ff8080"],
-    ["color-mix(in hsl, hsl(200 100% 50%), black)", "#005580"],
-    ["color-mix(in lab, black, lab(50% 50 -20))", "lab(25% 50 -20)"],
-    ["color-mix(in lch, lab(50% 0 0), lch(50% 50 120))", "lch(50% 25 120)"],
-    ["color-mix(in oklch, black, oklch(50% 0.2 120))", "oklch(25% .2 120)"],
-    ["color-mix(in srgb-linear, color(display-p3 0 1 0), white)", "color(srgb-linear .5 .972601 .527217)"],
+    // Lightness does not make anything powerless.
+    ["color-mix(in lab, black, lab(50% 50 -20))", "lab(25% 25 -10)"],
+    ["color-mix(in hsl, red, white)", "#df9f9f"],
+    ["color-mix(in hsl, hsl(200 100% 50%), black)", "#204a60"],
   ])("%s", (input, expected) => {
     expect(color(input, "css")).toBe(expected);
   });
 
+  // Rows of WPT css/css-color/parsing/color-computed-color-mix-function.html; the first two
+  // are also the worked example in css-color-5. The hue is the interesting part: white and
+  // black convert to a powerless hue, so the result takes the hue of the chromatic operand.
+  // Lightness and chroma go through cbrt()/pow(), hence the tolerance.
+  function lch(input: string): number[] {
+    const css = color(input, "css") as string;
+    expect(css).toMatch(/^(ok)?lch\(/);
+    return css.match(/-?[\d.]+(e-?\d+)?/g)!.map(Number);
+  }
+
+  test.each([
+    ["color-mix(in lch, white, blue)", [64.78, 65.6, 301.36]],
+    ["color-mix(in oklch, white, blue)", [72.6, 0.1566, 264.05]],
+    ["color-mix(in lch, red, black)", [27.15, 53.43, 40.86]],
+    ["color-mix(in lch, red, white)", [77.15, 53.43, 40.86]],
+    ["color-mix(in oklch, red, black)", [31.4, 0.1289, 29.23]],
+    ["color-mix(in oklch, red, white)", [81.4, 0.1289, 29.23]],
+  ])("%s", (input, [l, c, h]) => {
+    const [actualL, actualC, actualH] = lch(input);
+    expect(actualL).toBeCloseTo(l, 1);
+    expect(actualC).toBeCloseTo(c, c < 1 ? 3 : 1);
+    expect(actualH).toBeCloseTo(h, 1);
+  });
+
+  test("greys converted into lch keep no hue of their own", () => {
+    expect(lch("color-mix(in lch, gray, lch(50% 50 120))")[2]).toBe(120);
+    expect(lch("color-mix(in oklch, gray, oklch(50% 0.2 120))")[2]).toBe(120);
+    expect(lch("color-mix(in lch, white, lch(50% 50 120))")[2]).toBe(120);
+  });
+
   test("the mixed color is what the other output formats convert", () => {
-    expect(color("color-mix(in srgb, color(display-p3 0 1 0), white)", "hex")).toBe("#80fca0");
-    expect(color("color-mix(in srgb, color(srgb 1.13 0 0), white)", "hex")).toBe("#ff8886");
-    expect(color("color-mix(in srgb, color(display-p3 0 1 0), white)", "{rgb}")).toEqual({ r: 128, g: 252, b: 160 });
+    expect(color("color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))", "hex")).toBe("#0b9b0b");
+    expect(color("color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))", "{rgb}")).toEqual({
+      r: 11,
+      g: 155,
+      b: 11,
+    });
+    expect(color("color-mix(in lch, black, lch(50% 50 120))", "hex")).toBe(color("lch(25% 25 120)", "hex"));
   });
 });

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -649,3 +649,42 @@ describe("color-mix() percentage range", () => {
     expect(color(input, "css")).toBe(expected);
   });
 });
+
+// https://www.w3.org/TR/css-color-4/#interpolation-space: only an operand that is
+// converted into the interpolation space is gamut mapped and has its powerless
+// components treated as missing; an operand authored in that space is mixed as
+// written. Expected values are lightningcss output.
+describe("color-mix() converted operands", () => {
+  test.each([
+    // Authored in the interpolation space: mixed as written.
+    ["color-mix(in srgb, color(srgb -0.51 1.018 -0.31), color(srgb 0.6 0.2 0.4))", "#0b9b0b"],
+    ["color-mix(in srgb, color(srgb -0.5 1.5 -0.5), color(srgb 0.5 0.5 0.5))", "#0f0"],
+    ["color-mix(in srgb, color(srgb 1.13 0 0), white)", "#ff8886"],
+    ["color-mix(in hsl, hsl(120 none 50%), hsl(200 100% 50%))", "#0fa"],
+    ["color-mix(in hwb, hwb(120 50% none), hwb(200 0% 40%))", "#40997b"],
+    ["color-mix(in lab, lab(0% 30 40), lab(50% 50 -20))", "lab(25% 40 10)"],
+    ["color-mix(in lch, lch(50% 0 200), lch(50% 50 120))", "lch(50% 25 160)"],
+    ["color-mix(in oklch, oklch(50% 0 200), oklch(50% 0.2 120))", "oklch(50% .1 160)"],
+    ["color-mix(in srgb-linear, color(srgb-linear 1.5 0 0), white)", "color(srgb-linear 1.25 .5 .5)"],
+    // Converted into it: gamut mapped first, powerless components taken from the other side.
+    // color(display-p3 0 1 0) converts to the color(srgb -0.51 1.018 -0.31) used above.
+    ["color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))", "#4d9654"],
+    ["color-mix(in srgb, color(display-p3 0 1 0), white)", "#80fca0"],
+    ["color-mix(in srgb, white, color(display-p3 0 1 0))", "#80fca0"],
+    ["color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 0 1 0))", "#808428"],
+    ["color-mix(in hsl, white, red)", "#ff8080"],
+    ["color-mix(in hsl, hsl(200 100% 50%), black)", "#005580"],
+    ["color-mix(in lab, black, lab(50% 50 -20))", "lab(25% 50 -20)"],
+    ["color-mix(in lch, lab(50% 0 0), lch(50% 50 120))", "lch(50% 25 120)"],
+    ["color-mix(in oklch, black, oklch(50% 0.2 120))", "oklch(25% .2 120)"],
+    ["color-mix(in srgb-linear, color(display-p3 0 1 0), white)", "color(srgb-linear .5 .972601 .527217)"],
+  ])("%s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test("the mixed color is what the other output formats convert", () => {
+    expect(color("color-mix(in srgb, color(display-p3 0 1 0), white)", "hex")).toBe("#80fca0");
+    expect(color("color-mix(in srgb, color(srgb 1.13 0 0), white)", "hex")).toBe("#ff8886");
+    expect(color("color-mix(in srgb, color(display-p3 0 1 0), white)", "{rgb}")).toEqual({ r: 128, g: 252, b: 160 });
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7538,6 +7538,198 @@ describe("css tests", () => {
     );
   });
 
+  // https://www.w3.org/TR/css-color-4/#interpolation-space: an operand that has to be
+  // converted into the interpolation color space is gamut mapped there and has its
+  // powerless components treated as missing. An operand written directly in that space
+  // is interpolated as authored, out-of-gamut or powerless components included. Expected
+  // values are lightningcss output.
+  describe("color-mix() converted operands", () => {
+    describe("in srgb", () => {
+      // color(display-p3 0 1 0) converts to color(srgb -0.51 1.018 -0.31). Authored in
+      // srgb those channels are interpolated as-is; converted from display-p3 they are
+      // gamut mapped first. These two used to come out the other way around.
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb -0.51 1.018 -0.31), color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:#0b9b0b}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:#4d9654}",
+      );
+
+      // Authored in srgb: out-of-gamut channels cancel out during interpolation.
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb -0.5 1.5 -0.5), color(srgb 0.5 0.5 0.5)) }",
+        ".foo{color:#0f0}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb 0.5 0.5 0.5), color(srgb -0.5 1.5 -0.5)) }",
+        ".foo{color:#0f0}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb 1.5 -0.5 -0.5), color(srgb 0.5 0.5 0.5)) }",
+        ".foo{color:red}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb 2 0 0) 25%, color(srgb 0 1 1)) }",
+        ".foo{color:#80bfbf}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), color(srgb 0.5 1 1)) }",
+        ".foo{color:#d08080}",
+      );
+      // An out-of-gamut result is still mapped when it is serialized.
+      minify_test(".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), white) }", ".foo{color:#ff8886}");
+      minify_test(".foo { color: color-mix(in srgb, color(srgb none 2 0), rgb(0 255 0)) }", ".foo{color:#fff}");
+
+      // Converted into srgb: mapped into the srgb gamut before interpolating.
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0), white) }", ".foo{color:#80fca0}");
+      minify_test(".foo { color: color-mix(in srgb, white, color(display-p3 0 1 0)) }", ".foo{color:#80fca0}");
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 25%, white) }", ".foo{color:#bffdd0}");
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0 / 0.5), white) }", ".foo{color:#aafdc0bf}");
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 1 0 0), white) }", ".foo{color:#ff8786}");
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 0 1 0)) }",
+        ".foo{color:#808428}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 none 1 0), rgb(0 255 0)) }",
+        ".foo{color:#00fc21}",
+      );
+      minify_test(".foo { color: color-mix(in srgb, color(rec2020 0 1 0), white) }", ".foo{color:#80f8bb}");
+      minify_test(".foo { color: color-mix(in srgb, color(prophoto-rgb 0 1 0), white) }", ".foo{color:#80f9be}");
+      minify_test(".foo { color: color-mix(in srgb, lab(80% -120 80), white) }", ".foo{color:#80f0b3}");
+      minify_test(".foo { color: color-mix(in srgb, oklch(80% 0.3 145), white) }", ".foo{color:#80f29a}");
+
+      // One of each.
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 30%, color(srgb -0.51 1.018 -0.31)) }",
+        ".foo{color:#00fc3c}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, light-dark(color(display-p3 0 1 0), color(srgb 1.13 0 0)), white) }",
+        ".foo{color:light-dark(#80fca0,#ff8886)}",
+      );
+
+      // In-gamut operands are unaffected either way.
+      minify_test(".foo { color: color-mix(in srgb, red, blue) }", ".foo{color:purple}");
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)) }",
+        ".foo{color:#00f942}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), color(srgb 1.13 0 0)) }",
+        ".foo{color:#ff5645}",
+      );
+    });
+
+    describe("in srgb-linear", () => {
+      minify_test(
+        ".foo { color: color-mix(in srgb-linear, color(srgb-linear 1.5 0 0), white) }",
+        ".foo{color:color(srgb-linear 1.25 .5 .5)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb-linear, color(srgb-linear 1.5 0 0) 25%, white) }",
+        ".foo{color:color(srgb-linear 1.125 .75 .75)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb-linear, color(srgb 1.13 0 0), white) }",
+        ".foo{color:color(srgb-linear 1 .546954 .530043)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb-linear, color(display-p3 0 1 0), white) }",
+        ".foo{color:color(srgb-linear .5 .972601 .527217)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb-linear, color(rec2020 0 1 0), white) }",
+        ".foo{color:color(srgb-linear .5 .935714 .591488)}",
+      );
+    });
+
+    describe("in hsl", () => {
+      // hsl() without `none` parses to rgb, so these operands are all converted: the
+      // hue and saturation of white and black are powerless and come from the other side.
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 100% 50%), white) }", ".foo{color:#80ff80}");
+      minify_test(".foo { color: color-mix(in hsl, white, red) }", ".foo{color:#ff8080}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 100% 100%), red) }", ".foo{color:#ff8080}");
+      minify_test(".foo { color: color-mix(in hsl, black, hsl(200 100% 50%)) }", ".foo{color:#005580}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), black) }", ".foo{color:#005580}");
+      minify_test(".foo { color: color-mix(in hsl, rgb(none 0 0), hsl(200 100% 50%)) }", ".foo{color:#005580}");
+      minify_test(".foo { color: color-mix(in hsl, hwb(120 none 100%), hsl(200 100% 50%)) }", ".foo{color:#005580}");
+      minify_test(".foo { color: color-mix(in hsl, color(srgb 1.13 0 0), white) }", ".foo{color:#ffaba2}");
+      minify_test(".foo { color: color-mix(in hsl, color(display-p3 0 1 0), white) }", ".foo{color:#7cff9f}");
+
+      // hsl() with `none` stays in hsl: its hue is kept even though it is powerless,
+      // and the `none` component is filled in from the other operand.
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 0% none), hsl(200 100% 50%)) }", ".foo{color:#40bf95}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 none 100%), hsl(200 100% 50%)) }", ".foo{color:#80ffd5}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 none 50%), hsl(200 100% 50%)) }", ".foo{color:#0fa}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), hsl(120 none 50%)) }", ".foo{color:#0fa}");
+
+      minify_test(".foo { color: color-mix(in hsl, red, blue) }", ".foo{color:#f0f}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 0% 50%), hsl(200 100% 50%)) }", ".foo{color:#4095bf}");
+      minify_test(".foo { color: color-mix(in hsl, gray, hsl(120 100% 50%)) }", ".foo{color:#40bf40}");
+    });
+
+    describe("in hwb", () => {
+      minify_test(".foo { color: color-mix(in hwb, hwb(120 none 100%), hwb(200 0% 0%)) }", ".foo{color:#008055}");
+      minify_test(".foo { color: color-mix(in hwb, hwb(120 50% none), hwb(200 0% 40%)) }", ".foo{color:#40997b}");
+      minify_test(".foo { color: color-mix(in hwb, hwb(200 0% 40%), hwb(120 50% none)) }", ".foo{color:#40997b}");
+      minify_test(".foo { color: color-mix(in hwb, white, hwb(200 0% 0%)) }", ".foo{color:#80d4ff}");
+      minify_test(".foo { color: color-mix(in hwb, black, hwb(200 0% 0%)) }", ".foo{color:#005580}");
+    });
+
+    describe("in lab and oklab", () => {
+      // a and b are powerless at 0% lightness, but only for converted operands.
+      minify_test(".foo { color: color-mix(in lab, lab(0% 30 40), lab(50% 50 -20)) }", ".foo{color:lab(25% 40 10)}");
+      minify_test(".foo { color: color-mix(in lab, lch(0% 30 40), lab(50% 50 -20)) }", ".foo{color:lab(25% 50 -20)}");
+      minify_test(".foo { color: color-mix(in lab, black, lab(50% 50 -20)) }", ".foo{color:lab(25% 50 -20)}");
+      minify_test(".foo { color: color-mix(in lab, lab(50% 50 -20), black) }", ".foo{color:lab(25% 50 -20)}");
+      minify_test(
+        ".foo { color: color-mix(in oklab, oklab(0% 0.1 0.1), oklab(50% 0.1 -0.05)) }",
+        ".foo{color:oklab(25% .1 .025)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklab, oklch(0% 0.1 45), oklab(50% 0.1 -0.05)) }",
+        ".foo{color:oklab(25% .1 -.05)}",
+      );
+      minify_test(".foo { color: color-mix(in oklab, black, oklab(50% 0.1 -0.05)) }", ".foo{color:oklab(25% .1 -.05)}");
+      minify_test(
+        ".foo { color: color-mix(in lab, color(srgb 1.13 0 0), white) }",
+        ".foo{color:lab(80.5691% 44.3385 38.3499)}",
+      );
+    });
+
+    describe("in lch and oklch", () => {
+      // The hue is powerless at zero chroma; hue and chroma are powerless at 0% lightness.
+      minify_test(".foo { color: color-mix(in lch, lch(50% 0 200), lch(50% 50 120)) }", ".foo{color:lch(50% 25 160)}");
+      minify_test(".foo { color: color-mix(in lch, lab(50% 0 0), lch(50% 50 120)) }", ".foo{color:lch(50% 25 120)}");
+      minify_test(".foo { color: color-mix(in lch, lch(50% 50 120), lab(50% 0 0)) }", ".foo{color:lch(50% 25 120)}");
+      minify_test(".foo { color: color-mix(in lch, lch(0% 30 40), lch(50% 50 120)) }", ".foo{color:lch(25% 40 80)}");
+      minify_test(".foo { color: color-mix(in lch, lab(0% 30 40), lch(50% 50 120)) }", ".foo{color:lch(25% 50 120)}");
+      minify_test(".foo { color: color-mix(in lch, black, lch(50% 50 120)) }", ".foo{color:lch(25% 50 120)}");
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklch(50% 0 200), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(50% .1 160)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklab(50% 0 0), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(50% .1 120)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklch(0% 0.1 40), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(25% .15 80)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklab(0% 0.1 0.1), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(25% .2 120)}",
+      );
+      minify_test(".foo { color: color-mix(in oklch, black, oklch(50% 0.2 120)) }", ".foo{color:oklch(25% .2 120)}");
+      minify_test(".foo { color: color-mix(in lch, lch(50% 50 120), lch(50% 50 120)) }", ".foo{color:lch(50% 50 120)}");
+      minify_test(".foo { color: color-mix(in lch, red, blue) }", ".foo{color:lch(41.9294% 119.019 351.111)}");
+    });
+  });
+
   describe("page", () => {
     minify_test("@page { margin: 1em }", "@page{margin:1em}");
     minify_test("@page :left { margin: 1em }", "@page:left{margin:1em}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7538,32 +7538,68 @@ describe("css tests", () => {
     );
   });
 
-  // https://www.w3.org/TR/css-color-4/#interpolation-space: an operand that has to be
-  // converted into the interpolation color space is gamut mapped there and has its
-  // powerless components treated as missing. An operand written directly in that space
-  // is interpolated as authored, out-of-gamut or powerless components included. Expected
-  // values are lightningcss output.
-  describe("color-mix() converted operands", () => {
-    describe("in srgb", () => {
-      // color(display-p3 0 1 0) converts to color(srgb -0.51 1.018 -0.31). Authored in
-      // srgb those channels are interpolated as-is; converted from display-p3 they are
-      // gamut mapped first. These two used to come out the other way around.
+  // color-mix() converts its operands into the interpolation color space. Per css-color-4 the
+  // conversion leaves the channels alone, even when they end up outside the gamut of that
+  // space (#interpolation-space); the one thing it changes is that a hue made powerless by the
+  // conversion (the converted color is achromatic, within the epsilon of the space) becomes
+  // missing and is taken from the other operand (#powerless). An operand written directly in
+  // the interpolation space is mixed exactly as written. Unless a comment says otherwise the
+  // expected values are also lightningcss output; where they differ, the values follow the spec
+  // text and the WPT color-computed-color-mix-function tests.
+  describe("color-mix() operand conversion", () => {
+    describe("out-of-gamut operands are interpolated as written", () => {
+      // color(display-p3 0 1 0) is color(srgb -0.511605 1.01827 -0.310675), so both spellings
+      // mix to the same color. These used to come out swapped: the display-p3 operand was gamut
+      // mapped to #00f942 first (#4d9654, which is still what lightningcss produces) while the
+      // color(srgb) operand was not (#0b9b0b).
       minify_test(
         ".foo { color: color-mix(in srgb, color(srgb -0.51 1.018 -0.31), color(srgb 0.6 0.2 0.4)) }",
         ".foo{color:#0b9b0b}",
       );
       minify_test(
         ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4)) }",
-        ".foo{color:#4d9654}",
+        ".foo{color:#0b9b0b}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb 0.6 0.2 0.4), color(display-p3 0 1 0)) }",
+        ".foo{color:#0b9b0b}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb -0.51 1.018 -0.31) 25%, color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:#526739}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 25%, color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:#526739}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb -0.51 1.018 -0.31 / 0.5), color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:#3b792abf}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 none 1 0), color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:#0b9b0b}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 1 0 1)) }",
+        ".foo{color:#4a655c}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(rec2020 0 1 0), color(srgb 0.8 0.2 0.6)) }",
+        ".foo{color:#01a020}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, lab(80% -120 80), color(srgb 0.8 0.2 0.6)) }",
+        ".foo{color:#189337}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in srgb, light-dark(color(display-p3 0 1 0), color(srgb 1.13 0.2 0)), color(srgb 0.6 0.2 0.4)) }",
+        ".foo{color:light-dark(#0b9b0b,#d33)}",
       );
 
-      // Authored in srgb: out-of-gamut channels cancel out during interpolation.
+      // Out-of-range channels cancel out or add up during interpolation.
       minify_test(
         ".foo { color: color-mix(in srgb, color(srgb -0.5 1.5 -0.5), color(srgb 0.5 0.5 0.5)) }",
-        ".foo{color:#0f0}",
-      );
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(srgb 0.5 0.5 0.5), color(srgb -0.5 1.5 -0.5)) }",
         ".foo{color:#0f0}",
       );
       minify_test(
@@ -7578,155 +7614,161 @@ describe("css tests", () => {
         ".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), color(srgb 0.5 1 1)) }",
         ".foo{color:#d08080}",
       );
-      // An out-of-gamut result is still mapped when it is serialized.
-      minify_test(".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), white) }", ".foo{color:#ff8886}");
-      minify_test(".foo { color: color-mix(in srgb, color(srgb none 2 0), rgb(0 255 0)) }", ".foo{color:#fff}");
-
-      // Converted into srgb: mapped into the srgb gamut before interpolating.
-      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0), white) }", ".foo{color:#80fca0}");
-      minify_test(".foo { color: color-mix(in srgb, white, color(display-p3 0 1 0)) }", ".foo{color:#80fca0}");
-      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 25%, white) }", ".foo{color:#bffdd0}");
-      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0 / 0.5), white) }", ".foo{color:#aafdc0bf}");
-      minify_test(".foo { color: color-mix(in srgb, color(display-p3 1 0 0), white) }", ".foo{color:#ff8786}");
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 0 1 0)) }",
-        ".foo{color:#808428}",
-      );
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(display-p3 none 1 0), rgb(0 255 0)) }",
-        ".foo{color:#00fc21}",
-      );
-      minify_test(".foo { color: color-mix(in srgb, color(rec2020 0 1 0), white) }", ".foo{color:#80f8bb}");
-      minify_test(".foo { color: color-mix(in srgb, color(prophoto-rgb 0 1 0), white) }", ".foo{color:#80f9be}");
-      minify_test(".foo { color: color-mix(in srgb, lab(80% -120 80), white) }", ".foo{color:#80f0b3}");
-      minify_test(".foo { color: color-mix(in srgb, oklch(80% 0.3 145), white) }", ".foo{color:#80f29a}");
-
-      // One of each.
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 30%, color(srgb -0.51 1.018 -0.31)) }",
-        ".foo{color:#00fc3c}",
-      );
-      minify_test(
-        ".foo { color: color-mix(in srgb, light-dark(color(display-p3 0 1 0), color(srgb 1.13 0 0)), white) }",
-        ".foo{color:light-dark(#80fca0,#ff8886)}",
-      );
-
-      // In-gamut operands are unaffected either way.
-      minify_test(".foo { color: color-mix(in srgb, red, blue) }", ".foo{color:purple}");
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)) }",
-        ".foo{color:#00f942}",
-      );
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), color(srgb 1.13 0 0)) }",
-        ".foo{color:#ff5645}",
-      );
-    });
-
-    describe("in srgb-linear", () => {
       minify_test(
         ".foo { color: color-mix(in srgb-linear, color(srgb-linear 1.5 0 0), white) }",
         ".foo{color:color(srgb-linear 1.25 .5 .5)}",
       );
       minify_test(
-        ".foo { color: color-mix(in srgb-linear, color(srgb-linear 1.5 0 0) 25%, white) }",
-        ".foo{color:color(srgb-linear 1.125 .75 .75)}",
+        ".foo { color: color-mix(in srgb-linear, color(srgb-linear -0.5 1.5 -0.5), color(srgb-linear 0.5 0.5 0.5)) }",
+        ".foo{color:color(srgb-linear 0 1 0)}",
       );
+      // color(srgb 1.13 0 0) is color(srgb-linear 1.32166 0 0); lightningcss maps it first.
       minify_test(
-        ".foo { color: color-mix(in srgb-linear, color(srgb 1.13 0 0), white) }",
-        ".foo{color:color(srgb-linear 1 .546954 .530043)}",
+        ".foo { color: color-mix(in srgb-linear, color(srgb 1.13 0 0), color(srgb-linear 0 0.5 0.5)) }",
+        ".foo{color:color(srgb-linear .660828 .25 .25)}",
       );
-      minify_test(
-        ".foo { color: color-mix(in srgb-linear, color(display-p3 0 1 0), white) }",
-        ".foo{color:color(srgb-linear .5 .972601 .527217)}",
-      );
-      minify_test(
-        ".foo { color: color-mix(in srgb-linear, color(rec2020 0 1 0), white) }",
-        ".foo{color:color(srgb-linear .5 .935714 .591488)}",
-      );
+
+      // The result is still gamut mapped when it is converted to an rgb color.
+      minify_test(".foo { color: color-mix(in srgb, color(srgb none 2 0), rgb(0 255 0)) }", ".foo{color:#fff}");
+      minify_test(".foo { color: color-mix(in srgb, color(srgb 1.13 0 0), white) }", ".foo{color:#ff8886}");
+      minify_test(".foo { color: color-mix(in srgb, red, blue) }", ".foo{color:purple}");
     });
 
-    describe("in hsl", () => {
-      // hsl() without `none` parses to rgb, so these operands are all converted: the
-      // hue and saturation of white and black are powerless and come from the other side.
-      minify_test(".foo { color: color-mix(in hsl, hsl(120 100% 50%), white) }", ".foo{color:#80ff80}");
-      minify_test(".foo { color: color-mix(in hsl, white, red) }", ".foo{color:#ff8080}");
-      minify_test(".foo { color: color-mix(in hsl, hsl(120 100% 100%), red) }", ".foo{color:#ff8080}");
-      minify_test(".foo { color: color-mix(in hsl, black, hsl(200 100% 50%)) }", ".foo{color:#005580}");
-      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), black) }", ".foo{color:#005580}");
-      minify_test(".foo { color: color-mix(in hsl, rgb(none 0 0), hsl(200 100% 50%)) }", ".foo{color:#005580}");
-      minify_test(".foo { color: color-mix(in hsl, hwb(120 none 100%), hsl(200 100% 50%)) }", ".foo{color:#005580}");
-      minify_test(".foo { color: color-mix(in hsl, color(srgb 1.13 0 0), white) }", ".foo{color:#ffaba2}");
-      minify_test(".foo { color: color-mix(in hsl, color(display-p3 0 1 0), white) }", ".foo{color:#7cff9f}");
-
-      // hsl() with `none` stays in hsl: its hue is kept even though it is powerless,
-      // and the `none` component is filled in from the other operand.
-      minify_test(".foo { color: color-mix(in hsl, hsl(120 0% none), hsl(200 100% 50%)) }", ".foo{color:#40bf95}");
-      minify_test(".foo { color: color-mix(in hsl, hsl(120 none 100%), hsl(200 100% 50%)) }", ".foo{color:#80ffd5}");
-      minify_test(".foo { color: color-mix(in hsl, hsl(120 none 50%), hsl(200 100% 50%)) }", ".foo{color:#0fa}");
-      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), hsl(120 none 50%)) }", ".foo{color:#0fa}");
-
-      minify_test(".foo { color: color-mix(in hsl, red, blue) }", ".foo{color:#f0f}");
-      minify_test(".foo { color: color-mix(in hsl, hsl(120 0% 50%), hsl(200 100% 50%)) }", ".foo{color:#4095bf}");
-      minify_test(".foo { color: color-mix(in hsl, gray, hsl(120 100% 50%)) }", ".foo{color:#40bf40}");
-    });
-
-    describe("in hwb", () => {
-      minify_test(".foo { color: color-mix(in hwb, hwb(120 none 100%), hwb(200 0% 0%)) }", ".foo{color:#008055}");
-      minify_test(".foo { color: color-mix(in hwb, hwb(120 50% none), hwb(200 0% 40%)) }", ".foo{color:#40997b}");
-      minify_test(".foo { color: color-mix(in hwb, hwb(200 0% 40%), hwb(120 50% none)) }", ".foo{color:#40997b}");
-      minify_test(".foo { color: color-mix(in hwb, white, hwb(200 0% 0%)) }", ".foo{color:#80d4ff}");
-      minify_test(".foo { color: color-mix(in hwb, black, hwb(200 0% 0%)) }", ".foo{color:#005580}");
-    });
-
-    describe("in lab and oklab", () => {
-      // a and b are powerless at 0% lightness, but only for converted operands.
-      minify_test(".foo { color: color-mix(in lab, lab(0% 30 40), lab(50% 50 -20)) }", ".foo{color:lab(25% 40 10)}");
-      minify_test(".foo { color: color-mix(in lab, lch(0% 30 40), lab(50% 50 -20)) }", ".foo{color:lab(25% 50 -20)}");
-      minify_test(".foo { color: color-mix(in lab, black, lab(50% 50 -20)) }", ".foo{color:lab(25% 50 -20)}");
-      minify_test(".foo { color: color-mix(in lab, lab(50% 50 -20), black) }", ".foo{color:lab(25% 50 -20)}");
-      minify_test(
-        ".foo { color: color-mix(in oklab, oklab(0% 0.1 0.1), oklab(50% 0.1 -0.05)) }",
-        ".foo{color:oklab(25% .1 .025)}",
-      );
-      minify_test(
-        ".foo { color: color-mix(in oklab, oklch(0% 0.1 45), oklab(50% 0.1 -0.05)) }",
-        ".foo{color:oklab(25% .1 -.05)}",
-      );
-      minify_test(".foo { color: color-mix(in oklab, black, oklab(50% 0.1 -0.05)) }", ".foo{color:oklab(25% .1 -.05)}");
-      minify_test(
-        ".foo { color: color-mix(in lab, color(srgb 1.13 0 0), white) }",
-        ".foo{color:lab(80.5691% 44.3385 38.3499)}",
-      );
-    });
-
-    describe("in lch and oklch", () => {
-      // The hue is powerless at zero chroma; hue and chroma are powerless at 0% lightness.
-      minify_test(".foo { color: color-mix(in lch, lch(50% 0 200), lch(50% 50 120)) }", ".foo{color:lch(50% 25 160)}");
+    describe("a hue made powerless by the conversion is taken from the other operand", () => {
       minify_test(".foo { color: color-mix(in lch, lab(50% 0 0), lch(50% 50 120)) }", ".foo{color:lch(50% 25 120)}");
       minify_test(".foo { color: color-mix(in lch, lch(50% 50 120), lab(50% 0 0)) }", ".foo{color:lch(50% 25 120)}");
-      minify_test(".foo { color: color-mix(in lch, lch(0% 30 40), lch(50% 50 120)) }", ".foo{color:lch(25% 40 80)}");
-      minify_test(".foo { color: color-mix(in lch, lab(0% 30 40), lch(50% 50 120)) }", ".foo{color:lch(25% 50 120)}");
-      minify_test(".foo { color: color-mix(in lch, black, lch(50% 50 120)) }", ".foo{color:lch(25% 50 120)}");
-      minify_test(
-        ".foo { color: color-mix(in oklch, oklch(50% 0 200), oklch(50% 0.2 120)) }",
-        ".foo{color:oklch(50% .1 160)}",
-      );
+      minify_test(".foo { color: color-mix(in lch, white, lch(50% 50 120)) }", ".foo{color:lch(75% 25 120)}");
       minify_test(
         ".foo { color: color-mix(in oklch, oklab(50% 0 0), oklch(50% 0.2 120)) }",
         ".foo{color:oklch(50% .1 120)}",
       );
+      minify_test(".foo { color: color-mix(in oklch, white, oklch(50% 0.2 120)) }", ".foo{color:oklch(75% .1 120)}");
+      // Black too, but its zero chroma still counts (lightningcss: lch(25% 50 120), oklch(25% .2 120)).
+      minify_test(".foo { color: color-mix(in lch, black, lch(50% 50 120)) }", ".foo{color:lch(25% 25 120)}");
+      minify_test(".foo { color: color-mix(in lch, lch(50% 50 120), black) }", ".foo{color:lch(25% 25 120)}");
+      minify_test(".foo { color: color-mix(in oklch, black, oklch(50% 0.2 120)) }", ".foo{color:oklch(25% .1 120)}");
+      // Both hues missing: the result has none as well.
+      minify_test(".foo { color: color-mix(in lch, lab(50% 0 0), black) }", ".foo{color:lch(25% 0 none)}");
+      minify_test(".foo { color: color-mix(in oklch, oklab(50% 0 0), black) }", ".foo{color:oklch(25% 0 none)}");
+      // Greys converted into hsl/hwb already get a missing hue from the rgb conversion.
+      minify_test(".foo { color: color-mix(in hsl, gray, hsl(200 100% 50%)) }", ".foo{color:#4095bf}");
+      minify_test(".foo { color: color-mix(in hwb, gray, hwb(200 0% 0%)) }", ".foo{color:#4095c0}");
+
+      // The powerless hue epsilons of css-color-4: lch C <= 0.0015, oklch C <= 0.000004,
+      // hsl S <= 0.001%, hwb W + B >= 99.999%. (lightningcss only treats exactly 0 as powerless.)
+      minify_test(
+        ".foo { color: color-mix(in lch, lab(50% 0.001 0), lch(50% 50 120)) }",
+        ".foo{color:lch(50% 25.0005 120)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in lch, lab(50% 0.002 0), lch(50% 50 120)) }",
+        ".foo{color:lch(50% 25.001 60)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklab(50% 0.000002 0), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(50% .100001 120)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklab(50% 0.00001 0), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(50% .100005 60)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in hsl, color(srgb 0.5 0.5 0.500001), hsl(0 100% 50%)) }",
+        ".foo{color:#bf4040}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in hsl, color(srgb 0.5 0.5 0.5001), hsl(0 100% 50%)) }",
+        ".foo{color:#bf40bf}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in hwb, color(srgb 0.5 0.5 0.500001), hwb(0 0% 0%)) }",
+        ".foo{color:#bf4040}",
+      );
+      minify_test(".foo { color: color-mix(in hwb, color(srgb 0.5 0.5 0.5001), hwb(0 0% 0%)) }", ".foo{color:#bf40bf}");
+    });
+
+    describe("an operand written in the interpolation space keeps its powerless components", () => {
+      minify_test(".foo { color: color-mix(in lch, lch(50% 0 200), lch(50% 50 120)) }", ".foo{color:lch(50% 25 160)}");
+      minify_test(
+        ".foo { color: color-mix(in lch, lch(50% 0.001 200), lch(50% 50 120)) }",
+        ".foo{color:lch(50% 25.0005 160)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklch(50% 0 200), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(50% .1 160)}",
+      );
+      // hsl()/hwb() with a none component stay in hsl/hwb instead of becoming an rgb color.
+      minify_test(".foo { color: color-mix(in hsl, hsl(240 0% none), hsl(0 100% 50%)) }", ".foo{color:#bf40bf}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 0% none), hsl(200 100% 50%)) }", ".foo{color:#40bf95}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 none 100%), hsl(200 100% 50%)) }", ".foo{color:#80ffd5}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(120 none 50%), hsl(200 100% 50%)) }", ".foo{color:#0fa}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), hsl(120 none 50%)) }", ".foo{color:#0fa}");
+      minify_test(".foo { color: color-mix(in hwb, hwb(120 none 100%), hwb(200 0% 0%)) }", ".foo{color:#008055}");
+      minify_test(".foo { color: color-mix(in hwb, hwb(120 50% none), hwb(200 0% 40%)) }", ".foo{color:#40997b}");
+      minify_test(".foo { color: color-mix(in hwb, hwb(200 0% 40%), hwb(120 50% none)) }", ".foo{color:#40997b}");
+      // Without none, hsl() is an rgb color, so it is converted and its hue is powerless.
+      minify_test(".foo { color: color-mix(in hsl, hsl(240 0% 50%), hsl(0 100% 50%)) }", ".foo{color:#bf4040}");
+    });
+
+    describe("nothing else becomes missing", () => {
+      // css-color-4 no longer makes any channel powerless at 0% or 100% lightness, and lab/oklab
+      // have no powerless channels at all, so black and white contribute their zero chroma like
+      // any other color (WPT: color-mix(in hsl, red, white) is rgb(87.5% 62.5% 62.5%) and
+      // color-mix(in hsl, white, blue) is rgb(62.5% 62.5% 87.5%)). lightningcss still applies the
+      // old rules and gives lab(25% 50 -20), #ff8080 and #005580 for the first mixes below.
+      minify_test(".foo { color: color-mix(in lab, black, lab(50% 50 -20)) }", ".foo{color:lab(25% 25 -10)}");
+      minify_test(".foo { color: color-mix(in hsl, red, white) }", ".foo{color:#df9f9f}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), black) }", ".foo{color:#204a60}");
+      minify_test(".foo { color: color-mix(in lab, lab(50% 50 -20), black) }", ".foo{color:lab(25% 25 -10)}");
+      minify_test(
+        ".foo { color: color-mix(in oklab, black, oklab(50% 0.1 -0.05)) }",
+        ".foo{color:oklab(25% .05 -.025)}",
+      );
+      minify_test(".foo { color: color-mix(in hsl, red, black) }", ".foo{color:#602020}");
+      minify_test(".foo { color: color-mix(in hsl, white, blue) }", ".foo{color:#9f9fdf}");
+      minify_test(".foo { color: color-mix(in hsl, white 10%, blue) }", ".foo{color:#2525f4}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(200 100% 50%), white) }", ".foo{color:#9fcadf}");
+      minify_test(".foo { color: color-mix(in hwb, red, white) }", ".foo{color:#ff8080}");
+      minify_test(".foo { color: color-mix(in hwb, red, black) }", ".foo{color:maroon}");
+      minify_test(".foo { color: color-mix(in hwb, white, blue) }", ".foo{color:#8080ff}");
+
+      // 0% lightness operands, converted (lightningcss: lab(25% 50 -20), lch(25% 50 120)) and as written.
+      minify_test(".foo { color: color-mix(in lab, lch(0% 30 0), lab(50% 50 -20)) }", ".foo{color:lab(25% 40 -10)}");
+      minify_test(
+        ".foo { color: color-mix(in oklab, oklch(0% 0.1 0), oklab(50% 0.1 -0.05)) }",
+        ".foo{color:oklab(25% .1 -.025)}",
+      );
+      minify_test(".foo { color: color-mix(in lch, lab(0% 30 0), lch(50% 50 120)) }", ".foo{color:lch(25% 40 60)}");
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklab(0% 0.1 0), oklch(50% 0.2 120)) }",
+        ".foo{color:oklch(25% .15 60)}",
+      );
+      minify_test(".foo { color: color-mix(in lab, lab(0% 30 40), lab(50% 50 -20)) }", ".foo{color:lab(25% 40 10)}");
+      minify_test(
+        ".foo { color: color-mix(in oklab, oklab(0% 0.1 0.1), oklab(50% 0.1 -0.05)) }",
+        ".foo{color:oklab(25% .1 .025)}",
+      );
+      minify_test(".foo { color: color-mix(in lch, lch(0% 30 40), lch(50% 50 120)) }", ".foo{color:lch(25% 40 80)}");
       minify_test(
         ".foo { color: color-mix(in oklch, oklch(0% 0.1 40), oklch(50% 0.2 120)) }",
         ".foo{color:oklch(25% .15 80)}",
       );
+
+      // transparent is black with alpha 0; premultiplication makes its channels irrelevant.
+      minify_test(".foo { color: color-mix(in srgb, red 50%, transparent) }", ".foo{color:#ff000080}");
+      minify_test(".foo { color: color-mix(in hsl, hsl(40 80% 60%) 50%, transparent) }", ".foo{color:#ebb44780}");
       minify_test(
-        ".foo { color: color-mix(in oklch, oklab(0% 0.1 0.1), oklch(50% 0.2 120)) }",
-        ".foo{color:oklch(25% .2 120)}",
+        ".foo { color: color-mix(in oklab, oklab(60% 0.1 0.1) 50%, transparent) }",
+        ".foo{color:oklab(60% .1 .1/.5)}",
       );
-      minify_test(".foo { color: color-mix(in oklch, black, oklch(50% 0.2 120)) }", ".foo{color:oklch(25% .2 120)}");
-      minify_test(".foo { color: color-mix(in lch, lch(50% 50 120), lch(50% 50 120)) }", ".foo{color:lch(50% 50 120)}");
-      minify_test(".foo { color: color-mix(in lch, red, blue) }", ".foo{color:lch(41.9294% 119.019 351.111)}");
+      minify_test(
+        ".foo { color: color-mix(in oklch, oklch(60% 0.1 40) 50%, transparent) }",
+        ".foo{color:oklch(60% .1 40/.5)}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in lch, lch(60% 40 40) 50%, transparent) }",
+        ".foo{color:lch(60% 40 40/.5)}",
+      );
     });
   });
 


### PR DESCRIPTION
### Problem
- `color-mix()` is folded at build time (CSS bundler, `Bun.build`, `Bun.color()`), and the fold disagrees with what browsers compute whenever an operand has to be converted into the interpolation space and is out of gamut there or achromatic:
  - `color-mix(in srgb, color(srgb -0.51 1.018 -0.31), color(srgb 0.6 0.2 0.4))` folds to `#4d9654`; `color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))` (display-p3 green converts to exactly those srgb channels) folds to `#0b9b0b`. The first one is wrong: it is gamut mapped to `#00f942` before mixing. Browsers give `#0b9b0b` for both.
  - `color-mix(in lch, white, blue)` (the worked example in css-color-5) folds to `lch(64.78% 65.6 375.682)` instead of hue `301.364`: white converts to a meaningless hue, which is averaged in instead of being dropped. Same for every grey/white/black mixed in lch or oklch (`color-mix(in oklch, red, white)` gets hue 59.6 instead of red's 29.2).
  - `color-mix(in lch, lch(50% 0 200), lch(50% 50 120))` folds to hue 120 instead of 160, and `color-mix(in hsl, hsl(120 0% none), ...)` produces garbage: the operand written in the interpolation space is the one that gets its powerless components removed and gets gamut mapped (with `none` channels, the mapping runs on NaN).
- Cause, `src/css/values/color.rs` `CssColor::interpolate`: the `converted_*` flags were computed as "the operand's payload type is the interpolation space", i.e. true for the operand that was not converted, so gamut mapping and `adjust_powerless_components()` ran on the wrong operand. The Zig version this was ported from had the same inversion, so released versions behave the same (checked with 1.4.0).
- Flipping the flags alone is not enough (first revision of this PR): it would have started applying two rules that lightningcss still carries but css-color-4 does not have. Operands are not gamut mapped on conversion at all, and since 2023 lightness no longer makes channels powerless (only hues of achromatic colors are). With just the flip, `color-mix(in oklab, X, black)` would have kept X's full chroma, `color-mix(in hsl, red, white)` would have become `#ff8080`, and converted wide-gamut operands would have been mapped; main happens to fold all of those the way browsers do, and this PR keeps it that way.

### Fix
- `interpolate`: `converted_* = !is_in_space(...)` (helper renamed to say what it computes), and the operand gamut mapping block is deleted. Out-of-gamut operands are mixed as written; the result is still gamut mapped when it is converted to an rgb color for output, as before.
- `adjust_powerless_components`, applied to converted operands only: reduced to the rules in the current css-color-4, i.e. the hue is missing when the converted color is achromatic, using the per-space epsilons the spec lists (`lch` C <= 0.0015, `oklch` C <= 0.000004, `hsl` S <= 0.001%, `hwb` W + B >= 99.999%). The epsilon is a parameter of the `define_colorspace!` `powerless` knob. The lightness rules for lab/oklab, lch/oklch and hsl are gone; lab/oklab now have no powerless components. The epsilons also cover the ~1e-5 chroma residual bun's sRGB to Lab conversion leaves on greys, which the previous exact-zero test did not.
- Why this is right: css-color-4 #interpolation-space ("out of range values ... are not clipped; the values must be interpolated as-is") and #powerless ("if a powerless component is manually specified, it acts as normal ... if a color is automatically produced by color space conversion, then any powerless components in the result must instead be set to missing", plus the epsilon paragraph and tables); the per-space definitions only call hues powerless. The WPT rows for these cases (`color-computed-color-mix-function.html`: `in hsl` white/blue, red/white, red/black, `in lch`/`in oklch` white/blue and red/black, `lab(50 0 0)`/black) all agree with the new output. The css-color-5 example `color-mix(in lch, white, blue)` = `lch(64.7841% 65.6008 301.364)` now folds to `lch(64.7841% 65.6007 301.364)`.
- Relationship to lightningcss (this parser's upstream): of ~100 `color-mix()` inputs compared against 1.30.2, every input whose output changes here moves to the spec result, and most of them also match lightningcss. The remaining differences are exactly the two old rules above (lightningcss gamut maps converted operands into srgb/srgb-linear, and drops channels at 0%/100% lightness), plus the `map_gamut` result-mapping differences that predate this PR (#33333). The tests say which expectations differ from lightningcss and why. Things this does not touch: the clamp to the sRGB gamut when converting into hsl/hwb (shared with lightningcss, separate question), `transparent` mixes (unchanged: premultiplication zeroes its channels either way), in-gamut mixes.
- Verified: `test/js/bun/css/css.test.ts` ("color-mix() operand conversion", 78 cases: 40 fail on main, including both halves of the swapped pair, the black/grey/white hue cases, the `none` cases and one case on each side of every epsilon; the other 38 pin the outputs that must not change) and `test/js/bun/css/color.test.ts` (24 cases, 20 fail on main; includes the WPT rows with tolerances for the parts that go through cbrt/pow). Both files, `test/regression/issue/css-system-color-*.test.ts` and `doesnt_crash.test.ts` pass with the debug build; `cargo clippy -p bun_css` is clean.
- Found on the way and reported separately, not changed here: lch/oklch premultiply the hue by alpha; `longer hue` with equal hues does not go around the circle (both also in lightningcss); `lab(50 0 0)`-style number lightness does not parse; tiny negative numbers print as `--1e-7`; sRGB to Lab leaves a residual a/b on greys.

### Background
- Interpolation color space: `color-mix(in X, a, b)` converts both operands to space X, interpolates channel by channel, and converts the result back out. In this code an operand's space is its payload type (`PredefinedColor::Srgb(SRGB)`, `LABColor::Lch(LCH)`, `FloatColor::Hsl(HSL)` for an `hsl()` with a `none` channel, ...); `rgb()`/hex/named colors and `hsl()`/`hwb()` without `none` are 8-bit `CssColor::Rgba`, so they count as converted for every space (harmless for `in srgb`: in gamut, no powerless channels).
- Gamut: srgb, srgb-linear, hsl and hwb are bounded. A color converted from a wider space (display-p3, rec2020, lab, ...) can land outside, e.g. display-p3 green is `color(srgb -0.51 1.018 -0.31)`. The spec interpolates those values as they are; gamut mapping (`map_gamut`, a chroma reduction in oklch) is only applied to a final color that has to become an rgb color.
- Powerless component: a channel that has no effect on the color, i.e. the hue of a grey in hsl/hwb/lch/oklch. When such a color is converted into the interpolation space its hue becomes missing (`none`, NaN internally) and `fill_missing_components` takes the other operand's hue, so mixing white into a hue does not drag the hue around; a hue the author wrote out (`lch(50% 0 200)`) is used as written. Because conversions leave a tiny residual chroma on greys, the spec defines a per-space epsilon below which the hue counts as powerless.
- The 0%/100% lightness rules: older css-color-4 drafts also declared a/b (lab), chroma (lch) and saturation (hsl) powerless at 0% or 100% lightness; the 2023 spec removed that (changes list: "Removed incorrect assertions of powerlessness"), and browsers follow the current text. lightningcss still implements the older drafts, which is also where its operand gamut mapping comes from.

<details>
<summary>main vs this PR for a representative subset (minified, no targets)</summary>

```
input                                                                       main                         this PR                 lightningcss 1.30.2
color-mix(in srgb, color(srgb -0.51 1.018 -0.31), color(srgb 0.6 0.2 0.4))   #4d9654                      #0b9b0b                 #0b9b0b
color-mix(in srgb, color(display-p3 0 1 0), color(srgb 0.6 0.2 0.4))          #0b9b0b                      #0b9b0b                 #4d9654
color-mix(in srgb, color(srgb -0.5 1.5 -0.5), color(srgb 0.5 0.5 0.5))        #bfbfbf                      #0f0                    #0f0
color-mix(in srgb-linear, color(srgb-linear 1.5 0 0), white)                  color(srgb-linear 1 .57822 .554)   color(srgb-linear 1.25 .5 .5)   same as PR
color-mix(in lch, white, blue)                                                 lch(64.7841% 65.6007 375.682) lch(... 301.364)        lch(64.7842% 65.6007 301.364)
color-mix(in oklch, red, white)                                                oklch(81.3978% .128842 59.6169) oklch(... 29.2339)   same as PR
color-mix(in lch, red, black)                                                  lch(27.1453% 53.4186 20.4288) lch(27.1453% 53.4186 40.8577)  lch(27.1453% 106.837 40.8577)
color-mix(in lch, lch(50% 0 200), lch(50% 50 120))                             lch(50% 25 120)              lch(50% 25 160)         lch(50% 25 160)
color-mix(in lch, lab(50% 0 0), black)                                         lch(25% 0 0)                 lch(25% 0 none)         lch(25% 0 none)
color-mix(in hsl, hsl(120 0% none), hsl(200 100% 50%))                         #005580                      #40bf95                 #40bf95
color-mix(in hwb, hwb(120 50% none), hwb(200 0% 40%))                          #40cc9d                      #40997b                 #40997b
color-mix(in lab, lab(0% 30 40), lab(50% 50 -20))                              lab(25% 50 -20)              lab(25% 40 10)          lab(25% 40 10)
color-mix(in lab, black, lab(50% 50 -20))                                      lab(25% 25 -10)              lab(25% 25 -10)         lab(25% 50 -20)
color-mix(in hsl, red, white)                                                  #df9f9f                      #df9f9f                 #ff8080
color-mix(in oklab, oklab(60% 0.1 0.1) 50%, transparent)                       oklab(60% .1 .1/.5)          unchanged               same
```

WPT `color-computed-color-mix-function.html` expectations for the rows above: `in hsl, red, white` = `color(srgb 0.875 0.625 0.625)` (`#df9f9f`), `in lch, red, black` = `lch(27.145 53.4271 40.856)`, `in lch, white, blue` = `lch(64.78 65.6 301.37)`, `in oklch, red, white` = `oklch(0.81398 0.128877 29.2346)`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 60 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (35d0093ae)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.94ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.41ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.71ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.80ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [24.30ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [3.10ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.67ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.73ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.25ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.28ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.55ms]
(pass) color({"r":0,"g":25
... (truncated)

release without fix: 60 failed, 67 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.13ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.03ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.02ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.06ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [1.40ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.06ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.02ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.02ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.02ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ans
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (35d0093ae)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [2.96ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.53ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.53ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.62ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [14.40ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.47ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.65ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.31ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.24ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.24ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.50ms]
(pass) color({"r":0,"g":25
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     35d0093ae1
  features     baseline

22 deps, 123 codegen, 1176 objects in 837ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [8.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1238] fetch zlib
[zlib] up to date
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1237] subst deps/zlib/zconf.h
[12/1237] s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/color.rs       |  90 ++++++----------
 test/js/bun/css/color.test.ts |  72 +++++++++++++
 test/js/bun/css/css.test.ts   | 234 ++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 336 insertions(+), 60 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css/values/color.rs           13     18      0
test/js/bun/css/color.test.ts      6      6      0
test/js/bun/css/css.test.ts        5      4      0
```

</details>

<!-- robobun:evidence:end -->