### PR TITLE
css: warn about unknown bare pseudo-classes unless they are vendor prefixed

### DIFF
--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1299,17 +1299,18 @@ impl<'a> SelectorParser<'a> {
             if let Some(pseudo) = lookup_non_ts_pseudo_class(name) {
                 break 'pseudo_class pseudo;
             }
-            if strings::starts_with_char(name, b'_') {
-                self.options.warn(&loc.new_custom_error(
-                    SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name),
-                ));
-            } else if (self.options.css_modules.is_some()
+            if (self.options.css_modules.is_some()
                 && strings::eql_case_insensitive_ascii_check_length(name, b"local"))
                 || strings::eql_case_insensitive_ascii_check_length(name, b"global")
             {
                 return Err(
                     loc.new_custom_error(SelectorParseErrorKind::AmbiguousCssModuleClass(name))
                 );
+            }
+            if !strings::starts_with_char(name, b'-') {
+                self.options.warn(&loc.new_custom_error(
+                    SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name),
+                ));
             }
             return Ok(PseudoClass::Custom { name });
         };

--- a/test/js/bun/css/unknown-pseudo-warnings.test.ts
+++ b/test/js/bun/css/unknown-pseudo-warnings.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
+
+// An unknown pseudo-class or pseudo-element is kept as written and warned
+// about unless its name carries a vendor prefix (`:-moz-foo`), the rule
+// lightningcss uses. `:foo` used to warn only when the name started with `_`,
+// while `:foo()`, `::foo` and `::foo()` already followed the vendor-prefix rule.
+
+async function build(fileName: string, css: string) {
+  using dir = tempDir("css-unknown-pseudo", { [fileName]: css });
+  const result = await Bun.build({ entrypoints: [join(String(dir), fileName)], throw: false });
+  const output = result.success ? await result.outputs[0].text() : null;
+  return {
+    success: result.success,
+    logs: result.logs.map(log => `${log.level}: ${log.message}`),
+    // Drop the leading `/* <path relative to cwd> */` comment.
+    output: output === null ? null : output.slice(output.indexOf("\n") + 1),
+  };
+}
+
+function unsupported(name: string) {
+  return `warn: Invalid selector. Unsupported pseudo-class or pseudo-element '${name}'`;
+}
+
+describe.concurrent("unknown pseudo-classes and pseudo-elements", () => {
+  test.each([
+    ["a:weird", [unsupported("weird")]],
+    ["a:weird(x)", [unsupported("weird")]],
+    ["a::weird", [unsupported("weird")]],
+    ["a::weird(x)", [unsupported("weird")]],
+    ["a:_weird", [unsupported("_weird")]],
+    ["a:-x-weird", []],
+    ["a:-x-weird(x)", []],
+    ["a::-x-weird", []],
+    ["a::-x-weird(x)", []],
+  ])("%s is kept as written and warns unless vendor prefixed", async (selector, logs) => {
+    expect(await build("in.css", `${selector} { color: red }`)).toEqual({
+      success: true,
+      logs,
+      output: `${selector} {\n  color: red;\n}\n`,
+    });
+  });
+
+  test("every occurrence warns, wherever the pseudo-class appears in the selector", async () => {
+    const css = [
+      "a:not(:weird) { color: red }",
+      "a:is(:weird, .x) { color: red }",
+      ".a { &:weird { color: red } }",
+      "a:WEIRD { color: red }",
+    ].join("\n");
+    const { success, logs } = await build("in.css", css);
+    expect(logs).toEqual([unsupported("weird"), unsupported("weird"), unsupported("weird"), unsupported("WEIRD")]);
+    expect(success).toBe(true);
+  });
+
+  test("known pseudo-classes and pseudo-elements do not warn", async () => {
+    const css = [
+      "a:hover, a:focus-visible, a:any-link, input:user-valid, [popover]:popover-open { color: red }",
+      "input:-webkit-autofill, input:-moz-read-only, div:-webkit-full-screen { color: red }",
+      ":root, li:first-child, li:nth-child(2n of .x), p:lang(en), a:not(.x), :host { color: red }",
+      "a::before, a::-webkit-scrollbar-thumb, p::first-line, ::cue(v) { color: red }",
+    ].join("\n");
+    const { success, logs } = await build("in.css", css);
+    expect(logs).toEqual([]);
+    expect(success).toBe(true);
+  });
+
+  test("a stylesheet that is not a CSS module treats :local as an unknown pseudo-class", async () => {
+    expect(await build("in.css", ":local { color: red }")).toEqual({
+      success: true,
+      logs: [unsupported("local")],
+      output: ":local {\n  color: red;\n}\n",
+    });
+  });
+
+  test.each(["global", "local"])(":%s without a selector argument is still an error in a CSS module", async name => {
+    expect(await build("in.module.css", `:${name} { color: red }`)).toEqual({
+      success: false,
+      logs: [`error: Invalid selector. CSS module class: '${name}' is currently not supported.`],
+      output: null,
+    });
+  });
+
+  test("bun build reports the warnings on stderr and still emits the rules", async () => {
+    using dir = tempDir("css-unknown-pseudo-cli", {
+      "in.css": "a:weird { color: red }\na:-x-weird { color: red }\nb:odd { color: red }\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./in.css"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+      "warn: Invalid selector. Unsupported pseudo-class or pseudo-element 'weird'
+
+      warn: Invalid selector. Unsupported pseudo-class or pseudo-element 'odd'"
+    `);
+    expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+      "/* in.css */
+      a:weird {
+        color: red;
+      }
+
+      a:-x-weird {
+        color: red;
+      }
+
+      b:odd {
+        color: red;
+      }"
+    `);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/css/unknown-pseudo-warnings.test.ts
+++ b/test/js/bun/css/unknown-pseudo-warnings.test.ts
@@ -57,9 +57,11 @@ describe.concurrent("unknown pseudo-classes and pseudo-elements", () => {
   test("known pseudo-classes and pseudo-elements do not warn", async () => {
     const css = [
       "a:hover, a:focus-visible, a:any-link, input:user-valid, [popover]:popover-open { color: red }",
+      "dialog:modal, video:paused, my-element:defined, input:placeholder-shown, a:HOVER { color: red }",
       "input:-webkit-autofill, input:-moz-read-only, div:-webkit-full-screen { color: red }",
-      ":root, li:first-child, li:nth-child(2n of .x), p:lang(en), a:not(.x), :host { color: red }",
-      "a::before, a::-webkit-scrollbar-thumb, p::first-line, ::cue(v) { color: red }",
+      ":root, li:first-child, li:nth-child(2n of .x), p:lang(en), a:not(.x), :host, a:-webkit-any(.x) { color: red }",
+      "a::before, a::-webkit-scrollbar-thumb, p::first-line, ::cue(v), a::before:hover { color: red }",
+      "::-webkit-scrollbar-button:horizontal:decrement { color: red }",
     ].join("\n");
     const { success, logs } = await build("in.css", css);
     expect(logs).toEqual([]);


### PR DESCRIPTION
### Problem
- `bun build` stays silent on an unknown bare pseudo-class such as `a:hvoer { }` or `:weird { }`, while the other three shapes of unknown pseudo (`:weird(x)`, `::weird`, `::weird(x)`) already print `warn: Invalid selector. Unsupported pseudo-class or pseudo-element 'weird'`.
- Cause: the fallback in `SelectorParser::parse_non_ts_pseudo_class` (src/css/selectors/parser.rs:1302) warns only `if name starts with '_'`. lightningcss, which this parser is ported from, warns `if !name.starts_with('-')`, and that is also the rule used by `parse_non_ts_functional_pseudo_class` (line 1355), `parse_pseudo_element` (line 1414) and `parse_functional_pseudo_element` (line 1261) in the same file. The Zig parser had the same `'_'` check and it was ported as is; a rule that warns only about `_`-prefixed names does not correspond to any CSS convention, so this is a port slip rather than deliberate quieting.
- lightningcss 1.30.2 warns for `:weird` and stays quiet for `:-moz-whatever`; released Bun 1.4.0 does neither for the right reason (see the probe in the details below).

### Fix
- `parse_non_ts_pseudo_class` now warns for an unknown name unless it starts with `-`, the same condition as the three sibling fallbacks. The name is still kept as `PseudoClass::Custom` and printed unchanged; only the diagnostic changes and the build still succeeds.
- The `AmbiguousCssModuleClass` check for bare `:global` / `:local` moves ahead of the warning. With the new condition those names would otherwise take the warning branch and be accepted, so the order is what keeps them an error; it is also the order upstream has. The condition itself is byte-for-byte unchanged: its precedence bug is fixed separately in #38534, whose description scopes this warning out on purpose. The two diffs overlap in this one block, so whichever lands second needs a small rebase; if that is this PR, I will also add the case that only exists once both are in (bare `:global` in a plain stylesheet warns and is passed through, which is what lightningcss does).
- Why this is right: it matches the upstream fallback rule and makes all four unknown-pseudo fallbacks in the file agree. The only newly warned inputs are bare unknown names without a vendor prefix, and Bun already warned for the functional and pseudo-element forms of the same names. Probing 119 bare names (every entry of Bun's two lookup tables, the tree-structural names, and a sweep of spec and browser names) through this branch and lightningcss 1.30.2 gives the same result for 117; the two differences are `:global` (the #38534 bug) and `:active-view-transition`, below.
- Known new false positive: `:active-view-transition` is missing from `lookup_non_ts_pseudo_class` (its functional form `:active-view-transition-type()` already warns on 1.4.0 for the same reason), so with this change the bare form warns as well until the table entry is added. That is a table gap being fixed separately; this PR does not add the entry, and its tests deliberately do not pin the false positive.
- No test in the tree builds CSS with an unknown bare pseudo-class while asserting on warnings. The closest, `css/DeduplicateRules` in test/bundler/esbuild/css.test.ts, uses `a:x` and `a:x(y)` through `itBundled`'s default API backend, which only looks at error-level logs (test/bundler/expectBundled.ts:1288); it still passes.
- Tests: test/js/bun/css/unknown-pseudo-warnings.test.ts. On the unfixed build 4 of its 15 tests fail (`a:weird` warns; warnings inside `:not()` / `:is()` / nested `&:weird` / `a:WEIRD`; `:local` in a plain stylesheet warns; the `bun build` stderr case). The other 11 pin what must not change: functional and pseudo-element forms keep warning, `_`-prefixed names keep warning, vendor-prefixed names stay silent in all four shapes, known names from every section of both tables (including an uppercase one, the `-webkit-any()` alias, `::before:hover` and the `::-webkit-scrollbar-*` state pseudo-classes) stay silent, and bare `:global` / `:local` in a `.module.css` are still errors, not warnings.
- Also run with the debug build: test/js/bun/css/ (only pre-existing debug-build timeouts in css-fuzz and selector-list-error-recovery, unrelated to selector warnings), test/bundler/esbuild/css.test.ts and test/bundler/css/*.test.ts, all passing.

### Background
- The selector parser is a port of lightningcss (itself built on servo's `selectors` crate). Pseudo-classes are resolved in two stages: tree-structural ones (`:root`, `:first-child`, `:not()`, `:nth-child()`, ...) are handled by the generic selector code in `parse_simple_pseudo_class` / `parse_functional_pseudo_class`, everything else goes to the four `SelectorParser` fallbacks named above. A name none of them know becomes `PseudoClass::Custom` / `PseudoElement::Custom` and is printed back out as written; unknown selectors never fail the build, they only record a warning.
- Vendor-prefixed names (`:-moz-...`, `::-webkit-...`) are deliberately not warned about because browsers have many proprietary pseudos that no table is going to list.
- Warnings go through `ParserOptions::warn` into the bundler `Log`; `bun build` prints them as `warn:` lines on stderr and `Bun.build()` returns them in `result.logs`, which is what the new test reads. (For a plain `.css` file they currently carry no file name, only `.module.css` files set one; that is pre-existing and not changed here.)
- CSS modules (`*.module.css`): the functional `:global(.x)` / `:local(.x)` forms are supported; the bare switch forms `:global` / `:local` are not, and are rejected with `AmbiguousCssModuleClass` so class names are not scoped wrongly. This PR keeps that rejection and only changes which names warn.

<details>
<summary>lightningcss 1.30.2 and Bun 1.4.0 on the same input</summary>

```
$ cat warn.css
:unknownfn(x) { color: red }
:_weird { color: red }
:weird { color: red }
:-moz-whatever { color: red }
::weirdel { color: red }
::-webkit-el { color: red }
:-moz-fn(x) { color: red }

# lightningcss transform({ code, cssModules: false }).warnings  (cssModules: true is identical)
1:12 'unknownfn' is not recognized as a valid pseudo-class ...
2:2  '_weird' is not recognized as a valid pseudo-class ...
3:2  'weird' is not recognized as a valid pseudo-class ...
5:2  'weirdel' is not recognized as a valid pseudo-element ...

# bun 1.4.0: bun build warn.css  (stderr)
warn: Invalid selector. Unsupported pseudo-class or pseudo-element 'unknownfn'
warn: Invalid selector. Unsupported pseudo-class or pseudo-element '_weird'
warn: Invalid selector. Unsupported pseudo-class or pseudo-element 'weirdel'
```

With this PR the `'weird'` line (line 3 of the input) is reported as well; lines 4, 6 and 7 stay silent in both.
</details>

<details>
<summary>119-name parity probe (this branch vs lightningcss 1.30.2)</summary>

Each name was built as `a:<name> { color: red }` with this branch's `bun build` and with lightningcss `transform()`, comparing "warns about the name" / "silent" / "error".

```
probed 119 bare names: 117 agree, 2 differ
  active-view-transition   bun: warns   lightningcss: silent   (missing table entry, see above)
  global                   bun: error   lightningcss: warns    (#38534)
```
</details>
