### PR TITLE
css: minify a run of merged same-query @media rules once

### DIFF
--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -518,8 +518,6 @@ impl<R> CssRuleList<R> {
                         if let Some(CssRule::Media(last_rule)) = rules.last_mut()
                             && last_rule.query.eql(&med.query)
                         {
-                            // The merged body is minified once the run of
-                            // same-query rules ends (see `MergeState`).
                             last_rule.rules.v.append(&mut med.rules.v);
                             merge_state.pending_at_rule_minify = true;
                             break 'arm;
@@ -972,15 +970,11 @@ impl StyleRuleKeyMap {
 
 // ─── merge_style_rules ─────────────────────────────────────────────────────
 
-/// Cross-iteration state of the merges [`CssRuleList::minify`] performs into
-/// the last rule of its output list.
-///
-/// A merge only concatenates; re-minifying the merged result is deferred to
-/// the end of the merge run, which is when another rule gets pushed after it
-/// (every push goes through [`end_merge_run`]) or the list ends. Merges target
-/// the last *pushed* rule, so rules that minify away in between keep the run
-/// going. At most one of the two pending flags is set at a time: they describe
-/// the same last rule, which is either a style rule or an at-rule.
+/// State of the merges [`CssRuleList::minify`] performs into the last rule of
+/// its output list. A merge only concatenates; the result is minified once the
+/// run of merges ends, i.e. before the next push ([`end_merge_run`]) or when
+/// the list ends. The two pending flags are mutually exclusive: both describe
+/// the current last rule.
 ///
 /// `pending_minify` marks the last rule in the output list as a style rule
 /// whose declarations were concatenated by one or more declaration merges but
@@ -994,15 +988,11 @@ impl StyleRuleKeyMap {
 /// The flag must be cleared (via [`flush_pending_merges`]) before anything
 /// reads the merged declarations or appends another rule.
 ///
-/// `pending_at_rule_minify` marks the last rule as an at-rule (`@media`) whose
-/// body absorbed the bodies of following rules with the same prelude and has
-/// not been minified since. Re-minifying after every merge minified the bodies
-/// merged so far once per further merge, so a run of n same-query rules cost
-/// O(n^2) rule minifications; inside a style rule whose nesting is compiled
-/// away, every pass also charged the accumulated body against
-/// [`MAX_SELECTOR_EXPANSION`] again, so a few hundred such rules failed with
-/// `selector_expansion_limit_exceeded` while expanding to a tiny fraction of
-/// that. One minify per run keeps both linear.
+/// `pending_at_rule_minify` marks the last rule as an at-rule (`@media`) that
+/// absorbed the bodies of following same-prelude rules and has not been
+/// minified since. Minifying after every merge was the same O(n^2) on whole
+/// rule bodies, and also charged the accumulated body against
+/// [`MAX_SELECTOR_EXPANSION`] once per merge.
 ///
 /// `last_compat` caches `StyleRule::is_compatible` for the current last rule.
 /// Selector merges grow the last rule's selector list by one selector per
@@ -1017,13 +1007,9 @@ pub(crate) struct MergeState {
     last_compat: Option<bool>,
 }
 
-/// Settle the merge run targeting the last rule, leaving it fully minified.
-///
-/// For a style rule: re-run the declaration minifier on its merged
-/// declarations, then attempt the merge-with-previous cascade that a
-/// declaration merge enables (the re-minified declarations may now equal the
-/// previous rule's, allowing a selector merge, and so on). For an at-rule:
-/// minify its merged body.
+/// Minify whatever was merged into the last rule. For a style rule this also
+/// runs the merge-with-previous cascade the re-minified declarations may
+/// enable (they may now equal the previous rule's, and so on).
 fn flush_pending_merges<R: for<'b> css::generics::DeepClone<'b>>(
     rules: &mut Vec<CssRule<R>>,
     state: &mut MergeState,
@@ -1055,9 +1041,7 @@ fn flush_pending_merges<R: for<'b> css::generics::DeepClone<'b>>(
 
     if core::mem::take(&mut state.pending_at_rule_minify) {
         match rules.last_mut() {
-            // The rule was kept when it was first pushed; like the per-merge
-            // re-minify this replaces, this does not revisit that decision, so
-            // the drop result is ignored.
+            // The drop decision was made when the rule was pushed.
             Some(CssRule::Media(last)) => {
                 let _ = last.minify(context, parent_is_unused)?;
             }
@@ -1070,9 +1054,8 @@ fn flush_pending_merges<R: for<'b> css::generics::DeepClone<'b>>(
     Ok(())
 }
 
-/// Pushing a rule after the current last rule ends that rule's merge run:
-/// settle it and drop what is cached about it. Every push into the output
-/// list of [`CssRuleList::minify`] goes through this first.
+/// Every push into the output list goes through this first: it minifies what
+/// was merged into the current last rule and forgets what was cached about it.
 fn end_merge_run<R: for<'b> css::generics::DeepClone<'b>>(
     rules: &mut Vec<CssRule<R>>,
     state: &mut MergeState,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -494,8 +494,7 @@ impl<R> CssRuleList<R> {
         R: for<'b> css::generics::DeepClone<'b>,
     {
         let mut style_rules = StyleRuleKeyMap::default();
-        let mut merge_state = StyleRuleMergeState::default();
-        let mut pending_media_minify = false;
+        let mut merge_state = MergeState::default();
         let mut rules: Vec<CssRule<R>> = Vec::new();
 
         for rule in self.v.iter_mut() {
@@ -520,10 +519,9 @@ impl<R> CssRuleList<R> {
                             && last_rule.query.eql(&med.query)
                         {
                             // The merged body is minified once the run of
-                            // same-query rules ends (see
-                            // `flush_pending_media_merge`).
+                            // same-query rules ends (see `MergeState`).
                             last_rule.rules.v.append(&mut med.rules.v);
-                            pending_media_minify = true;
+                            merge_state.pending_at_rule_minify = true;
                             break 'arm;
                         }
                         if med.minify(context, parent_is_unused)? {
@@ -571,7 +569,6 @@ impl<R> CssRuleList<R> {
                             &mut rules,
                             &mut style_rules,
                             &mut merge_state,
-                            &mut pending_media_minify,
                             context,
                             parent_is_unused,
                         )?;
@@ -610,16 +607,7 @@ impl<R> CssRuleList<R> {
                     _ => {}
                 }
 
-                // Appending a non-style rule ends the current style-rule or
-                // `@media` merge run, so settle any pending merge first.
-                flush_pending_style_merge(&mut rules, &mut merge_state, context);
-                merge_state.last_compat = None;
-                flush_pending_media_merge(
-                    &mut rules,
-                    &mut pending_media_minify,
-                    context,
-                    parent_is_unused,
-                )?;
+                end_merge_run(&mut rules, &mut merge_state, context, parent_is_unused)?;
                 rules.push(core::mem::replace(rule, CssRule::Ignored));
                 moved_rule = true;
 
@@ -638,15 +626,8 @@ impl<R> CssRuleList<R> {
             }
         }
 
-        // The last merge run may still have a pending declaration or `@media`
-        // body merge.
-        flush_pending_style_merge(&mut rules, &mut merge_state, context);
-        flush_pending_media_merge(
-            &mut rules,
-            &mut pending_media_minify,
-            context,
-            parent_is_unused,
-        )?;
+        // The last merge run may still have a pending merge.
+        flush_pending_merges(&mut rules, &mut merge_state, context, parent_is_unused)?;
 
         // The old Vec is dropped on assignment.
         self.v = rules;
@@ -663,44 +644,11 @@ impl<R> CssRuleList<R> {
     }
 }
 
-/// Minify the last rule's body if it absorbed the bodies of following
-/// same-query `@media` rules (`*pending`). Must run before anything is pushed
-/// after it, which is what ends a merge run: a `@media` rule merges into the
-/// last *pushed* rule, so rules dropped in between keep the run going.
-///
-/// Re-minifying after every merge ran the bodies merged so far through the
-/// minifier once per further merge, so a run of n same-query rules cost O(n^2)
-/// style-rule minifications. Inside a style rule whose nesting is compiled
-/// away, every pass also charged the whole accumulated body against
-/// [`MAX_SELECTOR_EXPANSION`] again, so a few hundred such rules failed with
-/// `selector_expansion_limit_exceeded` while expanding to a tiny fraction of
-/// that. Minifying the merged body once per run keeps both linear.
-///
-/// The rule was kept when it was first pushed; like the per-merge re-minify,
-/// this does not revisit that decision, so the drop result is ignored.
-fn flush_pending_media_merge<R: for<'b> css::generics::DeepClone<'b>>(
-    rules: &mut [CssRule<R>],
-    pending: &mut bool,
-    context: &mut MinifyContext<'_, '_>,
-    parent_is_unused: bool,
-) -> Result<(), MinifyErr> {
-    if !core::mem::take(pending) {
-        return Ok(());
-    }
-    let Some(CssRule::Media(last)) = rules.last_mut() else {
-        debug_assert!(false, "pending @media merge without a @media rule last");
-        return Ok(());
-    };
-    let _ = last.minify(context, parent_is_unused)?;
-    Ok(())
-}
-
 fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     rule: &mut CssRule<R>,
     rules: &mut Vec<CssRule<R>>,
     style_rules: &mut StyleRuleKeyMap,
-    merge_state: &mut StyleRuleMergeState,
-    pending_media_minify: &mut bool,
+    merge_state: &mut MergeState,
     context: &mut MinifyContext<'_, '_>,
     parent_is_unused: bool,
 ) -> Result<(), MinifyErr> {
@@ -786,7 +734,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         // selectors/declarations of the new rule. This might mean that we can merge it
         // with the previous rule, so continue trying while we have style rules available.
         // A declaration merge defers both the re-minify and this cascade to
-        // the end of the merge run (see `flush_pending_style_merge`).
+        // the end of the merge run (see `flush_pending_merges`).
         if !merge_state.pending_minify {
             cascade_merge_with_previous(rules, merge_state, context);
         }
@@ -804,7 +752,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         // equal and start a new declaration merge, which the cascade returns
         // on. Settle it now: `sty` is pushed below, which would bury the
         // pending rule one slot down where no later flush can find it.
-        flush_pending_style_merge(rules, merge_state, context);
+        flush_pending_merges(rules, merge_state, context, parent_is_unused)?;
     }
 
     // If this iteration staged handler-context rules (e.g. the merged-in rule
@@ -819,7 +767,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
             && context.handler_context.rtl.is_empty()
             && context.handler_context.dark.is_empty())
     {
-        flush_pending_style_merge(rules, merge_state, context);
+        flush_pending_merges(rules, merge_state, context, parent_is_unused)?;
     }
 
     // Create additional rules for logical properties, @supports overrides, and incompatible selectors.
@@ -893,7 +841,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         // every rule already in the list is fully minified here, which the
         // duplicate check below relies on.
         debug_assert!(!merge_state.pending_minify);
-        flush_pending_media_merge(rules, pending_media_minify, context, parent_is_unused)?;
+        end_merge_run(rules, merge_state, context, parent_is_unused)?;
         rules.push(core::mem::replace(rule, CssRule::Ignored));
         merge_state.last_compat = sty_compat;
 
@@ -914,16 +862,12 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         }
     }
 
-    // Appending anything below ends the current merge run, so settle any
-    // pending declaration or `@media` body merge on the last rule first.
     if !logical.is_empty()
         || !supps.is_empty()
         || incompatible_rules.len() > 0
         || nested_rule.is_some()
     {
-        flush_pending_style_merge(rules, merge_state, context);
-        merge_state.last_compat = None;
-        flush_pending_media_merge(rules, pending_media_minify, context, parent_is_unused)?;
+        end_merge_run(rules, merge_state, context, parent_is_unused)?;
     }
 
     if !logical.is_empty() {
@@ -1028,8 +972,15 @@ impl StyleRuleKeyMap {
 
 // ─── merge_style_rules ─────────────────────────────────────────────────────
 
-/// Cross-iteration state for the style-rule merge fast path in
-/// [`CssRuleList::minify`].
+/// Cross-iteration state of the merges [`CssRuleList::minify`] performs into
+/// the last rule of its output list.
+///
+/// A merge only concatenates; re-minifying the merged result is deferred to
+/// the end of the merge run, which is when another rule gets pushed after it
+/// (every push goes through [`end_merge_run`]) or the list ends. Merges target
+/// the last *pushed* rule, so rules that minify away in between keep the run
+/// going. At most one of the two pending flags is set at a time: they describe
+/// the same last rule, which is either a style rule or an at-rule.
 ///
 /// `pending_minify` marks the last rule in the output list as a style rule
 /// whose declarations were concatenated by one or more declaration merges but
@@ -1040,8 +991,18 @@ impl StyleRuleKeyMap {
 /// prefixed background images, ...) keep that list O(n) long, so the total
 /// work was O(n^2), and worse for handlers whose re-processing re-expands
 /// their own output. Deferring to one re-minify per merge run keeps it O(n).
-/// The flag must be cleared (via [`flush_pending_style_merge`]) before
-/// anything reads the merged declarations or appends another rule.
+/// The flag must be cleared (via [`flush_pending_merges`]) before anything
+/// reads the merged declarations or appends another rule.
+///
+/// `pending_at_rule_minify` marks the last rule as an at-rule (`@media`) whose
+/// body absorbed the bodies of following rules with the same prelude and has
+/// not been minified since. Re-minifying after every merge minified the bodies
+/// merged so far once per further merge, so a run of n same-query rules cost
+/// O(n^2) rule minifications; inside a style rule whose nesting is compiled
+/// away, every pass also charged the accumulated body against
+/// [`MAX_SELECTOR_EXPANSION`] again, so a few hundred such rules failed with
+/// `selector_expansion_limit_exceeded` while expanding to a tiny fraction of
+/// that. One minify per run keeps both linear.
 ///
 /// `last_compat` caches `StyleRule::is_compatible` for the current last rule.
 /// Selector merges grow the last rule's selector list by one selector per
@@ -1050,25 +1011,30 @@ impl StyleRuleKeyMap {
 /// whenever the last rule changes and updated incrementally on selector
 /// merges (the merged result is compatible iff both inputs were).
 #[derive(Default)]
-pub(crate) struct StyleRuleMergeState {
+pub(crate) struct MergeState {
     pending_minify: bool,
+    pending_at_rule_minify: bool,
     last_compat: Option<bool>,
 }
 
-/// Re-run the declaration minifier on the last rule if it has pending merged
+/// Settle the merge run targeting the last rule, leaving it fully minified.
+///
+/// For a style rule: re-run the declaration minifier on its merged
 /// declarations, then attempt the merge-with-previous cascade that a
 /// declaration merge enables (the re-minified declarations may now equal the
-/// previous rule's, allowing a selector merge, and so on).
-fn flush_pending_style_merge<R>(
+/// previous rule's, allowing a selector merge, and so on). For an at-rule:
+/// minify its merged body.
+fn flush_pending_merges<R: for<'b> css::generics::DeepClone<'b>>(
     rules: &mut Vec<CssRule<R>>,
-    state: &mut StyleRuleMergeState,
+    state: &mut MergeState,
     context: &mut MinifyContext<'_, '_>,
-) {
+    parent_is_unused: bool,
+) -> Result<(), MinifyErr> {
     while state.pending_minify {
         state.pending_minify = false;
         let Some(CssRule::Style(last)) = rules.last_mut() else {
             debug_assert!(false, "pending declaration merge without a style rule last");
-            return;
+            break;
         };
         // The re-minify can re-stage handler-context rules: `color-scheme`
         // re-emits itself and pushes its dark-mode fallback vars on every
@@ -1086,15 +1052,45 @@ fn flush_pending_style_merge<R>(
         );
         cascade_merge_with_previous(rules, state, context);
     }
+
+    if core::mem::take(&mut state.pending_at_rule_minify) {
+        match rules.last_mut() {
+            // The rule was kept when it was first pushed; like the per-merge
+            // re-minify this replaces, this does not revisit that decision, so
+            // the drop result is ignored.
+            Some(CssRule::Media(last)) => {
+                let _ = last.minify(context, parent_is_unused)?;
+            }
+            _ => debug_assert!(
+                false,
+                "pending at-rule merge without a mergeable at-rule last"
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Pushing a rule after the current last rule ends that rule's merge run:
+/// settle it and drop what is cached about it. Every push into the output
+/// list of [`CssRuleList::minify`] goes through this first.
+fn end_merge_run<R: for<'b> css::generics::DeepClone<'b>>(
+    rules: &mut Vec<CssRule<R>>,
+    state: &mut MergeState,
+    context: &mut MinifyContext<'_, '_>,
+    parent_is_unused: bool,
+) -> Result<(), MinifyErr> {
+    flush_pending_merges(rules, state, context, parent_is_unused)?;
+    state.last_compat = None;
+    Ok(())
 }
 
 /// Try to merge the last style rule into the one before it, repeatedly, while
 /// merges keep succeeding. A declaration merge leaves `state.pending_minify`
-/// set, in which case the caller ([`flush_pending_style_merge`]) re-minifies
+/// set, in which case the caller ([`flush_pending_merges`]) re-minifies
 /// before cascading further.
 fn cascade_merge_with_previous<R>(
     rules: &mut Vec<CssRule<R>>,
-    state: &mut StyleRuleMergeState,
+    state: &mut MergeState,
     context: &mut MinifyContext<'_, '_>,
 ) {
     // The last rule was settled before cascading, so `merge_style_rules`'s
@@ -1141,7 +1137,7 @@ fn cached_is_compatible<R>(
 ///
 /// A declaration merge only concatenates the declaration lists and sets
 /// `pending_minify`; the re-minify is deferred to the end of the merge run
-/// (see [`StyleRuleMergeState`]). `pending_minify` may only be set on entry
+/// (see [`MergeState`]). `pending_minify` may only be set on entry
 /// when `last_style_rule` is the rule it tracks (the forward merge in
 /// `minify_style_arm`); the cascade always settles it first.
 /// `sty_compat` / `last_compat` cache `is_compatible` for the respective

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -495,6 +495,7 @@ impl<R> CssRuleList<R> {
     {
         let mut style_rules = StyleRuleKeyMap::default();
         let mut merge_state = StyleRuleMergeState::default();
+        let mut pending_media_minify = false;
         let mut rules: Vec<CssRule<R>> = Vec::new();
 
         for rule in self.v.iter_mut() {
@@ -518,8 +519,11 @@ impl<R> CssRuleList<R> {
                         if let Some(CssRule::Media(last_rule)) = rules.last_mut()
                             && last_rule.query.eql(&med.query)
                         {
+                            // The merged body is minified once the run of
+                            // same-query rules ends (see
+                            // `flush_pending_media_merge`).
                             last_rule.rules.v.append(&mut med.rules.v);
-                            let _ = last_rule.minify(context, parent_is_unused)?;
+                            pending_media_minify = true;
                             break 'arm;
                         }
                         if med.minify(context, parent_is_unused)? {
@@ -567,6 +571,7 @@ impl<R> CssRuleList<R> {
                             &mut rules,
                             &mut style_rules,
                             &mut merge_state,
+                            &mut pending_media_minify,
                             context,
                             parent_is_unused,
                         )?;
@@ -605,10 +610,16 @@ impl<R> CssRuleList<R> {
                     _ => {}
                 }
 
-                // Appending a non-style rule ends the current style-rule merge
-                // run, so settle any pending declaration merge first.
+                // Appending a non-style rule ends the current style-rule or
+                // `@media` merge run, so settle any pending merge first.
                 flush_pending_style_merge(&mut rules, &mut merge_state, context);
                 merge_state.last_compat = None;
+                flush_pending_media_merge(
+                    &mut rules,
+                    &mut pending_media_minify,
+                    context,
+                    parent_is_unused,
+                )?;
                 rules.push(core::mem::replace(rule, CssRule::Ignored));
                 moved_rule = true;
 
@@ -627,8 +638,15 @@ impl<R> CssRuleList<R> {
             }
         }
 
-        // The last merge run may still have a pending declaration merge.
+        // The last merge run may still have a pending declaration or `@media`
+        // body merge.
         flush_pending_style_merge(&mut rules, &mut merge_state, context);
+        flush_pending_media_merge(
+            &mut rules,
+            &mut pending_media_minify,
+            context,
+            parent_is_unused,
+        )?;
 
         // The old Vec is dropped on assignment.
         self.v = rules;
@@ -645,11 +663,44 @@ impl<R> CssRuleList<R> {
     }
 }
 
+/// Minify the last rule's body if it absorbed the bodies of following
+/// same-query `@media` rules (`*pending`). Must run before anything is pushed
+/// after it, which is what ends a merge run: a `@media` rule merges into the
+/// last *pushed* rule, so rules dropped in between keep the run going.
+///
+/// Re-minifying after every merge ran the bodies merged so far through the
+/// minifier once per further merge, so a run of n same-query rules cost O(n^2)
+/// style-rule minifications. Inside a style rule whose nesting is compiled
+/// away, every pass also charged the whole accumulated body against
+/// [`MAX_SELECTOR_EXPANSION`] again, so a few hundred such rules failed with
+/// `selector_expansion_limit_exceeded` while expanding to a tiny fraction of
+/// that. Minifying the merged body once per run keeps both linear.
+///
+/// The rule was kept when it was first pushed; like the per-merge re-minify,
+/// this does not revisit that decision, so the drop result is ignored.
+fn flush_pending_media_merge<R: for<'b> css::generics::DeepClone<'b>>(
+    rules: &mut [CssRule<R>],
+    pending: &mut bool,
+    context: &mut MinifyContext<'_, '_>,
+    parent_is_unused: bool,
+) -> Result<(), MinifyErr> {
+    if !core::mem::take(pending) {
+        return Ok(());
+    }
+    let Some(CssRule::Media(last)) = rules.last_mut() else {
+        debug_assert!(false, "pending @media merge without a @media rule last");
+        return Ok(());
+    };
+    let _ = last.minify(context, parent_is_unused)?;
+    Ok(())
+}
+
 fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     rule: &mut CssRule<R>,
     rules: &mut Vec<CssRule<R>>,
     style_rules: &mut StyleRuleKeyMap,
     merge_state: &mut StyleRuleMergeState,
+    pending_media_minify: &mut bool,
     context: &mut MinifyContext<'_, '_>,
     parent_is_unused: bool,
 ) -> Result<(), MinifyErr> {
@@ -842,6 +893,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         // every rule already in the list is fully minified here, which the
         // duplicate check below relies on.
         debug_assert!(!merge_state.pending_minify);
+        flush_pending_media_merge(rules, pending_media_minify, context, parent_is_unused)?;
         rules.push(core::mem::replace(rule, CssRule::Ignored));
         merge_state.last_compat = sty_compat;
 
@@ -863,7 +915,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     }
 
     // Appending anything below ends the current merge run, so settle any
-    // pending declaration merge on the last rule first.
+    // pending declaration or `@media` body merge on the last rule first.
     if !logical.is_empty()
         || !supps.is_empty()
         || incompatible_rules.len() > 0
@@ -871,6 +923,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     {
         flush_pending_style_merge(rules, merge_state, context);
         merge_state.last_compat = None;
+        flush_pending_media_merge(rules, pending_media_minify, context, parent_is_unused)?;
     }
 
     if !logical.is_empty() {

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -217,9 +217,12 @@ test("deferred @media merge re-minify keeps per-merge output", () => {
   expect(minify(run)).toBe("@media (width>=1px){.a{color:#00f}}");
   // ... with a style rule.
   expect(minify(run + ".c{color:green}")).toBe("@media (width>=1px){.a{color:#00f}}.c{color:green}");
-  // ... with another at-rule.
+  // ... with another at-rule, whether or not its arm minifies it.
   expect(minify(run + "@supports (display:grid){.c{color:green}}")).toBe(
     "@media (width>=1px){.a{color:#00f}}@supports (display:grid){.c{color:green}}",
+  );
+  expect(minify(run + "@keyframes k{to{opacity:0}}")).toBe(
+    "@media (width>=1px){.a{color:#00f}}@keyframes k{to{opacity:0}}",
   );
   // ... with a @media rule for a different query, after which a new run starts.
   expect(minify(run + "@media print{.c{color:green}}@media (min-width:1px){.d{color:blue}}")).toBe(

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -156,3 +156,92 @@ test("declaration merges do not drop partitioned incompatible selectors", () => 
     ".a {\n  color: #00f;\n}\n\n.b:focus-visible {\n  color: #00f;\n}\n",
   );
 });
+
+// Adjacent @media rules with the same query are merged into the first one.
+// The merge used to re-minify the whole merged body after every rule, so a
+// run of n such rules cost O(n^2) rule minifications: the 6000 rules below
+// took ~7.5s in a release build and (extrapolating from 51s for 2000) several
+// minutes in a debug build, against under a second of minifying now that the
+// merged body is minified once per run. The spawn timeout is what fails the
+// quadratic version; the per-test timeout only has to outlast it.
+test("a run of same-query @media rules is minified in linear time", async () => {
+  const script = `
+    const c = require("bun:internal-for-testing").cssInternals;
+    const n = 6000;
+    const rules = Array.from({ length: n }, (_, i) => ".a" + i + "{margin:" + i + "px}");
+    const merged = c.minifyTest(rules.map(rule => "@media (min-width:1px){" + rule + "}").join(""), "");
+    const single = c.minifyTest("@media (min-width:1px){" + rules.join("") + "}", "");
+    if (merged !== single) throw new Error("the merged run minified differently from a single block");
+    console.log("OK:" + n);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: "OK:6000\n",
+    stderr: "",
+    exitCode: 0,
+  });
+}, 90_000);
+
+// Every one of those re-minify passes also charged the accumulated body
+// against the selector-expansion limit again. Chrome 80 has no native nesting,
+// so nested rules are charged once per selector of the parent: under a
+// two-selector parent, 256 merged rules (512 expanded selectors) used to fail
+// with selector_expansion_limit_exceeded.
+test("a run of same-query @media rules nested in a multi-selector rule is charged against the expansion limit once", () => {
+  const targets = { chrome: 80 << 16 };
+  const rules = Array.from({ length: 1000 }, (_, i) => `.c${i}{color:red}`);
+  const single = cssInternals.minifyTest(`.a,.b{@media (min-width:1px){${rules.join("")}}}`, "", targets);
+  expect(single).toContain(":is(.a,.b) .c999{color:red}");
+
+  const merged = `.a,.b{${rules.map(rule => `@media (min-width:1px){${rule}}`).join("")}}`;
+  expect(cssInternals.minifyTest(merged, "", targets)).toBe(single);
+});
+
+// The deferred re-minify of the merged body has to happen before anything is
+// emitted after it, whichever way the run ends, and only rules that are
+// actually emitted end it. In every case below the two .a rules only collapse
+// (and `blue` is only minified) if the merged body was minified.
+test("deferred @media merge re-minify keeps per-merge output", () => {
+  const run = "@media (min-width:1px){.a{color:red}}@media (min-width:1px){.a{color:blue}}";
+  const minify = (source: string) => cssInternals.minifyTest(source, "");
+
+  // The run ends with the stylesheet.
+  expect(minify(run)).toBe("@media (width>=1px){.a{color:#00f}}");
+  // ... with a style rule.
+  expect(minify(run + ".c{color:green}")).toBe("@media (width>=1px){.a{color:#00f}}.c{color:green}");
+  // ... with another at-rule.
+  expect(minify(run + "@supports (display:grid){.c{color:green}}")).toBe(
+    "@media (width>=1px){.a{color:#00f}}@supports (display:grid){.c{color:green}}",
+  );
+  // ... with a @media rule for a different query, after which a new run starts.
+  expect(minify(run + "@media print{.c{color:green}}@media (min-width:1px){.d{color:blue}}")).toBe(
+    "@media (width>=1px){.a{color:#00f}}@media print{.c{color:green}}@media (width>=1px){.d{color:#00f}}",
+  );
+  // ... with a style rule that is emitted only as the fallback rules compiled
+  // from its logical property (chrome 60 needs them), not as itself.
+  const chrome60 = { chrome: 60 << 16 };
+  const fallbackRules = cssInternals.minifyTest(".c{inset-inline-start:0}", "", chrome60);
+  expect(fallbackRules).toContain("{left:0}");
+  expect(cssInternals.minifyTest(run + ".c{inset-inline-start:0}", "", chrome60)).toBe(
+    "@media (min-width:1px){.a{color:#00f}}" + fallbackRules,
+  );
+
+  // Rules that minify away in between do not end the run.
+  expect(
+    minify(
+      "@media (min-width:1px){.a{color:red}}" +
+        "@media not all{.z{color:red}}" +
+        "@media (min-width:1px){.a{color:blue}}" +
+        ".y{}" +
+        "@media (min-width:1px){.b{color:blue}}",
+    ),
+  ).toBe("@media (width>=1px){.a,.b{color:#00f}}");
+});


### PR DESCRIPTION
### Problem

- Minifying a stylesheet with many adjacent `@media` rules that share a query is quadratic in their number: 1000 rules take 0.19s, 2000 take 0.77s, 4000 take 3.6s, 8000 take 20s (release 1.4.0, `cssInternals.minifyTest`). The same rules inside one `@media` block take 6ms at 4000.
- A second symptom of the same loop: with targets that compile nesting away (anything without native nesting support), a run of such rules nested under a rule with more than one selector fails with `Nested CSS rules expand to more than 65536 selectors ...` from 256 rules on under a two-selector parent, although the output only has 512 selectors. Fewer rules are needed under parents with more selectors.
- Cause: the `CssRule::Media` arm of `CssRuleList::minify` (`src/css/rules/mod.rs:517` on main) appends the new rule's body to the previous rule and then re-minifies the whole previous rule, so the body merged so far is minified once more per further rule. Each of those passes also runs `StyleRule::charge_selector_expansion` for every rule in the body again, which is where the spurious limit error comes from.
- #31920 fixed the same shape for style rules merged by selector (`StyleRuleMergeState::pending_minify` in the same file); the `@media` arm was not covered.

### Fix

- The `@media` merge now only appends the body and sets a flag. The flag lives in the merge state #31920 added (renamed `StyleRuleMergeState` -> `MergeState`, new field `pending_at_rule_minify` next to the style rules' `pending_minify`), and one function, `flush_pending_merges`, settles whichever of the two is set: re-minify the style rule's declarations as before, or minify the at-rule's merged body. `end_merge_run` (flush + forget `last_compat`) is what every push into the output list calls first: the generic push in `CssRuleList::minify`, the style rule push and the extra-rule appends in `minify_style_arm`. The merged body is therefore minified once per run instead of once per merged rule, and its rules are charged against the expansion limit once.
- Why this is correct:
  - Which rules merge is unchanged: a `@media` rule still merges into `rules.last()` when that is a `@media` rule with an equal query. Rules that minify away in between (an empty rule, `@media not all {...}`, ...) never got pushed and so never ended a run; they still do not, which is also why settling is tied to pushes rather than to the loop iteration.
  - The flush happens before the merged body can be observed: nothing reads a merged rule's body except the printer, and every path that appends to `rules` goes through `end_merge_run`. A pending flag therefore always refers to `rules.last()` (`debug_assert`ed), and the two flags are mutually exclusive because they describe the same rule. Settling both kinds through one function means a push site cannot settle one and miss the other; `flush_pending_style_merge` no longer exists, so the push site #36224 adds in its `@keyframes` arm picks this up when it rebases instead of silently skipping the `@media` flush.
  - The per-merge re-minify ignored the drop result of re-minifying (the rule had already been kept), and so does the flush.
  - For a run of two rules the work done is exactly what it was. For longer runs the content merged in later is minified once instead of several times, so output can only differ where re-minifying already minified output is not a no-op. Today that is the `color-scheme` handler (duplicates its fallback vars per pass; #38512 fixes the handler, this change reduces the copies meanwhile) and a few single-pass leftovers that extra passes happened to clean up (a `lab()` fallback left before a later `color: red`, a duplicate rule created by selector partitioning). The output of a run no longer depends on how many rules it was split into; see the probe below.
- Verified:
  - `test/js/bun/css/duplicate-declaration-merge-hang.test.ts`: a 6000-rule run spawned with a timeout (the unfixed debug build is killed at 60s; 51s for 2000 rules), the nested 1000-rule run that used to throw the expansion error and now matches the single-block output, and an output test for each way a run can end (end of list, style rule, at-rule that is minified, `@keyframes` which is not, different query, a style rule emitted only as its compiled fallback rules) plus dropped rules in between. The first two fail on the unfixed debug build, all pass with the fix. Debug ASAN timings with the fix: 2000 rules 0.24s, 4000 0.48s, 8000 0.97s.
  - `bun bd test test/js/bun/css/` and `test/bundler/css/` + `test/bundler/esbuild/css.test.ts`: unchanged (the only local failures are the fuzz tests' and one 20k-rule test's debug-build timeouts, identical without this change).
  - Differential run of a debug build with and without the change over the 15 real-world stylesheets in `test/js/bun/css/files/` with no targets, chrome 80 and chrome 60/firefox 60/safari 10 targets: byte-identical. 800 generated stylesheets mixing same-query runs with dropped rules, nested rules, `@keyframes`, duplicates and logical properties: identical once the `color-scheme` declarations and the `SizeHandler` state leak below are excluded, apart from the single-pass leftovers described above. The restructuring from the first revision of this PR (separate flag and flush function) to the current one produced byte-identical output over the same corpus.
- Found along the way and filed separately: `SizeHandler` (margin/padding/inset) keeps its logical/physical `category` across declaration blocks, so after any logical property later rules keep redundant shorthands. It is independent of this change (`.a{margin:1px}.a{margin:0}@media not all{div{margin-inline-start:2px}}` already shows it through the style-rule merge on main), but it is what makes the order in which sibling rules are minified visible at all.
- #33680 (merging `@supports` rules instead of dropping the duplicate) currently re-minifies per merge, i.e. would add this shape back one arm over; on top of this PR it becomes `append` + `pending_at_rule_minify = true` plus a `CssRule::Supports` arm in `flush_pending_merges` (`SupportsRule::minify` has the same signature).

### Background

- `CssRuleList::minify` walks a rule list and builds a new `rules` vector. Style rules try to merge into `rules.last()`; `@media` rules with the same query as `rules.last()` are merged into it; rules that minify to nothing are simply not pushed. Because merging always targets the last *pushed* rule, a rule that is dropped between two mergeable rules does not separate them.
- Minifying a rule list is what merges rules inside it, removes duplicates and runs the property handlers over each declaration block, so a merged `@media` body has to be minified as a whole after its parts were appended; the question is only how often.
- Selector-expansion limit: when the targets lack native nesting, nested rules are later expanded into one selector per combination with the parent's selectors. To bound that, `StyleRule::minify` adds `parent selectors x own selectors` to a running total in `MinifyContext` and fails past 65536. The total is never decremented, so minifying the same rule twice charges it twice.

<details>
<summary>Probe: output depends on the run length before, not after</summary>

chrome 80 targets, `cssInternals.minifyTest`:

```
b1 = @media (min-width: 1px) { .a:hover { user-select: none } }
b2 = @media (min-width: 1px) { @media screen { .a, .g:is(.h) { color: lab(40% 56.6 39); color: red } } }
e  = @media (min-width: 1px) { }
```

| input | main | this PR |
| --- | --- | --- |
| one block with both bodies | `...{color:#b32323;color:red}` | same |
| b1 b2 | `...{color:#b32323;color:red}` | same |
| b1 b2 e | `...{color:red}` | `...{color:#b32323;color:red}` |
| b1 b2 e e | `...{color:red}` | `...{color:#b32323;color:red}` |

On main, appending an empty same-query block changes the output because it triggers one more pass over the body.

</details>

<details>
<summary>Timings</summary>

`n` adjacent `@media (min-width:1px){.aN{margin:Npx}}` rules:

| n | release 1.4.0 (unfixed) | debug ASAN unfixed | debug ASAN fixed |
| --- | --- | --- | --- |
| 500 | | 3.0s | |
| 1000 | 0.19s | 11.9s | |
| 2000 | 0.77s | 51s | 0.24s |
| 4000 | 3.6s | | 0.48s |
| 6000 | 7.4s | | 0.75s |
| 8000 | 20s | | 0.97s |

</details>

<details>
<summary>First revision of this PR</summary>

The first push kept the `@media` flag as a separate `pending_media_minify` bool threaded into `minify_style_arm`, with its own `flush_pending_media_merge` called next to `flush_pending_style_merge` at each push site. Review pointed out that this leaves every present and future push site with two separate obligations (and #36224's new push site would have met only one of them), so the flag was folded into the shared merge state and both kinds are settled through `flush_pending_merges` / `end_merge_run`. Output is identical between the two revisions.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/duplicate-declaration-merge-hang.test.ts
bun test v1.4.0 (dd6ce60fe)

test/js/bun/css/duplicate-declaration-merge-hang.test.ts:
(pass) duplicate declarations across merged rules minify in linear time instead of hanging [3209.80ms]
(pass) deferred merge re-minify keeps per-merge output [6.69ms]
(pass) stale duplicate-rule entries do not erase a later rule [2.22ms]
(pass) declaration merges do not drop partitioned incompatible selectors [2.57ms]
181 |     stderr: "pipe",
182 |     timeout: 60_000,
183 |     killSignal: "SIGKILL",
184 |   });
185 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
186 |   expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
                                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 137,
    "stderr": "",
-   "stdout": 
- "OK:6000
- "
- ,
+   "stdout": "",
  }

- Expected  - 5
+ Received  + 2

      at <anony
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/duplicate-declaration-merge-hang.test.ts:
(pass) duplicate declarations across merged rules minify in linear time instead of hanging [97.61ms]
(pass) deferred merge re-minify keeps per-merge output [0.58ms]
(pass) stale duplicate-rule entries do not erase a later rule [0.08ms]
(pass) declaration merges do not drop partitioned incompatible selectors [0.07ms]
(pass) a run of same-query @media rules is minified in linear time [9372.86ms]
200 |   const rules = Array.from({ length: 1000 }, (_, i) => `.c${i}{color:red}`);
201 |   const single = cssInternals.minifyTest(`.a,.b{@media (min-width:1px){${rules.join("")}}}`, "", targets);
202 |   expect(single).toContain(":is(.a,.b) .c999{color:red}");
203 | 
204 |   const merged = `.a,.b{${rules.map(rule => `@media (min-width:1px){${rule}}`).join("")}}`;
205 |   expect(cssInternals.minifyTest(merged, "", targets)).toBe(single);
                            ^
error: Nested CSS rules expand to more than 65536 selectors when compiled for the configured browser targets. Reduce the nesting depth or the number of selectors per rule, or target browsers that support CSS nesting.
   
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/duplicate-declaration-merge-hang.test.ts
bun test v1.4.0 (dd6ce60fe)

test/js/bun/css/duplicate-declaration-merge-hang.test.ts:
(pass) duplicate declarations across merged rules minify in linear time instead of hanging [3141.88ms]
(pass) deferred merge re-minify keeps per-merge output [6.67ms]
(pass) stale duplicate-rule entries do not erase a later rule [2.16ms]
(pass) declaration merges do not drop partitioned incompatible selectors [2.55ms]
(pass) a run of same-query @media rules is minified in linear time [3707.89ms]
(pass) a run of same-query @media rules nested in a multi-selector rule is charged against the expansion limit once [318.45ms]
(pass) deferred @media merge re-minify keeps per-merge output [15.91ms]

 7 pass
 0 fail
 17 expect() calls
Ran 7 tests across 1 file. [11.00s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     dd6ce60fe8
  features     baseline

22 deps, 123 codegen, 1176 objects in 801ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [18.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[6/1238] fetch zlib
[zlib] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] subst deps/zlib/zlib.h
[10/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[11/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/rules/mod.rs                               | 96 ++++++++++++++--------
 .../css/duplicate-declaration-merge-hang.test.ts   | 92 +++++++++++++++++++++
 2 files changed, 156 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/css/rules/mod.rs                                         17     31      0
test/js/bun/css/duplicate-declaration-merge-hang.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->