### PR TITLE
install: stop panicking when a progress bar name is longer than its buffer

### DIFF
--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -194,12 +194,7 @@ pub enum Unit {
 pub struct Node {
     pub(crate) context: *mut Progress,
     pub(crate) parent: *mut Node,
-    // The non-allocating design means `Node` cannot own the bytes. Most
-    // callers pass string literals; the two that show dynamic names
-    // (`PackageManager::set_node_name`, `create_command::ProgressBuf`) point
-    // this at a scratch buffer that outlives the node and bound the copy into
-    // it themselves. The alternative would be threading a lifetime through
-    // `Node`/`Progress`.
+    // Dynamic names (install, create) point at caller-owned scratch buffers that outlive the node.
     pub name: &'static [u8],
     pub unit: Unit,
     /// Must be handled atomically to be thread-safe.

--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -194,10 +194,12 @@ pub enum Unit {
 pub struct Node {
     pub(crate) context: *mut Progress,
     pub(crate) parent: *mut Node,
-    // The non-allocating design means `Node` cannot own the bytes. `'static`
-    // is the chosen simplification because all current callers (install/,
-    // cli/) pass string literals; the alternative would be threading a
-    // lifetime through `Node`/`Progress`.
+    // The non-allocating design means `Node` cannot own the bytes. Most
+    // callers pass string literals; the two that show dynamic names
+    // (`PackageManager::set_node_name`, `create_command::ProgressBuf`) point
+    // this at a scratch buffer that outlives the node and bound the copy into
+    // it themselves. The alternative would be threading a lifetime through
+    // `Node`/`Progress`.
     pub name: &'static [u8],
     pub unit: Unit,
     /// Must be handled atomically to be thread-safe.

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -992,6 +992,19 @@ pub fn is_utf8_char_boundary(c: u8) -> bool {
     (c as i8) >= -0x40
 }
 
+/// The longest prefix of `self_` that fits in `max_len` bytes without ending
+/// inside a multi-byte UTF-8 sequence. Returns `self_` unchanged when it fits.
+pub fn truncate_to_char_boundary(self_: &[u8], max_len: usize) -> &[u8] {
+    if self_.len() <= max_len {
+        return self_;
+    }
+    let mut end = max_len;
+    while !is_on_char_boundary(self_, end) {
+        end -= 1;
+    }
+    &self_[..end]
+}
+
 pub fn starts_with_case_insensitive_ascii(self_: &[u8], prefix: &[u8]) -> bool {
     self_.len() >= prefix.len()
         && eql_case_insensitive_ascii(&self_[0..prefix.len()], prefix, false)
@@ -2737,6 +2750,22 @@ mod tests {
         assert_eq!(super::first_non_ascii(b"ab\xC3"), Some(2));
         assert!(super::eql_case_insensitive_ascii(b"A", b"a", true));
         assert!(!super::eql_case_insensitive_ascii(b"Ab", b"a", true));
+    }
+
+    #[test]
+    fn truncate_to_char_boundary_never_splits_a_sequence() {
+        assert_eq!(super::truncate_to_char_boundary(b"abc", 3), b"abc");
+        assert_eq!(super::truncate_to_char_boundary(b"abc", 4), b"abc");
+        assert_eq!(super::truncate_to_char_boundary(b"abcd", 3), b"abc");
+        assert_eq!(super::truncate_to_char_boundary(b"abc", 0), b"");
+        // "aé" is `61 C3 A9`: a cut at byte 2 would land inside `é`.
+        assert_eq!(super::truncate_to_char_boundary("aéz".as_bytes(), 2), b"a");
+        assert_eq!(
+            super::truncate_to_char_boundary("aéz".as_bytes(), 3),
+            "aé".as_bytes()
+        );
+        // A 4-byte sequence that does not fit at all yields the empty prefix.
+        assert_eq!(super::truncate_to_char_boundary("😀".as_bytes(), 3), b"");
     }
 
     #[test]

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -992,8 +992,7 @@ pub fn is_utf8_char_boundary(c: u8) -> bool {
     (c as i8) >= -0x40
 }
 
-/// The longest prefix of `self_` that fits in `max_len` bytes without ending
-/// inside a multi-byte UTF-8 sequence. Returns `self_` unchanged when it fits.
+/// Longest prefix of `self_` within `max_len` bytes that does not split a UTF-8 sequence.
 pub fn truncate_to_char_boundary(self_: &[u8], max_len: usize) -> &[u8] {
     if self_.len() <= max_len {
         return self_;

--- a/src/install/PackageManager/ProgressStrings.rs
+++ b/src/install/PackageManager/ProgressStrings.rs
@@ -1,6 +1,6 @@
 use core::sync::atomic::Ordering;
 
-use bun_core::Output;
+use bun_core::{Output, strings};
 use const_format::concatcp;
 
 use crate::bun_progress::Node as ProgressNode;
@@ -94,24 +94,26 @@ impl PackageManager {
         name: &[u8],
         emoji: &[u8],
     ) {
+        let emoji_len = if Output::enable_ansi_colors_stderr() {
+            if IS_FIRST {
+                self.progress_name_buf[..emoji.len()].copy_from_slice(emoji);
+            }
+            emoji.len()
+        } else {
+            0
+        };
+        // Dependency names are user input of any length; the progress line is
+        // display-only, so a name that does not fit the buffer is cut short.
+        let name =
+            strings::truncate_to_char_boundary(name, self.progress_name_buf.len() - emoji_len);
+        self.progress_name_buf[emoji_len..][..name.len()].copy_from_slice(name);
+        let len = emoji_len + name.len();
         // SAFETY: `node` is `self.downloads_node` / `self.scripts_node`, both of
         // which point at storage owned by (or outliving) this `PackageManager`
         // singleton; `progress_name_buf` is an inline field of that same
         // singleton, so the buffer outlives every node that references it and
         // erasing the slice lifetime to `'static` is sound.
-        unsafe {
-            let len = if Output::enable_ansi_colors_stderr() {
-                if IS_FIRST {
-                    self.progress_name_buf[..emoji.len()].copy_from_slice(emoji);
-                }
-                self.progress_name_buf[emoji.len()..][..name.len()].copy_from_slice(name);
-                emoji.len() + name.len()
-            } else {
-                self.progress_name_buf[..name.len()].copy_from_slice(name);
-                name.len()
-            };
-            node.name = bun_ptr::detach_lifetime(&self.progress_name_buf[..len]);
-        }
+        node.name = unsafe { bun_ptr::detach_lifetime(&self.progress_name_buf[..len]) };
     }
 
     pub fn start_progress_bar_if_none(&mut self) {

--- a/src/install/PackageManager/ProgressStrings.rs
+++ b/src/install/PackageManager/ProgressStrings.rs
@@ -102,8 +102,7 @@ impl PackageManager {
         } else {
             0
         };
-        // Dependency names are user input of any length; the progress line is
-        // display-only, so a name that does not fit the buffer is cut short.
+        // Display-only, so a name longer than the buffer is simply cut short.
         let name =
             strings::truncate_to_char_boundary(name, self.progress_name_buf.len() - emoji_len);
         self.progress_name_buf[emoji_len..][..name.len()].copy_from_slice(name);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10400,3 +10400,88 @@ it.each([
     expect(exitCode).not.toBe(0);
   });
 });
+
+// The progress bar copies the name it is currently showing into a fixed
+// 768-byte buffer (PackageManager.progress_name_buf). Dependency and package
+// names have no length limit, so a longer name used to abort the install with
+// "panic: range end index 900 out of range for slice of length 768" whenever
+// the progress bar was on. BUN_INSTALL_PROGRESS=1 turns it on without a TTY;
+// with colors enabled an emoji shares the buffer with the name, so both color
+// settings are covered.
+describe("progress bar with a name longer than its name buffer", () => {
+  const longName = Buffer.alloc(900, "a").toString();
+  const progressEnvs = [
+    ["NO_COLOR", { ...env, BUN_INSTALL_PROGRESS: "1", NO_COLOR: "1" }],
+    ["FORCE_COLOR", { ...env, BUN_INSTALL_PROGRESS: "1", NO_COLOR: undefined, FORCE_COLOR: "1" }],
+  ] as const;
+
+  it.each(progressEnvs)("dependency whose manifest is fetched (%s)", async (_colors, progressEnv) => {
+    await withContext(defaultOpts, async ctx => {
+      const requests: string[] = [];
+      setContextHandler(ctx, request => {
+        requests.push(request.url);
+        return new Response("Not Found", { status: 404 });
+      });
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            [longName]: "1.0.0",
+          },
+        }),
+      );
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: progressEnv,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(requests).toEqual([`${ctx.registry_url}${longName}`]);
+      expect(Bun.stripANSI(err)).toContain(`error: GET ${ctx.registry_url}${longName} - 404`);
+      expect(Bun.stripANSI(err)).toContain(`error: ${longName}@1.0.0 failed to resolve`);
+      expect(out).not.toContain("1 package installed");
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  it.each(progressEnvs)("workspace package running a lifecycle script (%s)", async (_colors, progressEnv) => {
+    using dir = tempDir("install-progress-long-name", {
+      "package.json": JSON.stringify({
+        name: "foo",
+        workspaces: ["packages/*"],
+      }),
+      "packages/long/package.json": JSON.stringify({
+        name: longName,
+        version: "1.0.0",
+        scripts: {
+          postinstall: "echo ran > postinstall-ran",
+        },
+      }),
+    });
+
+    // Nothing depends on the workspace package, so the isolated linker never
+    // creates a node_modules entry with this name: the progress bar is the
+    // only thing that has to cope with it.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--linker", "isolated"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: progressEnv,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stderr: Bun.stripANSI(err), exitCode }).toEqual({
+      stderr: expect.not.stringContaining("error:"),
+      exitCode: 0,
+    });
+    expect(Bun.stripANSI(out)).toContain("Checked 2 packages");
+    expect(await file(join(String(dir), "packages", "long", "postinstall-ran")).text()).toBe("ran\n");
+  });
+});


### PR DESCRIPTION
### Problem
- `bun install` aborts whenever the progress bar is on (stderr is a TTY, or `BUN_INSTALL_PROGRESS=1`) and any dependency or package name is longer than the progress name buffer:
  ```
  panic: range end index 900 out of range for slice of length 768
  ```
  (`slice of length 761` / `758` with colors on, where the download / script emoji takes the first bytes of the buffer). Exit 134, nothing installed. With stderr piped the same install fails normally (`error: GET ... - 404`, exit 1) or succeeds.
- Cause: `PackageManager::set_node_name` (`src/install/PackageManager/ProgressStrings.rs:107` and `:110`) copies `name` into `progress_name_buf: [u8; 768]` (`src/install/PackageManager.rs:308`) using `name.len()` as the slice bound, with no check against the buffer size.
- The name comes straight from user or registry data: `dependencies` keys of the project or of any transitive package.json, manifest names, workspace names (`runTasks.rs` x6, `PackageInstaller.rs:2481`, `lifecycle_script_runner.rs:546` all route through `set_node_name`). So a single published package with an overlong dependency key breaks `bun install` on a terminal for everyone downstream.

### Fix
- `set_node_name` now truncates `name` to the bytes left in the buffer after the emoji, via a new `bun_core::strings::truncate_to_char_boundary`, and copies that; the emoji / no-emoji branches are folded into one copy so both bounds come from the same place.
- Truncating is correct here because the buffer is only ever read by `Progress::refresh`, which formats the node name into a 100-byte line buffer and already replaces anything past that with `... ` (`src/bun_core/Progress.rs:144`, `:629-646`). Nothing that fit before is displayed differently; names that used to panic are displayed like any other long name.
- The cut lands on a UTF-8 character boundary because `node.name` is printed through `fmt::s`, which is `from_utf8_unchecked` (`src/bun_core/fmt.rs:729`); a byte-count cut could hand it a split multi-byte sequence.
- The fix lives in `set_node_name` rather than at a call site because it is the only writer of the buffer, so all eight progress update sites (manifest, extract, resolve, lifecycle scripts) are covered at once.
- Verified:
  - `test/cli/install/bun-install.test.ts`, `describe("progress bar with a name longer than its name buffer")`: 4 cases, {manifest fetched for a 900-byte dependency name, workspace member with a 900-byte name running a postinstall script} x {`NO_COLOR`, `FORCE_COLOR`}, so both the download node and the scripts node and both buffer layouts are exercised. All 4 abort with the panic above on the unfixed binary (`USE_SYSTEM_BUN=1`) and pass with `bun bd test`.
  - `truncate_to_char_boundary` unit test in `src/bun_core/string/immutable.rs` covers the exact-fit, one-over, zero-length and mid-sequence cases (the width of the cut is not observable from outside because of the 100-byte display buffer, so it is covered there rather than end to end). `bun_core`'s lib tests do not link on their own, so this was type-checked with `cargo check -p bun_core --tests` and the function plus assertions were additionally run as a standalone `rustc` program.
  - `cargo fmt --check`, `cargo clippy -p bun_core -p bun_install` clean. The 14 tests in `bun-install.test.ts` that need outbound network fail identically with and without this change in my sandbox and are unrelated.
- Intentionally not touched: `bun install --linker hoisted` also aborts on a workspace member whose name is 513+ bytes, from a different buffer (`dest_name_buf` in `src/install/PackageInstall.rs:2242`). That is not display-only and needs its own fix; it is tracked separately. The lifecycle-script test here uses `--linker isolated`, which never creates a node_modules entry for the workspace member, so only the progress bar sees the long name.

### Background
- The install progress bar is `bun_core::Progress`, a non-allocating tree of `Node`s. A `Node` does not own its label: `name` is a `&'static [u8]`, so `PackageManager` keeps one inline `progress_name_buf` and repoints the node at a prefix of it on every update; `set_node_name` is that update.
- With colors enabled the label is `<emoji><name>` and the emoji is written into the front of the same buffer, which is why the usable space differs between the two modes.
- `BUN_INSTALL_PROGRESS=1` is the existing switch (`PackageManagerOptions.rs`) that keeps the progress bar on without a TTY; the tests use it instead of a pty, which also makes them run on Windows.

<details>
<summary>Reproduction on a stock build (1.4.0-canary.1, b7a043103)</summary>

```sh
D=$(mktemp -d); cd $D
python3 -c 'import json; json.dump({"name":"app","dependencies":{"a"*900:"1.0.0"}}, open("package.json","w"))'
echo 'registry=http://127.0.0.1:1/' > .npmrc
BUN_INSTALL_PROGRESS=1 NO_COLOR=1    bun install   # panic: ... slice of length 768
BUN_INSTALL_PROGRESS=1 FORCE_COLOR=1 bun install   # panic: ... slice of length 761
CI=1                                 bun install   # error: ConnectionRefused ..., exit 1

# scripts node: workspace member with a 900-byte name and a postinstall script
mkdir -p packages/long
python3 -c 'import json; json.dump({"name":"root","workspaces":["packages/*"]}, open("package.json","w")); json.dump({"name":"a"*900,"version":"1.0.0","scripts":{"postinstall":"echo ran > postinstall-ran"}}, open("packages/long/package.json","w"))'
BUN_INSTALL_PROGRESS=1 NO_COLOR=1    bun install --linker isolated   # panic: ... slice of length 768
BUN_INSTALL_PROGRESS=1 FORCE_COLOR=1 bun install --linker isolated   # panic: ... slice of length 758
CI=1                                 bun install --linker isolated   # exit 0, postinstall-ran written
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->