### PR TITLE
css: drop the logical longhands a 4-side margin/padding shorthand overrides instead of flushing them

### DIFF
--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -678,28 +678,23 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             let val = S::extract_shorthand(property);
 
             // The shorthand sets all four physical sides, which overrides everything
-            // buffered here, logical longhands included (in every writing mode). So unlike
-            // in the longhand arms, a category change is not a reason to flush: when logical
-            // properties are compiled, flushed inline longhands become `:lang()` rules
-            // emitted after this rule, where they would win over the shorthand. The buffered
-            // values are only emitted, as a fallback, when a target cannot parse the new
-            // value: per side for physical values, and for any side when logical values are
-            // buffered, since which side those resolve to depends on the writing mode.
+            // buffered here, logical longhands included (whichever side they resolve to). So
+            // unlike in the longhand arms, a category change is not a reason to flush: when
+            // logical properties are compiled, flushed inline longhands become `:lang()`
+            // rules emitted after this rule, where they would win over the shorthand. The
+            // buffered values are only still needed, as a fallback, by a target that rejects
+            // the shorthand's value, and a declaration is rejected as a whole, so one
+            // unsupported side is enough. `flush` is a no-op when nothing is buffered.
             if let Some(browsers) = context.targets.browsers {
-                let has_logical = self.block_start.is_some()
-                    || self.block_end.is_some()
-                    || self.inline_start.is_some()
-                    || self.inline_end.is_some();
-                let sides = [
-                    (PhysicalSlot::Top, S::shorthand_top(val)),
-                    (PhysicalSlot::Right, S::shorthand_right(val)),
-                    (PhysicalSlot::Bottom, S::shorthand_bottom(val)),
-                    (PhysicalSlot::Left, S::shorthand_left(val)),
-                ];
-                let needs_fallback = sides.iter().any(|&(slot, v)| {
-                    (has_logical || self.physical_slot_is_some(slot)) && !v.is_compatible(&browsers)
-                });
-                if needs_fallback {
+                let rejected_by_a_target = [
+                    S::shorthand_top(val),
+                    S::shorthand_right(val),
+                    S::shorthand_bottom(val),
+                    S::shorthand_left(val),
+                ]
+                .into_iter()
+                .any(|v| !v.is_compatible(&browsers));
+                if rejected_by_a_target {
                     self.flush(dest, context);
                 }
             }

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -677,11 +677,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         } else if tag == S::SHORTHAND {
             let val = S::extract_shorthand(property);
 
-            // The shorthand overrides everything buffered, logical longhands included, so a
-            // category change is no reason to flush here: compiled inline longhands would land
-            // in `:lang()` rules after this rule and win over the shorthand. Only a target that
-            // rejects the shorthand (one unsupported side rejects the whole declaration) still
-            // needs the buffered values, as a fallback.
+            // The buffered values are only live for a target that rejects the whole declaration.
             if let Some(browsers) = context.targets.browsers {
                 let rejected_by_a_target = [
                     S::shorthand_top(val),
@@ -700,6 +696,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             self.right = Some(S::shorthand_right(val).clone());
             self.bottom = Some(S::shorthand_bottom(val).clone());
             self.left = Some(S::shorthand_left(val).clone());
+            // Dead in every writing mode; flushing would put compiled inline ones after this rule.
             self.block_start = None;
             self.block_end = None;
             self.inline_start = None;

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -677,14 +677,11 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         } else if tag == S::SHORTHAND {
             let val = S::extract_shorthand(property);
 
-            // The shorthand sets all four physical sides, which overrides everything
-            // buffered here, logical longhands included (whichever side they resolve to). So
-            // unlike in the longhand arms, a category change is not a reason to flush: when
-            // logical properties are compiled, flushed inline longhands become `:lang()`
-            // rules emitted after this rule, where they would win over the shorthand. The
-            // buffered values are only still needed, as a fallback, by a target that rejects
-            // the shorthand's value, and a declaration is rejected as a whole, so one
-            // unsupported side is enough. `flush` is a no-op when nothing is buffered.
+            // The shorthand overrides everything buffered, logical longhands included, so a
+            // category change is no reason to flush here: compiled inline longhands would land
+            // in `:lang()` rules after this rule and win over the shorthand. Only a target that
+            // rejects the shorthand (one unsupported side rejects the whole declaration) still
+            // needs the buffered values, as a fallback.
             if let Some(browsers) = context.targets.browsers {
                 let rejected_by_a_target = [
                     S::shorthand_top(val),

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -676,34 +676,34 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             );
         } else if tag == S::SHORTHAND {
             let val = S::extract_shorthand(property);
-            self.flush_helper_physical(
-                PhysicalSlot::Top,
-                S::shorthand_top(val),
-                S::SHORTHAND_CATEGORY,
-                dest,
-                context,
-            );
-            self.flush_helper_physical(
-                PhysicalSlot::Right,
-                S::shorthand_right(val),
-                S::SHORTHAND_CATEGORY,
-                dest,
-                context,
-            );
-            self.flush_helper_physical(
-                PhysicalSlot::Bottom,
-                S::shorthand_bottom(val),
-                S::SHORTHAND_CATEGORY,
-                dest,
-                context,
-            );
-            self.flush_helper_physical(
-                PhysicalSlot::Left,
-                S::shorthand_left(val),
-                S::SHORTHAND_CATEGORY,
-                dest,
-                context,
-            );
+
+            // The shorthand sets all four physical sides, which overrides everything
+            // buffered here, logical longhands included (in every writing mode). So unlike
+            // in the longhand arms, a category change is not a reason to flush: when logical
+            // properties are compiled, flushed inline longhands become `:lang()` rules
+            // emitted after this rule, where they would win over the shorthand. The buffered
+            // values are only emitted, as a fallback, when a target cannot parse the new
+            // value: per side for physical values, and for any side when logical values are
+            // buffered, since which side those resolve to depends on the writing mode.
+            if let Some(browsers) = context.targets.browsers {
+                let has_logical = self.block_start.is_some()
+                    || self.block_end.is_some()
+                    || self.inline_start.is_some()
+                    || self.inline_end.is_some();
+                let sides = [
+                    (PhysicalSlot::Top, S::shorthand_top(val)),
+                    (PhysicalSlot::Right, S::shorthand_right(val)),
+                    (PhysicalSlot::Bottom, S::shorthand_bottom(val)),
+                    (PhysicalSlot::Left, S::shorthand_left(val)),
+                ];
+                let needs_fallback = sides.iter().any(|&(slot, v)| {
+                    (has_logical || self.physical_slot_is_some(slot)) && !v.is_compatible(&browsers)
+                });
+                if needs_fallback {
+                    self.flush(dest, context);
+                }
+            }
+
             self.top = Some(S::shorthand_top(val).clone());
             self.right = Some(S::shorthand_right(val).clone());
             self.bottom = Some(S::shorthand_bottom(val).clone());
@@ -712,6 +712,7 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
             self.block_end = None;
             self.inline_start = None;
             self.inline_end = None;
+            self.category = S::SHORTHAND_CATEGORY;
             self.has_any = true;
         } else {
             return false;

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2439,11 +2439,12 @@ describe("css tests", () => {
   // A 4-side shorthand sets all four physical sides, so logical longhands declared before it in the
   // same rule are dead in every writing mode. They must not survive into the output: when logical
   // properties are compiled for old targets, inline longhands become separate :lang() rules emitted
-  // after the rule, which would win over the shorthand.
+  // after the rule, which would win over the shorthand. The one reason to keep anything declared
+  // before the shorthand is a target that rejects the shorthand's value.
   describe("logical longhands overridden by a 4-side shorthand", () => {
-    for (const [shorthand, inlineStart, inlineEnd, inline, blockStart] of [
-      ["margin", "margin-inline-start", "margin-inline-end", "margin-inline", "margin-block-start"],
-      ["padding", "padding-inline-start", "padding-inline-end", "padding-inline", "padding-block-start"],
+    for (const [shorthand, inlineStart, inlineEnd, inline, blockStart, top] of [
+      ["margin", "margin-inline-start", "margin-inline-end", "margin-inline", "margin-block-start", "margin-top"],
+      ["padding", "padding-inline-start", "padding-inline-end", "padding-inline", "padding-block-start", "padding-top"],
     ]) {
       // Safari 8 compiles logical properties away (the :lang() cases above use it too); Safari 15
       // supports them.
@@ -2478,42 +2479,46 @@ describe("css tests", () => {
         });
       }
 
-      // The shorthand's value is not supported by the target, so the overridden declarations stay as
-      // a fallback, like physical longhands do (see the "length" tests).
-      prefix_test(
-        `
-        .foo {
-          ${inlineStart}: 2px;
-          ${shorthand}: max(2cqw, 22px);
-        }
-      `,
-        indoc`
-        .foo {
-          ${inlineStart}: 2px;
-          ${shorthand}: max(2cqw, 22px);
-        }
-      `,
-        {
-          safari: 14 << 16,
-        },
-      );
+      // Safari 14 does not support container query units, so it rejects the whole shorthand and the
+      // earlier declaration still applies there: it has to stay as a fallback, whether it is logical
+      // or a physical side whose own new value (5px) would have been fine. Safari 16 supports them,
+      // so the earlier declaration is dead.
+      for (const earlier of [`${inlineStart}: 2px`, `${top}: 10px`]) {
+        prefix_test(
+          `
+          .foo {
+            ${earlier};
+            ${shorthand}: 5px max(2cqw, 22px);
+          }
+        `,
+          indoc`
+          .foo {
+            ${earlier};
+            ${shorthand}: 5px max(2cqw, 22px);
+          }
+        `,
+          {
+            safari: 14 << 16,
+          },
+        );
 
-      prefix_test(
-        `
-        .foo {
-          ${inlineStart}: 2px;
-          ${shorthand}: max(2cqw, 22px);
-        }
-      `,
-        indoc`
-        .foo {
-          ${shorthand}: max(2cqw, 22px);
-        }
-      `,
-        {
-          safari: 16 << 16,
-        },
-      );
+        prefix_test(
+          `
+          .foo {
+            ${earlier};
+            ${shorthand}: 5px max(2cqw, 22px);
+          }
+        `,
+          indoc`
+          .foo {
+            ${shorthand}: 5px max(2cqw, 22px);
+          }
+        `,
+          {
+            safari: 16 << 16,
+          },
+        );
+      }
 
       // A logical longhand after the shorthand is live and stays.
       prefix_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2436,6 +2436,134 @@ describe("css tests", () => {
     );
   });
 
+  // A 4-side shorthand sets all four physical sides, so logical longhands declared before it in the
+  // same rule are dead in every writing mode. They must not survive into the output: when logical
+  // properties are compiled for old targets, inline longhands become separate :lang() rules emitted
+  // after the rule, which would win over the shorthand.
+  describe("logical longhands overridden by a 4-side shorthand", () => {
+    for (const [shorthand, inlineStart, inlineEnd, inline, blockStart] of [
+      ["margin", "margin-inline-start", "margin-inline-end", "margin-inline", "margin-block-start"],
+      ["padding", "padding-inline-start", "padding-inline-end", "padding-inline", "padding-block-start"],
+    ]) {
+      // Safari 8 compiles logical properties away (the :lang() cases above use it too); Safari 15
+      // supports them.
+      for (const [label, targets] of [
+        ["logical properties compiled", { safari: 8 << 16 }],
+        ["logical properties supported", { safari: 15 << 16 }],
+      ] as const) {
+        describe(`${shorthand}, ${label}`, () => {
+          for (const decls of [
+            `${inlineStart}: 2px`,
+            `${inlineEnd}: 2px`,
+            `${inline}: 2px 4px`,
+            `${blockStart}: 2px`,
+            `${inlineStart}: var(--x)`,
+            `${inlineStart}: 2px; ${blockStart}: 3px`,
+          ]) {
+            prefix_test(
+              `
+              .foo {
+                ${decls};
+                ${shorthand}: 0;
+              }
+            `,
+              indoc`
+              .foo {
+                ${shorthand}: 0;
+              }
+            `,
+              targets,
+            );
+          }
+        });
+      }
+
+      // The shorthand's value is not supported by the target, so the overridden declarations stay as
+      // a fallback, like physical longhands do (see the "length" tests).
+      prefix_test(
+        `
+        .foo {
+          ${inlineStart}: 2px;
+          ${shorthand}: max(2cqw, 22px);
+        }
+      `,
+        indoc`
+        .foo {
+          ${inlineStart}: 2px;
+          ${shorthand}: max(2cqw, 22px);
+        }
+      `,
+        {
+          safari: 14 << 16,
+        },
+      );
+
+      prefix_test(
+        `
+        .foo {
+          ${inlineStart}: 2px;
+          ${shorthand}: max(2cqw, 22px);
+        }
+      `,
+        indoc`
+        .foo {
+          ${shorthand}: max(2cqw, 22px);
+        }
+      `,
+        {
+          safari: 16 << 16,
+        },
+      );
+
+      // A logical longhand after the shorthand is live and stays.
+      prefix_test(
+        `
+        .foo {
+          ${shorthand}: 0;
+          ${inlineStart}: 2px;
+        }
+      `,
+        indoc`
+        .foo {
+          ${shorthand}: 0;
+          ${inlineStart}: 2px;
+        }
+      `,
+        {
+          safari: 15 << 16,
+        },
+      );
+    }
+
+    for (const [shorthand, inlineStart, inline, top, left] of [
+      ["margin", "margin-inline-start", "margin-inline", "margin-top", "margin-left"],
+      ["padding", "padding-inline-start", "padding-inline", "padding-top", "padding-left"],
+      ["inset", "inset-inline-start", "inset-inline", "top", "left"],
+      [
+        "scroll-margin",
+        "scroll-margin-inline-start",
+        "scroll-margin-inline",
+        "scroll-margin-top",
+        "scroll-margin-left",
+      ],
+    ]) {
+      minify_test(`.a{${inlineStart}:2px;${shorthand}:0}`, `.a{${shorthand}:0}`);
+      minify_test(`.a{${inline}:2px 4px;${shorthand}:0}`, `.a{${shorthand}:0}`);
+      minify_test(`.a{${inlineStart}:2px!important;${shorthand}:0!important}`, `.a{${shorthand}:0!important}`);
+      // Longhands after the shorthand still fold into it.
+      minify_test(`.a{${inlineStart}:2px;${shorthand}:0;${top}:5px}`, `.a{${shorthand}:5px 0 0}`);
+
+      // Only the 4-side shorthand overrides the other category: a 2-side logical shorthand leaves
+      // the physical sides alone (they map to different sides depending on the writing mode), and a
+      // logical longhand after the shorthand is live.
+      minify_test(`.a{${left}:2px;${inline}:0}`, `.a{${left}:2px;${inline}:0}`);
+      minify_test(`.a{${shorthand}:0;${inlineStart}:2px}`, `.a{${shorthand}:0;${inlineStart}:2px}`);
+      // An unparsed shorthand may hold a value some browser rejects, so the earlier declaration is
+      // kept as a fallback.
+      minify_test(`.a{${inlineStart}:2px;${shorthand}:var(--v)}`, `.a{${inlineStart}:2px;${shorthand}:var(--v)}`);
+    }
+  });
+
   describe("scroll-paddding", () => {
     prefix_test(
       `


### PR DESCRIPTION
### Problem

- When logical properties are compiled away for the targets, a `margin`/`padding` shorthand that overrides an earlier inline logical longhand in the same rule still gets that dead longhand compiled into `:lang()` fallback rules. Those rules are emitted after the rule, so they win the cascade and the output no longer matches the source:
  ```
  .a{margin-inline-start:3px;margin:0}
  -> .a{margin:0} .a:not(:lang(ae), ...){margin-left:3px} ... .a:lang(ae), ...{margin-right:3px}
  ```
  The source gives every side `0`; the output gives LTR pages `margin-left: 3px`. Same for `margin-inline-end`, `margin-inline`, unparsed `margin-inline-start: var(--x)`, and the `padding` family.
- With logical properties supported (the bundler's fixed browser targets, or `--target bun`), the same inputs are only under-minified: `bun build --minify` keeps `.a{margin-inline-start:3px;margin:0}` as written for all four families (`margin`, `padding`, `inset`, `scroll-margin`). Targets old enough to compile logical properties are not reachable from the `bun build` CLI today (`Targets::for_bundler_target` is fixed), so the wrong-cascade output above shows up through the internal test API that `test/js/bun/css` uses; the under-minification is what users see.
- Cause: `SizeHandler::handle_property`, `S::SHORTHAND` arm (`src/css/properties/margin_padding.rs:677`). It called `flush_helper_physical` for the four sides, and that helper flushes the whole buffer whenever the category changes (`margin_padding.rs:747`). After a logical longhand the buffer is `Logical` and the shorthand is `Physical`, so the buffered longhands were flushed, and for targets without logical properties `flush()` turns inline ones into `context.add_logical_rule(...)` rules (`margin_padding.rs:893`). Right after that the arm cleared the four logical slots anyway: the handler already knew they were overridden, it had just emitted them first.
- Upstream lightningcss 1.30.2 produces the same output for these inputs (its `side_handler!` shorthand arm has the same shape), so this is inherited rather than a porting error. Its `inset` handler, whose shorthand shares the logical category, already drops the overridden longhands (`inset-inline-start:3px;inset:0` -> `inset:0`), which is the behavior this change gives the other families.

### Fix

- The shorthand arm no longer flushes on a category change. It flushes in exactly one case: when one of the shorthand's four values is not supported by the targets (`is_compatible`), because such a target rejects the whole declaration and everything buffered before it, physical or logical, still applies there. Otherwise the shorthand replaces whatever is buffered, and the arm records the shorthand's category like every other buffering arm does.
- Why this is correct: the 4-side shorthand sets all four physical longhands, and each logical longhand resolves to one of those four in every writing mode, so nothing declared before the shorthand in the same block can take effect in a browser that applies the shorthand. The only browser where it still matters is one that rejects the shorthand's value, which is the fallback condition the arm keeps. A 2-side logical shorthand (`margin-inline`) is not treated this way because the sides it covers depend on the writing mode; only the 4-side shorthand arm changes.
- One physical-side detail changes along the way (raised in review): the old per-side check only kept a buffered `margin-top` if the shorthand's own top value was unsupported, so `margin-top:10px;margin:5px max(2cqw,22px)` lost its fallback for a target without container query units even though that target rejects the whole `margin` declaration. Checking the four values once keeps it; this is the only output change for physical-only input, and it only affects shorthands with a value some target rejects.
- Verified with `test/js/bun/css/css.test.ts`, new "logical longhands overridden by a 4-side shorthand" block: `margin` and `padding` with the longhand compiled (safari 8) and supported (safari 15) for inline-start, inline-end, `*-inline`, block-start, an unparsed longhand, and a mixed pair; the fallback cases (a logical longhand and a physical one before `5px max(2cqw, 22px)`, kept with safari 14, dropped with safari 16); a longhand declared after the shorthand staying; and minify cases for all four families, including `!important`, a longhand folding into the shorthand afterwards, and the three inputs that must stay as written. 44 of the 62 cases fail on bun 1.4.0 (`USE_SYSTEM_BUN=1`), all 62 pass with the fix.
- `bun bd test test/js/bun/css/css.test.ts`: 1204 pass; `test/bundler/css/`, `test/bundler/esbuild/css.test.ts`, `doesnt_crash`, `css-loader`: 288 pass. `bun build --minify` on the first snippet now prints `.a{margin:0}`.
- Overlap with #38551: that PR adds the same `self.category = S::SHORTHAND_CATEGORY` line to this arm and pins three intra-block outputs that this change improves (`.a{margin-inline-start:1px;margin:0}` becomes `.a{margin:0}`, `...;margin:0;margin-top:5px}` becomes `.a{margin:5px 0 0}`, `...;margin:0;margin-inline-end:2px}` becomes `.a{margin:0;margin-inline-end:2px}`). Whichever lands second needs those three expectations updated.
- Out of scope, reported separately: `border-width`/`border-style`/`border-color` after a logical border longhand have the same shape in `border.rs`, and a physical `margin-left` after a compiled `margin-inline-start` in the same rule also loses to the appended rules (that one needs the flush to emit only one of the two `:lang()` halves).

### Background

- The minifier runs each declaration block through property handlers. `SizeHandler` (one instantiation each for margin, padding, inset and scroll-margin) buffers the block's declarations of its family and writes them out in `flush()`, merged into a shorthand when possible. A declaration for a slot that is already buffered simply replaces it; that is how duplicates disappear and how `margin:0;margin-top:5px` becomes `margin:5px 0 0`.
- Logical properties (`margin-inline-start`, ...) resolve to a physical side based on the element's writing mode. The handler cannot merge them with physical values, so it buffers one category at a time and flushes the buffered category when the other one arrives, which preserves source order between two groups that are both live. The 4-side shorthand is the one declaration that overrides both groups at once, which is why that flush is unnecessary for it.
- Flushing is also used for fallbacks: if a new value uses syntax some target does not support (`max()`, container query units), the value it replaces is flushed first so that browser still gets the old declaration. `is_compatible` against the targets is that check, and it is the only flush condition the shorthand arm keeps.
- When the targets lack logical properties, `flush()` compiles block longhands into `margin-top`/`margin-bottom` inside the same rule, but inline ones depend on text direction, so `context.add_logical_rule()` emits them as separate `:lang()`-selected rules placed after the current rule. Anything emitted that way outranks the rule itself, which is why flushing a dead inline longhand changes the result while flushing a dead block longhand does not.
