### PR TITLE
runtime: apply --tsconfig-override compilerOptions to transpilation

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -675,8 +675,7 @@ fn merge_tsconfig_jsx_into(tsconfig: &TSConfigJSON, out: &mut crate::options_imp
 
 impl<'a> Transpiler<'a> {
     /// Initialize `self.linker` with back-pointers into this `Transpiler`,
-    /// optionally auto-configuring JSX / decorator options from the working
-    /// directory's `tsconfig.json` (or the `--tsconfig-override` file).
+    /// optionally auto-configuring JSX and decorators from the cwd tsconfig.
     pub fn configure_linker_with_auto_jsx(&mut self, auto_jsx: bool) {
         // `Linker::init` dropped its `arena` arg (linker.rs:172
         // — global mimalloc). `crate::linker::Linker` stores raw pointers

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -675,7 +675,8 @@ fn merge_tsconfig_jsx_into(tsconfig: &TSConfigJSON, out: &mut crate::options_imp
 
 impl<'a> Transpiler<'a> {
     /// Initialize `self.linker` with back-pointers into this `Transpiler`,
-    /// optionally auto-configuring JSX from the nearest `tsconfig.json`.
+    /// optionally auto-configuring JSX / decorator options from the working
+    /// directory's `tsconfig.json` (or the `--tsconfig-override` file).
     pub fn configure_linker_with_auto_jsx(&mut self, auto_jsx: bool) {
         // `Linker::init` dropped its `arena` arg (linker.rs:172
         // — global mimalloc). `crate::linker::Linker` stores raw pointers
@@ -701,7 +702,7 @@ impl<'a> Transpiler<'a> {
             // Most of the time, this will already be cached
             let top_level_dir = self.fs().top_level_dir;
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
-                if let Some(tsconfig) = root_dir.tsconfig_json() {
+                if let Some(tsconfig) = self.resolver.tsconfig_for_top_level_dir(&root_dir) {
                     // If we don't explicitly pass JSX, try to get it from the root tsconfig
                     if self.options.transform_options.jsx.is_none() {
                         self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
@@ -762,7 +763,7 @@ impl<'a> Transpiler<'a> {
                     _ => return Ok(()),
                 };
 
-                if let Some(tsconfig) = dir_info.tsconfig_json() {
+                if let Some(tsconfig) = self.resolver.tsconfig_for_top_level_dir(&dir_info) {
                     merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
                 }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4218,6 +4218,25 @@ impl<'a> Resolver<'a> {
         self.dir_info_cached_maybe_log(false, path).ok().flatten()
     }
 
+    /// The tsconfig whose compiler options (JSX pragma, decorators,
+    /// `useDefineForClassFields`) configure the transpiler as a whole, given
+    /// the working directory's `dir_info`: the `tsconfig.json` / `jsconfig.json`
+    /// in that directory, or the `--tsconfig-override` file standing in for it.
+    /// `dir_info_uncached` parses the override onto the filesystem root's
+    /// `DirInfo` and skips per-directory discovery, so under an override
+    /// `dir_info.tsconfig_json()` is `None` and the override is only reachable
+    /// as the inherited enclosing tsconfig.
+    pub fn tsconfig_for_top_level_dir(
+        &self,
+        dir_info: &DirInfo::DirInfo,
+    ) -> Option<&'static TSConfigJSON> {
+        if self.opts.tsconfig_override.is_some() {
+            dir_info.enclosing_tsconfig_json
+        } else {
+            dir_info.tsconfig_json()
+        }
+    }
+
     // NOTE: `follow_symlinks` is `true` at every call
     // site, so it's dropped here; `enable_logging` is a plain runtime parameter
     // (it gates one cold error-formatting branch) so this large dir-walk function

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4218,9 +4218,8 @@ impl<'a> Resolver<'a> {
         self.dir_info_cached_maybe_log(false, path).ok().flatten()
     }
 
-    /// The working directory's own tsconfig, or the `--tsconfig-override` file
-    /// standing in for it. `dir_info_uncached` attaches the override to the
-    /// filesystem root only, so it reaches `dir_info` as its enclosing tsconfig.
+    /// `dir_info`'s own tsconfig, or the `--tsconfig-override` file when one is
+    /// set (`dir_info_uncached` parses it onto the root `DirInfo`, so it is inherited).
     pub fn tsconfig_for_top_level_dir(
         &self,
         dir_info: &DirInfo::DirInfo,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4218,14 +4218,9 @@ impl<'a> Resolver<'a> {
         self.dir_info_cached_maybe_log(false, path).ok().flatten()
     }
 
-    /// The tsconfig whose compiler options (JSX pragma, decorators,
-    /// `useDefineForClassFields`) configure the transpiler as a whole, given
-    /// the working directory's `dir_info`: the `tsconfig.json` / `jsconfig.json`
-    /// in that directory, or the `--tsconfig-override` file standing in for it.
-    /// `dir_info_uncached` parses the override onto the filesystem root's
-    /// `DirInfo` and skips per-directory discovery, so under an override
-    /// `dir_info.tsconfig_json()` is `None` and the override is only reachable
-    /// as the inherited enclosing tsconfig.
+    /// The working directory's own tsconfig, or the `--tsconfig-override` file
+    /// standing in for it. `dir_info_uncached` attaches the override to the
+    /// filesystem root only, so it reaches `dir_info` as its enclosing tsconfig.
     pub fn tsconfig_for_top_level_dir(
         &self,
         dir_info: &DirInfo::DirInfo,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4218,8 +4218,7 @@ impl<'a> Resolver<'a> {
         self.dir_info_cached_maybe_log(false, path).ok().flatten()
     }
 
-    /// `dir_info`'s own tsconfig, or the `--tsconfig-override` file when one is
-    /// set (`dir_info_uncached` parses it onto the root `DirInfo`, so it is inherited).
+    /// The cwd's own tsconfig, or the `--tsconfig-override` file (inherited from the root `DirInfo`).
     pub fn tsconfig_for_top_level_dir(
         &self,
         dir_info: &DirInfo::DirInfo,

--- a/test/cli/run/tsconfig-override.test.ts
+++ b/test/cli/run/tsconfig-override.test.ts
@@ -303,3 +303,151 @@ describe("bun run --tsconfig-override", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// The override stands in for $cwd/tsconfig.json, so its compilerOptions must
+// drive transpilation (not only "paths" resolution). Each fixture prints
+// something that comes out differently under the defaults, and ./tsconfig.json
+// sets every option to a conflicting value so the override has to win over it.
+describe("--tsconfig-override compilerOptions", () => {
+  const files = {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        jsx: "react",
+        jsxFactory: "wrongFactory",
+        jsxFragmentFactory: "wrongFragment",
+        experimentalDecorators: false,
+        emitDecoratorMetadata: false,
+        useDefineForClassFields: true,
+      },
+    }),
+    "config/override.json": JSON.stringify({
+      compilerOptions: {
+        jsx: "react",
+        jsxFactory: "h",
+        jsxFragmentFactory: "Frag",
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+        useDefineForClassFields: false,
+      },
+    }),
+    // An empty node_modules keeps the default automatic JSX runtime from
+    // auto-installing react; it fails to resolve instead.
+    "node_modules/.gitkeep": "",
+    "jsx.tsx": `
+      const h = (tag: unknown, props: unknown, ...children: unknown[]) => ({ tag, props, children });
+      const Frag = "fragment";
+      console.log(JSON.stringify([<div a="1">hi</div>, <><br /></>]));
+    `,
+    "decorators.ts": `
+      function dec(...args: unknown[]) {
+        console.log(JSON.stringify(args.map(arg => typeof arg)));
+      }
+      class Foo {
+        @dec
+        method() {}
+      }
+    `,
+    "metadata.ts": `
+      const seen: Record<string, string> = {};
+      (Reflect as any).metadata = (metadataKey: string, value: any) => (_target: unknown, propertyKey: string) => {
+        seen[propertyKey + " " + metadataKey] = [value].flat().map(type => type.name).join(",");
+      };
+      function dec() {}
+      class Dep {}
+      class Foo {
+        @dec
+        prop: Dep;
+        @dec
+        method(a: string, b: number): boolean {
+          return true;
+        }
+      }
+      console.log(JSON.stringify(seen));
+    `,
+    "class-fields.ts": `
+      class Base {
+        x = 1;
+      }
+      class Derived extends Base {
+        x;
+      }
+      console.log(new Derived().x);
+    `,
+    "jsx.test.tsx": `
+      import { expect, test } from "bun:test";
+      const h = (tag: unknown, props: unknown) => ({ tag, props });
+      test("jsxFactory from the override", () => {
+        expect(<div a="1" />).toEqual({ tag: "div", props: { a: "1" } });
+      });
+    `,
+  };
+
+  const override = ["--tsconfig-override", "./config/override.json"];
+
+  async function run(dir: string, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("jsx, jsxFactory and jsxFragmentFactory", async () => {
+    await using dir = tempDir("tsconfig-override-jsx", files);
+    const { stdout, exitCode } = await run(dir, [...override, "jsx.tsx"]);
+
+    expect(stdout).toBe(
+      JSON.stringify([
+        { tag: "div", props: { a: "1" }, children: ["hi"] },
+        { tag: "fragment", props: null, children: [{ tag: "br", props: null, children: [] }] },
+      ]) + "\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("experimentalDecorators", async () => {
+    await using dir = tempDir("tsconfig-override-decorators", files);
+    const { stdout, exitCode } = await run(dir, [...override, "decorators.ts"]);
+
+    // TypeScript's legacy method decorators get (prototype, key, descriptor);
+    // standard decorators get (method, context).
+    expect(stdout).toBe(JSON.stringify(["object", "string", "object"]) + "\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("emitDecoratorMetadata", async () => {
+    await using dir = tempDir("tsconfig-override-metadata", files);
+    const { stdout, exitCode } = await run(dir, [...override, "metadata.ts"]);
+
+    expect(JSON.parse(stdout)).toEqual({
+      "prop design:type": "Dep",
+      "method design:type": "Function",
+      "method design:paramtypes": "String,Number",
+      "method design:returntype": "Boolean",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("useDefineForClassFields", async () => {
+    await using dir = tempDir("tsconfig-override-class-fields", files);
+    const { stdout, exitCode } = await run(dir, [...override, "class-fields.ts"]);
+
+    // With useDefineForClassFields: false, the uninitialized `x;` in Derived
+    // is dropped instead of redefining the inherited field as undefined.
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("applies to bun test", async () => {
+    await using dir = tempDir("tsconfig-override-bun-test", files);
+    const { stderr, exitCode } = await run(dir, ["test", ...override, "jsx.test.tsx"]);
+
+    expect(stderr).toContain(" 1 pass");
+    expect(stderr).toContain(" 0 fail");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `bun --tsconfig-override ./override.json x.tsx` (and `bun test --tsconfig-override`) ignores the override file's `compilerOptions.jsx` / `jsxFactory` / `jsxFragmentFactory` / `experimentalDecorators` / `emitDecoratorMetadata` / `useDefineForClassFields`. Only `paths` takes effect.
- The same file placed at `./tsconfig.json` is honored, and so is `bun build --tsconfig-override`, so this is runtime only. Repro below.
- The runtime transpiles every file with `transpiler.options.{jsx, emit_decorator_metadata, experimental_decorators, use_define_for_class_fields}` (`src/runtime/jsc_hooks.rs:2710`, `src/jsc/RuntimeTranspilerStore.rs:852`). Those are filled by `configure_linker_with_auto_jsx` (`src/bundler/transpiler.rs:703`) and `run_env_loader` (`transpiler.rs:765`) from `read_dir_info(cwd).tsconfig_json()`, i.e. the tsconfig sitting in the cwd itself.
- With an override, `dir_info_uncached` (`src/resolver/resolver.rs:6493`) skips per-directory `tsconfig.json` discovery and parses the override onto the filesystem root's `DirInfo` instead, so the cwd `DirInfo` has no `tsconfig_json()` and both sites apply nothing. The override only reaches the cwd `DirInfo` as its inherited `enclosing_tsconfig_json`.

### Fix
- Add `Resolver::tsconfig_for_top_level_dir(dir_info)`: returns `enclosing_tsconfig_json` when `opts.tsconfig_override` is set (that is the override), and `tsconfig_json()` otherwise. Both transpiler.rs sites use it.
- Correct because the flag is documented as replacing `$cwd/tsconfig.json` ("Specify custom tsconfig.json. Default $cwd/tsconfig.json"), and this routes the override through exactly the code path `$cwd/tsconfig.json` already takes, so override and in-place file now transpile identically. It also matches what `bun build --tsconfig-override` already does (the bundler reads the per-file enclosing tsconfig, which is the override).
- Without an override nothing changes: the helper returns the same `tsconfig_json()` as before, so running from a subdirectory still does not pick up a parent tsconfig (unchanged, documented cwd-only behavior).
- The runtime transpiler cache already keys on these options (`parse_entry.rs:hash_for_runtime_transpiler`), so toggling the flag between runs does not serve stale output.
- Verified: `test/cli/run/tsconfig-override.test.ts` gains five cases (jsx factory + fragment factory, experimentalDecorators, emitDecoratorMetadata, useDefineForClassFields, and the same through `bun test`), each with a conflicting `./tsconfig.json` in cwd so the override has to win over it. All five fail on current bun (override ignored) and pass with this change; the six existing `paths` cases still pass.
- Also ran with the change: `test/cli/test/bun-test.test.ts -t tsconfig-override`, `test/bundler/cli.test.ts -t tsconfig-override`, `test/bundler/transpiler/ts-use-define-for-class-fields.test.ts`, `test/bundler/bundler_decorator_metadata.test.ts`, `test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts`, `test/js/bun/resolve/tsconfig-extends-leak.test.ts`, `test/regression/issue/27575.test.ts`, `test/regression/issue/27526.test.ts`: all pass. `bun build` output for the repro is byte-identical before and after.

### Background
- `DirInfo`: the resolver's cached record for one directory. `tsconfig_json` is the tsconfig found in that directory itself; `enclosing_tsconfig_json` is the nearest one in that directory or any ancestor, copied down from the parent `DirInfo` when a child is created. Per-file resolution (and the bundler) uses the enclosing one, which is why `paths` and `bun build` already worked with the override.
- Transpiler-wide options: the runtime does not consult a tsconfig per file. It reads one tsconfig at startup, the cwd's, into `transpiler.options`, and every runtime transpile (including workers, whose VM repeats the same startup step) uses those values. `configure_linker` copies the options in at VM init; `run_env_loader` re-merges the JSX fields after `.env` loading so a tsconfig `jsx` setting wins over the NODE_ENV-driven dev/prod flip.
- `--tsconfig-override`: the resolver attaches the override to the filesystem root `DirInfo` so every directory inherits it, and stops looking for `tsconfig.json` files anywhere. That design is what makes `paths` apply everywhere, and also what leaves `tsconfig_json()` empty for the cwd.

<details>
<summary>Repro</summary>

```sh
mkdir /tmp/t && cd /tmp/t
printf 'const h = (...args: any[]) => JSON.stringify(args);\nconsole.log(<div a="1" />);\n' > x.tsx
printf '{"compilerOptions":{"jsx":"react","jsxFactory":"h"}}' > override.json

bun --tsconfig-override ./override.json x.tsx
# before: <div a="1" />            (override ignored, automatic runtime used)
# after:  ["div",{"a":"1"}]

cp override.json tsconfig.json && bun x.tsx
# ["div",{"a":"1"}]               (same file in place was already honored)

bun build --no-bundle x.tsx --tsconfig-override ./override.json
# emits h("div", { a: "1" })      (bundler was already honoring it)
```

The unrelated `Internal error: directory mismatch` line this flag prints on stderr is #34980.
</details>
