### PR TITLE
css: record the category when a 4-side shorthand replaces the buffered values

### DIFF
--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1424,6 +1424,7 @@ mod border_handler_body {
 
                     // Setting the `border` property resets `border-image`
                     self.border_image_handler.reset();
+                    self.category = Physical;
                     self.has_any = true;
                 }
                 Property::Unparsed(val) => {

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -712,6 +712,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             self.block_end = None;
             self.inline_start = None;
             self.inline_end = None;
+            self.category = S::SHORTHAND_CATEGORY;
             self.has_any = true;
         } else {
             return false;

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2455,7 +2455,8 @@ describe("css tests", () => {
   });
 
   // The property handlers are shared by every rule in a stylesheet. A logical property in one rule
-  // must not change how a later rule's shorthand is minified.
+  // must not change how a later rule's shorthand is minified. util.ts checks this for every test in
+  // this file; these are the direct cases, plus the in-rule outputs the fix changes or must not change.
   describe("shorthand after a logical property in an earlier rule", () => {
     for (const [shorthand, logical, top] of [
       ["margin", "margin-inline-start", "margin-top"],

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2454,6 +2454,78 @@ describe("css tests", () => {
     );
   });
 
+  // The property handlers are shared by every rule in a stylesheet. A logical property in one rule
+  // must not change how a later rule's shorthand is minified.
+  describe("shorthand after a logical property in an earlier rule", () => {
+    for (const [shorthand, logical, top] of [
+      ["margin", "margin-inline-start", "margin-top"],
+      ["padding", "padding-inline-start", "padding-top"],
+      ["inset", "inset-inline-start", "top"],
+      ["scroll-margin", "scroll-margin-inline-start", "scroll-margin-top"],
+    ]) {
+      minify_test(`div{${logical}:2px}.a{${shorthand}:1px;${shorthand}:0}`, `div{${logical}:2px}.a{${shorthand}:0}`);
+      minify_test(`div{${logical}:2px}.a{${shorthand}:0;${top}:5px}`, `div{${logical}:2px}.a{${shorthand}:5px 0 0}`);
+    }
+
+    minify_test("div{margin-inline:2px}.a{margin:1px;margin:0}", "div{margin-inline:2px}.a{margin:0}");
+    minify_test(
+      "div{margin-block-start:var(--x)}.a{margin:1px;margin:0}",
+      "div{margin-block-start:var(--x)}.a{margin:0}",
+    );
+    minify_test(
+      "div{margin-inline-start:2px}.a{color:red}.b{margin:1px;margin:0}",
+      "div{margin-inline-start:2px}.a{color:red}.b{margin:0}",
+    );
+    minify_test(
+      "div{margin-inline-start:2px}.a{margin:1px;margin:0}.b{margin:1px;margin:0}",
+      "div{margin-inline-start:2px}.a,.b{margin:0}",
+    );
+    minify_test(
+      "div{margin-inline-start:2px!important}.a{margin:1px!important;margin:0!important}",
+      "div{margin-inline-start:2px!important}.a{margin:0!important}",
+    );
+    // The earlier rule is dropped from the output, but it still went through the handlers.
+    minify_test("@media not all{div{margin-inline-start:2px}}.a{margin:1px;margin:0}", ".a{margin:0}");
+    // Same, for merged same-selector rules: the merged block is re-minified after the rule following it.
+    minify_test(".a{margin:1px}.a{margin:0}@media not all{div{margin-inline-start:2px}}", ".a{margin:0}");
+
+    minify_test(
+      "div{border-inline-start-color:red}.a{border:1px solid red;border-top-color:red}",
+      "div{border-inline-start-color:red}.a{border:1px solid red}",
+    );
+    minify_test(
+      "div{border-inline-start-color:red}.a{border:1px solid red;border-width:2px}",
+      "div{border-inline-start-color:red}.a{border:2px solid red}",
+    );
+    minify_test(
+      "div{border-inline-start-color:red!important}.a{border:1px solid red!important;border-top-color:red!important}",
+      "div{border-inline-start-color:red!important}.a{border:1px solid red!important}",
+    );
+
+    // Within one rule, a shorthand following a logical property behaves like the first declaration
+    // of a fresh rule: the logical value is flushed first (kept as a fallback for margin, reset by
+    // border), then later longhands fold into the shorthand.
+    minify_test(".a{margin-inline-start:1px;margin:0;margin-top:5px}", ".a{margin-inline-start:1px;margin:5px 0 0}");
+    minify_test(
+      ".a{border-inline-start-color:red;border:1px solid red;border-top-color:red}",
+      ".a{border:1px solid red}",
+    );
+    // Switching category in either direction still flushes, so the fallback order is preserved.
+    minify_test(".a{margin-inline-start:1px;margin:0}", ".a{margin-inline-start:1px;margin:0}");
+    minify_test(
+      ".a{margin:0;margin-inline-start:1px;margin-top:3px}",
+      ".a{margin:0;margin-inline-start:1px;margin-top:3px}",
+    );
+    minify_test(
+      ".a{margin-inline-start:1px;margin:0;margin-inline-end:2px}",
+      ".a{margin-inline-start:1px;margin:0;margin-inline-end:2px}",
+    );
+    minify_test(
+      ".a{border:1px solid red;border-inline-start-color:blue}",
+      ".a{border:1px solid red;border-inline-start-color:#00f}",
+    );
+  });
+
   describe("size", () => {
     prefix_test(
       `

--- a/test/js/bun/css/util.ts
+++ b/test/js/bun/css/util.ts
@@ -47,16 +47,46 @@ export function minify_error_test_with_options(source: string, expectedError: st
   });
 }
 
+// Every declaration block in a stylesheet goes through the same property handler instances, so state a
+// handler does not reset between blocks makes a block's output depend on the rules before it. Each test
+// below is therefore also run behind this rule, which leaves the handlers that keep per-block state
+// (logical vs. physical tracking, vendor prefix tracking, and the separate `!important` handlers) in
+// their non-default state, and is itself dropped from the output. The output must not change.
+const precedingRule = (() => {
+  const declarations = [
+    "margin-inline-start:1px",
+    "padding-inline-start:1px",
+    "inset-inline-start:1px",
+    "scroll-margin-inline-start:1px",
+    "scroll-padding-inline-start:1px",
+    "border-inline-start-color:red",
+    "border-start-start-radius:1px",
+    "inline-size:1px",
+    "background-image:-webkit-linear-gradient(red,blue)",
+  ];
+  return `@media not all{z{${[...declarations, ...declarations.map(d => d + "!important")].join(";")}}}`;
+})();
+
+function expectUnaffectedByPrecedingRule(run: (source: string) => string, source: string, output: string) {
+  // These at-rules are only valid before any other rule.
+  if (/@(?:charset|import|namespace)\b/.test(source)) return;
+  expect(run(precedingRule + source)).toBe(output);
+}
+
 export function minify_test(source: string, expected: string) {
   test(source, () => {
-    expect(minifyTestWithOptions(source, expected)).toEqual(expected);
+    const output = minifyTestWithOptions(source, expected);
+    expect(output).toEqual(expected);
+    expectUnaffectedByPrecedingRule(source => minifyTestWithOptions(source, expected), source, output);
   });
 }
 
 export function prefix_test(source: string, expected: string, targets: Browsers, skip?: boolean) {
   const testf = skip ? test.skip : test;
   testf(source, () => {
-    expect(prefixTest(source, expected, targets)).toEqualIgnoringWhitespace(expected);
+    const output = prefixTest(source, expected, targets);
+    expect(output).toEqualIgnoringWhitespace(expected);
+    expectUnaffectedByPrecedingRule(source => prefixTest(source, expected, targets), source, output);
   });
 }
 
@@ -69,6 +99,7 @@ export function cssTest(source: string, expected: string, browsers?: Browsers, s
     const output = _test(source, expected, browsers);
     console.log("Output", output);
     expect(output).toEqualIgnoringWhitespace(expected);
+    expectUnaffectedByPrecedingRule(source => _test(source, expected, browsers), source, output);
   });
 }
 


### PR DESCRIPTION
### Problem

- Once any rule in a stylesheet uses a logical margin, padding, inset or scroll-margin property, every later rule in the sheet stops collapsing that family's 4-side shorthand (`bun build --minify`, release 1.4.0 and main):
  ```
  div{margin-inline-start:2px}.a{margin:1px;margin:0}   ->  div{margin-inline-start:2px}.a{margin:1px;margin:0}
  .a{margin:1px;margin:0}                               ->  .a{margin:0}
  ```
  Longhands after the shorthand are no longer folded either (`.a{margin:0;margin-top:5px}` stays as written instead of `margin:5px 0 0`), and the same applies to a fallback pair like `margin:22px;margin:max(4%,22px)`. The earlier rule does not have to survive into the output (`@media not all{...}`), and the merged block of two same-selector rules is affected too, since it is re-minified after the rules that follow it.
- The same thing happens to `border:` after any logical border property: `div{border-inline-start-color:red}.a{border:1px solid red;border-top-color:red}` keeps the redundant `border-top-color`, and `border:1px solid red;border-width:2px` is no longer folded into `border:2px solid red`.
- The output is still correct CSS, just larger, and it depends on unrelated rules earlier in the sheet. Reach: none of the 15 real-world sheets in `test/js/bun/css/files/` changes; under-minification only, never wrong output.
- Cause: `SizeHandler` (`src/css/properties/margin_padding.rs`) and `BorderHandler` (`src/css/properties/border.rs`) have a `category` field recording whether the values they are currently buffering are physical or logical; when an incoming declaration's category differs, the buffered values are flushed first (`flush_helper_physical`, margin_padding.rs:747; `flush_helper!`, border.rs:1224). Every arm that buffers a value also sets `category`, except the 4-side shorthand arms (`S::SHORTHAND` at margin_padding.rs:677, `Property::Border` at border.rs:1414), which replace the buffered values and leave `category` as it was. `flush()` does not reset it either. The handlers live in one `DeclarationHandler` per stylesheet (`src/css/declaration.rs`) and are reused for every block, so a logical property in an earlier block leaves `category == Logical`; in a later block the first `margin:` then sees a category change (flushing nothing), stays recorded as Logical, and the second `margin:` (or a `margin-top:`) sees another change and flushes the first shorthand out instead of replacing or folding into it.
- Upstream lightningcss has the same shape in both handlers (`side_handler!` shorthand arm and the `Border(val)` arm) and the same output for these inputs (checked against 1.30.2 and current main), so this is inherited rather than a porting error.

### Fix

- The two shorthand arms now set `category` to the category of the values they buffer (`S::SHORTHAND_CATEGORY`, which is `Physical` for all four size handlers; `Physical` for `border`), the same thing `property_helper` / `set_border_helper!` do on every other arm.
- Why this is correct: after the arm runs, the buffer holds exactly the shorthand's physical values, so the recorded category matches the buffer. With every buffering arm recording its category, a stale value can only be observed while the buffer is empty, where the one thing it can trigger is a `flush()` of nothing, so a block's output no longer depends on earlier blocks. `flush()` therefore does not need to reset the field; `BorderRadiusHandler` and the width/height `SizeHandler` already work this way. The other handlers were checked for state that survives `finalize()`; these two arms were the only ones whose stale state reaches the output.
- Within one block the only change is after a logical property followed by the shorthand: the logical value is still flushed before the shorthand, but longhands after the shorthand now fold into it as they do in a fresh block: `.a{margin-inline-start:1px;margin:0;margin-top:5px}` becomes `.a{margin-inline-start:1px;margin:5px 0 0}`, and `.a{border-inline-start-color:red;border:1px solid red;border-top-color:red}` becomes `.a{border:1px solid red}` (the `border` arm already discarded the logical value). Same cascade result as the input; upstream emits the longer forms. Whether the flushed logical value should be kept at all is the subject of #38576, which changes the same arm, includes this PR's `category` line, and documents the three in-block expectations it will update if it lands second. #38561 (new scroll-padding handler) instantiates the same generic arm and picks this up unchanged.
- Test helpers: `minify_test`, `prefix_test` and `cssTest` in `test/js/bun/css/util.ts` now additionally minify every source behind a dropped `@media not all{z{...}}` rule that leaves the logical/physical and prefix tracking handlers, normal and `!important`, in a non-default state, and require the output to be unchanged (sources with `@charset`/`@import`/`@namespace`, which must come first, are exempt). This turns the whole file into a check that no handler leaks state between blocks, including handlers added later. On the unfixed build it flags 8 existing cases (3 border, 1 margin, 4 length shorthand folds); with the fix none. Cost on a local ASAN debug build: css.test.ts goes from about 6.5s to about 9.5s.
- Verified:
  - `test/js/bun/css/css.test.ts`, new "shorthand after a logical property in an earlier rule" block: the cross-block case and the shorthand+longhand case for margin, padding, inset and scroll-margin, the `margin-inline` / unparsed `margin-block-start: var()` triggers, an unrelated rule in between, two affected later rules, the `!important` handler instance, the dropped `@media not all` rule, the merged same-selector block, the three `border:` cases, the two in-block changes above and four in-block outputs that must stay as they are.
  - Debug build with the two source lines reverted: 28 failures in css.test.ts (the 20 new cases that exercise the leak plus the 8 existing cases flagged by the helper); with the fix: 1166 pass, 0 fail. Same 20 + 8 split on release 1.4.0.
  - `bun bd test test/js/bun/css/` and `test/bundler/css/` + `test/bundler/esbuild/css.test.ts`: no output changes; the only local failures are debug-build timeouts (the fuzz tests and two 5s-budget tests) that fail identically with the two lines reverted.
  - `bun build --minify` on the first snippet above now prints `div{margin-inline-start:2px}.a{margin:0}`.
- Found while here and filed separately: `InsetSpec` declares its shorthand as `Physical` where upstream uses `Logical` (so `inset:` is emitted for targets without it; this change is what keeps `.a{inset:1px;inset:0}` collapsing once that is flipped), and bun had no `scroll-padding` handler at all (#38561).

### Background

- The CSS minifier runs each declaration block through a chain of property handlers. A handler buffers the declarations of one family (e.g. all margin properties), and `finalize()` at the end of the block calls `flush()`, which writes the buffered values out, as a shorthand when possible. A declaration that arrives while an earlier one for the same slot is buffered simply replaces it, which is how duplicates disappear and how `margin:0; margin-top:5px` becomes `margin:5px 0 0`.
- Logical properties (`margin-inline-start`, `border-block-end-color`, ...) resolve to a physical side depending on writing direction, and may be compiled to physical properties for old targets. The handler cannot merge them with physical values, so it keeps one category of values buffered at a time: when a declaration of the other category arrives, the buffered values are flushed first, which preserves the source order between the two groups (`category` plus the flush-on-change checks). A flush that is triggered needlessly is harmless for correctness but loses the merging described above, which is the symptom here.
- The `DeclarationHandler` holding all the handlers is created once per stylesheet and reused for every block, so any handler state that is not reset by `flush()`/`finalize()`, or overwritten by the next declaration, carries over between blocks. `@media not all` never matches, so the minifier drops the whole rule after its declarations have been run through the handlers, which is what makes it usable as a way to dirty the handlers without affecting the output.