### PR TITLE
css modules: keep composes working after a nested rule in the same block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,6 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "scopeguard",
  "strum",
  "thiserror",
  "typed-arena",

--- a/src/css/Cargo.toml
+++ b/src/css/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true
-scopeguard.workspace = true
 const_format.workspace = true
 enum-map.workspace = true
 enumset.workspace = true

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -975,7 +975,6 @@ pub struct TopLevelRuleParser<'a, AtRuleParserT: CustomAtRuleParser> {
     // TODO: think about memory management
     pub(crate) rules: &'a mut CssRuleList<AtRuleParserT::AtRule>,
     pub(crate) composes: &'a mut ComposesMap,
-    pub(crate) composes_refs: SmallList<ast::Ref, 2>,
     pub(crate) local_properties: &'a mut LocalPropertyUsage,
 }
 
@@ -995,7 +994,6 @@ impl<'a, AtRuleParserT: CustomAtRuleParser> TopLevelRuleParser<'a, AtRuleParserT
             at_rule_parser,
             rules,
             composes,
-            composes_refs: SmallList::default(),
             local_properties,
         }
     }
@@ -1015,7 +1013,6 @@ impl<'a, AtRuleParserT: CustomAtRuleParser> TopLevelRuleParser<'a, AtRuleParserT
             allow_declarations: false,
             composes_state: ComposesState::DisallowEntirely,
             composes: &mut *self.composes,
-            composes_refs: &mut self.composes_refs,
             local_properties: &mut *self.local_properties,
         }
     }
@@ -1023,18 +1020,38 @@ impl<'a, AtRuleParserT: CustomAtRuleParser> TopLevelRuleParser<'a, AtRuleParserT
 
 // ───────────────────────────── NestedRuleParser ─────────────────────────────
 
+/// Whether the declarations of the block currently being parsed may use
+/// `composes`. Decided once per block from the rule that opens it (see
+/// `QualifiedRuleParser::parse_block`) and handed to the parser of that block;
+/// a block never changes the state of the block enclosing it.
 #[derive(Clone, Copy)]
 pub enum ComposesState {
-    Allow(SourceLocation),
+    /// The block is the body of a style rule that is not nested in another one
+    /// and whose selector is the single class `class`; every `composes` in it
+    /// is recorded against that class.
+    Allow {
+        loc: SourceLocation,
+        class: ast::Ref,
+    },
     DisallowNested(SourceLocation),
     DisallowNotSingleClass(SourceLocation),
     DisallowEntirely,
 }
 
+impl ComposesState {
+    /// The state for a block nested inside a block with this state.
+    pub(crate) fn nested(self) -> ComposesState {
+        match self {
+            ComposesState::Allow { loc, .. } => ComposesState::DisallowNested(loc),
+            state => state,
+        }
+    }
+}
+
 /// Dispatch trait for `parse_declaration_impl`. Implemented by `NestedRuleParser`.
 pub trait ComposesCtx {
     fn composes_state(&self) -> ComposesState;
-    fn record_composes(&mut self, composes: &mut Composes);
+    fn record_composes(&mut self, class: ast::Ref, composes: &Composes);
 }
 /// Unit `ComposesCtx` for callers that don't track `composes:`.
 pub struct NoComposesCtx;
@@ -1044,7 +1061,7 @@ impl ComposesCtx for NoComposesCtx {
         ComposesState::DisallowEntirely
     }
     #[inline]
-    fn record_composes(&mut self, _: &mut Composes) {}
+    fn record_composes(&mut self, _: ast::Ref, _: &Composes) {}
 }
 
 pub struct NestedRuleParser<'a, T: CustomAtRuleParser> {
@@ -1064,7 +1081,6 @@ pub struct NestedRuleParser<'a, T: CustomAtRuleParser> {
     pub(crate) allow_declarations: bool,
 
     pub(crate) composes_state: ComposesState,
-    pub(crate) composes_refs: &'a mut SmallList<ast::Ref, 2>,
     pub(crate) composes: &'a mut ComposesMap,
     pub(crate) local_properties: &'a mut LocalPropertyUsage,
 }
@@ -1174,24 +1190,21 @@ mod rule_parsers {
 
     // The borrow checker forbids passing `&mut *this` while also borrowing
     // `this.declarations` / `this.important_declarations`, so split-borrow the
-    // three composes fields into a small adaptor that implements the
-    // `ComposesCtx` dispatch trait.
+    // composes fields into a small adaptor that implements the `ComposesCtx`
+    // dispatch trait.
     struct NestedComposesCtx<'a> {
         state: ComposesState,
         arena: &'a Bump,
         composes: &'a mut ComposesMap,
-        composes_refs: &'a mut SmallList<ast::Ref, 2>,
     }
     impl<'a> ComposesCtx for NestedComposesCtx<'a> {
         #[inline]
         fn composes_state(&self) -> ComposesState {
             self.state
         }
-        fn record_composes(&mut self, composes: &mut Composes) {
-            for ref_ in self.composes_refs.slice() {
-                let entry = self.composes.entry(*ref_).or_default();
-                entry.composes.push(composes.deep_clone(self.arena));
-            }
+        fn record_composes(&mut self, class: ast::Ref, composes: &Composes) {
+            let entry = self.composes.entry(class).or_default();
+            entry.composes.push(composes.deep_clone(self.arena));
         }
     }
 
@@ -1434,24 +1447,16 @@ mod rule_parsers {
     // ── NestedRuleParser behavior (struct hoisted above) ─────────────────────────
 
     impl<'a, T: CustomAtRuleParser> NestedRuleParser<'a, T> {
+        /// Parses the block that `input` is positioned in with a child parser;
+        /// `composes_state` is the state for that block's own declarations.
         pub(crate) fn parse_nested(
             &mut self,
             input: &mut Parser,
             is_style_rule: bool,
+            composes_state: ComposesState,
         ) -> CssResult<(DeclarationBlock<'static>, CssRuleList<T::AtRule>)> {
             // TODO: think about memory management in error cases
             let mut rules = CssRuleList::<T::AtRule>::default();
-            let composes_state = if self.is_in_style_rule
-                && matches!(self.composes_state, ComposesState::Allow(_))
-            {
-                let ComposesState::Allow(l) = self.composes_state else {
-                    unreachable!()
-                };
-                ComposesState::DisallowNested(l)
-            } else {
-                // ComposesState is Copy.
-                self.composes_state
-            };
             // SAFETY: see `TopLevelRuleParser::nested` — `'static` erasure of the
             // parser arena.
             let bump: &'static Bump = unsafe { bun_ptr::detach_lifetime_ref(self.arena) };
@@ -1468,7 +1473,6 @@ mod rule_parsers {
                     || is_style_rule,
                 composes_state,
                 composes: &mut *self.composes,
-                composes_refs: &mut *self.composes_refs,
                 local_properties: &mut *self.local_properties,
             };
             // Spell out the impl with a fresh lifetime so `nested_parser` isn't
@@ -1530,7 +1534,8 @@ mod rule_parsers {
             // Declarations can be immediately within @media and @supports blocks
             // that are nested within a parent style rule. These act the same way
             // as if they were nested within a `& { ... }` block.
-            let (declarations, mut rules) = self.parse_nested(input, false)?;
+            let (declarations, mut rules) =
+                self.parse_nested(input, false, self.composes_state.nested())?;
 
             if declarations.len() > 0 {
                 rules.v.insert(
@@ -1550,6 +1555,39 @@ mod rule_parsers {
             }
 
             Ok(rules)
+        }
+
+        /// `composes` is allowed in the body of a style rule only when the rule
+        /// is not nested in another style rule and its selector is a single
+        /// class (the class the composed names are attached to). `loc` is the
+        /// rule's location, which the warnings for the disallowed cases point at.
+        fn composes_state_for_body(
+            &self,
+            selectors: &SelectorList,
+            loc: Location,
+        ) -> ComposesState {
+            let loc = SourceLocation {
+                line: loc.line,
+                column: loc.column,
+            };
+            if self.is_in_style_rule {
+                return ComposesState::DisallowNested(loc);
+            }
+            let [selector] = selectors.v.slice() else {
+                return ComposesState::DisallowNotSingleClass(loc);
+            };
+            let [component] = selector.components.as_slice() else {
+                return ComposesState::DisallowNotSingleClass(loc);
+            };
+            match component.as_class() {
+                // With css modules enabled every class selector refers to a
+                // local symbol (see `SelectorParser::new_local_identifier`).
+                Some(class) => ComposesState::Allow {
+                    loc,
+                    class: class.as_ref().unwrap(),
+                },
+                None => ComposesState::DisallowNotSingleClass(loc),
+            }
         }
     }
 
@@ -1896,7 +1934,8 @@ mod rule_parsers {
                     Ok(())
                 }
                 AtRulePrelude::Nest(selectors) => {
-                    let (declarations, rules) = this.parse_nested(input, true)?;
+                    let (declarations, rules) =
+                        this.parse_nested(input, true, this.composes_state.nested())?;
                     this.rules
                         .v
                         .push(CssRule::Nesting(css_rules::nesting::NestingRule {
@@ -2013,92 +2052,35 @@ mod rule_parsers {
             input: &mut Parser,
         ) -> CssResult<()> {
             let loc = this.get_loc(start);
-            // `composes_refs` is `&mut SmallList<..>` borrowed from the parent
-            // `TopLevelRuleParser`, so dropping `NestedRuleParser` on an error path
-            // does NOT clear the underlying storage. A safe `scopeguard::guard`
-            // over `&mut *this.composes_refs` would hold that borrow across
-            // `this.parse_nested(&mut self, …)` and trip borrowck, so capture the
-            // raw pointer instead — the guard fires at scope exit after all body
-            // borrows of `this` are released, and the pointee (owned by the parent
-            // `TopLevelRuleParser`) strictly outlives this frame.
-            let composes_refs_ptr: *mut SmallList<ast::Ref, 2> = &raw mut *this.composes_refs;
-            scopeguard::defer! {
-                // SAFETY: see the note above — no aliasing borrow live at drop.
-                unsafe { (*composes_refs_ptr).clear_retaining_capacity(); }
-            }
-            // allow composes if:
-            // - NOT in nested style rules
-            // - AND there is only one class selector
-            if input.flags.css_modules() {
-                'out: {
-                    if this.is_in_style_rule {
-                        this.composes_state = ComposesState::DisallowNested(SourceLocation {
-                            line: loc.line,
-                            column: loc.column,
-                        });
-                        break 'out;
-                    }
-                    if selectors.v.len() != 1 {
-                        this.composes_state =
-                            ComposesState::DisallowNotSingleClass(SourceLocation {
-                                line: loc.line,
-                                column: loc.column,
-                            });
-                        break 'out;
-                    }
-                    let sel = &selectors.v.slice()[0];
-                    if sel.components.len() != 1 {
-                        this.composes_state =
-                            ComposesState::DisallowNotSingleClass(SourceLocation {
-                                line: loc.line,
-                                column: loc.column,
-                            });
-                        break 'out;
-                    }
-                    let comp = &sel.components[0];
-                    if let Some(r) = comp.as_class() {
-                        let ref_ = r.as_ref().unwrap();
-                        this.composes_refs.append(ref_);
-                        this.composes_state = ComposesState::Allow(SourceLocation {
-                            line: loc.line,
-                            column: loc.column,
-                        });
-                        break 'out;
-                    }
-                    this.composes_state = ComposesState::DisallowNotSingleClass(SourceLocation {
-                        line: loc.line,
-                        column: loc.column,
-                    });
-                }
-            }
+            let composes_state = if input.flags.css_modules() {
+                this.composes_state_for_body(&selectors, loc)
+            } else {
+                ComposesState::DisallowEntirely
+            };
             let location = input.position();
-            let (declarations, rules) = this.parse_nested(input, true)?;
+            let (declarations, rules) = this.parse_nested(input, true, composes_state)?;
 
-            // We parsed a style rule with the `composes` property. Track which
-            // properties it used so we can validate it later.
-            if matches!(this.composes_state, ComposesState::Allow(_)) {
+            // Track which properties a class that may use `composes` declares, so
+            // the bundler can report properties that conflict between composed
+            // classes.
+            if let ComposesState::Allow { class, .. } = composes_state {
                 let len = input.position() - location;
                 let mut usage = PropertyBitset::init_empty();
                 let mut custom_properties: Vec<&'static [u8]> = Vec::new();
                 fill_property_bit_set(&mut usage, &declarations, &mut custom_properties);
 
-                let custom_properties_slice = custom_properties.slice();
-
-                for ref_ in this.composes_refs.slice() {
-                    let entry =
-                        this.local_properties
-                            .entry(*ref_)
-                            .or_insert_with(|| PropertyUsage {
-                                range: bun_ast::Range {
-                                    loc: bun_ast::Loc {
-                                        start: i32::try_from(location).expect("int cast"),
-                                    },
-                                    len: i32::try_from(len).expect("int cast"),
-                                },
-                                ..Default::default()
-                            });
-                    entry.fill(&usage, custom_properties_slice);
-                }
+                this.local_properties
+                    .entry(class)
+                    .or_insert_with(|| PropertyUsage {
+                        range: bun_ast::Range {
+                            loc: bun_ast::Loc {
+                                start: i32::try_from(location).expect("int cast"),
+                            },
+                            len: i32::try_from(len).expect("int cast"),
+                        },
+                        ..Default::default()
+                    })
+                    .fill(&usage, custom_properties.slice());
             }
 
             this.rules.v.push(CssRule::Style(StyleRule {
@@ -2135,7 +2117,6 @@ mod rule_parsers {
                 state: this.composes_state,
                 arena,
                 composes: &mut *this.composes,
-                composes_refs: &mut *this.composes_refs,
             };
             declaration::parse_declaration_impl(
                 name,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -1020,8 +1020,7 @@ impl<'a, AtRuleParserT: CustomAtRuleParser> TopLevelRuleParser<'a, AtRuleParserT
 
 // ───────────────────────────── NestedRuleParser ─────────────────────────────
 
-/// Whether the declarations of one block may use `composes`. Fixed when the
-/// block is opened; nested blocks get their own state and never change it.
+/// Whether the declarations of one block may use `composes`; fixed when the block is opened.
 #[derive(Clone, Copy)]
 pub enum ComposesState {
     /// `composes` declarations in the block are recorded against `class`.
@@ -1186,8 +1185,8 @@ mod rule_parsers {
 
     // The borrow checker forbids passing `&mut *this` while also borrowing
     // `this.declarations` / `this.important_declarations`, so split-borrow the
-    // composes fields into a small adaptor that implements the `ComposesCtx`
-    // dispatch trait.
+    // two composes fields into a small adaptor that implements the
+    // `ComposesCtx` dispatch trait.
     struct NestedComposesCtx<'a> {
         state: ComposesState,
         arena: &'a Bump,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -1020,15 +1020,11 @@ impl<'a, AtRuleParserT: CustomAtRuleParser> TopLevelRuleParser<'a, AtRuleParserT
 
 // ───────────────────────────── NestedRuleParser ─────────────────────────────
 
-/// Whether the declarations of the block currently being parsed may use
-/// `composes`. Decided once per block from the rule that opens it (see
-/// `QualifiedRuleParser::parse_block`) and handed to the parser of that block;
-/// a block never changes the state of the block enclosing it.
+/// Whether the declarations of one block may use `composes`. Fixed when the
+/// block is opened; nested blocks get their own state and never change it.
 #[derive(Clone, Copy)]
 pub enum ComposesState {
-    /// The block is the body of a style rule that is not nested in another one
-    /// and whose selector is the single class `class`; every `composes` in it
-    /// is recorded against that class.
+    /// `composes` declarations in the block are recorded against `class`.
     Allow {
         loc: SourceLocation,
         class: ast::Ref,
@@ -1447,8 +1443,7 @@ mod rule_parsers {
     // ── NestedRuleParser behavior (struct hoisted above) ─────────────────────────
 
     impl<'a, T: CustomAtRuleParser> NestedRuleParser<'a, T> {
-        /// Parses the block that `input` is positioned in with a child parser;
-        /// `composes_state` is the state for that block's own declarations.
+        /// `composes_state` applies to the declarations of the block being parsed.
         pub(crate) fn parse_nested(
             &mut self,
             input: &mut Parser,
@@ -1557,10 +1552,6 @@ mod rule_parsers {
             Ok(rules)
         }
 
-        /// `composes` is allowed in the body of a style rule only when the rule
-        /// is not nested in another style rule and its selector is a single
-        /// class (the class the composed names are attached to). `loc` is the
-        /// rule's location, which the warnings for the disallowed cases point at.
         fn composes_state_for_body(
             &self,
             selectors: &SelectorList,
@@ -1580,8 +1571,7 @@ mod rule_parsers {
                 return ComposesState::DisallowNotSingleClass(loc);
             };
             match component.as_class() {
-                // With css modules enabled every class selector refers to a
-                // local symbol (see `SelectorParser::new_local_identifier`).
+                // Always a ref with css modules on, see `new_local_identifier`.
                 Some(class) => ComposesState::Allow {
                     loc,
                     class: class.as_ref().unwrap(),
@@ -2060,9 +2050,7 @@ mod rule_parsers {
             let location = input.position();
             let (declarations, rules) = this.parse_nested(input, true, composes_state)?;
 
-            // Track which properties a class that may use `composes` declares, so
-            // the bundler can report properties that conflict between composed
-            // classes.
+            // See `LocalPropertyUsage`.
             if let ComposesState::Allow { class, .. } = composes_state {
                 let len = input.position() - location;
                 let mut usage = PropertyBitset::init_empty();

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -336,7 +336,7 @@ where
         delimiters |= css::Delimiters::CURLY_BRACKET;
     }
     let source_location = input.current_source_location();
-    let mut property = input.parse_until_before(delimiters, |input2: &mut css::Parser| {
+    let property = input.parse_until_before(delimiters, |input2: &mut css::Parser| {
         css::Property::parse(property_id, input2, options)
     })?;
     let important = input
@@ -348,11 +348,11 @@ where
     input.expect_exhausted()?;
 
     if input.flags.css_modules() {
-        if let css::Property::Composes(composes) = &mut property {
+        if let css::Property::Composes(composes) = &property {
             match composes_ctx.composes_state() {
                 css::ComposesState::DisallowEntirely => {}
-                css::ComposesState::Allow(_) => {
-                    composes_ctx.record_composes(composes);
+                css::ComposesState::Allow { class, .. } => {
+                    composes_ctx.record_composes(class, composes);
                 }
                 css::ComposesState::DisallowNested(info) => {
                     options.warn_fmt(

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
-import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -256,56 +253,61 @@ describe("css", () => {
       `);
     },
   });
-});
-
-describe.concurrent("css modules composes with nested rules", () => {
-  async function build(entrypoint: string, files: Record<string, string>) {
-    using dir = tempDir("css-module-composes-nested", files);
-    return await Bun.build({
-      entrypoints: [join(String(dir), entrypoint)],
-      throw: false,
-    });
-  }
 
   // `.button` and the class it composes both set `color`, which the bundler
   // reports. It can only do so if the `composes` was recorded and the
   // properties of `.button` were tracked; a nested rule anywhere in the body
-  // used to break one or the other, and a nested rule before the `composes`
-  // additionally produced the nested-selector warning. The exact log list
-  // checks all of that.
-  const conflict = ["The value of color in the class button is undefined."];
-  test.each([
-    ["before", `.icon { color: green; } color: blue; composes: other from "./other.module.css";`],
-    ["after", `color: blue; composes: other from "./other.module.css"; .icon { color: green; }`],
-  ])("nested rule %s the composes: it is recorded and the class's properties are tracked", async (_, body) => {
-    const result = await build("entry.js", {
-      "entry.js": `
-        import styles from "./styles.module.css";
-        console.log(styles);
-      `,
-      "styles.module.css": `.button { ${body} }`,
-      "other.module.css": `.other { color: red; }`,
-    });
-    expect(result.logs.map(log => log.message)).toEqual(conflict);
-    expect(result.success).toBe(true);
-  });
+  // used to break one or the other.
+  const composesWithNestedRuleCases = [
+    {
+      name: "Before",
+      body: /* css */ `.icon { color: green; } color: blue; composes: other from "./other.module.css";`,
+    },
+    {
+      name: "After",
+      body: /* css */ `color: blue; composes: other from "./other.module.css"; .icon { color: green; }`,
+    },
+  ];
 
-  test("composes is still rejected inside rules nested in a style rule", async () => {
-    const result = await build("styles.module.css", {
-      "styles.module.css": `
+  for (const { name, body } of composesWithNestedRuleCases) {
+    itBundled(`css-module/ComposesConflictWithNestedRule${name}`, {
+      files: {
+        "/entry.js": `
+          import styles from "./styles.module.css";
+          console.log(styles);
+        `,
+        "/styles.module.css": `.button { ${body} }`,
+        "/other.module.css": `.other { color: red; }`,
+      },
+      entryPoints: ["/entry.js"],
+      outdir: "/out",
+      // Any error-level log that is not listed here, or listed but missing, fails the test.
+      bundleErrors: { "/styles.module.css": ["The value of color in the class button is undefined."] },
+    });
+  }
+
+  // `.c .d` is rejected for its own selector; it used to get the nested-selector
+  // warning left behind by `.icon`.
+  itBundled("css-module/ComposesRejectedInsideNestedRules", {
+    files: {
+      "/styles.module.css": /* css */ `
         .base { color: red; }
         .a { .icon { composes: base; } }
         .b { @media (min-width: 1px) { composes: base; } }
         .c .d { .icon { color: green; } composes: base; }
       `,
-    });
-    // `.c .d` is rejected for its own selector; it used to get the nested-selector
-    // warning left behind by `.icon`. Printing a rejected `composes` also fails
-    // the build with an error, which is not what this checks.
-    expect(result.logs.filter(log => log.level !== "error").map(log => log.message)).toEqual([
-      '"composes" is not allowed inside nested selectors',
-      '"composes" is not allowed inside nested selectors',
-      '"composes" only works inside single class selectors',
-    ]);
+    },
+    entryPoints: ["/styles.module.css"],
+    outdir: "/out",
+    backend: "api",
+    onAfterApiBundle(build) {
+      expect(build.logs.filter(log => log.level !== "error").map(log => log.message)).toEqual([
+        '"composes" is not allowed inside nested selectors',
+        '"composes" is not allowed inside nested selectors',
+        '"composes" only works inside single class selectors',
+      ]);
+    },
+    // The printer still refuses to print a rejected `composes` declaration.
+    bundleErrors: { "/styles.module.css": ["Failed to generate CSS for this file (PrintError)"] },
   });
 });

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -211,5 +214,98 @@ describe("css", () => {
       const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;
       expect(css).toContain(`.${betaOwn}`);
     },
+  });
+
+  // Whether `composes` is allowed is decided per style rule. Parsing a rule
+  // nested in the body used to leave that rule's "disallowed" verdict behind,
+  // so every `composes` written after it was rejected with the nested-selector
+  // warning and dropped from the export.
+  itBundled("css-module/ComposesAfterNestedRule", {
+    files: {
+      "/entry.js": `
+        import styles from "./styles.module.css";
+        console.log(styles);
+      `,
+      "/styles.module.css": `
+        .base { color: red; }
+        .other { cursor: pointer; }
+        .button {
+          .icon { color: green; }
+          composes: base;
+          @media (min-width: 1px) { padding: 1px; }
+          composes: other;
+          color: blue;
+        }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          base: "base_-MSaAA",
+          other: "other_-MSaAA",
+          button: "base_-MSaAA other_-MSaAA button_-MSaAA",
+          icon: "icon_-MSaAA"
+        };
+
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+    },
+  });
+});
+
+describe.concurrent("css modules composes with nested rules", () => {
+  async function build(entrypoint: string, files: Record<string, string>) {
+    using dir = tempDir("css-module-composes-nested", files);
+    return await Bun.build({
+      entrypoints: [join(String(dir), entrypoint)],
+      throw: false,
+    });
+  }
+
+  // `.button` and the class it composes both set `color`, which the bundler
+  // reports. It can only do so if the `composes` was recorded and the
+  // properties of `.button` were tracked; a nested rule anywhere in the body
+  // used to break one or the other, and a nested rule before the `composes`
+  // additionally produced the nested-selector warning. The exact log list
+  // checks all of that.
+  const conflict = ["The value of color in the class button is undefined."];
+  test.each([
+    ["before", `.icon { color: green; } color: blue; composes: other from "./other.module.css";`],
+    ["after", `color: blue; composes: other from "./other.module.css"; .icon { color: green; }`],
+  ])("nested rule %s the composes: it is recorded and the class's properties are tracked", async (_, body) => {
+    const result = await build("entry.js", {
+      "entry.js": `
+        import styles from "./styles.module.css";
+        console.log(styles);
+      `,
+      "styles.module.css": `.button { ${body} }`,
+      "other.module.css": `.other { color: red; }`,
+    });
+    expect(result.logs.map(log => log.message)).toEqual(conflict);
+    expect(result.success).toBe(true);
+  });
+
+  test("composes is still rejected inside rules nested in a style rule", async () => {
+    const result = await build("styles.module.css", {
+      "styles.module.css": `
+        .base { color: red; }
+        .a { .icon { composes: base; } }
+        .b { @media (min-width: 1px) { composes: base; } }
+        .c .d { .icon { color: green; } composes: base; }
+      `,
+    });
+    // `.c .d` is rejected for its own selector; it used to get the nested-selector
+    // warning left behind by `.icon`. Printing a rejected `composes` also fails
+    // the build with an error, which is not what this checks.
+    expect(result.logs.filter(log => log.level !== "error").map(log => log.message)).toEqual([
+      '"composes" is not allowed inside nested selectors',
+      '"composes" is not allowed inside nested selectors',
+      '"composes" only works inside single class selectors',
+    ]);
   });
 });


### PR DESCRIPTION
### Problem
- In a CSS module, `composes` written after a nested rule in the same block is rejected: `.a { .z { color: green } composes: c; color: blue }` prints `warn: "composes" is not allowed inside nested selectors` and the export for `a` does not contain `c`'s class name. The same file with `composes: c` moved before `.z { }` works. Reproduces on bun 1.4.0 and main.
- Two more symptoms of the same cause, found while fixing it:
  - `.a { composes: c from "./o.module.css"; .z { } }` composes fine, but the "The value of X in the class a is undefined." conflict diagnostic is never produced for `a`, because its property usage is not recorded.
  - `.a .b { .z { } composes: c }` warns "not allowed inside nested selectors" instead of "only works inside single class selectors".
- Cause: `QualifiedRuleParser::parse_block` for `NestedRuleParser` (`src/css/css_parser.rs`) decided whether `composes` is allowed in the rule it was opening by writing into the parser it was called on, which is the parser of the *enclosing* block: it set `this.composes_state` and pushed the rule's class onto `composes_refs`, a single list shared by every parser of the stylesheet, which a `scopeguard` cleared when `parse_block` returned. Once a nested rule had been parsed, the enclosing block's remaining declarations saw `DisallowNested` (first symptom) and an empty `composes_refs` (so `record_composes` would have recorded nothing), and the enclosing `parse_block` iterated the emptied list when recording the class's property usage (second symptom).

### Fix
- `ComposesState::Allow` now carries the class the block's `composes` declarations are recorded against, which replaces `composes_refs` (the list only ever held that one class: a class is pushed only when not nested in a style rule, so at most one was live at a time).
- `parse_block` computes the state for the block it opens (`composes_state_for_body`) and passes it to `parse_nested`; the other two `parse_nested` callers (`parse_style_block` for nested at-rules, `@nest`) pass `self.composes_state.nested()`, which is the derivation `parse_nested` did internally before. Nothing writes to the enclosing parser any more, so a block's state is fixed for its whole body, and `parse_block` records property usage for its own class rather than for whatever the shared list holds. The shared list, the `scopeguard` that cleared it (the crate's only use of `scopeguard`), and the `TopLevelRuleParser` field backing it are removed.
- Why this is correct: whether `composes` is allowed is a property of the rule being parsed (not nested in a style rule, single class selector); it cannot depend on what was parsed earlier in the body. The rules enforced are unchanged, so every case that was rejected for its own sake is still rejected (nested rule, nested `@media`, non-single-class selector; see the last test), and the warning locations are unchanged. esbuild accepts the repro.
- Verified with `bun bd test test/bundler/css/css-modules.test.ts` (4 new `itBundled` tests; all 4 fail on the released bun: the export lacks the composed classes, the conflict diagnostic is missing in both orderings, `.c .d` gets the wrong warning). Also green with the debug build: `test/bundler/esbuild/css.test.ts` (56), `test/js/bun/css/css.test.ts` (1142), `test/js/bun/css/doesnt_crash.test.ts`, `test/js/bun/css/css-loader.test.ts`, `test/bundler/bundler_loader.test.ts`, the PrintError test in `test/bundler/cli.test.ts`; `cargo clippy -p bun_css` and `cargo fmt` clean.
- Related, found while fixing this and filed separately; each is independent of this change: #38538 (a rejected `composes` still makes printing fail; once it lands, the `bundleErrors` line of `ComposesRejectedInsideNestedRules` goes away), #38537 (the conflict diagnostic is logged as an error although the build succeeds; it moves the `bundleErrors` expectations of the conflict tests), #38523 (the conflict check keeps only the last rule's custom properties).

### Background
- `composes` (CSS modules): `.a { composes: b; }` makes the JS export for `a` contain `b`'s generated class name as well as its own. Bun follows esbuild: the declaration is dropped from the CSS output and instead recorded at parse time in the stylesheet's `composes` map, keyed by the class's symbol, which the bundler reads when generating the module's exports. esbuild (and bun) only allow it directly in a rule whose selector is a single class and which is not nested inside another style rule.
- `NestedRuleParser`: the CSS parser creates one of these per block. `parse_block` runs on the parser of the block that contains the rule and calls `parse_nested`, which creates the child parser for the rule's body; `composes_state` is the child's verdict for its own declarations, consulted by `parse_declaration_impl` (`src/css/declaration.rs`) for every `composes` it meets.
- `local_properties`: for each class that may use `composes`, the parser records which properties its rule declares. The bundler (`validate_composes_from_properties` in `src/bundler/linker_context/scanImportsAndExports.rs`) uses it to report a property defined by both a class and the class it composes from another file, since the CSS modules spec leaves that order undefined.

<details>
<summary>Behavior matrix with the debug build (exports of <code>a</code>; <code>.c</code>/<code>.d</code> are plain classes)</summary>

| stylesheet | before | after |
| --- | --- | --- |
| `.a { .z {} composes: c }` | `a`, nested warning | `c a` |
| `.a { composes: c; .z {} }` | `c a`, no conflict check for `a` | `c a`, conflict check runs |
| `.a { .y {} composes: c; .z {} composes: d }` | `a`, 2 nested warnings | `c d a` |
| `.a { @media (x) { color: green } composes: c }` | `c a` | `c a` |
| `.a { @nest .p & {} composes: c }` | `c a` | `c a` |
| `.a { .z { composes: c } }` | nested warning | nested warning |
| `.a { @media (x) { composes: c } }` | nested warning | nested warning |
| `.a .b { .z {} composes: c }` | nested warning | single-class warning |

The three rejected cases additionally fail to print ("Failed to generate CSS for this file (PrintError)") before and after; that is pre-existing (#38538), which is why `ComposesRejectedInsideNestedRules` lists that error and asserts the warnings from `onAfterApiBundle`.
</details>

