### PR TITLE
udp: resolve a hostname to the same address on the bind and connect side

### DIFF
--- a/docs/runtime/networking/udp.mdx
+++ b/docs/runtime/networking/udp.mdx
@@ -22,6 +22,21 @@ const socket = await Bun.udpSocket({
 console.log(socket.port); // 41234
 ```
 
+Specify the address to bind (the default is `0.0.0.0`):
+
+```ts
+const socket = await Bun.udpSocket({
+  hostname: "localhost", // [!code ++]
+});
+
+console.log(socket.address.address); // 127.0.0.1
+```
+
+`hostname` can be an IP address or a hostname. A hostname that resolves to both an IPv4 and an IPv6 address, like `localhost`,
+is bound on its IPv4 address. `connect.hostname` (see [Connections](#connections)) follows the same rule, so a server bound to a
+hostname and a client connected to that hostname end up on the same address. To use IPv6, pass an IPv6 address such as `::1`,
+or `::` to accept both.
+
 ### Send a datagram
 
 Specify the data to send, the destination port, and the destination address.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6760,6 +6760,14 @@ declare module "bun" {
     }
 
     export interface SocketOptions<DataBinaryType extends BinaryType> {
+      /**
+       * Local address to bind: an IP address or a hostname. A hostname that
+       * resolves to both an IPv4 and an IPv6 address (such as `"localhost"`)
+       * binds the IPv4 one; use an IPv6 literal (`"::1"`, or `"::"` for a
+       * dual-stack socket) to bind IPv6.
+       *
+       * @default "0.0.0.0"
+       */
       hostname?: string;
       port?: number;
       binaryType?: DataBinaryType;
@@ -6767,11 +6775,25 @@ declare module "bun" {
     }
 
     export interface ConnectSocketOptions<DataBinaryType extends BinaryType> {
+      /**
+       * Local address to bind, see {@link SocketOptions.hostname}. It also
+       * decides which of the peer's addresses can be connected to: the
+       * default IPv4 socket cannot connect to an IPv6 address.
+       *
+       * @default "0.0.0.0"
+       */
       hostname?: string;
       port?: number;
       binaryType?: DataBinaryType;
       socket?: ConnectedSocketHandler<DataBinaryType>;
       connect: {
+        /**
+         * Peer address: an IP address or a hostname. Like the bind side, a
+         * hostname with both an IPv4 and an IPv6 address connects to the IPv4
+         * one when the local socket can carry it, so a server bound to a
+         * hostname and a client connected to the same hostname meet on the
+         * same address.
+         */
         hostname: string;
         port: number;
       };

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1846,10 +1846,29 @@ static void bsd_v4_mapped_addr(const struct sockaddr_in *in4, struct sockaddr_in
     memcpy(&out->sin6_addr.s6_addr[12], &in4->sin_addr, sizeof(in4->sin_addr));
 }
 
+/* Whether an AF_INET6 socket can address IPv4 peers (through v4-mapped
+ * addresses). Decided up front rather than by attempting the connect, so the
+ * choice does not depend on how each kernel rejects the doomed attempt and the
+ * errno reported for a name with no usable address stays meaningful. */
+static int bsd_inet6_socket_reaches_inet(LIBUS_SOCKET_DESCRIPTOR fd, const struct sockaddr_in6 *bound) {
+#ifdef IPV6_V6ONLY
+    int v6only = 0;
+    socklen_t len = sizeof(v6only);
+    if (getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &v6only, (socklen_t *) &len) == 0 && v6only) {
+        return 0;
+    }
+#endif
+    /* A socket bound to a real IPv6 address (::1, ...) has no IPv4 source
+     * address to send from; one bound to the wildcard or to a mapped address
+     * does. */
+    return IN6_IS_ADDR_UNSPECIFIED(&bound->sin6_addr) || IN6_IS_ADDR_V4MAPPED(&bound->sin6_addr);
+}
+
 /* `host` may be a name. Its addresses are tried IPv4 first, the order
  * LIBUS_UDP_PREFER_IPV4 binds them in, so a name denotes the same address on
  * both ends of a Bun.udpSocket pair no matter what order the resolver returns.
- * Only addresses the socket's own family can carry are attempted.
+ * Only addresses the socket can reach are attempted, so a socket that cannot
+ * use a name's IPv4 address gets its IPv6 one.
  *
  * Returns 0, a getaddrinfo() error code, or LIBUS_SOCKET_ERROR with
  * errno (WSAGetLastError() on Windows) set. */
@@ -1859,6 +1878,9 @@ int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int por
         return (int)LIBUS_SOCKET_ERROR;
     }
     int socket_is_inet6 = local.mem.ss_family == AF_INET6;
+    int reaches_inet = socket_is_inet6
+        ? bsd_inet6_socket_reaches_inet(fd, (const struct sockaddr_in6 *) &local.mem)
+        : 1;
 
     struct addrinfo hints, *result = NULL;
     memset(&hints, 0, sizeof(struct addrinfo));
@@ -1891,10 +1913,15 @@ int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int por
                 if (!socket_is_inet6) {
                     continue;
                 }
-            } else if (socket_is_inet6) {
-                bsd_v4_mapped_addr((const struct sockaddr_in *) rp->ai_addr, &mapped);
-                addr = (const struct sockaddr *) &mapped;
-                addrlen = sizeof(mapped);
+            } else {
+                if (!reaches_inet) {
+                    continue;
+                }
+                if (socket_is_inet6) {
+                    bsd_v4_mapped_addr((const struct sockaddr_in *) rp->ai_addr, &mapped);
+                    addr = (const struct sockaddr *) &mapped;
+                    addrlen = sizeof(mapped);
+                }
             }
 
             attempted = 1;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1762,17 +1762,23 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
         return LIBUS_SOCKET_ERROR;
     }
 
+    /* Same shape as bsd_create_listen_socket: one family gets first pick, the
+     * other is the fallback (also taken when the preferred family's socket()
+     * fails, e.g. IPv6 disabled on the host). See LIBUS_UDP_PREFER_IPV4. */
+    int preferred_family = (options & LIBUS_UDP_PREFER_IPV4) ? AF_INET : AF_INET6;
+    int fallback_family = (options & LIBUS_UDP_PREFER_IPV4) ? AF_INET6 : AF_INET;
+
     LIBUS_SOCKET_DESCRIPTOR listenFd = LIBUS_SOCKET_ERROR;
     struct addrinfo *listenAddr = NULL;
     for (struct addrinfo *a = result; a && listenFd == LIBUS_SOCKET_ERROR; a = a->ai_next) {
-        if (a->ai_family == AF_INET6) {
+        if (a->ai_family == preferred_family) {
             listenFd = bsd_create_socket(a->ai_family, a->ai_socktype, a->ai_protocol, err);
             listenAddr = a;
         }
     }
 
     for (struct addrinfo *a = result; a && listenFd == LIBUS_SOCKET_ERROR; a = a->ai_next) {
-        if (a->ai_family == AF_INET) {
+        if (a->ai_family == fallback_family) {
             listenFd = bsd_create_socket(a->ai_family, a->ai_socktype, a->ai_protocol, err);
             listenAddr = a;
         }
@@ -1828,8 +1834,33 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     return listenFd;
 }
 
+/* The IPv4-mapped form (::ffff:a.b.c.d) is how a dual-stack AF_INET6 socket
+ * addresses an IPv4 peer. Linux accepts a plain sockaddr_in there as well;
+ * Windows does not. */
+static void bsd_v4_mapped_addr(const struct sockaddr_in *in4, struct sockaddr_in6 *out) {
+    memset(out, 0, sizeof(*out));
+    out->sin6_family = AF_INET6;
+    out->sin6_port = in4->sin_port;
+    out->sin6_addr.s6_addr[10] = 0xff;
+    out->sin6_addr.s6_addr[11] = 0xff;
+    memcpy(&out->sin6_addr.s6_addr[12], &in4->sin_addr, sizeof(in4->sin_addr));
+}
+
+/* `host` may be a name. Its addresses are tried IPv4 first, the order
+ * LIBUS_UDP_PREFER_IPV4 binds them in, so a name denotes the same address on
+ * both ends of a Bun.udpSocket pair no matter what order the resolver returns.
+ * Only addresses the socket's own family can carry are attempted.
+ *
+ * Returns 0, a getaddrinfo() error code, or LIBUS_SOCKET_ERROR with
+ * errno (WSAGetLastError() on Windows) set. */
 int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int port) {
-    struct addrinfo hints, *result;
+    struct bsd_addr_t local;
+    if (bsd_local_addr(fd, &local) != 0) {
+        return (int)LIBUS_SOCKET_ERROR;
+    }
+    int socket_is_inet6 = local.mem.ss_family == AF_INET6;
+
+    struct addrinfo hints, *result = NULL;
     memset(&hints, 0, sizeof(struct addrinfo));
 
     hints.ai_family = AF_UNSPEC;
@@ -1844,18 +1875,46 @@ int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int por
         return gai_error;
     }
 
-    if (result == NULL) {
-        return -1;
-    }
+    int attempted = 0;
+    int last_error = 0;
+    static const int family_order[2] = { AF_INET, AF_INET6 };
+    for (int i = 0; i < 2; i++) {
+        for (struct addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {
+            if (rp->ai_family != family_order[i]) {
+                continue;
+            }
 
-    for (struct addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {
-        if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
-            freeaddrinfo(result);
-            return 0;
+            const struct sockaddr *addr = rp->ai_addr;
+            socklen_t addrlen = (socklen_t) rp->ai_addrlen;
+            struct sockaddr_in6 mapped;
+            if (rp->ai_family == AF_INET6) {
+                if (!socket_is_inet6) {
+                    continue;
+                }
+            } else if (socket_is_inet6) {
+                bsd_v4_mapped_addr((const struct sockaddr_in *) rp->ai_addr, &mapped);
+                addr = (const struct sockaddr *) &mapped;
+                addrlen = sizeof(mapped);
+            }
+
+            attempted = 1;
+            if (connect(fd, addr, addrlen) == 0) {
+                freeaddrinfo(result);
+                return 0;
+            }
+            last_error = LIBUS_ERR;
         }
     }
 
-    freeaddrinfo(result);
+    if (result != NULL) {
+        freeaddrinfo(result);
+    }
+
+#ifdef _WIN32
+    WSASetLastError(attempted ? last_error : WSAEAFNOSUPPORT);
+#else
+    errno = attempted ? last_error : EAFNOSUPPORT;
+#endif
     return (int)LIBUS_SOCKET_ERROR;
 }
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -160,6 +160,15 @@ enum {
      * unconnected socket it also makes the next send fail for a datagram
      * bound to a different, live peer. */
     LIBUS_UDP_LINUX_RECVERR = 128,
+    /* Bind a UDP host that resolves to both families on its IPv4 address
+     * rather than the IPv6 one bsd_create_listen_socket would pick. A TCP
+     * client tries every address a name resolves to, so a listener's choice
+     * of family is invisible to it; a datagram goes to exactly one address,
+     * so a UDP socket has to bind where its peers send. Bun.udpSocket's peers
+     * are IPv4 unless configured otherwise (default hostname "0.0.0.0", and
+     * us_udp_socket_connect tries IPv4 first), so it sets this. HTTP/3 does
+     * not: its UDP socket has to follow the TCP listener's family. */
+    LIBUS_UDP_PREFER_IPV4 = 256,
 };
 
 /* Library types publicly available */

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -685,7 +685,9 @@ impl UDPSocket {
                 on_recv_error,
                 hostname_z.as_ptr(),
                 config.port,
-                config.flags,
+                // "localhost" binds 127.0.0.1, not ::1: the default socket
+                // here is IPv4, so that is where this API's peers send.
+                config.flags | uws::LIBUS_UDP_PREFER_IPV4,
                 Some(&mut err),
                 this_ptr.cast::<c_void>(),
             )

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -685,8 +685,7 @@ impl UDPSocket {
                 on_recv_error,
                 hostname_z.as_ptr(),
                 config.port,
-                // "localhost" binds 127.0.0.1, not ::1: the default socket
-                // here is IPv4, so that is where this API's peers send.
+                // This API's peers are IPv4 unless configured otherwise; see the flag's definition.
                 config.flags | uws::LIBUS_UDP_PREFER_IPV4,
                 Some(&mut err),
                 this_ptr.cast::<c_void>(),

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -85,6 +85,7 @@ pub const DEDICATED_COMPRESSOR: i32 = 248;
 pub use bun_uws_sys::{
     LIBUS_LISTEN_DEFAULT, LIBUS_LISTEN_EXCLUSIVE_PORT, LIBUS_LISTEN_REUSE_ADDR,
     LIBUS_LISTEN_REUSE_PORT, LIBUS_SOCKET_ALLOW_HALF_OPEN, LIBUS_SOCKET_IPV6_ONLY,
+    LIBUS_UDP_PREFER_IPV4,
 };
 
 // Re-export the `_sys` definitions so higher tiers see one type. `to_js`

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -30,6 +30,9 @@ pub const LIBUS_LISTEN_REUSE_PORT: core::ffi::c_int = 4;
 pub const LIBUS_SOCKET_IPV6_ONLY: core::ffi::c_int = 8;
 pub const LIBUS_LISTEN_REUSE_ADDR: core::ffi::c_int = 16;
 pub const LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE: core::ffi::c_int = 32;
+/// Bind a UDP host that resolves to both families to its IPv4 address. See
+/// the enum in `libusockets.h` for why UDP differs from TCP listen here.
+pub const LIBUS_UDP_PREFER_IPV4: core::ffi::c_int = 256;
 
 /// BoringSSL `SSL_CTX` (alias so callers don't need a direct boringssl dep).
 pub type SslCtx = bun_boringssl_sys::SSL_CTX;

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -30,8 +30,7 @@ pub const LIBUS_LISTEN_REUSE_PORT: core::ffi::c_int = 4;
 pub const LIBUS_SOCKET_IPV6_ONLY: core::ffi::c_int = 8;
 pub const LIBUS_LISTEN_REUSE_ADDR: core::ffi::c_int = 16;
 pub const LIBUS_LISTEN_DISALLOW_REUSE_PORT_FAILURE: core::ffi::c_int = 32;
-/// Bind a UDP host that resolves to both families to its IPv4 address. See
-/// the enum in `libusockets.h` for why UDP differs from TCP listen here.
+/// UDP bind: a host with both families binds its IPv4 address (rationale in `libusockets.h`).
 pub const LIBUS_UDP_PREFER_IPV4: core::ffi::c_int = 256;
 
 /// BoringSSL `SSL_CTX` (alias so callers don't need a direct boringssl dep).

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -1,9 +1,16 @@
-import { udpSocket } from "bun";
+import { dns, udpSocket } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, disableAggressiveGCScope, isWindows, randomPort } from "harness";
 import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
+
+// Whether getaddrinfo(), which is what udpSocket() resolves hostnames with,
+// gives "localhost" an IPv6 address here. Debian, macOS and Windows do;
+// Ubuntu's hosts file maps it to 127.0.0.1 only.
+const localhostHasIPv6 = (await dns.lookup("localhost", { backend: "libc", socketType: "udp" })).some(
+  ({ family }) => family === 6,
+);
 
 describe("udpSocket()", () => {
   test.each(["setTTL", "setMulticastTTL"])(
@@ -253,11 +260,12 @@ describe("udpSocket()", () => {
     },
   );
 
-  // "localhost" resolves to both 127.0.0.1 and ::1 on a stock hosts file. A
+  // On most hosts files "localhost" resolves to both 127.0.0.1 and ::1. A
   // datagram goes to exactly one of them, and everything this API creates by
   // default is IPv4 (the default hostname is "0.0.0.0"), so a hostname has to
   // mean its IPv4 address on both the bind and the connect side or the two
-  // ends of a pair silently land on different loopbacks.
+  // ends of a pair silently land on different loopbacks. Where "localhost" is
+  // IPv4-only these cases still hold, they just cannot fail the old way.
   describe("hostname resolves to the same address on both ends", () => {
     type Received = { data: string; port: number; address: string };
 
@@ -307,9 +315,44 @@ describe("udpSocket()", () => {
       }
     });
 
-    // `loopback` is the address the pair meets on: what the server's hostname
-    // bound, and therefore where the server sees the client's datagram from.
-    test.each([
+    type Pairing = {
+      /** What the server binds. */
+      server: string;
+      /** Client options; `connectTo` defaults to the server's hostname. */
+      client: { hostname?: string; flags?: number; connectTo?: string };
+      /** The address the pair meets on: what the server's hostname bound, and
+       * therefore where the server sees the client's datagram come from. */
+      loopback: string;
+      /** The client's view of the same address. */
+      remote: { address: string; family: string };
+    };
+
+    async function expectPairToMeet({
+      server: serverHostname,
+      client: { connectTo = serverHostname, ...clientOptions },
+      loopback,
+      remote,
+    }: Pairing) {
+      const { server, received } = await listen(serverHostname);
+      try {
+        expect(server.address.address).toBe(loopback);
+        const client = await udpSocket({ ...clientOptions, connect: { hostname: connectTo, port: server.port } });
+        try {
+          expect(client.remoteAddress).toEqual({ ...remote, port: server.port });
+          expect(await sendUntilReceived(received, () => client.send("hello"))).toEqual({
+            data: "hello",
+            port: client.port,
+            address: loopback,
+          });
+        } finally {
+          client.close();
+        }
+      } finally {
+        server.close();
+      }
+    }
+
+    test.each<Pairing & { label: string }>([
       {
         label: "default client connected to the server's hostname",
         server: "localhost",
@@ -334,41 +377,35 @@ describe("udpSocket()", () => {
         remote: { address: "::ffff:127.0.0.1", family: "IPv6" },
       },
       {
-        // A socket bound to ::1 cannot carry the mapped IPv4 address, so the
-        // connect falls through to the hostname's IPv6 address.
-        label: "client bound to ::1 connected to a hostname",
+        label: "dual-stack client connected to an IPv6 literal",
+        server: "::1",
+        client: { hostname: "::", connectTo: "::1" },
+        loopback: "::1",
+        remote: { address: "::1", family: "IPv6" },
+      },
+    ])("$label", expectPairToMeet);
+
+    // These clients cannot address IPv4 peers at all, so the hostname's IPv4
+    // address is skipped in favor of its IPv6 one. That needs a hostname that
+    // has one, which "localhost" does not everywhere.
+    test.skipIf(!localhostHasIPv6).each<Pairing & { label: string }>([
+      {
+        label: "client bound to ::1 connected to a hostname gets its IPv6 address",
         server: "::1",
         client: { hostname: "::1", connectTo: "localhost" },
         loopback: "::1",
         remote: { address: "::1", family: "IPv6" },
       },
-    ])(
-      "$label",
-      async ({
-        server: serverHostname,
-        client: { connectTo = serverHostname, ...clientOptions },
-        loopback,
-        remote,
-      }) => {
-        const { server, received } = await listen(serverHostname);
-        try {
-          expect(server.address.address).toBe(loopback);
-          const client = await udpSocket({ ...clientOptions, connect: { hostname: connectTo, port: server.port } });
-          try {
-            expect(client.remoteAddress).toEqual({ ...remote, port: server.port });
-            expect(await sendUntilReceived(received, () => client.send("hello"))).toEqual({
-              data: "hello",
-              port: client.port,
-              address: loopback,
-            });
-          } finally {
-            client.close();
-          }
-        } finally {
-          server.close();
-        }
+      {
+        // `flags` is the usockets option word node:dgram's `ipv6Only` sets;
+        // 8 is LIBUS_SOCKET_IPV6_ONLY.
+        label: "IPv6-only client connected to a hostname gets its IPv6 address",
+        server: "::1",
+        client: { hostname: "::", flags: 8, connectTo: "localhost" },
+        loopback: "::1",
+        remote: { address: "::1", family: "IPv6" },
       },
-    );
+    ])("$label", expectPairToMeet);
 
     test("a server bound by hostname receives datagrams sent to 127.0.0.1", async () => {
       const { server, received } = await listen("localhost");
@@ -389,10 +426,14 @@ describe("udpSocket()", () => {
       }
     });
 
-    test("the default (IPv4) socket cannot connect to an IPv6 address", async () => {
+    test.each([
+      ["the default (IPv4) socket", "::1", {}],
+      ["a socket bound to ::1", "127.0.0.1", { hostname: "::1" }],
+      ["an IPv6-only socket", "127.0.0.1", { hostname: "::", flags: 8 }],
+    ])("%s cannot connect to %s", async (_, hostname, options) => {
       let error: any;
       try {
-        (await udpSocket({ connect: { hostname: "::1", port: 1 } })).close();
+        (await udpSocket({ ...options, connect: { hostname, port: 1 } })).close();
       } catch (e) {
         error = e;
       }

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -253,6 +253,156 @@ describe("udpSocket()", () => {
     },
   );
 
+  // "localhost" resolves to both 127.0.0.1 and ::1 on a stock hosts file. A
+  // datagram goes to exactly one of them, and everything this API creates by
+  // default is IPv4 (the default hostname is "0.0.0.0"), so a hostname has to
+  // mean its IPv4 address on both the bind and the connect side or the two
+  // ends of a pair silently land on different loopbacks.
+  describe("hostname resolves to the same address on both ends", () => {
+    type Received = { data: string; port: number; address: string };
+
+    async function listen(hostname: string) {
+      const { promise, resolve, reject } = Promise.withResolvers<Received>();
+      const server = await udpSocket({
+        hostname,
+        socket: {
+          data(_socket, data, port, address) {
+            resolve({ data: data.toString(), port, address });
+          },
+          error(_socket, error) {
+            reject(error);
+          },
+        },
+      });
+      return { server, received: promise };
+    }
+
+    // Loopback UDP is reliable in practice but not guaranteed, so re-send
+    // (like the send tests above do) until the server reports a datagram. A
+    // datagram sent to the wrong loopback address never arrives, so that case
+    // is caught by the address assertions before anything is sent.
+    async function sendUntilReceived(received: Promise<Received>, send: () => void): Promise<Received> {
+      let settled = false;
+      const observed = received.then(
+        () => (settled = true),
+        () => (settled = true),
+      );
+      while (!settled) {
+        send();
+        await Promise.race([observed, Bun.sleep(10)]);
+      }
+      return received;
+    }
+
+    test.each([
+      ["localhost", { address: "127.0.0.1", family: "IPv4" }],
+      ["127.0.0.1", { address: "127.0.0.1", family: "IPv4" }],
+      ["::1", { address: "::1", family: "IPv6" }],
+    ])("binding %s lands on %j", async (hostname, expected) => {
+      const socket = await udpSocket({ hostname });
+      try {
+        expect(socket.address).toEqual({ ...expected, port: socket.port });
+      } finally {
+        socket.close();
+      }
+    });
+
+    // `loopback` is the address the pair meets on: what the server's hostname
+    // bound, and therefore where the server sees the client's datagram from.
+    test.each([
+      {
+        label: "default client connected to the server's hostname",
+        server: "localhost",
+        client: {},
+        loopback: "127.0.0.1",
+        remote: { address: "127.0.0.1", family: "IPv4" },
+      },
+      {
+        // The same IPv4 address bind picked, in the form a dual-stack socket
+        // addresses it, whatever order the resolver returned the two in.
+        label: "dual-stack client connected to the server's hostname",
+        server: "localhost",
+        client: { hostname: "::" },
+        loopback: "127.0.0.1",
+        remote: { address: "::ffff:127.0.0.1", family: "IPv6" },
+      },
+      {
+        label: "dual-stack client connected to an IPv4 literal",
+        server: "127.0.0.1",
+        client: { hostname: "::", connectTo: "127.0.0.1" },
+        loopback: "127.0.0.1",
+        remote: { address: "::ffff:127.0.0.1", family: "IPv6" },
+      },
+      {
+        // A socket bound to ::1 cannot carry the mapped IPv4 address, so the
+        // connect falls through to the hostname's IPv6 address.
+        label: "client bound to ::1 connected to a hostname",
+        server: "::1",
+        client: { hostname: "::1", connectTo: "localhost" },
+        loopback: "::1",
+        remote: { address: "::1", family: "IPv6" },
+      },
+    ])(
+      "$label",
+      async ({
+        server: serverHostname,
+        client: { connectTo = serverHostname, ...clientOptions },
+        loopback,
+        remote,
+      }) => {
+        const { server, received } = await listen(serverHostname);
+        try {
+          expect(server.address.address).toBe(loopback);
+          const client = await udpSocket({ ...clientOptions, connect: { hostname: connectTo, port: server.port } });
+          try {
+            expect(client.remoteAddress).toEqual({ ...remote, port: server.port });
+            expect(await sendUntilReceived(received, () => client.send("hello"))).toEqual({
+              data: "hello",
+              port: client.port,
+              address: loopback,
+            });
+          } finally {
+            client.close();
+          }
+        } finally {
+          server.close();
+        }
+      },
+    );
+
+    test("a server bound by hostname receives datagrams sent to 127.0.0.1", async () => {
+      const { server, received } = await listen("localhost");
+      try {
+        expect(server.address.address).toBe("127.0.0.1");
+        const client = await udpSocket({});
+        try {
+          expect(await sendUntilReceived(received, () => client.send("hello", server.port, "127.0.0.1"))).toEqual({
+            data: "hello",
+            port: client.port,
+            address: "127.0.0.1",
+          });
+        } finally {
+          client.close();
+        }
+      } finally {
+        server.close();
+      }
+    });
+
+    test("the default (IPv4) socket cannot connect to an IPv6 address", async () => {
+      let error: any;
+      try {
+        (await udpSocket({ connect: { hostname: "::1", port: 1 } })).close();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      // udp_socket.rs reports connect failures on Windows through the
+      // getaddrinfo mapping, so only the POSIX code is precise.
+      if (!isWindows) expect(error.code).toBe("EAFNOSUPPORT");
+    });
+  });
+
   const validateRecv = (socket, data, port, address, binaryType, bytes) => {
     // This test file takes 1 minute in CI because we are running GC too much.
     using _ = disableAggressiveGCScope();


### PR DESCRIPTION
### Problem
- `Bun.udpSocket({ hostname: "localhost" })` binds `::1`; `Bun.udpSocket({ connect: { hostname: "localhost", port } })` connects to `127.0.0.1`. Every call succeeds and `send()` returns `true`, but nothing arrives (Linux later delivers an `ECONNREFUSED` from the ICMP reply). Reproduces with the current release on Linux and Windows, on any host whose hosts file maps `localhost` to both addresses (Debian, Docker images, macOS, Windows; Ubuntu's maps it to `127.0.0.1` only, so it does not show there).
- The same server is also unreachable from the documented client patterns, `send(data, port, "127.0.0.1")` and `connect: { hostname: "127.0.0.1" }`: `send()` takes IP literals only, and a socket created without `hostname` is IPv4 (`"0.0.0.0"`, `src/runtime/socket/udp_socket.rs:402`).
- Bind side: `bsd_create_udp_socket` (`packages/bun-usockets/src/bsd.c:1742`) prefers the `AF_INET6` result, copied from `bsd_create_listen_socket`. Harmless for TCP, where a client tries every address a name resolves to; a datagram goes to exactly one address.
- Connect side: `bsd_connect_udp_socket` (`bsd.c:1831`) connects in resolver order, so the address a name means depends on the resolver and on the local socket's family. It also hands IPv4 results to a dual-stack socket as a raw `sockaddr_in`, which Linux accepts and Windows rejects (`{ hostname: "::", connect: { hostname: "127.0.0.1" } }` failed there, reported as a misleading `ENOTFOUND`).

### Fix
- New `LIBUS_UDP_PREFER_IPV4` option: `bsd_create_udp_socket` binds the host's IPv4 address when it has one and falls back to IPv6 otherwise (`"::1"` and IPv6-only names still bind IPv6). Set only by `Bun.udpSocket`.
- The HTTP/3 listener does not set it: its UDP socket has to land on the same family as the TCP listener created from the same hostname. node:quic and node:dgram pass IP literals, for which the option changes nothing.
- `bsd_connect_udp_socket` tries IPv4 results first, the order the bind side now uses, so a name means the same address on both ends whatever the resolver order or the client's local family. It decides up front which results the socket can address: an `AF_INET` socket only IPv4 ones; an `AF_INET6` socket IPv6 ones, plus IPv4 ones through their v4-mapped form (what Windows requires, and what the kernel reports as the peer anyway) unless it is `IPV6_V6ONLY` or bound to a specific IPv6 address such as `::1`, which has no IPv4 source to send from. Deciding this in the walk rather than by letting the kernel reject the attempt keeps the outcome identical across platforms. With no usable result it reports `EAFNOSUPPORT` (what Linux already reported for these cases); otherwise `errno` is the last connect error instead of whatever `freeaddrinfo` left behind.
- Why IPv4 is the right family: a UDP socket bound by name has to bind where this API's peers send, and those peers are IPv4 unless the user configures otherwise (default `hostname`, literal `send()` destinations). It is also what the Node equivalent of Bun's default socket does: a `udp4` socket bound to `"localhost"` resolves it within its own family to `127.0.0.1`.
- Why not the alternatives: preferring IPv6 on the connect side instead would break the pairing that works today (default `0.0.0.0` server, client connecting to `"localhost"`), and a dual-stack default would change `address` and `remoteAddress` for every existing socket.
- Behavior change: a server bound to a two-family hostname now sits on its IPv4 address, so a client that reached it only by explicitly using IPv6 (a `::1`-bound client, or `send(..., "::1")` from a `"::"` socket) has to use the hostname or `127.0.0.1` instead. Before this change no default-configured client could reach such a server. Nothing in the repo asserted the old address; node:dgram resolves names itself.
- Tests: `test/js/bun/udp/udp_socket.test.ts`, `hostname resolves to the same address on both ends` (13 cases). Unfixed build: 4 fail on Linux with a two-family `localhost` (hostname bind lands on `::1`; default and dual-stack clients by name; `send` to `127.0.0.1`), 5 on Windows (plus the dual-stack client to an IPv4 literal); each fails on an address assertion before anything is sent. Fixed build: all pass on Linux and on a Windows x64 debug build. The two cases that need a two-family name are skipped where `getaddrinfo` gives `localhost` no IPv6 address (the Ubuntu CI lanes); verified both ways here by editing the container's hosts file.
- Also run: `udp_socket.test.ts`, `udp_socket_recv_flags.test.ts`, `dgram.test.ts` in full; the ported `test-dgram-connect*`, `test-dgram-*-send-default-host`, `test-dgram-address`, `test-dgram-udp6-*` node tests; `serve-http3.test.ts` for the unflagged path; `bun-types.test.ts` for the JSDoc.
- Docs: a paragraph in `docs/runtime/networking/udp.mdx` and JSDoc on the `hostname` options saying which address a hostname means.

### Background
- `getaddrinfo` returns every address a name maps to. For `localhost` that is `::1` and `127.0.0.1` on most hosts files, in an order that depends on the OS and resolver configuration (`/etc/gai.conf` on glibc); on Ubuntu's hosts file it is `127.0.0.1` only.
- A socket has one address family. An `AF_INET` socket can only talk to IPv4 peers. An `AF_INET6` socket with `IPV6_V6ONLY` off (dual-stack, what `hostname: "::"` creates) can also talk to IPv4 peers, addressing them as `::ffff:a.b.c.d` (v4-mapped); `getpeername` reports that form, which is why `remoteAddress` reads `::ffff:127.0.0.1` in the dual-stack tests. A socket bound to a specific IPv6 address such as `::1`, or one with `IPV6_V6ONLY` set, cannot use mapped addresses.
- `connect()` on a UDP socket only records the peer address. It succeeds for any routable address the socket can carry and says nothing about whether anyone listens there, so TCP's try-every-address approach does not carry over; the two ends have to agree by convention.
- `bsd_create_udp_socket` is shared by `Bun.udpSocket`, node:quic endpoints and the HTTP/3 listener in `Bun.serve`, hence an option rather than a new default. `bsd_connect_udp_socket` has one caller (`Bun.udpSocket`'s `connect` option, and the `connect()` method node:dgram calls with resolved literals), so it is changed directly.
- The `flags` option used by two tests is the usockets option word node:dgram passes through `Bun.udpSocket`; `8` is `LIBUS_SOCKET_IPV6_ONLY`, i.e. dgram's `ipv6Only`.

<details>
<summary>Pairing matrix, before and after (Linux with a two-family localhost; Windows identical except where noted)</summary>

```
server              client                                 before                          after
default (0.0.0.0)   connect "localhost"                    works                           works
bind "localhost"    connect "localhost"                    ::1 vs 127.0.0.1, lost          works, 127.0.0.1 on both ends
bind "localhost"    connect "127.0.0.1"                    lost                            works
bind "localhost"    send(..., "127.0.0.1")                 lost                            works
bind "127.0.0.1"    connect "localhost"                    works                           works
bind "localhost"    hostname "::", connect "localhost"     works (::1 on both ends)        works (mapped 127.0.0.1)
bind "127.0.0.1"    hostname "::", connect "127.0.0.1"     Linux works, Windows fails      works on both
bind "::1"          hostname "::", connect "::1"           works                           works
bind "::1"          hostname "::1", connect "localhost"    works (resolver order)          works (IPv4 result skipped)
bind "::1"          IPv6-only "::", connect "localhost"    works (resolver order)          works (IPv4 result skipped)
bind "::1"          connect "localhost"                    lost                            lost (IPv6 server, IPv4 client)
bind "localhost"    connect "::1"                          EAFNOSUPPORT                    EAFNOSUPPORT (default socket is IPv4)
```
</details>
