### PR TITLE
Blob: share a body part's store instead of moving it out of the caller's Blob

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2510,7 +2510,7 @@ where
                 }
 
                 if let Some(body__) = opts.fast_get(ctx, jsc::BuiltinName::Body)? {
-                    match Blob::get::<true, false>(ctx, body__) {
+                    match Blob::get::<false>(ctx, body__) {
                         Ok(new_blob) => body = BodyValue::Blob(new_blob),
                         Err(_) => {
                             return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4,11 +4,8 @@
 //! operations like writing `Store::File` to another `Store::File` knows to use a
 //! basic file copy instead of a naive read write loop.
 
-use core::cell::Cell;
 use core::ffi::{c_char, c_void};
 use core::ptr::NonNull;
-
-use bun_jsc::JsCell;
 
 use crate::webcore::jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsResult, VirtualMachine,
@@ -364,22 +361,13 @@ pub trait BlobExt {
         lifetime: Lifetime,
     ) -> JsResult<JSValue>;
     fn to_form_data(&self, global: &JSGlobalObject, _lifetime: Lifetime) -> JsResult<JSValue>;
-    fn get<const MOVE: bool, const REQUIRE_ARRAY: bool>(
-        global: &JSGlobalObject,
-        arg: JSValue,
-    ) -> JsResult<Blob>
+    /// `new Blob(parts)` semantics. With `REQUIRE_ARRAY = false` (body inits,
+    /// `Bun.write` sources) a bare part is accepted too. A part that is itself
+    /// a Blob shares its store; the source Blob is left untouched.
+    fn get<const REQUIRE_ARRAY: bool>(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob>
     where
         Self: Sized;
-    fn from_js_move(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob>
-    where
-        Self: Sized;
-    fn from_js_clone(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob>
-    where
-        Self: Sized;
-    fn from_js_clone_optional_array(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob>
-    where
-        Self: Sized;
-    fn from_js_without_defer_gc<const MOVE: bool, const REQUIRE_ARRAY: bool>(
+    fn from_js_without_defer_gc<const REQUIRE_ARRAY: bool>(
         global: &JSGlobalObject,
         arg: JSValue,
     ) -> JsResult<Blob>
@@ -2354,7 +2342,7 @@ impl BlobExt for Blob {
                 blob = Blob::init(Vec::new(), global_this);
             }
             _ => {
-                blob = Blob::get::<false, true>(global_this, args[0])?;
+                blob = Blob::get::<true>(global_this, args[0])?;
 
                 if args.len() > 1 {
                     let options = args[1];
@@ -3174,33 +3162,11 @@ impl BlobExt for Blob {
         Ok(unsafe { self.to_form_data_with_bytes::<{ Lifetime::Temporary }>(global, view_ptr) })
     }
     #[inline]
-    fn get<const MOVE: bool, const REQUIRE_ARRAY: bool>(
-        global: &JSGlobalObject,
-        arg: JSValue,
-    ) -> JsResult<Blob> {
-        match (MOVE, REQUIRE_ARRAY) {
-            (true, false) => Self::from_js_move(global, arg),
-            (false, false) => Self::from_js_clone_optional_array(global, arg),
-            (_, true) => Self::from_js_clone(global, arg),
-        }
+    fn get<const REQUIRE_ARRAY: bool>(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob> {
+        Self::from_js_without_defer_gc::<REQUIRE_ARRAY>(global, arg)
     }
 
-    #[inline]
-    fn from_js_move(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob> {
-        Self::from_js_without_defer_gc::<true, false>(global, arg)
-    }
-
-    #[inline]
-    fn from_js_clone(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob> {
-        Self::from_js_without_defer_gc::<false, true>(global, arg)
-    }
-
-    #[inline]
-    fn from_js_clone_optional_array(global: &JSGlobalObject, arg: JSValue) -> JsResult<Blob> {
-        Self::from_js_without_defer_gc::<false, false>(global, arg)
-    }
-
-    fn from_js_without_defer_gc<const MOVE: bool, const REQUIRE_ARRAY: bool>(
+    fn from_js_without_defer_gc<const REQUIRE_ARRAY: bool>(
         global: &JSGlobalObject,
         arg: JSValue,
     ) -> JsResult<Blob> {
@@ -3233,7 +3199,7 @@ impl BlobExt for Blob {
             }
         }
 
-        if might_only_be_one_thing || !MOVE {
+        if might_only_be_one_thing {
             // Fast path: one item, we don't need to join
             match top_value.js_type_loose() {
                 jsc::JSType::Cell
@@ -3263,47 +3229,11 @@ impl BlobExt for Blob {
 
                 jsc::JSType::DOMWrapper => {
                     if !fail_if_top_value_is_not_typed_array_like {
-                        if let Some(blob_ptr) = top_value.as_::<Blob>() {
-                            // SAFETY: live JS heap pointer; single-threaded JS execution.
-                            // Shared access only — Blob state is Cell/JsCell-based.
-                            let blob = unsafe { &*blob_ptr };
-                            if MOVE {
-                                // Move the store without bumping its refcount, but take
-                                // independent ownership of name/content_type so the
-                                // source's eventual finalize() doesn't double-free them.
-                                // *Take* the StoreRef out of `blob`
-                                // (no clone, no into_raw leak) and field-copy the
-                                // rest, deep-owning `name`/`content_type` — net 0 on
-                                // the store refcount.
-                                let _blob = Blob {
-                                    reported_estimated_size: Cell::new(
-                                        blob.reported_estimated_size.get(),
-                                    ),
-                                    size: Cell::new(blob.size.get()),
-                                    offset: Cell::new(blob.offset.get()),
-                                    store: JsCell::new(blob.take_store()), // ← the move
-                                    content_type: JsCell::new(blob.content_type.get().clone()),
-                                    content_type_was_set: Cell::new(
-                                        blob.content_type_was_set.get(),
-                                    ),
-                                    charset: Cell::new(blob.charset.get()),
-                                    is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
-                                    ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
-                                    global_this: Cell::new(blob.global_this.get()),
-                                    last_modified: Cell::new(blob.last_modified.get()),
-                                    name: blob.name.clone(),
-                                };
-                                return Ok(_blob);
-                            } else {
-                                return Ok(blob.dupe());
-                            }
+                        if let Some(blob) = top_value.as_class_ref::<Blob>() {
+                            return Ok(blob.dupe());
                         } else if let Some(artifact) =
                             top_value.as_class_ref::<crate::api::BuildArtifact>()
                         {
-                            // The previous "move" path here only nulled the store on a
-                            // local copy and left `build.blob` fully intact, so it was
-                            // never a real move. Share the store and deep-copy owned
-                            // buffers instead — regardless of `MOVE`.
                             return Ok(artifact.blob.dupe());
                         } else {
                             // Dispatch on the `ZigStringSlice` variant to detect an
@@ -5201,7 +5131,7 @@ pub(crate) fn write_file_internal(
             break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
         }
 
-        break 'brk Blob::get::<false, false>(global_this, data)?;
+        break 'brk Blob::get::<false>(global_this, data)?;
     };
     // Detach the source blob on scope exit.
     let mut source_blob = scopeguard::guard(source_blob, |b| b.detach());
@@ -5539,11 +5469,11 @@ pub(crate) fn jsdom_file_construct(
         // copies bytes (`to_owned_slice`) or takes its own ref (`dupe_ref`).
         let name_value_str = OwnedString::new(BunString::from_js(args[1], global_this)?);
 
-        blob = Blob::get::<false, true>(global_this, args[0])?;
+        blob = Blob::get::<true>(global_this, args[0])?;
         if let Some(store_) = blob.store.get() {
             match store_.data_mut() {
                 store::Data::Bytes(bytes) => {
-                    // `get::<_, true>` on a single-Blob sequence returns
+                    // `get::<true>` on a single-Blob sequence returns
                     // `dupe()` (a shared StoreRef), so this `Bytes` may already
                     // carry an owned `stored_name` from the source blob; the
                     // assignment drops (frees) the previous `Box<[u8]>`.

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1050,7 +1050,7 @@ impl Value {
             ));
         }
 
-        let blob = match Blob::get::<true, false>(global_this, value) {
+        let blob = match Blob::get::<false>(global_this, value) {
             Ok(b) => b,
             Err(_err) => {
                 if !global_this.has_exception() {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,7 +1,8 @@
 import { file, spawn, version } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, exampleSite } from "harness";
+import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
+import { join } from "path";
 
 const exampleServer = exampleSite("http");
 
@@ -141,6 +142,55 @@ for (const { body, fn } of bodyTypes) {
             expect(await fn(actual).blob()).toStrictEqual(actual);
           });
         }
+      });
+      // Bun also accepts an array of blob parts as a body. A Blob part has to be
+      // shared with the body, not moved out of the caller's Blob.
+      describe("array containing a Blob", () => {
+        test("the Blob still reads back its bytes after being used as a body part", async () => {
+          const blob = new Blob(["hello world"], { type: "text/plain" });
+          const actual = fn([blob] as any);
+          expect(actual.headers.get("content-type")).toBe(blob.type);
+          expect(await actual.text()).toBe("hello world");
+          expect(blob.size).toBe(11);
+          expect(await blob.text()).toBe("hello world");
+          expect(await blob.slice(6).text()).toBe("world");
+        });
+        test("the same Blob can back several bodies", async () => {
+          const blob = new Blob(["hello world"]);
+          const first = fn([blob] as any);
+          const second = fn([blob] as any);
+          expect(await Promise.all([first.text(), second.text(), blob.text()])).toEqual([
+            "hello world",
+            "hello world",
+            "hello world",
+          ]);
+        });
+        test("a File keeps its name and bytes", async () => {
+          const f = new File(["file bytes"], "part.txt");
+          // f.name is read only after the body was built: a byte-backed File
+          // keeps its name in the store, so losing the store loses the name too.
+          expect(await fn([f] as any).text()).toBe("file bytes");
+          expect({ name: f.name, size: f.size, text: await f.text() }).toEqual({
+            name: "part.txt",
+            size: 10,
+            text: "file bytes",
+          });
+        });
+        test("a Bun.file() stays readable", async () => {
+          using dir = tempDir("body-array-bun-file", { "data.txt": "from disk" });
+          const f = file(join(String(dir), "data.txt"));
+          expect(await fn([f] as any).text()).toBe("from disk");
+          expect(await f.text()).toBe("from disk");
+        });
+        test("a BuildArtifact stays readable", async () => {
+          using dir = tempDir("body-array-build-artifact", { "entry.js": `console.log("artifact-body-marker");` });
+          const { outputs } = await Bun.build({ entrypoints: [join(String(dir), "entry.js")] });
+          const [artifact] = outputs;
+          const expected = await artifact.text();
+          expect(expected).toContain("artifact-body-marker");
+          expect(await fn([artifact] as any).text()).toBe(expected);
+          expect(await artifact.text()).toBe(expected);
+        });
       });
       describe("FormData", () => {
         const forms = [
@@ -1259,5 +1309,25 @@ describe("constructing a body from an unusable ReadableStream", () => {
     rs.getReader();
     expect(() => new Response(rs)).toThrow(TypeError);
     expect(() => new Request("http://example.com/", { method: "POST", body: rs, duplex: "half" })).toThrow(TypeError);
+  });
+});
+
+// server.fetch() builds the Request body through the same blob-part extraction
+// as the constructors above, without going through new Request().
+describe("server.fetch() body option", () => {
+  test.each([
+    ["a Blob", (blob: Blob) => blob],
+    ["an array containing a Blob", (blob: Blob) => [blob]],
+  ])("%s is shared with the request, not moved out of the caller's Blob", async (_, body) => {
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        return new Response(await req.text());
+      },
+    });
+    const blob = new Blob(["hello world"]);
+    const response = await server.fetch(String(server.url), { method: "POST", body: body(blob) as any });
+    expect(await response.text()).toBe("hello world");
+    expect(await blob.text()).toBe("hello world");
   });
 });


### PR DESCRIPTION
### Problem
- Passing a Blob as a body part empties the caller's Blob: after `new Response([blob])` the response reads `"hello world"` but `blob.text()` resolves to `""` while `blob.size` still reports 11.
- Same for `new Request(url, { body: [blob] })`, and for `server.fetch(url, { body: blob })` even without the array (that path calls the helper directly). A `File` part additionally loses its `name`, and a `Bun.file()` or `BuildArtifact` part reads back empty afterwards.
- Cause: `Body::Value::from_js` (src/runtime/webcore/Body.rs:1053) and `Server::on_fetch` (src/runtime/server/server_body.rs:2513) called `Blob::get::<MOVE = true, ..>`. In the single-Blob-part fast path of `from_js_without_defer_gc` (src/runtime/webcore/Blob.rs, `JSType::DOMWrapper` arm) `MOVE` built the body blob with `store: blob.take_store()`, which takes the store out of the JS-visible Blob the user still holds. The non-`MOVE` arm and the direct `new Response(blob)` path (Body.rs:991) share the store with `dupe()` instead.
- `as_::<Blob>()` also matches a `BuildArtifact` (it returns the artifact's inner blob), which is why artifacts were affected too.

### Fix
- The fast-path arm now returns `blob.dupe()` unconditionally (the one behavioral change in the diff). `dupe()` creates a new view on the same refcounted store, so the body is still zero-copy; the only difference from the removed field copy is the extra store reference, which is exactly what keeps the caller's Blob valid.
- Correct because a JS-visible Blob owns its store reference for as long as its wrapper is alive: every other place that derives a Blob from a JS Blob (`new Blob([blob])`, `new Response(blob)`, `Bun.write(dst, [blob])`, `blob.slice()`) takes its own reference, and Node/the spec never modify a Blob used as a body (Node stringifies the array to `"[object Blob]"` and leaves the Blob intact; Bun keeps its array-of-parts extension, it just stops mutating the part).
- With no caller moving any more, the `MOVE` const generic and the `from_js_move` / `from_js_clone` / `from_js_clone_optional_array` wrappers it selected between are dead and are deleted; `get` now takes only `REQUIRE_ARRAY`. The `might_only_be_one_thing || !MOVE` condition becomes `might_only_be_one_thing`: for a multi-part array the fast-path block matched nothing and fell through, so this is behavior preserving. The now unused `Cell` / `JsCell` imports go with it.
- Tests: test/js/web/fetch/body.test.ts, `array containing a Blob` (run for both Request and Response: plain Blob, the same Blob backing two bodies, File name + bytes, Bun.file(), BuildArtifact) and `server.fetch() body option` (bare Blob and `[blob]`). All 12 fail on the unfixed build (`USE_SYSTEM_BUN=1`) with the source reading back `""` (and `name: undefined` for the File), and pass with `bun bd test`.
- The rest of body.test.ts, blob.test.ts, blob-array-fast-path.test.ts, blob-file-name-ownership.test.ts, blob-write.test.ts, blob-cow.test.ts, FormData.test.ts, structured-clone-blob-file.test.ts and response.test.ts pass with the debug build (response.test.ts `handle stack overflow` times out locally under the debug build independently of this change).

### Background
- A `Blob` in bun is a small view (`offset`, `size`, metadata) onto a `Store`, the refcounted owner of the bytes (or of the file path / S3 key for `Bun.file()` / S3 blobs). Several Blobs can view one store; `blob.dupe()` makes another view and bumps the store's refcount, `take_store()` removes a Blob's view without touching the refcount, leaving that Blob with no store at all. A Blob without a store reads as empty but keeps its cached `size`, which is the `11` / `""` mismatch above.
- `Blob::get::<REQUIRE_ARRAY>` is the shared "blob parts to Blob" routine behind `new Blob(parts)` / `new File(parts, name)` (`REQUIRE_ARRAY = true`) and behind body inits and `Bun.write()` sources (`false`, a bare part is accepted as well). When the input is a single Blob part it takes a fast path that reuses the part's store instead of copying bytes; that fast path is the code changed here.
- Array bodies (`new Response([...])`) are a bun extension: the fetch spec would stringify the array. That extension is unchanged by this PR.

<details>
<summary>Repro and outputs</summary>

```js
const b = new Blob(["hello world"]);
const r = new Response([b]);
console.log(JSON.stringify(await r.text()), "|", b.size, JSON.stringify(await b.text()));
```

```
node v26.3.0:        "[object Blob]" | 11 "hello world"
bun 1.4.0 (before):  "hello world"   | 11 ""
this branch:         "hello world"   | 11 "hello world"
```

Other entry points on bun 1.4.0, all fixed by this branch:

```
Request body:[b]            -> b.text() === ""
server.fetch({ body: b })   -> b.text() === ""          (no array needed)
server.fetch({ body: [b] }) -> b.text() === ""
Response([file])            -> file.text() === "", file.name === undefined
Response([Bun.file(p)])     -> later Bun.file reads return ""
Response([buildArtifact])   -> artifact.text() === ""
Response([b]); Response([b])-> second response body is "" as well
```

</details>
