### PR TITLE
HTMLRewriter: carry the input body's Content-Type onto the transformed Response

### DIFF
--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -342,6 +342,7 @@ rewriter.onDocument({
 When transforming a Response, HTMLRewriter:
 
 - Preserves the status code, headers, and other response properties
+- Sets `Content-Type` from the input body when no header gives one: the `type` of a `Bun.file()` or `Blob` body, or `text/plain;charset=utf-8` for a string body
 - Transforms the body while maintaining streaming capabilities
 - Handles content-encoding (like gzip) automatically
 - Marks the original response body as used after transformation

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -964,8 +964,7 @@ impl RewriterPipe {
         original: &Response,
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
-        // Status and headers (#3334), taken before `wire_input` consumes the body a
-        // Content-Type may derive from.
+        // Taken before `wire_input` consumes the body its Content-Type may derive from (#3334).
         let mut init = original.clone_init(global)?;
         // A string body is `text/plain` by itself; the Response overload's output body is not.
         if sync_only_noun.is_none() && original.get_body_value().was_string() {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -964,11 +964,12 @@ impl RewriterPipe {
         original: &Response,
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
-        // Taken before `wire_input` consumes the body the Content-Type derives from (#3334).
-        let mut headers = original.clone_headers(global)?;
+        // Status and headers (#3334), taken before `wire_input` consumes the body a
+        // Content-Type may derive from.
+        let mut init = original.clone_init(global)?;
         // A string body is `text/plain` by itself; the Response overload's output body is not.
         if sync_only_noun.is_none() && original.get_body_value().was_string() {
-            headers
+            init.headers
                 .get_or_insert_with(HeadersRef::create_empty)
                 .put_default(
                     jsc::HTTPHeaderName::ContentType,
@@ -1037,11 +1038,7 @@ impl RewriterPipe {
         // the sink buffers into `output_buffer`, and `on_start_streaming`
         // hands that over as `DrainResult::Owned`.
         let result = bun_core::heap::alloc_nn(Response::init(
-            webcore::response::Init {
-                headers,
-                status_code: 200,
-                ..Default::default()
-            },
+            init,
             webcore::Body::new({
                 let mut pv = webcore::body::PendingValue::new(global);
                 pv.task = Some(pipe.cast::<c_void>());
@@ -1058,12 +1055,6 @@ impl RewriterPipe {
         // SAFETY: `result` is the live Response just allocated above.
         this.response
             .set(Some(unsafe { RefPtr::init_ref(result.as_ptr()) }));
-
-        result_ref.set_init(
-            original.get_method(),
-            original.get_init_status_code(),
-            original.get_init_status_text().clone(),
-        );
 
         let response_js_value = result_ref.to_js(&this.global);
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -964,8 +964,7 @@ impl RewriterPipe {
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
         // https://github.com/oven-sh/bun/issues/3334
-        // Before `wire_input` takes the body: the output body is a stream, so
-        // a Blob input's Content-Type can only be carried over as a header.
+        // Before `wire_input` consumes the body the Content-Type is derived from.
         let headers = original.clone_headers(global)?;
 
         let pipe = bun_core::heap::alloc_nn(RewriterPipe {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -22,6 +22,7 @@ use bun_sys::Error as SysError;
 use crate::api::native_promise_context;
 use crate::generated_classes::{js_HTMLRewriterTransform, js_Response};
 use crate::webcore::blob::SizeType as BlobSizeType;
+use crate::webcore::response::HeadersRef;
 use crate::webcore::sink::JSSink;
 use crate::webcore::streams::{
     self, SourceHandle, Start, StartTag, StreamError, StreamResult, Writable, WritablePending,
@@ -963,9 +964,18 @@ impl RewriterPipe {
         original: &Response,
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
-        // https://github.com/oven-sh/bun/issues/3334
-        // Before `wire_input` consumes the body the Content-Type is derived from.
-        let headers = original.clone_headers(global)?;
+        // Taken before `wire_input` consumes the body the Content-Type derives from (#3334).
+        let mut headers = original.clone_headers(global)?;
+        // A string body is `text/plain` by itself; the Response overload's output body is not.
+        if sync_only_noun.is_none() && original.get_body_value().was_string() {
+            headers
+                .get_or_insert_with(HeadersRef::create_empty)
+                .put_default(
+                    jsc::HTTPHeaderName::ContentType,
+                    &BunString::ascii(&bun_http_types::MimeType::TEXT.value),
+                    global,
+                )?;
+        }
 
         let pipe = bun_core::heap::alloc_nn(RewriterPipe {
             global: GlobalRef::from(global),

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -963,6 +963,11 @@ impl RewriterPipe {
         original: &Response,
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
+        // https://github.com/oven-sh/bun/issues/3334
+        // Before `wire_input` takes the body: the output body is a stream, so
+        // a Blob input's Content-Type can only be carried over as a header.
+        let headers = original.clone_headers(global)?;
+
         let pipe = bun_core::heap::alloc_nn(RewriterPipe {
             global: GlobalRef::from(global),
             cell: Cell::new(JSValue::ZERO),
@@ -1024,6 +1029,7 @@ impl RewriterPipe {
         // hands that over as `DrainResult::Owned`.
         let result = bun_core::heap::alloc_nn(Response::init(
             webcore::response::Init {
+                headers,
                 status_code: 200,
                 ..Default::default()
             },
@@ -1049,9 +1055,6 @@ impl RewriterPipe {
             original.get_init_status_code(),
             original.get_init_status_text().clone(),
         );
-
-        // https://github.com/oven-sh/bun/issues/3334
-        result_ref.set_init_headers(original.clone_init_headers(global)?);
 
         let response_js_value = result_ref.to_js(&this.global);
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -199,7 +199,7 @@ impl Request {
 
     /// Immutable view of the body value.
     #[inline]
-    fn body_value(&self) -> &BodyValue {
+    pub(crate) fn body_value(&self) -> &BodyValue {
         &self.body
     }
 
@@ -1157,18 +1157,18 @@ impl Request {
                     }
 
                     if !fields.contains(Fields::Headers) {
-                        if let Some(headers) = response.get_init_headers_mut() {
-                            // The flag is set unconditionally once `getInitHeaders()` yielded a
-                            // value, even if `cloneThis` returns null — so a later arg can't
-                            // repopulate headers from a different source.
-                            match headers.clone_this(global_this) {
-                                Ok(h) => {
-                                    // SAFETY: clone_this returns a +1 ref FetchHeaders.
-                                    req.headers.set(h.map(|p| unsafe { HeadersRef::adopt(p) }));
+                        // The flag is set once the Response had headers to give, even if the
+                        // copy came back null — so a later arg can't repopulate headers from a
+                        // different source.
+                        let had_headers = response.get_init_headers().is_some();
+                        match response.clone_headers(global_this) {
+                            Ok(headers) => {
+                                if had_headers || headers.is_some() {
+                                    req.headers.set(headers);
                                     fields.insert(Fields::Headers);
                                 }
-                                Err(e) => bail!(Err(e)),
                             }
+                            Err(e) => bail!(Err(e)),
                         }
                     }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1157,9 +1157,7 @@ impl Request {
                     }
 
                     if !fields.contains(Fields::Headers) {
-                        // The flag is set once the Response had headers to give, even if the
-                        // copy came back null — so a later arg can't repopulate headers from a
-                        // different source.
+                        // Flagged whenever the Response had headers (even if the copy came back null) so a later arg can't repopulate them.
                         let had_headers = response.get_init_headers().is_some();
                         match response.clone_headers(global_this) {
                             Ok(headers) => {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -334,12 +334,6 @@ impl Response {
     }
 
     #[inline]
-    pub(crate) fn set_init_headers(&self, headers: Option<HeadersRef>) {
-        // old headers dropped (HeadersRef::Drop derefs the C++ handle)
-        self.init.with_mut(|init| init.headers = headers);
-    }
-
-    #[inline]
     pub(crate) fn get_init_status_code(&self) -> u16 {
         self.init.get().status_code
     }
@@ -389,17 +383,13 @@ impl Response {
         self.init_mut().headers.as_deref_mut()
     }
 
-    /// Deep-copy this response's init headers (if any) into a fresh
-    /// `HeadersRef`. Centralises the `FetchHeaders::clone_this` +
-    /// `HeadersRef::adopt` pair so callers stay `unsafe`-free.
-    #[inline]
-    pub(crate) fn clone_init_headers(
-        &self,
-        global: &JSGlobalObject,
-    ) -> JsResult<Option<HeadersRef>> {
-        match self.init_mut().headers.as_ref() {
+    /// Deep-copy of the headers the `.headers` getter would report, without
+    /// materializing them on `self`: the `FetchHeaders` once one exists,
+    /// otherwise the body's Content-Type (`None` when there is neither).
+    pub(crate) fn clone_headers(&self, global: &JSGlobalObject) -> JsResult<Option<HeadersRef>> {
+        match self.init.get().headers.as_ref() {
             Some(headers) => headers.clone_this(global),
-            None => Ok(None),
+            None => self.create_headers_from_body(global),
         }
     }
 
@@ -589,26 +579,40 @@ impl Response {
         &self,
         global_this: &JSGlobalObject,
     ) -> JsResult<&mut HeadersRef> {
+        if self.init.get().headers.is_none() {
+            let headers = self
+                .create_headers_from_body(global_this)?
+                .unwrap_or_else(HeadersRef::create_empty);
+            self.init.with_mut(|init| init.headers = Some(headers));
+        }
+
         // R-2 escape hatch via `init_mut()` — the returned `&mut HeadersRef`
         // borrows `self.init`; callers (`get_headers`, `construct_*`) do not
         // hold the borrow across calls that re-enter Response host-fns.
-        let init = self.init_mut();
-        if init.headers.is_none() {
-            init.headers = Some(HeadersRef::create_empty());
+        Ok(self.init_mut().headers.as_mut().unwrap())
+    }
 
-            if let BodyValue::Blob(blob) = self.body.get().value.get() {
-                let content_type = blob.content_type_slice();
-                if !content_type.is_empty() {
-                    init.headers.as_mut().unwrap().put(
-                        HTTPHeaderName::ContentType,
-                        &BunString::ascii(content_type),
-                        global_this,
-                    )?;
-                }
-            }
+    /// The headers a Response constructed without a `headers` init still has:
+    /// `Some` only when the body is a Blob with a Content-Type (`Bun.file()`
+    /// mime type, `Blob.type`, the FormData boundary).
+    fn create_headers_from_body(
+        &self,
+        global_this: &JSGlobalObject,
+    ) -> JsResult<Option<HeadersRef>> {
+        let BodyValue::Blob(blob) = self.body.get().value.get() else {
+            return Ok(None);
+        };
+        let content_type = blob.content_type_slice();
+        if content_type.is_empty() {
+            return Ok(None);
         }
-
-        Ok(init.headers.as_mut().unwrap())
+        let mut headers = HeadersRef::create_empty();
+        headers.put(
+            HTTPHeaderName::ContentType,
+            &BunString::ascii(content_type),
+            global_this,
+        )?;
+        Ok(Some(headers))
     }
 
     pub(crate) fn get_headers(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -85,8 +85,7 @@ impl HeadersRef {
             .map(|p| unsafe { Self::adopt(p) }))
     }
 
-    /// The headers a lazy `.headers` getter creates for `body` on first access: the body
-    /// Blob's `Content-Type` (`Bun.file()` mime, `Blob.type`), or `None` when it has none.
+    /// What a lazy `.headers` getter creates for `body`: its Blob's `Content-Type` (`Bun.file()` mime, `Blob.type`), or `None`.
     pub(crate) fn for_body(body: &BodyValue, global: &JSGlobalObject) -> JsResult<Option<Self>> {
         let BodyValue::Blob(blob) = body else {
             return Ok(None);
@@ -391,10 +390,7 @@ impl Response {
         }
     }
 
-    /// The `ResponseInit` this Response presents to one that takes over its status and
-    /// headers with a different body (`new Response(body, response)`, `HTMLRewriter`):
-    /// the headers are what the `.headers` getter would report, so a body Blob's type
-    /// comes along even when `.headers` was never read.
+    /// Status and what `.headers` would report, for a Response that takes them over with a new body (`new Response(body, response)`, `HTMLRewriter`).
     pub(crate) fn clone_init(&self, global: &JSGlobalObject) -> JsResult<Init> {
         let init = self.init.get();
         Ok(Init {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -84,6 +84,25 @@ impl HeadersRef {
             .clone_this(global)?
             .map(|p| unsafe { Self::adopt(p) }))
     }
+
+    /// The headers a lazy `.headers` getter creates for `body` on first access: the body
+    /// Blob's `Content-Type` (`Bun.file()` mime, `Blob.type`), or `None` when it has none.
+    pub(crate) fn for_body(body: &BodyValue, global: &JSGlobalObject) -> JsResult<Option<Self>> {
+        let BodyValue::Blob(blob) = body else {
+            return Ok(None);
+        };
+        let content_type = blob.content_type_slice();
+        if content_type.is_empty() {
+            return Ok(None);
+        }
+        let mut headers = Self::create_empty();
+        headers.put(
+            HTTPHeaderName::ContentType,
+            &BunString::ascii(content_type),
+            global,
+        )?;
+        Ok(Some(headers))
+    }
 }
 
 impl core::ops::Deref for HeadersRef {
@@ -325,25 +344,6 @@ impl Response {
     }
 
     #[inline]
-    pub(crate) fn set_init(&self, method: Method, status_code: u16, status_text: BunString) {
-        self.init.with_mut(|init| {
-            init.method = method;
-            init.status_code = status_code;
-            init.status_text = status_text;
-        });
-    }
-
-    #[inline]
-    pub(crate) fn get_init_status_code(&self) -> u16 {
-        self.init.get().status_code
-    }
-
-    #[inline]
-    pub(crate) fn get_init_status_text(&self) -> &BunString {
-        &self.init.get().status_text
-    }
-
-    #[inline]
     pub(crate) fn set_url(&self, url: BunString) {
         self.url.set(url);
     }
@@ -387,8 +387,22 @@ impl Response {
     pub(crate) fn clone_headers(&self, global: &JSGlobalObject) -> JsResult<Option<HeadersRef>> {
         match self.init.get().headers.as_ref() {
             Some(headers) => headers.clone_this(global),
-            None => self.create_headers_from_body(global),
+            None => HeadersRef::for_body(self.body.get().value.get(), global),
         }
+    }
+
+    /// The `ResponseInit` this Response presents to one that takes over its status and
+    /// headers with a different body (`new Response(body, response)`, `HTMLRewriter`):
+    /// the headers are what the `.headers` getter would report, so a body Blob's type
+    /// comes along even when `.headers` was never read.
+    pub(crate) fn clone_init(&self, global: &JSGlobalObject) -> JsResult<Init> {
+        let init = self.init.get();
+        Ok(Init {
+            headers: self.clone_headers(global)?,
+            status_code: init.status_code,
+            status_text: init.status_text.clone(),
+            method: init.method,
+        })
     }
 
     #[inline]
@@ -578,8 +592,7 @@ impl Response {
         global_this: &JSGlobalObject,
     ) -> JsResult<&mut HeadersRef> {
         if self.init.get().headers.is_none() {
-            let headers = self
-                .create_headers_from_body(global_this)?
+            let headers = HeadersRef::for_body(self.body.get().value.get(), global_this)?
                 .unwrap_or_else(HeadersRef::create_empty);
             self.init.with_mut(|init| init.headers = Some(headers));
         }
@@ -588,27 +601,6 @@ impl Response {
         // borrows `self.init`; callers (`get_headers`, `construct_*`) do not
         // hold the borrow across calls that re-enter Response host-fns.
         Ok(self.init_mut().headers.as_mut().unwrap())
-    }
-
-    /// `Some` only when the body is a Blob with a Content-Type (`Bun.file()` mime, `Blob.type`).
-    fn create_headers_from_body(
-        &self,
-        global_this: &JSGlobalObject,
-    ) -> JsResult<Option<HeadersRef>> {
-        let BodyValue::Blob(blob) = self.body.get().value.get() else {
-            return Ok(None);
-        };
-        let content_type = blob.content_type_slice();
-        if content_type.is_empty() {
-            return Ok(None);
-        }
-        let mut headers = HeadersRef::create_empty();
-        headers.put(
-            HTTPHeaderName::ContentType,
-            &BunString::ascii(content_type),
-            global_this,
-        )?;
-        Ok(Some(headers))
     }
 
     pub(crate) fn get_headers(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
@@ -1248,16 +1240,20 @@ impl Init {
 
         if js_type == JSType::DOMWrapper {
             // fast path: it's a Request object or a Response object
-            // we can skip calling JS getters
+            // we can skip calling JS getters, but must report what they would
             if let Some(req) = response_init.as_direct::<Request>() {
                 // SAFETY: `as_direct` returned a live `*mut Request` owned by the
                 // JS wrapper cell; the wrapper is rooted by `response_init` for
                 // the duration of this call, so no GC can finalize it here.
                 // Everything touched is `&self`.
                 let req = unsafe { &*req };
-                if let Some(headers) = req.get_fetch_headers_unless_empty() {
-                    result.headers = headers.clone_this(global_this)?;
-                }
+                result.headers = match req.get_fetch_headers_unless_empty() {
+                    Some(headers) => headers.clone_this(global_this)?,
+                    None if !req.has_fetch_headers() => {
+                        HeadersRef::for_body(req.body_value(), global_this)?
+                    }
+                    None => None,
+                };
 
                 result.method = req.method;
                 return Ok(Some(result));
@@ -1267,7 +1263,7 @@ impl Init {
                 // SAFETY: `as_direct` returned a live `*mut Response` owned by the
                 // JS wrapper cell; rooted by `response_init` for this call.
                 let resp = unsafe { &*resp };
-                return Ok(Some(resp.init.get().clone(global_this)?));
+                return Ok(Some(resp.clone_init(global_this)?));
             }
         }
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -383,9 +383,7 @@ impl Response {
         self.init_mut().headers.as_deref_mut()
     }
 
-    /// Deep-copy of the headers the `.headers` getter would report, without
-    /// materializing them on `self`: the `FetchHeaders` once one exists,
-    /// otherwise the body's Content-Type (`None` when there is neither).
+    /// Deep copy of what the `.headers` getter would report, without materializing it on `self`.
     pub(crate) fn clone_headers(&self, global: &JSGlobalObject) -> JsResult<Option<HeadersRef>> {
         match self.init.get().headers.as_ref() {
             Some(headers) => headers.clone_this(global),
@@ -592,9 +590,7 @@ impl Response {
         Ok(self.init_mut().headers.as_mut().unwrap())
     }
 
-    /// The headers a Response constructed without a `headers` init still has:
-    /// `Some` only when the body is a Blob with a Content-Type (`Bun.file()`
-    /// mime type, `Blob.type`, the FormData boundary).
+    /// `Some` only when the body is a Blob with a Content-Type (`Bun.file()` mime, `Blob.type`).
     fn create_headers_from_body(
         &self,
         global_this: &JSGlobalObject,

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -44,12 +44,42 @@ describe("2-arg form", () => {
     expect(response.status).toBe(200);
     expect(response.statusText).toBe("");
   });
+
+  // A Response or Request used as the init carries the headers its `.headers`
+  // getter reports, including a Content-Type that only its body Blob implies
+  // and that the getter would have added on first access.
+  test("a Response or Request init carries its body Blob's Content-Type", () => {
+    const typed = () => new Blob(["<p>hi</p>"], { type: "text/html" });
+    const contentType = (init: Response | Request) => new Response("replaced", init).headers.get("content-type");
+
+    expect(contentType(new Response(typed(), { status: 201 }))).toBe("text/html;charset=utf-8");
+    expect(new Response("replaced", new Response(typed(), { status: 201 })).status).toBe(201);
+    expect(contentType(new Request("http://example.com/", { method: "POST", body: typed() }))).toBe(
+      "text/html;charset=utf-8",
+    );
+    // An explicit header wins, a deleted one stays deleted, an untyped body adds none.
+    expect(contentType(new Response(typed(), { headers: { "content-type": "text/x-custom" } }))).toBe("text/x-custom");
+    const deleted = new Response(typed());
+    deleted.headers.delete("content-type");
+    expect(contentType(deleted)).toBe(null);
+    expect(contentType(new Response(new Blob(["<p>hi</p>"])))).toBe(null);
+    expect(contentType(new Response("a string"))).toBe(null);
+    // `new Request(input, init)` with a Response init takes its headers the same way.
+    expect(new Request("http://example.com/", new Response(typed())).headers.get("content-type")).toBe(
+      "text/html;charset=utf-8",
+    );
+    expect(
+      new Request(new Request("http://example.com/", { method: "POST", body: "a" }), new Response(typed())).headers.get(
+        "content-type",
+      ),
+    ).toBe("text/html;charset=utf-8");
+  });
 });
 
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (8.0 KB) {
+    "Response (9.75 KB) {
       ok: true,
       url: "",
       status: 200,

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1788,6 +1788,94 @@ it("#3334 regression", async () => {
   Bun.gc(true);
 });
 
+// A Response built without a `headers` init only reports its body's
+// Content-Type once `.headers` is read. The transformed Response's body is a
+// stream, so transform() has to carry that header over itself.
+describe("transform() carries the input Response's Content-Type", () => {
+  const rewrite = input =>
+    new HTMLRewriter()
+      .on("p", {
+        element(element) {
+          element.setInnerContent("rewritten");
+        },
+      })
+      .transform(input);
+
+  const contentTypeAndBody = async response => ({
+    contentType: response.headers.get("content-type"),
+    body: await response.text(),
+  });
+
+  it("Bun.file() body", async () => {
+    using dir = tempDir("html-rewriter-content-type", { "index.html": "<p>original</p>" });
+    const response = rewrite(new Response(Bun.file(join(String(dir), "index.html"))));
+    expect(await contentTypeAndBody(response)).toEqual({
+      contentType: "text/html;charset=utf-8",
+      body: "<p>rewritten</p>",
+    });
+  });
+
+  it("typed Blob body", async () => {
+    const response = rewrite(new Response(new Blob(["<p>original</p>"], { type: "text/html" })));
+    expect(await contentTypeAndBody(response)).toEqual({
+      contentType: "text/html;charset=utf-8",
+      body: "<p>rewritten</p>",
+    });
+  });
+
+  it("Response built by fetch() for a data: URL", async () => {
+    const response = rewrite(await fetch("data:text/html,<p>original</p>"));
+    expect(await contentTypeAndBody(response)).toEqual({
+      contentType: "text/html;charset=utf-8",
+      body: "<p>rewritten</p>",
+    });
+  });
+
+  it("FormData body keeps the boundary of the encoded body", async () => {
+    const form = new FormData();
+    form.append("field", "<p>original</p>");
+    const { contentType, body } = await contentTypeAndBody(rewrite(new Response(form)));
+    expect(contentType).toStartWith("multipart/form-data; boundary=");
+    const boundary = contentType.slice("multipart/form-data; boundary=".length);
+    expect(body).toStartWith(`--${boundary}\r\n`);
+    expect(body).toContain("<p>rewritten</p>");
+  });
+
+  it("headers init and the body's Content-Type are both carried", async () => {
+    const response = rewrite(
+      new Response(new Blob(["<p>original</p>"], { type: "text/html" }), { headers: { "x-custom": "1" } }),
+    );
+    expect([...response.headers]).toEqual([
+      ["content-type", "text/html;charset=utf-8"],
+      ["x-custom", "1"],
+    ]);
+  });
+
+  it("a Content-Type deleted from the input's headers stays deleted", async () => {
+    const input = new Response(new Blob(["<p>original</p>"], { type: "text/html" }));
+    input.headers.delete("content-type");
+    expect(await contentTypeAndBody(rewrite(input))).toEqual({ contentType: null, body: "<p>rewritten</p>" });
+  });
+
+  it("an untyped Blob body gets no Content-Type", async () => {
+    const response = rewrite(new Response(new Blob(["<p>original</p>"])));
+    expect(await contentTypeAndBody(response)).toEqual({ contentType: null, body: "<p>rewritten</p>" });
+  });
+
+  it("Bun.serve sends the carried Content-Type", async () => {
+    using dir = tempDir("html-rewriter-served-content-type", { "index.html": "<p>original</p>" });
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => rewrite(new Response(Bun.file(join(String(dir), "index.html")))),
+    });
+    const response = await fetch(`http://localhost:${server.port}/`);
+    expect(await contentTypeAndBody(response)).toEqual({
+      contentType: "text/html;charset=utf-8",
+      body: "<p>rewritten</p>",
+    });
+  });
+});
+
 it("#3489", async () => {
   var el;
   await new HTMLRewriter()

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -16,6 +16,7 @@ import {
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
+import { pathToFileURL } from "url";
 var setTimeoutAsync = (fn, delay) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -1824,12 +1825,15 @@ describe("transform() carries the input Response's Content-Type", () => {
     });
   });
 
-  it("Response built by fetch() for a data: URL", async () => {
-    const response = rewrite(await fetch("data:text/html,<p>original</p>"));
-    expect(await contentTypeAndBody(response)).toEqual({
-      contentType: "text/html;charset=utf-8",
-      body: "<p>rewritten</p>",
-    });
+  it("Response built by fetch() for a data: or file: URL", async () => {
+    using dir = tempDir("html-rewriter-content-type-fetch", { "index.html": "<p>original</p>" });
+    for (const url of ["data:text/html,<p>original</p>", pathToFileURL(join(String(dir), "index.html"))]) {
+      const response = rewrite(await fetch(url));
+      expect(await contentTypeAndBody(response)).toEqual({
+        contentType: "text/html;charset=utf-8",
+        body: "<p>rewritten</p>",
+      });
+    }
   });
 
   it("FormData body keeps the boundary of the encoded body", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1789,8 +1789,9 @@ it("#3334 regression", async () => {
 });
 
 // A Response built without a `headers` init only reports its body's
-// Content-Type once `.headers` is read. The transformed Response's body is a
-// stream, so transform() has to carry that header over itself.
+// Content-Type once `.headers` is read, and a string body's `text/plain` only
+// when Bun.serve sends it. The transformed Response's body is a stream, so
+// transform() has to carry that header over itself.
 describe("transform() carries the input Response's Content-Type", () => {
   const rewrite = input =>
     new HTMLRewriter()
@@ -1862,16 +1863,62 @@ describe("transform() carries the input Response's Content-Type", () => {
     expect(await contentTypeAndBody(response)).toEqual({ contentType: null, body: "<p>rewritten</p>" });
   });
 
+  it("a string body is text/plain, as Bun.serve sends it", async () => {
+    expect(await contentTypeAndBody(rewrite(new Response("<p>original</p>")))).toEqual({
+      contentType: "text/plain;charset=utf-8",
+      body: "<p>rewritten</p>",
+    });
+    // Non-ASCII takes the UTF-8 re-encode path for the input.
+    expect(await contentTypeAndBody(rewrite(new Response("<p>original ☃</p>")))).toEqual({
+      contentType: "text/plain;charset=utf-8",
+      body: "<p>rewritten</p>",
+    });
+  });
+
+  it("a string body keeps the Content-Type of its headers init", async () => {
+    const response = rewrite(new Response("<p>original</p>", { headers: { "Content-Type": "text/html" } }));
+    expect([...response.headers]).toEqual([["content-type", "text/html"]]);
+  });
+
+  it("the string and ArrayBuffer overloads still return the body alone", () => {
+    expect(rewrite("<p>original</p>")).toBe("<p>rewritten</p>");
+    const output = rewrite(new TextEncoder().encode("<p>original</p>").buffer);
+    expect(output).toBeInstanceOf(ArrayBuffer);
+    expect(new TextDecoder().decode(output)).toBe("<p>rewritten</p>");
+  });
+
   it("Bun.serve sends the carried Content-Type", async () => {
-    using dir = tempDir("html-rewriter-served-content-type", { "index.html": "<p>original</p>" });
+    // `big.html` takes more than one file read, so its output is still
+    // streaming (chunked) when the server writes the headers.
+    const filler = Buffer.alloc(512 * 1024, "x").toString();
+    const big = `<html><body><p>original</p>${filler}<p>original</p></body></html>`;
+    const bigRewritten = `<html><body><p>rewritten</p>${filler}<p>rewritten</p></body></html>`;
+    using dir = tempDir("html-rewriter-served-content-type", { "index.html": "<p>original</p>", "big.html": big });
+    const inputs = {
+      "/file": () => new Response(Bun.file(join(String(dir), "index.html"))),
+      "/big-file": () => new Response(Bun.file(join(String(dir), "big.html"))),
+      "/blob": () => new Response(new Blob(["<p>original</p>"], { type: "text/html" })),
+      "/string": () => new Response("<p>original</p>"),
+      "/header": () => new Response("<p>original</p>", { headers: { "content-type": "text/html" } }),
+    };
     await using server = Bun.serve({
       port: 0,
-      fetch: () => rewrite(new Response(Bun.file(join(String(dir), "index.html")))),
+      fetch: req => rewrite(inputs[new URL(req.url).pathname]()),
     });
-    const response = await fetch(`http://localhost:${server.port}/`);
-    expect(await contentTypeAndBody(response)).toEqual({
-      contentType: "text/html;charset=utf-8",
-      body: "<p>rewritten</p>",
+    const served = {};
+    for (const path of Object.keys(inputs)) {
+      const response = await fetch(new URL(path, server.url));
+      let body = await response.text();
+      if (path === "/big-file")
+        body = body === bigRewritten ? "(big.html rewritten)" : `unexpected ${body.length} bytes`;
+      served[path] = { contentType: response.headers.get("content-type"), body };
+    }
+    expect(served).toEqual({
+      "/file": { contentType: "text/html;charset=utf-8", body: "<p>rewritten</p>" },
+      "/big-file": { contentType: "text/html;charset=utf-8", body: "(big.html rewritten)" },
+      "/blob": { contentType: "text/html;charset=utf-8", body: "<p>rewritten</p>" },
+      "/string": { contentType: "text/plain;charset=utf-8", body: "<p>rewritten</p>" },
+      "/header": { contentType: "text/html", body: "<p>rewritten</p>" },
     });
   });
 });


### PR DESCRIPTION
### Problem

- `HTMLRewriter.transform(new Response(Bun.file("index.html")))` returns a Response with no `Content-Type`. `Bun.serve` sends `application/octet-stream` and browsers download the page. A typed `Blob`, `FormData` and a string body lose their type too.
- Cause: `RewriterPipe::init` (`src/runtime/api/html_rewriter.rs`) copied only materialized headers. A Response has none until its `.headers` getter runs, and that getter adds a body Blob's type. A string body's `text/plain` is never a header: `Bun.serve` derives it from the body. The output body is new, so the type is gone.
- `new Response(body, otherResponse)`, `new Response(body, request)` and `new Request(input, response)` copy headers through such a fast path too and missed the Blob type.

### Fix

- `HeadersRef::for_body` builds the headers the getter would add. The getter, `Response::clone_headers`, the new `Response::clone_init` and the three fast paths all use it, so every copy reports what the source's `.headers` reports. A deleted `Content-Type` stays deleted.
- `RewriterPipe::init` takes `clone_init` before it consumes the body, and adds `text/plain;charset=utf-8` for a string body with no `Content-Type` header, as `StaticRoute::from_js` already does. The `transform(string | ArrayBuffer)` overloads skip this.
- Verified: `test/js/workerd/html-rewriter.test.js` (6 of 11 new cases fail on stock bun) and `test/js/web/fetch/response.test.ts` (fast paths). Self-reviewed: 4 concerns raised, 4 addressed. Other suites in Notes.

### Background

- A `Response` keeps headers in `Init.headers: Option<HeadersRef>`, a refcounted C++ `FetchHeaders`. `new Response(body)` allocates none. The `.headers` getter does, on first access.
- A string body never gets a header. `Bun.serve` reads `was_string` off the body and sends `text/plain`.
- `transform(response)` builds a new Response from the input's status and headers with lol-html's output as its body, and consumes the input body.

<details><summary>Notes</summary>

- Reading `input.headers` once before `transform()` hid the bug for Blob bodies, which is why it went unnoticed.
- In-process, `transform(new Response("...")).headers.get("content-type")` is now `text/plain;charset=utf-8` while the input's own getter still reports `null`. Cloudflare Workers and the Fetch spec report `text/plain;charset=UTF-8` for both. Making `new Response("...").headers` itself report it is the broader change tracked in #8530 / #17085 / #33677 and is not part of this PR. Once a body-level content-type accessor lands there, the string rule in `RewriterPipe::init` (and the same one in `StaticRoute::from_js`) folds into `HeadersRef::for_body`.
- When the output is still streaming as `Bun.serve` writes the headers (a file larger than one read), stock bun sends no `Content-Type` at all instead of `application/octet-stream`. The header fixes both paths.
- An untyped `Blob`, an `ArrayBuffer` body and a `ReadableStream` body imply no type and get no header, same as before.
- `Response.json(data, otherResponse)` with a typed-Blob `otherResponse` now keeps that Response's type instead of `application/json`. That is the same result as when `otherResponse.headers` had been read first, and what the spec's "set Content-Type unless present" step gives.
- `test/js/web/fetch/response.test.ts` has a `print size` snapshot of its own file size, updated for the added test.
- The `Bun.serve` test case covers a buffered file, a streamed (chunked) file, a typed Blob, a string, and an explicit header.
- Other suites run: `test/js/workerd/html-rewriter-{end-error,leak}`, `test/js/web/html/html-rewriter-doctype`, `test/js/web/fetch/{headers,fetch_headers,body,body-clone,blob,request-cyclic-reference}`, `test/js/web/request/request`, `test/js/node/http/node-fetch`, `test/js/bun/http/{bun-serve-headers,bun-serve-file,serve-stream-body-error}`.
- Repro on bun 1.4.2:

```js
const rewrite = r => new HTMLRewriter().on("p", { element(e) { e.setInnerContent("bye"); } }).transform(r);

rewrite(new Response(Bun.file("index.html"))).headers.get("content-type"); // null
const input = new Response(Bun.file("index.html"));
input.headers;
rewrite(input).headers.get("content-type"); // "text/html;charset=utf-8"

// Bun.serve({ fetch: () => rewrite(new Response(Bun.file("index.html"))) })
//   -> Content-Type: application/octet-stream
// Bun.serve({ fetch: () => rewrite(new Response("<p>hi</p>")) })
//   -> Content-Type: application/octet-stream (direct: text/plain;charset=utf-8)

new Response("x", new Response(new Blob(["x"], { type: "text/html" }))).headers.get("content-type"); // null
```

- Related: #42015 keeps the body-derived `Content-Type` on `Init` from construction on, so it also survives a body that was read or streamed before `.headers`. It covers the typed-body half of this PR (with the same `clone_init` / `clone_headers` entry points) but not the string `text/plain` rule or the `Bun.serve` rewriter tests. Whichever lands first, the other rebases down to its remainder. #32913 is the older per-consumer take on the same ordering bug and leaves `HTMLRewriter.transform` alone.

</details>
