### PR TITLE
bun build: make --format=cjs default --target to node, as documented

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -408,7 +408,7 @@ To use ES Module syntax in browsers, set `format` to `"esm"` and load the bundle
 
 #### format: "cjs" - CommonJS
 
-To build a CommonJS module, set `format` to `"cjs"`. When choosing `"cjs"`, the default target changes from `"browser"` (esm) to `"node"` (cjs). CommonJS modules transpiled with `format: "cjs"`, `target: "node"` run in both Bun and Node.js (assuming the APIs in use are supported by both).
+To build a CommonJS module, set `format` to `"cjs"`. On the command line, `--format=cjs` changes the default `--target` from `"browser"` to `"node"`. `Bun.build()` keeps its default of `target: "browser"`, so pass `target` explicitly there. CommonJS modules transpiled with `format: "cjs"`, `target: "node"` run in both Bun and Node.js (assuming the APIs in use are supported by both).
 
 <Tabs>
   <Tab title="JavaScript">

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -450,7 +450,7 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
             "--no-clear-screen                Disable clearing the terminal screen on reload when --watch is enabled"
         ),
         parse_param!(
-            "--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\""
+            "--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\". Defaults to \"browser\", or \"node\" with --format=cjs"
         ),
         parse_param!("--outdir <STR>                   Default to \"dist\" if multiple files"),
         parse_param!("--outfile <STR>                  Write to a file"),
@@ -921,6 +921,8 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         load_config_with_cmd_args(cmd, &args, ctx)?;
     }
 
+    // The caller stores the returned `opts` as `ctx.args`; anything written to
+    // `ctx.args` below this line is discarded.
     let mut opts: api::TransformOptions = ctx.args.clone();
 
     let defines_tuple = DefineColonList::resolve(args.options(b"--define"))?;
@@ -2061,9 +2063,9 @@ fn parse_build_command_options(
             FeatureFlags::BAKE_DEBUGGING_FEATURES && args.flag(b"--debug-no-minify");
     }
 
+    // `--bytecode` (like `--compile`) forces the target to bun in `BuildCommand::exec`.
     if ctx.bundler_options.bytecode {
         ctx.bundler_options.output_format = options::Format::Cjs;
-        ctx.args.target = Some(api::Target::Bun);
     }
 
     if let Some(public_path) = args.option(b"--public-path") {
@@ -2516,8 +2518,8 @@ fn parse_build_command_options(
                 Output::flush();
             }
             options::Format::Cjs => {
-                if ctx.args.target.is_none() {
-                    ctx.args.target = Some(api::Target::Node);
+                if opts.target.is_none() {
+                    opts.target = Some(api::Target::Node);
                 }
             }
             _ => {}

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -921,8 +921,6 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         load_config_with_cmd_args(cmd, &args, ctx)?;
     }
 
-    // The caller stores the returned `opts` as `ctx.args`; anything written to
-    // `ctx.args` below this line is discarded.
     let mut opts: api::TransformOptions = ctx.args.clone();
 
     let defines_tuple = DefineColonList::resolve(args.options(b"--define"))?;

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -450,7 +450,7 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
             "--no-clear-screen                Disable clearing the terminal screen on reload when --watch is enabled"
         ),
         parse_param!(
-            "--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\". Defaults to \"browser\", or \"node\" with --format=cjs"
+            "--target <STR>                   The intended execution environment for the bundle. \"browser\", \"bun\" or \"node\". Defaults to \"browser\", \"node\" with --format=cjs, or \"bun\" with --compile or --bytecode"
         ),
         parse_param!("--outdir <STR>                   Default to \"dist\" if multiple files"),
         parse_param!("--outfile <STR>                  Write to a file"),

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -599,8 +599,7 @@ describe.concurrent("bun build --format=cjs defaults --target to node", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: expect.any(String), stderr: "", exitCode: 0 });
     return stdout;
   }
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -579,3 +579,68 @@ describe.concurrent("modules that fail to print", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// Without --target, `bun build` bundles for the browser, except that --format=cjs
+// defaults to node (docs/bundler/index.mdx, "format: cjs"). The entry point imports
+// a node builtin because the two targets bundle it differently: the browser target
+// replaces it with an empty stub, the node target keeps it as a require().
+describe.concurrent("bun build --format=cjs defaults --target to node", () => {
+  const files = {
+    "entry.js": `import { readFileSync } from "node:fs";\nconsole.log(typeof readFileSync);\n`,
+  };
+  const browserStub = "(() => ({}))";
+
+  async function build(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  test("--format=cjs alone bundles for node", async () => {
+    using dir = tempDir("build-cjs-default-target", files);
+    const out = await build(String(dir), "--format=cjs", "entry.js");
+    expect(out).toMatchInlineSnapshot(`
+      "// entry.js
+      var import_node_fs = require("node:fs");
+      console.log(typeof import_node_fs.readFileSync);
+      "
+    `);
+  });
+
+  test("an explicit --target=browser is kept", async () => {
+    using dir = tempDir("build-cjs-target-browser", files);
+    const out = await build(String(dir), "--format=cjs", "--target=browser", "entry.js");
+    expect(out).toContain(browserStub);
+    expect(out).not.toContain('require("node:fs")');
+  });
+
+  test("an explicit --target=bun is kept, whichever flag comes first", async () => {
+    using dir = tempDir("build-cjs-target-bun", files);
+    const out = await build(String(dir), "--target=bun", "--format=cjs", "entry.js");
+    expect(out).toStartWith("// @bun @bun-cjs\n");
+    expect(out).toContain('require("fs")');
+  });
+
+  test("--bytecode still forces --target=bun", async () => {
+    using dir = tempDir("build-cjs-bytecode", files);
+    await build(String(dir), "--format=cjs", "--bytecode", "--outdir=out", "entry.js");
+    const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
+    expect(out).toStartWith("// @bun @bytecode @bun-cjs\n");
+    expect(out).toContain('require("fs")');
+  });
+
+  test.each(["esm", "iife"])("--format=%s still defaults to the browser target", async format => {
+    using dir = tempDir(`build-${format}-default-target`, files);
+    const out = await build(String(dir), `--format=${format}`, "entry.js");
+    expect(out).toContain(browserStub);
+    expect(out).not.toContain('"node:fs"');
+  });
+});


### PR DESCRIPTION
### Problem

- `docs/bundler/index.mdx` ("format: cjs") says choosing `cjs` changes the default target from `browser` to `node`. `bun build x.js --format=cjs` still bundles for the browser: a `node:fs` import comes out as the browser stub `var import_node_fs = (() => ({}));` instead of `require("node:fs")`, and dependencies resolve through their `browser` conditions. Only `--format=cjs --target=node` produces what the docs describe.
- Cause: `parse()` in `src/runtime/cli/Arguments.rs` works on `opts`, a clone of `ctx.args`, and returns it; the caller (`src/runtime/cli/mod.rs`, `ctx.args = arguments::parse(cmd, ctx)?`) replaces `ctx.args` with it. The `--format=cjs` arm of `parse_build_command_options` wrote the default into `ctx.args.target`, so it was thrown away. Every other target write in that function goes to `opts.target`.
- Pre-existing: the Zig version had the same value copy (`var opts = ctx.args;` then `.cjs => ctx.args.target = .node`), so the documented default has never taken effect in any release.

### Fix

- The `--format=cjs` arm writes `opts.target` (still only when no target is set; `--target` is applied earlier in the same function, so an explicit `--target=browser`/`bun` wins in either flag order).
- The `--bytecode` arm had the same dead `ctx.args.target = bun` write. It is removed: `BuildCommand::exec` (`src/runtime/cli/build_command.rs`) already forces the target to `bun` for `--bytecode` and `--compile`, which is also why those two combined with `--format=cjs` still build for `bun` after this change. `--bytecode --target=node` still fails with "target must be 'bun' when bytecode is true", as before.
- Why this is the right direction rather than deleting the doc sentence: the default is what the docs and the CLI code have both said since CommonJS output was added (#14232), and a CommonJS bundle built for the browser target stubs out every node builtin, which is not useful output for anyone asking for CommonJS. Scripts that want the old behavior pass `--target=browser`; `--target` given explicitly is never overridden. Behavior change for scripts that run `bun build --format=cjs` without `--target`: node builtins are kept as `require()` calls and packages resolve through their `node` conditions instead of `browser`.
- `Bun.build()` is unchanged: its `target` has always defaulted to `"browser"` unconditionally (that is what `bun.d.ts` documents), and there was never code for a `cjs` rule there. The doc paragraph now says which surface does what instead of claiming the rule for both; `--target`'s `--help` line mentions the default.
- Verified by `test/bundler/cli.test.ts`, "bun build --format=cjs defaults --target to node": the `--format=cjs` case fails on the unfixed build (browser stub in the snapshot) and passes with the fix; the other cases (explicit `--target=browser`, explicit `--target=bun` with the flags in the other order, `--bytecode`, `--format=esm`/`iife` still browser) pass before and after and pin the paths this change must not affect.
- Also run with the fixed build: the rest of `test/bundler/cli.test.ts`, `test/regression/issue/26298.test.ts` (`--compile --bytecode` without `--target`), and manually `--format=cjs --compile` (executable builds and runs) and `--format=cjs --bytecode --target=node` (still rejected). The bundle from `bun build x.js --format=cjs` now prints `function` for `typeof readFileSync` under both Node 26 and Bun; before it printed `undefined` in both.

### Background

- `api::TransformOptions` (`ctx.args`) is the option struct the CLI hands to the bundler; `target: Option<Target>` is `None` until a flag or a default sets it, and `None` is read as `browser` when the bundler options are built (`Target::from_api`).
- `bun build` flag parsing lives in `Arguments::parse`, which fills in `opts` and returns it; `ctx.bundler_options` (format, minify, bytecode, ...) is a separate struct that is mutated in place, which is why the neighbouring `ctx.bundler_options.*` writes in the same function do work.
- Bundler targets decide how builtins and packages resolve: `browser` inlines the polyfills in `src/node-fallbacks` for the builtins that have one (`path`, `events`, ...) and an empty stub for the rest (`fs`), and prefers the `browser` export condition / `package.json` `browser` field; `node` keeps builtins as `require()` calls and prefers the `node` condition. The test imports `node:fs` because that difference shows up in a one-line bundle.
