### PR TITLE
bun build --no-bundle: keep css url() references instead of failing to parse

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3067,11 +3067,15 @@ impl<'a> Transpiler<'a> {
         // `'bump`-threading note).
         let alloc: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref::<Arena>(self.arena) };
 
+        // Every `url()` becomes an import record at parse time and is printed
+        // back from it. Nothing resolves them here, so they round-trip as
+        // written, like `@import` already does.
+        let mut import_records = Vec::<bun_ast::ImportRecord>::new();
         let (mut sheet, extra) = match bun_css::StyleSheet::<bun_css::DefaultAtRule>::parse(
             alloc,
             entry.contents(),
             opts,
-            None,
+            Some(&mut import_records),
             bun_ast::Index::INVALID,
         ) {
             Ok(v) => v,
@@ -3100,7 +3104,9 @@ impl<'a> Transpiler<'a> {
                 minify: self.options.minify_whitespace,
                 ..bun_css::PrinterOptions::default()
             },
-            None,
+            Some(bun_css::ImportInfo::init_outside_of_bundler(
+                &import_records,
+            )),
             None,
             &symbols,
         ) {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -579,3 +579,89 @@ describe.concurrent("modules that fail to print", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe.concurrent("bun build --no-bundle keeps css url() references as written", () => {
+  // None of the referenced files exist: --no-bundle transpiles the one file
+  // and must not try to resolve, copy, or inline what it points at.
+  async function transpileCss(css: string, ...flags: string[]) {
+    using dir = tempDir("build-no-bundle-css", { "in.css": css });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", ...flags, "in.css"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  test("quoted relative url", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss('.x { background: url("./img.png") }\n');
+    expect(stderr).toBe("");
+    expect(stdout).toBe('.x {\n  background: url("./img.png");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("unquoted relative url", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss(".x { background-image: url(./img.png) }\n");
+    expect(stderr).toBe("");
+    expect(stdout).toBe('.x {\n  background-image: url("./img.png");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("data: url", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss(".x { background: url(data:image/png;base64,AAAA) }\n");
+    expect(stderr).toBe("");
+    expect(stdout).toBe('.x {\n  background: url("data:image/png;base64,AAAA");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("url with a fragment", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss('.x { mask: url("sprites.svg#icon") }\n');
+    expect(stderr).toBe("");
+    expect(stdout).toBe('.x {\n  mask: url("sprites.svg#icon");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("@font-face src", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss('@font-face { font-family: F; src: url("./f.woff2") }\n');
+    expect(stderr).toBe("");
+    expect(stdout).toBe('@font-face {\n  font-family: F;\n  src: url("./f.woff2");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("url inside a custom property", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss(":root { --bg: url(./img.png) }\n");
+    expect(stderr).toBe("");
+    expect(stdout).toBe(':root {\n  --bg: url("./img.png");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("image-set()", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss(
+      '.x { background-image: image-set(url("./a.png") 1x, "./a@2x.png" 2x) }\n',
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe('.x {\n  background-image: image-set("./a.png" 1x, "./a@2x.png" 2x);\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("alongside @import", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss(
+      '@import "./base.css";\n.x { background: url("./img.png") }\n',
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe('@import "./base.css";\n\n.x {\n  background: url("./img.png");\n}\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("--minify", async () => {
+    const [stdout, stderr, exitCode] = await transpileCss(
+      '.x { background: url("./img.png") }\n.y { background: url(data:image/png;base64,AAAA) }\n',
+      "--minify",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe(".x{background:url(./img.png)}.y{background:url(data:image/png;base64,AAAA)}");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `bun build --no-bundle x.css` exits 1 with `error: Unexpected token: ./img.png parsing` as soon as the stylesheet contains a `url()`, quoted, unquoted or `data:` alike. `bun build x.css` (bundled) works, and a `--no-bundle` stylesheet that only has `@import` works.
- The transpile-only CSS path is `Transpiler::build_css_output` (src/bundler/transpiler.rs). It called `StyleSheet::parse` with no import record list. bun_css stores every `url()` as an index into that list, and when there is no list `Parser::add_import_record` (src/css/css_parser.rs) returns an unexpected-token error for the url, which fails the whole parse.
- This has never worked: the Zig version of this function passed `null` as well.

### Fix
- `build_css_output` collects the records into a local `Vec<ImportRecord>` while parsing and passes `ImportInfo::init_outside_of_bundler(&records)` to `to_css`.
- Why this is the right output: nothing on the `--no-bundle` path resolves anything, so the records keep an invalid `source_index`, and for such records the printer's `get_import_record_url` returns `record.path.text`, the url exactly as written. That is the behavior `@import` already has on this path, and it is the same parse/print pairing the in-tree CSS test binding uses (src/css_jsc/css_internals.rs).
- Verified with the new `bun build --no-bundle keeps css url() references as written` block in test/bundler/cli.test.ts (9 cases: quoted, unquoted and `data:` urls, a `#fragment`, `@font-face src`, a custom property, `image-set()`, a file that also has `@import`, and `--minify`). All 9 fail on bun 1.4.0 with the error above and pass with this change; the rest of cli.test.ts still passes.
- Not covered here: `--no-bundle` on a `.module.css` file still panics in `Printer::lookup_symbol`. That happens with or without a `url()` and is a separate problem in the same function.

### Background
- Import record: `bun_ast::ImportRecord`, one entry per thing a file references (the path as written, the kind, and after resolution a `source_index`). The CSS parser creates one per `url()`, and CSS values such as `Url` keep only the record index, so the printer needs the same list to print them back.
- `ImportInfo` (src/css/printer.rs) is what the CSS printer reads urls from. Inside the bundler it also carries the tables used to rewrite records that resolved to an inlined `data:` URL or a copied asset. `init_outside_of_bundler` leaves those tables empty; they are only consulted for records with a valid `source_index`, which this path never produces.
- `--no-bundle` (`transform_only`) makes `bun build` transpile each entry point on its own through `Transpiler::transform` instead of `BundleV2`, leaving imports for whoever consumes the output to resolve.
