### PR TITLE
inspect: print instances of an anonymous export default class as "default"

### DIFF
--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -133,7 +133,7 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
 
         if (auto* object = thisValue.getObject()) {
             auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            auto className = object->calculatedClassName(object);
+            auto className = functionNameForDisplay(vm, object->calculatedClassName(object));
             if (topExceptionScope.exception()) {
                 (void)topExceptionScope.tryClearException();
             }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4908,7 +4908,7 @@ void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
 
     JSObject* obj = value.toObject(arg1);
 
-    auto calculated = JSObject::calculatedClassName(obj);
+    auto calculated = Zig::functionNameForDisplay(JSC::getVM(arg1), JSObject::calculatedClassName(obj));
     if (calculated.length() > 0) {
         *arg2 = Zig::toZigString(calculated);
         return;

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -606,6 +606,7 @@ describe("console.logging function displays async and generator names", async ()
     });
   }
 });
+
 describe("console.logging class displays names and extends", async () => {
   class A {}
   const cases = [A, class B extends A {}, class extends A {}, class {}];
@@ -651,6 +652,69 @@ it("anonymous export default class and function are named 'default'", async () =
     stderr: "",
     exitCode: 0,
   });
+});
+
+// Same binding, seen through an instance: the `Foo {}` prefix comes from the constructor's display
+// name (JSObject::calculatedClassName), which must also render `*default*` as "default".
+it("instances of an anonymous `export default class` print as `default`", async () => {
+  using dir = tempDir("inspect-export-default-class", {
+    "plain.mjs": `export default class {}`,
+    "explicit-ctor.mjs": `export default class { constructor() { this.a = 1; } }`,
+    "expression.mjs": `export default (class {});`,
+    "number.mjs": `export default class extends Number {}`,
+    "boolean.mjs": `export default class extends Boolean {}`,
+    // A class that really is called starDefault must keep its name.
+    "really-named-starDefault.mjs": `export class starDefault {}`,
+    "main.mjs": `
+      import Plain from "./plain.mjs";
+      import ExplicitCtor from "./explicit-ctor.mjs";
+      import Expression from "./expression.mjs";
+      import Num from "./number.mjs";
+      import Bool from "./boolean.mjs";
+      import { starDefault } from "./really-named-starDefault.mjs";
+
+      console.log(Plain.name, ExplicitCtor.name, Expression.name, Num.name, Bool.name);
+      console.log(Plain, new Plain());
+      console.log(Bun.inspect(new Plain()));
+      console.log({ inst: new Plain() });
+      console.log(new ExplicitCtor());
+      console.log(new Expression());
+      console.log(new Num(1));
+      console.log(new Bool(true));
+      console.log(Plain.prototype);
+      class Sub extends Plain {}
+      console.log(new Sub());
+      console.log(new starDefault());
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toMatchInlineSnapshot(`
+    "default default default default default
+    [class default] default {}
+    default {}
+    {
+      inst: default {},
+    }
+    default {
+      a: 1,
+    }
+    default {}
+    [Number (default): 1]
+    [Boolean (default): true]
+    default {}
+    Sub {}
+    starDefault {}
+    "
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 // Bun's built-in modules are compiled as JSC builtins. zlib's convenience methods and fs.promises'


### PR DESCRIPTION
Stacked on #38517 (this PR's base branch); the diff shown here is only the instance half. Merge #38517 first, GitHub retargets this one to main.

### Problem
- `console.log(new Cls())` / `Bun.inspect(new Cls())`, where `Cls` is an anonymous `export default class {}`, prints `starDefault {}`. Node prints `default {}`, and `Cls.name` is already `"default"` in Bun.
- Same for everything the formatter derives from the instance's constructor: nested values (`{ inst: starDefault {} }`), `export default class extends Number {}` (`[Number (starDefault): 1]`), `Boolean` subclasses, `Cls.prototype`.
- Cause: the formatter gets that name from `JSC__JSValue__getClassName` (src/jsc/bindings/bindings.cpp), which returns JSC's `JSObject::calculatedClassName`. That resolves the constructor and returns `JSFunction::calculatedDisplayName`, which falls back to the executable's `ecmaName`. For an anonymous `export default` the parser sets that name to the private `*default*` identifier (`starDefaultPrivateName`), whose string is `"starDefault"`. `JSFunction::reifyName` maps it to `"default"` when it creates `.name`; `calculatedDisplayName` does not.
- #38517 adds `Zig::functionNameForDisplay` (the `*default*` to `"default"` filter) and applies it where Bun prints the function value itself (`[class default]`, `[Function: default]`, stack frames). With #38517 alone the same program prints `[class default] starDefault {}`: the instance path reads the name through `calculatedClassName`, which #38517 leaves out.

### Fix
- `JSC__JSValue__getClassName`: pass the `calculatedClassName` result through `Zig::functionNameForDisplay`, so the class value and its instances go through the one filter.
- `CallSite::formatAsString` (src/jsc/bindings/CallSite.cpp): the `Type.` prefix it builds from the receiver reads the same `calculatedClassName`, so it gets the same one-line treatment. It is not reachable today (CallSites are built from recorded `JSC::StackFrame`s via `JSCStackTrace::fromExisting`, whose frames carry no call frame, so the receiver is always `undefined`), which is why the test cannot cover it; it is changed so that every display consumer of `calculatedClassName` is filtered, not just the one with a repro.
- Correct because `calculatedClassName` is, for these objects, exactly the constructor's `calculatedDisplayName`, the string #38517 already filters when printing the constructor; this makes the instance agree with the class value, with `Cls.name`, and with node. The filter is an identity test on the `*default*` symbol's `StringImpl`, so a class that is really named `starDefault` is untouched (covered by the test).
- The remaining `calculatedClassName` callers (two in `Bun__deepEquals`) compare the names of both operands and are left alone.
- Verified: new test in test/js/bun/util/inspect.test.js (`instances of an anonymous export default class print as default`), next to #38517's test. Built with src/ reverted to the #38517 state it fails with `[class default] starDefault {}` and the seven other instance lines reading `starDefault`; with this branch it passes. It covers a plain class, an explicit constructor, `export default (class {})`, `Number` and `Boolean` subclasses, `Cls.prototype`, a named subclass (unchanged) and a class really named `starDefault` (unchanged).
- Also green on the debug build: all of inspect.test.js (77), test/js/bun/test/stack.test.ts (9), test/js/node/v8/capture-stack-trace.test.js (43), the last two because of the CallSite change.
- Fixing `JSFunction::calculatedDisplayName` / `getCalculatedDisplayName` in oven-sh/WebKit would also cover JSC's own `Error.prototype.stack` and would let these two call sites drop the filter; it would not remove the filter itself, since #38517 also applies it to Bun-side reads of the raw `ecmaName`. So the Bun-side filter is the shape either way, and this PR only adds callers to it.

### Background
- `ecmaName`: the name JSC records on a function's executable for `.name` purposes (the class name for a class, `f` for `const f = () => {}`). `JSFunction::name()` is the syntactic name and is empty for these, so display-name helpers fall back to `ecmaName`.
- `*default*`: the spec's binding name for an anonymous `export default`. JSC represents it as the private identifier `starDefaultPrivateName`; it is not meant to be user visible, so `reifyName` turns it into `"default"` when materializing `.name`.
- `JSObject::calculatedClassName`: JSC helper that names an object after its `constructor` (own property first, then through the prototype chain), falling back to `Symbol.toStringTag` and the native class name. Bun's formatter uses it for the `Foo {}` prefix.
- `Zig::functionNameForDisplay` (#38517): takes a name string and returns `"default"` if the string is the `*default*` identifier's own `StringImpl`, otherwise the string unchanged.

<details>
<summary>Earlier shape of this PR</summary>

The first revision was independent of #38517 and did the identity compare inline in `JSC__JSValue__getClassName` (`calculated.impl() == vm.propertyNames->starDefaultPrivateName.impl()`), leaving `CallSite.cpp` alone because it is unreachable. #38517 has since moved to a string post-filter with the same compare, so this revision is stacked on it and calls that helper instead of carrying a second copy of the mapping.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->