### PR TITLE
css: compute the D50 reference white in f32 so greys convert to lab(l 0 0) like lightningcss

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2726,8 +2726,7 @@ fn polar_to_rectangular(l: f32, c: f32, h: f32) -> (f32, f32, f32) {
     (l, a, b)
 }
 
-// lightningcss's expression, evaluated in f32 like upstream. Rounding it through f64 (#14832) puts
-// x and z one ulp higher, and lab()/lch() of most greys then print a, b around 1e-5 instead of 0 0.
+// Must stay bit-identical to lightningcss's D50, so this is evaluated in f32 like upstream.
 const D50: [f32; 3] = [0.3457 / 0.3585, 1.00000, (1.0 - 0.3457 - 0.3585) / 0.3585];
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2726,10 +2726,8 @@ fn polar_to_rectangular(l: f32, c: f32, h: f32) -> (f32, f32, f32) {
     (l, a, b)
 }
 
-// The same f32 expression as lightningcss (`D50` in its values/color.rs), so the constants are
-// bit-identical to upstream's. Evaluating it in f64 and casting (#14832) gives x and z one ulp
-// higher, which stops lab()/lch() output from matching upstream: most greys then come out with
-// a, b around 1e-5 instead of 0 0.
+// lightningcss's expression, evaluated in f32 like upstream. Rounding it through f64 (#14832) puts
+// x and z one ulp higher, and lab()/lch() of most greys then print a, b around 1e-5 instead of 0 0.
 const D50: [f32; 3] = [0.3457 / 0.3585, 1.00000, (1.0 - 0.3457 - 0.3585) / 0.3585];
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2726,9 +2726,10 @@ fn polar_to_rectangular(l: f32, c: f32, h: f32) -> (f32, f32, f32) {
     (l, a, b)
 }
 
-// Deliberately computed in f32 (as lightningcss does), not in f64 and then cast: the f32 values
-// nearest to the exact quotients are one ulp away from where the f32 XYZd65 -> XYZd50 matrix below
-// puts achromatic colors, which leaves lab(from gray l a b) with a, b around 1e-5 instead of 0 0.
+// The same f32 expression as lightningcss (`D50` in its values/color.rs), so the constants are
+// bit-identical to upstream's. Evaluating it in f64 and casting (#14832) gives x and z one ulp
+// higher, which stops lab()/lch() output from matching upstream: most greys then come out with
+// a, b around 1e-5 instead of 0 0.
 const D50: [f32; 3] = [0.3457 / 0.3585, 1.00000, (1.0 - 0.3457 - 0.3585) / 0.3585];
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -2775,8 +2776,8 @@ impl From<LAB> for LCH {
 impl From<LAB> for XYZd50 {
     fn from(lab_: LAB) -> XYZd50 {
         // https://github.com/w3c/csswg-drafts/blob/fba005e2ce9bcac55b49e4aa19b87208b3a0631e/css-color-4/conversions.js#L352
-        const K: f32 = (24389.0f64 / 27.0f64) as f32; // 29^3/3^3
-        const E: f32 = (216.0f64 / 24389.0f64) as f32; // 6^3/29^3
+        const K: f32 = 24389.0 / 27.0; // 29^3/3^3
+        const E: f32 = 216.0 / 24389.0; // 6^3/29^3
 
         let lab = lab_.resolve_missing();
         let l = lab.l * 100.0;

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2726,11 +2726,10 @@ fn polar_to_rectangular(l: f32, c: f32, h: f32) -> (f32, f32, f32) {
     (l, a, b)
 }
 
-const D50: [f32; 3] = [
-    (0.3457f64 / 0.3585f64) as f32,
-    1.00000,
-    ((1.0f64 - 0.3457f64 - 0.3585f64) / 0.3585f64) as f32,
-];
+// Deliberately computed in f32 (as lightningcss does), not in f64 and then cast: the f32 values
+// nearest to the exact quotients are one ulp away from where the f32 XYZd65 -> XYZd50 matrix below
+// puts achromatic colors, which leaves lab(from gray l a b) with a, b around 1e-5 instead of 0 0.
+const D50: [f32; 3] = [0.3457 / 0.3585, 1.00000, (1.0 - 0.3457 - 0.3585) / 0.3585];
 
 // ──────────────────────────────────────────────────────────────────────────
 // Handwritten conversions.

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -540,6 +540,13 @@ describe("css string output parses back to the same color", () => {
     }
   });
 
+  // A grey lies on the reference white axis, so a and b are exactly 0, as in lightningcss. The
+  // D50 white point used to be rounded one f32 ulp away from where the D65 -> D50 adaptation puts
+  // greys, which printed #808080 as lab(53.585022% -0.000029802322 0.000011920929).
+  test.each(["#000000", "#212121", "#808080", "#bdbdbd", "#ffffff"])("lab of grey %s has a = b = 0", input => {
+    expect(color(input, "lab")).toMatch(/^lab\(\d+(\.\d+)?% 0 0\)$/);
+  });
+
   // A `none` component is a zero value outside of interpolation, and `NaN` is not
   // a token any CSS parser accepts.
   test("a none component does not leak NaN into the output", () => {

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -540,9 +540,9 @@ describe("css string output parses back to the same color", () => {
     }
   });
 
-  // A grey lies on the reference white axis, so a and b are exactly 0, as in lightningcss. The
-  // D50 white point used to be rounded one f32 ulp away from where the D65 -> D50 adaptation puts
-  // greys, which printed #808080 as lab(53.585022% -0.000029802322 0.000011920929).
+  // These greys come out as exactly a = b = 0, as they do in lightningcss. The D50 white point
+  // used to be rounded one f32 ulp away from where the D65 -> D50 adaptation puts greys, which
+  // biased all of them: #808080 printed as lab(53.585022% -0.000029802322 0.000011920929).
   test.each(["#000000", "#212121", "#808080", "#bdbdbd", "#ffffff"])("lab of grey %s has a = b = 0", input => {
     expect(color(input, "lab")).toMatch(/^lab\(\d+(\.\d+)?% 0 0\)$/);
   });

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -540,9 +540,10 @@ describe("css string output parses back to the same color", () => {
     }
   });
 
-  // These greys come out as exactly a = b = 0, as they do in lightningcss. The D50 white point
-  // used to be rounded one f32 ulp away from where the D65 -> D50 adaptation puts greys, which
-  // biased all of them: #808080 printed as lab(53.585022% -0.000029802322 0.000011920929).
+  // These greys print exactly 0 0, as they do in lightningcss, whose f32 D50 constants the
+  // conversion uses; with D50 rounded from f64 (one ulp higher in x and z) #808080 printed as
+  // lab(53.585022% -0.000029802322 0.000011920929). The platform notes in css.test.ts
+  // ("achromatic colors converted to lab() and lch()") apply to the same inputs here.
   test.each(["#000000", "#212121", "#808080", "#bdbdbd", "#ffffff"])("lab of grey %s has a = b = 0", input => {
     expect(color(input, "lab")).toMatch(/^lab\(\d+(\.\d+)?% 0 0\)$/);
   });

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7559,12 +7559,16 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
-  // Expected strings are lightningcss 1.30.2 output. These achromatic colors divide out against
-  // the D50 reference white exactly, so lab() gives a = b = 0 and lch() gives c = 0 with no made-up
-  // hue. The reference white used to be rounded one f32 ulp away from where the D65 -> D50
-  // adaptation puts greys, which biased every grey by about that much: gray came out as
-  // lab(53.585% -.0000298023 .0000119209) and lch(53.585% .0000320981 158.199).
+  // Expected strings are lightningcss 1.30.2 output. Using its f32 D50 constants makes a/b (and c/h)
+  // match it for all 256 sRGB greys, 163 of which print exactly 0 0; with D50 rounded from f64 (one
+  // ulp higher in x and z) only 130 did, and gray printed lab(53.585% -.0000298023 .0000119209) and
+  // lch(53.585% .0000320981 158.199).
   describe("achromatic colors converted to lab() and lch()", () => {
+    // Except for white, the greys below have bit-identical x, y, z by the time xyz -> lab takes cube
+    // roots (the sRGB ones also need powf to return the nearest float, which the true value is
+    // within 0.2 ulp of at these inputs), so their 0 0 does not depend on the platform's libm.
+    // white reaches the cube root with z / D50[2] = 1 - 2^-24 and relies on cbrtf rounding that to
+    // 1, as the oklch(100% 0 0deg) -> lab(100% 0 0 / .5) fallbacks pinned above always have.
     minify_test(".foo { color: lab(from gray l a b) }", ".foo{color:lab(53.585% 0 0)}");
     minify_test(".foo { color: lab(from white l a b) }", ".foo{color:lab(100% 0 0)}");
     minify_test(".foo { color: lab(from #212121 l a b) }", ".foo{color:lab(12.74% 0 0)}");
@@ -7575,9 +7579,6 @@ describe("css tests", () => {
     minify_test(".foo { color: lch(from #212121 l c h) }", ".foo{color:lch(12.74% 0 0)}");
     minify_test(".foo { color: lch(from #bdbdbd l c h) }", ".foo{color:lch(76.6112% 0 0)}");
 
-    // srgb-linear skips the sRGB transfer function (libm powf), and for these values the three
-    // channels are still bit-identical when they reach the cbrt in xyz -> lab, so a = b = 0 here
-    // does not depend on the platform's libm.
     minify_test(".foo { color: lab(from color(srgb-linear 0.05 0.05 0.05) l a b) }", ".foo{color:lab(26.7348% 0 0)}");
     minify_test(".foo { color: lab(from color(srgb-linear 0.1 0.1 0.1) l a b) }", ".foo{color:lab(37.8424% 0 0)}");
     minify_test(".foo { color: lab(from color(srgb-linear 0.4 0.4 0.4) l a b) }", ".foo{color:lab(69.4695% 0 0)}");
@@ -7587,7 +7588,7 @@ describe("css tests", () => {
     minify_test(".foo { color: lch(from color(srgb-linear 0.4 0.4 0.4) l c h) }", ".foo{color:lch(69.4695% 0 0)}");
     minify_test(".foo { color: lch(from color(srgb-linear 0.8 0.8 0.8) l c h) }", ".foo{color:lch(91.6849% 0 0)}");
 
-    // The residual used to leak into anything computed from the converted color: -9.99999 here.
+    // The converted grey's a/b feed into the mix (b was -9.99999 with the f64 constants).
     minify_test(".foo { color: color-mix(in lab, gray, lab(50% 50 -20)) }", ".foo{color:lab(51.7925% 25 -10)}");
     minify_test(".foo { color: color-mix(in lab, white, lab(50% 50 -20)) }", ".foo{color:lab(75% 25 -10)}");
     minify_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7559,10 +7559,11 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
-  // Expected strings are lightningcss 1.30.2 output. Achromatic colors sit on the reference
-  // white axis, so lab() gives exactly a = b = 0 (and lch() c = 0, so no made-up hue). The D50
-  // reference white used to be rounded one f32 ulp away from where the D65 -> D50 adaptation
-  // puts them, leaving lab(53.585% -.0000298023 .0000119209) and lch(53.585% .0000320981 158.199).
+  // Expected strings are lightningcss 1.30.2 output. These achromatic colors divide out against
+  // the D50 reference white exactly, so lab() gives a = b = 0 and lch() gives c = 0 with no made-up
+  // hue. The reference white used to be rounded one f32 ulp away from where the D65 -> D50
+  // adaptation puts greys, which biased every grey by about that much: gray came out as
+  // lab(53.585% -.0000298023 .0000119209) and lch(53.585% .0000320981 158.199).
   describe("achromatic colors converted to lab() and lch()", () => {
     minify_test(".foo { color: lab(from gray l a b) }", ".foo{color:lab(53.585% 0 0)}");
     minify_test(".foo { color: lab(from white l a b) }", ".foo{color:lab(100% 0 0)}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7559,6 +7559,59 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
+  // Expected strings are lightningcss 1.30.2 output. Achromatic colors sit on the reference
+  // white axis, so lab() gives exactly a = b = 0 (and lch() c = 0, so no made-up hue). The D50
+  // reference white used to be rounded one f32 ulp away from where the D65 -> D50 adaptation
+  // puts them, leaving lab(53.585% -.0000298023 .0000119209) and lch(53.585% .0000320981 158.199).
+  describe("achromatic colors converted to lab() and lch()", () => {
+    minify_test(".foo { color: lab(from gray l a b) }", ".foo{color:lab(53.585% 0 0)}");
+    minify_test(".foo { color: lab(from white l a b) }", ".foo{color:lab(100% 0 0)}");
+    minify_test(".foo { color: lab(from #212121 l a b) }", ".foo{color:lab(12.74% 0 0)}");
+    minify_test(".foo { color: lab(from #bdbdbd l a b) }", ".foo{color:lab(76.6112% 0 0)}");
+    minify_test(".foo { color: lab(from black l a b) }", ".foo{color:lab(0% 0 0)}");
+    minify_test(".foo { color: lch(from gray l c h) }", ".foo{color:lch(53.585% 0 0)}");
+    minify_test(".foo { color: lch(from white l c h) }", ".foo{color:lch(100% 0 0)}");
+    minify_test(".foo { color: lch(from #212121 l c h) }", ".foo{color:lch(12.74% 0 0)}");
+    minify_test(".foo { color: lch(from #bdbdbd l c h) }", ".foo{color:lch(76.6112% 0 0)}");
+
+    // srgb-linear skips the sRGB transfer function (libm powf), and for these values the three
+    // channels are still bit-identical when they reach the cbrt in xyz -> lab, so a = b = 0 here
+    // does not depend on the platform's libm.
+    minify_test(".foo { color: lab(from color(srgb-linear 0.05 0.05 0.05) l a b) }", ".foo{color:lab(26.7348% 0 0)}");
+    minify_test(".foo { color: lab(from color(srgb-linear 0.1 0.1 0.1) l a b) }", ".foo{color:lab(37.8424% 0 0)}");
+    minify_test(".foo { color: lab(from color(srgb-linear 0.4 0.4 0.4) l a b) }", ".foo{color:lab(69.4695% 0 0)}");
+    minify_test(".foo { color: lab(from color(srgb-linear 0.8 0.8 0.8) l a b) }", ".foo{color:lab(91.6849% 0 0)}");
+    minify_test(".foo { color: lch(from color(srgb-linear 0.05 0.05 0.05) l c h) }", ".foo{color:lch(26.7348% 0 0)}");
+    minify_test(".foo { color: lch(from color(srgb-linear 0.1 0.1 0.1) l c h) }", ".foo{color:lch(37.8424% 0 0)}");
+    minify_test(".foo { color: lch(from color(srgb-linear 0.4 0.4 0.4) l c h) }", ".foo{color:lch(69.4695% 0 0)}");
+    minify_test(".foo { color: lch(from color(srgb-linear 0.8 0.8 0.8) l c h) }", ".foo{color:lch(91.6849% 0 0)}");
+
+    // The residual used to leak into anything computed from the converted color: -9.99999 here.
+    minify_test(".foo { color: color-mix(in lab, gray, lab(50% 50 -20)) }", ".foo{color:lab(51.7925% 25 -10)}");
+    minify_test(".foo { color: color-mix(in lab, white, lab(50% 50 -20)) }", ".foo{color:lab(75% 25 -10)}");
+    minify_test(
+      ".foo { color: color-mix(in lab, color(srgb-linear 0.4 0.4 0.4), lab(50% 50 -20)) }",
+      ".foo{color:lab(59.7348% 25 -10)}",
+    );
+
+    // Chromatic colors, and the lab() -> xyz-d50 direction (which scales by the same reference
+    // white), print the same six digits as before.
+    minify_test(".foo { color: lab(from red l a b) }", ".foo{color:lab(54.2905% 80.8049 69.891)}");
+    minify_test(".foo { color: lch(from #123456 l c h) }", ".foo{color:lch(20.6755% 24.6983 264.711)}");
+    minify_test(
+      ".foo { color: color(from lab(100% 0 0) xyz-d50 x y z) }",
+      ".foo{color:color(xyz-d50 .964296 1 .825105)}",
+    );
+    minify_test(
+      ".foo { color: color(from lab(50% 10 -20) xyz-d50 x y z) }",
+      ".foo{color:color(xyz-d50 .197006 .184187 .247013)}",
+    );
+    minify_test(
+      ".foo { color: color(from lab(50% 0 0) srgb r g b) }",
+      ".foo{color:color(srgb .466326 .466327 .466327)}",
+    );
+  });
+
   describe("container", () => {
     minify_test("@container (width > 100px) { a { color: red } }", "@container (width>100px){a{color:red}}");
     minify_test("@container not (width > 100px) { a { color: red } }", "@container not (width>100px){a{color:red}}");


### PR DESCRIPTION
### Problem
- Achromatic sRGB colors converted into CIE Lab come out with nonzero `a`/`b` where lightningcss (which this code ports) prints 0. With `bun build --minify`, `.a{color:lab(from gray l a b)}` prints `lab(53.585% -.0000298023 .0000119209)` and `.a{color:lch(from gray l c h)}` prints `lch(53.585% .0000320981 158.199)`; lightningcss 1.30.2 prints `lab(53.585% 0 0)` and `lch(53.585% 0 0)`. `white` prints `lab(100% 0 .0000119209)` / `lch(100% .0000119209 90)`. `Bun.color("#808080", "lab")` returns `lab(53.585022% -0.000029802322 0.000011920929)`. Reproduces on bun 1.4.0 and main.
- The residual propagates: `color-mix(in lab, gray, lab(50% 50 -20))` prints `lab(51.7925% 25 -9.99999)` instead of `-10`, and a grey converted into lch carries a chroma of about 3e-5 with an invented hue (158.199 for greys, 90 for white), which is above the `f32::EPSILON` powerless threshold and so takes part in lch interpolation.
- Cause: `D50` (`src/css/values/color.rs:2729`) is evaluated in f64 and cast. lightningcss evaluates the identical expression in f32 (`const D50: &[f32] = &[0.3457 / 0.3585, 1.00000, (1.0 - 0.3457 - 0.3585) / 0.3585]` in its `values/color.rs`), and the two differ by exactly one f32 ulp in x (`0x3f76dc15` vs `0x3f76dc14`) and z (`0x3f533a0e` vs `0x3f533a0d`). The f32 D65 -> D50 adaptation matrix (`impl From<XYZd65> for XYZd50`) puts sRGB white at `0x3f76dc14` in x and `0x3f533a0c` in z, so with the larger divisors in `impl From<XYZd50> for LAB` (`color.rs:3204`) the normalized x and z of greys sit systematically below y, and `500 * (f0 - f1)` / `200 * (f1 - f2)` turn that one-sided shift into the values above (hence the constant signs and the constant 158.199 hue). The f64 form dates from the Zig port (#14832 replaced the upstream expression with an explicit f64 `@floatCast`, leaving upstream's values `0.9642956, 1.0, 0.82510453` in a comment next to it); the Rust rewrite kept it.

### Fix
- Evaluate `D50` in f32, i.e. use upstream's expression as written, so the constants are bit-identical to lightningcss's. `D50` is used by `XYZd50 -> LAB` (divide) and `LAB -> XYZd50` (multiply), so both directions move together. `K` and `E` in `LAB -> XYZd50` are rewritten in the same f32 form as their counterparts in `XYZd50 -> LAB`; their operands are exactly representable, so both forms produce the same bits (checked with `to_bits()`), this is consistency only.
- Why this is the right value: what the f32 pipeline needs is for the divisors to sit where the f32 adaptation matrix actually puts greys, and that is a property of lightningcss's f32 constants, not of the mathematically nearest ones. The f64-derived values are the nearest f32s to the exact quotients, but they are one ulp above that point in both x and z, which shifted every grey the same way. With upstream's constants x is exactly on it and z is within an ulp, and what remains is ordinary two-sided rounding noise. Measured over the 256 sRGB greys: 130 printed exactly `0 0` before, 163 do now, and those 163 are exactly the greys for which lightningcss 1.30.2 prints `0 0`; the a/b (lab) and c/h (lch) of all 256 greys now match lightningcss byte for byte (232 of the 512 outputs differed before; the 18 that still differ do so only in the last digit of L, a separate printer issue noted below). This is not a snap-to-zero: where lightningcss keeps a one-ulp residual (`#ccc`, prophoto greys), bun now keeps the identical one (table below). Converting out of `lab()` also moved towards upstream (147 -> 132 differing outputs in a 686-case sweep; all remaining ones are the two unrelated issues below plus the `srgb-linear` relative-color parse bug fixed in #38487).
- Nothing else moves: `test/js/bun/css/css.test.ts`, `test/js/bun/css/color.test.ts`, `test/bundler/css/wpt/`, `test/js/bun/css/doesnt_crash.test.ts` and `test/regression/issue/css-system-color-contexts.test.ts` pass unchanged.
- Tests: `test/js/bun/css/css.test.ts` ("achromatic colors converted to lab() and lch()", expected strings are lightningcss 1.30.2 output; 19 of the 25 fail without the fix, the other 6 pin chromatic colors and the lab() -> xyz-d50 direction) and `test/js/bun/css/color.test.ts` ("lab of grey %s has a = b = 0", 4 of 5 fail without the fix).
  - Platform exposure of the exact `0 0` pins: for the `color(srgb-linear ...)` inputs, `gray`, `#212121` and `#bdbdbd`, the three normalized channels are bit-identical before the cube root (for the sRGB ones this needs `powf` to return the nearest float, and the true value is within about 0.2 ulp of it at those inputs), so any libm prints `0 0`. `white` reaches the cube root with z = `1 - 2^-24` and relies on `cbrtf` rounding that to 1; that is the same input the existing `oklch(100% 0 0deg)` -> `lab(100% 0 0 / .5)` expectations in this file have required on every CI platform until now (with the new constants those pins need the symmetric `1 + 2^-23` case instead), so it adds no exposure the suite did not already have. Linux glibc, musl and Windows lanes passed on the first CI run; the test comments say which pins depend on what.
- Out of scope: `color-mix(in lch, gray, ...)` additionally needs #38508 (powerless components of converted operands) to match lightningcss; with this PR alone the grey's hue is 0 with zero chroma but still gets interpolated. Two printer issues that showed up while comparing (the f32 is widened to f64 before rounding to 6 digits, which is what makes e.g. `#595959` print L as 37.8242% here and 37.8243% upstream; tiny negative numbers print as `--1e-7`) are tracked separately. `LAB -> XYZd50` cubes with libm `powf(f, 3.0)` where lightningcss uses `f * f * f`, which differs from upstream in the 1e-7 range of residuals and in occasional last digits; not visible for any test here and left alone.

### Background
- CSS Color 4 defines `lab()`/`lch()` relative to the D50 white point, while sRGB, display-p3, rec2020 and `oklab()` are relative to D65. sRGB -> Lab therefore goes sRGB -> linear sRGB -> XYZ (D65) -> XYZ (D50), through a fixed 3x3 chromatic adaptation matrix, -> Lab. This is why `oklab(from gray ...)` already matched lightningcss and only the Lab leg was off.
- The Lab step divides X, Y, Z by the reference white and takes cube roots; `L` comes from the Y term, and `a`/`b` are 500 and 200 times the differences between the three terms. For a grey the three normalized terms should be equal, so a one-ulp difference between them is multiplied by 500 or 200 and becomes visible. `lch()` is `lab()` in polar form (chroma = length of (a, b), hue = their angle), so a residual (a, b) yields an arbitrary hue.
- The CSS color pipeline is f32 throughout and is a port of lightningcss; `test/js/bun/css/css.test.ts` asserts lightningcss's exact output strings, which is why its constants, rather than the mathematically nearest ones, are the target.

<details>
<summary>Before/after against lightningcss 1.30.2 (minify, no targets)</summary>

```
input                                          lightningcss                           bun before                                bun after
lab(from gray l a b)                           lab(53.585% 0 0)                       lab(53.585% -.0000298023 .0000119209)     lab(53.585% 0 0)
lab(from white l a b)                          lab(100% 0 0)                          lab(100% 0 .0000119209)                   lab(100% 0 0)
lab(from #212121 l a b)                        lab(12.74% 0 0)                        lab(12.74% -.00000745058 .00000298023)    lab(12.74% 0 0)
lch(from gray l c h)                           lch(53.585% 0 0)                       lch(53.585% .0000320981 158.199)          lch(53.585% 0 0)
lch(from white l c h)                          lch(100% 0 0)                          lch(100% .0000119209 90)                  lch(100% 0 0)
lab(from color(srgb-linear .4 .4 .4) l a b)    lab(69.4695% 0 0)                      lab(69.4695% -.0000298023 .0000119209)    lab(69.4695% 0 0)
lch(from color(srgb-linear .4 .4 .4) l c h)    lch(69.4695% 0 0)                      lch(69.4695% .0000320981 158.199)         lch(69.4695% 0 0)
color-mix(in lab, gray, lab(50% 50 -20))       lab(51.7925% 25 -10)                   lab(51.7925% 25 -9.99999)                 lab(51.7925% 25 -10)
lab(from #ccc l a b)                           lab(82.0458% -.0000298023 0)           lab(82.0458% -.0000298023 .0000119209)    lab(82.0458% -.0000298023 0)
lab(from color(prophoto-rgb 1 1 1) l a b)      lab(100% .0000298023 -.0000119209)     lab(100% .0000298023 0)                   lab(100% .0000298023 -.0000119209)
lab(from color(display-p3 .5 .5 .5) l a b)     lab(53.389% -.0000298023 .0000119209)  same                                      same
color(from lab(100% 0 0) xyz-d50 x y z)        color(xyz-d50 .964296 1 .825105)       same                                      same
oklab(from gray l a b)                         oklab(59.9871% 2.98023e-8 2.98023e-8)  same                                      same
```

The constants, as rustc evaluates them (the same values fall out of `Math.fround` in JS):

```
           f32 (upstream, this PR)         f64 then cast (before)          sRGB white through the f32 D65 -> D50 matrix
x          0.9642956   0x3f76dc14          0.9642957   0x3f76dc15          0.9642956   0x3f76dc14
z          0.82510453  0x3f533a0d          0.8251046   0x3f533a0e          0.8251045   0x3f533a0c
white z / D50[2]:  0x3f7fffff (1 - 2^-24), cbrtf -> 1.0      before: 0x3f7ffffe, cbrtf -> 0.99999994, b = .0000119209
```
</details>

<details>
<summary>Changes made after the initial version</summary>

- The D50 comment was reduced to one line pointing at the bit-identity requirement (the earlier versions narrated the rounding and overstated it: only x lands exactly on the matrix's white point, z is within an ulp, and 93 greys legitimately keep lightningcss's own one-ulp residuals).
- `K`/`E` in `LAB -> XYZd50` were rewritten in the f32 form used 400 lines later in `XYZd50 -> LAB`; bit-identical, so no test moves.
- The test comments now state what is measured (the 130 -> 163 counts and which pins depend on `powf`/`cbrtf`) instead of an invariant that does not hold for every grey.
</details>
