### PR TITLE
bun build --no-bundle: scope CSS module locals instead of crashing

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2375,30 +2375,12 @@ impl<'a> LinkerContext<'a> {
 
                         let source = &all_sources[r#ref.source_index() as usize];
 
-                        // SAFETY: `Symbol.original_name` is a `*const [u8]` arena
-                        // pointer; valid for the link step.
-                        let original_name: &[u8] = symbol.original_name.slice();
-                        // The hash itself is short-lived; use a scratch bump.
-                        let scratch = ::bun_alloc::Arena::new();
-                        let path_hash = ::bun_base64::wyhash_url_safe(
-                            &scratch,
-                            // use path relative to cwd for determinism
-                            format_args!("{}", bstr::BStr::new(&source.path.pretty)),
-                            false,
-                        );
-
-                        let mut final_generated_name = Vec::<u8>::new();
-                        use std::io::Write;
-                        write!(
-                            &mut final_generated_name,
-                            "{}_{}",
-                            bstr::BStr::new(original_name),
-                            bstr::BStr::new(path_hash)
-                        )
-                        .expect("infallible: in-memory write");
                         // The map owns its boxed values (freed with `mangled_props`).
                         self.mangled_props
-                            .put(r#ref, final_generated_name.into_boxed_slice())
+                            .put(
+                                r#ref,
+                                local_css_name(symbol.original_name.slice(), source.path.pretty),
+                            )
                             .expect("OOM");
                     }
                 }
@@ -2557,6 +2539,25 @@ impl<'a> LinkerContext<'a> {
         });
     }
 } // end — split: tree-shaking trio below
+
+/// The name a CSS module's local class or id is printed as:
+/// `<original name>_<hash of the file's path relative to the project root>`.
+/// Used both by `mangle_local_css` and by the `--no-bundle` CSS path
+/// (`Transpiler::build_css_output`), so a `.module.css` file transpiled on its
+/// own gets the same names the bundler would give it.
+pub(crate) fn local_css_name(original_name: &[u8], pretty_path: &[u8]) -> Box<[u8]> {
+    let scratch = Bump::new();
+    let path_hash = ::bun_base64::wyhash_url_safe(
+        &scratch,
+        format_args!("{}", bstr::BStr::new(pretty_path)),
+        false,
+    );
+    let mut name = Vec::with_capacity(original_name.len() + 1 + path_hash.len());
+    name.extend_from_slice(original_name);
+    name.push(b'_');
+    name.extend_from_slice(path_hash);
+    name.into_boxed_slice()
+}
 
 /// `js_printer::RequireOrImportMetaSource` — manual-vtable shim so the printer
 /// can call back into `LinkerContext::require_or_import_meta_for_source`.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2375,12 +2375,30 @@ impl<'a> LinkerContext<'a> {
 
                         let source = &all_sources[r#ref.source_index() as usize];
 
+                        // SAFETY: `Symbol.original_name` is a `*const [u8]` arena
+                        // pointer; valid for the link step.
+                        let original_name: &[u8] = symbol.original_name.slice();
+                        // The hash itself is short-lived; use a scratch bump.
+                        let scratch = ::bun_alloc::Arena::new();
+                        let path_hash = ::bun_base64::wyhash_url_safe(
+                            &scratch,
+                            // use path relative to cwd for determinism
+                            format_args!("{}", bstr::BStr::new(&source.path.pretty)),
+                            false,
+                        );
+
+                        let mut final_generated_name = Vec::<u8>::new();
+                        use std::io::Write;
+                        write!(
+                            &mut final_generated_name,
+                            "{}_{}",
+                            bstr::BStr::new(original_name),
+                            bstr::BStr::new(path_hash)
+                        )
+                        .expect("infallible: in-memory write");
                         // The map owns its boxed values (freed with `mangled_props`).
                         self.mangled_props
-                            .put(
-                                r#ref,
-                                local_css_name(symbol.original_name.slice(), source.path.pretty),
-                            )
+                            .put(r#ref, final_generated_name.into_boxed_slice())
                             .expect("OOM");
                     }
                 }
@@ -2539,25 +2557,6 @@ impl<'a> LinkerContext<'a> {
         });
     }
 } // end — split: tree-shaking trio below
-
-/// The name a CSS module's local class or id is printed as:
-/// `<original name>_<hash of the file's path relative to the project root>`.
-/// Used both by `mangle_local_css` and by the `--no-bundle` CSS path
-/// (`Transpiler::build_css_output`), so a `.module.css` file transpiled on its
-/// own gets the same names the bundler would give it.
-pub(crate) fn local_css_name(original_name: &[u8], pretty_path: &[u8]) -> Box<[u8]> {
-    let scratch = Bump::new();
-    let path_hash = ::bun_base64::wyhash_url_safe(
-        &scratch,
-        format_args!("{}", bstr::BStr::new(pretty_path)),
-        false,
-    );
-    let mut name = Vec::with_capacity(original_name.len() + 1 + path_hash.len());
-    name.extend_from_slice(original_name);
-    name.push(b'_');
-    name.extend_from_slice(path_hash);
-    name.into_boxed_slice()
-}
 
 /// `js_printer::RequireOrImportMetaSource` — manual-vtable shim so the printer
 /// can call back into `LinkerContext::require_or_import_meta_for_source`.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2856,9 +2856,7 @@ impl<'a> Transpiler<'a> {
 
         let mut file_path = Fs::Path::init(file_path_text);
 
-        // Computed the way the bundler computes `Source.path.pretty` (see
-        // `generic_path_with_pretty_initialized`: forward slashes on every
-        // platform), because CSS module names are hashed from it.
+        // Forward slashes on every platform, like the bundler's `Source.path.pretty`.
         let top_level_dir = self.fs().top_level_dir;
         let rel = bun_paths::resolve_path::relative_platform::<
             bun_paths::resolve_path::platform::Loose,
@@ -3073,9 +3071,7 @@ impl<'a> Transpiler<'a> {
         // `'bump`-threading note).
         let alloc: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref::<Arena>(self.arena) };
 
-        // Every class/id selector of a CSS module becomes a `LocalCss` symbol
-        // `Ref` carrying this source index; the printer resolves those through
-        // the symbol map and local names built below, so the three must agree.
+        // CSS module locals are `Ref`s into the one-list symbol map built below.
         let source_index = bun_ast::Index::RUNTIME;
         let (mut sheet, extra) = match bun_css::StyleSheet::<bun_css::DefaultAtRule>::parse(
             alloc,
@@ -3102,8 +3098,7 @@ impl<'a> Transpiler<'a> {
             );
             return None;
         }
-        // Same `<name>_<hash of the path relative to the cwd>` names that
-        // `LinkerContext::mangle_local_css` gives these locals in a bundle.
+        // Same names `LinkerContext::mangle_local_css` gives these locals in a bundle.
         let mut local_names = bun_css::LocalsResultsMap::default();
         if !sheet.local_scope.is_empty() {
             let path_hash = ::bun_base64::wyhash_url_safe(

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3102,19 +3102,19 @@ impl<'a> Transpiler<'a> {
             );
             return None;
         }
+        // Same `<name>_<hash of the path relative to the cwd>` names that
+        // `LinkerContext::mangle_local_css` gives these locals in a bundle.
         let mut local_names = bun_css::LocalsResultsMap::default();
-        for (inner_index, symbol) in extra.symbols.iter().enumerate() {
-            if symbol.kind == bun_ast::symbol::Kind::LocalCss {
+        if !sheet.local_scope.is_empty() {
+            let path_hash = ::bun_base64::wyhash_url_safe(
+                alloc,
+                format_args!("{}", bstr::BStr::new(file_path_pretty)),
+                false,
+            );
+            for (local, entry) in sheet.local_scope.iter() {
                 local_names.insert(
-                    bun_ast::Ref::new(
-                        u32::try_from(inner_index).expect("int cast"),
-                        source_index.get(),
-                        bun_ast::RefTag::Symbol,
-                    ),
-                    crate::linker_context_mod::local_css_name(
-                        symbol.original_name.slice(),
-                        file_path_pretty,
-                    ),
+                    entry.ref_.to_real_ref(source_index.get()),
+                    strings::concat(&[local, b"_", path_hash]),
                 );
             }
         }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2856,8 +2856,14 @@ impl<'a> Transpiler<'a> {
 
         let mut file_path = Fs::Path::init(file_path_text);
 
+        // Computed the way the bundler computes `Source.path.pretty` (see
+        // `generic_path_with_pretty_initialized`: forward slashes on every
+        // platform), because CSS module names are hashed from it.
         let top_level_dir = self.fs().top_level_dir;
-        let rel = bun_paths::resolve_path::relative(top_level_dir, file_path_text);
+        let rel = bun_paths::resolve_path::relative_platform::<
+            bun_paths::resolve_path::platform::Loose,
+            false,
+        >(top_level_dir, file_path_text);
         file_path.pretty = crate::linker::dupe(rel);
 
         let mut output_file = options::OutputFile::zero_value();
@@ -3067,12 +3073,16 @@ impl<'a> Transpiler<'a> {
         // `'bump`-threading note).
         let alloc: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref::<Arena>(self.arena) };
 
+        // Every class/id selector of a CSS module becomes a `LocalCss` symbol
+        // `Ref` carrying this source index; the printer resolves those through
+        // the symbol map and local names built below, so the three must agree.
+        let source_index = bun_ast::Index::RUNTIME;
         let (mut sheet, extra) = match bun_css::StyleSheet::<bun_css::DefaultAtRule>::parse(
             alloc,
             entry.contents(),
             opts,
             None,
-            bun_ast::Index::INVALID,
+            source_index,
         ) {
             Ok(v) => v,
             Err(e) => {
@@ -3092,7 +3102,23 @@ impl<'a> Transpiler<'a> {
             );
             return None;
         }
-        let symbols = bun_ast::symbol::Map::init_list(Default::default());
+        let mut local_names = bun_css::LocalsResultsMap::default();
+        for (inner_index, symbol) in extra.symbols.iter().enumerate() {
+            if symbol.kind == bun_ast::symbol::Kind::LocalCss {
+                local_names.insert(
+                    bun_ast::Ref::new(
+                        u32::try_from(inner_index).expect("int cast"),
+                        source_index.get(),
+                        bun_ast::RefTag::Symbol,
+                    ),
+                    crate::linker_context_mod::local_css_name(
+                        symbol.original_name.slice(),
+                        file_path_pretty,
+                    ),
+                );
+            }
+        }
+        let symbols = bun_ast::symbol::Map::init_with_one_list(extra.symbols);
         let result = match sheet.to_css(
             alloc,
             &bun_css::PrinterOptions {
@@ -3101,7 +3127,7 @@ impl<'a> Transpiler<'a> {
                 ..bun_css::PrinterOptions::default()
             },
             None,
-            None,
+            Some(&local_names),
             &symbols,
         ) {
             Ok(v) => v,

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -212,4 +214,85 @@ describe("css", () => {
       expect(css).toContain(`.${betaOwn}`);
     },
   });
+});
+
+// `bun build --no-bundle` prints each entry point on its own without going
+// through the linker, so it has to scope the locals of a `.module.css` file
+// itself. It used to crash on the first class or id selector instead.
+describe.concurrent("css-module --no-bundle", () => {
+  const stylesheet = /* css */ `
+    .foo { color: red }
+    #bar { color: blue }
+    .foo .baz { color: green }
+    :global(.keep) .foo { color: green }
+    .btn { composes: foo; padding: 0 }
+    @keyframes spin { to { opacity: 1 } }
+    .spinner { animation: spin 1s }
+  `;
+
+  async function build(cwd: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test("scopes classes, ids and keyframes", async () => {
+    using dir = tempDir("css-module-no-bundle", { "styles.module.css": stylesheet });
+
+    expect(await build(String(dir), "--no-bundle", "styles.module.css")).toMatchInlineSnapshot(`
+      ".foo_-MSaAA {
+        color: red;
+      }
+
+      #bar_-MSaAA {
+        color: #00f;
+      }
+
+      .foo_-MSaAA .baz_-MSaAA {
+        color: green;
+      }
+
+      .keep .foo_-MSaAA {
+        color: green;
+      }
+
+      .btn_-MSaAA {
+        padding: 0;
+      }
+
+      @keyframes spin_-MSaAA {
+        to {
+          opacity: 1;
+        }
+      }
+
+      .spinner_-MSaAA {
+        animation: 1s spin_-MSaAA;
+      }
+      "
+    `);
+  });
+
+  // The class and id names hash the file's path relative to the cwd, so a
+  // file in a subdirectory gets different names than one at the top level,
+  // and `bun build --no-bundle` has to agree with `bun build` on both.
+  test.each(["styles.module.css", "nested/deep.module.css"])(
+    "prints the same names as bun build for %s",
+    async entry => {
+      using dir = tempDir("css-module-no-bundle-parity", { [entry]: stylesheet });
+
+      const bundled = await build(String(dir), entry);
+      const header = `/* ${entry} */\n`;
+      expect(bundled).toStartWith(header);
+      expect(await build(String(dir), "--no-bundle", entry)).toBe(bundled.slice(header.length));
+    },
+  );
 });


### PR DESCRIPTION
### Problem
- `bun build --no-bundle a.module.css` crashes on any stylesheet that has a class or id selector:
  `panic: called Option::unwrap() on a None value`, top frame `bun_css::printer::Printer::lookup_symbol` (src/css/printer.rs:189), reached from `serialize_component` printing a `.class`/`#id`. Repro: `printf '.foo { color: red }' > a.module.css && bun build --no-bundle a.module.css`. `bun build a.module.css` (bundled) prints `.foo_BLNoTg` fine.
- The transpile-only CSS path is `Transpiler::build_css_output` (src/bundler/transpiler.rs). It turns CSS modules on for `*.module.css`, which makes the parser replace every class/id name with a symbol `Ref`, but then it parsed with `Index::INVALID` as the source index and printed against an empty `symbol::Map`, throwing away the `extra.symbols` list the parse returned. A `Ref` whose source index is the invalid sentinel makes `symbol::Map::get_const` return `None`, and the printer unwraps it.
- This never worked: the Zig version of the function passed `Index.invalid` and an empty `Symbol.Map` too. Only `bun build --no-bundle` reaches this function.

### Fix
- `build_css_output` parses with `Index::RUNTIME` (the source index single-file transforms use), prints with `symbol::Map::init_with_one_list(extra.symbols)` so the refs resolve (the printer follows every ref through the map before it consults the local names), and passes a `LocalsResultsMap` naming each entry of the sheet's `local_scope` `<name>_<hash of the file's pretty path>`.
- That is the same hash input and format `LinkerContext::mangle_local_css` uses, so `--no-bundle` output for a `.module.css` file is byte for byte what `bun build` emits for that file (minus the `/* file */` header).
- Those four lines (`wyhash_url_safe` of the pretty path, joined to the name with `_`) are knowingly a second copy of what `mangle_local_css` does, not a helper shared with the linker. The `prints the same names as bun build` tests run both commands on the same file and compare the bytes, so the copies cannot drift unnoticed; the linker stays untouched by a crash fix; and the copy is what gets deleted once the single-file `local_names()` constructor being added to bun_css in #38547 hashes the same input as the linker (details block below), at which point this loop becomes a one-line call.
- The pretty path the transpiler computes for an entry point now uses the same `relative_platform::<Loose>` call the bundler uses for `Source.path.pretty` (forward slashes on Windows). It was only used in an error message before; now it feeds the hash, so on Windows a file in a subdirectory would otherwise hash `sub\a.module.css` while the bundler hashes `sub/a.module.css`.
- Non-module stylesheets are unaffected: their parse produces no symbols and an empty `local_scope`, so the map and local names stay empty exactly as before. Bundled builds are untouched (no change outside this function).
- Verified with the new `css-module --no-bundle` block in test/bundler/css/css-modules.test.ts: a snapshot of the scoped output (classes, an id, a nested selector, `:global()`, `composes`, `@keyframes` plus its `animation` reference), and a check that `--no-bundle` prints the same bytes as `bun build` for both a top-level file and one in a subdirectory. All 3 fail on bun 1.4.0 with the panic above and pass with this change.
- Also still passing: the rest of test/bundler/css/css-modules.test.ts, test/bundler/cli.test.ts, test/bundler/bundler_loader.test.ts, test/bundler/esbuild/css.test.ts.

### Background
- CSS modules in bun_css: when `css_modules` is enabled, the parser does not keep class/id names as strings. It appends a `LocalCss` symbol to a per-file symbol list, records the name in the sheet's `local_scope` (name to `CssRef`), and stores a `Ref` (source index + index into that list) in the selector. The printer turns the `Ref` back into text by looking it up in a `LocalsResultsMap` (`Ref` to generated name), falling back to the symbol's original name. Keyframes and other non-selector names are scoped separately, by the printer itself, from the file name.
- `symbol::Map` is the bundler's two-level symbol table, indexed by a `Ref`'s source index and then its inner index. `Index::RUNTIME` (0) is the source index bun uses when there is only one file, and `init_with_one_list` builds a map whose only entry is that file's list, so the two line up.
- In a real bundle, `LinkerContext::mangle_local_css` fills the `LocalsResultsMap` for every CSS module in the graph; `--no-bundle` (`transform_only`) transpiles each entry point on its own through `Transpiler::transform` and never runs the linker, so this path has to fill the map itself.
- `Source.path.pretty` is the path relative to the cwd that the bundler shows in output comments and hashes for CSS module names; it is documented as forward-slash on every platform.

<details>
<summary>Earlier revision</summary>

The first push also extracted the name construction out of `mangle_local_css` into a shared `local_css_name` helper in LinkerContext.rs and rewired the linker onto it. Review pointed out that the helper would be deleted again as soon as the naming moves into bun_css (#38547 adds the constructor; a separate fix for same-basename `.module.css` files colliding on their `@keyframes` names makes the bundler hash the pretty path everywhere), so that refactor was dropped and the linker is untouched; the naming loop now lives only in `build_css_output`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts
bun test v1.4.0 (57b7cbf0d)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [608.22ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [147.16ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [121.55ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [182.59ms]
(pass) css > css-module/RepeatedClassAndIdReferences [218.70ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [124.60ms]
237 |       cwd,
238 |       stdout: "pipe",
239 |       stderr: "pipe",
240 |     });
241 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
242 |     expect(stderr).toBe("");
                         ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Debug v1.4.0 (57b7cbf0d) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/debug/bun-debug" "build" "--no-
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [12.56ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [7.94ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [5.48ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [8.05ms]
(pass) css > css-module/RepeatedClassAndIdReferences [6.79ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [7.88ms]
237 |       cwd,
238 |       stdout: "pipe",
239 |       stderr: "pipe",
240 |     });
241 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
242 |     expect(stderr).toBe("");
                         ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Canary v1.4.0-canary.1 (b7a043103) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "build" "--no-bundle" "styles.module.css"
+ 
+ Elapsed: 2ms | User: 0ms | Sys: 1ms
+ RSS: 11.96 MB | Peak: 62.39 MB | Commit: 14.16 MB | Faults: 0
+ 
+ panic: called `Option::unwra
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/css-modules.test.ts
bun test v1.4.0 (57b7cbf0d)

test/bundler/css/css-modules.test.ts:
(pass) css > css-module/GlobalPseudoFunction [601.34ms]
(pass) css > css-module/BundleTwoFilesWithoutCodeSplitting [164.38ms]
(pass) css > css-module/BundleTwoFilesWithCodeSplitting [112.81ms]
(pass) css > css-module/AnimationNameScopedToKeyframes [121.55ms]
(pass) css > css-module/RepeatedClassAndIdReferences [213.97ms]
(pass) css > css-module/ExportsMapMultipleClassesAndComposes [132.00ms]
(pass) css-module --no-bundle > scopes classes, ids and keyframes [203.75ms]
(pass) css-module --no-bundle > prints the same names as bun build for styles.module.css [571.54ms]
(pass) css-module --no-bundle > prints the same names as bun build for nested/deep.module.css [571.72ms]

 9 pass
 0 fail
 5 snapshots, 40 expect() calls
Ran 9 tests across 1 file. [6.06s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     57b7cbf0d1
  features     baseline

22 deps, 123 codegen, 1176 objects in 950ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [15.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1238] gen bindgenv2
[4/1238] gen ErrorCode+*.h
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [43.00ms]
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[9/1237] fetch zlib
[zlib] up to date
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1237] gen ProcessBindingHTTPParser.lut.h
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs            | 29 +++++++++++--
 test/bundler/css/css-modules.test.ts | 83 ++++++++++++++++++++++++++++++++++++
 2 files changed, 108 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/transpiler.rs                 7      9      0
test/bundler/css/css-modules.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->