### PR TITLE
cli: evaluate `bun -p test` / `bun --print test` / `bun -pe help` instead of dispatching the code as a subcommand

### DIFF
--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -890,8 +890,7 @@ pub mod command {
         strings::contains_char(basename, b'.')
     }
 
-    /// `-e` and `-p` take a value, so every `-e…` / `-p…` token (node's `-pe`
-    /// included) is an eval flag; clusters such as `-bp` are not recognized.
+    /// `-e`/`-p` take a value, so any `-e…`/`-p…` token is one; clusters like `-bp` are not.
     #[inline]
     fn is_eval_flag(arg: &[u8]) -> bool {
         matches!(arg, [b'-', b'e' | b'p', ..] | b"--eval" | b"--print")
@@ -947,8 +946,7 @@ pub mod command {
             return Tag::AutoCommand;
         };
         while !first_arg_name.is_empty() && first_arg_name[0] == b'-' {
-            // The rest of argv is the script and its arguments: `bun -p test` evaluates
-            // `test` (https://github.com/oven-sh/bun/issues/23631).
+            // The rest of argv belongs to the script: https://github.com/oven-sh/bun/issues/23631
             if is_eval_flag(first_arg_name) {
                 return Tag::AutoCommand;
             }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -890,6 +890,18 @@ pub mod command {
         strings::contains_char(basename, b'.')
     }
 
+    /// `-e` / `--eval` / `-p` / `--print` in any spelling `arguments::parse`
+    /// accepts for [`Tag::AutoCommand`]: the value as the next token, attached
+    /// (`-p1+1`, `-p=1+1`, `--print=1+1`), or node's `-pe` (a
+    /// `NODE_SHORT_ALIASES` entry). `-e` and `-p` take a value, so anything
+    /// trailing them in the same token is that value, never another flag.
+    #[inline]
+    fn is_eval_flag(arg: &[u8]) -> bool {
+        matches!(arg, [b'-', b'e' | b'p', ..] | b"--eval" | b"--print")
+            || arg.starts_with(b"--eval=")
+            || arg.starts_with(b"--print=")
+    }
+
     /// `#[inline(never)]`: argv→`Tag` classification, called once from
     /// `Cli::start` on every `bun` invocation. Kept a concrete symbol so
     /// `src/startup.order` can place it next to `Cli::start` /
@@ -937,10 +949,12 @@ pub mod command {
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
-        while !first_arg_name.is_empty()
-            && first_arg_name[0] == b'-'
-            && !(first_arg_name.len() > 1 && first_arg_name[1] == b'e')
-        {
+        while !first_arg_name.is_empty() && first_arg_name[0] == b'-' {
+            // What follows an eval flag is the script and its argv, so `bun -p test`
+            // evaluates `test` rather than running `bun test`.
+            if is_eval_flag(first_arg_name) {
+                return Tag::AutoCommand;
+            }
             // `--interactive` stays on AutoCommand: Arguments.rs parses it and the no-target check
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass
             // that and boot the legacy `bun repl` implementation instead.
@@ -1066,9 +1080,6 @@ pub mod command {
             if bun_core::Environment::ENABLE_FUZZILLI {
                 return Tag::FuzzilliCommand;
             }
-            return Tag::AutoCommand;
-        }
-        if x == RootCommandMatcher::case(b"-e") {
             return Tag::AutoCommand;
         }
         Tag::AutoCommand

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -890,11 +890,8 @@ pub mod command {
         strings::contains_char(basename, b'.')
     }
 
-    /// `-e` / `--eval` / `-p` / `--print` in any spelling `arguments::parse`
-    /// accepts for [`Tag::AutoCommand`]: the value as the next token, attached
-    /// (`-p1+1`, `-p=1+1`, `--print=1+1`), or node's `-pe` (a
-    /// `NODE_SHORT_ALIASES` entry). `-e` and `-p` take a value, so anything
-    /// trailing them in the same token is that value, never another flag.
+    /// `-e` and `-p` take a value, so every `-e…` / `-p…` token (node's `-pe`
+    /// included) is an eval flag; clusters such as `-bp` are not recognized.
     #[inline]
     fn is_eval_flag(arg: &[u8]) -> bool {
         matches!(arg, [b'-', b'e' | b'p', ..] | b"--eval" | b"--print")
@@ -950,8 +947,8 @@ pub mod command {
             return Tag::AutoCommand;
         };
         while !first_arg_name.is_empty() && first_arg_name[0] == b'-' {
-            // What follows an eval flag is the script and its argv, so `bun -p test`
-            // evaluates `test` rather than running `bun test`.
+            // The rest of argv is the script and its arguments: `bun -p test` evaluates
+            // `test` (https://github.com/oven-sh/bun/issues/23631).
             if is_eval_flag(first_arg_name) {
                 return Tag::AutoCommand;
             }

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -109,8 +109,7 @@ for (const flag of ["-e", "--print"]) {
 }
 
 // https://github.com/oven-sh/bun/issues/23631
-// Each child runs in an empty directory so that a token dispatched as a
-// subcommand (`bun test`, `bun x`, ...) has nothing to act on.
+// Empty cwd: a token dispatched as a subcommand (`bun test`, `bun x`, ...) must find nothing to act on.
 describe("eval flags take precedence over subcommand names", () => {
   describe("the code is a subcommand name", () => {
     const cases: string[][] = [

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,7 +1,7 @@
 import { SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
 
@@ -107,6 +107,74 @@ for (const flag of ["-e", "--print"]) {
     });
   });
 }
+
+// The subcommand lookup skips the leading flags and matches the next argument
+// against the subcommand names. It used to stop only at `-e`; after any other
+// eval flag the code (or, with an attached value, the script's first argument)
+// was matched instead, so `bun -p test` ran the test runner and `bun -pe help`
+// printed bun's help. Every child runs in an empty directory so a misdispatched
+// subcommand has nothing to act on.
+describe("eval flags take precedence over subcommand names", () => {
+  describe("the code is a subcommand name", () => {
+    const cases: string[][] = [
+      ["-p", "test"],
+      ["--print", "test"],
+      ["--eval", "test"],
+      ["-pe", "help"],
+      ["-e", "test"],
+      // The eval flag comes after another flag.
+      ["--smol", "-p", "test"],
+    ];
+
+    for (const args of cases) {
+      const name = args[args.length - 1];
+      test.concurrent(`bun ${args.join(" ")} evaluates \`${name}\``, async () => {
+        using dir = tempDir("eval-subcommand-name", {});
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), ...args],
+          cwd: String(dir),
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain(`ReferenceError: ${name} is not defined`);
+        expect(stdout).toBe("");
+        expect(exitCode).toBe(1);
+      });
+    }
+  });
+
+  describe("a script argument is a subcommand name", () => {
+    const argv = "JSON.stringify(process.argv.slice(1))";
+    const cases: string[][] = [
+      [`-p${argv}`, "test"],
+      [`-p=${argv}`, "test"],
+      [`--print=${argv}`, "test"],
+      [`--eval=console.log(${argv})`, "help"],
+      [`-e=console.log(${argv})`, "test"],
+      ["-p", argv, "test"],
+    ];
+
+    for (const args of cases) {
+      const name = args[args.length - 1];
+      test.concurrent(`bun ${args.join(" ")} passes \`${name}\` to the script`, async () => {
+        using dir = tempDir("eval-subcommand-arg", {});
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), ...args],
+          cwd: String(dir),
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout).toBe(JSON.stringify([name]) + "\n");
+        expect(exitCode).toBe(0);
+      });
+    }
+  });
+});
 
 describe("--print for cjs/esm", () => {
   test("eval result between esm imports", async () => {

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -108,21 +108,18 @@ for (const flag of ["-e", "--print"]) {
   });
 }
 
-// The subcommand lookup skips the leading flags and matches the next argument
-// against the subcommand names. It used to stop only at `-e`; after any other
-// eval flag the code (or, with an attached value, the script's first argument)
-// was matched instead, so `bun -p test` ran the test runner and `bun -pe help`
-// printed bun's help. Every child runs in an empty directory so a misdispatched
-// subcommand has nothing to act on.
+// https://github.com/oven-sh/bun/issues/23631
+// Each child runs in an empty directory so that a token dispatched as a
+// subcommand (`bun test`, `bun x`, ...) has nothing to act on.
 describe("eval flags take precedence over subcommand names", () => {
   describe("the code is a subcommand name", () => {
     const cases: string[][] = [
       ["-p", "test"],
-      ["--print", "test"],
+      ["--print", "x"],
       ["--eval", "test"],
       ["-pe", "help"],
       ["-e", "test"],
-      // The eval flag comes after another flag.
+      // The eval flag is reached after skipping an unrelated flag.
       ["--smol", "-p", "test"],
     ];
 


### PR DESCRIPTION
Addresses the `bun --print x` half of #23631. Its other half (`bun run --eval` / `bun run --print` print the `bun run` usage) is a different code path and is not changed here.

### Problem
- `bun -p test`, `bun --print test` and `bun --eval test` start the test runner (`bun test v1.4.0 ... No tests found!`) instead of evaluating `test`; `bun --print x` prints the bunx usage (#23631); `bun -pe help` prints bun's help. `bun -e test` is the only spelling that evaluates (ReferenceError, as node does for all of them).
- The attached-value forms are misrouted through the script's first argument: `bun -p=1 test`, `bun -p1 test`, `bun --print=1 test` and `bun --eval=1 test` all run the test runner. Any subcommand name in that position is dispatched: `bun -p a foo` is `bun add foo` (it writes package.json and hits the registry), `bun -p i` is `bun install`.
- Cause: `Command::which()` (src/runtime/cli/mod.rs, the `while` loop before the `RootCommandMatcher` lookup) steps over every leading `-` token to find the subcommand name, and its only stop condition is a token starting with `-e`. `-p`, `-pe`, `--print` and `--eval` are stepped over like boolean flags, so the token after them (the code, or the first script argument when the code is attached) is what gets matched against the subcommand names.

### Fix
- `which()` now stops at any eval flag spelling and returns `AutoCommand`: `-e...`, `-p...` (covers `-p <code>`, `-p<code>`, `-p=<code>` and node's `-pe`), `--eval`, `--eval=...`, `--print`, `--print=...` (new `is_eval_flag`).
- Correct because this is the set of tokens `arguments::parse` reads as an eval for `AutoCommand`, and once one of them is present, everything after it is the script or its argv by definition, so there is no subcommand to look for. `-e` and `-p` take a value, so a token starting with either is always that flag with an attached value (clap reads `-pe` as `-p` via `NODE_SHORT_ALIASES`, `-p1+1` as `-p` with `1+1`); the prefix rule is exactly how the token will be parsed. Matches node, where `node -p test` / `node -pe help` / `node --print=1 test` never do anything but evaluate.
- The `-e` entry in the keyword matcher is removed: it was only reachable through the old carve-out (the loop now returns before the matcher for any flag token).
- Behaviour change to be aware of: `bun -p install` and friends used to reach the install command, which then read `-p` as `--production`. That was an accident of the skip loop; `bun -p <x>` is documented as print-eval and `bun install -p` / `--production` are unchanged. Short clusters such as `-bp <code>` are not recognised by `which()`; they were not before either (`bun -bp test` errors in the test runner today) and node rejects them outright.
- Verified with test/cli/run/run-eval.test.ts (`eval flags take precedence over subcommand names`, including the issue's literal `bun --print x`): 9 of the 12 new cases fail on the unfixed binary (the `-e`, `-e=` and `-p <non-keyword> test` cases are controls that already passed) and all pass with the fix; the rest of the file, test/cli/run/as-node.test.ts and test/cli/run/crash-report-command-char.test.ts still pass.

### Background
- `Command::which()` classifies argv into a command `Tag` before any argument parsing happens. Because runtime flags may precede the subcommand (`bun --bun test`, and `BUN_OPTIONS` is spliced in right after argv0), it skips leading `-` tokens and matches the first remaining token against the subcommand names (`test`, `help`, `x`, `add`, `i`, ...). Anything that does not match is `AutoCommand`.
- `AutoCommand` is the `bun <file>` / `bun -e <code>` path: `arguments::parse` parses argv with `AUTO_PARAMS` (where `-e/--eval` and `-p/--print` take a value and `-pe` is aliased to `-p`), and `exec_auto_or_run` runs the eval when one was given. That side already handled every spelling; only the classifier in front of it did not.
- Related but separate open fixes to the same loop: #38568 stops it at a lone `-` (stdin), #36644 steps over the values of `--cwd` / `--env-file`. Neither covers the eval flags, which must stop the search rather than be stepped over (`bun -p 1 test` has to evaluate `1` with `test` as a script argument).
