### PR TITLE
assert.partialDeepStrictEqual: settle Set members and Map keys by lookup instead of rescanning per entry

### DIFF
--- a/src/jsc/bindings/PendingEntries.h
+++ b/src/jsc/bindings/PendingEntries.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "root.h"
+#include <wtf/Vector.h>
+
+namespace Bun {
+
+enum class Claim : uint8_t {
+    Missed, // nothing claimed (also returned when `matches` threw; check the scope first)
+    Claimed,
+    Exhausted, // claimed the last open entry
+};
+
+// One side's entries still needing a counterpart, claimed one at a time while the other side is walked. Plain copies: the caller roots them.
+template<typename Entry>
+struct PendingEntries {
+    using Queue = WTF::Vector<Entry, 8>;
+
+    Queue entries;
+    size_t first { 0 };
+    size_t end;
+    // Node's guess: keep probing the end that hit last, so same-order and reversed inputs stay linear.
+    bool probeFront { true };
+
+    explicit PendingEntries(Queue&& queued)
+        : entries(std::move(queued))
+        , end(entries.size())
+    {
+        ASSERT(end);
+    }
+
+    size_t openCount() const { return end - first; }
+
+    // What a walk leaves behind for an entry known to match nothing, without running the probes.
+    void recordMiss() { probeFront = true; }
+
+    // Probe order of node's partialObject{Set,Map}Equiv: front guess, back guess, then the rest back to front.
+    template<typename Matches>
+    Claim claimWith(JSC::ThrowScope& scope, const Matches& matches)
+    {
+        ASSERT(first < end);
+        size_t scanFrom = first;
+        if (probeFront) {
+            bool hit = matches(entries[first]);
+            RETURN_IF_EXCEPTION(scope, Claim::Missed);
+            if (hit) {
+                first++;
+                return first == end ? Claim::Exhausted : Claim::Claimed;
+            }
+            if (openCount() == 1)
+                return Claim::Missed;
+            probeFront = false;
+            scanFrom++;
+        }
+        size_t i = end - 1;
+        bool hit = matches(entries[i]);
+        RETURN_IF_EXCEPTION(scope, Claim::Missed);
+        if (!hit) {
+            probeFront = true;
+            while (!hit && i > scanFrom) {
+                i--;
+                hit = matches(entries[i]);
+                RETURN_IF_EXCEPTION(scope, Claim::Missed);
+            }
+            if (!hit)
+                return Claim::Missed;
+            entries[i] = entries[end - 1];
+        }
+        end--;
+        return first == end ? Claim::Exhausted : Claim::Claimed;
+    }
+};
+
+} // namespace Bun

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -393,6 +393,14 @@ static bool arraySubsequence(JSC::JSGlobalObject* globalObject, JSC::MarkedArgum
     return nonIndexObjectSubset(globalObject, gcBuffer, cycles, scope, actual, expected);
 }
 
+// Node's `typeof x !== "object" || x === null`: primitives, null, and callables. Such a value
+// never matches structurally; in compareBranch full strict deep equality decides it, and as a
+// Set member or Map key only an identical counterpart can satisfy it.
+static bool isSpecialValue(JSValue value)
+{
+    return !value.isObject() || value.isCallable();
+}
+
 enum class Pairing { Open,
     Complete };
 
@@ -468,9 +476,10 @@ struct PendingMapEntry {
 };
 
 // Expected's entries as a subset of actual's (node's mapEquiv + partialObjectMapEquiv). A
-// primitive key is settled by one lookup: actual must hold that key and the values must
-// match, since no other entry can stand in for it. Object keys, identical ones included, are
-// queued and matched structurally, key and value together, while actual is walked once.
+// special (non-object or callable) key is settled by one lookup: actual must hold that key and
+// the values must match, since no other entry can stand in for it. Object keys, identical ones
+// included, are queued and matched structurally, key and value together, while actual's
+// object-keyed entries are walked once; its other entries are passed over, as in node.
 static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
@@ -483,7 +492,7 @@ static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
         RETURN_IF_EXCEPTION(scope, false);
         JSValue expectedKey, expectedValue;
         while (iter->nextKeyValue(globalObject, expectedKey, expectedValue)) {
-            if (expectedKey.isObject()) {
+            if (!isSpecialValue(expectedKey)) {
                 gcBuffer.append(expectedKey);
                 gcBuffer.append(expectedValue);
                 queued.append({ expectedKey, expectedValue });
@@ -514,7 +523,7 @@ static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
     JSValue actualKey, actualValue;
     while (iter->nextKeyValue(globalObject, actualKey, actualValue)) {
         visited++;
-        if (actualKey.isObject()) {
+        if (!isSpecialValue(actualKey)) {
             Pairing pairing = pending.claimWith(scope, [&](const PendingMapEntry& entry) -> bool {
                 bool keyEqual = compareBranch(globalObject, gcBuffer, cycles, scope, actualKey, entry.key);
                 RETURN_IF_EXCEPTION(scope, false);
@@ -535,10 +544,11 @@ static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
 }
 
 // Expected's members as a subset of actual's (node's setEquiv + partialObjectSetEquiv). A
-// member actual holds by identity is settled by one lookup, and a primitive it does not hold
-// can match nothing else. The remaining objects are matched with subset semantics
-// (Set([{a:1,b:2}]) partially contains Set([{a:1}])) while actual is walked once; the actual
-// members expected also holds were settled by the lookup and stay reserved for their twin.
+// member actual holds by identity is settled by one lookup, and a special (non-object or
+// callable) member it does not hold can match nothing else. The remaining objects are matched
+// with subset semantics (Set([{a:1,b:2}]) partially contains Set([{a:1}])) while actual is
+// walked once; the actual members expected also holds were settled by the lookup and stay
+// reserved for their twin.
 static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
@@ -555,7 +565,7 @@ static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
             RETURN_IF_EXCEPTION(scope, false);
             if (held)
                 continue;
-            if (!expectedMember.isObject())
+            if (isSpecialValue(expectedMember))
                 return false;
             gcBuffer.append(expectedMember);
             queued.append(expectedMember);
@@ -571,10 +581,15 @@ static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
     JSValue actualMember;
     while (iter->next(globalObject, actualMember)) {
         visited++;
-        if (actualMember.isObject()) {
-            bool reserved = expectedSet->has(globalObject, actualMember);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (!reserved) {
+        bool reserved = expectedSet->has(globalObject, actualMember);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (!reserved) {
+            if (isSpecialValue(actualMember)) {
+                // Node probes such a stray member too (unlike a stray Map key, which it passes
+                // over): every probe misses, and all a full miss leaves behind is the direction
+                // reset, which the pairing of the members after it depends on.
+                pending.probeFront = true;
+            } else {
                 Pairing pairing = pending.claimWith(scope, [&](JSValue expectedMember) -> bool {
                     return compareBranch(globalObject, gcBuffer, cycles, scope, actualMember, expectedMember);
                 });
@@ -676,14 +691,6 @@ static bool setSubsetAndProps(JSC::JSGlobalObject* globalObject, JSC::MarkedArgu
     if (!contents)
         return false;
     return objectSubset(globalObject, gcBuffer, cycles, scope, actual, expected);
-}
-
-static bool isSpecialValue(JSValue value)
-{
-    // `typeof x !== "object"`: primitives, null, and callables are decided
-    // by full strict deep equality. Every specific type (Error, Date, RegExp,
-    // boxed primitives, ...) has already been handled by its own arm above.
-    return !value.isObject() || value.isCallable();
 }
 
 static bool compareBranch(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -393,170 +393,202 @@ static bool arraySubsequence(JSC::JSGlobalObject* globalObject, JSC::MarkedArgum
     return nonIndexObjectSubset(globalObject, gcBuffer, cycles, scope, actual, expected);
 }
 
-// Expected's entries as a subset of actual's: identity keys fast-path with
-// index reservation so no actual entry is consumed twice; object keys match
-// by partial deep equality.
+enum class Pairing { Open,
+    Complete };
+
+// The expected Set members / Map entries a hash lookup could not settle (copies; the caller
+// rooted them in gcBuffer), claimed one by one while actual is walked once.
+template<typename Entry>
+struct PendingExpected {
+    using Queue = WTF::Vector<Entry, 8>;
+
+    Queue entries;
+    size_t first { 0 };
+    size_t last;
+    // Front guesses keep hitting while actual arrives in expected's order, back guesses while
+    // it arrives reversed; only when both miss is the rest of the window scanned.
+    bool probeFront { true };
+
+    explicit PendingExpected(Queue&& queued)
+        : entries(std::move(queued))
+        , last(entries.size() - 1)
+    {
+        ASSERT(!entries.isEmpty());
+    }
+
+    size_t openCount() const { return last - first + 1; }
+
+    // One actual entry against the open window, in node's order (partialObjectSetEquiv /
+    // partialObjectMapEquiv, down to which entry is claimed when several would do): the front
+    // guess, the back guess, then the rest back to front. A claimed entry is swap-removed so it
+    // is never compared again; Complete means nothing is left to claim. `matches` may throw;
+    // callers RETURN_IF_EXCEPTION after this returns.
+    template<typename Matches>
+    Pairing claimWith(JSC::ThrowScope& scope, const Matches& matches)
+    {
+        size_t scanFrom = first;
+        if (probeFront) {
+            bool hit = matches(entries[first]);
+            RETURN_IF_EXCEPTION(scope, Pairing::Open);
+            if (hit) {
+                if (first == last)
+                    return Pairing::Complete;
+                first++;
+                return Pairing::Open;
+            }
+            if (first == last)
+                return Pairing::Open;
+            probeFront = false;
+            scanFrom++;
+        }
+        bool hit = matches(entries[last]);
+        RETURN_IF_EXCEPTION(scope, Pairing::Open);
+        if (!hit) {
+            probeFront = true;
+            size_t i = last;
+            while (!hit && i > scanFrom) {
+                i--;
+                hit = matches(entries[i]);
+                RETURN_IF_EXCEPTION(scope, Pairing::Open);
+            }
+            if (!hit)
+                return Pairing::Open;
+            entries[i] = entries[last];
+        }
+        if (first == last)
+            return Pairing::Complete;
+        last--;
+        return Pairing::Open;
+    }
+};
+
+struct PendingMapEntry {
+    JSValue key;
+    JSValue value;
+};
+
+// Expected's entries as a subset of actual's (node's mapEquiv + partialObjectMapEquiv). A
+// primitive key is settled by one lookup: actual must hold that key and the values must
+// match, since no other entry can stand in for it. Object keys, identical ones included, are
+// queued and matched structurally, key and value together, while actual is walked once.
 static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
     JSC::JSMap* actualMap = uncheckedDowncast<JSC::JSMap>(actual.asCell());
     JSC::JSMap* expectedMap = uncheckedDowncast<JSC::JSMap>(expected.asCell());
 
-    // Materialized lazily, rooted in gcBuffer (keys then values, pairwise).
-    bool materialized = false;
-    size_t entriesStart = 0;
-    size_t entryCount = 0;
-    WTF::Vector<bool, 8> usedIndices;
-    JSC::MarkedArgumentBuffer usedIdentityKeys;
-
-    auto materialize = [&]() -> bool {
-        if (materialized)
-            return true;
-        materialized = true;
-        entriesStart = gcBuffer.size();
-        auto iter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), actualMap, JSC::IterationKind::Entries);
-        if (scope.exception()) [[unlikely]]
-            return false;
-        JSValue key, value;
-        while (iter->nextKeyValue(globalObject, key, value)) {
-            gcBuffer.append(key);
-            gcBuffer.append(value);
-            entryCount++;
-        }
-        usedIndices.fill(false, entryCount);
-        return true;
-    };
-
-    auto identityKeyUsed = [&](JSValue key) -> bool {
-        for (size_t i = 0; i < usedIdentityKeys.size(); i++) {
-            bool same = JSC::sameValue(globalObject, usedIdentityKeys.at(i), key);
-            // sameValue can resolve ropes and throw; plain check because the macro can't live
-            // inside a lambda — callers RETURN_IF_EXCEPTION right after this returns.
-            if (scope.exception()) [[unlikely]]
+    PendingExpected<PendingMapEntry>::Queue queued;
+    {
+        auto iter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), expectedMap, JSC::IterationKind::Entries);
+        RETURN_IF_EXCEPTION(scope, false);
+        JSValue expectedKey, expectedValue;
+        while (iter->nextKeyValue(globalObject, expectedKey, expectedValue)) {
+            if (expectedKey.isObject()) {
+                gcBuffer.append(expectedKey);
+                gcBuffer.append(expectedValue);
+                queued.append({ expectedKey, expectedValue });
+                continue;
+            }
+            JSValue actualValue = actualMap->get(globalObject, expectedKey);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (actualValue.isUndefined()) {
+                // get() answers undefined both for a missing key and for a key holding undefined.
+                bool held = actualMap->has(globalObject, expectedKey);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!held)
+                    return false;
+            }
+            bool equal = compareBranch(globalObject, gcBuffer, cycles, scope, actualValue, expectedValue);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (!equal)
                 return false;
-            if (same)
+        }
+    }
+    if (queued.isEmpty())
+        return true;
+
+    PendingExpected<PendingMapEntry> pending(std::move(queued));
+    auto iter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), actualMap, JSC::IterationKind::Entries);
+    RETURN_IF_EXCEPTION(scope, false);
+    size_t visited = 0;
+    JSValue actualKey, actualValue;
+    while (iter->nextKeyValue(globalObject, actualKey, actualValue)) {
+        visited++;
+        if (actualKey.isObject()) {
+            Pairing pairing = pending.claimWith(scope, [&](const PendingMapEntry& entry) -> bool {
+                bool keyEqual = compareBranch(globalObject, gcBuffer, cycles, scope, actualKey, entry.key);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!keyEqual)
+                    return false;
+                return compareBranch(globalObject, gcBuffer, cycles, scope, actualValue, entry.value);
+            });
+            RETURN_IF_EXCEPTION(scope, false);
+            if (pairing == Pairing::Complete)
                 return true;
         }
-        return false;
-    };
-
-    auto expectedIter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), expectedMap, JSC::IterationKind::Entries);
-    RETURN_IF_EXCEPTION(scope, false);
-    JSValue expectedKey, expectedValue;
-    while (expectedIter->nextKeyValue(globalObject, expectedKey, expectedValue)) {
-        bool consumed = false;
-        bool identityPresent = actualMap->has(globalObject, expectedKey);
-        RETURN_IF_EXCEPTION(scope, false);
-        bool expectedKeyAlreadyUsed = identityKeyUsed(expectedKey);
-        // sameValue can resolve rope strings and throw; the lambda cannot
-        // hold the check macro, so check at every call site.
-        RETURN_IF_EXCEPTION(scope, false);
-        if (identityPresent && !expectedKeyAlreadyUsed) {
-            // Reserve the identity entry's index so the deep-matching loop
-            // below cannot consume it twice.
-            size_t identityIndex = SIZE_MAX;
-            if (materialized) {
-                for (size_t i = 0; i < entryCount; i++) {
-                    bool same = JSC::sameValueZero(globalObject, gcBuffer.at(entriesStart + i * 2), expectedKey);
-                    // Same rope-resolution hazard as identityKeyUsed: bail
-                    // before the next VM-entering call, not after the loop.
-                    RETURN_IF_EXCEPTION(scope, false);
-                    if (same) {
-                        identityIndex = i;
-                        break;
-                    }
-                }
-            }
-            if (identityIndex == SIZE_MAX || !usedIndices[identityIndex]) {
-                JSValue actualValue = actualMap->get(globalObject, expectedKey);
-                RETURN_IF_EXCEPTION(scope, false);
-                bool equal = compareBranch(globalObject, gcBuffer, cycles, scope, actualValue, expectedValue);
-                RETURN_IF_EXCEPTION(scope, false);
-                if (equal) {
-                    usedIdentityKeys.append(expectedKey);
-                    if (identityIndex != SIZE_MAX)
-                        usedIndices[identityIndex] = true;
-                    consumed = true;
-                }
-            }
-        }
-        if (consumed)
-            continue;
-        if (!expectedKey.isObject())
-            return false;
-        if (!materialize())
-            return false;
-        RETURN_IF_EXCEPTION(scope, false);
-        bool matched = false;
-        for (size_t i = 0; i < entryCount; i++) {
-            if (usedIndices[i])
-                continue;
-            JSValue candidateKey = gcBuffer.at(entriesStart + i * 2);
-            bool candidateIsUsedIdentity = identityKeyUsed(candidateKey);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (candidateIsUsedIdentity)
-                continue;
-            bool keyEqual = compareBranch(globalObject, gcBuffer, cycles, scope, candidateKey, expectedKey);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (!keyEqual)
-                continue;
-            bool valueEqual = compareBranch(globalObject, gcBuffer, cycles, scope, gcBuffer.at(entriesStart + i * 2 + 1), expectedValue);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (valueEqual) {
-                usedIndices[i] = true;
-                matched = true;
-                break;
-            }
-        }
-        if (!matched)
+        const size_t size = actualMap->size();
+        const size_t unvisited = size > visited ? size - visited : 0;
+        if (unvisited < pending.openCount())
             return false;
     }
-    return true;
+    return false;
 }
 
-// Expected's items as a subset of actual's; item equality is the partial
-// comparison itself — node matches object items with subset semantics
-// (Set([{a:1,b:2}]) partially contains Set([{a:1}])).
+// Expected's members as a subset of actual's (node's setEquiv + partialObjectSetEquiv). A
+// member actual holds by identity is settled by one lookup, and a primitive it does not hold
+// can match nothing else. The remaining objects are matched with subset semantics
+// (Set([{a:1,b:2}]) partially contains Set([{a:1}])) while actual is walked once; the actual
+// members expected also holds were settled by the lookup and stay reserved for their twin.
 static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
     JSC::JSSet* actualSet = uncheckedDowncast<JSC::JSSet>(actual.asCell());
     JSC::JSSet* expectedSet = uncheckedDowncast<JSC::JSSet>(expected.asCell());
 
-    const size_t itemsStart = gcBuffer.size();
-    size_t itemCount = 0;
+    PendingExpected<JSValue>::Queue queued;
     {
-        auto iter = JSC::JSSetIterator::create(vm, globalObject->setIteratorStructure(), actualSet, JSC::IterationKind::Keys);
+        auto iter = JSC::JSSetIterator::create(vm, globalObject->setIteratorStructure(), expectedSet, JSC::IterationKind::Keys);
         RETURN_IF_EXCEPTION(scope, false);
-        JSValue item;
-        while (iter->next(globalObject, item)) {
-            gcBuffer.append(item);
-            itemCount++;
+        JSValue expectedMember;
+        while (iter->next(globalObject, expectedMember)) {
+            bool held = actualSet->has(globalObject, expectedMember);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (held)
+                continue;
+            if (!expectedMember.isObject())
+                return false;
+            gcBuffer.append(expectedMember);
+            queued.append(expectedMember);
         }
     }
-    WTF::Vector<bool, 8> usedIndices;
-    usedIndices.fill(false, itemCount);
+    if (queued.isEmpty())
+        return true;
 
-    auto expectedIter = JSC::JSSetIterator::create(vm, globalObject->setIteratorStructure(), expectedSet, JSC::IterationKind::Keys);
+    PendingExpected<JSValue> pending(std::move(queued));
+    auto iter = JSC::JSSetIterator::create(vm, globalObject->setIteratorStructure(), actualSet, JSC::IterationKind::Keys);
     RETURN_IF_EXCEPTION(scope, false);
-    JSValue expectedItem;
-    while (expectedIter->next(globalObject, expectedItem)) {
-        bool matched = false;
-        for (size_t i = 0; i < itemCount; i++) {
-            if (usedIndices[i])
-                continue;
-            bool equal = compareBranch(globalObject, gcBuffer, cycles, scope, gcBuffer.at(itemsStart + i), expectedItem);
+    size_t visited = 0;
+    JSValue actualMember;
+    while (iter->next(globalObject, actualMember)) {
+        visited++;
+        if (actualMember.isObject()) {
+            bool reserved = expectedSet->has(globalObject, actualMember);
             RETURN_IF_EXCEPTION(scope, false);
-            if (equal) {
-                usedIndices[i] = true;
-                matched = true;
-                break;
+            if (!reserved) {
+                Pairing pairing = pending.claimWith(scope, [&](JSValue expectedMember) -> bool {
+                    return compareBranch(globalObject, gcBuffer, cycles, scope, actualMember, expectedMember);
+                });
+                RETURN_IF_EXCEPTION(scope, false);
+                if (pairing == Pairing::Complete)
+                    return true;
             }
         }
-        if (!matched)
+        const size_t size = actualSet->size();
+        const size_t unvisited = size > visited ? size - visited : 0;
+        if (unvisited < pending.openCount())
             return false;
     }
-    return true;
+    return false;
 }
 
 // Errors compare name/message/errors leniently: `undefined` (or an empty

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -393,9 +393,7 @@ static bool arraySubsequence(JSC::JSGlobalObject* globalObject, JSC::MarkedArgum
     return nonIndexObjectSubset(globalObject, gcBuffer, cycles, scope, actual, expected);
 }
 
-// Node's `typeof x !== "object" || x === null`: primitives, null, and callables. Such a value
-// never matches structurally; in compareBranch full strict deep equality decides it, and as a
-// Set member or Map key only an identical counterpart can satisfy it.
+// Node's `typeof x !== "object" || x === null`: such a value matches only an identical counterpart.
 static bool isSpecialValue(JSValue value)
 {
     return !value.isObject() || value.isCallable();
@@ -404,8 +402,7 @@ static bool isSpecialValue(JSValue value)
 enum class Pairing { Open,
     Complete };
 
-// The expected Set members / Map entries a hash lookup could not settle (copies; the caller
-// rooted them in gcBuffer), claimed one by one while actual is walked once.
+// Expected entries no lookup could settle; copies, kept alive by the caller's gcBuffer appends.
 template<typename Entry>
 struct PendingExpected {
     using Queue = WTF::Vector<Entry, 8>;
@@ -413,8 +410,7 @@ struct PendingExpected {
     Queue entries;
     size_t first { 0 };
     size_t last;
-    // Front guesses keep hitting while actual arrives in expected's order, back guesses while
-    // it arrives reversed; only when both miss is the rest of the window scanned.
+    // Node's guess: keep probing the end that hit last, so same-order and reversed inputs stay linear.
     bool probeFront { true };
 
     explicit PendingExpected(Queue&& queued)
@@ -426,11 +422,7 @@ struct PendingExpected {
 
     size_t openCount() const { return last - first + 1; }
 
-    // One actual entry against the open window, in node's order (partialObjectSetEquiv /
-    // partialObjectMapEquiv, down to which entry is claimed when several would do): the front
-    // guess, the back guess, then the rest back to front. A claimed entry is swap-removed so it
-    // is never compared again; Complete means nothing is left to claim. `matches` may throw;
-    // callers RETURN_IF_EXCEPTION after this returns.
+    // Node's partialObject{Set,Map}Equiv probe order: front guess, back guess, then the rest back to front.
     template<typename Matches>
     Pairing claimWith(JSC::ThrowScope& scope, const Matches& matches)
     {
@@ -475,11 +467,7 @@ struct PendingMapEntry {
     JSValue value;
 };
 
-// Expected's entries as a subset of actual's (node's mapEquiv + partialObjectMapEquiv). A
-// special (non-object or callable) key is settled by one lookup: actual must hold that key and
-// the values must match, since no other entry can stand in for it. Object keys, identical ones
-// included, are queued and matched structurally, key and value together, while actual's
-// object-keyed entries are walked once; its other entries are passed over, as in node.
+// Node's mapEquiv: special keys are settled by lookup; object keys, identical ones included, are paired off.
 static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
@@ -543,12 +531,7 @@ static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
     return false;
 }
 
-// Expected's members as a subset of actual's (node's setEquiv + partialObjectSetEquiv). A
-// member actual holds by identity is settled by one lookup, and a special (non-object or
-// callable) member it does not hold can match nothing else. The remaining objects are matched
-// with subset semantics (Set([{a:1,b:2}]) partially contains Set([{a:1}])) while actual is
-// walked once; the actual members expected also holds were settled by the lookup and stay
-// reserved for their twin.
+// Node's setEquiv: members actual holds are settled by lookup; the other objects are paired off partially.
 static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
@@ -585,9 +568,7 @@ static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
         RETURN_IF_EXCEPTION(scope, false);
         if (!reserved) {
             if (isSpecialValue(actualMember)) {
-                // Node probes such a stray member too (unlike a stray Map key, which it passes
-                // over): every probe misses, and all a full miss leaves behind is the direction
-                // reset, which the pairing of the members after it depends on.
+                // Node probes a stray member too (unlike a stray Map key); all its misses leave behind is this.
                 pending.probeFront = true;
             } else {
                 Pairing pairing = pending.claimWith(scope, [&](JSValue expectedMember) -> bool {

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -34,6 +34,8 @@
 #include "JSKeyObject.h"
 
 #include "NodeUtilTypesModule.h"
+#include "PendingEntries.h"
+#include <wtf/HashSet.h>
 
 using namespace JSC;
 
@@ -399,120 +401,68 @@ static bool isSpecialValue(JSValue value)
     return !value.isObject() || value.isCallable();
 }
 
-enum class Pairing { Open,
-    Complete };
-
-// Expected entries no lookup could settle; copies, kept alive by the caller's gcBuffer appends.
-template<typename Entry>
-struct PendingExpected {
-    using Queue = WTF::Vector<Entry, 8>;
-
-    Queue entries;
-    size_t first { 0 };
-    size_t last;
-    // Node's guess: keep probing the end that hit last, so same-order and reversed inputs stay linear.
-    bool probeFront { true };
-
-    explicit PendingExpected(Queue&& queued)
-        : entries(std::move(queued))
-        , last(entries.size() - 1)
-    {
-        ASSERT(!entries.isEmpty());
-    }
-
-    size_t openCount() const { return last - first + 1; }
-
-    // Node's partialObject{Set,Map}Equiv probe order: front guess, back guess, then the rest back to front.
-    template<typename Matches>
-    Pairing claimWith(JSC::ThrowScope& scope, const Matches& matches)
-    {
-        size_t scanFrom = first;
-        if (probeFront) {
-            bool hit = matches(entries[first]);
-            RETURN_IF_EXCEPTION(scope, Pairing::Open);
-            if (hit) {
-                if (first == last)
-                    return Pairing::Complete;
-                first++;
-                return Pairing::Open;
-            }
-            if (first == last)
-                return Pairing::Open;
-            probeFront = false;
-            scanFrom++;
-        }
-        bool hit = matches(entries[last]);
-        RETURN_IF_EXCEPTION(scope, Pairing::Open);
-        if (!hit) {
-            probeFront = true;
-            size_t i = last;
-            while (!hit && i > scanFrom) {
-                i--;
-                hit = matches(entries[i]);
-                RETURN_IF_EXCEPTION(scope, Pairing::Open);
-            }
-            if (!hit)
-                return Pairing::Open;
-            entries[i] = entries[last];
-        }
-        if (first == last)
-            return Pairing::Complete;
-        last--;
-        return Pairing::Open;
-    }
-};
-
 struct PendingMapEntry {
     JSValue key;
     JSValue value;
 };
 
-// Node's mapEquiv: special keys are settled by lookup; object keys, identical ones included, are paired off.
+// Every key actual holds is settled by lookup plus value comparison; the object keys it does not hold are paired off.
 static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
     JSC::JSMap* actualMap = uncheckedDowncast<JSC::JSMap>(actual.asCell());
     JSC::JSMap* expectedMap = uncheckedDowncast<JSC::JSMap>(expected.asCell());
 
-    PendingExpected<PendingMapEntry>::Queue queued;
+    Bun::PendingEntries<PendingMapEntry>::Queue queued;
+    WTF::Vector<JSC::JSCell*, 8> settledKeys;
     {
         auto iter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), expectedMap, JSC::IterationKind::Entries);
         RETURN_IF_EXCEPTION(scope, false);
         JSValue expectedKey, expectedValue;
         while (iter->nextKeyValue(globalObject, expectedKey, expectedValue)) {
-            if (!isSpecialValue(expectedKey)) {
-                gcBuffer.append(expectedKey);
-                gcBuffer.append(expectedValue);
-                queued.append({ expectedKey, expectedValue });
-                continue;
-            }
             JSValue actualValue = actualMap->get(globalObject, expectedKey);
             RETURN_IF_EXCEPTION(scope, false);
-            if (actualValue.isUndefined()) {
+            bool settled = !actualValue.isUndefined();
+            if (!settled) {
                 // get() answers undefined both for a missing key and for a key holding undefined.
-                bool held = actualMap->has(globalObject, expectedKey);
+                settled = actualMap->has(globalObject, expectedKey);
                 RETURN_IF_EXCEPTION(scope, false);
-                if (!held)
-                    return false;
             }
-            bool equal = compareBranch(globalObject, gcBuffer, cycles, scope, actualValue, expectedValue);
-            RETURN_IF_EXCEPTION(scope, false);
-            if (!equal)
-                return false;
+            if (settled) {
+                settled = compareBranch(globalObject, gcBuffer, cycles, scope, actualValue, expectedValue);
+                RETURN_IF_EXCEPTION(scope, false);
+            }
+            if (isSpecialValue(expectedKey)) {
+                if (!settled)
+                    return false;
+                continue;
+            }
+            gcBuffer.append(expectedKey);
+            if (settled) {
+                // Node queues identical keys too (comparisons.js v26.3.0 L882-L891): order-dependent, and quadratic once reordered.
+                settledKeys.append(expectedKey.asCell());
+                continue;
+            }
+            gcBuffer.append(expectedValue);
+            queued.append({ expectedKey, expectedValue });
         }
     }
     if (queued.isEmpty())
         return true;
 
-    PendingExpected<PendingMapEntry> pending(std::move(queued));
+    // As node's setEquiv does for members: a settled key's actual entry is spoken for.
+    WTF::HashSet<JSC::JSCell*> reserved;
+    for (JSC::JSCell* key : settledKeys)
+        reserved.add(key);
+    Bun::PendingEntries<PendingMapEntry> pending(std::move(queued));
     auto iter = JSC::JSMapIterator::create(vm, globalObject->mapIteratorStructure(), actualMap, JSC::IterationKind::Entries);
     RETURN_IF_EXCEPTION(scope, false);
     size_t visited = 0;
     JSValue actualKey, actualValue;
     while (iter->nextKeyValue(globalObject, actualKey, actualValue)) {
         visited++;
-        if (!isSpecialValue(actualKey)) {
-            Pairing pairing = pending.claimWith(scope, [&](const PendingMapEntry& entry) -> bool {
+        if (!isSpecialValue(actualKey) && !reserved.contains(actualKey.asCell())) {
+            Bun::Claim claim = pending.claimWith(scope, [&](const PendingMapEntry& entry) -> bool {
                 bool keyEqual = compareBranch(globalObject, gcBuffer, cycles, scope, actualKey, entry.key);
                 RETURN_IF_EXCEPTION(scope, false);
                 if (!keyEqual)
@@ -520,7 +470,7 @@ static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
                 return compareBranch(globalObject, gcBuffer, cycles, scope, actualValue, entry.value);
             });
             RETURN_IF_EXCEPTION(scope, false);
-            if (pairing == Pairing::Complete)
+            if (claim == Bun::Claim::Exhausted)
                 return true;
         }
         const size_t size = actualMap->size();
@@ -531,14 +481,14 @@ static bool mapSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
     return false;
 }
 
-// Node's setEquiv: members actual holds are settled by lookup; the other objects are paired off partially.
+// Node's setEquiv (comparisons.js v26.3.0 L628-L775): members actual holds are settled by lookup, the rest paired off.
 static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
 {
     auto& vm = globalObject->vm();
     JSC::JSSet* actualSet = uncheckedDowncast<JSC::JSSet>(actual.asCell());
     JSC::JSSet* expectedSet = uncheckedDowncast<JSC::JSSet>(expected.asCell());
 
-    PendingExpected<JSValue>::Queue queued;
+    Bun::PendingEntries<JSValue>::Queue queued;
     {
         auto iter = JSC::JSSetIterator::create(vm, globalObject->setIteratorStructure(), expectedSet, JSC::IterationKind::Keys);
         RETURN_IF_EXCEPTION(scope, false);
@@ -557,7 +507,7 @@ static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
     if (queued.isEmpty())
         return true;
 
-    PendingExpected<JSValue> pending(std::move(queued));
+    Bun::PendingEntries<JSValue> pending(std::move(queued));
     auto iter = JSC::JSSetIterator::create(vm, globalObject->setIteratorStructure(), actualSet, JSC::IterationKind::Keys);
     RETURN_IF_EXCEPTION(scope, false);
     size_t visited = 0;
@@ -568,14 +518,14 @@ static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
         RETURN_IF_EXCEPTION(scope, false);
         if (!reserved) {
             if (isSpecialValue(actualMember)) {
-                // Node probes a stray member too (unlike a stray Map key); all its misses leave behind is this.
-                pending.probeFront = true;
+                // Node probes a stray member too (unlike a stray Map key, which it passes over).
+                pending.recordMiss();
             } else {
-                Pairing pairing = pending.claimWith(scope, [&](JSValue expectedMember) -> bool {
+                Bun::Claim claim = pending.claimWith(scope, [&](JSValue expectedMember) -> bool {
                     return compareBranch(globalObject, gcBuffer, cycles, scope, actualMember, expectedMember);
                 });
                 RETURN_IF_EXCEPTION(scope, false);
-                if (pairing == Pairing::Complete)
+                if (claim == Bun::Claim::Exhausted)
                     return true;
             }
         }

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -848,12 +848,19 @@ describe("detached ArrayBuffer", () => {
 // actual has three or more members): whatever a hash lookup can settle is settled by one
 // lookup, and only the expected objects left over are matched structurally, each claiming an
 // actual entry of its own, while actual is walked once. Every expectation below was
-// cross-checked against node v26.
+// cross-checked against node v26, except the two Map cases that say otherwise: node pairs off
+// object keys that both Maps hold structurally like any other, which makes the outcome depend on
+// insertion order; Bun settles them by identity, as node itself does for Set members and as Bun
+// always has.
 describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
   const set = (...members: unknown[]) => new Set(members);
   const map = (...entries: [unknown, unknown][]) => new Map(entries);
   const twin = { a: 1, b: 2 };
   const fn = () => {};
+  // Keys both Maps hold: token1/token2 are structurally interchangeable, shared is contained in {k:1,m:1}.
+  const token1 = {};
+  const token2 = {};
+  const shared = { k: 1 };
   // [description, actual, expected, whether expected is partially contained in actual]
   const cases: [string, unknown, unknown, boolean][] = [
     ["Set: a member both sides hold is paired with itself", set(twin, { a: 1, c: 3 }, 1), set({ a: 1 }, twin), true],
@@ -920,6 +927,29 @@ describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
       true,
     ],
     ["Map: a key both sides hold with a different value", map([twin, 1], [{ a: 1 }, 2]), map([twin, 2]), false],
+    [
+      // Node rejects this: walking actual in order, token1's entry claims token2's structurally
+      // identical expected entry, and {a:1} then does not contain {a:1,b:1}.
+      "Map: entries both sides hold, in another order (node: rejected)",
+      map([token1, { a: 1, b: 1 }], [token2, { a: 1 }]),
+      map([token2, { a: 1 }], [token1, { a: 1, b: 1 }]),
+      true,
+    ],
+    [
+      // Node accepts this by handing shared's expected entry to the {k:1,m:1} key (whose value
+      // contains {x:1}) and then matching {k:1} against shared's actual entry. Here shared's
+      // entries are settled with each other first, so {k:1} -> {y:2} has to fit {k:1,m:1} -> {x:1}.
+      "Map: a key both sides hold is settled with itself even when another pairing would work (node: accepted)",
+      map([{ k: 1, m: 1 }, { x: 1 }], [shared, { x: 1, y: 2 }]),
+      map([shared, { x: 1 }], [{ k: 1 }, { y: 2 }]),
+      false,
+    ],
+    [
+      "Map: a key both sides hold cannot also stand in for another entry",
+      map([shared, 3], [{ q: 1 }, 3]),
+      map([shared, 3], [{ k: 1 }, 3]),
+      false,
+    ],
     [
       "Map: object and primitive keys in another order",
       map(["p", 0], [{ k: 1 }, 1], [{ k: 2 }, 2]),
@@ -1043,6 +1073,52 @@ describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
     );
   });
 
+  // The expected objects still waiting for a counterpart are held as plain copies while user code
+  // runs. Here a getter on the first actual member probed deletes every entry from the expected
+  // collection (entry by entry: clear() leaves the old table, and the objects in it, reachable
+  // from iterators), collects garbage and allocates look-alikes into the freed cells; the rest of
+  // the pairing then reads every pending object, so they have to have been kept alive by the
+  // comparison itself. There are enough of them that the copies live on the heap, out of reach of
+  // the conservative stack scan. (Bun has always compared the entries as they were when the
+  // comparison started; node re-reads Map values while pairing and so rejects the Map case.)
+  describe("keeps the pending expected entries alive across a GC", () => {
+    const n = 64;
+    function firstActual(expected: Set<unknown> | Map<unknown, unknown>) {
+      let probed = false;
+      return {
+        get id() {
+          if (!probed) {
+            probed = true;
+            for (const entry of expected.keys()) expected.delete(entry);
+            Bun.gc(true);
+            const lookAlikes: object[] = [];
+            for (let i = 0; i < 4 * n; i++) lookAlikes.push({ id: -1 });
+          }
+          return 0;
+        },
+      };
+    }
+    const others = () => Array.from({ length: n - 1 }, (_, i) => ({ id: i + 1 }));
+    const fresh = () => Array.from({ length: n }, (_, i) => ({ id: i }));
+
+    test("Set", () => {
+      const expected = new Set(fresh());
+      const actual = new Set([firstActual(expected), ...others()]);
+      assert.partialDeepStrictEqual(actual, expected);
+      expect(expected.size).toBe(0);
+    });
+
+    test("Map", () => {
+      const expected = new Map(fresh().map(key => [key, { v: key.id }]));
+      const actual = new Map<object, object>([
+        [firstActual(expected), { v: 0, extra: true }],
+        ...others().map(key => [key, { v: key.id, extra: true }] as [object, object]),
+      ]);
+      assert.partialDeepStrictEqual(actual, expected);
+      expect(expected.size).toBe(0);
+    });
+  });
+
   // Each actual member is compared against one or two expected members: the front guess keeps
   // hitting while the sides were built in the same order, the back guess while they were built
   // in opposite orders, so the getters are read 2n times (2n + 2 reversed). Rescanning every
@@ -1081,6 +1157,20 @@ describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
       const expected = new Map(reversed ? other.reverse() : other);
       assert.partialDeepStrictEqual(actual, expected);
       expect(reads).toBeLessThanOrEqual(4 * n);
+    });
+
+    // Members and keys both sides hold are settled by lookup, so their contents are never read,
+    // in whatever order the sides were built.
+    test.each(["Set", "Map"])("%s contents both sides hold, shuffled", kind => {
+      let reads = 0;
+      const keys = members(() => reads++);
+      // A fixed stride permutation, so neither the same-order nor the reversed-order guess fits.
+      const shuffled = keys.map((_, i) => keys[(i * 37) % n]);
+      const position = new Map(keys.map((key, i) => [key, i]));
+      const actual = kind === "Set" ? new Set(keys) : new Map(keys.map(key => [key, position.get(key)]));
+      const expected = kind === "Set" ? new Set(shuffled) : new Map(shuffled.map(key => [key, position.get(key)]));
+      assert.partialDeepStrictEqual(actual, expected);
+      expect(reads).toBe(0);
     });
   });
 

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -2,6 +2,7 @@
 // Expectations come from the documented semantics of assert.deepStrictEqual/deepEqual,
 // cross-checked against Node.js. Cases Bun gets wrong today are marked `test.failing`.
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import assert from "node:assert";
 import util from "node:util";
 
@@ -840,6 +841,234 @@ describe("detached ArrayBuffer", () => {
     expect(() => assert.deepStrictEqual(detachedView(), detachedView())).not.toThrow();
     expect(() => assert.deepStrictEqual(detachedView(), new Uint8Array(0))).not.toThrow();
   });
+});
+
+// assert.partialDeepStrictEqual pairs off Set members and Map entries the way node's
+// setEquiv/mapEquiv do (lib/internal/util/comparisons.js; for Sets, the path node takes once
+// actual has three or more members): whatever a hash lookup can settle is settled by one
+// lookup, and only the expected objects left over are matched structurally, each claiming an
+// actual entry of its own, while actual is walked once. Every expectation below was
+// cross-checked against node v26.
+describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
+  const set = (...members: unknown[]) => new Set(members);
+  const map = (...entries: [unknown, unknown][]) => new Map(entries);
+  const twin = { a: 1, b: 2 };
+  const fn = () => {};
+  // [description, actual, expected, whether expected is partially contained in actual]
+  const cases: [string, unknown, unknown, boolean][] = [
+    ["Set: a member both sides hold is paired with itself", set(twin, { a: 1, c: 3 }, 1), set({ a: 1 }, twin), true],
+    ["Set: a member both sides hold, other order", set({ a: 1, c: 3 }, twin, 1), set(twin, { a: 1 }), true],
+    ["Set: members match with subset semantics", set({ a: 1, b: 2 }, { c: 3, d: 4 }, 0), set({ c: 3 }, { a: 1 }), true],
+    ["Set: each expected object claims a member of its own", set({ a: 1 }, 5, 6), set({ a: 1 }, { a: 1 }), false],
+    ["Set: duplicates pair off one to one", set({ a: 1 }, { a: 1 }, 5), set({ a: 1 }, { a: 1 }), true],
+    [
+      "Set: an expected object without a counterpart",
+      set({ a: 1 }, { b: 2 }, { c: 3 }),
+      set({ c: 3 }, { z: 0 }),
+      false,
+    ],
+    ["Set: a primitive actual does not hold", set({}, 1, 3), set(2), false],
+    ["Set: an object when actual holds only primitives", set(1, 2, 3), set({}), false],
+    ["Set: a function both sides hold", set(fn, 1, 2), set(fn), true],
+    ["Set: a function only expected holds", set(() => {}, 1, 2), set(() => {}), false],
+    ["Set: nested collections", set(set(1, 2, 3), [4, 5], 0), set([5], set(2)), true],
+    [
+      "Set: own properties are still compared",
+      Object.assign(set(1, 2), { x: 1 }),
+      Object.assign(set(1), { x: 2 }),
+      false,
+    ],
+    ["Map: a primitive key actual does not hold", map(["a", 1], ["c", 1]), map(["b", 1]), false],
+    ["Map: a primitive key with a different value", map(["a", 1], ["b", 2]), map(["a", 2]), false],
+    [
+      "Map: a primitive key, value matched with subset semantics",
+      map(["a", { x: 1, y: 2 }]),
+      map(["a", { x: 1 }]),
+      true,
+    ],
+    ["Map: a key holding undefined", map(["a", undefined], ["b", 1]), map(["a", undefined]), true],
+    ["Map: a missing key is not a key holding undefined", map(["b", 1]), map(["a", undefined]), false],
+    [
+      "Map: an object key matches on key and value together",
+      map([twin, { x: 1, y: 2 }]),
+      map([{ a: 1 }, { x: 1 }]),
+      true,
+    ],
+    ["Map: an object key whose value differs", map([twin, { x: 1 }]), map([{ a: 1 }, { x: 2 }]), false],
+    [
+      "Map: each expected entry claims an entry of its own",
+      map([{ a: 1 }, 1], ["k", 0]),
+      map([{ a: 1 }, 1], [{ a: 1 }, 1]),
+      false,
+    ],
+    [
+      "Map: duplicate keys pair off one to one",
+      map([{ a: 1 }, 1], [{ a: 1 }, 1], ["k", 0]),
+      map([{ a: 1 }, 1], [{ a: 1 }, 1]),
+      true,
+    ],
+    [
+      "Map: equal keys carrying each other's values",
+      map([{ k: 1 }, "x"], [{ k: 1 }, "y"]),
+      map([{ k: 1 }, "y"], [{ k: 1 }, "x"]),
+      true,
+    ],
+    [
+      "Map: a key both sides hold, its value under a structurally equal key",
+      map([twin, 1], [{ a: 1, b: 2 }, 2]),
+      map([twin, 2]),
+      true,
+    ],
+    ["Map: a key both sides hold with a different value", map([twin, 1], [{ a: 1 }, 2]), map([twin, 2]), false],
+    [
+      "Map: object and primitive keys in another order",
+      map(["p", 0], [{ k: 1 }, 1], [{ k: 2 }, 2]),
+      map([{ k: 2 }, 2], ["p", 0], [{ k: 1 }, 1]),
+      true,
+    ],
+    ["Map: an object key when actual holds only primitive keys", map(["a", 1], ["b", 1]), map([{}, 1]), false],
+    [
+      "Map: nested collections as keys and values",
+      map([map(["a", 1], ["b", 2]), [1, 2, 3]]),
+      map([map(["a", 1]), [2]]),
+      true,
+    ],
+    [
+      "Map: own properties are still compared",
+      Object.assign(map([1, 1]), { x: 1 }),
+      Object.assign(map([1, 1]), { x: 2 }),
+      false,
+    ],
+  ];
+
+  test.each(cases)("%s", (_, actual, expected, contained) => {
+    if (contained) {
+      assert.partialDeepStrictEqual(actual, expected);
+    } else {
+      expect(() => assert.partialDeepStrictEqual(actual, expected)).toThrow(assert.AssertionError);
+    }
+  });
+
+  // Expected in a stride order, so neither the front nor the back guess fits and most members
+  // are found by scanning the open window and swap-removed from the middle of it.
+  test("a permuted expected side is paired off completely", () => {
+    const n = 24;
+    const actual = Array.from({ length: n }, (_, i) => ({ id: i, extra: true }));
+    const expected = Array.from({ length: n }, (_, i) => ({ id: (i * 7 + 3) % n }));
+    assert.partialDeepStrictEqual(new Set(actual), new Set(expected));
+    assert.partialDeepStrictEqual(new Set(actual), new Set(expected.slice(0, n / 2)));
+    expect(() => assert.partialDeepStrictEqual(new Set(actual), new Set([...expected.slice(1), { id: n }]))).toThrow(
+      assert.AssertionError,
+    );
+
+    const actualMap = new Map(actual.map(key => [key, key.id]));
+    assert.partialDeepStrictEqual(actualMap, new Map(expected.map(key => [key, key.id])));
+    expect(() =>
+      assert.partialDeepStrictEqual(actualMap, new Map(expected.map(key => [key, key.id === 5 ? -1 : key.id]))),
+    ).toThrow(assert.AssertionError);
+  });
+
+  test("self-referential members terminate", () => {
+    const selfSet = () => {
+      const self = new Set<unknown>();
+      self.add(self);
+      return self;
+    };
+    const selfMap = () => {
+      const self = new Map<unknown, unknown>();
+      self.set("self", self);
+      return self;
+    };
+    assert.partialDeepStrictEqual(set(selfSet(), 1), set(selfSet()));
+    assert.partialDeepStrictEqual(map([{ k: 1 }, selfMap()], ["s", 1]), map([{ k: 1 }, selfMap()]));
+    assert.partialDeepStrictEqual(map(["s", selfMap()]), map(["s", selfMap()]));
+  });
+
+  test("an exception thrown while comparing propagates", () => {
+    const throwing = () => ({
+      get x(): number {
+        throw new Error("boom");
+      },
+    });
+    expect(() => assert.partialDeepStrictEqual(set(throwing()), set(throwing()))).toThrow("boom");
+    expect(() => assert.partialDeepStrictEqual(map(["k", throwing()]), map(["k", throwing()]))).toThrow("boom");
+    expect(() => assert.partialDeepStrictEqual(map([throwing(), 1]), map([throwing(), 1]))).toThrow("boom");
+    expect(() => assert.partialDeepStrictEqual(map([{ k: 1 }, throwing()]), map([{ k: 1 }, throwing()]))).toThrow(
+      "boom",
+    );
+  });
+
+  // Each actual member is compared against one or two expected members: the front guess keeps
+  // hitting while the sides were built in the same order, the back guess while they were built
+  // in opposite orders, so the getters are read 2n times (2n + 2 reversed). Rescanning every
+  // unclaimed actual member per expected member, which this replaced, read them about n*n
+  // times in the reversed case.
+  describe("number of structural comparisons", () => {
+    const n = 128;
+    function members(onRead: () => void) {
+      return Array.from({ length: n }, (_, i) => ({
+        get id() {
+          onRead();
+          return i;
+        },
+      }));
+    }
+    const orders: [string, boolean][] = [
+      ["same order", false],
+      ["opposite order", true],
+    ];
+
+    test.each(orders)("Set members, %s", (_, reversed) => {
+      let reads = 0;
+      const onRead = () => reads++;
+      const actual = new Set(members(onRead));
+      const other = members(onRead);
+      const expected = new Set(reversed ? other.reverse() : other);
+      assert.partialDeepStrictEqual(actual, expected);
+      expect(reads).toBeLessThanOrEqual(4 * n);
+    });
+
+    test.each(orders)("Map entries with object keys, %s", (_, reversed) => {
+      let reads = 0;
+      const onRead = () => reads++;
+      const actual = new Map(members(onRead).map((key, i) => [key, i] as const));
+      const other = members(onRead).map((key, i) => [key, i] as const);
+      const expected = new Map(reversed ? other.reverse() : other);
+      assert.partialDeepStrictEqual(actual, expected);
+      expect(reads).toBeLessThanOrEqual(4 * n);
+    });
+  });
+
+  // Primitive members and primitive keys are settled by hash lookups, which nothing can
+  // observe, so the size is the discriminator: at these sizes the rescan per member that this
+  // replaced needs well over a minute for either collection in a debug build, the lookups well
+  // under a second (the child spends its few seconds starting up and building the
+  // collections), and the spawn timeout sits in between.
+  test("primitive members and keys are settled by lookups, not rescans", async () => {
+    const fixture = `
+      const assert = require("node:assert");
+      const ints = Array.from({ length: 100_000 }, (_, i) => i);
+      assert.partialDeepStrictEqual(new Set(ints), new Set(ints));
+      const entries = Array.from({ length: 12_000 }, (_, i) => ["key" + i, i]);
+      assert.partialDeepStrictEqual(new Map(entries), new Map(entries));
+      console.log("done");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "done",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 90_000);
 });
 
 describe("AssertionError", () => {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -927,6 +927,15 @@ describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
       true,
     ],
     ["Map: an object key when actual holds only primitive keys", map(["a", 1], ["b", 1]), map([{}, 1]), false],
+    ["Map: a function key both sides hold", map([fn, 1], ["k", 2]), map([fn, 1]), true],
+    ["Map: a function key both sides hold with a different value", map([fn, 1]), map([fn, 2]), false],
+    ["Map: a function key only expected holds", map([() => {}, 1], ["k", 1]), map([() => {}, 1]), false],
+    [
+      "Map: a function key only expected holds, next to entries that would pair",
+      map([{ a: 1 }, 1], ["k", 1]),
+      map([{ a: 1 }, 1], [fn, 1]),
+      false,
+    ],
     [
       "Map: nested collections as keys and values",
       map([map(["a", 1], ["b", 2]), [1, 2, 3]]),
@@ -947,6 +956,42 @@ describe("assert.partialDeepStrictEqual on Sets and Maps", () => {
     } else {
       expect(() => assert.partialDeepStrictEqual(actual, expected)).toThrow(assert.AssertionError);
     }
+  });
+
+  // The pairing is greedy, and which pairing it finds depends on whether a member that can
+  // match nothing (a primitive or a function neither side shares) sits between the objects:
+  // node probes such a Set member, which sends the next member back to the front of the
+  // window, and skips such a Map key, which leaves the next entry probing the back. Bun follows
+  // node in both, so the same four objects pair off differently as Set members and as Map keys.
+  // After `fitsC` claims C off the back of [A, B, C], `fitsAB` is offered A (Set) or B (Map);
+  // whether the last member can take what is left decides the outcome.
+  describe("a member that matches nothing, between members that do", () => {
+    const A = { a: 1 };
+    const B = { b: 2 };
+    const C = { c: 3 };
+    const fitsC = { c: 3, w: 1 };
+    const fitsAB = { a: 1, b: 2 };
+    const fitsB = { b: 2, y: 1 };
+    const fitsA = { a: 1, y: 1 };
+    const strays: [string, unknown][] = [
+      ["a primitive", 7],
+      ["a function", () => {}],
+    ];
+
+    test.each(strays)("%s in a Set", (_, stray) => {
+      assert.partialDeepStrictEqual(set(fitsC, stray, fitsAB, fitsB), set(A, B, C));
+      expect(() => assert.partialDeepStrictEqual(set(fitsC, stray, fitsAB, fitsA), set(A, B, C))).toThrow(
+        assert.AssertionError,
+      );
+    });
+
+    test.each(strays)("%s as a Map key", (_, stray) => {
+      const expected = map([A, 1], [B, 1], [C, 1]);
+      assert.partialDeepStrictEqual(map([fitsC, 1], [stray, 1], [fitsAB, 1], [fitsA, 1]), expected);
+      expect(() =>
+        assert.partialDeepStrictEqual(map([fitsC, 1], [stray, 1], [fitsAB, 1], [fitsB, 1]), expected),
+      ).toThrow(assert.AssertionError);
+    });
   });
 
   // Expected in a stride order, so neither the front nor the back guess fits and most members


### PR DESCRIPTION
### Problem
- `assert.partialDeepStrictEqual` is quadratic on Sets and Maps whatever they contain. Release build, two equal collections: a Set of 100k integers takes 4.8 s (node: ~30 ms), a Map of 10k string keys 275 ms (node: ~10 ms); every doubling costs 4x.
- `setSubset` (src/jsc/modules/NodeUtilTypesModule.cpp) has no hash path at all: for each expected member it walks every actual member from index 0, skipping the ones already claimed, until `compareBranch` matches. Primitives go through that walk too, and in the common same-order case the skips alone are n*n/2.
- `mapSubset` does look keys up, but records each claimed key in a `MarkedArgumentBuffer` and rescans that list with `sameValue` (`identityKeyUsed`) once per expected entry, so a Map with n primitive keys does n*n/2 string comparisons; its object-key path also rescans actual from index 0 and calls `identityKeyUsed` per candidate.
- A smaller correctness bug in the same code: a Set member that both sides hold by identity could be claimed by some structural subset of it that came earlier in expected, after which the member itself found nothing, so `partialDeepStrictEqual(new Set([x, w, 1]), new Set([{ a: 1 }, x]))` threw (with `x = { a: 1, b: 2 }`, `w = { a: 1, c: 3 }`). Node passes it.

### Fix
- Both functions now work in two passes, the shape of node's `setEquiv` / `mapEquiv` (lib/internal/util/comparisons.js, v26.3.0 L628-L921):
  - Pass over expected: everything a hash lookup can settle is settled by one lookup. Set: a member actual holds (`JSSet::has`) is done; a special member (node's `typeof` test, the file's `isSpecialValue`: primitives, null, functions) it does not hold fails the comparison, since nothing else can match it. Map: every key is looked up (`JSMap::get`, plus `has` when the stored value is `undefined`) and its value compared; a special key that fails this fails the comparison, an object key that fails it is queued, and an object key that passes reserves its actual entry. Only the queued objects go on to pass two.
  - Pass over actual, once: each object member / object-keyed entry that is not reserved claims one queued entry (`PendingEntries::claimWith`, new header src/jsc/bindings/PendingEntries.h) in node's probe order: the front of the open window while that keeps hitting, the back while that keeps hitting, otherwise a scan of the rest; a claimed entry is swap-removed; the pass stops as soon as the window is empty or fewer actual entries remain than are open. A stray Set member (special, not held by expected) records a miss, which is all node's probes of it leave behind; a stray Map key is passed over, as in node.
- Result: primitive and identity content costs one or two hash lookups per entry, and a structural residue costs one or two comparisons per actual entry when the sides were built in the same or the opposite order. Residues in unrelated orders still scan the window, as node's do.
- Where the results come from:
  - The lookup paths give the answers the old code gave: `compareBranch` of anything against a special value is true only for SameValueZero pairs (what `has`/`get` test; Sets and Map keys normalize -0), a special Map key already had to be held with a matching value, and object keys both Maps hold were already settled by lookup on main and in every release.
  - Structural matching is not one-to-one (an expected `{ a: 1 }` fits every actual object with `a: 1`), so every implementation here is a greedy pairing and the question is only whose order to use. For everything except Map keys both sides hold it is node's, down to which entry is claimed when several fit: on 4,000 randomized contended instances without shared keys (strays included) plus the hand-written cases, this branch's Set and Map results are identical to node v26.3.0's, and so are its Set results on 4,000 more instances with shared members. (Node's separate shortcut for Sets with fewer than three actual members is not mirrored; it contradicts node's general path.)
  - Map keys both sides hold are the one deliberate divergence, kept from main: node queues them like any other object key (mapEquiv L882-L891), so the result for an identity-keyed Map depends on insertion order and, once the orders differ, the pairing is quadratic; an earlier revision of this PR did the same and turned a reordered 10k-key identity Map from milliseconds into seconds while flipping it from passing (every release so far) to throwing. Settling such keys first is what node does for Set members and what Bun always did for Maps. On the 4,000 shared-key instances the Map results differ from node's in 22, all of them Maps node rejects because of the order its walk happened to take; the code comments and the two table rows marked "node: ..." in the test spell the divergence out.
- Tests, all in `test/js/node/assert/deep-equal.test.ts`, `describe("assert.partialDeepStrictEqual on Sets and Maps")` (every expectation checked against node except the two rows that say so): a table of Set/Map pairing cases including the shared-key shapes and the reservation, the stray-member cases (the same four objects pair off differently as Set members and as Map keys, with a primitive and with a function as the stray), a permuted-order pairing test, self-referential members, exceptions propagating from each comparison site, getter counts (same-order and reversed-order residues are linear, and contents both sides hold are never read at all), a GC test in which a getter empties the expected collection entry by entry, collects, and reuses the freed cells (without the `gcBuffer` appends that root the pending copies it fails for Sets and trips UBSan for Maps), and a spawned child comparing a 100k-integer Set and a 12k-string-key Map, which on main is still running when its 60 s timeout kills it and finishes in a few seconds here. Against main 6 of the new tests fail (identity case, the two Map stray cases, both reversed getter counts, the spawned child); with the fix the file passes (356 tests).
- Also run: `assert.test.cjs`, `regression/issue/24338`, `regression/issue/28522`, `assert-typedarray-deepequal.test.ts`, the vendored `test-assert-class.js`, `test-assert-typedarray-deepequal.js`, `test-assert-deep-with-error.js`, `test-util-isDeepStrictEqual.js` (all pass), the new tests and the corpus under `BUN_JSC_validateExceptionChecks=1` (clean), and node's upstream `test/parallel/test-assert-partial-deep-equal.js` (140 cases, not vendored), which passes except its File/Blob prototype case, a pre-existing unrelated difference (`Object.getPrototypeOf(File.prototype)` is not `Blob.prototype` in Bun).
- Timings, comparison only, debug build (`bun bd`), main -> this branch: Set of 20k integers 2114 ms -> 63 ms; Map of 4k string keys 9456 ms -> 34 ms; Set of 2k objects with expected reversed 106.7 s -> 147 ms; Map of 2k object keys with expected reversed 100.1 s -> 104 ms; same-order 2k objects unchanged (~120 ms). Release build: Set of 100k integers 4.8 s -> 34 ms; Map of 10k string keys 275 ms -> 11 ms. Identity-keyed Map with expected shuffled, this branch: 10k keys 60 ms, 20k 113 ms, and with one structural entry added (so the reservation set is built and consulted) 109 ms / 240 ms, measured in a run where the 20k-integer Set took ~115 ms; main is linear here too.
- Sibling PR #38510 does the full-equality counterpart in bindings.cpp and currently carries its own copy of the window (`pairOffEntries`). `PendingEntries` is in a header, returns `Missed` / `Claimed` / `Exhausted` and leaves an exhausted window at zero open entries, so that engine can drive it too (strict: a miss is final; matcher mode: fall back, then sweep what is still open); whichever lands second can drop its copy.

### Background
- Partial mode (`assert.partialDeepStrictEqual(actual, expected)`): expected must be contained in actual. For Sets and Maps every expected member/entry needs a distinct counterpart in actual, and an object member matches with the same partial semantics, so `Set([{ a: 1, b: 2 }])` contains `Set([{ a: 1 }])`. `compareBranch` in this file is that comparison; it short-circuits on SameValueZero, so a member compared with itself always matches.
- `JSSet::has` / `JSMap::get` use the collection's own hash table: SameValueZero, i.e. identity for objects and value equality for primitives (`-0` is stored as `+0`). That settles primitives and identical objects in O(1); structurally equal but distinct objects can only be found by comparing.
- Node's window (`partialObjectSetEquiv` / `partialObjectMapEquiv`): the leftover expected objects sit in an array with an open range and a direction bit. Since a matching actual entry usually arrives at one end of the range, node tries the end that hit last and falls back to a scan; a scan hit is replaced with the range's last entry and the range shrinks, so claimed entries are never compared again. The direction bit is state: an entry that misses everything flips it back to the front, which is why a stray member between the objects can change which pairing the walk finds, and why the Set walk (node probes strays) and the Map walk (node skips non-object keys) treat strays differently. `PendingEntries` is that array, range and bit.
- `gcBuffer` is the `MarkedArgumentBuffer` the whole comparison shares to keep every value it has copied out of a collection alive across the user code (getters) comparisons can run. The queued entries and the settled keys are appended to it; the window itself is a plain `WTF::Vector` and the reservation set holds raw cell pointers, neither of which the GC sees, which is what the GC test checks.

<details>
<summary>Earlier revisions</summary>

- The first push skipped stray Set members without recording the miss and classified Map keys with `isObject()`, which admits functions; review caught both (`new Set([{c:3,w:1}, 7, {a:1,b:2}, {b:2,y:1}])` against `new Set([{a:1}, {b:2}, {c:3}])` passes in node and on main but threw there). Fixed in 406614f with the stray-member cases.
- Through d3000dd the Map path queued keys both sides hold, for exact node parity. Self-review measured what that costs (a reordered identity-keyed Map of 10k entries: milliseconds on main and 1.3.14, seconds there) and pointed out the behaviour flip it caused; a81f038 restored the identity settle described above, added the reservation, moved the window into the header and added the GC test.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.0 (235f97c1e)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [63.27ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [4.63ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [69.95ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [13.15ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [8.08ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [4.57ms]
(pass) assert.deepStrictEqual > rejects '' and false [4.68ms]
(pass) assert.deepStrictEqual > rejects null and undefined [4.32ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [12.40ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [5.79ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [10.05ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [5.58ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [4.89ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [10.00ms]
(pass) assert.
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [1.15ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.07ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [1.27ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [0.25ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [0.10ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [0.05ms]
(pass) assert.deepStrictEqual > rejects '' and false [0.03ms]
(pass) assert.deepStrictEqual > rejects null and undefined [0.04ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [0.18ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [0.07ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [0.16ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [0.08ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [0.08ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [0.06ms]
(pass) assert.deepStrictEqual > accepts two boxed booleans [0.05ms]
(pass) assert.deepStrictEqual > accepts two boxed symbols [0.05ms]
(pass) assert.deepStrictEqual > accepts two boxe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.0 (235f97c1e)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [63.55ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [4.52ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [71.30ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [12.32ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [8.29ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [4.76ms]
(pass) assert.deepStrictEqual > rejects '' and false [4.19ms]
(pass) assert.deepStrictEqual > rejects null and undefined [4.72ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [11.83ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [5.74ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [10.24ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [5.09ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [4.87ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [10.05ms]
(pass) assert.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     235f97c1ed
  features     baseline

22 deps, 123 codegen, 1176 objects in 806ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [11.00ms]
[3/1238] gen bindgenv2
[4/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[7/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/PendingEntries.h       |  74 +++++++
 src/jsc/modules/NodeUtilTypesModule.cpp | 246 ++++++++++-----------
 test/js/node/assert/deep-equal.test.ts  | 364 ++++++++++++++++++++++++++++++++
 3 files changed, 546 insertions(+), 138 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/PendingEntries.h            0      2      0
src/jsc/modules/NodeUtilTypesModule.cpp     12     26      0
test/js/node/assert/deep-equal.test.ts       6     17      0
```

</details>

<!-- robobun:evidence:end -->