### PR TITLE
bun-types: type BuildMessage/ResolveMessage level and importKind as the strings the runtime reports

### DIFF
--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - "src/**/*.rs"
       - "src/jsc/bindings/**"
+      - "packages/bun-types/bun.d.ts"
+      - "docs/**/*.mdx"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "test/harness.ts"
@@ -26,6 +28,8 @@ on:
     paths:
       - "src/**/*.rs"
       - "src/jsc/bindings/**"
+      - "packages/bun-types/bun.d.ts"
+      - "docs/**/*.mdx"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "test/harness.ts"

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1608,7 +1608,7 @@ class BuildMessage {
   name: string;
   position?: Position;
   message: string;
-  level: "error" | "warning" | "info" | "debug" | "verbose";
+  level: "error" | "warn" | "note" | "debug" | "verbose";
 }
 
 class ResolveMessage extends BuildMessage {
@@ -1814,17 +1814,17 @@ declare class ResolveMessage {
   readonly referrer: string;
   readonly specifier: string;
   readonly importKind:
-    | "entry_point"
-    | "stmt"
-    | "require"
-    | "import"
-    | "dynamic"
-    | "require_resolve"
-    | "at"
-    | "at_conditional"
-    | "url"
-    | "internal";
-  readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+    | "import-statement"
+    | "require-call"
+    | "require-resolve"
+    | "dynamic-import"
+    | "import-rule"
+    | "url-token"
+    | "composes"
+    | "internal"
+    | "entry-point-run"
+    | "entry-point-build";
+  readonly level: "error" | "warn" | "note" | "debug" | "verbose";
 
   toString(): string;
 }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2755,20 +2755,42 @@ declare module "bun" {
   }
 
   type ImportKind =
+    /** An `import` or `export ... from` statement */
     | "import-statement"
+    /** A `require()` call */
     | "require-call"
+    /** A `require.resolve()` call */
     | "require-resolve"
+    /** An `import()` expression */
     | "dynamic-import"
+    /** A CSS `@import` rule */
     | "import-rule"
+    /** A CSS `url()` token */
     | "url-token"
+    /** A CSS modules `composes: ... from "./other.module.css"` declaration */
+    | "composes"
+    /** An import injected by Bun itself */
     | "internal"
+    /** An entry point passed to `bun run` or `bun <file>` */
     | "entry-point-run"
+    /** An entry point passed to `bun build` or `Bun.build()` */
     | "entry-point-build";
 
   interface Import {
     path: string;
     kind: ImportKind;
   }
+
+  /**
+   * Severity of a {@link BuildMessage} or {@link ResolveMessage}.
+   *
+   * - `"error"`: the build (or module load) failed because of this message
+   * - `"warn"`: reported, but the build went on
+   * - `"note"`: additional context for another message
+   * - `"debug"` and `"verbose"`: only reported when the log level is raised
+   *   above the default, for example with {@link TranspilerOptions.logLevel}
+   */
+  type BuildMessageLevel = "error" | "warn" | "note" | "debug" | "verbose";
 
   namespace Build {
     type Architecture = "x64" | "arm64" | "aarch64";

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -996,18 +996,8 @@ declare class ResolveMessage {
   readonly message: string;
   readonly referrer: string;
   readonly specifier: string;
-  readonly importKind:
-    | "entry_point"
-    | "stmt"
-    | "require"
-    | "import"
-    | "dynamic"
-    | "require_resolve"
-    | "at"
-    | "at_conditional"
-    | "url"
-    | "internal";
-  readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+  readonly importKind: Bun.ImportKind;
+  readonly level: Bun.BuildMessageLevel;
 
   toString(): string;
 }
@@ -1016,7 +1006,7 @@ declare class BuildMessage {
   readonly name: "BuildMessage";
   readonly position: Position | null;
   readonly message: string;
-  readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+  readonly level: Bun.BuildMessageLevel;
 }
 
 interface ErrorOptions {

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -549,6 +549,7 @@ impl Kind {
         }
     }
 
+    /// Public API (`BuildMessage.level`); mirrored by bun-types `BuildMessageLevel`.
     #[inline]
     pub fn string(self) -> &'static [u8] {
         match self {

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -35,27 +35,6 @@ impl Default for ResolveMessage {
     }
 }
 
-/// `ImportKind.label()` — the canonical table lives in
-/// `bun_ast::ImportKind::label`, but
-/// `bun_ast::MetadataResolve.import_kind` is the type-only `bun_ast::ImportKind`.
-/// Replicate the table here verbatim.
-fn import_kind_label(kind: ImportKind) -> &'static [u8] {
-    match kind {
-        ImportKind::EntryPointRun => b"entry-point-run",
-        ImportKind::EntryPointBuild => b"entry-point-build",
-        ImportKind::Stmt => b"import-statement",
-        ImportKind::Require => b"require-call",
-        ImportKind::Dynamic => b"dynamic-import",
-        ImportKind::RequireResolve => b"require-resolve",
-        ImportKind::At => b"import-rule",
-        ImportKind::AtConditional => b"",
-        ImportKind::Url => b"url-token",
-        ImportKind::Composes => b"composes",
-        ImportKind::Internal => b"internal",
-        ImportKind::HtmlManifest => b"html_manifest",
-    }
-}
-
 /// Host-agnostic bare-specifier check for Node ESM error shaping. Must not vary by host:
 /// relative, separator-led, and ASCII-letter drive forms are path-like; everything else is a
 /// package. Unlike `bun_paths::is_absolute`, the drive byte must be alphabetic.
@@ -479,7 +458,7 @@ impl ResolveMessage {
     pub fn get_import_kind(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(match &this.msg.metadata {
             bun_ast::Metadata::Resolve(resolve) => {
-                ZigString::init(import_kind_label(resolve.import_kind)).to_js(global)
+                ZigString::init(resolve.import_kind.label()).to_js(global)
             }
             _ => ZigString::init(b"").to_js(global),
         })

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -49,6 +49,22 @@ Bun.build({
           expectType(result.success).is<boolean>();
           expectType(result.outputs).is<Bun.BuildArtifact[]>();
           expectType(result.logs).is<Array<BuildMessage | ResolveMessage>>();
+
+          for (const log of result.logs) {
+            // The unions themselves are checked against src/ast/lib.rs by
+            // test/internal/source-lints/import-kind-and-level-names.test.ts.
+            expectType(log.level).is<Bun.BuildMessageLevel>();
+            if (log.level === "warn") {
+              expectType(log.level).is<"warn">();
+            }
+
+            if (log instanceof ResolveMessage) {
+              expectType(log.importKind).is<Bun.ImportKind>();
+              if (log.importKind === "require-call") {
+                expectType(log.importKind).is<"require-call">();
+              }
+            }
+          }
         });
 
         build.onBeforeParse(

--- a/test/internal/source-lints/README.md
+++ b/test/internal/source-lints/README.md
@@ -16,4 +16,9 @@ The workflow runs on a bare checkout (no `bun install`), so tests here may
 only import built-ins, relative paths, and `harness` (resolved via
 `test/tsconfig.json` paths).
 
+The workflow only triggers for the `paths:` listed in it. A lint that reads
+files outside those paths (for example `packages/bun-types/bun.d.ts` or the
+docs) needs them added there, or a change to those files is only checked by
+whichever later PR happens to trigger the workflow.
+
 To run locally: `bun test test/internal/source-lints/`.

--- a/test/internal/source-lints/import-kind-and-level-names.test.ts
+++ b/test/internal/source-lints/import-kind-and-level-names.test.ts
@@ -1,0 +1,143 @@
+import { Glob } from "bun";
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// `BuildMessage.level` / `ResolveMessage.level` are `bun_ast::Kind::string()`
+// and `ResolveMessage.importKind` (also the metafile's and scanImports()' `kind`)
+// is `bun_ast::ImportKind::label()`, both in src/ast/lib.rs. The bun-types
+// `BuildMessageLevel` and `ImportKind` unions and the `class BuildMessage` /
+// `class ResolveMessage` snippets in the docs are hand-written copies of those
+// strings, and they had drifted from the runtime for years (`"warning"`,
+// `"stmt"`, no `"composes"`). This lint fails when any copy differs from the
+// Rust tables.
+//
+// A variant that is deliberately kept out of the union goes into `notPublic`
+// below with the reason; every other label has to be in every copy. Deleting
+// such a variant from the enum fails the first test until it is removed here too.
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), "utf8");
+
+const libRs = read("src/ast/lib.rs");
+
+const notPublic = [
+  // `@import` rules with conditions have an empty label, so a ResolveMessage for
+  // one currently reports `importKind: ""`. A runtime gap, not a documented value.
+  "AtConditional",
+  // Reported today only as the metafile `kind` of the first server-side importer
+  // of an HTML file, and #38621 removes that rewrite while keeping the variant,
+  // so a documented "html_manifest" would outlive its last use without this
+  // lint noticing. If #38621 is dropped instead, delete this entry.
+  "HtmlManifest",
+];
+
+/** The variants of `pub enum <name> { A = 0, B = 1, … }` in src/ast/lib.rs. */
+function enumVariants(name: string): string[] {
+  const body = libRs.match(new RegExp(`^pub enum ${name} \\{([^}]*)\\}`, "m"))?.[1];
+  expect(body).toBeDefined();
+  return [...body!.matchAll(/^\s*([A-Z][A-Za-z0-9]*)(?:\s*=\s*\d+)?,/gm)].map(([, variant]) => variant);
+}
+
+/**
+ * `variant -> string` for each arm of `pub fn <fn>(self) -> &'static [u8] { match self { … } }`
+ * in src/ast/lib.rs. Empty when the function was not found; the first test
+ * below compares the arms with the enum's variants, which catches that.
+ */
+function matchArms(enumName: string, fn: string): Map<string, string> {
+  const body =
+    libRs.match(new RegExp(`pub fn ${fn}\\(self\\) -> &'static \\[u8\\] \\{\\s*match self \\{([^}]*)\\}`))?.[1] ?? "";
+  const arms = new Map<string, string>();
+  for (const [, variant, label] of body.matchAll(new RegExp(`^\\s*${enumName}::([A-Za-z0-9]+) => b"([^"]*)",`, "gm"))) {
+    arms.set(variant, label);
+  }
+  return arms;
+}
+
+const levelArms = matchArms("Kind", "string");
+const labelArms = matchArms("ImportKind", "label");
+
+/** What every copy of the level union has to list, sorted. */
+const levels = [...levelArms.values()].sort();
+
+/** What every copy of the import kind union has to list, sorted. */
+const importKinds = [...labelArms]
+  .filter(([variant]) => !notPublic.includes(variant))
+  .map(([, label]) => label)
+  .sort();
+
+/**
+ * The members of the string-literal union that follows each match of `prefix`
+ * in `source`, sorted, one entry per match. Comments between the members are
+ * ignored. A match followed by something other than a string-literal union
+ * (for example `importKind: ImportKind;`) yields `null`.
+ */
+function unionsAfter(source: string, prefix: RegExp): (string[] | null)[] {
+  return [...source.matchAll(prefix)].map(match => {
+    const body = source
+      .slice(match.index! + match[0].length)
+      .replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, "")
+      .match(/^([^;]*);/)?.[1];
+    expect(body).toBeDefined();
+    const members = [...body!.matchAll(/"([^"]*)"/g)].map(([, name]) => name);
+    return members.length > 0 && body!.replace(/"[^"]*"|\||\s/g, "") === "" ? members.sort() : null;
+  });
+}
+
+const typeAlias = (name: string) => new RegExp(`^\\s*type ${name}\\s*=`, "gm");
+const property = (name: string) => new RegExp(`^\\s*(?:readonly\\s+)?${name}:`, "gm");
+
+test("src/ast/lib.rs: Kind::string() and ImportKind::label() were parsed for every variant", () => {
+  expect([...levelArms.keys()].sort()).toEqual(enumVariants("Kind").sort());
+  expect([...labelArms.keys()].sort()).toEqual(enumVariants("ImportKind").sort());
+  expect(notPublic.filter(variant => !labelArms.has(variant))).toEqual([]);
+  expect(levels.length).toBeGreaterThanOrEqual(5);
+  expect(importKinds.length).toBeGreaterThanOrEqual(10);
+  expect(new Set(levels).size).toBe(levels.length);
+  expect(new Set(importKinds).size).toBe(importKinds.length);
+});
+
+test("src/ast/lib.rs: a variant without a label is listed in `notPublic`", () => {
+  const unlabeled = [...labelArms].filter(([, label]) => label === "").map(([variant]) => variant);
+  expect(unlabeled.filter(variant => !notPublic.includes(variant))).toEqual([]);
+  expect(importKinds).not.toContain("");
+});
+
+test("packages/bun-types/bun.d.ts: BuildMessageLevel lists Kind::string()", () => {
+  expect(unionsAfter(read("packages/bun-types/bun.d.ts"), typeAlias("BuildMessageLevel"))).toEqual([levels]);
+});
+
+test("packages/bun-types/bun.d.ts: ImportKind lists ImportKind::label()", () => {
+  expect(unionsAfter(read("packages/bun-types/bun.d.ts"), typeAlias("ImportKind"))).toEqual([importKinds]);
+});
+
+test("docs: every BuildMessage / ResolveMessage snippet lists the same strings", () => {
+  // docs/runtime/transpiler.mdx lists the kinds scanImports() returns, which is
+  // deliberately a subset of ImportKind (no CSS or HTML kinds); it declares
+  // neither class, so it is not picked up here.
+  const snippets: [file: string, body: string][] = [];
+  for (const rel of [...new Glob("**/*.mdx").scanSync({ cwd: path.join(repoRoot, "docs") })].sort()) {
+    const file = `docs/${rel.replaceAll("\\", "/")}`;
+    for (const [, body] of read(file).matchAll(
+      /^(?:declare )?class (?:BuildMessage|ResolveMessage)\b[^{]*\{([^}]*)\}/gm,
+    )) {
+      snippets.push([file, body]);
+    }
+  }
+  // Currently the two snippets under "Logs and errors" and the reference block
+  // in docs/bundler/index.mdx. An empty scan means the glob or pattern broke.
+  expect(snippets.length).toBeGreaterThan(0);
+
+  const levelCopies = snippets.flatMap(([file, body]) =>
+    unionsAfter(body, property("level")).map(copy => [file, copy]),
+  );
+  expect(levelCopies.length).toBeGreaterThan(0);
+  expect(levelCopies).toEqual(levelCopies.map(([file]) => [file, levels]));
+
+  // `importKind: ImportKind;` (a reference rather than a copy) is fine; a
+  // spelled-out union has to match.
+  const importKindCopies = snippets
+    .flatMap(([file, body]) => unionsAfter(body, property("importKind")).map(copy => [file, copy]))
+    .filter(([, copy]) => copy !== null);
+  expect(importKindCopies.length).toBeGreaterThan(0);
+  expect(importKindCopies).toEqual(importKindCopies.map(([file]) => [file, importKinds]));
+});


### PR DESCRIPTION
### Problem
- `BuildMessage.level` and `ResolveMessage.level` are declared as `"error" | "warning" | "info" | "debug" | "verbose"` (packages/bun-types/globals.d.ts), but both getters return `bun_ast::Kind::string()` (src/jsc/BuildMessage.rs and src/jsc/ResolveMessage.rs `get_level`; table in src/ast/lib.rs), whose values are `"error" | "warn" | "note" | "debug" | "verbose"`. So `log.level === "warn"` (the value that comes back) is a TS2367 error, while `log.level === "warning"` type-checks and is never true.
- `ResolveMessage.importKind` is declared as the old enum tag names (`"stmt" | "require" | "require_resolve" | "at" | ...`), but the getter has returned `ImportKind::label()` (`"import-statement" | "require-call" | "require-resolve" | "import-rule" | ...`) since #2833, the same change that added the `level` unions above. Same failure mode.
- `Bun.ImportKind` in bun.d.ts, the declared mirror of `ImportKind::label()`, is missing `"composes"`, which a `ResolveMessage` for `composes: x from "./missing.css"` reports.
- The copies drifted because nothing compares them with the Rust tables: the only guard was a "keep bun.d.ts in sync" comment in src/ast/lib.rs, and src/jsc/ResolveMessage.rs kept its own verbatim copy of the label table as well.
- Reproduces on bun 1.4.0 and current main; probe output below.

### Fix
- `Bun.ImportKind` gains `"composes"` (each member now documented), and a new `Bun.BuildMessageLevel` alias holds the `Kind::string()` arms. `ResolveMessage.importKind` and both `level` declarations reference those two types, so each union is declared once. The docs copies in docs/bundler/index.mdx are updated to match.
- The declarations change rather than the runtime: these strings have been returned unchanged since before bun-types existed, and tests and user code compare against them (test/bundler/bun-build-api.test.ts, test/bundler/metafile.test.ts).
- `ResolveMessage::get_import_kind` now calls `ImportKind::label()` instead of its private copy of the table (the copy's justification was stale: `MetadataResolve.import_kind` is the `bun_ast::ImportKind` that has `label()`). The table is identical, so the reported strings do not change (verified with the probe below on a debug build).
- New source lint test/internal/source-lints/import-kind-and-level-names.test.ts parses the `Kind::string()` and `ImportKind::label()` arms out of src/ast/lib.rs and fails when `Bun.BuildMessageLevel`, `Bun.ImportKind`, or any `class BuildMessage` / `class ResolveMessage` snippet in the docs differs from them. Two variants are listed as exclusions with their reasons: `AtConditional` (its label is `""`) and `HtmlManifest` (see below). Same shape as the Loader lint in #38424; the source-lints workflow and README hunks are identical to that PR's so the two merge in either order.
- On main's declarations the lint fails (`BuildMessageLevel` absent, `ImportKind` missing `"composes"`); with this change it passes. test/integration/bun-types/fixture/build.ts additionally compiles realistic usage (`log.level === "warn"`, `log.importKind === "require-call"`) and checks that the globals resolve to the two aliases, under both the DOM and non-DOM tsconfigs.
- Also run: `bun bd test test/js/bun/resolve/resolve-error.test.ts test/bundler/bun-build-api.test.ts` (74 pass) and `bun test test/internal/source-lints/` (151 pass).

### Not changed here
- `ImportKind::label()` returns `""` for a conditional CSS `@import`, so that one `ResolveMessage` reports `importKind: ""` today. That is a runtime gap for a separate change; the lint documents it rather than adding `""` to the type.
- `"html_manifest"` (the `HtmlManifest` variant) is deliberately left out of `Bun.ImportKind`, so the metafile `kind` of the first server-side importer of an HTML file (the only place it is reported today; it is never a `ResolveMessage.importKind`) stays untyped for now. #38621 removes that rewrite but keeps the variant, so a member added now would outlive its last use and the lint could not tell. The lint lists the variant as an exclusion with that reason; if #38621 is dropped, the entry gets deleted and the lint then demands the member.
- Plugin `onResolve` args get the wrong `kind` for CSS imports because the JS-side id table is hand-written; #37095 fixes that.
- The declarations also omit members the runtime has (`notes`, `line`, `column`, `toJSON`, the `Error` base); separate change.
- docs/runtime/transpiler.mdx lists the kinds `scanImports()` returns, which is deliberately a subset of `ImportKind` (a JS scan cannot produce the CSS kinds), so it is left as is and not linted.

### Background
- A bundler diagnostic is a `bun_ast::Msg` whose `kind` is a `bun_ast::Kind` (`Err`, `Warn`, `Note`, `Debug`, `Verbose`). `Bun.build` returns each one wrapped as a `BuildMessage`, or a `ResolveMessage` when it carries resolve metadata, and `level` is `Kind::string()` of that kind. `Note` is the kind of the entries in a message's `notes`.
- `bun_ast::ImportKind` classifies the import record being resolved. `label()` is its public string form, shared by `ResolveMessage.importKind`, the metafile `kind` field and `Transpiler.scanImports()`; `Bun.ImportKind` is the TypeScript mirror of that table.
- test/internal/source-lints/ holds tests that only read the source tree. They are excluded from the Buildkite lanes and run on GitHub Actions (.github/workflows/source-lints.yml) for the paths listed there, which is why bun.d.ts and the docs are added to that list.

<details>
<summary>Runtime probe (bun 1.4.0 and a debug build of this branch print the same rows)</summary>

```ts
const { logs } = await Bun.build({
  entrypoints: [
    "unknown-at-rule.css",          // @foo bar; .a { color: red }
    "missing-imports.ts",           // import / require / require.resolve / import() of missing files
    "missing-css-imports.css",      // @import "./missing.css"; @import "./missing-cond.css" supports(...); url("./missing.png")
    "missing-composes.module.css",  // .a { composes: b from "./missing.module.css" }
  ].map(f => import.meta.dir + "/" + f),
  throw: false,
});
for (const l of logs) console.log(l.name, l.level, l instanceof ResolveMessage ? l.importKind : null, l.message);
```

```
ResolveMessage error ""                 Could not resolve: "./missing-cond.css"
ResolveMessage error "dynamic-import"   Could not resolve: "./missing-dynamic"
ResolveMessage error "import-statement" Could not resolve: "./missing-import"
ResolveMessage error "require-resolve"  Could not resolve: "./missing-require-resolve"
ResolveMessage error "require-call"     Could not resolve: "./missing-require"
ResolveMessage error "import-rule"      Could not resolve: "./missing.css"
ResolveMessage error "composes"         Could not resolve: "./missing.module.css"
ResolveMessage error "url-token"        Could not resolve: "./missing.png"
BuildMessage   warn  null               invalid @ rule encountered: '@foo'
```

</details>

<details>
<summary>Earlier revision of this PR</summary>

The first push fixed the same declarations but re-pinned the unions as literals in the bun-types fixture and added a `Bun.build` + tsc case to test/integration/bun-types/bun-types.test.ts. Self-review pointed out that the literal pins only compared TypeScript with TypeScript, that test/integration/bun-types is excluded from the Buildkite lanes (so the `Bun.build` half never ran against the build under test), that the tsc helper extraction collided with #37421, and that ResolveMessage.rs still carried its own copy of the label table. This revision replaces all of that with the source lint, the shared aliases and the `label()` call described above; bun-types.test.ts is no longer touched.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/import-kind-and-level-names.test.ts
bun test v1.4.0 (e1ea82a0a)

test/internal/source-lints/import-kind-and-level-names.test.ts:
(pass) src/ast/lib.rs: Kind::string() and ImportKind::label() were parsed for every variant [30.02ms]
(pass) src/ast/lib.rs: a variant without a label is listed in `notPublic` [7.39ms]
101 |   expect(unlabeled.filter(variant => !notPublic.includes(variant))).toEqual([]);
102 |   expect(importKinds).not.toContain("");
103 | });
104 | 
105 | test("packages/bun-types/bun.d.ts: BuildMessageLevel lists Kind::string()", () => {
106 |   expect(unionsAfter(read("packages/bun-types/bun.d.ts"), typeAlias("BuildMessageLevel"))).toEqual([levels]);
                                                                                                 ^
error: expect(received).toEqual(expected)

- [
-   [
-     "debug",
-     "error",
-     "note",
-     "verbose",
-     "warn",
-   ],
- ]
+ []

- Expected  - 9
+ Received  + 1

      at <anonymous> (/workspace/bun/test/internal/source-lints/import-kind-
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (4dcef48c6)

test/internal/source-lints/import-kind-and-level-names.test.ts:
(pass) src/ast/lib.rs: Kind::string() and ImportKind::label() were parsed for every variant [2.55ms]
(pass) src/ast/lib.rs: a variant without a label is listed in `notPublic` [0.09ms]
101 |   expect(unlabeled.filter(variant => !notPublic.includes(variant))).toEqual([]);
102 |   expect(importKinds).not.toContain("");
103 | });
104 | 
105 | test("packages/bun-types/bun.d.ts: BuildMessageLevel lists Kind::string()", () => {
106 |   expect(unionsAfter(read("packages/bun-types/bun.d.ts"), typeAlias("BuildMessageLevel"))).toEqual([levels]);
                                                                                                 ^
error: expect(received).toEqual(expected)

- [
-   [
-     "debug",
-     "error",
-     "note",
-     "verbose",
-     "warn",
-   ],
- ]
+ []

- Expected  - 9
+ Received  + 1

      at <anonymous> (/workspace/bun/test/internal/source-lints/import-kind-and-level-names.test.ts:106:92)
(fail) packages/bun-types/bun.d.ts: BuildMessageLevel lists Kind::string() [4.98ms]
105 | test("packages/bun-types/bun.d.ts: BuildMessageLevel lists Kind::s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/import-kind-and-level-names.test.ts
bun test v1.4.0 (e1ea82a0a)

test/internal/source-lints/import-kind-and-level-names.test.ts:
(pass) src/ast/lib.rs: Kind::string() and ImportKind::label() were parsed for every variant [30.07ms]
(pass) src/ast/lib.rs: a variant without a label is listed in `notPublic` [7.06ms]
(pass) packages/bun-types/bun.d.ts: BuildMessageLevel lists Kind::string() [29.14ms]
(pass) packages/bun-types/bun.d.ts: ImportKind lists ImportKind::label() [20.44ms]
(pass) docs: every BuildMessage / ResolveMessage snippet lists the same strings [264.46ms]

 5 pass
 0 fail
 24 expect() calls
Ran 5 tests across 1 file. [2.84s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 751ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/133] gen ErrorCode+*.h
[2/133] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/133] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[4/133] gen cpp.rs (cppbind)
[5/133] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.github/workflows/source-lints.yml                 |   4 +
 docs/bundler/index.mdx                             |  24 ++--
 packages/bun-types/bun.d.ts                        |  22 ++++
 packages/bun-types/globals.d.ts                    |  16 +--
 src/ast/lib.rs                                     |   1 +
 src/jsc/ResolveMessage.rs                          |  23 +---
 test/integration/bun-types/fixture/build.ts        |  16 +++
 test/internal/source-lints/README.md               |   5 +
 .../import-kind-and-level-names.test.ts            | 143 +++++++++++++++++++++
 9 files changed, 207 insertions(+), 47 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
.github/workflows/source-lints.yml                            1      3      0
docs/bundler/index.mdx                                        3      4      0
packages/bun-types/bun.d.ts                                   3      6      0
packages/bun-types/globals.d.ts                               2      3      0
src/ast/lib.rs                                                4      7      0
src/jsc/ResolveMessage.rs                                     1      2      0
test/integration/bun-types/fixture/build.ts                   3      3      0
test/internal/source-lints/README.md                          1      1      0
…ternal/source-lints/import-kind-and-level-names.test.ts      3      7      0
```

</details>

<!-- robobun:evidence:end -->