### PR TITLE
cli: do not skip a lone `-` when picking the subcommand (`bun - add x` ran `bun add x`)

### DIFF
--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -937,8 +937,7 @@ pub mod command {
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
-        // A lone `-` (the stdin script) ends the search like `-e` does: what follows
-        // it belongs to the script, not to the subcommand lookup.
+        // A lone `-` (stdin script) ends the search like `-e`: the rest of argv is the script's.
         while first_arg_name.len() > 1 && first_arg_name[0] == b'-' && first_arg_name[1] != b'e' {
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -937,10 +937,8 @@ pub mod command {
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
-        // Step over leading flags to reach the subcommand name. A lone `-` is not a
-        // flag: it is the stdin entry point (`bun - <args>`, as in `node -`), so it
-        // ends the search like `-e` does. Otherwise the argument after it would be
-        // taken as the subcommand and `bun - add x` would run `bun add x`.
+        // A lone `-` (the stdin script) ends the search like `-e` does: what follows
+        // it belongs to the script, not to the subcommand lookup.
         while first_arg_name.len() > 1 && first_arg_name[0] == b'-' && first_arg_name[1] != b'e' {
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -937,10 +937,11 @@ pub mod command {
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
-        while !first_arg_name.is_empty()
-            && first_arg_name[0] == b'-'
-            && !(first_arg_name.len() > 1 && first_arg_name[1] == b'e')
-        {
+        // Step over leading flags to reach the subcommand name. A lone `-` is not a
+        // flag: it is the stdin entry point (`bun - <args>`, as in `node -`), so it
+        // ends the search like `-e` does. Otherwise the argument after it would be
+        // taken as the subcommand and `bun - add x` would run `bun add x`.
+        while first_arg_name.len() > 1 && first_arg_name[0] == b'-' && first_arg_name[1] != b'e' {
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass
             // that and boot the legacy `bun repl` implementation instead.

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,7 +1,7 @@
 import { SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
 
@@ -274,6 +274,42 @@ describe("echo | bun run -", () => {
   }
 
   group(run);
+});
+
+// `-` is the stdin entry point, not a flag: whatever follows it belongs to the
+// script (`node - help` runs stdin with argv ["-", "help"]). The subcommand
+// lookup used to skip the `-` and dispatch on the next argument instead, so
+// `bun - help` printed bun's help and `bun - add x` ran `bun add x`.
+describe("bun - <args> runs stdin even when an arg is a subcommand name", () => {
+  const cases: { flags: string[]; args: string[] }[] = [
+    { flags: [], args: ["help"] },
+    { flags: [], args: ["add", "--help"] },
+    { flags: [], args: ["test"] },
+    // Landed on `bun run`, which happened to read stdin but dropped "run" from argv.
+    { flags: [], args: ["run", "x"] },
+    // The `-` is reached after stepping over a real flag.
+    { flags: ["--silent"], args: ["upgrade", "--help"] },
+  ];
+
+  for (const { flags, args } of cases) {
+    test.concurrent(["bun", ...flags, "-", ...args].join(" "), async () => {
+      // An empty cwd: if the args are dispatched as a subcommand instead, it
+      // must not find a project (or test files) to act on.
+      using dir = tempDir("bun-dash-stdin", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...flags, "-", ...args],
+        cwd: String(dir),
+        env: bunEnv,
+        stdin: Buffer.from("console.log(JSON.stringify(process.argv.slice(1)))"),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(JSON.stringify(["-", ...args]) + "\n");
+      expect(exitCode).toBe(0);
+    });
+  }
 });
 
 test("process._eval (undefined for normal run)", async () => {


### PR DESCRIPTION
### Problem
- `bun - <args>` is the short form of `bun run -` (run the script piped on stdin), but when an argument after the `-` spells a subcommand, that subcommand runs instead and stdin is never read:
  - `bun - help` prints bun's help (exit 0), `bun - test` starts the test runner, `bun - upgrade` runs the upgrader.
  - `bun - a b` and `bun --bun - i` run `bun add`: they fetch packages from the registry and write `package.json`, `bun.lock` and `node_modules` into the cwd.
  - `bun - run x` does read stdin, but `process.argv` comes out as `["-", "x"]` instead of `["-", "run", "x"]`.
- `bun run - help` and `node - help` both run the stdin script with argv `["-", "help"]`; only the `bun -` spelling misbehaves, and only when the next word happens to be a keyword, so `bun - foo` works and hides it.
- Cause: the leading-flag skip loop in `Command::which()` (`src/runtime/cli/mod.rs:940`) steps over every token that starts with `-` before matching the subcommand name. A lone `-` passes that test, so the token after it is the one matched.

### Fix
- The loop now only steps over tokens of at least two bytes (`-x`, `--xy`). A lone `-` stops it, matches no keyword, and `which()` returns `AutoCommand`, the same way it already stops at `-e`. `reserved_command::exec` in the same file already uses this `len() > 1 && [0] == '-'` test for "is a flag".
- Why this is right: `-` is an operand of the run path, not a flag. `AutoCommand` parses it as the first positional (`stop_after_positional_at = 1`), `RunCommand::exec_with_cfg` sends a `-` target to `exec_stdin`, and `exec_stdin` already prepends `-` to the passthrough args to mirror `node -`. So once `which()` stops at the `-`, every following argument reaches the script unchanged, which is exactly what `bun run - <args>` and `node - <args>` do today.
- Nothing else is reclassified: an empty token, `-e...`, and every other `-...` token take the same branch as before, and `bun -` alone or `bun - <non-keyword>` already ended up as `AutoCommand`.
- Deliberately not changed here:
  - `--` before a keyword (`bun -- test`, `bun -- a b`) still selects the keyword. It is the same loop, but `--` is not the stdin marker and changing it changes what `bun -- <subcommand>` means (npm also resolves `npm -- help` to the command), so that is a separate decision. Happy to add it here if wanted.
  - `process.execArgv` of a stdin script is `["-"]` (node: `[]`), which also breaks `fork()` from such a script. That is pre-existing for `bun run -` too, lives in `src/runtime/node/node_process.rs`, and is fixed by #38577.
- Related changes to the same loop, each independent of this one:
  - #38578 stops the loop at the other eval flags (`bun -p test` currently starts the test runner) and rewrites the same `while` header; it conflicts textually with this PR. Whichever lands second keeps this PR's `len() > 1` guard, i.e. `while first_arg_name.len() > 1 && first_arg_name[0] == b'-' { if is_eval_flag(..) { return Tag::AutoCommand; } .. }`.
  - #36644 steps over the values of `--cwd` / `--env-file` inside the loop body; it does not touch the `-` case and composes with this change (`bun --cwd dir - help` needs both).
- Verification:
  - `test/cli/run/run-eval.test.ts`, new `bun - <args>` block: `help`, `add --help`, `test`, `run x`, and `--silent - upgrade --help` (the `-` reached after a real flag). Each runs in an empty temp dir and asserts the stdin script printed `["-", ...args]`. All 5 fail on bun 1.4.0-canary.1 (`USE_SYSTEM_BUN=1`: help text / add usage / test runner output / `["-","x"]`) and pass with `bun bd test`.
  - The rest of `run-eval.test.ts` (42 tests) and `test/cli/bun.test.ts` pass with the debug build.
  - `cargo fmt --all -- --check` is clean.

### Background
- `Command::which()` chooses the subcommand (`Tag`) straight from argv before any option parsing: it skips leading global flags such as `--bun` or `--silent`, then compares the next token against the keyword table (`add`/`a`, `install`/`i`, `x`, `test`, `help`, `run`, ...). Any other token means `AutoCommand`, the path that runs a file, a package.json script, or stdin, and that path parses argv with the real CLI parser afterwards.
- `-e` is the existing precedent for a token that ends the search: its value is code, so the loop stops on it and the invocation becomes `AutoCommand` regardless of what the code looks like.
- `process.execArgv` is rebuilt separately from argv by `node_process.rs`, which is why the dispatch fix here and the execArgv fix in #38577 are different files.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->