### PR TITLE
usockets(tls): flush the ciphertext write batch every 4 records so Windows does not stall a timer tick per backpressure round

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2470,6 +2470,15 @@ unsigned int us_internal_ssl_spill_pending(struct us_socket_t *s) {
   return loop_ssl_data->ssl_spill_len - loop_ssl_data->ssl_spill_off;
 }
 
+/* Ciphertext per batch flush, i.e. per send(): four records (64 KiB plus record
+ * overhead). Keep each send() below 128 KiB: on Windows (64 KiB default
+ * SO_SNDBUF) a refused send() of 128 KiB or more is not reported writable again
+ * until the next ~15.6 ms timer tick even though the peer drains the socket at
+ * once, while smaller refused sends are reported as soon as space frees up. The
+ * former 8-record batches (131248 bytes) paid that tick on every backpressure
+ * round of every large TLS write. */
+#define US_SSL_WRITE_BATCH_FLUSH_BYTES (4 * 16384)
+
 int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   if (us_socket_is_closed(s) || us_internal_ssl_is_shut_down(s) || length == 0) return 0;
 
@@ -2535,7 +2544,7 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     /* A batching allocation failure marks the socket fatal from inside the BIO;
      * stop sealing records for a connection that is being torn down. */
     if (s->ssl_fatal_error) break;
-    if (batching && loop_ssl_data->ssl_write_batch_len >= 131072) {
+    if (batching && loop_ssl_data->ssl_write_batch_len >= US_SSL_WRITE_BATCH_FLUSH_BYTES) {
       if (!ssl_flush_write_batch(loop_ssl_data, s)) break; /* wire blocked: stop consuming */
       if (s->ssl_fatal_error) break;
     }

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2470,14 +2470,21 @@ unsigned int us_internal_ssl_spill_pending(struct us_socket_t *s) {
   return loop_ssl_data->ssl_spill_len - loop_ssl_data->ssl_spill_off;
 }
 
+/* Plaintext sealed per SSL_write call: one full TLS record. */
+#define US_SSL_RECORD_PLAINTEXT 16384
+
 /* Ciphertext per batch flush, i.e. per send(): four records (64 KiB plus record
- * overhead). Keep each send() below 128 KiB: on Windows (64 KiB default
- * SO_SNDBUF) a refused send() of 128 KiB or more is not reported writable again
- * until the next ~15.6 ms timer tick even though the peer drains the socket at
- * once, while smaller refused sends are reported as soon as space frees up. The
- * former 8-record batches (131248 bytes) paid that tick on every backpressure
- * round of every large TLS write. */
-#define US_SSL_WRITE_BATCH_FLUSH_BYTES (4 * 16384)
+ * overhead), plus the write's partial last record when that is all that is
+ * left, so the common 64 KiB chunk plus a few bytes of framing (an h2 DATA
+ * flight, a node:tls header + chunk writev) still goes out in one send()
+ * instead of trailing a tiny record in its own segment. Every send() must stay
+ * below 128 KiB: on Windows (64 KiB default SO_SNDBUF) a refused send() of
+ * 128 KiB or more is not reported writable again until the next ~15.6 ms timer
+ * tick even though the peer drains the socket at once, while smaller refused
+ * sends are reported as soon as space frees up. The former 8-record batches
+ * (131248 bytes) paid that tick on every backpressure round of every large TLS
+ * write; a batch is now at most about 80 KiB. */
+#define US_SSL_WRITE_BATCH_FLUSH_BYTES (4 * US_SSL_RECORD_PLAINTEXT)
 
 int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   if (us_socket_is_closed(s) || us_internal_ssl_is_shut_down(s) || length == 0) return 0;
@@ -2526,7 +2533,7 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   int last_ssl_written = 1;
   while (total < length) {
     int chunk = length - total;
-    if (chunk > 16384) chunk = 16384;
+    if (chunk > US_SSL_RECORD_PLAINTEXT) chunk = US_SSL_RECORD_PLAINTEXT;
     /* Same deferred-close protocol as the SSL_do_handshake/SSL_read drivers. */
     s->ssl_in_use = 1;
     last_ssl_written = SSL_write(s_ssl(s), data + total, chunk);
@@ -2544,7 +2551,9 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     /* A batching allocation failure marks the socket fatal from inside the BIO;
      * stop sealing records for a connection that is being torn down. */
     if (s->ssl_fatal_error) break;
-    if (batching && loop_ssl_data->ssl_write_batch_len >= US_SSL_WRITE_BATCH_FLUSH_BYTES) {
+    /* A partial last record rides along with the batch (see the flush size). */
+    if (batching && loop_ssl_data->ssl_write_batch_len >= US_SSL_WRITE_BATCH_FLUSH_BYTES &&
+        length - total >= US_SSL_RECORD_PLAINTEXT) {
       if (!ssl_flush_write_batch(loop_ssl_data, s)) break; /* wire blocked: stop consuming */
       if (s->ssl_fatal_error) break;
     }

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -1,6 +1,6 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tls } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
@@ -336,5 +336,91 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
       new Promise<void>(resolve => h.req.once("close", () => resolve())),
     ]);
     expect(h.client.closed || h.client.destroyed).toBe(true);
+  });
+});
+
+// us_internal_ssl_write seals a large write into records and hands them to the
+// kernel a batch at a time, one send() per batch (openssl.c
+// US_SSL_WRITE_BATCH_FLUSH_BYTES). A batch must stay below 128 KiB: on Windows
+// (64 KiB default SO_SNDBUF) a refused send() of 128 KiB or more is not
+// reported writable again until the next ~15.6 ms timer tick, and the former
+// 8-record batches (131248 bytes) paid that tick on every backpressure round
+// of every large TLS write (an https fetch of a 1 MiB body took ~16 ms on
+// Windows 11 vs ~1 ms over plain http). Refusing the first send() of the
+// write with injected backpressure makes the batch size observable on every
+// platform: write() reports exactly the plaintext whose ciphertext sits in
+// the refused (spilled) batch, and the spill is re-sent on the next writable
+// event, so the peer still receives the whole payload.
+describe.skipIf(!fault.available())("TLS write batching", () => {
+  afterEach(() => fault.clear());
+
+  test("a large write hands the kernel at most 4 records per send()", async () => {
+    const payload = Buffer.alloc(1024 * 1024, "t");
+    const firstWrite = Promise.withResolvers<number>();
+    const delivered = Promise.withResolvers<Buffer>();
+    const chunks: Buffer[] = [];
+    let receivedLength = 0;
+    // -1 until the instrumented first write has happened.
+    let offset = -1;
+
+    function pump(socket: Bun.Socket) {
+      if (offset < 0) return;
+      while (offset < payload.length) {
+        const written = socket.write(payload.subarray(offset));
+        if (written <= 0) return;
+        offset += written;
+      }
+      socket.end();
+    }
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls,
+      socket: {
+        // The client's "go" arrives decrypted, so this side's handshake is
+        // over and the next send() in the process is the first batch flush.
+        data(socket) {
+          if (offset >= 0) return;
+          fault.set({ syscall: "send", action: "zero", repeat: 1 });
+          offset = socket.write(payload);
+          fault.clear();
+          firstWrite.resolve(offset);
+        },
+        drain: pump,
+        error(_socket, error) {
+          firstWrite.reject(error);
+          delivered.reject(error);
+        },
+      },
+    });
+
+    using client = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      tls: { ca: tls.cert },
+      socket: {
+        open(socket) {
+          socket.write("go");
+        },
+        data(_socket, chunk) {
+          chunks.push(chunk);
+          receivedLength += chunk.length;
+          if (receivedLength >= payload.length) delivered.resolve(Buffer.concat(chunks));
+        },
+        close() {
+          delivered.reject(new Error(`client closed after ${receivedLength} of ${payload.length} bytes`));
+        },
+        error(_socket, error) {
+          delivered.reject(error);
+        },
+      },
+    });
+
+    expect(await firstWrite.promise).toBe(4 * 16384);
+    const received = await delivered.promise;
+    expect(received.length).toBe(payload.length);
+    expect(received.equals(payload)).toBe(true);
+    client.end();
   });
 });

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -339,23 +339,32 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
   });
 });
 
-// us_internal_ssl_write seals a large write into records and hands them to the
-// kernel a batch at a time, one send() per batch (openssl.c
+// us_internal_ssl_write seals a write into 16 KiB records and hands them to the
+// kernel a batch at a time, one send() per batch: four records, plus the
+// write's partial last record when that is all that is left (openssl.c
 // US_SSL_WRITE_BATCH_FLUSH_BYTES). A batch must stay below 128 KiB: on Windows
 // (64 KiB default SO_SNDBUF) a refused send() of 128 KiB or more is not
 // reported writable again until the next ~15.6 ms timer tick, and the former
 // 8-record batches (131248 bytes) paid that tick on every backpressure round
 // of every large TLS write (an https fetch of a 1 MiB body took ~16 ms on
 // Windows 11 vs ~1 ms over plain http). Refusing the first send() of the
-// write with injected backpressure makes the batch size observable on every
-// platform: write() reports exactly the plaintext whose ciphertext sits in
-// the refused (spilled) batch, and the spill is re-sent on the next writable
-// event, so the peer still receives the whole payload.
+// write with injected backpressure makes the batch boundaries observable on
+// every platform: write() reports exactly the plaintext whose ciphertext sits
+// in the refused (spilled) batch, and the spill is re-sent on the next
+// writable event, so the peer still receives the whole payload.
 describe.skipIf(!fault.available())("TLS write batching", () => {
   afterEach(() => fault.clear());
 
-  test("a large write hands the kernel at most 4 records per send()", async () => {
-    const payload = Buffer.alloc(1024 * 1024, "t");
+  const record = 16384;
+
+  test.each([
+    { shape: "1 MiB", length: 1024 * 1024, firstBatch: 4 * record },
+    // A 64 KiB stream chunk plus its framing (five h2 DATA frame headers here):
+    // the 45-byte fifth record rides in the same batch instead of becoming a
+    // second send() of its own.
+    { shape: "64 KiB + 45 byte", length: 4 * record + 45, firstBatch: 4 * record + 45 },
+  ])("a $shape write puts $firstBatch bytes of plaintext in its first send()", async ({ length, firstBatch }) => {
+    const payload = Buffer.alloc(length, "t");
     const firstWrite = Promise.withResolvers<number>();
     const delivered = Promise.withResolvers<Buffer>();
     const chunks: Buffer[] = [];
@@ -417,7 +426,7 @@ describe.skipIf(!fault.available())("TLS write batching", () => {
       },
     });
 
-    expect(await firstWrite.promise).toBe(4 * 16384);
+    expect(await firstWrite.promise).toBe(firstBatch);
     const received = await delivered.promise;
     expect(received.length).toBe(payload.length);
     expect(received.equals(payload)).toBe(true);

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -404,7 +404,7 @@ describe.skipIf(!fault.available())("TLS write batching", () => {
       },
     });
 
-    using client = await Bun.connect({
+    using _client = await Bun.connect({
       hostname: "127.0.0.1",
       port: server.port,
       tls: { ca: tls.cert },
@@ -430,6 +430,5 @@ describe.skipIf(!fault.available())("TLS write batching", () => {
     const received = await delivered.promise;
     expect(received.length).toBe(payload.length);
     expect(received.equals(payload)).toBe(true);
-    client.end();
   });
 });


### PR DESCRIPTION
### Problem

- On Windows, every TLS write large enough to hit socket backpressure stalls for one timer tick (~15.6 ms) per backpressure round. Measured on Windows 11 arm64 with the release canary at 032b8dbf1: an in-process `fetch` of a 1 MiB `Bun.serve` body takes 16.0 ms over https vs 0.8 ms over http, 4 MiB takes 16 to 47 ms vs 2 ms; curl against the same server gets a 1 MiB body in 14.6 ms median; a raw `Bun.listen({ tls })` socket writing 4 MiB to a `node` reader waits 15.3 ms median on each of its ~10 backpressure rounds (4 MiB in 150 ms). Found via `test/js/web/fetch/fetch-leak.test.ts`, whose TLS fixture took 17 s on the windows-11-aarch64 lane vs 1.4 s over plain TCP.
- Cause: `us_internal_ssl_write` (`packages/bun-usockets/src/crypto/openssl.c`) flushes its ciphertext batch once it holds 131072 bytes, i.e. after 8 records, so every batch flush is a 131248-byte `send()`. On Windows a refused non-blocking `send()` of 131072 bytes or more (twice the default 64 KiB `SO_SNDBUF`) is not reported writable again until the next timer tick, even though the peer drains the socket immediately; a refused `send()` below that size is reported writable as soon as space frees up. Reproduced with plain TCP `Bun.listen` writes and a `node` reader: 8 MiB in chunks of 131071 bytes takes ~10 ms with 0 to 2 tick-long stalls, in chunks of 131072 bytes it takes 95 to 157 ms with 6 to 10 stalls, and every size tried between 131072 and 163840 behaves like 131072 (tables below).
- Plain HTTP is unaffected because uWS hands the whole body to a single `send()`, which Windows accepts in full, so nothing is refused. Windows Server 2019 defaults `SO_SNDBUF` to 128 KiB and shows no stall at 131248, which is why the windows-x64 image does not reproduce it.

### Fix

- Flush the batch after 4 records instead of 8 (`US_SSL_WRITE_BATCH_FLUSH_BYTES`), and let a write's partial last record ride along when it is all that is left, so a 64 KiB chunk plus a few bytes of framing (an h2 DATA flight, a node:tls header + chunk writev) is still one `send()` rather than a 65.6 KB send followed by a runt record in its own segment. A batch `send()` is now ~65.6 KB, at most ~80 KiB with a riding tail, i.e. well under the size at which Windows stops reporting refused sends promptly. One constant, all platforms.
- This is correct to do because the batch size is only a syscall-count optimization (batching landed in #31584 to replace one `send()` per 16 KiB record); the spill and drain logic is unchanged and just runs with smaller batches. It also halves the spill, i.e. the ciphertext the layers above may count as written while it is still in userspace, which that code already tries to keep small. Nothing in the tree depends on the old size.
- Cost: a TLS write of more than 64 KiB plus one record issues one `send()` per 4 records instead of per 8 (1 MiB: 16 sends of 65624 bytes instead of 8 of 131248); writes of up to 64 KiB plus a partial record still go out in one `send()` as before. Verified with a `send()` interposer on the Linux debug build: `write(65581)` is one send of 65691 bytes, `write(131117)` is 65624 + 65691, `write(1 MiB)` is 16 x 65624.
- Test: `test/js/bun/net/socket-syscall-fault.test.ts`, "TLS write batching". It fault-injects a zero-byte `send()` on the first batch flush of a `Bun.listen({ tls })` write, so `write()` reports exactly the plaintext in the refused batch, and checks that the peer still receives the whole payload through the spill drain. A 1 MiB write reports 65536 (131072 without this change; the unfixed debug build fails with `Expected: 65536, Received: 131072`), and a 64 KiB + 45 byte write reports 65581 (65536 with the 4-record flush alone, which is the runt shape). Like the rest of the file it needs the fault-injection build (debug/ASAN) and skips elsewhere; it also passes on Windows arm64 with fault injection compiled in.
- Windows 11 arm64, debug build with this change: the raw TLS 4 MiB write to a `node` reader resumes each backpressure round in 0.7 to 2.1 ms median, 2.7 ms max (was 15.3 ms median); curl gets 1 MiB in 1.37 ms median (was 14.6 ms); in-process https 1 MiB is 3.2 ms median vs 2.3 ms for http on the same debug build (was 16.0 vs 0.8 on the release canary).
- Also ran on Linux with the change: the rest of `socket-syscall-fault`, `node-tls-server`, `tls-syscall-fault`, `node-http-backpressure` (TLS spill variants), `node-http2`, `node-tls-connect`, `socket.test.ts`, `fetch-leak`. The only failures also fail with the unmodified `openssl.c` in this container: tests that listen and connect via `localhost` where `/etc/hosts` lists `::1` first, one test needing the internet, and CPU-bound tests running into the 5 s default timeout on a loaded debug+ASAN box.

### Background

- TLS write batching: `us_internal_ssl_write` calls `SSL_write` once per 16 KiB record. While it runs, the write BIO appends each sealed record to a per-loop buffer instead of calling `send()`; the buffer is flushed with one `send()` every N records and once more at the end of the write. If a flush is refused or partial, the rest of that batch is parked in the loop's spill slot (BoringSSL already counts those records as sent, so they must go out first) and re-sent from the socket's next writable event; the write returns how much plaintext was consumed up to and including the refused batch, and the caller keeps the rest.
- Refused send and writable event: uSockets writes with non-blocking `send()`. A refusal (`EAGAIN` / `WSAEWOULDBLOCK`) arms the socket's writable poll (on Windows a libuv `uv_poll`, which is an AFD poll request) and the write resumes when the kernel reports the socket writable. The stall is the time between the refusal and that report.
- `SO_SNDBUF`: the kernel's per-socket send buffer size. Windows defaults it to 64 KiB on Windows 10/11 and to 128 KiB on Server 2019; the size at which refused sends stop being reported promptly was measured at exactly twice that value.

<details>
<summary>Measurements (Windows 11 arm64, release canary at 032b8dbf1 unless noted)</summary>

Plain TCP `Bun.listen` server writing 8 MiB in fixed-size `socket.write()` chunks to a `node` reader in another process; per run: total time / refused writes / refusals that took more than 3 ms to drain (all of those were 13 to 19 ms):

```
chunk= 131000: 11.00 ms/55/0 |  9.71 ms/57/0 |   7.88 ms/57/0 |  14.05 ms/56/1
chunk= 131071: 38.28 ms/51/2 |  9.97 ms/57/0 |  21.57 ms/55/1 |  13.98 ms/59/1
chunk= 131072: 130.18 ms/39/8 | 154.94 ms/38/10 | 157.12 ms/38/10 | 94.71 ms/31/6
chunk= 131073: 145.45 ms/39/9 | 156.24 ms/45/10 | 141.70 ms/45/9 | 141.03 ms/40/9
chunk= 131248: (4 MiB runs) 97.33 ms/19/6 | 44.18 ms/22/3 | 77.64 ms/21/5 | 92.55 ms/21/6
chunk= 135168: 163.96 ms/40/10 | 154.96 ms/43/10 | 161.18 ms/37/10 | 141.89 ms/41/9
chunk= 163840: 57.23 ms/55/3 | 90.76 ms/47/5 | 62.50 ms/55/3 | 150.96 ms/45/10
chunk=  65536, 65624, 98304, 130990 (8 MiB): 9 to 13 ms, 0 stalls in 4 runs each
```

Same probe on Windows Server 2019 x64 (`SO_SNDBUF` default 131072 there): 0 stalls at 65536, 131072, 131248 and 262144.

TLS `Bun.listen` socket, one 4 MiB `write()`, `node` reader, time from each refused write to its `drain`:

```
unfixed (debug build):  10 rounds, gaps median 15.3 ms, max 20 to 25 ms, 118 to 185 ms total
fixed   (debug build):  16 to 38 rounds, gaps median 0.7 to 2.1 ms, max 2.7 ms, 34 to 44 ms total
```

`Bun.serve` 1 MiB body, one keep-alive connection:

```
client            unfixed release            fixed debug
curl (schannel)   median 14.6 to 15.2 ms     median 1.37 ms
in-process fetch  https 16.0 / http 0.8 ms   https 3.2 / http 2.3 ms
```

send() sizes per TLS `write()` on the Linux debug build with this branch (LD_PRELOAD interposer; the first write also carries the 386-byte session ticket flight):

```
write(65536)   -> 66010
write(65581)   -> 65691
write(65541)   -> 65651
write(81920)   -> 65624, 16406
write(98304)   -> 65624, 32812
write(131117)  -> 65624, 65691
write(1 MiB)   -> 16 x 65624
```

The same stall also shows up, less often, for plain TCP writers that happen to use chunks in the affected size range; this PR only changes the TLS batch, which is the one systematic source of such sends.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket-syscall-fault.test.ts

<!-- robobun:evidence:end -->