### PR TITLE
event loop: a fatal error ends the run even while immediates are queued

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1203,6 +1203,13 @@ impl VirtualMachine {
     }
 
     pub fn is_event_loop_alive(&self) -> bool {
+        // An error nothing in script handled ends the run (node exits from the
+        // error itself): pending immediates must not keep it turning any more
+        // than pending timers or I/O do. `--hot`/`--watch` count such errors too
+        // but keep running until the next reload; for them the terms below decide.
+        if self.unhandled_error_counter > 0 && !self.is_watcher_enabled() {
+            return false;
+        }
         let el = self.event_loop_shared();
         self.is_event_loop_alive_excluding_immediates()
             || !el.immediate_tasks.is_empty()

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1202,12 +1202,14 @@ impl VirtualMachine {
                 > 0)
     }
 
+    /// An error nothing in script handled was reported and ends this run.
+    /// `--hot`/`--watch` report such errors too but run on until the next reload.
+    pub fn has_fatal_unhandled_error(&self) -> bool {
+        self.unhandled_error_counter > 0 && !self.is_watcher_enabled()
+    }
+
     pub fn is_event_loop_alive(&self) -> bool {
-        // An error nothing in script handled ends the run (node exits from the
-        // error itself): pending immediates must not keep it turning any more
-        // than pending timers or I/O do. `--hot`/`--watch` count such errors too
-        // but keep running until the next reload; for them the terms below decide.
-        if self.unhandled_error_counter > 0 && !self.is_watcher_enabled() {
+        if self.has_fatal_unhandled_error() {
             return false;
         }
         let el = self.event_loop_shared();

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1059,11 +1059,15 @@ describe.concurrent(() => {
         stdio: ["ignore", "pipe", "pipe"],
       });
       const stderr = proc.stderr.text();
-      const { value: firstLine } = await forEachLine(proc.stdout).next();
+      const stdoutLines = forEachLine(proc.stdout);
+      const { value: firstLine } = await stdoutLines.next();
+      // What a watcher makes of the fixture's process.exit() is not under test
+      // here: stop the fixture ourselves once it has reported, then drain it.
       proc.kill();
-      await proc.exited;
-      expect(firstLine).toBe("immediates still running after the error");
+      await Array.fromAsync(stdoutLines);
       expect(await stderr).toInclude("error: boom");
+      expect(firstLine).toBe("immediates still running after the error");
+      await proc.exited;
     });
   });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,7 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, forEachLine, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -969,6 +969,101 @@ describe.concurrent(() => {
       expect(stdout).toBeEmpty();
       // 7 is node's "the uncaughtException handler itself threw"; there is no handler here.
       expect(exitCode).toBe(1);
+    });
+  });
+
+  describe("fatal error while immediates are pending", () => {
+    // Node runs nothing after an uncaught exception or unhandled rejection that
+    // nothing handled: the process exits from the error itself. This immediate
+    // requeues itself forever; if the run loop keeps turning after the error it
+    // says so and exits 42 rather than spinning until the test times out.
+    const requeueingImmediate = `
+      let errored = false;
+      let runsAfterError = 0;
+      setImmediate(function again() {
+        if (errored && ++runsAfterError === 50) {
+          console.log("immediates still running after the error");
+          process.exit(42);
+        }
+        setImmediate(again);
+      });`;
+
+    it("an uncaught exception exits 1 instead of being kept alive by a requeueing setImmediate", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `${requeueingImmediate}
+           process.on("exit", c => console.log("exit", c));
+           setTimeout(() => { errored = true; throw new Error("boom"); }, 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("exit 1\n");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("an unhandled rejection exits 1 instead of being kept alive by a requeueing setImmediate", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `${requeueingImmediate}
+           setTimeout(() => { errored = true; Promise.reject(new Error("boom")); }, 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("an unhandled rejection from a beforeExit listener exits 1 instead of being kept alive by a requeueing setImmediate", async () => {
+      // Same thing for the drain that follows 'beforeExit', which is a second
+      // run loop of its own.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.once("beforeExit", () => {
+             ${requeueingImmediate}
+             errored = true;
+             Promise.reject(new Error("boom"));
+           });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it.each(["--hot", "--watch"])("%s still runs the immediates after the error", async flag => {
+      // The watcher modes print the error and keep the process alive for the
+      // next reload instead of exiting on it, so what was running keeps running.
+      using dir = tempDir("process-fatal-immediates", {
+        "index.js": `${requeueingImmediate}
+          setTimeout(() => { errored = true; throw new Error("boom"); }, 1);`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), flag, "index.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const stderr = proc.stderr.text();
+      const { value: firstLine } = await forEachLine(proc.stdout).next();
+      proc.kill();
+      await proc.exited;
+      expect(firstLine).toBe("immediates still running after the error");
+      expect(await stderr).toInclude("error: boom");
     });
   });
 


### PR DESCRIPTION
### Problem
- After bun reports a fatal error (an uncaught exception or an unhandled rejection with no listener for it), a program that has a `setImmediate` queued keeps running. With a self-requeueing immediate it never exits: intervals keep firing, I/O keeps being served, and the error that was printed has no further effect. Node exits 1 from the error itself.
  ```js
  setImmediate(function again() { setImmediate(again); });
  setInterval(() => console.log("tick"), 200);
  setTimeout(() => { throw new Error("fatal"); }, 100);
  ```
  `bun x.js` prints `error: fatal` and then prints `tick` forever (1.4.0 and main); `node x.js` exits 1 right after the error. The same happens with `Promise.reject(...)` in place of the throw, and with an unhandled rejection raised by a `beforeExit` listener that also queues an immediate.
- Cause: `VirtualMachine::is_event_loop_alive()` (`src/jsc/VirtualMachine.rs`) is `is_event_loop_alive_excluding_immediates() || immediates queued`, and only the first operand contains the `unhandled_error_counter == 0` check. Every run loop (`Run::start` in `src/runtime/cli/run_command.rs`, `on_before_exit()`, `WebWorker::spin`) is `while vm.is_event_loop_alive() { tick(); auto_tick_active(); }`, so once an error has been counted, queued immediates alone keep the loop turning, and each turn also polls I/O and fires due timers. The immediate terms were split out of the gated expression in #16855 (they were inside it before); the split was for unref'd immediates and moving them out of the counter gate was a side effect.

### Fix
- New predicate `has_fatal_unhandled_error()` (`unhandled_error_counter > 0 && !is_watcher_enabled()`); `is_event_loop_alive()` returns false when it holds, before looking at anything queued. The rest of the predicate is unchanged.
- Why this is right: a counted error already means "this run is over" everywhere else in bun: it is what makes the same loops stop for timers and I/O, `on_before_exit()` skips `beforeExit` because of it (#34639), and the exit code is 1. Immediates were the one kind of pending work exempt from it, and that exemption is what node never has: after a fatal error nothing else runs.
- Why the watcher exemption: `--hot` and `--watch` print the error and keep the process alive until the next reload, but they count the error too. Today the immediate terms are what still runs a hot-reloaded program's immediates after an error (timers already stop there, which #38206 fixes by not counting errors in watcher mode). Without the exemption this change would have taken immediates away from those modes as well; with it they behave exactly as before, and once #38206 lands the counter is never nonzero in watcher mode, so the `is_watcher_enabled()` half of the new predicate becomes inert and can be dropped.
- Other callers of the predicate: `bun repl -e` / `bun repl -p` (the one caller in `repl.rs`, a one-shot eval followed by a drain) had the same hang and now exits 1 like `bun -e`; the interactive REPL does not use it. Not affected: `bun test` (its counter is a tally, and its drive loop does not consult this predicate; the `--watch` idle loop has a watcher installed), workers, whose error hook already requests termination, so their loop exits either way (checked: a worker with the same requeueing immediate exits on both builds), and the inspector thread's own VM (`Debugger.rs`), whose script (`src/js/internal/debugger.ts`) schedules no immediates or timers, so the immediate terms never decide anything there.
- Still out of scope: the rest of the loop turn in which the error was reported still runs (remaining immediates of the same batch, due timers of the same `auto_tick_active()` pass; e.g. `setTimeout(() => { Promise.reject(e); setImmediate(cb); })` still runs `cb` once because the rejection is only reported at the top of the next turn). That is bounded and pre-existing for timers and tasks as well; a separate change reports rejections left by immediates before the poll and returns early from `auto_tick_active()` once the run is over, and composes with this one.
- Tests, `test/js/node/process/process.test.js`, new block "fatal error while immediates are pending": an uncaught exception, an unhandled rejection, and an unhandled rejection from a `beforeExit` listener, each with a requeueing immediate that exits 42 if it is still being run after the error. All three fail on the current release (`immediates still running after the error`, exit 42) and pass with this change (exit 1, nothing after the error). A fourth test pins that `--hot` and `--watch` still run the immediates after the error; it passes before and after.
- Also run on this build: the rest of `process.test.js` (the only failures are `process.env.USER` being unset in this container and three tests that time out under the whole-file concurrency of a debug build but pass alone), `test/cli/hot/hot.test.ts`, `test/cli/hot/watch.test.ts`, `test/cli/watch/watch.test.ts`, `test/js/node/timers/node-timers.test.ts`, `test/js/node/worker_threads/worker_threads.test.ts`, `test/js/web/workers/worker.test.ts` (three failures that are this debug build's speed, not errors: two pass with a longer timeout, the third asserts within a 30ms window while a worker takes about 145ms to start here), `test/js/bun/spawn/exit-code.test.ts`, `bun-serve-propagate-errors`, `serve-reused-response`, `test/js/bun/test/bun_test.test.ts`, `test/cli/test/test-changed.test.ts`, and the 43 node `test-promise*`, `test-promises-*`, `test-process-exit*`, `test-process-beforeexit*`, `test-timers-immediate*`, `test-timers-unref*`, `test-timers-uncaught-exception`, `test-worker-exit*`, `test-worker-uncaught*` files, all passing.

### Background
- `unhandled_error_counter`: a field on the VM, incremented in `uncaught_exception()` and `unhandled_rejection()` when no `uncaughtException`/`unhandledRejection` listener took the error (the error is printed at the same time). For `bun run` it is the fatal-error state: the run loops stop when it is nonzero, `on_before_exit()` skips `beforeExit`, and the process exits 1. `bun test` increments it on separate branches and only compares it before and after a test to attribute errors; `--hot`/`--watch` increment it too but their run loop never returns.
- Immediates and liveness: `setImmediate` callbacks sit in the event loop's `immediate_tasks`/`next_immediate_tasks` lists and are run at the start of `auto_tick_active()`, before the I/O poll. A ref'd immediate also holds a ref on the I/O loop, but an unref'd one does not, so `is_event_loop_alive()` checks the lists themselves in addition to `is_event_loop_alive_excluding_immediates()` (refs, queued tasks, in-flight work), which `run_immediate_task` uses to decide whether an unref'd immediate should run at all. This change does not touch that function.
- The run loop: `tick()` runs queued tasks and microtasks; `auto_tick_active()` runs immediates, polls I/O for as long as the timer heap allows (not at all while immediates are queued), then fires due timers. The condition is only re-checked between turns, which is why the turn that reports the error still completes.

<details>
<summary>Probes (release 1.4.0 vs this build, linux x64)</summary>

```
$ cat x.js
let n = 0;
function loop() { n++; setImmediate(loop); }
loop();
setInterval(() => console.log("interval tick, immediates so far:", n), 200);
setTimeout(() => { throw new Error("fatal"); }, 100);

$ timeout 2 bun x.js            # 1.4.0: error: fatal, then 9 interval lines, killed (124)
$ timeout 2 bun-debug x.js      # this build: error: fatal, exit 1
$ node x.js                     # exit 1 right after the error

# same with Promise.reject(new Error("fatal rejection")) in the timer: 124 -> 1

# worker_threads variant (same script inside a Worker): both builds report the
# error to the parent and the worker exits; the worker's error hook requests
# termination, which spin() checks separately from is_event_loop_alive().

# bun repl -e, the caller in repl.rs:
$ timeout 5 bun repl -e 'setImmediate(function again(){ setImmediate(again) }); setTimeout(() => console.log("kept running"), 300); setTimeout(() => { throw new Error("boom") }, 1)'
# 1.4.0: error: boom, kept running, killed (124);  this build: error: boom, exit 1

# remaining same-turn tail, unchanged by this PR:
$ cat batch.js
setImmediate(() => { throw new Error("boom"); });
setImmediate(() => console.log("same batch"));
setImmediate(() => setImmediate(() => console.log("next batch")));
setTimeout(() => console.log("timer"), 0);
$ bun batch.js        # 1.4.0:      same batch, timer, next batch; exit 1
$ bun-debug batch.js  # this build: same batch, timer; exit 1
$ node batch.js       # timer (fires before the check phase); exit 1
```
</details>
