### PR TITLE
install: stop aborting on linked package names that do not fit the symlink buffers

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2121,11 +2121,11 @@ impl<'a> PackageInstall<'a> {
                 }
             }
         };
-        // `dest_path` is `name` or `@scope/name` (`alias_is_safe_install_target`), so the
-        // entry name is its NUL-terminated tail.
+        // The entry name is the NUL-terminated tail of `dest_path`.
         let dest: &ZStr = ZStr::from_slice_with_nul(
             &dest_path.as_bytes_with_nul()[subdir.map_or(0, |dir| dir.len() + 1)..],
         );
+        debug_assert_eq!(dest.as_bytes(), bun_paths::basename(dest_path.as_bytes()));
         // When we're linking on Windows, we want to avoid keeping the source directory handle open
         #[cfg(windows)]
         {
@@ -2242,15 +2242,13 @@ impl<'a> PackageInstall<'a> {
                 Err(err) => return InstallResult::fail(err.into(), Step::LinkingDependency, None),
             };
 
-            let target = path::resolve_path::relative(dest_dir_path, to_path);
-            // `symlinkat` takes `&ZStr`; build a NUL-terminated copy of the target in a
-            // stack buffer.
             let mut target_buf = PathBuffer::uninit();
-            target_buf[..target.len()].copy_from_slice(target);
-            target_buf[target.len()] = 0;
-            // SAFETY: NUL written above.
-            let target_z = ZStr::from_buf(&target_buf, target.len());
-            if let Err(err) = sys::symlinkat(target_z, dest_dir.fd(), dest) {
+            let target = path::resolve_path::relative_buf_z(
+                target_buf.as_mut_slice(),
+                dest_dir_path,
+                to_path,
+            );
+            if let Err(err) = sys::symlinkat(target, dest_dir.fd(), dest) {
                 return InstallResult::fail(err.into(), Step::LinkingDependency, None);
             }
         }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2121,7 +2121,11 @@ impl<'a> PackageInstall<'a> {
                 }
             }
         };
-        let dest = bun_paths::basename(dest_path.as_bytes());
+        // `dest_path` is `name` or `@scope/name` (`alias_is_safe_install_target`), so the
+        // entry name is its NUL-terminated tail.
+        let dest: &ZStr = ZStr::from_slice_with_nul(
+            &dest_path.as_bytes_with_nul()[subdir.map_or(0, |dir| dir.len() + 1)..],
+        );
         // When we're linking on Windows, we want to avoid keeping the source directory handle open
         #[cfg(windows)]
         {
@@ -2172,7 +2176,14 @@ impl<'a> PackageInstall<'a> {
                 dest_buf[offset] = bun_paths::SEP_WINDOWS;
                 offset += 1;
             }
-            dest_buf[offset..offset + dest.len()].copy_from_slice(dest);
+            if offset + dest.len() >= dest_buf.len() {
+                return InstallResult::fail(
+                    crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG),
+                    Step::LinkingDependency,
+                    None,
+                );
+            }
+            dest_buf[offset..offset + dest.len()].copy_from_slice(dest.as_bytes());
             offset += dest.len();
             dest_buf[offset] = 0;
 
@@ -2232,18 +2243,14 @@ impl<'a> PackageInstall<'a> {
             };
 
             let target = path::resolve_path::relative(dest_dir_path, to_path);
-            // `symlinkat` takes `&ZStr` for both target and dest; build NUL-terminated
-            // copies in stack buffers.
+            // `symlinkat` takes `&ZStr`; build a NUL-terminated copy of the target in a
+            // stack buffer.
             let mut target_buf = PathBuffer::uninit();
             target_buf[..target.len()].copy_from_slice(target);
             target_buf[target.len()] = 0;
             // SAFETY: NUL written above.
             let target_z = ZStr::from_buf(&target_buf, target.len());
-            let mut dest_name_buf = [0u8; 512];
-            dest_name_buf[..dest.len()].copy_from_slice(dest);
-            // SAFETY: zero-initialized; NUL at [dest.len()].
-            let dest_z = ZStr::from_buf(&dest_name_buf, dest.len());
-            if let Err(err) = sys::symlinkat(target_z, dest_dir.fd(), dest_z) {
+            if let Err(err) = sys::symlinkat(target_z, dest_dir.fd(), dest) {
                 return InstallResult::fail(err.into(), Step::LinkingDependency, None);
             }
         }

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -7,6 +7,7 @@ import {
   assertManifestsPopulated,
   bunEnv as baseEnv,
   bunExe,
+  isWindows,
   readdirSorted,
   runBunInstall,
   toMatchNodeModulesAt,
@@ -2322,5 +2323,40 @@ describe("packages whose version label is longer than 512 bytes", () => {
     expect(await file(join(packageDir, "node_modules", "baz", "index.js")).text()).toBe(
       '#! /usr/bin/env node\n\nconsole.log("patched baz");\n',
     );
+  });
+});
+
+// The hoisted installer links a workspace package into node_modules under its name. A name
+// too long for the buffer that symlink is given used to abort the whole install instead of
+// failing that one package with ENAMETOOLONG. On POSIX that buffer held 512 bytes. On
+// Windows the name is appended to the absolute node_modules path in a 98302 byte buffer
+// (bun refuses names of 98302 bytes and up), so the name has to come within a node_modules
+// path (`\\?\C:\x\node_modules\` at the very least) of that size to overflow it.
+describe("workspace packages whose name is too long to link", () => {
+  const longName = Buffer.alloc(isWindows ? 98302 - 20 : 600, "a").toString();
+
+  // A scoped package is linked inside a separately opened `node_modules/@scope` directory.
+  test.concurrent.each([
+    ["unscoped", longName],
+    ["scoped", `@scope/${longName}`],
+  ])("%s name fails with ENAMETOOLONG", async (_, name) => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", workspaces: ["pkgs/*"] })),
+      write(join(packageDir, "pkgs", "pkg1", "package.json"), JSON.stringify({ name, version: "1.0.0" })),
+    ]);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--linker", "hoisted"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: ctx.env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain(`ENAMETOOLONG: failed linking dependency/workspace to node_modules for package ${name}`);
+    expect(out).toContain("Failed to install 1 package");
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- `bun install --linker hoisted` aborts when a workspace (or `link:`) package has to be linked into `node_modules` under a name longer than 512 bytes:
  ```
  panic: range end index 600 out of range for slice of length 512
  ```
  Exit 134, the rest of the install is lost. Names of up to 512 bytes fail just that package with `ENAMETOOLONG: failed linking dependency/workspace to node_modules for package ...` / `Failed to install 1 package` (exit 1), and the installer accepts names up to one byte below the path buffer size (4095 bytes on Linux, 1023 on macOS), so every length in between aborts.
- Cause: the POSIX branch of `PackageInstall::install_from_link` (`src/install/PackageInstall.rs`) copies the entry name into `dest_name_buf: [u8; 512]` to get a NUL-terminated string for `symlinkat`, without checking the length. At exactly 512 bytes the copy fits but the NUL does not, so a release build hands `symlinkat` a string that runs past the buffer and a debug build trips the `ZStr::from_buf` assertion.
- The Windows branch has the same unchecked copy into a bigger buffer: the name is appended to the absolute `node_modules` path in a 98302 byte `PathBuffer`, so a name within a `node_modules` path length of the 98301 byte maximum aborts as well:
  ```
  panic: range end index 98327 out of range for slice of length 98302
  ```

### Fix
- POSIX: the copy is removed. The name is the tail of `destination_dir_subpath`, which is already NUL-terminated (`alias_is_safe_install_target` guarantees it is `name` or `@scope/name`), so that tail is passed to `symlinkat` directly. Nothing is left to bounds check: the file system rejects a name over `NAME_MAX` with `ENAMETOOLONG`, which is exactly what happens to the names of up to 512 bytes today, so longer names now fail the same way.
- Windows: the name plus its NUL is checked against the space left behind the directory path before it is copied, and the package fails with `ENAMETOOLONG` under `Step::LinkingDependency` when it does not fit, the same failure the directory path check a few lines above produces. A destination that does not fit the buffer cannot exist on disk, so this is the error the OS would give for it.
- Both changes only touch the failure path: a name that fits is linked from byte-identical arguments as before.
- Verified:
  - `test/cli/install/bun-workspaces.test.ts`, `describe("workspace packages whose name is too long to link")`: an unscoped and a scoped (`@scope/<name>`, which links inside a separately opened scope directory) workspace member, with a 600 byte name on POSIX and a 98282 byte name on Windows. Both cases abort with the panics above on the unfixed binary on Linux (`USE_SYSTEM_BUN=1`) and on Windows (stock build of current main), and pass with `bun bd test` on Linux x64 and Windows x64.
  - The rest of `bun-workspaces.test.ts` (70 tests) and `bun-link.test.ts` pass with the debug build, except `bun-link.test.ts` "should link dependency without crashing", which fails on main with any debug build independently of this change (#37335).
  - `cargo check -p bun_install` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, `cargo clippy -p bun_install` and `cargo fmt --check` are clean.

### Not in this PR
- A second `bun install` (with `node_modules` present) of a name within 13 bytes of the path buffer size (4083 to 4095 bytes on Linux) still aborts, from a different place: the verify step appends `/package.json` to the buffer the name was copied into (`get_installed_package_json_source`). Reported separately.
- The progress bar's name buffer, which aborts on long names whenever the progress bar is shown: #38558.

### Background
- A hoisted install puts workspace members, `link:` packages and `file:` dependencies on the project root into `node_modules` as symlinks (junctions on Windows); `install_from_link` creates that one link. The link's name is `destination_dir_subpath`, the dependency's name as it appears under `node_modules`. It comes from package.json, and `alias_is_safe_install_target` (`PackageInstaller.rs`) only lets through a single component or `@scope/name` shorter than the path buffer.
- `ZStr` is bun's borrowed NUL-terminated byte string, the type the syscall wrappers take. `as_bytes_with_nul()` is the bytes including the terminator and `ZStr::from_slice_with_nul` borrows a slice ending in one, so the tail of an existing `ZStr` is a `ZStr` without a copy.
- `PathBuffer` is a stack buffer of the platform's maximum path length: 4096 bytes on Linux, 1024 on macOS, 98302 on Windows (32767 UTF-16 units at up to three UTF-8 bytes each, plus the NUL). `NAME_MAX`, the longest single component a file system accepts, is 255 bytes on Linux and macOS, so every name this change is about is rejected by the OS once it gets there.

<details>
<summary>Name lengths probed on the unfixed build (workspace member, <code>CI=1 bun install --linker hoisted</code>)</summary>

```
Linux x64 (1.4.0-canary.1, b7a043103)            unfixed                                          fixed
  300, 511, 512                                    ENAMETOOLONG: failed linking ..., exit 1         same
  513, 600, 1024, 4082                             panic: ... out of range for slice of length 512  ENAMETOOLONG: failed linking ..., exit 1
  @<600 a's>/pkg (long scope, short name)          ENAMETOOLONG (creating the scope dir), exit 1    same
  @s/<600 b's>   (short scope, long name)          panic: ... slice of length 512                   ENAMETOOLONG: failed linking ..., exit 1
  4096, 5000                                       error: refusing to install dependency with unsafe name, exit 1   same

Windows x64 (1.4.0-canary.1, eabb96de7), node_modules path 61 chars
  600, 98000                                       ENOENT: failed linking ..., exit 1               same
  98240, 98260, 98282, 98301                       panic: ... out of range for slice of length 98302, exit 3   ENAMETOOLONG: failed linking ..., exit 1
  @scope/<98282 a's>                               panic: ... slice of length 98302                 ENAMETOOLONG: failed linking ..., exit 1
  98302                                            error: refusing to install dependency with unsafe name, exit 1   same
```
</details>
