### PR TITLE
css: minify the scroll-padding properties

### DIFF
--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -11,7 +11,7 @@ use crate::css_properties::custom::CustomPropertyName;
 use crate::css_properties::flex::FlexHandler;
 use crate::css_properties::font::FontHandler;
 use crate::css_properties::margin_padding::{
-    InsetHandler, MarginHandler, PaddingHandler, ScrollMarginHandler,
+    InsetHandler, MarginHandler, PaddingHandler, ScrollMarginHandler, ScrollPaddingHandler,
 };
 use crate::css_properties::prefix_handler::FallbackHandler;
 use crate::css_properties::size::SizeHandler;
@@ -396,6 +396,7 @@ pub struct DeclarationHandler<'bump> {
     pub(crate) margin: MarginHandler,
     pub(crate) padding: PaddingHandler,
     pub(crate) scroll_margin: ScrollMarginHandler,
+    pub(crate) scroll_padding: ScrollPaddingHandler,
     pub(crate) transition: TransitionHandler,
     pub(crate) font: FontHandler,
     pub(crate) inset: InsetHandler,
@@ -425,6 +426,7 @@ impl<'bump> DeclarationHandler<'bump> {
         self.margin.finalize(&mut self.decls, context);
         self.padding.finalize(&mut self.decls, context);
         self.scroll_margin.finalize(&mut self.decls, context);
+        self.scroll_padding.finalize(&mut self.decls, context);
         self.transition.finalize(&mut self.decls, context);
         self.font.finalize(&mut self.decls, context);
         self.inset.finalize(&mut self.decls, context);
@@ -464,6 +466,9 @@ impl<'bump> DeclarationHandler<'bump> {
                 .scroll_margin
                 .handle_property(property, &mut self.decls, context)
             || self
+                .scroll_padding
+                .handle_property(property, &mut self.decls, context)
+            || self
                 .transition
                 .handle_property(property, &mut self.decls, context)
             || self
@@ -496,6 +501,7 @@ impl<'bump> DeclarationHandler<'bump> {
             margin: Default::default(),
             padding: Default::default(),
             scroll_margin: Default::default(),
+            scroll_padding: Default::default(),
             transition: Default::default(),
             font: Default::default(),
             inset: Default::default(),

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -267,6 +267,7 @@ define_rect_shorthand! {
 pub type MarginHandler = SizeHandler<MarginSpec>;
 pub type PaddingHandler = SizeHandler<PaddingSpec>;
 pub type ScrollMarginHandler = SizeHandler<ScrollMarginSpec>;
+pub type ScrollPaddingHandler = SizeHandler<ScrollPaddingSpec>;
 pub type InsetHandler = SizeHandler<InsetSpec>;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -278,7 +279,7 @@ pub type InsetHandler = SizeHandler<InsetSpec>;
 // helpers) calls through `S::*`. Each concrete handler is a zero-sized
 // marker type implementing the spec.
 //
-// A macro could generate the four `SizeHandlerSpec` impls from a single
+// A macro could generate the five `SizeHandlerSpec` impls from a single
 // argument table, eliminating the per-spec extract/construct boilerplate.
 // Left explicit for reviewability.
 
@@ -1345,6 +1346,43 @@ impl SizeHandlerSpec for ScrollMarginSpec {
     );
 }
 
+pub struct ScrollPaddingSpec;
+impl SizeHandlerSpec for ScrollPaddingSpec {
+    const TOP: PropertyIdTag = PropertyIdTag::ScrollPaddingTop;
+    const BOTTOM: PropertyIdTag = PropertyIdTag::ScrollPaddingBottom;
+    const LEFT: PropertyIdTag = PropertyIdTag::ScrollPaddingLeft;
+    const RIGHT: PropertyIdTag = PropertyIdTag::ScrollPaddingRight;
+    const BLOCK_START: PropertyIdTag = PropertyIdTag::ScrollPaddingBlockStart;
+    const BLOCK_END: PropertyIdTag = PropertyIdTag::ScrollPaddingBlockEnd;
+    const INLINE_START: PropertyIdTag = PropertyIdTag::ScrollPaddingInlineStart;
+    const INLINE_END: PropertyIdTag = PropertyIdTag::ScrollPaddingInlineEnd;
+    const SHORTHAND: PropertyIdTag = PropertyIdTag::ScrollPadding;
+    const BLOCK_SHORTHAND: PropertyIdTag = PropertyIdTag::ScrollPaddingBlock;
+    const INLINE_SHORTHAND: PropertyIdTag = PropertyIdTag::ScrollPaddingInline;
+    const SHORTHAND_CATEGORY: PropertyCategory = PropertyCategory::Physical;
+    const FEATURE: Option<Feature> = None;
+    const SHORTHAND_FEATURE: Option<Feature> = None;
+    type Shorthand = ScrollPadding;
+    type BlockShorthand = ScrollPaddingBlock;
+    type InlineShorthand = ScrollPaddingInline;
+    size_handler_spec_projections!(
+        ScrollPaddingTop,
+        ScrollPaddingBottom,
+        ScrollPaddingLeft,
+        ScrollPaddingRight,
+        ScrollPaddingBlockStart,
+        ScrollPaddingBlockEnd,
+        ScrollPaddingInlineStart,
+        ScrollPaddingInlineEnd,
+        ScrollPadding,
+        ScrollPaddingBlock,
+        ScrollPaddingInline,
+        ScrollPadding,
+        ScrollPaddingBlock,
+        ScrollPaddingInline
+    );
+}
+
 pub struct InsetSpec;
 impl SizeHandlerSpec for InsetSpec {
     const TOP: PropertyIdTag = PropertyIdTag::Top;
@@ -1381,6 +1419,3 @@ impl SizeHandlerSpec for InsetSpec {
         InsetInline
     );
 }
-
-// NOTE: `ScrollPadding{,Block,Inline}` value types are defined above but no
-// `ScrollPaddingHandler` is instantiated.

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2436,7 +2436,134 @@ describe("css tests", () => {
     );
   });
 
-  describe("scroll-paddding", () => {
+  describe("scroll-padding", () => {
+    cssTest(
+      `
+      .foo {
+        scroll-padding-left: 10px;
+        scroll-padding-right: 10px;
+        scroll-padding-top: 20px;
+        scroll-padding-bottom: 20px;
+      }
+    `,
+      indoc`
+      .foo {
+        scroll-padding: 20px 10px;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        scroll-padding-block-start: 15px;
+        scroll-padding-block-end: 15px;
+      }
+    `,
+      indoc`
+      .foo {
+        scroll-padding-block: 15px;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        scroll-padding-left: 10px;
+        scroll-padding-right: 10px;
+        scroll-padding-inline-start: 15px;
+        scroll-padding-inline-end: 15px;
+        scroll-padding-top: 20px;
+        scroll-padding-bottom: 20px;
+      }
+    `,
+      indoc`
+      .foo {
+        scroll-padding-left: 10px;
+        scroll-padding-right: 10px;
+        scroll-padding-inline: 15px;
+        scroll-padding-top: 20px;
+        scroll-padding-bottom: 20px;
+      }
+    `,
+    );
+
+    // Later declarations of the same scroll-padding property replace earlier ones.
+    minify_test(".foo { scroll-padding: 1px; scroll-padding: 0 }", ".foo{scroll-padding:0}");
+    minify_test(".foo { scroll-padding-top: 1px; scroll-padding-top: 2px }", ".foo{scroll-padding-top:2px}");
+    minify_test(".foo { scroll-padding-block: 1px; scroll-padding-block: 2px }", ".foo{scroll-padding-block:2px}");
+    minify_test(
+      ".foo { scroll-padding-top: 1px; scroll-padding-right: 2px; scroll-padding-bottom: 3px; scroll-padding-left: 4px }",
+      ".foo{scroll-padding:1px 2px 3px 4px}",
+    );
+    minify_test(
+      ".foo { scroll-padding-top: auto; scroll-padding-right: auto; scroll-padding-bottom: auto; scroll-padding-left: auto }",
+      ".foo{scroll-padding:auto}",
+    );
+    minify_test(".foo { scroll-padding: 1px; scroll-padding-left: 2px }", ".foo{scroll-padding:1px 1px 1px 2px}");
+    minify_test(".foo { scroll-padding-left: 2px; scroll-padding: 1px }", ".foo{scroll-padding:1px}");
+    minify_test(
+      ".foo { scroll-padding-inline-start: 1px; scroll-padding-inline-end: 2px }",
+      ".foo{scroll-padding-inline:1px 2px}",
+    );
+    minify_test(
+      ".foo { scroll-padding-block: 1px 2px; scroll-padding-block-end: 3px }",
+      ".foo{scroll-padding-block:1px 3px}",
+    );
+    minify_test(
+      ".foo { scroll-padding-block-start: 1px; scroll-padding-block-end: 1px; scroll-padding-inline-start: 2px; scroll-padding-inline-end: 3px }",
+      ".foo{scroll-padding-block:1px;scroll-padding-inline:2px 3px}",
+    );
+    minify_test(
+      ".foo { scroll-padding-top: 1px !important; scroll-padding-right: 1px !important; scroll-padding-bottom: 1px !important; scroll-padding-left: 1px !important }",
+      ".foo{scroll-padding:1px!important}",
+    );
+    // `!important` declarations are minified separately from normal ones, so a
+    // mixed set of longhands cannot be merged into one shorthand.
+    minify_test(
+      ".foo { scroll-padding-top: 1px; scroll-padding-right: 1px; scroll-padding-bottom: 1px; scroll-padding-left: 1px !important }",
+      ".foo{scroll-padding-top:1px;scroll-padding-bottom:1px;scroll-padding-right:1px;scroll-padding-left:1px!important}",
+    );
+    // scroll-margin and scroll-padding are merged independently of each other,
+    // with scroll-margin emitted first.
+    minify_test(
+      ".foo { scroll-padding-top: 1px; scroll-margin-top: 2px; scroll-padding-bottom: 1px; scroll-margin-bottom: 2px; scroll-padding-left: 1px; scroll-margin-left: 2px; scroll-padding-right: 1px; scroll-margin-right: 2px }",
+      ".foo{scroll-margin:2px;scroll-padding:1px}",
+    );
+    // Partially collected longhands in one rule must not leak into the next.
+    minify_test(
+      ".foo { scroll-padding-block-start: 1px } .bar { scroll-padding-top: 2px; scroll-padding-bottom: 2px; scroll-padding-left: 2px; scroll-padding-right: 2px }",
+      ".foo{scroll-padding-block-start:1px}.bar{scroll-padding:2px}",
+    );
+
+    // An unparsed value (var()) may not be supported everywhere the parsed one
+    // is, so the earlier declaration is kept as a fallback.
+    minify_test(
+      ".foo { scroll-padding-top: 1px; scroll-padding-top: var(--x) }",
+      ".foo{scroll-padding-top:1px;scroll-padding-top:var(--x)}",
+    );
+    minify_test(
+      ".foo { scroll-padding: 1px; scroll-padding: var(--x) }",
+      ".foo{scroll-padding:1px;scroll-padding:var(--x)}",
+    );
+    minify_test(
+      ".foo { scroll-padding-block-start: 1px; scroll-padding-block-end: var(--x) }",
+      ".foo{scroll-padding-block-start:1px;scroll-padding-block-end:var(--x)}",
+    );
+    // Switching between physical and logical properties flushes what was
+    // collected so far instead of merging across the two.
+    minify_test(
+      ".foo { scroll-padding: 1px; scroll-padding-block-start: 2px }",
+      ".foo{scroll-padding:1px;scroll-padding-block-start:2px}",
+    );
+    minify_test(
+      ".foo { scroll-padding-top: 1px; scroll-padding-block-start: 1px; scroll-padding-top: 2px }",
+      ".foo{scroll-padding-top:1px;scroll-padding-block-start:1px;scroll-padding-top:2px}",
+    );
+
+    // Unlike padding, the logical scroll-padding properties are never compiled
+    // down to physical ones, whatever the targets.
     prefix_test(
       `
       .foo {
@@ -2446,6 +2573,39 @@ describe("css tests", () => {
       indoc`
       .foo {
         scroll-padding-inline: 2px;
+      }
+    `,
+      {
+        safari: 8 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        scroll-padding-inline-start: 2px;
+        scroll-padding-inline-end: 2px;
+      }
+    `,
+      indoc`
+      .foo {
+        scroll-padding-inline: 2px;
+      }
+    `,
+      {
+        safari: 8 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        scroll-padding-block-start: 2px;
+      }
+    `,
+      indoc`
+      .foo {
+        scroll-padding-block-start: 2px;
       }
     `,
       {


### PR DESCRIPTION
### Problem

- The CSS minifier (`bun build --minify`, `Bun.build`) leaves `scroll-padding` declarations exactly as written (release 1.4.0 and main): duplicates stay and longhands are never merged, while every sibling family is minified.
  ```
  .a{scroll-padding:1px;scroll-padding:0}                                  ->  unchanged   (expected .a{scroll-padding:0})
  .a{scroll-padding-top:1px;scroll-padding-right:1px;
     scroll-padding-bottom:1px;scroll-padding-left:1px}                    ->  unchanged   (expected .a{scroll-padding:1px})
  .a{scroll-margin:1px;scroll-margin:0}                                    ->  .a{scroll-margin:0}
  ```
- Cause: merging for this kind of property is done by `SizeHandler` in `src/css/properties/margin_padding.rs`, which is instantiated for margin, padding, scroll-margin and inset (margin_padding.rs:267) but not for scroll-padding; `DeclarationHandler` in `src/css/declaration.rs:390` accordingly has no `scroll_padding` handler, so the declarations fall through every handler and are copied to the output. The `ScrollPadding`, `ScrollPaddingBlock` and `ScrollPaddingInline` value types and all the `Property` variants already exist (the properties parse and print fine); only the handler is missing. The removed .zig sources had the same four handlers, so this was never implemented rather than lost in the port.

### Fix

- Adds `ScrollPaddingSpec` and `pub type ScrollPaddingHandler = SizeHandler<ScrollPaddingSpec>`, and runs it from `DeclarationHandler` (field, `handle_property` chain, `finalize`, `new`) directly after `scroll_margin`.
- The spec is `ScrollMarginSpec` with the scroll-padding variants substituted: physical shorthand category, and no logical compat feature (`FEATURE` / `SHORTHAND_FEATURE` = `None`), so the logical scroll-padding properties are never rewritten to physical ones for old targets. This is the configuration upstream lightningcss uses for its `ScrollPaddingHandler`. The handler also sits where upstream puts it (right after scroll-margin), so a block mixing several families emits its merged declarations in the same order as upstream.
- Checked against the lightningcss 1.30.2 binary in the repo's `node_modules`: 67 scroll-padding inputs (duplicates, every merge shape, physical/logical mixes, `var()` values, `!important`, multiple rules, interleaving with other families), each run with no targets, `safari 8` and `chrome 90`, produce byte-identical output from this branch and upstream. 34 of them differ on the released build.
- Verified: `test/js/bun/css/css.test.ts`, "scroll-padding" block (the old `scroll-paddding` block, which held one prefix test): 18 of the 25 cases fail on the released build and all pass with the fix; the remaining 7 pin behaviour that must stay the same with the handler in place (a `var()` value keeps the earlier declaration as a fallback, switching between physical and logical properties flushes instead of merging, logical properties survive old targets). The whole file (1166 tests) and `doesnt_crash`, `duplicate-declaration-merge-hang` and `css-loader` pass; `cargo clippy -p bun_css` is clean.
- #38551 fixes the shorthand arm of the shared `SizeHandler` body; the new instantiation picks that up automatically, and nothing here depends on it.
- Known limitation shared with every buffered family: `DeclarationHandler` has no arm for the `all` shorthand, so buffered declarations are written out after a later `all:` (`.a{margin-top:1px;all:unset}` already minifies to `.a{all:unset;margin-top:1px}` on the released build, where upstream emits `.a{all:unset}`). With this change scroll-padding behaves like margin here, where before it was copied through in source order. The comparison above therefore excludes inputs containing `all`; the missing `all` arm is a separate, pre-existing bug in `declaration.rs` and is filed on its own.

### Background

- The minifier pushes each declaration of a block through a chain of per-family handlers (`DeclarationHandler::handle_property`); the first one that accepts a declaration buffers it, and a declaration nobody accepts is copied to the output unchanged. At the end of the block `finalize` makes every handler flush its buffer, emitting one shorthand when all four sides are buffered and the individual longhands otherwise. A later declaration for an already buffered side replaces it, which is what removes duplicates.
- `SizeHandler<S>` is the handler for the four-sided families. `S: SizeHandlerSpec` only supplies the property ids, value types and two options: the category of the shorthand, and which compat `Feature` (if any) says a target lacks the logical properties, in which case they are compiled down to physical ones. scroll-padding, like scroll-margin, has no such feature: every browser that supports scroll-padding supports its logical variants.
