### PR TITLE
bun-types: declare the Error base and the runtime members of BuildMessage and ResolveMessage

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1604,18 +1604,30 @@ Most of the time, an explicit try/catch is not needed, as Bun prints uncaught ex
 Each item in `error.errors` is an instance of `BuildMessage` or `ResolveMessage` (subclasses of `Error`), containing detailed information for each error.
 
 ```ts title="build.ts" icon="/icons/typescript.svg"
-class BuildMessage {
-  name: string;
-  position?: Position;
+class BuildMessage extends Error {
+  name: "BuildMessage";
+  position: Position | null;
   message: string;
   level: "error" | "warning" | "info" | "debug" | "verbose";
+  notes: BuildMessage[]; // related locations, each with level "note"
+  line: number; // zero-based; position.line is one-based
+  column: number; // zero-based; position.column is one-based
+  toJSON(): Pick<BuildMessage, "name" | "position" | "message" | "level">;
 }
 
-class ResolveMessage extends BuildMessage {
+class ResolveMessage extends Error {
+  name: "ResolveMessage";
+  position: Position | null;
+  message: string;
+  level: "error" | "warning" | "info" | "debug" | "verbose";
   code: string;
+  requireStack: string[] | undefined; // only set when a require() failed
   referrer: string;
   specifier: string;
   importKind: ImportKind;
+  line: number; // zero-based; position.line is one-based
+  column: number; // zero-based; position.column is one-based
+  toJSON(): Pick<ResolveMessage, "name" | "position" | "message" | "level" | "specifier" | "importKind" | "referrer">;
 }
 ```
 
@@ -1806,11 +1818,23 @@ interface BuildOutput {
   logs: Array<BuildMessage | ResolveMessage>;
 }
 
-declare class ResolveMessage {
+interface Position {
+  lineText: string;
+  file: string;
+  namespace: string;
+  line: number; // one-based
+  column: number; // one-based
+  length: number;
+  offset: number;
+}
+
+declare class ResolveMessage extends Error {
   readonly name: "ResolveMessage";
   readonly position: Position | null;
   readonly code: string;
   readonly message: string;
+  stack: string; // "ResolveMessage: <message>", no stack frames
+  readonly requireStack: string[] | undefined; // only set when a require() failed
   readonly referrer: string;
   readonly specifier: string;
   readonly importKind:
@@ -1825,8 +1849,24 @@ declare class ResolveMessage {
     | "url"
     | "internal";
   readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+  readonly line: number; // zero-based, 0 without a position
+  readonly column: number; // zero-based, 0 without a position
 
-  toString(): string;
+  toString(): string; // "ResolveMessage: <message>"
+  toJSON(): Pick<ResolveMessage, "name" | "position" | "message" | "level" | "specifier" | "importKind" | "referrer">;
+}
+
+declare class BuildMessage extends Error {
+  readonly name: "BuildMessage";
+  readonly position: Position | null;
+  readonly message: string;
+  readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+  readonly notes: BuildMessage[]; // related locations, each with level "note"
+  readonly line: number; // zero-based, 0 without a position
+  readonly column: number; // zero-based, 0 without a position
+
+  toString(): string; // "BuildMessage: <message>"
+  toJSON(): Pick<BuildMessage, "name" | "position" | "message" | "level">;
 }
 ```
 

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -989,11 +989,28 @@ interface Position {
   offset: number;
 }
 
-declare class ResolveMessage {
+/**
+ * A module specifier that could not be resolved. Thrown by `import`,
+ * `require()` and {@link Bun.resolveSync}, and reported in
+ * {@link Bun.BuildOutput.logs} by {@link Bun.build}.
+ */
+declare class ResolveMessage extends Error {
   readonly name: "ResolveMessage";
   readonly position: Position | null;
   readonly code: string;
   readonly message: string;
+  /**
+   * `"ResolveMessage: <message>"`, with no `at ...` frames: no JavaScript
+   * stack is captured when resolution fails.
+   */
+  stack: string;
+  /**
+   * Like the `requireStack` of a Node.js `MODULE_NOT_FOUND` error: the module
+   * whose `require()` or `require.resolve()` call did not find {@link specifier}
+   * (only the direct caller is recorded). `undefined` for every other failure,
+   * including everything reached through `import`.
+   */
+  readonly requireStack: string[] | undefined;
   readonly referrer: string;
   readonly specifier: string;
   readonly importKind:
@@ -1008,15 +1025,69 @@ declare class ResolveMessage {
     | "url"
     | "internal";
   readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+  /**
+   * Zero-based line of {@link position}, or `0` when there is no position.
+   * `position.line` is the same line, one-based.
+   */
+  readonly line: number;
+  /**
+   * Zero-based column of {@link position}, or `0` when there is no position.
+   * `position.column` is the same column, one-based.
+   */
+  readonly column: number;
 
+  /**
+   * `"ResolveMessage: <message>"`, which is also what converting the object to
+   * a string (`String(...)`, a template literal) produces.
+   */
   toString(): string;
+  /**
+   * The fields `JSON.stringify()` serializes this message as.
+   */
+  toJSON(): Pick<ResolveMessage, "name" | "position" | "message" | "level" | "specifier" | "importKind" | "referrer">;
+  [Symbol.toPrimitive](hint: "default" | "string"): string;
+  [Symbol.toPrimitive](hint: string): string | null;
 }
 
-declare class BuildMessage {
+/**
+ * An error, warning or note produced while parsing or bundling a module.
+ * Thrown by `import` and `require()` of a file with a syntax error, and
+ * reported in {@link Bun.BuildOutput.logs} by {@link Bun.build}.
+ */
+declare class BuildMessage extends Error {
   readonly name: "BuildMessage";
   readonly position: Position | null;
   readonly message: string;
   readonly level: "error" | "warning" | "info" | "debug" | "verbose";
+  /**
+   * Secondary locations attached to this message, each a `BuildMessage` whose
+   * `level` is `"note"`, such as the original declaration behind a
+   * "has already been declared" error. Empty when there are none.
+   */
+  readonly notes: BuildMessage[];
+  /**
+   * Zero-based line of {@link position}, or `0` when there is no position.
+   * `position.line` is the same line, one-based.
+   */
+  readonly line: number;
+  /**
+   * Zero-based column of {@link position}, or `0` when there is no position.
+   * `position.column` is the same column, one-based.
+   */
+  readonly column: number;
+
+  /**
+   * `"BuildMessage: <message>"`, which is also what converting the object to a
+   * string (`String(...)`, a template literal) produces.
+   */
+  toString(): string;
+  /**
+   * The fields `JSON.stringify()` serializes this message as. {@link notes}
+   * are not included.
+   */
+  toJSON(): Pick<BuildMessage, "name" | "position" | "message" | "level">;
+  [Symbol.toPrimitive](hint: "default" | "string"): string;
+  [Symbol.toPrimitive](hint: string): string | null;
 }
 
 interface ErrorOptions {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -1,6 +1,6 @@
 import { $ as Shell, fileURLToPath } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, makeTree } from "harness";
+import { bunEnv, bunExe, isDebug, makeTree, tempDir } from "harness";
 import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -369,34 +369,143 @@ describe("@types/bun integration test", () => {
 
   // Runs on debug builds too: spawning tsc over a single file is cheap,
   // unlike the in-process LanguageService runs above.
+  async function expectToTypecheck(dirName: string, fileName: string, source: string) {
+    const checkDir = join(TEMP_DIR, dirName);
+    const tsconfig = structuredClone(sourceTsconfig);
+    tsconfig.include = [fileName];
+    tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+    await mkdir(checkDir, { recursive: true });
+    await makeTree(checkDir, {
+      "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      [fileName]: source,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+      env: bunEnv,
+      cwd: checkDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
-           view satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+      await expectToTypecheck(
+        "mmap-options-check",
+        "mmap-options.ts",
+        `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+         view satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
+         Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+      );
+    });
+  });
+
+  describe("BuildMessage / ResolveMessage", () => {
+    test("declare the Error base and the members the runtime objects have", async () => {
+      using dir = tempDir("bun-types-message-members", {
+        "redeclared.ts": "let a = 1;\nlet a = 2;\n",
+        "missing-import.ts": 'import "./missing";\n',
       });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
+      const { logs } = await Bun.build({
+        entrypoints: [join(String(dir), "redeclared.ts"), join(String(dir), "missing-import.ts")],
+        throw: false,
+      });
+      const buildMessage = logs.find(log => log instanceof BuildMessage)!;
+      const resolveMessage = logs.find(log => log instanceof ResolveMessage)!;
+      let requireFailure: unknown;
+      try {
+        require(join(String(dir), "missing-require"));
+      } catch (e) {
+        requireFailure = e;
+      }
+      if (!(requireFailure instanceof ResolveMessage)) throw new Error("require() did not throw a ResolveMessage");
+
+      const buildJsonKeys = Object.keys(buildMessage.toJSON());
+      const resolveJsonKeys = Object.keys(resolveMessage.toJSON());
+
+      // The runtime shape the declarations below have to mirror.
+      expect({
+        errors: [buildMessage instanceof Error, resolveMessage instanceof Error],
+        stacks: [buildMessage.stack, resolveMessage.stack],
+        notes: buildMessage.notes.map((note): [boolean, string] => [note instanceof BuildMessage, note.level]),
+        // zero-based [line, column], unlike the one-based position.line / position.column
+        locations: [
+          [buildMessage.line, buildMessage.column, buildMessage.position?.line, buildMessage.position?.column],
+          [resolveMessage.line, resolveMessage.column, resolveMessage.position?.line, resolveMessage.position?.column],
+        ],
+        requireStacks: [resolveMessage.requireStack, requireFailure.requireStack],
+        strings: [`${buildMessage}`, buildMessage[Symbol.toPrimitive]("number")],
+        json: { build: buildJsonKeys, resolve: resolveJsonKeys },
+      }).toEqual({
+        errors: [true, true],
+        stacks: [undefined, `ResolveMessage: ${resolveMessage.message}`],
+        notes: [[true, "note"]],
+        locations: [
+          [1, 4, 2, 5],
+          [0, 7, 1, 8],
+        ],
+        requireStacks: [undefined, [expect.any(String)]],
+        strings: [`BuildMessage: ${buildMessage.message}`, null],
+        json: {
+          build: ["name", "position", "message", "level"],
+          resolve: ["name", "position", "message", "level", "specifier", "importKind", "referrer"],
+        },
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+      await expectToTypecheck(
+        "build-message-members-check",
+        "build-logs.ts",
+        [
+          `declare const output: Bun.BuildOutput;`,
+          `for (const log of output.logs) {`,
+          `  log.stack satisfies string | undefined;`,
+          `  log.cause satisfies unknown;`,
+          `  log.line satisfies number;`,
+          `  log.column satisfies number;`,
+          `  log[Symbol.toPrimitive]("default") satisfies string;`,
+          `  log[Symbol.toPrimitive]("number") satisfies string | null;`,
+          `  if (log instanceof ResolveMessage) {`,
+          `    log.stack satisfies string;`,
+          `    log.requireStack satisfies string[] | undefined;`,
+          `    const json = log.toJSON();`,
+          ...resolveJsonKeys.map(key => `    json.${key};`),
+          `    // @ts-expect-error - not serialized`,
+          `    json.code;`,
+          `    // @ts-expect-error - not serialized`,
+          `    json.requireStack;`,
+          `  } else {`,
+          `    log.notes satisfies BuildMessage[];`,
+          `    log.notes[0]?.notes satisfies BuildMessage[] | undefined;`,
+          `    const json = log.toJSON();`,
+          ...buildJsonKeys.map(key => `    json.${key};`),
+          `    // @ts-expect-error - not serialized`,
+          `    json.notes;`,
+          `    // @ts-expect-error - only ResolveMessage has requireStack`,
+          `    log.requireStack;`,
+          `  }`,
+          `}`,
+          `try {`,
+          `  require("./missing");`,
+          `} catch (e) {`,
+          `  if (e instanceof ResolveMessage) {`,
+          `    const requireStack: string[] = e.requireStack ?? [];`,
+          `    console.error(e.stack, requireStack, e.line, e.column);`,
+          `  } else if (e instanceof BuildMessage) {`,
+          `    const error: Error = e;`,
+          `    console.error(error.stack, e.notes, e.line, e.column);`,
+          `  }`,
+          `}`,
+        ].join("\n"),
+      );
     });
   });
 

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -49,6 +49,58 @@ Bun.build({
           expectType(result.success).is<boolean>();
           expectType(result.outputs).is<Bun.BuildArtifact[]>();
           expectType(result.logs).is<Array<BuildMessage | ResolveMessage>>();
+
+          for (const log of result.logs) {
+            // Both message classes extend Error and share the location getters.
+            expectAssignable<Error>(log);
+            expectType(log.cause).is<unknown>();
+            expectType(log.position).is<Position | null>();
+            expectType(log.line).is<number>();
+            expectType(log.column).is<number>();
+            expectType(log.toString()).is<string>();
+            expectType(log[Symbol.toPrimitive]("default")).is<string>();
+            expectType(log[Symbol.toPrimitive]("number")).is<string | null>();
+
+            if (log instanceof ResolveMessage) {
+              expectType(log.name).is<"ResolveMessage">();
+              expectType(log.stack).is<string>();
+              expectType(log.requireStack).is<string[] | undefined>();
+
+              const json = log.toJSON();
+              expectType(json.name).is<"ResolveMessage">();
+              expectType(json.position).is<Position | null>();
+              expectType(json.message).is<string>();
+              expectType(json.level).is<ResolveMessage["level"]>();
+              expectType(json.specifier).is<string>();
+              expectType(json.importKind).is<ResolveMessage["importKind"]>();
+              expectType(json.referrer).is<string>();
+              // @ts-expect-error - toJSON() does not serialize code
+              json.code;
+              // @ts-expect-error - notes only exist on BuildMessage
+              log.notes;
+            } else {
+              expectType(log).is<BuildMessage>();
+              expectType(log.name).is<"BuildMessage">();
+              // Inherited from Error: a BuildMessage has no stack of its own.
+              expectType(log.stack).is<string | undefined>();
+              expectType(log.notes).is<BuildMessage[]>();
+              for (const note of log.notes) {
+                expectType(note.level).is<BuildMessage["level"]>();
+                expectType(note.position).is<Position | null>();
+                expectType(note.notes).is<BuildMessage[]>();
+              }
+
+              const json = log.toJSON();
+              expectType(json.name).is<"BuildMessage">();
+              expectType(json.position).is<Position | null>();
+              expectType(json.message).is<string>();
+              expectType(json.level).is<BuildMessage["level"]>();
+              // @ts-expect-error - toJSON() does not serialize notes
+              json.notes;
+              // @ts-expect-error - requireStack only exists on ResolveMessage
+              log.requireStack;
+            }
+          }
         });
 
         build.onBeforeParse(
@@ -66,3 +118,17 @@ Bun.build({
     },
   ],
 });
+
+// Failed imports and require() calls throw the same classes.
+try {
+  Bun.resolveSync("./missing", import.meta.dir);
+} catch (e) {
+  if (e instanceof ResolveMessage) {
+    const requireStack: string[] = e.requireStack ?? [];
+    const stack: string = e.stack;
+    console.error(stack, requireStack, `${e.specifier} at ${e.line}:${e.column}`);
+  } else if (e instanceof BuildMessage) {
+    const error: Error = e;
+    console.error(error.stack, e.notes.length, `${e.position?.file} at ${e.line}:${e.column}`);
+  }
+}


### PR DESCRIPTION
### Problem
- `declare class BuildMessage` and `declare class ResolveMessage` in packages/bun-types/globals.d.ts declare 4 and 9 members and no base class. The runtime objects (src/jsc/resolve_message.classes.ts, getters in src/jsc/BuildMessage.rs and src/jsc/ResolveMessage.rs) have `Error.prototype` in their chain (`prototypeBase: "Error"`) and also expose `line`, `column`, `toString()`, `toJSON()` and `Symbol.toPrimitive` on both, `notes` on `BuildMessage`, and `stack` and `requireStack` on `ResolveMessage`.
- So ordinary code over `Bun.build()` logs or a caught import/require failure is a type error while working at runtime: `log.line`, `log.column`, `log.stack`, `log.notes`, `err.requireStack`, `log.toJSON()` all fail with TS2339 (`Property 'line' does not exist on type 'BuildMessage | ResolveMessage'`).
- Reproduces with bun 1.4.0 and current main; probe below.

### Fix
- Both classes now `extends Error` and declare the members above. Every declared member is one the runtime defines, with the type the getter returns:
  - `line` / `column`: `number`, documented as zero-based (`get_line` / `get_column` return `location.line - 1`, and `0` without a location), unlike the one-based `position.line` / `position.column`.
  - `BuildMessage.notes`: `BuildMessage[]` (`get_notes` wraps each note as a `BuildMessage` of kind note).
  - `ResolveMessage.stack`: `string`, mutable like the runtime accessor (it has a setter) and like `Error.stack`. `BuildMessage` gets no `stack` of its own because the runtime defines none there; the inherited optional `Error.stack` is what it actually has (`undefined`).
  - `ResolveMessage.requireStack`: `string[] | undefined`. The getter always exists and returns `undefined` for anything but a failed `require()` / `require.resolve()`, so it is declared as always present rather than optional.
  - `toJSON()`: `Pick<...>` of exactly the keys the runtime `to_json` writes (`name`, `position`, `message`, `level`, plus `specifier`, `importKind`, `referrer` on `ResolveMessage`). `Pick` keeps it in sync with the member declarations, including the `level` / `importKind` unions being corrected in #38542.
  - `[Symbol.toPrimitive]`: `string` for the `"default"` / `"string"` hints, `string | null` otherwise, which is what `to_primitive` does.
- The `level` and `importKind` literal unions are wrong too but are fixed by #38542; those lines are left untouched here so the two changes compose. #35632 adds a real `stack` to `BuildMessage` at runtime and would tighten the inherited declaration when it lands.
- docs/bundler/index.mdx carries two hand-written copies of these declarations; both updated to match (the first one also described `ResolveMessage` as extending `BuildMessage`, which it does not: `resolveMessage instanceof BuildMessage` is `false`).
- Verified with test/integration/bun-types/bun-types.test.ts. The new case builds a file with a redeclared variable and a file with an unresolvable import, asserts the runtime shape (Error base, note array, zero-based line/column next to the one-based position, `requireStack` for `require()` only, `toJSON()` keys, `toPrimitive` results), then type-checks code using exactly that shape against the packed declarations with tsc. The tsc helper is shared with the existing `Bun.mmap` case and runs on debug builds too. test/integration/bun-types/fixture/build.ts pins the exact member types and is checked under each tsconfig the file runs (no lib, DOM, tsgo) on release builds.
- Without the globals.d.ts change the new case fails with 22 tsc errors and the fixture fails under every tsconfig; with it the file passes under both `bun test` (release, 16 pass) and `bun bd test` (debug).

### Background
- `Bun.build()` returns each bundler diagnostic in `logs` as a `BuildMessage`, or a `ResolveMessage` when it came from failing to resolve an import. A failed `import` / `import()` / `require()` at runtime throws the same classes.
- These are native classes generated from `.classes.ts` definitions: every member listed under `proto` there is a getter or method on the prototype, and `prototypeBase: "Error"` puts `Error.prototype` behind that prototype, which is why `instanceof Error` holds but the constructor-side statics of `Error` are not involved.
- `requireStack` mirrors the property Node.js puts on its `MODULE_NOT_FOUND` errors; Bun records only the direct caller, so it is a one-element array.

<details>
<summary>Runtime probe (bun 1.4.0, same on a debug build of main)</summary>

```ts
// entry.ts: import "./does-not-exist";   bad.ts: let a = 1; let a = 2;
const r = await Bun.build({ entrypoints: ["./entry.ts", "./bad.ts"], throw: false });
const [m, b] = [r.logs.find(l => l instanceof ResolveMessage), r.logs.find(l => l instanceof BuildMessage)] as any[];
console.log(m instanceof Error, m instanceof BuildMessage, m.line, m.column, m.position.line, m.position.column, typeof m.stack, m.requireStack, Object.keys(m.toJSON()));
// true false 0 7 1 8 string undefined [ "name", "position", "message", "level", "specifier", "importKind", "referrer" ]
console.log(b instanceof Error, b.line, b.column, b.notes.map((n: any) => [n.constructor.name, n.level]), b.stack, Object.keys(b.toJSON()), b[Symbol.toPrimitive]("number"), `${b}`);
// true 0 15 [ [ "BuildMessage", "note" ] ] undefined [ "name", "position", "message", "level" ] null BuildMessage: "a" has already been declared
try { require("./missing"); } catch (e: any) { console.log(e.requireStack, e.stack); }
// [ "/tmp/x/probe.ts" ] ResolveMessage: Cannot find module './missing'\nRequire stack:\n- /tmp/x/probe.ts
```

tsc over the same property accesses with the declarations from main:

```
error TS2339: Property 'line' does not exist on type 'BuildMessage | ResolveMessage'.
error TS2339: Property 'stack' does not exist on type 'ResolveMessage'.
error TS2339: Property 'requireStack' does not exist on type 'ResolveMessage'.
error TS2339: Property 'notes' does not exist on type 'BuildMessage'.
error TS2339: Property 'toJSON' does not exist on type 'BuildMessage'.
```

</details>
