### PR TITLE
css modules: drop a rejected composes instead of failing the file at print time

### DIFF
--- a/src/css/css_modules.rs
+++ b/src/css/css_modules.rs
@@ -171,31 +171,6 @@ impl<'a> CssModule<'a> {
         Some(the_hash)
     }
 
-    pub(crate) fn handle_composes(
-        &mut self,
-        _dest: &mut css::Printer,
-        selectors: &css::selector::parser::SelectorList,
-        _composes: &css::css_properties::css_modules::Composes,
-        _source_index: u32,
-    ) -> css::Maybe<(), css::PrinterErrorKind> {
-        // let bump = dest.arena;
-        for sel in selectors.v.slice() {
-            if sel.len() == 1
-                && matches!(
-                    sel.components[0],
-                    css::selector::parser::Component::Class(_)
-                )
-            {
-                continue;
-            }
-
-            // The composes property can only be used within a simple class selector.
-            return Err(css::PrinterErrorKind::invalid_composes_selector);
-        }
-
-        Ok(())
-    }
-
     pub(crate) fn add_dashed(&mut self, bump: &'a Bump, local: &'a [u8], source_index: u32) {
         use bun_collections::array_hash_map::MapEntry;
         if let MapEntry::Vacant(v) =

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3134,6 +3134,20 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Marks a record returned by `add_import_record` as unused because the
+    /// declaration that added it is being discarded after it was parsed. The
+    /// bundler neither resolves nor bundles unused records.
+    pub(crate) fn mark_import_record_unused(&mut self, import_record_idx: u32) {
+        let ptr = self
+            .import_records
+            .expect("add_import_record only hands out indices when import records are tracked");
+        // SAFETY: see `Parser.import_records` field doc.
+        let import_records = unsafe { &mut *ptr.as_ptr() };
+        import_records[import_record_idx as usize]
+            .flags
+            .insert(bun_ast::ImportRecordFlags::IS_UNUSED);
+    }
+
     #[inline]
     pub(crate) fn arena(&self) -> &Bump {
         self.input.tokenizer.arena

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3134,8 +3134,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// For a record whose declaration is dropped after parsing; the bundler
-    /// neither resolves nor bundles unused records.
     pub(crate) fn mark_import_record_unused(&mut self, import_record_idx: u32) {
         let ptr = self
             .import_records

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3134,9 +3134,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Marks a record returned by `add_import_record` as unused because the
-    /// declaration that added it is being discarded after it was parsed. The
-    /// bundler neither resolves nor bundles unused records.
+    /// For a record whose declaration is dropped after parsing; the bundler
+    /// neither resolves nor bundles unused records.
     pub(crate) fn mark_import_record_unused(&mut self, import_record_idx: u32) {
         let ptr = self
             .import_records

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -311,10 +311,8 @@ pub(crate) fn parse_declaration<'bump>(
     )
 }
 
-// Composes handling dispatches through the `ComposesCtx` trait (defined in
-// `css_parser.rs`); `NoComposesCtx` returns `DisallowEntirely` for the
-// declaration blocks that are not style rules (@keyframes, @page, ...), where
-// `composes` has no meaning.
+// `NoComposesCtx` (declaration blocks that are not style rules, e.g. @page)
+// reports `DisallowEntirely`.
 pub(crate) fn parse_declaration_impl<'bump, C>(
     name: &[u8],
     input: &mut css::Parser,
@@ -349,9 +347,8 @@ where
 
     if input.flags.css_modules() {
         if let css::Property::Composes(composes) = &mut property {
-            // A rejected `composes` is warned about and dropped, as in esbuild, so
-            // the only ones left in the AST are the accepted ones in style rules,
-            // which the printer omits (see `StyleRule::to_css_base`).
+            // Rejected declarations are dropped, as in esbuild; `StyleRule::to_css_base`
+            // relies on only accepted ones surviving.
             match composes_ctx.composes_state() {
                 css::ComposesState::Allow(_) => {
                     composes_ctx.record_composes(composes);

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -311,8 +311,6 @@ pub(crate) fn parse_declaration<'bump>(
     )
 }
 
-// `NoComposesCtx` (declaration blocks that are not style rules, e.g. @page)
-// reports `DisallowEntirely`.
 pub(crate) fn parse_declaration_impl<'bump, C>(
     name: &[u8],
     input: &mut css::Parser,
@@ -347,8 +345,7 @@ where
 
     if input.flags.css_modules() {
         if let css::Property::Composes(composes) = &mut property {
-            // Rejected declarations are dropped, as in esbuild; `StyleRule::to_css_base`
-            // relies on only accepted ones surviving.
+            // `StyleRule::to_css_base` relies on rejected declarations being dropped here.
             match composes_ctx.composes_state() {
                 css::ComposesState::Allow(_) => {
                     composes_ctx.record_composes(composes);

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -311,10 +311,10 @@ pub(crate) fn parse_declaration<'bump>(
     )
 }
 
-// Composes handling dispatches through the `ComposesCtx`
-// trait (defined in `css_parser.rs`); `NoComposesCtx` returns
-// `DisallowEntirely` so the no-tracking fast-path collapses into the match's
-// no-op arm.
+// Composes handling dispatches through the `ComposesCtx` trait (defined in
+// `css_parser.rs`); `NoComposesCtx` returns `DisallowEntirely` for the
+// declaration blocks that are not style rules (@keyframes, @page, ...), where
+// `composes` has no meaning.
 pub(crate) fn parse_declaration_impl<'bump, C>(
     name: &[u8],
     input: &mut css::Parser,
@@ -350,12 +350,20 @@ where
     if input.flags.css_modules() {
         if let css::Property::Composes(composes) = &mut property {
             // A rejected `composes` is warned about and dropped, as in esbuild, so
-            // a style rule only ever holds accepted ones, which the printer omits
-            // (see `StyleRule::to_css_base`).
+            // the only ones left in the AST are the accepted ones in style rules,
+            // which the printer omits (see `StyleRule::to_css_base`).
             match composes_ctx.composes_state() {
-                css::ComposesState::DisallowEntirely => {}
                 css::ComposesState::Allow(_) => {
                     composes_ctx.record_composes(composes);
+                }
+                css::ComposesState::DisallowEntirely => {
+                    options.warn_fmt(
+                        format_args!("\"composes\" is not valid here"),
+                        source_location.line,
+                        source_location.column,
+                    );
+                    composes.discard(input);
+                    return Ok(());
                 }
                 css::ComposesState::DisallowNested(info) => {
                     options.warn_fmt(

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -349,6 +349,9 @@ where
 
     if input.flags.css_modules() {
         if let css::Property::Composes(composes) = &mut property {
+            // A rejected `composes` is warned about and dropped, as in esbuild, so
+            // a style rule only ever holds accepted ones, which the printer omits
+            // (see `StyleRule::to_css_base`).
             match composes_ctx.composes_state() {
                 css::ComposesState::DisallowEntirely => {}
                 css::ComposesState::Allow(_) => {
@@ -360,6 +363,8 @@ where
                         info.line,
                         info.column,
                     );
+                    composes.discard(input);
+                    return Ok(());
                 }
                 css::ComposesState::DisallowNotSingleClass(info) => {
                     options.warn_fmt_with_notes(
@@ -373,6 +378,8 @@ where
                             location: Some(info.to_logger_location(options.filename)),
                         }]),
                     );
+                    composes.discard(input);
+                    return Ok(());
                 }
             }
         }

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -211,10 +211,6 @@ pub enum PrinterErrorKind {
     },
     /// A [std::fmt::Error](std::fmt::Error) was encountered in the underlying destination.
     fmt_error,
-    /// The CSS modules `composes` property cannot be used within nested rules.
-    invalid_composes_nesting,
-    /// The CSS modules `composes` property cannot be used with a simple class selector.
-    invalid_composes_selector,
     /// The CSS modules pattern must end with `[local]` for use in CSS grid.
     invalid_css_modules_pattern_in_grid,
     /// Substituting parent selectors for `&` while compiling CSS nesting for
@@ -237,12 +233,6 @@ impl fmt::Display for PrinterErrorKind {
                 bs(*url)
             ),
             Self::fmt_error => f.write_str("Formatting error occurred"),
-            Self::invalid_composes_nesting => {
-                f.write_str("The 'composes' property cannot be used within nested rules")
-            }
-            Self::invalid_composes_selector => {
-                f.write_str("The 'composes' property can only be used with a simple class selector")
-            }
             Self::invalid_css_modules_pattern_in_grid => {
                 f.write_str("CSS modules pattern must end with '[local]' when used in CSS grid")
             }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -222,11 +222,6 @@ impl<'a> Printer<'a> {
         b"unknown.css"
     }
 
-    /// Returns whether the indent level is greater than one.
-    pub(crate) fn is_nested(&self) -> bool {
-        self.indent_amt > 2
-    }
-
     /// Add an error related to std lib fmt errors
     pub(crate) fn add_fmt_error(&mut self) -> PrintErr {
         self.error_kind = Some(css::PrinterError {

--- a/src/css/properties/css_modules.rs
+++ b/src/css/properties/css_modules.rs
@@ -5,8 +5,6 @@ use crate::printer::Printer;
 
 use crate::css_values::ident::{CustomIdent, CustomIdentList};
 
-use crate::dependencies::Location;
-
 use bun_alloc::Arena; // bumpalo::Bump re-export (CSS is an AST/arena crate)
 use bun_wyhash::Wyhash;
 
@@ -18,13 +16,11 @@ pub struct Composes {
     pub from: Option<Specifier>,
     /// The source location of the `composes` property.
     pub loc: bun_ast::Loc,
-    pub(crate) cssparser_loc: Location,
 }
 
 impl Composes {
     pub fn parse(input: &mut Parser) -> css::Result<Composes> {
         let loc = input.position();
-        let loc2 = input.current_source_location();
         let mut names = CustomIdentList::default();
         while let Ok(name) = input.try_parse(Self::parse_one_ident) {
             names.append(name);
@@ -49,8 +45,16 @@ impl Composes {
             loc: bun_ast::Loc {
                 start: i32::try_from(loc).expect("int cast"),
             },
-            cssparser_loc: Location::from_source_location(loc2),
         })
+    }
+
+    /// Drops the declaration after it was parsed: releases the import record a
+    /// `from "<file>"` specifier added, so the bundler does not pull that file in
+    /// on behalf of a declaration that has no effect.
+    pub(crate) fn discard(&self, input: &mut Parser) {
+        if let Some(Specifier::ImportRecordIndex(import_record_idx)) = self.from {
+            input.mark_import_record_unused(import_record_idx);
+        }
     }
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
@@ -89,7 +93,6 @@ impl Composes {
             names,
             from: self.from.as_ref().map(|f| f.deep_clone(bump)),
             loc: self.loc,
-            cssparser_loc: self.cssparser_loc,
         }
     }
 
@@ -107,7 +110,7 @@ impl Composes {
             (Some(a), Some(b)) if Specifier::eql(*a, *b) => {}
             _ => return false,
         }
-        lhs.loc == rhs.loc && lhs.cssparser_loc == rhs.cssparser_loc
+        lhs.loc == rhs.loc
     }
 }
 

--- a/src/css/properties/css_modules.rs
+++ b/src/css/properties/css_modules.rs
@@ -48,9 +48,8 @@ impl Composes {
         })
     }
 
-    /// Drops the declaration after it was parsed: releases the import record a
-    /// `from "<file>"` specifier added, so the bundler does not pull that file in
-    /// on behalf of a declaration that has no effect.
+    /// Releases the import record of a `from "<file>"` specifier when the parser
+    /// drops the declaration.
     pub(crate) fn discard(&self, input: &mut Parser) {
         if let Some(Specifier::ImportRecordIndex(import_record_idx)) = self.from {
             input.mark_import_record_unused(import_record_idx);

--- a/src/css/properties/css_modules.rs
+++ b/src/css/properties/css_modules.rs
@@ -48,8 +48,7 @@ impl Composes {
         })
     }
 
-    /// Releases the import record of a `from "<file>"` specifier when the parser
-    /// drops the declaration.
+    /// For a declaration the parser drops: releases the `from "<file>"` import record.
     pub(crate) fn discard(&self, input: &mut Parser) {
         if let Some(Specifier::ImportRecordIndex(import_record_idx)) = self.from {
             input.mark_import_record_unused(import_record_idx);

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -158,7 +158,6 @@ impl<R> StyleRule<R> {
     }
 
     fn to_css_base(&self, dest: &mut Printer, is_final_prefix_pass: bool) -> Result<(), PrintErr> {
-        use css::error::PrinterErrorKind;
         use css::properties::Property;
 
         // If supported, or there are no targets, preserve nesting. Otherwise, write nested rules after parent.
@@ -198,40 +197,13 @@ impl<R> StyleRule<R> {
             ];
             for (decls, important) in decls_groups {
                 for decl in decls {
-                    // The CSS modules `composes` property is handled specially, and omitted during printing.
-                    // We need to add the classes it references to the list for the selectors in this rule.
-                    if let Property::Composes(composes) = decl {
-                        if dest.is_nested() && dest.css_module.is_some() {
-                            return dest.new_error(
-                                PrinterErrorKind::invalid_composes_nesting,
-                                Some(composes.cssparser_loc),
-                            );
-                        }
-
-                        if dest.css_module.is_some() {
-                            // `handle_composes` needs `&mut dest` while the
-                            // module also lives in `dest.css_module`. Move the
-                            // module out for the duration of the call, then put
-                            // it back before any `dest.new_error` early return.
-                            let mut cm = dest.css_module.take();
-                            let err = if let Some(css_module) = &mut cm {
-                                css_module
-                                    .handle_composes(
-                                        dest,
-                                        &self.selectors,
-                                        composes,
-                                        self.loc.source_index,
-                                    )
-                                    .err()
-                            } else {
-                                None
-                            };
-                            dest.css_module = cm;
-                            if let Some(error_kind) = err {
-                                return dest.new_error(error_kind, Some(composes.cssparser_loc));
-                            }
-                            continue;
-                        }
+                    // In CSS modules `composes` is validated and recorded by the
+                    // parser (`StyleSheet::composes`); the printer only omits it.
+                    // Unlike lightningcss, nothing is checked here: the bundler wraps
+                    // a file's rules in the conditions of the `@import` that pulled
+                    // it in, so nesting in the output says nothing about the source.
+                    if dest.css_module.is_some() && matches!(decl, Property::Composes(_)) {
+                        continue;
                     }
 
                     dest.newline()?;

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -197,11 +197,9 @@ impl<R> StyleRule<R> {
             ];
             for (decls, important) in decls_groups {
                 for decl in decls {
-                    // In CSS modules `composes` is validated and recorded by the
-                    // parser (`StyleSheet::composes`); the printer only omits it.
-                    // Unlike lightningcss, nothing is checked here: the bundler wraps
-                    // a file's rules in the conditions of the `@import` that pulled
-                    // it in, so nesting in the output says nothing about the source.
+                    // `composes` was validated and recorded by the parser (`StyleSheet::composes`).
+                    // Don't re-check nesting here like lightningcss: the bundler wraps imported
+                    // files in their `@import` conditions, so output nesting is meaningless.
                     if dest.css_module.is_some() && matches!(decl, Property::Composes(_)) {
                         continue;
                     }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -560,13 +560,16 @@ describe.concurrent("modules that fail to print", () => {
   });
 
   test("bun build fails instead of emitting a truncated stylesheet when CSS cannot be generated", async () => {
-    // `composes` on a non-simple selector makes the CSS printer fail; the
-    // whole stylesheet body used to be dropped while the build exited 0.
+    // The default browser target compiles nesting away by substituting the
+    // parent selector for each `&`; with two references per level the printer
+    // gives up once the expansion limit is hit. The whole stylesheet body used
+    // to be dropped while the build exited 0.
+    const depth = 20;
     using dir = tempDir("build-css-print-err", {
-      "styles.module.css": ".b { color: blue }\n.a .c { composes: b; color: red }\n",
+      "styles.css": "&:is(.a, &.b) {\n".repeat(depth) + "color: red;\n" + "}\n".repeat(depth),
     });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "styles.module.css"],
+      cmd: [bunExe(), "build", "styles.css"],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -574,7 +577,7 @@ describe.concurrent("modules that fail to print", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Failed to generate CSS for this file");
-    expect(stderr).toContain("styles.module.css");
+    expect(stderr).toContain("styles.css");
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,6 +1,3 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -215,215 +212,338 @@ describe("css", () => {
       expect(css).toContain(`.${betaOwn}`);
     },
   });
-});
 
-/**
- * Runs `bun build <entry> --outdir out` on the given files (plus an `entry.js`
- * that imports `styles.module.css` and logs its exports). On success, returns
- * the emitted stylesheet and, for a JS entry, the exports object it logs.
- */
-async function buildCssModule(files: Record<string, string>, entry = "entry.js") {
-  using dir = tempDir("css-module-composes", {
-    "entry.js": `import styles from "./styles.module.css";\nconsole.log(JSON.stringify(styles));`,
-    ...files,
-  });
-  const run = async (args: string[]) => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), ...args],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
-  };
+  // Whether a `composes` declaration counts is decided by the parser: it has to
+  // sit directly in a style rule whose selector is a single class. Accepted ones
+  // are recorded for the exports object and omitted from the stylesheet; the
+  // rest get a warning and are dropped, like esbuild does (they used to fail the
+  // whole build at print time). A dropped declaration leaves an empty rule
+  // behind, which the minifier removes, so rules holding nothing but a rejected
+  // `composes` must not appear in the output.
+  const notAllowedNested = '"composes" is not allowed inside nested selectors';
+  const notSingleClass = '"composes" only works inside single class selectors';
+  const notValidHere = '"composes" is not valid here';
+  const entry = /* js */ `
+    import styles from "./styles.module.css";
+    console.log(styles);
+  `;
 
-  const { stderr, exitCode } = await run(["build", entry, "--outdir", "out"]);
-  if (exitCode !== 0) return { stderr, exitCode, css: undefined, exports: undefined };
-  const css = await Bun.file(join(String(dir), "out", "entry.css")).text();
-  const exports = entry.endsWith(".js") ? JSON.parse((await run([join("out", "entry.js")])).stdout) : undefined;
-  return { stderr, exitCode, css, exports };
-}
-
-// The parser decides whether a `composes` declaration counts (it has to sit
-// directly in a style rule whose selector is a single class) and records the
-// accepted ones for the bundler; the printer omits the property from the
-// stylesheet. Rejected declarations are reported as warnings and dropped, like
-// esbuild does; they must not fail the build.
-describe.concurrent("css-module composes placement", () => {
-  test("inside a nested style rule it is rejected with a warning", async () => {
-    const { stderr, exitCode, exports, css } = await buildCssModule({
-      "styles.module.css": `
+  itBundled("css-module/ComposesInNestedRuleIsDropped", {
+    files: {
+      "/entry.js": entry,
+      "/styles.module.css": /* css */ `
         .c { color: red }
-        .a { .z { composes: c; color: blue } }
+        .a {
+          .z { composes: c; color: blue }
+          .y { composes: c }
+        }
       `,
-    });
-    expect({ exitCode, stderr }).toEqual({
-      exitCode: 0,
-      stderr: expect.stringContaining('"composes" is not allowed inside nested selectors'),
-    });
-    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA", z: "z_-MSaAA" });
-    expect(css).toMatchInlineSnapshot(`
-      "/* styles.module.css */
-      .c_-MSaAA {
-        color: red;
-      }
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    bundleWarnings: { "/styles.module.css": [notAllowedNested, notAllowedNested] },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          c: "c_-MSaAA",
+          a: "a_-MSaAA",
+          z: "z_-MSaAA",
+          y: "y_-MSaAA"
+        };
 
-      .a_-MSaAA .z_-MSaAA {
-        color: #00f;
-      }
-      "
-    `);
-  });
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .c_-MSaAA {
+          color: red;
+        }
 
-  test("on a selector that is not a single class it is rejected with a warning", async () => {
-    const { stderr, exitCode, exports, css } = await buildCssModule({
-      "styles.module.css": `
-        .c { color: red }
-        .a .b { composes: c; color: blue }
-      `,
-    });
-    expect({ exitCode, stderr }).toEqual({
-      exitCode: 0,
-      stderr: expect.stringContaining('"composes" only works inside single class selectors'),
-    });
-    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA", b: "b_-MSaAA" });
-    expect(css).toMatchInlineSnapshot(`
-      "/* styles.module.css */
-      .c_-MSaAA {
-        color: red;
-      }
-
-      .a_-MSaAA .b_-MSaAA {
-        color: #00f;
-      }
-      "
-    `);
-  });
-
-  test("directly inside an at-rule nested in a style rule it is rejected with a warning", async () => {
-    const { stderr, exitCode, exports, css } = await buildCssModule({
-      "styles.module.css": `
-        .c { color: red }
-        .a { @media (min-width: 1px) { composes: c; color: blue } }
-      `,
-    });
-    expect({ exitCode, stderr }).toEqual({
-      exitCode: 0,
-      stderr: expect.stringContaining('"composes" is not allowed inside nested selectors'),
-    });
-    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA" });
-    expect(css).toMatchInlineSnapshot(`
-      "/* styles.module.css */
-      .c_-MSaAA {
-        color: red;
-      }
-
-      @media (min-width: 1px) {
-        .a_-MSaAA {
+        .a_-MSaAA .z_-MSaAA {
           color: #00f;
         }
-      }
-      "
-    `);
+        "
+      `);
+    },
   });
 
-  test("in a style rule inside a top-level at-rule it is accepted", async () => {
-    const { stderr, exitCode, exports, css } = await buildCssModule({
-      "styles.module.css": `
+  itBundled("css-module/ComposesOnNonSingleClassSelectorIsDropped", {
+    files: {
+      "/entry.js": entry,
+      "/styles.module.css": /* css */ `
         .c { color: red }
-        @media (min-width: 1px) { .b { composes: c } }
-        @supports (display: grid) { @layer x { .d { composes: c; color: blue } } }
+        .a .b { composes: c; color: blue }
+        .d, .e { composes: c }
       `,
-    });
-    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
-    expect(exports).toEqual({ c: "c_-MSaAA", b: "c_-MSaAA b_-MSaAA", d: "c_-MSaAA d_-MSaAA" });
-    expect(css).toMatchInlineSnapshot(`
-      "/* styles.module.css */
-      .c_-MSaAA {
-        color: red;
-      }
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    bundleWarnings: { "/styles.module.css": [notSingleClass, notSingleClass] },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          c: "c_-MSaAA",
+          a: "a_-MSaAA",
+          b: "b_-MSaAA",
+          d: "d_-MSaAA",
+          e: "e_-MSaAA"
+        };
 
-      @media (min-width: 1px) {
-        .b_-MSaAA {
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .c_-MSaAA {
+          color: red;
         }
-      }
 
-      @supports (display: grid) {
-        @layer x {
-          .d_-MSaAA {
+        .a_-MSaAA .b_-MSaAA {
+          color: #00f;
+        }
+        "
+      `);
+    },
+  });
+
+  itBundled("css-module/ComposesInAtRuleNestedInRuleIsDropped", {
+    files: {
+      "/entry.js": entry,
+      "/styles.module.css": /* css */ `
+        .c { color: red }
+        .a {
+          @media (min-width: 1px) { composes: c }
+          @media (min-width: 2px) { composes: c; color: blue }
+        }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    bundleWarnings: { "/styles.module.css": [notAllowedNested, notAllowedNested] },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          c: "c_-MSaAA",
+          a: "a_-MSaAA"
+        };
+
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .c_-MSaAA {
+          color: red;
+        }
+
+        @media (min-width: 2px) {
+          .a_-MSaAA {
             color: #00f;
           }
         }
-      }
-      "
-    `);
+        "
+      `);
+    },
   });
 
-  test("a module pulled in by a conditional @import still prints", async () => {
-    const { stderr, exitCode, css } = await buildCssModule(
-      {
-        "entry.css": `@import "./styles.module.css" layer(base) supports(display: grid) (min-width: 1px);`,
-        "styles.module.css": `
-          .c { color: red }
-          .b { composes: c }
-        `,
-      },
-      "entry.css",
-    );
-    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
-    expect(css).toMatchInlineSnapshot(`
-      "/* styles.module.css */
-      @media (min-width: 1px) {
-        @supports (display: grid) {
-          @layer base {
-            .c_-MSaAA {
-              color: red;
-            }
+  itBundled("css-module/ComposesOutsideStyleRuleIsDropped", {
+    files: {
+      "/entry.js": entry,
+      "/styles.module.css": /* css */ `
+        .c { color: red }
+        @keyframes fade {
+          from { composes: x from "./other.module.css"; opacity: 0 }
+          to { opacity: 1 }
+        }
+        @page { composes: c; margin: 1cm }
+        .s { animation: fade 1s }
+      `,
+      "/other.module.css": /* css */ `.x { color: green }`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    // Only @page reports its declaration: @keyframes bodies are parsed with a
+    // fresh ParserOptions (rules/keyframes.rs), which has nowhere to log to.
+    // The keyframe's declaration is still dropped, as the stylesheet shows.
+    bundleWarnings: { "/styles.module.css": [notValidHere] },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          c: "c_-MSaAA",
+          s: "s_-MSaAA"
+        };
 
-            .b_-MSaAA {
-            }
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      // other.module.css is not part of the bundle.
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .c_-MSaAA {
+          color: red;
+        }
+
+        @keyframes fade_-MSaAA {
+          from {
+            opacity: 0;
+          }
+
+          to {
+            opacity: 1;
           }
         }
-      }
 
-      /* entry.css */
+        @page {
+          margin: 1cm;
+        }
 
-      "
-    `);
+        .s_-MSaAA {
+          animation: 1s fade_-MSaAA;
+        }
+        "
+      `);
+    },
   });
 
-  test("a rejected declaration does not pull in the file it composes from", async () => {
-    const { stderr, exitCode, exports, css } = await buildCssModule({
-      "styles.module.css": `
+  itBundled("css-module/RejectedComposesFromDoesNotImportTheFile", {
+    files: {
+      "/entry.js": entry,
+      "/styles.module.css": /* css */ `
         .c { color: red }
         .a .b { composes: x from "./other.module.css"; color: blue }
         .a .d { composes: y from "./missing.module.css" }
         .ok { composes: c }
       `,
-      "other.module.css": `.x { color: green }`,
-    });
-    expect({ exitCode, stderr }).toEqual({
-      exitCode: 0,
-      stderr: expect.stringContaining('"composes" only works inside single class selectors'),
-    });
-    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA", b: "b_-MSaAA", d: "d_-MSaAA", ok: "c_-MSaAA ok_-MSaAA" });
-    // Neither other.module.css nor the unresolvable missing.module.css is part
-    // of the bundle.
-    expect(css).toMatchInlineSnapshot(`
-      "/* styles.module.css */
-      .c_-MSaAA {
-        color: red;
-      }
+      "/other.module.css": /* css */ `.x { color: green }`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    bundleWarnings: { "/styles.module.css": [notSingleClass, notSingleClass] },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          c: "c_-MSaAA",
+          a: "a_-MSaAA",
+          b: "b_-MSaAA",
+          d: "d_-MSaAA",
+          ok: "c_-MSaAA ok_-MSaAA"
+        };
 
-      .a_-MSaAA .b_-MSaAA {
-        color: #00f;
-      }
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      // Neither other.module.css nor the unresolvable missing.module.css is
+      // part of the bundle.
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .c_-MSaAA {
+          color: red;
+        }
 
-      .ok_-MSaAA {
-      }
-      "
-    `);
+        .a_-MSaAA .b_-MSaAA {
+          color: #00f;
+        }
+
+        .ok_-MSaAA {
+        }
+        "
+      `);
+    },
+  });
+
+  // The printer used to reject any `composes` printed inside a block, which
+  // also covered rules the parser had accepted. The CLI backend makes any
+  // warning fail these two tests.
+  itBundled("css-module/ComposesInRuleInsideTopLevelAtRule", {
+    files: {
+      "/entry.js": entry,
+      "/styles.module.css": /* css */ `
+        .c { color: red }
+        @media (min-width: 1px) { .b { composes: c } }
+        @supports (display: grid) { @layer x { .d { composes: c; color: blue } } }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    backend: "cli",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          c: "c_-MSaAA",
+          b: "c_-MSaAA b_-MSaAA",
+          d: "c_-MSaAA d_-MSaAA"
+        };
+
+        // entry.js
+        console.log(styles_module_default);
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .c_-MSaAA {
+          color: red;
+        }
+
+        @media (min-width: 1px) {
+          .b_-MSaAA {
+          }
+        }
+
+        @supports (display: grid) {
+          @layer x {
+            .d_-MSaAA {
+              color: #00f;
+            }
+          }
+        }
+        "
+      `);
+    },
+  });
+
+  itBundled("css-module/ComposesInModuleImportedWithConditions", {
+    files: {
+      "/entry.css": /* css */ `@import "./styles.module.css" layer(base) supports(display: grid) (min-width: 1px);`,
+      "/styles.module.css": /* css */ `
+        .c { color: red }
+        .b { composes: c }
+      `,
+    },
+    entryPoints: ["/entry.css"],
+    outdir: "/out",
+    backend: "cli",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        @media (min-width: 1px) {
+          @supports (display: grid) {
+            @layer base {
+              .c_-MSaAA {
+                color: red;
+              }
+
+              .b_-MSaAA {
+              }
+            }
+          }
+        }
+
+        /* entry.css */
+
+        "
+      `);
+    },
   });
 });

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -211,5 +214,216 @@ describe("css", () => {
       const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;
       expect(css).toContain(`.${betaOwn}`);
     },
+  });
+});
+
+/**
+ * Runs `bun build <entry> --outdir out` on the given files (plus an `entry.js`
+ * that imports `styles.module.css` and logs its exports). On success, returns
+ * the emitted stylesheet and, for a JS entry, the exports object it logs.
+ */
+async function buildCssModule(files: Record<string, string>, entry = "entry.js") {
+  using dir = tempDir("css-module-composes", {
+    "entry.js": `import styles from "./styles.module.css";\nconsole.log(JSON.stringify(styles));`,
+    ...files,
+  });
+  const run = async (args: string[]) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  };
+
+  const { stderr, exitCode } = await run(["build", entry, "--outdir", "out"]);
+  if (exitCode !== 0) return { stderr, exitCode, css: undefined, exports: undefined };
+  const css = await Bun.file(join(String(dir), "out", "entry.css")).text();
+  const exports = entry.endsWith(".js") ? JSON.parse((await run([join("out", "entry.js")])).stdout) : undefined;
+  return { stderr, exitCode, css, exports };
+}
+
+// The parser decides whether a `composes` declaration counts (it has to sit
+// directly in a style rule whose selector is a single class) and records the
+// accepted ones for the bundler; the printer omits the property from the
+// stylesheet. Rejected declarations are reported as warnings and dropped, like
+// esbuild does; they must not fail the build.
+describe.concurrent("css-module composes placement", () => {
+  test("inside a nested style rule it is rejected with a warning", async () => {
+    const { stderr, exitCode, exports, css } = await buildCssModule({
+      "styles.module.css": `
+        .c { color: red }
+        .a { .z { composes: c; color: blue } }
+      `,
+    });
+    expect({ exitCode, stderr }).toEqual({
+      exitCode: 0,
+      stderr: expect.stringContaining('"composes" is not allowed inside nested selectors'),
+    });
+    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA", z: "z_-MSaAA" });
+    expect(css).toMatchInlineSnapshot(`
+      "/* styles.module.css */
+      .c_-MSaAA {
+        color: red;
+      }
+
+      .a_-MSaAA .z_-MSaAA {
+        color: #00f;
+      }
+      "
+    `);
+  });
+
+  test("on a selector that is not a single class it is rejected with a warning", async () => {
+    const { stderr, exitCode, exports, css } = await buildCssModule({
+      "styles.module.css": `
+        .c { color: red }
+        .a .b { composes: c; color: blue }
+      `,
+    });
+    expect({ exitCode, stderr }).toEqual({
+      exitCode: 0,
+      stderr: expect.stringContaining('"composes" only works inside single class selectors'),
+    });
+    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA", b: "b_-MSaAA" });
+    expect(css).toMatchInlineSnapshot(`
+      "/* styles.module.css */
+      .c_-MSaAA {
+        color: red;
+      }
+
+      .a_-MSaAA .b_-MSaAA {
+        color: #00f;
+      }
+      "
+    `);
+  });
+
+  test("directly inside an at-rule nested in a style rule it is rejected with a warning", async () => {
+    const { stderr, exitCode, exports, css } = await buildCssModule({
+      "styles.module.css": `
+        .c { color: red }
+        .a { @media (min-width: 1px) { composes: c; color: blue } }
+      `,
+    });
+    expect({ exitCode, stderr }).toEqual({
+      exitCode: 0,
+      stderr: expect.stringContaining('"composes" is not allowed inside nested selectors'),
+    });
+    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA" });
+    expect(css).toMatchInlineSnapshot(`
+      "/* styles.module.css */
+      .c_-MSaAA {
+        color: red;
+      }
+
+      @media (min-width: 1px) {
+        .a_-MSaAA {
+          color: #00f;
+        }
+      }
+      "
+    `);
+  });
+
+  test("in a style rule inside a top-level at-rule it is accepted", async () => {
+    const { stderr, exitCode, exports, css } = await buildCssModule({
+      "styles.module.css": `
+        .c { color: red }
+        @media (min-width: 1px) { .b { composes: c } }
+        @supports (display: grid) { @layer x { .d { composes: c; color: blue } } }
+      `,
+    });
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+    expect(exports).toEqual({ c: "c_-MSaAA", b: "c_-MSaAA b_-MSaAA", d: "c_-MSaAA d_-MSaAA" });
+    expect(css).toMatchInlineSnapshot(`
+      "/* styles.module.css */
+      .c_-MSaAA {
+        color: red;
+      }
+
+      @media (min-width: 1px) {
+        .b_-MSaAA {
+        }
+      }
+
+      @supports (display: grid) {
+        @layer x {
+          .d_-MSaAA {
+            color: #00f;
+          }
+        }
+      }
+      "
+    `);
+  });
+
+  test("a module pulled in by a conditional @import still prints", async () => {
+    const { stderr, exitCode, css } = await buildCssModule(
+      {
+        "entry.css": `@import "./styles.module.css" layer(base) supports(display: grid) (min-width: 1px);`,
+        "styles.module.css": `
+          .c { color: red }
+          .b { composes: c }
+        `,
+      },
+      "entry.css",
+    );
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+    expect(css).toMatchInlineSnapshot(`
+      "/* styles.module.css */
+      @media (min-width: 1px) {
+        @supports (display: grid) {
+          @layer base {
+            .c_-MSaAA {
+              color: red;
+            }
+
+            .b_-MSaAA {
+            }
+          }
+        }
+      }
+
+      /* entry.css */
+
+      "
+    `);
+  });
+
+  test("a rejected declaration does not pull in the file it composes from", async () => {
+    const { stderr, exitCode, exports, css } = await buildCssModule({
+      "styles.module.css": `
+        .c { color: red }
+        .a .b { composes: x from "./other.module.css"; color: blue }
+        .a .d { composes: y from "./missing.module.css" }
+        .ok { composes: c }
+      `,
+      "other.module.css": `.x { color: green }`,
+    });
+    expect({ exitCode, stderr }).toEqual({
+      exitCode: 0,
+      stderr: expect.stringContaining('"composes" only works inside single class selectors'),
+    });
+    expect(exports).toEqual({ c: "c_-MSaAA", a: "a_-MSaAA", b: "b_-MSaAA", d: "d_-MSaAA", ok: "c_-MSaAA ok_-MSaAA" });
+    // Neither other.module.css nor the unresolvable missing.module.css is part
+    // of the bundle.
+    expect(css).toMatchInlineSnapshot(`
+      "/* styles.module.css */
+      .c_-MSaAA {
+        color: red;
+      }
+
+      .a_-MSaAA .b_-MSaAA {
+        color: #00f;
+      }
+
+      .ok_-MSaAA {
+      }
+      "
+    `);
   });
 });

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -105,7 +105,7 @@ function errorOrWarnParser(isError = true) {
       let fileLine = "";
       if (fileLineI !== -1) {
         const fileLineEnd = text.indexOf("\n", fileLineI + 1);
-        fileLine = text.slice(fileLineI + "\n    at ".length, fileLineEnd);
+        fileLine = text.slice(fileLineI + " at ".length, fileLineEnd);
         i = fileLineEnd;
       }
       list.push([message, fileLine]);
@@ -1086,9 +1086,18 @@ function expectBundled(
         const allWarnings = warnParser(warningText)
           .map(([error, source]) => {
             if (!source) return;
-            const [_str2, fullFilename, line, col] = source.match(/bun-build-tests[\/\\](.*):(\d+):(\d+)/)!;
-            const file = fullFilename.slice(id.length + path.basename(tempDirectory).length + 1).replaceAll("\\", "/");
-            return { error, file, line, col };
+            const absolute = source.match(/bun-build-tests[\/\\](.*):(\d+):(\d+)/);
+            if (absolute) {
+              const [_str2, fullFilename, line, col] = absolute;
+              const file = fullFilename
+                .slice(id.length + path.basename(tempDirectory).length + 1)
+                .replaceAll("\\", "/");
+              return { error, file, line, col };
+            }
+            // CSS parser warnings only carry the file's basename, e.g.
+            // `at styles.module.css:1:6`; key them as if the file were at the root.
+            const bare = source.match(/^(.+):(\d+):(\d+)$/);
+            return bare ? { error, file: "/" + bare[1], line: bare[2], col: bare[3] } : { error, file: source };
           })
           .filter(Boolean);
         const expectedWarnings = bundleWarnings


### PR DESCRIPTION
### Problem
- A `composes` declaration the CSS modules parser rejects (inside a nested rule, inside an at-rule nested in a rule, or on a selector that is not a single class) gets its warning, and then `bun build` still exits 1 with `error: Failed to generate CSS for this file (PrintError)`.
- Cause: `parse_declaration_impl` (src/css/declaration.rs) warns but still pushes the declaration, and `StyleRule::to_css_base` (src/css/rules/style.rs) validated `composes` a second time at print time (`Printer::is_nested`, `CssModule::handle_composes`) and failed the whole stylesheet.
- The print-time check was also stricter than the parser. `is_nested()` is only "indent > 2", so an accepted `composes` failed with no warning at all when its rule is printed inside any block:
  - `@media (min-width: 1px) { .b { composes: c } }` (accepted by the parser, exported by the bundler, then PrintError).
  - a valid module reached through `@import "./x.module.css" layer(foo);` (or a media / supports condition): the bundler wraps the file's rules in the matching `@layer` / `@media` / `@supports` block itself (prepareCssAstsForChunk.rs), so the file can never print.
- A rejected `composes: x from "./other.module.css"` kept its import record, so `other.module.css` was bundled (or failed resolution) on behalf of a declaration that has no effect. The same happened, without any warning, for a `composes` written outside a style rule of a module (`@keyframes`, `@page`, ...), which was also printed as if it were a real property.
- esbuild builds all of these: rejected declarations get a warning and are dropped, `composes` in a rule inside a top-level at-rule works.

### Fix
- `parse_declaration_impl` drops every rejected `composes` after warning (the previously silent "outside a style rule" case now warns `"composes" is not valid here`, esbuild's wording), and `Composes::discard` marks the import record of its `from "<file>"` specifier `IS_UNUSED` (the existing flag for "the parser created this record and then decided it is not needed"; the bundler neither resolves nor orders such records).
- `StyleRule::to_css_base` only omits `composes` from the output. `handle_composes`, `Printer::is_nested`, the two printer error kinds and `Composes::cssparser_loc` had no other users and are removed.
- Why this is correct: the parser's verdict is the only one the bundler uses (`StyleSheet::composes` feeds `generateCodeForLazyExport` / `scanImportsAndExports`; the printer never emitted the property), so the print-time validation only ever turned an already reported warning into a build failure, or, in the wrapped cases, rejected rules the parser had correctly accepted. With rejected declarations dropped at parse time, the only `composes` left in the AST are accepted ones in style rules, so there is nothing left for the printer to check. This matches esbuild for `.module.css` files, including not bundling the `from` file of a rejected declaration. (`composes` in plain, non-module `.css` files is still parsed as a property and bundles its `from` file; that is a separate pre-existing divergence, tracked separately, and untouched here.)
- `test/bundler/expectBundled.ts`: the warning parser assumed every warning location is an absolute path inside the test directory and threw on CSS parser warnings, which only carry the file's basename (`at styles.module.css:1:6`). Those are now keyed as `/<basename>`, so `bundleWarnings` can assert the exact list of CSS warnings. Warnings that did parse before parse exactly as before.
- Verified with the seven new `css-module/Composes*` cases in `test/bundler/css/css-modules.test.ts`: the three rejected shapes (each with one declaration that shares a rule with a real property and one that is alone, so the rule holding only the rejected `composes` has to disappear from the output), `@keyframes` / `@page`, a rejected `from` that must neither bundle an existing file nor fail on a missing one, `@media` / `@supports` + `@layer` acceptance, and a module imported with conditions. All seven fail on the unfixed build (the builds exit 1, or in the `@keyframes` / `@page` case bundle `other.module.css` without a warning) and pass with the fix.
- `test/bundler/cli.test.ts` "fails instead of emitting a truncated stylesheet" used a rejected `composes` as its PrintError trigger, which no longer exists; it now uses the nesting expansion limit (passes before and after, it is not the proof for this change).
- Also ran test/bundler/esbuild/{css,default,importstar,packagejson,splitting}.test.ts, test/bundler/bundler_jsx.test.ts and test/bundler/bundler_edgecase.test.ts (every suite that asserts warnings or errors through the harness; all green), test/js/bun/css/{css,doesnt_crash,css-loader,nested-selector-expansion}.test.ts, `cargo clippy -p bun_css`, `cargo fmt`.
- Overlaps textually with #38520 (different bug: per-block composes state) in `declaration.rs` and the test file; whichever lands second rebases trivially.

### Background
- CSS modules `composes`: `.a { composes: b }` makes the JS export for `a` the string `"b_<hash> a_<hash>"`. Bun implements it in the parser: when a style rule is opened, `NestedRuleParser::parse_block` (css_parser.rs) computes a `ComposesState` from the selector shape and nesting depth (declaration blocks that are not style rules get `DisallowEntirely`); `parse_declaration_impl` then either records the declaration into `StyleSheet::composes` (`Allow`) or warns. The bundler builds the exports object from that map. The property itself is never printed.
- lightningcss, which this printer is ported from, has no such parser-side map; it resolves `composes` while printing, which is why its printer validated the selector and nesting. In Bun those checks duplicated the parser's, and the failure surfaced as a generic `PrintError` because the bundler discards printer error details (generateCompileResultForCssChunk.rs).
- `ImportRecordFlags::IS_UNUSED`: a record the parser created and later decided is unnecessary (TypeScript type-only imports use it). `resolve_import_records` skips such records, so they keep an invalid `source_index`, and `findImportedFilesInCSSOrder` only follows `composes` records with a valid one.
- The `@keyframes` fixture only produces the `@page` warning: keyframe bodies are parsed with a fresh `ParserOptions` that has no logger (rules/keyframes.rs), so warnings raised there are dropped today. The declaration is still removed, which the test's stylesheet snapshot shows; making those warnings visible is tracked separately.

<details>
<summary>Repro and esbuild comparison</summary>

`entry.js` does `import styles from "./w.module.css"`; `bun build entry.js --outdir out` (bun 1.4.0 and main before this change):

```
.c { color: red }
.a { .z { composes: c } }                       -> warn + "Failed to generate CSS for this file (PrintError)", exit 1
.a .b { composes: c }                           -> warn + PrintError, exit 1
.a { @media (min-width: 1px) { composes: c } }  -> warn + PrintError, exit 1
@media (min-width: 1px) { .b { composes: c } }  -> PrintError only, exit 1
.a .b { composes: x from "./missing.css" }      -> error: Could not resolve "./missing.css"
@keyframes k { from { composes: x from "./other.module.css" } }
                                                -> no warning, other.module.css bundled, composes printed
```

`entry.css` with `@import "./w.module.css" layer(foo);` where w.module.css is just `.c { color: red } .b { composes: c }` -> PrintError, exit 1.

esbuild 0.25 on the same inputs: the rejected shapes warn and export `{c, a, z}` / `{c, a, b}` / `{c, a}` with no composition, `@media` exports `b: "w_c w_b"`, files named by rejected declarations are never resolved, and every build succeeds. With this change Bun produces the same exports and exit codes for all of them.

<em>Earlier revision of this PR:</em> the first push left the "outside a style rule" case untouched and tested the rest by spawning `bun build` directly, because the harness could not parse CSS warnings; the self-review pointed out both, which the second commit addresses.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->