### PR TITLE
css: print numbers from the f32's shortest digits, not its f64 expansion

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -6171,14 +6171,26 @@ pub fn dtoa_short(buf: &mut [u8; 129], value: f32, precision: u8) -> (&[u8], Opt
 pub(crate) fn dtoa_short_impl(buf: &mut [u8; 129], value: f32, precision: u8) -> (&[u8], Notation) {
     buf[0] = b'0';
     debug_assert!(value.is_finite());
-    // bun_core::fmt::FormatDouble::dtoa wants a fixed-size [u8; 124] buffer.
-    let buf_len = {
-        let inner: &mut [u8; 124] = (&mut buf[1..125])
-            .try_into()
-            .expect("infallible: size matches");
-        bun_core::fmt::FormatDouble::dtoa(inner, value as f64).len()
+    // `restrict_prec` has to round the f32's own shortest round-trip digits,
+    // as lightningcss (dtoa-short) does. Formatting `value as f64` would hand
+    // it the f32's f64 expansion instead: f32 56.89655 is 56.896549224853516,
+    // which rounds to 56.8965 where lightningcss prints 56.8966, and f32
+    // 0.000001 is 9.999999974752427e-7, whose carry comes out as `10e-7`.
+    //
+    // dtoa-short prints magnitudes from 1e-6 up to (not including) 1e21 in
+    // plain notation and everything else in exponent form (`1e-7`, `1e21`: no
+    // `+`); `{}` and `{:e}` are exactly those two layouts. The f32 literals
+    // below are the f32s nearest to the two powers of ten, and a digit string
+    // round-trips to an f32 at or above that nearest f32 exactly when the
+    // string itself is at or above the power of ten, so this magnitude test
+    // agrees with dtoa-short's digit-based one for every f32.
+    let magnitude = value.abs();
+    let len = if magnitude == 0.0 || (1e-6..1e21).contains(&magnitude) {
+        bun_core::fmt::buf_print_infallible(&mut buf[1..], format_args!("{value}")).len()
+    } else {
+        bun_core::fmt::buf_print_infallible(&mut buf[1..], format_args!("{value:e}")).len()
     };
-    restrict_prec(&mut buf[0..buf_len + 1], precision)
+    restrict_prec(&mut buf[..len + 1], precision)
 }
 
 fn restrict_prec(buf: &mut [u8], prec: u8) -> (&[u8], Notation) {

--- a/test/internal/int_from_float.test.ts
+++ b/test/internal/int_from_float.test.ts
@@ -67,11 +67,11 @@ describe("bun.intFromFloat function", () => {
     expect(normalizeCSSOutput(output)).toMatchInlineSnapshot(`
       "/* [path] */
       .test-large {
-        border-radius: 3.40282e+38px;
+        border-radius: 3.40282e38px;
       }
 
       .test-negative-large {
-        border-radius: -3.40282e+38px;
+        border-radius: -3.40282e38px;
       }"
     `);
   });

--- a/test/js/bun/css/angle-serialization-hang.test.ts
+++ b/test/js/bun/css/angle-serialization-hang.test.ts
@@ -21,10 +21,10 @@ const cases: [css: string, expected: string][] = [
   ["a { ro: 1.3157e308rad }", "a{ro:3.40282e38rad}"],
   [
     "a { rotate: 0.0000000000000000000000000000000000000\t00000000000000000000000000000000000200000000000000000000000000000001rad }",
-    "a{rotate:0 2e+32rad}",
+    "a{rotate:0 2e32rad}",
   ],
   // Other paths that serialize an Angle: transform functions and filters.
-  ["a { transform: rotate(3.3e33rad) }", "a{transform:rotate(3.3e+33rad)}"],
+  ["a { transform: rotate(3.3e33rad) }", "a{transform:rotate(3.3e33rad)}"],
   ["a { filter: hue-rotate(1e50rad) }", "a{filter:hue-rotate(3.40282e38rad)}"],
   // calc() can produce a real infinity.
   ["a { rotate: calc(infinity * 1rad) }", "a{rotate:3.40282e38rad}"],

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -191,6 +191,66 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("number serialization", () => {
+    // Numbers are f32 and print with 6 significant digits. The digits that get
+    // rounded are the f32's own shortest representation (what lightningcss
+    // rounds), not its f64 expansion: 56.89655 is the shortest form of an f32
+    // whose f64 expansion is 56.896549224853516. Expectations are lightningcss output.
+    describe("rounds the f32's shortest digits", () => {
+      minify_test(".foo{line-height:56.89655}", ".foo{line-height:56.8966}");
+      minify_test(".foo{line-height:-56.89655}", ".foo{line-height:-56.8966}");
+      minify_test(".foo{width:56.89655px}", ".foo{width:56.8966px}");
+      minify_test(".foo{width:56.89655%}", ".foo{width:56.8966%}");
+      minify_test(".foo{--a:56.89655}", ".foo{--a:56.8966}");
+      minify_test(".foo{unknown:56.89655}", ".foo{unknown:56.8966}");
+      minify_test("@media (min-aspect-ratio: 56.89655){.a{b:c}}", "@media (aspect-ratio>=56.8966){.a{b:c}}");
+      minify_test(".foo{color:oklab(from lab(50% 0 0) l a b)}", ".foo{color:oklab(56.8966% 5.96046e-8 2.98023e-8)}");
+    });
+
+    // The f64 expansion of f32 0.000001 is 9.999999974752427e-7; rounding that
+    // to 6 digits carried into an unnormalized `10e-7`.
+    describe("magnitudes below 1", () => {
+      minify_test(".foo{opacity:0.000001}", ".foo{opacity:.000001}");
+      minify_test(".foo{opacity:-0.000001}", ".foo{opacity:-.000001}");
+      minify_test(".foo{width:0.000001px}", ".foo{width:.000001px}");
+      minify_test(".foo{width:-0.000001px}", ".foo{width:-.000001px}");
+      minify_test(".foo{--a:0.000001}", ".foo{--a:.000001}");
+      minify_test(".foo{unknown:0.000001}", ".foo{unknown:.000001}");
+      minify_test("@media (min-resolution: 0.000001dppx){.a{b:c}}", "@media (resolution>=.000001x){.a{b:c}}");
+      // Exponent form starts below 1e-6.
+      minify_test(".foo{opacity:0.0000012345678}", ".foo{opacity:.00000123457}");
+      minify_test(".foo{opacity:0.0000001}", ".foo{opacity:1e-7}");
+      minify_test(".foo{opacity:0.00000012345678}", ".foo{opacity:1.23457e-7}");
+      minify_test(".foo{width:0.0000001px}", ".foo{width:1e-7px}");
+      minify_test(".foo{width:0.9999995px}", ".foo{width:1px}");
+    });
+
+    // The exponent is written like lightningcss writes it (`1e21`, not the
+    // JavaScript `1e+21`), and f32 1e22 (f64 expansion 9.999999778196308e21)
+    // no longer carries into `10e+21`.
+    describe("magnitudes of 1e21 and above", () => {
+      minify_test(".foo{width:100000000000000000000px}", ".foo{width:100000000000000000000px}");
+      minify_test(".foo{width:1e21px}", ".foo{width:1e21px}");
+      minify_test(".foo{width:-1e21px}", ".foo{width:-1e21px}");
+      minify_test(".foo{width:1e22px}", ".foo{width:1e22px}");
+      minify_test(".foo{width:123456789012345678901234px}", ".foo{width:1.23457e23px}");
+      minify_test(".foo{width:3.4028235e38px}", ".foo{width:3.40282e38px}");
+      minify_test(".foo{line-height:1e22}", ".foo{line-height:1e22}");
+      minify_test(".foo{line-height:123456789012345678901234}", ".foo{line-height:1.23457e23}");
+      minify_test(".foo{--a:1e21}", ".foo{--a:1e21}");
+      minify_test(".foo{unknown:1e22em}", ".foo{unknown:1e22em}");
+    });
+
+    describe("integers and zero", () => {
+      minify_test(".foo{width:1234567px}", ".foo{width:1234570px}");
+      minify_test(".foo{width:999999.5px}", ".foo{width:1000000px}");
+      minify_test(".foo{width:9999995px}", ".foo{width:10000000px}");
+      minify_test(".foo{line-height:1e3}", ".foo{line-height:1000}");
+      minify_test(".foo{opacity:0}", ".foo{opacity:0}");
+      minify_test(".foo{opacity:-0}", ".foo{opacity:0}");
+      minify_test(".foo{line-height:-0.0}", ".foo{line-height:0}");
+    });
+  });
   describe("border_spacing", () => {
     minify_test(
       `
@@ -1401,13 +1461,13 @@ describe("css tests", () => {
         border-left-color: color(display-p3 .643308 .192455 .167712);
         border-left-color: lab(40% 56.6 39);
         border-right-color: #ee00be;
-        border-right-color: color(display-p3 .972961 -.362078 .804206);
+        border-right-color: color(display-p3 .972962 -.362078 .804206);
         border-right-color: lch(50.998% 135.363 338);
       }
 
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left-color: #ee00be;
-        border-left-color: color(display-p3 .972961 -.362078 .804206);
+        border-left-color: color(display-p3 .972962 -.362078 .804206);
         border-left-color: lch(50.998% 135.363 338);
         border-right-color: #b32323;
         border-right-color: color(display-p3 .643308 .192455 .167712);

--- a/test/regression/issue/21907.test.ts
+++ b/test/regression/issue/21907.test.ts
@@ -85,13 +85,13 @@ test("CSS parser should handle extremely large floating-point values without cra
   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
     "/* [path] */
     .test-rounded-full {
-      border-radius: 3.40282e+38px;
+      border-radius: 3.40282e38px;
       width: 2147480000px;
       height: -2147480000px;
     }
 
     .test-negative {
-      border-radius: -3.40282e+38px;
+      border-radius: -3.40282e38px;
     }
 
     .test-very-large, .test-large-integer {


### PR DESCRIPTION
### Problem
- The CSS printer gets the last digit of some numbers wrong and prints some magnitudes in odd forms. With `bun build --minify` (or `minify_test`):
  - `.a{line-height:56.89655}` prints `56.8965`; lightningcss prints `56.8966`. Reported through `oklab(from lab(50% 0 0) l a b)`, whose `l` channel is that f32: bun prints `oklab(56.8965% ...)`, lightningcss `oklab(56.8966% ...)`.
  - `.a{opacity:0.000001}` prints `opacity:10e-7` (lightningcss: `.000001`); `width:0.000001px` prints `10e-7px`.
  - `.a{width:1e22px}` prints `10e+21px`, `width:1e21px` prints `1e+21px`, `123456789012345678901234px` prints `1.23457e+23px` (lightningcss: `1e22px`, `1e21px`, `1.23457e23px`). The infinity clamp a few lines up already hardcodes `3.40282e38`, so a finite `3.4028235e38px` printed differently (`3.40282e+38px`) from a clamped one.
- Cause: `dtoa_short_impl` (src/css/css_parser.rs:6179) formats `value as f64` with WTF's double formatter, so `restrict_prec` rounds the f32's f64 expansion instead of the f32's own shortest digits, which is what lightningcss rounds. f32 `56.89655` is exactly `56.896549224853516`, which rounds down; f32 `0.000001` is `9.999999974752427e-7`, whose 6-digit rounding carries into `10` and `restrict_prec` (like its upstream) does not renormalize the mantissa; and WTF spells exponents the JavaScript way (`e+21`).
- Measured over all 4,278,190,080 finite f32 values, the current output differs from lightningcss's formatter for 24.05% of them (1.27% of the values with `1e-4 <= |v| < 1e7`).
- The doubled minus in `opacity:-0.000001` -> `--10e-7` is the separate `-0` trimming bug (#38516). With this change that input prints `-.000001`, since the number now comes out as `-0.000001`.

### Fix
- `dtoa_short_impl` formats the f32 itself with Rust's shortest round-trip formatting: `{}` for `1e-6 <= |v| < 1e21` (and zero), `{:e}` otherwise. That is the notation split dtoa-short uses, and `{:e}` spells the exponent the way dtoa does (`1e-7`, `1e21`, no `+`). `restrict_prec` is unchanged and now rounds the same digit string lightningcss rounds.
- The magnitude test is exact: the literals are the f32s nearest to 1e-6 and 1e21, and a digit string round-trips to an f32 at or above that nearest f32 exactly when the string is at or above the power of ten. Checked for every finite f32: the notation chosen matches the dtoa crate's for all of them, and the final output is identical to a direct port of dtoa's layout code for all of them.
- Remaining differences from lightningcss after this change: 0.0203% of all f32 values (0.0095% of those in `1e-4 <= |v| < 1e7`). All of them are values where the dtoa crate's Grisu2 emits a longer digit string than the shortest one (for example `0.000103867496` for the f32 whose shortest form is `0.0001038675`; it also never emits a string that sits exactly halfway between two f32s, such as `51990450`, even though parsing it rounds to even and gets the f32 back) and the two strings round differently at 6 digits. Reproducing those would mean formatting with the dtoa crate itself (it is already compiled into bun through lol_html -> cssparser -> dtoa-short); this change uses std instead, since in those cases lightningcss is the side not printing the shortest digits.
- Expectation updates, all to what lightningcss 1.30.2 prints for the same input:
  - css.test.ts border test: `color(display-p3 .972961 ...)` -> `.972962`. That f32's shortest form is `.9729615`, which is what the test expected before rounding was added; `.972961` is this bug (the f64 expansion is `0.97296148...`), and lightningcss's own expectation for this color is `.972962`.
  - angle-serialization-hang.test.ts `2e+32rad` / `3.3e+33rad` -> `2e32rad` / `3.3e33rad`; issue/21907.test.ts and internal/int_from_float.test.ts `3.40282e+38px` -> `3.40282e38px`.
- Verification:
  - test/js/bun/css/css.test.ts, new "number serialization" block: 37 `minify_test` cases across the number, dimension, percentage, custom property, unknown property token and media query paths, plus the reported `oklab()` case. 24 of them fail on the unfixed build (plus the border test and the three expectation updates above); all pass with the fix.
  - test/js/bun/css (css.test.ts, color.test.ts, the doesnt_crash real-world stylesheet snapshots), test/bundler/css (WPT color tests), test/bundler/esbuild/css.test.ts, bundler_loader, bundler_regressions and the CSS regression tests pass with the fix.
  - 20,000 random numeric literals (1 to 9 digits, magnitudes 1e-20 to 1e29) minified as a length, a number, a percentage, a custom property token and an unknown property token, compared with lightningcss 1.30.2 on the same input: the unfixed binary differs on 1,290 of them (6.45%), the fixed one on 1 (`line-height:51990450`, the halfway case described above).
  - Digit generation costs about 78ns per number in a release microbenchmark. For scale, the dtoa crate takes 42ns, and producing the f64 expansion's digits with Rust's f64 formatter (a stand-in for the WTF call the old path made, which also handed `restrict_prec` a longer string) takes 145ns.

### Background
- Every CSS number in this printer is an f32 and is printed with at most 6 significant digits. lightningcss does this through cssparser -> dtoa-short: the dtoa crate writes the f32's shortest round-trip digits (plain notation for `1e-6 <= |v| < 1e21`, otherwise `d.ddde<exp>`), then `restrict_prec` rounds that string to 6 digits. `restrict_prec` in css_parser.rs is a port of that second step; it only works on the text it is given, so the digit string it receives decides the result.
- "Shortest round-trip digits" are the fewest decimal digits that parse back to the same float, and they depend on the float's width: an f32 needs at most 9, while the same value formatted as an f64 gets up to 17 digits describing the f32's exact binary value. Rounding the two strings to 6 digits disagrees whenever the shortest f32 form has 7 digits ending in 5 (`56.89655`) or the expansion is a run of nines (`9.999999974752427e-7`).
- Rust's `Display` (`{}`) and `LowerExp` (`{:e}`) for floats with no precision produce exactly those shortest round-trip digits for the float's own width; `{}` always uses plain notation and `{:e}` always uses exponent notation, which is why the code picks between them.

<details>
<summary>Exhaustive comparison against the dtoa crate (all 2^32 bit patterns)</summary>

A scratch program ran dtoa 1.0.11 (the version in Cargo.lock, what dtoa-short formats with) and the new code through a copy of `restrict_prec(6)` for every bit pattern, and also ran the new code against a direct port of dtoa's layout routine fed with the same std digits. The old path was simulated as the shortest f64 digits of `value as f64` in JavaScript's layout.

```
mode=all: 4278190080 finite f32 values tested (613269204 with 1e-4 <= |v| < 1e7 or zero)

shipped vs prettify-port oracle (must be 0):             0
shipped layout (decimal/exponent) != dtoa's (must be 0): 0

current (f64 path) output != lightningcss: 1029016718 (24.0526%), in common range: 7813410 (1.2741%)
shipped fix     output != lightningcss:        867882 (0.0203%),  in common range:   58378 (0.0095%)
  examples in common range:
    v=1.038675e-4  lightningcss="0.000103867" (its digits "0.000103867496")  fix="0.000103868"
    v=1.079955e-4  lightningcss="0.000107995" (its digits "0.000107995496")  fix="0.000107996"
    v=1.240325e-4  lightningcss="0.000124032" (its digits "0.00012403249")   fix="0.000124033"
    v=1.488005e-4  lightningcss="0.0001488"   (its digits "0.00014880049")   fix="0.000148801"
  examples elsewhere (subnormals):
    v=1.68679e-40  lightningcss="1.68678e-40" (its digits "1.68678e-40")  fix="1.68679e-40"
```

Microbenchmark (release, 100k CSS-like values, ns per number for digit generation only):

```
shipped: f32 `{}` / `{:e}`              77.5 ns/call
dtoa crate (lightningcss)               41.6 ns/call
f64 `{}`/`{:e}` of the widened value   144.6 ns/call
```
</details>
