### PR TITLE
css modules: locate cross-file composes errors on the composes declaration

### DIFF
--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -146,31 +146,42 @@ pub(crate) fn generate_code_for_lazy_export(
                     }
                 }
 
+                /// `css_ref` is defined in `ast` (file `definition_idx`); the
+                /// `composes` declaration naming it is at `compose_loc` in file
+                /// `composing_idx`, which differs for `composes: x from "./other.css"`.
                 fn warn_non_single_class_composes(
                     &mut self,
                     ast: &BundlerStyleSheet,
                     css_ref: CssRef,
-                    idx: IndexInt,
+                    definition_idx: IndexInt,
+                    composing_idx: IndexInt,
                     compose_loc: Loc,
                 ) {
                     let _ = self.arena;
-                    let syms: &SymbolList<'_> = &self.all_symbols[idx as usize];
+                    let syms: &SymbolList<'_> = &self.all_symbols[definition_idx as usize];
                     // `Symbol.original_name: StoreStr` — arena-owned for the link pass.
                     let name: &[u8] = syms[css_ref.inner_index() as usize].original_name.slice();
                     let loc = ast.local_scope.get(name).unwrap().loc;
 
-                    self.log.add_range_error_fmt_with_note(
-                        Some(&self.all_sources[idx as usize]),
+                    let notes: Box<[bun_ast::Data]> = Box::new([bun_ast::range_data(
+                        Some(&self.all_sources[definition_idx as usize]),
+                        bun_ast::Range {
+                            loc,
+                            ..Default::default()
+                        },
+                        bun_ast::alloc_print(format_args!(
+                            "The definition of {} is here.",
+                            bun_fmt::quote(name),
+                        )),
+                    )]);
+                    self.log.add_range_error_fmt_with_notes(
+                        Some(&self.all_sources[composing_idx as usize]),
                         bun_ast::Range { loc: compose_loc, ..Default::default() },
+                        notes,
                         format_args!(
                             "The composes property cannot be used with {}, because it is not a single class name.",
                             bun_fmt::quote(name),
                         ),
-                        format_args!(
-                            "The definition of {} is here.",
-                            bun_fmt::quote(name),
-                        ),
-                        bun_ast::Range { loc, ..Default::default() },
                     );
                 }
 
@@ -228,6 +239,7 @@ pub(crate) fn generate_code_for_lazy_export(
                                                     other_file,
                                                     other_name_ref,
                                                     import_record.source_index.get(),
+                                                    idx,
                                                     compose.loc,
                                                 );
                                             } else {
@@ -277,6 +289,7 @@ pub(crate) fn generate_code_for_lazy_export(
                                             self.warn_non_single_class_composes(
                                                 ast,
                                                 name_ref,
+                                                idx,
                                                 idx,
                                                 compose.loc,
                                             );

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -146,9 +146,6 @@ pub(crate) fn generate_code_for_lazy_export(
                     }
                 }
 
-                /// `css_ref` is defined in `ast` (file `definition_idx`); the
-                /// `composes` declaration naming it is at `compose_loc` in file
-                /// `composing_idx`, which differs for `composes: x from "./other.css"`.
                 fn warn_non_single_class_composes(
                     &mut self,
                     ast: &BundlerStyleSheet,

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1388,6 +1388,7 @@ mod __css_validation {
         // composes from itself, so bind as shared.
         let css_ast: &BundlerStyleSheet = col_ref!(css_asts)[id].as_deref().unwrap();
         let import_records: &[ImportRecord] = col_ref!(import_records_list)[id].as_slice();
+        let source: &Source = &col_ref!(input_files)[id];
 
         // Validate cross-file "composes: ... from" named imports
         for composes in css_ast.composes.values() {
@@ -1407,21 +1408,21 @@ mod __css_validation {
                 else {
                     continue;
                 };
+                let other_source: &Source =
+                    &col_ref!(input_files)[record.source_index.get() as usize];
                 for name in compose.names.slice() {
                     let name_v = name.v();
                     if !other_css_ast.local_scope.contains(name_v) {
+                        // `compose.loc` points into this file's `composes`
+                        // declaration; only the message names the other file.
                         // Split-borrow — see `LinkerContext::log_disjoint`.
-                        let _ = this.log_disjoint().add_error_fmt(
-                            &col_ref!(input_files)[record.source_index.get() as usize],
+                        this.log_disjoint().add_error_fmt(
+                            source,
                             compose.loc,
                             format_args!(
                                 "The name \"{}\" never appears in \"{}\" as a CSS modules locally scoped class name. Note that \"composes\" only works with single class selectors.",
                                 bstr::BStr::new(name_v),
-                                bstr::BStr::new(
-                                    &col_ref!(input_files)[record.source_index.get() as usize]
-                                        .path
-                                        .pretty
-                                ),
+                                bstr::BStr::new(&other_source.path.pretty),
                             ),
                         );
                     }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1413,8 +1413,6 @@ mod __css_validation {
                 for name in compose.names.slice() {
                     let name_v = name.v();
                     if !other_css_ast.local_scope.contains(name_v) {
-                        // `compose.loc` points into this file's `composes`
-                        // declaration; only the message names the other file.
                         // Split-borrow — see `LinkerContext::log_disjoint`.
                         this.log_disjoint().add_error_fmt(
                             source,

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -416,10 +416,25 @@ describe("bundler", () => {
     },
   });
 
-  // The location of a "never appears" error is the `composes` declaration that
-  // asked for the name, whether the name was looked up in another file or in
-  // the same one. The cross-file error used to be attached to the other file,
+  // Errors about the names listed in a `composes` declaration are located on
+  // that declaration, whether the name was looked up in another file or in the
+  // same one. The cross-file variants used to be attached to the other file,
   // with an offset that only made sense in the composing file.
+  // `notes` (missing from the type declarations) holds a message's notes, each a BuildMessage.
+  function composesDiagnostics(build: Bun.BuildOutput) {
+    expect(build.success).toBe(false);
+    const locate = ({ message, position }: BuildMessage | ResolveMessage) => ({
+      message,
+      file: basename(position!.file),
+      line: position!.line,
+      column: position!.column,
+      lineText: position!.lineText,
+    });
+    return build.logs
+      .map(log => ({ ...locate(log), notes: (log as unknown as { notes: BuildMessage[] }).notes.map(locate) }))
+      .sort((a, b) => a.line - b.line || a.message.localeCompare(b.message));
+  }
+
   itBundled("css/ImportCSSFromJSComposesFromMissingImportLocation", {
     files: {
       "/entry.js": `
@@ -450,37 +465,92 @@ describe("bundler", () => {
       ],
     },
     onAfterApiBundle(build) {
-      expect(build.success).toBe(false);
-      const errors = build.logs
-        .map(log => ({
-          message: log.message.slice(0, log.message.indexOf(" as a CSS modules")),
-          file: basename(log.position!.file),
-          line: log.position!.line,
-          column: log.position!.column,
-          lineText: log.position!.lineText,
-        }))
-        .sort((a, b) => a.line - b.line || a.message.localeCompare(b.message));
-      expect(errors).toEqual([
+      const suffix =
+        ' as a CSS modules locally scoped class name. Note that "composes" only works with single class selectors.';
+      const composesLine = {
+        file: "styles.module.css",
+        line: 5,
+        column: 12,
+        lineText: '  composes: missing alsoMissing from "./other.module.css";',
+      };
+      expect(composesDiagnostics(build)).toEqual([
+        { message: `The name "alsoMissing" never appears in "other.module.css"${suffix}`, ...composesLine, notes: [] },
+        { message: `The name "missing" never appears in "other.module.css"${suffix}`, ...composesLine, notes: [] },
         {
-          message: 'The name "alsoMissing" never appears in "other.module.css"',
-          file: "styles.module.css",
-          line: 5,
-          column: 12,
-          lineText: '  composes: missing alsoMissing from "./other.module.css";',
-        },
-        {
-          message: 'The name "missing" never appears in "other.module.css"',
-          file: "styles.module.css",
-          line: 5,
-          column: 12,
-          lineText: '  composes: missing alsoMissing from "./other.module.css";',
-        },
-        {
-          message: 'The name "missingHere" never appears in "styles.module.css"',
+          message: `The name "missingHere" never appears in "styles.module.css"${suffix}`,
           file: "styles.module.css",
           line: 8,
           column: 12,
           lineText: "  composes: missingHere;",
+          notes: [],
+        },
+      ]);
+    },
+  });
+
+  // The composed name exists in the other file but is an id, not a class. The
+  // error belongs on the `composes` declaration; its note on the definition.
+  itBundled("css/ImportCSSFromJSComposesNonClassNameLocation", {
+    files: {
+      "/entry.js": `
+          import styles from "./styles.module.css"
+          console.log(styles)
+        `,
+      "/styles.module.css": [
+        "#localId {",
+        "  color: red;",
+        "}",
+        ".foo {",
+        '  composes: otherId from "./other.module.css";',
+        "}",
+        ".bar {",
+        "  composes: localId;",
+        "}",
+      ].join("\n"),
+      "/other.module.css": [".x {", "  color: blue;", "}", "#otherId {", "  color: green;", "}"].join("\n"),
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    backend: "api",
+    bundleErrors: {
+      "/styles.module.css": [
+        'The composes property cannot be used with "otherId", because it is not a single class name.',
+        'The composes property cannot be used with "localId", because it is not a single class name.',
+      ],
+    },
+    onAfterApiBundle(build) {
+      expect(composesDiagnostics(build)).toEqual([
+        {
+          message: 'The composes property cannot be used with "otherId", because it is not a single class name.',
+          file: "styles.module.css",
+          line: 5,
+          column: 12,
+          lineText: '  composes: otherId from "./other.module.css";',
+          notes: [
+            {
+              message: 'The definition of "otherId" is here.',
+              file: "other.module.css",
+              line: 4,
+              column: 1,
+              lineText: "#otherId {",
+            },
+          ],
+        },
+        {
+          message: 'The composes property cannot be used with "localId", because it is not a single class name.',
+          file: "styles.module.css",
+          line: 8,
+          column: 12,
+          lineText: "  composes: localId;",
+          notes: [
+            {
+              message: 'The definition of "localId" is here.',
+              file: "styles.module.css",
+              line: 1,
+              column: 1,
+              lineText: "#localId {",
+            },
+          ],
         },
       ]);
     },

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1,5 +1,5 @@
-import { describe } from "bun:test";
-import { join } from "node:path";
+import { describe, expect } from "bun:test";
+import { basename, join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -396,14 +396,16 @@ describe("bundler", () => {
     },
     entryPoints: ["/entry.js"],
     outdir: "/out",
+    // The errors are reported on the `composes` declarations in
+    // styles.module.css; the message names the file that was searched.
     bundleErrors: {
       "/styles.module.css": [
+        'The name "z" never appears in "file.module.css"',
+        'The name "x" never appears in "file.css"',
         // TODO: renable when we support :local and :global
         // 'Cannot use global name "y" with "composes"',
         // 'Cannot use global name "x" with "composes"',
       ],
-      "/file.module.css": ['The name "z" never appears in "file.module.css"'],
-      "/file.css": ['The name "x" never appears in "file.css"'],
     },
     bundleWarnings: {
       "/styles.module.css": [
@@ -411,6 +413,76 @@ describe("bundler", () => {
         // 'The global name "y" is defined in file.module.css. Use the ":local" selector to change "y" into a local name.',
         // 'The global name "x" is defined in file.css. Use the "local-css" loader for "file.css" to enable local names.',
       ],
+    },
+  });
+
+  // The location of a "never appears" error is the `composes` declaration that
+  // asked for the name, whether the name was looked up in another file or in
+  // the same one. The cross-file error used to be attached to the other file,
+  // with an offset that only made sense in the composing file.
+  itBundled("css/ImportCSSFromJSComposesFromMissingImportLocation", {
+    files: {
+      "/entry.js": `
+          import styles from "./styles.module.css"
+          console.log(styles)
+        `,
+      "/styles.module.css": [
+        ".base {",
+        "  color: red;",
+        "}",
+        ".foo {",
+        '  composes: missing alsoMissing from "./other.module.css";',
+        "}",
+        ".bar {",
+        "  composes: missingHere;",
+        "}",
+      ].join("\n"),
+      "/other.module.css": ".x { color: blue }",
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    backend: "api",
+    bundleErrors: {
+      "/styles.module.css": [
+        'The name "missing" never appears in "other.module.css"',
+        'The name "alsoMissing" never appears in "other.module.css"',
+        'The name "missingHere" never appears in "styles.module.css"',
+      ],
+    },
+    onAfterApiBundle(build) {
+      expect(build.success).toBe(false);
+      const errors = build.logs
+        .map(log => ({
+          message: log.message.slice(0, log.message.indexOf(" as a CSS modules")),
+          file: basename(log.position!.file),
+          line: log.position!.line,
+          column: log.position!.column,
+          lineText: log.position!.lineText,
+        }))
+        .sort((a, b) => a.line - b.line || a.message.localeCompare(b.message));
+      expect(errors).toEqual([
+        {
+          message: 'The name "alsoMissing" never appears in "other.module.css"',
+          file: "styles.module.css",
+          line: 5,
+          column: 12,
+          lineText: '  composes: missing alsoMissing from "./other.module.css";',
+        },
+        {
+          message: 'The name "missing" never appears in "other.module.css"',
+          file: "styles.module.css",
+          line: 5,
+          column: 12,
+          lineText: '  composes: missing alsoMissing from "./other.module.css";',
+        },
+        {
+          message: 'The name "missingHere" never appears in "styles.module.css"',
+          file: "styles.module.css",
+          line: 8,
+          column: 12,
+          lineText: "  composes: missingHere;",
+        },
+      ]);
     },
   });
 
@@ -654,11 +726,9 @@ describe("bundler", () => {
       },
       entryPoints: ["/entry.js"],
       outdir: "/out",
-      bundleErrors: testCase.expectedError
-        ? testCase.name === "ImportedNonClass"
-          ? { "/other.module.css": [testCase.expectedError] }
-          : { "/styles.module.css": [testCase.expectedError] }
-        : undefined,
+      // Every error, including the one for a name composed from other.module.css,
+      // is reported on the `composes` declaration in styles.module.css.
+      bundleErrors: testCase.expectedError ? { "/styles.module.css": [testCase.expectedError] } : undefined,
       bundleWarnings: testCase.expectedWarning ? { "/styles.module.css": [testCase.expectedWarning] } : undefined,
       onAfterBundle(api) {
         // Check that the output files were generated correctly


### PR DESCRIPTION
### Problem
- Two `composes: name from "./other.css"` errors are located in the wrong file. The message text is right, but the file, line and excerpt are those of `other.css`, at whatever line a byte offset taken from the composing file happens to land on (clamped to the end of `other.css` when it is shorter):
  - `The name "zzz" never appears in "other.css" as a CSS modules locally scoped class name...` when `other.css` has no local `zzz` (src/bundler/linker_context/scanImportsAndExports.rs, `validate_css_import_composes`).
  - `The composes property cannot be used with "zzz", because it is not a single class name.` when `other.css` defines `zzz` as something other than a class, e.g. `#zzz` (src/bundler/linker_context/generateCodeForLazyExport.rs, `warn_non_single_class_composes`). Its `The definition of "zzz" is here.` note was already correct.
- Cause, same in both: the diagnostic is built from the imported file's `Source` and `compose.loc`, which is an offset into the composing file. In the second site this happened because the function took one source index and used it for both the note (definition, other file) and the error (declaration, composing file).
- esbuild, and bun's own same-file variants (`composes: zzz;`), locate these errors on the `composes` declaration. The mismatch dates back to the CSS modules implementation; two existing tests encoded the wrong file.

### Fix
- `validate_css_import_composes`: attach the error to the composing file's `Source` (`input_files[id]`); the message still names the file that was searched.
- `warn_non_single_class_composes`: take the composing file's index alongside the defining file's. The error is attached to the composing file at `compose.loc`; the note is built with `range_data` against the defining file, the same way the linker builds its other multi-file notes (`add_range_error_fmt_with_notes`). The same-file arm passes the same index twice and is unchanged in behavior.
- Correct because `compose.loc` is recorded by the `composes` value parser as a position in the file being parsed, so it can only be resolved against that file's contents; every other composes diagnostic in these two functions already pairs sources and offsets this way.
- Tests, all in test/bundler/esbuild/css.test.ts:
  - `css/ImportCSSFromJSComposesFromMissingImport` and `css/ImportCSSFromJSComposesImportedNonClass` now expect the errors under `styles.module.css` (they expected the imported file, including the case where it is a plain, non-module stylesheet).
  - New `css/ImportCSSFromJSComposesFromMissingImportLocation` and `css/ImportCSSFromJSComposesNonClassNameLocation` check file, line, column and line text of every error and note reported by `Bun.build`: two names in one cross-file `composes`, a cross-file non-class name, and a same-file case of each for comparison. The notes still point at the definitions in the other file.
- Verified: the four tests fail on the released 1.4.0 (`USE_SYSTEM_BUN=1 bun test`) and pass with `bun bd test`; the rest of css.test.ts and test/bundler/css/css-modules.test.ts pass.

### Background
- `composes` is the CSS modules property that makes one class's exported name also include other classes. `composes: a from "./x.css"` looks `a` up among `x.css`'s locally scoped names. The linker validates that lookup twice: `validate_css_import_composes` while scanning imports (is the name there at all), and `generate_code_for_lazy_export` while building the file's export object (is it a class that can be composed).
- A bundler diagnostic is a message plus a `Source` (one input file) and a `Loc` (byte offset). Line, column and excerpt are computed by resolving the offset against that `Source`'s contents, so the `Source` has to be the file the offset was taken from. A note is a second such (text, `Source`, offset) triple attached to the message and may point into a different file.

<details>
<summary>Before / after with <code>bun build entry.js --outdir out</code></summary>

`styles.module.css` has a ~200 byte comment before `.foo { composes: zzz from "./file.module.css"; }`; `file.module.css` is the one-line `.x{color:red}`.

Before (1.4.0):

```
1 | .x{color:red}
                 ^
error: The name "zzz" never appears in "file.module.css" as a CSS modules locally scoped class name. Note that "composes" only works with single class selectors.
    at /tmp/repro/file.module.css:1:14
```

After:

```
4 |   composes: zzz from "./file.module.css";
               ^
error: The name "zzz" never appears in "file.module.css" as a CSS modules locally scoped class name. Note that "composes" only works with single class selectors.
    at /tmp/repro/styles.module.css:4:12
```

esbuild reports the same thing as `styles.module.css:4:12: ERROR: The name "zzz" never appears in "file.module.css" ...`.

Same layout, but `other.module.css` is `#bar {\n  color: blue;\n}` and the declaration is `composes: bar from "./other.module.css"`. Before:

```
3 | }
     ^
error: The composes property cannot be used with "bar", because it is not a single class name.
    at /tmp/repro/other.module.css:3:2

1 | #bar {
    ^
note: The definition of "bar" is here.
   at /tmp/repro/other.module.css:1:1
```

After:

```
4 |   composes: bar from "./other.module.css";
               ^
error: The composes property cannot be used with "bar", because it is not a single class name.
    at /tmp/repro/styles.module.css:4:12

1 | #bar {
    ^
note: The definition of "bar" is here.
   at /tmp/repro/other.module.css:1:1
```
</details>
