### PR TITLE
Bump WebKit: stop the functions JSC synthesizes for a class from corrupting coverage of the code defining it

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "687eb8e1b73cb2d45ea9e689a97ea8cb867ab754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-436-e0512545";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-436-e0512545";
+export const WEBKIT_VERSION = "autobuild-preview-pr-436-4ad7a9e3";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -4,8 +4,8 @@ exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 "TN:
 SF:demo1.ts
 FNF:1
-FNH:0
-DA:2,2
+FNH:1
+DA:2,17
 DA:3,8
 LF:2
 LH:2

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -5,11 +5,10 @@ exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 SF:demo1.ts
 FNF:1
 FNH:0
-DA:2,19
-DA:3,16
-DA:4,1
-LF:3
-LH:3
+DA:2,2
+DA:3,8
+LF:2
+LH:2
 end_of_record
 TN:
 SF:demo2.ts

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -628,11 +628,13 @@ async function coverageReport(dir: string, file: string) {
   };
 }
 
-// JSC runs a class's instance (and, separately, static) field initializers in a function it synthesizes
-// without source positions of its own. It used to be recorded as a function spanning the file from offset 0
-// for the length of the scope that defines the class (in a CommonJS module: the module wrapper, i.e. the
-// whole file), and its own basic blocks spanned that whole scope. The tests below cover what that did to
-// the report; the engine's data is covered by test/js/bun/jsc-stress/fixtures/class-field-initializer.js.
+// JSC synthesizes two functions for a class that are not in the file: one running its instance (or,
+// separately, its static) field initializers, and the constructor of a class that declares none. The
+// initializer used to be recorded as a function spanning the file from offset 0 for the length of the scope
+// that defines the class (in a CommonJS module: the module wrapper, i.e. the whole file), and its own basic
+// blocks spanned that whole scope; the default constructor used to be recorded as a function on the first
+// characters of the file that never executes. The tests below cover what that did to the report; the
+// engine's data is covered by test/js/bun/jsc-stress/fixtures/class-field-initializer-and-default-constructor.js.
 
 test.concurrent("coverage of a CommonJS module with a class that is never instantiated", async () => {
   using dir = tempDir("cov", {
@@ -688,10 +690,13 @@ test("defines both classes, instantiates one", () => {
 `,
   });
 
-  const { row, lines } = await coverageReport(String(dir), "lib.js");
-  // Unused's initializer used to be reported as an uncalled function spanning the first make().length
-  // characters of the file, which is where describe() is.
-  expect(row).toMatch(/\|\s+100\.00 \|\s*$/);
+  const { row, functions, lines } = await coverageReport(String(dir), "lib.js");
+  // Used to be " lib.js | 60.00 | 81.82 | 1-2": Unused's initializer was reported as an uncalled function
+  // spanning the first make().length characters of the file, which is where describe() is; Description's
+  // initializer counted as a third executed function and the two classes' default constructors as one
+  // more that never executes.
+  expect(row).toMatch(/^ lib\.js\s+\|\s+100\.00 \|\s+100\.00 \|\s*$/);
+  expect(functions).toEqual({ found: 2, hit: 2 });
   expect(lines(1, 2, 3, 5, 6, 8, 9, 10, 12)).toEqual({
     1: "hit",
     2: "hit",
@@ -703,6 +708,35 @@ test("defines both classes, instantiates one", () => {
     10: "hit",
     12: "hit",
   });
+});
+
+test.concurrent("coverage of classes that do not declare a constructor", async () => {
+  using dir = tempDir("cov", {
+    "lib.js": `let made = 0;
+export class Base {}
+export class Derived extends Base {}
+export class Unused {}
+export function make() {
+  made += 1;
+  return [new Base(), new Derived(), made];
+}
+`,
+    "lib.test.js": `import { test, expect } from "bun:test";
+import { Base, Derived, make } from "./lib.js";
+test("instantiates the base and the derived class", () => {
+  expect(make()).toEqual([expect.any(Base), expect.any(Derived), 1]);
+});
+`,
+  });
+
+  const { row, functions, lines } = await coverageReport(String(dir), "lib.js");
+  // Used to be " lib.js | 33.33 | 71.43 | 1-3": the constructors JSC synthesizes for Base and Unused (one
+  // entry, they have the same offsets) and for Derived were reported as functions that never execute,
+  // instantiated or not (#7025), and since their offsets fall on the first lines of the file, those lines
+  // were reported as the uncovered bodies of these functions (#29691).
+  expect(row).toMatch(/^ lib\.js\s+\|\s+100\.00 \|\s+100\.00 \|\s*$/);
+  expect(functions).toEqual({ found: 1, hit: 1 });
+  expect(lines(1, 2, 3, 4, 6, 7)).toEqual({ 1: "hit", 2: "hit", 3: "hit", 4: "hit", 6: "hit", 7: "hit" });
 });
 
 test.concurrent("coverage does not count a class's field initializer as a function once it has run", async () => {
@@ -755,10 +789,12 @@ test("takes one branch", () => {
 `,
     });
 
-    const { row, lines } = await coverageReport(String(dir), "lib.js");
-    // The static initializer runs when the class is defined, and its basic block used to span the whole
-    // module: the dead pick(false) (and pick()'s untaken path) were reported as executed, 100.00% lines.
+    const { row, functions, lines } = await coverageReport(String(dir), "lib.js");
+    // Used to be " lib.js | 50.00 | 100.00 |". The static initializer runs when the class is defined, and
+    // its basic block spanned the whole module: the dead pick(false) (and pick()'s untaken path) were
+    // reported as executed. The 50% was WithStatic's default constructor, reported as never executing.
     expect(row).not.toMatch(/\|\s+100\.00 \|\s*$/);
+    expect(functions).toEqual({ found: 1, hit: 1 });
     expect(lines(1, 2, 4, 5, 6, 10, 11)).toEqual({
       1: "hit",
       2: "hit",
@@ -795,9 +831,12 @@ test("never takes the branch", () => {
 `,
     });
 
-    const { row, lines } = await coverageReport(String(dir), "lib.js");
-    // The initializer's basic block used to span all of run(), reporting lines 7-8 as executed.
+    const { row, functions, lines } = await coverageReport(String(dir), "lib.js");
+    // Used to be " lib.js | 66.67 | 100.00 |": the initializer's basic block spanned all of run(), reporting
+    // lines 7-8 as executed, and the functions were run(), the initializer and Counter's default
+    // constructor (never reported as executed, although every run() call runs it).
     expect(row).not.toMatch(/\|\s+100\.00 \|\s*$/);
+    expect(functions).toEqual({ found: 1, hit: 1 });
     expect(lines(1, 2, 3, 5, 6, 7, 8, 10)).toEqual({
       1: "hit",
       2: "hit",

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -589,3 +589,224 @@ Ran 1 test across 1 file."
 `);
   expect(result.exitCode).toBe(0);
 });
+
+/**
+ * Runs `bun test --coverage` in `dir` and returns what it reported for `file`: the row of the text
+ * reporter, the function counts of the lcov record, and a lookup of line numbers to "hit", "MISSED", or
+ * "-" for a line the lcov record does not list as executable at all.
+ */
+async function coverageReport(dir: string, file: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=text", "--coverage-reporter=lcov", "--coverage-dir=cov"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const row = stderr
+    .split("\n")
+    .find(line => line.startsWith(` ${file} `))
+    ?.trimEnd();
+  expect({ stdout, stderr, exitCode, row }).toMatchObject({ exitCode: 0, row: expect.any(String) });
+
+  const record = readFileSync(path.join(dir, "cov", "lcov.info"), "utf-8")
+    .split("end_of_record")
+    .find(record => record.includes(`SF:${file}\n`))!;
+  const functions = {
+    found: Number(record.match(/^FNF:(\d+)$/m)![1]),
+    hit: Number(record.match(/^FNH:(\d+)$/m)![1]),
+  };
+  const status: Record<number, "hit" | "MISSED"> = {};
+  for (const [, line, hits] of record.matchAll(/^DA:(\d+),(\d+)$/gm)) {
+    status[Number(line)] = Number(hits) > 0 ? "hit" : "MISSED";
+  }
+  return {
+    row: row!,
+    functions,
+    lines: (...numbers: number[]) => Object.fromEntries(numbers.map(line => [line, status[line] ?? "-"])),
+  };
+}
+
+// JSC runs a class's instance (and, separately, static) field initializers in a function it synthesizes
+// without source positions of its own. It used to be recorded as a function spanning the file from offset 0
+// for the length of the scope that defines the class (in a CommonJS module: the module wrapper, i.e. the
+// whole file), and its own basic blocks spanned that whole scope. The tests below cover what that did to
+// the report; the engine's data is covered by test/js/bun/jsc-stress/fixtures/class-field-initializer.js.
+
+test.concurrent("coverage of a CommonJS module with a class that is never instantiated", async () => {
+  using dir = tempDir("cov", {
+    "lib.js": `function used() {
+  return 1;
+}
+class Unused {
+  field = 1;
+}
+function alsoUsed() {
+  return 2;
+}
+module.exports = { used, alsoUsed, Unused };
+`,
+    "lib.test.js": `const { test, expect } = require("bun:test");
+const { used, alsoUsed } = require("./lib.js");
+test("uses the functions, not the class", () => {
+  expect(used() + alsoUsed()).toBe(3);
+});
+`,
+  });
+
+  const { row, functions, lines } = await coverageReport(String(dir), "lib.js");
+  // Used to be " lib.js | 75.00 | 10.00 | 1-9": the initializer's range covered the whole wrapper and
+  // counted as a function that never ran.
+  expect(row).toMatch(/^ lib\.js\s+\|\s+100\.00 \|\s+100\.00 \|\s*$/);
+  expect(lines(1, 2, 4, 7, 8, 10)).toEqual({ 1: "hit", 2: "hit", 4: "hit", 7: "hit", 8: "hit", 10: "hit" });
+  expect(functions.hit).toBe(functions.found);
+});
+
+test.concurrent("coverage of a class that is never instantiated, defined inside a function", async () => {
+  using dir = tempDir("cov", {
+    "lib.js": `export function describe(name) {
+  class Description {
+    name = name;
+  }
+  const description = new Description();
+  return description.name;
+}
+export function make() {
+  class Unused {
+    field = 1;
+  }
+  return typeof Unused;
+}
+`,
+    "lib.test.js": `import { test, expect } from "bun:test";
+import { describe as describeName, make } from "./lib.js";
+test("defines both classes, instantiates one", () => {
+  expect(describeName("x")).toBe("x");
+  expect(make()).toBe("function");
+});
+`,
+  });
+
+  const { row, lines } = await coverageReport(String(dir), "lib.js");
+  // Unused's initializer used to be reported as an uncalled function spanning the first make().length
+  // characters of the file, which is where describe() is.
+  expect(row).toMatch(/\|\s+100\.00 \|\s*$/);
+  expect(lines(1, 2, 3, 5, 6, 8, 9, 10, 12)).toEqual({
+    1: "hit",
+    2: "hit",
+    3: "hit",
+    5: "hit",
+    6: "hit",
+    8: "hit",
+    9: "hit",
+    10: "hit",
+    12: "hit",
+  });
+});
+
+test.concurrent("coverage does not count a class's field initializer as a function once it has run", async () => {
+  using dir = tempDir("cov", {
+    "lib.js": `export function make() {
+  class WithField {
+    constructor() {
+      this.made = true;
+    }
+    field = 1;
+  }
+  return new WithField();
+}
+`,
+    "lib.test.js": `import { test, expect } from "bun:test";
+import { make } from "./lib.js";
+test("instantiates", () => {
+  expect(make()).toEqual({ made: true, field: 1 });
+});
+`,
+  });
+
+  const { functions } = await coverageReport(String(dir), "lib.js");
+  // make() and the constructor. The initializer used to be reported as a third function once it had run.
+  expect(functions).toEqual({ found: 2, hit: 2 });
+});
+
+test.concurrent(
+  "coverage of a module with a class that has a static field still reports the module's dead code",
+  async () => {
+    using dir = tempDir("cov", {
+      "lib.js": `export class WithStatic {
+  static count = 0;
+}
+export function pick(a) {
+  if (a) {
+    return 1;
+  }
+  return 2;
+}
+if (typeof globalThis.__coverage_test_never_set__ === "string") {
+  pick(false);
+}
+`,
+      "lib.test.js": `import { test, expect } from "bun:test";
+import { pick } from "./lib.js";
+test("takes one branch", () => {
+  expect(pick(true)).toBe(1);
+});
+`,
+    });
+
+    const { row, lines } = await coverageReport(String(dir), "lib.js");
+    // The static initializer runs when the class is defined, and its basic block used to span the whole
+    // module: the dead pick(false) (and pick()'s untaken path) were reported as executed, 100.00% lines.
+    expect(row).not.toMatch(/\|\s+100\.00 \|\s*$/);
+    expect(lines(1, 2, 4, 5, 6, 10, 11)).toEqual({
+      1: "hit",
+      2: "hit",
+      4: "hit",
+      5: "hit",
+      6: "hit",
+      10: "hit",
+      11: "MISSED",
+    });
+  },
+);
+
+test.concurrent(
+  "coverage of a function that instantiates a class with a field still reports the function's dead code",
+  async () => {
+    using dir = tempDir("cov", {
+      "lib.js": `export function run(flag) {
+  class Counter {
+    count = 0;
+  }
+  const counter = new Counter();
+  if (flag) {
+    counter.count = 1;
+    counter.count = 2;
+  }
+  return counter;
+}
+`,
+      "lib.test.js": `import { test, expect } from "bun:test";
+import { run } from "./lib.js";
+test("never takes the branch", () => {
+  expect(run(false).count).toBe(0);
+});
+`,
+    });
+
+    const { row, lines } = await coverageReport(String(dir), "lib.js");
+    // The initializer's basic block used to span all of run(), reporting lines 7-8 as executed.
+    expect(row).not.toMatch(/\|\s+100\.00 \|\s*$/);
+    expect(lines(1, 2, 3, 5, 6, 7, 8, 10)).toEqual({
+      1: "hit",
+      2: "hit",
+      3: "hit",
+      5: "hit",
+      6: "hit",
+      7: "MISSED",
+      8: "MISSED",
+      10: "hit",
+    });
+  },
+);

--- a/test/js/bun/jsc-stress/fixtures/class-field-initializer-and-default-constructor.js
+++ b/test/js/bun/jsc-stress/fixtures/class-field-initializer-and-default-constructor.js
@@ -1,11 +1,14 @@
 // @bun
 //@ requireOptions("--useControlFlowProfiler=true", "--useDollarVM=true")
 
-// The function that runs a class's field initializers is synthesized from the source of the scope that
-// defines the class and has no positions of its own, so the function range it would record is
-// [0, length of that scope's source - 1] and the basic blocks at its start and end would span that whole
-// scope. None of that may appear in the profiler's data for the source. The programs are assembled as
-// strings so that the lengths involved are under control; loadString() evaluates each as its own program.
+// Two functions of a class are synthesized rather than parsed from the source of the code that defines the
+// class, and neither may appear in the profiler's data for that source. The function that runs the class's
+// field initializers is built over the source of the scope that defines the class without positions of its
+// own, so the function range it would record is [0, length of that scope's source - 1] and the basic blocks
+// at its start and end would span that whole scope (parts 1 to 5). The default constructor of a class that
+// does not declare one is built from a template, so the range it would record is made of offsets into the
+// template, i.e. the first few characters of the source (part 6). The programs are assembled as strings so
+// that the lengths and offsets involved are under control; loadString() evaluates each as its own program.
 
 var hasBasicBlockExecuted = $vm.hasBasicBlockExecuted;
 var basicBlockExecutionCount = $vm.basicBlockExecutionCount;
@@ -69,3 +72,17 @@ assert(basicBlockExecutionCount(globalThis.definesConditionalField, "'taken'") =
 assert(!hasBasicBlockExecuted(globalThis.definesConditionalField, "'not taken'"), "the branch the field initializer did not take is recorded");
 assert(basicBlockExecutionCount(globalThis.definesConditionalField, "var before") === 1, "the code before the class ran once, not once per instance");
 assert(basicBlockExecutionCount(globalThis.definesConditionalField, "new C()") === 1, "the code after the class ran once, not once per instance");
+
+// 6. Classes that do not declare a constructor. The default constructor's range would be made of the
+//    template's offsets, which fall on the first characters of the program: with a short function name, on
+//    the parameter list of a function declared there and called, and being far shorter than that function's
+//    first block it would be the range consulted for it. A derived class's default constructor has a longer
+//    template than a base class's, so both are checked; a class that declares its constructor is the control.
+function checkFunctionDeclaredBefore(name, classes) {
+    var declaration = padTo("function " + name + "() { var x = 1; /**/ }", 200);
+    loadString(declaration + "\n" + classes + "\n" + name + "();\n");
+    assert(hasBasicBlockExecuted(globalThis[name], "()"), name + "() ran; `" + classes + "` must not hide that");
+}
+checkFunctionDeclaredBefore("run", "class Base {}");
+checkFunctionDeclaredBefore("run", "class Parent { constructor() {} } class Derived extends Parent {}");
+checkFunctionDeclaredBefore("run", "class Declared { constructor() { this.x = 1; } }");

--- a/test/js/bun/jsc-stress/fixtures/class-field-initializer.js
+++ b/test/js/bun/jsc-stress/fixtures/class-field-initializer.js
@@ -1,0 +1,71 @@
+// @bun
+//@ requireOptions("--useControlFlowProfiler=true", "--useDollarVM=true")
+
+// The function that runs a class's field initializers is synthesized from the source of the scope that
+// defines the class and has no positions of its own, so the function range it would record is
+// [0, length of that scope's source - 1] and the basic blocks at its start and end would span that whole
+// scope. None of that may appear in the profiler's data for the source. The programs are assembled as
+// strings so that the lengths involved are under control; loadString() evaluates each as its own program.
+
+var hasBasicBlockExecuted = $vm.hasBasicBlockExecuted;
+var basicBlockExecutionCount = $vm.basicBlockExecutionCount;
+
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message);
+}
+
+// Widens the "/**/" comment in source until source is exactly length characters long.
+function padTo(source, length) {
+    assert(source.length <= length, "cannot pad a source of " + source.length + " characters to " + length);
+    var padding = "";
+    while (source.length + padding.length < length)
+        padding += "*";
+    return source.replace("/**/", "/*" + padding + "*/");
+}
+
+// 1. A class with an instance field that is never instantiated. The initializer's range would be the first
+//    makeClass.length characters of the program, i.e. the start of ran, and being shorter than the block
+//    that ran's body forms it would be the range consulted for ran's code.
+var ran = padTo("function ran() { var x = 1; /**/ return x; }", 400);
+var makeClass = padTo("function makeClass() { return class { field = 1; }; /**/ }", 200);
+loadString(ran + "\n" + makeClass + "\nran();\nmakeClass();\n");
+assert(hasBasicBlockExecuted(globalThis.ran, "var x"), "ran() ran; a class that was never instantiated must not hide that");
+assert(hasBasicBlockExecuted(globalThis.makeClass, "return class"), "makeClass() ran");
+
+// 2. The same with a static field, whose initializer runs as soon as the class is defined: the range would
+//    now claim that a function that has never been called has executed.
+var neverRan = padTo("function neverRan() { var y = 1; /**/ return y; }", 400);
+var makeStatic = padTo("function makeStatic() { return class { static field = 1; }; /**/ }", 200);
+loadString(neverRan + "\n" + makeStatic + "\nmakeStatic();\n");
+assert(!hasBasicBlockExecuted(globalThis.neverRan, "var y"), "neverRan() never ran; a static field initializer must not claim it did");
+assert(hasBasicBlockExecuted(globalThis.makeStatic, "return class"), "makeStatic() ran");
+
+// 3. A function that is never called, declared at offset 0, and a function of exactly the same length that
+//    instantiates a class with an instance field. Running the initializer would mark [0, length - 1], which
+//    is the never-called function's range, as executed.
+var makeInstance = "function makeInstance() { return new (class { field = 1; })(); /**/ }";
+var neverCalled = padTo("function neverCalled() { return 'never called'; /**/ }", makeInstance.length);
+loadString(neverCalled + "\n" + makeInstance + "\nmakeInstance();\n");
+assert(!hasBasicBlockExecuted(globalThis.neverCalled, "return 'never called'"), "neverCalled() was never called; instantiating a class must not claim it was");
+assert(hasBasicBlockExecuted(globalThis.makeInstance, "return new"), "makeInstance() ran");
+
+// 4. The initializer's own basic block would span the defining scope. When that scope is itself a single
+//    basic block (no return statement, no control flow), it would be that very block, and every run of the
+//    initializer would count as a run of the scope.
+loadString("function definesAndInstantiates() { class C { field = 1; } new C(); new C(); new C(); }\ndefinesAndInstantiates();\n");
+assert(basicBlockExecutionCount(globalThis.definesAndInstantiates, "new C()") === 1, "definesAndInstantiates() ran once, however many instances it created");
+
+loadString("function definesWithStaticField() { class C { static field = 1; } var defined = C; }\ndefinesWithStaticField();\n");
+assert(basicBlockExecutionCount(globalThis.definesWithStaticField, "var defined") === 1, "definesWithStaticField() ran once; the static initializer running is not a second time");
+
+// 5. Control flow inside an initializer expression delimits blocks that do have positions of their own, and
+//    those are still recorded. The blocks before the first and after the last of them would run to the
+//    start and to the end of the defining scope, and being narrower than the scope's own block they would
+//    be the ranges consulted for the code around the class.
+loadString("function definesConditionalField(flag) { var before = 1; class C { field = flag ? 'taken' : 'not taken'; } new C(); new C(); }\ndefinesConditionalField(true);\n");
+assert(hasBasicBlockExecuted(globalThis.definesConditionalField, "'taken'"), "the branch the field initializer took is recorded");
+assert(basicBlockExecutionCount(globalThis.definesConditionalField, "'taken'") === 2, "the field was initialized once per instance");
+assert(!hasBasicBlockExecuted(globalThis.definesConditionalField, "'not taken'"), "the branch the field initializer did not take is recorded");
+assert(basicBlockExecutionCount(globalThis.definesConditionalField, "var before") === 1, "the code before the class ran once, not once per instance");
+assert(basicBlockExecutionCount(globalThis.definesConditionalField, "new C()") === 1, "the code after the class ran once, not once per instance");

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -189,7 +189,7 @@ const ffiFixtures = [
 
 // From WebKit's JSTests/controlFlowProfiler. These read the profiler's data back through `$vm` (their
 // `//@ requireOptions` line enables it), which only builds of JSC that compile it in expose.
-const controlFlowProfilerFixtures = ["class-field-initializer.js"];
+const controlFlowProfilerFixtures = ["class-field-initializer-and-default-constructor.js"];
 
 const preloadPath = path.join(import.meta.dir, "preload.js");
 

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -187,7 +187,23 @@ const ffiFixtures = [
   "ffi-view-args.js",
 ];
 
+// From WebKit's JSTests/controlFlowProfiler. These read the profiler's data back through `$vm` (their
+// `//@ requireOptions` line enables it), which only builds of JSC that compile it in expose.
+const controlFlowProfilerFixtures = ["class-field-initializer.js"];
+
 const preloadPath = path.join(import.meta.dir, "preload.js");
+
+const dollarVMProbe = Bun.spawnSync({
+  cmd: [
+    bunExe(),
+    "-e",
+    'process.stdout.write(typeof globalThis.$vm !== "object" ? "none" : typeof $vm.ffiFunction === "function" ? "ffi" : "vm")',
+  ],
+  env: { ...bunEnv, BUN_JSC_useDollarVM: "1" },
+  stdout: "pipe",
+}).stdout.toString();
+const hasDollarVMFFI = dollarVMProbe === "ffi";
+const hasDollarVM = hasDollarVMFFI || dollarVMProbe === "vm";
 
 // Under ASAN, JSC disables the wasm fault signal handler (and therefore wasm
 // shared memory) unless ASAN is told to let the process handle SIGSEGV. CI's
@@ -271,21 +287,41 @@ describe.concurrent("JSC JIT Stress Tests", () => {
     }
   });
 
-  describe("FFI (bun:ffi engine)", () => {
-    const probeEnv = { ...bunEnv, BUN_JSC_useDollarVM: "1" };
-    const probe = Bun.spawnSync({
-      cmd: [
-        bunExe(),
-        "-e",
-        'process.stdout.write(typeof globalThis.$vm === "object" && typeof $vm.ffiFunction === "function" ? "1" : "0")',
-      ],
-      env: probeEnv,
-      stdout: "pipe",
-    });
-    const hasDollarVM = probe.stdout.toString() === "1";
-
-    for (const fixture of ffiFixtures) {
+  describe("Control flow profiler", () => {
+    for (const fixture of controlFlowProfilerFixtures) {
       test.skipIf(!hasDollarVM)(
+        fixture,
+        async () => {
+          const fixturePath = path.join(fixturesDir, fixture);
+          const jscEnv = parseJSCFlags(fixturePath);
+
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "--preload", preloadPath, fixturePath],
+            env: { ...fixtureEnv, ...jscEnv },
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+
+          const [stdout, stderr, exitCode] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+          ]);
+
+          if (exitCode !== 0) {
+            console.log("stdout:", stdout);
+            console.log("stderr:", stderr);
+          }
+          expect(exitCode).toBe(0);
+        },
+        fixtureTimeout,
+      );
+    }
+  });
+
+  describe("FFI (bun:ffi engine)", () => {
+    for (const fixture of ffiFixtures) {
+      test.skipIf(!hasDollarVMFFI)(
         fixture,
         async () => {
           const fixturePath = path.join(ffiFixturesDir, fixture);

--- a/test/js/bun/jsc-stress/preload.js
+++ b/test/js/bun/jsc-stress/preload.js
@@ -32,3 +32,7 @@ globalThis.fullGC = jsc.fullGC;
 globalThis.edenGC = jsc.edenGC;
 globalThis.numberOfDFGCompiles = jsc.numberOfDFGCompiles;
 globalThis.noDFG = jsc.noFTL;
+
+// loadString: evaluates the string as a program of its own in the global scope, like the jsc shell does.
+const { runInThisContext } = require("node:vm");
+globalThis.loadString = source => runInThisContext(source);


### PR DESCRIPTION
### Problem

- `bun test --coverage` on a CommonJS module that defines a class with an instance field and never instantiates it reports the whole file as uncovered, plus one extra uncovered function: the repro below prints ` lib.js | 75.00 | 10.00 | 1-9` on 1.4.0 although `used()` and `alsoUsed()` ran; deleting `field = 1;` gives 100% / 100%. A class with fields defined inside any function of an ES module does the same to the start of that file.
  ```js
  function used() { return 1; }
  class Unused { field = 1; }
  function alsoUsed() { return 2; }
  module.exports = { used, alsoUsed, Unused };
  ```
- The opposite happens once the initializer runs, which a static field does as soon as the class is defined: every unexecuted line in the scope that defines the class is reported as executed. A module with `export class WithStatic { static count = 0; }`, a function with an untaken branch and a dead top-level `if` reports 100% lines on 1.4.0; a function that instantiates a local class with a field reports its own dead branches as covered. The initializer is also counted as one more (executed) function.
- Every class that does not declare a constructor counts as one function that never executes, however often it is instantiated, and the first lines of the file are reported as that function's uncovered body: a module with three such classes and one called function reports ` lib.js | 33.33 | 71.43 | 1-3` (#7025, #24908, #29691).
- Cause: both functions JSC synthesizes for a class are recorded by `CodeBlock.cpp` as functions of the source that defines the class, with offsets that are not offsets into that source. The field initializer function (`BytecodeGenerator::emitNewClassFieldInitializerFunction`) has no positions of its own and is built over the source of the defining scope, so it is recorded as `[0, length of that scope - 1]`, punched out of the defining scope's block as a gap, and its own first and last basic blocks run from the start to the end of that scope. The default constructor (`emitNewDefaultConstructor`) is built from JSC's template string, so it is recorded with the template's offsets (the first dozen or so characters of the file, three dozen for a derived class) and, since its own code block is linked against the template, never marked as executed. `src/sourcemap_jsc/CodeCoverage.rs` then zeroes every line of an unexecuted function range and marks every line of an executed block, giving the three symptoms above. A module-level class in an ES module only escapes the first symptom because the initializer's phantom key coincides with the module's own (already executed) entry; inside a CommonJS wrapper or any function it is a real entry.

### Fix

- oven-sh/WebKit#436: `CodeBlock.cpp` skips both synthesized functions (`ClassFieldInitializerMode` executables and `isBuiltinDefaultClassConstructor()` ones) when inserting into and removing from `FunctionHasExecutedCache` and when inserting function gaps, and does not record the first and last basic blocks of a field initializer's code block; the blocks in between are delimited by control flow inside the field initializer expressions, have real positions, and are still recorded. This PR pins that PR's preview build, `autobuild-preview-pr-436-4ad7a9e3` (WebKit main `f0f60fd2` plus that change; main has moved two unrelated commits since the current pin, oven-sh/WebKit#428 and #432, which this pin carries as well).
- Why this is the right fix: none of the recorded numbers describe the class. The initializer's range is the length of the enclosing scope measured from offset 0 of the file and its outer blocks are the enclosing scope, whose own blocks already say what ran; the constructor's range is a position in a template. Dropping them leaves the class's text attributed to the block of the code that defines it, which is exactly what a class that declares its constructor and has no fields gets today, so no shape loses information it had. Bun cannot do this on its side: the initializer's range is indistinguishable by value from a real function (it starts at 0, like a function declared at the top of an ES module), the executables it could be matched against are garbage collected independently of the profiler's tables, and the constructor's gap is applied inside JSC before bun sees any data. Both functions violate the same invariant at the same three lines, which is why the second revision of the WebKit PR handles both rather than leaving the constructor to by-value filters in each consumer (#38282, #36651, #36655 and #35755 each carry one); once this lands those filters have nothing left to match.
- Not done: giving the two functions real ranges (the class's text, roughly what V8 reports) needs JSC's gap handling to cope with a class range enclosing its methods and distinct keys for a class's instance and static initializers; that is a separate, larger change. The attribution of bytes to lines is also unchanged (#38282), so the new tests only assert line statuses and function counts that do not depend on it.
- Before this can merge, oven-sh/WebKit#436 has to land and `WEBKIT_VERSION` has to move to its merge commit's `autobuild-<sha>` (the preview release is deleted when the WebKit PR merges). #38285 and #38260 (among others) pin other previews in the same line; whichever lands last re-pins to a main sha containing all of the engine changes.
- Tests:
  - `test/cli/test/coverage.test.ts`: the CommonJS repro, a class defined inside a function, the initializer no longer counted as a function once it ran, the two over-reporting shapes (static field at module level, instantiated class inside a function), and classes without a constructor (base, derived, unused, with a short first line). At the current pin they fail with ` 75.00 | 10.00 | 1-9`, ` 60.00 | 81.82 | 1-2`, `FNF:3` instead of `2`, `100.00` lines twice, and ` 33.33 | 71.43 | 1-3`; against the first preview (initializer only) the constructor test and the function counts of the three fixtures with constructor-less classes still fail; all pass on the pinned preview.
  - `test/js/bun/jsc-stress/fixtures/class-field-initializer-and-default-constructor.js`: the WebKit PR's `JSTests/controlFlowProfiler` test, verbatim, reading the profiler's tables back through `$vm`: 9 of its 16 assertions fail at the current pin (7 initializer, 2 constructor), exactly the 2 constructor ones fail on the first preview, all pass on the pinned one. It needs the jsc shell's `loadString()`, which `preload.js` now provides, and `$vm`, so it runs in its own group gated on the same probe the FFI fixtures use; the probe moved to file scope for that.
  - The `lcov coverage reporter` snapshot changes for `demo1.ts` (`export class Y { #hello; }`, never instantiated): it used to list its default constructor as one unexecuted function (`FNH:0`) and counted line 2 from inverted ranges (the initializer's gap had garbled the module's only block, `DA:2,19 DA:3,16 DA:4,1`). It now lists one executed function, which is the module's own range: the reporter counts that range for every file without functions (`export const x = 1;` alone gives `FNF:1 FNH:1` on 1.4.0), and `demo1.ts` now simply is such a file. Line 2 has the bytes the constructor's gap used to cut out, the `};` line (only ever attributed through the inverted ranges) is gone, and the file still reports 100% of its lines.
- Also run against the pinned preview: the rest of `coverage.test.ts`, `parallel.test.ts -t coverage`, `inspector-profiler.test.ts` (45 pass; `Profiler.takePreciseCoverage` for the repro no longer lists the `[0, 215]` and `[1, 15]` count-0 entries, everything else identical), one fixture from each other jsc-stress group, and WebKit's `JSTests/controlFlowProfiler` (8 existing tests) and `JSTests/typeProfiler` (20 tests) on the preview's `jsc` shell.

### Background

- JSC's control flow profiler (what `--coverage` turns on) keeps two tables per source: basic blocks, `[start, end]` text ranges with an executed flag and a count, recorded when a code block is created from the profiling opcodes in it, with the text of nested functions cut out as "gaps"; and `FunctionHasExecutedCache`, one `[start, end]` range per function expression or declaration, inserted as unexecuted when the code containing it is compiled and flipped when the function itself gets a code block. Bun reads both (`src/jsc/bindings/CodeCoverage.cpp`) and turns them into line coverage: bytes of executed blocks mark lines hit, and every line of a function range that never executed is forced to unexecuted.
- Class fields are compiled into a separate function per class (one for instance fields, run by the constructor; one for static fields, run right after the class is defined), and a class without a `constructor` gets one compiled from a fixed template, which is why a field, or the absence of a constructor, changes what the profiler sees although the source has no function there.
- Bun does not build JavaScriptCore from source: `scripts/build/deps/webkit.ts` pins a release of the oven-sh/WebKit fork and the build downloads its prebuilt libraries. A PR against the fork gets a prerelease tagged `autobuild-preview-pr-<n>-<sha8>` that bun can pin to test it; merging to the fork's main produces the permanent `autobuild-<sha>` release.
- `test/js/bun/jsc-stress/` runs WebKit `JSTests`-style files through bun with a preload that supplies the jsc shell globals they use; a `//@ requireOptions(...)` line in a fixture becomes `BUN_JSC_*` options. `$vm` is JSC's testing object (here `hasBasicBlockExecuted` / `basicBlockExecutionCount`, which answer from the smallest recorded range enclosing an offset inside a function's source); release builds of JSC may not compile it in, hence the probe.

<details>
<summary>Raw profiler data behind the symptoms (jsc shell at the current pin)</summary>

`function outer() { class C { a = 1; } new C(); var after = 2; if (after === 3) { after = 4; } return after; }` called once (`$vm.dumpBasicBlockExecutionRanges()`): `outer`'s own blocks are `[14, 78]` executed, `[79, 92]` (the untaken `if` body) not executed, `[93, 106]` executed, `[107, 108]` not executed. The initializer adds one more block, `[14, 108]` executed: the whole of `outer`, covering the untaken body. With a conditional in the field initializer it instead adds a block from the start of `outer` to just before the conditional's first branch and one from just after its last branch to the end of `outer`, around the two real branch blocks; after the fix only those two remain.

The function ranges are visible through `$vm.hasBasicBlockExecuted`, which answers from the smallest range enclosing an offset. In a program consisting of a 400 character function `ran()` that is called, followed by a 200 character function returning a class with a field, `hasBasicBlockExecuted(ran, "var x")` is `false` at the current pin: the initializer's unexecuted `[0, 199]` is the smallest range enclosing the start of `ran`. In a program starting with `function run() { ... }` (200 characters, called) followed by `class Base {}`, `hasBasicBlockExecuted(run, "()")` is `false` for the same reason: the constructor's unexecuted template range is the smallest one enclosing offset 12. These are assertions 1 and 6 of the fixture.

</details>

<details>
<summary>First revision of this PR</summary>

Pinned `autobuild-preview-pr-436-e0512545`, which handled the field initializer only and left the default constructor to the bun-side filters; self-review pointed out that the constructor violates the same invariant at the same sites and that the gap it punches cannot be filtered after the fact, so the WebKit PR was widened and this PR re-pinned. The first revision's five coverage tests and 13-assertion fixture passed on its preview; the snapshot then read `FNF:1 FNH:0 DA:2,2 DA:3,8`.

</details>
