### PR TITLE
cli: read the script from stdin for `node -` in node emulation

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2784,8 +2784,9 @@ impl RunCommand {
         Self::boot_and_handle_error(ctx, &absolute_script_path, None)
     }
 
-    /// `bun run -` — read script from stdin into `ctx.runtime_options.eval`
-    /// and boot the VM with the synthetic `[stdin]` path.
+    /// `bun run -` / `node -` — read script from stdin into
+    /// `ctx.runtime_options.eval` and boot the VM with the synthetic `[stdin]`
+    /// path. `false` means stdin could not be read; the caller exits 1.
     fn exec_stdin(ctx: &mut ContextData) -> crate::Result<bool> {
         bun_core::scoped_log!(RUN_LOG, "Executing from stdin");
 
@@ -2924,6 +2925,16 @@ impl RunCommand {
                 return Self::exec_node_repl(ctx);
             }
             Self::exec_as_if_node_missing_script();
+        }
+
+        // `node -` reads the script from stdin. `Arguments::parse` stopped at
+        // this positional, so everything after the `-` is already in
+        // `ctx.passthrough`; `exec_stdin` puts the `-` itself back in front.
+        if ctx.positionals[0].as_ref() == b"-" {
+            if Self::exec_stdin(ctx)? {
+                return Ok(());
+            }
+            Global::exit(1);
         }
 
         // borrowck — `boot_and_handle_error` takes `&mut ctx`, so

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -111,4 +111,51 @@ describe("fake node cli", () => {
     expect(result.stderr.toString()).toContain("Missing script");
     expect(result.success).toBe(false);
   });
+
+  // `node -` runs the script piped to stdin. Like node, the `-` stays in
+  // process.argv[1] and everything after it is user argv, even when a file
+  // literally named `-` exists in cwd.
+  describe("node - runs the script from stdin", () => {
+    function nodeStdin(args: string[], script: string, files: Record<string, string> = {}) {
+      using temp = tempDir("fake-node", { "-": "console.log('fail: ran the file named -')", ...files });
+      const result = Bun.spawnSync([bunExe(), "--bun", "node", ...args], {
+        cwd: String(temp),
+        env: { ...bunEnv, NODE_ENV: undefined },
+        stdin: Buffer.from(script),
+      });
+      return {
+        stdout: result.stdout.toString("utf8"),
+        stderr: result.stderr.toString("utf8"),
+        exitCode: result.exitCode,
+      };
+    }
+
+    const logArgv = "console.log(JSON.stringify(process.argv.slice(1)))";
+    test.each([
+      { args: ["-"], argv: ["-"] },
+      { args: ["-", "a", "b"], argv: ["-", "a", "b"] },
+      { args: ["-", "--flag", "-x"], argv: ["-", "--flag", "-x"] },
+      { args: ["--", "-", "a"], argv: ["-", "a"] },
+    ])("node $args", ({ args, argv }) => {
+      const { stdout, stderr, exitCode } = nodeStdin(args, logArgv);
+      expect(stdout).toBe(JSON.stringify(argv) + "\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    test("the stdin script's exit code is the process exit code", () => {
+      const { stdout, exitCode } = nodeStdin(["-"], "console.log('ran'); process.exitCode = 3");
+      expect(stdout).toBe("ran\n");
+      expect(exitCode).toBe(3);
+    });
+
+    test("--require preloads run before the stdin script", () => {
+      const { stdout, stderr, exitCode } = nodeStdin(["--require", "./pre.js", "-"], "console.log(globalThis.pre)", {
+        "pre.js": "globalThis.pre = 'preloaded'",
+      });
+      expect(stdout).toBe("preloaded\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- When bun runs as `node` (argv0 is `node`: the shim `bun --bun` puts on PATH, or a `node` symlink to bun), `node -` does not read the script from stdin. It fails with `error: Module not found '<cwd>/-'` and exit code 1; if a file named `-` happens to exist in cwd, it runs that file instead. `some-tool | node -` is the standard node way to run a generated script, and it works in plain bun (`bun run -`).
- Cause: `RunCommand::exec_as_if_node` (src/runtime/cli/run_command.rs) goes from the `-e`/`-p` branch straight to "the positional is a file name" and joins it onto cwd. It never checks for the `-` marker. The `bun run -` path (`exec_with_cfg` -> `exec_stdin`) does. Not a regression: the Zig `execAsIfNode` had the same shape.

### Fix
- `exec_as_if_node` now routes a bare `-` positional to the existing `exec_stdin`, the same function `bun run -` uses. A failed stdin read exits 1, which is also what `bun run -` does.
- Why this is right: it matches node. `echo 'console.log(process.argv.slice(1))' | node - a b` prints `["-","a","b"]` (node v26.3.0). Bun's argument parser stops at the first positional for the node command, so `a b` are already in `ctx.passthrough`, and `exec_stdin` prepends the `-` itself, so the argv comes out the same. `-e`/`-p` are checked earlier in the function and still win over a `-` positional, as in node, and `node ./-` still runs a file of that name because only the bare `-` is the marker.
- Not changed: `process.execArgv` for a stdin script still contains `"-"`. That is computed elsewhere (`create_exec_argv` in node_process.rs) and is the same for `bun run -` today; it is a separate fix.
- Verified: test/cli/run/as-node.test.ts, new `node - runs the script from stdin` block (argv for `-`, `- a b`, `- --flag -x`, `-- - a`; exit code propagation; `--require` preload before the stdin script). All 6 fail on the released binary and pass with this change. The rest of as-node.test.ts and test/cli/run/run-eval.test.ts (the `bun run -` coverage) still pass with the debug build.

### Background
- Node emulation: when bun's argv0 is `node`, `Command::which` (src/runtime/cli/mod.rs) dispatches to `RunAsNodeCommand`, whose body is `exec_as_if_node`. It imitates the node CLI rather than `bun run`: no package.json script lookup, no `node_modules/.bin` lookup, the positional is always a file.
- `exec_stdin`: reads all of stdin into `ctx.runtime_options.eval.script` and boots the VM with the synthetic entry point `<cwd>/[stdin]`; the module loader serves that path from the in-memory script (the same mechanism `[eval]` uses). It also pushes `"-"` to the front of `ctx.passthrough`, which becomes `process.argv` after the executable.
- positionals vs passthrough: `Arguments::parse` uses `stop_after_positional_at = 1` for the node command, so `ctx.positionals` holds only the script argument and every later argument lands in `ctx.passthrough` unparsed. That is why the new branch only has to look at `positionals[0]`.
