### PR TITLE
css: emit the physical longhands instead of the inset shorthand for targets without it

### DIFF
--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -322,10 +322,16 @@ pub trait SizeHandlerSpec {
     const LEFT_ID: PropertyId;
     const RIGHT_ID: PropertyId;
     const SHORTHAND_CATEGORY: PropertyCategory;
-    /// Optional prefix feature for the shorthand.
+    /// Compat feature of the logical longhands. Where the targets lack it, `flush`
+    /// lowers them to physical properties.
     const FEATURE: Option<Feature>;
-    /// `shorthand_extra.?.shorthand_feature`.
+    /// Compat feature of the `*-block` / `*-inline` pair shorthands.
     const SHORTHAND_FEATURE: Option<Feature>;
+    /// Compat feature of the 4-side shorthand itself. `inset` shipped together with
+    /// the logical inset properties, so where the targets lack it `flush` emits the
+    /// four physical longhands instead. `None` when the shorthand is emitted
+    /// regardless of targets (`margin`, `padding`, `scroll-margin`).
+    const PHYSICAL_SHORTHAND_FEATURE: Option<Feature>;
 
     // ---- value-type bindings ----
     // In every instantiation in this file the longhand value type is
@@ -808,6 +814,10 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         self.has_any = true;
     }
 
+    fn is_supported(feature: Option<Feature>, context: &PropertyHandlerContext) -> bool {
+        feature.is_none_or(|feature| !context.should_compile_logical(feature))
+    }
+
     fn flush(&mut self, dest: &mut DeclarationList, context: &mut PropertyHandlerContext) {
         if !self.has_any {
             return;
@@ -819,15 +829,11 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         let bottom = self.bottom.take();
         let left = self.left.take();
         let right = self.right.take();
-        let logical_supported = match S::FEATURE {
-            Some(feature) => !context.should_compile_logical(feature),
-            None => true,
-        };
+        let logical_supported = Self::is_supported(S::FEATURE, context);
+        let shorthand_supported = Self::is_supported(S::PHYSICAL_SHORTHAND_FEATURE, context);
 
         match (top, bottom, left, right) {
-            (Some(top), Some(bottom), Some(left), Some(right))
-                if S::SHORTHAND_CATEGORY != PropertyCategory::Logical || logical_supported =>
-            {
+            (Some(top), Some(bottom), Some(left), Some(right)) if shorthand_supported => {
                 dest.push(S::make_shorthand(top, bottom, left, right));
             }
             (top, bottom, left, right) => {
@@ -992,11 +998,8 @@ impl<S: SizeHandlerSpec> SizeHandler<S> {
         context: &mut PropertyHandlerContext,
     ) {
         // _ = this; // autofix
-        let shorthand_supported = logical_supported
-            && match S::SHORTHAND_FEATURE {
-                Some(f) => !context.should_compile_logical(f),
-                None => true,
-            };
+        let shorthand_supported =
+            logical_supported && Self::is_supported(S::SHORTHAND_FEATURE, context);
 
         let (start_prop, end_prop) = match pair {
             LogicalSidePair::Block => (S::BLOCK_START, S::BLOCK_END),
@@ -1250,6 +1253,7 @@ impl SizeHandlerSpec for MarginSpec {
     const SHORTHAND_CATEGORY: PropertyCategory = PropertyCategory::Physical;
     const FEATURE: Option<Feature> = Some(Feature::LogicalMargin);
     const SHORTHAND_FEATURE: Option<Feature> = Some(Feature::LogicalMarginShorthand);
+    const PHYSICAL_SHORTHAND_FEATURE: Option<Feature> = None;
     type Shorthand = Margin;
     type BlockShorthand = MarginBlock;
     type InlineShorthand = MarginInline;
@@ -1287,6 +1291,7 @@ impl SizeHandlerSpec for PaddingSpec {
     const SHORTHAND_CATEGORY: PropertyCategory = PropertyCategory::Physical;
     const FEATURE: Option<Feature> = Some(Feature::LogicalPadding);
     const SHORTHAND_FEATURE: Option<Feature> = Some(Feature::LogicalPaddingShorthand);
+    const PHYSICAL_SHORTHAND_FEATURE: Option<Feature> = None;
     type Shorthand = Padding;
     type BlockShorthand = PaddingBlock;
     type InlineShorthand = PaddingInline;
@@ -1324,6 +1329,7 @@ impl SizeHandlerSpec for ScrollMarginSpec {
     const SHORTHAND_CATEGORY: PropertyCategory = PropertyCategory::Physical;
     const FEATURE: Option<Feature> = None;
     const SHORTHAND_FEATURE: Option<Feature> = None;
+    const PHYSICAL_SHORTHAND_FEATURE: Option<Feature> = None;
     type Shorthand = ScrollMargin;
     type BlockShorthand = ScrollMarginBlock;
     type InlineShorthand = ScrollMarginInline;
@@ -1361,6 +1367,7 @@ impl SizeHandlerSpec for InsetSpec {
     const SHORTHAND_CATEGORY: PropertyCategory = PropertyCategory::Physical;
     const FEATURE: Option<Feature> = Some(Feature::LogicalInset);
     const SHORTHAND_FEATURE: Option<Feature> = Some(Feature::LogicalInset);
+    const PHYSICAL_SHORTHAND_FEATURE: Option<Feature> = Some(Feature::LogicalInset);
     type Shorthand = Inset;
     type BlockShorthand = InsetBlock;
     type InlineShorthand = InsetInline;

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2436,6 +2436,207 @@ describe("css tests", () => {
     );
   });
 
+  describe("inset", () => {
+    // The `inset` shorthand is gated on the same compat data as the logical inset properties
+    // (LogicalInset: Chrome 87, Firefox 63, Safari 14.1). For older targets the four physical
+    // longhands are emitted instead of it.
+    const withoutInset = { chrome: 60 << 16, firefox: 50 << 16, safari: 10 << 16 };
+
+    minify_test(".foo{top:0;right:0;bottom:0;left:0}", ".foo{inset:0}");
+
+    prefix_test(
+      `
+      .foo {
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+    `,
+      indoc`
+      .foo {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    `,
+      withoutInset,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        inset: 0;
+      }
+    `,
+      indoc`
+      .foo {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    `,
+      withoutInset,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        inset: 1px 2px 3px 4px;
+      }
+    `,
+      indoc`
+      .foo {
+        top: 1px;
+        bottom: 3px;
+        left: 4px;
+        right: 2px;
+      }
+    `,
+      withoutInset,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        inset: 0 !important;
+      }
+    `,
+      indoc`
+      .foo {
+        top: 0 !important;
+        bottom: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+      }
+    `,
+      withoutInset,
+    );
+
+    // Both lowerings compose: the shorthand becomes longhands, and the logical pair shorthand
+    // after it is lowered to left/right as before, keeping source order.
+    prefix_test(
+      `
+      .foo {
+        inset: 0;
+        inset-inline: 3px;
+      }
+    `,
+      indoc`
+      .foo {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        left: 3px;
+        right: 3px;
+      }
+    `,
+      withoutInset,
+    );
+
+    // A value with var() cannot be lowered, so it is kept as written; the parsed
+    // declaration before it is still lowered.
+    prefix_test(
+      `
+      .foo {
+        inset: 0;
+        inset: var(--x);
+      }
+    `,
+      indoc`
+      .foo {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        inset: var(--x);
+      }
+    `,
+      withoutInset,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+    `,
+      indoc`
+      .foo {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+      }
+    `,
+      {
+        chrome: 86 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+    `,
+      indoc`
+      .foo {
+        inset: 0;
+      }
+    `,
+      {
+        chrome: 87 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        inset: 0;
+      }
+    `,
+      indoc`
+      .foo {
+        inset: 0;
+      }
+    `,
+      {
+        chrome: 87 << 16,
+        firefox: 63 << 16,
+        safari: (14 << 16) | (1 << 8),
+      },
+    );
+
+    // Only `inset` is gated on the targets; the other 4-side shorthands are always emitted.
+    prefix_test(
+      `
+      .foo {
+        margin: 0;
+        padding: 0;
+        scroll-margin: 0;
+      }
+    `,
+      indoc`
+      .foo {
+        margin: 0;
+        padding: 0;
+        scroll-margin: 0;
+      }
+    `,
+      withoutInset,
+    );
+  });
+
   describe("scroll-paddding", () => {
     prefix_test(
       `


### PR DESCRIPTION
### Problem
- Minifying CSS with browser targets that predate the `inset` shorthand (Chrome < 87, Firefox < 63, Safari < 14.1) still emits `inset`, and also upgrades `top`/`right`/`bottom`/`left` longhands into it. With `{ chrome: 60 }` both `.a{inset:0}` and `.a{top:0;right:0;bottom:0;left:0}` come out as `.a{inset:0}`, which the targeted browser ignores. lightningcss emits `.a{top:0;bottom:0;left:0;right:0}` for both.
- `SizeHandler::flush` (src/css/properties/margin_padding.rs) does have a longhand fallback branch, but it was keyed on `S::SHORTHAND_CATEGORY != Logical || logical_supported`, and every spec, `InsetSpec` included, sets `SHORTHAND_CATEGORY` to `Physical`, so the shorthand was emitted unconditionally. Present since the original port; the Zig version had the same value.

### Fix
- Adds `SizeHandlerSpec::PHYSICAL_SHORTHAND_FEATURE: Option<Feature>`: the compat feature the 4-side shorthand itself needs. `InsetSpec` sets it to `Feature::LogicalInset`; `MarginSpec`, `PaddingSpec` and `ScrollMarginSpec` set `None`. `flush` now emits the 4-side shorthand only when that feature is supported and otherwise falls through to the existing `top`/`bottom`/`left`/`right` branch. The fixing lines are the `if shorthand_supported` guard in `flush` and the `InsetSpec` constant; the rest of the diff is the `is_supported` helper (so the `Option<Feature>` check is not copied a third time) and doc comments on the neighbouring constants.
- Why `LogicalInset`: it is the compat entry that already gates `inset-block`/`inset-inline` in this same handler (`SHORTHAND_FEATURE`), and it is what lightningcss keys the `inset` fallback on, so the outputs above now match lightningcss for these targets. Going through `context.should_compile_logical` keeps the `logical-properties` include/exclude flags and the style-attribute exemption working the same way as for the rest of the family.
- Why not flip `SHORTHAND_CATEGORY` to `Logical` as upstream declares it: in this handler the category also decides which buffered declarations get flushed before and after a shorthand. Making it `Logical` for inset would stop `inset: 0; top: 5px` from folding into `inset: 5px 0 0` (output that #38551 pins and that lightningcss produces), and without #38551 it would also stop `inset: 1px; inset: 0` from collapsing. Target support is a separate question from that buffering, so it gets its own constant. `SHORTHAND_CATEGORY` is left as is (it is `Physical` for every spec, and #38551 adds a use of it); this change has no overlap with #38551.
- Only the target-gating changes. For targets that support `inset`, or with no targets, the output is identical to before; `margin`, `padding` and `scroll-margin` are unaffected because their constant is `None`.
- Intentionally not touched: a 4-side shorthand written after an inline logical longhand in the same rule (`margin-inline-start: 3px; margin: 0` with old targets) still flushes the dead longhand into trailing `:lang()` fallback rules. That is a separate pre-existing bug shared by every handler in this file (lightningcss has it too) and is being tracked separately.
- Verified with the new `describe("inset")` block in test/js/bun/css/css.test.ts: 7 cases (longhands with old targets, `inset: 0`, a 4-value `inset`, `!important`, `inset` followed by `inset-inline`, `inset` followed by an unparsed `inset: var()`, and the Chrome 86 boundary) fail on the unfixed build (`USE_SYSTEM_BUN=1` and a debug build with src/ stashed) and pass with the fix; 4 cases pin the unchanged behaviour (no targets, Chrome 87 boundary, supported targets, margin/padding/scroll-margin with old targets). Expected outputs were checked against lightningcss 1.30.2.
- `bun bd test test/js/bun/css/css.test.ts`: 1153 pass, 0 fail. test/regression/issue/25794.test.ts and test/js/bun/css/duplicate-declaration-merge-hang.test.ts pass. `cargo clippy -p bun_css` and `cargo fmt` are clean.

### Background
- `SizeHandler<S>` is the minifier's property handler shared by the margin, padding, scroll-margin and inset families. It buffers a rule's declarations for one family and, on `flush`, writes them back out merged: four physical sides become the 4-side shorthand, a block or inline pair becomes `*-block`/`*-inline`.
- `Feature` (src/css/compat.rs) is a table of browser versions per CSS feature; `context.should_compile_logical(feature)` is true when the configured targets include a browser below the feature's version (or the user forced logical-property lowering), in which case the handler has to emit something older browsers understand.
- `inset` is defined by the CSS Logical Properties spec and shipped in the same browser releases as `inset-block`/`inset-inline`, so its support is described by the same `LogicalInset` entry. `margin`, `padding` and `scroll-margin` have no such constraint on their 4-side shorthands.
- `SHORTHAND_CATEGORY` / `PropertyCategory` track whether the values currently buffered came from physical or logical properties; when a declaration of the other category arrives, the buffered ones are written out first so the earlier declaration stays as a fallback. That is the mechanism #38551 touches, and it is why it is not the right knob for target support.
