### PR TITLE
css: print @supports `not` conditions without a leading space

### DIFF
--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -18,10 +18,8 @@ type CSSNumber = f32;
 type CSSInteger = i32;
 
 // ───────────────────────── QueryCondition trait ─────────────────────────
-// Implementors: MediaCondition, StyleQuery, ContainerCondition.
-// NOT SupportsCondition — its variant set {Not, And(Vec), Or(Vec), Declaration,
-// Selector, Unknown} and its `needs_parens(&Self)` contract are structurally
-// different and must stay hand-rolled.
+// Implementors: MediaCondition, StyleQuery, ContainerCondition. SupportsCondition
+// (different leaves, `needs_parens(&Self)`) has its own printer in rules/supports.rs.
 //
 // `deep_clone` is intentionally NOT on this trait. The single mechanism is
 // `#[derive(DeepClone)]` (generics.rs). The hand-expansions in callers exist

--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -18,8 +18,7 @@ type CSSNumber = f32;
 type CSSInteger = i32;
 
 // ───────────────────────── QueryCondition trait ─────────────────────────
-// Implementors: MediaCondition, StyleQuery, ContainerCondition. SupportsCondition
-// (different leaves, `needs_parens(&Self)`) has its own printer in rules/supports.rs.
+// Implementors: MediaCondition, StyleQuery, ContainerCondition.
 //
 // `deep_clone` is intentionally NOT on this trait. The single mechanism is
 // `#[derive(DeepClone)]` (generics.rs). The hand-expansions in callers exist

--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -20,8 +20,8 @@ type CSSInteger = i32;
 // ───────────────────────── QueryCondition trait ─────────────────────────
 // Implementors: MediaCondition, StyleQuery, ContainerCondition.
 // NOT SupportsCondition — its variant set {Not, And(Vec), Or(Vec), Declaration,
-// Selector, Unknown} and its `needs_parens(&Self)` / `b" not "` contract are
-// structurally different and must stay hand-rolled.
+// Selector, Unknown} and its `needs_parens(&Self)` contract are structurally
+// different and must stay hand-rolled.
 //
 // `deep_clone` is intentionally NOT on this trait. The single mechanism is
 // `#[derive(DeepClone)]` (generics.rs). The hand-expansions in callers exist

--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -150,7 +150,7 @@ impl SupportsCondition {
     pub fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
         match self {
             SupportsCondition::Not(condition) => {
-                dest.write_str(b" not ")?;
+                dest.write_str(b"not ")?;
                 condition.to_css_with_parens_if_needed(dest, condition.needs_parens(self))?;
             }
             SupportsCondition::And(conditions) => {

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1660,6 +1660,51 @@ c {
     },
   });
 
+  // `not` conditions print without a stray leading space in all three places
+  // they can appear: an @supports rule, the @supports wrapper generated for a
+  // bundled conditional @import, and a supports() clause on an external @import.
+  itBundled("css/CSSAtSupportsNotCondition", {
+    files: {
+      "/entry.css": /* css */ `
+        @import "http://example.com/foo.css" supports(not (display: grid));
+        @import "./foo.css" supports(not (display: grid));
+        @supports not (display: grid) {
+          a { color: red }
+        }
+        @supports (display: grid) and (not (display: inline-grid)) {
+          b { color: red }
+        }
+      `,
+      "/foo.css": /* css */ `body { color: red }`,
+    },
+    outfile: "/out.css",
+    onAfterBundle(api) {
+      // Exact comparison on purpose: the bug is a whitespace difference.
+      api.expectFile("/out.css").toBe(/* css */ `@import "http://example.com/foo.css" supports(not (display: grid));
+
+/* foo.css */
+@supports not (display: grid) {
+  body {
+    color: red;
+  }
+}
+
+/* entry.css */
+@supports not (display: grid) {
+  a {
+    color: red;
+  }
+}
+
+@supports (display: grid) and (not (display: inline-grid)) {
+  b {
+    color: red;
+  }
+}
+`);
+    },
+  });
+
   const files = [
     "/001/default/style.css",
     "/001/relative-url/style.css",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7559,6 +7559,61 @@ describe("css tests", () => {
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
   });
 
+  describe("supports", () => {
+    // Whatever precedes a `not` condition (`@supports `, a grouping `(`, or
+    // `supports(` in @import) already writes its own separator, so `not` must
+    // not be printed with a leading space of its own.
+    minify_test("@supports not (display:grid) { a { color: red } }", "@supports not (display:grid){a{color:red}}");
+    minify_test(
+      "@supports not selector(:focus-visible) { a { color: red } }",
+      "@supports not selector(:focus-visible){a{color:red}}",
+    );
+    minify_test(
+      "@supports not ((display:grid) and (display:flex)) { a { color: red } }",
+      "@supports not ((display:grid) and (display:flex)){a{color:red}}",
+    );
+    minify_test(
+      "@supports not ((display:grid) or (display:flex)) { a { color: red } }",
+      "@supports not ((display:grid) or (display:flex)){a{color:red}}",
+    );
+    minify_test(
+      "@supports not (not (display:grid)) { a { color: red } }",
+      "@supports not (not (display:grid)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display:grid) and (not (display:inline-grid)) { a { color: red } }",
+      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (not (display:grid)) and (display:flex) { a { color: red } }",
+      "@supports (not (display:grid)) and (display:flex){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display:grid) or (not (display:inline-grid)) { a { color: red } }",
+      "@supports (display:grid) or (not (display:inline-grid)){a{color:red}}",
+    );
+    minify_test(
+      "@import url(foo.css) supports(not (display:grid));",
+      '@import "foo.css" supports(not (display:grid));',
+    );
+    minify_test(
+      "@import url(foo.css) supports((display:grid) and (not (display:flex)));",
+      '@import "foo.css" supports((display:grid) and (not (display:flex)));',
+    );
+    minify_test(
+      "@import url(foo.css) supports(not (display:grid)) screen;",
+      '@import "foo.css" supports(not (display:grid)) screen;',
+    );
+
+    // The minified forms parse back to themselves.
+    minify_test("@supports not (display:grid){a{color:red}}", "@supports not (display:grid){a{color:red}}");
+    minify_test(
+      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
+      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
+    );
+    minify_test('@import "foo.css" supports(not (display:grid));', '@import "foo.css" supports(not (display:grid));');
+  });
+
   describe("container", () => {
     minify_test("@container (width > 100px) { a { color: red } }", "@container (width>100px){a{color:red}}");
     minify_test("@container not (width > 100px) { a { color: red } }", "@container not (width>100px){a{color:red}}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6451,6 +6451,61 @@ describe("css tests", () => {
     error_test("@media (prefers-color-scheme = dark) { .foo { color: chartreuse }}", "ParserError::InvalidMediaQuery");
   });
 
+  describe("supports", () => {
+    // Whatever precedes a `not` condition (`@supports `, a grouping `(`, or
+    // `supports(` in @import) already writes its own separator, so `not` must
+    // not be printed with a leading space of its own.
+    minify_test("@supports not (display:grid) { a { color: red } }", "@supports not (display:grid){a{color:red}}");
+    minify_test(
+      "@supports not selector(:focus-visible) { a { color: red } }",
+      "@supports not selector(:focus-visible){a{color:red}}",
+    );
+    minify_test(
+      "@supports not ((display:grid) and (display:flex)) { a { color: red } }",
+      "@supports not ((display:grid) and (display:flex)){a{color:red}}",
+    );
+    minify_test(
+      "@supports not ((display:grid) or (display:flex)) { a { color: red } }",
+      "@supports not ((display:grid) or (display:flex)){a{color:red}}",
+    );
+    minify_test(
+      "@supports not (not (display:grid)) { a { color: red } }",
+      "@supports not (not (display:grid)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display:grid) and (not (display:inline-grid)) { a { color: red } }",
+      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (not (display:grid)) and (display:flex) { a { color: red } }",
+      "@supports (not (display:grid)) and (display:flex){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display:grid) or (not (display:inline-grid)) { a { color: red } }",
+      "@supports (display:grid) or (not (display:inline-grid)){a{color:red}}",
+    );
+    minify_test(
+      "@import url(foo.css) supports(not (display:grid));",
+      '@import "foo.css" supports(not (display:grid));',
+    );
+    minify_test(
+      "@import url(foo.css) supports((display:grid) and (not (display:flex)));",
+      '@import "foo.css" supports((display:grid) and (not (display:flex)));',
+    );
+    minify_test(
+      "@import url(foo.css) supports(not (display:grid)) screen;",
+      '@import "foo.css" supports(not (display:grid)) screen;',
+    );
+
+    // The minified forms parse back to themselves.
+    minify_test("@supports not (display:grid){a{color:red}}", "@supports not (display:grid){a{color:red}}");
+    minify_test(
+      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
+      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
+    );
+    minify_test('@import "foo.css" supports(not (display:grid));', '@import "foo.css" supports(not (display:grid));');
+  });
+
   describe("transition", () => {
     minify_test(".foo { transition-duration: 500ms }", ".foo{transition-duration:.5s}");
     minify_test(".foo { transition-duration: .5s }", ".foo{transition-duration:.5s}");
@@ -7557,61 +7612,6 @@ describe("css tests", () => {
     minify_test("@page toc,index{margin:1em}", "@page toc,index{margin:1em}");
     minify_test("@page CompanyLetterHead:first{margin:1em}", "@page CompanyLetterHead:first{margin:1em}");
     minify_test("@page \\31 st{margin:1em}", "@page \\31 st{margin:1em}");
-  });
-
-  describe("supports", () => {
-    // Whatever precedes a `not` condition (`@supports `, a grouping `(`, or
-    // `supports(` in @import) already writes its own separator, so `not` must
-    // not be printed with a leading space of its own.
-    minify_test("@supports not (display:grid) { a { color: red } }", "@supports not (display:grid){a{color:red}}");
-    minify_test(
-      "@supports not selector(:focus-visible) { a { color: red } }",
-      "@supports not selector(:focus-visible){a{color:red}}",
-    );
-    minify_test(
-      "@supports not ((display:grid) and (display:flex)) { a { color: red } }",
-      "@supports not ((display:grid) and (display:flex)){a{color:red}}",
-    );
-    minify_test(
-      "@supports not ((display:grid) or (display:flex)) { a { color: red } }",
-      "@supports not ((display:grid) or (display:flex)){a{color:red}}",
-    );
-    minify_test(
-      "@supports not (not (display:grid)) { a { color: red } }",
-      "@supports not (not (display:grid)){a{color:red}}",
-    );
-    minify_test(
-      "@supports (display:grid) and (not (display:inline-grid)) { a { color: red } }",
-      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
-    );
-    minify_test(
-      "@supports (not (display:grid)) and (display:flex) { a { color: red } }",
-      "@supports (not (display:grid)) and (display:flex){a{color:red}}",
-    );
-    minify_test(
-      "@supports (display:grid) or (not (display:inline-grid)) { a { color: red } }",
-      "@supports (display:grid) or (not (display:inline-grid)){a{color:red}}",
-    );
-    minify_test(
-      "@import url(foo.css) supports(not (display:grid));",
-      '@import "foo.css" supports(not (display:grid));',
-    );
-    minify_test(
-      "@import url(foo.css) supports((display:grid) and (not (display:flex)));",
-      '@import "foo.css" supports((display:grid) and (not (display:flex)));',
-    );
-    minify_test(
-      "@import url(foo.css) supports(not (display:grid)) screen;",
-      '@import "foo.css" supports(not (display:grid)) screen;',
-    );
-
-    // The minified forms parse back to themselves.
-    minify_test("@supports not (display:grid){a{color:red}}", "@supports not (display:grid){a{color:red}}");
-    minify_test(
-      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
-      "@supports (display:grid) and (not (display:inline-grid)){a{color:red}}",
-    );
-    minify_test('@import "foo.css" supports(not (display:grid));', '@import "foo.css" supports(not (display:grid));');
   });
 
   describe("container", () => {


### PR DESCRIPTION
### Problem
- The CSS printer puts a stray space in front of `not` in `@supports` conditions, in both normal and `--minify` output:
  - `@supports not (display: grid) {}` prints as `@supports  not (display: grid){}` (two spaces)
  - `@supports (a) and (not (b)) {}` prints as `... and ( not (b))`
  - `@import url(x.css) supports(not (a));` prints as `supports( not (a))`
  - the `@supports` wrapper the bundler generates for a bundled `@import ... supports(not (a))` has the same two spaces
- Cause: `SupportsCondition::to_css` (src/css/rules/supports.rs:153) writes `" not "` for the `Not` variant, but every site that can precede a condition already writes its own separator: `SupportsRule::to_css` writes `"@supports "`, `to_css_with_parens_if_needed` writes the grouping `(`, and the `@import` printer writes `" supports("`.
- `@media not ...` and `@container not ...` already print correctly; their shared printer in src/css/media_query.rs writes `"not "`.

### Fix
- Write `"not "` instead of `" not "`. The comment in media_query.rs that cited the `" not "` contract as a reason `SupportsCondition` is printed separately is deleted, since that reason no longer exists.
- Correct because the `Not` variant is only ever printed from those three call sites, each of which has already emitted the separator, and `needs_parens` always returns true for `Not`, so a `Not` nested in `and`/`or`/`not` is always preceded by `(`. The output now matches lightningcss (1.30.2) byte for byte for every input in the tests.
- Verified:
  - test/js/bun/css/css.test.ts, new `supports` block (after `media`, where #38589 and #33680 also add theirs, so whichever lands later folds its cases into the one block on rebase): 14 minify round trips covering `@supports not`, `not` over `selector()`, `not` over an `and`/`or` group, `not (not ...)`, `not` as either operand of `and`/`or`, and `@import ... supports(not ...)` with and without a media list. All 14 fail on the released bun with the stray space as the only difference, and pass with this change. The declarations in these inputs are written pre-minified (`(display:grid)`) so the expectations do not change when #38589 starts minifying them.
  - test/bundler/esbuild/css.test.ts, `css/CSSAtSupportsNotCondition`: exact (not whitespace insensitive) comparison of non-minified bundler output covering an `@supports not` rule, the wrapper generated for a bundled conditional `@import`, and a `supports(not ...)` clause on an external `@import`. Fails before, passes after.
  - Full test/js/bun/css/css.test.ts and test/bundler/esbuild/css.test.ts pass with the debug build; no existing test or snapshot depended on the old spacing.
- Deliberately not included here, because they are separate bugs in the same printer with their own fixes:
  - parenthesized `(property: value)` conditions are kept as raw text instead of being parsed as declarations, and `declaration_to_css` drops the vendor prefix of a prefixed declaration (`supports(-webkit-mask: none)` prints as `supports((mask:none))`): both fixed by #38589.
  - `#[derive(ToCss)]` structs write a separator after a `None` field, so `align-items:center` minifies to `align-items: center`: a separate fix is being prepared.
- Related open PRs touching `@supports`: #38552 (parser, scanning past nested blocks), #38589 (declaration conditions), #33680 (merging same-condition rules). The source change here is independent of all three and merges cleanly with each; only the test block overlaps with #38589 and #33680, as described above.

### Background
- `SupportsCondition` (src/css/rules/supports.rs) is the parsed form of a `<supports-condition>`, used by both the `@supports` rule and the `supports()` clause of `@import`. It is a tree of `Not` / `And` / `Or` nodes over leaf conditions (`Declaration`, `selector(...)`, or an unknown parenthesized blob kept as raw text).
- `to_css_with_parens_if_needed` prints a child node and wraps it in `(`...`)` when `needs_parens` says the grammar requires it; for `Not` children that is always, since `not` may only appear directly after `@supports`, `supports(`, or an opening paren.
- When the bundler inlines a stylesheet pulled in through `@import ... supports(cond)`, it wraps the imported rules in a synthesized `SupportsRule` carrying that condition (src/bundler/linker_context/prepareCssAstsForChunk.rs), which is why the bundler output was affected by the same line.
- This is not a regression from the Rust port; the previous implementation printed the same `" not "`.
