### PR TITLE
css: make the css_modules test option work and turn its bare test calls into real tests

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -943,11 +943,9 @@ pub mod zig_base64 {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// LAYERING: hoisted from `bun_css::css_modules::hash` so `bun_bundler` can
-// call the *same* implementation without taking a hard dep on `bun_css` (and
-// without re-implementing the hash, which would diverge — see review of
-// `LinkerContext.rs::css_modules_hash_shim`). `bun_css` re-exports this as
-// `css_modules::hash` for its in-crate callers.
+// `bun_css` wraps this as `css_modules::hash`; everything that derives a CSS
+// module name (`css_modules::local_name`, the printer's pattern path) or a
+// dependency placeholder from a path goes through that wrapper.
 //
 // Behavior: wyhash(u64) of the formatted args,
 // truncated to u32, url-safe-base64-encoded into a bump-allocated slice. If

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -943,9 +943,7 @@ pub mod zig_base64 {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// `bun_css` wraps this as `css_modules::hash`; everything that derives a CSS
-// module name (`css_modules::local_name`, the printer's pattern path) or a
-// dependency placeholder from a path goes through that wrapper.
+// The hash behind CSS module names; `bun_css` wraps it as `css_modules::hash`.
 //
 // Behavior: wyhash(u64) of the formatted args,
 // truncated to u32, url-safe-base64-encoded into a bump-allocated slice. If

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2379,7 +2379,10 @@ impl<'a> LinkerContext<'a> {
                         self.mangled_props
                             .put(
                                 r#ref,
-                                local_css_name(symbol.original_name.slice(), source.path.pretty),
+                                crate::bun_css::css_modules::local_name(
+                                    symbol.original_name.slice(),
+                                    source.path.pretty,
+                                ),
                             )
                             .expect("OOM");
                     }
@@ -2539,25 +2542,6 @@ impl<'a> LinkerContext<'a> {
         });
     }
 } // end — split: tree-shaking trio below
-
-/// The name a CSS module's local class or id is printed as:
-/// `<original name>_<hash of the file's path relative to the project root>`.
-/// Used both by `mangle_local_css` and by the `--no-bundle` CSS path
-/// (`Transpiler::build_css_output`), so a `.module.css` file transpiled on its
-/// own gets the same names the bundler would give it.
-pub(crate) fn local_css_name(original_name: &[u8], pretty_path: &[u8]) -> Box<[u8]> {
-    let scratch = Bump::new();
-    let path_hash = ::bun_base64::wyhash_url_safe(
-        &scratch,
-        format_args!("{}", bstr::BStr::new(pretty_path)),
-        false,
-    );
-    let mut name = Vec::with_capacity(original_name.len() + 1 + path_hash.len());
-    name.extend_from_slice(original_name);
-    name.push(b'_');
-    name.extend_from_slice(path_hash);
-    name.into_boxed_slice()
-}
 
 /// `js_printer::RequireOrImportMetaSource` — manual-vtable shim so the printer
 /// can call back into `LinkerContext::require_or_import_meta_for_source`.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2375,30 +2375,12 @@ impl<'a> LinkerContext<'a> {
 
                         let source = &all_sources[r#ref.source_index() as usize];
 
-                        // SAFETY: `Symbol.original_name` is a `*const [u8]` arena
-                        // pointer; valid for the link step.
-                        let original_name: &[u8] = symbol.original_name.slice();
-                        // The hash itself is short-lived; use a scratch bump.
-                        let scratch = ::bun_alloc::Arena::new();
-                        let path_hash = ::bun_base64::wyhash_url_safe(
-                            &scratch,
-                            // use path relative to cwd for determinism
-                            format_args!("{}", bstr::BStr::new(&source.path.pretty)),
-                            false,
-                        );
-
-                        let mut final_generated_name = Vec::<u8>::new();
-                        use std::io::Write;
-                        write!(
-                            &mut final_generated_name,
-                            "{}_{}",
-                            bstr::BStr::new(original_name),
-                            bstr::BStr::new(path_hash)
-                        )
-                        .expect("infallible: in-memory write");
                         // The map owns its boxed values (freed with `mangled_props`).
                         self.mangled_props
-                            .put(r#ref, final_generated_name.into_boxed_slice())
+                            .put(
+                                r#ref,
+                                local_css_name(symbol.original_name.slice(), source.path.pretty),
+                            )
                             .expect("OOM");
                     }
                 }
@@ -2557,6 +2539,25 @@ impl<'a> LinkerContext<'a> {
         });
     }
 } // end — split: tree-shaking trio below
+
+/// The name a CSS module's local class or id is printed as:
+/// `<original name>_<hash of the file's path relative to the project root>`.
+/// Used both by `mangle_local_css` and by the `--no-bundle` CSS path
+/// (`Transpiler::build_css_output`), so a `.module.css` file transpiled on its
+/// own gets the same names the bundler would give it.
+pub(crate) fn local_css_name(original_name: &[u8], pretty_path: &[u8]) -> Box<[u8]> {
+    let scratch = Bump::new();
+    let path_hash = ::bun_base64::wyhash_url_safe(
+        &scratch,
+        format_args!("{}", bstr::BStr::new(pretty_path)),
+        false,
+    );
+    let mut name = Vec::with_capacity(original_name.len() + 1 + path_hash.len());
+    name.extend_from_slice(original_name);
+    name.push(b'_');
+    name.extend_from_slice(path_hash);
+    name.into_boxed_slice()
+}
 
 /// `js_printer::RequireOrImportMetaSource` — manual-vtable shim so the printer
 /// can call back into `LinkerContext::require_or_import_meta_for_source`.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2856,8 +2856,14 @@ impl<'a> Transpiler<'a> {
 
         let mut file_path = Fs::Path::init(file_path_text);
 
+        // Computed the way the bundler computes `Source.path.pretty` (see
+        // `generic_path_with_pretty_initialized`: forward slashes on every
+        // platform), because CSS module names are hashed from it.
         let top_level_dir = self.fs().top_level_dir;
-        let rel = bun_paths::resolve_path::relative(top_level_dir, file_path_text);
+        let rel = bun_paths::resolve_path::relative_platform::<
+            bun_paths::resolve_path::platform::Loose,
+            false,
+        >(top_level_dir, file_path_text);
         file_path.pretty = crate::linker::dupe(rel);
 
         let mut output_file = options::OutputFile::zero_value();
@@ -3067,12 +3073,16 @@ impl<'a> Transpiler<'a> {
         // `'bump`-threading note).
         let alloc: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref::<Arena>(self.arena) };
 
+        // Every class/id selector of a CSS module becomes a `LocalCss` symbol
+        // `Ref` carrying this source index; the printer resolves those through
+        // the symbol map and local names built below, so the three must agree.
+        let source_index = bun_ast::Index::RUNTIME;
         let (mut sheet, extra) = match bun_css::StyleSheet::<bun_css::DefaultAtRule>::parse(
             alloc,
             entry.contents(),
             opts,
             None,
-            bun_ast::Index::INVALID,
+            source_index,
         ) {
             Ok(v) => v,
             Err(e) => {
@@ -3092,7 +3102,23 @@ impl<'a> Transpiler<'a> {
             );
             return None;
         }
-        let symbols = bun_ast::symbol::Map::init_list(Default::default());
+        let mut local_names = bun_css::LocalsResultsMap::default();
+        for (inner_index, symbol) in extra.symbols.iter().enumerate() {
+            if symbol.kind == bun_ast::symbol::Kind::LocalCss {
+                local_names.insert(
+                    bun_ast::Ref::new(
+                        u32::try_from(inner_index).expect("int cast"),
+                        source_index.get(),
+                        bun_ast::RefTag::Symbol,
+                    ),
+                    crate::linker_context_mod::local_css_name(
+                        symbol.original_name.slice(),
+                        file_path_pretty,
+                    ),
+                );
+            }
+        }
+        let symbols = bun_ast::symbol::Map::init_with_one_list(extra.symbols);
         let result = match sheet.to_css(
             alloc,
             &bun_css::PrinterOptions {
@@ -3101,7 +3127,7 @@ impl<'a> Transpiler<'a> {
                 ..bun_css::PrinterOptions::default()
             },
             None,
-            None,
+            Some(&local_names),
             &symbols,
         ) {
             Ok(v) => v,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3102,22 +3102,7 @@ impl<'a> Transpiler<'a> {
             );
             return None;
         }
-        let mut local_names = bun_css::LocalsResultsMap::default();
-        for (inner_index, symbol) in extra.symbols.iter().enumerate() {
-            if symbol.kind == bun_ast::symbol::Kind::LocalCss {
-                local_names.insert(
-                    bun_ast::Ref::new(
-                        u32::try_from(inner_index).expect("int cast"),
-                        source_index.get(),
-                        bun_ast::RefTag::Symbol,
-                    ),
-                    crate::linker_context_mod::local_css_name(
-                        symbol.original_name.slice(),
-                        file_path_pretty,
-                    ),
-                );
-            }
-        }
+        let local_names = sheet.local_names(source_index, file_path_pretty);
         let symbols = bun_ast::symbol::Map::init_with_one_list(extra.symbols);
         let result = match sheet.to_css(
             alloc,

--- a/src/css/css_modules.rs
+++ b/src/css/css_modules.rs
@@ -453,22 +453,13 @@ impl<'a> CssModuleReference<'a> {
     }
 }
 
-/// The canonical implementation is `bun_base64::wyhash_url_safe`; this keeps the
-/// `css_modules::hash` path for in-crate callers (`dependencies.rs`,
-/// `rules/import.rs`, `local_name`).
 #[inline]
 pub(crate) fn hash<'a>(bump: &'a Bump, args: Arguments<'_>, at_start: bool) -> &'a [u8] {
     bun_base64::wyhash_url_safe(bump, args, at_start)
 }
 
-/// The name a CSS module's local (a class or id selector) is printed as:
-/// `<local>_<hash of path>`, where `path` is the stylesheet's path relative to
-/// the project (`Source.path.pretty` in the bundler) so the names are stable
-/// across machines. The bundler applies this to every local in the graph
-/// (`LinkerContext::mangle_local_css`); [`StyleSheet::local_names`] applies it
-/// to a sheet printed on its own.
-///
-/// [`StyleSheet::local_names`]: crate::StyleSheet::local_names
+/// The printed name of a CSS module's local (class or id): `<local>_<hash of path>`,
+/// `path` being the sheet's project-relative path (`Source.path.pretty` in the bundler).
 pub fn local_name(local: &[u8], path: &[u8]) -> Box<[u8]> {
     let scratch = Bump::new();
     let path_hash = hash(&scratch, format_args!("{}", bstr::BStr::new(path)), false);

--- a/src/css/css_modules.rs
+++ b/src/css/css_modules.rs
@@ -453,12 +453,24 @@ impl<'a> CssModuleReference<'a> {
     }
 }
 
-/// LAYERING: canonical implementation lives in `bun_base64::wyhash_url_safe`
-/// (a leaf crate) so `bun_bundler::LinkerContext::mangle_local_css` can call
-/// the *same* hasher without depending on `bun_css`. Re-export here so
-/// in-crate callers (`dependencies.rs`, `rules/import.rs`) keep the
-/// `css_modules::hash` path.
+/// The canonical implementation is `bun_base64::wyhash_url_safe`; this keeps the
+/// `css_modules::hash` path for in-crate callers (`dependencies.rs`,
+/// `rules/import.rs`, `local_name`).
 #[inline]
 pub(crate) fn hash<'a>(bump: &'a Bump, args: Arguments<'_>, at_start: bool) -> &'a [u8] {
     bun_base64::wyhash_url_safe(bump, args, at_start)
+}
+
+/// The name a CSS module's local (a class or id selector) is printed as:
+/// `<local>_<hash of path>`, where `path` is the stylesheet's path relative to
+/// the project (`Source.path.pretty` in the bundler) so the names are stable
+/// across machines. The bundler applies this to every local in the graph
+/// (`LinkerContext::mangle_local_css`); [`StyleSheet::local_names`] applies it
+/// to a sheet printed on its own.
+///
+/// [`StyleSheet::local_names`]: crate::StyleSheet::local_names
+pub fn local_name(local: &[u8], path: &[u8]) -> Box<[u8]> {
+    let scratch = Bump::new();
+    let path_hash = hash(&scratch, format_args!("{}", bstr::BStr::new(path)), false);
+    [local, b"_", path_hash].concat().into_boxed_slice()
 }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2555,6 +2555,25 @@ mod stylesheet_impl {
             return Ok(ToCssResult { code: dest });
         }
 
+        /// The `local_names` to print this sheet with when it is not part of a
+        /// bundle (the bundler names the locals of the whole graph at once in
+        /// `LinkerContext::mangle_local_css`): every css-modules local, named
+        /// by [`css_modules::local_name`] as if the sheet were bundled from
+        /// `path`. Empty unless the sheet was parsed with css modules on.
+        ///
+        /// `source_index` must be the index the sheet was parsed with, since
+        /// the local refs embed it.
+        pub fn local_names(&self, source_index: SrcIndex, path: &[u8]) -> LocalsResultsMap {
+            let mut local_names = LocalsResultsMap::default();
+            for (local, entry) in self.local_scope.iter() {
+                local_names.insert(
+                    entry.ref_.to_real_ref(source_index.get()),
+                    css_modules::local_name(local, path),
+                );
+            }
+            local_names
+        }
+
         pub fn parse(
             arena: &'static Bump,
             code: &[u8],

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2555,14 +2555,9 @@ mod stylesheet_impl {
             return Ok(ToCssResult { code: dest });
         }
 
-        /// The `local_names` to print this sheet with when it is not part of a
-        /// bundle (the bundler names the locals of the whole graph at once in
-        /// `LinkerContext::mangle_local_css`): every css-modules local, named
-        /// by [`css_modules::local_name`] as if the sheet were bundled from
-        /// `path`. Empty unless the sheet was parsed with css modules on.
-        ///
-        /// `source_index` must be the index the sheet was parsed with, since
-        /// the local refs embed it.
+        /// The `local_names` for printing this sheet outside a bundle (the bundler
+        /// builds the whole graph's in `LinkerContext::mangle_local_css`).
+        /// `source_index` must be the one the sheet was parsed with: the refs embed it.
         pub fn local_names(&self, source_index: SrcIndex, path: &[u8]) -> LocalsResultsMap {
             let mut local_names = LocalsResultsMap::default();
             for (local, entry) in self.local_scope.iter() {

--- a/src/css_jsc/css_internals.rs
+++ b/src/css_jsc/css_internals.rs
@@ -23,9 +23,7 @@ pub(crate) enum TestCategory {
     ParserOptions,
 }
 
-/// Stands in for the path of the stylesheet under test when the `css_modules`
-/// option is on: the names of its locals are hashed from it, exactly as
-/// `bun build` would hash the path of a real `test.module.css`.
+/// The path `css_modules` test sheets are named as if they were read from.
 const CSS_MODULE_FILENAME: &[u8] = b"test.module.css";
 
 // These test-only wrappers are consumed as plain safe fns through
@@ -172,9 +170,7 @@ fn testing_impl(
     };
 
     let mut import_records = Vec::<ImportRecord>::default();
-    // Same single-sheet setup as `Transpiler::build_css_output`: css-modules
-    // locals are refs into `extra.symbols` at this source index, which
-    // `init_with_one_list` below puts at index 0.
+    // Index 0, where `init_with_one_list` below puts the symbols.
     let source_index = bun_ast::Index::RUNTIME;
     match StyleSheet::<DefaultAtRule>::parse(
         alloc,
@@ -268,8 +264,7 @@ fn parser_options_from_js(
         .get_truthy(global, b"css_modules")?
         .filter(|val| val.to_boolean())
     {
-        // Bun's css modules have no lightningcss-style `pure` mode, so a test
-        // asking for it must not silently run without it.
+        // Bun has no `pure` mode; a test asking for it must not silently run without it.
         if val.is_object() && val.get_boolean_loose(global, b"pure")? == Some(true) {
             return Err(global.throw(format_args!("css_modules.pure is not supported")));
         }

--- a/src/css_jsc/css_internals.rs
+++ b/src/css_jsc/css_internals.rs
@@ -23,6 +23,11 @@ pub(crate) enum TestCategory {
     ParserOptions,
 }
 
+/// Stands in for the path of the stylesheet under test when the `css_modules`
+/// option is on: the names of its locals are hashed from it, exactly as
+/// `bun build` would hash the path of a real `test.module.css`.
+const CSS_MODULE_FILENAME: &[u8] = b"test.module.css";
+
 // These test-only wrappers are consumed as plain safe fns through
 // `dispatch_js2native.rs` re-exports, so they don't use the
 // `#[bun_jsc::host_fn]` C-ABI shim.
@@ -92,8 +97,8 @@ fn testing_impl(
 ) -> JsResult<JSValue> {
     use bun_ast::ImportRecord;
     use bun_css::{
-        DefaultAtRule, ImportRecordHandler, LocalsResultsMap, MinifyOptions, ParserOptions,
-        PrinterOptions, StyleSheet,
+        DefaultAtRule, ImportRecordHandler, MinifyOptions, ParserOptions, PrinterOptions,
+        StyleSheet,
     };
     use bun_jsc::{LogJsc as _, StringJsc as _};
 
@@ -167,12 +172,16 @@ fn testing_impl(
     };
 
     let mut import_records = Vec::<ImportRecord>::default();
+    // Same single-sheet setup as `Transpiler::build_css_output`: css-modules
+    // locals are refs into `extra.symbols` at this source index, which
+    // `init_with_one_list` below puts at index 0.
+    let source_index = bun_ast::Index::RUNTIME;
     match StyleSheet::<DefaultAtRule>::parse(
         alloc,
         source.slice(),
         parser_options,
         Some(&mut import_records),
-        bun_ast::Index::INVALID,
+        source_index,
     ) {
         Ok(ret) => {
             let (mut stylesheet, extra) = ret;
@@ -187,8 +196,8 @@ fn testing_impl(
                 }
             }
 
-            let symbols = bun_ast::symbol::Map::init_list(Default::default());
-            let local_names = LocalsResultsMap::default();
+            let local_names = stylesheet.local_names(source_index, CSS_MODULE_FILENAME);
+            let symbols = bun_ast::symbol::Map::init_with_one_list(extra.symbols);
             let result = match stylesheet.to_css(
                 alloc,
                 &PrinterOptions {
@@ -255,16 +264,18 @@ fn parser_options_from_js(
         }
     }
 
-    // if (try jsobj.getTruthy(globalThis, "css_modules")) |val| {
-    //     opts.css_modules = bun.css.css_modules.Config{
-    //
-    //     };
-    //     if (val.isObject()) {
-    //         if (try val.getTruthy(globalThis, "pure")) |pure_val| {
-    //             opts.css_modules.pure = pure_val.toBoolean();
-    //         }
-    //     }
-    // }
+    if let Some(val) = jsobj
+        .get_truthy(global, b"css_modules")?
+        .filter(|val| val.to_boolean())
+    {
+        // Bun's css modules have no lightningcss-style `pure` mode, so a test
+        // asking for it must not silently run without it.
+        if val.is_object() && val.get_boolean_loose(global, b"pure")? == Some(true) {
+            return Err(global.throw(format_args!("css_modules.pure is not supported")));
+        }
+        opts.filename = CSS_MODULE_FILENAME;
+        opts.css_modules = Some(bun_css::css_modules::Config::default());
+    }
 
     Ok(())
 }

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -212,4 +214,85 @@ describe("css", () => {
       expect(css).toContain(`.${betaOwn}`);
     },
   });
+});
+
+// `bun build --no-bundle` prints each entry point on its own without going
+// through the linker, so it has to scope the locals of a `.module.css` file
+// itself. It used to crash on the first class or id selector instead.
+describe.concurrent("css-module --no-bundle", () => {
+  const stylesheet = /* css */ `
+    .foo { color: red }
+    #bar { color: blue }
+    .foo .baz { color: green }
+    :global(.keep) .foo { color: green }
+    .btn { composes: foo; padding: 0 }
+    @keyframes spin { to { opacity: 1 } }
+    .spinner { animation: spin 1s }
+  `;
+
+  async function build(cwd: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test("scopes classes, ids and keyframes", async () => {
+    using dir = tempDir("css-module-no-bundle", { "styles.module.css": stylesheet });
+
+    expect(await build(String(dir), "--no-bundle", "styles.module.css")).toMatchInlineSnapshot(`
+      ".foo_-MSaAA {
+        color: red;
+      }
+
+      #bar_-MSaAA {
+        color: #00f;
+      }
+
+      .foo_-MSaAA .baz_-MSaAA {
+        color: green;
+      }
+
+      .keep .foo_-MSaAA {
+        color: green;
+      }
+
+      .btn_-MSaAA {
+        padding: 0;
+      }
+
+      @keyframes spin_-MSaAA {
+        to {
+          opacity: 1;
+        }
+      }
+
+      .spinner_-MSaAA {
+        animation: 1s spin_-MSaAA;
+      }
+      "
+    `);
+  });
+
+  // The class and id names hash the file's path relative to the cwd, so a
+  // file in a subdirectory gets different names than one at the top level,
+  // and `bun build --no-bundle` has to agree with `bun build` on both.
+  test.each(["styles.module.css", "nested/deep.module.css"])(
+    "prints the same names as bun build for %s",
+    async entry => {
+      using dir = tempDir("css-module-no-bundle-parity", { [entry]: stylesheet });
+
+      const bundled = await build(String(dir), entry);
+      const header = `/* ${entry} */\n`;
+      expect(bundled).toStartWith(header);
+      expect(await build(String(dir), "--no-bundle", entry)).toBe(bundled.slice(header.length));
+    },
+  );
 });

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { cssInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
@@ -10,7 +11,7 @@ import {
   indoc,
   minify_error_test_with_options,
   minify_test,
-  minifyTestWithOptions as minify_test_with_options,
+  minify_test_with_options,
   ParserFlags,
   ParserOptions,
   prefix_test,
@@ -5728,6 +5729,7 @@ describe("css tests", () => {
     minify_test_with_options(".foo >>> .bar {width: 20px}", ".foo>>>.bar{width:20px}", deep_options);
     minify_test_with_options(".foo /deep/ .bar {width: 20px}", ".foo /deep/ .bar{width:20px}", deep_options);
 
+    // Bun has no "pure" css modules mode (see `ParserOptions` in ./util.ts), so these stay skipped.
     let pure_css_module_options: ParserOptions = {
       css_modules: {
         pure: true,
@@ -5754,39 +5756,9 @@ describe("css tests", () => {
       "MinifyErrorKind::ImpureCSSModuleSelector",
       pure_css_module_options,
     );
-    minify_test_with_options(":local(.foo) {width: 20px}", "._8Z4fiW_foo{width:20px}", pure_css_module_options);
-    minify_test_with_options("div.my-class {color: red;}", "div._8Z4fiW_my-class{color:red}", pure_css_module_options);
-    minify_test_with_options("#id {color: red;}", "#_8Z4fiW_id{color:red}", pure_css_module_options);
-    minify_test_with_options("a .my-class{color: red;}", "a ._8Z4fiW_my-class{color:red}", pure_css_module_options);
-    minify_test_with_options(".my-class a {color: red;}", "._8Z4fiW_my-class a{color:red}", pure_css_module_options);
-    minify_test_with_options(
-      ".my-class:is(a) {color: red;}",
-      "._8Z4fiW_my-class:is(a){color:red}",
-      pure_css_module_options,
-    );
-    minify_test_with_options(
-      "div:has(.my-class) {color: red;}",
-      "div:has(._8Z4fiW_my-class){color:red}",
-      pure_css_module_options,
-    );
-    minify_test_with_options(
-      ".foo { html &:hover { a_value: some-value; } }",
-      "._8Z4fiW_foo{html &:hover{a_value:some-value}}",
-      pure_css_module_options,
-    );
-    minify_test_with_options(
-      ".foo { span { color: red; } }",
-      "._8Z4fiW_foo{& span{color:red}}",
-      pure_css_module_options,
-    );
     minify_error_test_with_options(
       "html { .foo { span { color: red; } } }",
       "MinifyErrorKind::ImpureCSSModuleSelector",
-      pure_css_module_options,
-    );
-    minify_test_with_options(
-      ".foo { div { span { color: red; } } }",
-      "._8Z4fiW_foo{& div{& span{color:red}}}",
       pure_css_module_options,
     );
     minify_error_test_with_options(
@@ -5804,10 +5776,62 @@ describe("css tests", () => {
       "MinifyErrorKind::ImpureCSSModuleSelector",
       pure_css_module_options,
     );
+    test("css_modules: { pure: true } is rejected rather than silently ignored", () => {
+      expect(() => cssInternals.minifyTestWithOptions(".foo {}", "", pure_css_module_options)).toThrow(
+        "css_modules.pure is not supported",
+      );
+    });
+
+    // With css modules on, the binding parses the source as `test.module.css`, so every local is
+    // suffixed with that filename's hash, `_SsLGXg` (what `bun build test.module.css` emits too).
+    let css_module_options: ParserOptions = {
+      css_modules: true,
+    };
+
+    // Without the option nothing is scoped and :local() is left alone like any unknown pseudo-class.
+    minify_test(":local(.foo) {width: 20px}", ":local(.foo){width:20px}");
+    minify_test_with_options(".foo {width: 20px}", ".foo{width:20px}", { css_modules: false });
+    minify_test_with_options(".foo {color: red}", ".foo_SsLGXg{color:red}", { css_modules: { pure: false } });
+    minify_test_with_options(":local(.foo) {width: 20px}", ".foo_SsLGXg{width:20px}", css_module_options);
+    minify_test_with_options(":global(.foo) .bar {width: 20px}", ".foo .bar_SsLGXg{width:20px}", css_module_options);
+    minify_test_with_options("div.my-class {color: red;}", "div.my-class_SsLGXg{color:red}", css_module_options);
+    minify_test_with_options("#id {color: red;}", "#id_SsLGXg{color:red}", css_module_options);
+    minify_test_with_options(".foo #bar {color: red;}", ".foo_SsLGXg #bar_SsLGXg{color:red}", css_module_options);
+    minify_test_with_options("a .my-class{color: red;}", "a .my-class_SsLGXg{color:red}", css_module_options);
+    minify_test_with_options(".my-class a {color: red;}", ".my-class_SsLGXg a{color:red}", css_module_options);
+    minify_test_with_options(
+      ".foo {color: red} .bar .foo {color: blue}",
+      ".foo_SsLGXg{color:red}.bar_SsLGXg .foo_SsLGXg{color:#00f}",
+      css_module_options,
+    );
+    minify_test_with_options(".my-class:is(a) {color: red;}", ".my-class_SsLGXg:is(a){color:red}", css_module_options);
+    minify_test_with_options(
+      "div:has(.my-class) {color: red;}",
+      "div:has(.my-class_SsLGXg){color:red}",
+      css_module_options,
+    );
+    minify_test_with_options(
+      ".foo { html &:hover { a_value: some-value; } }",
+      ".foo_SsLGXg{html &:hover{a_value:some-value}}",
+      css_module_options,
+    );
+    minify_test_with_options(".foo { span { color: red; } }", ".foo_SsLGXg{& span{color:red}}", css_module_options);
+    minify_test_with_options(
+      ".foo { div { span { color: red; } } }",
+      ".foo_SsLGXg{& div{& span{color:red}}}",
+      css_module_options,
+    );
     minify_test_with_options(
       "@scope (.a) to (.b) { .foo { color: red } }",
-      "@scope(._8Z4fiW_a) to (._8Z4fiW_b){._8Z4fiW_foo{color:red}}",
-      pure_css_module_options,
+      "@scope(.a_SsLGXg) to (.b_SsLGXg){.foo_SsLGXg{color:red}}",
+      css_module_options,
+    );
+    // Keyframes names are scoped by the printer from the filename, selectors from the path; for a top-level
+    // file like this one both hash the same string, so the suffixes must match.
+    minify_test_with_options(
+      ".foo { animation: spin 1s } @keyframes spin { to { opacity: 0 } }",
+      ".foo_SsLGXg{animation:1s spin_SsLGXg}@keyframes spin_SsLGXg{to{opacity:0}}",
+      css_module_options,
     );
 
     error_test(

--- a/test/js/bun/css/util.ts
+++ b/test/js/bun/css/util.ts
@@ -25,9 +25,15 @@ export type Browsers = {
 };
 
 export type ParserOptions = {
-  css_modules?: {
-    pure: boolean;
-  };
+  /**
+   * Scopes class and id selectors to the file, as for `*.module.css`. The binding parses the source as
+   * `test.module.css`, so every local is printed as `<name>_SsLGXg` (the hash of that filename, the same
+   * one `bun build` would give the file).
+   *
+   * Bun has no lightningcss-style `pure` mode; the binding throws if it is requested, so the
+   * `minify_error_test_with_options` cases that need it stay skipped.
+   */
+  css_modules?: boolean | { pure: boolean };
   flags?: ParserFlags[];
 };
 
@@ -50,6 +56,12 @@ export function minify_error_test_with_options(source: string, expectedError: st
 export function minify_test(source: string, expected: string) {
   test(source, () => {
     expect(minifyTestWithOptions(source, expected)).toEqual(expected);
+  });
+}
+
+export function minify_test_with_options(source: string, expected: string, options: ParserOptions) {
+  test(source, () => {
+    expect(minifyTestWithOptions(source, expected, options)).toEqual(expected);
   });
 }
 
@@ -80,5 +92,3 @@ export function attrTest(source: string, expected: string, minify: boolean, targ
 export function indoc(...args: any) {
   return dedent(...args);
 }
-
-export { minifyTestWithOptions };


### PR DESCRIPTION
### Problem
- `test/js/bun/css/css.test.ts` imported the raw `minifyTestWithOptions` binding under the name `minify_test_with_options`, so the 13 `minify_test_with_options(...)` calls in `describe("selectors")` ran at collection time, registered no test, and never compared the output to `expected` (the binding reads `expected` into `_expected` and drops it). They could only fail by throwing.
- 11 of those calls pass `css_modules`, and the binding ignored that option: `parser_options_from_js` in `src/css_jsc/css_internals.rs` had the `css_modules` branch commented out (it was commented out in the Zig version too, since #16514). Their lightningcss-ported expectations (`._8Z4fiW_foo{...}`) never held; with released bun 1.4.0 the binding prints `:local(.foo){width:20px}`, `div.my-class{color:red}`, etc.
- Wiring the option alone is not enough: with css modules on, the parser turns every class/id into a symbol ref (`css_parser.rs` `add_symbol_for_name`) and the printer resolves it through the symbol map and `local_names` (`printer.rs` `lookup_symbol`). `testing_impl` parsed with `Index::INVALID`, printed with an empty `symbol::Map` and an empty `LocalsResultsMap`, and threw away `extra.symbols`, so it had nothing to print those refs with.
- The `pure` css-modules mode the block was ported for does not exist in bun (`rules/style.rs` still carries it as a TODO; there is no `ImpureCSSModuleSelector` error kind), which is why the `minify_error_test_with_options` cases next to these are `test.skip`.

### Fix
- `css_internals.rs`: a truthy `css_modules` option enables `css_modules::Config::default()` and sets the filename to `test.module.css`, the same shape `ParseTask.rs` uses for real module files. `css_modules: { pure: true }` throws `css_modules.pure is not supported` instead of silently running without it. `testing_impl` parses the sheet as source 0, builds the printer's symbol map from `extra.symbols` with `symbol::Map::init_with_one_list`, and passes the table from `StyleSheet::local_names` as `local_names`. Nothing changes for calls without the option: they produce no refs, so the symbol map and name table are never consulted.
- `css_parser.rs`: new `StyleSheet::local_names(arena, source_index)` maps every entry of the sheet's `local_scope` to its generated name by applying the configured css-modules `Pattern` with the hash of the sheet's filename. It returns an empty map when css modules are off.
- `css_modules.rs`: the per-source hash computed inline in `CssModule::new` becomes `Config::hash_source`, so `local_names` and the printer's own `write_ident` path (keyframes names, custom idents) hash the same input with the same settings. No behavior change for the bundler.
- Why this is the right output: for a single sheet it yields exactly what `bun build` emits for that file. The bundler names locals `<name>_<wyhash_url_safe(path)>` in `LinkerContext::mangle_local_css`; the default pattern is `[local]_[hash]` with the same hasher, and `bun build test.module.css` prints `.foo_SsLGXg`, which is the suffix the updated expectations use. The keyframes test in the diff pins that selectors and `@keyframes` names, which are scoped by two different code paths, get the same suffix.
- `util.ts`: real `minify_test_with_options` wrapper (`test()` + `expect(...).toEqual(expected)`), the raw binding is no longer re-exported, and `ParserOptions.css_modules` documents what the option does and that `pure` is rejected.
- `css.test.ts`: the 11 css-modules cases now run against bun's `<name>_SsLGXg` output, plus cases for `:global()` leaving its argument alone, a name reused across rules resolving to one local, class and id in one selector, `css_modules: false`, `{ pure: false }`, the `pure: true` rejection, keyframes scoping, and `:local()` passing through when the option is off. The skipped pure-mode error cases are unchanged.
- Verified: `USE_SYSTEM_BUN=1 bun test test/js/bun/css/css.test.ts -t selectors` fails the 17 new/updated tests (242 pass, 17 fail); `bun bd test test/js/bun/css/css.test.ts -t selectors` passes (259 pass, 0 fail). Also green with the debug build: the rest of `test/js/bun/css/` (except `css-fuzz.test.ts`, which times out here before and after because each of its 1000 `Bun.build` iterations takes ~50ms under ASAN), `test/regression/issue/27598.test.ts`, `test/bundler/css/css-modules.test.ts`, `test/bundler/esbuild/css.test.ts`, `test/bundler/bundler_loader.test.ts`, `test/internal/source-lints/`, and `cargo fmt --check`.

### Background
- CSS modules in bun: when `ParserOptions.css_modules` is set, each class/id name in a selector is registered once in the sheet's `local_scope` (name to `CssRef`) and becomes a `bun_ast::Symbol` of kind `LocalCss` in `StylesheetExtra.symbols`; the selector AST stores a `Ref` (inner index + the source index passed to `parse`) instead of the text. `:local(x)` prints `x` scoped, `:global(x)` prints it unscoped.
- `LocalsResultsMap` (`local_names`): a `Ref` to generated-name table the printer consults for each such ref; a ref missing from it prints under its original name. In a bundle `LinkerContext::mangle_local_css` fills it for every file and hands it to `to_css`; the CSS crate itself never produced one, which is what `StyleSheet::local_names` adds for sheets printed on their own.
- `symbol::Map`: per-source list of symbol lists indexed by a ref's source index, which is why the test binding has to parse as source 0 and wrap `extra.symbols` with `init_with_one_list`.
- Keyframes and custom idents are scoped by a separate, lightningcss-derived path (`Printer::write_ident` applying `Config.pattern` with a hash of the sheet's filename), so a standalone sheet has two naming paths that must agree; `Config::hash_source` is the shared piece.
- `bun:internal-for-testing`'s `cssInternals` functions are test-only bindings over the CSS parser/minifier/printer; `testing_impl` is the shared body behind `minifyTest`, `minifyTestWithOptions`, `testWithOptions`, `prefixTest`, and friends, so all of them gain the option.

Two unrelated bugs noticed while reading this code were reported separately: `bun build --no-bundle x.module.css` panics in `Printer::lookup_symbol` (same missing symbols/local names, in `transpiler.rs`), and a bare `:global` pseudo-class is rejected even without css modules (`selectors/parser.rs` precedence).
