### PR TITLE
css modules: keep every rule's custom properties for the composes conflict check

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2257,7 +2257,7 @@ pub struct ComposesEntry {
 
 pub struct PropertyUsage {
     pub bitset: PropertyBitset,
-    pub custom_properties: Box<[&'static [u8]]>, // TODO: lifetime — arena slices
+    pub custom_properties: Vec<&'static [u8]>, // TODO: lifetime — arena slices
     pub range: bun_ast::Range,
 }
 
@@ -2265,7 +2265,7 @@ impl Default for PropertyUsage {
     fn default() -> Self {
         Self {
             bitset: PropertyBitset::init_empty(),
-            custom_properties: Box::default(),
+            custom_properties: Vec::new(),
             range: bun_ast::Range::default(),
         }
     }
@@ -2277,11 +2277,7 @@ impl PropertyUsage {
     #[inline]
     pub(crate) fn fill(&mut self, used: &PropertyBitset, custom_properties: &[&'static [u8]]) {
         self.bitset.set_union(used);
-        if !custom_properties.is_empty() {
-            self.custom_properties = [&*self.custom_properties, custom_properties]
-                .concat()
-                .into_boxed_slice();
-        }
+        self.custom_properties.extend_from_slice(custom_properties);
     }
 }
 

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2257,7 +2257,8 @@ pub struct ComposesEntry {
 
 pub struct PropertyUsage {
     pub bitset: PropertyBitset,
-    pub custom_properties: Vec<&'static [u8]>, // TODO: lifetime — arena slices
+    /// Arena slices with the lifetime erased; see `fill_property_bit_set`.
+    pub custom_properties: Vec<&'static [u8]>,
     pub range: bun_ast::Range,
 }
 
@@ -2297,7 +2298,7 @@ pub(crate) fn fill_property_bit_set(
                 // SAFETY: `'bump`-erasure — `CustomPropertyName` stores an
                 // arena-owned `*const [u8]`; detach from `block`'s borrow so
                 // callers can move `block` afterwards. Re-thread once
-                // `PropertyUsage` carries the arena lifetime (TODO at field def).
+                // `PropertyUsage` carries the arena lifetime.
                 let name: &'static [u8] = unsafe { src_str(c.name.as_str()) };
                 custom_properties.push(name);
                 continue;

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2272,11 +2272,16 @@ impl Default for PropertyUsage {
 }
 
 impl PropertyUsage {
+    /// Called once per style rule selecting the class, so both the bitset and
+    /// the custom property list accumulate across all of the class's rules.
     #[inline]
     pub(crate) fn fill(&mut self, used: &PropertyBitset, custom_properties: &[&'static [u8]]) {
         self.bitset.set_union(used);
-        // TODO: lifetime — box for now.
-        self.custom_properties = custom_properties.to_vec().into_boxed_slice();
+        if !custom_properties.is_empty() {
+            self.custom_properties = [&*self.custom_properties, custom_properties]
+                .concat()
+                .into_boxed_slice();
+        }
     }
 }
 

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2272,8 +2272,6 @@ impl Default for PropertyUsage {
 }
 
 impl PropertyUsage {
-    /// Called once per style rule selecting the class, so both the bitset and
-    /// the custom property list accumulate across all of the class's rules.
     #[inline]
     pub(crate) fn fill(&mut self, used: &PropertyBitset, custom_properties: &[&'static [u8]]) {
         self.bitset.set_union(used);

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
-import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -215,54 +212,87 @@ describe("css", () => {
       expect(css).toContain(`.${betaOwn}`);
     },
   });
-});
 
-describe("css-module composes conflicts are checked against every rule of a class", () => {
-  // Composing two classes from different files that declare the same property is
-  // undefined, and the bundler reports it. The properties a class declares are
-  // collected per style rule, so a class written as several `.x { }` rules has to
-  // keep the custom properties of all of them, not only of the rule parsed last.
-  const cases: [name: string, styles: string, other: string, expected: string[]][] = [
-    [
-      "custom properties of every rule of the composing class",
-      `.button { --x: 2; composes: other from "./other.module.css" }
-       .button { --y: 3 }`,
-      `.other { --x: 1; --y: 1 }`,
-      ["The value of --x in the class button is undefined.", "The value of --y in the class button is undefined."],
-    ],
-    [
-      "a later rule without custom properties keeps the earlier ones",
-      `.button { --x: 2; composes: other from "./other.module.css" }
-       .button { margin: 0 }`,
-      `.other { --x: 1; margin: 1px }`,
-      ["The value of --x in the class button is undefined.", "The value of margin in the class button is undefined."],
-    ],
-    [
-      "custom properties of every rule of the composed class",
-      `.button { --x: 2; composes: other from "./other.module.css" }`,
-      `.other { --x: 1 }
-       .other { color: red }`,
-      ["The value of --x in the class button is undefined."],
-    ],
-    [
-      "disjoint custom properties spread over several rules do not conflict",
-      `.button { --x: 2; composes: other from "./other.module.css" }
-       .button { --y: 3 }`,
-      `.other { --z: 1 }
-       .other { --w: 1 }`,
-      [],
-    ],
+  // Composing two classes from different files that both declare a property is
+  // undefined, so the bundler reports it. A class's properties are collected one
+  // style rule at a time, so a class written as several rules has to keep the
+  // custom properties of all of them, not only of the rule parsed last.
+  const composesConflictCases = [
+    {
+      name: "EveryRuleOfTheComposingClass",
+      styles: /* css */ `
+        .button { --x: 2; composes: other from "./other.module.css" }
+        .button { --y: 3 }
+      `,
+      other: /* css */ `.other { --x: 1; --y: 1 }`,
+      errors: [
+        "The value of --x in the class button is undefined.",
+        "The value of --y in the class button is undefined.",
+      ],
+    },
+    {
+      name: "RuleInsideAtMedia",
+      styles: /* css */ `
+        .button { --x: 2; composes: other from "./other.module.css" }
+        @media (min-width: 1px) {
+          .button { --y: 3 }
+        }
+      `,
+      other: /* css */ `.other { --x: 1; --y: 1 }`,
+      errors: [
+        "The value of --x in the class button is undefined.",
+        "The value of --y in the class button is undefined.",
+      ],
+    },
+    {
+      name: "LaterRuleWithoutCustomProperties",
+      styles: /* css */ `
+        .button { --x: 2; composes: other from "./other.module.css" }
+        .button { margin: 0 }
+      `,
+      other: /* css */ `.other { --x: 1; margin: 1px }`,
+      errors: [
+        "The value of --x in the class button is undefined.",
+        "The value of margin in the class button is undefined.",
+      ],
+    },
+    {
+      name: "EveryRuleOfTheComposedClass",
+      styles: /* css */ `.button { --x: 2; composes: other from "./other.module.css" }`,
+      other: /* css */ `
+        .other { --x: 1 }
+        .other { color: red }
+      `,
+      errors: ["The value of --x in the class button is undefined."],
+    },
+    {
+      name: "DisjointPropertiesAcrossRules",
+      styles: /* css */ `
+        .button { --x: 2; composes: other from "./other.module.css" }
+        .button { --y: 3 }
+      `,
+      other: /* css */ `
+        .other { --z: 1 }
+        .other { --w: 1 }
+      `,
+      errors: [],
+    },
   ];
 
-  test.concurrent.each(cases)("%s", async (_name, styles, other, expected) => {
-    using dir = tempDir("css-modules-composes-conflicts", {
-      "entry.js": `import styles from "./styles.module.css"; console.log(styles);`,
-      "styles.module.css": styles,
-      "other.module.css": other,
+  for (const { name, styles, other, errors } of composesConflictCases) {
+    itBundled(`css-module/ComposesConflict${name}`, {
+      files: {
+        "/entry.js": `
+          import styles from "./styles.module.css";
+          console.log(styles);
+        `,
+        "/styles.module.css": styles,
+        "/other.module.css": other,
+      },
+      entryPoints: ["/entry.js"],
+      outdir: "/out",
+      // Without bundleErrors, any error-level log fails the test.
+      bundleErrors: errors.length ? { "/styles.module.css": errors } : undefined,
     });
-
-    const result = await Bun.build({ entrypoints: [join(String(dir), "entry.js")], throw: false });
-
-    expect(result.logs.map(log => log.message).sort()).toEqual(expected);
-  });
+  }
 });

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -211,5 +214,55 @@ describe("css", () => {
       const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;
       expect(css).toContain(`.${betaOwn}`);
     },
+  });
+});
+
+describe("css-module composes conflicts are checked against every rule of a class", () => {
+  // Composing two classes from different files that declare the same property is
+  // undefined, and the bundler reports it. The properties a class declares are
+  // collected per style rule, so a class written as several `.x { }` rules has to
+  // keep the custom properties of all of them, not only of the rule parsed last.
+  const cases: [name: string, styles: string, other: string, expected: string[]][] = [
+    [
+      "custom properties of every rule of the composing class",
+      `.button { --x: 2; composes: other from "./other.module.css" }
+       .button { --y: 3 }`,
+      `.other { --x: 1; --y: 1 }`,
+      ["The value of --x in the class button is undefined.", "The value of --y in the class button is undefined."],
+    ],
+    [
+      "a later rule without custom properties keeps the earlier ones",
+      `.button { --x: 2; composes: other from "./other.module.css" }
+       .button { margin: 0 }`,
+      `.other { --x: 1; margin: 1px }`,
+      ["The value of --x in the class button is undefined.", "The value of margin in the class button is undefined."],
+    ],
+    [
+      "custom properties of every rule of the composed class",
+      `.button { --x: 2; composes: other from "./other.module.css" }`,
+      `.other { --x: 1 }
+       .other { color: red }`,
+      ["The value of --x in the class button is undefined."],
+    ],
+    [
+      "disjoint custom properties spread over several rules do not conflict",
+      `.button { --x: 2; composes: other from "./other.module.css" }
+       .button { --y: 3 }`,
+      `.other { --z: 1 }
+       .other { --w: 1 }`,
+      [],
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_name, styles, other, expected) => {
+    using dir = tempDir("css-modules-composes-conflicts", {
+      "entry.js": `import styles from "./styles.module.css"; console.log(styles);`,
+      "styles.module.css": styles,
+      "other.module.css": other,
+    });
+
+    const result = await Bun.build({ entrypoints: [join(String(dir), "entry.js")], throw: false });
+
+    expect(result.logs.map(log => log.message).sort()).toEqual(expected);
   });
 });


### PR DESCRIPTION
### Problem
- With CSS modules, the bundler reports `The value of --x in the class button is undefined.` when a class and a class it `composes` from another file both declare `--x`. The report is lost as soon as the class is written as more than one rule in its file:
  ```css
  .button { --x: 2; composes: other from "./other.module.css" }
  .button { --y: 3 }
  ```
  with `.other { --x: 1 }` in other.module.css builds without a diagnostic. The same two rules with `color` in place of `--x` are reported.
- The composed side has the same hole: `.other { --x: 1 } .other { color: red }` hides the `--x` conflict with a single-rule `.button`.
- `PropertyUsage::fill` (src/css/css_parser.rs:2276) runs once per style rule selecting the class. It unions the rule's standard properties into the class's bitset but assigns the rule's custom property list, so the class entry only ever holds the custom properties of the rule parsed last (none, when that rule has none).

### Fix
- `PropertyUsage::custom_properties` becomes a `Vec` and `fill` appends each rule's custom properties to it, so the list is the union over the class's rules, as the bitset already is. Appending keeps recording linear in the number of rules of a class (a first version of this PR rebuilt a boxed slice per rule, which was quadratic for a class repeated many times).
- The check asks what the class declares in its file, and every rule selecting the class contributes to that, so the union is the right thing to compare. esbuild records it the same way: one property map per class that each rule of the class adds to (`processDeclarations` in internal/css_parser/css_decls.go).
- A name repeated in the list already happens today when one rule declares `--x` twice. The consumer, `add_property_or_warn` in src/bundler/linker_context/scanImportsAndExports.rs, keys on the name and returns early when the earlier entry came from the same file, so a class cannot conflict with itself and each conflict is still reported once.
- The diagnostic's position is unchanged: it points at the class's first rule in the file, as before, whichever rule declares the property.
- Verified with the `css-module/ComposesConflict*` cases added to test/bundler/css/css-modules.test.ts (itBundled with `bundleErrors`; the default API backend checks error-level logs even though the build itself succeeds): 4 of the 5 fail on the released build, each missing exactly the `--x` declared in the earlier rule; the fifth pins that disjoint properties spread over several rules stay silent. All 5 pass with the fix.
- test/bundler/esbuild/css.test.ts and the rest of test/bundler/css/ pass with the fix.

### Background
- `composes` (CSS modules): `.a { composes: b from "./x.module.css" }` makes the exported name for `a` include `b`'s generated class name, so an element using `a` gets the declarations of both classes. The spec does not define which class wins when the two live in different files, so a property declared by both is reported by `validate_composes_from_properties` (scanImportsAndExports.rs) at link time.
- `PropertyUsage`: the parser's per-class record of the properties declared by rules whose selector is exactly that one class (top-level rules and rules inside `@media` and similar blocks; rules nested in another style rule are not recorded). Standard properties go into a bitset indexed by property id; custom (`--*`) properties have no id and are kept as a list of names. The entry is created once per class (`local_properties.entry(..).or_insert_with(..)` in `parse_block`) and `fill`ed once per rule.

<details>
<summary>Repro output (Bun.build with throw: false, other.module.css is <code>.other { color: red; --x: 1 }</code>)</summary>

```
case                      styles.module.css                                                          1.4.0                                    fixed
single                    .button { --x: 2; composes: other from "./other.module.css" }              --x in the class button is undefined     same
two_rules                 + .button { --y: 3 }                                                       (nothing)                                --x in the class button is undefined
two_rules_std             .button { color: blue; composes: ... }  + .button { margin: 0 }            color in the class button is undefined   same
conflict_in_second_rule   .button { composes: ... }  + .button { --x: 3 }                            --x in the class button is undefined     same
```

Recording cost for one class repeated N times with 8 custom properties per rule (debug build, `.t { }` recorded vs `.t:hover { }` control, which is not recorded): N=8000 4.1s vs 3.1s, N=16000 7.3s vs 5.9s, N=32000 15.1s vs 12.6s, i.e. linear. The boxed-slice version of this PR measured +3.4s, +15.2s and +48.8s over the control at the same sizes.
</details>
