### PR TITLE
css: print negative numbers below 1 with a single minus sign

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1699,22 +1699,6 @@ pub fn trim_leading_char(slice: &[u8], char: u8) -> &[u8] {
     b""
 }
 
-/// Trim leading pattern of 2 bytes
-///
-/// e.g.
-/// `trim_leading_pattern2("abcdef", 'a', 'b') == "cdef"`
-pub fn trim_leading_pattern2(slice_: &[u8], byte1: u8, byte2: u8) -> &[u8] {
-    let mut slice = slice_;
-    while slice.len() >= 2 {
-        if slice[0] == byte1 && slice[1] == byte2 {
-            slice = &slice[2..];
-        } else {
-            break;
-        }
-    }
-    slice
-}
-
 /// prefix is of type &[u8] or &[u16]
 pub fn trim_prefix_comptime<'a, T: crate::NoUninit + Eq>(
     buffer: &'a [T],

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5892,16 +5892,31 @@ pub mod serializer {
             token
                 .to_css_generic(&mut fbs)
                 .map_err(|_| dest.add_fmt_error())?;
-            let s = fbs.get_written();
-            if value < 0.0 {
-                dest.write_str("-")?;
-                dest.write_bytes(strings::trim_leading_pattern2(s, b'-', b'0'))
-            } else {
-                dest.write_bytes(strings::trim_leading_char(s, b'0'))
-            }
+            write_without_leading_zero(fbs.get_written(), dest)
         } else {
             token.to_css_generic(dest).map_err(|_| dest.add_fmt_error())
         }
+    }
+
+    /// Writes a serialized number whose magnitude is below 1 without the zero in
+    /// front of the decimal point: `0.5px` -> `.5px`, `-0.5px` -> `-.5px`.
+    ///
+    /// Not every such number has that zero: `dtoa_short` prints magnitudes below
+    /// 1e-6 in exponent form (`-1e-7`) and rounds -0.9999999 to `-1`. Those are
+    /// written unchanged.
+    pub(crate) fn write_without_leading_zero(
+        number: &[u8],
+        dest: &mut Printer,
+    ) -> Result<(), PrintErr> {
+        let rest: &[u8] = match number {
+            [b'-', b'0', b'.', ..] => {
+                dest.write_char(b'-')?;
+                &number[2..]
+            }
+            [b'0', b'.', ..] => &number[1..],
+            _ => number,
+        };
+        dest.write_str(rest)
     }
 
     /// Write a CSS identifier, escaping characters as necessary.

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5898,12 +5898,8 @@ pub mod serializer {
         }
     }
 
-    /// Writes a serialized number whose magnitude is below 1 without the zero in
-    /// front of the decimal point: `0.5px` -> `.5px`, `-0.5px` -> `-.5px`.
-    ///
-    /// Not every such number has that zero: `dtoa_short` prints magnitudes below
-    /// 1e-6 in exponent form (`-1e-7`) and rounds -0.9999999 to `-1`. Those are
-    /// written unchanged.
+    /// `0.5px` -> `.5px`, `-0.5px` -> `-.5px`. A magnitude below 1 can also leave
+    /// `dtoa_short` as `-1e-7` or, rounded, `-1`; those have no zero to drop.
     pub(crate) fn write_without_leading_zero(
         number: &[u8],
         dest: &mut Printer,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5898,8 +5898,7 @@ pub mod serializer {
         }
     }
 
-    /// `0.5px` -> `.5px`, `-0.5px` -> `-.5px`. A magnitude below 1 can also leave
-    /// `dtoa_short` as `-1e-7` or, rounded, `-1`; those have no zero to drop.
+    /// `0.5px` -> `.5px`, `-0.5px` -> `-.5px`; `-1e-7px` and `-1px` are written as is.
     pub(crate) fn write_without_leading_zero(
         number: &[u8],
         dest: &mut Printer,

--- a/src/css/values/number.rs
+++ b/src/css/values/number.rs
@@ -26,12 +26,7 @@ impl CSSNumberFns {
         if number != 0.0 && number.abs() < 1.0 {
             let mut dtoa_buf: [u8; 129] = [0; 129];
             let (str, _) = css::dtoa_short(&mut dtoa_buf, number, 6);
-            if number < 0.0 {
-                dest.write_char(b'-')?;
-                dest.write_str(bun_core::strings::trim_leading_pattern2(str, b'-', b'0'))
-            } else {
-                dest.write_str(bun_core::trim_leading_char(str, b'0'))
-            }
+            css::serializer::write_without_leading_zero(str, dest)
         } else {
             css::to_css::float32(number, dest)
         }

--- a/src/css/values/percentage.rs
+++ b/src/css/values/percentage.rs
@@ -47,14 +47,7 @@ impl Percentage {
             if percent.to_css_generic(&mut fbs).is_err() {
                 return Err(dest.add_fmt_error());
             }
-            let buf = fbs.get_written();
-            if self.v < 0.0 {
-                dest.write_char(b'-')?;
-                dest.write_str(bun_core::strings::trim_leading_pattern2(buf, b'-', b'0'))?;
-            } else {
-                dest.write_str(bun_core::trim_leading_char(buf, b'0'))?;
-            }
-            Ok(())
+            css::serializer::write_without_leading_zero(fbs.get_written(), dest)
         } else {
             percent.to_css(dest)
         }

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -229,6 +229,13 @@ test("invalid format string lists the accepted values", () => {
 const weird = [
   ["rgb(-255, 0, 0)", "#000"],
   ["rgb(256, 0, 0)", "red"],
+  // Negative components that print in exponent form or round to -1 used to come out with two
+  // minus signs ("lab(50% --5e-8 0)"), which no CSS parser, including Bun.color, accepts.
+  ["lab(50% -0.00000005 0)", "lab(50% -5e-8 0)"],
+  ["lch(50% 10 -0.0000001)", "lch(50% 10 -1e-7)"],
+  ["color(srgb 0 -0.000000192523 1)", "color(srgb 0 -1.92523e-7 1)"],
+  ["color(display-p3 -0.9999999 0 0)", "color(display-p3 -1 0 0)"],
+  ["lab(50% -0.5 0)", "lab(50% -.5 0)"],
 ];
 describe("weird", () => {
   test.each(weird)("color(%s, 'css') === %s", (input, expected) => {
@@ -537,6 +544,18 @@ describe("css string output parses back to the same color", () => {
     expect(components).toHaveLength(3);
     for (let i = 0; i < 3; i++) {
       expect(components[i]).toBeCloseTo((reference as number[])[i], 1);
+    }
+  });
+
+  test("tiny negative components round-trip", () => {
+    for (const input of [
+      "lab(50% -0.00000005 0)",
+      "lch(50% 10 -0.0000001)",
+      "color(srgb 0 -0.000000192523 1)",
+      "color(display-p3 -0.9999999 0 0)",
+    ]) {
+      const css = color(input, "css") as string;
+      expect(color(css, "css")).toBe(css);
     }
   });
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2256,13 +2256,13 @@ describe("css tests", () => {
       `,
     );
 
-    // Color space conversions routinely leave components like these behind. The exact residual
-    // depends on the platform's libm, so only check that every component is a number.
-    test("relative color conversion prints each component as a number", () => {
-      const output = minify_test_with_options(".foo{color:color(from color(display-p3 0 0 1) srgb r g b)}", "");
-      const number = String.raw`-?(?:\d+(?:\.\d+)?|\.\d+)(?:e-?\d+)?`;
-      expect(output).toMatch(new RegExp(String.raw`^\.foo\{color:color\(srgb ${number} ${number} ${number}\)\}$`));
-    });
+    // Color space conversions leave components like this behind on their own: the green
+    // channel of display-p3 blue in sRGB is an f32 rounding residual. (The blue channel goes
+    // through powf and is not pinned here.)
+    minify_test(
+      ".foo{color:color(from color(display-p3 0 0 1) srgb r g 1)}",
+      ".foo{color:color(srgb 0 -1.92523e-7 1)}",
+    );
   });
 
   describe("padding", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2190,6 +2190,81 @@ describe("css tests", () => {
     }
   });
 
+  describe("numbers with a magnitude below 1", () => {
+    // The printer drops the zero in front of the decimal point (-0.5 -> -.5). Negative values
+    // that dtoa prints in exponent form (-0.0000001 -> -1e-7) or rounds up to -1 have no such
+    // zero; they used to come out with a second minus sign (--1e-7, --1), which is not a number.
+    describe("<number>", () => {
+      minify_test(".foo{opacity:-0.0000001}", ".foo{opacity:-1e-7}");
+      minify_test(".foo{opacity:-0.9999999}", ".foo{opacity:-1}");
+      minify_test(".foo{opacity:-0.5}", ".foo{opacity:-.5}");
+      minify_test(".foo{opacity:-0.05}", ".foo{opacity:-.05}");
+      minify_test(".foo{opacity:0.0000001}", ".foo{opacity:1e-7}");
+      minify_test(".foo{opacity:0.9999999}", ".foo{opacity:1}");
+      minify_test(".foo{opacity:0.5}", ".foo{opacity:.5}");
+      minify_test(".foo{line-height:-0.0000001}", ".foo{line-height:-1e-7}");
+      minify_test(".foo{flex-grow:-0.0000001}", ".foo{flex-grow:-1e-7}");
+      minify_test(".foo{aspect-ratio:-0.0000001/-0.9999999}", ".foo{aspect-ratio:-1e-7/-1}");
+      minify_test(".foo{transition-duration:-0.0000001s}", ".foo{transition-duration:-1e-7s}");
+      minify_test(":root{--x:-0.0000001}", ":root{--x:-1e-7}");
+      minify_test(":root{--x:-0.9999999}", ":root{--x:-1}");
+      minify_test(":root{--x:-0.5}", ":root{--x:-.5}");
+      minify_test(".foo{color:color(srgb 0 -0.000000192523 1)}", ".foo{color:color(srgb 0 -1.92523e-7 1)}");
+      minify_test(".foo{color:lab(50% -0.00000005 0)}", ".foo{color:lab(50% -5e-8 0)}");
+      minify_test(".foo{color:oklab(50% -0.00000005 0)}", ".foo{color:oklab(50% -5e-8 0)}");
+      minify_test(
+        ".foo{transform:translate(-0.0000001px,-0.9999999px)scale(-0.0000001,-0.9999999)}",
+        ".foo{transform:translate(-1e-7px,-1px)scale(-1e-7,-1)}",
+      );
+    });
+
+    describe("<dimension>", () => {
+      minify_test(".foo{margin:-0.0000001px}", ".foo{margin:-1e-7px}");
+      minify_test(".foo{margin:-0.9999999px}", ".foo{margin:-1px}");
+      minify_test(".foo{margin:-0.5px}", ".foo{margin:-.5px}");
+      minify_test(".foo{margin:0.0000001px}", ".foo{margin:1e-7px}");
+      minify_test(".foo{margin:0.5px}", ".foo{margin:.5px}");
+      minify_test(".foo{width:calc(1px * -0.0000001)}", ".foo{width:-1e-7px}");
+      minify_test(".foo{rotate:-0.0000001deg}", ".foo{rotate:-1e-7deg}");
+      minify_test(":root{--x:-0.0000001px}", ":root{--x:-1e-7px}");
+      minify_test(":root{--x:-0.9999999px}", ":root{--x:-1px}");
+      minify_test(":root{--x:-0.5px}", ":root{--x:-.5px}");
+    });
+
+    describe("<percentage>", () => {
+      minify_test(".foo{width:-0.0000005%}", ".foo{width:-5e-7%}");
+      minify_test(".foo{width:-0.9999999%}", ".foo{width:-1%}");
+      minify_test(".foo{width:-0.5%}", ".foo{width:-.5%}");
+      minify_test(".foo{width:0.0000005%}", ".foo{width:5e-7%}");
+      minify_test(".foo{width:0.5%}", ".foo{width:.5%}");
+    });
+
+    cssTest(
+      `
+        .foo {
+          opacity: -0.0000001;
+          width: -0.0000005%;
+          margin: -0.9999999px;
+        }
+      `,
+      indoc`
+        .foo {
+          opacity: -1e-7;
+          width: -5e-7%;
+          margin: -1px;
+        }
+      `,
+    );
+
+    // Color space conversions routinely leave components like these behind. The exact residual
+    // depends on the platform's libm, so only check that every component is a number.
+    test("relative color conversion prints each component as a number", () => {
+      const output = minify_test_with_options(".foo{color:color(from color(display-p3 0 0 1) srgb r g b)}", "");
+      const number = String.raw`-?(?:\d+(?:\.\d+)?|\.\d+)(?:e-?\d+)?`;
+      expect(output).toMatch(new RegExp(String.raw`^\.foo\{color:color\(srgb ${number} ${number} ${number}\)\}$`));
+    });
+  });
+
   describe("padding", () => {
     cssTest(
       `


### PR DESCRIPTION
### Problem
- The CSS printer writes small negative numbers with two minus signs: `.a{opacity:-0.0000001}` becomes `.a{opacity:--1e-7}`, `margin:-0.0000001px` becomes `margin:--1e-7px`, `color(srgb 0 -0.000000192523 1)` becomes `color(srgb 0 --1.92523e-7 1)`. `--1e-7` tokenizes as an identifier, so browsers drop the declaration. Same on released bun 1.4.0 and main, with or without `--minify`; lightningcss prints `-1e-7` / `-1e-7px` / `-1.92523e-7`.
- Values that round up to 1 hit it too: `opacity:-0.9999999` prints `--1`, `margin:-0.9999999px` prints `--1px`, `width:-0.9999999%` prints `--1%`.
- It also happens without unusual input: color space conversions leave residuals like this behind, e.g. `color(from color(display-p3 0 0 1) srgb r g b)` printed `color(srgb 0 --1.92523e-7 1.04202)`.
- `Bun.color()` prints through the same code, so `Bun.color("lab(50% -0.00000005 0)", "css")` (and with no format argument) returned `"lab(50% --5e-8 0)"`, a string `Bun.color` itself parses as `null`, although the `"css"` format is documented to return valid CSS.
- Cause: three copies of the same shortcut, in `CSSNumberFns::to_css` (`src/css/values/number.rs`), `Percentage::to_css` (`src/css/values/percentage.rs`) and `serializer::serialize_dimension` (`src/css/css_parser.rs`). For a value with a magnitude below 1 they format it and strip the leading zero; on the negative side they write `-` and then strip a `-0` prefix (`trim_leading_pattern2(s, b'-', b'0')`). `dtoa_short` prints magnitudes below 1e-6 in exponent form (`-1e-7`) and rounds `-0.9999999` to `-1`, so there is no `-0` prefix to strip and the extra `-` lands in front of the one already in the string.

### Fix
- One helper, `serializer::write_without_leading_zero`, replaces the three copies: it strips a `0.` or `-0.` prefix (`-0.5px` -> `-.5px`) and writes anything else unchanged (`-1e-7px`, `-1px`). `trim_leading_pattern2` in `bun_core` had no other callers and is removed.
- Correct because the only place a formatted number below 1 has a droppable zero is the `0.` in front of the decimal point; a number in exponent form or rounded to `1` has nothing to drop, and the sign is now the one dtoa wrote rather than a second one written by the caller. Number and dimension output now matches lightningcss; the percentage path is the same code shape (lightningcss 1.30.2 still prints `width:-0.9999999%` as `--1%`), and its output now matches what bun already printed for the same value in a custom property (`--x:-0.9999999%` -> `-1%`).
- Verified:
  - `test/js/bun/css/css.test.ts` ("numbers with a magnitude below 1"): 35 cases across the number, dimension and percentage printers, custom properties, calc, colors, transforms, the non-minified printer and the display-p3 -> sRGB residual above (pinned with the blue channel replaced by a literal so no `powf` result is in the expected string). 22 fail on the released build (`--1e-7`, `--1`, `--1px`, `--5e-7%`, `--1.92523e-7`, ...), 13 pin the unchanged `-.5` / `1e-7` / `1` output; all 35 pass with the fix.
  - `test/js/bun/css/color.test.ts`: four `Bun.color(x, "css")` / `Bun.color(x)` cases (`lab`, `lch`, `color(srgb)`, `color(display-p3)`) plus a round-trip check that the `"css"` output parses back; all fail on the released build, pass with the fix. The rest of the file, including its 432 snapshots, is unchanged.
  - `test/js/bun/css/` (2325 tests) and `test/bundler/css/` (169 tests, including the WPT color conversions) pass with the debug build. Two tests in `nested-vendor-prefix-duplication.test.ts` / `selector-list-error-recovery.test.ts` sit at the 5s timeout on this debug+ASAN machine; they print only integers and do not reach the changed code.
  - `cargo fmt --check` and `cargo clippy -p bun_css -p bun_core` are clean.

### Background
- `dtoa_short` (`src/css/css_parser.rs`) is the float formatter behind every CSS number bun prints: WebKit's number-to-string output (the same format as JavaScript's `Number#toString`, which switches to exponent form below 1e-6) rounded to 6 significant digits. It is a port of the `dtoa-short` crate lightningcss uses, so the digits it produces match lightningcss, including rounding `-0.9999999` to `-1`.
- CSS allows a `<number>` to omit the zero before the decimal point, so the minifier prints `0.5` as `.5` and `-0.5` as `-.5`. This shortcut is taken in three printers: plain numbers (`opacity`, color components, `transform` arguments, custom property tokens), dimensions (lengths, angles, custom property dimension tokens, `calc()` results) and percentages.
- A CSS token starting with `--` is an identifier (the custom property syntax), not a number, which is why `--1e-7` makes the whole declaration invalid rather than being read as a negative number.
