### PR TITLE
install: fail verification instead of panicking when <alias>/package.json does not fit the path buffer

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -5,7 +5,7 @@ use bun_core::Progress::Progress;
 use bun_core::{Global, Output};
 use bun_core::{MutableString, ZStr};
 use bun_paths::strings;
-use bun_paths::{self as path, OSPathChar, OSPathSlice, PathBuffer, SEP, SEP_STR};
+use bun_paths::{self as path, OSPathChar, OSPathSlice, PathBuffer, SEP};
 use bun_semver::String as SemverString;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
@@ -753,6 +753,48 @@ impl UninstallTask {
     }
 }
 
+/// `<destination_dir_subpath>/<name>`, written in place after the alias in
+/// `destination_dir_subpath_buf`. Dropping it restores the alias's NUL terminator.
+struct DestinationSubpath<'b> {
+    buf: &'b mut [u8],
+    alias_len: usize,
+    len: usize,
+}
+
+impl<'b> DestinationSubpath<'b> {
+    /// `None` when the path and its NUL terminator do not fit `buf`: the alias is
+    /// only required to fit the buffer by itself (`alias_is_safe_install_target`).
+    fn new(buf: &'b mut [u8], alias_len: usize, name: &[u8]) -> Option<Self> {
+        let name_start = alias_len + 1;
+        let len = name_start + name.len();
+        if len >= buf.len() {
+            return None;
+        }
+        buf[alias_len] = SEP;
+        buf[name_start..len].copy_from_slice(name);
+        buf[len] = 0;
+        Some(Self {
+            buf,
+            alias_len,
+            len,
+        })
+    }
+}
+
+impl core::ops::Deref for DestinationSubpath<'_> {
+    type Target = ZStr;
+
+    fn deref(&self) -> &ZStr {
+        ZStr::from_buf(self.buf, self.len)
+    }
+}
+
+impl Drop for DestinationSubpath<'_> {
+    fn drop(&mut self) {
+        self.buf[self.alias_len] = 0;
+    }
+}
+
 // ───────────────────────────── impl PackageInstall ─────────────────────────────
 
 impl<'a> PackageInstall<'a> {
@@ -791,28 +833,17 @@ impl<'a> PackageInstall<'a> {
     // 1. verify that .bun-tag exists (was it installed from bun?)
     // 2. check .bun-tag against the resolved version
     fn verify_git_resolution(&mut self, repo: &Repository, root_node_modules_dir: &Dir) -> bool {
-        let dest_len = self.destination_dir_subpath.len();
-        let suffix: &[u8] = &[SEP, b'.', b'b', b'u', b'n', b'-', b't', b'a', b'g'];
-        // Reshaped for borrowck — write into buf via raw indices.
-        self.destination_dir_subpath_buf[dest_len..dest_len + suffix.len()].copy_from_slice(suffix);
-        self.destination_dir_subpath_buf[dest_len + SEP_STR.len() + b".bun-tag".len()] = 0;
-        // SAFETY: NUL written above.
-        let bun_tag_path = unsafe {
-            ZStr::from_raw_mut(
-                self.destination_dir_subpath_buf.as_mut_ptr(),
-                dest_len + SEP_STR.len() + b".bun-tag".len(),
-            )
+        let Some(bun_tag_path) = DestinationSubpath::new(
+            self.destination_dir_subpath_buf,
+            self.destination_dir_subpath.len(),
+            b".bun-tag",
+        ) else {
+            return false;
         };
-        let _restore = scopeguard::guard(
-            self.destination_dir_subpath_buf.as_mut_ptr(),
-            // SAFETY: p points into destination_dir_subpath_buf which outlives this scope;
-            // dest_len < buf capacity (was the prior NUL position).
-            move |p| unsafe { *p.add(dest_len) = 0 },
-        );
 
         let Ok(bun_tag_file) = self
             .node_modules
-            .read_small_file(root_node_modules_dir, bun_tag_path)
+            .read_small_file(root_node_modules_dir, &bun_tag_path)
         else {
             return false;
         };
@@ -872,30 +903,15 @@ impl<'a> PackageInstall<'a> {
         mutable.reset();
         mutable.expand_to_capacity();
 
-        let dest_len = self.destination_dir_subpath.len();
-        // Write the literal directly into the path buffer; no intermediate Vec.
-        let suffix: &[u8] = &[
-            SEP, b'p', b'a', b'c', b'k', b'a', b'g', b'e', b'.', b'j', b's', b'o', b'n',
-        ];
-        self.destination_dir_subpath_buf[dest_len..dest_len + suffix.len()].copy_from_slice(suffix);
-        self.destination_dir_subpath_buf[dest_len + SEP_STR.len() + b"package.json".len()] = 0;
-        // SAFETY: NUL written above.
-        let package_json_path = unsafe {
-            ZStr::from_raw_mut(
-                self.destination_dir_subpath_buf.as_mut_ptr(),
-                dest_len + SEP_STR.len() + b"package.json".len(),
-            )
-        };
-        let _restore = scopeguard::guard(
-            self.destination_dir_subpath_buf.as_mut_ptr(),
-            // SAFETY: p points into destination_dir_subpath_buf which outlives this scope;
-            // dest_len < buf capacity (was the prior NUL position).
-            move |p| unsafe { *p.add(dest_len) = 0 },
-        );
+        let package_json_path = DestinationSubpath::new(
+            self.destination_dir_subpath_buf,
+            self.destination_dir_subpath.len(),
+            b"package.json",
+        )?;
 
         let package_json_file = self
             .node_modules
-            .open_file(root_node_modules_dir, package_json_path)
+            .open_file(root_node_modules_dir, &package_json_path)
             .ok()?;
         // defer package_json_file.close()
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6,6 +6,7 @@ import {
   bunEnv,
   bunExe,
   bunEnv as env,
+  isLinux,
   isWindows,
   joinP,
   readdirSorted,
@@ -895,6 +896,58 @@ describe.concurrent("bun-install", () => {
     expect(stderr).toContain("long-git-dep");
     expect(stdout).toContain("bun install v1.");
     expect(exitCode).toBe(1);
+  });
+
+  // When node_modules already exists, the hoisted installer first checks what is installed at
+  // node_modules/<alias> by appending "/package.json" (or "/.bun-tag" for git dependencies) to
+  // the alias inside the path buffer holding it. The alias may be up to one byte short of the
+  // buffer (4096 bytes on Linux, 1024 on macOS), so aliases a few bytes short of it used to crash
+  // the install right there instead of failing like any other name the file system rejects.
+  // On Windows the buffer is far larger than any path the OS accepts.
+  describe.concurrent.skipIf(isWindows)("dependency alias that fills the path buffer", () => {
+    const alias = Buffer.alloc((isLinux ? 4096 : 1024) - 6, "a").toString();
+
+    async function installIntoExistingNodeModules(cwd: string) {
+      await using proc = spawn({
+        // hardlink (the Linux default) creates node_modules/<alias> itself on every platform, so
+        // the failure is reported the same way on macOS, whose default backend is clonefile.
+        cmd: [bunExe(), "install", "--linker", "hoisted", "--backend", "hardlink"],
+        cwd,
+        env: { ...env, BUN_INSTALL_CACHE_DIR: join(cwd, ".cache") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("ENAMETOOLONG: failed opening node_modules/package dir for package pkg");
+      expect(stdout).toContain("Failed to install 1 package");
+      expect(exitCode).toBe(1);
+    }
+
+    it("file: dependency is verified through <alias>/package.json", async () => {
+      using dir = tempDir("long-alias-file-dep", {
+        "package.json": JSON.stringify({ name: "app", dependencies: { [alias]: "file:./pkg" } }),
+        "pkg/package.json": JSON.stringify({ name: "pkg", version: "1.0.0" }),
+        "node_modules": {},
+      });
+
+      await installIntoExistingNodeModules(String(dir));
+    });
+
+    it("git dependency is verified through <alias>/.bun-tag", async () => {
+      using dir = tempDir("long-alias-git-dep", {
+        "work/package.json": JSON.stringify({ name: "pkg", version: "1.0.0" }),
+        "app/node_modules": {},
+      });
+      await createDumbHttpGitRepo(String(dir), {});
+      using server = serveDirectory(String(dir));
+      const app = join(String(dir), "app");
+      await writeFile(
+        join(app, "package.json"),
+        JSON.stringify({ name: "app", dependencies: { [alias]: `git+http://localhost:${server.port}/repo.git` } }),
+      );
+
+      await installIntoExistingNodeModules(app);
+    });
   });
 
   it("should handle empty string in dependencies", async () => {


### PR DESCRIPTION
### Problem
- `bun install` (hoisted linker) aborts with `panic: range end index 4103 out of range for slice of length 4096` (exit 134) when `node_modules` already exists and a dependency alias is between `MAX_PATH_BYTES - 13` and `MAX_PATH_BYTES - 1` bytes long (4083..4095 on Linux, 1011..1023 on macOS). An alias in the last bytes of that window panics with `index out of bounds: the len is 4096 but the index is 4096` instead; git and github dependencies panic the same way from 9 bytes below the buffer size.
- `alias_is_safe_install_target` (`src/install/PackageInstaller.rs:412`) only requires the alias itself to fit the `PathBuffer` it is copied into. `verify()` then appends `/package.json` (`get_installed_package_json_source`, `src/install/PackageInstall.rs:875`) or `/.bun-tag` (`verify_git_resolution`, `src/install/PackageInstall.rs:794`) plus a NUL to the alias in that same buffer with no length check.
- `verify()` only runs when `node_modules` already existed before the install (a fresh `node_modules` skips it), which is why a first install of such an alias fails cleanly with `ENAMETOOLONG` and any later install, or the first install into a project that already has a `node_modules`, aborts.

### Fix
- Both verify helpers now build their path through one `DestinationSubpath` helper, which returns `None` when `<alias>/<name>` plus its NUL does not fit the buffer, and restores the alias's NUL terminator when dropped. The helpers treat that like any other unreadable `package.json` / `.bun-tag`: verification fails.
- A failed verification means "reinstall", and that reinstall reports the same `ENAMETOOLONG: failed opening node_modules/package dir for package <name>` / `Failed to install 1 package` / exit 1 that a fresh install of the same alias already reports, so an alias a few bytes short of the buffer now behaves like one that is 600 bytes long. Rejecting the alias in `alias_is_safe_install_target` instead would report it as an unsafe name, and that predicate is also used by the isolated linker, which has no such suffix.
- The helper holds a reborrow of `destination_dir_subpath_buf` for as long as the path is in use, which replaces the raw pointer + `scopeguard` restore the two helpers each had; the bytes written are the same as before.
- Verified with `test/cli/install/bun-install.test.ts`, "dependency alias that fills the path buffer": a `file:` dependency and a git dependency (served from a local dumb-http repo) aliased under a `MAX_PATH_BYTES - 6` byte name, installed into a pre-created `node_modules`. Unfixed, they abort with the two panics above (`4103` and `4099` out of range); fixed, both report `ENAMETOOLONG` and exit 1. Skipped on Windows, where the buffer (98302 bytes) is larger than any path the OS accepts.
- Also ran `bun-install.test.ts` (git / folder / workspace / file: subsets), `bun-workspaces.test.ts`, `bun-install-patch.test.ts` and `bun-link.test.ts` with the debug build; the only failures are the bitbucket/gitlab tests (no network here) and `bun-link` "should link dependency without crashing", which fails on main too because the debug build prints a stack trace on install failure (#37335). `cargo clippy -p bun_install` is clean and `cargo check -p bun_install` passes for `x86_64-pc-windows-msvc` and `x86_64-apple-darwin`.
- The same alias as a workspace package name additionally hits the 512 byte name buffer in `install_from_link`, which #38571 fixes separately; with both fixes a workspace named this way fails the same way as the two cases tested here.

### Background
- The hoisted linker installs each dependency at `node_modules/<alias>`, where the alias is the key in `dependencies` (or the workspace package's name). `PackageInstaller` copies the alias into `destination_dir_subpath_buf`, a stack `PathBuffer` of `MAX_PATH_BYTES` (4096 on Linux, 1024 on macOS, 98302 on Windows), and `PackageInstall` works with the NUL-terminated prefix of that buffer as the install destination.
- `verify()` decides whether an entry already in `node_modules` can be kept: for most resolutions it reads `<alias>/package.json` and compares name and version, for git/github resolutions it reads the `<alias>/.bun-tag` file bun writes on checkout and compares the commit. Both build the file path by temporarily appending to the alias in the buffer and putting the NUL back afterwards. `false` from `verify()` means the package is (re)installed.

<details>
<summary>Repro on an unfixed build (Linux)</summary>

```sh
D=$(mktemp -d) && cd $D && mkdir -p pkg node_modules
printf '{"name":"app","dependencies":{"%s":"file:./pkg"}}' "$(head -c 4090 /dev/zero | tr '\0' a)" > package.json
printf '{"name":"pkg","version":"1.0.0"}' > pkg/package.json
bun install --linker hoisted
# panic: range end index 4103 out of range for slice of length 4096   (exit 134)
# with the fix, and without the pre-created node_modules on any build:
# ENAMETOOLONG: failed opening node_modules/package dir for package pkg
# Failed to install 1 package                                           (exit 1)
```

With a 4083 byte name the suffix itself fits and the NUL write panics with `index out of bounds: the len is 4096 but the index is 4096`; a git dependency aliased under the 4090 byte name panics with `range end index 4099`.
</details>
