### PR TITLE
node:fs: non-recursive rm treats a file that is already being deleted as gone

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7822,16 +7822,16 @@ impl NodeFS {
             // as EPERM, the same errno as a genuine access denial. `unlinkat`
             // goes through NtCreateFile itself and treats those statuses as
             // success, which is what makes the recursive branch immune to this
-            // race; give it the same chance here.
+            // race; give it the same chance here. If the other deleter has
+            // finished by now the name is gone, which the lstat below reports.
             #[cfg(windows)]
             if e1 == E::EPERM && sys::unlinkat(FD::cwd(), dest).is_ok() {
                 return Ok(());
             }
-            // unlink's errno is not a reliable "does the path exist" answer:
-            // Linux reports a missing name on a read-only mount as EROFS, for
-            // example. Node decides existence with the lstat() in
-            // validateRmOptions, so ask lstat before treating the failure as
-            // anything other than ENOENT.
+            // unlink's errno is not a reliable "does the path exist" answer
+            // (Linux reports a missing name on a read-only mount as EROFS).
+            // Node decides existence with the lstat() in validateRmOptions, so
+            // ask lstat before treating the failure as anything but ENOENT.
             let gone = e1 == E::ENOENT
                 || matches!(sys::lstat(dest), Err(err) if err.get_errno() == E::ENOENT);
             if gone {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7817,7 +7817,24 @@ impl NodeFS {
                 }
                 return Ok(());
             }
-            if e1 == E::ENOENT {
+            // libuv's unlink reports a file that another handle is in the
+            // middle of deleting (STATUS_DELETE_PENDING / STATUS_FILE_DELETED)
+            // as EPERM, the same errno as a genuine access denial. `unlinkat`
+            // goes through NtCreateFile itself and treats those statuses as
+            // success, which is what makes the recursive branch immune to this
+            // race; give it the same chance here.
+            #[cfg(windows)]
+            if e1 == E::EPERM && sys::unlinkat(FD::cwd(), dest).is_ok() {
+                return Ok(());
+            }
+            // unlink's errno is not a reliable "does the path exist" answer:
+            // Linux reports a missing name on a read-only mount as EROFS, for
+            // example. Node decides existence with the lstat() in
+            // validateRmOptions, so ask lstat before treating the failure as
+            // anything other than ENOENT.
+            let gone = e1 == E::ENOENT
+                || matches!(sys::lstat(dest), Err(err) if err.get_errno() == E::ENOENT);
+            if gone {
                 if args.force {
                     return Ok(());
                 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7817,21 +7817,15 @@ impl NodeFS {
                 }
                 return Ok(());
             }
-            // libuv's unlink reports a file that another handle is in the
-            // middle of deleting (STATUS_DELETE_PENDING / STATUS_FILE_DELETED)
-            // as EPERM, the same errno as a genuine access denial. `unlinkat`
-            // goes through NtCreateFile itself and treats those statuses as
-            // success, which is what makes the recursive branch immune to this
-            // race; give it the same chance here. If the other deleter has
-            // finished by now the name is gone, which the lstat below reports.
+            // libuv folds STATUS_DELETE_PENDING / STATUS_FILE_DELETED into EPERM;
+            // unlinkat (DeleteFileBun, what the recursive branch uses) treats
+            // them as success.
             #[cfg(windows)]
             if e1 == E::EPERM && sys::unlinkat(FD::cwd(), dest).is_ok() {
                 return Ok(());
             }
-            // unlink's errno is not a reliable "does the path exist" answer
-            // (Linux reports a missing name on a read-only mount as EROFS).
-            // Node decides existence with the lstat() in validateRmOptions, so
-            // ask lstat before treating the failure as anything but ENOENT.
+            // unlink's errno does not say whether the path exists (EROFS for a
+            // missing name on a read-only mount); node decides that with lstat.
             let gone = e1 == E::ENOENT
                 || matches!(sys::lstat(dest), Err(err) if err.get_errno() == E::ENOENT);
             if gone {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3130,6 +3130,131 @@ describe("rm", () => {
     fs.rmSync(dir, { recursive: true, force: true });
     expect(fs.existsSync(dir)).toBe(false);
   });
+
+  // A failed unlink does not by itself say whether the target is still there:
+  // Windows reports a file that another rm is in the middle of deleting with
+  // the same EPERM as a genuine access denial, and Linux reports a missing name
+  // on a read-only mount as EROFS. rm has to find out before deciding that
+  // force has nothing to ignore.
+  describe("deciding whether the target exists", () => {
+    type Outcome = "ok" | { code: string; syscall: string };
+    const outcome = (err: any): Outcome => (err == null ? "ok" : { code: err.code, syscall: err.syscall });
+
+    // rmSync, promises.rm and callback rm all end in the same native rm.
+    async function rmEveryWay(target: string, options: { force: boolean }): Promise<Outcome[]> {
+      let sync: Outcome = "ok";
+      try {
+        rmSync(target, options);
+      } catch (err) {
+        sync = outcome(err);
+      }
+      const promise = await promises.rm(target, options).then(() => "ok" as const, outcome);
+      const callback = await new Promise<Outcome>(resolve => fs.rm(target, options, err => resolve(outcome(err))));
+      return [sync, promise, callback];
+    }
+
+    // The target is still there, so neither force nor the missing-path error applies.
+    async function expectRmToFail(target: string) {
+      for (const force of [true, false]) {
+        const codes = (await rmEveryWay(target, { force })).map(result => (result === "ok" ? "ok" : result.code));
+        expect(codes).not.toContain("ok");
+        expect(codes).not.toContain("ENOENT");
+      }
+    }
+
+    it("concurrent rm({ force: true }) calls racing for the same file all resolve", async () => {
+      using dir = tempDir("rm-force-race", {});
+      const file = join(String(dir), "victim.txt");
+      const rejections: Record<string, number> = {};
+      for (let round = 0; round < 50; round++) {
+        await promises.writeFile(file, "x");
+        const results = await Promise.allSettled(Array.from({ length: 20 }, () => promises.rm(file, { force: true })));
+        for (const result of results) {
+          if (result.status === "rejected") {
+            const code = result.reason?.code ?? String(result.reason);
+            rejections[code] = (rejections[code] ?? 0) + 1;
+          }
+        }
+        expect(existsSync(file)).toBe(false);
+      }
+      expect(rejections).toEqual({});
+    });
+
+    // Linux rejects unlink on a read-only mount (EROFS) before looking the
+    // name up, while lstat says the name does not exist. Containers mount
+    // these read-only; when none of them is, there is nothing to test.
+    const codeOf = (op: () => unknown) => {
+      try {
+        op();
+        return undefined;
+      } catch (err: any) {
+        return err.code;
+      }
+    };
+    const missingOnReadOnlyMount = (() => {
+      if (!isLinux) return undefined;
+      for (const mount of ["/sys", "/proc/sys", "/sys/fs/cgroup"]) {
+        const missing = join(mount, "bun-fs-test-rm-does-not-exist");
+        if (codeOf(() => unlinkSync(missing)) === "EROFS" && codeOf(() => lstatSync(missing)) === "ENOENT") {
+          return missing;
+        }
+      }
+      return undefined;
+    })();
+
+    it.skipIf(!missingOnReadOnlyMount)("a missing path on a read-only mount is missing, not EROFS", async () => {
+      expect(await rmEveryWay(missingOnReadOnlyMount!, { force: true })).toEqual(["ok", "ok", "ok"]);
+
+      const enoent = { code: "ENOENT", syscall: "lstat" };
+      expect(await rmEveryWay(missingOnReadOnlyMount!, { force: false })).toEqual([enoent, enoent, enoent]);
+    });
+
+    // "<file>/x": unlink and lstat both fail with ENOTDIR, which is not the
+    // same thing as missing. (Windows reports this path as ENOENT.)
+    it.skipIf(isWindows)("a path through a regular file is not treated as missing", async () => {
+      using dir = tempDir("rm-force-notdir", { afile: "x" });
+      const afile = join(String(dir), "afile");
+
+      await expectRmToFail(join(afile, "x"));
+      expect(existsSync(afile)).toBe(true);
+    });
+
+    // unlink fails but the file is still there, so the unlink error stands.
+    // (root is not subject to directory permissions.)
+    const isRoot = process.getuid?.() === 0;
+    it.skipIf(isWindows || isRoot)("a file that cannot be unlinked reports the unlink error", async () => {
+      using dir = tempDir("rm-force-eacces", { "locked/file.txt": "x" });
+      const locked = join(String(dir), "locked");
+      const target = join(locked, "file.txt");
+      fs.chmodSync(locked, 0o555);
+      try {
+        const eacces = { code: "EACCES", syscall: "rm" };
+        expect(await rmEveryWay(target, { force: true })).toEqual([eacces, eacces, eacces]);
+        expect(await rmEveryWay(target, { force: false })).toEqual([eacces, eacces, eacces]);
+        expect(existsSync(target)).toBe(true);
+      } finally {
+        fs.chmodSync(locked, 0o755);
+      }
+    });
+
+    // Windows refuses to delete the executable of a running process. That is
+    // reported with the same EPERM as a file being deleted by someone else,
+    // but this file is staying, so rm has to fail.
+    it.skipIf(!isWindows)("a file that is in use reports the error", async () => {
+      using dir = tempDir("rm-force-in-use", {});
+      const image = join(String(dir), "in-use.exe");
+      copyFileSync(process.env.ComSpec ?? join(process.env.SystemRoot ?? "C:\\Windows", "System32", "cmd.exe"), image);
+      // cmd /k waits for commands on stdin, which is never written to.
+      const proc = Bun.spawn({ cmd: [image, "/d", "/k"], stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+      try {
+        await expectRmToFail(image);
+        expect(existsSync(image)).toBe(true);
+      } finally {
+        proc.kill();
+        await proc.exited;
+      }
+    });
+  });
 });
 
 describe("rmdir", () => {


### PR DESCRIPTION
### Problem

- `fs.promises.rm(file, { force: true })` (same for `rmSync` and callback `rm`) rejects with `EFAULT: bad address in system call argument, rm '<file>'` on Windows when another `rm` of the same file is in flight. 20 concurrent calls x 200 rounds on Windows x64 with Bun 1.4.0: 1419 to 1535 of the 4000 calls rejected. Node 26: 0. This is the `EFAULT ... rm 'C:\...\htpasswd' at createTestDir (test/harness.ts)` flake on the Windows lanes: `VerdaccioRegistry.createTestDir()` runs `rm(htpasswd, { force: true })` from every concurrent install test at once.
- Cause: the non-recursive branch of `NodeFS::rm` (`src/runtime/node/node_fs.rs`, around line 7797) treats only `ENOENT` from `sys::unlink` as "the path is gone". On Windows `sys::unlink` is libuv's `uv_fs_unlink`, which reports a file that another handle is in the middle of deleting as `EPERM`, the same errno as a real access denial (raw `fs.promises.unlink` in the same race: `EPERM` for about 30% of the calls, under Node as well). `EPERM` is not in `map_rm_errno_narrow` (line 9606), so it comes out as `EFAULT`.
- The recursive branch does not have the problem: it deletes through `sys::unlinkat`, which on Windows is `DeleteFileBun` (`src/sys/windows/mod.rs` line 1122 and line 1197), and that treats `STATUS_DELETE_PENDING` / `STATUS_FILE_DELETED` as success. `rm(file, { recursive: true, force: true })` in the same race: 0 rejections.
- The same shape exists off Windows: unlink's errno is not an existence answer in general. Linux refuses to unlink on a read-only mount (`EROFS`) before it looks the name up, so `rm("/sys/does-not-exist", { force: true })` rejects with `EROFS` where Node resolves (and without `force`, Bun reports `EROFS` where Node reports `ENOENT` from `lstat`).
- Related open PRs, none of which covers this: #33436 rewrites this same hunk to report the real errno (`ENOTDIR`, `EPERM`, ...) for failures that are real; it does not make `force` ignore a target that is gone, and this PR leaves `map_rm_errno_narrow` to it. The two are independent and can land in either order; the conflict between them is confined to this hunk. #37155 (#36984) is the recursive branch's version of the same class on macOS/BSD, inside `dt_delete_file`; the recursive branch is not touched here because on Windows `DeleteFileBun` already covers it (numbers above). #34832 changes `DeleteFileBun`'s non-NTFS read-only fallback and is orthogonal.

### Fix

- Windows: when unlink fails with `EPERM`, try `sys::unlinkat(Fd::cwd(), dest)`. This is the same call, with the same pre-resolved path, that the recursive branch starts with (`dt_delete_file(Dir::cwd(), resolved)`). `Ok` means the file was deleted now or is already being deleted, so `rm` has done its job. It cannot delete anything libuv's unlink would have refused: it opens with `FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT`, so a directory (plain or reparse point) fails with `EISDIR` and a symlink is handled as the link itself. Any `Err` falls through to the existing error path, so failures that are real are reported exactly as before.
- All platforms: when unlink fails with anything other than `ENOENT`, ask `lstat`; `ENOENT` from it takes the existing `ENOENT` path (`force` resolves, otherwise the `lstat`-tagged `ENOENT` Node reports). Any other `lstat` result leaves the unlink error as it was. This is how Node decides: `validateRmOptions` does the `lstat`, and `force` ignores exactly its `ENOENT`.
- Both layers are needed for the race, and one of them is needed off Windows. A loser of the race that got `EPERM` from unlink is in one of two states when it retries: the other deleter's handle is still open, so the name is still visible and only the NTSTATUS says the file is going away (`unlinkat` returns `Ok`; an `lstat` here still finds the name, and with only the `lstat` layer the debug build kept rejecting 12 of 1000 calls), or that handle has closed and the name is gone (`unlinkat` returns `ENOENT`, and the `lstat` layer turns that into the existing gone path). The `lstat` layer is also the whole fix for the Linux `EROFS` case, which the Windows-only retry says nothing about.
- libuv's unlink stays the primary call rather than deleting through `DeleteFileBun` outright, as the recursive branch does: it is the call Node's own `rm` makes, so keeping it keeps non-recursive `rm` equal to Node by construction for the cases that differ between the two primitives (directory symlinks and junctions, which libuv unlinks and `DeleteFileBun` refuses with `EISDIR`; read-only files on filesystems without `FileDispositionInformationEx`, which libuv handles and `DeleteFileBun` does not yet, see #34832; reparse points that are not symlinks). The retry only adds the one thing libuv cannot express.
- Verified with `test/js/node/fs/fs.test.ts`, `rm > deciding whether the target exists`:
  - race test: Bun 1.4.0 on Windows x64 rejects 507 to 532 of the 1000 calls with `EFAULT`; debug build of this branch passes. The standalone 200 x 20 repro gives 0 rejections in three runs with absolute paths and one with relative paths, and `rm` without `force` reports only `ENOENT` (no `EFAULT`), like the recursive branch.
  - read-only mount test: Bun 1.4.0 on Linux fails (`EROFS` from all three entry points); debug build passes. Skips itself where none of `/sys`, `/proc/sys`, `/sys/fs/cgroup` is read-only.
  - `<file>/x`, a file in an unwritable directory (non-root POSIX), and the executable of a running process (Windows) pin the other direction: unlink fails, the target is still there, `rm` still fails and reports no `ENOENT`. These pass before and after; the Windows one was also checked by hand to go through the new `EPERM` branch.
  - Also run: the whole of `fs.test.ts` on the Linux debug build (514 pass) and the Windows debug build (only `readSync works on large files` fails, and it fails identically with the release binary on that VM); `test/js/node/test/parallel/test-fs-rm.js` on Linux as root and as an unprivileged user, and on Windows; `rm-windows-ntstatus.test.ts` on Windows.

### Background

- Non-recursive `rm` path: `fs.rm` / `fs.rmSync` / `fs.promises.rm` all do an `lstat` in JS (for `ERR_FS_EISDIR`), then call the native `NodeFS::rm`, which calls `sys::unlink` (libc `unlink` on POSIX, `uv_fs_unlink` on Windows) and maps a failure through `map_rm_errno_narrow`, whose fallthrough is `EFAULT`.
- Deleting on Windows means opening a handle with `DELETE` access and setting its delete disposition. With `FILE_DISPOSITION_POSIX_SEMANTICS` (requested by both libuv and `DeleteFileBun`) the name is removed when that handle closes. Until then the file is delete pending: opening it by name fails with `STATUS_DELETE_PENDING`, and setting the disposition through a handle opened earlier fails with `STATUS_FILE_DELETED` or `STATUS_DELETE_PENDING`. `RtlNtStatusToDosError` turns both into `ERROR_ACCESS_DENIED`, and libuv's `uv_translate_sys_error` turns that into `UV_EPERM`, so libuv callers cannot tell the two apart.
- `DeleteFileBun` is Bun's own `NtCreateFile(DELETE)` + `NtSetInformationFile` deletion, reached through `sys::unlinkat` on Windows. It sees the NTSTATUS directly and returns success for the two delete-pending statuses, which is what keeps recursive `rm` out of this race.
- Node's `force` semantic: `rm` validates the path with `lstat` first and `force` swallows exactly an `ENOENT` from that `lstat`; the unlink that follows (rimraf) additionally swallows `ENOENT` and, on Windows `EPERM`, re-stats the path before giving up.

<details>
<summary>Repro used (Windows x64, Bun 1.4.0 vs Node 26.3.0, 200 rounds x 20 calls)</summary>

```
rm{force}       bun: {"EFAULT/-4074/rm":1419}                                 node: {}
rm{rec,force}   bun: {}                                                        node: {}
rm              bun: {"ENOENT/-4058/lstat":1998,"EFAULT/-4074/rm":1429}        node: {}
unlink          bun: {"EPERM/-4048/unlink":1136,"ENOENT/-4058/unlink":2466}    node: {"ENOENT":3152,"EPERM":355}
```

Debug build of this branch, same script, three runs: `rm{force}` `{}`, `rm` only `ENOENT/lstat`, `rm{rec,force}` `{}`.

Linux, `rm` of a missing name under the read-only `/sys` mount (Bun 1.4.0 / Node 26.3.0): `rmSync`, `promises.rm`, callback `rm` with `{ force: true }`: `EROFS (rm)` x3 / ok x3; without `force`: `EROFS (rm)` x3 / `ENOENT (lstat)` x3.
</details>

