### PR TITLE
test(install): don't require the refetched manifest to be cached before install exits

### DIFF
--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9688,7 +9688,14 @@ test("npm manifest cache entries are only reused for the package name they were 
   expect(npmPackages.map(pkg => pkg.name)).toEqual(["no-deps"]);
   expect(npmPackages[0].resolution.resolved).toBe(`http://localhost:${port}/no-deps/-/no-deps-1.0.0.tgz`);
 
-  expect(parseManifest(byName["no-deps"], registryUrl()).name).toBe("no-deps");
+  // The rejected entry is deleted as soon as it is read; its replacement is written by a
+  // thread pool task that `bun install` does not wait for (#37203). The first install above
+  // still had tarballs to download while its manifests were being written, but this one has
+  // everything cached and exits while the write is still in flight (always, with a Windows
+  // debug build). So the file is either gone or holds no-deps; it must never still be basic-1's.
+  if (await exists(byName["no-deps"])) {
+    expect(parseManifest(byName["no-deps"], registryUrl()).name).toBe("no-deps");
+  }
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-install-registry.test.ts` > "npm manifest cache entries are only reused for the package name they were saved for" (added in #37669) fails on every run with a debug build on Windows (Server 2019 x64, 5 of 5 runs; it passes on the release Windows lanes and on Linux):
  ```
  error: failed to open manifest file "...\.bun-cache\472ae378b15ad7b8-9eb9626f42b8b153.npm": ENOENT
  ```
  at the last assertion, `parseManifest(byName["no-deps"], ...)` after the second install.
- The second install behaves correctly: the entry holding basic-1's manifest is rejected and deleted (`Serializer::load_by_file_id`, src/install/npm.rs), no-deps is fetched again, `node_modules/no-deps` is 1.0.0 and the lockfile points at the no-deps tarball. The assertion additionally requires the refetched manifest to be back on disk when the process exits.
- That write is a thread pool task (`Serializer::save_async`) that `bun install` does not wait for. #37203 tried adding a wait and reverted it: the write is fire-and-forget by design, a missing entry only means a refetch. In this test the no-deps tarball is already in the cache from the first install, so nothing remains to do after the manifest arrives and the install exits before the task lands. On a Windows debug build that is not a narrow race: with timestamps added locally, the save task took about 25 ms from start to rename while the main thread went from receiving the manifest to "Saved lockfile" in about 12 ms, so the file was missing on every run.
- The first install of the same test (and the other tests that read the cache after an install) also rely on the writes landing, but there the tarball downloads and extraction happen after the manifests arrive: on the same machine its two writes had finished about 45 ms before it was done resolving. #37203's measurements show that margin can still be lost occasionally under heavy load on release builds; this PR only changes the one install that has no margin at all.

### Fix
- The last assertion no longer requires the write to have landed: if the file exists again it must be the no-deps manifest; if it does not, the stale entry was deleted and the write was still in flight, which is the documented behavior.
- The test still fails without the #37669 name check: without it the basic-1 entry is neither rejected nor deleted, so the file still parses as `basic-1` and fails this assertion, and no-deps would resolve through basic-1's manifest, failing the lockfile and `node_modules` assertions before it.
- Same approach as #37203, which removed the same dependency on the background write from the security scanner matrix. Tests whose subject is the cache entry itself (including the first half of this one) cannot use this shape; making those deterministic would need an install-side wait, which #37203 decided against, so it is not attempted here.
- Verified: Windows x64 debug build, `bun bd test test/cli/install/bun-install-registry.test.ts -t "only reused for the package name"`: failed 5 of 5 runs before this change, passes 5 of 5 after; the expect count in those runs shows the file was absent every time, so the new branch is what runs there. Linux x64 debug+ASAN: passes before and after, as on main.
- Test-only change, so there is no build for which this file fails on Linux; the before/after evidence is the Windows debug runs above.
- #38504 rewrites this file's setup; the lines changed here are identical in both versions, so either side rebases trivially.

### Background
- Manifest cache: each fetched npm manifest is serialized to `<cache>/<hash>.npm` and reused by later installs until it expires. Since #37669, an entry whose stored package name does not match the requested one is deleted on load and the manifest is fetched again.
- The file is written by `Serializer::save_async` (src/install/npm.rs): the parsed manifest is cloned into a task on the install thread pool, which writes a temporary file and renames it into place. The task is not counted as a pending task, so the command can finish, and the process exit, while it is still running. #37203 discusses this and keeps it that way.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->