### PR TITLE
Remove cmake-era setup from the Nix shells and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,6 @@ A Nix flake is provided as an alternative to manual dependency installation:
 
 ```bash
 nix develop
-# or explicitly use the pure shell
-# nix develop .#pure
-export CMAKE_SYSTEM_PROCESSOR=$(uname -m)
 bun bd
 ```
 
@@ -150,7 +147,7 @@ $ export PATH="$PATH:/usr/lib/llvm21/bin"
 
 ## Building Bun
 
-After cloning the repository, run the following command to build. This may take a while as it will clone submodules and build dependencies.
+After cloning the repository, run the following command to build. This may take a while as it downloads and builds dependencies.
 
 ```bash
 $ bun run build
@@ -305,7 +302,7 @@ Note that if you make changes to our [WebKit fork](https://github.com/oven-sh/We
 
 The Clang compiler typically uses the `libstdc++` C++ standard library by default. `libstdc++` is the default C++ Standard Library implementation provided by the GNU Compiler Collection (GCC). While Clang may link against the `libc++` library, this requires explicitly providing the `-stdlib` flag when running Clang.
 
-Bun relies on C++20 features like `std::span`, which are not available in GCC versions lower than 11. GCC 10 doesn't have all of the C++20 features implemented. As a result, running `make setup` may fail with the following error:
+Bun relies on C++20 features like `std::span`, which are not available in GCC versions lower than 11. GCC 10 doesn't have all of the C++20 features implemented. As a result, running `bun run build` may fail with the following error:
 
 ```
 fatal error: 'span' file not found
@@ -313,7 +310,7 @@ fatal error: 'span' file not found
          ^~~~~~
 ```
 
-The issue may manifest when initially running `bun setup` as Clang being unable to compile a simple program:
+The issue may manifest when initially running `bun run build` as Clang being unable to compile a simple program:
 
 ```
 The C++ compiler
@@ -363,7 +360,7 @@ $ xcode-select --install
 Bun defaults to linking `libatomic` statically, as not all systems have it. If you are building on a distro that does not have a static libatomic available, you can run the following command to enable dynamic linking:
 
 ```bash
-$ bun run build -DUSE_STATIC_LIBATOMIC=OFF
+$ bun run build --static-libatomic=off
 ```
 
 The built version of Bun may not work on other systems if compiled this way.

--- a/flake.nix
+++ b/flake.nix
@@ -139,11 +139,6 @@
             export CXX="${pkgs.lib.getExe' clang "clang++"}"
             export AR="${llvm}/bin/llvm-ar"
             export RANLIB="${llvm}/bin/llvm-ranlib"
-            export CMAKE_C_COMPILER="$CC"
-            export CMAKE_CXX_COMPILER="$CXX"
-            export CMAKE_AR="$AR"
-            export CMAKE_RANLIB="$RANLIB"
-            export CMAKE_SYSTEM_PROCESSOR="$(uname -m)"
             export TMPDIR="''${TMPDIR:-/tmp}"
           '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
             export LD="${pkgs.lib.getExe' lld "ld.lld"}"
@@ -166,10 +161,6 @@
             echo "  bun bd test <test-file>   # Run tests"
             echo "====================================="
           '';
-
-          # Additional environment variables
-          CMAKE_BUILD_TYPE = "Debug";
-          ENABLE_CCACHE = "1";
         };
       }
     );

--- a/shell.nix
+++ b/shell.nix
@@ -81,11 +81,6 @@ pkgs.mkShell rec {
     export CXX="${pkgs.lib.getExe' pkgs.clang_21 "clang++"}"
     export AR="${pkgs.llvm_21}/bin/llvm-ar"
     export RANLIB="${pkgs.llvm_21}/bin/llvm-ranlib"
-    export CMAKE_C_COMPILER="$CC"
-    export CMAKE_CXX_COMPILER="$CXX"
-    export CMAKE_AR="$AR"
-    export CMAKE_RANLIB="$RANLIB"
-    export CMAKE_SYSTEM_PROCESSOR=$(uname -m)
     export TMPDIR=''${TMPDIR:-/tmp}
   '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
     export LD="${pkgs.lib.getExe' pkgs.lld_21 "ld.lld"}"


### PR DESCRIPTION
### Problem
- `flake.nix` and `shell.nix` still export `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`, `CMAKE_AR`, `CMAKE_RANLIB` and `CMAKE_SYSTEM_PROCESSOR` from their `shellHook`, and `flake.nix` still sets `CMAKE_BUILD_TYPE = "Debug"` and `ENABLE_CCACHE = "1"` (flake.nix:142-146, 171-172; shell.nix:84-88).
- The Nix snippet in `CONTRIBUTING.md` (line 12-13) tells contributors to `export CMAKE_SYSTEM_PROCESSOR=$(uname -m)` before `bun bd`, and offers a `nix develop .#pure` shell that `flake.nix` has never defined (it only has `devShells.default`).
- `CONTRIBUTING.md` also still documents `bun run build -DUSE_STATIC_LIBATOMIC=OFF` (line 366) and refers to `make setup` / `bun setup` / cloning submodules (lines 153, 308, 316).
- All of this dates from the CMake build, which #28640 deleted. Nothing in the tree reads these variables any more:
  - `git grep -nE 'env(\.|\[)CMAKE_|ENABLE_CCACHE' -- scripts` is empty.
  - The compiler, archiver, ranlib and build type reach the one remaining cmake consumer (the nested cmake build for local WebKit) as explicit `-D` arguments from the resolved toolchain, `scripts/build/source.ts:1148-1152` and `:1194`, so the environment is never consulted for them.
  - The target arch comes from clang's default target (`clangTargetArch`, `scripts/build/tools.ts:192`), with no environment override.
  - ccache is used whenever it is found (`cfg.ccache`, `scripts/build/source.ts:1178`); `ENABLE_CCACHE` and the `CMAKE_BUILD_TYPE` env lookup were features of the deleted `optionx` cmake macro.
  - `-DUSE_STATIC_LIBATOMIC=OFF` is not a `--flag`, so `scripts/build.ts` `parseArgs` treats it as the first exec arg: the build runs with static libatomic anyway and the define is handed to the freshly built binary.

### Fix
- Drop the five `CMAKE_*` exports from both shell hooks and the `CMAKE_BUILD_TYPE` / `ENABLE_CCACHE` attributes from `flake.nix`. `CC`, `CXX`, `AR`, `RANLIB`, `LD`, `NIX_CFLAGS_LINK`, `LD_LIBRARY_PATH` and `pkgs.cmake` stay: cc-rs build scripts read the first group when `cargo check` / `bun run watch` are run straight from the shell, and `scripts/build/configure.ts:50` still requires cmake for the nested dep builds.
- Port to `CONTRIBUTING.md` the same factual fixes `docs/project/contributing.mdx` already received in #33706: Nix snippet reduced to `nix develop` + `bun bd`, libatomic workaround becomes `bun run build --static-libatomic=off`, troubleshooting text says `bun run build`, and the build section says dependencies are downloaded rather than cloned as submodules. The two files now agree on every command they document; the remaining differences between them are wording only.
- Why this is correct: every removed line names a variable or command that no longer has a reader, and every replacement is what the current build system implements (`staticLibatomic` in `scripts/build.ts` boolFields, `scripts/build/config.ts:902-905`).
- Verified:
  - `bun scripts/build.ts --configure-only --static-libatomic=off` configures and the generated `build.ninja` no longer links `-l:libatomic.a`; the default configure still does.
  - After the change, `git grep -n 'CMAKE_SYSTEM_PROCESSOR\|ENABLE_CCACHE\|CMAKE_C_COMPILER\|CMAKE_AR\|CMAKE_RANLIB' -- ':!vendor'` hits only `scripts/build` code that produces these values itself (`source.ts` `-D` args, `deps/webkit.ts`, `xmac.mjs`), comments, and an old `package.json` used as fixture data in `test/js/bun/util/zstd.test.ts`.
  - `prettier --check CONTRIBUTING.md` passes.
  - No Nix is available where this was prepared, so `nix develop` itself was not re-run; the nix change only deletes whole lines inside otherwise unchanged `shellHook` strings and the mkShell attrset.
- Scope: this is not a fix for the nix shell itself. On main, `flake.lock` still pins the nixpkgs from #23406 (2025-10-07), which predates the `pkgs.nodejs_26` that #31991 put at `flake.nix:35`, so `nix develop` currently fails at evaluation with or without this PR; #37073 (open) updates the lock and makes the build honour `CC`/`CXX`/`AR`/`RANLIB`/`LD`. #37073 keeps the lines removed here and edits other regions of both files, so the two apply in either order. This PR only removes lines that have no reader under any outcome of that work.
- Docs and dev-shell only; there is no test to add.

### Background
- `scripts/build/` replaced the CMake build in #28640. It resolves the toolchain itself (`tools.ts`) and writes a `build.ninja`; the only cmake it still runs is for `nested-cmake` dependencies (today just a local WebKit build), and it passes every toolchain setting to that cmake on the command line.
- `optionx` was a macro in the deleted `cmake/Globals.cmake` that let any build option (`ENABLE_CCACHE`, `CMAKE_BUILD_TYPE`, ...) be supplied through the environment. That is the mechanism the Nix shells were feeding; it no longer exists.
- `CMAKE_<LANG>_COMPILER`, `CMAKE_AR` and `CMAKE_SYSTEM_PROCESSOR` are cmake cache/internal variables, not environment variables cmake reads (cmake reads `CC`/`CXX` from the environment), so exporting them only ever had an effect through project-specific code, of which none remains.
- `mkShell` turns unknown attributes such as `CMAKE_BUILD_TYPE = "Debug"` into environment variables of the dev shell; removing them removes only those variables.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->