### PR TITLE
Fix crash when a property walk in Bun.inspect throws part way through

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5605,10 +5605,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5680,7 +5681,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto) [[unlikely]]
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,61 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("property walk that throws part way through", () => {
+  async function run(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("skips a prototype property whose Proxy get trap throws", async () => {
+    const result = await run(`
+      const proto = new Proxy({ a: 1, b: 2 }, {
+        get(target, key, receiver) {
+          if (key === "a") throw new Error("boom");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(result).toEqual({ stdout: "{\n  b: 2,\n}\n", stderr: "", exitCode: 0 });
+  });
+
+  it("stops walking when a Proxy getPrototypeOf trap throws", async () => {
+    const result = await run(`
+      const proto = new Proxy({ a: 1 }, {
+        getPrototypeOf() { throw new Error("boom"); },
+      });
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(result).toEqual({ stdout: "{\n  a: 1,\n}\n", stderr: "", exitCode: 0 });
+  });
+
+  it("lazy Bun properties failing with a stack overflow", async () => {
+    // Close to the stack limit, initializing the lazy properties of the Bun
+    // object that have to run JS (Bun.$, Bun.sql, ...) throws a stack overflow
+    // in the middle of the walk. How close depends on how much native stack
+    // each initializer needs, so inspect at a spread of depths above the
+    // frame where the recursion overflowed (level 0).
+    const result = await run(`
+      const levels = new Set([0, 64, 128, 256, 512, 1024, 2048]);
+      let level = -1;
+      function recurse() {
+        try { recurse(); } catch {}
+        level++;
+        if (levels.has(level)) {
+          try { Bun.inspect(Bun); } catch {}
+        }
+      }
+      recurse();
+      console.log("ok");
+    `);
+    expect(result).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -971,6 +971,10 @@ describe.concurrent("property walk that throws part way through", () => {
     // each initializer needs, so inspect at a spread of depths above the
     // frame where the recursion overflowed (level 0).
     const result = await run(`
+      // On Windows Bun.env has an inspect.custom function. Calling one for the
+      // first time loads node:util, which is a separate crash when it happens
+      // near the stack limit, so load it up front.
+      Bun.inspect({ [Bun.inspect.custom]() { return 0; } });
       const levels = new Set([0, 64, 128, 256, 512, 1024, 2048]);
       let level = -1;
       function recurse() {


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the property walk used by `Bun.inspect` / `console.log` (`JSC__JSValue__forEachPropertyImpl` in `bindings.cpp`) when something throws part way through the walk. Found by the fuzzer (fingerprint `9fd31e294032711d`).

In the slow path, when `getPropertySlot` threw it returned false and the loop did `continue` without clearing the exception, so the next property was looked up with a stale exception pending on the VM. Two ways to get there:

- `Bun.inspect(Bun)` close to the stack limit (the fuzzer's case). The `Bun.$` builder calls into JS, which throws a stack overflow. The walk then reified the next lazy property (`Bun.Archive`) with that exception still pending, which trips the exception scope assertion in `to_js_host_call` in debug builds. In release builds every following `setUpStaticFunctionSlot` sees the stale exception and reports the property as missing, so the rest of the object is silently dropped from the output.
- An object whose prototype is a Proxy with a throwing `get` trap. Same stale exception, and at the end of the step `iterating->getPrototype(globalObject).getObject()` gets back an empty `JSValue` (every JSC entry point bails on the pending exception) and calls `getObject()` on it, which is a null dereference. A throwing `getPrototypeOf` trap reaches the same line directly. Both of these segfault the current release build (`Segmentation fault at address 0x5`):

```js
const proto = new Proxy({ a: 1, b: 2 }, { get(t, k, r) { if (k === "a") throw new Error("boom"); return Reflect.get(t, k, r); } });
Bun.inspect(Object.create(proto));
```

The fix clears the exception before deciding whether to skip the property (this is what `forEachPropertyOrdered` already does) and stops the prototype walk when `getPrototype` throws, matching how the fast path in the same function treats `getPrototypeOf` traps. The throwing property is skipped and the rest of the object is still printed, consistent with how this function already treats throwing getters.

With that fixed, the fuzzer script hit a second assertion in the same scenario: the `Bun.sql` / `Bun.SQL` builders had a `#if BUN_DEBUG` block calling `reportUncaughtExceptionAtEventLoop` while the exception was still pending on the VM. Every other caller clears the exception first; running the uncaught exception handler with one pending makes the `process._fatalException` lookup reify a property and then report it missing, which fails the `object->structure() == this` assertion in `Structure::storedPrototype`. A plain `Bun.sql` access near the stack limit aborts a debug build the same way. The builder already propagates the error to whoever touched the property (verified: `Bun.sql` throws the RangeError and works again later once there is stack), so the debug-only report is removed rather than reordered.

### How did you verify your code works?

Added three tests to `test/js/bun/util/inspect.test.js`, each running the repro in a child process:

- prototype Proxy with a throwing `get` trap: prints `{ b: 2 }`
- prototype Proxy with a throwing `getPrototypeOf` trap: prints `{ a: 1 }`
- `Bun.inspect(Bun)` at a spread of depths just above a stack overflow

Against the unfixed binaries: the two Proxy tests segfault with `USE_SYSTEM_BUN=1` and fail with a UBSan null member call on a debug build, and the stack overflow test fails on a debug build with the fuzzer's `Unexpected exception observed` assertion. With only the `bindings.cpp` change built, the stack overflow test fails with the `storedPrototype` assertion from the `Bun.sql` builder; with both changes all three pass (`bun bd test test/js/bun/util/inspect.test.js`, 77 pass), as do `test/js/bun/console`. The original fuzzer script, which inspects `Bun` at every one of the ~52k frames on the way back up from the overflow, runs to completion on the debug build.

The stack overflow test only detects the bug on debug builds, since release builds have no assertion to hit there; the Proxy tests cover release.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->