### PR TITLE
Bun.Transpiler: allocate exports.replace string values in the instance arena

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1047,7 +1047,7 @@ impl IntoExprData for &E::EString {
 impl Expr {
     /// When the lifetime of an Expr.Data's pointer must exist longer than reset() is called, use this function.
     /// Be careful to free the memory (or use an arena that does it for you)
-    /// Also, prefer Expr.init or Expr.alloc when possible. This will be slower.
+    /// Prefer `Expr::init` for nodes that only need to live until the current parse's reset().
     #[inline]
     pub fn allocate<T: IntoExprData>(bump: &Bump, st: T, loc: Loc) -> Expr {
         data::Store::assert();

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -46,9 +46,10 @@ pub struct JSTranspiler {
     pub(crate) config: JsCell<Config>,
     pub(crate) scan_pass_result: JsCell<ScanPassResult>,
     pub(crate) buffer_writer: JsCell<Option<JSPrinter::BufferWriter>>,
-    // Arena bulk-frees the config strings. Boxed so its
-    // address is stable across the move into `Box<JSTranspiler>` —
-    // `transpiler.arena` holds a `&'static Arena` pointing into it.
+    // Arena bulk-frees the config strings and the `exports.replace` value
+    // nodes in `config.runtime.replace_exports`. Boxed so its address is stable
+    // across the move into `Box<JSTranspiler>` — `transpiler.arena` holds a
+    // `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
     // Intrusive refcount field for `bun_ptr::IntrusiveRc<JSTranspiler>`:
     // single-thread intrusive `bun.ptr.RefCount` because `*JSTranspiler`
@@ -933,12 +934,16 @@ fn export_replacement_value(
         let zig_str = value.get_zig_string(global)?;
         let mut buf = Vec::new();
         write!(&mut buf, "{}", zig_str).expect("unreachable");
-        // Bump-allocate so the bytes
-        // live as long as the JSTranspiler arena that owns the resulting Expr;
+        // This Expr lives in `Config.runtime.replace_exports` for the lifetime of
+        // the JSTranspiler and is copied into every later parse, so both the bytes
+        // and the `E::EString` node must live in the JSTranspiler's arena.
+        // `Expr::init` would put the node in the thread-local AST store, which
+        // the next parse on this thread (e.g. a `require()`) resets.
         // `E::EString::init` erases the borrow to `'static` per the AST
         // crate's `Str` convention (see ast/E.rs).
         let data = arena.alloc_slice_copy(&buf);
-        return Ok(Some(Expr::init(
+        return Ok(Some(Expr::allocate(
+            arena,
             bun_ast::E::EString::init(data),
             bun_ast::Loc::EMPTY,
         )));

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -46,10 +46,9 @@ pub struct JSTranspiler {
     pub(crate) config: JsCell<Config>,
     pub(crate) scan_pass_result: JsCell<ScanPassResult>,
     pub(crate) buffer_writer: JsCell<Option<JSPrinter::BufferWriter>>,
-    // Arena bulk-frees the config strings and the `exports.replace` value
-    // nodes in `config.runtime.replace_exports`. Boxed so its address is stable
-    // across the move into `Box<JSTranspiler>` — `transpiler.arena` holds a
-    // `&'static Arena` pointing into it.
+    // Arena bulk-frees the config strings. Boxed so its
+    // address is stable across the move into `Box<JSTranspiler>` —
+    // `transpiler.arena` holds a `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
     // Intrusive refcount field for `bun_ptr::IntrusiveRc<JSTranspiler>`:
     // single-thread intrusive `bun.ptr.RefCount` because `*JSTranspiler`
@@ -934,14 +933,12 @@ fn export_replacement_value(
         let zig_str = value.get_zig_string(global)?;
         let mut buf = Vec::new();
         write!(&mut buf, "{}", zig_str).expect("unreachable");
-        // This Expr lives in `Config.runtime.replace_exports` for the lifetime of
-        // the JSTranspiler and is copied into every later parse, so both the bytes
-        // and the `E::EString` node must live in the JSTranspiler's arena.
-        // `Expr::init` would put the node in the thread-local AST store, which
-        // the next parse on this thread (e.g. a `require()`) resets.
+        // Bump-allocate so the bytes
+        // live as long as the JSTranspiler arena that owns the resulting Expr;
         // `E::EString::init` erases the borrow to `'static` per the AST
         // crate's `Str` convention (see ast/E.rs).
         let data = arena.alloc_slice_copy(&buf);
+        // Not `Expr::init`: the thread-local store it appends to is reset by the next parse.
         return Ok(Some(Expr::allocate(
             arena,
             bun_ast::E::EString::init(data),

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -899,6 +899,9 @@ fn export_replacement_value(
     global: &JSGlobalObject,
     arena: &Arena,
 ) -> JsResult<Option<bun_ast::Expr>> {
+    // The result outlives every parse, so it must not be built in the thread-local store.
+    let _guard = bun_ast::expr::Disabler::scope();
+
     if value.is_boolean() {
         return Ok(Some(Expr {
             data: bun_ast::ExprData::EBoolean(bun_ast::E::Boolean {
@@ -938,7 +941,6 @@ fn export_replacement_value(
         // `E::EString::init` erases the borrow to `'static` per the AST
         // crate's `Str` convention (see ast/E.rs).
         let data = arena.alloc_slice_copy(&buf);
-        // Not `Expr::init`: the thread-local store it appends to is reset by the next parse.
         return Ok(Some(Expr::allocate(
             arena,
             bun_ast::E::EString::init(data),

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2100,9 +2100,7 @@ export default class {
         'export default "dflt";\n',
       ]);
       expect(exitCode).toBe(0);
-      // Only the failing case is slow: symbolizing the sanitizer report of the
-      // crashed child takes longer than the default timeout.
-    }, 60_000);
+    });
   });
 
   const bunTranspiler = new Bun.Transpiler({

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2048,12 +2048,21 @@ export default class {
       // String values are the only replacement values that are heap-allocated
       // AST nodes. They used to be allocated in the thread-local AST store,
       // which every synchronous parse on the main thread (a require() of a
-      // CommonJS file, an import of a JSON file, ...) resets, so a transform
-      // after such a parse printed the replacement from freed memory. Debug
-      // builds poison the store on reset, which makes the stale read a crash
-      // of the child process; release builds silently reuse the memory.
+      // CommonJS file, an import of a JSON file, ...) resets and then refills
+      // with that module's own nodes, so a later transform printed the
+      // replacement out of memory that by then held some other node. Debug
+      // builds poison the store on reset, so any reset exposes the stale read;
+      // release builds only misbehave once the slot has been reused, which is
+      // why the required module declares a few hundred strings (a few dozen
+      // are enough to reach the slot).
+      const resetLines = [];
+      for (let i = 0; i < 300; i++) {
+        resetLines.push(`const s${i} = "other string ${i}";`);
+      }
+      resetLines.push("module.exports = { s0, s299 };");
+
       using dir = tempDir("transpiler-replace-string-values", {
-        "reset.cjs": `module.exports = {};`,
+        "reset.cjs": resetLines.join("\n"),
         "reset.json": `{}`,
         "entry.mjs": `
           const transpiler = new Bun.Transpiler({

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2043,6 +2043,66 @@ export default class {
       expect(output.includes("localVarToReplace")).toBe(true);
       expect(output.includes("localVarToRemove")).toBe(false);
     });
+
+    it("string replacement values survive other modules being loaded after the transpiler is created", async () => {
+      // String values are the only replacement values that are heap-allocated
+      // AST nodes. They used to be allocated in the thread-local AST store,
+      // which every synchronous parse on the main thread (a require() of a
+      // CommonJS file, an import of a JSON file, ...) resets, so a transform
+      // after such a parse printed the replacement from freed memory. Debug
+      // builds poison the store on reset, which makes the stale read a crash
+      // of the child process; release builds silently reuse the memory.
+      using dir = tempDir("transpiler-replace-string-values", {
+        "reset.cjs": `module.exports = {};`,
+        "reset.json": `{}`,
+        "entry.mjs": `
+          const transpiler = new Bun.Transpiler({
+            exports: {
+              replace: {
+                foo: "bar",
+                getStaticProps: ["__N_SSG", "ssg"],
+                default: "dflt",
+              },
+            },
+          });
+
+          require("./reset.cjs");
+          await import("./reset.json");
+
+          console.log(
+            JSON.stringify([
+              transpiler.transformSync("export const foo = 1;"),
+              transpiler.transformSync("export function getStaticProps() {}"),
+              transpiler.transformSync("export default 1;"),
+              await transpiler.transform("export const foo = 1;"),
+              await transpiler.transform("export function getStaticProps() {}"),
+              await transpiler.transform("export default 1;"),
+            ]),
+          );
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual([
+        'export const foo = "bar";\n',
+        'export var __N_SSG = "ssg";\n',
+        'export default "dflt";\n',
+        'export const foo = "bar";\n',
+        'export var __N_SSG = "ssg";\n',
+        'export default "dflt";\n',
+      ]);
+      expect(exitCode).toBe(0);
+      // Only the failing case is slow: symbolizing the sanitizer report of the
+      // crashed child takes longer than the default timeout.
+    }, 60_000);
   });
 
   const bunTranspiler = new Bun.Transpiler({


### PR DESCRIPTION
### Problem

- `new Bun.Transpiler({ exports: { replace: { foo: "bar" } } })` followed by any synchronous parse on the same thread (a `require()` of a CommonJS file, an `import` of a `.json` file, ...) and then a `transformSync()` / `transform()` of a module that exports `foo` prints the replacement from memory that no longer belongs to it.
- Debug builds crash deterministically in the printer (the store is poisoned with `0xAA` on reset):
  ```
  ERROR: AddressSanitizer: unknown-crash on address 0xaaaaaaaaaaaaaaaa
  READ of size 2863311530
      #2 bun_alloc::baby_vec::BabyVec<u8>::extend_from_slice   src/bun_alloc/baby_vec.rs
      #3 bun_ast::e::EString::resolve_rope_if_needed            src/ast/e.rs
      #4 bun_js_printer::Printer::print_expr                    src/js_printer/lib.rs
      #13 JSTranspiler::transform_sync                          src/runtime/api/JSTranspiler.rs
  ```
  Release builds read whatever the intervening parse left in that slot: with a small module in between the output is still correct by luck; with a module of a few dozen declarations or more it prints the wrong value (`export const foo = "";`) or dies with `panic(main thread): Segmentation fault ... Crashed while printing input.jsx`, depending on what landed there.
- Cause: `export_replacement_value` in `src/runtime/api/JSTranspiler.rs` copies the string bytes into the `JSTranspiler`'s own arena but builds the node with `Expr::init`, which appends the `E::EString` struct to the thread-local AST store. The returned `Expr` (a pointer to that struct) is kept in `config.runtime.replace_exports` for the life of the transpiler and copied into every later parse, while the next parse on the main thread resets that store and fills it with its own nodes.
- Only string values are affected: booleans, numbers, `null` and `undefined` are stored inline in `ExprData`. Both the plain form (`foo: "bar"`) and the inject form (`foo: ["name", "bar"]`) go through this function.

### Fix

- Build the node with `Expr::allocate(arena, ..)` instead of `Expr::init(..)`, so the `E::EString` struct lives in the same arena as its bytes.
- Correct because that arena (`JSTranspiler.arena`) is never reset and is dropped together with the `Config` holding the `Expr`, so the node lives exactly as long as the pointer to it. This is also what the code did before the port (`allocator.create(E.String)` on the instance allocator), and what `DefineData::parse` in `src/bundler/defines.rs` does for the same reason with `define` values.
- `export_replacement_value` now also holds `bun_ast::expr::Disabler::scope()`, the existing debug-only guard used by `PackageJSONEditor` for the same situation: if this function ever appends to the thread-local store again, debug builds panic at construction time (`[bun_ast::expr::Expr] called while disabled`), which every existing `exports.replace` test would hit. Checked by temporarily putting `Expr::init` back: `transpiler.test.js` aborts at module load with that panic. `Expr::allocate` never reaches the store, so the guard is inert for the fixed code, and it compiles to nothing in release.
- The doc comment on `Expr::allocate` pointed at a non-existent `Expr.alloc`; it now says when to use `Expr::init` instead.
- Verified with `test/bundler/transpiler/transpiler.test.js` ("string replacement values survive other modules being loaded after the transpiler is created"): a spawned fixture creates the transpiler, `require()`s a CommonJS module with 300 string declarations, imports a JSON file, then transforms an `export const`, an `export function` (inject form) and an `export default` through both `transformSync()` and `transform()`. The required module is deliberately large so that release builds reuse the slot too: without the fix the test fails on a release build (all six outputs print `""`) and on a debug build (sanitizer report from the child); with the fix it passes on both.
- The rest of `transpiler.test.js` passes with the change (189 pass, 0 fail).

### Background

- AST node store: `Expr` is a small `Copy` value; for heap-sized node kinds such as `E::EString` it holds a pointer into a thread-local slab (`src/ast/new_store.rs`). The slab is bulk-reset at the start of every parse that runs on that thread without a per-parse allocator scope, and the following parse writes its own nodes over the same memory, so anything built with `Expr::init` is only valid until the next such parse. `Expr::allocate(bump, ..)` is the variant for nodes that must outlive that reset; it puts the node in the caller's arena instead. Debug builds additionally fill the slab with `0xAA` on reset, which is why the stale read is a deterministic crash there.
- `bun_ast::expr::Disabler` is a debug-only flag checked by the slab's `append`; `Disabler::scope()` sets it for the current scope, turning any `Expr::init` of a slab-backed node inside that scope into a panic. It is a no-op in release builds.
- `Bun.Transpiler` option parsing runs in the constructor with no allocator scope active, so `Expr::init` there lands in the thread-local slab. `transformSync()` / `transform()` parse into their own per-call arena, which is why the bug only shows up once some other synchronous parse on the main thread (module loading) has reset the slab.

<details>
<summary>Per-form probe on a debug build, before and after the change</summary>

Each row is a separate process: construct the transpiler, `require("./reset.cjs")`, then transform the given source.

| value | source | before | after |
| --- | --- | --- | --- |
| `foo: "bar"` | `export const foo = 1;` (sync) | ASAN crash | `export const foo = "bar";` |
| `getStaticProps: ["__N_SSG", "ssg"]` | `export function getStaticProps() {}` (sync) | ASAN crash | `export var __N_SSG = "ssg";` |
| `default: "dflt"` | `export default 1;` (sync) | ASAN crash | `export default "dflt";` |
| `foo: "bar"` | `export const foo = 1;` (async) | ASAN crash | `export const foo = "bar";` |
| `getStaticProps: ["__N_SSG", "ssg"]` | `export function getStaticProps() {}` (async) | ASAN crash | `export var __N_SSG = "ssg";` |
| `num: 42` | `export const num = 1;` | `export const num = 42;` | unchanged |
| `inj: ["__INJ", true]` | `export function inj() {}` | `export var __INJ = true;` | unchanged |
| `foo: "bar"`, no `require()` in between | `export const foo = 1;` | `export const foo = "bar";` | unchanged |

</details>

<details>
<summary>Release build without the fix, by size of the module required in between</summary>

Same fixture as the test, release binary at `b7a043103`, `reset.cjs` holding N string declarations. 5, 10 and 20 declarations: correct output on every run (the slot is not reached). 40 and more: wrong output or a segmentation fault on every run. The test uses 300.

</details>
