### PR TITLE
event loop: report immediates' rejections before polling, and stop polling once a fatal error ended the run

### DIFF
--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -191,7 +191,7 @@ impl Debugger {
     ///
     /// Aliasing: `this.debugger` is read through a raw pointer
     /// with fresh short-lived borrows because `event_loop().tick()` /
-    /// `auto_tick_active()` re-enter JS, which calls `VirtualMachine::get()`
+    /// `auto_tick()` re-enter JS, which calls `VirtualMachine::get()`
     /// and may form independent `&mut VirtualMachine` borrows. Holding a
     /// long-lived `&mut Debugger` (which borrows from `&mut VirtualMachine`)
     /// across those calls is UB.
@@ -318,7 +318,11 @@ impl Debugger {
             };
             match wait {
                 Wait::Forever => {
-                    this.event_loop_mut().auto_tick_active();
+                    // A condition wait, like `wait_for_promise`, not a run loop:
+                    // `auto_tick_active` stops polling once a counted error has
+                    // ended the run (see its contract), and under `bun test`,
+                    // where such errors end nothing, that would spin here.
+                    this.event_loop_mut().auto_tick();
 
                     if bun_core::Environment::ENABLE_LOGS {
                         bun_core::scoped_log!(

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -397,10 +397,23 @@ impl EventLoop {
         self.drain_microtasks_with_global(global, jsc_vm)
     }
 
+    /// Whether the callbacks this loop runs from the current frame get their
+    /// microtask checkpoint here (`exit()` drains at depth 1). False while the
+    /// loop is being ticked from inside JS (`wait_for_promise` under a
+    /// callback), from a deferred task, or with draining suppressed (spawnSync):
+    /// there the enclosing frame's `tick()` drains, and reports rejections,
+    /// afterwards, and a promise whose `.catch()` is still queued must not be
+    /// reported before it.
+    fn checkpoints_here(&self) -> bool {
+        let vm = self.vm_ref();
+        self.entered_event_loop_count == 0
+            && !vm.is_inside_deferred_task_queue.get()
+            && !vm.suppress_microtask_drain.get()
+    }
+
     // should be called after exit()
     pub fn maybe_drain_microtasks(&mut self) -> Result<(), Stopped> {
-        if self.entered_event_loop_count == 0 && !self.vm_ref().is_inside_deferred_task_queue.get()
-        {
+        if self.checkpoints_here() {
             return self.drain_microtasks();
         }
         Ok(())
@@ -880,8 +893,9 @@ impl EventLoop {
     }
 
     /// `tickImmediateTasks` — swaps the two
-    /// immediate queues, drains the now-current batch, then recycles the
-    /// drained Vec as the next-tick buffer.
+    /// immediate queues, drains the now-current batch, reports the promise
+    /// rejections it left unhandled (as `tick()` does for its tasks), then
+    /// recycles the drained Vec as the next-tick buffer.
     ///
     /// Note: the real `ImmediateObject` lives in `bun_runtime` (cycle), so
     /// the per-task body dispatches through `__bun_run_immediate_task` (link-
@@ -913,19 +927,36 @@ impl EventLoop {
 
         let mut exception_thrown = false;
         for task in to_run_now.iter() {
+            // `|=`: a callback that threw skipped its own checkpoint
+            // (`run_immediate_task`), which the batch tail below owes it even
+            // when a later task returns `false` (cleared, or unref'd and skipped).
             // SAFETY: ImmediateObject pointers are kept alive by the JS heap
             // until `__bun_run_immediate_task` consumes them; `virtual_machine` is the
             // live owning VM per caller contract.
-            exception_thrown = unsafe { __bun_run_immediate_task(*task, virtual_machine) };
+            exception_thrown |= unsafe { __bun_run_immediate_task(*task, virtual_machine) };
         }
         // Re-escape `this` after the re-entrant loop so nothing about `*this`
         // is carried across it.
         let this: *mut Self = core::hint::black_box(this);
 
-        // make sure microtasks are drained if the last task had an exception
-        if exception_thrown {
+        // SAFETY: as above.
+        if !to_run_now.is_empty() && unsafe { (*this).checkpoints_here() } {
             // SAFETY: as above.
-            let _ = unsafe { (*this).maybe_drain_microtasks() };
+            let stopped = exception_thrown && unsafe { (*this).drain_microtasks() }.is_err();
+            // Every callback of the batch has had its checkpoint, so what they
+            // left rejected is unhandled: report it before the caller polls.
+            // The poll parks until the next timer or I/O event, which can be far
+            // off or never come, and the places that otherwise report these
+            // (the caller's next `tick()`, `auto_tick`'s tail) come after it.
+            // Not with an exception pending (as in `tick()`: by now that is the
+            // termination, or one that escaped its fold), which the handlers
+            // would run on top of.
+            // SAFETY: as above; `global_ref()` is `'static`, so no borrow of
+            // `*this` is live while the handlers re-enter this loop.
+            let global = unsafe { (*this).global_ref() };
+            if !stopped && !global.has_exception() {
+                global.handle_rejected_promises();
+            }
         }
 
         // SAFETY: as above; this read MUST observe pushes JS made during the

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1132,7 +1132,19 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
-    // SAFETY: as above.
+    // An error nothing handled (raised by those immediates, or reported by the
+    // caller's `tick()` just before this) ends the run: the run loops calling
+    // this (`Run::start`, `on_before_exit`, `WebWorker::spin`, the REPL) loop on
+    // `is_event_loop_alive()`, which the counter fails unless more immediates
+    // are queued, and they run nothing further. Parking in the poll below would
+    // only delay that exit until some unrelated wakeup, or forever, and run
+    // whatever the wakeup brings first. (With immediates queued the loop comes
+    // back for them, and the poll does not block anyway.)
+    // SAFETY: per fn contract.
+    if unsafe { &*vm }.unhandled_error_counter > 0 && !unsafe { &*vm }.is_event_loop_alive() {
+        return;
+    }
+    // SAFETY: `el` is the live per-thread event loop.
     let has_yielded_tasks = unsafe { (*el).promote_yield_tasks() };
     #[cfg(windows)]
     if has_yielded_tasks || !unsafe { &*el }.immediate_tasks.is_empty() {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1121,6 +1121,16 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 /// `on_before_exit` drain loops where blocking when the loop is idle would
 /// hang shutdown.
 ///
+/// Contract: the callers are loops of the form `while is_event_loop_alive()
+/// { tick(); auto_tick_active(); }` (`Run::start`, `on_before_exit`,
+/// `WebWorker::spin`, the REPL, the debugger thread's own loop), so once a
+/// counted error has made that condition false this returns without polling.
+/// A wait for some other condition must use [`auto_tick`], as
+/// `wait_for_promise` and the debugger's attach wait do, or it would spin
+/// instead of parking while the counter is nonzero. (`AnyEventLoop::tick_once`
+/// also calls this, for a single pump between batches of install work; one
+/// skipped poll there changes nothing.)
+///
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
@@ -1133,13 +1143,12 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
     // An error nothing handled (raised by those immediates, or reported by the
-    // caller's `tick()` just before this) ends the run: the run loops calling
-    // this (`Run::start`, `on_before_exit`, `WebWorker::spin`, the REPL) loop on
-    // `is_event_loop_alive()`, which the counter fails unless more immediates
-    // are queued, and they run nothing further. Parking in the poll below would
-    // only delay that exit until some unrelated wakeup, or forever, and run
-    // whatever the wakeup brings first. (With immediates queued the loop comes
-    // back for them, and the poll does not block anyway.)
+    // caller's `tick()` just before this) ends the run: the caller's loop
+    // condition is now false (see the contract above; the counter fails it
+    // unless more immediates are queued) and it runs nothing further. Parking
+    // in the poll below would only delay that exit until some unrelated wakeup,
+    // or forever, and run whatever the wakeup brings first. (With immediates
+    // queued the loop comes back for them, and the poll does not block anyway.)
     // SAFETY: per fn contract.
     if unsafe { &*vm }.unhandled_error_counter > 0 && !unsafe { &*vm }.is_event_loop_alive() {
         return;

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -749,3 +749,41 @@ test("my-test", () => {
     });
   }
 });
+
+test("a rejection left by a setImmediate callback is reported before the test's due timer fires", async () => {
+  // The timer is due by the time the immediate returns (the immediate blocks
+  // past its deadline), so it fires in the runner's next poll of the event
+  // loop. The rejection must be reported when the immediate returns, not after
+  // that poll: with a test waiting on something slower than a due timer, the
+  // report used to wait along with it.
+  using dir = tempDir("unhandled-immediate", {
+    "my-test.test.js": /* js */ `
+      import { test } from "bun:test";
+      test("my-test", async () => {
+        const { promise, resolve } = Promise.withResolvers();
+        // Concatenated so the marker only appears in stderr when the timer
+        // fires, not in the source excerpt printed with the error.
+        setTimeout(() => { console.error("## timer " + "fired ##"); resolve(); }, 0);
+        setImmediate(() => { Promise.reject(new Error("## rejected in immediate ##")); Bun.sleepSync(5); });
+        await promise;
+      });
+    `,
+    "package.json": "{}",
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "test", "my-test.test.js"],
+    cwd: String(dir),
+    stdout: "ignore",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  const reportedAt = stderr.indexOf("error: ## rejected in immediate ##");
+  const timerAt = stderr.indexOf("## timer fired ##");
+  expect(reportedAt).toBeGreaterThan(-1);
+  expect(timerAt).toBeGreaterThan(reportedAt);
+  expect(stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
+});

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import inspector from "node:inspector";
 
 test("inspector.url()", () => {
@@ -550,6 +551,100 @@ test("inspector.waitForDebugger() blocks again on the second call after a fronte
   expect(JSON.parse(stdout.trim().split("\n").at(-1)!)).toEqual({ first: 1, second: 2 });
   expect(exitCode).toBe(0);
 });
+
+// Under `bun test` an error nothing handled is tallied, not fatal, so a later
+// waitForDebugger() runs with the VM's unhandled-error count nonzero. The wait
+// must still park the thread: the run loops' turn of the event loop
+// (auto_tick_active) stops polling once that count has ended a run, so a wait
+// ticking with it would spin here instead. Measured from outside, on the
+// fixture's main thread, before any client connects, so that nothing but the
+// wait itself is in the window. /proc is what makes the per-thread reading
+// possible, hence Linux only.
+const waitForDebuggerAfterUnhandledErrorFixture = `
+import { test } from "bun:test";
+import inspector from "node:inspector";
+
+test("leaves an error nothing handles", () => {
+  Promise.reject(new Error("tallied by the runner"));
+});
+
+test("then waits for a debugger", () => {
+  inspector.open(0, "127.0.0.1", false);
+  process.stderr.write("WAITING_FOR_DEBUGGER\\n");
+  inspector.waitForDebugger();
+  inspector.close();
+});
+`;
+
+test.skipIf(!isLinux)(
+  "inspector.waitForDebugger() parks the thread after an earlier unhandled error under bun test",
+  async () => {
+    using dir = tempDir("inspector-wait-after-error", {
+      "wait.test.ts": waitForDebuggerAfterUnhandledErrorFixture,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "wait.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    const decoder = new TextDecoder();
+    const reader = proc.stderr.getReader();
+    let stderrText = "";
+    while (!stderrText.includes("WAITING_FOR_DEBUGGER")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`stderr closed before the fixture started waiting; got: ${stderrText}`);
+      stderrText += decoder.decode(value);
+    }
+    expect(stderrText).toContain("tallied by the runner");
+    const wsUrl = stderrText.match(/Debugger listening on (ws:\S+)/)?.[1];
+    expect(wsUrl).toBeDefined();
+
+    // utime + stime of the main thread, in clock ticks (100 per second), from
+    // /proc/<pid>/task/<pid>/stat; the fields follow the parenthesized name.
+    const mainThreadTicks = () => {
+      const stat = readFileSync(`/proc/${proc.pid}/task/${proc.pid}/stat`, "utf8");
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+      return Number(fields[11]) + Number(fields[12]);
+    };
+    const windowMs = 500;
+    const windowTicks = windowMs / 10;
+    const ticksBefore = mainThreadTicks();
+    // The measurement window: the fixture is waiting for a client the whole
+    // time, and the question is what that costs it.
+    await Bun.sleep(windowMs);
+    const ticksDuringWait = mainThreadTicks() - ticksBefore;
+
+    const ws = new WebSocket(wsUrl!);
+    const opened = Promise.withResolvers<void>();
+    ws.onopen = () => opened.resolve();
+    ws.onerror = error => opened.reject(error);
+    await opened.promise;
+    ws.send(JSON.stringify({ id: 1, method: "Runtime.runIfWaitingForDebugger", params: {} }));
+    const drained = (async () => {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        stderrText += decoder.decode(value);
+      }
+    })();
+    const exitCode = await proc.exited;
+    await drained;
+    ws.close();
+
+    // Parked: the thread runs nothing in the window (0 ticks, 1 if the idle GC
+    // timer fires). Spinning: about the whole window.
+    expect(ticksDuringWait).toBeLessThan(windowTicks / 4);
+    // The tallied error fails the file; that it was tallied is the case under test.
+    expect(exitCode).toBe(1);
+  },
+  // Boots a `bun test` child with the inspector, then holds it for the window;
+  // several seconds on a debug build.
+  30_000,
+);
 
 test("Runtime.consoleAPICalled is emitted while the Runtime domain is enabled", () => {
   const session = new inspector.Session();

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -641,9 +641,6 @@ test.skipIf(!isLinux)(
     // The tallied error fails the file; that it was tallied is the case under test.
     expect(exitCode).toBe(1);
   },
-  // Boots a `bun test` child with the inspector, then holds it for the window;
-  // several seconds on a debug build.
-  30_000,
 );
 
 test("Runtime.consoleAPICalled is emitted while the Runtime domain is enabled", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1516,6 +1516,101 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
+  // Every case arms a 0ms timer and then blocks past its deadline inside the
+  // callback under test, so by the time the callback returns the timer is due:
+  // it fires in the very next poll of the event loop, if there is one. Its
+  // output therefore shows whether the loop went on to poll after the callback
+  // instead of acting on the error first. (A due timer is the wakeup here; in
+  // real programs the poll waits for whatever the program is waiting on, which
+  // used to delay these errors by up to the idle GC timer, or forever.)
+  describe("errors nothing handled are acted on before the event loop polls again", () => {
+    const runPastTheTimer = `Bun.sleepSync(5);`;
+
+    async function run(script) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.split("\n").filter(Boolean), stderr, exitCode };
+    }
+
+    it("a rejection left by a setImmediate callback is emitted before the due timer fires", async () => {
+      const result = await run(`
+        process.on("unhandledRejection", e => console.log("unhandledRejection", e.message));
+        setTimeout(() => console.log("timer"), 0);
+        setImmediate(() => { Promise.reject(new Error("x")); ${runPastTheTimer} });
+      `);
+      expect(result).toEqual({ stdout: ["unhandledRejection x", "timer"], stderr: "", exitCode: 0 });
+    });
+
+    it("a fatal rejection left by a setImmediate callback ends the run; the due timer never fires", async () => {
+      const { stdout, stderr, exitCode } = await run(`
+        setTimeout(() => console.log("timer"), 0);
+        setImmediate(() => { Promise.reject(new Error("boom")); ${runPastTheTimer} });
+      `);
+      expect(stdout).toEqual([]);
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("a fatal throw from a setImmediate callback ends the run; the due timer never fires", async () => {
+      const { stdout, stderr, exitCode } = await run(`
+        setTimeout(() => console.log("timer"), 0);
+        setImmediate(() => { ${runPastTheTimer} throw new Error("boom"); });
+      `);
+      expect(stdout).toEqual([]);
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("a fatal rejection left by a task callback ends the run; the timer it made due never fires", async () => {
+      // An fs callback runs from the task queue, so here the rejection is
+      // reported by the tick that ran the callback (that part always worked),
+      // and what is under test is that the loop then exits instead of polling
+      // once more. Started from a timer so that the callback runs from the run
+      // loop proper, not from the tick that follows the entry point.
+      const { stdout, stderr, exitCode } = await run(`
+        setTimeout(() => require("fs").stat(".", () => {
+          setTimeout(() => console.log("timer"), 0);
+          Promise.reject(new Error("boom"));
+          ${runPastTheTimer}
+        }), 0);
+      `);
+      expect(stdout).toEqual([]);
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it.each([
+      ["returns", ""],
+      // A callback that throws gets its microtask checkpoint at the end of the
+      // immediate batch instead of at its own exit; a sibling that was cleared
+      // in the meantime must not make the batch forget that.
+      ["throws, after clearing the immediate queued behind it", `clearImmediate(sibling); throw new Error("boom");`],
+    ])("a rejection handled by a microtask of the setImmediate callback that %s is not reported", async (_, tail) => {
+      const result = await run(`
+        process.on("uncaughtException", e => console.log("uncaughtException", e.message));
+        process.on("unhandledRejection", e => console.log("unhandledRejection", e.message));
+        setTimeout(() => console.log("timer"), 0);
+        setImmediate(() => {
+          const p = Promise.reject(new Error("x"));
+          queueMicrotask(() => p.catch(() => {}));
+          ${runPastTheTimer}
+          ${tail}
+        });
+        const sibling = setImmediate(() => {});
+      `);
+      expect(result).toEqual({
+        stdout: tail ? ["uncaughtException boom", "timer"] : ["timer"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1523,7 +1523,7 @@ describe.concurrent(() => {
   // instead of acting on the error first. (A due timer is the wakeup here; in
   // real programs the poll waits for whatever the program is waiting on, which
   // used to delay these errors by up to the idle GC timer, or forever.)
-  describe("errors nothing handled are acted on before the event loop polls again", () => {
+  describe.concurrent("errors nothing handled are acted on before the event loop polls again", () => {
     const runPastTheTimer = `Bun.sleepSync(5);`;
 
     async function run(script) {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -726,7 +726,7 @@ describe("error event", () => {
 //
 // Run in a separate process: under `bun test` itself, a worker's rejections are
 // routed to the test runner instead of the worker's own listeners.
-describe("a rejection left by a setImmediate callback is reported before the worker's loop polls", () => {
+describe.concurrent("a rejection left by a setImmediate callback is reported before the worker's loop polls", () => {
   // Resolves to what the parent thread saw from the worker, in order, once it exited.
   async function observeWorker(workerSource: string) {
     await using proc = Bun.spawn({

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -717,6 +717,63 @@ describe("error event", () => {
   });
 });
 
+// The worker arms a 0ms timer and blocks past its deadline inside the immediate,
+// so the timer is due when the immediate returns and fires in the worker's very
+// next poll, if the loop gets there before acting on the rejection. Node
+// reports the rejection when the immediate returns; so must the worker's loop,
+// rather than after the poll, which with a keep-alive and nothing due would
+// have parked it until the idle GC timer, or forever.
+//
+// Run in a separate process: under `bun test` itself, a worker's rejections are
+// routed to the test runner instead of the worker's own listeners.
+describe("a rejection left by a setImmediate callback is reported before the worker's loop polls", () => {
+  // Resolves to what the parent thread saw from the worker, in order, once it exited.
+  async function observeWorker(workerSource: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+        const { Worker } = require("worker_threads");
+        const seen = [];
+        const worker = new Worker(${JSON.stringify(workerSource)}, { eval: true });
+        worker.on("message", message => seen.push({ message }));
+        worker.on("error", error => seen.push({ error: error.message }));
+        worker.on("exit", () => console.log(JSON.stringify(seen)));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test("an unhandledRejection listener runs before the due timer", async () => {
+    const seen = await observeWorker(/* js */ `
+      const { parentPort } = require("worker_threads");
+      process.on("unhandledRejection", e => parentPort.postMessage("unhandledRejection " + e.message));
+      setTimeout(() => parentPort.postMessage("timer"), 0);
+      setImmediate(() => { Promise.reject(new Error("x")); Bun.sleepSync(5); });
+    `);
+    expect(seen).toEqual([{ message: "unhandledRejection x" }, { message: "timer" }]);
+  });
+
+  test("with no listener, the parent gets 'error' and the worker's exit handlers run before the due timer", async () => {
+    const seen = await observeWorker(/* js */ `
+      const { parentPort } = require("worker_threads");
+      let timerFired = false;
+      setTimeout(() => { timerFired = true; }, 0);
+      process.on("exit", () => parentPort.postMessage({ timerFired }));
+      setImmediate(() => { Promise.reject(new Error("boom")); Bun.sleepSync(5); });
+    `);
+    expect(seen).toEqual([{ error: "boom" }, { message: { timerFired: false } }]);
+  });
+});
+
 describe("getHeapSnapshot", () => {
   test("throws if the wrong options are passed", () => {
     const worker = new Worker("", { eval: true });


### PR DESCRIPTION
### Problem
- A promise rejected inside a `setImmediate` callback, while something else keeps the event loop alive, is not reported when the immediate returns. It is reported when the loop next wakes up for an unrelated reason: on 1.4.0 that is the idle GC timer, about 1 to 1.7s later; with `BUN_GC_TIMER_DISABLE=1` (or once that timer has backed off to its 30s mode) never, and the process just sits there. Node reports it when the callback returns. Main thread and `worker_threads` Workers alike (the parent's `'error'` event is what arrives late or never).
  ```js
  setInterval(() => {}, 100000);
  setTimeout(() => setImmediate(() => Promise.reject(new Error("x"))), 300);
  ```
  `bun x.js`: `error: x` after ~1.7s, exit 1. `BUN_GC_TIMER_DISABLE=1 bun x.js`: nothing, runs until killed. `node x.js`: `error`, exit 1, immediately.
- Cause 1: rejections are only examined by `handle_rejected_promises()` at the end of `EventLoop::tick()` (`src/jsc/event_loop.rs`) and at the tail of `auto_tick()` (`src/runtime/jsc_hooks.rs`), both after the poll. Immediates run at the top of `auto_tick()` / `auto_tick_active()`, and nothing looks at the list between them and `tick_with_timeout()`, which parks until the next timer or I/O event.
- Cause 2 (found while fixing 1, same shape): once an error nothing handled has been counted (`unhandled_error_counter`, which is what makes every run loop's `while is_event_loop_alive()` stop), the `auto_tick_active()` of that same turn still goes on to park in the poll. So even a rejection that is reported on time (from a timer or I/O callback) only ends the process at the next unrelated wakeup, and whatever that wakeup brings runs first: `setTimeout(() => Promise.reject(e), 1); setTimeout(() => console.log("later"), 20)` prints `later` after the error on 1.4.0 (node prints nothing), and with a long interval instead of the second timer the exit waits for the GC timer, or forever. A `throw` inside an immediate has the same second half: reported at once, exit delayed the same way.

### Fix
- `EventLoop::tick_immediate_tasks()` ends its batch by calling `handle_rejected_promises()`, the same call `tick()` makes for its tasks, so the immediates phase reports what it left unhandled before the caller computes the poll. Both `auto_tick()` (used by `bun test` and the sync waits) and `auto_tick_active()` (the run loops) go through it. Skipped when the batch ran nothing (nothing can have been rejected since `tick()` looked).
- It only reports when the batch's callbacks got their microtask checkpoint in this loop (`checkpoints_here()`: depth 0, not inside a deferred task, draining not suppressed), which is the same condition under which each callback's `exit()` drained. Otherwise a rejection whose `.catch()` is still sitting in the microtask queue would be reported early; in those nested cases the enclosing frame's `tick()` drains and reports as before. This is also why the existing `exception_thrown` tracking becomes `|=`: a throwing immediate deliberately skips its own checkpoint (node defers a failed immediate's ticks), the batch tail drains for it, and a later task that returned `false` (it had been cleared) used to erase that. The `returns` / `throws, after clearing the immediate queued behind it` tests pin both. `maybe_drain_microtasks()` (since #37275 also used by the fold in `Task.rs`) is unchanged in behaviour and now spells its condition as `checkpoints_here()` too. As in `tick()`, the report is skipped once the VM has been stopped or an exception is still pending at the batch tail.
- `auto_tick_active()` returns after the immediates when an error has been counted and `is_event_loop_alive()` is therefore false. Its callers are the run loops, `while is_event_loop_alive() { tick(); auto_tick_active(); }` (`Run::start`, `on_before_exit()`, `WebWorker::spin`, the REPL, the debugger thread's own loop), which are about to stop, so the poll could only delay that; this is now stated as the function's contract in its doc comment. The `is_event_loop_alive()` half keeps the one case where the counter does not stop those loops today, queued immediates, behaving exactly as before (the loop comes back for them and the poll does not block while they are queued); making the counter end the run in that case too is #38522, which composes with this (its change makes this return fire there as well). Not added to `auto_tick()`: under `bun test` the counter is a tally and the runner keeps going.
- The one caller that was not such a loop, the debugger's attach wait (`wait_for_debugger_if_necessary`, reached by `--inspect-wait`/`--inspect-brk` and `inspector.waitForDebugger()`), loops on the connection arriving, so with the counter nonzero (under `bun test` after any unhandled error, since the counter is a tally there) the early return would have made it spin until the frontend attached instead of parking: measured at 51 of the 50 clock ticks in a 500ms window. It now ticks with `auto_tick()`, like `wait_for_promise` and the tree's other condition waits, which parks regardless of the counter (0 to 1 ticks in the same window); the connection still arrives through the `tick()` in that loop. `AnyEventLoop::tick_once` also calls `auto_tick_active()`, for one pump between batches of install work; a skipped poll there changes nothing (the waits after it use `auto_tick()`), noted in the doc comment.
- Matches node in what is observable: the rejection is reported when the immediate returns, and after a fatal error nothing else runs. Not node's per-callback granularity (a sibling immediate queued behind the rejecting one still runs before the report); that is #33354's subject.
- Overlap with the open event-loop PRs, stated precisely since they edit the same functions: #33354 (per-callback reports after every timer and immediate callback, with a C++ signature change; open since July and conflicting with main) contains this same `|=` line and a batch-tail report in the same `tick_immediate_tasks` hunk, so whichever of the two lands second drops those lines from its diff; with #33354 in, this PR's batch-tail report would be reached with an already empty list. #37981 and #33356 add reports at the two exits of `auto_tick_active()`, the function whose top this PR edits (separate hunks; a merge with #37981's branch was checked clean); neither covers the immediates-to-poll gap or the park, and this PR does not cover their turn-went-idle case. #37365 folds `auto_tick_active` into a const-generic `auto_tick`; whichever lands second re-expresses the two-line return as its `ACTIVE`-only arm. #38522 makes the counter end the run with immediates queued; composes (see above). #38206 stops counting errors in watcher mode; unaffected. #38483 (merged, now in this PR's base) fixed the worker's `process.exit()` / `throw`-from-an-immediate shapes by waking its poll; the `Promise.reject` shape is this PR, and its tests and this PR's pass together on this base.
- Verified on the debug build; each new test fails on a build without the `src/` change (checked with the 1.4.0 release binary: 4 of the 6 process tests, both worker tests and the runner test fail; the two `is not reported` controls pass both ways, as intended):
  - `test/js/node/process/process.test.js`, new block `errors nothing handled are acted on before the event loop polls again`: listener order, fatal rejection from an immediate, fatal throw from an immediate, fatal rejection from a task callback (cause 2 on its own), and the two controls. Each arms a 0ms timer and blocks past its deadline in the callback under test, so the timer fires in the very next poll if there is one; that makes both directions deterministic and platform independent (on Windows timers fire inside the poll call, so a marker made due by the callback itself cannot distinguish anything there; these markers are due before the poll is entered).
  - `test/js/node/worker_threads/worker_threads.test.ts`, new block `a rejection left by a setImmediate callback is reported before the worker's loop polls` (subprocess: under `bun test` a worker's rejections go to the runner, not its listeners): listener order, and the `'error'` event plus the worker's `'exit'` handler observing that the due timer never fired.
  - `test/js/bun/test/test-test.test.ts`: under the runner's own loop the error is printed before the test's due timer fires.
  - `test/js/node/inspector/inspector.test.ts` (Linux only): a `bun test` child tallies an unhandled rejection, then calls `waitForDebugger()`; the test reads the child's main-thread utime+stime from `/proc/<pid>/task/<pid>/stat` across a 500ms window before any client connects, then attaches and resumes it. This one cannot fail on main (main's attach wait parked because there was no early return); it fails with this PR's early return minus the `Debugger.rs` change (51 ticks, checked by reverting that file alone) and passes with it (0 to 1 ticks). The four existing `waitForDebugger` / `--inspect-wait` tests in `inspector.test.ts` and `test/cli/inspect/inspect.test.ts` still pass (the `--inspect=<url>` websocket cases in the latter fail identically on the release binary in this container, a networking matter).
  - Rebased onto d4ccab469b (main minus its current tip, 2f5c1804ef, which does not compile: `PostgresSQLConnection.rs` uses a helper #37275 removed; tracked separately and unrelated to these files). #37275 renamed `JsTerminated` to `Stopped` and gave `maybe_drain_microtasks()` a second caller, which is where the two `event_loop.rs` details above come from; all of the new tests, the probe matrix below, the 54 upstream files, the timers suites, the runner suites and the worker suites were re-run on the rebased build with the same results.
  - Also run, no new failures: whole `process.test.js` (only `process.env.USER` unset here), whole `worker_threads.test.ts` (one terminate-ordering test failed once under the full-file debug load and passes 4/4 alone), `test/js/node/timers` + `test/js/web/timers` (the 4 failures are the `bun-asan` execPath detection in the leak fixtures, pre-existing), 11 `bun test` runner suites, `test/js/web/workers/worker.test.ts` (4 known debug-speed failures), `shell/commands/exit` + `false`, `spawn/exit-code`, `hot.test.ts`, `watch.test.ts`, `repl.test.ts`, and 54 upstream files (`test-promise*`, `test-promises-*`, `test-timers-immediate*` / `clearImmediate*` / `setimmediate*` / `unref*` / `ordering`, `test-microtask-*`, `test-next-tick-*`, `test-process-beforeexit*`, `test-beforeexit-event-exit`, `test-process-exit-code*`, `test-process-exception-capture*`, `test-worker-uncaught-*`, `test-unhandled-exception-with-worker-inuse`).

### Background
- Rejected-promise list: JSC tells bun when a promise is rejected with no handler attached; bun appends it to a per-global list. `handle_rejected_promises()` walks the list and, for each promise still without a handler, emits `process`'s `'unhandledRejection'` or, with no listener, calls the VM's fatal hook (main thread: print, count the error; worker: post `'error'` to the parent, run its `'exit'` handlers, request its stop). A handler attached before the walk takes the promise off the list, which is why the walk must come after the callback's microtask checkpoint.
- Microtask checkpoint: `EventLoop::enter()` / `exit()` count nesting; the `exit()` that brings the depth to 0 drains `process.nextTick` callbacks and microtasks. An immediate run from the top of the loop therefore drains at its own exit; one run while the loop is being ticked from inside a JS frame (a synchronous `wait_for_promise`) does not, the enclosing `tick()` does later.
- Loop turn: every run loop alternates `tick()` (queued tasks, microtasks, then the rejection walk) with `auto_tick_active()` (immediates, then a poll whose timeout comes from the timer heap, then due timers). `auto_tick()` is the same with a rejection walk at its tail, used where a caller waits for something specific. With a keep-alive and no timer due, the poll's timeout is unbounded except for the idle GC timer, a 1s (later 30s) per-VM repeating timer that `BUN_GC_TIMER_DISABLE=1` removes.
- `unhandled_error_counter`: bumped when an error reaches the top with no listener. `is_event_loop_alive()` is false while it is nonzero (unless immediates are queued, see #38522), which is how `bun run` and workers exit 1 after such an error; `bun test` uses it as a tally instead.

<details>
<summary>Before / after on the shapes above (linux x64; before = 1.4.0 release, after = this branch's debug build)</summary>

| shape | before | after | node |
|---|---|---|---|
| interval keep-alive, `Promise.reject` in an immediate | reported + exit after ~1.7s; never with `BUN_GC_TIMER_DISABLE=1` | reported + exit 1 at once | same |
| interval keep-alive, `Promise.reject` in a 300ms timer | reported at once, exit after ~0.7s; never with the GC timer off | exit 1 at once | same |
| interval keep-alive, `throw` in an immediate | reported at once, exit after ~0.7s; never with the GC timer off | exit 1 at once | same |
| `Promise.reject` in a timer, 20ms sibling timer | error, then `later` | error only | error only |
| listener + due timer, reject in an immediate | `timer`, `unhandledRejection` | `unhandledRejection`, `timer` | same as after |
| worker: keep-alive, reject in an immediate | parent `'error'` after ~0.7s, never with the GC timer off | `'error'` ~14ms after the immediate (debug build), worker exits | same (worker exit code 0 vs node's 1 is #34193, unchanged) |
| reject handled by a queued microtask, immediate returns / throws | not reported | not reported | same |
| fatal in an immediate that queued another immediate | second immediate runs, then exit | unchanged (#38522) | nothing runs |
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts test/js/node/inspector/inspector.test.ts test/js/node/process/process.test.js

<!-- robobun:evidence:end -->