### PR TITLE
css: emit the color-scheme fallback vars once when a merged block is re-minified

### DIFF
--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -72,8 +72,7 @@ impl<'a> PropertyHandlerContext<'a> {
     }
 
     pub(crate) fn add_dark_rule(&mut self, property: css::Property) {
-        // A merged block is re-run through the handlers before its staged rules
-        // are collected (see `flush_pending_style_merge`), staging these again.
+        // A merged block is minified again before its staged rules are collected.
         if !self.dark.iter().any(|staged| staged.eql(&property)) {
             self.dark.push(property);
         }

--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -72,7 +72,11 @@ impl<'a> PropertyHandlerContext<'a> {
     }
 
     pub(crate) fn add_dark_rule(&mut self, property: css::Property) {
-        self.dark.push(property);
+        // A merged block is re-run through the handlers before its staged rules
+        // are collected (see `flush_pending_style_merge`), staging these again.
+        if !self.dark.iter().any(|staged| staged.eql(&property)) {
+            self.dark.push(property);
+        }
     }
 
     pub(crate) fn add_logical_rule(&mut self, ltr: css::Property, rtl: css::Property) {

--- a/src/css/properties/ui.rs
+++ b/src/css/properties/ui.rs
@@ -107,27 +107,18 @@ fn color_scheme_map_get(ident: &[u8]) -> Option<ColorSchemeKeyword> {
 const LIGHT_VAR: &[u8] = b"--buncss-light";
 const DARK_VAR: &[u8] = b"--buncss-dark";
 
-/// Emits the `--buncss-light` / `--buncss-dark` fallback variables for
-/// `color-scheme` when the targets lack `light-dark()`.
-///
-/// Merging adjacent rules (same-query `@media`, same-selector style rules)
-/// re-runs the handlers over the merged block, so a block that already went
-/// through this handler comes back with the variables it emitted as plain
-/// custom properties, followed by the `color-scheme` declaration that emits
-/// them again. The handler therefore owns both variable names and keeps a
-/// block down to one declaration of each, so re-minifying its output
-/// reproduces it instead of growing it.
+/// Compiles `color-scheme` to the `--buncss-light` / `--buncss-dark` variables
+/// when the targets lack `light-dark()`. Merged blocks are minified again, which
+/// feeds those variables back in, so each is kept to one declaration per block.
 #[derive(Default)]
 pub struct ColorSchemeHandler {
     /// Index in `dest` of the declaration currently holding each variable.
     light: Option<usize>,
     dark: Option<usize>,
-    /// `dest.len()` right after the last `color-scheme` declaration pushed in
-    /// this block. A variable declared before it cannot be updated in place
-    /// with a value declared after it: re-minifying the block emits the
-    /// `color-scheme`'s variables again at its position, which would override
-    /// the later value.
-    after_color_scheme: usize,
+    /// Declarations below this index are not updated in place: a `color-scheme`
+    /// declaration emits its variables again when the block is minified again,
+    /// so a value set after it has to stay after it.
+    in_place_from: usize,
 }
 
 // `define_var` needs no arena because `TokenList.v` is a std `Vec<TokenOrValue>`.
@@ -168,7 +159,7 @@ impl ColorSchemeHandler {
                 }
                 // ColorScheme is `Copy` (bitflags u8), so reconstruct the variant directly.
                 dest.push(Property::ColorScheme(color_scheme));
-                self.after_color_scheme = dest.len();
+                self.in_place_from = dest.len();
                 true
             }
             Property::Custom(CustomProperty {
@@ -181,7 +172,7 @@ impl ColorSchemeHandler {
                     _ => return false,
                 };
                 let declaration = property.deep_clone(dest.bump());
-                set_var(slot, self.after_color_scheme, dest, declaration);
+                set_var(slot, self.in_place_from, dest, declaration);
                 true
             }
             _ => false,
@@ -196,13 +187,13 @@ impl ColorSchemeHandler {
     ) {
         set_var(
             &mut self.light,
-            self.after_color_scheme,
+            self.in_place_from,
             dest,
             define_var(LIGHT_VAR, light),
         );
         set_var(
             &mut self.dark,
-            self.after_color_scheme,
+            self.in_place_from,
             dest,
             define_var(DARK_VAR, dark),
         );
@@ -215,21 +206,19 @@ impl ColorSchemeHandler {
     ) {
         self.light = None;
         self.dark = None;
-        self.after_color_scheme = 0;
+        self.in_place_from = 0;
     }
 }
 
-/// Replace the variable's existing declaration in place when it was pushed
-/// after the block's last `color-scheme` declaration (`dest` only grows while a
-/// block is handled, so indices stay valid); otherwise append a new one.
+/// `dest` only grows while a block is handled, so `slot` stays valid.
 fn set_var(
     slot: &mut Option<usize>,
-    after_color_scheme: usize,
+    in_place_from: usize,
     dest: &mut css::DeclarationList,
     declaration: Property,
 ) {
     match *slot {
-        Some(index) if index >= after_color_scheme => dest[index] = declaration,
+        Some(index) if index >= in_place_from => dest[index] = declaration,
         _ => {
             *slot = Some(dest.len());
             dest.push(declaration);

--- a/src/css/properties/ui.rs
+++ b/src/css/properties/ui.rs
@@ -107,17 +107,13 @@ fn color_scheme_map_get(ident: &[u8]) -> Option<ColorSchemeKeyword> {
 const LIGHT_VAR: &[u8] = b"--buncss-light";
 const DARK_VAR: &[u8] = b"--buncss-dark";
 
-/// Compiles `color-scheme` to the `--buncss-light` / `--buncss-dark` variables
-/// when the targets lack `light-dark()`. Merged blocks are minified again, which
-/// feeds those variables back in, so each is kept to one declaration per block.
+/// Compiles `color-scheme` to the `--buncss-light` / `--buncss-dark` variables, one declaration of each per block.
 #[derive(Default)]
 pub struct ColorSchemeHandler {
     /// Index in `dest` of the declaration currently holding each variable.
     light: Option<usize>,
     dark: Option<usize>,
-    /// Declarations below this index are not updated in place: a `color-scheme`
-    /// declaration emits its variables again when the block is minified again,
-    /// so a value set after it has to stay after it.
+    /// Variables before the last `color-scheme` stay put: minifying the block again re-emits them there.
     in_place_from: usize,
 }
 

--- a/src/css/properties/ui.rs
+++ b/src/css/properties/ui.rs
@@ -2,9 +2,12 @@
 use crate as css;
 
 use css::css_properties::Property;
+use css::css_properties::custom::{CustomProperty, CustomPropertyName};
 use css::{PrintErr, Printer, PropertyHandlerContext};
 
 use css::css_values::ident::DashedIdent;
+
+use bun_alloc::ArenaVecExt as _;
 
 // bumpalo::Bump re-export (CSS is an arena crate)
 
@@ -101,8 +104,31 @@ fn color_scheme_map_get(ident: &[u8]) -> Option<ColorSchemeKeyword> {
     }
 }
 
+const LIGHT_VAR: &[u8] = b"--buncss-light";
+const DARK_VAR: &[u8] = b"--buncss-dark";
+
+/// Emits the `--buncss-light` / `--buncss-dark` fallback variables for
+/// `color-scheme` when the targets lack `light-dark()`.
+///
+/// Merging adjacent rules (same-query `@media`, same-selector style rules)
+/// re-runs the handlers over the merged block, so a block that already went
+/// through this handler comes back with the variables it emitted as plain
+/// custom properties, followed by the `color-scheme` declaration that emits
+/// them again. The handler therefore owns both variable names and keeps a
+/// block down to one declaration of each, so re-minifying its output
+/// reproduces it instead of growing it.
 #[derive(Default)]
-pub struct ColorSchemeHandler;
+pub struct ColorSchemeHandler {
+    /// Index in `dest` of the declaration currently holding each variable.
+    light: Option<usize>,
+    dark: Option<usize>,
+    /// `dest.len()` right after the last `color-scheme` declaration pushed in
+    /// this block. A variable declared before it cannot be updated in place
+    /// with a value declared after it: re-minifying the block emits the
+    /// `color-scheme`'s variables again at its position, which would override
+    /// the later value.
+    after_color_scheme: usize,
+}
 
 // `define_var` needs no arena because `TokenList.v` is a std `Vec<TokenOrValue>`.
 impl ColorSchemeHandler {
@@ -120,30 +146,66 @@ impl ColorSchemeHandler {
                     .is_compatible(css::compat::Feature::LightDark)
                 {
                     if color_scheme.contains(ColorScheme::LIGHT) {
-                        dest.push(define_var(b"--buncss-light", css::Token::Ident(b"initial")));
-                        dest.push(define_var(b"--buncss-dark", css::Token::Whitespace(b" ")));
+                        self.define_vars(
+                            dest,
+                            css::Token::Ident(b"initial"),
+                            css::Token::Whitespace(b" "),
+                        );
 
                         if color_scheme.contains(ColorScheme::DARK) {
-                            context.add_dark_rule(define_var(
-                                b"--buncss-light",
-                                css::Token::Whitespace(b" "),
-                            ));
-                            context.add_dark_rule(define_var(
-                                b"--buncss-dark",
-                                css::Token::Ident(b"initial"),
-                            ));
+                            context
+                                .add_dark_rule(define_var(LIGHT_VAR, css::Token::Whitespace(b" ")));
+                            context
+                                .add_dark_rule(define_var(DARK_VAR, css::Token::Ident(b"initial")));
                         }
                     } else if color_scheme.contains(ColorScheme::DARK) {
-                        dest.push(define_var(b"--buncss-light", css::Token::Whitespace(b" ")));
-                        dest.push(define_var(b"--buncss-dark", css::Token::Ident(b"initial")));
+                        self.define_vars(
+                            dest,
+                            css::Token::Whitespace(b" "),
+                            css::Token::Ident(b"initial"),
+                        );
                     }
                 }
                 // ColorScheme is `Copy` (bitflags u8), so reconstruct the variant directly.
                 dest.push(Property::ColorScheme(color_scheme));
+                self.after_color_scheme = dest.len();
+                true
+            }
+            Property::Custom(CustomProperty {
+                name: CustomPropertyName::Custom(name),
+                ..
+            }) => {
+                let slot = match name.v() {
+                    LIGHT_VAR => &mut self.light,
+                    DARK_VAR => &mut self.dark,
+                    _ => return false,
+                };
+                let declaration = property.deep_clone(dest.bump());
+                set_var(slot, self.after_color_scheme, dest, declaration);
                 true
             }
             _ => false,
         }
+    }
+
+    fn define_vars(
+        &mut self,
+        dest: &mut css::DeclarationList,
+        light: css::Token,
+        dark: css::Token,
+    ) {
+        set_var(
+            &mut self.light,
+            self.after_color_scheme,
+            dest,
+            define_var(LIGHT_VAR, light),
+        );
+        set_var(
+            &mut self.dark,
+            self.after_color_scheme,
+            dest,
+            define_var(DARK_VAR, dark),
+        );
     }
 
     pub(crate) fn finalize(
@@ -151,15 +213,36 @@ impl ColorSchemeHandler {
         _: &mut css::DeclarationList<'_>,
         _: &mut PropertyHandlerContext<'_>,
     ) {
+        self.light = None;
+        self.dark = None;
+        self.after_color_scheme = 0;
+    }
+}
+
+/// Replace the variable's existing declaration in place when it was pushed
+/// after the block's last `color-scheme` declaration (`dest` only grows while a
+/// block is handled, so indices stay valid); otherwise append a new one.
+fn set_var(
+    slot: &mut Option<usize>,
+    after_color_scheme: usize,
+    dest: &mut css::DeclarationList,
+    declaration: Property,
+) {
+    match *slot {
+        Some(index) if index >= after_color_scheme => dest[index] = declaration,
+        _ => {
+            *slot = Some(dest.len());
+            dest.push(declaration);
+        }
     }
 }
 
 fn define_var(name: &'static [u8], value: css::Token) -> Property {
-    // `name` is `&'static [u8]` because all call sites pass byte-string literals.
+    // `name` is `&'static [u8]` because all call sites pass `LIGHT_VAR` / `DARK_VAR`.
     // `TokenList.v` is `Vec<TokenOrValue>` (std Vec — see custom.rs:320), so no arena
     // threading is needed here.
-    Property::Custom(css::css_properties::custom::CustomProperty {
-        name: css::css_properties::custom::CustomPropertyName::Custom(DashedIdent { v: name }),
+    Property::Custom(CustomProperty {
+        name: CustomPropertyName::Custom(DashedIdent { v: name }),
         value: css::TokenList {
             v: vec![css::css_properties::custom::TokenOrValue::Token(value)],
         },

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -504,11 +504,8 @@ impl<R> CssRuleList<R> {
 
             'arm: {
                 match rule {
-                    // Left behind by the duplicate check below (`rules[i] =
-                    // Ignored`) when an already minified list is minified
-                    // again, e.g. after a same-query `@media` merge. Pushing it
-                    // would clear the duplicate table and end the merge run
-                    // for a rule that prints nothing.
+                    // Left by the duplicate check below when this list was
+                    // minified before; pushing it would act as a merge barrier.
                     CssRule::Ignored => break 'arm,
                     CssRule::Keyframes(_keyframez) => {
                         // KeyframesRule minify (unused-symbol drop + same-name

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -504,6 +504,12 @@ impl<R> CssRuleList<R> {
 
             'arm: {
                 match rule {
+                    // Left behind by the duplicate check below (`rules[i] =
+                    // Ignored`) when an already minified list is minified
+                    // again, e.g. after a same-query `@media` merge. Pushing it
+                    // would clear the duplicate table and end the merge run
+                    // for a rule that prints nothing.
+                    CssRule::Ignored => break 'arm,
                     CssRule::Keyframes(_keyframez) => {
                         // KeyframesRule minify (unused-symbol drop + same-name
                         // merge + vendor-prefix downlevel + fallbacks) is

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -504,8 +504,7 @@ impl<R> CssRuleList<R> {
 
             'arm: {
                 match rule {
-                    // Left by the duplicate check below when this list was
-                    // minified before; pushing it would act as a merge barrier.
+                    // Left by the duplicate check below when this list was minified before.
                     CssRule::Ignored => break 'arm,
                     CssRule::Keyframes(_keyframez) => {
                         // KeyframesRule minify (unused-symbol drop + same-name

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7536,6 +7536,167 @@ describe("css tests", () => {
         `,
       { chrome: Some(90 << 16) },
     );
+
+    // Merging adjacent rules (same-query @media, same-selector style rules)
+    // re-minifies the already minified block, so the fallback vars emitted by
+    // the first pass come back through the handler. Each pass must produce the
+    // same output rather than adding another copy of the vars (and of the
+    // generated dark-mode rule's declarations).
+    prefix_test(
+      `
+      @media (min-width: 1px) { .foo { color-scheme: light dark; } }
+      @media (min-width: 1px) { .bar { color: red; } }
+      @media (min-width: 1px) { .baz { color: green; } }
+      `,
+      `@media (min-width: 1px) {
+          .foo {
+            --buncss-light: initial;
+            --buncss-dark: ;
+            color-scheme: light dark;
+          }
+
+          @media (prefers-color-scheme: dark) {
+            .foo {
+              --buncss-light: ;
+              --buncss-dark: initial;
+            }
+          }
+
+          .bar {
+            color: red;
+          }
+
+          .baz {
+            color: green;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `
+      @media (min-width: 1px) { .foo { color-scheme: dark; } }
+      @media (min-width: 1px) { .bar { color: red; } }
+      `,
+      `@media (min-width: 1px) {
+          .foo {
+            --buncss-light: ;
+            --buncss-dark: initial;
+            color-scheme: dark;
+          }
+
+          .bar {
+            color: red;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `
+      @media (min-width: 1px) { .foo { color-scheme: light !important; } }
+      @media (min-width: 1px) { .bar { color: red; } }
+      `,
+      `@media (min-width: 1px) {
+          .foo {
+            --buncss-light: initial !important;
+            --buncss-dark: !important;
+            color-scheme: light !important;
+          }
+
+          .bar {
+            color: red;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `
+      .foo { color: red; }
+      .foo { color-scheme: light dark; }
+      `,
+      `.foo {
+          color: red;
+          --buncss-light: initial;
+          --buncss-dark: ;
+          color-scheme: light dark;
+        }
+
+        @media (prefers-color-scheme: dark) {
+          .foo {
+            --buncss-light: ;
+            --buncss-dark: initial;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `
+      .foo { color-scheme: dark; }
+      .foo { color: red; }
+      `,
+      `.foo {
+          --buncss-light: ;
+          --buncss-dark: initial;
+          color-scheme: dark;
+          color: red;
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    // A var set after color-scheme overrides the emitted one, so it has to stay
+    // after color-scheme when the block is re-minified; a var set before it is
+    // overridden by the emitted one and is replaced in place.
+    prefix_test(
+      `
+      .foo { color-scheme: dark; --buncss-light: keep; }
+      .foo { color: red; }
+      `,
+      `.foo {
+          --buncss-light: ;
+          --buncss-dark: initial;
+          color-scheme: dark;
+          --buncss-light: keep;
+          color: red;
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      `
+      .foo { --buncss-light: dead; color-scheme: dark; }
+      .foo { color: red; }
+      `,
+      `.foo {
+          --buncss-light: ;
+          --buncss-dark: initial;
+          color-scheme: dark;
+          color: red;
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
+    // Targets that support light-dark() emit no vars; a re-minified block
+    // must stay untouched.
+    prefix_test(
+      `
+      @media (min-width: 1px) { .foo { color-scheme: light dark; } }
+      @media (min-width: 1px) { .bar { color: red; } }
+      `,
+      `@media (width >= 1px) {
+          .foo {
+            color-scheme: light dark;
+          }
+
+          .bar {
+            color: red;
+          }
+        }
+        `,
+      { firefox: Some(120 << 16) },
+    );
   });
 
   describe("page", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7678,6 +7678,78 @@ describe("css tests", () => {
         `,
       { chrome: Some(90 << 16) },
     );
+    // When the selector is not compatible with the targets (a nested rule
+    // below chrome 88, :has() on any current target), the re-emitted
+    // dark-mode rule cannot be declaration-merged with the previous pass's
+    // copy and is removed as a duplicate instead, which leaves an Ignored
+    // placeholder in the list. The next merge must not treat that placeholder
+    // as a rule, or the copies start piling up again.
+    prefix_test(
+      `
+      @media (min-width: 1px) { .foo { color: red; &:hover { color-scheme: light dark; } } }
+      @media (min-width: 1px) { .bar { color: red; } }
+      @media (min-width: 1px) { .baz { color: green; } }
+      `,
+      `@media (min-width: 1px) {
+          .foo {
+            color: red;
+          }
+
+          .foo:hover {
+            --buncss-light: initial;
+            --buncss-dark: ;
+            color-scheme: light dark;
+          }
+
+          @media (prefers-color-scheme: dark) {
+            .foo:hover {
+              --buncss-light: ;
+              --buncss-dark: initial;
+            }
+          }
+
+          .bar {
+            color: red;
+          }
+
+          .baz {
+            color: green;
+          }
+        }
+        `,
+      { chrome: Some(80 << 16) },
+    );
+    prefix_test(
+      `
+      @media (min-width: 1px) { :root:has(.dark) { color-scheme: light dark; } }
+      @media (min-width: 1px) { .bar { color: red; } }
+      @media (min-width: 1px) { .baz { color: green; } }
+      `,
+      `@media (min-width: 1px) {
+          :root:has(.dark) {
+            --buncss-light: initial;
+            --buncss-dark: ;
+            color-scheme: light dark;
+          }
+
+          @media (prefers-color-scheme: dark) {
+            :root:has(.dark) {
+              --buncss-light: ;
+              --buncss-dark: initial;
+            }
+          }
+
+          .bar {
+            color: red;
+          }
+
+          .baz {
+            color: green;
+          }
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
     // Targets that support light-dark() emit no vars; a re-minified block
     // must stay untouched.
     prefix_test(

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -96,15 +96,15 @@ test("duplicate declarations across merged rules minify in linear time instead o
 // re-minify did for merge runs that interact with the handler context or the
 // merge-with-previous cascade.
 test("deferred merge re-minify keeps per-merge output", () => {
-  // The merged-in rule stages dark-mode fallback vars; its re-minify stages
-  // them again, and both sets belong in this rule's @media extras. The
-  // deferred flush must run before the extras are collected (and must not
-  // assert or leak the re-staged entries into a later rule's extras).
-  expect(cssInternals._test(".a{color:red}.a{color-scheme:light dark}", "", { chrome: 80 << 16 })).toBe(
+  // The merged-in rule stages dark-mode fallback vars, and its re-minify
+  // stages them again (deduplicated into the same entries). The deferred
+  // flush must run before the extras are collected, so the dark-mode rule is
+  // attached to this rule and the re-staged entries are neither leaked into
+  // the next rule's extras (.b must not get a dark-mode rule) nor asserted on.
+  // The re-minify must also not emit a second copy of the fallback vars.
+  expect(cssInternals._test(".a{color:red}.a{color-scheme:light dark}.b{color:blue}", "", { chrome: 80 << 16 })).toBe(
     ".a {\n" +
       "  color: red;\n" +
-      "  --buncss-light: initial;\n" +
-      "  --buncss-dark: ;\n" +
       "  --buncss-light: initial;\n" +
       "  --buncss-dark: ;\n" +
       "  color-scheme: light dark;\n" +
@@ -114,9 +114,11 @@ test("deferred merge re-minify keeps per-merge output", () => {
       "  .a {\n" +
       "    --buncss-light: ;\n" +
       "    --buncss-dark: initial;\n" +
-      "    --buncss-light: ;\n" +
-      "    --buncss-dark: initial;\n" +
       "  }\n" +
+      "}\n" +
+      "\n" +
+      ".b {\n" +
+      "  color: #00f;\n" +
       "}\n",
   );
 


### PR DESCRIPTION
### Problem

- `bun build --minify` (default browser targets) on two adjacent `@media` rules with the same query, the first containing `color-scheme`, emits every fallback declaration twice:
  ```css
  @media (min-width: 1px) { .b { color-scheme: light dark } }
  @media (min-width: 1px) { .c { color: red } }
  ```
  ```css
  @media (min-width:1px){.b{--buncss-light:initial;--buncss-dark: ;--buncss-light:initial;--buncss-dark: ;color-scheme:light dark}@media (prefers-color-scheme:dark){.b{--buncss-light: ;--buncss-dark:initial;--buncss-light: ;--buncss-dark:initial}}.c{color:red}}
  ```
  The same doubling happens when two same-selector style rules merge (`.a{color:red}.a{color-scheme:light dark}`; `test/js/bun/css/duplicate-declaration-merge-hang.test.ts` was pinning that output). Every further merge adds another copy. The output is valid CSS, so this is bloat only.
- Both merges re-run the property handlers over a block that was already minified (`CssRule::Media` arm of `CssRuleList::minify` and `flush_pending_style_merge`, both in `src/css/rules/mod.rs`). `ColorSchemeHandler::handle_property` (`src/css/properties/ui.rs`) does not give the same result for its own output: the `--buncss-light` / `--buncss-dark` declarations it emitted on the first pass come back as ordinary custom properties and are kept, the `color-scheme` declaration after them emits a fresh pair, and `add_dark_rule` stages the `prefers-color-scheme: dark` declarations a second time (`src/css/context.rs`; the staged list becomes a rule without going through the handlers, so it doubles too).
- A second, rule-level copy of the problem shows up when the selector is not compatible with the targets (a nested `&` rule below chrome 88, which is the bundler's default target, `:has()`, `:focus-visible` on old targets): the dark-mode rule re-emitted on each pass cannot be declaration-merged with the previous pass's copy, so it is removed as a duplicate, which leaves a `CssRule::Ignored` placeholder in the list. The next same-query merge minified that list again and treated the placeholder as a rule (pushed it, cleared the duplicate table, ended the merge run), so from then on one extra copy of the dark-mode rule survived every second merge (1, 1, 2, 2, 3, ... copies). lightningcss skips these placeholders and keeps one copy.

### Fix

- `ColorSchemeHandler` remembers the index in the output block of the declaration holding each of its two variables; its own emissions and incoming `--buncss-light` / `--buncss-dark` custom properties update that declaration in place instead of appending, and `finalize` resets the state per block (the same shape as `FallbackHandler`'s `color` / `text-shadow` indices).
- The in-place update is refused for a declaration that sits before a `color-scheme` declaration pushed later in the block (`in_place_from`): a value written after `color-scheme` overrides the emitted one and has to stay after it, because a re-minify emits the `color-scheme` values again at their position. `.foo { color-scheme: dark; --buncss-light: keep }` therefore still means what it meant before, including after a merge. (Upstream's generic custom-property dedupe, which updates the first occurrence in place, loses `keep` in exactly this re-minify, so it is not something to copy here.)
- `PropertyHandlerContext::add_dark_rule` skips a declaration that is already staged; the staged list belongs to the rule being minified and is only drained after the merged block has been settled, so the second pass stages the same two declarations again.
- `CssRuleList::minify` skips `CssRule::Ignored` input entries. They are only ever produced by this function's own duplicate removal, print nothing, and carry nothing a later pass needs; this is also what upstream does.
- Why a handler-level fix rather than a general custom-property dedupe: the handler's own emissions never pass through an input-side dedupe (upstream has one and still doubles the declarations), so the handler has to own its two reserved names either way; and a dedupe of arbitrary custom properties is a separate, user-visible minifier feature (a value-dedupe during merges was turned down in #31279 in favor of #31920, which keeps declarations untouched). For hand-written `--buncss-*` declarations the effect of this change is limited to collapsing repeats of the same variable within one block to its last value, which is the same CSS: within a block the last declaration of a property wins and the relative order of different properties does not matter, and `!important` declarations are tracked by a separate handler instance.
- Scope: the same class of problem exists in two other handlers (`transition` re-adds prefixed `transform` entries, `background-image: image-set()` re-emits its fallbacks, both only on old targets); they are separate code and are filed separately. The `@media` merge loop itself (which re-minifies the accumulated block once per merged rule) is unchanged. One bounded residual remains and matches upstream: a rule that has both `color-scheme: light dark` and logical-property fallbacks ends up with two copies of its dark-mode rule after the first merge (the fresh copy is emitted before the logical rules, the old one arrives after them), and stays at two.
- Verified:
  - `test/js/bun/css/css.test.ts` (`color-scheme` block): three merged `@media` rules with `light dark`, `dark` only and `!important`; both directions of a style-rule merge; a variable written after `color-scheme` surviving a merge; a variable written before it being replaced; the nested `&` (chrome 80) and `:root:has()` (chrome 90) shapes followed by two merges producing one dark-mode rule; targets with `light-dark()` support staying untouched. Nine of these fail on the current release (`USE_SYSTEM_BUN=1`), all pass with the fix.
  - `test/js/bun/css/duplicate-declaration-merge-hang.test.ts`: the pinned style-merge output now expects one copy of each declaration, and a trailing `.b` rule checks that the re-staged dark-mode entries do not leak into the next rule.
  - `bun bd test test/js/bun/css/`, `test/bundler/css/`, `test/bundler/esbuild/css.test.ts`: no output changes (the only local failures are debug-build timeouts in the local-only fuzz and process-spawning tests, see #38500).
  - Sweep under the ASAN debug build: 49,896 (input, targets) runs built from every `color-scheme` value, with `--buncss-*` / other declarations before and after it, `!important`, two `color-scheme` declarations per block, compatible and incompatible selectors, style merges, one to four `@media` merges, a user `prefers-color-scheme: dark` rule, nesting and `@layer`. Minifying the output again reproduces it byte for byte in every run, no block declares the same variable twice between `color-scheme` declarations, and no dark-mode block repeats a rule. On the current release 42,570 of the runs are not stable. A separate probe of 138 other properties across three target sets through both merge paths found only the two handlers mentioned above growing.

### Background

- When the targets do not support `light-dark()`, `color-scheme` is compiled to two custom properties: `--buncss-light` / `--buncss-dark` are set to `initial` or to an empty value so that `var(--buncss-light, X) var(--buncss-dark, Y)` (what `light-dark(X, Y)` compiles to) resolves to one of the two. For `color-scheme: light dark` the handler also stages a `@media (prefers-color-scheme: dark)` rule flipping the two variables; `PropertyHandlerContext` collects staged declarations and `minify_style_arm` turns them into extra rules emitted after the style rule they belong to.
- `DeclarationBlock::minify` feeds each declaration through a chain of property handlers that push into one output list, then calls `finalize` on each handler; the same handler objects are reused for every block. The output list only grows while a block is handled, which is what makes remembering indices into it safe.
- `CssRuleList::minify` merges an `@media` rule into a preceding one with the same query by appending its rules and minifying the combined rule, and merges a style rule into a preceding one with the same selectors by appending its declarations and re-minifying them at the end of the run (#31920). In both cases handlers see their own output as input, so each handler has to produce the same output for it. Duplicate style rules found during a pass are not removed from the list but replaced with `CssRule::Ignored`, which the printer skips.
