### PR TITLE
js_parser: keep the identifier when assigning to a define with a constant value

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -255,8 +255,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.symbols[result.r#ref.inner_index() as usize].set_has_been_assigned_to(true);
         }
 
-        let mut original_name: Option<&[u8]> = None;
-
         // Substitute user-specified defines for unbound symbols
         if p.symbols[e_.ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Unbound
             && !result.is_inside_with_scope
@@ -272,7 +270,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
                     // Don't substitute an identifier for a non-identifier if this is an
-                    // assignment target, since it'll cause a syntax error
+                    // assignment target, since it'll cause a syntax error. The original
+                    // identifier is kept in that case.
                     if matches!(newvalue.data.tag(), Tag::EIdentifier)
                         || in_.assign_target == js_ast::AssignTarget::None
                     {
@@ -280,8 +279,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         *e = newvalue;
                         return;
                     }
-
-                    original_name = def.original_name();
                 }
 
                 // Copy the side effect flags over in case this expression is unused
@@ -326,7 +323,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         *e = p.handle_identifier(
             expr.loc,
             e_,
-            original_name,
+            None,
             IdentifierOpts::default()
                 .with_assign_target(in_.assign_target)
                 .with_is_delete_target(is_delete_target)

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -270,8 +270,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.value_for_define(expr.loc, in_.assign_target, is_delete_target, def);
 
                     // Don't substitute an identifier for a non-identifier if this is an
-                    // assignment target, since it'll cause a syntax error. The original
-                    // identifier is kept in that case.
+                    // assignment target, since it'll cause a syntax error
                     if matches!(newvalue.data.tag(), Tag::EIdentifier)
                         || in_.assign_target == js_ast::AssignTarget::None
                     {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,11 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: assigning to an identifier whose define has a non-identifier
+/// value keeps the identifier instead of printing the value (#21210). `bun test`
+/// caches output transpiled with user defines, so older entries may hold the
+/// invalid output.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,8 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: Assigning to a define with a non-identifier value keeps the
-/// identifier instead of printing the value (#21210).
+/// Version 26: Assigning to a define with a constant value keeps the identifier (#21210).
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,10 +51,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: assigning to an identifier whose define has a non-identifier
-/// value keeps the identifier instead of printing the value (#21210). `bun test`
-/// caches output transpiled with user defines, so older entries may hold the
-/// invalid output.
+/// Version 26: Assigning to a define with a non-identifier value keeps the
+/// identifier instead of printing the value (#21210).
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -4625,35 +4625,68 @@ describe.concurrent("bundler", () => {
       stdout: "1\n2",
     },
   });
-  // TODO: this doesnt warn in esbuild ???
-  // itBundled("default/DefineAssignWarning", {
-  //   // GENERATED
-  //   files: {
-  //     "/read.js": /* js */ `
-  //       console.log(
-  //         [a, b.c, b['c']],
-  //         [d, e.f, e['f']],
-  //         [g, h.i, h['i']],
-  //       )
-  //     `,
-  //     "/write.js": /* js */ `
-  //       console.log(
-  //         [a = 0, b.c = 0, b['c'] = 0],
-  //         [d = 0, e.f = 0, e['f'] = 0],
-  //         [g = 0, h.i = 0, h['i'] = 0],
-  //       )
-  //     `,
-  //   },
-  //   entryPoints: ["/read.js", "/write.js"],
-  //   define: {
-  //     a: "null",
-  //     "b.c": "null",
-  //     d: "ident",
-  //     "e.f": "ident",
-  //     g: "dot.chain",
-  //     "h.i": "dot.chain",
-  //   },
-  // });
+  // A define with a constant value (`a`) is only substituted where it is read;
+  // as an assignment target the identifier stays as written, since `null = 0`
+  // is a syntax error. esbuild also logs an "assign-to-define" warning there,
+  // bun does not. A define whose value is an identifier (`d`) is substituted
+  // in both positions.
+  itBundled("default/DefineAssignWarning", {
+    files: {
+      "/read.js": /* js */ `
+        capture(a);
+        capture(d);
+      `,
+      "/write.js": /* js */ `
+        capture(a = 1);
+        capture(a += 1);
+        capture(a++);
+        capture(--a);
+        capture([a] = [3]);
+        capture({ x: a } = { x: 4 });
+        capture(a ??= 5);
+        for (a in { 5: 0 });
+        for (a of [6]);
+        capture(d = 7);
+        console.log(a, globalThis.a, globalThis.ident);
+      `,
+    },
+    entryPoints: ["/read.js", "/write.js"],
+    define: {
+      a: "null",
+      d: "ident",
+    },
+    runtimeFiles: {
+      // The output is an ES module, so the globals it assigns to must exist.
+      "/test.js": /* js */ `
+        globalThis.capture = x => x;
+        globalThis.a = undefined;
+        globalThis.ident = undefined;
+        await import("./out/write.js");
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.captureFile("/out/read.js")).toEqual(["null", "ident"]);
+      expect(api.captureFile("/out/write.js")).toEqual([
+        "a = 1",
+        "a += 1",
+        "a++",
+        "--a",
+        "[a] = [3]",
+        "{ x: a } = { x: 4 }",
+        "a ??= 5",
+        "ident = 7",
+      ]);
+      const write = api.readFile("/out/write.js");
+      expect(write).toContain("for (a in { 5: 0 })");
+      expect(write).toContain("for (a of [6])");
+    },
+    run: {
+      file: "/test.js",
+      // The read of `a` is replaced with the define, the writes went to the
+      // real global.
+      stdout: "null 6 7",
+    },
+  });
   itBundled("default/KeepNamesTreeShaking", {
     todo: true, // TODO: Full keepNames implementation with Object.defineProperty
     files: {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3052,6 +3052,34 @@ console.log(resolve.length)
       expectPrinted_("Math.log('hi')", 'console.error("hi")');
     });
 
+    it("define with a constant value keeps the identifier in an assignment target", () => {
+      // Only reads of `user_undefined` are replaced; `undefined = 1` would
+      // silently assign to the wrong name.
+      expectPrinted_(
+        `user_undefined = 1; console.log(user_undefined);`,
+        `user_undefined = 1;\nconsole.log(undefined);\n`,
+      );
+      expectPrinted_(`user_undefined += 1`, `user_undefined += 1`);
+      expectPrinted_(`user_undefined++`, `user_undefined++`);
+      expectPrinted_(`[user_undefined] = [1]`, `[user_undefined] = [1]`);
+      expectPrinted_(`({ a: user_undefined } = { a: 1 })`, `({ a: user_undefined } = { a: 1 })`);
+      expectPrinted_(`for (user_undefined of []);`, `for (user_undefined of [])\n  ;\n`);
+      expectPrintedMin_(
+        `user_undefined = 1; console.log(user_undefined);`,
+        `user_undefined = 1;\nconsole.log(void 0);\n`,
+      );
+
+      // A define whose value is itself assignable is substituted either way.
+      expectPrinted_(`user_nested = 1`, `location.origin = 1`);
+
+      // Non-identifier values used to be looked up as if they were a symbol
+      // name, printing the value's source text as the assignment target.
+      const constants = new Bun.Transpiler({ define: { STR: JSON.stringify("abc"), NUM: "1" } });
+      expect(constants.transformSync(`STR = 1; NUM = 1; console.log(STR, NUM);`, "js")).toBe(
+        `STR = 1;\nNUM = 1;\nconsole.log("abc", 1);\n`,
+      );
+    });
+
     it("jsx symbol should work", () => {
       expectBunPrinted_(`var x = jsx; export default x;`, "var x = jsx;\nexport default x");
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3074,9 +3074,13 @@ console.log(resolve.length)
 
       // Non-identifier values used to be looked up as if they were a symbol
       // name, printing the value's source text as the assignment target.
-      const constants = new Bun.Transpiler({ define: { STR: JSON.stringify("abc"), NUM: "1" } });
-      expect(constants.transformSync(`STR = 1; NUM = 1; console.log(STR, NUM);`, "js")).toBe(
-        `STR = 1;\nNUM = 1;\nconsole.log("abc", 1);\n`,
+      // Object values are inlined at every read (esbuild hoists them into a
+      // variable instead), so in an assignment target they count as constants too.
+      const constants = new Bun.Transpiler({
+        define: { STR: JSON.stringify("abc"), NUM: "1", OBJ: JSON.stringify({ a: 1 }) },
+      });
+      expect(constants.transformSync(`STR = 1; NUM = 1; OBJ = 1; console.log(STR, NUM, OBJ);`, "js")).toBe(
+        `STR = 1;\nNUM = 1;\nOBJ = 1;\nconsole.log("abc", 1, { a: 1 });\n`,
       );
     });
 


### PR DESCRIPTION
### Problem
- Assigning to an identifier that has a `--define` with a constant value emits invalid JavaScript (#21210). `X = 5;` with `--define 'X="abc"'` prints `"abc" = 5;`, `--define X=1` prints `1 = 5;`. Same through `Bun.build({ define })`, `bun build --no-bundle`, `new Bun.Transpiler({ define })`, and `bun --define ... file.js`, where the program then fails to load with `SyntaxError: Left side of assignment is not a reference.`
- With `--define X=undefined` the output is valid but wrong: `undefined = 5;` assigns to a different name than the source did.
- Every assignment form is affected (`X = v`, `X += v`, `X++`, `[X] = arr`, `({ k: X } = obj)`, `for (X in ...)`, `for (X of ...)`, `X ??= v`); reads of `X` are substituted correctly.
- Cause: `e_identifier` in `src/js_parser/visit/visit_expr.rs` correctly refuses to substitute a non-identifier define value into an assignment target, but then fell through with `original_name = def.original_name()`. For a define, `original_name` holds the value's source text (`"abc"`, `1`, `undefined`), and `handle_identifier` (`src/js_parser/p.rs`, the trailing `if let Some(name) = original_name` branch) runs `find_symbol` on that text, which allocates an unbound symbol literally named `"abc"` and rebinds the identifier to it. The printer then emits the symbol's name verbatim.

### Fix
- Drop the fallthrough: when the define value cannot be an assignment target, `e_identifier` leaves the identifier bound to the symbol `find_symbol` already resolved for it and passes `None` to `handle_identifier`. The read-side substitution and the identifier-valued define path are unchanged.
- This matches esbuild (`defineValueCanBeUsedInAssignTarget` in `js_parser.go`): only an identifier or property access value is substituted in assignment position, otherwise the original identifier is kept. The output for the new test input is byte for byte what esbuild 0.21 produces. esbuild additionally logs an `assign-to-define` warning, except in files where it suppresses warnings about weird code (`node_modules`, verified with esbuild 0.21.5); bun sets `suppress_warnings_about_weird_code` for every file, so the ported warning would never fire and is not added here (#21210 also asks for it; `Bun.Transpiler.transformSync` currently throws on any warning, so adding one unconditionally would turn this case into an exception there).
- Keeping the identifier is the only output that preserves the program's meaning: the write has to go to the real global `X` (a constant cannot be written to), and the builtin identifier defines (`undefined`, `NaN`, `Infinity`, whose `original_name` is empty) already took exactly this path, so `undefined = 1` has always printed as written.
- Runtime transpiler cache version bumped to 26. `bun run` disables the cache when user defines are set, but `bun test` (CLI `--define` or bunfig `define`) does not, so entries transpiled before this change can hold the invalid output and would otherwise keep being served until the source file changes. (`bun test` caching define-dependent output at all is a separate pre-existing problem and is being handled separately.)
- `handle_identifier`'s `original_name` parameter stays in this PR because `value_for_define` still uses it to bind identifier-valued defines. #38533 rewrites that caller and touches the same hunk of `e_identifier` (trivial conflict in either order); once both are in, the parameter has no live `Some(..)` caller left (the one in `fold.rs` returns earlier through `is_import_item`) and can be deleted by whichever lands second.
- Verified:
  - `test/bundler/esbuild/default.test.ts` `default/DefineAssignWarning` (the previously commented-out port of esbuild's test, adapted): every assignment form plus a run of the output. Fails on the released binary with `"null = 1"`, `"null += 1"`, ... in place of `"a = 1"`, `"a += 1"`, ...; passes with the fix.
  - `test/bundler/transpiler/transpiler.test.js` `define with a constant value keeps the identifier in an assignment target`: `Bun.Transpiler` with `undefined`, string, number and object values, with and without `minify.syntax`. Fails on the released binary, passes with the fix.
  - Also green with the fix: `esbuild/default.test.ts`, `esbuild/extra.test.ts`, `esbuild/dce.test.ts`, `bundler_edgecase.test.ts`, `bundler_drop.test.ts`, `bundler_env.test.ts`, `bundler_jsx.test.ts`, `transpiler.test.js`, the `define` cases in `bun-build-api.test.ts`, `regression/issue/32686.test.ts`, and for the cache bump `cli/run/transpiler-cache.test.ts` and `regression/issue/30887.test.ts`.

### Background
- A define (`--define K=V`, `define: { K: V }`) replaces each occurrence of the expression `K` with the expression `V` during the parser's visit pass. `DefineData` stores `V` parsed as an AST node plus its raw text in `original_name`; for an identifier value that text is what gets resolved to a symbol, for a constant it is just the literal's source.
- `find_symbol` looks a name up through the scope chain and, when nothing declares it, allocates an unbound symbol with that name. The printer emits unbound symbols by name, so a symbol named `"abc"` prints as `"abc"`.
- `handle_identifier` is the step every identifier reference goes through after resolution (constant inlining, import rewriting, TypeScript enum/namespace handling). Its optional `original_name` argument makes it re-resolve the identifier under that name; it exists for synthesized identifiers such as define values, not for identifiers that came from the source.
- The runtime transpiler cache (`src/jsc/RuntimeTranspilerCache.rs`) stores the transpiled output of source files of 4 KiB or more on disk, keyed by the source bytes and a hash of the transpiler options. `EXPECTED_VERSION` is bumped whenever transpiler output changes so that entries written by an older binary miss.

<details>
<summary>Before / after</summary>

```
$ printf 'X = 5;\nconsole.log(typeof X);\n' > entry.js
$ bun build entry.js --define 'X="abc"'        # before
"abc" = 5;
console.log("string");
$ bun build entry.js --define 'X="abc"'        # after (same as esbuild)
X = 5;
console.log("string");

$ printf 'globalThis.X = 0;\nX = 5;\nX += 1;\nconsole.log(X, globalThis.X);\n' > rt.js
$ bun --define 'X="abc"' rt.js                 # before
SyntaxError: Left side of assignment is not a reference.
$ bun --define 'X="abc"' rt.js                 # after
abc 6
```
</details>

Fixes #21210
