### PR TITLE
pm view: escape control characters coming from the registry

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3325,6 +3325,87 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
     write_bytes(writer, remain)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// escapeControlChars
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Renders the wrapped `Display` with C0 controls, DEL and C1 controls
+/// spelled out (`\n`, `\r`, `\t`, `\x1b`, `\x7f`, `\u009b`) instead of
+/// written raw. For text somebody else authored (a registry manifest, a
+/// dependency's `package.json`): printed raw, an ESC/CR/C1 sequence can erase
+/// or repaint the line it is shown on and a newline can forge further lines
+/// of our output. Everything else passes through unchanged.
+pub struct EscapeControlChars<T>(pub T);
+
+/// [`EscapeControlChars`] for a value that is legitimately multi-line and is
+/// printed on its own (`bun pm view <pkg> readme`): `\t`, `\n` and `\r\n`
+/// pass through. A `\r` not followed by `\n` is still escaped; on a terminal
+/// it only overwrites the line printed so far.
+pub struct EscapeControlCharsMultiline<T>(pub T);
+
+/// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.
+pub fn escape_control_chars(text: &[u8]) -> EscapeControlChars<&bstr::BStr> {
+    EscapeControlChars(bstr::BStr::new(text))
+}
+
+/// [`EscapeControlCharsMultiline`] over raw bytes; invalid UTF-8 renders as U+FFFD.
+pub fn escape_control_chars_multiline(text: &[u8]) -> EscapeControlCharsMultiline<&bstr::BStr> {
+    EscapeControlCharsMultiline(bstr::BStr::new(text))
+}
+
+impl<T: Display> Display for EscapeControlChars<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = EscapeControlCharsWriter {
+            f,
+            keep_line_breaks: false,
+        };
+        write!(writer, "{}", self.0)
+    }
+}
+
+impl<T: Display> Display for EscapeControlCharsMultiline<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = EscapeControlCharsWriter {
+            f,
+            keep_line_breaks: true,
+        };
+        write!(writer, "{}", self.0)
+    }
+}
+
+struct EscapeControlCharsWriter<'a, 'f> {
+    f: &'a mut Formatter<'f>,
+    keep_line_breaks: bool,
+}
+
+impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let mut start = 0;
+        let mut chars = s.char_indices().peekable();
+        while let Some((i, c)) = chars.next() {
+            let pass_through = match c {
+                '\t' | '\n' => self.keep_line_breaks,
+                '\r' => self.keep_line_breaks && matches!(chars.peek(), Some((_, '\n'))),
+                '\0'..='\x1f' | '\x7f' | '\u{80}'..='\u{9f}' => false,
+                _ => true,
+            };
+            if pass_through {
+                continue;
+            }
+            self.f.write_str(&s[start..i])?;
+            match c {
+                '\n' => self.f.write_str("\\n")?,
+                '\r' => self.f.write_str("\\r")?,
+                '\t' => self.f.write_str("\\t")?,
+                c if c.is_ascii() => write!(self.f, "\\x{:02x}", c as u32)?,
+                c => write!(self.f, "\\u{:04x}", c as u32)?,
+            }
+            start = i + c.len_utf8();
+        }
+        self.f.write_str(&s[start..])
+    }
+}
+
 // js_bindings (fmtString for highlighter.test.ts) lives in src/jsc/fmt_jsc.rs
 // alongside fmt_jsc.bind.ts; bun_core/ stays JSC-free.
 

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -316,7 +316,10 @@ pub(crate) fn view(
                         bun_fmt::format_json_string_utf8(slice, Default::default())
                     ));
                 } else {
-                    Output::print(format_args!("{}\n", BStr::new(slice)));
+                    Output::print(format_args!(
+                        "{}\n",
+                        bun_fmt::escape_control_chars_multiline(slice)
+                    ));
                 }
                 Output::flush();
                 return Ok(());
@@ -416,21 +419,23 @@ pub(crate) fn view(
             .len_u32() as usize;
     }
 
+    // Every string printed below is registry-controlled: always go through
+    // `escape_control_chars`.
     prettyln!(
         "<b><blue><u>{}<r><d>@<r><blue><b><u>{}<r> <d>|<r> <cyan>{}<r> <d>|<r> deps<d>:<r> {} <d>|<r> versions<d>:<r> {}",
-        BStr::new(pkg_name),
-        BStr::new(pkg_version),
-        BStr::new(license),
+        bun_fmt::escape_control_chars(pkg_name),
+        bun_fmt::escape_control_chars(pkg_version),
+        bun_fmt::escape_control_chars(license),
         dep_count,
         versions_len,
     );
 
     // Get description and homepage from the top-level package manifest, not the version-specific one
     if let Some(desc) = json.get_string_cloned(&bump, b"description").ok().flatten() {
-        prettyln!("{}", BStr::new(desc));
+        prettyln!("{}", bun_fmt::escape_control_chars(desc));
     }
     if let Some(hp) = json.get_string_cloned(&bump, b"homepage").ok().flatten() {
-        prettyln!("<blue>{}<r>", BStr::new(hp));
+        prettyln!("<blue>{}<r>", bun_fmt::escape_control_chars(hp));
     }
 
     if let Some(mut iter) = json.get_array(b"keywords") {
@@ -447,7 +452,10 @@ pub(crate) fn view(
             }
         }
         if !keywords.list.is_empty() {
-            prettyln!("<d>keywords:<r> {}", BStr::new(keywords.list.as_slice()));
+            prettyln!(
+                "<d>keywords:<r> {}",
+                bun_fmt::escape_control_chars(keywords.list.as_slice())
+            );
         }
     }
 
@@ -481,8 +489,8 @@ pub(crate) fn view(
             };
             prettyln!(
                 "- <cyan>{}<r><d>:<r> {}",
-                BStr::new(dep_name),
-                BStr::new(dep_version),
+                bun_fmt::escape_control_chars(dep_name),
+                bun_fmt::escape_control_chars(dep_version),
             );
         }
     }
@@ -490,13 +498,22 @@ pub(crate) fn view(
     if let Some(dist) = manifest.get_object(b"dist") {
         prettyln!("\n<d><r><b>dist<r>");
         if let Some(t) = dist.get_string_cloned(&bump, b"tarball").ok().flatten() {
-            prettyln!(" <d>.<r>tarball<d>:<r> {}", BStr::new(t));
+            prettyln!(
+                " <d>.<r>tarball<d>:<r> {}",
+                bun_fmt::escape_control_chars(t)
+            );
         }
         if let Some(s) = dist.get_string_cloned(&bump, b"shasum").ok().flatten() {
-            prettyln!(" <d>.<r>shasum<r><d>:<r> <green>{}<r>", BStr::new(s));
+            prettyln!(
+                " <d>.<r>shasum<r><d>:<r> <green>{}<r>",
+                bun_fmt::escape_control_chars(s)
+            );
         }
         if let Some(i) = dist.get_string_cloned(&bump, b"integrity").ok().flatten() {
-            prettyln!(" <d>.<r>integrity<r><d>:<r> <green>{}<r>", BStr::new(i));
+            prettyln!(
+                " <d>.<r>integrity<r><d>:<r> <green>{}<r>",
+                bun_fmt::escape_control_chars(i)
+            );
         }
         if let Some(u) = dist.get_number(b"unpackedSize") {
             prettyln!(
@@ -522,12 +539,14 @@ pub(crate) fn view(
             let val_expr = prop.value.as_ref().expect("infallible: prop has value");
             if let Some(tag) = tagname_expr.as_string(&bump) {
                 if let Some(val) = val_expr.as_string(&bump) {
+                    let tag_fmt = bun_fmt::escape_control_chars(tag);
+                    let val_fmt = bun_fmt::escape_control_chars(val);
                     if tag == b"latest" {
-                        prettyln!("<cyan>{}<r><d>:<r> {}", BStr::new(tag), BStr::new(val));
+                        prettyln!("<cyan>{}<r><d>:<r> {}", tag_fmt, val_fmt);
                     } else if tag == b"beta" {
-                        prettyln!("<blue>{}<r><d>:<r> {}", BStr::new(tag), BStr::new(val));
+                        prettyln!("<blue>{}<r><d>:<r> {}", tag_fmt, val_fmt);
                     } else {
-                        prettyln!("<magenta>{}<r><d>:<r> {}", BStr::new(tag), BStr::new(val));
+                        prettyln!("<magenta>{}<r><d>:<r> {}", tag_fmt, val_fmt);
                     }
                 }
             }
@@ -548,9 +567,13 @@ pub(crate) fn view(
                 .flatten()
                 .unwrap_or(b"");
             if !em.is_empty() {
-                prettyln!("<d>-<r> {} <d>\\<{}\\><r>", BStr::new(nm), BStr::new(em));
+                prettyln!(
+                    "<d>-<r> {} <d>\\<{}\\><r>",
+                    bun_fmt::escape_control_chars(nm),
+                    bun_fmt::escape_control_chars(em)
+                );
             } else if !nm.is_empty() {
-                prettyln!("<d>-<r> {}", BStr::new(nm));
+                prettyln!("<d>-<r> {}", bun_fmt::escape_control_chars(nm));
             }
         }
     }
@@ -563,13 +586,19 @@ pub(crate) fn view(
             .ok()
             .flatten()
         {
-            prettyln!("\n<b>Published<r><d>:<r> {}", BStr::new(published_time));
+            prettyln!(
+                "\n<b>Published<r><d>:<r> {}",
+                bun_fmt::escape_control_chars(published_time)
+            );
         } else if let Some(modified_time) = time_obj
             .get_string_cloned(&bump, b"modified")
             .ok()
             .flatten()
         {
-            prettyln!("\n<b>Published<r><d>:<r> {}", BStr::new(modified_time));
+            prettyln!(
+                "\n<b>Published<r><d>:<r> {}",
+                bun_fmt::escape_control_chars(modified_time)
+            );
         }
     }
 

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
 describe.concurrent("bun info", () => {
@@ -369,6 +369,101 @@ describe.concurrent("bun info", () => {
         "
       `);
     });
+  });
+});
+
+describe.concurrent("bun info with control characters in the packument", () => {
+  // One of each kind of byte the registry must not be able to write to the
+  // terminal: ESC (clear screen, then an OSC title change), BEL, a bare CR
+  // (overwrites the line), CRLF, tab, DEL, and the C1 controls NEL (U+0085)
+  // and CSI (U+009B).
+  const hostile = "\x1b[2J\x1b]0;PWNED\x07\rX\r\nY\tZ\x7f\u0085\u009b[31m";
+  // How the summary view renders it: every control becomes a visible escape.
+  const escaped = String.raw`\x1b[2J\x1b]0;PWNED\x07\rX\r\nY\tZ\x7f\u0085\u009b[31m`;
+  // How `bun pm view <pkg> <field>` renders it: CRLF and tab are kept since
+  // the field itself may be multi-line (readme), everything else is escaped.
+  const escapedMultiline = String.raw`\x1b[2J\x1b]0;PWNED\x07\rX` + "\r\nY\tZ" + String.raw`\x7f\u0085\u009b[31m`;
+
+  const packument = {
+    name: "hostile",
+    "dist-tags": { latest: "1.0.0", ["tag" + hostile]: "1.0.0" },
+    description: "D" + hostile,
+    homepage: "H" + hostile,
+    keywords: ["K" + hostile, "plain"],
+    maintainers: [{ name: "M" + hostile, email: "E" + hostile }, { name: "N" + hostile }],
+    time: { "1.0.0": "P" + hostile },
+    versions: {
+      "1.0.0": {
+        name: "n" + hostile,
+        version: "1.0.0",
+        license: "L" + hostile,
+        description: "D" + hostile,
+        dependencies: { ["dep" + hostile]: "^1" + hostile },
+        dist: { tarball: "T" + hostile, shasum: "S" + hostile, integrity: "I" + hostile },
+      },
+    },
+  };
+
+  async function view(...args: string[]) {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json(packument),
+    });
+    using dir = tempDir("bun-info-control-chars", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0" }),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      env: { ...bunEnv, NPM_CONFIG_REGISTRY: server.url.href },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("escapes every field of the summary view", async () => {
+    const { stdout, stderr, exitCode } = await view("info", "hostile");
+
+    // Only the newlines bun itself prints between lines may remain.
+    expect(stdout).not.toMatch(/[\x00-\x09\x0b-\x1f\x7f\u0080-\u009f]/);
+    expect(stdout.replaceAll(escaped, "<escaped>")).toMatchInlineSnapshot(`
+      "n<escaped>@1.0.0 | L<escaped> | deps: 1 | versions: 1
+      D<escaped>
+      H<escaped>
+      keywords: K<escaped>, plain
+
+      dependencies (1):
+      - dep<escaped>: ^1<escaped>
+
+      dist
+       .tarball: T<escaped>
+       .shasum: S<escaped>
+       .integrity: I<escaped>
+
+      dist-tags:
+      latest: 1.0.0
+      tag<escaped>: 1.0.0
+
+      maintainers:
+      - M<escaped> <E<escaped>>
+      - N<escaped>
+
+      Published: P<escaped>
+      "
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("keeps line structure but escapes the rest when printing a single string field", async () => {
+    const { stdout, stderr, exitCode } = await view("pm", "view", "hostile", "description");
+
+    expect(stdout).toBe(`D${escapedMultiline}\n`);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun pm view <pkg>` / `bun info <pkg>` write every string of the registry packument to the terminal byte for byte: description, license, homepage, keywords, dependency names and ranges, `dist.tarball` / `shasum` / `integrity`, dist-tag names, maintainer names and emails, and the `time` entry.
- A packument string can therefore drive the terminal of whoever looks at the package: `ESC[2J` clears the screen, `ESC]0;...BEL` sets the window title, `ESC]52;...` writes the clipboard, `ESC]8;;url` turns a label such as `react` into a link to another host, `\r` overwrites the line bun printed so far, and an embedded `\n` forges further lines of `bun info` output (for example a fake `dependencies` section). 8-bit C1 controls (U+0080..U+009F, `C2 80`..`C2 9F` in UTF-8) go through the same way. The same bytes come out on a pipe; bun only strips its own colors there.
- Cause: `src/runtime/cli/pm_view_command.rs` formats each field with `BStr`, which only replaces invalid UTF-8. The same applies to `bun pm view <pkg> <field>` for a string field (line 319).
- Reproduced on bun 1.4.0 against a loopback registry serving a packument with these bytes in every field listed above; `bun pm view hv | od -c` shows the raw `033` bytes after bun's own color codes.

### Fix
- Adds `bun_core::fmt::escape_control_chars` / `EscapeControlChars` (`src/bun_core/fmt.rs`): a `Display` adapter that writes C0 controls, DEL and C1 controls as `\n`, `\r`, `\t`, `\x1b`, `\x7f`, `\u009b` and passes every other character through unchanged. Same helper and output format as the one #38525 adds for the `bun pm untrusted` listing, so the two rebase onto each other cleanly; this one also adds `escape_control_chars_multiline`.
- `pm view` prints every registry-controlled string through it. Fields of the summary view are single-line, so there a newline is escaped too; output for packages without control characters is byte-identical to before (the existing `bun-info.test.ts` snapshots still pass).
- `bun pm view <pkg> <field>` on a string field uses the multi-line variant: `\t`, `\n` and `\r\n` pass through, since fields like `readme` are legitimately multi-line and the value is the whole output; a `\r` not followed by `\n` and every other control is still escaped.
- Verified:
  - `test/cli/install/bun-info.test.ts` ("bun info with control characters in the packument"): a local `Bun.serve` registry puts ESC, BEL, bare CR, CRLF, tab, DEL, U+0085 and U+009B in every field; one test snapshots the whole summary view with each field escaped and asserts no control byte remains in stdout, the other checks the field view keeps CRLF and tab and escapes the rest. Both fail on the released binary (raw bytes in stdout) and pass with this change.
  - Whole `bun-info.test.ts` file passes with the debug build; `cargo fmt`, `cargo clippy -p bun_core`, `test/internal/source-lints` clean.
- Not changed here: `--json` and non-string fields (`bun pm view <pkg> versions`) are printed by `js_printer::print_json`, which spells control characters as JavaScript `\x1B` escapes and so produces invalid JSON. That is #4823 and is fixed by the open #38150, which I confirmed also fixes `bun pm view --json` output. `bun audit` prints advisory titles and URLs the same raw way and can adopt the helper separately.

### Background
- A packument is the registry's JSON document for a package (`GET <registry>/<name>`): top-level `description`, `dist-tags`, `maintainers`, `time`, plus one manifest per version. Its free-text fields are whatever the publisher put in `package.json`, so for `bun info <name>` they are attacker-controlled for any package name the user is persuaded to look up.
- C0 controls are bytes 0x00..0x1F (ESC, BEL, CR, LF, ...), DEL is 0x7F, and C1 controls are U+0080..U+009F, which terminals treat as one-byte forms of common ESC sequences (U+009B is CSI, the same as `ESC [`). In UTF-8 output they are two-byte sequences, which is why the adapter works on decoded chars rather than bytes; non-ASCII text such as `»` or a non-English description is not a control and is left alone.
- `prettyln!` only interprets `<b>`/`<r>` markup in the compile-time template; arguments are ordinary `Display` values, so wrapping each argument is sufficient and the adapter is a `core::fmt::Write` shim placed between the argument's `Display` and the real `Formatter`.
