### PR TITLE
css: print sub-1 dimensions without a fixed size scratch buffer

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5346,18 +5346,7 @@ impl Token {
             }
             Token::Dimension(d) => {
                 serializer::write_numeric(d.num.value, d.num.int_value, d.num.has_sign, writer)?;
-                // Disambiguate with scientific notation.
-                let unit = d.unit;
-                if (unit.len() == 1 && unit[0] == b'e')
-                    || (unit.len() == 1 && unit[0] == b'E')
-                    || unit.starts_with(b"e-")
-                    || unit.starts_with(b"E-")
-                {
-                    writer.write_all(b"\\65 ")?;
-                    serializer::serialize_name(&unit[1..], writer)
-                } else {
-                    serializer::serialize_identifier(unit, writer)
-                }
+                serializer::serialize_dimension_unit(d.unit, writer)
             }
             Token::Whitespace(content) => writer.write_all(content),
             Token::Comment(content) => {
@@ -5440,17 +5429,8 @@ impl Token {
             Token::Dimension(dim) => {
                 serializer::write_numeric(dim.num.value, dim.num.int_value, dim.num.has_sign, dest)
                     .map_err(|_| dest.add_fmt_error())?;
-                let unit = dim.unit;
-                if unit == b"e"
-                    || unit == b"E"
-                    || unit.starts_with(b"e-")
-                    || unit.starts_with(b"E-")
-                {
-                    dest.write_str("\\65 ")?;
-                    dest.serialize_name(&unit[1..])
-                } else {
-                    dest.serialize_identifier(unit)
-                }
+                serializer::serialize_dimension_unit(dim.unit, dest)
+                    .map_err(|_| dest.add_fmt_error())
             }
             Token::Whitespace(content) => dest.write_bytes(content),
             Token::Comment(content) => {
@@ -5872,6 +5852,12 @@ pub mod serializer {
         unit: &'static [u8],
         dest: &mut Printer,
     ) -> Result<(), PrintErr> {
+        if value != 0.0 && value.abs() < 1.0 {
+            // Prints `.5px`. The unit goes straight to `dest`: in a token list it is whatever
+            // the stylesheet used, so it has no length bound a scratch buffer could be sized for.
+            CSSNumberFns::to_css(value, dest)?;
+            return serialize_dimension_unit(unit, dest).map_err(|_| dest.add_fmt_error());
+        }
         let int_value: Option<i32> = if fract(value) == 0.0 {
             Some(value as i32) // saturating cast
         } else {
@@ -5885,22 +5871,20 @@ pub mod serializer {
             },
             unit,
         });
-        if value != 0.0 && value.abs() < 1.0 {
-            // TODO: calculate the actual number of chars here
-            let mut buf = [0u8; 64];
-            let mut fbs = FixedBufWriter::new(&mut buf);
-            token
-                .to_css_generic(&mut fbs)
-                .map_err(|_| dest.add_fmt_error())?;
-            let s = fbs.get_written();
-            if value < 0.0 {
-                dest.write_str("-")?;
-                dest.write_bytes(strings::trim_leading_pattern2(s, b'-', b'0'))
-            } else {
-                dest.write_bytes(strings::trim_leading_char(s, b'0'))
-            }
+        token.to_css_generic(dest).map_err(|_| dest.add_fmt_error())
+    }
+
+    /// Writes a dimension's unit. A unit that would read as an exponent of the preceding
+    /// number (`e`, `e-...`) gets its `e` escaped.
+    pub(crate) fn serialize_dimension_unit<W: WriteAll + ?Sized>(
+        unit: &[u8],
+        writer: &mut W,
+    ) -> bun_io::Result<()> {
+        if unit == b"e" || unit == b"E" || unit.starts_with(b"e-") || unit.starts_with(b"E-") {
+            writer.write_all(b"\\65 ")?;
+            serialize_name(&unit[1..], writer)
         } else {
-            token.to_css_generic(dest).map_err(|_| dest.add_fmt_error())
+            serialize_identifier(unit, writer)
         }
     }
 
@@ -6048,7 +6032,7 @@ pub mod serializer {
         }
     }
 
-    /// Fixed-buffer writer for `serialize_dimension` — alias for the canonical
+    /// Fixed-buffer writer for `Percentage::to_css` — alias for the canonical
     /// `bun_io::FixedBufferStream`. Callers use `.get_written()` (was `.buffered()`).
     pub(crate) type FixedBufWriter<'a> = bun_io::FixedBufferStream<&'a mut [u8]>;
 }

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -125,6 +125,44 @@ describe("css tests", () => {
     // Same trimming applies inside function arguments.
     minify_test(":root{--a:f(x y z)}", ":root{--a:f(x y z)}");
     minify_test(":root{--a:f( x y z )}", ":root{--a:f(x y z)}");
+
+    describe("dimension tokens with a long unit", () => {
+      // A dimension with a magnitude below 1 is printed without its leading zero (`.5px`). That
+      // path used to serialize the whole token into a 64 byte scratch buffer, so a unit long
+      // enough to overflow it failed the whole stylesheet with a PrintError. In custom properties
+      // and in declarations that fall back to a token list the unit is whatever the stylesheet
+      // says, so its length is unbounded.
+      const unit = Buffer.alloc(200, "a").toString();
+      minify_test(`.a{--x:0.5${unit}}`, `.a{--x:.5${unit}}`);
+      minify_test(`.a{--x:-0.5${unit}}`, `.a{--x:-.5${unit}}`);
+      minify_test(`.a{--x:.25${unit} f(0.75${unit})}`, `.a{--x:.25${unit} f(.75${unit})}`);
+      // A known property with an unknown unit, and an unknown property, are printed as token lists too.
+      minify_test(`.a{width:0.5${unit}}`, `.a{width:.5${unit}}`);
+      minify_test(`.a{unknown-prop:0.5${unit}}`, `.a{unknown-prop:.5${unit}}`);
+      minify_test(`@foo 0.5${unit};`, `@foo .5${unit};`);
+      cssTest(`.a{--x:0.5${unit}}`, `.a {\n  --x: .5${unit};\n}\n`);
+      // `0.5` plus 61 bytes of unit exactly filled the old buffer; one more byte overflowed it.
+      const unit61 = Buffer.alloc(61, "a").toString();
+      const unit62 = Buffer.alloc(62, "a").toString();
+      minify_test(`.a{--x:0.5${unit61}}`, `.a{--x:.5${unit61}}`);
+      minify_test(`.a{--x:0.5${unit62}}`, `.a{--x:.5${unit62}}`);
+      // Zero and values of 1 and above never went through the scratch buffer.
+      minify_test(`.a{--x:0${unit}}`, `.a{--x:0${unit}}`);
+      minify_test(`.a{--x:1.5${unit}}`, `.a{--x:1.5${unit}}`);
+      minify_test(`.a{--x:-2${unit}}`, `.a{--x:-2${unit}}`);
+      // A unit that would read as an exponent gets its `e` escaped, whichever way the number is printed.
+      minify_test(`.a{--x:0.5e-${unit}}`, `.a{--x:.5\\65 -${unit}}`);
+      minify_test(`.a{--x:0.5e-foo}`, `.a{--x:.5\\65 -foo}`);
+      minify_test(`.a{--x:-0.5E}`, `.a{--x:-.5\\65 }`);
+      minify_test(`.a{--x:2e-foo}`, `.a{--x:2\\65 -foo}`);
+      minify_test(`.a{--x:2E}`, `.a{--x:2\\65 }`);
+      minify_test(`.a{--x:0.5ex 2em}`, `.a{--x:.5ex 2em}`);
+      // Arguments of unknown pseudo-classes are printed as raw tokens, with the same unit escaping.
+      minify_test(`.a:-x-foo(0.5e-x 2e-${unit}){color:red}`, `.a:-x-foo(0.5\\65 -x 2\\65 -${unit}){color:red}`);
+      minify_test(`.a:-x-foo(0.5E 2e 0.5px){color:red}`, `.a:-x-foo(0.5\\65  2\\65  0.5px){color:red}`);
+      // Typed dimensions inside a token list still drop the leading zero.
+      minify_test(`.a{--x:0.5px 0.5deg 0.5s 0.5dpi}`, `.a{--x:.5px .5deg .5s .5dpi}`);
+    });
   });
 
   describe("pseudo-class edge case", () => {


### PR DESCRIPTION
### Problem
- `bun build` on a stylesheet containing a dimension with a magnitude below 1 and a long unit fails outright: `.a{--x:0.5aaaa...(62+ a's)}` gives `error: Failed to generate CSS for this file (PrintError)` and exit code 1. Same for `.a{width:0.5<long unit>}` (unknown unit, so the declaration is kept as a token list) and `@foo 0.5<long unit>;`. Reproduces on released bun 1.4.0 and on main; lightningcss prints `.a{--x:.5aaaa...}`.
- Cause: `serializer::serialize_dimension` (`src/css/css_parser.rs`, around line 5888) strips the leading zero (`0.5px` -> `.5px`) by serializing the whole token, number plus unit, into a `[u8; 64]` `FixedBufWriter` and trimming the result (lightningcss formats into a growable `String` here; the fixed buffer, with its "TODO: calculate the actual number of chars" comment, dates from the original port). The unit of a token-list dimension is copied verbatim from the stylesheet (`src/css/properties/custom.rs:417`), so once `number + unit` exceeds 64 bytes the buffer write fails, the error is reported through `dest.add_fmt_error()`, and the whole print fails. `0.5` plus a 61 byte unit still fits; 62 bytes does not. Values of 0 and of magnitude 1 and above take the other branch, which writes straight to the printer, so only sub-1 values are affected.

### Fix
- The fixing change is the early branch at the top of `serialize_dimension`: for a sub-1 value the number is printed with `CSSNumberFns::to_css`, which already strips the leading zero and writes straight to the printer, and the unit is then written straight to the printer as well. No scratch buffer is involved, so there is no length the unit can exceed.
- `CSSNumberFns::to_css` produces byte for byte what the old buffer path produced for the number part: in this branch the token's `int_value` is `None` and `has_sign` only reflects the sign, so `write_numeric` reduced to `dtoa_short(value, 6)`, and the zero stripping was the same `trim_leading_*` code as in `number.rs`. The trimming never reached the unit (the formatted number always starts with `0.`, `-0.`, or a non-zero digit), so writing the unit separately prints the same bytes.
- The unit escaping that `Token::Dimension` applies (a unit of `e`, `E`, `e-...`, `E-...` gets its `e` escaped as `\65 ` so it does not read as an exponent) was duplicated in `Token::to_css_generic` and `Token::to_css`; it moves into `serializer::serialize_dimension_unit`, which both `Token` printers and the new branch call, so the sub-1 path escapes units exactly like the other path.
- The zero / `>= 1` branch is unchanged (still builds the token and prints it through `to_css_generic`). `Percentage::to_css` uses the same scratch-buffer shape but only ever holds a 6 digit number and `%`, so it is left alone. The `FixedBufWriter` alias stays for it; only its doc comment is updated.
- Verified:
  - `test/js/bun/css/css.test.ts` ("dimension tokens with a long unit"): 21 cases. The 9 with a sub-1 value and a long unit (custom property, negative, nested in a function, known property with unknown unit, unknown property, unknown at-rule prelude, non-minified output, the 62 byte boundary, and an escaped `e-` unit) fail on the released build and on an unfixed debug build with `Formatting error occurred`; the other 12 pin output that must not change (61 byte boundary, `0` and `>= 1` values with a long unit, `\65 ` escaping through all three printers, typed dimensions in a token list). All 21 pass with the fix.
  - `test/js/bun/css/` and `test/bundler/css/` pass with the debug build, apart from two tests in `nested-vendor-prefix-duplication.test.ts` and `selector-list-error-recovery.test.ts` that sit within ~1% of their 5s budget on this debug+ASAN machine both with and without the change (4935ms vs 4950ms, 4690ms vs 4707ms); neither prints a sub-1 dimension.
  - `cargo fmt --check` and `cargo clippy -p bun_css` are clean.
- Overlaps with two open PRs that rewrite the same function. This PR merges cleanly onto main by itself; for each of the two I merged it on top of the other PR, resolved the conflict as described, and ran both PRs' test blocks with a debug build:
  - #38516 (double minus sign on negative sub-1 numbers) edits the trimming inside the buffer block this PR deletes: one conflict region. Keep this PR's `serialize_dimension` body and keep #38516's `write_without_leading_zero` helper (its `number.rs` and `percentage.rs` callers merge cleanly). Dimensions then get the single-minus fix through `CSSNumberFns::to_css`; the 56 tests of the two blocks pass.
  - #38482 (exact integer tokens) splits the function into a `serialize_dimension` wrapper plus `serialize_dimension_num`, which the token-list path (`custom.rs:417`) then calls directly: three conflict regions. The two `Token::Dimension` arms take #38482's `write_numeric(&num, ..)` followed by this PR's `serialize_dimension_unit` call, and the sub-1 early return goes at the top of `serialize_dimension_num` (on `num.value`), not in the wrapper; left in the wrapper, token-list dimensions would print `0.5aaa...` again, which the long-unit tests here catch. Resolved that way, the 46 tests of the two blocks and `test/regression/issue/21907.test.ts` pass.

### Background
- A CSS `<dimension>` token is a number immediately followed by an identifier unit (`0.5px`). Typed values (lengths, angles, times, resolutions) carry one of a fixed set of units. Custom property values, declarations bun has no typed entry for (or whose unit it does not know), and unknown at-rule preludes are instead kept as a `TokenList` and printed token by token; a dimension token in such a list keeps whatever unit, of whatever length, the stylesheet used. All of these print through `serialize_dimension`.
- CSS allows a number to omit the zero before the decimal point, so the printer writes `0.5px` as `.5px`. The old code did this by formatting the full token into a fixed stack buffer and trimming the front; `CSSNumberFns::to_css` (`src/css/values/number.rs`) is the equivalent for a bare `<number>` and writes straight to the printer.
- A unit of `e` or starting with `e-` would make `1e3` / `1e-3` read back as a number in exponent notation rather than as a dimension, so the unit's `e` is written as the escape `\65 ` (`0.5e-foo` prints as `.5\65 -foo`).
- `Printer` records a write failure as a `PrinterError` of kind `fmt_error`; the bundler reports that as the "Failed to generate CSS for this file (PrintError)" error and fails the build for that file.

