### PR TITLE
css: emit unparsed border-block-* declarations when compiling logical borders

### DIFF
--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1603,12 +1603,11 @@ mod border_handler_body {
 
             macro_rules! prop {
                 ($id:ident) => {{
-                    let _ = &dest; // autofix
-                    let mut upppppppppp = unparsed.with_property_id(arena, PropertyId::$id);
-                    context.add_unparsed_fallbacks(arena, &mut upppppppppp);
+                    let mut up = unparsed.with_property_id(arena, PropertyId::$id);
+                    context.add_unparsed_fallbacks(arena, &mut up);
                     self.flushed_properties
                         .insert(BorderProperty::try_from_property_id(PropertyIdTag::$id).unwrap());
-                    // Intentionally not pushed to dest (preserves existing behavior; likely a bug).
+                    dest.push(Property::Unparsed(up));
                 }};
             }
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -1185,6 +1185,121 @@ describe("css tests", () => {
       },
     );
 
+    // Unparsed (var()) block-axis properties don't depend on direction, so compiling
+    // logical properties away renames them to the physical top/bottom property in place.
+    for (const [logical, physical] of [
+      ["border-block-start", "border-top"],
+      ["border-block-start-width", "border-top-width"],
+      ["border-block-start-style", "border-top-style"],
+      ["border-block-start-color", "border-top-color"],
+      ["border-block-end", "border-bottom"],
+      ["border-block-end-width", "border-bottom-width"],
+      ["border-block-end-style", "border-bottom-style"],
+      ["border-block-end-color", "border-bottom-color"],
+    ]) {
+      prefix_test(
+        `
+        .foo {
+          ${logical}: var(--test);
+        }
+      `,
+        `
+        .foo {
+          ${physical}: var(--test);
+        }
+      `,
+        {
+          safari: 8 << 16,
+        },
+      );
+
+      prefix_test(
+        `
+        .foo {
+          ${logical}: var(--test);
+        }
+      `,
+        `
+        .foo {
+          ${logical}: var(--test);
+        }
+      `,
+        {
+          safari: 13 << 16,
+        },
+      );
+    }
+
+    prefix_test(
+      `
+      .foo {
+        border-block-start: var(--start);
+        border-block-end: var(--end);
+      }
+    `,
+      `
+      .foo {
+        border-top: var(--start);
+        border-bottom: var(--end);
+      }
+    `,
+      {
+        safari: 8 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-top: 1px solid red;
+        border-block-start-width: var(--width);
+      }
+    `,
+      `
+      .foo {
+        border-top: 1px solid red;
+        border-top-width: var(--width);
+      }
+    `,
+      {
+        safari: 8 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-block-end-color: var(--color);
+        border-block-end-width: 2px;
+      }
+    `,
+      `
+      .foo {
+        border-bottom-color: var(--color);
+        border-bottom-width: 2px;
+      }
+    `,
+      {
+        safari: 8 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-block-start-width: var(--width) !important;
+      }
+    `,
+      `
+      .foo {
+        border-top-width: var(--width) !important;
+      }
+    `,
+      {
+        safari: 8 << 16,
+      },
+    );
+
     for (const prop of [
       "border-inline-start-color",
       "border-inline-end-color",
@@ -1523,6 +1638,33 @@ describe("css tests", () => {
         safari: 8 << 16,
       },
     );
+
+    for (const [logical, physical] of [
+      ["border-block-start", "border-top"],
+      ["border-block-end", "border-bottom"],
+    ]) {
+      prefix_test(
+        `
+        .foo {
+          ${logical}: var(--border-width) solid lab(40% 56.6 39);
+        }
+      `,
+        `
+        .foo {
+          ${physical}: var(--border-width) solid #b32323;
+        }
+
+        @supports (color: lab(0% 0 0)) {
+          .foo {
+            ${physical}: var(--border-width) solid lab(40% 56.6 39);
+          }
+        }
+      `,
+        {
+          safari: 8 << 16,
+        },
+      );
+    }
 
     prefix_test(
       `


### PR DESCRIPTION
### Problem

- When logical border properties are compiled away for targets that lack them, an unparsed `border-block-start` / `border-block-end` declaration (one whose value contains `var()`, so the parser keeps it as `Property::Unparsed`) is removed from the output instead of being renamed to the physical property. With the rule otherwise empty, the whole rule is gone:
  ```
  .a { border-block-start-width: var(--x) }          ->  (nothing)
  .a { margin-block-start: var(--x) }                ->  .a { margin-top: var(--x) }      (margin, for comparison)
  .a { border-block-start-width: 2px }               ->  .a { border-top-width: 2px }     (parsed value, for comparison)
  ```
- The same branch also changes the cascade when other declarations are present, and drops the base declaration of a color fallback:
  ```
  .a { border-top: 1px solid red; border-block-start-width: var(--w) }
      ->  .a { border-top: 1px solid red }

  .a { border-block-start: var(--w) solid lab(40% 56.6 39) }
      ->  @supports (color: lab(0% 0 0)) { .a { border-top: var(--w) solid lab(40% 56.6 39) } }
          (the `.a { border-top: var(--w) solid #b32323 }` base declaration is missing)
  ```
- All eight block-axis longhands and shorthands are affected (`border-block-{start,end}` and their `-width` / `-style` / `-color` longhands). The inline-axis ones are not: they take a different branch that emits `:lang()` based ltr/rtl rules.
- Cause: `BorderHandler::flush_unparsed` in `src/css/properties/border.rs`. The `prop!` macro used by the eight block-axis arms builds the re-targeted `UnparsedProperty`, registers its fallbacks with the context and records it in `flushed_properties`, but never pushes it to `dest`. It carried the comment "Intentionally not pushed to dest (preserves existing behavior; likely a bug)", inherited from the pre-port implementation. The `_` arm right below it, the `logical_supported` path above it, and the parsed path (`fc_push!` / `fc_fallbacks!` for `BorderTop*` / `BorderBottom*`) all push.
- Reachability: the bundler's built-in browser targets (chrome 87 / safari 14 / firefox 78 / edge 88) support logical borders, so `bun build` does not take this branch today. It is taken by anything that passes older targets to the CSS compiler (currently the `bun:internal-for-testing` CSS API, where it was found).

### Fix

- `prop!` now pushes the re-targeted property to `dest`, after `add_unparsed_fallbacks` has registered the `@supports` fallbacks and possibly rewritten the value to the fallback color, which is the same order the `_` arm uses. The oddly named local and the now unneeded `let _ = &dest;` are cleaned up; nothing else changes.
- Why this is correct: a block-axis logical property maps to a fixed physical side (`block-start` is `top`, `block-end` is `bottom`) regardless of text direction, so renaming the declaration in place is the complete translation. That is exactly what the parsed path does for the same properties, what `SizeHandler::prop` does for `margin-block-*` / `padding-block-*` with `var()`, and what upstream lightningcss's `flush_unparsed` does for these arms. `flushed_properties` was already being updated as if the declaration had been emitted, so the rest of the handler's state is unchanged by this fix.
- Verified with `test/js/bun/css/css.test.ts` (`border` block): the eight logical to physical mappings with `var()`, the same eight left alone on a target that supports logical borders, both block sides in one rule, an unparsed longhand after a parsed physical shorthand, a parsed longhand after an unparsed one, `!important`, and the `var()` + `lab()` fallback case for both shorthands. 14 of the 22 new cases fail on the released 1.4.0 (`USE_SYSTEM_BUN=1`), all pass with the fix (`bun bd test`, 1164 pass / 0 fail in the file).
- The expected output of all 22 new cases is what lightningcss 1.30.2 prints for the same input and targets (checked with the npm package that is already in the repo's `node_modules`).
- Also run with the fix: `test/bundler/css/` and `test/bundler/esbuild/css.test.ts` (225 pass), `test/js/bun/css/{color,doesnt_crash,css-loader}.test.ts` (1056 pass).

### Background

- Property handlers: the CSS minifier feeds each declaration block through a chain of handlers. `BorderHandler` buffers the border declarations of a block and writes them back out (merged into shorthands where possible) when it flushes; a declaration that a handler neither buffers nor pushes to `dest` is simply absent from the output.
- Unparsed properties: when a known property's value cannot be fully parsed (typically because it contains `var()`), it is stored as `Property::Unparsed` with the property id plus the raw token list. Such values cannot be merged, so `BorderHandler` flushes whatever it has buffered and then handles the unparsed declaration on its own in `flush_unparsed`, which is the function changed here.
- Compiling logical properties: for targets without logical property support, block-axis properties are renamed to their top/bottom equivalents, while inline-axis properties depend on text direction and are emitted as separate ltr/rtl rules via `add_logical_rule`.
- `add_unparsed_fallbacks`: for an unparsed value containing a color the targets do not support (for example `lab()`), this registers copies of the declaration under `@supports` conditions with the context and rewrites the declaration itself to the widely supported fallback color. The caller is still responsible for emitting that rewritten declaration, which is the step that was missing.
