### PR TITLE
Pair off Set members and Map entries once in deepEquals instead of rescanning per member

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1840,10 +1840,278 @@ static std::optional<bool> specialObjectsDequalSlow(const DeepEqualsMode& mode, 
     return std::nullopt;
 }
 
+// Entries take one slot each (Set members) or two (a Map entry's key and value).
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity, bool entriesHaveValues>
+static bool entryPairEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, const MarkedArgumentBuffer& left, size_t leftIndex, const MarkedArgumentBuffer& right, size_t rightIndex)
+{
+    constexpr size_t slotsPerEntry = entriesHaveValues ? 2 : 1;
+    size_t l = leftIndex * slotsPerEntry;
+    size_t r = rightIndex * slotsPerEntry;
+    bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, left.at(l), right.at(r), gcBuffer, stack, scope, true);
+    if constexpr (entriesHaveValues) {
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!equal)
+            return false;
+        equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, left.at(l + 1), right.at(r + 1), gcBuffer, stack, scope, true);
+    }
+    return equal;
+}
+
+// Each left entry takes a distinct equal right entry; with matchers (which equal several entries) one that takes nothing still passes if it has some counterpart, as in Jest.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity, bool entriesHaveValues, typename LeftEntryHasCounterpart, typename RightEntryHasCounterpart>
+static bool pairOffEntries(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, const MarkedArgumentBuffer& left, const MarkedArgumentBuffer& right, const LeftEntryHasCounterpart& leftEntryHasCounterpart, const RightEntryHasCounterpart& rightEntryHasCounterpart)
+{
+    ASSERT(left.size() == right.size());
+    const size_t count = left.size() / (entriesHaveValues ? 2 : 1);
+
+    auto entriesEqual = [&](size_t leftIndex, size_t rightIndex) {
+        return entryPairEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity, entriesHaveValues>(globalObject, gcBuffer, stack, scope, left, leftIndex, right, rightIndex);
+    };
+
+    // Indices of the right entries not taken yet live in open[start, end).
+    Vector<size_t, 16> open(count, [](size_t i) { return i; });
+    size_t start = 0;
+    size_t end = count;
+    bool guessFront = true;
+    bool someRightEntryStaysOpen = false;
+    for (size_t i = 0; i < count; i++) {
+        ASSERT(start < end);
+        bool equal = entriesEqual(i, open[guessFront ? start : end - 1]);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (equal) {
+            if (guessFront)
+                start++;
+            else
+                end--;
+            continue;
+        }
+
+        bool paired = false;
+        if (guessFront) {
+            for (size_t k = end; k-- > start + 1;) {
+                equal = entriesEqual(i, open[k]);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!equal)
+                    continue;
+                guessFront = k != end - 1;
+                end--;
+                open[k] = open[end];
+                paired = true;
+                break;
+            }
+        } else {
+            for (size_t k = start; k < end - 1; k++) {
+                equal = entriesEqual(i, open[k]);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!equal)
+                    continue;
+                guessFront = true;
+                open[k] = open[start];
+                start++;
+                paired = true;
+                break;
+            }
+        }
+        if (paired)
+            continue;
+
+        if constexpr (!enableAsymmetricMatchers) {
+            // Structural equality is an equivalence relation here, so no other pairing would help.
+            return false;
+        } else {
+            bool hasCounterpart = leftEntryHasCounterpart(i);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (!hasCounterpart)
+                return false;
+            someRightEntryStaysOpen = true;
+        }
+    }
+
+    if constexpr (enableAsymmetricMatchers) {
+        if (someRightEntryStaysOpen) {
+            for (size_t k = start; k < end; k++) {
+                bool hasCounterpart = rightEntryHasCounterpart(open[k]);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!hasCounterpart)
+                    return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+// pairOffEntries fallbacks. The operand order matters to matchers and to the cycle stack.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static bool setHasCounterpart(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSValue member, bool memberIsFromSet1, JSSet* otherSet)
+{
+    auto iter = JSSetIterator::create(globalObject->vm(), globalObject->setIteratorStructure(), otherSet, IterationKind::Keys);
+    JSValue candidate;
+    while (iter->next(globalObject, candidate)) {
+        bool equal = memberIsFromSet1
+            ? Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, member, candidate, gcBuffer, stack, scope, true)
+            : Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, candidate, member, gcBuffer, stack, scope, true);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (equal) {
+            return true;
+        }
+    }
+    return false;
+}
+
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static bool mapHasCounterpart(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSValue key, JSValue value, bool entryIsFromMap1, JSMap* otherMap)
+{
+    auto iter = JSMapIterator::create(globalObject->vm(), globalObject->mapIteratorStructure(), otherMap, IterationKind::Entries);
+    JSValue candidateKey, candidateValue;
+    while (iter->nextKeyValue(globalObject, candidateKey, candidateValue)) {
+        bool equal = entryIsFromMap1
+            ? Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key, candidateKey, gcBuffer, stack, scope, true)
+            : Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, candidateKey, key, gcBuffer, stack, scope, true);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!equal) {
+            continue;
+        }
+        equal = entryIsFromMap1
+            ? Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value, candidateValue, gcBuffer, stack, scope, true)
+            : Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, candidateValue, value, gcBuffer, stack, scope, true);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (equal) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Only the members the other side does not hold by SameValueZero need structural matching.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static bool setContentsEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSSet* set1, JSSet* set2)
+{
+    VM& vm = globalObject->vm();
+    if (set1->size() != set2->size()) {
+        return false;
+    }
+
+    MarkedArgumentBuffer unmatched1;
+    {
+        auto iter = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
+        JSValue key;
+        while (iter->next(globalObject, key)) {
+            bool has = set2->has(globalObject, key);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (has) {
+                continue;
+            }
+            if constexpr (!enableAsymmetricMatchers) {
+                // Only an asymmetric matcher could equal a primitive set2 does not hold.
+                if (key.isPrimitive()) {
+                    return false;
+                }
+            }
+            unmatched1.appendWithCrashOnOverflow(key);
+        }
+    }
+    if (unmatched1.isEmpty()) {
+        return true;
+    }
+
+    MarkedArgumentBuffer unmatched2;
+    {
+        auto iter = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
+        JSValue key;
+        while (iter->next(globalObject, key)) {
+            bool has = set1->has(globalObject, key);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (!has) {
+                unmatched2.appendWithCrashOnOverflow(key);
+            }
+        }
+    }
+    if (unmatched1.size() != unmatched2.size()) {
+        return false;
+    }
+
+    return pairOffEntries<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity, false>(
+        globalObject, gcBuffer, stack, scope, unmatched1, unmatched2,
+        [&](size_t index) { return setHasCounterpart<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, unmatched1.at(index), true, set2); },
+        [&](size_t index) { return setHasCounterpart<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, unmatched2.at(index), false, set1); });
+}
+
+// Like setContentsEqual, but an entry is only settled through the hash table if the values agree too.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static bool mapContentsEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSMap* map1, JSMap* map2)
+{
+    VM& vm = globalObject->vm();
+    if (map1->size() != map2->size()) {
+        return false;
+    }
+
+    MarkedArgumentBuffer unmatched1;
+    MarkedArgumentBuffer unmatched2;
+    {
+        auto iter = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
+        JSValue key, value1;
+        while (iter->nextKeyValue(globalObject, key, value1)) {
+            JSValue value2 = map2->get(globalObject, key);
+            RETURN_IF_EXCEPTION(scope, false);
+            bool has = true;
+            if (value2.isUndefined()) {
+                has = map2->has(globalObject, key);
+                RETURN_IF_EXCEPTION(scope, false);
+            }
+            if (has) {
+                bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, true);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (valuesEqual) {
+                    continue;
+                }
+            }
+            if constexpr (!enableAsymmetricMatchers) {
+                // Only an asymmetric matcher could still equal a primitive key.
+                if (key.isPrimitive()) {
+                    return false;
+                }
+            }
+            unmatched1.appendWithCrashOnOverflow(key);
+            unmatched1.appendWithCrashOnOverflow(value1);
+            if (has) {
+                // A structurally equal key elsewhere may carry each of the two values.
+                unmatched2.appendWithCrashOnOverflow(key);
+                unmatched2.appendWithCrashOnOverflow(value2);
+            }
+        }
+    }
+    if (unmatched1.isEmpty()) {
+        return true;
+    }
+
+    // Every key map1 holds was dealt with above, whether or not the values agreed.
+    {
+        auto iter = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
+        JSValue key, value;
+        while (iter->nextKeyValue(globalObject, key, value)) {
+            bool has = map1->has(globalObject, key);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (has) {
+                continue;
+            }
+            unmatched2.appendWithCrashOnOverflow(key);
+            unmatched2.appendWithCrashOnOverflow(value);
+        }
+    }
+    if (unmatched1.size() != unmatched2.size()) {
+        return false;
+    }
+
+    return pairOffEntries<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity, true>(
+        globalObject, gcBuffer, stack, scope, unmatched1, unmatched2,
+        [&](size_t index) { return mapHasCounterpart<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, unmatched1.at(index * 2), unmatched1.at(index * 2 + 1), true, map2); },
+        [&](size_t index) { return mapHasCounterpart<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, unmatched2.at(index * 2), unmatched2.at(index * 2 + 1), false, map1); });
+}
+
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2)
 {
-    VM& vm = globalObject->vm();
     uint8_t c1Type = c1->type();
     uint8_t c2Type = c2->type();
 
@@ -1855,39 +2123,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        JSSet* set1 = uncheckedDowncast<JSSet>(c1);
-        JSSet* set2 = uncheckedDowncast<JSSet>(c2);
-
-        if (set1->size() != set2->size()) {
+        bool contentsEqual = setContentsEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, uncheckedDowncast<JSSet>(c1), uncheckedDowncast<JSSet>(c2));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!contentsEqual) {
             return false;
-        }
-
-        auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
-        JSValue key1;
-        while (iter1->next(globalObject, key1)) {
-            bool has = set2->has(globalObject, key1);
-            RETURN_IF_EXCEPTION(scope, {});
-            if (has) {
-                continue;
-            }
-
-            // We couldn't find the key in the second set. This may be a false positive due to how
-            // JSValues are represented in JSC, so we need to fall back to a linear search to be sure.
-            auto iter2 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
-            JSValue key2;
-            bool foundMatchingKey = false;
-            while (iter2->next(globalObject, key2)) {
-                bool equal = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, false);
-                RETURN_IF_EXCEPTION(scope, {});
-                if (equal) {
-                    foundMatchingKey = true;
-                    break;
-                }
-            }
-
-            if (!foundMatchingKey) {
-                return false;
-            }
         }
 
         if constexpr (checkPrototypes) {
@@ -1901,47 +2140,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             return false;
         }
 
-        JSMap* map1 = uncheckedDowncast<JSMap>(c1);
-        JSMap* map2 = uncheckedDowncast<JSMap>(c2);
-        size_t leftSize = map1->size();
-
-        if (leftSize != map2->size()) {
+        bool contentsEqual = mapContentsEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, uncheckedDowncast<JSMap>(c1), uncheckedDowncast<JSMap>(c2));
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!contentsEqual) {
             return false;
-        }
-
-        auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
-        JSValue key1, value1;
-        while (iter1->nextKeyValue(globalObject, key1, value1)) {
-            JSValue value2 = map2->get(globalObject, key1);
-            RETURN_IF_EXCEPTION(scope, {});
-            if (value2.isUndefined()) {
-                // We couldn't find the key in the second map. This may be a false positive due to
-                // how JSValues are represented in JSC, so we need to fall back to a linear search
-                // to be sure.
-                auto iter2 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
-                JSValue key2;
-                bool foundMatchingKey = false;
-                while (iter2->nextKeyValue(globalObject, key2, value2)) {
-                    bool keysEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, key1, key2, gcBuffer, stack, scope, false);
-                    RETURN_IF_EXCEPTION(scope, {});
-                    if (keysEqual) {
-                        foundMatchingKey = true;
-                        break;
-                    }
-                }
-
-                if (!foundMatchingKey) {
-                    return false;
-                }
-
-                // Compare both values below.
-            }
-
-            bool valuesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, value1, value2, gcBuffer, stack, scope, false);
-            RETURN_IF_EXCEPTION(scope, {});
-            if (!valuesEqual) {
-                return false;
-            }
         }
 
         if constexpr (checkPrototypes) {

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -1,4 +1,6 @@
 import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import assert from "node:assert";
+import util from "node:util";
 import vm from "node:vm";
 
 describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
@@ -128,6 +130,262 @@ describe("Bun.deepEquals strict mode", () => {
   // against Object.prototype.
   it.failing("distinguishes a null-prototype object from an object literal", () => {
     expect(Bun.deepEquals(Object.create(null), {}, true)).toBe(false);
+  });
+});
+
+// Set members and Map keys with no identical counterpart on the other side are matched
+// structurally, and each one has to claim a counterpart of its own: Set([{a:1},{a:1}]) is
+// not Set([{a:1},{a:2}]), and a Map entry matches on key and value together, so two
+// structurally equal keys may carry their values in either order. Every entry point below
+// shares the native comparison; expect() additionally understands asymmetric matchers.
+describe("Set and Map entries without an identical counterpart", () => {
+  type Check = (a: unknown, b: unknown, equal: boolean) => void;
+  const exactEntryPoints: Record<string, Check> = {
+    "Bun.deepEquals": (a, b, equal) => expect(Bun.deepEquals(a, b)).toBe(equal),
+    "Bun.deepEquals strict": (a, b, equal) => expect(Bun.deepEquals(a, b, true)).toBe(equal),
+    "util.isDeepStrictEqual": (a, b, equal) => expect(util.isDeepStrictEqual(a, b)).toBe(equal),
+    "assert.deepEqual": (a, b, equal) =>
+      equal ? assert.deepEqual(a, b) : expect(() => assert.deepEqual(a, b)).toThrow(assert.AssertionError),
+    "assert.deepStrictEqual": (a, b, equal) =>
+      equal ? assert.deepStrictEqual(a, b) : expect(() => assert.deepStrictEqual(a, b)).toThrow(assert.AssertionError),
+  };
+  const expectEntryPoints: Record<string, Check> = {
+    "expect().toEqual": (a, b, equal) => (equal ? expect(a).toEqual(b) : expect(a).not.toEqual(b)),
+    "expect().toStrictEqual": (a, b, equal) => (equal ? expect(a).toStrictEqual(b) : expect(a).not.toStrictEqual(b)),
+  };
+
+  const set = (...members: unknown[]) => new Set(members);
+  const map = (...entries: [unknown, unknown][]) => new Map(entries);
+  const shared = { a: 1 };
+  // [description, a, b, equal]; every case is checked in both argument orders.
+  const cases: [string, unknown, unknown, boolean][] = [
+    ["Set: same objects, other order", set({ a: 1 }, { a: 2 }, { a: 3 }), set({ a: 3 }, { a: 1 }, { a: 2 }), true],
+    ["Set: duplicates on both sides", set({ a: 1 }, { a: 1 }, { a: 2 }), set({ a: 2 }, { a: 1 }, { a: 1 }), true],
+    ["Set: a duplicate in place of a distinct member", set({ a: 1 }, { a: 1 }), set({ a: 1 }, { a: 2 }), false],
+    [
+      "Set: a duplicate nested structure",
+      set({ a: { b: 1 } }, { a: { b: 1 } }),
+      set({ a: { b: 1 } }, { a: { b: 2 } }),
+      false,
+    ],
+    ["Set: a member both sides hold cannot stand in twice", set(shared, { a: 1 }), set(shared, { a: 2 }), false],
+    ["Set: a primitive only one side holds", set(1, { a: 1 }), set(2, { a: 1 }), false],
+    ["Set: one object differs", set({ a: 1 }, { a: 2 }), set({ a: 1 }, { a: 3 }), false],
+    [
+      "Map: equal keys, values in other order",
+      map([{ k: 1 }, "x"], [{ k: 1 }, "y"]),
+      map([{ k: 1 }, "y"], [{ k: 1 }, "x"]),
+      true,
+    ],
+    ["Map: equal RegExp keys in the same order", map([/a/, "x"], [/a/, "y"]), map([/a/, "x"], [/a/, "y"]), true],
+    [
+      "Map: three equal keys, permuted values",
+      map([{ k: 1 }, 1], [{ k: 1 }, 2], [{ k: 1 }, 3]),
+      map([{ k: 1 }, 3], [{ k: 1 }, 1], [{ k: 1 }, 2]),
+      true,
+    ],
+    ["Map: one value differs", map([{ k: 1 }, "x"], [{ k: 1 }, "y"]), map([{ k: 1 }, "x"], [{ k: 1 }, "z"]), false],
+    ["Map: one key differs", map([{ k: 1 }, "x"], [{ k: 1 }, "y"]), map([{ k: 1 }, "x"], [{ k: 2 }, "y"]), false],
+    [
+      "Map: a duplicate key in place of a distinct one",
+      map([{ k: 1 }, 1], [{ k: 1 }, 1]),
+      map([{ k: 1 }, 1], [{ k: 2 }, 1]),
+      false,
+    ],
+    [
+      "Map: a key both sides hold, value moved to an equal key",
+      map([shared, 1], [{ a: 1 }, 2]),
+      map([shared, 2], [{ a: 1 }, 1]),
+      true,
+    ],
+    ["Map: a key both sides hold, different values", map([shared, 1]), map([shared, 2]), false],
+    [
+      "Map: object and primitive keys, other order",
+      map(["p", 0], [{ k: 1 }, 1], [{ k: 1 }, 2]),
+      map([{ k: 1 }, 2], ["p", 0], [{ k: 1 }, 1]),
+      true,
+    ],
+    ["Map: a primitive key only one side holds", map(["p", 1], [{ k: 1 }, 1]), map(["q", 1], [{ k: 1 }, 1]), false],
+    [
+      "Map: undefined values are not missing entries",
+      map(["a", undefined], ["b", 1]),
+      map(["b", 1], ["a", undefined]),
+      true,
+    ],
+    [
+      "Map: undefined value under a key only one side holds",
+      map(["a", undefined], ["b", 1]),
+      map(["c", undefined], ["b", 1]),
+      false,
+    ],
+  ];
+
+  describe.each(Object.entries({ ...exactEntryPoints, ...expectEntryPoints }))("%s", (_, check) => {
+    it.each(cases)("%s", (_, a, b, equal) => {
+      check(a, b, equal);
+      check(b, a, equal);
+    });
+  });
+
+  // Without matchers in play structural equality is an equivalence relation, so the
+  // comparison can insist on a one-to-one pairing. expect() cannot: an asymmetric matcher
+  // accepts several members, so when the pairing fails it falls back to requiring a
+  // counterpart for every member on either side (what Jest checks), which accepts
+  // different duplicate counts. Whether one of the duplicates is the same object on both
+  // sides must not change either answer.
+  const sharedKey = { k: 1 };
+  const duplicateCountCases: [string, unknown, unknown][] = [
+    ["Set", set({ a: 1 }, { a: 1 }, { a: 2 }), set({ a: 1 }, { a: 2 }, { a: 2 })],
+    ["Set sharing a member", set(shared, { a: 1 }, { a: 2 }), set(shared, { a: 2 }, { a: 2 })],
+    ["Map", map([{ k: 1 }, 1], [{ k: 1 }, 1], [{ k: 1 }, 2]), map([{ k: 1 }, 1], [{ k: 1 }, 2], [{ k: 1 }, 2])],
+    [
+      "Map sharing a key",
+      map([sharedKey, 1], [{ k: 1 }, 1], [{ k: 1 }, 2]),
+      map([sharedKey, 1], [{ k: 1 }, 2], [{ k: 1 }, 2]),
+    ],
+  ];
+
+  describe.each(Object.entries(exactEntryPoints))("%s", (_, check) => {
+    it.each(duplicateCountCases)("%s: different duplicate counts", (_, a, b) => {
+      check(a, b, false);
+      check(b, a, false);
+    });
+  });
+
+  describe.each(Object.entries(expectEntryPoints))("%s", (_, check) => {
+    it.each(duplicateCountCases)("%s: different duplicate counts", (_, a, b) => {
+      check(a, b, true);
+      check(b, a, true);
+    });
+  });
+
+  describe.each(Object.entries(expectEntryPoints))("%s with asymmetric matchers", (_, check) => {
+    it("a member taken by a matcher can still satisfy a later member", () => {
+      // {a:1} takes expect.anything() first; the concrete {a:1} is left for {a:2}.
+      check(set({ a: 1 }, { a: 2 }), set(expect.anything(), { a: 1 }), true);
+      check(set(expect.anything(), { a: 1 }), set({ a: 1 }, { a: 2 }), true);
+    });
+
+    it("overlapping matchers", () => {
+      const received = set({ type: "a", id: 1 }, { type: "a", id: 2 });
+      check(received, set(expect.objectContaining({ type: "a" }), expect.objectContaining({ id: 1 })), true);
+      check(received, set(expect.objectContaining({ type: "a" }), expect.objectContaining({ id: 3 })), false);
+    });
+
+    it("a Map entry is matched on key and value, so a matcher key can carry a different value", () => {
+      const received = map([{ a: 1 }, "x"], [{ a: 2 }, "y"]);
+      check(received, map([expect.anything(), "y"], [{ a: 1 }, "x"]), true);
+      check(received, map([expect.anything(), "z"], [{ a: 1 }, "x"]), false);
+    });
+
+    it("matchers in the values of object-keyed entries", () => {
+      const received = map([{ k: 1 }, 5], [{ k: 2 }, "s"]);
+      check(received, map([{ k: 2 }, expect.any(String)], [{ k: 1 }, expect.any(Number)]), true);
+      check(received, map([{ k: 2 }, expect.any(Number)], [{ k: 1 }, expect.any(Number)]), false);
+    });
+  });
+
+  // A member's comparison goes onto the cycle stack like an array element's does, so a
+  // collection holding a self-referential collection terminates instead of recursing until
+  // the stack runs out.
+  describe("self-referential members", () => {
+    function selfSet() {
+      const self = new Set<unknown>();
+      self.add(self);
+      return self;
+    }
+    function selfMap() {
+      const self = new Map<unknown, unknown>();
+      self.set("self", self);
+      return self;
+    }
+
+    it.each(Object.entries({ ...exactEntryPoints, ...expectEntryPoints }))("%s", (_, check) => {
+      check(set(selfSet()), set(selfSet()), true);
+      check(set(selfSet(), { a: 1 }), set(selfSet(), { a: 2 }), false);
+      // Under an object key the value is compared while pairing off entries, under a
+      // string key while the keys are looked up.
+      check(map([{ k: 1 }, selfMap()]), map([{ k: 1 }, selfMap()]), true);
+      check(map(["k", selfMap()]), map(["k", selfMap()]), true);
+      check(map([{ k: 1 }, selfMap()]), map([{ k: 2 }, selfMap()]), false);
+    });
+
+    it("a collection that contains itself", () => {
+      const a = new Set<unknown>([1, { a: 1 }]);
+      a.add(a);
+      const b = new Set<unknown>();
+      b.add(b);
+      b.add(1);
+      b.add({ a: 1 });
+      expect(Bun.deepEquals(a, b)).toBe(true);
+      expect(a).toEqual(b);
+    });
+  });
+
+  it("an exception thrown while comparing members propagates", () => {
+    const throwing = () => ({
+      get x(): number {
+        throw new Error("boom");
+      },
+    });
+    expect(() => Bun.deepEquals(set(throwing()), set(throwing()))).toThrow("boom");
+    expect(() => Bun.deepEquals(map([throwing(), 1]), map([throwing(), 1]))).toThrow("boom");
+    expect(() => Bun.deepEquals(map(["k", throwing()]), map(["k", throwing()]))).toThrow("boom");
+    expect(() => util.isDeepStrictEqual(set(throwing()), set(throwing()))).toThrow("boom");
+    expect(() => expect(set(throwing())).toEqual(set(throwing()))).toThrow("boom");
+  });
+
+  // Each member is compared against a counterpart or two, not against everything the other
+  // side holds, whether the sides were built in the same order or in opposite orders. The
+  // getter counts how often the comparison looks inside a member; the rescan of the whole
+  // other side per member that this replaces read it about n*n times.
+  describe("number of structural comparisons", () => {
+    const n = 128;
+    const linearEntryPoints: Record<string, (a: unknown, b: unknown) => boolean> = {
+      "Bun.deepEquals": (a, b) => Bun.deepEquals(a, b),
+      "util.isDeepStrictEqual": (a, b) => util.isDeepStrictEqual(a, b),
+      "expect().toEqual": (a, b) => {
+        expect(a).toEqual(b);
+        return true;
+      },
+    };
+
+    function members(onRead: () => void) {
+      return Array.from({ length: n }, (_, i) => ({
+        get id() {
+          onRead();
+          return i;
+        },
+      }));
+    }
+
+    describe.each(Object.entries(linearEntryPoints))("%s", (_, isEqual) => {
+      it.each([
+        ["Set, same order", false],
+        ["Set, opposite order", true],
+      ])("%s", (_, reversed) => {
+        let reads = 0;
+        const onRead = () => reads++;
+        const a = new Set(members(onRead));
+        const other = members(onRead);
+        const b = new Set(reversed ? other.reverse() : other);
+        expect(isEqual(a, b)).toBe(true);
+        expect(reads).toBeLessThanOrEqual(8 * n);
+      });
+
+      it.each([
+        ["Map with object keys, same order", false],
+        ["Map with object keys, opposite order", true],
+      ])("%s", (_, reversed) => {
+        let reads = 0;
+        const onRead = () => reads++;
+        const a = new Map(members(onRead).map((key, i) => [key, i] as const));
+        const other = members(onRead).map((key, i) => [key, i] as const);
+        const b = new Map(reversed ? other.reverse() : other);
+        expect(isEqual(a, b)).toBe(true);
+        expect(reads).toBeLessThanOrEqual(8 * n);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.deepEquals`, `expect().toEqual` and `node:assert` / `util.isDeepStrictEqual` take O(n^2) deep comparisons on a Set of n structurally equal objects, or a Map with n object keys. 2500 / 5000 / 10000 members take 150 / 610 / 2440 ms in `Bun.deepEquals` and 1120 / 4430 ms (2500 / 5000) through `util.isDeepStrictEqual`; node v26 takes about 7 ms for any of them. Sets and Maps of primitives, and arrays of objects, were already linear.
- Cause: the `JSSetType` / `JSMapType` arms of `specialObjectsDequal` (`src/jsc/bindings/bindings.cpp`) handled every member that misses the other side's hash table by iterating the whole other side from the start until something compared equal, and never removed a match from consideration. With n distinct objects that is n*n/2 comparisons.
- Not removing matches is also a correctness bug: `Set([{a:1},{a:1}])` compared equal to `Set([{a:1},{a:2}])` (#28760), and a Map entry stopped at the first structurally equal key, so `Map([[/a/,"x"],[/a/,"y"]])` did not equal an identical Map (#34830). The same eight assertions fail in node's own `test/parallel/test-assert-deep.js`.
- Member comparisons were also made with `addToStack=false`, so `Set([s])` against `Set([t])` where `s` and `t` each contain themselves recursed until `RangeError: Maximum call stack size exceeded`.

### Fix
- `setContentsEqual` / `mapContentsEqual` walk each side once: members (keys) the other side holds by SameValueZero are settled through its hash table as before; the rest are collected per side into a `MarkedArgumentBuffer` (key and value slots for Maps). The two leftover lists must have the same length, and without matchers a leftover primitive fails immediately since only an object can still compare equal structurally.
- `pairOffEntries` pairs the leftovers: each left entry takes a distinct right entry (key and value for Maps) out of a window of still-open indices. Like node's `setObjectEquiv` / `mapObjectEquiv` it first tries the entry at the end of the window that matched last time, so sides built in the same order or in opposite orders cost one comparison per entry; only other orders sweep the window. Consuming matches is exact for `Bun.deepEquals` and the node entry points because structural equality without matchers is an equivalence relation.
- `expect()` can see asymmetric matchers, which accept several entries, so when an entry finds nothing open it falls back to what Jest checks: some counterpart for it anywhere in the whole other collection (`setHasCounterpart` / `mapHasCounterpart`, settled members included, so the answer does not depend on which members happen to be shared by reference), and once everything else is paired off, some counterpart for every right entry nobody took. The forward half is exactly what `expect()` checked before, so everything that passed before and has a counterpart for every expected entry still passes (for example `Set([{a:1},{a:2}])` against `Set([expect.anything(), {a:1}])`); what it newly rejects is an expected entry nothing received matches, which is also what catches one received member standing in for two. An equal number of entries on each side with different duplicate counts (`{A, A, B}` vs `{A, B, B}`) still passes through `expect()` only, as in Jest and before; the test file records that, with and without a shared member.
- A Map key that is present on both sides but carries a different value now goes into the leftovers along with the other side's entry (node and Jest both do this), so `Map([[k,1],[{...k},2]])` equals `Map([[k,2],[{...k},1]])`.
- Member comparisons pass `addToStack=true`, the same as array elements and properties, so nested self-referential collections terminate.
- Verified by `test/js/bun/bun-object/deep-equals.test.ts`: a table of Set/Map cases checked in both argument orders through all seven entry points, every expectation cross-checked against node v26.3.0; the matcher fallback; the cycle cases; and a count of how often a member's getter is read while comparing 128 members in the same and in opposite order (2n now, about n*n before), through `Bun.deepEquals`, `util.isDeepStrictEqual` and `toEqual`. 92 of these fail on the current release, all pass with the fix.
- Also run: `test/js/node/assert/deep-equal.test.ts`, `assert-typedarray-deepequal.test.ts`, `deep-equals-temporal.test.ts`, `test/js/bun/test/expect.test.js`, `expect-extend.test.js`, the vendored `test-util-isDeepStrictEqual.js` (all green), and node's upstream `test-assert-deep.js` with its assertion helpers made non-fatal: 46 failing call sites before, 38 after, the 8 fixed ones being its Set/Map multiset cases, no new failures.
- #28763 fixes the same two correctness issues but keeps iterating the other side from index 0 for every member, so its cost stays quadratic; this supersedes it. The node entry point still compares a content-equal Set or Map twice (the `break` to the own-property walk lets `Bun__deepEquals` call `specialObjectsDequal` again with the operands swapped); that is a constant factor shared with the other `break` arms and is left as is.
- Rebased twice. #39770 moved the other special-object arms into the shared `specialObjectsDequalSlow` but deliberately kept the Set and Map arms specialised per mode; the helpers here follow that and stay templated. #40251 then removed the `RETURN_IF_EXCEPTION` after `JS{Set,Map}Iterator::create` in those arms as redundant (the `VM&` overload cannot throw), so the same six checks are dropped from the helpers here to follow that rule. Otherwise the helpers are unchanged from the reviewed version.

Fixes #28760
Fixes #34830

### Background
- `Bun__deepEquals` is one template instantiated per entry point: `isStrict` (`toStrictEqual`, `Bun.deepEquals(a, b, true)`), `enableAsymmetricMatchers` (everything reached through `expect()`), and `checkPrototypes` (`node:assert` and `util.isDeepStrictEqual`, which additionally compare prototypes and own properties of Sets and Maps). `specialObjectsDequal` is where it handles types with internal state such as Sets, Maps, Dates and typed arrays.
- `JSSet::has` / `JSMap::get` look a value up by SameValueZero, i.e. identity for objects, so they settle primitives and shared objects in O(1) but say nothing about distinct objects that are structurally equal; those are what the leftover lists contain.
- `MarkedArgumentBuffer` is a GC-visible vector of `JSValue`s; `gcBuffer` in these signatures is one too. A getter running during a nested comparison can mutate the Set or Map being compared and trigger GC, so collected members have to live in one rather than in a plain `WTF::Vector`.
- The `stack` parameter is the cycle-detection stack of (left, right) pairs currently being compared; `addToStack` decides whether a pair is pushed while its own properties or members are compared. A pair found on it is treated as equal, which is what makes cyclic structures terminate.
- An asymmetric matcher (`expect.anything()`, `expect.objectContaining(...)`) is a JSC cell of type `JSDOMWrapperType` that `Bun__deepEquals` consults before anything else when matchers are enabled. Because one matcher can equal many values, "every left entry takes a distinct right entry" can fail even though a valid one-to-one pairing exists, which is why `expect()` needs the fallback.

<details>
<summary>Timing, CPU ms</summary>

Each side is `new Set(Array.from({ length: n }, (_, i) => ({ id: i })))`, or a `new Map` keyed by such objects; fresh process per run, `Bun.gc(true)` before each timed call.

Current release (1.4.0), same-order inputs:

```
                            n:   2500   5000  10000
Bun.deepEquals     Set<obj>      152    611   2437
                   Map<obj,_>    153    615   2457
util.isDeepStrictEqual  Set     1120   4433
expect().toEqual        Set      155    641
node v26.3.0, any of these        ~7     ~7     ~8
```

With this change. These are from the debug+ASAN build (the only one built here), so only the scaling is comparable with the table above:

```
                            n:  10000  20000  40000
Bun.deepEquals     Set<obj>      130    269    528
                   Map<obj,_>    166    303    607
expect().toEqual   Set<obj>      132    256    520
util.isDeepStrictEqual Set      1498   2974
Set<obj>, opposite order (n = 2500 / 5000 / 10000): 33 / 79 / 130
```

The node entry point's larger per-member constant in the debug build is not specific to Sets: strict mode compares class names per object (two plain 10000-element arrays take 661 ms strict versus 57 ms loose in this build), and the double pass mentioned above doubles it.

</details>

<details>
<summary>Assertions in node's test-assert-deep.js that change from failing to passing</summary>

```js
assertNotDeepOrStrict(new Set([{ a: 1 }, { a: 1 }]), new Set([{ a: 1 }, { a: 2 }]));
assertNotDeepOrStrict(new Set([{ a: 1 }, { a: 1 }, { a: 2 }]), new Set([{ a: 1 }, { a: 2 }, { a: 2 }]));   // twice in the file
assertNotDeepOrStrict(new Map([[{ x: 1 }, 5], [{ x: 1 }, 5]]), new Map([[{ x: 1 }, 5], [{ x: 2 }, 5]]));
assertDeepAndStrictEqual(new Map([[{}, 'a'], [{}, 'b']]), new Map([[{}, 'b'], [{}, 'a']]));
assertNotDeepOrStrict(new Set([{}, {}]), new Set([{}, 1]));
assertNotDeepOrStrict(new Set([[{}, 1], [{}, 1]]), new Set([[{}, 1], [1, 1]]));
assertNotDeepOrStrict(new Map([[{}, 1], [{}, 1]]), new Map([[{}, 1], [1, 1]]));
```

The remaining 38 failing call sites in that file are unchanged by this PR (loose-mode primitive coercion such as `Set(['1'])` vs `Set([1])`, error message wording, and similar).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->

