### PR TITLE
node emulation: keep the first positional in process.argv for node -e / -p

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2900,19 +2900,11 @@ impl RunCommand {
             return Self::exec_node_repl(ctx);
         }
 
+        // `Arguments::parse` stops at the first positional for this command
+        // too, so `node -e code a b` arrives as positionals=["a"],
+        // passthrough=["b"]; `exec_eval` folds both into `process.argv`.
         if !ctx.runtime_options.eval.script.is_empty() {
-            // synthetic `[eval]` path under cwd
-            let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
-            let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-            let cwd_bytes = cwd.as_bytes();
-            let cwd_len = cwd_bytes.len();
-            entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
-            entry_point_buf[cwd_len..cwd_len + EVAL_TRIGGER.len()].copy_from_slice(EVAL_TRIGGER);
-            let entry: Box<[u8]> = entry_point_buf[..cwd_len + EVAL_TRIGGER.len()]
-                .to_vec()
-                .into_boxed_slice();
-            return Self::boot(ctx, entry, None);
+            return Self::exec_eval(ctx);
         }
 
         if ctx.positionals.is_empty() {

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -97,6 +97,22 @@ describe("fake node cli", () => {
     );
   });
 
+  // Like node, `-e`/`-p` take no script positional: everything after the
+  // code is process.argv (the first of them used to be dropped).
+  const argvExpr = "JSON.stringify(process.argv.slice(1))";
+  const logArgv = `console.log(${argvExpr})`;
+  test.each([
+    { args: ["-e", logArgv, "a", "b"], argv: ["a", "b"] },
+    { args: ["-e", logArgv, "a"], argv: ["a"] },
+    { args: ["-e", logArgv, "a", "--flag", "b"], argv: ["a", "--flag", "b"] },
+    { args: ["-e", logArgv], argv: [] },
+    { args: ["-p", argvExpr, "a", "b"], argv: ["a", "b"] },
+    { args: ["-pe", argvExpr, "a", "b"], argv: ["a", "b"] },
+  ])("node $args passes every positional through process.argv", ({ args, argv }) => {
+    using temp = tempDir("fake-node", {});
+    expect(JSON.parse(fakeNodeRun(temp, args).stdout)).toEqual(argv);
+  });
+
   // Bare `node` now matches Node.js: a TTY stdin enters the REPL, a
   // non-TTY stdin (pipe) prints "Missing script". fakeNodeRun's default
   // stdin is platform-dependent (Windows may inherit a console), so pin


### PR DESCRIPTION
### Problem
- When bun runs as `node` (the `node` symlink bun installs, `bun --bun node ...`, or anything that spawns bun with `argv0 = node`), `-e` / `-p` / `-pe` drop the first argument after the code from `process.argv`:
  ```
  $ bun --bun node -e 'console.log(JSON.stringify(process.argv.slice(1)))' a b
  ["b"]
  $ node -e 'console.log(JSON.stringify(process.argv.slice(1)))' a b        # node v26.3.0
  ["a","b"]
  $ bun -e 'console.log(JSON.stringify(process.argv.slice(1)))' a b         # plain bun is already right
  ["a","b"]
  ```
  With a single argument (`node -e code a`) it is lost entirely and `process.argv.slice(1)` is `[]`.
- Cause: `Arguments::parse` parses `RunAsNodeCommand` with `stop_after_positional_at: 1` (`src/runtime/cli/Arguments.rs:786`, same as `AutoCommand`), so `node -e code a b` arrives as `ctx.positionals = ["a"]`, `ctx.passthrough = ["b"]`. The `-e` branch of `RunCommand::exec_as_if_node` (`src/runtime/cli/run_command.rs:2903`) built the synthetic `cwd/[eval]` entry and called `boot()` directly, and `boot()` only hands `ctx.passthrough` to `vm.argv` (`run_command.rs:966`). `positionals[0]` was never copied over.
- `bun -e` does not have the bug because `Command::exec_auto_or_run` routes it through `RunCommand::exec_eval` (`run_command.rs:2859`), which prepends `positionals` onto `passthrough` before booting. The `bun -e` form of this bug was #12209 (closed); the `exec_as_if_node` branch was a copy of `exec_eval` minus that step (the pre-port Zig `execAsIfNode` had the same shape, so this is not a regression).

### Fix
- `exec_as_if_node`'s `-e`/`-p` branch now calls `Self::exec_eval(ctx)` instead of re-implementing it; the fixing line is the `return Self::exec_eval(ctx);` hunk, the rest of the diff is the deleted copy.
- Correct because `-e`/`-p` never take a script positional, so under node everything after the code is `process.argv` (output above); `exec_eval` is the one place that already encodes that for the `bun -e` path, and the two commands split argv identically (`stop_after_positional_at: 1`), so the node path needs the identical merge. The `[eval]` entry path and `boot()` call are unchanged, `exec_eval` builds the same ones.
- No-argument `node -e code` is unaffected: `exec_eval` skips the merge when `positionals` is empty. `node --interactive -e code` is unaffected: it is routed to `exec_node_repl` before this branch, as before.
- Verified: `test/cli/run/as-node.test.ts` gains a `test.each` covering `-e` with one, two, and flag-like arguments, `-e` with none, `-p`, and `-pe`. With the released bun (`USE_SYSTEM_BUN=1`) the five cases with arguments fail (each receives the list minus its first entry); with this build all 17 tests in the file pass.
- Also run against this build: `test/cli/run/run-eval.test.ts` (37 pass, covers the shared `exec_eval` path for `bun -e`), the `bun-as-node` tests in `test/js/bun/repl/repl.test.ts`, and the `argv0=node` tests in `test/cli/run/env.test.ts`.

### Background
- Node emulation: `Command::which` (`src/runtime/cli/mod.rs`) dispatches to `RunAsNodeCommand` when `argv[0]` is `node`; `RunCommand::exec_as_if_node` is that command's body. It is how `bun --bun` makes child processes that exec `node` run under bun.
- `positionals` vs `passthrough`: the CLI parser collects non-flag arguments into `ctx.positionals` until it has seen `stop_after_positional_at` of them; everything after that point, flags included, is left unparsed in `ctx.passthrough`. For the run-like commands the limit is 1 so that flags after the script name belong to the script. `boot()` installs `ctx.passthrough` as `vm.argv`, which becomes `process.argv` after the executable path.
- `[eval]`: `-e` code has no file, so bun boots the VM with a synthetic `<cwd>/[eval]` entry path, and the module loader serves `ctx.runtime_options.eval.script` for that path.

### Related, not changed here
Other node-CLI shapes in the same `exec_as_if_node` / argv area, each already owned by its own open issue or PR, so this PR stays one hunk:
- `node -` reading the script from stdin: #38566. Bare `node` with piped stdin, and `--port` being remapped to `--print` in node mode, are also filed separately.
- A `--` among the user arguments being stripped from `process.argv` (`bun file.js -- x` and `node -e code a -- x` both lose the `--`, node keeps it): #13984 / #36684. `process.execArgv` not stopping at `-` / `--`: #25387 / #38577.
- `node -v` / `--version` in the shim: #36128. `--check` and the wider node v26 CLI compatibility work: #32622.
