### PR TITLE
cli: exit 1 when bun build --app is given a --target other than bun

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2208,6 +2208,7 @@ fn parse_build_command_options(
                             )
                         ),
                     );
+                    Global::exit(1);
                 }
             }
         }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import fs, { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
 
@@ -515,6 +515,52 @@ describe("CLI argument error messages", () => {
     expect(stderr).toContain('"FOO"');
     expect(stderr).toContain("key=value");
     expect(exitCode).toBe(1);
+  });
+
+  // bunEnv sets BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE, so --app is accepted by
+  // release builds too.
+  describe.concurrent("--app --target", () => {
+    const files = {
+      // `bun build --app` evaluates this file first, so the marker on stdout
+      // tells whether the build started at all.
+      "bun.app.ts": `console.log("config evaluated");\nexport default {};`,
+    };
+
+    test.each([
+      ["node", "Node"],
+      ["browser", "Browser"],
+    ])("--target=%s is rejected before the build starts", async (target, received) => {
+      using dir = tempDir("build-app-target-err", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--app", `--target=${target}`, "bun.app.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr: normalizeBunSnapshot(stderr) }).toEqual({
+        stdout: "",
+        stderr: `error: target must be 'bun' when using --app. Received: ${received}`,
+      });
+      expect(exitCode).toBe(1);
+    });
+
+    test("--target=bun is accepted", async () => {
+      using dir = tempDir("build-app-target-bun", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--app", "--target=bun", "bun.app.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      // The config above has no `app` section, so the build itself fails
+      // later on; this only checks that the target check let it start.
+      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("target must be 'bun'");
+      expect(stdout).toBe("config evaluated\n");
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun build --app --target=node ./bun.app.ts` prints `error: target must be 'bun' when using --app. Received: Node` and then carries on: the config file is evaluated, the build runs, and the process exits 0 when the build succeeds.
- The `--app` arm of the `--target` check in `src/runtime/cli/Arguments.rs` (`parse_build_command_options`) prints the message but never exits. The `--bytecode` arm directly above it prints the same kind of message and calls `Global::exit(1)`.
- The missing exit dates back to the commit that added the arm (e93c5ad993, in the Zig `Arguments.zig`): it was written as a copy of the `--bytecode` arm without its `Global.exit(1)`. The Rust port reproduced it as-is.

### Fix
- Add `Global::exit(1)` after the error message, so `--app` with a non-bun target behaves like `--bytecode` with a non-bun target: one error line, exit 1, nothing built.
- Exiting (rather than dropping the check or downgrading it to a warning) is the right outcome: an `--app` build always produces a Bun server plus browser client bundles and never reads `--target` (`src/runtime/bake/production.rs` builds its own transpilers), so a different `--target` is a request the build cannot honor. Printing `error:` and then exiting 0 hides exactly that from scripts and CI.
- Test: `test/bundler/cli.test.ts` ("CLI argument error messages > --app --target"). `--target=node` and `--target=browser` must produce exactly the error line on stderr, nothing on stdout (the config file logs a marker when it is evaluated), and exit 1; `--target=bun` must still start the build. The two rejected cases fail on the current release (stderr continues with the bake banner, `Loading configuration` and the config error, and the marker shows up on stdout) and pass with this change.
- Also verified the new tests under the debug ASAN build with `detect_leaks=1`, since the fix adds a new process-exit path during argument parsing.

### Background
- `bun build --app` is the production build for Bun's experimental full-stack framework support (Bake). It is gated behind a feature flag that is on in canary and debug builds and can be enabled with `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1`; the test harness's `bunEnv` sets that variable, which is how the test runs on release builds as well.
- `Global::exit(1)` flushes stdout/stderr and exits the process; it is the idiom used by the other fatal argument errors in this function (`Global::crash()` is the same thing with the exit code fixed at 1).
