### PR TITLE
css: keep scanning an @supports condition after a nested block

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3298,8 +3298,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse the input until exhaustion and check that it contains no "error"
-    /// token. See `Token::is_parse_error`. This also checks nested blocks and
-    /// functions recursively.
+    /// token. See `Token::is_parse_error`.
     pub(crate) fn expect_no_error_token(&mut self) -> CssResult<()> {
         loop {
             let tok = match self.next_including_whitespace_and_comments() {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3298,7 +3298,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse the input until exhaustion and check that it contains no "error"
-    /// token. See `Token::is_parse_error`.
+    /// token. See `Token::is_parse_error`. Nested blocks and functions are
+    /// checked recursively, and parsing continues after each of them.
     pub(crate) fn expect_no_error_token(&mut self) -> CssResult<()> {
         loop {
             let tok = match self.next_including_whitespace_and_comments() {
@@ -3308,7 +3309,6 @@ impl<'a> Parser<'a> {
             match tok {
                 Token::Function(_) | Token::OpenParen | Token::OpenSquare | Token::OpenCurly => {
                     self.parse_nested_block(|i| i.expect_no_error_token())?;
-                    return Ok(());
                 }
                 _ => {
                     if tok.is_parse_error() {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -3298,8 +3298,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse the input until exhaustion and check that it contains no "error"
-    /// token. See `Token::is_parse_error`. Nested blocks and functions are
-    /// checked recursively, and parsing continues after each of them.
+    /// token. See `Token::is_parse_error`. This also checks nested blocks and
+    /// functions recursively.
     pub(crate) fn expect_no_error_token(&mut self) -> CssResult<()> {
         loop {
             let tok = match self.next_including_whitespace_and_comments() {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 import {
   cssTest,
@@ -7625,6 +7625,94 @@ describe("css tests", () => {
       "@container style(((--a:1) or (--b:2)) and (--c:3)){a{color:red}}",
       "@container style(((--a:1) or (--b:2)) and (--c:3)){a{color:red}}",
     );
+  });
+
+  describe("supports", () => {
+    // The raw-condition scan (`expect_no_error_token`) used to stop after the
+    // first function or bracket block, so anything following one in a
+    // condition was left unconsumed and failed the stylesheet with
+    // "Unexpected token". Each `SupportsCondition` shape that stores a raw
+    // slice is covered: a parenthesized condition, `selector()`, and the
+    // declaration form used by `@import ... supports()`.
+    minify_test(
+      "@supports (transform:translate(1px) rotate(1deg)){a{color:red}}",
+      "@supports (transform:translate(1px) rotate(1deg)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (grid-template-columns:[a] 1fr [b]){a{color:red}}",
+      "@supports (grid-template-columns:[a] 1fr [b]){a{color:red}}",
+    );
+    minify_test("@supports (--x:{a} b){a{color:red}}", "@supports (--x:{a} b){a{color:red}}");
+    minify_test(
+      '@supports (mask:url("a.svg") no-repeat){a{color:red}}',
+      '@supports (mask:url("a.svg") no-repeat){a{color:red}}',
+    );
+    minify_test(
+      "@supports (transform:translate(1px) rotate(1deg)) and (color:rgb(0 0 0) x){a{color:red}}",
+      "@supports (transform:translate(1px) rotate(1deg)) and (color:rgb(0 0 0) x){a{color:red}}",
+    );
+    minify_test(
+      "@supports (color:rgb(0 0 0) x) or (transform:translate(1px) rotate(1deg)){a{color:red}}",
+      "@supports (color:rgb(0 0 0) x) or (transform:translate(1px) rotate(1deg)){a{color:red}}",
+    );
+    minify_test("@supports selector(a:has(b) c){a{color:red}}", "@supports selector(a:has(b) c){a{color:red}}");
+    minify_test("@supports selector(:is(a) > b){a{color:red}}", "@supports selector(:is(a) > b){a{color:red}}");
+    minify_test(
+      "@supports selector([a] b) and selector(:is(c) d){a{color:red}}",
+      "@supports selector([a] b) and selector(:is(c) d){a{color:red}}",
+    );
+    minify_test(
+      "@supports (transform:translate(1px) rotate(1deg)){a{color:red}}b{color:green}",
+      "@supports (transform:translate(1px) rotate(1deg)){a{color:red}}b{color:green}",
+    );
+    minify_test(
+      "@import url(x.css) supports(transform:translate(1px) rotate(1deg));",
+      '@import "x.css" supports(transform:translate(1px) rotate(1deg));',
+    );
+    minify_test(
+      "@import url(x.css) supports(grid-template-columns:[a] 1fr [b]);",
+      '@import "x.css" supports(grid-template-columns:[a] 1fr [b]);',
+    );
+    minify_test(
+      "@import url(x.css) supports(selector(a:has(b) c));",
+      '@import "x.css" supports(selector(a:has(b) c));',
+    );
+
+    // Scanning past a block must still reject the error tokens behind it.
+    for (const source of [
+      "@supports (transform:translate(1px) ]){a{color:red}}",
+      "@supports (transform:translate(1px) }){a{color:red}}",
+      "@supports selector(a:has(b) ]){a{color:red}}",
+      "@import url(x.css) supports(transform:translate(1px) ]);",
+    ]) {
+      test(`ERROR: ${source}`, () => {
+        expect(() => minify_test_with_options(source, "")).toThrow("Unexpected token");
+      });
+    }
+
+    // Tokens after a block are not a license to accept junk after the
+    // condition itself.
+    test("ERROR: @supports foo(bar) baz{a{color:red}}", () => {
+      expect(() => minify_test_with_options("@supports foo(bar) baz{a{color:red}}", "")).toThrow("Unexpected token");
+    });
+
+    test("bundles a stylesheet whose conditions have tokens after a function", async () => {
+      using dir = tempDir("css-supports-after-block", {
+        "entry.css": `
+          @import "./dep.css" supports(transform: translate(1px) rotate(1deg));
+          @supports (mask: url("a.svg") no-repeat) { .a { color: red } }
+          @supports selector(a:has(b) c) { .b { color: green } }
+        `,
+        "dep.css": ".dep { color: blue }",
+      });
+
+      const result = await Bun.build({ entrypoints: [join(String(dir), "entry.css")] });
+      const output = await result.outputs[0].text();
+      expect(output).toContain("@supports (transform: translate(1px) rotate(1deg))");
+      expect(output).toContain(".dep {");
+      expect(output).toContain('@supports (mask: url("a.svg") no-repeat)');
+      expect(output).toContain("@supports selector(a:has(b) c)");
+    });
   });
 
   describe("font-palette-values", () => {


### PR DESCRIPTION
### Problem
- `bun build` fails on any stylesheet whose `@supports` condition has a token after a function or bracket block inside it, e.g. `@supports (transform: translate(1px) rotate(1deg)) { ... }` or `@supports selector(a:has(b) c) { ... }`:
  ```
  error: Unexpected token: rotate
      at decl.css:1:37
  ```
- `@import "x.css" supports(transform: translate(1px) rotate(1deg));` fails the same way. The same conditions with nothing after the block (`(transform: translate(1px))`) work, and lightningcss and esbuild accept all of them.
- Cause: `Parser::expect_no_error_token` (src/css/css_parser.rs:3302) returned `Ok(())` right after checking the first nested block, instead of continuing to the end of the input. Its callers in src/css/rules/supports.rs (`parse_declaration`, the `selector()` arm and the unknown-condition fallback of `parse_in_parens`) run it inside `parse_nested_block`, which requires the block to be fully consumed, so the leftover tokens (`rotate(1deg)`, `c`) fail the at-rule prelude and with it the whole file.
- The Zig implementation this was ported from had the same early return, so this is not a port regression; it has been this way since the CSS parser was added.

### Fix
- Drop the early return so the loop keeps scanning after each nested block. This is what upstream rust-cssparser's `expect_no_error_token` does, and what every caller wants: they want the whole condition consumed and checked for error tokens, then take the raw slice.
- Error tokens that appear after a block are still rejected, because the loop now reaches them (`(transform: translate(1px) ])` still fails with `Unexpected token: ]`, as before), and junk after a complete condition (`@supports foo(bar) baz`) is still rejected by the prelude exhaustion check.
- Nothing else calls `expect_no_error_token`, so the change is confined to `@supports` and `@import ... supports()` conditions. Nesting depth is unchanged (the first block was always descended into before too), so the existing maximum nesting depth limit behaves as it did.
- Verified with the new `supports` block in test/js/bun/css/css.test.ts: 14 of the 19 tests fail on the released binary (`USE_SYSTEM_BUN=1`) and all pass with this change. The block covers all three raw-slice condition shapes (parenthesized condition, `selector()`, and the declaration form used by `@import ... supports()`), function / `[]` / `{}` blocks, `and` / `or` combinations, the error-token cases above, and a `Bun.build` of a stylesheet using all of them (including an `@import ... supports()` that the bundler turns into an `@supports` block).
- Also ran test/js/bun/css/css.test.ts, supports-condition-newline.test.ts, doesnt_crash.test.ts, css-loader.test.ts and test/bundler/esbuild/css.test.ts with the debug build: all pass.

### Background
- `@supports` conditions are mostly not interpreted by the CSS parser: `SupportsCondition` stores the text between the parentheses (or inside `selector(...)`, or the declaration value for `@import ... supports(...)`) as a raw slice of the input and prints it back verbatim. `expect_no_error_token` is the scan that decides how far that slice extends and that it contains no tokenizer error tokens (bad string, bad url, stray closing bracket).
- `parse_nested_block` runs a closure over the contents of the block whose opening token was just consumed and then requires the closure to have consumed the whole block; any leftover token is reported as `Unexpected token`. That is where the error in this bug comes from.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (ffe280646)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.49ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.16ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.12ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release without fix: 14 failed, 67 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.15ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.63ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (ffe280646)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.58ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.02ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ffe2806463
  features     baseline

22 deps, 123 codegen, 1176 objects in 682ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [23.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [7.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[7/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] gen JSBuffer.lut.h
Generating
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/css_parser.rs       |  1 -
 test/js/bun/css/css.test.ts | 90 ++++++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 89 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/css/css_parser.rs            5      4      0
test/js/bun/css/css.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->