### PR TITLE
install.ps1: make the "another bun.exe is already in PATH" check work

### DIFF
--- a/src/runtime/cli/install.ps1
+++ b/src/runtime/cli/install.ps1
@@ -29,7 +29,8 @@ $MinBuildName = "Windows 10 1809 / Windows Server 2019"
 
 $WinVer = [System.Environment]::OSVersion.Version
 if ($WinVer.Major -lt 10 -or ($WinVer.Major -eq 10 -and $WinVer.Build -lt $MinBuild)) {
-  Write-Warning "Bun requires at ${MinBuildName} or newer.`n`nThe install will still continue but it may not work.`n"
+  Write-Output "Install Failed:"
+  Write-Output "Bun requires ${MinBuildName} or newer.`n"
   return 1
 }
 
@@ -274,8 +275,8 @@ function Install-Bun {
 
   $hasExistingOther = $false;
   try {
-    $existing = Get-Command bun -ErrorAction
-    if ($existing.Source -ne "${BunBin}\bun.exe") {
+    $existing = Get-Command bun -ErrorAction SilentlyContinue
+    if ($existing -and $existing.Source -ne "${BunBin}\bun.exe") {
       Write-Warning "Note: Another bun.exe is already in %PATH% at $($existing.Source)`nTyping 'bun' in your terminal will not use what was just installed.`n"
       $hasExistingOther = $true;
     }

--- a/test/internal/install-ps1.test.ts
+++ b/test/internal/install-ps1.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Coverage for the PowerShell scripts in the repo, mainly src/runtime/cli/install.ps1
+ * (what `irm bun.sh/install.ps1 | iex` runs). The installer cannot run end to end
+ * without downloading a release, so this file
+ *
+ *   1. lints every .ps1 for a common parameter that was given no value. PowerShell
+ *      parses `Get-Command bun -ErrorAction` fine and only rejects it when the
+ *      command binds its parameters, so the mistake surfaces as a runtime exception
+ *      (and not at all inside a `try {} catch {}`), and
+ *   2. runs the installer's "is some other bun already in PATH?" block, extracted
+ *      from the script, in real Windows PowerShell and pwsh against a fake PATH.
+ *
+ * Part 2 needs the Windows lanes, which do not run test/internal/source-lints/,
+ * which is why the lint in part 1 lives here too.
+ */
+import { Glob } from "bun";
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const installScript = path.join(repoRoot, "src", "runtime", "cli", "install.ps1");
+
+test("no PowerShell script passes a value-taking common parameter without a value", async () => {
+  // Common parameters (about_CommonParameters) that take an argument. A line
+  // where one of them is followed by nothing, a statement terminator, a comment,
+  // or the next parameter is missing its argument.
+  const dangling =
+    /-(?:ErrorAction|WarningAction|InformationAction|ProgressAction|ErrorVariable|WarningVariable|InformationVariable|OutVariable|OutBuffer|PipelineVariable)\b[ \t]*(?:$|[;|)}#]|-[A-Za-z])/i;
+
+  const violations: string[] = [];
+  let scanned = 0;
+  for (const root of ["src", "scripts", ".buildkite"]) {
+    for await (const rel of new Glob("**/*.ps1").scan({ cwd: path.join(repoRoot, root) })) {
+      scanned++;
+      const relFromRepo = path.join(root, rel).replaceAll("\\", "/");
+      const source = readFileSync(path.join(repoRoot, root, rel), "utf8")
+        .replaceAll("\r\n", "\n")
+        .replace(/<#[\s\S]*?#>/g, m => m.replace(/[^\n]/g, ""));
+      for (const [index, line] of source.split("\n").entries()) {
+        if (line.trimStart().startsWith("#")) continue;
+        if (dangling.test(line)) violations.push(`${relFromRepo}:${index + 1}: ${line.trim()}`);
+      }
+    }
+  }
+
+  // install.ps1 and uninstall.ps1 at least; guards against the scan silently
+  // matching nothing if the scripts move.
+  expect(scanned).toBeGreaterThanOrEqual(2);
+  expect(violations).toEqual([]);
+});
+
+// The block that decides whether typing `bun` after the install would run
+// something other than the bun.exe that was just installed. Its outputs are the
+// warning it prints and $hasExistingOther, which the rest of the script uses to
+// decide whether adding the install dir to PATH is worth anything.
+function existingBunCheck(): string {
+  const source = readFileSync(installScript, "utf8");
+  const startMarker = "$hasExistingOther = $false";
+  const endMarker = "} catch {}";
+  const start = source.indexOf(startMarker);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf(endMarker, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end + endMarker.length);
+}
+
+// Runs the block once per PATH layout. Mirrors what the installer has set up by
+// the time the block runs: $ErrorActionPreference is Stop, $BunBin is the
+// DirectoryInfo returned by `mkdir -Force`, and the string form of that object is
+// what an earlier install would have written into PATH.
+const driver = (block: string) => `
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$ErrorActionPreference = "Stop"
+$BunBin = mkdir -Force "$PSScriptRoot\\bun\\bin"
+$other = "$PSScriptRoot\\other"
+$shim = "$PSScriptRoot\\npm"
+
+$layouts = [ordered]@{
+  "nothing named bun in PATH" = "$PSScriptRoot\\empty"
+  "only the installed bun.exe in PATH" = "$BunBin"
+  "another bun.exe in PATH" = "$other"
+  "a bun.cmd shim in PATH" = "$shim"
+  "another bun.exe ahead of the installed one" = "$other;$BunBin"
+  "the installed one ahead of another bun.exe" = "$BunBin;$other"
+}
+
+$check = @'
+${block}
+'@
+
+$results = [ordered]@{}
+foreach ($name in $layouts.Keys) {
+  $env:Path = $layouts[$name]
+  $hasExistingOther = $null
+  $warnings = @(Invoke-Expression $check 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
+  $results[$name] = [ordered]@{
+    hasExistingOther = $hasExistingOther
+    warning = if ($warnings.Count -gt 0) { $warnings[0].Message } else { $null }
+  }
+}
+$results | ConvertTo-Json -Compress -Depth 3
+`;
+
+describe.skipIf(!isWindows).concurrent("install.ps1: existing bun in PATH check", () => {
+  // `powershell` (Windows PowerShell 5.1) is what the documented install command
+  // uses; pwsh is what scripts/bootstrap.ps1 runs the installer with.
+  test.each(["powershell", "pwsh"])("%s", async shell => {
+    using dir = tempDir("install-ps1", {
+      "driver.ps1": driver(existingBunCheck()),
+      // Get-Command only looks at names and PATHEXT; nothing here is executed.
+      "bun/bin/bun.exe": "",
+      "other/bun.exe": "",
+      "npm/bun.cmd": "",
+      "empty/.keep": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        shell,
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        path.join(String(dir), "driver.ps1"),
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const otherExe = path.join(String(dir), "other", "bun.exe");
+    const shimCmd = path.join(String(dir), "npm", "bun.cmd");
+    const shadowed = (by: string) => ({ hasExistingOther: true, warning: expect.stringContaining(by) });
+    const usesNewInstall = { hasExistingOther: false, warning: null };
+    expect(JSON.parse(stdout)).toEqual({
+      "nothing named bun in PATH": usesNewInstall,
+      "only the installed bun.exe in PATH": usesNewInstall,
+      "another bun.exe in PATH": shadowed(otherExe),
+      "a bun.cmd shim in PATH": shadowed(shimCmd),
+      "another bun.exe ahead of the installed one": shadowed(otherExe),
+      "the installed one ahead of another bun.exe": usesNewInstall,
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `src/runtime/cli/install.ps1` (what `irm bun.sh/install.ps1 | iex` runs) ends with a check that is supposed to warn when typing `bun` would run something other than the bun.exe it just installed. It has never fired: line 277 is `Get-Command bun -ErrorAction`, with no value after `-ErrorAction`.
- PowerShell accepts that line at parse time and throws when the cmdlet binds its parameters (`Missing an argument for parameter 'ErrorAction'`). The `catch {}` under it swallows the exception, so `$hasExistingOther` is `$false` on every machine: the warning is unreachable and the PATH update below always runs as if nothing else were installed. Same result in Windows PowerShell 5.1 and pwsh 7.5; the line has been like this since the script was added (4403c407).
- A few lines up, the minimum Windows build check prints "Bun requires at <version> or newer. The install will still continue but it may not work." and then returns without installing, so the text is wrong about what happens next (and missing a word).

### Fix
- `Get-Command bun -ErrorAction SilentlyContinue`, and only compare `.Source` when a command came back.
- The `$existing -and` guard is load bearing: with `SilentlyContinue` a machine with no `bun` in PATH gets `$null`, and `$null.Source -ne "...\bun.exe"` is `$true`, so the one-token fix by itself would make every fresh install print the warning with an empty path and skip adding `~\.bun\bin` to PATH (verified, table below).
- Resulting behaviour is what the script's own comment describes, and what `install.sh` already does (it skips PATH setup when `bun` already resolves): nothing in PATH or only the new install: no warning, PATH updated as before; another `bun.exe` or a `bun.cmd` shim (npm global install, scoop, ...) ahead of it: warning naming that file, PATH left alone, since appending `~\.bun\bin` would not change what `bun` resolves to. `Get-Command bun` returns the single command PowerShell itself would run, so PATH order is respected.
- The version check now fails the same way the architecture check above it does (`Install Failed:` plus the reason). Bun targets win10_rs5 and does not start on older builds, so the `return 1` stays (#19911 removed it instead, which reviewers objected to); only the text changes.
- Test: `test/internal/install-ps1.test.ts`
  - every host: lints the repo's `.ps1` files for a value-taking common parameter with nothing after it. On main it fails with `src/runtime/cli/install.ps1:277: $existing = Get-Command bun -ErrorAction`.
  - Windows: extracts the check from the script and runs it in `powershell` (what the documented install command uses) and `pwsh` (what `scripts/bootstrap.ps1` runs the installer with) against six PATH layouts. On main the three shadowed layouts come back `false`; with the unguarded one-token fix the empty-PATH layout comes back `true`; with this change all six match. Ran on Windows Server 2019 x64 in both editions.
  - It is in `test/internal/` rather than `test/internal/source-lints/` because the Windows half needs the Buildkite Windows lanes, which exclude that directory.
- Also checked: the modified script still parses with zero errors in both editions, and the new failure text renders as intended in both.

### Background
- Common parameters (`-ErrorAction`, `-WarningAction`, `-ErrorVariable`, ...) are accepted by every cmdlet. `-ErrorAction` takes an `ActionPreference`: `SilentlyContinue` makes a non-terminating error (here: command not found) produce no output and no exception; `Stop` turns it into an exception.
- Parameter binding happens when the command runs, not when the script is parsed. A parameter name with nothing after it parses like a switch, so `Get-Command bun -ErrorAction` is a syntactically valid script that fails on that line at run time.
- The script sets `$ErrorActionPreference = "Stop"` near the top, which is why the binding failure surfaced as an exception for the `catch {}` to swallow rather than as printed error text.
- `Get-Command <name>` returns the one command that typing `<name>` would run (first matching PATH directory, PATHEXT order within it), or nothing. `.Source` is its full path. PowerShell's `-ne` on strings is case-insensitive, so PATH casing does not affect the comparison.

<details>
<summary>Probe of the extracted block on Windows Server 2019 (powershell 5.1 and pwsh 7.5 gave identical results)</summary>

`$BunBin` is the `mkdir -Force` result exactly as in the script; `same` is `"$BunBin"` on PATH, `other` is a directory with a different `bun.exe`, `shim` a directory with a `bun.cmd`.

| PATH                | main            | `SilentlyContinue` only       | this PR                 |
| ------------------- | --------------- | ----------------------------- | ----------------------- |
| empty dir           | false, no warn  | **true, warns with empty path** | false, no warn          |
| same                | false, no warn  | false, no warn                | false, no warn          |
| same (trailing `\`) | false, no warn  | false, no warn                | false, no warn          |
| same (upper-cased)  | false, no warn  | false, no warn                | false, no warn          |
| other               | false, no warn  | true, warns `other\bun.exe`   | true, warns `other\bun.exe` |
| shim                | false, no warn  | true, warns `npm\bun.cmd`     | true, warns `npm\bun.cmd` |
| other;same          | false, no warn  | true, warns `other\bun.exe`   | true, warns `other\bun.exe` |
| same;other          | false, no warn  | false, no warn                | false, no warn          |

Raw `Get-Command bun -ErrorAction` with nothing after it throws `Missing an argument for parameter 'ErrorAction'. Specify a parameter of type 'System.Management.Automation.ActionPreference' and try again.` in both editions, whether or not a bun is in PATH.

Not changed: a PATH entry for the install dir written with forward slashes compares unequal and still gets the warning (the installer itself writes backslash paths, and in that case the directory is already in PATH so skipping the update is harmless).
</details>
