### PR TITLE
js_parser: resolve the symbol named by an identifier or dotted define value

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4895,7 +4895,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             parts[0],
             parts[1..].iter().copied(),
             true,
-            IdentifierOpts::new().with_was_originally_identifier(true),
+            IdentifierOpts::new(),
         )
     }
 
@@ -4906,9 +4906,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         first: &'a [u8],
         rest: impl Iterator<Item = &'a [u8]>,
         can_be_removed_if_unused: bool,
-        opts: IdentifierOpts,
+        last_link_opts: IdentifierOpts,
     ) -> Result<Expr, crate::Error> {
+        let mut rest = rest.peekable();
         let result = self.find_symbol(loc, first)?;
+        let head_opts = if rest.peek().is_some() {
+            IdentifierOpts::new()
+        } else {
+            last_link_opts
+        };
 
         let value = self.handle_identifier(
             loc,
@@ -4916,28 +4922,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .with_must_keep_due_to_with_stmt(result.is_inside_with_scope)
                 .with_can_be_removed_if_unused(can_be_removed_if_unused),
             None,
-            opts,
+            head_opts.with_was_originally_identifier(true),
         );
-        Ok(self.member_expression(loc, value, rest))
+        Ok(self.member_expression(loc, value, rest, last_link_opts))
     }
 
-    fn member_expression(
+    fn member_expression<I: Iterator<Item = &'a [u8]>>(
         &mut self,
         loc: bun_ast::Loc,
         initial_value: Expr,
-        parts: impl Iterator<Item = &'a [u8]>,
+        mut parts: core::iter::Peekable<I>,
+        last_link_opts: IdentifierOpts,
     ) -> Expr {
         let mut value = initial_value;
 
-        for part in parts {
-            if let Some(rewrote) = self.maybe_rewrite_property_access(
-                loc,
-                value,
-                part,
-                loc,
-                // All defaults on the packed-u8 IdentifierOpts.
-                IdentifierOpts::default(),
-            ) {
+        while let Some(part) = parts.next() {
+            let opts = if parts.peek().is_some() {
+                IdentifierOpts::new()
+            } else {
+                last_link_opts
+            };
+            if let Some(rewrote) = self.maybe_rewrite_property_access(loc, value, part, loc, opts) {
                 value = rewrote;
             } else {
                 value = self.new_expr(
@@ -6351,14 +6356,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .original_name()
                     .expect("identifier define must have original_name");
                 let (first, rest) = strings::split_once_char(path, b'.').unwrap_or((path, b""));
-                // `X = 1` assigns to the property access built below, not to `first`.
-                let opts = if rest.is_empty() {
-                    IdentifierOpts::new()
-                        .with_assign_target(assign_target)
-                        .with_is_delete_target(is_delete_target)
-                } else {
-                    IdentifierOpts::new()
-                };
                 return self
                     .member_expression_for_names(
                         loc,
@@ -6366,7 +6363,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // `tokenize`, not `split`: an empty `rest` has no parts.
                         strings::tokenize(rest, b"."),
                         id.can_be_removed_if_unused(),
-                        opts.with_was_originally_identifier(true),
+                        IdentifierOpts::new()
+                            .with_assign_target(assign_target)
+                            .with_is_delete_target(is_delete_target),
                     )
                     .expect("unreachable");
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4899,8 +4899,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    /// `first.rest[0].rest[1]...` for names taken from options (JSX factory,
-    /// define value) rather than from the source; `first` resolves as if written at `loc`.
+    /// `first.rest[0]...` as if written at `loc`, for names that come from options, not source.
     fn member_expression_for_names(
         &mut self,
         loc: bun_ast::Loc,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4890,28 +4890,46 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         parts: &[&'a [u8]],
     ) -> Result<Expr, crate::Error> {
-        let result = self.find_symbol(loc, parts[0])?;
+        self.member_expression_for_names(
+            loc,
+            parts[0],
+            parts[1..].iter().copied(),
+            true,
+            IdentifierOpts::new().with_was_originally_identifier(true),
+        )
+    }
+
+    /// Builds `first.rest[0].rest[1]...` for names that did not come from the
+    /// source text (JSX factories, `--define` values). `first` is resolved
+    /// like an identifier written at `loc`, so whatever it names is counted as
+    /// used, renamed along with its declaration, and rewritten when it is an
+    /// import.
+    fn member_expression_for_names(
+        &mut self,
+        loc: bun_ast::Loc,
+        first: &'a [u8],
+        rest: impl Iterator<Item = &'a [u8]>,
+        can_be_removed_if_unused: bool,
+        opts: IdentifierOpts,
+    ) -> Result<Expr, crate::Error> {
+        let result = self.find_symbol(loc, first)?;
 
         let value = self.handle_identifier(
             loc,
             E::Identifier::init(result.r#ref)
                 .with_must_keep_due_to_with_stmt(result.is_inside_with_scope)
-                .with_can_be_removed_if_unused(true),
-            Some(parts[0]),
-            IdentifierOpts::new().with_was_originally_identifier(true),
+                .with_can_be_removed_if_unused(can_be_removed_if_unused),
+            None,
+            opts,
         );
-        if parts.len() > 1 {
-            return Ok(self.member_expression(loc, value, &parts[1..]));
-        }
-
-        Ok(value)
+        Ok(self.member_expression(loc, value, rest))
     }
 
     fn member_expression(
         &mut self,
         loc: bun_ast::Loc,
         initial_value: Expr,
-        parts: &[&'a [u8]],
+        parts: impl Iterator<Item = &'a [u8]>,
     ) -> Expr {
         let mut value = initial_value;
 
@@ -4929,7 +4947,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 value = self.new_expr(
                     E::Dot {
                         target: value,
-                        name: (*part).into(),
+                        name: part.into(),
                         name_loc: loc,
                         can_be_removed_if_unused: self.options.features.dead_code_elimination,
                         ..Default::default()
@@ -6325,35 +6343,40 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         assign_target: js_ast::AssignTarget,
         is_delete_target: bool,
-        define_data: &DefineData,
+        define_data: &'a DefineData,
     ) -> Expr {
         // Callers gate on `!valueless()` before reaching here, so `value` is a
         // real Expr.Data by contract.
         let value = define_data.value;
         match value {
             js_ast::ExprData::EIdentifier(id) => {
-                // Identifier defines always carry a name. Match the
-                // contract so `handle_identifier`'s trailing `find_symbol`
-                // rebind runs against the *resolved* scope ref, not the
-                // define-time ref silently passed through with `None`.
-                let original_name: &[u8] = define_data
+                // `DefineData::parse` stores a value like `ns.value` as one
+                // identifier whose original_name is the whole dotted path:
+                // only the first segment names a symbol.
+                let original_name: &'a [u8] = define_data
                     .original_name()
                     .expect("identifier define must have original_name");
-                // SAFETY: `define_data` borrows `p.define: &'a Define`; the
-                // backing `original_name` bytes live for `'a`. Erase the local
-                // borrow lifetime to satisfy `handle_identifier`'s
-                // `Option<&'a [u8]>` param.
-                let original_name: &'a [u8] =
-                    unsafe { bun_collections::detach_lifetime(original_name) };
-                return self.handle_identifier(
-                    loc,
-                    id,
-                    Some(original_name),
+                let (first, rest) =
+                    strings::split_once_char(original_name, b'.').unwrap_or((original_name, b""));
+                let opts = if rest.is_empty() {
                     IdentifierOpts::new()
                         .with_assign_target(assign_target)
                         .with_is_delete_target(is_delete_target)
-                        .with_was_originally_identifier(true),
-                );
+                } else {
+                    // The assignment or delete applies to the property
+                    // access built below, not to the symbol it reads.
+                    IdentifierOpts::new()
+                };
+                return self
+                    .member_expression_for_names(
+                        loc,
+                        first,
+                        // `tokenize`, not `split`: an empty `rest` has no parts.
+                        strings::tokenize(rest, b"."),
+                        id.can_be_removed_if_unused(),
+                        opts.with_was_originally_identifier(true),
+                    )
+                    .expect("unreachable");
             }
             js_ast::ExprData::EString(str_) => {
                 return self.new_expr(&*str_, loc);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4899,11 +4899,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    /// Builds `first.rest[0].rest[1]...` for names that did not come from the
-    /// source text (JSX factories, `--define` values). `first` is resolved
-    /// like an identifier written at `loc`, so whatever it names is counted as
-    /// used, renamed along with its declaration, and rewritten when it is an
-    /// import.
+    /// `first.rest[0].rest[1]...` for names taken from options (JSX factory,
+    /// define value) rather than from the source; `first` resolves as if written at `loc`.
     fn member_expression_for_names(
         &mut self,
         loc: bun_ast::Loc,
@@ -6350,21 +6347,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let value = define_data.value;
         match value {
             js_ast::ExprData::EIdentifier(id) => {
-                // `DefineData::parse` stores a value like `ns.value` as one
-                // identifier whose original_name is the whole dotted path:
-                // only the first segment names a symbol.
-                let original_name: &'a [u8] = define_data
+                // `DefineData::parse` keeps an `a.b.c` value as one identifier named "a.b.c".
+                let path: &'a [u8] = define_data
                     .original_name()
                     .expect("identifier define must have original_name");
-                let (first, rest) =
-                    strings::split_once_char(original_name, b'.').unwrap_or((original_name, b""));
+                let (first, rest) = strings::split_once_char(path, b'.').unwrap_or((path, b""));
+                // `X = 1` assigns to the property access built below, not to `first`.
                 let opts = if rest.is_empty() {
                     IdentifierOpts::new()
                         .with_assign_target(assign_target)
                         .with_is_delete_target(is_delete_target)
                 } else {
-                    // The assignment or delete applies to the property
-                    // access built below, not to the symbol it reads.
                     IdentifierOpts::new()
                 };
                 return self

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -271,9 +271,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let newvalue: Expr =
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
-                    // Only an identifier or a property access can be assigned to, so
-                    // substituting anything else into an assignment target would
-                    // produce a syntax error
+                    // Substituting anything else into an assignment target is a syntax error
                     if matches!(newvalue.data.tag(), Tag::EIdentifier | Tag::EDot)
                         || in_.assign_target == js_ast::AssignTarget::None
                     {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -271,9 +271,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let newvalue: Expr =
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
-                    // Substituting anything else into an assignment target is a syntax error
-                    if matches!(newvalue.data.tag(), Tag::EIdentifier | Tag::EDot)
-                        || in_.assign_target == js_ast::AssignTarget::None
+                    // Substituting a constant into an assignment target is a syntax error
+                    if matches!(
+                        newvalue.data.tag(),
+                        Tag::EIdentifier | Tag::EDot | Tag::EImportIdentifier
+                    ) || in_.assign_target == js_ast::AssignTarget::None
                     {
                         p.ignore_usage(e_.ref_);
                         *e = newvalue;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -271,9 +271,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let newvalue: Expr =
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
-                    // Don't substitute an identifier for a non-identifier if this is an
-                    // assignment target, since it'll cause a syntax error
-                    if matches!(newvalue.data.tag(), Tag::EIdentifier)
+                    // Only an identifier or a property access can be assigned to, so
+                    // substituting anything else into an assignment target would
+                    // produce a syntax error
+                    if matches!(newvalue.data.tag(), Tag::EIdentifier | Tag::EDot)
                         || in_.assign_target == js_ast::AssignTarget::None
                     {
                         p.ignore_usage(e_.ref_);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -274,7 +274,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // Substituting a constant into an assignment target is a syntax error
                     if matches!(
                         newvalue.data.tag(),
-                        Tag::EIdentifier | Tag::EDot | Tag::EImportIdentifier
+                        Tag::EIdentifier
+                            | Tag::EDot
+                            | Tag::EImportIdentifier
+                            | Tag::ECommonjsExportIdentifier
                     ) || in_.assign_target == js_ast::AssignTarget::None
                     {
                         p.ignore_usage(e_.ref_);

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3263,8 +3263,9 @@ describe("bundler", () => {
     run: { stdout: "esm esm true cjs" },
   });
   // Assigning through a define is assigning to its value, with the same rules
-  // as writing the value out: import bindings and namespace members are
-  // rejected, a property of an imported object is fine.
+  // and rewrites as writing the value out: import bindings and namespace
+  // members are rejected, a property of an imported object is fine, and a
+  // CommonJS export is converted like any other `exports.x = ...`.
   itBundled("edgecase/DefineValueImportBindingCannotBeAssigned", {
     files: {
       "/entry.js": /* js */ `
@@ -3302,6 +3303,21 @@ describe("bundler", () => {
     },
     define: { X: "box.prop" },
     run: { stdout: "stored" },
+  });
+  itBundled("edgecase/DefineValueCommonJSExportCanBeAssigned", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as lib from "./lib.cjs";
+        console.log(lib.foo);
+      `,
+      "/lib.cjs": /* js */ `
+        exports.bar = 1;
+        X = 2;
+      `,
+    },
+    define: { X: "exports.foo" },
+    cjs2esm: true,
+    run: { stdout: "2" },
   });
 });
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3243,6 +3243,19 @@ describe("bundler", () => {
     minifyIdentifiers: true,
     run: { stdout: "transpiled" },
   });
+  // TypeScript drops imports it sees no use of; a use through a define counts.
+  itBundled("edgecase/DefineValueKeepsTypeScriptImportWithoutBundling", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { ns } from "./ns.js";
+        console.log(X);
+      `,
+      "/ns.js": /* js */ `export const ns = { value: "kept" };`,
+    },
+    define: { X: "ns.value" },
+    bundling: false,
+    run: { stdout: "kept" },
+  });
   itBundled("edgecase/DefineValueReferencesImports", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3170,10 +3170,113 @@ describe("bundler", () => {
     },
     run: { stdout: "try:false" },
   });
+
+  // A define whose value names a symbol (`--define X=ns.value`) has to become a
+  // reference to that symbol at every use site. Printing the value's text
+  // instead leaves the declaration unused, so tree shaking drops it and
+  // minification renames it out from under the substituted expression.
+  itBundled("edgecase/DefineDotKeyValueReferencesLocal", {
+    files: {
+      "/entry.js": /* js */ `
+        const cfg = { foo: "from cfg" };
+        console.log(process.env.FOO);
+      `,
+    },
+    define: { "process.env.FOO": "cfg.foo" },
+    run: { stdout: "from cfg" },
+  });
+  itBundled("edgecase/DefineImportMetaValueReferencesLocal", {
+    files: {
+      "/entry.js": /* js */ `
+        const shim = { meta: { url: "shimmed url" } };
+        console.log(import.meta.url);
+      `,
+    },
+    define: { "import.meta": "shim.meta" },
+    run: { stdout: "shimmed url" },
+  });
+  itBundled("edgecase/DefineValueDeepPropertyChainReferencesLocal", {
+    files: {
+      "/entry.js": /* js */ `
+        const a = { b: { c: "deep" } };
+        console.log(X);
+      `,
+    },
+    define: { X: "a.b.c" },
+    run: { stdout: "deep" },
+  });
+  itBundled("edgecase/DefineValueFollowsRenamedLocal", {
+    files: {
+      "/entry.js": /* js */ `
+        const namespaceObject = { value: "renamed" };
+        console.log(typeof namespaceObject, X);
+      `,
+    },
+    define: { X: "namespaceObject.value" },
+    minifyIdentifiers: true,
+    run: { stdout: "object renamed" },
+  });
+  itBundled("edgecase/DefineValueAsAssignmentTargetFollowsRenamedLocal", {
+    files: {
+      "/entry.js": /* js */ `
+        const namespaceObject = {};
+        X = "assigned";
+        console.log(X);
+      `,
+    },
+    define: { X: "namespaceObject.value" },
+    minifyIdentifiers: true,
+    run: { stdout: "assigned" },
+  });
+  itBundled("edgecase/DefineValueFollowsRenamedLocalWithoutBundling", {
+    files: {
+      "/entry.js": /* js */ `
+        function read() {
+          const namespaceObject = { value: "transpiled" };
+          return X;
+        }
+        console.log(read());
+      `,
+    },
+    define: { X: "namespaceObject.value" },
+    bundling: false,
+    minifyIdentifiers: true,
+    run: { stdout: "transpiled" },
+  });
+  itBundled("edgecase/DefineValueReferencesImports", {
+    files: {
+      "/entry.js": /* js */ `
+        import { esm } from "./esm.js";
+        import * as ns from "./esm.js";
+        import { cjs } from "./cjs.cjs";
+        console.log(FROM_ESM, FROM_NAMESPACE, FROM_CJS === cjs, FROM_CJS_PROPERTY);
+      `,
+      "/esm.js": /* js */ `export const esm = { value: "esm" };`,
+      "/cjs.cjs": /* js */ `module.exports = { cjs: { value: "cjs" } };`,
+    },
+    define: {
+      FROM_ESM: "esm.value",
+      FROM_NAMESPACE: "ns.esm.value",
+      FROM_CJS: "cjs",
+      FROM_CJS_PROPERTY: "cjs.value",
+    },
+    run: { stdout: "esm esm true cjs" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {
   describe(`bundler_edgecase/${backend}`, () => {
+    itBundled("edgecase/DefineValueReferencesLocal", {
+      files: {
+        "/entry.js": /* js */ `
+          const ns = { value: "from ns" };
+          console.log(X);
+        `,
+      },
+      define: { X: "ns.value" },
+      backend,
+      run: { stdout: "from ns" },
+    });
     itBundled("edgecase/ProcessEnvArbitrary", {
       files: {
         "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3262,8 +3262,9 @@ describe("bundler", () => {
     },
     run: { stdout: "esm esm true cjs" },
   });
-  // Assigning through a define is assigning to its value: an import binding
-  // is rejected like a direct assignment would be, a property of one is fine.
+  // Assigning through a define is assigning to its value, with the same rules
+  // as writing the value out: import bindings and namespace members are
+  // rejected, a property of an imported object is fine.
   itBundled("edgecase/DefineValueImportBindingCannotBeAssigned", {
     files: {
       "/entry.js": /* js */ `
@@ -3275,6 +3276,19 @@ describe("bundler", () => {
     define: { X: "binding" },
     bundleErrors: {
       "/entry.js": ['Cannot assign to import "binding"'],
+    },
+  });
+  itBundled("edgecase/DefineValueNamespaceMemberCannotBeAssigned", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./other.js";
+        X = 1;
+      `,
+      "/other.js": /* js */ `export let member = 0;`,
+    },
+    define: { X: "ns.member" },
+    bundleErrors: {
+      "/entry.js": ['Cannot assign to import "member"'],
     },
   });
   itBundled("edgecase/DefineValuePropertyOfImportCanBeAssigned", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3262,6 +3262,33 @@ describe("bundler", () => {
     },
     run: { stdout: "esm esm true cjs" },
   });
+  // Assigning through a define is assigning to its value: an import binding
+  // is rejected like a direct assignment would be, a property of one is fine.
+  itBundled("edgecase/DefineValueImportBindingCannotBeAssigned", {
+    files: {
+      "/entry.js": /* js */ `
+        import { binding } from "./other.js";
+        X = 1;
+      `,
+      "/other.js": /* js */ `export let binding = 0;`,
+    },
+    define: { X: "binding" },
+    bundleErrors: {
+      "/entry.js": ['Cannot assign to import "binding"'],
+    },
+  });
+  itBundled("edgecase/DefineValuePropertyOfImportCanBeAssigned", {
+    files: {
+      "/entry.js": /* js */ `
+        import { box } from "./other.js";
+        X = "stored";
+        console.log(box.prop);
+      `,
+      "/other.js": /* js */ `export const box = {};`,
+    },
+    define: { X: "box.prop" },
+    run: { stdout: "stored" },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -504,6 +504,32 @@ describe("bundler", () => {
       expect(file).toContain('import * as React from "react"');
     },
   });
+  // A factory reached through a namespace import only uses the factory export,
+  // the same as writing `H.h(...)` by hand. Counting it as a use of `H` itself
+  // would make the bundle build the namespace object and keep every sibling.
+  itBundled("jsx/FactoryThroughNamespaceImportOnlyUsesFactory", {
+    files: {
+      "/index.jsx": /* jsx */ `
+        import * as H from "hyper";
+        console.log(JSON.stringify([<div id="x">hi</div>, <>frag</>]));
+      `,
+      "/node_modules/hyper/index.js": /* js */ `
+        export function h(tag, props, ...children) { return [tag, props, children]; }
+        export function Fragment() {}
+        export const unusedSibling = "REMOVE";
+      `,
+    },
+    jsx: {
+      runtime: "classic",
+      factory: "H.h",
+      fragment: "H.Fragment",
+    },
+    dce: true,
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toContain("__export(");
+    },
+    run: { stdout: '[["div",{"id":"x"},["hi"]],[null,null,["frag"]]]' },
+  });
   itBundled("jsx/jsxImportSource pragma works", {
     files: {
       "/index.jsx": /* jsx */ `

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2075,7 +2075,6 @@ describe("bundler", () => {
     ],
   });
   itBundled("ts/EnumDefine", {
-    todo: true,
     files: {
       "/entry.ts": `
       enum a { b = 123, c = d }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2197,6 +2197,26 @@ export default <>hi</>
     expect(exitCode).toBe(0);
   });
 
+  // `X: "ns.value"` must reference the `ns` in scope at the use site rather
+  // than print the define's text, or renaming `ns` breaks the substitution.
+  it("define value that reads a property off a local follows the renamed local", () => {
+    const minifier = new Bun.Transpiler({
+      loader: "js",
+      define: { X: "namespaceObject.value", "process.env.FOO": "configObject.foo" },
+      minify: { identifiers: true },
+    });
+    const code = minifier.transformSync(`
+      function read() {
+        const namespaceObject = { value: "from namespace" }, configObject = { foo: "from config" };
+        return [X, process.env.FOO];
+      }
+      report(read());
+    `);
+    let result;
+    new Function("report", code)(value => (result = value));
+    expect(result).toEqual(["from namespace", "from config"]);
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2217,6 +2217,26 @@ export default <>hi</>
     expect(result).toEqual(["from namespace", "from config"]);
   });
 
+  // Each JSX element is one use of its factory, so a factory that is a
+  // single-use local is inlined exactly like the equivalent hand-written call.
+  it("a JSX element counts as one use of a classic factory", () => {
+    const minifier = new Bun.Transpiler({ loader: "jsx", minify: { syntax: true } });
+    const code = minifier.transformSync(`
+      /* @jsxRuntime classic */
+      /* @jsx h */
+      export function render(mk) {
+        const h = mk();
+        return <div id="x">hi</div>;
+      }
+    `);
+    expect(code).toBe(`export function render(mk) {
+  return mk()("div", {
+    id: "x"
+  }, "hi");
+}
+`);
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",


### PR DESCRIPTION
### Problem
- `bun build entry.js --define X=ns.value` with `const ns = { value: 1 }` in the same file prints `var x = ns.value;` and drops `const ns`: the output throws `ReferenceError: ns is not defined`.
- With `--minify-identifiers` the declaration is renamed (`var o = ...`) while the substituted expression still says `ns.value`. Same with `Bun.build({ define })`, `bun build --no-bundle`, `new Bun.Transpiler({ define, minify: { identifiers: true } })`, and dot keys such as `"process.env.FOO": "cfg.foo"`. In a TypeScript file an import used only through a define is removed as unused.
- `--define X=v` where `v` is imported from a CommonJS file prints a bare `v` instead of `import_foo.v`.
- Cause: `DefineData::parse` (src/bundler/defines.rs:356) stores any value made of identifier segments as one `EIdentifier` whose `original_name` is the whole text (`ns.value`). `value_for_define` (src/js_parser/p.rs:6323 on main) handed that text to `handle_identifier`, which ran `find_symbol` on `"ns.value"` as a single name. That allocates an unbound symbol literally named `ns.value` which the printer emits verbatim; the real `ns` symbol never gets a use recorded, so it is tree-shaken, renamed independently, or (TypeScript) has its import elided. For a bare value the lookup happened after `handle_identifier`'s import and assignment checks had already run against the placeholder ref, so an import was never rewritten to an import reference and those checks looked at whatever symbol happened to be declared first in the file.

### Fix
- `value_for_define` splits the value at the first `.`, resolves the first segment with `find_symbol`, passes the resolved ref through `handle_identifier`, and appends the remaining segments as property accesses. This is the same shape esbuild uses for define values (`instantiateDefineExpr`); esbuild 0.21 produces byte-identical output for the probes in the details block below, including the minified one.
- Why it is correct: a define value is a replacement expression, so its identifier has to mean whatever that name means at the use site. Resolving it there is what records the use (so tree shaking and TypeScript import elision keep the declaration), binds it to the symbol the renamer renames, and lets `handle_identifier` substitute import references. A name with no declaration still resolves to an unbound symbol and prints exactly as before (the existing `DefineInfiniteLoopESBuildIssue2407` and `Bun.Transpiler` `location.origin` / `hello.mars` tests cover this).
- The assign/delete flags handed to `value_for_define` go to the last link of the chain (the identifier itself for a bare value, the final property access otherwise), which is where `e_dot` would put them for the same expression written in source. So `X = 1` with `X=box.prop` (imported `box`) is accepted like `box.prop = 1`, while `X=binding` or `X=ns.member` (namespace import) fail when bundling with the same `Cannot assign to import "..."` error the literal assignment gets.
- `e_identifier`'s assignment-position guard accepts every reference shape the chain can now produce (`EIdentifier`, `EDot`, `EImportIdentifier`, `ECommonjsExportIdentifier`) and still refuses constants. An `EImportIdentifier` there has already been reported as an error when bundling (without bundling it prints the binding name, as main did); an `ECommonjsExportIdentifier` is the same rewrite a literal `exports.foo = ...` gets, so `--define X=exports.foo` with `X = 2` now bundles to `var $foo = 2` instead of main's top-level `exports.foo = 2`. Constant values in assignment position are unchanged here; #38563 fixes them.
- `value_for_define` now takes `&'a DefineData` (every caller already passes a reference into `p.define: &'a Define`), which removes the `detach_lifetime` that laundered the name's lifetime.
- Shared with JSX: `jsx_strings_to_member_expression` already built exactly this kind of chain, so both paths now go through `member_expression_for_names`. The JSX path passes no usage flags, so its chain is built as before, but it no longer re-resolves the factory name inside `handle_identifier`, so each element records one use of the factory instead of two. That is visible in two places, both now pinned: a factory reached through `import * as H` no longer counts as a capture of `H`, so the bundle stops building the namespace object and keeping every sibling export (same output as a hand-written `H.h(...)` and as esbuild; `jsx/FactoryThroughNamespaceImportOnlyUsesFactory`), and a single-use local factory is inlined under minify-syntax exactly like the hand-written call already was (`a JSX element counts as one use of a classic factory` in transpiler.test.js).
- After this change the only caller still passing a name to `handle_identifier`'s `original_name` parameter is `e_identifier`'s constant-assignment fallback, which #38563 removes (the `fold.rs` caller passes one but returns earlier as an import item). Whichever of the two PRs lands second should delete the parameter and the rebind block at the end of `handle_identifier`; if #38563 merges first I will do that here.
- Verified with `bun bd test`, all failing on the unfixed build unless noted:
  - test/bundler/bundler_edgecase.test.ts: 14 new `edgecase/Define*` cases (identifier key, dot key, `import.meta` key, three-segment chain, minified bundle, minified `--no-bundle`, TypeScript import kept without bundling, assignment target, ESM / namespace / CommonJS imports, the assign-to-import errors for a binding and for a namespace member, assignment to a property of an import, assignment to a CommonJS export, and the base case through both the CLI and `Bun.build`). `DefineValuePropertyOfImportCanBeAssigned` passes either way and pins the flag placement described above.
  - test/bundler/esbuild/ts.test.ts: `ts/EnumDefine` (a define whose value names an enum member) passes now, so its `todo` is removed.
  - test/bundler/bundler_jsx.test.ts and test/bundler/transpiler/transpiler.test.js: the two JSX cases above plus a `Bun.Transpiler` define case with `minify.identifiers`.
  - Also green: bundler_edgecase, bundler_jsx, bundler_minify, bundler_env, bundler_drop, bundler_cjs, bundler_cjs2esm, bun-build-api, transpiler.test.js, esbuild/default, esbuild/dce, esbuild/ts, esbuild/tsconfig, test/internal/source-lints.

### Background
- A define (`--define K=V`, `define: { K: V }`) replaces every occurrence of the expression `K` with the expression `V` during the parser's visit pass. `Define` holds these as `DefineData`; a `V` whose segments are all identifiers is stored as an `EIdentifier` placeholder plus the raw text, and `value_for_define` turns it into a real expression each time `K` is matched (`e_identifier`, `e_dot` and `e_import_meta` in visit_expr.rs all go through it).
- `find_symbol` looks a name up through the scope chain at the current location, creating an unbound (global) symbol if nothing declares it, and records a use of the symbol. Tree shaking keeps a declaration only if a use of its symbol was recorded, the TypeScript parser drops imports with no recorded use, and the minifier renames a declaration and all recorded references to the same symbol together.
- `handle_identifier` is the post-resolution step every identifier reference goes through: it inlines constants, reports assignments to imports when bundling, and turns references to imported bindings into `EImportIdentifier`, which the printer renders as `import_foo.v` for CommonJS imports.
- `maybe_rewrite_property_access` is what `e_dot` runs on a property access once its target is visited: it turns `ns.x` on a namespace import into an import reference, `exports.x` in a CommonJS file into a named export, and so on. The chain built here goes through it the same way, which is why the same rewrites and errors come out.
- A namespace import is "captured" when its symbol has a recorded use of its own (something other than `ns.prop` reads it); only then does the bundler materialize the namespace object for it.

<details>
<summary>Before / after on main</summary>

```
$ printf 'const ns = { value: 1 };\nexport const x = X;\n' > entry.js
$ bun build entry.js --define X=ns.value        # before
var x = ns.value;
export { x };
$ bun build entry.js --define X=ns.value        # after (same as esbuild)
var ns = { value: 1 };
var x = ns.value;
export { x };

$ bun build entry.js --define X=v --define Y=v.value   # v imported from foo.cjs, before
var a = v;
var b = v.value;
                                                       # after
var a = import_foo.v;
var b = import_foo.v.value;

$ printf 'import { ns } from "./ns.js";\nconsole.log(X);\n' > entry.ts
$ bun build entry.ts --no-bundle --define X=ns.value   # before: import elided
console.log(ns.value);
                                                       # after
import { ns } from "./ns.js";
console.log(ns.value);
```
</details>
