### PR TITLE
Ask for the machine and build architecture in the bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -26,7 +26,7 @@ body:
       label: What platform is your computer?
       description: |
         For MacOS and Linux: copy the output of `uname -mprs`
-        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $(if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" })"` in the PowerShell console
+        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $((Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').PROCESSOR_ARCHITECTURE)"` in the PowerShell console
   - type: textarea
     attributes:
       label: What steps can reproduce the bug?

--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -20,7 +20,7 @@ body:
   - type: input
     attributes:
       label: What version of Bun is running?
-      description: Copy the output of `bun --revision`
+      description: Copy the output of `bun -p "Bun.version_with_sha + ' ' + process.arch"` (or of `bun --revision` if Bun does not start)
   - type: input
     attributes:
       label: What platform is your computer?

--- a/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
@@ -18,7 +18,7 @@ body:
   - type: input
     attributes:
       label: What version of Bun is running?
-      description: Copy the output of `bun --revision`
+      description: Copy the output of `bun -p "Bun.version_with_sha + ' ' + process.arch"` (or of `bun --revision` if Bun does not start)
   - type: input
     attributes:
       label: What platform is your computer?

--- a/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/3-typescript-bug-report.yml
@@ -24,7 +24,7 @@ body:
       label: What platform is your computer?
       description: |
         For MacOS and Linux: copy the output of `uname -mprs`
-        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $(if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" })"` in the PowerShell console
+        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $((Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').PROCESSOR_ARCHITECTURE)"` in the PowerShell console
   - type: textarea
     attributes:
       label: What steps can reproduce the bug?

--- a/docs/feedback.mdx
+++ b/docs/feedback.mdx
@@ -46,7 +46,7 @@ Here's how to open a helpful issue for a bug, a performance problem, or a featur
     	Provide as much detail as possible, including:
     	- A clear and concise title
     	- A code example or steps to reproduce the issue
-    	- The version of Bun you are using (run `bun --version`)
+    	- The version of Bun you are using (run `bun -p "Bun.version_with_sha + ' ' + process.arch"`, or `bun --revision` if Bun does not start)
     	- A description of the issue (what you expected to happen and what actually happened)
     	- The operating system and version you are using
     		<Note>

--- a/docs/feedback.mdx
+++ b/docs/feedback.mdx
@@ -52,7 +52,7 @@ Here's how to open a helpful issue for a bug, a performance problem, or a featur
     		<Note>
     			- For macOS and Linux: copy the output of `uname -mprs`
     		  - For Windows: copy the output of this command in the PowerShell console:
-    				`"$([Environment]::OSVersion | ForEach-Object VersionString) $(if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" })"`
+    				`"$([Environment]::OSVersion | ForEach-Object VersionString) $((Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment').PROCESSOR_ARCHITECTURE)"`
     		</Note>
     </Step>
 


### PR DESCRIPTION
### Problem
- Since #26746 Bun ships two Windows builds (`bun-windows-x64`, `bun-windows-aarch64`), and a report from an ARM64 machine can be about either: the native build, or the x64 build running under emulation (`bun upgrade` keeps whichever architecture is installed, see `ARCH_LABEL` in `src/runtime/cli/upgrade_command.rs`). The same applies to x64 Bun under Rosetta on macOS.
- The bug report templates collect neither half of that. The platform field in `.github/ISSUE_TEMPLATE/2-bug-report.yml` and `3-typescript-bug-report.yml` (and the copy of the same command in `docs/feedback.mdx`) asks Windows users for a snippet based on `[Environment]::Is64BitOperatingSystem`, which prints `x64` on an ARM64 machine (run on a Windows 11 ARM64 box: `Microsoft Windows NT 10.0.26100.0 x64`). The version field asks for `bun --revision`, which prints the same `1.4.0-canary.1+7cf62962b` for the x64 and the arm64 build of a release.
- @190n asked for the template to distinguish these cases in #19911, which is being closed in favor of this PR (its install script half is superseded by #26746).

### Fix
- Platform field: the Windows command now reads `PROCESSOR_ARCHITECTURE` from `HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment` and prints `AMD64` or `ARM64`. This is the machine's architecture whatever shell the command is pasted into; `$env:PROCESSOR_ARCHITECTURE` (the variant in #19911) describes the PowerShell process and prints `x86` in a 32-bit host on both kinds of machine. It is the same read `src/runtime/cli/install.ps1` (line 19) uses, and the key is readable by `BUILTIN\Users`.
- Version field: now asks for `bun -p "Bun.version_with_sha + ' ' + process.arch"`, which prints e.g. `v1.4.0-canary.1 (7cf62962b) arm64`. `process.arch` is a compile-time constant (`constructArch` in `src/jsc/bindings/BunProcess.cpp`), so it names the build that is installed; together with the platform line that tells native from emulated. `bun --revision` stays as the fallback for a Bun that does not start, since it is answered before the runtime is initialized. `docs/feedback.mdx` asked for `bun --version` (no commit) here and now asks for the same command as the templates.
- Both commands are identical in all three files. Templates and docs only, so there is no test to add.
- Verified by running both commands, extracted byte for byte from the committed files, on Windows Server 2019 x64 and Windows 11 ARM64: the platform command in pwsh 7, Windows PowerShell 5.1 and the 32-bit (`SysWOW64`) Windows PowerShell host prints `... AMD64` in all three on x64 and `... ARM64` in all three on ARM64; the version command in pwsh 7, Windows PowerShell 5.1 and cmd.exe prints `v1.4.0-canary.1 (7cf62962b) x64` on x64 and `v1.4.0-canary.1 (7cf62962b) arm64` on ARM64, and the same command prints `... x64` in sh and bash on Linux. Both YAML files still parse, with the quotes in the version command intact.

### Background
- `PROCESSOR_ARCHITECTURE` is set by Windows per process: a 32-bit or emulated process sees the architecture it is emulating, and the real one is only exposed through `PROCESSOR_ARCHITEW6432`. The copy under the `Session Manager\Environment` registry key is the system-wide value and always names the real CPU, which is why `install.ps1` reads it from there.
- `Bun.version_with_sha` is the `v1.2.3 (abcdef012)` string the crash handler also prints, so the version line in a report matches the format maintainers already see in crash output.

<details>
<summary>Raw output of the three candidate platform snippets in each host</summary>

```
x64 machine (Windows Server 2019), pwsh 7 / PS 5.1 / PS 5.1 32-bit host
  old (Is64BitOperatingSystem):   x64   / x64   / x64
  $env:PROCESSOR_ARCHITECTURE:    AMD64 / AMD64 / x86
  registry (this PR):             AMD64 / AMD64 / AMD64

ARM64 machine (Windows 11), pwsh 7 / PS 5.1 / PS 5.1 32-bit host
  old (Is64BitOperatingSystem):   x64   / x64   / x64
  $env:PROCESSOR_ARCHITECTURE:    ARM64 / ARM64 / x86
  registry (this PR):             ARM64 / ARM64 / ARM64
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->