### PR TITLE
error printer: clear a throwing error.message getter's exception before the next property read

### DIFF
--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -507,16 +507,21 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
     }
     if (except.type == SYNTAX_ERROR_CODE) {
         except.message = Bun::toStringRef(err->sanitizedMessageString(global));
-
-    } else if (JSC::JSValue message = obj->getIfPropertyExists(global, vm.propertyNames->message)) {
-        RETURN_IF_EXCEPTION(scope, );
-        except.message = Bun::toStringRef(global, message);
-        if (!scope.clearExceptionExceptTermination()) [[unlikely]]
-            return;
     } else {
-        RETURN_IF_EXCEPTION(scope, );
-
-        except.message = Bun::toStringRef(err->sanitizedMessageString(global));
+        // This one intentionally calls getters.
+        JSC::JSValue message = obj->getIfPropertyExists(global, vm.propertyNames->message);
+        if (scope.exception()) [[unlikely]] {
+            if (!scope.clearExceptionExceptTermination())
+                return;
+            message = {};
+        }
+        if (message) {
+            except.message = Bun::toStringRef(global, message);
+            if (!scope.clearExceptionExceptTermination()) [[unlikely]]
+                return;
+        } else {
+            except.message = Bun::toStringRef(err->sanitizedMessageString(global));
+        }
     }
 
     if (!scope.clearExceptionExceptTermination()) [[unlikely]] {

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -10,7 +10,7 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | import { bunEnv, bunExe, tempDir } from "harness";
+2 | import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 3 | 
 4 | test("error.cause", () => {
 5 |   const err = new Error("error 1");
@@ -20,7 +20,7 @@ error: error 2
       at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | import { bunEnv, bunExe, tempDir } from "harness";
+2 | import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 3 | 
 4 | test("error.cause", () => {
 5 |   const err = new Error("error 1");
@@ -181,6 +181,154 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
   expect(() => {
     throw err;
   }).toThrow();
+});
+
+// Debug builds verify JSC exception checks in the printer under this flag;
+// release builds compile the verification out and ignore it.
+const validateExceptionChecksEnv = { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" };
+
+describe.concurrent("error.message getter that throws", () => {
+  // The printer reads `message` through a real [[Get]]. The getter's exception
+  // must not stay pending while the printer goes on to read other properties.
+  // Each sink runs in its own process: the failure mode is an abort.
+  const code = sink =>
+    [
+      `class E extends Error { get message() { throw new RangeError("from the getter"); } }`,
+      sink,
+      `console.log("after");`,
+    ].join("\n");
+
+  async function run(sink) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code(sink)],
+      env: validateExceptionChecksEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr: normalizeBunSnapshot(stderr), exitCode };
+  }
+
+  test("console.error", async () => {
+    const { stdout, stderr, exitCode } = await run(`console.error(new E());`);
+    expect(stderr).toMatchInlineSnapshot(`
+      "1 | class E extends Error { get message() { throw new RangeError("from the getter"); } }
+      2 | console.error(new E());
+                        ^
+      Error: 
+            at <cwd>/[eval]:2:15"
+    `);
+    expect(stdout).toBe("after\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.inspect", async () => {
+    const { stdout, stderr, exitCode } = await run(`console.error(Bun.inspect(new E()));`);
+    expect(stderr).toMatchInlineSnapshot(`
+      "1 | class E extends Error { get message() { throw new RangeError("from the getter"); } }
+      2 | console.error(Bun.inspect(new E()));
+                                    ^
+      Error: 
+            at <cwd>/[eval]:2:27"
+    `);
+    expect(stdout).toBe("after\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("uncaught exception", async () => {
+    const { stdout, stderr, exitCode } = await run(`throw new E();`);
+    expect(stderr).toMatchInlineSnapshot(`
+      "1 | class E extends Error { get message() { throw new RangeError("from the getter"); } }
+      2 | throw new E();
+                ^
+      Error: 
+            at <cwd>/[eval]:2:7
+
+      Bun v<bun-version>"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("unhandled rejection", async () => {
+    const { stdout, stderr, exitCode } = await run(`Promise.reject(new E());`);
+    expect(stderr).toMatchInlineSnapshot(`
+      "1 | class E extends Error { get message() { throw new RangeError("from the getter"); } }
+      2 | Promise.reject(new E());
+                         ^
+      Error: 
+            at <cwd>/[eval]:2:16
+
+      Bun v<bun-version>"
+    `);
+    expect(stdout).toBe("after\n");
+    expect(exitCode).toBe(1);
+  });
+
+  // A worker formats its uncaught error on the worker thread before it
+  // dispatches the error to the parent. The parent gets a clone of the error
+  // (worker_threads) or an ErrorEvent (Web Worker); nothing is printed.
+  const workerSource = JSON.stringify(code(`throw new E();`).replace(`console.log("after");`, ""));
+
+  test("uncaught in a worker_threads Worker", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      [
+        `const worker = new (require("node:worker_threads").Worker)(${workerSource}, { eval: true });`,
+        `worker.on("error", e => console.log("error event:", e.constructor.name, JSON.stringify(e.message)));`,
+        `worker.on("exit", code => console.log("exit event:", code));`,
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`after\nerror event: Error ""\nexit event: 1\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("uncaught in a Web Worker", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      [
+        `const url = URL.createObjectURL(new Blob([${workerSource}], { type: "application/javascript" }));`,
+        `const worker = new Worker(url);`,
+        `worker.onerror = ev => console.log("error event:", ev.constructor.name);`,
+        `worker.addEventListener("close", ev => console.log("close event:", ev.code));`,
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`after\nerror event: ErrorEvent\nclose event: 1\n`);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// The header the printer renders for each kind of `message`. A value that
+// cannot be read as a string prints like an empty message.
+describe.concurrent.each([
+  ["a number", `e.message = 42;`, "error: 42"],
+  ["a Symbol", `e.message = Symbol("sym");`, "Error: "],
+  ["an object with toString", `e.message = { toString() { return "from toString"; } };`, "error: from toString"],
+  ["an object whose toString throws", `e.message = { toString() { throw new RangeError("ts"); } };`, "Error: "],
+  [
+    "found through a Proxy whose has trap throws",
+    `delete e.message; Object.setPrototypeOf(e, new Proxy(Error.prototype, { has() { throw new RangeError("has"); } }));`,
+    "Error: ",
+  ],
+])("error.message that is %s", (_, setup, header) => {
+  test("prints the header and the stack", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        [`const e = new Error("boom");`, setup, `console.error(e);`, `console.log("after");`].join("\n"),
+      ],
+      env: validateExceptionChecksEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr)).toBe(
+      [`1 | const e = new Error("boom");`, `                  ^`, header, `      at <cwd>/[eval]:1:15`].join("\n"),
+    );
+    expect(stdout).toBe("after\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("source map remapping of the printed stack", () => {


### PR DESCRIPTION
### Problem
- Printing an Error whose `message` getter throws aborts an asserts build: `ASSERTION FAILED: Unexpected exception observed` in `ExceptionScope::assertNoExceptionExceptTermination`, top frame `Bun__JSObject__getCodePropertyVMInquiry`, called from `print_error_instance_body`. `console.error(e)`, `Bun.inspect(e)`, an uncaught `throw e`, an unhandled rejection, and an uncaught throw inside a worker all hit it. A release build prints `error` with no name and no frames.
- Cause: `fromErrorInstance` (`src/jsc/bindings/ZigException.cpp:511`) reads `message` with `getIfPropertyExists`, a real `[[Get]]`. When the getter throws, the read returns a placeholder value with the exception pending, and `RETURN_IF_EXCEPTION` left it pending. The next VMInquiry read (`code`) asserts.

### Fix
- Check the scope right after the lookup. If it threw (not a termination), clear it and drop the value. Then convert what was found, or fall back to `ErrorInstance::sanitizedMessageString` as for an absent `message`.
- Correct because the function runs under a `TopExceptionScope`: it swallows exceptions and prints what it has. The `stack` read below already works this way. The error now prints as one with an empty message: `Error: ` plus its frames.
- Verified: `test/js/bun/util/inspect-error.test.js`, two new describe blocks (six entry points, including a `worker_threads` Worker and a Web Worker, and five kinds of non-string `message`). The children run with `BUN_JSC_validateExceptionChecks=1`. Without the fix the debug build aborts in seven of them. Also ran `inspect.test.js`, `reportError.test.ts`, `error-name-preservation.test.ts`, `error-code-mirror.test.ts`.

### Background
- `fromErrorInstance` fills the `ZigException` struct (name, message, frames) that the Rust error printer renders. Every printer entry point reaches it.
- A `TopExceptionScope` sits at the top of the JS stack. Code under it does not propagate exceptions. It clears them, except a termination (VM shutdown), which makes it return early.
- A VMInquiry read never runs JS. JSC asserts that no exception is pending when one starts: with no JS frame to catch it, a pending exception is a dropped error.
- `getIfPropertyExists` runs getters and Proxy traps. After a throw, its return value is not meaningful.

<details><summary>Notes</summary>

- This PR first carried a fix for the same site under `BUN_JSC_validateExceptionChecks=1` with a non-string `message` (`e.message = 42`). Main has since gained a `RETURN_IF_EXCEPTION` after the lookup. That satisfies the check validation but leaves the getter's exception pending, which is the abort above. The branch was replaced with a version rebased on current main. The non-string cases stay covered by the second describe block.
- Repro, any of the four sinks:
  ```js
  class E extends Error { get message() { throw new RangeError("m"); } }
  console.error(new E()); // or Bun.inspect(new E()); throw new E(); Promise.reject(new E());
  ```
  Release 1.4.1: `error`, no name, no frames, exit code 0 for `console.error`. Node prints `[object Error]`.
- Workers reach the same site from the worker thread: `web_worker.rs` `on_unhandled_rejection` formats the uncaught error with `format2` before it dispatches it to the parent, so the abort took the whole process down. With the fix the parent gets what a release build already delivers: a cloned `Error` with an empty `message` (`worker_threads`) or an `ErrorEvent` (Web Worker), then exit code 1. Checked with the throw at the top level, in a timer, and as an unhandled rejection, for both worker kinds, under `BUN_JSC_validateExceptionChecks=1`.
- Other readers in the same file were checked: `exceptionFromString` clears after each read and only converts strings. The `stack` read in `fromErrorInstance` clears and only uses strings. `sanitizedNameString` and the `syscall`, `code`, `path`, `fd`, `errno` reads are VMInquiry and never run getters.
- Hostile variants run under `BUN_JSC_validateExceptionChecks=1` with no assertion: throwing `name`, `stack`, all three at once, `message` as an object whose `toString` throws, a throwing getter on a `cause`, inside an `AggregateError`, as an own accessor, nested in objects and arrays, through `%o`, and through the `bun test` reporters (a thrown and a rejected hostile error, `toEqual`, `toThrow`, `toMatchInlineSnapshot`).
- `console.error("%s", e)` calls `String(e)` and propagates the getter's RangeError to the caller on release too. That is a separate path and is unchanged here.
- The existing `error.cause` inline snapshot changes only because it contains the file's import line, which now also imports `normalizeBunSnapshot`.
</details>


