### PR TITLE
bun build --no-bundle: minify css with the build target's browser targets

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3084,7 +3084,15 @@ impl<'a> Transpiler<'a> {
                 return None;
             }
         };
-        if let Err(e) = sheet.minify(alloc, &bun_css::MinifyOptions::default(), &extra) {
+        let targets = bun_css::Targets::for_bundler_target(self.options.target);
+        if let Err(e) = sheet.minify(
+            alloc,
+            &bun_css::MinifyOptions {
+                targets,
+                unused_symbols: Default::default(),
+            },
+            &extra,
+        ) {
             self.log_mut().add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,
@@ -3096,7 +3104,7 @@ impl<'a> Transpiler<'a> {
         let result = match sheet.to_css(
             alloc,
             &bun_css::PrinterOptions {
-                targets: bun_css::Targets::for_bundler_target(self.options.target),
+                targets,
                 minify: self.options.minify_whitespace,
                 ..bun_css::PrinterOptions::default()
             },

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -579,3 +579,101 @@ describe.concurrent("modules that fail to print", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe.concurrent("bun build --no-bundle css", () => {
+  // Everything in here is rewritten for the browser targets while the
+  // stylesheet is minified, not while it is printed: color fallbacks, a
+  // prefixed selector, a prefixed property, a prefixed value and a font stack.
+  const files = {
+    "styles.css": [
+      ".a { color: oklch(70% 0.1 200) }",
+      ".b:fullscreen { color: red }",
+      ".c { background-clip: text }",
+      ".d { width: fit-content }",
+      ".e { font-family: system-ui }",
+      "",
+    ].join("\n"),
+  };
+
+  async function build(cwd: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args, "styles.css"],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    // Only a bundled stylesheet starts with a comment naming its source file.
+    return stdout.replace("/* styles.css */\n", "");
+  }
+
+  test("lowers css for the default (browser) target the same way a bundled build does", async () => {
+    using dir = tempDir("no-bundle-css-browser", files);
+    const [transpiled, bundled] = await Promise.all([build(String(dir), "--no-bundle"), build(String(dir))]);
+    expect(transpiled).toMatchInlineSnapshot(`
+      ".a {
+        color: #40b1b7;
+        color: color(display-p3 .381906 .685023 .710512);
+        color: lab(66.1711% -31.3595 -12.905);
+      }
+
+      .b:-webkit-full-screen {
+        color: red;
+      }
+
+      .b:fullscreen {
+        color: red;
+      }
+
+      .c {
+        -webkit-background-clip: text;
+        background-clip: text;
+      }
+
+      .d {
+        width: -moz-fit-content;
+        width: fit-content;
+      }
+
+      .e {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue;
+      }
+      "
+    `);
+    expect(transpiled).toBe(bundled);
+  });
+
+  test.each(["bun", "node"])("--target=%s leaves css alone the same way a bundled build does", async target => {
+    using dir = tempDir(`no-bundle-css-${target}`, files);
+    const [transpiled, bundled] = await Promise.all([
+      build(String(dir), "--no-bundle", `--target=${target}`),
+      build(String(dir), `--target=${target}`),
+    ]);
+    expect(transpiled).toMatchInlineSnapshot(`
+      ".a {
+        color: oklch(70% .1 200);
+      }
+
+      .b:fullscreen {
+        color: red;
+      }
+
+      .c {
+        background-clip: text;
+      }
+
+      .d {
+        width: fit-content;
+      }
+
+      .e {
+        font-family: system-ui;
+      }
+      "
+    `);
+    expect(transpiled).toBe(bundled);
+  });
+});

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -518,68 +518,6 @@ describe("CLI argument error messages", () => {
   });
 });
 
-describe.concurrent("modules that fail to print", () => {
-  // A TOML dotted header builds an object nested arbitrarily deep without
-  // recursing in the parser, so the printer's recursion guard is the first
-  // thing to hit it. The build must fail instead of emitting truncated
-  // output with exit code 0.
-  const deepToml = "[" + Buffer.alloc(200_000, "a.").toString() + "a]\nd = 1\n";
-
-  test("bun build fails instead of emitting a truncated bundle", async () => {
-    using dir = tempDir("build-deep-toml", { "deep.toml": deepToml });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "deep.toml"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Maximum call stack size exceeded while generating code for this file");
-    expect(stderr).toContain("deep.toml");
-    // No partial bundle: the printer used to bail mid-print and emit only
-    // the trailing export stub.
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(1);
-  });
-
-  test("bun build --no-bundle fails instead of emitting empty output", async () => {
-    using dir = tempDir("build-deep-toml-nb", { "deep.toml": deepToml });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-bundle", "deep.toml"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain('Maximum call stack size exceeded while generating code for "');
-    expect(stderr).toContain("deep.toml");
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(1);
-  });
-
-  test("bun build fails instead of emitting a truncated stylesheet when CSS cannot be generated", async () => {
-    // `composes` on a non-simple selector makes the CSS printer fail; the
-    // whole stylesheet body used to be dropped while the build exited 0.
-    using dir = tempDir("build-css-print-err", {
-      "styles.module.css": ".b { color: blue }\n.a .c { composes: b; color: red }\n",
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "styles.module.css"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Failed to generate CSS for this file");
-    expect(stderr).toContain("styles.module.css");
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(1);
-  });
-});
-
 describe.concurrent("bun build --no-bundle css", () => {
   // Everything in here is rewritten for the browser targets while the
   // stylesheet is minified, not while it is printed: color fallbacks, a
@@ -675,5 +613,67 @@ describe.concurrent("bun build --no-bundle css", () => {
       "
     `);
     expect(transpiled).toBe(bundled);
+  });
+});
+
+describe.concurrent("modules that fail to print", () => {
+  // A TOML dotted header builds an object nested arbitrarily deep without
+  // recursing in the parser, so the printer's recursion guard is the first
+  // thing to hit it. The build must fail instead of emitting truncated
+  // output with exit code 0.
+  const deepToml = "[" + Buffer.alloc(200_000, "a.").toString() + "a]\nd = 1\n";
+
+  test("bun build fails instead of emitting a truncated bundle", async () => {
+    using dir = tempDir("build-deep-toml", { "deep.toml": deepToml });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "deep.toml"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Maximum call stack size exceeded while generating code for this file");
+    expect(stderr).toContain("deep.toml");
+    // No partial bundle: the printer used to bail mid-print and emit only
+    // the trailing export stub.
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("bun build --no-bundle fails instead of emitting empty output", async () => {
+    using dir = tempDir("build-deep-toml-nb", { "deep.toml": deepToml });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "deep.toml"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('Maximum call stack size exceeded while generating code for "');
+    expect(stderr).toContain("deep.toml");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("bun build fails instead of emitting a truncated stylesheet when CSS cannot be generated", async () => {
+    // `composes` on a non-simple selector makes the CSS printer fail; the
+    // whole stylesheet body used to be dropped while the build exited 0.
+    using dir = tempDir("build-css-print-err", {
+      "styles.module.css": ".b { color: blue }\n.a .c { composes: b; color: red }\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "styles.module.css"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Failed to generate CSS for this file");
+    expect(stderr).toContain("styles.module.css");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- `bun build --no-bundle x.css` prints modern CSS as written, while `bun build x.css` (same file, same default `--target=browser`) lowers it:
  ```
  $ printf '.c { color: oklch(70%% 0.1 200) }' > n.css
  $ bun build n.css               # .c { color: #40b1b7; color: color(display-p3 ...); color: lab(...); }
  $ bun build --no-bundle n.css   # .c { color: oklch(70% .1 200); }
  ```
  The same goes for everything else lowered in the minify pass: `:fullscreen` -> `:-webkit-full-screen`, `background-clip: text` -> `-webkit-background-clip`, `fit-content` -> `-moz-fit-content`, `inset-inline-*` logical properties, the `system-ui` font stack, `lab()`/`color()` fallbacks.
- Cause: the `--no-bundle` CSS path, `Transpiler::build_css_output` (src/bundler/transpiler.rs), called `sheet.minify(.., &MinifyOptions::default(), ..)`, i.e. `targets.browsers == None`, so every "should I compile this feature" check answered no. The bundler's `ParseTask` (src/bundler/ParseTask.rs, `Loader::Css` arm) minifies with `Targets::for_bundler_target(target)`. `build_css_output` already used those targets for printing, just not for minifying, which is why print-time lowering such as nesting already matched and minify-time lowering did not.
- Pre-existing: the Zig version of this function had the same `MinifyOptions.default()`, so this is not a rewrite regression.

### Fix
- `build_css_output` computes `Targets::for_bundler_target(self.options.target)` once and passes it to both `minify` and `to_css`. The fixing line is the `targets` field of the `MinifyOptions` passed to `sheet.minify`; the `to_css` change only switches it to the shared local.
- Correct because `--no-bundle` only turns off bundling ("Transpile file only, do not bundle" in `--help`); `--target` is still accepted and this path already applied it to the print step, so the per-file transform should be the one the bundler applies to the same file for the same target. After this change the `Targets` handed to both passes are derived exactly as `ParseTask` (minify) and `generateCompileResultForCssChunk` (print) derive them.
- `--target=bun` and `--target=node` are unaffected: `for_bundler_target` returns `browsers: None` for them, which is what `MinifyOptions::default()` was already passing.
- Verified: new `bun build --no-bundle css` block at the end of test/bundler/cli.test.ts builds the same stylesheet with and without `--no-bundle` and asserts byte-equal output (minus the bundler's `/* styles.css */` header) plus an inline snapshot of the lowered CSS. The browser-target test fails on the released build (snapshot diff shows all five declarations left unlowered) and passes with this change; the `--target=bun` / `--target=node` cases pass both ways and pin that those targets stay untouched.
- Also checked by hand with the debug build: three larger probe files (colors, logical properties, media range syntax, a dozen prefixed selectors/properties/values) now produce byte-identical output from `bun build` and `bun build --no-bundle` with default flags and with `--minify-whitespace`.
- Scope: this is only the targets. The `PrinterOptions.minify` flag is a separate, pre-existing discrepancy (`--minify-syntax` or `--minify-identifiers` alone compacts stylesheet bodies in the bundler but not in `--no-bundle`, and the bundler's own `@layer` / external `@import` arms and chunk header disagree with its bodies too); it needs a decision on which policy is right, so it is tracked separately rather than folded in here. See Notes.

### Background
- `bun_css` lowers CSS in two places. `StyleSheet::minify` walks the AST and rewrites declarations and selectors for the configured browser targets (adds fallback declarations, vendor-prefixed copies, expands logical properties) and also does target-independent folding such as `0.1` -> `.1`. `StyleSheet::to_css` then prints, and a few features (nesting, for example) are lowered during printing instead. Both steps take a `Targets`.
- `Targets::for_bundler_target` (src/css/targets.rs) maps a build target to browser versions: the browser target gets Bun's fixed default set (`BROWSER_DEFAULT`: es2020-era Chrome/Edge/Opera, Firefox 78, Safari 14), while bun and node get `browsers: None`, which disables all target-dependent lowering. There is no user-facing way to pick other browser versions, so "browser target" and "default set" are the same thing in both build modes.
- `--no-bundle` routes entry points through `Transpiler::transform` -> `build_with_resolve_result_eager` -> `build_css_output` instead of `BundleV2`, so it has its own parse/minify/print sequence that has to be kept in step with `ParseTask`.

<details>
<summary>Notes</summary>

- `--minify` output now also matches modulo a trailing newline: bundled output ends with `\n`, `--no-bundle` output does not. That holds for JS as well and is unrelated to targets, so it is left alone here.
- `PrinterOptions.minify` policy, as found when reviewing this change: `generateCompileResultForCssChunk.rs` uses `minify_whitespace || minify_syntax || minify_identifiers` for stylesheet bodies (`SourceIndex` arm, also `prepareCssAstsForChunk.rs`) but `minify_whitespace` alone for the `Layers` and `ExternalPath` arms, the `/* file.css */` header is gated on `minify_whitespace`, and `build_css_output` uses `minify_whitespace` alone. So `bun build --minify-syntax a.css` prints a header over a compacted body while `bun build --no-bundle --minify-syntax a.css` prints pretty CSS; `--minify-whitespace` behaves the same in both. Pre-existing (same in the Zig original), independent of the targets fix, and tracked separately so all of those sites can be made to agree in one change once the policy is picked.
- Other `build_css_output` issues tracked separately and independent of this change: `url()` failing to parse under `--no-bundle` (#38528) and the css-modules panic in `Printer::lookup_symbol` (#38540). This PR changes different lines of the function from either of them; `git merge-tree` of this branch with each of them is conflict-free (the test block here sits ahead of `modules that fail to print` so it does not collide with the block #38528 appends at the end of the file).
</details>

