### PR TITLE
Name anonymous export default functions and classes "default" in stack traces and inspect

### DIFF
--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -524,56 +524,15 @@ String sourceURL(JSC::VM& vm, JSC::JSFunction* function)
     return Zig::sourceURL(function->jsExecutable()->source());
 }
 
-String functionNameForDisplay(JSC::VM& vm, const JSC::Identifier& name)
+String functionNameForDisplay(JSC::VM& vm, String name)
 {
-    if (name == vm.propertyNames->starDefaultPrivateName) {
+    // Compared by identity: the private identifier's string is its own unique StringImpl, so a
+    // function that is really called "starDefault" keeps its name.
+    if (name.impl() == vm.propertyNames->starDefaultPrivateName.impl()) {
         return vm.propertyNames->defaultKeyword.string();
     }
 
-    return name.string();
-}
-
-// Own data properties only: this also runs from error finalizers, where getters must not run
-// and nothing may be allocated on the JS heap.
-static String ownStringPropertyWithoutGC(JSC::JSObject* object, const JSC::Identifier& propertyName)
-{
-    unsigned attributes;
-    PropertyOffset offset = object->structure()->getConcurrently(propertyName.impl(), attributes);
-    if (offset == invalidOffset || (attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
-        return String();
-    }
-
-    JSValue value = object->getDirect(offset);
-    if (!value || !value.isString()) {
-        return String();
-    }
-
-    return asString(value)->tryGetValueWithoutGC();
-}
-
-String calculatedDisplayName(JSC::VM& vm, JSC::JSObject* object)
-{
-    auto jstype = object->type();
-    if (jstype != JSC::JSFunctionType && jstype != JSC::InternalFunctionType) {
-        return emptyString();
-    }
-
-    String displayName = ownStringPropertyWithoutGC(object, vm.propertyNames->displayName);
-    if (!displayName.isEmpty()) {
-        return displayName;
-    }
-
-    if (jstype == JSC::InternalFunctionType) {
-        return uncheckedDowncast<JSC::InternalFunction>(object)->name();
-    }
-
-    auto* function = uncheckedDowncast<JSC::JSFunction>(object);
-    String name = function->nameWithoutGC(vm);
-    if (!name.isEmpty() || function->isHostFunction()) {
-        return name;
-    }
-
-    return functionNameForDisplay(vm, function->jsExecutable()->ecmaName());
+    return name;
 }
 
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
@@ -586,7 +545,7 @@ String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
     }
 
     if (codeType == JSC::FunctionCode) {
-        return functionNameForDisplay(vm, uncheckedDowncast<JSC::FunctionExecutable>(executable)->ecmaName());
+        return functionNameForDisplay(vm, uncheckedDowncast<JSC::FunctionExecutable>(executable)->ecmaName().string());
     }
 
     return String();
@@ -594,7 +553,9 @@ String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
 
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* object)
 {
-    if (object->type() == JSC::ProxyObjectType) return {};
+    WTF::String functionName;
+    auto jstype = object->type();
+    if (jstype == JSC::ProxyObjectType) return {};
 
     // First try the "name" property.
     {
@@ -617,7 +578,30 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::
         }
     }
 
-    return calculatedDisplayName(vm, object);
+    {
+        // Then try the "displayName" property (what this does internally)
+        auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        functionName = JSC::getCalculatedDisplayName(vm, object);
+        if (topExceptionScope.exception()) [[unlikely]] {
+            (void)topExceptionScope.tryClearException();
+        }
+    }
+
+    {
+        if (functionName.isEmpty()) {
+            if (jstype == JSC::JSFunctionType) {
+                auto* function = uncheckedDowncast<JSC::JSFunction>(object);
+                functionName = function->nameWithoutGC(vm);
+                if (functionName.isEmpty() && !function->isHostFunction()) {
+                    functionName = function->jsExecutable()->ecmaName().string();
+                }
+            } else if (jstype == JSC::InternalFunctionType) {
+                functionName = uncheckedDowncast<JSC::InternalFunction>(object)->name();
+            }
+        }
+    }
+
+    return functionNameForDisplay(vm, WTF::move(functionName));
 }
 
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const JSC::StackFrame& frame, FinalizerSafety finalizerSafety, unsigned int* flags)
@@ -628,17 +612,63 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const
         if (auto* callee = frame.callee()) {
             if (auto* object = callee->getObject()) {
                 auto jstype = object->type();
-                if (flags && (jstype == JSC::JSFunctionType || jstype == JSC::InternalFunctionType)) {
-                    *flags |= static_cast<unsigned int>(FunctionNameFlags::Function);
-                }
+                Structure* structure = object->structure();
+
+                auto setTypeFlagsIfNecessary = [&]() {
+                    if (flags) {
+                        if (jstype == JSC::JSFunctionType || jstype == JSC::InternalFunctionType) {
+                            *flags |= static_cast<unsigned int>(FunctionNameFlags::Function);
+                        }
+                    }
+                };
 
                 // First try the "name" property.
-                String name = ownStringPropertyWithoutGC(object, vm.propertyNames->name);
-                if (!name.isEmpty()) {
-                    return name;
+                {
+                    unsigned attributes;
+                    PropertyOffset offset = structure->getConcurrently(vm.propertyNames->name.impl(), attributes);
+                    if (offset != invalidOffset && !(attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
+                        JSValue name = object->getDirect(offset);
+                        if (name && name.isString()) {
+                            auto str = asString(name)->tryGetValueWithoutGC();
+                            if (!str->isEmpty()) {
+                                setTypeFlagsIfNecessary();
+                                return str;
+                            }
+                        }
+                    }
                 }
 
-                return calculatedDisplayName(vm, object);
+                // Then try the "displayName" property.
+                {
+                    unsigned attributes;
+                    PropertyOffset offset = structure->getConcurrently(vm.propertyNames->displayName.impl(), attributes);
+                    if (offset != invalidOffset && !(attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
+                        JSValue name = object->getDirect(offset);
+                        if (name && name.isString()) {
+                            auto str = asString(name)->tryGetValueWithoutGC();
+                            if (!str->isEmpty()) {
+                                setTypeFlagsIfNecessary();
+                                return str;
+                            }
+                        }
+                    }
+                }
+
+                // Lastly, try type-specific properties.
+                if (jstype == JSC::JSFunctionType) {
+                    auto* function = uncheckedDowncast<JSC::JSFunction>(object);
+                    auto str = function->nameWithoutGC(vm);
+                    if (str.isEmpty() && !function->isHostFunction()) {
+                        setTypeFlagsIfNecessary();
+                        return functionNameForDisplay(vm, function->jsExecutable()->ecmaName().string());
+                    }
+                    setTypeFlagsIfNecessary();
+                    return str;
+                } else if (jstype == JSC::InternalFunctionType) {
+                    auto str = uncheckedDowncast<JSC::InternalFunction>(object)->name();
+                    setTypeFlagsIfNecessary();
+                    return str;
+                }
             }
         }
 

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -526,8 +526,7 @@ String sourceURL(JSC::VM& vm, JSC::JSFunction* function)
 
 String functionNameForDisplay(JSC::VM& vm, String name)
 {
-    // Compared by identity: the private identifier's string is its own unique StringImpl, so a
-    // function that is really called "starDefault" keeps its name.
+    // Identity, not equality: a function that is actually named "starDefault" keeps its name.
     if (name.impl() == vm.propertyNames->starDefaultPrivateName.impl()) {
         return vm.propertyNames->defaultKeyword.string();
     }

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -524,6 +524,58 @@ String sourceURL(JSC::VM& vm, JSC::JSFunction* function)
     return Zig::sourceURL(function->jsExecutable()->source());
 }
 
+String functionNameForDisplay(JSC::VM& vm, const JSC::Identifier& name)
+{
+    if (name == vm.propertyNames->starDefaultPrivateName) {
+        return vm.propertyNames->defaultKeyword.string();
+    }
+
+    return name.string();
+}
+
+// Own data properties only: this also runs from error finalizers, where getters must not run
+// and nothing may be allocated on the JS heap.
+static String ownStringPropertyWithoutGC(JSC::JSObject* object, const JSC::Identifier& propertyName)
+{
+    unsigned attributes;
+    PropertyOffset offset = object->structure()->getConcurrently(propertyName.impl(), attributes);
+    if (offset == invalidOffset || (attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
+        return String();
+    }
+
+    JSValue value = object->getDirect(offset);
+    if (!value || !value.isString()) {
+        return String();
+    }
+
+    return asString(value)->tryGetValueWithoutGC();
+}
+
+String calculatedDisplayName(JSC::VM& vm, JSC::JSObject* object)
+{
+    auto jstype = object->type();
+    if (jstype != JSC::JSFunctionType && jstype != JSC::InternalFunctionType) {
+        return emptyString();
+    }
+
+    String displayName = ownStringPropertyWithoutGC(object, vm.propertyNames->displayName);
+    if (!displayName.isEmpty()) {
+        return displayName;
+    }
+
+    if (jstype == JSC::InternalFunctionType) {
+        return uncheckedDowncast<JSC::InternalFunction>(object)->name();
+    }
+
+    auto* function = uncheckedDowncast<JSC::JSFunction>(object);
+    String name = function->nameWithoutGC(vm);
+    if (!name.isEmpty() || function->isHostFunction()) {
+        return name;
+    }
+
+    return functionNameForDisplay(vm, function->jsExecutable()->ecmaName());
+}
+
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
 {
     auto codeType = codeBlock->codeType();
@@ -534,7 +586,7 @@ String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
     }
 
     if (codeType == JSC::FunctionCode) {
-        return uncheckedDowncast<JSC::FunctionExecutable>(executable)->ecmaName().string();
+        return functionNameForDisplay(vm, uncheckedDowncast<JSC::FunctionExecutable>(executable)->ecmaName());
     }
 
     return String();
@@ -542,9 +594,7 @@ String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock)
 
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* object)
 {
-    WTF::String functionName;
-    auto jstype = object->type();
-    if (jstype == JSC::ProxyObjectType) return {};
+    if (object->type() == JSC::ProxyObjectType) return {};
 
     // First try the "name" property.
     {
@@ -567,30 +617,7 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::
         }
     }
 
-    {
-        // Then try the "displayName" property (what this does internally)
-        auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        functionName = JSC::getCalculatedDisplayName(vm, object);
-        if (topExceptionScope.exception()) [[unlikely]] {
-            (void)topExceptionScope.tryClearException();
-        }
-    }
-
-    {
-        if (functionName.isEmpty()) {
-            if (jstype == JSC::JSFunctionType) {
-                auto* function = uncheckedDowncast<JSC::JSFunction>(object);
-                functionName = function->nameWithoutGC(vm);
-                if (functionName.isEmpty() && !function->isHostFunction()) {
-                    functionName = function->jsExecutable()->ecmaName().string();
-                }
-            } else if (jstype == JSC::InternalFunctionType) {
-                functionName = uncheckedDowncast<JSC::InternalFunction>(object)->name();
-            }
-        }
-    }
-
-    return functionName;
+    return calculatedDisplayName(vm, object);
 }
 
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const JSC::StackFrame& frame, FinalizerSafety finalizerSafety, unsigned int* flags)
@@ -601,63 +628,17 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const
         if (auto* callee = frame.callee()) {
             if (auto* object = callee->getObject()) {
                 auto jstype = object->type();
-                Structure* structure = object->structure();
-
-                auto setTypeFlagsIfNecessary = [&]() {
-                    if (flags) {
-                        if (jstype == JSC::JSFunctionType || jstype == JSC::InternalFunctionType) {
-                            *flags |= static_cast<unsigned int>(FunctionNameFlags::Function);
-                        }
-                    }
-                };
+                if (flags && (jstype == JSC::JSFunctionType || jstype == JSC::InternalFunctionType)) {
+                    *flags |= static_cast<unsigned int>(FunctionNameFlags::Function);
+                }
 
                 // First try the "name" property.
-                {
-                    unsigned attributes;
-                    PropertyOffset offset = structure->getConcurrently(vm.propertyNames->name.impl(), attributes);
-                    if (offset != invalidOffset && !(attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
-                        JSValue name = object->getDirect(offset);
-                        if (name && name.isString()) {
-                            auto str = asString(name)->tryGetValueWithoutGC();
-                            if (!str->isEmpty()) {
-                                setTypeFlagsIfNecessary();
-                                return str;
-                            }
-                        }
-                    }
+                String name = ownStringPropertyWithoutGC(object, vm.propertyNames->name);
+                if (!name.isEmpty()) {
+                    return name;
                 }
 
-                // Then try the "displayName" property.
-                {
-                    unsigned attributes;
-                    PropertyOffset offset = structure->getConcurrently(vm.propertyNames->displayName.impl(), attributes);
-                    if (offset != invalidOffset && !(attributes & (PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue))) {
-                        JSValue name = object->getDirect(offset);
-                        if (name && name.isString()) {
-                            auto str = asString(name)->tryGetValueWithoutGC();
-                            if (!str->isEmpty()) {
-                                setTypeFlagsIfNecessary();
-                                return str;
-                            }
-                        }
-                    }
-                }
-
-                // Lastly, try type-specific properties.
-                if (jstype == JSC::JSFunctionType) {
-                    auto* function = uncheckedDowncast<JSC::JSFunction>(object);
-                    auto str = function->nameWithoutGC(vm);
-                    if (str.isEmpty() && !function->isHostFunction()) {
-                        setTypeFlagsIfNecessary();
-                        return function->jsExecutable()->ecmaName().string();
-                    }
-                    setTypeFlagsIfNecessary();
-                    return str;
-                } else if (jstype == JSC::InternalFunctionType) {
-                    auto str = uncheckedDowncast<JSC::InternalFunction>(object)->name();
-                    setTypeFlagsIfNecessary();
-                    return str;
-                }
+                return calculatedDisplayName(vm, object);
             }
         }
 

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -235,6 +235,17 @@ public:
     static constexpr unsigned AddNewKeyword = 1 << 4;
 };
 
+// The name JSC recorded for a function, as it should be shown to users. An anonymous
+// `export default` is bound to the private `*default*` identifier, which stringifies as
+// "starDefault"; its reified `name` property is "default" (JSFunction::reifyName).
+String functionNameForDisplay(JSC::VM& vm, const JSC::Identifier& name);
+
+// Bun's counterpart of JSC::getCalculatedDisplayName: a non-empty own "displayName" property, else
+// the function's own name, else (for JS functions) its ecmaName via functionNameForDisplay. Empty
+// for anything that is not a function. Runs no JS and allocates nothing on the JS heap, so it is
+// also used to format stack traces from error finalizers.
+String calculatedDisplayName(JSC::VM& vm, JSC::JSObject* object);
+
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock);
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* callee);
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const JSC::StackFrame& frame, FinalizerSafety, unsigned int* flags);

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -235,16 +235,10 @@ public:
     static constexpr unsigned AddNewKeyword = 1 << 4;
 };
 
-// The name JSC recorded for a function, as it should be shown to users. An anonymous
-// `export default` is bound to the private `*default*` identifier, which stringifies as
-// "starDefault"; its reified `name` property is "default" (JSFunction::reifyName).
-String functionNameForDisplay(JSC::VM& vm, const JSC::Identifier& name);
-
-// Bun's counterpart of JSC::getCalculatedDisplayName: a non-empty own "displayName" property, else
-// the function's own name, else (for JS functions) its ecmaName via functionNameForDisplay. Empty
-// for anything that is not a function. Runs no JS and allocates nothing on the JS heap, so it is
-// also used to format stack traces from error finalizers.
-String calculatedDisplayName(JSC::VM& vm, JSC::JSObject* object);
+// An anonymous `export default` is bound to JSC's private `*default*` identifier, whose string is
+// "starDefault". JSC only substitutes "default" when it reifies the function's `name` property
+// (JSFunction::reifyName); apply the same substitution to a name taken from the executable instead.
+String functionNameForDisplay(JSC::VM& vm, String name);
 
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock);
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* callee);

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -235,9 +235,7 @@ public:
     static constexpr unsigned AddNewKeyword = 1 << 4;
 };
 
-// An anonymous `export default` is bound to JSC's private `*default*` identifier, whose string is
-// "starDefault". JSC only substitutes "default" when it reifies the function's `name` property
-// (JSFunction::reifyName); apply the same substitution to a name taken from the executable instead.
+// Renders an anonymous `export default`'s internal `*default*` binding as "default", like JSFunction::reifyName does for `.name`.
 String functionNameForDisplay(JSC::VM& vm, String name);
 
 String functionName(JSC::VM& vm, JSC::CodeBlock* codeBlock);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4957,8 +4957,7 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
             return;
         }
 
-        // JSFunction::name() returns "" for the `*default*` binding of an anonymous `export default`.
-        actualName = Zig::functionNameForDisplay(vm, function->jsExecutable()->name());
+        actualName = Zig::functionNameForDisplay(vm, function->jsExecutable()->name().string());
 
         *arg2 = Zig::toZigString(actualName);
         return;
@@ -4982,7 +4981,7 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
-    auto displayName = Zig::calculatedDisplayName(vm, object);
+    auto displayName = Zig::functionNameForDisplay(vm, JSC::getCalculatedDisplayName(vm, object));
 
     // JSC doesn't include @@toStringTag in calculated display name
     if (displayName.isEmpty()) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4957,7 +4957,8 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
             return;
         }
 
-        actualName = function->jsExecutable()->name().string();
+        // JSFunction::name() returns "" for the `*default*` binding of an anonymous `export default`.
+        actualName = Zig::functionNameForDisplay(vm, function->jsExecutable()->name());
 
         *arg2 = Zig::toZigString(actualName);
         return;
@@ -4981,7 +4982,7 @@ void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalOb
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = value.getObject();
-    auto displayName = JSC::getCalculatedDisplayName(vm, object);
+    auto displayName = Zig::calculatedDisplayName(vm, object);
 
     // JSC doesn't include @@toStringTag in calculated display name
     if (displayName.isEmpty()) {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -148,4 +148,121 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// JSC binds an anonymous `export default` to the internal `*default*` identifier and only maps it
+// to the observable name "default" when the `name` property is reified. Frame names must say
+// "default" too (as node does), whether or not something has read `.name` yet.
+describe("anonymous export default is named 'default'", () => {
+  const modules = {
+    "class.mjs": `export default class { constructor() { this.stack = new Error("class").stack; } }`,
+    "subclass.mjs": `
+      class Base { constructor() { this.stack = new Error("subclass").stack; } }
+      export default class extends Base {}
+    `,
+    "arrow.mjs": `export default () => new Error("arrow").stack;`,
+    "expression.mjs": `export default (function () { return new Error("expression").stack; });`,
+    // A function really called starDefault keeps its name; only the internal binding is renamed.
+    "named-star-default.mjs": `export default function starDefault() { return new Error("starDefault").stack; }`,
+    "throws.mjs": `export default class { constructor() { throw new Error("thrown by an anonymous default export"); } }`,
+    "uncaught.mjs": `
+      import Thrower from "./throws.mjs";
+      new Thrower();
+    `,
+    "unhandled-rejection.mjs": `
+      import Thrower from "./throws.mjs";
+      Promise.resolve().then(() => new Thrower());
+    `,
+    "main.mjs": `
+      import Class from "./class.mjs";
+      import Subclass from "./subclass.mjs";
+      import arrow from "./arrow.mjs";
+      import expression from "./expression.mjs";
+      import starDefault from "./named-star-default.mjs";
+
+      const frameNames = (stack, count) =>
+        stack
+          .split("\\n")
+          .slice(1, 1 + count)
+          .map(line => line.trim().replace(/^at /, "").replace(/ \\(.*$/, ""));
+
+      const topCallSite = getStack => {
+        const previous = Error.prepareStackTrace;
+        Error.prepareStackTrace = (_, callSites) => [callSites[0].getFunctionName(), callSites[0].isConstructor()];
+        try {
+          return getStack();
+        } finally {
+          Error.prepareStackTrace = previous;
+        }
+      };
+
+      const observe = () => ({
+        class: frameNames(new Class().stack, 1),
+        subclass: frameNames(new Subclass().stack, 2),
+        arrow: frameNames(arrow(), 1),
+        expression: frameNames(expression(), 1),
+        starDefault: frameNames(starDefault(), 1),
+        callSites: [topCallSite(() => new Class().stack), topCallSite(arrow)],
+      });
+
+      const beforeReadingName = observe();
+      const names = [Class.name, Subclass.name, arrow.name, expression.name, starDefault.name];
+      const afterReadingName = observe();
+      console.log(JSON.stringify({ beforeReadingName, names, afterReadingName }));
+    `,
+  };
+
+  const expected = {
+    class: ["new default"],
+    subclass: ["new Base", "new default"],
+    arrow: ["default"],
+    expression: ["default"],
+    starDefault: ["starDefault"],
+    callSites: [
+      ["default", true],
+      ["default", false],
+    ],
+  };
+
+  test.concurrent("error.stack and CallSite#getFunctionName", async () => {
+    using dir = tempDir("export-default-name", modules);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: JSON.parse(stdout), stderr, exitCode }).toEqual({
+      result: {
+        beforeReadingName: expected,
+        names: ["default", "default", "default", "default", "starDefault"],
+        afterReadingName: expected,
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Bun's own error printer names frames through a separate, GC-safe lookup from error.stack.
+  test.concurrent.each([
+    ["uncaught.mjs", ["at new default (file:NN:NN)", "at <dir>/uncaught.mjs"]],
+    ["unhandled-rejection.mjs", ["at new default (file:NN:NN)", "at <anonymous> (file:NN:NN)"]],
+  ])("frames printed for an uncaught error: %s", async (entry, frames) => {
+    using dir = tempDir("export-default-name", modules);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const printedFrames = normalizeBunSnapshot(stderr, String(dir))
+      .split("\n")
+      .map(line => line.trim().replace(/:\d+:\d+$/, ""))
+      .filter(line => line.startsWith("at "));
+    expect({ stdout, printedFrames, exitCode }).toEqual({ stdout: "", printedFrames: frames, exitCode: 1 });
+  });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
+import { readdir } from "node:fs/promises";
+import { gzip } from "node:zlib";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -649,6 +651,18 @@ it("anonymous export default class and function are named 'default'", async () =
     stderr: "",
     exitCode: 0,
   });
+});
+
+// Bun's built-in modules are compiled as JSC builtins. zlib's convenience methods and fs.promises'
+// wrappers are anonymous function expressions that get their `name` defined afterwards; the local
+// variable each was assigned to inside the module (`fn`, `wrapped`) must not show up here.
+it("functions from built-in modules do not inspect as their internal variable name", () => {
+  expect([gzip.name, Bun.inspect(gzip), readdir.name, Bun.inspect(readdir)]).toEqual([
+    "gzip",
+    "[Function]",
+    "readdir",
+    "[AsyncFunction]",
+  ]);
 });
 
 it("console.log on a Blob shows name", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -615,6 +615,40 @@ describe("console.logging class displays names and extends", async () => {
       expect(Bun.inspect(cases[i])).toBe(expected_logs[i]);
     });
   }
+});
+
+// JSC names an anonymous `export default` after its internal `*default*` binding; `.name` is
+// "default", and so is what node prints.
+it("anonymous export default class and function are named 'default'", async () => {
+  using dir = tempDir("inspect-export-default", {
+    "class.mjs": `export default class {}`,
+    "subclass.mjs": `
+      export class Base {}
+      export default class extends Base {}
+    `,
+    "arrow.mjs": `export default () => {};`,
+    "main.mjs": `
+      import Class from "./class.mjs";
+      import Subclass from "./subclass.mjs";
+      import arrow from "./arrow.mjs";
+
+      const element = { $$typeof: Symbol.for("react.element"), type: Class, props: {}, key: null };
+      console.log(JSON.stringify([Class, Subclass, arrow, element].map(value => Bun.inspect(value))));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ inspected: JSON.parse(stdout), stderr, exitCode }).toEqual({
+    inspected: ["[class default]", "[class default extends Base]", "[Function: default]", "<default />"],
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 it("console.log on a Blob shows name", () => {


### PR DESCRIPTION
### Problem

- A stack frame inside an anonymous `export default class { ... }` renders as `at new starDefault (p.mjs:1:55)` until something reads the class's `.name`; after that the same frame renders `at new default (...)`, which is also what node prints. `D.name` itself is always `"default"`, so the frame name depends on evaluation order.
- Same for `export default class extends Base {}` (synthesized constructor), `export default () => ...` and `export default (function () { ... })`, and on every surface that shows a frame name: `error.stack`, `CallSite#getFunctionName()` under `Error.prepareStackTrace`, and the frames Bun's own uncaught error / unhandled rejection printer writes to stderr.
- `Bun.inspect` / `console.log` of the class or function prints `[class starDefault]`, `[class starDefault extends Base]`, `[Function: starDefault]`, and a JSX element whose type is such a class prints `<starDefault />` (node: `[class default]`, `[Function: default]`). These stay wrong even after `.name` is read.
- Cause: JSC binds an anonymous default export to the private `*default*` identifier (`vm.propertyNames->starDefaultPrivateName`, whose string is `"starDefault"`) and only substitutes `"default"` when it reifies the `name` property (`JSFunction::reifyName`). Bun's name lookups use an already reified own `name` property when there is one and otherwise take the name from the executable, where it is still the raw identifier:
  - `src/jsc/bindings/ErrorStackTrace.cpp`: `functionName(vm, codeBlock)` and the `FinalizerSafety::MustNotTriggerGC` branch read `ecmaName()` directly; `functionName(vm, globalObject, object)` gets it through `JSC::getCalculatedDisplayName`, whose last fallback is `ecmaName()` too.
  - `src/jsc/bindings/bindings.cpp`: `JSC__JSValue__getName` (inspect of functions and classes, `describe(Class)` names) through `JSC::getCalculatedDisplayName`, and `JSC__JSValue__getNameProperty` (JSX tag names) through `jsExecutable()->name()`. That fallback is only reached when `JSFunction::name()` returned `""`, which it does precisely for `*default*`, so it could only ever produce `""` or `"starDefault"`.

### Fix

- `Zig::functionNameForDisplay(vm, name)` returns `"default"` when `name` is the `*default*` identifier's string and returns `name` unchanged otherwise. The five fallbacks above pass their result through it; nothing else about any lookup changes, so every other name comes out exactly as before (verified below for the builtin-module functions that the first revision of this PR got wrong).
- The check is `name.impl() == starDefaultPrivateName.impl()`, the same comparison `Identifier::operator==` performs in `JSFunction::reifyName`. The private identifier's string is its own unique `StringImpl`, so a function that is really named `starDefault` is left alone.
- Why this is correct: `"default"` is the name JSC itself reifies for these functions (`JSFunction::reifyName` and `JSFunction::originalName` apply the same substitution), so the lookups now return the same string before and after `.name` is materialized, and they match node for every shape above.
- The fuller shape of this fix is in JSC: `JSFunction::calculatedDisplayName` / `getCalculatedDisplayName` (and the callers of `ecmaName()` in `StackFrame`, `SamplingProfiler` and the inspector) have the same missing substitution, which is also why `console.log(new D())` still prints `starDefault {}` (`JSObject::calculatedClassName`, tracked in #38530) and why `--cpu-prof` and the debugger show the same name. Fixing it in the fork would cover all of those and reduce this PR to its tests; that needs a WebKit PR and a version bump, and the two direct `ecmaName()` reads in `ErrorStackTrace.cpp` are Bun's own code either way. This PR fixes the surfaces Bun formats itself now; when the fork applies the substitution, `functionNameForDisplay` becomes an identity function and can be deleted along with its five call sites.
- Also fixed by the same change today, without a dedicated test here: the `Received function starDefault` suffix of native `ERR_INVALID_ARG_TYPE` messages, since `determineSpecificType` uses `functionName(vm, globalObject, object)`; #38473 independently reworks that call site to read `.name`.
- Verified:
  - `test/js/bun/test/stack.test.ts` ("anonymous export default is named 'default'"): `error.stack` for all four shapes plus a control function really named `starDefault`, `CallSite#getFunctionName()`, before and after `.name` is read, and the frames printed for an uncaught throw and an unhandled rejection (those go through the `MustNotTriggerGC` branch; confirmed by reverting only that line, which fails exactly those two cases). All three fail on the released bun with `starDefault` and pass with this change.
  - `test/js/bun/util/inspect.test.js` ("anonymous export default class and function are named 'default'"): `[class default]`, `[class default extends Base]`, `[Function: default]`, `<default />`. Fails on the released bun, passes with this change.
  - `test/js/bun/util/inspect.test.js` ("functions from built-in modules do not inspect as their internal variable name"): `Bun.inspect(zlib.gzip)` stays `[Function]` and `Bun.inspect(fs.promises.readdir)` stays `[AsyncFunction]`. Passes on the released bun and with this change; fails on the first revision of this PR (`[Function: fn]`, `[AsyncFunction: wrapped]`).
  - `Bun.inspect` of `zlib.gzip`, `zlib.gunzipSync`, `fs.promises.readFile` / `writeFile`, `Readable.prototype.map`, `util.promisify`, `events.once`, `Bun.serve`, `Array.prototype.map`, `new Promise` resolvers, functions with an empty or non-empty `displayName`, inferred names and bound functions is byte-identical between the released bun and this change.
  - `test/js/node/v8/capture-stack-trace.test.js`, `test/js/bun/util/inspect-error.test.js`, `reportError.test.ts`, `error-name-preservation.test.ts`, `test/js/bun/test/describe.test.ts`, `test/js/node/util/{bun-inspect,custom-inspect}.test.*`, the two `prepare-stack-trace` / `bindings-stack-trace` regression tests and the rest of `inspect.test.js` pass (the two "minified file" cases in `inspect-error.test.js` fail identically on main under debug builds, where `BUN_DEBUG` enables `showPrivateScriptsInStackTraces`). `error-gc-test.test.js` and `inspect-error-leak.test.js`, which stress these lookups under `Bun.gc`, pass under the debug ASAN build with their timeouts raised.

### Background

- `*default*`: the spec's name for the module-internal binding created by `export default <anonymous declaration or expression>`. JSC represents it with a private symbol whose description is `starDefault`; that symbol is also the `StringImpl` behind the identifier's string, which is what the identity comparison relies on.
- `ecmaName()`: the name JSC's parser records on a function's executable for the purposes of the ECMAScript `name` property (for example `f` in `const f = () => {}`). `JSFunction::name()` returns the binding name instead, and returns `""` for `*default*`.
- Lazy `name` reification: JSC does not create a function's own `name` property until it is first looked up. Bun's lookups read that property when it exists (so `Object.defineProperty(fn, "name", ...)` wins) and otherwise fall back to the executable, which is why the output used to depend on whether `.name` had been read.
- `FinalizerSafety::MustNotTriggerGC`: Bun formats some stack traces while JSC is finalizing an error, or when printing an error that still owns its raw frames, where running getters or allocating on the JS heap is not allowed. That branch reads structure slots directly; this PR only wraps its existing `ecmaName()` return, which allocates nothing (`defaultKeyword.string()` is a VM-lifetime string).

<details>
<summary>First revision of this PR (superseded)</summary>

The first revision replaced `JSC::getCalculatedDisplayName` in both `ErrorStackTrace.cpp` and `JSC__JSValue__getName` with a Bun copy of the displayName / name / ecmaName chain that used the stack-trace rule for builtin functions (`isHostFunction()` instead of JSC's `isHostOrBuiltinFunction()`). Functions defined in Bun's built-in modules are JSC builtins, so `Bun.inspect` started printing their inferred internal names: `zlib.gzip` became `[Function: fn]` and the `fs.promises` wrappers became `[AsyncFunction: wrapped]`. Review caught it; the current revision leaves every lookup as it was and only post-filters the result, and the new builtin-module test pins that output.

</details>
