### PR TITLE
install: escape control characters in the bun pm untrusted/trust script listing

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3343,12 +3343,9 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
 // escapeControlChars
 // ───────────────────────────────────────────────────────────────────────────
 
-/// Renders the wrapped `Display` with C0 controls, DEL and C1 controls
-/// spelled out (`\n`, `\r`, `\t`, `\x1b`, `\x7f`, `\u009b`) instead of
-/// written raw. For text somebody else authored (a dependency's
-/// `package.json`, a registry manifest): printed raw, an ESC/CR/C1 sequence
-/// can erase or repaint the line it is shown on and a newline can forge
-/// further lines of our output. Everything else passes through unchanged.
+/// `Display` adapter that spells out C0 controls, DEL and C1 controls
+/// (`\n`, `\x1b`, `\x7f`, `\u009b`, ...) so text authored by a dependency
+/// cannot erase, repaint or forge lines of terminal output when printed.
 pub struct EscapeControlChars<T>(pub T);
 
 /// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3364,20 +3364,33 @@ struct EscapeControlCharsWriter<'a, 'f>(&'a mut Formatter<'f>);
 
 impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
         let mut start = 0;
-        for (i, c) in s.char_indices() {
-            if !matches!(c, '\0'..='\x1f' | '\x7f' | '\u{80}'..='\u{9f}') {
-                continue;
-            }
+        let mut cursor = 0;
+        // `\` doubles as the quote char so the scan stops at nothing else extra.
+        while let Some(offset) =
+            strings::index_of_needs_escape_for_java_script_string(&bytes[cursor..], b'\\')
+        {
+            let i = cursor + offset as usize;
+            let (code_point, len) = match bytes[i] {
+                byte @ (0x00..=0x1F | 0x7F) => (byte as u32, 1),
+                0xC2 if matches!(bytes.get(i + 1), Some(0x80..=0x9F)) => (bytes[i + 1] as u32, 2),
+                byte => {
+                    let char_len = strings::wtf8_byte_sequence_length(byte) as usize;
+                    cursor = (i + char_len).min(bytes.len());
+                    continue;
+                }
+            };
             self.0.write_str(&s[start..i])?;
-            match c {
-                '\n' => self.0.write_str("\\n")?,
-                '\r' => self.0.write_str("\\r")?,
-                '\t' => self.0.write_str("\\t")?,
-                c if c.is_ascii() => write!(self.0, "\\x{:02x}", c as u32)?,
-                c => write!(self.0, "\\u{:04x}", c as u32)?,
+            match code_point {
+                0x0A => self.0.write_str("\\n")?,
+                0x0D => self.0.write_str("\\r")?,
+                0x09 => self.0.write_str("\\t")?,
+                0x00..=0x7F => write!(self.0, "\\x{:02x}", code_point)?,
+                _ => write!(self.0, "\\u{:04x}", code_point)?,
             }
-            start = i + c.len_utf8();
+            start = i + len;
+            cursor = start;
         }
         self.0.write_str(&s[start..])
     }

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3339,6 +3339,53 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
     write_bytes(writer, remain)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// escapeControlChars
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Renders the wrapped `Display` with C0 controls, DEL and C1 controls
+/// spelled out (`\n`, `\r`, `\t`, `\x1b`, `\x7f`, `\u009b`) instead of
+/// written raw. For text somebody else authored (a dependency's
+/// `package.json`, a registry manifest): printed raw, an ESC/CR/C1 sequence
+/// can erase or repaint the line it is shown on and a newline can forge
+/// further lines of our output. Everything else passes through unchanged.
+pub struct EscapeControlChars<T>(pub T);
+
+/// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.
+pub fn escape_control_chars(text: &[u8]) -> EscapeControlChars<&bstr::BStr> {
+    EscapeControlChars(bstr::BStr::new(text))
+}
+
+impl<T: Display> Display for EscapeControlChars<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = EscapeControlCharsWriter(f);
+        write!(writer, "{}", self.0)
+    }
+}
+
+struct EscapeControlCharsWriter<'a, 'f>(&'a mut Formatter<'f>);
+
+impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let mut start = 0;
+        for (i, c) in s.char_indices() {
+            if !matches!(c, '\0'..='\x1f' | '\x7f' | '\u{80}'..='\u{9f}') {
+                continue;
+            }
+            self.0.write_str(&s[start..i])?;
+            match c {
+                '\n' => self.0.write_str("\\n")?,
+                '\r' => self.0.write_str("\\r")?,
+                '\t' => self.0.write_str("\\t")?,
+                c if c.is_ascii() => write!(self.0, "\\x{:02x}", c as u32)?,
+                c => write!(self.0, "\\u{:04x}", c as u32)?,
+            }
+            start = i + c.len_utf8();
+        }
+        self.0.write_str(&s[start..])
+    }
+}
+
 // js_bindings (fmtString for highlighter.test.ts) lives in src/jsc/fmt_jsc.rs
 // alongside fmt_jsc.bind.ts; bun_core/ stays JSC-free.
 

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -426,8 +426,6 @@ impl List {
         resolution_buf: &[u8],
         format_type: PrintFormat,
     ) {
-        // Folder name, resolution and script bodies are all authored by the
-        // dependency; this listing is what the user reads before `bun pm trust`.
         let resolution = EscapeControlChars(resolution.fmt(resolution_buf, PathSep::Posix));
         let needle = bun_paths::NODE_MODULES_NEEDLE;
         if let Some(i) = strings::index_of(self.cwd.as_bytes(), needle) {

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -1,7 +1,7 @@
 use bstr::BStr;
 
 use bun_core::ZBox;
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{EscapeControlChars, PathSep, escape_control_chars};
 use bun_core::strings;
 use bun_install::lockfile::Lockfile;
 use bun_install::lockfile::Scripts as LockfileScripts;
@@ -426,21 +426,24 @@ impl List {
         resolution_buf: &[u8],
         format_type: PrintFormat,
     ) {
+        // Folder name, resolution and script bodies are all authored by the
+        // dependency; this listing is what the user reads before `bun pm trust`.
+        let resolution = EscapeControlChars(resolution.fmt(resolution_buf, PathSep::Posix));
         let needle = bun_paths::NODE_MODULES_NEEDLE;
         if let Some(i) = strings::index_of(self.cwd.as_bytes(), needle) {
             bun_core::pretty!(
                 "<d>.{s}{s} @{f}<r>\n",
                 BStr::new(SEP_STR.as_bytes()),
-                BStr::new(strings::without_trailing_slash(
+                escape_control_chars(strings::without_trailing_slash(
                     &self.cwd.as_bytes()[i + 1..]
                 )),
-                resolution.fmt(resolution_buf, PathSep::Posix),
+                resolution,
             );
         } else {
             bun_core::pretty!(
                 "<d>{s} @{f}<r>\n",
-                BStr::new(strings::without_trailing_slash(self.cwd.as_bytes())),
-                resolution.fmt(resolution_buf, PathSep::Posix),
+                escape_control_chars(strings::without_trailing_slash(self.cwd.as_bytes())),
+                resolution,
             );
         }
 
@@ -451,12 +454,12 @@ impl List {
                     PrintFormat::Completed => bun_core::pretty!(
                         " <green>✓<r> [{s}]<d>:<r> <cyan>{s}<r>\n",
                         BStr::new(name),
-                        BStr::new(script),
+                        escape_control_chars(script),
                     ),
                     PrintFormat::Untrusted => bun_core::pretty!(
                         " <yellow>»<r> [{s}]<d>:<r> <cyan>{s}<r>\n",
                         BStr::new(name),
-                        BStr::new(script),
+                        escape_control_chars(script),
                     ),
                 }
             }

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1084,3 +1084,62 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+test("bun pm untrusted and bun pm trust escape control characters in dependency scripts", async () => {
+  // Everything after `#` is a shell comment, so only the echo runs once the package is
+  // trusted. Printed raw, though, the tail erases the listing line (ESC[2K), returns to
+  // column 1 (ESC[1G) and repaints it as the harmless looking command. `\r`, DEL and the
+  // 8-bit CSI (U+009B) are the other control characters a terminal would act on.
+  const script = 'echo "real command" #\x1b[2K\x1b[1G\r\x7f\u009b » [postinstall]: node scripts/postinstall.js';
+  const shown = 'echo "real command" #\\x1b[2K\\x1b[1G\\r\\x7f\\u009b » [postinstall]: node scripts/postinstall.js';
+
+  using dir = tempDir("pm-untrusted-control-chars", {
+    "package.json": JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: {
+        "nice-pkg": "file:./nice-pkg",
+      },
+    }),
+    "nice-pkg/package.json": JSON.stringify({
+      name: "nice-pkg",
+      version: "1.0.0",
+      scripts: {
+        postinstall: script,
+      },
+    }),
+  });
+
+  async function run(...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  let [stdout, stderr, exitCode] = await run("install");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("Blocked 1 postinstall");
+  expect(exitCode).toBe(0);
+
+  [stdout, stderr, exitCode] = await run("pm", "untrusted");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain(` » [postinstall]: ${shown}\n`);
+  expect(stdout).not.toContain("\x1b");
+  expect(stdout).not.toContain("\x7f");
+  expect(stdout).not.toContain("\u009b");
+  expect(exitCode).toBe(0);
+
+  [stdout, stderr, exitCode] = await run("pm", "trust", "nice-pkg");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain(` ✓ [postinstall]: ${shown}\n`);
+  expect(stdout).toContain("1 script ran across 1 package");
+  expect(stdout).not.toContain("\x1b");
+  expect(stdout).not.toContain("\x7f");
+  expect(stdout).not.toContain("\u009b");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,7 +1,16 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, normalizeBunSnapshot, readdirSorted, tempDir, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunEnv as env,
+  isWindows,
+  normalizeBunSnapshot,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+} from "harness";
 import { cpSync } from "node:fs";
 import { join } from "path";
 import {
@@ -1085,13 +1094,26 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(exitCode).toBe(0);
 });
 
+async function runInDir(dir: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+}
+
 test("bun pm untrusted and bun pm trust escape control characters in dependency scripts", async () => {
-  // Everything after `#` is a shell comment, so only the echo runs once the package is
-  // trusted. Printed raw, though, the tail erases the listing line (ESC[2K), returns to
-  // column 1 (ESC[1G) and repaints it as the harmless looking command. `\r`, DEL and the
-  // 8-bit CSI (U+009B) are the other control characters a terminal would act on.
-  const script = 'echo "real command" #\x1b[2K\x1b[1G\r\x7f\u009b » [postinstall]: node scripts/postinstall.js';
-  const shown = 'echo "real command" #\\x1b[2K\\x1b[1G\\r\\x7f\\u009b » [postinstall]: node scripts/postinstall.js';
+  // Both lines of the script are a shell comment after the echo, so only the echo runs once
+  // the package is trusted. Printed raw, though, the first comment erases the listing line
+  // (ESC[2K) and returns to column 1 (ESC[1G), and the newline lets the second one pose as
+  // a further listing entry. `\r`, `\t`, DEL and the 8-bit CSI (U+009B) are the remaining
+  // kinds of control character a terminal acts on.
+  const script = 'echo "real command" #\x1b[2K\x1b[1G\r\x7f\u009b\n#\t» [postinstall]: node scripts/postinstall.js';
+  const shown =
+    'echo "real command" #\\x1b[2K\\x1b[1G\\r\\x7f\\u009b\\n#\\t» [postinstall]: node scripts/postinstall.js';
 
   using dir = tempDir("pm-untrusted-control-chars", {
     "package.json": JSON.stringify({
@@ -1110,23 +1132,12 @@ test("bun pm untrusted and bun pm trust escape control characters in dependency 
     }),
   });
 
-  async function run(...args: string[]) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), ...args],
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  }
-
-  let [stdout, stderr, exitCode] = await run("install");
+  let [stdout, stderr, exitCode] = await runInDir(String(dir), "install");
   expect(stderr).not.toContain("error:");
   expect(stdout).toContain("Blocked 1 postinstall");
   expect(exitCode).toBe(0);
 
-  [stdout, stderr, exitCode] = await run("pm", "untrusted");
+  [stdout, stderr, exitCode] = await runInDir(String(dir), "pm", "untrusted");
   expect(stderr).not.toContain("error:");
   expect(stdout).toContain(` » [postinstall]: ${shown}\n`);
   expect(stdout).not.toContain("\x1b");
@@ -1134,12 +1145,46 @@ test("bun pm untrusted and bun pm trust escape control characters in dependency 
   expect(stdout).not.toContain("\u009b");
   expect(exitCode).toBe(0);
 
-  [stdout, stderr, exitCode] = await run("pm", "trust", "nice-pkg");
+  [stdout, stderr, exitCode] = await runInDir(String(dir), "pm", "trust", "nice-pkg");
   expect(stderr).not.toContain("error:");
   expect(stdout).toContain(` ✓ [postinstall]: ${shown}\n`);
   expect(stdout).toContain("1 script ran across 1 package");
   expect(stdout).not.toContain("\x1b");
   expect(stdout).not.toContain("\x7f");
   expect(stdout).not.toContain("\u009b");
+  expect(exitCode).toBe(0);
+});
+
+// The dependency alias becomes the node_modules folder and the file: target becomes the
+// resolution, so a dependent can put control characters in both. Windows does not allow
+// them in file names, so the packages cannot be installed there in the first place.
+test.skipIf(isWindows)("bun pm untrusted escapes control characters in the package path and resolution", async () => {
+  using dir = tempDir("pm-untrusted-control-chars-path", {
+    "package.json": JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: {
+        "nice\x1b[2Kpkg": "file:./real\rpkg",
+      },
+    }),
+    "real\rpkg/package.json": JSON.stringify({
+      name: "real-pkg",
+      version: "1.0.0",
+      scripts: {
+        postinstall: "exit 0",
+      },
+    }),
+  });
+
+  let [stdout, stderr, exitCode] = await runInDir(String(dir), "install");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("Blocked 1 postinstall");
+  expect(exitCode).toBe(0);
+
+  [stdout, stderr, exitCode] = await runInDir(String(dir), "pm", "untrusted");
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("./node_modules/nice\\x1b[2Kpkg @real\\rpkg\n » [postinstall]: exit 0\n");
+  expect(stdout).not.toContain("\x1b");
+  expect(stdout).not.toContain("\r");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1102,7 +1102,11 @@ async function runInDir(dir: string, ...args: string[]) {
     stderr: "pipe",
     env,
   });
-  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = result;
+  // Every caller expects success; failing here shows the whole stderr rather than only the exit code.
+  if (exitCode !== 0) expect(stderr).toBe("");
+  return result;
 }
 
 test("bun pm untrusted and bun pm trust escape control characters in dependency scripts", async () => {


### PR DESCRIPTION
### Problem
- `bun pm untrusted` (and the listing `bun pm trust` prints after running) writes each blocked lifecycle script to the terminal byte for byte, including control bytes.
- A package whose `postinstall` is `curl ...|sh ;: <ESC>[2K<ESC>[1G » [postinstall]: node scripts/postinstall.js` therefore shows up on screen as ` » [postinstall]: node scripts/postinstall.js`: `ESC[2K` erases the line bun just wrote and `ESC[1G` moves back to column 1, so the package repaints its own entry. `\r`, newlines (forging extra entries), DEL and the 8-bit C1 controls (U+0080..U+009F, e.g. U+009B = CSI) pass through the same way. Reproduced on 1.4.0 and 1.4.0-canary.1, on a pty and on a pipe.
- This screen is the one bun tells the user to read before running `bun pm trust`, so the command reviewed and the command executed can differ.
- Source: `List::print_scripts` in `src/install/lockfile/Package/Scripts.rs` formats the script body (and the package folder name and resolution, which a dependency also controls through aliases and `file:` specs) with `BStr`, which only replaces invalid UTF-8.

### Fix
- Adds `bun_core::fmt::escape_control_chars` / `EscapeControlChars` (`src/bun_core/fmt.rs`): a `Display` adapter that writes C0 controls, DEL and C1 controls as `\n`, `\r`, `\t`, `\x1b`, `\x7f`, `\^[` and passes every other character (including non-ASCII such as the `»` bun itself prints) through unchanged. It wraps any `Display`, so it works on both byte slices and existing formatters like `Resolution::fmt`.
- `print_scripts` routes the script body, the folder name and the resolution through it, for both the untrusted (`»`) and completed (`✓`) formats. Output for scripts without control characters is byte-identical to before.
- The escaped form is unambiguous about what `bun pm trust` will run (the `curl ...|sh` prefix stays visible) and cannot move the cursor, so the listing shows exactly the string that gets executed.
- Verified:
  - `test/cli/install/bun-pm.test.ts` ("bun pm untrusted and bun pm trust escape control characters in dependency scripts"): installs a `file:` dependency whose postinstall carries ESC, CR, DEL and U+009B, then checks both commands print the escaped text and no raw control characters. Fails on the released binary (raw bytes in stdout), passes with this change; the rest of the file still passes.
  - Manual run of the report's repro with the debug build prints `;: \x1b[2K\x1b[1G » [postinstall]: ...` on one line; an alias containing ESC/CR renders as `./node_modules/bad\x1b[2Kname\r @pkg`.
  - `cargo clippy -p bun_core -p bun_install`, `cargo fmt --check`, `test/internal/source-lints/` clean.

### Background
- Lifecycle scripts (`preinstall`/`install`/`postinstall`/...) of dependencies are not run by `bun install` unless the package is in `trustedDependencies`. `bun pm untrusted` lists the blocked scripts so the user can decide; `bun pm trust <name>` runs them and adds the package to `trustedDependencies`, then prints the same listing with `✓` markers.
- C0 controls are bytes 0x00-0x1F (ESC, CR, LF, ...); DEL is 0x7F; C1 controls are U+0080-U+009F, which terminals treat as one-byte equivalents of common ESC sequences (U+009B is CSI, the same as `ESC [`). In UTF-8 output they are the two-byte sequences `C2 80`..`C2 9F`, which is why the adapter works on decoded characters rather than raw bytes; the multi-byte `»` (U+00BB, `C2 BB`) is not a control and is left alone.
- The adapter is a `core::fmt::Write` shim placed between the inner `Display` and the real `Formatter`, so whatever the inner value writes is filtered; `pretty!`'s `{s}`/`{f}` placeholders are plain `Display` placeholders, so the call sites only needed their argument wrapped.
- Only the `pm untrusted` / `pm trust` listing is changed here. Other install output that echoes dependency-authored strings (package names in summaries, `bun pm ls`, `bun info`, ...) can adopt the same helper separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-pm.test.ts

<!-- robobun:evidence:end -->