### PR TITLE
css: only reject bare :global / :local pseudo-classes in CSS modules

### DIFF
--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1303,9 +1303,9 @@ impl<'a> SelectorParser<'a> {
                 self.options.warn(&loc.new_custom_error(
                     SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name),
                 ));
-            } else if (self.options.css_modules.is_some()
-                && strings::eql_case_insensitive_ascii_check_length(name, b"local"))
-                || strings::eql_case_insensitive_ascii_check_length(name, b"global")
+            } else if self.options.css_modules.is_some()
+                && (strings::eql_case_insensitive_ascii_check_length(name, b"local")
+                    || strings::eql_case_insensitive_ascii_check_length(name, b"global"))
             {
                 return Err(
                     loc.new_custom_error(SelectorParseErrorKind::AmbiguousCssModuleClass(name))

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -21,6 +21,74 @@ describe("css", () => {
     },
   });
 
+  // The bare (non-functional) `:global` / `:local` switch syntax is not
+  // supported, so it is an error in a CSS module, where it would be ambiguous.
+  itBundled("css-module/BareGlobalPseudoClassIsAnError", {
+    files: {
+      "/index.module.css": /* css */ `
+      :global {
+        color: red;
+      }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.module.css"],
+    bundleErrors: {
+      "/index.module.css": ["CSS module class: 'global' is currently not supported."],
+    },
+  });
+
+  itBundled("css-module/BareLocalPseudoClassIsAnError", {
+    files: {
+      "/index.module.css": /* css */ `
+      :local {
+        color: red;
+      }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.module.css"],
+    bundleErrors: {
+      "/index.module.css": ["CSS module class: 'local' is currently not supported."],
+    },
+  });
+
+  // Outside of a CSS module they are unknown pseudo-classes like any other and
+  // are passed through unchanged.
+  itBundled("css-module/BareGlobalAndLocalPseudoClassesInPlainCss", {
+    files: {
+      "/index.css": /* css */ `
+      :global {
+        color: red;
+      }
+      :local {
+        color: blue;
+      }
+      :global .foo {
+        color: green;
+      }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toEqualIgnoringWhitespace(`
+      /* index.css */
+      :global {
+        color: red;
+      }
+
+      :local {
+        color: #00f;
+      }
+
+      :global .foo {
+        color: green;
+      }
+      `);
+    },
+  });
+
   itBundled("css-module/BundleTwoFilesWithoutCodeSplitting", {
     files: {
       "/foo-entry.js": `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5719,6 +5719,14 @@ describe("css tests", () => {
     minify_test(".foo ::unknown(something(foo)) .bar {width: 20px}", ".foo ::unknown(something(foo)) .bar{width:20px}");
     minify_test(".foo ::unknown([abc]) .bar {width: 20px}", ".foo ::unknown([abc]) .bar{width:20px}");
 
+    // Without CSS modules, bare `:global` / `:local` are ordinary unknown pseudo-classes.
+    minify_test(":global {width: 20px}", ":global{width:20px}");
+    minify_test(":local {width: 20px}", ":local{width:20px}");
+    minify_test(":GLOBAL {width: 20px}", ":GLOBAL{width:20px}");
+    minify_test(":global .foo {width: 20px}", ":global .foo{width:20px}");
+    minify_test(".foo:global .bar {width: 20px}", ".foo:global .bar{width:20px}");
+    minify_test(".foo { :global { width: 20px } }", ".foo{& :global{width:20px}}");
+
     let deep_options: ParserOptions = {
       flags: [ParserFlags.DEEP_SELECTOR_COMBINATOR],
     };

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5726,6 +5726,10 @@ describe("css tests", () => {
     minify_test(":global .foo {width: 20px}", ":global .foo{width:20px}");
     minify_test(".foo:global .bar {width: 20px}", ".foo:global .bar{width:20px}");
     minify_test(".foo { :global { width: 20px } }", ".foo{& :global{width:20px}}");
+    // Inside a forgiving selector list the rejected `:global` alternative used to be dropped
+    // silently (`.x:is(:global .foo, .bar)` minified to `.x.bar`) instead of failing the parse.
+    minify_test(".x:is(:global .foo, .bar) {width: 20px}", ".x:is(:global .foo,.bar){width:20px}");
+    minify_test(".x:where(:global .foo, .bar) {width: 20px}", ".x:where(:global .foo,.bar){width:20px}");
 
     let deep_options: ParserOptions = {
       flags: [ParserFlags.DEEP_SELECTOR_COMBINATOR],


### PR DESCRIPTION
### Problem
- A plain (non-module) stylesheet containing a bare `:global` pseudo-class fails to parse: `bun build plain.css` on `:global { color: red }` exits 1 with `error: Invalid selector. CSS module class: 'global' is currently not supported.`
- The same stylesheet with `:local { color: red }` parses fine, so the two names are treated differently.
- Inside a forgiving selector list the failure is silent instead: `.x:is(:global .foo, .bar) {}` in plain CSS builds successfully as `.x.bar {}`, dropping the `:global .foo` alternative with no diagnostic (`:is()` / `:where()` discard the alternatives that fail to parse).
- Found by reading the parser while working on the CSS modules tests; there is no linked issue.
- Cause: in `SelectorParser::parse_non_ts_pseudo_class` (src/css/selectors/parser.rs:1306) the condition is `(css_modules.is_some() && name == "local") || name == "global"`, so the CSS modules check only guards `local` and `global` is rejected in every stylesheet. The Zig version had the same `a and b or c` shape and was ported as is.

### Fix
- Parenthesize the condition so `css_modules.is_some()` guards both names. Outside CSS modules both now fall through to `PseudoClass::Custom` like any other unknown pseudo-class; inside CSS modules both are still rejected with `AmbiguousCssModuleClass`.
- This is the upstream behavior: lightningcss 1.30.2 passes `:global{}` / `:local{}` through with `cssModules: false` and throws `Ambiguous CSS module class not supported` for both with `cssModules: true`. It is also what the error's name says it is for: without CSS modules there is nothing for the name to be ambiguous with, and the functional forms a few lines below (`:local(...)` / `:global(...)`) are already gated the same way.
- Tests:
  - test/js/bun/css/css.test.ts: `:global`, `:GLOBAL`, `:local`, `:global .foo`, `.foo:global .bar`, a nested `:global`, and `:global .foo` as an `:is()` / `:where()` alternative all minify unchanged without CSS modules (the `global` cases fail before this change; the `:is()` one used to minify to `.x.bar`).
  - test/bundler/css/css-modules.test.ts: bare `:global` and bare `:local` in a `.module.css` are still bundle errors; the same selectors in a plain `.css` entry point bundle through unchanged (fails before this change).
- Verified: both files above pass with `bun bd test`; the full css.test.ts (1148 tests) and test/bundler/esbuild/css.test.ts still pass; `bun build` on a plain `.css` file with `:global {}` now succeeds while `.module.css` still reports the error.
- Intentionally left alone: the `if` on the line above (`starts_with_char(name, b'_')`) decides only whether an "unsupported pseudo-class" warning is emitted and differs from the `!starts_with('-')` rule the sibling fallbacks use. It does not affect what parses, and changing it adds a warning to every stylesheet with an unknown bare pseudo-class, so it is tracked as a separate change rather than folded into this one. This PR's condition is the only `css_modules` gate in the selector parser with this shape; the functional `:local()` / `:global()` arms were already gated per name.

### Background
- CSS modules (`*.module.css` in the bundler, `css_modules` in `ParserOptions`) rewrite class names to file-scoped hashed names. The functional `:global(.x)` / `:local(.x)` pseudo-classes opt one selector out of or into that rewriting.
- The css-modules syntax also has a bare "switch" form (`:global .x`, or `:global` on its own) that changes the mode for the rest of the selector. Bun, like lightningcss, does not implement it, and reports `AmbiguousCssModuleClass` when it shows up in a CSS module rather than silently scoping the wrong names.
- With CSS modules off, no rewriting happens and an unknown pseudo-class is kept as `PseudoClass::Custom` and printed back out as written, so `:global` from plain CSS (which another tool in the pipeline may consume) is just passed through.
- `:is()` and `:where()` take a "forgiving" selector list: per the Selectors spec, an alternative that fails to parse is dropped and the rest of the list is kept, which is why the selector-level error above turned into silently narrowed output there.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (50da4a9e7)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [600.84ms]
(pass) css > css-module/BareGlobalPseudoClassIsAnError [99.83ms]
(pass) css > css-module/BareLocalPseudoClassIsAnError [133.17ms]
1363 |             }
1364 | 
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.css:1:2: Invalid selector. CSS module class: 'global' is currently not supported.
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1368:21)
(fail) css > css-module/BareGlobalAndLocalPseudoClassesInPlainCss [100.43ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [174.33ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [114.92ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [147.77ms]
(pass) css > css-module/RepeatedClassAn
... (truncated)

release without fix: 8 failed, 67 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [16.56ms]
(pass) css > css-module/BareGlobalPseudoClassIsAnError [3.52ms]
(pass) css > css-module/BareLocalPseudoClassIsAnError [3.79ms]
1363 |             }
1364 | 
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/index.css:1:2: Invalid selector. CSS module class: 'global' is currently not supported.
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1368:21)
(fail) css > css-module/BareGlobalAndLocalPseudoClassesInPlainCss [4.96ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [8.68ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [5.08ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [5.91ms]
(pass) css > css-module/RepeatedClassAndIdReferences [5.79ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [7.32ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: colum
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (50da4a9e7)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [628.57ms]
(pass) css > css-module/BareGlobalPseudoClassIsAnError [139.12ms]
(pass) css > css-module/BareLocalPseudoClassIsAnError [118.00ms]
(pass) css > css-module/BareGlobalAndLocalPseudoClassesInPlainCss [122.81ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [220.76ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [128.61ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [168.94ms]
(pass) css > css-module/RepeatedClassAndIdReferences [226.04ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [124.66ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     50da4a9e7f
  features     baseline

22 deps, 123 codegen, 1176 objects in 941ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [128.00ms]
[6/1237] fetch zlib
[zlib] up to date
[7/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[9/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1237] gen JSBuffer.lut
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/selectors/parser.rs          |  6 ++--
 test/bundler/css/css-modules.test.ts | 68 ++++++++++++++++++++++++++++++++++++
 test/js/bun/css/css.test.ts          | 12 +++++++
 3 files changed, 83 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/css/selectors/parser.rs               2      1      0
test/bundler/css/css-modules.test.ts      1      1      0
test/js/bun/css/css.test.ts               3      2      0
```

</details>

<!-- robobun:evidence:end -->