### PR TITLE
css: resolve relative color channel keywords as numbers in the function's range

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -131,20 +131,22 @@ Relative color syntax modifies individual components of an existing color. Adjus
 
 ```css title="styles.css" icon="file-code"
 .theme-color {
-  /* Start with a base color and increase lightness by 15% */
-  --accent: lch(from purple calc(l + 15%) c h);
+  /* Start with a base color and add 15 to its lightness, which runs from 0 to 100 */
+  --accent: lch(from purple calc(l + 15) c h);
 
   /* Take our brand blue and make a desaturated version */
   --subtle-blue: oklch(from var(--brand-blue) l calc(c * 0.8) h);
 }
 ```
 
-Bun's CSS bundler computes these relative color modifications at build time (when not using CSS variables) and generates static color values for browser compatibility:
+The channel keywords (`l`, `c`, `h`, `r`, `alpha`, ...) are numbers in the range the color function itself uses: `rgb()` channels run from 0 to 255, `hsl()` saturation and lightness and `lab()`/`lch()` lightness from 0 to 100, `oklab()`/`oklch()` lightness and `alpha` from 0 to 1.
+
+Bun's CSS bundler computes these relative color modifications at build time when the origin color is known, and leaves the ones that depend on CSS variables for the browser:
 
 ```css
 .theme-color {
-  --accent: lch(69.32% 58.34 328.37);
-  --subtle-blue: oklch(60.92% 0.112 240.01);
+  --accent: lch(44.6915% 66.8257 327.105);
+  --subtle-blue: oklch(from var(--brand-blue) l calc(c * 0.8) h);
 }
 ```
 

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1127,16 +1127,16 @@ pub(crate) fn parse_color_function(
     let mut parser = ComponentParser::new(true);
 
     crate::match_ignore_ascii_case! { function, {
-        b"lab" => parse_lab::<LAB>(input, &mut parser, |l, a, b, alpha| {
+        b"lab" => parse_lab::<LAB>(input, &mut parser, LAB_LIGHTNESS_RANGE, |l, a, b, alpha| {
             LABColor::Lab(LAB { l, a, b, alpha })
         }),
-        b"oklab" => parse_lab::<OKLAB>(input, &mut parser, |l, a, b, alpha| {
+        b"oklab" => parse_lab::<OKLAB>(input, &mut parser, OKLAB_LIGHTNESS_RANGE, |l, a, b, alpha| {
             LABColor::Oklab(OKLAB { l, a, b, alpha })
         }),
-        b"lch" => parse_lch::<LCH>(input, &mut parser, |l, c, h, alpha| {
+        b"lch" => parse_lch::<LCH>(input, &mut parser, LAB_LIGHTNESS_RANGE, |l, c, h, alpha| {
             LABColor::Lch(LCH { l, c, h, alpha })
         }),
-        b"oklch" => parse_lch::<OKLCH>(input, &mut parser, |l, c, h, alpha| {
+        b"oklch" => parse_lch::<OKLCH>(input, &mut parser, OKLAB_LIGHTNESS_RANGE, |l, c, h, alpha| {
             LABColor::Oklch(OKLCH { l, c, h, alpha })
         }),
         b"color" => parse_predefined(input, &mut parser),
@@ -1174,10 +1174,28 @@ pub(crate) fn parse_color_function(
     }}
 }
 
+// The value a channel's `100%` stands for in each color function. The colorspace
+// structs store these channels as unit values, and in the relative color syntax
+// the channel keywords (`r`, `l`, `alpha`, ...) are `<number>`s in the range of
+// the function being parsed: `r` is 0..255 in `rgb()` but 0..1 in
+// `color(srgb ...)`, `l` is 0..100 in `lab()` but 0..1 in `oklab()`. Each
+// function tells its `RelativeComponentParser` the ranges of its channels and
+// divides the `<number>`s it parses by the same ranges.
+// https://drafts.csswg.org/css-color-5/#relative-colors
+const RGB_CHANNEL_RANGE: f32 = 255.0;
+/// `hsl()` saturation and lightness, `hwb()` whiteness and blackness.
+const HSL_CHANNEL_RANGE: f32 = 100.0;
+const LAB_LIGHTNESS_RANGE: f32 = 100.0;
+const OKLAB_LIGHTNESS_RANGE: f32 = 1.0;
+
 pub(crate) fn parse_rgb_components(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
 ) -> CssResult<(f32, f32, f32, bool)> {
+    if let Some(from) = &mut parser.from {
+        from.ranges = (RGB_CHANNEL_RANGE, RGB_CHANNEL_RANGE, RGB_CHANNEL_RANGE);
+    }
+
     let red = parser.parse_number_or_percentage(input)?;
 
     let is_legacy_syntax = parser.from.is_none()
@@ -1212,7 +1230,7 @@ pub(crate) fn parse_rgb_components(
                     if v.is_nan() {
                         v
                     } else {
-                        v.round().clamp(0.0, 255.0) / 255.0
+                        v.round().clamp(0.0, RGB_CHANNEL_RANGE) / RGB_CHANNEL_RANGE
                     }
                 }
                 NumberOrPercentage::Percentage { unit_value } => unit_value.clamp(0.0, 1.0),
@@ -1311,6 +1329,7 @@ fn delta_eok<T: Into<OKLAB>>(a_: T, b_: OKLCH) -> f32 {
 pub(crate) fn parse_lab<T>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
+    l_range: f32,
     func: fn(f32, f32, f32, f32) -> LABColor,
 ) -> CssResult<CssColor>
 where
@@ -1319,8 +1338,12 @@ where
     // https://www.w3.org/TR/css-color-4/#funcdef-lab
     input.parse_nested_block(|i| {
         parser.parse_relative::<T, CssColor, _>(i, |i, p| {
+            if let Some(from) = &mut p.from {
+                from.ranges.0 = l_range;
+            }
+
             // f32::max() does not propagate NaN, so use clamp for now until f32::maximum() is stable.
-            let l = p.parse_percentage(i)?.clamp(0.0, f32::MAX);
+            let l = p.parse_unit_channel(i, l_range)?.clamp(0.0, f32::MAX);
             let a = p.parse_number(i)?;
             let b = p.parse_number(i)?;
             let alpha = parse_alpha(i, p)?;
@@ -1333,11 +1356,14 @@ where
 pub(crate) fn parse_lch<T: Colorspace + ColorGamut + Into<OKLCH> + From<OKLCH> + Into<OKLAB>>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
+    l_range: f32,
     func: fn(f32, f32, f32, f32) -> LABColor,
 ) -> CssResult<CssColor> {
     input.parse_nested_block(|i| {
         parser.parse_relative::<T, CssColor, _>(i, |i, p| {
             if let Some(from) = &mut p.from {
+                from.ranges.0 = l_range;
+
                 // Relative angles should be normalized.
                 // https://www.w3.org/TR/css-color-5/#relative-LCH
                 from.components.2 = from.components.2.rem_euclid(360.0);
@@ -1346,7 +1372,7 @@ pub(crate) fn parse_lch<T: Colorspace + ColorGamut + Into<OKLCH> + From<OKLCH> +
                 }
             }
 
-            let l = p.parse_percentage(i)?.clamp(0.0, f32::MAX);
+            let l = p.parse_unit_channel(i, l_range)?.clamp(0.0, f32::MAX);
             let c = p.parse_number(i)?.clamp(0.0, f32::MAX);
             let h = parse_angle_or_number(i, p)?;
             let alpha = parse_alpha(i, p)?;
@@ -1387,19 +1413,28 @@ pub(crate) fn parse_hsl_hwb_components<T>(
     allows_legacy: bool,
 ) -> CssResult<(f32, f32, f32, bool)> {
     let _ = core::marker::PhantomData::<T>; // autofix
+    if let Some(from) = &mut parser.from {
+        from.ranges.1 = HSL_CHANNEL_RANGE;
+        from.ranges.2 = HSL_CHANNEL_RANGE;
+    }
+
     let h = parse_angle_or_number(input, parser)?;
     let is_legacy_syntax = allows_legacy
         && parser.from.is_none()
         && !h.is_nan()
         && input.try_parse(|i| i.expect_comma()).is_ok();
 
-    let a = parser.parse_percentage(input)?.clamp(0.0, 1.0);
+    let a = parser
+        .parse_unit_channel(input, HSL_CHANNEL_RANGE)?
+        .clamp(0.0, 1.0);
 
     if is_legacy_syntax {
         input.expect_comma()?;
     }
 
-    let b = parser.parse_percentage(input)?.clamp(0.0, 1.0);
+    let b = parser
+        .parse_unit_channel(input, HSL_CHANNEL_RANGE)?
+        .clamp(0.0, 1.0);
 
     if is_legacy_syntax && (a.is_nan() || b.is_nan()) {
         return Err(input.new_custom_error(css::ParserError::invalid_value));
@@ -1709,14 +1744,13 @@ macro_rules! define_colorspace {
     };
 }
 
-const CT_PCT: ChannelType = ChannelType::PERCENTAGE;
 const CT_NUM: ChannelType = ChannelType::NUMBER;
 const CT_ANG: ChannelType = ChannelType::ANGLE;
 
 define_colorspace! {
     /// A color in the [CIE Lab](https://www.w3.org/TR/css-color-4/#cie-lab) color space.
     LAB { l, a, b }
-    types = (CT_PCT, CT_NUM, CT_NUM);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = unbounded;
     premultiply = rectangular;
     powerless = lab;
@@ -1726,7 +1760,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`sRGB`](https://www.w3.org/TR/css-color-4/#predefined-sRGB) color space.
     SRGB { r, g, b }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = bounded;
     premultiply = rectangular;
     powerless = none;
@@ -1747,7 +1781,7 @@ impl SRGB {
 define_colorspace! {
     /// A color in the [`hsl`](https://www.w3.org/TR/css-color-4/#the-hsl-notation) color space.
     HSL { h, s, l }
-    types = (CT_ANG, CT_PCT, CT_PCT);
+    types = (CT_ANG, CT_NUM, CT_NUM);
     gamut = hsl_hwb;
     premultiply = polar;
     powerless = hsl;
@@ -1757,7 +1791,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`hwb`](https://www.w3.org/TR/css-color-4/#the-hwb-notation) color space.
     HWB { h, w, b }
-    types = (CT_ANG, CT_PCT, CT_PCT);
+    types = (CT_ANG, CT_NUM, CT_NUM);
     gamut = hsl_hwb;
     premultiply = polar;
     powerless = hwb;
@@ -1769,7 +1803,7 @@ define_colorspace! {
     SRGBLinear { r, g, b }
     // `r` intentionally uses the angle channel type (sic) — kept for
     // behavioral compatibility.
-    types = (CT_ANG, CT_PCT, CT_PCT);
+    types = (CT_ANG, CT_NUM, CT_NUM);
     gamut = bounded;
     premultiply = rectangular;
     powerless = none;
@@ -1779,7 +1813,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`display-p3`](https://www.w3.org/TR/css-color-4/#predefined-display-p3) color space.
     P3 { r, g, b }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = bounded;
     premultiply = none;
     powerless = none;
@@ -1789,7 +1823,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`a98-rgb`](https://www.w3.org/TR/css-color-4/#predefined-a98-rgb) color space.
     A98 { r, g, b }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = bounded;
     premultiply = none;
     powerless = none;
@@ -1799,7 +1833,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`prophoto-rgb`](https://www.w3.org/TR/css-color-4/#predefined-prophoto-rgb) color space.
     ProPhoto { r, g, b }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = bounded;
     premultiply = none;
     powerless = none;
@@ -1809,7 +1843,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`rec2020`](https://www.w3.org/TR/css-color-4/#predefined-rec2020) color space.
     Rec2020 { r, g, b }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = bounded;
     premultiply = none;
     powerless = none;
@@ -1819,7 +1853,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`xyz-d50`](https://www.w3.org/TR/css-color-4/#predefined-xyz) color space.
     XYZd50 { x, y, z }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = unbounded;
     premultiply = rectangular;
     powerless = none;
@@ -1829,7 +1863,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [`xyz-d65`](https://www.w3.org/TR/css-color-4/#predefined-xyz) color space.
     XYZd65 { x, y, z }
-    types = (CT_PCT, CT_PCT, CT_PCT);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = unbounded;
     premultiply = rectangular;
     powerless = none;
@@ -1839,7 +1873,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [CIE LCH](https://www.w3.org/TR/css-color-4/#cie-lab) color space.
     LCH { l, c, h }
-    types = (CT_PCT, CT_NUM, CT_ANG);
+    types = (CT_NUM, CT_NUM, CT_ANG);
     gamut = unbounded;
     premultiply = rectangular;
     powerless = lch;
@@ -1849,7 +1883,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [OKLab](https://www.w3.org/TR/css-color-4/#ok-lab) color space.
     OKLAB { l, a, b }
-    types = (CT_PCT, CT_NUM, CT_NUM);
+    types = (CT_NUM, CT_NUM, CT_NUM);
     gamut = unbounded;
     premultiply = rectangular;
     powerless = lab;
@@ -1859,7 +1893,7 @@ define_colorspace! {
 define_colorspace! {
     /// A color in the [OKLCH](https://www.w3.org/TR/css-color-4/#ok-lab) color space.
     OKLCH { l, c, h }
-    types = (CT_PCT, CT_NUM, CT_ANG);
+    types = (CT_NUM, CT_NUM, CT_ANG);
     gamut = unbounded;
     premultiply = rectangular;
     powerless = lch;
@@ -1936,10 +1970,13 @@ impl ComponentParser {
 
     fn parse_number_or_percentage(&self, input: &mut css::Parser) -> CssResult<NumberOrPercentage> {
         if let Some(from) = &self.from {
-            if let Ok(res) =
-                input.try_parse(|i| RelativeComponentParser::parse_number_or_percentage(i, from))
+            if let Ok(value) = input.try_parse(|i| RelativeComponentParser::parse_number(i, from)) {
+                return Ok(NumberOrPercentage::Number { value });
+            }
+            if let Ok(unit_value) =
+                input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
             {
-                return Ok(res);
+                return Ok(NumberOrPercentage::Percentage { unit_value });
             }
         }
 
@@ -1983,14 +2020,26 @@ impl ComponentParser {
         }
     }
 
-    fn parse_percentage(&self, input: &mut css::Parser) -> CssResult<f32> {
+    /// Parses a channel that is stored as a unit value and written as a
+    /// `<percentage>`, or, in the relative color syntax, as a `<number>` (a
+    /// channel keyword, a calc() over them, or a literal) whose `100%` is
+    /// `range`.
+    fn parse_unit_channel(&self, input: &mut css::Parser, range: f32) -> CssResult<f32> {
         if let Some(from) = &self.from {
-            if let Ok(res) = input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
+            if let Ok(value) = input.try_parse(|i| self.parse_number(i)) {
+                return Ok(value / range);
+            }
+            if let Ok(unit_value) =
+                input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
             {
-                return Ok(res);
+                return Ok(unit_value);
             }
         }
 
+        self.parse_percentage(input)
+    }
+
+    fn parse_percentage(&self, input: &mut css::Parser) -> CssResult<f32> {
         if let Ok(val) = input.try_parse(Percentage::parse) {
             Ok(val.v)
         } else if self.allow_none {
@@ -2062,7 +2111,12 @@ impl NumberOrPercentage {
 
 pub(crate) struct RelativeComponentParser {
     pub(crate) names: (&'static [u8], &'static [u8], &'static [u8]),
+    /// The origin color's channels as the colorspace struct stores them.
     pub(crate) components: (f32, f32, f32, f32),
+    /// What each stored channel is multiplied by to get the `<number>` its
+    /// keyword stands for in the function being parsed (`RGB_CHANNEL_RANGE` and
+    /// friends). Set by that function's component parser; 1 where the two agree.
+    pub(crate) ranges: (f32, f32, f32),
     pub(crate) types: (ChannelType, ChannelType, ChannelType),
 }
 
@@ -2071,6 +2125,7 @@ impl RelativeComponentParser {
         RelativeComponentParser {
             names: color.channels(),
             components: color.components(),
+            ranges: (1.0, 1.0, 1.0),
             types: color.types(),
         }
     }
@@ -2092,11 +2147,14 @@ impl RelativeComponentParser {
             return Ok(css::color::AngleOrNumber::Number { value });
         }
 
-        // `Calc::Value` is `Box<V>`, so box the temporary `Angle`.
+        // A calc() with an <angle> in it, e.g. `calc(h + 30deg)`. The hue
+        // keyword is an angle inside it, every other keyword stays a <number>.
         if let Ok(value) = input.try_parse(|i| {
             match Calc::<Angle>::parse_with(i, this, |ctx, ident| {
-                let value = ctx.get_ident(ident, allowed)?;
-                Some(Calc::Value(Box::new(Angle::Deg(value))))
+                if let Some((degrees, _)) = ctx.get_ident(ident, ChannelType::ANGLE) {
+                    return Some(Calc::Value(Box::new(Angle::Deg(degrees))));
+                }
+                Some(Calc::Number(ctx.get_number(ident, ChannelType::NUMBER)?))
             }) {
                 Ok(Calc::Value(v)) => Ok(*v),
                 _ => Err(i.new_custom_error(css::ParserError::invalid_value)),
@@ -2105,69 +2163,6 @@ impl RelativeComponentParser {
             return Ok(css::color::AngleOrNumber::Angle {
                 degrees: value.to_degrees(),
             });
-        }
-
-        Err(input.new_error_for_next_token())
-    }
-
-    fn parse_number_or_percentage(
-        input: &mut css::Parser,
-        this: &RelativeComponentParser,
-    ) -> CssResult<NumberOrPercentage> {
-        let allowed = ChannelType::PERCENTAGE | ChannelType::NUMBER;
-        if let Ok(value) =
-            input.try_parse(|i| RelativeComponentParser::parse_ident(i, this, allowed))
-        {
-            return Ok(NumberOrPercentage::Percentage { unit_value: value });
-        }
-
-        if let Ok(value) =
-            input.try_parse(|i| RelativeComponentParser::parse_calc(i, this, allowed))
-        {
-            return Ok(NumberOrPercentage::Percentage { unit_value: value });
-        }
-
-        if let Ok(value) = input.try_parse(|i| {
-            match Calc::<Percentage>::parse_with(i, this, |ctx, ident| {
-                let v = ctx.get_ident(ident, allowed)?;
-                // value variant is a *Percentage
-                // but we immediately dereference it and discard the pointer
-                // so using a field on this closure struct instead of making a gratuitous allocation
-                Some(Calc::Value(Box::new(Percentage { v })))
-            }) {
-                Ok(Calc::Value(v)) => Ok(*v),
-                _ => Err(i.new_custom_error(css::ParserError::invalid_value)),
-            }
-        }) {
-            return Ok(NumberOrPercentage::Percentage {
-                unit_value: value.v,
-            });
-        }
-
-        Err(input.new_error_for_next_token())
-    }
-
-    fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
-        if let Ok(value) = input
-            .try_parse(|i| RelativeComponentParser::parse_ident(i, this, ChannelType::PERCENTAGE))
-        {
-            return Ok(value);
-        }
-
-        if let Ok(value) = input.try_parse(|i| {
-            let calc_value = match Calc::<Percentage>::parse_with(i, this, |ctx, ident| {
-                let v = ctx.get_ident(ident, ChannelType::PERCENTAGE)?;
-                Some(Calc::Value(Box::new(Percentage { v })))
-            }) {
-                Ok(v) => v,
-                Err(_) => return Err(i.new_custom_error(css::ParserError::invalid_value)),
-            };
-            if let Calc::Value(v) = calc_value {
-                return Ok(*v);
-            }
-            Err(i.new_custom_error(css::ParserError::invalid_value))
-        }) {
-            return Ok(value.v);
         }
 
         Err(input.new_error_for_next_token())
@@ -2189,13 +2184,30 @@ impl RelativeComponentParser {
         Err(input.new_error_for_next_token())
     }
 
+    /// A math function the `<number>` pass could not fold, evaluated as a
+    /// `<percentage>` and returned as a unit value. A keyword is its channel as
+    /// a percentage of the channel's range here, which is what folds
+    /// `min(r, g)` (`reduce_args` only compares values) and what gives
+    /// `calc(l + 10%)` its pre-existing meaning. Callers try `parse_number`
+    /// first, so a math function over plain numbers gets the CSS Color 5
+    /// meaning, in which the keywords are `<number>`s.
+    fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
+        match Calc::<Percentage>::parse_with(input, this, |ctx, ident| {
+            let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;
+            Some(Calc::Value(Box::new(Percentage { v: unit_value })))
+        }) {
+            Ok(Calc::Value(v)) => Ok(v.v),
+            _ => Err(input.new_custom_error(css::ParserError::invalid_value)),
+        }
+    }
+
     fn parse_ident(
         input: &mut css::Parser,
         this: &RelativeComponentParser,
         allowed_types: ChannelType,
     ) -> CssResult<f32> {
         let ident = input.expect_ident()?;
-        match this.get_ident(ident, allowed_types) {
+        match this.get_number(ident, allowed_types) {
             Some(v) => Ok(v),
             None => Err(input.new_error_for_next_token()),
         }
@@ -2207,7 +2219,7 @@ impl RelativeComponentParser {
         allowed_types: ChannelType,
     ) -> CssResult<f32> {
         if let Ok(calc_val) = Calc::<f32>::parse_with(input, this, |ctx, ident| {
-            let v = ctx.get_ident(ident, allowed_types)?;
+            let v = ctx.get_number(ident, allowed_types)?;
             Some(Calc::Number(v))
         }) {
             // PERF: I don't like this redundant allocation
@@ -2221,29 +2233,37 @@ impl RelativeComponentParser {
         Err(input.new_custom_error(css::ParserError::invalid_value))
     }
 
-    fn get_ident(&self, ident: &[u8], allowed_types: ChannelType) -> Option<f32> {
+    /// The `<number>` a channel keyword stands for in the function being parsed.
+    fn get_number(&self, ident: &[u8], allowed_types: ChannelType) -> Option<f32> {
+        let (value, range) = self.get_ident(ident, allowed_types)?;
+        Some(value * range)
+    }
+
+    /// A channel keyword's stored value and the range it is scaled by to become
+    /// a `<number>`.
+    fn get_ident(&self, ident: &[u8], allowed_types: ChannelType) -> Option<(f32, f32)> {
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.0)
             && allowed_types.intersects(self.types.0)
         {
-            return Some(self.components.0);
+            return Some((self.components.0, self.ranges.0));
         }
 
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.1)
             && allowed_types.intersects(self.types.1)
         {
-            return Some(self.components.1);
+            return Some((self.components.1, self.ranges.1));
         }
 
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.2)
             && allowed_types.intersects(self.types.2)
         {
-            return Some(self.components.2);
+            return Some((self.components.2, self.ranges.2));
         }
 
         if strings::eql_case_insensitive_ascii_check_length(ident, b"alpha")
-            && allowed_types.contains(ChannelType::PERCENTAGE)
+            && allowed_types.contains(ChannelType::NUMBER)
         {
-            return Some(self.components.3);
+            return Some((self.components.3, 1.0));
         }
 
         None
@@ -2251,15 +2271,15 @@ impl RelativeComponentParser {
 }
 
 bitflags::bitflags! {
-    /// A channel type for a color space.
+    /// What a color space's channel keyword stands for in the relative color
+    /// syntax, which decides the positions it may be used in.
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct ChannelType: u8 {
-        /// Channel represents a percentage.
-        const PERCENTAGE = 1 << 0;
-        /// Channel represents an angle.
-        const ANGLE = 1 << 1;
-        /// Channel represents a number.
-        const NUMBER = 1 << 2;
+        /// A hue in degrees.
+        const ANGLE = 1 << 0;
+        /// A `<number>` in the range of the function being parsed (see
+        /// `RGB_CHANNEL_RANGE`); every channel other than a hue, and `alpha`.
+        const NUMBER = 1 << 1;
     }
 }
 

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1126,8 +1126,6 @@ pub(crate) fn parse_color_function(
 ) -> CssResult<CssColor> {
     let mut parser = ComponentParser::new(true);
 
-    // The lightness percent basis: `lab()`/`lch()` write lightness as 0..100,
-    // the ok variants as 0..1.
     crate::match_ignore_ascii_case! { function, {
         b"lab" => parse_lab::<LAB>(input, &mut parser, 100.0, |l, a, b, alpha| {
             LABColor::Lab(LAB { l, a, b, alpha })
@@ -1176,11 +1174,8 @@ pub(crate) fn parse_color_function(
     }}
 }
 
-/// Percent basis (what `100%` stands for, see `RelativeComponentParser`) of the
-/// `rgb()` channels.
+// See `RelativeComponentParser::percent_basis`.
 const RGB_PERCENT_BASIS: f32 = 255.0;
-/// Percent basis of `hsl()` saturation and lightness and `hwb()` whiteness and
-/// blackness.
 const HSL_PERCENT_BASIS: f32 = 100.0;
 
 pub(crate) fn parse_rgb_components(
@@ -2015,15 +2010,8 @@ impl ComponentParser {
         }
     }
 
-    /// Parses a channel that is stored as a unit value and written as a
-    /// `<percentage>`, or, in the relative color syntax, as a `<number>` (a
-    /// channel keyword, a calc() over them, or a literal) out of `percent_basis`.
-    ///
-    /// css-color-4 also allows the `<number>` outside the relative syntax. That
-    /// is left for the change that stops folding out-of-gamut origin colors:
-    /// today `rgb(from lab(100 104 -51) r g b)` is left alone only because the
-    /// origin does not parse, and accepting it would fold it to a gamut-mapped
-    /// color, which browsers do not do.
+    /// A channel stored as a unit value: a `<percentage>`, or in the relative
+    /// color syntax also a `<number>` out of `percent_basis`.
     fn parse_unit_channel(&self, input: &mut css::Parser, percent_basis: f32) -> CssResult<f32> {
         if let Some(from) = &self.from {
             if let Ok(value) = input.try_parse(|i| self.parse_number(i)) {
@@ -2109,19 +2097,14 @@ impl NumberOrPercentage {
 // RelativeComponentParser
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Resolves the channel keywords of a relative color (`rgb(from red r g b)`).
-/// https://drafts.csswg.org/css-color-5/#relative-colors
 pub(crate) struct RelativeComponentParser {
     pub(crate) names: (&'static [u8], &'static [u8], &'static [u8]),
-    /// The origin color's channels as the colorspace struct stores them.
     pub(crate) components: (f32, f32, f32, f32),
-    /// What `100%` of each channel is in the function being parsed: 255 for the
-    /// `rgb()` channels, 100 for `hsl()` saturation/lightness and `lab()`
-    /// lightness, 1 for `color()`, the ok variants and everything unscaled. The
-    /// structs store those channels as unit values, and a keyword is a
-    /// `<number>` in the function's own range, so a keyword resolves to
-    /// `component * percent_basis`. `r` is 200 in `rgb()` but 0.784 in
-    /// `color(srgb ...)`, which is why the function being parsed sets this.
+    /// What `100%` of each channel is in the function being parsed (255 in
+    /// `rgb()`, 1 in `color(srgb ...)`, for the same `SRGB` components). The
+    /// structs store unit values and a keyword is a `<number>` in the function's
+    /// range, so a keyword is `component * percent_basis`.
+    /// https://drafts.csswg.org/css-color-5/#relative-colors
     pub(crate) percent_basis: (f32, f32, f32),
     pub(crate) types: (ChannelType, ChannelType, ChannelType),
 }
@@ -2153,8 +2136,6 @@ impl RelativeComponentParser {
             return Ok(css::color::AngleOrNumber::Number { value });
         }
 
-        // A calc() with an <angle> in it, e.g. `calc(h + 30deg)`. The hue
-        // keyword is an angle inside it, every other keyword stays a <number>.
         if let Ok(value) = input.try_parse(|i| {
             match Calc::<Angle>::parse_with(i, this, |ctx, ident| {
                 if let Some((degrees, _)) = ctx.get_ident(ident, ChannelType::ANGLE) {
@@ -2190,13 +2171,9 @@ impl RelativeComponentParser {
         Err(input.new_error_for_next_token())
     }
 
-    /// A math function the `<number>` pass could not fold, evaluated as a
-    /// `<percentage>` and returned as a unit value. Callers try `parse_number`
-    /// first, so this only sees functions with a percentage in them, plus
-    /// `min(r, g)`, which `reduce_args` folds here because it only compares
-    /// values. A keyword is its channel as a percentage of its basis here, as
-    /// before this parser had a basis; typing it as a `<number>` like upstream
-    /// does needs `Percentage::from_calc` to reject a number first (#38513).
+    /// Second pass for what `parse_number` could not fold: a math function with
+    /// a percentage in it, or `min(r, g)` (`reduce_args` only compares values).
+    /// A keyword is its channel as a percentage of its basis here.
     fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
         match Calc::<Percentage>::parse_with(input, this, |ctx, ident| {
             let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;
@@ -2239,13 +2216,12 @@ impl RelativeComponentParser {
         Err(input.new_custom_error(css::ParserError::invalid_value))
     }
 
-    /// The `<number>` a channel keyword stands for in the function being parsed.
     fn get_number(&self, ident: &[u8], allowed_types: ChannelType) -> Option<f32> {
         let (component, percent_basis) = self.get_ident(ident, allowed_types)?;
         Some(component * percent_basis)
     }
 
-    /// A channel keyword's stored component and its percent basis.
+    /// Returns the keyword's stored component and its percent basis.
     fn get_ident(&self, ident: &[u8], allowed_types: ChannelType) -> Option<(f32, f32)> {
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.0)
             && allowed_types.intersects(self.types.0)
@@ -2276,15 +2252,12 @@ impl RelativeComponentParser {
 }
 
 bitflags::bitflags! {
-    /// What a color space's channel keyword stands for in the relative color
-    /// syntax, which decides the positions it may be used in.
+    /// What a channel keyword stands for in the relative color syntax.
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct ChannelType: u8 {
         /// A hue in degrees.
         const ANGLE = 1 << 0;
-        /// A `<number>` in the range of the function being parsed (see
-        /// `RelativeComponentParser::percent_basis`); every channel other than
-        /// a hue, and `alpha`.
+        /// A `<number>` in the function's range; every other channel, and `alpha`.
         const NUMBER = 1 << 1;
     }
 }

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1186,7 +1186,7 @@ pub(crate) fn parse_rgb_components(
         from.percent_basis = (RGB_PERCENT_BASIS, RGB_PERCENT_BASIS, RGB_PERCENT_BASIS);
     }
 
-    let red = parser.parse_number_or_percentage(input)?;
+    let red = parser.parse_number_or_percentage(input, RGB_PERCENT_BASIS)?;
 
     let is_legacy_syntax = parser.from.is_none()
         && !red.unit_value().is_nan()
@@ -1228,8 +1228,8 @@ pub(crate) fn parse_rgb_components(
         }
 
         let r = get_component(red);
-        let g = get_component(parser.parse_number_or_percentage(input)?);
-        let b = get_component(parser.parse_number_or_percentage(input)?);
+        let g = get_component(parser.parse_number_or_percentage(input, RGB_PERCENT_BASIS)?);
+        let b = get_component(parser.parse_number_or_percentage(input, RGB_PERCENT_BASIS)?);
         (r, g, b)
     };
 
@@ -1491,11 +1491,13 @@ fn parse_alpha(input: &mut css::Parser, parser: &ComponentParser) -> CssResult<f
     Ok(res)
 }
 
+/// Alpha and the `color()` channels, whose percent basis is 1, so a number and
+/// a unit value are the same thing.
 pub(crate) fn parse_number_or_percentage(
     input: &mut css::Parser,
     parser: &ComponentParser,
 ) -> CssResult<f32> {
-    let result = parser.parse_number_or_percentage(input)?;
+    let result = parser.parse_number_or_percentage(input, 1.0)?;
     Ok(match result {
         NumberOrPercentage::Number { value } => value,
         NumberOrPercentage::Percentage { unit_value } => unit_value,
@@ -1958,13 +1960,18 @@ impl ComponentParser {
         func(input, self)
     }
 
-    fn parse_number_or_percentage(&self, input: &mut css::Parser) -> CssResult<NumberOrPercentage> {
+    /// `percent_basis` is what `100%` of the channel being parsed stands for.
+    fn parse_number_or_percentage(
+        &self,
+        input: &mut css::Parser,
+        percent_basis: f32,
+    ) -> CssResult<NumberOrPercentage> {
         if let Some(from) = &self.from {
             if let Ok(value) = input.try_parse(|i| RelativeComponentParser::parse_number(i, from)) {
                 return Ok(NumberOrPercentage::Number { value });
             }
-            if let Ok(unit_value) =
-                input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
+            if let Ok(unit_value) = input
+                .try_parse(|i| RelativeComponentParser::parse_percentage(i, from, percent_basis))
             {
                 return Ok(NumberOrPercentage::Percentage { unit_value });
             }
@@ -2016,8 +2023,8 @@ impl ComponentParser {
             if let Ok(value) = input.try_parse(|i| self.parse_number(i)) {
                 return Ok(value / percent_basis);
             }
-            if let Ok(unit_value) =
-                input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
+            if let Ok(unit_value) = input
+                .try_parse(|i| RelativeComponentParser::parse_percentage(i, from, percent_basis))
             {
                 return Ok(unit_value);
             }
@@ -2170,10 +2177,18 @@ impl RelativeComponentParser {
 
     /// Second pass for what `parse_number` could not fold: math functions with a
     /// percentage in them, and `min(r, g)`, since `reduce_args` only compares values.
-    fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
-        match Calc::<Percentage>::parse_with(input, this, |ctx, ident| {
-            let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;
-            Some(Calc::Value(Box::new(Percentage { v: unit_value })))
+    /// A keyword is its `<number>` as a fraction of the channel's `percent_basis`,
+    /// so `min(l, a)` compares lab's 0..100 `l` with `a` on the same scale.
+    fn parse_percentage(
+        input: &mut css::Parser,
+        this: &RelativeComponentParser,
+        percent_basis: f32,
+    ) -> CssResult<f32> {
+        match Calc::<Percentage>::parse_with(input, this, move |ctx, ident| {
+            let number = ctx.get_number(ident, ChannelType::NUMBER)?;
+            Some(Calc::Value(Box::new(Percentage {
+                v: number / percent_basis,
+            })))
         }) {
             Ok(Calc::Value(v)) => Ok(v.v),
             _ => Err(input.new_custom_error(css::ParserError::invalid_value)),

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1126,17 +1126,19 @@ pub(crate) fn parse_color_function(
 ) -> CssResult<CssColor> {
     let mut parser = ComponentParser::new(true);
 
+    // The lightness percent basis: `lab()`/`lch()` write lightness as 0..100,
+    // the ok variants as 0..1.
     crate::match_ignore_ascii_case! { function, {
-        b"lab" => parse_lab::<LAB>(input, &mut parser, LAB_LIGHTNESS_RANGE, |l, a, b, alpha| {
+        b"lab" => parse_lab::<LAB>(input, &mut parser, 100.0, |l, a, b, alpha| {
             LABColor::Lab(LAB { l, a, b, alpha })
         }),
-        b"oklab" => parse_lab::<OKLAB>(input, &mut parser, OKLAB_LIGHTNESS_RANGE, |l, a, b, alpha| {
+        b"oklab" => parse_lab::<OKLAB>(input, &mut parser, 1.0, |l, a, b, alpha| {
             LABColor::Oklab(OKLAB { l, a, b, alpha })
         }),
-        b"lch" => parse_lch::<LCH>(input, &mut parser, LAB_LIGHTNESS_RANGE, |l, c, h, alpha| {
+        b"lch" => parse_lch::<LCH>(input, &mut parser, 100.0, |l, c, h, alpha| {
             LABColor::Lch(LCH { l, c, h, alpha })
         }),
-        b"oklch" => parse_lch::<OKLCH>(input, &mut parser, OKLAB_LIGHTNESS_RANGE, |l, c, h, alpha| {
+        b"oklch" => parse_lch::<OKLCH>(input, &mut parser, 1.0, |l, c, h, alpha| {
             LABColor::Oklch(OKLCH { l, c, h, alpha })
         }),
         b"color" => parse_predefined(input, &mut parser),
@@ -1174,26 +1176,19 @@ pub(crate) fn parse_color_function(
     }}
 }
 
-// The value a channel's `100%` stands for in each color function. The colorspace
-// structs store these channels as unit values, and in the relative color syntax
-// the channel keywords (`r`, `l`, `alpha`, ...) are `<number>`s in the range of
-// the function being parsed: `r` is 0..255 in `rgb()` but 0..1 in
-// `color(srgb ...)`, `l` is 0..100 in `lab()` but 0..1 in `oklab()`. Each
-// function tells its `RelativeComponentParser` the ranges of its channels and
-// divides the `<number>`s it parses by the same ranges.
-// https://drafts.csswg.org/css-color-5/#relative-colors
-const RGB_CHANNEL_RANGE: f32 = 255.0;
-/// `hsl()` saturation and lightness, `hwb()` whiteness and blackness.
-const HSL_CHANNEL_RANGE: f32 = 100.0;
-const LAB_LIGHTNESS_RANGE: f32 = 100.0;
-const OKLAB_LIGHTNESS_RANGE: f32 = 1.0;
+/// Percent basis (what `100%` stands for, see `RelativeComponentParser`) of the
+/// `rgb()` channels.
+const RGB_PERCENT_BASIS: f32 = 255.0;
+/// Percent basis of `hsl()` saturation and lightness and `hwb()` whiteness and
+/// blackness.
+const HSL_PERCENT_BASIS: f32 = 100.0;
 
 pub(crate) fn parse_rgb_components(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
 ) -> CssResult<(f32, f32, f32, bool)> {
     if let Some(from) = &mut parser.from {
-        from.ranges = (RGB_CHANNEL_RANGE, RGB_CHANNEL_RANGE, RGB_CHANNEL_RANGE);
+        from.percent_basis = (RGB_PERCENT_BASIS, RGB_PERCENT_BASIS, RGB_PERCENT_BASIS);
     }
 
     let red = parser.parse_number_or_percentage(input)?;
@@ -1230,7 +1225,7 @@ pub(crate) fn parse_rgb_components(
                     if v.is_nan() {
                         v
                     } else {
-                        v.round().clamp(0.0, RGB_CHANNEL_RANGE) / RGB_CHANNEL_RANGE
+                        v.round().clamp(0.0, RGB_PERCENT_BASIS) / RGB_PERCENT_BASIS
                     }
                 }
                 NumberOrPercentage::Percentage { unit_value } => unit_value.clamp(0.0, 1.0),
@@ -1329,7 +1324,7 @@ fn delta_eok<T: Into<OKLAB>>(a_: T, b_: OKLCH) -> f32 {
 pub(crate) fn parse_lab<T>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
-    l_range: f32,
+    l_basis: f32,
     func: fn(f32, f32, f32, f32) -> LABColor,
 ) -> CssResult<CssColor>
 where
@@ -1339,11 +1334,11 @@ where
     input.parse_nested_block(|i| {
         parser.parse_relative::<T, CssColor, _>(i, |i, p| {
             if let Some(from) = &mut p.from {
-                from.ranges.0 = l_range;
+                from.percent_basis.0 = l_basis;
             }
 
             // f32::max() does not propagate NaN, so use clamp for now until f32::maximum() is stable.
-            let l = p.parse_unit_channel(i, l_range)?.clamp(0.0, f32::MAX);
+            let l = p.parse_unit_channel(i, l_basis)?.clamp(0.0, f32::MAX);
             let a = p.parse_number(i)?;
             let b = p.parse_number(i)?;
             let alpha = parse_alpha(i, p)?;
@@ -1356,13 +1351,13 @@ where
 pub(crate) fn parse_lch<T: Colorspace + ColorGamut + Into<OKLCH> + From<OKLCH> + Into<OKLAB>>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
-    l_range: f32,
+    l_basis: f32,
     func: fn(f32, f32, f32, f32) -> LABColor,
 ) -> CssResult<CssColor> {
     input.parse_nested_block(|i| {
         parser.parse_relative::<T, CssColor, _>(i, |i, p| {
             if let Some(from) = &mut p.from {
-                from.ranges.0 = l_range;
+                from.percent_basis.0 = l_basis;
 
                 // Relative angles should be normalized.
                 // https://www.w3.org/TR/css-color-5/#relative-LCH
@@ -1372,7 +1367,7 @@ pub(crate) fn parse_lch<T: Colorspace + ColorGamut + Into<OKLCH> + From<OKLCH> +
                 }
             }
 
-            let l = p.parse_unit_channel(i, l_range)?.clamp(0.0, f32::MAX);
+            let l = p.parse_unit_channel(i, l_basis)?.clamp(0.0, f32::MAX);
             let c = p.parse_number(i)?.clamp(0.0, f32::MAX);
             let h = parse_angle_or_number(i, p)?;
             let alpha = parse_alpha(i, p)?;
@@ -1414,8 +1409,8 @@ pub(crate) fn parse_hsl_hwb_components<T>(
 ) -> CssResult<(f32, f32, f32, bool)> {
     let _ = core::marker::PhantomData::<T>; // autofix
     if let Some(from) = &mut parser.from {
-        from.ranges.1 = HSL_CHANNEL_RANGE;
-        from.ranges.2 = HSL_CHANNEL_RANGE;
+        from.percent_basis.1 = HSL_PERCENT_BASIS;
+        from.percent_basis.2 = HSL_PERCENT_BASIS;
     }
 
     let h = parse_angle_or_number(input, parser)?;
@@ -1425,7 +1420,7 @@ pub(crate) fn parse_hsl_hwb_components<T>(
         && input.try_parse(|i| i.expect_comma()).is_ok();
 
     let a = parser
-        .parse_unit_channel(input, HSL_CHANNEL_RANGE)?
+        .parse_unit_channel(input, HSL_PERCENT_BASIS)?
         .clamp(0.0, 1.0);
 
     if is_legacy_syntax {
@@ -1433,7 +1428,7 @@ pub(crate) fn parse_hsl_hwb_components<T>(
     }
 
     let b = parser
-        .parse_unit_channel(input, HSL_CHANNEL_RANGE)?
+        .parse_unit_channel(input, HSL_PERCENT_BASIS)?
         .clamp(0.0, 1.0);
 
     if is_legacy_syntax && (a.is_nan() || b.is_nan()) {
@@ -2022,12 +2017,17 @@ impl ComponentParser {
 
     /// Parses a channel that is stored as a unit value and written as a
     /// `<percentage>`, or, in the relative color syntax, as a `<number>` (a
-    /// channel keyword, a calc() over them, or a literal) whose `100%` is
-    /// `range`.
-    fn parse_unit_channel(&self, input: &mut css::Parser, range: f32) -> CssResult<f32> {
+    /// channel keyword, a calc() over them, or a literal) out of `percent_basis`.
+    ///
+    /// css-color-4 also allows the `<number>` outside the relative syntax. That
+    /// is left for the change that stops folding out-of-gamut origin colors:
+    /// today `rgb(from lab(100 104 -51) r g b)` is left alone only because the
+    /// origin does not parse, and accepting it would fold it to a gamut-mapped
+    /// color, which browsers do not do.
+    fn parse_unit_channel(&self, input: &mut css::Parser, percent_basis: f32) -> CssResult<f32> {
         if let Some(from) = &self.from {
             if let Ok(value) = input.try_parse(|i| self.parse_number(i)) {
-                return Ok(value / range);
+                return Ok(value / percent_basis);
             }
             if let Ok(unit_value) =
                 input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
@@ -2109,14 +2109,20 @@ impl NumberOrPercentage {
 // RelativeComponentParser
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Resolves the channel keywords of a relative color (`rgb(from red r g b)`).
+/// https://drafts.csswg.org/css-color-5/#relative-colors
 pub(crate) struct RelativeComponentParser {
     pub(crate) names: (&'static [u8], &'static [u8], &'static [u8]),
     /// The origin color's channels as the colorspace struct stores them.
     pub(crate) components: (f32, f32, f32, f32),
-    /// What each stored channel is multiplied by to get the `<number>` its
-    /// keyword stands for in the function being parsed (`RGB_CHANNEL_RANGE` and
-    /// friends). Set by that function's component parser; 1 where the two agree.
-    pub(crate) ranges: (f32, f32, f32),
+    /// What `100%` of each channel is in the function being parsed: 255 for the
+    /// `rgb()` channels, 100 for `hsl()` saturation/lightness and `lab()`
+    /// lightness, 1 for `color()`, the ok variants and everything unscaled. The
+    /// structs store those channels as unit values, and a keyword is a
+    /// `<number>` in the function's own range, so a keyword resolves to
+    /// `component * percent_basis`. `r` is 200 in `rgb()` but 0.784 in
+    /// `color(srgb ...)`, which is why the function being parsed sets this.
+    pub(crate) percent_basis: (f32, f32, f32),
     pub(crate) types: (ChannelType, ChannelType, ChannelType),
 }
 
@@ -2125,7 +2131,7 @@ impl RelativeComponentParser {
         RelativeComponentParser {
             names: color.channels(),
             components: color.components(),
-            ranges: (1.0, 1.0, 1.0),
+            percent_basis: (1.0, 1.0, 1.0),
             types: color.types(),
         }
     }
@@ -2185,12 +2191,12 @@ impl RelativeComponentParser {
     }
 
     /// A math function the `<number>` pass could not fold, evaluated as a
-    /// `<percentage>` and returned as a unit value. A keyword is its channel as
-    /// a percentage of the channel's range here, which is what folds
-    /// `min(r, g)` (`reduce_args` only compares values) and what gives
-    /// `calc(l + 10%)` its pre-existing meaning. Callers try `parse_number`
-    /// first, so a math function over plain numbers gets the CSS Color 5
-    /// meaning, in which the keywords are `<number>`s.
+    /// `<percentage>` and returned as a unit value. Callers try `parse_number`
+    /// first, so this only sees functions with a percentage in them, plus
+    /// `min(r, g)`, which `reduce_args` folds here because it only compares
+    /// values. A keyword is its channel as a percentage of its basis here, as
+    /// before this parser had a basis; typing it as a `<number>` like upstream
+    /// does needs `Percentage::from_calc` to reject a number first (#38513).
     fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
         match Calc::<Percentage>::parse_with(input, this, |ctx, ident| {
             let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;
@@ -2235,29 +2241,28 @@ impl RelativeComponentParser {
 
     /// The `<number>` a channel keyword stands for in the function being parsed.
     fn get_number(&self, ident: &[u8], allowed_types: ChannelType) -> Option<f32> {
-        let (value, range) = self.get_ident(ident, allowed_types)?;
-        Some(value * range)
+        let (component, percent_basis) = self.get_ident(ident, allowed_types)?;
+        Some(component * percent_basis)
     }
 
-    /// A channel keyword's stored value and the range it is scaled by to become
-    /// a `<number>`.
+    /// A channel keyword's stored component and its percent basis.
     fn get_ident(&self, ident: &[u8], allowed_types: ChannelType) -> Option<(f32, f32)> {
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.0)
             && allowed_types.intersects(self.types.0)
         {
-            return Some((self.components.0, self.ranges.0));
+            return Some((self.components.0, self.percent_basis.0));
         }
 
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.1)
             && allowed_types.intersects(self.types.1)
         {
-            return Some((self.components.1, self.ranges.1));
+            return Some((self.components.1, self.percent_basis.1));
         }
 
         if strings::eql_case_insensitive_ascii_check_length(ident, self.names.2)
             && allowed_types.intersects(self.types.2)
         {
-            return Some((self.components.2, self.ranges.2));
+            return Some((self.components.2, self.percent_basis.2));
         }
 
         if strings::eql_case_insensitive_ascii_check_length(ident, b"alpha")
@@ -2278,7 +2283,8 @@ bitflags::bitflags! {
         /// A hue in degrees.
         const ANGLE = 1 << 0;
         /// A `<number>` in the range of the function being parsed (see
-        /// `RGB_CHANNEL_RANGE`); every channel other than a hue, and `alpha`.
+        /// `RelativeComponentParser::percent_basis`); every channel other than
+        /// a hue, and `alpha`.
         const NUMBER = 1 << 1;
     }
 }

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -2010,8 +2010,7 @@ impl ComponentParser {
         }
     }
 
-    /// A channel stored as a unit value: a `<percentage>`, or in the relative
-    /// color syntax also a `<number>` out of `percent_basis`.
+    /// A unit value: a `<percentage>`, or in relative syntax a `<number>` out of `percent_basis`.
     fn parse_unit_channel(&self, input: &mut css::Parser, percent_basis: f32) -> CssResult<f32> {
         if let Some(from) = &self.from {
             if let Ok(value) = input.try_parse(|i| self.parse_number(i)) {
@@ -2100,11 +2099,9 @@ impl NumberOrPercentage {
 pub(crate) struct RelativeComponentParser {
     pub(crate) names: (&'static [u8], &'static [u8], &'static [u8]),
     pub(crate) components: (f32, f32, f32, f32),
-    /// What `100%` of each channel is in the function being parsed (255 in
-    /// `rgb()`, 1 in `color(srgb ...)`, for the same `SRGB` components). The
-    /// structs store unit values and a keyword is a `<number>` in the function's
-    /// range, so a keyword is `component * percent_basis`.
-    /// https://drafts.csswg.org/css-color-5/#relative-colors
+    /// What `100%` of each channel is in the function being parsed: 255 in `rgb()`
+    /// but 1 in `color(srgb ...)` for the same unit-value `components`. A keyword
+    /// is the `<number>` `component * percent_basis`.
     pub(crate) percent_basis: (f32, f32, f32),
     pub(crate) types: (ChannelType, ChannelType, ChannelType),
 }
@@ -2171,9 +2168,8 @@ impl RelativeComponentParser {
         Err(input.new_error_for_next_token())
     }
 
-    /// Second pass for what `parse_number` could not fold: a math function with
-    /// a percentage in it, or `min(r, g)` (`reduce_args` only compares values).
-    /// A keyword is its channel as a percentage of its basis here.
+    /// Second pass for what `parse_number` could not fold: math functions with a
+    /// percentage in them, and `min(r, g)`, since `reduce_args` only compares values.
     fn parse_percentage(input: &mut css::Parser, this: &RelativeComponentParser) -> CssResult<f32> {
         match Calc::<Percentage>::parse_with(input, this, |ctx, ident| {
             let (unit_value, _) = ctx.get_ident(ident, ChannelType::NUMBER)?;

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -684,11 +684,15 @@ describe("relative color channel keywords", () => {
     expect(color(input, "css")).toBe(expected);
   });
 
-  // min()/max() of two keywords fold through the percentage pass, as before.
+  // min()/max() of keywords fold through the percentage pass, comparing the
+  // keywords as numbers in the function's range: min(200, 100), min(50, 40),
+  // max(20, 30), min(1, 200), min(50, 20).
   test.each([
     ["rgb(from rgb(200 100 50) min(r, g) g b)", "#646432"],
     ["hsl(from hsl(120 50% 40%) h min(s, l) l)", "#3d8f3d"],
     ["hwb(from hwb(120 20% 30%) h max(w, b) b)", "#4cb34c"],
+    ["rgb(from rgb(200 100 50) r g b / min(alpha, r))", "#c86432"],
+    ["lab(from lab(50% 20 30) min(l, a) a b)", "lab(20% 20 30)"],
   ])("%s", (input, expected) => {
     expect(color(input, "css")).toBe(expected);
   });

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -649,3 +649,56 @@ describe("color-mix() percentage range", () => {
     expect(color(input, "css")).toBe(expected);
   });
 });
+
+// https://drafts.csswg.org/css-color-5/#relative-colors
+// Each channel keyword is a <number> in the range of the function it is used
+// in: r/g/b are 0..255 in rgb(), s/l and lab()/lch() l are 0..100, oklab() l,
+// color() channels and alpha are 0..1. lightningcss 1.30 produces the same
+// values as the first group below.
+describe("relative color channel keywords", () => {
+  test.each([
+    ["rgb(from rgb(200 100 50) r g b)", "#c86432"],
+    ["rgb(from rgb(200 100 50) calc(r + 10) g b)", "#d26432"],
+    ["rgb(from red calc(100) g b)", "#640000"],
+    ["rgb(from rgb(none 100 50) calc(r + 10) g b)", "#0a6432"],
+    ["rgb(from rgb(200 100 50) r g b / calc(g / 255))", "#c8643264"],
+    ["rgb(from rgb(200 100 50) calc(alpha * 255) g b)", "#ff6432"],
+    ["rgb(from rgb(200 100 50) r g b / calc(alpha - 0.5))", "#c8643280"],
+    ["hsl(from hsl(120 50% 40%) h s l)", "#393"],
+    ["hsl(from hsl(120 50% 40%) h calc(s + 10) l)", "#29a329"],
+    ["hsl(from hsl(120 50% 40%) h s calc(l - 10))", "#267326"],
+    ["hsl(from hsl(120 50% 40%) h 60 l)", "#29a329"],
+    ["hsl(from hsl(120 50% 40%) h 60% l)", "#29a329"],
+    ["hsl(from hsl(120 50% 40%) calc(s * 2) s l)", "#593"],
+    ["hsl(from hsl(120 50% 40%) h s l / calc(l / 100))", "#3936"],
+    ["hwb(from hwb(120 20% 30%) h calc(w + 10) b)", "#4db34d"],
+    ["lab(from lab(50% 20 30) l a b)", "lab(50% 20 30)"],
+    ["lab(from lab(50% 20 30) calc(l + 10) a b)", "lab(60% 20 30)"],
+    ["lab(from lab(50% 20 30) l l l)", "lab(50% 50 50)"],
+    ["lab(from lab(50% 20 30) a b l)", "lab(20% 30 50)"],
+    ["lch(from lch(50% 30 120) calc(l + 10) c h)", "lch(60% 30 120)"],
+    ["oklab(from oklab(50% 0.1 0.1) calc(l + 0.1) a b)", "oklab(60% .1 .1)"],
+    ["oklch(from oklch(50% 0.1 120) calc(l + 0.1) c h)", "oklch(60% .1 120)"],
+    ["color(from color(srgb 0.5 0.2 0.1) srgb calc(r + 0.1) g b)", "color(srgb .6 .2 .1)"],
+  ])("%s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  // min()/max() of two keywords fold through the percentage pass, as before.
+  test.each([
+    ["rgb(from rgb(200 100 50) min(r, g) g b)", "#646432"],
+    ["hsl(from hsl(120 50% 40%) h min(s, l) l)", "#3d8f3d"],
+    ["hwb(from hwb(120 20% 30%) h max(w, b) b)", "#4cb34c"],
+  ])("%s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test.each([
+    // A <number> cannot be added to an <angle>.
+    "hsl(from hsl(120 50% 40%) calc(s + 30deg) s l)",
+    // The hue keyword is only a hue.
+    "hsl(from hsl(120 50% 40%) h h l)",
+  ])("%s is invalid", input => {
+    expect(color(input, "css")).toBeNull();
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7699,7 +7699,6 @@ describe("css tests", () => {
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h calc(s + 10) l) }", ".foo{color:#29a329}");
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l + 10)) }", ".foo{color:#40bf40}");
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l * 2)) }", ".foo{color:#b3e6b3}");
-      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l + 100)) }", ".foo{color:#fff}");
       minify_test(".foo { color: hsl(from rgb(200 100 50) h calc(s + 10) l) }", ".foo{color:#d56025}");
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h 60 l) }", ".foo{color:#29a329}");
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h 60% l) }", ".foo{color:#29a329}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7660,6 +7660,135 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  describe("relative colors", () => {
+    // The channel keywords are <number>s in the range of the function being
+    // written: r/g/b are 0..255 in rgb(), s/l (and hwb() w/b) and lab()/lch()
+    // l are 0..100, oklab()/oklch() l, color() channels and alpha are 0..1.
+    // https://drafts.csswg.org/css-color-5/#relative-colors
+    // lightningcss 1.30 produces the same output for all of these, except that
+    // it leaves calc(h + 30) and the "percentage pass" block unparsed.
+    describe("rgb()", () => {
+      minify_test(".foo { color: rgb(from rgb(200 100 50) r g b) }", ".foo{color:#c86432}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) b g r) }", ".foo{color:#3264c8}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) calc(r + 10) g b) }", ".foo{color:#d26432}");
+      minify_test(".foo { color: rgba(from rgb(200 100 50) calc(r - 10) g b) }", ".foo{color:#be6432}");
+      minify_test(".foo { color: rgb(from red calc(100) g b) }", ".foo{color:#640000}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) calc(r / 2) calc(g * 2) b) }", ".foo{color:#64c832}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) calc(r + 100) calc(g - 300) b) }", ".foo{color:#ff0032}");
+      minify_test(".foo { color: rgb(from hsl(120 50% 40%) calc(r + 10) g b) }", ".foo{color:#3d9933}");
+      minify_test(
+        ".foo { color: rgb(from light-dark(rgb(200 100 50), rgb(50 100 200)) calc(r + 10) g b) }",
+        ".foo{color:light-dark(#d26432,#3c64c8)}",
+      );
+      // A missing channel is 0.
+      minify_test(".foo { color: rgb(from rgb(none 100 50) calc(r + 10) g b) }", ".foo{color:#0a6432}");
+      // r is 200 (not 200/255) when used as the alpha, and alpha is 1 (not 255) when used as a channel.
+      minify_test(".foo { color: rgb(from rgb(200 100 50) r g b / calc(r / 255)) }", ".foo{color:#c86432c8}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) calc(alpha * 255) g b) }", ".foo{color:#ff6432}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) r g b / calc(alpha - 0.5)) }", ".foo{color:#c8643280}");
+      // An unresolved alpha keeps the resolved channels.
+      minify_test(
+        ".foo { color: rgb(from rgb(200 100 50) calc(r + 10) g b / var(--a)) }",
+        ".foo{color:rgb(210 100 50/var(--a))}",
+      );
+    });
+
+    describe("hsl() and hwb()", () => {
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s l) }", ".foo{color:#393}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h l s) }", ".foo{color:#4db34d}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h calc(s + 10) l) }", ".foo{color:#29a329}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l + 10)) }", ".foo{color:#40bf40}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l * 2)) }", ".foo{color:#b3e6b3}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s calc(l + 100)) }", ".foo{color:#fff}");
+      minify_test(".foo { color: hsl(from rgb(200 100 50) h calc(s + 10) l) }", ".foo{color:#d56025}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h 60 l) }", ".foo{color:#29a329}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h 60% l) }", ".foo{color:#29a329}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h s l / calc(l / 100)) }", ".foo{color:#3936}");
+      minify_test(
+        ".foo { color: hsl(from hsl(120 50% 40%) h calc(s + 10) l / var(--a)) }",
+        ".foo{color:hsl(120 60% 40%/var(--a))}",
+      );
+      minify_test(".foo { color: hwb(from hwb(120 20% 30%) h w b) }", ".foo{color:#33b333}");
+      minify_test(".foo { color: hwb(from hwb(120 20% 30%) h calc(w + 10) b) }", ".foo{color:#4db34d}");
+      minify_test(".foo { color: hwb(from hwb(120 20% 30%) h w calc(b + 10)) }", ".foo{color:#339a33}");
+
+      describe("hue", () => {
+        // Any non-hue keyword is a <number>, which a hue accepts and an <angle>
+        // can be multiplied by but not added to. The hue keyword is only a hue.
+        minify_test(".foo { color: hsl(from hsl(120 50% 40%) s s l) }", ".foo{color:#983}");
+        minify_test(".foo { color: hsl(from hsl(120 50% 40%) alpha s l) }", ".foo{color:#993533}");
+        minify_test(".foo { color: hsl(from hsl(120 50% 40%) calc(s * 1deg) s l) }", ".foo{color:#983}");
+        minify_test(".foo { color: hsl(from hsl(120 50% 40%) calc(h + 30) s l) }", ".foo{color:#396}");
+        minify_test(".foo { color: hsl(from hsl(120 50% 40%) calc(h + 30deg) s l) }", ".foo{color:#396}");
+        minify_test(
+          ".foo { color: hsl(from hsl(120 50% 40%) calc(s + 30deg) s l) }",
+          ".foo{color:hsl(from #393 calc(s + 30deg)s l)}",
+        );
+        minify_test(".foo { color: hsl(from hsl(120 50% 40%) h h l) }", ".foo{color:hsl(from #393 h h l)}");
+      });
+    });
+
+    describe("lab(), lch(), oklab() and oklch()", () => {
+      minify_test(".foo { color: lab(from lab(50% 20 30) l a b) }", ".foo{color:lab(50% 20 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) calc(l + 10) a b) }", ".foo{color:lab(60% 20 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) calc(l * 2) a b) }", ".foo{color:lab(100% 20 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) 60 a b) }", ".foo{color:lab(60% 20 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) calc(l + a) a b) }", ".foo{color:lab(70% 20 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) a b l) }", ".foo{color:lab(20% 30 50)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) l alpha b) }", ".foo{color:lab(50% 1 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) l a b / calc(l / 100)) }", ".foo{color:lab(50% 20 30/.5)}");
+      minify_test(
+        ".foo { color: lab(from rgb(200 100 50) calc(l + 10) a b) }",
+        ".foo{color:lab(64.2174% 38.1977 46.2491)}",
+      );
+      minify_test(
+        ".foo { color: lab(from light-dark(lab(50% 20 30), lab(20% 30 50)) calc(l + 10) a b) }",
+        ".foo{color:light-dark(lab(60% 20 30),lab(30% 30 50))}",
+      );
+      minify_test(".foo { color: lch(from lch(50% 30 120) calc(l + 10) c h) }", ".foo{color:lch(60% 30 120)}");
+      minify_test(".foo { color: lch(from lch(50% 30 120) c l h) }", ".foo{color:lch(30% 50 120)}");
+      minify_test(".foo { color: lch(from lch(50% 30 120) l c calc(h + 30)) }", ".foo{color:lch(50% 30 150)}");
+      // The ok variants write lightness in 0..1.
+      minify_test(".foo { color: oklab(from oklab(50% 0.1 0.1) l a b) }", ".foo{color:oklab(50% .1 .1)}");
+      minify_test(".foo { color: oklab(from oklab(50% 0.1 0.1) calc(l + 0.1) a b) }", ".foo{color:oklab(60% .1 .1)}");
+      minify_test(".foo { color: oklch(from oklch(50% 0.1 120) calc(l + 0.1) c h) }", ".foo{color:oklch(60% .1 120)}");
+      minify_test(
+        ".foo { color: oklch(from oklch(50% 0.1 120) l c h / calc(l - 0.1)) }",
+        ".foo{color:oklch(50% .1 120/.4)}",
+      );
+    });
+
+    describe("color()", () => {
+      minify_test(
+        ".foo { color: color(from color(srgb 0.5 0.2 0.1) srgb calc(r + 0.1) g b) }",
+        ".foo{color:color(srgb .6 .2 .1)}",
+      );
+      minify_test(
+        ".foo { color: color(from color(srgb 0.5 0.2 0.1) srgb r g b / calc(alpha - 0.5)) }",
+        ".foo{color:color(srgb .5 .2 .1/.5)}",
+      );
+      minify_test(
+        ".foo { color: color(from rgb(200 100 50) xyz x y z) }",
+        ".foo{color:color(xyz .289515 .216258 .0566732)}",
+      );
+    });
+
+    describe("percentage pass", () => {
+      // What the <number> pass cannot fold is retried as a percentage
+      // expression, which is what folds min()/max() of two keywords. Unchanged
+      // from before, and lightningcss leaves these unparsed.
+      minify_test(".foo { color: rgb(from rgb(200 100 50) min(r, g) g b) }", ".foo{color:#646432}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) r g max(g, b)) }", ".foo{color:#c86464}");
+      minify_test(
+        ".foo { color: color(from color(srgb 0.8 0.4 0.2) srgb min(r, g) g b) }",
+        ".foo{color:color(srgb .4 .4 .2)}",
+      );
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h min(s, l) l) }", ".foo{color:#3d8f3d}");
+      minify_test(".foo { color: hwb(from hwb(120 20% 30%) h max(w, b) b) }", ".foo{color:#4cb34c}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h calc(50% + 10%) l) }", ".foo{color:#29a329}");
+    });
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7774,8 +7774,10 @@ describe("css tests", () => {
 
     describe("percentage pass", () => {
       // What the <number> pass cannot fold is retried as a percentage
-      // expression, which is what folds min()/max() of two keywords. Unchanged
-      // from before, and lightningcss leaves these unparsed.
+      // expression, which is what folds min()/max() of keywords; lightningcss
+      // leaves all of these unparsed. Every keyword is compared as a number in
+      // the function's range, so alpha (1) and lab a/b (unscaled) mean the same
+      // thing next to r (0..255) or l (0..100) as they do on their own.
       minify_test(".foo { color: rgb(from rgb(200 100 50) min(r, g) g b) }", ".foo{color:#646432}");
       minify_test(".foo { color: rgb(from rgb(200 100 50) r g max(g, b)) }", ".foo{color:#c86464}");
       minify_test(
@@ -7785,6 +7787,13 @@ describe("css tests", () => {
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h min(s, l) l) }", ".foo{color:#3d8f3d}");
       minify_test(".foo { color: hwb(from hwb(120 20% 30%) h max(w, b) b) }", ".foo{color:#4cb34c}");
       minify_test(".foo { color: hsl(from hsl(120 50% 40%) h calc(50% + 10%) l) }", ".foo{color:#29a329}");
+      // min(200, 1), min(1, 200), min(50, 1), min(50, 20), max(20, 30), min(50, 30).
+      minify_test(".foo { color: rgb(from rgb(200 100 50) min(r, alpha) g b) }", ".foo{color:#016432}");
+      minify_test(".foo { color: rgb(from rgb(200 100 50) r g b / min(alpha, r)) }", ".foo{color:#c86432}");
+      minify_test(".foo { color: hsl(from hsl(120 50% 40%) h min(s, alpha) l) }", ".foo{color:#656765}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) min(l, a) a b) }", ".foo{color:lab(20% 20 30)}");
+      minify_test(".foo { color: lab(from lab(50% 20 30) max(a, b) a b) }", ".foo{color:lab(30% 20 30)}");
+      minify_test(".foo { color: lch(from lch(50% 30 120) min(l, c) c h) }", ".foo{color:lch(30% 30 120)}");
     });
   });
 


### PR DESCRIPTION
### Problem
- In relative color syntax, adding a plain number to a channel keyword computes the wrong color, and so does a channel written without a keyword:
  ```
  rgb(from rgb(200 100 50) calc(r + 10) g b)      -> #ff6432         (browsers, lightningcss 1.30.2: #d26432)
  rgb(from red calc(100) g b)                     -> red             (#640000)
  hsl(from hsl(120 50% 40%) h calc(s + 10) l)     -> #666            (#29a329)
  lab(from lab(50% 20 30) calc(l + 10) a b)       -> lab(none 20 30) (lab(60% 20 30))
  rgb(from rgb(200 100 50) r g b / calc(r / 255)) -> alpha 1/255     (alpha 200/255)
  ```
  `calc(r * 2)` and bare keywords happen to come out right, which is why this went unnoticed since the CSS parser landed. No user has reported it; it was found by diffing `Bun.color` against lightningcss. It does reach users: the idiom in our own docs, `lch(from purple calc(l + 15) c h)`, is emitted into the stylesheet as `lch(none 66.8 327)` (a `none` lightness, i.e. black) by `bun build` on 1.4.0, and every browser has shipped this syntax since 2024.
- CSS Color 5 defines each keyword as a `<number>` in the range of the function being written: `r`/`g`/`b` are 0..255 in `rgb()`, `s`/`l` (and `hwb()` `w`/`b`) and `lab()`/`lch()` `l` are 0..100, `oklab()`/`oklch()` `l`, `color()` channels and `alpha` are 0..1 (https://drafts.csswg.org/css-color-5/#relative-colors).
- Cause, in `src/css/values/color.rs`: `RelativeComponentParser::new` copies the origin's components as the colorspace structs store them (unit values: `r` is 0.784 for 200, `l` is 0.5 for 50%), the `define_colorspace!` tables type those channels as percentages, and `RelativeComponentParser::parse_number_or_percentage` returns a keyword or `calc()` result as `NumberOrPercentage::Percentage`. So `calc(r + 10)` is 0.784 + 10 read as a percentage, and `hsl()`/`lab()` lightness goes through `parse_percentage`, where keyword + number ends in `Percentage::from_calc` returning NaN. The same typing also rejected spec-valid positions: a number literal for `s`/`l`, and `a`/`b`/`alpha` anywhere a `<number>` is accepted (`lab(from c a b l)`, `hsl(from c s s l)`).

### Fix
- Upstream fixed this in lightningcss 1.30 (parcel-bundler/lightningcss#465) by typing every non-hue channel as a number and storing `rgb()`, `hsl()` and `lab()` channels in their CSS ranges, so a keyword is simply the stored value. Bun's structs store unit values (and `Bun.color`, color-mix and the serializers are built on that), so this PR keeps the storage and carries upstream's percent basis on the relative parser instead: `RelativeComponentParser` gains `percent_basis`, set by the function being parsed (255 in `parse_rgb_components`, 100 in `parse_hsl_hwb_components`, the new `l_basis` argument of `parse_lab`/`parse_lch`, 100 or 1, which is upstream's argument of the same name; `color()` keeps 1). The fixing line is `get_number`: a keyword resolves to `component * percent_basis`, and `parse_ident` and the `calc()` callback use it. `ComponentParser::parse_number_or_percentage` returns those as `Number`, which `rgb()` already divides by 255 and `color()`/alpha already use as is. If the structs ever move to CSS-range storage like upstream, `percent_basis` becomes 1 everywhere and is deleted.
- The percentage-written channels (`hsl()`/`hwb()` second and third channel, `lab()`/`lch()`/`oklab()`/`oklch()` lightness) go through the new `ComponentParser::parse_unit_channel(basis)`: in relative syntax it parses a `<number>` (keyword, `calc()`, or literal) and divides by the basis, otherwise a `<percentage>` exactly as before. css-color-4 also allows a plain `<number>` there outside relative syntax (`lab(50 20 30)`, #16727). That is deliberately not added here: the out-of-gamut origins in `test/bundler/css/wpt/relative_color_out_of_gamut.test.ts` are currently left unfolded only because `lab(100 104.3 -50.9)` does not parse, and making it parse without also changing how out-of-gamut origins are folded produces the `#fff` outputs that were rejected in #33047's review. The doc comment on `parse_unit_channel` says so; dropping its `from` gate is the one-line change for whichever PR lands the gamut policy.
- `ChannelType::PERCENTAGE` is gone (upstream's tables have the same shape): every non-hue channel and `alpha` is `NUMBER`, hues stay `ANGLE`, so a keyword is accepted wherever the function takes a `<number>` and the hue keyword only where it takes a hue. In the `<angle>` calc pass a non-hue keyword is now a `Calc::Number` instead of being read as degrees (also upstream's rule), so `calc(s * 1deg)` works and `calc(s + 30deg)` is rejected; the only inputs that folded before and are rejected now are `lab()` `a`/`b` and `lch()` `c` used inside an angle `calc()`, e.g. `lch(from c l c calc(c + 10deg))`.
- The second pass over a math function the number pass could not fold (`RelativeComponentParser::parse_percentage`, what folds `min(r, g)`, and what gives `calc(l + 10%)` its meaning) now takes the basis of the channel being parsed and substitutes `number / basis` for a keyword, so everything in it is compared as the number CSS Color 5 defines. Main substituted the stored component, which was only right while every keyword in the expression had the same basis as the channel: `rgb(from c min(r, alpha) g b)` folded to min(0.784, 1), i.e. 200, instead of min(200, 1), and once `a`/`b`/`c` are admitted there (they are numbers now) `lab(from lab(50% 20 30) min(l, a) a b)` would have folded to 50% instead of 20% (caught in review). Same-basis expressions are byte-identical to before. Upstream types the keywords as numbers in this pass instead; #38513 ports that (it also needs `Percentage::from_calc` to reject a number, otherwise the keyword + percentage spellings turn into `none` channels), which folds the same `min()`/`max()` cases to the same values in the number pass and decides the fate of the `+ 10%` spellings. The two PRs edit the same function, so whichever lands second has a small rebase; both orders end at upstream's shape.
- #38487 fixes the `srgb-linear` `r` channel type. This PR rewrites the same `types = ...` line (the `CT_PCT` constant it uses no longer exists) but leaves `r` as the `(sic)` angle it is on main, so that fix is still needed and becomes `(CT_NUM, CT_NUM, CT_NUM)` after this. #38486 (origin alpha) is unaffected: alpha is not scaled.
- Why this is right: every value asserted by the new tests is byte for byte what lightningcss 1.30.2 emits for the same input, except where the test comments say it leaves the input unparsed (`calc(h + 30)`, and the `min()`/`max()` folds, which bun folded before this change too). Pass-through outputs do not move: the basis multiplies stored values that `rgb()` rounds and the other functions divide straight back, and the relative color WPT expectations pass unchanged.
- Docs: the relative color example in `docs/bundler/css.mdx` used `calc(l + 15%)`, which browsers reject; it now uses the spec spelling this change makes work, and both output lines are what `bun build` prints (the `var()` line is passed through; it was shown as computed before).
- Verified with `bun bd test test/js/bun/css/css.test.ts` (new `relative colors` block, 66 cases through the minifier: every function, converted and `light-dark()` origins, a missing channel, keywords used as alpha and alpha as a channel, the `/ var(--a)` path in `src/css/properties/custom.rs`, the hue rules, the `min()`/`max()` pass) and `bun bd test test/js/bun/css/color.test.ts` (30 cases through `Bun.color`, including the lines above). Without the `src/` change 37 of the 66 and 18 of the 30 fail on the released binary; the rest pin behavior that must not move. With it both files pass, and so do `test/bundler/css/` (including the relative color WPT file) and the rest of `test/js/bun/css/`, apart from the 20k-rule case in `nested-vendor-prefix-duplication.test.ts`, which has no colors in it and sits at its 5 s budget on this loaded machine (#38513 measured it at 4.9 s on main too), and `css-fuzz.test.ts`, which is skipped in CI.

### Background
- Relative color syntax: `rgb(from <origin> r g b / alpha)` converts the origin color into the function's color space and lets each channel be written as a keyword naming one of the converted channels, a `calc()` over them, or a literal.
- Percent basis: the value a channel's `100%` stands for, 255 for an `rgb()` channel, 100 for `hsl()` saturation or `lab()` lightness, 1 for alpha. It is also the factor between Bun's stored unit value and the `<number>` CSS uses for the channel, which is what the relative parser needs.
- `ComponentParser` parses one channel of any color function; when a `from` origin is present it first asks its `RelativeComponentParser` (built from the converted origin) to resolve keywords and keyword `calc()`s, and falls back to literal parsing. `parse_rgb_components` and `parse_hsl_hwb_components` are shared with `custom.rs`, which handles `rgb(... / var(--x))` by resolving the channels and keeping the alpha as tokens.
- `Calc<f32>` evaluates a math function whose terms are numbers, substituting keywords through a callback; `Calc<Percentage>` does the same with percentage terms and is the second pass described above.

<details>
<summary>Every probe whose output changes (Bun.color(x, "css"); the right column is also lightningcss 1.30.2's answer)</summary>

```
input                                                   before        after
rgb(from rgb(200 100 50) calc(r + 10) g b)              #ff6432       #d26432
rgb(from rgb(200 100 50) calc(r - 10) g b)              #006432       #be6432
rgb(from red calc(100) g b)                             red           #640000
rgb(from rgb(none 100 50) calc(r + 10) g b)             #ff6432       #0a6432
rgb(from hsl(120 50% 40%) calc(r + 10) g b)             #f93          #3d9933
rgb(from rgb(200 100 50) r g b / calc(r / 255))         #c8643201     #c86432c8
rgb(from rgb(200 100 50) r g b / r)                     #c86432c8     #c86432
rgb(from rgb(200 100 50) alpha g b)                     #ff6432       #016432
rgb(from light-dark(rgb(200 100 50), rgb(50 100 200)) calc(r + 10) g b)
                                        light-dark(#ff6432, #ff64c8)   light-dark(#d26432, #3c64c8)
hsl(from hsl(120 50% 40%) h calc(s + 10) l)             #666          #29a329
hsl(from hsl(120 50% 40%) h s calc(l + 10))             #000          #40bf40
hsl(from hsl(120 50% 40%) h 60 l)                       null          #29a329
hsl(from hsl(120 50% 40%) s s l)                        null          #983
hsl(from hsl(120 50% 40%) alpha s l)                    null          #993533
hsl(from hsl(120 50% 40%) h alpha l)                    #0c0          #656765
hsl(from hsl(120 50% 40%) h s l / calc(l / 100))        #33993301     #3936
hsl(from hsl(120 50% 40%) calc(s * 1deg) s l)           null          #983
hsl(from rgb(200 100 50) h calc(s + 10) l)              #7d7d7d       #d56025
hwb(from hwb(120 20% 30%) h calc(w + 10) b)             #00b300       #4db34d
hwb(from hwb(120 20% 30%) h 30 b)                       null          #4db34d
lab(from lab(50% 20 30) calc(l + 10) a b)               lab(none 20 30)   lab(60% 20 30)
lab(from lab(50% 20 30) 60 a b)                         null          lab(60% 20 30)
lab(from lab(50% 20 30) a b l)                          null          lab(20% 30 50)
lab(from lab(50% 20 30) l alpha b)                      null          lab(50% 1 30)
lab(from lab(50% 20 30) l a b / calc(l / 100))          lab(50% 20 30 / .005)   lab(50% 20 30 / .5)
lab(from rgb(200 100 50) calc(l + 10) a b)              lab(none 38.1977 46.2491)   lab(64.2174% 38.1977 46.2491)
lch(from lch(50% 30 120) calc(l + 10) c h)              lch(none 30 120)   lch(60% 30 120)
lch(from lch(50% 30 120) c l h)                         null          lch(30% 50 120)
lch(from lch(50% 30 120) l c calc(c + 10deg))           lch(50% 30 40)   null
oklab(from oklab(50% 0.1 0.1) calc(l + 0.1) a b)        oklab(none .1 .1)   oklab(60% .1 .1)
oklch(from rgb(200 100 50) calc(l + 0.1) c h)           oklch(none .142265 45.0831)   oklch(71.3838% .142265 45.0831)
```

Unchanged, as intended: every bare keyword pass-through, `calc(r * 2)`, `calc(h + 30)`, `calc(h + 30deg)`, `color()` in every space, every alpha written as a number or percentage, `min(r, g)`, `calc(l + 10%)`, and the hue keyword being rejected outside hue positions.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 55 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (9ecdaf271)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.51ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.99ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.51ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.48ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [15.49ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.16ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [2.17ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.40ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.26ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.30ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.64ms]
(pass) color({"r":0,"g":25
... (truncated)

release without fix: 55 failed, 67 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [1.69ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.06ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.02ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.06ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.81ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.04ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.02ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit"))
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.01ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ansi-24bit")
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (9ecdaf271)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [3.39ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [2.22ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.57ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.27ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [15.36ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.07ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [2.02ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.32ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.25ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.24ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.58ms]
(pass) color({"r":0,"g":25
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9ecdaf2718
  features     baseline

22 deps, 123 codegen, 1176 objects in 936ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [20.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [8.00ms]
[4/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [14.00ms]
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1238] gen .bind.ts → GeneratedBindings.cpp
[8/1238] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBind
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/css.mdx          |  12 ++-
 src/css/values/color.rs       | 242 ++++++++++++++++++++++--------------------
 test/js/bun/css/color.test.ts |  57 ++++++++++
 test/js/bun/css/css.test.ts   | 137 ++++++++++++++++++++++++
 4 files changed, 327 insertions(+), 121 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
docs/bundler/css.mdx               2      3      0
src/css/values/color.rs           23     55      0
test/js/bun/css/color.test.ts      3      5      0
test/js/bun/css/css.test.ts        3     18      0
```

</details>

<!-- robobun:evidence:end -->