### PR TITLE
audit: fail closed on malformed registry responses and escape control characters in the report

### DIFF
--- a/docs/pm/cli/audit.mdx
+++ b/docs/pm/cli/audit.mdx
@@ -58,3 +58,5 @@ bun audit --json
 ### Exit code
 
 `bun audit` exits with code `0` if no vulnerabilities are found and `1` if the report lists any, including when `--json` is passed.
+
+It also exits with code `1`, after printing an error, when the registry's response is not an advisory report (for example, a registry or proxy that answers the audit request with an HTML page or an error object). A response that cannot be read never counts as a clean audit.

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3325,6 +3325,57 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
     write_bytes(writer, remain)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// escapeControlChars
+// ───────────────────────────────────────────────────────────────────────────
+
+pub struct EscapeControlChars<'a>(pub(crate) &'a [u8]);
+
+/// For text that came over the network (registry metadata, advisory titles)
+/// and is about to be printed on a terminal. Control characters are written
+/// as `\n` / `\u001b` escapes, so the text can neither emit escape sequences
+/// nor overwrite or forge lines of the surrounding report. Escaped: C0
+/// (`0x00..=0x1F`), DEL, and C1 (U+0080..=U+009F, UTF-8 `C2 80..=C2 9F`),
+/// which terminals such as xterm also accept as CSI/OSC introducers.
+/// Everything else, including invalid UTF-8, is printed as [`bstr::BStr`]
+/// prints it.
+pub fn escape_control_chars(text: &[u8]) -> EscapeControlChars<'_> {
+    EscapeControlChars(text)
+}
+
+impl Display for EscapeControlChars<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let text = self.0;
+        let mut run_start = 0;
+        let mut i = 0;
+        while i < text.len() {
+            let (code_point, len) = match text[i] {
+                byte @ (0x00..=0x1F | 0x7F) => (byte as u16, 1),
+                0xC2 if matches!(text.get(i + 1), Some(0x80..=0x9F)) => (text[i + 1] as u16, 2),
+                _ => {
+                    i += 1;
+                    continue;
+                }
+            };
+            write!(f, "{}", bstr::BStr::new(&text[run_start..i]))?;
+            match code_point {
+                0x08 => f.write_str("\\b")?,
+                0x09 => f.write_str("\\t")?,
+                0x0A => f.write_str("\\n")?,
+                0x0C => f.write_str("\\f")?,
+                0x0D => f.write_str("\\r")?,
+                _ => {
+                    f.write_str("\\u")?;
+                    write_bytes(f, &hex_u16::<true>(code_point))?;
+                }
+            }
+            i += len;
+            run_start = i;
+        }
+        write!(f, "{}", bstr::BStr::new(&text[run_start..]))
+    }
+}
+
 // js_bindings (fmtString for highlighter.test.ts) lives in src/jsc/fmt_jsc.rs
 // alongside fmt_jsc.bind.ts; bun_core/ stays JSC-free.
 

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 
 use bun_ast::{ExprData, e as E};
 use bun_collections::{StringArrayHashMap, StringHashMap};
+use bun_core::fmt::escape_control_chars;
 use bun_core::{Global, Output, pretty, prettyln};
 use bun_core::{MutableString, strings};
 use bun_http::{self as http, HeaderBuilder};
@@ -101,9 +102,8 @@ impl AuditCommand {
         Global::exit(code);
     }
 
-    /// Returns the exit code of the command. 0 if no vulnerabilities were found, 1 if vulnerabilities were found.
-    /// The exception is when you pass --json, it will simply return 0 as that was considered a successful "request
-    /// for the audit information"
+    /// Returns the exit code of the command: 0 when the registry reported no vulnerabilities, 1 when
+    /// it reported some (with `--json` too) or when its response was not an advisory report at all.
     fn audit(
         _ctx: Command::Context,
         pm: &mut PackageManager,
@@ -130,59 +130,76 @@ impl AuditCommand {
 
         let packages_result = collect_packages_for_audit(pm, audit_prod_only)?;
 
-        let response_text = send_audit_request(pm, &packages_result.audit_body)?;
+        let mut audit_url: Vec<u8> = Vec::new();
+        write!(
+            &mut audit_url,
+            "{}/-/npm/v1/security/advisories/bulk",
+            BStr::new(strings::without_trailing_slash(pm.options.scope.url.href()))
+        )
+        .expect("unreachable");
+
+        let response_text = send_audit_request(pm, &audit_url, &packages_result.audit_body)?;
+
+        let source = bun_ast::Source::init_path_string(b"audit-response.json", &response_text[..]);
+        let mut log = bun_ast::Log::init();
+        let Ok(parsed) = bun_json::ParsedJson::parse_json(&source, &mut log) else {
+            return Ok(reject_response(&audit_url, "JSON"));
+        };
 
         if json_output {
             let _ = Output::writer().write_all(&response_text);
             let _ = Output::writer().write_all(b"\n");
+        }
 
-            if !response_text.is_empty() {
-                let source =
-                    bun_ast::Source::init_path_string(b"audit-response.json", &response_text[..]);
-                let mut log = bun_ast::Log::init();
+        let Some(advisories) = bulk_advisories(&parsed.root) else {
+            return Ok(reject_response(&audit_url, "a list of advisories"));
+        };
 
-                let parsed = match bun_json::ParsedJson::parse_json(&source, &mut log) {
-                    Ok(e) => e,
-                    Err(_) => {
-                        bun_core::pretty_errorln!(
-                            "<red>error<r>: audit request failed to parse json. Is the registry down?"
-                        );
-                        return Ok(1); // If we can't parse then safe to assume a similar failure
-                    }
-                };
+        if json_output {
+            return Ok(u32::from(!advisories.is_empty()));
+        }
 
-                // If the response is an empty object, no vulnerabilities
-                if let ExprData::EObjectJSON(obj) = &parsed.root.data {
-                    if obj.get().properties().is_empty() {
-                        return Ok(0);
-                    }
-                }
+        let exit_code = print_enhanced_audit_report(
+            &advisories,
+            pm,
+            &dependency_tree,
+            audit_level,
+            ignore_list,
+        )?;
 
-                // If there's any content in the response, there are vulnerabilities
-                return Ok(1);
-            }
+        print_skipped_packages(&packages_result.skipped_packages);
 
-            return Ok(0);
-        } else if !response_text.is_empty() {
-            let exit_code = print_enhanced_audit_report(
-                &response_text,
-                pm,
-                &dependency_tree,
-                audit_level,
-                ignore_list,
-            )?;
+        Ok(exit_code)
+    }
+}
 
-            print_skipped_packages(&packages_result.skipped_packages);
+/// The bulk advisory endpoint answers `{ [package name]: Advisory[] }`; this flattens that into
+/// `(package name, advisory)` pairs. `None` for a document of any other shape (an HTML error page,
+/// a mirror's `{"error": ...}`, ...), which must not pass for a clean audit.
+fn bulk_advisories(root: &bun_ast::Expr) -> Option<Vec<(&[u8], &E::ObjectJSON)>> {
+    let ExprData::EObjectJSON(report) = &root.data else {
+        return None;
+    };
 
-            return Ok(exit_code);
-        } else {
-            prettyln!("<green>No vulnerabilities found<r>");
-
-            print_skipped_packages(&packages_result.skipped_packages);
-
-            return Ok(0);
+    let mut advisories = Vec::new();
+    for package in report.get().properties() {
+        for advisory in package.value.as_array()?.items() {
+            advisories.push((package.key.slice(), advisory.as_object()?));
         }
     }
+
+    Some(advisories)
+}
+
+/// Exit code for a response that is not an advisory report. Only the URL is named: the body is
+/// whatever a proxy, captive portal or audit-less mirror sent, and never goes to the terminal raw.
+fn reject_response(audit_url: &[u8], expected: &str) -> u32 {
+    bun_core::pretty_errorln!(
+        "<red>error<r>: audit request to {} failed: response is not {}",
+        bun_core::fmt::redacted_npm_url(audit_url),
+        expected
+    );
+    1
 }
 
 fn print_skipped_packages(skipped_packages: &[Box<[u8]>]) {
@@ -192,7 +209,7 @@ fn print_skipped_packages(skipped_packages: &[Box<[u8]>]) {
             if i > 0 {
                 pretty!(", ");
             }
-            pretty!("{}", BStr::new(package_name));
+            pretty!("{}", escape_control_chars(package_name));
         }
 
         if skipped_packages.len() > 1 {
@@ -426,6 +443,7 @@ fn collect_packages_for_audit(
 
 fn send_audit_request(
     pm: &mut PackageManager,
+    audit_url: &[u8],
     body: &[u8],
 ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
     libdeflate::load();
@@ -464,14 +482,7 @@ fn send_audit_request(
         );
     }
 
-    let mut url_str: Vec<u8> = Vec::new();
-    write!(
-        &mut url_str,
-        "{}/-/npm/v1/security/advisories/bulk",
-        BStr::new(strings::without_trailing_slash(pm.options.scope.url.href()))
-    )
-    .expect("unreachable");
-    let url = URL::parse(&url_str);
+    let url = URL::parse(audit_url);
 
     let http_proxy = pm.http_proxy(&url);
 
@@ -723,259 +734,222 @@ struct VulnCounts {
 }
 
 fn print_enhanced_audit_report(
-    response_text: &[u8],
+    advisories: &[(&[u8], &E::ObjectJSON)],
     pm: &mut PackageManager,
     dependency_tree: &StringHashMap<Vec<Box<[u8]>>>,
     audit_level: Option<AuditLevel>,
     ignore_list: &[&[u8]],
 ) -> Result<u32, bun_alloc::AllocError> {
-    let source = bun_ast::Source::init_path_string(b"audit-response.json", response_text);
-    let mut log = bun_ast::Log::init();
-
-    let parsed = match bun_json::ParsedJson::parse_json(&source, &mut log) {
-        Ok(e) => e,
-        Err(_) => {
-            let _ = Output::writer().write_all(response_text);
-            let _ = Output::writer().write_all(b"\n");
-            return Ok(1);
-        }
-    };
-    let expr = parsed.root;
-
-    if let ExprData::EObjectJSON(obj) = &expr.data {
-        if obj.get().properties().is_empty() {
-            prettyln!("<green>No vulnerabilities found<r>");
-            return Ok(0);
-        }
-    }
-
     let mut audit_result = AuditResult::init();
 
     let mut vuln_counts = VulnCounts::default();
 
-    if let ExprData::EObjectJSON(obj) = &expr.data {
-        for prop in obj.get().properties() {
-            let package_name: &[u8] = prop.key.slice();
+    for &(package_name, advisory) in advisories {
+        let vulnerability = parse_vulnerability(package_name, advisory)?;
 
-            if let Some(arr) = prop.value.as_array() {
-                for vuln in arr.items() {
-                    if let Some(vuln_obj) = vuln.as_object() {
-                        let vulnerability = parse_vulnerability(package_name, vuln_obj)?;
-
-                        if let Some(level) = audit_level {
-                            if !level.should_include_severity(&vulnerability.severity) {
-                                continue;
-                            }
-                        }
-
-                        if !ignore_list.is_empty() {
-                            let mut should_ignore = false;
-                            for ignored_cve in ignore_list {
-                                if strings::eql(&vulnerability.id, ignored_cve)
-                                    || strings::index_of(&vulnerability.url, ignored_cve).is_some()
-                                {
-                                    should_ignore = true;
-                                    break;
-                                }
-                            }
-                            if should_ignore {
-                                continue;
-                            }
-                        }
-
-                        if vulnerability.severity.as_ref() == b"low" {
-                            vuln_counts.low += 1;
-                        } else if vulnerability.severity.as_ref() == b"moderate" {
-                            vuln_counts.moderate += 1;
-                        } else if vulnerability.severity.as_ref() == b"high" {
-                            vuln_counts.high += 1;
-                        } else if vulnerability.severity.as_ref() == b"critical" {
-                            vuln_counts.critical += 1;
-                        } else {
-                            vuln_counts.moderate += 1;
-                        }
-
-                        audit_result.all_vulnerabilities.push(vulnerability);
-                    }
-                }
+        if let Some(level) = audit_level {
+            if !level.should_include_severity(&vulnerability.severity) {
+                continue;
             }
         }
 
-        for vulnerability in &audit_result.all_vulnerabilities {
-            let paths = find_dependency_paths(&vulnerability.package_name, dependency_tree, pm)?;
-
-            let result = audit_result
-                .vulnerable_packages
-                .get_or_put(&vulnerability.package_name)?;
-            if !result.found_existing {
-                *result.value_ptr = PackageInfo {
-                    vulnerabilities: Vec::new(),
-                    dependents: paths,
-                };
+        if !ignore_list.is_empty() {
+            let mut should_ignore = false;
+            for ignored_cve in ignore_list {
+                if strings::eql(&vulnerability.id, ignored_cve)
+                    || strings::index_of(&vulnerability.url, ignored_cve).is_some()
+                {
+                    should_ignore = true;
+                    break;
+                }
             }
-            result.value_ptr.vulnerabilities.push(VulnerabilityInfo {
-                severity: vulnerability.severity.clone(),
-                title: vulnerability.title.clone(),
-                url: vulnerability.url.clone(),
-                vulnerable_versions: vulnerability.vulnerable_versions.clone(),
-                id: vulnerability.id.clone(),
-                package_name: vulnerability.package_name.clone(),
-            });
-        }
-
-        for (_, package_info) in audit_result.vulnerable_packages.iter() {
-            if !package_info.vulnerabilities.is_empty() {
-                let main_vuln = &package_info.vulnerabilities[0];
-
-                // const is_direct_dependency: bool = brk: {
-                //     for (package_info.dependents.items) |path| {
-                //         if (path.is_direct) {
-                //             break :brk true;
-                //         }
-                //     }
-                //
-                //     break :brk false;
-                // };
-
-                if !main_vuln.vulnerable_versions.is_empty() {
-                    prettyln!(
-                        "<red>{}<r>  {}",
-                        BStr::new(&main_vuln.package_name),
-                        BStr::new(&main_vuln.vulnerable_versions)
-                    );
-                } else {
-                    prettyln!("<red>{}<r>", BStr::new(&main_vuln.package_name));
-                }
-
-                for path in &package_info.dependents {
-                    if path.path.len() > 1 {
-                        if path.path[0].starts_with(b"workspace:") {
-                            let vulnerable_pkg = &path.path[path.path.len() - 1];
-                            let workspace_part = &path.path[0];
-
-                            prettyln!(
-                                "  <d>{} › <red>{}<r>",
-                                BStr::new(workspace_part),
-                                BStr::new(vulnerable_pkg)
-                            );
-                        } else {
-                            let vulnerable_pkg = &path.path[0];
-
-                            let mut reversed_items: Vec<&[u8]> = Vec::new();
-                            for item in &path.path[1..] {
-                                reversed_items.push(item);
-                            }
-                            reversed_items.reverse();
-
-                            let mut vuln_pkg_path: Vec<u8> = Vec::new();
-                            for (i, item) in reversed_items.iter().enumerate() {
-                                if i > 0 {
-                                    vuln_pkg_path.extend_from_slice(" › ".as_bytes());
-                                }
-                                vuln_pkg_path.extend_from_slice(item);
-                            }
-
-                            prettyln!(
-                                "  <d>{} › <red>{}<r>",
-                                BStr::new(&vuln_pkg_path),
-                                BStr::new(vulnerable_pkg)
-                            );
-                        }
-                    } else {
-                        prettyln!("  <d>(direct dependency)<r>");
-                    }
-                }
-
-                for vuln in &package_info.vulnerabilities {
-                    if !vuln.title.is_empty() {
-                        if vuln.severity.as_ref() == b"critical" {
-                            prettyln!(
-                                "  <red>critical<d>:<r> {} - <d>{}<r>",
-                                BStr::new(&vuln.title),
-                                BStr::new(&vuln.url)
-                            );
-                        } else if vuln.severity.as_ref() == b"high" {
-                            prettyln!(
-                                "  <red>high<d>:<r> {} - <d>{}<r>",
-                                BStr::new(&vuln.title),
-                                BStr::new(&vuln.url)
-                            );
-                        } else if vuln.severity.as_ref() == b"moderate" {
-                            prettyln!(
-                                "  <yellow>moderate<d>:<r> {} - <d>{}<r>",
-                                BStr::new(&vuln.title),
-                                BStr::new(&vuln.url)
-                            );
-                        } else {
-                            prettyln!(
-                                "  <cyan>low<d>:<r> {} - <d>{}<r>",
-                                BStr::new(&vuln.title),
-                                BStr::new(&vuln.url)
-                            );
-                        }
-                    }
-                }
-
-                // if (is_direct_dependency) {
-                //     Output.prettyln("  To fix: <green>`bun update {s}`<r>", .{package_info.name});
-                // } else {
-                //     Output.prettyln("  To fix: <green>`bun update --latest`<r><d> (may be a breaking change)<r>", .{});
-                // }
-
-                prettyln!("");
+            if should_ignore {
+                continue;
             }
         }
 
-        let total =
-            vuln_counts.low + vuln_counts.moderate + vuln_counts.high + vuln_counts.critical;
-        if total > 0 {
-            pretty!("<b>{} vulnerabilities<r> (", total);
-
-            let mut has_previous = false;
-            if vuln_counts.critical > 0 {
-                pretty!("<red><b>{} critical<r>", vuln_counts.critical);
-                has_previous = true;
-            }
-            if vuln_counts.high > 0 {
-                if has_previous {
-                    pretty!(", ");
-                }
-                pretty!("<red>{} high<r>", vuln_counts.high);
-                has_previous = true;
-            }
-            if vuln_counts.moderate > 0 {
-                if has_previous {
-                    pretty!(", ");
-                }
-                pretty!("<yellow>{} moderate<r>", vuln_counts.moderate);
-                has_previous = true;
-            }
-            if vuln_counts.low > 0 {
-                if has_previous {
-                    pretty!(", ");
-                }
-                pretty!("<cyan>{} low<r>", vuln_counts.low);
-            }
-            prettyln!(")");
-
-            prettyln!("");
-            prettyln!("To update all dependencies to the latest compatible versions:");
-            prettyln!("  <green>bun update<r>");
-            prettyln!("");
-            prettyln!(
-                "To update all dependencies to the latest versions (including breaking changes):"
-            );
-            prettyln!("  <green>bun update --latest<r>");
-            prettyln!("");
+        if vulnerability.severity.as_ref() == b"low" {
+            vuln_counts.low += 1;
+        } else if vulnerability.severity.as_ref() == b"moderate" {
+            vuln_counts.moderate += 1;
+        } else if vulnerability.severity.as_ref() == b"high" {
+            vuln_counts.high += 1;
+        } else if vulnerability.severity.as_ref() == b"critical" {
+            vuln_counts.critical += 1;
+        } else {
+            vuln_counts.moderate += 1;
         }
 
-        if total > 0 {
-            return Ok(1);
-        }
-    } else {
-        let _ = Output::writer().write_all(response_text);
-        let _ = Output::writer().write_all(b"\n");
+        audit_result.all_vulnerabilities.push(vulnerability);
     }
 
-    Ok(0)
+    if audit_result.all_vulnerabilities.is_empty() {
+        prettyln!("<green>No vulnerabilities found<r>");
+        return Ok(0);
+    }
+
+    for vulnerability in &audit_result.all_vulnerabilities {
+        let paths = find_dependency_paths(&vulnerability.package_name, dependency_tree, pm)?;
+
+        let result = audit_result
+            .vulnerable_packages
+            .get_or_put(&vulnerability.package_name)?;
+        if !result.found_existing {
+            *result.value_ptr = PackageInfo {
+                vulnerabilities: Vec::new(),
+                dependents: paths,
+            };
+        }
+        result.value_ptr.vulnerabilities.push(VulnerabilityInfo {
+            severity: vulnerability.severity.clone(),
+            title: vulnerability.title.clone(),
+            url: vulnerability.url.clone(),
+            vulnerable_versions: vulnerability.vulnerable_versions.clone(),
+            id: vulnerability.id.clone(),
+            package_name: vulnerability.package_name.clone(),
+        });
+    }
+
+    for (_, package_info) in audit_result.vulnerable_packages.iter() {
+        if !package_info.vulnerabilities.is_empty() {
+            let main_vuln = &package_info.vulnerabilities[0];
+
+            // const is_direct_dependency: bool = brk: {
+            //     for (package_info.dependents.items) |path| {
+            //         if (path.is_direct) {
+            //             break :brk true;
+            //         }
+            //     }
+            //
+            //     break :brk false;
+            // };
+
+            if !main_vuln.vulnerable_versions.is_empty() {
+                prettyln!(
+                    "<red>{}<r>  {}",
+                    escape_control_chars(&main_vuln.package_name),
+                    escape_control_chars(&main_vuln.vulnerable_versions)
+                );
+            } else {
+                prettyln!("<red>{}<r>", escape_control_chars(&main_vuln.package_name));
+            }
+
+            for path in &package_info.dependents {
+                if path.path.len() > 1 {
+                    if path.path[0].starts_with(b"workspace:") {
+                        let vulnerable_pkg = &path.path[path.path.len() - 1];
+                        let workspace_part = &path.path[0];
+
+                        prettyln!(
+                            "  <d>{} › <red>{}<r>",
+                            escape_control_chars(workspace_part),
+                            escape_control_chars(vulnerable_pkg)
+                        );
+                    } else {
+                        let vulnerable_pkg = &path.path[0];
+
+                        let mut reversed_items: Vec<&[u8]> = Vec::new();
+                        for item in &path.path[1..] {
+                            reversed_items.push(item);
+                        }
+                        reversed_items.reverse();
+
+                        let mut vuln_pkg_path: Vec<u8> = Vec::new();
+                        for (i, item) in reversed_items.iter().enumerate() {
+                            if i > 0 {
+                                vuln_pkg_path.extend_from_slice(" › ".as_bytes());
+                            }
+                            vuln_pkg_path.extend_from_slice(item);
+                        }
+
+                        prettyln!(
+                            "  <d>{} › <red>{}<r>",
+                            escape_control_chars(&vuln_pkg_path),
+                            escape_control_chars(vulnerable_pkg)
+                        );
+                    }
+                } else {
+                    prettyln!("  <d>(direct dependency)<r>");
+                }
+            }
+
+            for vuln in &package_info.vulnerabilities {
+                if !vuln.title.is_empty() {
+                    if vuln.severity.as_ref() == b"critical" {
+                        prettyln!(
+                            "  <red>critical<d>:<r> {} - <d>{}<r>",
+                            escape_control_chars(&vuln.title),
+                            escape_control_chars(&vuln.url)
+                        );
+                    } else if vuln.severity.as_ref() == b"high" {
+                        prettyln!(
+                            "  <red>high<d>:<r> {} - <d>{}<r>",
+                            escape_control_chars(&vuln.title),
+                            escape_control_chars(&vuln.url)
+                        );
+                    } else if vuln.severity.as_ref() == b"moderate" {
+                        prettyln!(
+                            "  <yellow>moderate<d>:<r> {} - <d>{}<r>",
+                            escape_control_chars(&vuln.title),
+                            escape_control_chars(&vuln.url)
+                        );
+                    } else {
+                        prettyln!(
+                            "  <cyan>low<d>:<r> {} - <d>{}<r>",
+                            escape_control_chars(&vuln.title),
+                            escape_control_chars(&vuln.url)
+                        );
+                    }
+                }
+            }
+
+            // if (is_direct_dependency) {
+            //     Output.prettyln("  To fix: <green>`bun update {s}`<r>", .{package_info.name});
+            // } else {
+            //     Output.prettyln("  To fix: <green>`bun update --latest`<r><d> (may be a breaking change)<r>", .{});
+            // }
+
+            prettyln!("");
+        }
+    }
+
+    let total = vuln_counts.low + vuln_counts.moderate + vuln_counts.high + vuln_counts.critical;
+    pretty!("<b>{} vulnerabilities<r> (", total);
+
+    let mut has_previous = false;
+    if vuln_counts.critical > 0 {
+        pretty!("<red><b>{} critical<r>", vuln_counts.critical);
+        has_previous = true;
+    }
+    if vuln_counts.high > 0 {
+        if has_previous {
+            pretty!(", ");
+        }
+        pretty!("<red>{} high<r>", vuln_counts.high);
+        has_previous = true;
+    }
+    if vuln_counts.moderate > 0 {
+        if has_previous {
+            pretty!(", ");
+        }
+        pretty!("<yellow>{} moderate<r>", vuln_counts.moderate);
+        has_previous = true;
+    }
+    if vuln_counts.low > 0 {
+        if has_previous {
+            pretty!(", ");
+        }
+        pretty!("<cyan>{} low<r>", vuln_counts.low);
+    }
+    prettyln!(")");
+
+    prettyln!("");
+    prettyln!("To update all dependencies to the latest compatible versions:");
+    prettyln!("  <green>bun update<r>");
+    prettyln!("");
+    prettyln!("To update all dependencies to the latest versions (including breaking changes):");
+    prettyln!("  <green>bun update --latest<r>");
+    prettyln!("");
+
+    Ok(1)
 }

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -398,4 +398,149 @@ describe("`bun audit`", () => {
     expect(stdout).toBe("No vulnerabilities found\n");
     expect(exitCode).toBe(0);
   });
+
+  describe("registry responses", () => {
+    const projectDependingOnMs: DirectoryTree = {
+      "package.json": JSON.stringify({
+        name: "test",
+        version: "1.0.0",
+        dependencies: {
+          ms: "0.7.0",
+        },
+      }),
+      "bun.lock": JSON.stringify({
+        "lockfileVersion": 1,
+        "workspaces": {
+          "": {
+            "name": "test",
+            "dependencies": {
+              ms: "0.7.0",
+            },
+          },
+        },
+        "packages": {
+          ms: ["ms@0.7.0", "", {}, fakeIntegrity],
+        },
+      }),
+    };
+
+    async function auditAgainst(responseBody: string, args: string[] = []) {
+      await using registry = Bun.serve({
+        port: 0,
+        fetch: () => new Response(responseBody, { headers: { "content-type": "application/json" } }),
+      });
+      using dir = tempDir("bun-test-audit-registry-response", projectDependingOnMs);
+
+      await using proc = spawn({
+        cmd: [bunExe(), "audit", ...args],
+        cwd: String(dir),
+        env: { ...bunEnv, NPM_CONFIG_REGISTRY: registry.url.href },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const [banner, ...rest] = stderr.split("\n");
+      expect(banner).toStartWith("bun audit v");
+
+      const auditUrl = `${registry.url.origin}/-/npm/v1/security/advisories/bulk`;
+      return {
+        result: { stdout, stderr: rest.join("\n"), exitCode },
+        rejected: (expected: "JSON" | "a list of advisories") =>
+          `error: audit request to ${auditUrl} failed: response is not ${expected}\n`,
+      };
+    }
+
+    const notAdvisoryLists = [
+      "[]",
+      "null",
+      '"all clear"',
+      '{"error":"audit is not supported by this registry"}',
+      '{"ms":{"severity":"high","title":"advisory object where the array should be"}}',
+      '{"ms":["high"]}',
+    ];
+
+    test.concurrent.each(notAdvisoryLists)("%s is a failed audit, not a clean one", async responseBody => {
+      const { result, rejected } = await auditAgainst(responseBody);
+      expect(result).toEqual({ stdout: "", stderr: rejected("a list of advisories"), exitCode: 1 });
+    });
+
+    test.concurrent.each(notAdvisoryLists)("--json relays %s and exits 1", async responseBody => {
+      const { result, rejected } = await auditAgainst(responseBody, ["--json"]);
+      expect(result).toEqual({ stdout: `${responseBody}\n`, stderr: rejected("a list of advisories"), exitCode: 1 });
+    });
+
+    const notJson = ["<html>\x1b[2J\x1b]0;owned\x07sign in to continue</html>", "Not Found"];
+
+    test.concurrent.each(notJson)("a non-JSON body (%j) is neither echoed nor a clean audit", async responseBody => {
+      const { result, rejected } = await auditAgainst(responseBody);
+      expect(result).toEqual({ stdout: "", stderr: rejected("JSON"), exitCode: 1 });
+    });
+
+    test.concurrent.each(notJson)("--json does not echo a non-JSON body (%j) either", async responseBody => {
+      const { result, rejected } = await auditAgainst(responseBody, ["--json"]);
+      expect(result).toEqual({ stdout: "", stderr: rejected("JSON"), exitCode: 1 });
+    });
+
+    test.concurrent("a package listed with no advisories is a clean audit", async () => {
+      const { result } = await auditAgainst('{"ms":[]}');
+      expect(result).toEqual({ stdout: "No vulnerabilities found\n", stderr: "", exitCode: 0 });
+    });
+
+    test.concurrent("--json exits 0 when the packages are listed with no advisories", async () => {
+      const { result } = await auditAgainst('{"ms":[]}', ["--json"]);
+      expect(result).toEqual({ stdout: '{"ms":[]}\n', stderr: "", exitCode: 0 });
+    });
+
+    test.concurrent("an empty body is a clean audit", async () => {
+      const { result } = await auditAgainst("");
+      expect(result).toEqual({ stdout: "No vulnerabilities found\n", stderr: "", exitCode: 0 });
+    });
+
+    test.concurrent("--audit-level filtering out every advisory prints a clean audit, not nothing", async () => {
+      const { result } = await auditAgainst(
+        JSON.stringify({ ms: [{ severity: "low", title: "minor", url: "https://example.com/minor" }] }),
+        ["--audit-level", "critical"],
+      );
+      expect(result).toEqual({ stdout: "No vulnerabilities found\n", stderr: "", exitCode: 0 });
+    });
+
+    test.concurrent("control characters in advisories and package names are escaped in the report", async () => {
+      const { result } = await auditAgainst(
+        JSON.stringify({
+          ms: [
+            {
+              severity: "high",
+              title: "ms \x1b[2J\x1b]0;owned\x07 ReDoS in \\d+\r\n\tparsing\x7f \x9b \u00a9 2015",
+              url: "https://example.com/ms\x1b]8;;https://evil.example/\x07",
+              vulnerable_versions: "<2.0.0\x1b[0m",
+            },
+          ],
+          "ms\x1b[31m": [{ severity: "critical", title: "not a real package", url: "https://example.com/fake" }],
+        }),
+      );
+      expect(result).toEqual({
+        stdout: [
+          "ms  <2.0.0\\u001b[0m",
+          "  (direct dependency)",
+          "  high: ms \\u001b[2J\\u001b]0;owned\\u0007 ReDoS in \\d+\\r\\n\\tparsing\\u007f \\u009b \u00a9 2015 - https://example.com/ms\\u001b]8;;https://evil.example/\\u0007",
+          "",
+          "ms\\u001b[31m",
+          "  critical: not a real package - https://example.com/fake",
+          "",
+          "2 vulnerabilities (1 critical, 1 high)",
+          "",
+          "To update all dependencies to the latest compatible versions:",
+          "  bun update",
+          "",
+          "To update all dependencies to the latest versions (including breaking changes):",
+          "  bun update --latest",
+          "",
+          "",
+        ].join("\n"),
+        stderr: "",
+        exitCode: 1,
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `bun audit` treats a 200 response that is not an advisory report as a clean audit. A body of `[]`, `null`, `"..."` or a number is written to stdout and the command exits 0; an object whose values are not arrays (for example `{"error":"audit is not supported"}` from a mirror) prints nothing and exits 0. `bun audit --json` exits 1 for the same bodies, so the two modes disagree, and a misconfigured mirror or proxy reads as "no vulnerabilities" in CI.
- A body that is not JSON at all (captive portal, proxy error page) is written to stdout verbatim in both modes (`print_enhanced_audit_report` parse-failure branch, and `--json` echoed before parsing). #35887 is this path in the wild: a registry served a gzip body without `Content-Encoding` and `bun audit` printed the compressed bytes. With this change that case prints the `response is not JSON` error instead; making that audit actually succeed is #35890, so #35887 stays open after this PR (it is left to #35890).
- Package names, `title`, `url` and `vulnerable_versions` from the response are printed byte for byte (`src/runtime/cli/audit_command.rs`, the `BStr::new(..)` arguments in `print_enhanced_audit_report`), so an advisory can emit terminal escape sequences (clear screen, set title, OSC 8 links) or use CR/LF to overwrite or forge report lines.
- Cause of the exit codes: `print_enhanced_audit_report` only counted advisories it could find and returned 0 otherwise, including for the `else` branch that echoed a non-object root (`audit_command.rs` ~745-750 and ~975-980 before this change).

### Fix
- `audit()` parses the body once and runs it through the new `bulk_advisories()`, which accepts exactly `{ [package]: Advisory[] }` (an object whose values are arrays of objects) and flattens it into `(package, advisory)` pairs. Anything else, and any body that is not JSON, goes to `reject_response()`: one error line on stderr naming the audit URL (`error: audit request to <url> failed: response is not JSON` / `... is not a list of advisories`) and exit 1, in both modes. The body is never echoed on the non-JSON path; `--json` still relays a body that is JSON, as documented, and only its exit code changes.
- `print_enhanced_audit_report` now takes the validated pairs, prints `No vulnerabilities found` when nothing is left to report (covers `{}`, packages listed with empty arrays, and everything filtered out by `--audit-level` / `--ignore`, which used to print nothing), and returns 1 otherwise. `--json` exits on whether the response lists any advisory, so `{"ms":[]}` exits 0 like the human report does (it exited 1 before). Most of the diff in this function is de-indentation from removing the `if let` wrappers the validation made redundant (`git diff -w`).
- Every string this command prints that did not come from a literal goes through `bun_core::fmt::escape_control_chars`, a new `Display` formatter next to `quote` / `escape_powershell`: C0 controls, DEL and C1 controls (U+0080..U+009F) are rendered as `\n`, `\r`, `\t`, `\^[`, `\^[` and so on; everything else, backslashes included, passes through unchanged, and invalid UTF-8 is rendered the way `BStr` renders it. Other commands that print registry metadata (`bun pm view`, the security scanner output) are not touched here; they can adopt the same formatter.
- The audit URL is built once in `audit()` and passed to `send_audit_request`, so the error message names the URL that was actually requested.
- Empty 200 bodies still count as clean (they parse as `{}`), unchanged on purpose: the previous code handled that case explicitly and some registries may answer that way; the new test pins it.
- Verified with `test/cli/install/bun-audit.test.ts` (new `registry responses` block): 20 of the 21 new cases fail on the released bun (`USE_SYSTEM_BUN=1`) and all 38 tests in the file pass with `bun bd test`. The one case that passes both ways (`an empty body is a clean audit`) pins the behavior left unchanged. Also ran `cargo clippy -p bun_core -p bun_runtime`, `cargo fmt --check`, and the `source-lints` byte-search / dead-code tests.
- Docs: one paragraph added to the exit code section of `docs/pm/cli/audit.mdx`.
- Note: #38333 rewrites `audit_command.rs` (multi-registry audit, `bun audit fix`). This change is independent of it and will need a rebase if it lands first; as of its current head, that branch still exits 0 for `{"error":...}`-shaped bodies, still echoes a non-JSON body in `--json` mode, and still prints advisory strings unescaped, so the three pieces here (`bulk_advisories`, `reject_response`, `escape_control_chars` at the print sites) carry over as-is.

### Background
- The bulk advisory endpoint is `<registry>/-/npm/v1/security/advisories/bulk`. `bun audit` POSTs `{ [package]: [versions] }` and the registry answers `{ [package]: Advisory[] }`, where each advisory is an object with `severity`, `title`, `url`, `vulnerable_versions` and `id`; a package with nothing to report is normally omitted, so `{}` means clean. The registry is chosen by the project's `.npmrc` / `bunfig.toml`, which is why a mirror or proxy can answer with anything.
- Terminals act on control characters in program output: ESC starts CSI/OSC sequences (clear screen, window title, hyperlinks), BEL terminates OSC, CR and LF move the cursor to overwrite or add lines. C1 controls are the 8-bit equivalents (U+009B is CSI, U+009D is OSC); in UTF-8 they arrive as the two bytes `C2 80..C2 9F`, and xterm-like terminals honor them, which is why the formatter escapes that range as well as the ASCII range.
- `pretty!` / `prettyln!` rewrite `<red>`-style tags in the format string at compile time; interpolated arguments are written as-is, so escaping has to happen in the argument, which is what a `Display` formatter gives us without allocating.
- `bun_json::ParsedJson::parse_json` is strict JSON; a raw ESC byte inside a string is a parse error (checked), so a valid document can only carry DEL and C1 controls raw, and everything else reaches the report through `\uXXXX` escapes that the parser decodes. The formatter handles both forms.

<details>
<summary>Before / after for the bodies from the report (stub registry answering every POST with the body, project with one npm dependency)</summary>

Before (bun 1.4.0-canary.1):

```
[]                         exit 0, stdout "[]"              (--json: exit 1)
null / 123 / "str"         exit 0, body echoed              (--json: exit 1)
{"error":"rate limited"}   exit 0, stdout ""                (--json: exit 1)
{"ms":{"severity":...}}    exit 0, stdout ""                (--json: exit 1)
<html>ESC[2J...</html>     exit 1, body echoed with ESC bytes, both modes
advisory with ESC/BEL/CR   ESC, BEL, CR, DEL, U+009B written raw to stdout
```

After:

```
[] / null / 123 / "str" / {"error":...} / {"ms":{...}} / {"ms":["high"]}
    both modes: stderr "error: audit request to http://127.0.0.1:PORT/-/npm/v1/security/advisories/bulk failed: response is not a list of advisories", exit 1
    (--json still writes the JSON body to stdout)
<html>...</html> / "Not Found"
    both modes: stdout empty, stderr "... response is not JSON", exit 1
advisory with control characters:
    ms  <2.0.0\^[[0m
      (direct dependency)
      high: ms \^[[2J\^[]0;owned\^G ReDoS in \d+\r\n\tparsing\u007f \^[ © 2015 - https://example.com/ms\^[]8;;https://evil.example/\^G
{} / empty body            "No vulnerabilities found", exit 0 (unchanged)
{"ms":[]}                  "No vulnerabilities found", exit 0 (was: stdout "", exit 0; --json was exit 1)
```

</details>

