### PR TITLE
bundler: report the CSS modules composes property conflict as a warning

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1958,6 +1958,9 @@ impl Log {
         notes: Box<[Data]>,
         args: fmt::Arguments<'_>,
     ) {
+        if !Kind::Warn.should_print(self.level) {
+            return;
+        }
         let text = alloc_print(args);
         self.add_formatted_msg(Kind::Warn, source, r, text, notes, true, false)
     }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1511,53 +1511,41 @@ mod __css_validation {
                     .original_name
                     .slice();
 
-                let _ = self.log.add_msg(bun_ast::Msg {
-                    kind: bun_ast::Kind::Err,
-                    data: bun_ast::range_data(
-                        Some(&col_ref!(self.all_sources)[source_index as usize]),
-                        range,
+                let notes: Box<[bun_ast::Data]> = Box::new([
+                    bun_ast::range_data(
+                        Some(&col_ref!(self.all_sources)[entry.value_ptr.source_index as usize]),
+                        entry.value_ptr.range,
                         bun_ast::alloc_print(format_args!(
-                            "The value of {} in the class {} is undefined.",
-                            bstr::BStr::new(property_name),
-                            bstr::BStr::new(local_original_name),
+                            "The first definition of {} is in this style rule:",
+                            bstr::BStr::new(property_name)
                         )),
-                    )
-                    .clone_line_text(self.log.clone_line_text),
-                    notes: Box::<[bun_ast::Data]>::from(
-                        &[
-                            bun_ast::range_data(
-                                Some(
-                                    &col_ref!(self.all_sources)
-                                        [entry.value_ptr.source_index as usize],
-                                ),
-                                entry.value_ptr.range,
-                                bun_ast::alloc_print(format_args!(
-                                    "The first definition of {} is in this style rule:",
-                                    bstr::BStr::new(property_name)
-                                )),
-                            ),
-                            bun_ast::Data {
-                                text: {
-                                    use std::io::Write;
-                                    let mut v = Vec::new();
-                                    let _ = write!(
-                                        &mut v,
-                                        "The specification of \"composes\" does not define an order when class declarations from separate files are composed together. \
-                                         The value of the {} property for {} may change unpredictably as the code is edited. \
-                                         Make sure that all definitions of {} for {} are in a single file.",
-                                        bun_core::fmt::quote(property_name),
-                                        bun_core::fmt::quote(local_original_name),
-                                        bun_core::fmt::quote(property_name),
-                                        bun_core::fmt::quote(local_original_name),
-                                    );
-                                    std::borrow::Cow::Owned(v)
-                                },
-                                ..Default::default()
-                            },
-                        ][..],
                     ),
-                    ..Default::default()
-                });
+                    bun_ast::Data {
+                        text: bun_ast::alloc_print(format_args!(
+                            "The specification of \"composes\" does not define an order when class declarations from separate files are composed together. \
+                             The value of the {} property for {} may change unpredictably as the code is edited. \
+                             Make sure that all definitions of {} for {} are in a single file.",
+                            bun_core::fmt::quote(property_name),
+                            bun_core::fmt::quote(local_original_name),
+                            bun_core::fmt::quote(property_name),
+                            bun_core::fmt::quote(local_original_name),
+                        )),
+                        ..Default::default()
+                    },
+                ]);
+
+                // A warning, like esbuild: the build still succeeds, this only flags
+                // behavior the CSS modules spec leaves undefined.
+                self.log.add_range_warning_fmt_with_notes(
+                    Some(&col_ref!(self.all_sources)[source_index as usize]),
+                    range,
+                    notes,
+                    format_args!(
+                        "The value of {} in the class {} is undefined.",
+                        bstr::BStr::new(property_name),
+                        bstr::BStr::new(local_original_name),
+                    ),
+                );
                 // Don't warn more than once
                 entry.value_ptr.source_index = Index::INVALID.get();
             }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1534,8 +1534,6 @@ mod __css_validation {
                     },
                 ]);
 
-                // A warning, like esbuild: the build still succeeds, this only flags
-                // behavior the CSS modules spec leaves undefined.
                 self.log.add_range_warning_fmt_with_notes(
                     Some(&col_ref!(self.all_sources)[source_index as usize]),
                     range,

--- a/test/bundler/esbuild/__snapshots__/css.test.ts.snap
+++ b/test/bundler/esbuild/__snapshots__/css.test.ts.snap
@@ -1434,28 +1434,3 @@ exports[`esbuild-bundler css/CSSAndJavaScriptCodeSplittingESBuildIssue1064: /d.c
 "@import "./shared.css";
 body { color: blue }"
 `;
-
-exports[`bundler css/ComposesWithSharedPropertiesError 1`] = `
-"// styles.module.css
-var styles_module_default = {
-  button: "otherButton_NlEjJA button_-MSaAA"
-};
-
-// entry.js
-console.log(styles_module_default);
-"
-`;
-
-exports[`bundler css/ComposesWithSharedPropertiesError 2`] = `
-"/* other.module.css */
-.otherButton_NlEjJA {
-  color: red;
-  font-size: 16px;
-}
-
-/* styles.module.css */
-.button_-MSaAA {
-  color: #00f;
-}
-"
-`;

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1,5 +1,5 @@
-import { describe } from "bun:test";
-import { join } from "node:path";
+import { describe, expect } from "bun:test";
+import { basename, join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -668,32 +668,83 @@ describe("bundler", () => {
     });
   }
 
-  itBundled("css/ComposesWithSharedPropertiesError", {
-    files: {
-      "/entry.js": `
+  // Composing classes from separate files that set the same property is
+  // undefined behavior per the CSS modules spec. The build still succeeds, so
+  // the diagnostic is a warning (as in esbuild), not an error.
+  const composesWithSharedPropertiesFiles = {
+    "/entry.js": `
       import styles from "./styles.module.css"
       console.log(styles)
     `,
-      "/styles.module.css": `
+    "/styles.module.css": `
       .button {
         color: blue;
         composes: otherButton from "./other.module.css";
       }
     `,
-      "/other.module.css": `
+    "/other.module.css": `
       .otherButton {
         color: red;
         font-size: 16px;
       }
     `,
-    },
+  };
+
+  itBundled("css/ComposesWithSharedPropertiesWarning", {
+    files: composesWithSharedPropertiesFiles,
     entryPoints: ["/entry.js"],
     outdir: "/out",
-    bundleWarnings: true,
+    bundleWarnings: {
+      "/styles.module.css": ["The value of color in the class button is undefined."],
+    },
     onAfterBundle(api) {
-      // Check that the output files were generated correctly
-      api.expectFile("/out/entry.js").toMatchSnapshot();
-      api.expectFile("/out/entry.css").toMatchSnapshot();
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          button: "otherButton_NlEjJA button_-MSaAA"
+        };
+
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* other.module.css */
+        .otherButton_NlEjJA {
+          color: red;
+          font-size: 16px;
+        }
+
+        /* styles.module.css */
+        .button_-MSaAA {
+          color: #00f;
+        }
+        "
+      `);
+    },
+  });
+
+  itBundled("css/ComposesWithSharedPropertiesWarningAPI", {
+    files: composesWithSharedPropertiesFiles,
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    backend: "api",
+    onAfterApiBundle(build) {
+      expect(build.success).toBe(true);
+      expect(
+        build.logs.map(log => ({
+          level: log.level,
+          message: log.message,
+          file: basename(log.position!.file),
+        })),
+      ).toEqual([
+        {
+          level: "warn",
+          message: "The value of color in the class button is undefined.",
+          file: "styles.module.css",
+        },
+      ]);
+      expect(build.outputs.map(output => basename(output.path)).sort()).toEqual(["entry.css", "entry.js"]);
     },
   });
 

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { basename, join } from "node:path";
 import { itBundled } from "../expectBundled";
 
@@ -746,6 +747,34 @@ describe("bundler", () => {
       ]);
       expect(build.outputs.map(output => basename(output.path)).sort()).toEqual(["entry.css", "entry.js"]);
     },
+  });
+
+  // Bun.build() returns every message the bundler recorded, so a bunfig
+  // logLevel that hides warnings has to keep this one out of the log like any
+  // other warning. Spawned because bunfig.toml is read at process startup.
+  test.concurrent.each([
+    ['logLevel = "warn"', [["warn", "The value of color in the class button is undefined."]]],
+    ['logLevel = "error"', []],
+  ])("css/ComposesWithSharedPropertiesWarning honors bunfig %s", async (bunfig, expectedLogs) => {
+    using dir = tempDir("composes-loglevel", {
+      ...composesWithSharedPropertiesFiles,
+      "bunfig.toml": bunfig,
+      "build.js": `
+        const result = await Bun.build({ entrypoints: ["./entry.js"], throw: false });
+        console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => [log.level, log.message]) }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ success: true, logs: expectedLogs });
+    expect(exitCode).toBe(0);
   });
 
   itBundled("css/ComposesSameFile", {


### PR DESCRIPTION
### Problem
- A CSS module class that `composes:` a class from another file, where both set the same property, makes `bun build` print `error: The value of color in the class button is undefined.` and then exit 0 with all outputs written.
- `Bun.build()` on the same input resolves with `success: true` and `logs: [{ level: "error", ... }]`, so an error-level log shows up on a successful build.
- Cause: `add_property_or_warn` in `src/bundler/linker_context/scanImportsAndExports.rs` builds the `Msg` by hand with `kind: Kind::Err` and pushes it with `Log::add_msg`. `add_msg` only appends to `msgs`; it does not bump `Log.errors`, and the linker decides pass/fail from that counter (`LinkerContext.rs`, `if self.log().has_errors()` right after `scan_imports_and_exports`). So the message was displayed as an error but never counted as one.
- Present since the check was added (the original implementation had the same `kind = .err` + `addMsg`); reproduces on 1.4.0 and main.

### Fix
- Emit the message with `Log::add_range_warning_fmt_with_notes`, which sets `Kind::Warn` and bumps `Log.warnings`. The message text, its location, and both notes are unchanged.
- A warning is the right level: the CSS modules spec leaves the composed value undefined rather than making the input invalid, and the build already succeeds in this case. It is also what esbuild does for the same input (`[WARNING] The value of "color" in the "button" class is undefined [undefined-composes-from]`, exit 0), while esbuild errors for the neighboring `composes` check (`The name "x" never appears in ...`), which bun also reports with `add_error_fmt` and which still fails the build. Making this one an error that fails the build instead would break builds that work today for something the spec only calls undefined.
- Counting it as a warning also makes the log's counters agree with its contents, which is how every other raw `Msg` push in the bundler behaves (`bundle_v2.rs`, `ParseTask.rs` bump `errors`/`warnings` next to `add_msg`).
- `src/ast/lib.rs`: `add_range_warning_fmt_with_notes` now starts with the same `Kind::Warn.should_print(self.level)` check as every other `add_*warning*` helper. It was the only one without it, so the composes warning would otherwise have been the one bundler warning still present in `Bun.build().logs` under a bunfig `logLevel = "error"` (the CLI was unaffected either way because `Log::print` filters at print time). Its only other caller, the duplicate-dependency warning in `install/lockfile/Package.rs`, is printed through `Log::print`, so nothing changes for it.
- Verified with `test/bundler/esbuild/css.test.ts`:
  - `css/ComposesWithSharedPropertiesWarning` runs the CLI and asserts the `warn:` line for `styles.module.css` plus the unchanged output files (previously `bundleWarnings: true`, which asserted nothing about the message; its two external snapshots are now inline).
  - `css/ComposesWithSharedPropertiesWarningAPI` runs `Bun.build` in-process and asserts `success === true`, exactly one log with `level: "warn"` pointing at `styles.module.css`, and both outputs.
  - `css/ComposesWithSharedPropertiesWarning honors bunfig logLevel` spawns `bun` in a directory with a `bunfig.toml` and checks `Bun.build().logs`: the warning is present with `logLevel = "warn"` and absent with `logLevel = "error"`.
  - All four fail on the current release build (`USE_SYSTEM_BUN=1`: no `warn:` line, and `level` is `"error"` in every `logs` assertion) and pass with `bun bd test`.
  - Also passing with the debug build: `test/bundler/css/css-modules.test.ts`, `test/cli/run/log-test.test.ts` (bunfig `logLevel`), and the duplicate-dependency tests in `test/regression/issue/07740.test.ts` and `test/cli/install/bun-workspaces.test.ts`.

### Background
- `bun_ast::Log` keeps a `msgs` list and separate `errors` / `warnings` counters. The `add_*error*` / `add_*warning*` helpers bump the matching counter and push the message; the low-level `add_msg` only pushes. The bundler and `Bun.build` decide whether a build failed from `Log.errors`, while printing (`Log::print`) and `Bun.build`'s `logs` array read `msgs`, which is how a message's displayed level and the build outcome can disagree.
- `Log.level` is the configured log level (bunfig `logLevel`, default `warn`). `Log::print` skips messages below it, and the warning helpers skip recording them in the first place; `Bun.build().logs` is built from `msgs` without a level check, so for the JS API the helper-side check is the only filter.
- `composes` is the CSS modules mechanism for a class to inherit another class's declarations, optionally from another file (`composes: other from "./other.module.css"`). When both classes declare the same property across files, the spec does not define which declaration wins, so bundlers flag it; the check itself lives in `validate_composes_from_properties` and is unchanged here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/css.test.ts
bun test v1.4.0 (ac3e1e273)

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [535.89ms]
(pass) bundler > css/CSSEntryPointEmpty [126.63ms]
(pass) bundler > css/CSSNesting [106.27ms]
(pass) bundler > css/CSSAtImportMissing [92.42ms]
(pass) bundler > css/CSSAtImportSimple [92.33ms]
(pass) bundler > css/CSSAtImportDiamond [94.96ms]
(pass) bundler > css/CSSAtImportCycle [89.70ms]
(pass) bundler > css/CSSUrlImport [89.06ms]
(pass) bundler > css/ImportCSSFromJSComposes [125.03ms]
(pass) bundler > css/ImportCSSFromJSComposesFromMissingImport [274.83ms]
(pass) bundler > css/ImportCSSFromJSComposesFromNotCSS [83.62ms]
(pass) bundler > css/ImportCSSFromJSComposesCircular [134.77ms]
(pass) bundler > css/ImportCSSFromJSComposesFromCircular [102.21ms]
(pass) bundler > css/ImportCSSFromJSComposesIDSelector [95.22ms]
(pass) bundler > css/ImportCSSFromJSComposesElementSelector [101.20ms]
(pass) bundler > css/ImportCSSFromJSComposesCompoundSelector [100.66ms]
(pass) bundler > css/ImportCSSFromJSComp
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [18.12ms]
(pass) bundler > css/CSSEntryPointEmpty [6.77ms]
(pass) bundler > css/CSSNesting [6.09ms]
(pass) bundler > css/CSSAtImportMissing [3.00ms]
(pass) bundler > css/CSSAtImportSimple [8.56ms]
(pass) bundler > css/CSSAtImportDiamond [13.34ms]
(pass) bundler > css/CSSAtImportCycle [6.54ms]
(pass) bundler > css/CSSUrlImport [7.77ms]
(pass) bundler > css/ImportCSSFromJSComposes [8.27ms]
(pass) bundler > css/ImportCSSFromJSComposesFromMissingImport [13.36ms]
(pass) bundler > css/ImportCSSFromJSComposesFromNotCSS [2.93ms]
(pass) bundler > css/ImportCSSFromJSComposesCircular [11.59ms]
(pass) bundler > css/ImportCSSFromJSComposesFromCircular [9.96ms]
(pass) bundler > css/ImportCSSFromJSComposesIDSelector [6.68ms]
(pass) bundler > css/ImportCSSFromJSComposesElementSelector [3.62ms]
(pass) bundler > css/ImportCSSFromJSComposesCompoundSelector [6.65ms]
(pass) bundler > css/ImportCSSFromJSComposesComplexSelector [3.52ms]
(pass) bundler > css/ImportCSSFromJSComposesPseudoClass [5.13ms]
(pass) bundler > css/ImportCSSFromJSComposesAttributeSelector [3.43ms]
(pass) bundle
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/css.test.ts
bun test v1.4.0 (ac3e1e273)

test/bundler/esbuild/css.test.ts:
(pass) bundler > css/CSSEntryPoint [856.04ms]
(pass) bundler > css/CSSEntryPointEmpty [187.74ms]
(pass) bundler > css/CSSNesting [138.40ms]
(pass) bundler > css/CSSAtImportMissing [139.67ms]
(pass) bundler > css/CSSAtImportSimple [248.46ms]
(pass) bundler > css/CSSAtImportDiamond [157.19ms]
(pass) bundler > css/CSSAtImportCycle [142.73ms]
(pass) bundler > css/CSSUrlImport [143.44ms]
(pass) bundler > css/ImportCSSFromJSComposes [206.46ms]
(pass) bundler > css/ImportCSSFromJSComposesFromMissingImport [445.20ms]
(pass) bundler > css/ImportCSSFromJSComposesFromNotCSS [141.93ms]
(pass) bundler > css/ImportCSSFromJSComposesCircular [156.38ms]
(pass) bundler > css/ImportCSSFromJSComposesFromCircular [172.54ms]
(pass) bundler > css/ImportCSSFromJSComposesIDSelector [162.45ms]
(pass) bundler > css/ImportCSSFromJSComposesElementSelector [156.80ms]
(pass) bundler > css/ImportCSSFromJSComposesCompoundSelector [159.76ms]
(pass) bundler > css/ImportCSSFro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 737ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/133] gen ErrorCode+*.h
[2/133] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/133] gen cpp.rs (cppbind)
[4/133] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[5/133] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/lib.rs                                     |   3 +
 .../linker_context/scanImportsAndExports.rs        |  74 ++++++---------
 .../bundler/esbuild/__snapshots__/css.test.ts.snap |  25 -----
 test/bundler/esbuild/css.test.ts                   | 104 ++++++++++++++++++---
 4 files changed, 125 insertions(+), 81 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/ast/lib.rs                                           6      1      0
src/bundler/linker_context/scanImportsAndExports.rs      4      3      0
test/bundler/esbuild/__snapshots__/css.test.ts.snap      1      1      0
test/bundler/esbuild/css.test.ts                         3      4      0
```

</details>

**root cause** · written by the author bot

The CSS modules composes shared-property diagnostic in the linker was pushed as a hand-built message with an error kind, so a build that succeeded still reported an error-level log even though the condition is undefined behavior rather than invalid input and esbuild treats it as a warning. The fix emits it through the log's range warning helper with notes, preserving the message, location, and notes while counting it as a warning, and gives that helper the same log level guard as the other warning helpers. Tests now assert the warning level in CLI output and Bun.build logs and check that th…

<!-- robobun:evidence:end -->