### PR TITLE
js_parser: visit the value an exports.replace entry discards as dead code

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -279,10 +279,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             .features
                             .replace_exports
                             .get_ptr(name)
-                            .map(|r| (bun_ptr::BackRef::new(r), r.is_replace()));
-                        if let Some((ptr, is_replace)) = found {
+                            .map(bun_ptr::BackRef::new);
+                        if let Some(ptr) = found {
                             replacement = Some(ptr);
-                            if self.options.features.dead_code_elimination && !is_replace {
+                            // Every entry kind discards this initializer, so nothing it references is a use.
+                            if self.options.features.dead_code_elimination {
                                 self.is_control_flow_dead = true;
                             }
                         }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -381,7 +381,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let mut mark_for_replace: bool = false;
-        // `Replace` keeps this statement with a new value; `Delete` and `Inject` drop it.
         let mut replace_keeps_stmt: bool = false;
 
         let orig_dead = p.is_control_flow_dead;
@@ -402,8 +401,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
         }
 
-        // Only the discarded value is dead; the statement a `Replace` entry keeps is not.
-        // For the other kinds the flag stays set and the checks below drop the statement.
+        // The statement a `Replace` entry keeps is live; only its old value was dead.
         macro_rules! discarded_value_visited {
             () => {
                 if replace_keeps_stmt {
@@ -811,8 +809,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 replace_expr,
                             ) = entry
                             {
-                                // The class is discarded, so it is not lowered: lowering
-                                // writes the class back into `data.value`.
                                 data.value = js_ast::StmtOrExpr::Expr(replace_expr);
                                 stmts.push(*stmt);
                             } else {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -381,19 +381,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let mut mark_for_replace: bool = false;
+        // `Replace` keeps this statement with a new value; `Delete` and `Inject` drop it.
+        let mut replace_keeps_stmt: bool = false;
 
         let orig_dead = p.is_control_flow_dead;
         if p.options.features.replace_exports.count() > 0 {
             if let Some(entry) = p.options.features.replace_exports.get_ptr(b"default") {
-                p.is_control_flow_dead =
-                    p.options.features.dead_code_elimination && !entry.is_replace();
+                // Every entry kind discards the exported value, so nothing it references is a use.
+                if p.options.features.dead_code_elimination {
+                    p.is_control_flow_dead = true;
+                }
                 mark_for_replace = true;
+                replace_keeps_stmt = entry.is_replace();
             }
         }
 
         macro_rules! restore_dead {
             () => {
                 p.is_control_flow_dead = orig_dead;
+            };
+        }
+
+        // Only the discarded value is dead; the statement a `Replace` entry keeps is not.
+        // For the other kinds the flag stays set and the checks below drop the statement.
+        macro_rules! discarded_value_visited {
+            () => {
+                if replace_keeps_stmt {
+                    restore_dead!();
+                }
             };
         }
 
@@ -423,6 +438,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.react_compiler_candidate_name = None;
                 p.react_compiler_in_react_hoc = false;
                 p.decorator_class_name = prev_decorator_class_name;
+                discarded_value_visited!();
 
                 if p.is_control_flow_dead {
                     restore_dead!();
@@ -605,6 +621,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let open_parens_loc = func.func.open_parens_loc;
                         func.func = p.visit_func(core::mem::take(&mut func.func), open_parens_loc);
                         p.react_compiler_candidate_name = None;
+                        discarded_value_visited!();
 
                         if p.is_control_flow_dead {
                             p.react_refresh.hook_ctx_storage = prev;
@@ -774,6 +791,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     StmtData::SClass(mut class_ref) => {
                         let class: &mut S::Class = &mut *class_ref;
                         let _ = p.visit_class(s2_loc, &mut class.class, data.default_name.ref_);
+                        discarded_value_visited!();
 
                         if p.is_control_flow_dead {
                             restore_dead!();

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -811,7 +811,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 replace_expr,
                             ) = entry
                             {
+                                // The class is discarded, so it is not lowered: lowering
+                                // writes the class back into `data.value`.
                                 data.value = js_ast::StmtOrExpr::Expr(replace_expr);
+                                stmts.push(*stmt);
                             } else {
                                 let _ = p.inject_replacement_export(
                                     stmts,
@@ -819,10 +822,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     bun_ast::Loc::EMPTY,
                                     &entry,
                                 );
-                                restore_dead!();
-                                record_on_exit!();
-                                return Ok(());
                             }
+                            restore_dead!();
+                            record_on_exit!();
+                            return Ok(());
                         }
 
                         if !data.default_name.ref_.is_symbol() {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2099,6 +2099,21 @@ export default class {
         expect(replacing.scan(source).imports).toEqual([]);
       });
 
+      it("typescript: drops the binding but keeps the import statement, like eliminate does", () => {
+        // TypeScript removes an import statement only when its bindings are unused in the
+        // whole file, dead code included, so the statement survives as a side effect import.
+        const ts = new Bun.Transpiler({
+          loader: "ts",
+          exports: { replace: { foo: 42 }, eliminate: ["loader"] },
+          treeShaking: true,
+          trimUnusedImports: true,
+        });
+        expect(ts.transformSync(deadImport + `export const foo = () => ${deadCall};`)).toBe(
+          'import"fs";\nexport const foo = 42;\n',
+        );
+        expect(ts.transformSync(deadImport + `export const loader = () => ${deadCall};`)).toBe('import"fs";\n');
+      });
+
       it("keeps an import that is also used outside the discarded value", () => {
         expect(
           replacing.transformSync(

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2085,6 +2085,9 @@ export default class {
         ["function declaration", `export default function Page() { return ${deadCall}; }`],
         ["class declaration", `export default class Page { method() { return ${deadCall}; } }`],
         ["anonymous class", `export default class { method() { return ${deadCall}; } }`],
+        // The import is referenced outside of any method body here, so the class itself must go.
+        ["class extending the import", `export default class Page extends deadFS {}`],
+        ["class with a static initializer", `export default class { static contents = ${deadCall}; }`],
       ])("export default %s, replaced: trims an import only the discarded value used", (_, source) => {
         expect(replacingDefault.transformSync(deadImport + source)).toBe("export default 42;\n");
         expect(replacingDefault.scan(deadImport + source)).toEqual({ exports: ["default"], imports: [] });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2083,15 +2083,11 @@ export default class {
         ["expression", `export default ${deadCall};`],
         ["arrow function", `export default () => ${deadCall};`],
         ["function declaration", `export default function Page() { return ${deadCall}; }`],
+        ["class declaration", `export default class Page { method() { return ${deadCall}; } }`],
+        ["anonymous class", `export default class { method() { return ${deadCall}; } }`],
       ])("export default %s, replaced: trims an import only the discarded value used", (_, source) => {
         expect(replacingDefault.transformSync(deadImport + source)).toBe("export default 42;\n");
         expect(replacingDefault.scan(deadImport + source)).toEqual({ exports: ["default"], imports: [] });
-      });
-
-      it("export default class, replaced: trims an import only the discarded value used", () => {
-        const source = deadImport + `export default class Page { method() { return ${deadCall}; } }`;
-        expect(replacingDefault.scan(source)).toEqual({ exports: ["default"], imports: [] });
-        expect(replacingDefault.transformSync(source)).not.toContain("deadFS");
       });
 
       it("does not record an import() made inside the discarded value", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2044,68 +2044,78 @@ export default class {
       expect(output.includes("localVarToRemove")).toBe(false);
     });
 
-    // The value being replaced never reaches the output, so whatever only it referenced
-    // is unused. `foo` is replaced with a plain value, `getStaticProps` is replaced by an
-    // injected export and `loader` is eliminated; the three kinds must trim alike.
-    const deadImport = `import deadFS from 'fs';\n`;
-    const deadCall = `deadFS.readFileSync("/etc/passwd")`;
-
-    it.each([
-      ["export const, replaced", `export const foo = () => ${deadCall};`, 'export const foo = "bar";\n'],
-      ["export var, replaced", `export var foo = () => ${deadCall};`, 'export var foo = "bar";\n'],
-      ["export let, replaced", `export let foo = () => ${deadCall};`, 'export let foo = "bar";\n'],
-      ["export function, replaced", `export function foo() { return ${deadCall}; }`, 'export var foo = "bar";\n'],
-      ["export const, injected", `export const getStaticProps = () => ${deadCall};`, "export const __N_SSG = true;\n"],
-      ["export const, eliminated", `export const loader = () => ${deadCall};`, ""],
-    ])("%s: trims an import used only by the discarded value", (_, source, expected) => {
-      expect(transpiler.transformSync(deadImport + source)).toBe(expected);
-      expect(transpiler.scan(deadImport + source).imports).toEqual([]);
-    });
-
-    it("does not record an import() made inside the discarded value", () => {
-      const source = `export const foo = () => import("./only-used-here");`;
-      expect(transpiler.transformSync(source)).toBe('export const foo = "bar";\n');
-      expect(transpiler.scan(source).imports).toEqual([]);
-    });
-
-    it("keeps an import that is also used outside the discarded value", () => {
-      expect(
-        transpiler.transformSync(
-          `import deadFS from 'fs';
-          import liveFS from 'fs';
-          export const foo = () => ${deadCall};
-          export function baz() { return liveFS.readFileSync("/etc/passwd"); }`,
-        ),
-      ).toBe(
-        'import liveFS from "fs";\nexport const foo = "bar";\nexport function baz() {\n  return liveFS.readFileSync("/etc/passwd");\n}\n',
-      );
-
-      // Only the replaced declaration of the statement is dead, not its siblings.
-      expect(
-        transpiler.transformSync(`import { dead, live } from 'fs';\nexport const foo = () => dead(), other = live;`),
-      ).toBe('import { live } from "fs";\nexport const foo = "bar";\nexport const other = live;\n');
-    });
-
-    describe("export default", () => {
-      const replaceDefault = new Bun.Transpiler({
-        exports: { replace: { default: "bar" } },
+    describe("the value an entry discards is dead code", () => {
+      // A plain replacement (`foo`), an injected export (`getStaticProps`) and an eliminated
+      // export (`loader`) all drop the original value, so the three must trim its imports alike.
+      const replacing = new Bun.Transpiler({
+        exports: {
+          replace: { foo: 42, getStaticProps: ["__N_SSG", true] },
+          eliminate: ["loader"],
+        },
         treeShaking: true,
         trimUnusedImports: true,
+      });
+      const replacingDefault = new Bun.Transpiler({
+        exports: { replace: { default: 42 } },
+        treeShaking: true,
+        trimUnusedImports: true,
+      });
+      const deadImport = `import deadFS from 'fs';\n`;
+      const deadCall = `deadFS.readFileSync("/etc/passwd")`;
+
+      it.each([
+        ["export const, replaced", `export const foo = () => ${deadCall};`, "export const foo = 42;\n"],
+        ["export var, replaced", `export var foo = () => ${deadCall};`, "export var foo = 42;\n"],
+        ["export let, replaced", `export let foo = () => ${deadCall};`, "export let foo = 42;\n"],
+        ["export function, replaced", `export function foo() { return ${deadCall}; }`, "export var foo = 42;\n"],
+        [
+          "export const, injected",
+          `export const getStaticProps = () => ${deadCall};`,
+          "export const __N_SSG = true;\n",
+        ],
+        ["export const, eliminated", `export const loader = () => ${deadCall};`, ""],
+      ])("%s: trims an import only the discarded value used", (_, source, expected) => {
+        expect(replacing.transformSync(deadImport + source)).toBe(expected);
+        expect(replacing.scan(deadImport + source).imports).toEqual([]);
       });
 
       it.each([
         ["expression", `export default ${deadCall};`],
         ["arrow function", `export default () => ${deadCall};`],
         ["function declaration", `export default function Page() { return ${deadCall}; }`],
-      ])("%s: trims an import used only by the discarded value", (_, source) => {
-        expect(replaceDefault.transformSync(deadImport + source)).toBe('export default "bar";\n');
-        expect(replaceDefault.scan(deadImport + source)).toEqual({ exports: ["default"], imports: [] });
+      ])("export default %s, replaced: trims an import only the discarded value used", (_, source) => {
+        expect(replacingDefault.transformSync(deadImport + source)).toBe("export default 42;\n");
+        expect(replacingDefault.scan(deadImport + source)).toEqual({ exports: ["default"], imports: [] });
       });
 
-      it("class declaration: trims an import used only by the discarded value", () => {
+      it("export default class, replaced: trims an import only the discarded value used", () => {
         const source = deadImport + `export default class Page { method() { return ${deadCall}; } }`;
-        expect(replaceDefault.scan(source)).toEqual({ exports: ["default"], imports: [] });
-        expect(replaceDefault.transformSync(source)).not.toContain("deadFS");
+        expect(replacingDefault.scan(source)).toEqual({ exports: ["default"], imports: [] });
+        expect(replacingDefault.transformSync(source)).not.toContain("deadFS");
+      });
+
+      it("does not record an import() made inside the discarded value", () => {
+        const source = `export const foo = () => import("./only-used-here");`;
+        expect(replacing.transformSync(source)).toBe("export const foo = 42;\n");
+        expect(replacing.scan(source).imports).toEqual([]);
+      });
+
+      it("keeps an import that is also used outside the discarded value", () => {
+        expect(
+          replacing.transformSync(
+            `import deadFS from 'fs';
+            import liveFS from 'fs';
+            export const foo = () => ${deadCall};
+            export function baz() { return liveFS.readFileSync("/etc/passwd"); }`,
+          ),
+        ).toBe(
+          'import liveFS from "fs";\nexport const foo = 42;\nexport function baz() {\n  return liveFS.readFileSync("/etc/passwd");\n}\n',
+        );
+
+        // Only the replaced declaration is dead, not the other declarations of the same statement.
+        expect(
+          replacing.transformSync(`import { dead, live } from 'fs';\nexport const foo = () => dead(), other = live;`),
+        ).toBe('import { live } from "fs";\nexport const foo = 42;\nexport const other = live;\n');
       });
     });
   });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2043,6 +2043,71 @@ export default class {
       expect(output.includes("localVarToReplace")).toBe(true);
       expect(output.includes("localVarToRemove")).toBe(false);
     });
+
+    // The value being replaced never reaches the output, so whatever only it referenced
+    // is unused. `foo` is replaced with a plain value, `getStaticProps` is replaced by an
+    // injected export and `loader` is eliminated; the three kinds must trim alike.
+    const deadImport = `import deadFS from 'fs';\n`;
+    const deadCall = `deadFS.readFileSync("/etc/passwd")`;
+
+    it.each([
+      ["export const, replaced", `export const foo = () => ${deadCall};`, 'export const foo = "bar";\n'],
+      ["export var, replaced", `export var foo = () => ${deadCall};`, 'export var foo = "bar";\n'],
+      ["export let, replaced", `export let foo = () => ${deadCall};`, 'export let foo = "bar";\n'],
+      ["export function, replaced", `export function foo() { return ${deadCall}; }`, 'export var foo = "bar";\n'],
+      ["export const, injected", `export const getStaticProps = () => ${deadCall};`, "export const __N_SSG = true;\n"],
+      ["export const, eliminated", `export const loader = () => ${deadCall};`, ""],
+    ])("%s: trims an import used only by the discarded value", (_, source, expected) => {
+      expect(transpiler.transformSync(deadImport + source)).toBe(expected);
+      expect(transpiler.scan(deadImport + source).imports).toEqual([]);
+    });
+
+    it("does not record an import() made inside the discarded value", () => {
+      const source = `export const foo = () => import("./only-used-here");`;
+      expect(transpiler.transformSync(source)).toBe('export const foo = "bar";\n');
+      expect(transpiler.scan(source).imports).toEqual([]);
+    });
+
+    it("keeps an import that is also used outside the discarded value", () => {
+      expect(
+        transpiler.transformSync(
+          `import deadFS from 'fs';
+          import liveFS from 'fs';
+          export const foo = () => ${deadCall};
+          export function baz() { return liveFS.readFileSync("/etc/passwd"); }`,
+        ),
+      ).toBe(
+        'import liveFS from "fs";\nexport const foo = "bar";\nexport function baz() {\n  return liveFS.readFileSync("/etc/passwd");\n}\n',
+      );
+
+      // Only the replaced declaration of the statement is dead, not its siblings.
+      expect(
+        transpiler.transformSync(`import { dead, live } from 'fs';\nexport const foo = () => dead(), other = live;`),
+      ).toBe('import { live } from "fs";\nexport const foo = "bar";\nexport const other = live;\n');
+    });
+
+    describe("export default", () => {
+      const replaceDefault = new Bun.Transpiler({
+        exports: { replace: { default: "bar" } },
+        treeShaking: true,
+        trimUnusedImports: true,
+      });
+
+      it.each([
+        ["expression", `export default ${deadCall};`],
+        ["arrow function", `export default () => ${deadCall};`],
+        ["function declaration", `export default function Page() { return ${deadCall}; }`],
+      ])("%s: trims an import used only by the discarded value", (_, source) => {
+        expect(replaceDefault.transformSync(deadImport + source)).toBe('export default "bar";\n');
+        expect(replaceDefault.scan(deadImport + source)).toEqual({ exports: ["default"], imports: [] });
+      });
+
+      it("class declaration: trims an import used only by the discarded value", () => {
+        const source = deadImport + `export default class Page { method() { return ${deadCall}; } }`;
+        expect(replaceDefault.scan(source)).toEqual({ exports: ["default"], imports: [] });
+        expect(replaceDefault.transformSync(source)).not.toContain("deadFS");
+      });
+    });
   });
 
   const bunTranspiler = new Bun.Transpiler({


### PR DESCRIPTION
### Problem

- `Bun.Transpiler` with `exports: { replace: { getStaticProps: "x" } }` (a plain replacement value) prints the replacement, but an import used only by the value it replaced survives `trimUnusedImports`, and `scan()` keeps reporting it (including `import()` records made inside that value):
  ```js
  new Bun.Transpiler({ loader: "tsx", trimUnusedImports: true, exports: { replace: { getStaticProps: "x" } } })
    .transformSync(`import { serverHelper } from "./server-only";\nexport const getStaticProps = () => serverHelper();\n`);
  // import { serverHelper } from "./server-only";   <- should be gone, nothing left uses it
  // export const getStaticProps = "x";
  ```
- Same for `export var` / `export let`, `export default <expr>`, `export default () => ...` and `export default function f() {}`. `eliminate: [...]` and the inject form (`replace: { x: ["__N_SSG", true] }`) trim the import, so the three entry kinds disagree. Once #38352 lands, helpers only the replaced value called would be kept too, for the same reason.
- Scope of what this changes in the output today: with the `js` / `jsx` loaders the import statement disappears and `scan()` stops listing it; with `ts` / `tsx` the binding is removed but the statement stays as a bare `import "./server-only"` and `scan()` still lists it, exactly what `eliminate` produces there today, because TypeScript import removal is keyed on `ts_use_counts`, which counts dead code too. #38352 changes that scanner rule for files with `exports` entries; with it, both kinds drop the statement.
- There is no user report for this; it was found while working on #38352, which lists it as out of scope. It is the missing half of what `exports.eliminate` has done since the option was added, and it is what lets #38352's declaration removal apply to replaced exports as well.
- `export default class X {}` with a replacement value printed the class itself instead of the replacement.
- Cause of the first two: `visit_decls` (`src/js_parser/visit/mod.rs`, the `is_control_flow_dead` assignment next to the `replace_exports` lookup) and `s_export_default` (`src/js_parser/visit/visit_stmt.rs`) only set `is_control_flow_dead` for non-`Replace` entries before visiting the original value. `replace_decl_and_possibly_remove` / the `mark_for_replace` blocks then overwrite the value for `Replace` as well, so it was visited as live code for nothing and every symbol it referenced kept the use count recorded during that visit. The check dates from the commit that introduced the API (42414d5667); `s_function` and `s_class` already mark the body dead for every entry kind.
- Cause of the third: the class branch of `s_export_default` wrote the replacement into `data.value` and then fell through to the class lowering, which writes the lowered class back into `data.value`.

### Fix

- `visit_decls`: set `is_control_flow_dead` for any matching entry. The flag is restored right after the initializer is visited, as before, so the replacement value itself (visited in `replace_decl_and_possibly_remove`) and the other declarations of the same statement stay live.
- `s_export_default`: set the flag for any matching entry, and for a `Replace` entry restore it right after the value has been visited (`discarded_value_visited!`, used after the expression, function and class visits). The early `if p.is_control_flow_dead` returns and everything after them behave as before: `Delete` / `Inject` still return early, `Replace` still reaches the replacement, now with the old value's uses not counted.
- Class branch: the `Replace` arm pushes the replaced statement and returns, as the function branch already does, instead of falling through to the lowering. Needed here because the dead visit now empties the discarded class's method bodies, which would have been visible in the wrongly printed class. #33378 carries the same change to this arm.
- Why this is right: for every entry kind the visited value is discarded, so `record_usage` must not count its references; that is the only thing `is_control_flow_dead` changes for it (plus not registering `import()` / `require()` records and not running macros inside it, which `eliminate` already does). `exports.eliminate` has used this exact mechanism since the API was added, so `Replace` now goes through the same well exercised path. The `dead_code_elimination` gate is kept, like the other sites.
- Not changed on purpose:
  - `export { name }` clauses keep the local declaration in the output, so its initializer really is live; `s_export_clause` is untouched (#33386 covers that form).
  - An inject entry for `default` (`replace: { default: ["__N_SSG", true] }`) still emits nothing when dead code elimination is on. That path is byte for byte the same before and after this change (the value was already visited dead and the early return already fired); #33378 fixes it.
  - With `deadCodeElimination: false` the import is still kept, as for the other sites.
- Verified with `test/bundler/transpiler/transpiler.test.js` (`exports.replace` > `the value an entry discards is dead code`): const / var / let / function declarations plus injected and eliminated entries side by side, seven `export default` shapes (expression, arrow, function, named class, anonymous class, a class whose `extends` clause uses the import, a class whose static field initializer uses it) each asserting the exact output and `scan()`, an `import()` inside the replaced value, the `ts` loader output described above (pinned next to `eliminate`'s, so #38352 updates both together), and two cases that must keep an import still used elsewhere (another statement, and a sibling declaration of the same `export const`). 13 of the 16 fail on `main`'s parser (the three that pass are the `export function`, injected and eliminated rows, which document the behaviour the others are brought in line with), all pass with the fix.
- Also ran the rest of `test/bundler/transpiler` and `test/js/bun/transpiler` with the debug build; the only failures were `jsx-production.test.ts` cases hitting their 5 s timeout; a single one of those subprocesses takes 5.6 s in this debug build on its own, and they do not use the `exports` option.
- The tests use numeric replacement values: a string value's AST node is created in the thread-local AST store during option parsing and dangles once any synchronous parse resets that store (deterministic ASAN crash in the printer on `main`, independent of this change). That is reported separately; numbers and booleans are stored inline in `ExprData` and are not affected.

### Relationship to the other open PRs in this area

- #33378 (function / class declarations, `export default` inject, uninitialized declarations): independent of this change, but the two overlap on the class `Replace` arm and both add a macro at the same spot in `s_export_default`; whichever lands second has a two-hunk rebase with no semantic interaction. #33378 landing first is the simpler order.
- #38352 (`treeShaking` removes unused declarations, `ts` / `tsx` drop the emptied import statement): this PR is what makes that removal reach values that were replaced rather than eliminated; without this, #38352 keeps the replaced value's helpers and imports alive. After #38352 the `ts` assertion added here becomes the `js` output.
- #33386 (`export { name }` clauses) and the string replacement value lifetime bug (reported separately) are disjoint from this change.

### Background

- `exports.replace` / `exports.eliminate` (`Bun.Transpiler` options) become `replace_exports`, a map from export name to `ReplaceableExport::{Delete, Replace(value), Inject { name, value }}` (`src/ast/runtime.rs`). The visitor consults it when it reaches an exported declaration: `Delete` drops the declaration, `Replace` keeps it with `value` as its initializer, `Inject` drops it and emits `export var <name> = value` instead. In all three cases the original value never reaches the output.
- `is_control_flow_dead` is the parser flag for "the code being visited will not be emitted" (`if (false)` bodies and the like). While it is set, `record_usage` does not bump `use_count_estimate` and `import()` / `require()` do not create import records. The import scanner later removes import bindings whose `use_count_estimate` is 0; with `trimUnusedImports` an import statement left without bindings is dropped (`js` / `jsx` loaders) or kept as a bare side effect import (`ts` / `tsx`, because TypeScript's separate `ts_use_counts` still sees the reference).
- `exports.eliminate` already worked because the eliminated declaration was visited with this flag set; in addition an export whose whole statement disappears leaves an empty part, and `append_part` gives the uses recorded in an empty part back. A replaced export keeps its statement, so only the first mechanism can apply to it, which is what this change enables.
- `s_export_default` holds the `S::ExportDefault` payload through `data`; the `Stmt` pushed to the output shares that arena allocation, so assigning `data.value` before or after `stmts.push(*stmt)` both end up in the output. The class lowering (`lower_class`) returns a fresh statement list and the branch stores its class statement back into `data.value`, which is what undid the replacement.

<details>
<summary>Before / after for the shapes involved (jsx loader, trimUnusedImports)</summary>

```
source: import {a} from './a';  +  the export below          main                                   this PR
export const foo = () => a();          replace foo: 42      import { a } from "./a"; export const foo = 42;      export const foo = 42;
export var   foo = () => a();          replace foo: 42      import kept                                          export var foo = 42;
export function foo() { return a() }   replace foo: 42      export var foo = 42;                                 unchanged
export const foo = () => a();          inject  foo: [..]    export const __N_SSG = true;                         unchanged
export const foo = () => a();          eliminate foo        (empty)                                              unchanged
export default a();                    replace default: 42  import kept; export default 42;                      export default 42;
export default () => a();              replace default: 42  import kept                                          export default 42;
export default function P() {..a()..}  replace default: 42  import kept                                          export default 42;
export default class P { m(){a()} }    replace default: 42  class printed, import kept                           export default 42;
export default class { m(){a()} }      replace default: 42  class printed, import kept                           export default 42;
export default class P {}              inject default: [..] (empty)                                              unchanged (#33378)
scan() of the first line              replace foo: 42      imports: [{ path: "./a" }]                           imports: []
ts loader, first line                 replace foo: 42      import { a } from "./a"; export const foo = 42;      import "./a"; export const foo = 42;   (eliminate already prints import "./a")
```

</details>

<details>
<summary>Earlier revision of this description</summary>

The first revision left the class branch alone and documented that, with the dead visit, a replaced `export default class` was still printed but with empty method bodies until #33378 landed. Review pointed out that this leaves the path in a worse intermediate state, so the statement push from #33378's class hunk is now included here and the class shapes are asserted exactly.

</details>

