### PR TITLE
css: parse calc(<channel> * <percentage>) in relative colors

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -1771,10 +1771,10 @@ impl CalcValue for Percentage {
     fn into_calc(self) -> Calc<Self> {
         Calc::Value(Box::new(self))
     }
-    fn from_calc(c: Calc<Self>, _input: &mut css::Parser) -> CssResult<Self> {
+    fn from_calc(c: Calc<Self>, input: &mut css::Parser) -> CssResult<Self> {
         match c {
             Calc::Value(v) => Ok(*v),
-            _ => Ok(Percentage { v: f32::NAN }),
+            _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
         }
     }
     #[inline]

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2184,12 +2184,8 @@ impl RelativeComponentParser {
         Err(input.new_error_for_next_token())
     }
 
-    /// A math function the `<number>` pass could not fold, evaluated as a
-    /// `<percentage>` and returned as a unit value. The keywords are `<number>`s
-    /// first, per CSS Color 5 (`calc(r * 50%)`). That fails for the forms bun has
-    /// always accepted with the keyword standing for a percentage of its range
-    /// (`calc(l + 10%)`, and `min(r, g)`, which `reduce_args` only folds over
-    /// values), so those are retried that way.
+    /// A `<percentage>` math function, as a unit value. The keywords are `<number>`s
+    /// (`calc(r * 50%)`), else percentages of their range as before (`calc(l + 10%)`).
     fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
         if let Ok(unit_value) = input.try_parse(|i| {
             RelativeComponentParser::parse_percentage_calc(i, this, |ctx, ident| {

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2185,17 +2185,32 @@ impl RelativeComponentParser {
     }
 
     /// A math function the `<number>` pass could not fold, evaluated as a
-    /// `<percentage>` and returned as a unit value. A keyword is its channel as
-    /// a percentage of the channel's range here, which is what folds
-    /// `min(r, g)` (`reduce_args` only compares values) and what gives
-    /// `calc(l + 10%)` its pre-existing meaning. Callers try `parse_number`
-    /// first, so a math function over plain numbers gets the CSS Color 5
-    /// meaning, in which the keywords are `<number>`s.
+    /// `<percentage>` and returned as a unit value. The keywords are `<number>`s
+    /// first, per CSS Color 5 (`calc(r * 50%)`). That fails for the forms bun has
+    /// always accepted with the keyword standing for a percentage of its range
+    /// (`calc(l + 10%)`, and `min(r, g)`, which `reduce_args` only folds over
+    /// values), so those are retried that way.
     fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
-        match Calc::<Percentage>::parse_with(input, this, |ctx, ident| {
+        if let Ok(unit_value) = input.try_parse(|i| {
+            RelativeComponentParser::parse_percentage_calc(i, this, |ctx, ident| {
+                Some(Calc::Number(ctx.get_number(ident, ChannelType::NUMBER)?))
+            })
+        }) {
+            return Ok(unit_value);
+        }
+
+        RelativeComponentParser::parse_percentage_calc(input, this, |ctx, ident| {
             let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;
             Some(Calc::Value(Box::new(Percentage { v: unit_value })))
-        }) {
+        })
+    }
+
+    fn parse_percentage_calc(
+        input: &mut css::Parser,
+        this: &RelativeComponentParser,
+        keyword: impl Fn(&RelativeComponentParser, &[u8]) -> Option<Calc<Percentage>> + Copy,
+    ) -> CssResult<f32> {
+        match Calc::<Percentage>::parse_with(input, this, keyword) {
             Ok(Calc::Value(v)) => Ok(v.v),
             _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
         }

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2184,8 +2184,7 @@ impl RelativeComponentParser {
         Err(input.new_error_for_next_token())
     }
 
-    /// A `<percentage>` math function, as a unit value. The keywords are `<number>`s
-    /// (`calc(r * 50%)`), else percentages of their range as before (`calc(l + 10%)`).
+    /// A `<percentage>` math function over the channel keywords, as a unit value.
     fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
         if let Ok(unit_value) = input.try_parse(|i| {
             RelativeComponentParser::parse_percentage_calc(i, this, |ctx, ident| {
@@ -2195,6 +2194,7 @@ impl RelativeComponentParser {
             return Ok(unit_value);
         }
 
+        // Keyword as a percentage of its range: `calc(l + 10%)`, `min(r, g)`.
         RelativeComponentParser::parse_percentage_calc(input, this, |ctx, ident| {
             let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;
             Some(Calc::Value(Box::new(Percentage { v: unit_value })))

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -550,6 +550,103 @@ describe("css string output parses back to the same color", () => {
   });
 });
 
+// https://drafts.csswg.org/css-color-5/#relative-colors
+// Inside a math function a channel keyword is a <number> in the function's
+// range, so multiplying it by a <percentage> gives a <percentage> of the
+// channel. Every value in the first three groups is lightningcss 1.30 output.
+describe("relative color calc() with percentages", () => {
+  const origin = "color(srgb .8 .4 .2)";
+
+  test.each([
+    ["calc(r * 50%)", ".4"],
+    ["calc(50% * r)", ".4"],
+    ["calc(r * -50%)", "-.4"],
+    ["calc(r * 50% + 10%)", ".5"],
+    ["calc(50% - r * 25%)", ".3"],
+    ["calc(r / 2 * 100%)", ".4"],
+    ["calc(r * g * 50%)", ".16"],
+    ["calc((r + g) * 50%)", ".6"],
+    ["min(r * 50%, 30%)", ".3"],
+    ["max(r * 50%, 30%)", ".4"],
+    ["round(r * 100%, 30%)", ".9"],
+    ["mod(r * 100%, 30%)", ".2"],
+    ["hypot(r * 100%, 30%)", ".8544"],
+  ])("%s is a percentage of the channel", (expr, expected) => {
+    expect(color(`color(from ${origin} srgb ${expr} g b)`, "css")).toBe(`color(srgb ${expected} .4 .2)`);
+  });
+
+  const spaces: [space: string, channels: string, printed?: string][] = [
+    ["srgb", "g b"],
+    ["srgb-linear", "g b"],
+    ["display-p3", "g b"],
+    ["prophoto-rgb", "g b"],
+    ["rec2020", "g b"],
+    ["xyz-d50", "y z"],
+    ["xyz-d65", "y z", "xyz"],
+    ["xyz", "y z"],
+  ];
+  test.each(spaces)("color(from ... %s calc(<channel> * <percentage>))", (space, channels, printed = space) => {
+    const [b, c] = channels.split(" ");
+    expect(color(`color(from color(${space} .8 .4 .2) ${space} ${b} calc(${b} * 50%) calc(50% * ${c}))`, "css")).toBe(
+      `color(${printed} .4 .2 .1)`,
+    );
+  });
+
+  // The keyword is the channel's <number> in the function's own range (r is 200
+  // in rgb(), s is 50 in hsl(), l is 50 in lab() and .5 in oklab()), not the
+  // unit value the color is stored as.
+  test.each([
+    ["rgb(from rgb(200 100 50) calc(r * 50%) g b)", "#ff6432"],
+    ["rgb(from rgb(200 100 50) calc(r * 0.1%) g b)", "#336432"],
+    ["rgb(from rgb(200 100 50) r g b / calc(r * 0.1%))", "#c8643233"],
+    ["rgb(from rgb(200 100 50 / .5) r g b / calc(alpha * 50%))", "#c8643240"],
+    ["hsl(from hsl(120 50% 40%) h calc(s * 50%) l)", "#0c0"],
+    ["hsl(from hsl(120 50% 40%) h calc(s * 1%) l)", "#393"],
+    ["hsl(from hsl(120 50% 40%) h s calc(l * 1.5%))", "#6c6"],
+    ["hsl(from hsl(120 50% 40%) h s l / calc(s * 0.5%))", "#33993340"],
+    ["hwb(from hwb(120 20% 30%) h calc(w * 2%) b)", "#66b366"],
+    ["hwb(from hwb(120 20% 30% / .5) h w b / calc(alpha * 50%))", "#33b33340"],
+    ["lab(from lab(50% 20 30) calc(l * 1.2%) a b)", "lab(60% 20 30)"],
+    ["lab(from lab(50% 20 30) l a b / calc(l * 1%))", "lab(50% 20 30 / .5)"],
+    ["lch(from lch(50% 30 120) calc(l * 1%) c h)", "lch(50% 30 120)"],
+    ["lch(from lch(50% 30 120 / .5) l c h / calc(alpha * 50%))", "lch(50% 30 120 / .25)"],
+    ["oklab(from oklab(50% .1 .1) calc(l * 50%) a b)", "oklab(25% .1 .1)"],
+    ["oklab(from oklab(50% .1 .1 / .5) l a b / calc(50% * alpha))", "oklab(50% .1 .1 / .25)"],
+    ["oklch(from oklch(50% .1 120) calc(l * 50%) c h)", "oklch(25% .1 120)"],
+    ["oklch(from oklch(50% .1 120 / .5) l c h / calc(alpha * 50%))", "oklch(50% .1 120 / .25)"],
+    ["color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha * 50%))", "color(srgb .8 .4 .2 / .25)"],
+  ])("%s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  // Forms bun accepted before, with the keyword standing for a percentage of its
+  // range (the documented `calc(l + 15%)`), still mean what they did.
+  test.each([
+    ["lab(from lab(50% 20 30) calc(l + 15%) a b)", "lab(65% 20 30)"],
+    ["hsl(from hsl(120 50% 40%) h calc(s - 10%) l)", "#3d8f3d"],
+    ["rgb(from rgb(200 100 50 / .5) r g b / calc(alpha - 20%))", "#c864324d"],
+    [`color(from ${origin} srgb calc(r + 10%) g b)`, "color(srgb .9 .4 .2)"],
+    [`color(from ${origin} srgb min(r, 50%) g b)`, "color(srgb .5 .4 .2)"],
+    [`color(from ${origin} srgb min(r, g) g b)`, "color(srgb .4 .4 .2)"],
+    [`color(from ${origin} srgb calc(r * .5) g b)`, "color(srgb .4 .4 .2)"],
+  ])("%s still parses", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test.each([
+    `color(from ${origin} srgb calc(r * 50% + .1) g b)`,
+    `color(from ${origin} srgb calc(r * 50% - g) g b)`,
+    `color(from ${origin} srgb calc(r * 50% * 10%) g b)`,
+    // Without relative color syntax there is no keyword to fall back on; these
+    // used to evaluate to NaN and parse as a `none` channel.
+    "color(srgb calc(1 + 50%) 0 0)",
+    "color(srgb calc(50% + 1) 0 0)",
+    "hsl(120 calc(50% + 1) 40%)",
+  ])("%s mixes a number and a percentage and does not parse", input => {
+    expect(color(input, "css")).toBeNull();
+  });
+});
+
 describe("input forms", () => {
   test.each([
     ["a named color", "red"],

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -180,6 +180,71 @@ describe("css tests", () => {
     minify_test(`a { opacity: calc(NaN) }`, `a{opacity:0}`);
     minify_test(`a { rotate: calc(NaN * 1deg) }`, `a{rotate:0deg}`);
     minify_test(`a { transition-duration: calc(NaN * 1s) }`, `a{transition-duration:0s}`);
+
+    // A <number> and a <percentage> cannot be added: the declaration is invalid and
+    // is left as written, not evaluated to NaN and serialized as 0.
+    minify_test(`a { opacity: calc(50% + 1) }`, `a{opacity:calc(50% + 1)}`);
+    minify_test(`a { opacity: calc(1 - 50%) }`, `a{opacity:calc(1 - 50%)}`);
+    minify_test(`a { opacity: calc(50% + 25%) }`, `a{opacity:.75}`);
+    minify_test(`a { opacity: calc(50% * 1.5) }`, `a{opacity:.75}`);
+  });
+
+  describe("relative color calc() with percentages", () => {
+    // https://drafts.csswg.org/css-color-5/#relative-colors: a channel keyword is
+    // a <number> in the function's range, so `calc(r * 50%)` is a <percentage> of
+    // the channel. Expected values are lightningcss output.
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb calc(r * 50%) calc(50% * g) b) }",
+      ".foo{color:color(srgb .4 .2 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(display-p3 .8 .4 .2) display-p3 r calc(g * 50% + 10%) calc(50% - b * 50%)) }",
+      ".foo{color:color(display-p3 .8 .3 .4)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb min(r * 50%, 30%) max(g * 50%, 30%) b) }",
+      ".foo{color:color(srgb .3 .3 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb round(r * 100%, 30%) g b) }",
+      ".foo{color:color(srgb .9 .4 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2 / .5) srgb r g b / calc(alpha * 50%)) }",
+      ".foo{color:color(srgb .8 .4 .2/.25)}",
+    );
+    minify_test(".foo { color: rgb(from rgb(200 100 50) calc(r * 50%) g b) }", ".foo{color:#ff6432}");
+    minify_test(".foo { color: rgb(from rgb(200 100 50) calc(r * 0.1%) g b) }", ".foo{color:#336432}");
+    minify_test(".foo { color: rgb(from rgb(200 100 50) r g b / calc(r * 0.1%)) }", ".foo{color:#c8643233}");
+    minify_test(".foo { color: rgb(from rgb(200 100 50 / .5) r g b / calc(alpha * 50%)) }", ".foo{color:#c8643240}");
+    // Not `rgb(255 0 0/calc(alpha*50%))`, which no browser accepts.
+    minify_test(".foo { color: rgb(from red r g b / calc(alpha * 50%)) }", ".foo{color:#ff000080}");
+    minify_test(".foo { color: hsl(from hsl(120 50% 40%) h calc(s * 50%) l) }", ".foo{color:#0c0}");
+    minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l * 1.5%)) }", ".foo{color:#6c6}");
+    minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s l / calc(s * 0.5%)) }", ".foo{color:#33993340}");
+    minify_test(".foo { color: hwb(from hwb(120 20% 30%) h calc(w * 2%) b) }", ".foo{color:#66b366}");
+    minify_test(".foo { color: lab(from lab(50% 20 30) calc(l * 1.2%) a b) }", ".foo{color:lab(60% 20 30)}");
+    minify_test(".foo { color: lab(from lab(50% 20 30) l a b / calc(l * 1%)) }", ".foo{color:lab(50% 20 30/.5)}");
+    minify_test(".foo { color: lch(from lch(50% 30 120) calc(l * 1%) c h) }", ".foo{color:lch(50% 30 120)}");
+    minify_test(".foo { color: oklab(from oklab(50% .1 .1) calc(l * 50%) a b) }", ".foo{color:oklab(25% .1 .1)}");
+    minify_test(
+      ".foo { color: oklch(from oklch(50% .1 120 / .5) l c h / calc(alpha * 50%)) }",
+      ".foo{color:oklch(50% .1 120/.25)}",
+    );
+
+    // The keyword-as-percentage forms bun accepted before keep their meaning.
+    minify_test(".foo { color: lab(from lab(50% 20 30) calc(l + 15%) a b) }", ".foo{color:lab(65% 20 30)}");
+    minify_test(".foo { color: rgb(from rgb(200 100 50 / .5) r g b / calc(alpha - 20%)) }", ".foo{color:#c864324d}");
+    minify_test(
+      ".foo { color: color(from color(srgb .8 .4 .2) srgb min(r, 50%) calc(g + 10%) b) }",
+      ".foo{color:color(srgb .5 .5 .2)}",
+    );
+
+    minify_test(
+      ".foo { color: color(from red srgb calc(r * 50% + .1) g b) }",
+      ".foo{color:color(from red srgb calc(r*50% + .1)g b)}",
+    );
+    minify_test(".foo { color: color(srgb calc(1 + 50%) 0 0) }", ".foo{color:color(srgb calc(1 + 50%)0 0)}");
   });
   describe("calc stack overflow", () => {
     // https://github.com/oven-sh/bun/issues/20128


### PR DESCRIPTION
Stacked on #38553 (this PR's base branch); the diff shown here is only this change. It needs #38553 because the values it folds are the keyword numbers that PR introduces.

### Problem
- In relative color syntax, a math function that multiplies a channel keyword by a percentage never parses: `Bun.color("color(from red srgb calc(r * 50%) g b)", "css")` is `null`, and in a stylesheet the declaration is kept as an unparsed token stream (no folding, no fallbacks). `calc(r * 0.5)` works; `calc(50% * r)`, `min(r * 50%, 30%)`, `calc(l * 1%)` and `calc(alpha * 50%)` do not, in every color function. lightningcss 1.30.2 folds all of them.
- For `rgb()`/`hsl()`/`hwb()` it is worse than not folding: `rgb(from red r g b / calc(alpha * 50%))` is emitted as `rgb(255 0 0/calc(alpha*50%))`, which no browser accepts, because the path that keeps an unparseable alpha verbatim (how `/ var(--alpha)` is supported) takes over.
- Cause: `RelativeComponentParser::parse_percentage` (the `Calc<Percentage>` pass, `src/css/values/color.rs`) only knows a keyword as a `Percentage` value. `r * 50%` is then a percentage times a percentage, which `Calc::parse_product` rejects (one operand has to be a `Calc::Number`).
- `Percentage::from_calc` (`src/css/values/calc.rs`) returned `Percentage { v: NaN }` for anything that is not a plain value, so adding a number to a percentage silently produced NaN: `opacity: calc(50% + 1)` minifies to `opacity:0` today and `color(srgb calc(1 + 50%) 0 0)` to `color(srgb none 0 0)`.

### Fix
- `parse_percentage` evaluates the expression twice at most: first with each keyword as the `<number>` #38553 gives it (`get_number`: `r` is 200 in `rgb()`, `l` is 50 in `lab()`, `.8` in `color(srgb ...)`), which is what CSS Color 5 says the keyword is and folds `calc(r * 50%)` to a percentage of the channel; if that fails, with the keyword as a percentage of its range, which is exactly the evaluation the pass did before. The second pass keeps `calc(l + 15%)` (the example in `docs/bundler/css.mdx` until #38553 reworded it), `calc(alpha - 20%)`, `min(r, 50%)` and `min(r, g)` meaning what they meant; nothing that folded before stops folding or changes value. The helper `parse_percentage_calc` is the old body, parameterized on the keyword callback.
- `Percentage::from_calc` fails like the `Angle` and `Time` impls next to it instead of producing NaN. The first pass relies on this: with NaN, `calc(l + 15%)` would come out of the first pass as a NaN channel instead of reaching the second one. It also turns `opacity: calc(50% + 1)` and `color(srgb calc(1 + 50%) 0 0)` into declarations left as written, which is what a browser does with them. Upstream's equivalent conversion is `unreachable!()` (it panics on `opacity: calc(50% + 1)`); the NaN came from the Zig port.
- Why the values are right: the number pass produces the same percentages lightningcss does in every function, because the keywords are in the function's range and a percentage result maps onto the stored unit value for all of them (`100%` is 255 in `rgb()`, 100 in `hsl()`/`lab()`, 1 in `oklab()`/`color()`/alpha). Every value asserted in the first three test groups is byte-identical to lightningcss 1.30.2 output, including `rgb(from rgb(200 100 50) calc(r * 50%) g b)` saturating to `#ff6432`, `calc(r * 0.1%)` giving `#336432`, and `lab(from lab(50% 20 30) calc(l * 1.2%) a b)` giving `lab(60% 20 30)`. An earlier revision of this PR sat on main and fed the stored unit values into the multiply, which gave `#646432` for the first of those; that is why it is stacked now.
- Verified with `bun bd test test/js/bun/css/color.test.ts` (block `relative color calc() with percentages`: 13 expression shapes, every `color()` space, channel and alpha positions in all eight functions, the forms that keep their old meaning, and the forms that are invalid either way) and `bun bd test test/js/bun/css/css.test.ts` (the same through the minifier, plus the `opacity` cases in `calc edge case`). With this PR's `src/` changes removed (base branch alone), 43 of the 53 new `color.test.ts` cases and 22 of the 28 new `css.test.ts` cases fail; the rest pin behavior that must not change. All of `test/js/bun/css/`, `test/bundler/css/` and the css regression tests pass on the stacked branch (2545 tests), including every test #38553 adds.

### Background
- Relative color syntax (`rgb(from <origin> r g b / alpha)`, `color(from <origin> srgb r g b)`) lets a channel be written as a keyword naming the origin's channel, or as a math function over those keywords. CSS Color 5 defines the keywords as `<number>`s in the range of the function being written (`r` in `rgb()` is 0..255, in `color()` 0..1); #38553 is what makes bun resolve them that way.
- `Calc<V>` is the parsed form of a math function over values of type `V`. `Calc::Number` is a dimensionless number and `Calc::Value(V)` a typed value; `*` needs one `Calc::Number` operand, `+` converts both sides to `V` through `from_calc`, and `min()`/`max()` fold through `reduce_args`, which only compares `Calc::Value`s (this is why `min(r, g)` folds in the second pass and not the first).
- A relative component is parsed by trying the expression as `Calc<f32>` (all numbers; `parse_number`) and then as `Calc<Percentage>` (`parse_percentage`, the function this PR changes); the consumers divide a number by the channel's range and take a percentage as the stored unit value directly.
- When a declaration's value fails to parse, bun keeps its raw tokens and prints them back, which is why the bug shows up as missing folding rather than an error, except in `rgb()`/`hsl()`/`hwb()`, whose unparsed-alpha path resolves the channels and prints the alpha tokens as they were.

<details>
<summary>Before / after (bun build --minify; the last column is also what lightningcss 1.30.2 emits)</summary>

```
input                                                      main / #38553                        this PR
color(from red srgb calc(r * 50%) g b)                     unparsed                             color(srgb .5 0 0)
rgb(from rgb(200 100 50) calc(r * 50%) g b)                unparsed                             #ff6432
rgb(from rgb(200 100 50) calc(r * 0.1%) g b)               unparsed                             #336432
rgb(from rgb(200 100 50) r g b / calc(r * 0.1%))           unparsed                             #c8643233
rgb(from red r g b / calc(alpha * 50%))                    rgb(255 0 0/calc(alpha*50%))         #ff000080
hsl(from hsl(120 50% 40%) h s calc(l * 1.5%))              unparsed                             #6c6
lab(from lab(50% 20 30) calc(l * 1.2%) a b)                unparsed                             lab(60% 20 30)
lab(from lab(50% 20 30) l a b / calc(l * 1%))              unparsed                             lab(50% 20 30/.5)
oklab(from oklab(50% .1 .1) calc(l * 50%) a b)             unparsed                             oklab(25% .1 .1)
color(from color(srgb .8 .4 .2) srgb min(r * 50%, 30%) g b) unparsed                            color(srgb .3 .4 .2)
lab(from lab(50% 20 30) calc(l + 15%) a b)                 lab(65% 20 30)                       lab(65% 20 30)      (unchanged; lightningcss: unparsed)
color(from color(srgb .8 .4 .2) srgb min(r, 50%) g b)      color(srgb .5 .4 .2)                 color(srgb .5 .4 .2) (unchanged; lightningcss: unparsed)
color(srgb calc(1 + 50%) 0 0)                              color(srgb none 0 0)                 unparsed            (lightningcss: panics)
opacity: calc(50% + 1)                                     0                                    calc(50% + 1)       (lightningcss: panics)
```

</details>
