### PR TITLE
css modules: keep names inside :global(...) out of the exports object

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -1642,6 +1642,7 @@ mod rule_parsers {
                         let mut selector_parser = selector_parser::SelectorParser {
                             is_nesting_allowed: true,
                             options: this.options,
+                            in_global_scope: false,
                         };
                         let scope_start = if input.try_parse(|p| p.expect_parenthesis_block()).is_ok() {
                             Some(input.parse_nested_block(|input2| {
@@ -1675,6 +1676,7 @@ mod rule_parsers {
                         let mut selector_parser = selector_parser::SelectorParser {
                             is_nesting_allowed: true,
                             options: this.options,
+                            in_global_scope: false,
                         };
                         let selectors = SelectorList::parse(
                             &mut selector_parser,
@@ -1988,6 +1990,7 @@ mod rule_parsers {
             let mut selector_parser = selector_parser::SelectorParser {
                 is_nesting_allowed: true,
                 options: this.options,
+                in_global_scope: false,
             };
             if this.is_in_style_rule {
                 SelectorList::parse_relative(

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1165,6 +1165,11 @@ impl WebKitScrollbarPseudoElement {
 pub struct SelectorParser<'a> {
     pub(crate) is_nesting_allowed: bool,
     pub(crate) options: &'a ParserOptions<'a>,
+    /// CSS modules: set while parsing the argument of `:global(...)` and
+    /// cleared again inside a nested `:local(...)`. Classes and ids parsed in
+    /// this state keep their written name instead of becoming local symbols,
+    /// so they are neither renamed nor exported.
+    pub(crate) in_global_scope: bool,
     // PERF: re-thread `&'bump Bump` here to restore arena allocation.
 }
 
@@ -1180,7 +1185,7 @@ impl<'a> SelectorParser<'a> {
         raw: Str,
         loc: usize,
     ) -> <impl_::Selectors as SelectorImpl>::LocalIdentifier {
-        if input.flags.css_modules() {
+        if input.flags.css_modules() && !self.in_global_scope {
             return <impl_::Selectors as SelectorImpl>::LocalIdentifier::from_ref(
                 input.add_symbol_for_name(
                     raw,
@@ -1346,10 +1351,10 @@ impl<'a> SelectorParser<'a> {
                 direction: Direction::parse(parser)?,
             },
             b"local" if self.options.css_modules.is_some() => PseudoClass::Local {
-                selector: Box::new(Selector::parse(self, parser)?),
+                selector: self.parse_css_module_scoped_selector(parser, false)?,
             },
             b"global" if self.options.css_modules.is_some() => PseudoClass::Global {
-                selector: Box::new(Selector::parse(self, parser)?),
+                selector: self.parse_css_module_scoped_selector(parser, true)?,
             },
             _ => {
                 if !strings::starts_with_char(name, b'-') {
@@ -1370,6 +1375,21 @@ impl<'a> SelectorParser<'a> {
         }};
 
         Ok(pseudo_class)
+    }
+
+    /// Parses the argument of `:local(...)` / `:global(...)`. The scope covers
+    /// only the argument: it is restored even when the argument fails to parse,
+    /// because `:is()`-style error recovery keeps parsing the rest of the
+    /// selector list with this same parser.
+    fn parse_css_module_scoped_selector(
+        &mut self,
+        parser: &mut CssParser,
+        global: bool,
+    ) -> CResult<Box<Selector>> {
+        let enclosing_scope = core::mem::replace(&mut self.in_global_scope, global);
+        let selector = Selector::parse(self, parser);
+        self.in_global_scope = enclosing_scope;
+        Ok(Box::new(selector?))
     }
 
     pub(crate) fn is_nesting_allowed(&self) -> bool {

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1117,11 +1117,12 @@ pub(crate) mod serialize {
             // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill
             PseudoClass::Autofill(prefix) => write_prefixed(dest, *prefix, b"autofill")?,
 
-            PseudoClass::Local { selector } => serialize_selector(selector, dest, context, false)?,
-            PseudoClass::Global { selector } => {
-                let css_module = dest.css_module.take();
-                serialize_selector(selector, dest, context, false)?;
-                dest.css_module = css_module;
+            // The parser already scoped the classes and ids inside these: a
+            // local one is a `Ref` (printed under its generated name), a
+            // global one is a plain `Ident` (printed as written). That also
+            // covers `:local(...)` nested inside `:global(...)`.
+            PseudoClass::Local { selector } | PseudoClass::Global { selector } => {
+                serialize_selector(selector, dest, context, false)?
             }
 
             // https://webkit.org/blog/363/styling-scrollbars/

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -21,6 +21,304 @@ describe("css", () => {
     },
   });
 
+  // Classes and ids inside `:global(...)` are printed as written, so they must
+  // not show up in the exports object either (the hashed name they would be
+  // exported under matches nothing in the stylesheet).
+  itBundled("css-module/GlobalPseudoFunctionNamesAreNotExported", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        :global(.g) { color: red }
+        .local :global(.h) { color: blue }
+        :global(#gid) { color: green }
+        .scoped { color: pink }
+        #sid { color: black }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          local: "local_-MSaAA",
+          scoped: "scoped_-MSaAA",
+          sid: "sid_-MSaAA"
+        };
+
+        // entry.js
+        console.log(JSON.stringify(styles_module_default));
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .g {
+          color: red;
+        }
+
+        .local_-MSaAA .h {
+          color: #00f;
+        }
+
+        #gid {
+          color: green;
+        }
+
+        .scoped_-MSaAA {
+          color: pink;
+        }
+
+        #sid_-MSaAA {
+          color: #000;
+        }
+        "
+      `);
+    },
+  });
+
+  // `:local(...)` nested inside `:global(...)` makes its argument local again
+  // (esbuild does the same), and the scope switch ends at the closing paren.
+  itBundled("css-module/LocalPseudoFunctionInsideGlobal", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        :global(.a :local(.b)) { color: red }
+        :global(:is(.c, .d) :local(.e):not(.f)) .after { color: blue }
+        .before:not(:global(.n)) { color: green }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          b: "b_-MSaAA",
+          e: "e_-MSaAA",
+          after: "after_-MSaAA",
+          before: "before_-MSaAA"
+        };
+
+        // entry.js
+        console.log(JSON.stringify(styles_module_default));
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .a .b_-MSaAA {
+          color: red;
+        }
+
+        :is(.c, .d) .e_-MSaAA:not(.f) .after_-MSaAA {
+          color: #00f;
+        }
+
+        .before_-MSaAA:not(.n) {
+          color: green;
+        }
+        "
+      `);
+    },
+  });
+
+  // `:is()` drops an invalid selector and keeps parsing the rest of its list
+  // with the same selector parser, so a `:global(...)` whose argument fails to
+  // parse must still hand the enclosing (local) scope back.
+  itBundled("css-module/GlobalScopeRestoredAfterInvalidArgument", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        .x:is(:global(.), .y) { color: red }
+        .p:is(:global(), .q) { color: blue }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          x: "x_-MSaAA",
+          y: "y_-MSaAA",
+          p: "p_-MSaAA",
+          q: "q_-MSaAA"
+        };
+
+        // entry.js
+        console.log(JSON.stringify(styles_module_default));
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .x_-MSaAA.y_-MSaAA {
+          color: red;
+        }
+
+        .p_-MSaAA.q_-MSaAA {
+          color: #00f;
+        }
+        "
+      `);
+    },
+  });
+
+  // The same name used both as a local class and inside `:global(...)` is
+  // exported once, for the local use; the global use still prints as written.
+  itBundled("css-module/GlobalAndLocalUseOfSameName", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        .g { color: red }
+        :global(.g) { color: blue }
+        .wrap :global(.g) { color: green }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          g: "g_-MSaAA",
+          wrap: "wrap_-MSaAA"
+        };
+
+        // entry.js
+        console.log(JSON.stringify(styles_module_default));
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .g_-MSaAA {
+          color: red;
+        }
+
+        .g {
+          color: #00f;
+        }
+
+        .wrap_-MSaAA .g {
+          color: green;
+        }
+        "
+      `);
+    },
+  });
+
+  // Rules nested inside a `:global(...)` rule are not inside the parens, so
+  // their own classes are still local.
+  itBundled("css-module/GlobalPseudoFunctionDoesNotLeakIntoNestedRules", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        :global(.a) {
+          .b { color: red }
+          &:global(.c) .d { color: blue }
+        }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {
+          b: "b_-MSaAA",
+          d: "d_-MSaAA"
+        };
+
+        // entry.js
+        console.log(JSON.stringify(styles_module_default));
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .a .b_-MSaAA {
+          color: red;
+        }
+
+        .a.c .d_-MSaAA {
+          color: #00f;
+        }
+        "
+      `);
+    },
+  });
+
+  itBundled("css-module/OnlyGlobalSelectorsExportsNothing", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        :global(.a) { color: red }
+        :global(#b) :global(.c) { color: blue }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// styles.module.css
+        var styles_module_default = {};
+
+        // entry.js
+        console.log(JSON.stringify(styles_module_default));
+        "
+      `);
+      api.expectFile("/out/entry.css").toMatchInlineSnapshot(`
+        "/* styles.module.css */
+        .a {
+          color: red;
+        }
+
+        #b .c {
+          color: #00f;
+        }
+        "
+      `);
+    },
+  });
+
+  // A name that only ever appears inside `:global(...)` is not a local, so it
+  // cannot be composed (previously this composed a hashed name that no rule
+  // in the output used).
+  itBundled("css-module/ComposesNameOnlyDefinedAsGlobal", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(JSON.stringify(styles));
+      `,
+      "/styles.module.css": `
+        .a { composes: g; color: red }
+        :global(.g) { color: blue }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    bundleErrors: {
+      "/styles.module.css": [
+        'The name "g" never appears in "styles.module.css" as a CSS modules locally scoped class name.',
+      ],
+    },
+  });
+
   itBundled("css-module/BundleTwoFilesWithoutCodeSplitting", {
     files: {
       "/foo-entry.js": `

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -402,7 +402,11 @@ describe("bundler", () => {
         // 'Cannot use global name "y" with "composes"',
         // 'Cannot use global name "x" with "composes"',
       ],
-      "/file.module.css": ['The name "z" never appears in "file.module.css"'],
+      "/file.module.css": [
+        // `y` only exists inside `:global(...)`, so it is not a local name either.
+        'The name "y" never appears in "file.module.css"',
+        'The name "z" never appears in "file.module.css"',
+      ],
       "/file.css": ['The name "x" never appears in "file.css"'],
     },
     bundleWarnings: {


### PR DESCRIPTION
### Problem
- In a CSS module, a class or id written inside `:global(...)` is printed unhashed in the stylesheet (correct), but it is also exported from the JS exports object, under a hashed name that no rule in the output uses. For `:global(.g) {}` plus `.local :global(.h) {}`, `import styles from "./w.module.css"` gives `{ g: "g_V1RUew", local: "local_V1RUew", h: "h_V1RUew" }` while the CSS contains `.g` and `.local_V1RUew .h`. esbuild exports `{ local }` only.
- `:local(...)` nested inside `:global(...)` had the opposite mismatch: `:global(.a :local(.b))` printed `.a .b` but exported `b: "b_V1RUew"` (esbuild prints `.a .b_hash`).
- A name that only exists inside `:global(...)` could be `composes`d, producing the same phantom hashed name in the export.
- Cause: `:global(...)` (src/css/selectors/parser.rs, `parse_non_ts_functional_pseudo_class`) parses its argument with the ordinary selector path, so `parse_one_simple_selector` runs `new_local_identifier` for every class and id inside it and registers them in the sheet's `local_scope`. The exports object is built from `local_scope` (src/bundler/linker_context/generateCodeForLazyExport.rs). The printer only hid this on the CSS side: the `PseudoClass::Global` arm in src/css/selectors/selector.rs cleared `dest.css_module` while printing its argument, which made those refs print under their original names (the fallback added by #18257 for #18170, which was the crash this caused before).

### Fix
- `SelectorParser` gets an `in_global_scope` flag. `:global(...)` sets it and `:local(...)` clears it for the duration of their argument (restored afterwards, also on a parse error, since `:is()`-style recovery keeps going with the same parser). `new_local_identifier` returns a plain identifier instead of registering a symbol while the flag is set, so global names are never in `local_scope`: not renamed, not exported, not composable.
- The printer's `Global` arm now prints its argument like the `Local` arm does. Scoping is decided once, at parse time, per class/id (local = `Ref`, global = `Ident`), and both the stylesheet and the exports object follow that one decision, which is also what makes the nested `:local(...)` case print the name it is exported under.
- Why this is right: it matches esbuild's `local-css` semantics for all of the above (`:global()` argument is global, a nested `:local()` is local again, a global-only name cannot be composed), and it is what the exports object is documented to be: a map from the file's local names to the generated names.
- `css/ImportCSSFromJSComposesFromMissingImport` (test/bundler/esbuild/css.test.ts) now also expects the error for `y`, which that test defines only as `:global(.y)`; esbuild errors on it too.
- Tests: test/bundler/css/css-modules.test.ts (`GlobalPseudoFunctionNamesAreNotExported`, `LocalPseudoFunctionInsideGlobal`, `GlobalScopeRestoredAfterInvalidArgument`, `GlobalAndLocalUseOfSameName`, `GlobalPseudoFunctionDoesNotLeakIntoNestedRules`, `OnlyGlobalSelectorsExportsNothing`, `ComposesNameOnlyDefinedAsGlobal`). Without the src change 5 of them fail (plus the esbuild test); with it all pass.
- Also run: test/bundler/css/, test/bundler/esbuild/css.test.ts, test/bundler/cli.test.ts, test/bundler/bundler_loader.test.ts, test/js/bun/css/css.test.ts, test/internal/source-lints/, `cargo clippy -p bun_css`.

### Background
- CSS modules in the bundler: for `*.module.css`, every class and id selector is parsed into a `Ref` to a per-file symbol (`Parser::add_symbol_for_name`, which also records the name in the sheet's `local_scope`). The linker later picks a generated name per symbol (`mangle_local_css`), the CSS printer looks refs up in that map, and the JS side of the import is an object literal with one entry per `local_scope` entry. A selector component can instead hold a plain `Ident`, which the printer writes as is; that is what every class in a non-module stylesheet is, and now also what a global name in a module is.
- `:global(...)` / `:local(...)` are the CSS modules pseudo-classes for opting a piece of a selector out of (or back into) local scoping. The wrappers themselves are not printed; only their argument is.
- `Printer.css_module` is the printer's CSS-modules state; it is `Some` for the whole of a module stylesheet. Class/id components use it to decide between printing the generated name (`lookup_symbol`) and the original one, which is the switch the old `Global` arm flipped.

<details>
<summary>Repro before / after (<code>bun build entry.js --outdir out</code>)</summary>

`w.module.css`:

```css
:global(.g) { color: red }
.local :global(.h) { color: blue }
:global(.a :local(.b)) { color: green }
:local(.c) { color: pink }
#gid { color: black }
:global(#gid2) { color: white }
```

Bun 1.4.0 exports:

```
{"g":"g_V1RUew","local":"local_V1RUew","h":"h_V1RUew","a":"a_V1RUew","b":"b_V1RUew","c":"c_V1RUew","gid":"gid_V1RUew","gid2":"gid2_V1RUew"}
```

and prints `.g`, `.local_V1RUew .h`, `.a .b`, `.c_V1RUew`, `#gid_V1RUew`, `#gid2`.

With this change the exports are `local`, `b`, `c`, `gid`, and the third rule prints as `.a .b_V1RUew`. esbuild 0.25.1 on the same input exports `local`, `b`, `c`, `gid` and prints `.a .w_b`.
</details>
