### PR TITLE
css: parse (property: value) @supports conditions as declarations and merge same-condition rules

### DIFF
--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -530,7 +530,8 @@ impl<R> CssRuleList<R> {
                         if let Some(CssRule::Supports(last_rule)) = rules.last_mut()
                             && last_rule.condition.eql(&supp.condition)
                         {
-                            // Drop the duplicate-condition rule outright.
+                            last_rule.rules.v.append(&mut supp.rules.v);
+                            last_rule.minify(context, parent_is_unused)?;
                             break 'arm;
                         }
                         supp.minify(context, parent_is_unused)?;

--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -54,10 +54,21 @@ impl Declaration {
 
 impl Declaration {
     fn eql(&self, other: &Self) -> bool {
-        // `PropertyId` carries its own tag+prefix `PartialEq` (see
-        // properties_generated.rs `impl PartialEq for PropertyId`); `value` is
-        // byte-slice equality.
-        self.property_id == other.property_id && self.value == other.value
+        // `PropertyId`'s `PartialEq` compares the tag and the vendor prefix;
+        // `value` is byte-slice equality.
+        self.property_id == other.property_id
+            && same_custom_name(&self.property_id, &other.property_id)
+            && self.value == other.value
+    }
+}
+
+/// Every custom (`--x`) and unknown property is `PropertyId::Custom`, which
+/// `PropertyId`'s tag-based `PartialEq` treats as one property; the names tell
+/// them apart. Known properties are fully identified by their tag.
+fn same_custom_name(a: &PropertyId, b: &PropertyId) -> bool {
+    match (a, b) {
+        (PropertyId::Custom(a), PropertyId::Custom(b)) => a == b,
+        _ => true,
     }
 }
 
@@ -208,7 +219,8 @@ impl SupportsCondition {
                 .copied()
                 .filter(|f| prefix.contains(*f)),
             |d| d.write_str(b") or ("),
-            |d, _flag| {
+            |d, flag| {
+                flag.to_css(d)?;
                 d.serialize_name(name)?;
                 d.delim(b':', false)?;
                 // Raw parser-input slice: may span newlines.
@@ -244,6 +256,9 @@ impl SupportsCondition {
             )));
         }
 
+        const AND: i32 = 1;
+        const OR: i32 = 2;
+
         let in_parens: SupportsCondition = SupportsCondition::parse_in_parens(input)?;
         let mut expected_type: Option<i32> = None;
         let mut conditions: Vec<SupportsCondition, ArenaPtr> =
@@ -254,13 +269,13 @@ impl SupportsCondition {
         loop {
             // A closure capturing `&mut expected_type` threads the expected
             // type through the parse attempt.
-            let _condition =
+            let next_condition =
                 input.try_parse(|i: &mut css::Parser| -> css::Result<SupportsCondition> {
                     let location = i.current_source_location();
                     let s = i.expect_ident_cloned()?;
                     let found_type: i32 = crate::match_ignore_ascii_case! { s, {
-                        b"and" => 1,
-                        b"or" => 2,
+                        b"and" => AND,
+                        b"or" => OR,
                         _ => return Err(location.new_unexpected_token_error(css::Token::Ident(s))),
                     }};
 
@@ -275,48 +290,35 @@ impl SupportsCondition {
                     SupportsCondition::parse_in_parens(i)
                 });
 
-            match _condition {
-                Ok(condition) => {
-                    if conditions.is_empty() {
-                        conditions.push(in_parens.deep_clone(input.arena()));
-                        if let SupportsCondition::Declaration(decl) = &in_parens {
-                            let property_id = &decl.property_id;
-                            let value = decl.value;
-                            let _ = seen_declarations.put(
-                                SeenDeclKey(
-                                    property_id.with_prefix(css::VendorPrefix::NONE),
-                                    value,
-                                ),
-                                0,
-                            );
-                        }
-                    }
+            let Ok(condition) = next_condition else {
+                break;
+            };
 
-                    if let SupportsCondition::Declaration(decl) = &condition {
-                        // Merge multiple declarations with the same property id (minus prefix) and value together.
-                        let property_id_ = &decl.property_id;
-                        let value = decl.value;
-
-                        let property_id = property_id_.with_prefix(css::VendorPrefix::NONE);
-                        let key = SeenDeclKey(property_id, value);
-                        if let Some(index) = seen_declarations.get(&key) {
-                            let cond = &mut conditions[*index];
-                            if let SupportsCondition::Declaration(d) = cond {
-                                d.property_id.add_prefix(property_id.prefix());
-                            }
-                        } else {
-                            let _ = seen_declarations.put(key, conditions.len());
-                            conditions.push(SupportsCondition::Declaration(Declaration {
-                                property_id,
-                                value,
-                            }));
-                        }
-                    } else {
-                        conditions.push(condition);
-                    }
+            if conditions.is_empty() {
+                conditions.push(in_parens.deep_clone(input.arena()));
+                if let SupportsCondition::Declaration(decl) = &in_parens {
+                    let _ = seen_declarations.put(SeenDeclKey::new(decl), 0);
                 }
-                Err(_) => break,
             }
+
+            // `(-webkit-foo: v) or (foo: v)` tests one declaration under several
+            // prefixes, so under `or` the prefixes fold into the declaration seen
+            // first; `declaration_to_css` prints it back as that `or` chain. The
+            // same fold under `and` would turn the conjunction into a
+            // disjunction, so `and` keeps every operand as written.
+            if let SupportsCondition::Declaration(decl) = &condition {
+                if expected_type == Some(OR) {
+                    let key = SeenDeclKey::new(decl);
+                    if let Some(index) = seen_declarations.get(&key) {
+                        if let SupportsCondition::Declaration(seen) = &mut conditions[*index] {
+                            seen.property_id.add_prefix(decl.property_id.prefix());
+                        }
+                        continue;
+                    }
+                    let _ = seen_declarations.put(key, conditions.len());
+                }
+            }
+            conditions.push(condition);
         }
 
         if conditions.len() == 1 {
@@ -324,10 +326,10 @@ impl SupportsCondition {
             return Ok(ret);
         }
 
-        if expected_type == Some(1) {
+        if expected_type == Some(AND) {
             return Ok(SupportsCondition::And(conditions));
         }
-        if expected_type == Some(2) {
+        if expected_type == Some(OR) {
             return Ok(SupportsCondition::Or(conditions));
         }
         Ok(in_parens)
@@ -369,7 +371,16 @@ impl SupportsCondition {
                 }
             }
             css::Token::OpenParen => {
-                let res = input.try_parse(|i| i.parse_nested_block(SupportsCondition::parse));
+                // `( <supports-condition> )` or `( <declaration> )`; anything else
+                // in the parens is kept verbatim as `Unknown` below.
+                let res = input.try_parse(|i| {
+                    i.parse_nested_block(|i2| {
+                        if let Ok(condition) = i2.try_parse(SupportsCondition::parse) {
+                            return Ok(condition);
+                        }
+                        SupportsCondition::parse_declaration(i2)
+                    })
+                });
                 if res.is_ok() {
                     return res;
                 }
@@ -384,9 +395,17 @@ impl SupportsCondition {
     }
 }
 
-// Dedup key for `@supports` declaration conditions; manual Hash/PartialEq
-// (wrapping_add of string hash and enum int).
+// Key of the `or` prefix fold in `SupportsCondition::parse`: the declared
+// property ignoring its vendor prefix (which is what the fold accumulates),
+// plus the raw value. `PropertyId`'s own `PartialEq` is not used because it
+// compares the prefix.
 struct SeenDeclKey(PropertyId, &'static [u8]);
+
+impl SeenDeclKey {
+    fn new(decl: &Declaration) -> Self {
+        Self(decl.property_id, decl.value)
+    }
+}
 
 impl core::hash::Hash for SeenDeclKey {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
@@ -399,8 +418,7 @@ impl core::hash::Hash for SeenDeclKey {
 
 impl PartialEq for SeenDeclKey {
     fn eq(&self, other: &Self) -> bool {
-        // Tag-only equality + slice byte equality.
-        self.0.tag() as u16 == other.0.tag() as u16 && self.1 == other.1
+        self.0.tag() == other.0.tag() && same_custom_name(&self.0, &other.0) && self.1 == other.1
     }
 }
 impl Eq for SeenDeclKey {}

--- a/test/bundler/esbuild/css.test.ts
+++ b/test/bundler/esbuild/css.test.ts
@@ -1275,6 +1275,89 @@ b {
     },
   });
 
+  // `(property: value)` conditions are printed from their parsed form, both in
+  // @supports rules and in the @supports wrapper generated for a conditional
+  // @import, so they pick up the output's formatting. Exact comparisons on
+  // purpose: the difference is whitespace and grouping.
+  const atSupportsDeclarationFiles = {
+    "/entry.css": /* css */ `
+      @import "./dep.css" supports((-webkit-mask: none) or (mask: none));
+      @supports (display:grid) {
+        a { color: red }
+      }
+      @supports (background:url(ignored.png)) and (--x:1) {
+        b { color: red }
+      }
+    `,
+    "/dep.css": /* css */ `c { color: red }`,
+  };
+
+  itBundled("css/AtSupportsDeclarationConditions", {
+    files: atSupportsDeclarationFiles,
+    outfile: "/out.css",
+    onAfterBundle(api) {
+      api.expectFile("/out.css").toBe(/* css */ `/* dep.css */
+@supports ((-webkit-mask: none) or (mask: none)) {
+  c {
+    color: red;
+  }
+}
+
+/* entry.css */
+@supports (display: grid) {
+  a {
+    color: red;
+  }
+}
+
+@supports (background: url(ignored.png)) and (--x: 1) {
+  b {
+    color: red;
+  }
+}
+`);
+    },
+  });
+
+  itBundled("css/AtSupportsDeclarationConditionsMinified", {
+    files: atSupportsDeclarationFiles,
+    outfile: "/out.css",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      const expected =
+        "@supports ((-webkit-mask:none) or (mask:none)){c{color:red}}" +
+        "@supports (display:grid){a{color:red}}" +
+        "@supports (background:url(ignored.png)) and (--x:1){b{color:red}}\n";
+      api.expectFile("/out.css").toBe(expected);
+    },
+  });
+
+  // Within one file, consecutive @supports rules with the same condition are
+  // merged into the first one; the later ones used to be dropped. Rules from
+  // different files are minified separately and stay separate.
+  itBundled("css/AtSupportsSameConditionRulesAreMerged", {
+    files: {
+      "/entry.css": /* css */ `
+        @import "./dep.css";
+        @supports (display: grid) { a { color: red } }
+        @supports (display:grid) { b { color: red } }
+        @supports (--a: 1) { c { color: red } }
+        @supports (--b: 1) { d { color: red } }
+      `,
+      "/dep.css": /* css */ `@supports (display: grid) { e { color: red } }`,
+    },
+    outfile: "/out.css",
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      const expected =
+        "@supports (display:grid){e{color:red}}" +
+        "@supports (display:grid){a,b{color:red}}" +
+        "@supports (--a:1){c{color:red}}" +
+        "@supports (--b:1){d{color:red}}\n";
+      api.expectFile("/out.css").toBe(expected);
+    },
+  });
+
   itBundled("css/PackageURLsInCSS", {
     files: {
       "/entry.css": /* css */ `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6478,6 +6478,11 @@ describe("css tests", () => {
       "@supports (display: grid) { .a { color: red } } @supports (display: flex) { .b { color: blue } }",
       "@supports (display: grid){.a{color:red}}@supports (display: flex){.b{color:#00f}}",
     );
+    // https://github.com/oven-sh/bun/issues/24770
+    minify_test(
+      ".test { border-top: 1px solid red; @supports (color: blue) { border-top: 1px solid blue } @supports (color: blue) { border-left: 1px solid blue } @supports (color: blue) { border-bottom: 1px solid blue } }",
+      ".test{border-top:1px solid red;@supports (color: blue){&{border-top:1px solid #00f;border-bottom:1px solid #00f;border-left:1px solid #00f}}}",
+    );
   });
 
   describe("transition", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6452,9 +6452,106 @@ describe("css tests", () => {
   });
 
   describe("supports", () => {
+    // A parenthesized `property: value` is parsed into a declaration
+    // condition and printed from it (the form `@import ... supports()` has
+    // always used), so the condition minifies instead of being copied
+    // verbatim. The value itself is still kept as written.
+    minify_test(
+      "@supports (width: calc(10px * 2)) { .test { width: calc(10px * 2) } }",
+      "@supports (width:calc(10px * 2)){.test{width:20px}}",
+    );
+    minify_test(
+      "@supports (color: hsl(0deg, 0%, 0%)) { .test { color: hsl(0deg, 0%, 0%) } }",
+      "@supports (color:hsl(0deg, 0%, 0%)){.test{color:#000}}",
+    );
+    minify_test("@supports (DISPLAY : grid) { a { color: red } }", "@supports (display:grid){a{color:red}}");
+    minify_test("@supports (--x: 1) { a { color: red } }", "@supports (--x:1){a{color:red}}");
+    minify_test("@supports (foo-bar: baz) { a { color: red } }", "@supports (foo-bar:baz){a{color:red}}");
+    minify_test(
+      "@supports (transition-timing-function: linear(0, 1)) { a { color: red } }",
+      "@supports (transition-timing-function:linear(0, 1)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display: grid) and (gap: 1px) { a { color: red } }",
+      "@supports (display:grid) and (gap:1px){a{color:red}}",
+    );
+    minify_test(
+      "@supports ((display: grid) or (display: flex)) and (gap: 1px) { a { color: red } }",
+      "@supports ((display:grid) or (display:flex)) and (gap:1px){a{color:red}}",
+    );
+    minify_test(
+      "@supports (position: -webkit-sticky) or (position: sticky) { a { color: red } }",
+      "@supports (position:-webkit-sticky) or (position:sticky){a{color:red}}",
+    );
+    minify_test("@import url(x.css) supports((display: grid));", '@import "x.css" supports(display:grid);');
+    minify_test(
+      "@import url(x.css) supports((display: grid) and (gap: 1px));",
+      '@import "x.css" supports((display:grid) and (gap:1px));',
+    );
+
+    // Vendor-prefixed properties keep their prefix when printed.
+    minify_test("@supports (-webkit-mask: none) { a { color: red } }", "@supports ((-webkit-mask:none)){a{color:red}}");
+    minify_test("@import url(x.css) supports(-webkit-mask: none);", '@import "x.css" supports((-webkit-mask:none));');
+
+    // Prefix variants of one declaration joined by `or` fold into a single
+    // condition, whichever order they are written in, as do exact duplicates.
+    minify_test(
+      "@supports (-webkit-mask: none) or (mask: none) { a { color: red } }",
+      "@supports ((-webkit-mask:none) or (mask:none)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (mask: none) or (-webkit-mask: none) { a { color: red } }",
+      "@supports ((-webkit-mask:none) or (mask:none)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display: grid) or (-webkit-mask: none) or (mask: none) { a { color: red } }",
+      "@supports (display:grid) or ((-webkit-mask:none) or (mask:none)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (display: grid) or (display: grid) { a { color: red } }",
+      "@supports (display:grid){a{color:red}}",
+    );
+    minify_test(
+      "@import url(x.css) supports((-webkit-mask: none) or (mask: none));",
+      '@import "x.css" supports((-webkit-mask:none) or (mask:none));',
+    );
+    minify_test(
+      "@supports ((-webkit-mask:none) or (mask:none)){a{color:red}}",
+      "@supports ((-webkit-mask:none) or (mask:none)){a{color:red}}",
+    );
+
+    // Nothing else folds: a different value, `and` (folding would turn it
+    // into `or`), or custom and unknown properties that differ only by name.
+    minify_test(
+      "@supports (-webkit-mask: none) or (mask: url(a.png)) { a { color: red } }",
+      "@supports ((-webkit-mask:none)) or (mask:url(a.png)){a{color:red}}",
+    );
+    minify_test(
+      "@supports (-webkit-mask: none) and (mask: none) { a { color: red } }",
+      "@supports ((-webkit-mask:none)) and (mask:none){a{color:red}}",
+    );
+    minify_test("@supports (--a: 1) or (--b: 1) { a { color: red } }", "@supports (--a:1) or (--b:1){a{color:red}}");
+    minify_test(
+      "@supports (-webkit-foo: 1) or (foo: 1) { a { color: red } }",
+      "@supports (-webkit-foo:1) or (foo:1){a{color:red}}",
+    );
+
+    // Parenthesized content that is neither a condition nor a declaration is
+    // still kept verbatim, as are unknown functions and selector().
+    minify_test("@supports (unknown) { a { color: red } }", "@supports (unknown){a{color:red}}");
+    minify_test(
+      "@supports (display: grid) or (foo bar) { a { color: red } }",
+      "@supports (display:grid) or (foo bar){a{color:red}}",
+    );
+    minify_test("@supports unknown(test) { a { color: red } }", "@supports unknown(test){a{color:red}}");
+    minify_test("@supports selector(a > b) { a { color: red } }", "@supports selector(a > b){a{color:red}}");
+
+    // Adjacent @supports rules with the same condition are merged (the later
+    // one used to be dropped). Conditions compare by their parsed form, so
+    // the spelling of a declaration condition does not matter.
     cssTest(
       `@supports (display: grid) { .a { color: red } }
-@supports (display: grid) { .b { color: blue } }`,
+@supports (display:grid) { .b { color: blue } }`,
       indoc`@supports (display: grid) {
   .a {
     color: red;
@@ -6468,20 +6565,43 @@ describe("css tests", () => {
     );
     minify_test(
       "@supports (display: grid) { .a { color: red } } @supports (display: grid) { .b { color: blue } }",
-      "@supports (display: grid){.a{color:red}.b{color:#00f}}",
+      "@supports (display:grid){.a{color:red}.b{color:#00f}}",
     );
     minify_test(
       "@supports (display: grid) { .a { color: red } } @supports (display: grid) { .b { color: blue } } @supports (display: grid) { .c { color: green } }",
-      "@supports (display: grid){.a{color:red}.b{color:#00f}.c{color:green}}",
+      "@supports (display:grid){.a{color:red}.b{color:#00f}.c{color:green}}",
     );
     minify_test(
-      "@supports (display: grid) { .a { color: red } } @supports (display: flex) { .b { color: blue } }",
-      "@supports (display: grid){.a{color:red}}@supports (display: flex){.b{color:#00f}}",
+      "@supports (-webkit-mask: none) or (mask: none) { .a { color: red } } @supports (mask: none) or (-webkit-mask: none) { .b { color: blue } }",
+      "@supports ((-webkit-mask:none) or (mask:none)){.a{color:red}.b{color:#00f}}",
+    );
+    minify_test(
+      "@supports selector(a > b) { .a { color: red } } @supports selector(a > b) { .b { color: blue } }",
+      "@supports selector(a > b){.a{color:red}.b{color:#00f}}",
     );
     // https://github.com/oven-sh/bun/issues/24770
     minify_test(
       ".test { border-top: 1px solid red; @supports (color: blue) { border-top: 1px solid blue } @supports (color: blue) { border-left: 1px solid blue } @supports (color: blue) { border-bottom: 1px solid blue } }",
-      ".test{border-top:1px solid red;@supports (color: blue){&{border-top:1px solid #00f;border-bottom:1px solid #00f;border-left:1px solid #00f}}}",
+      ".test{border-top:1px solid red;@supports (color:blue){&{border-top:1px solid #00f;border-bottom:1px solid #00f;border-left:1px solid #00f}}}",
+    );
+
+    // Different conditions stay separate rules, including custom or unknown
+    // properties that share a value and a known property with two prefixes.
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: flex) { .b { color: blue } }",
+      "@supports (display:grid){.a{color:red}}@supports (display:flex){.b{color:#00f}}",
+    );
+    minify_test(
+      "@supports (--a: 1) { .a { color: red } } @supports (--b: 1) { .b { color: blue } }",
+      "@supports (--a:1){.a{color:red}}@supports (--b:1){.b{color:#00f}}",
+    );
+    minify_test(
+      "@supports (-webkit-backdrop-filter: blur(1px)) { .a { color: red } } @supports (backdrop-filter: blur(1px)) { .b { color: blue } }",
+      "@supports (-webkit-backdrop-filter:blur(1px)){.a{color:red}}@supports (backdrop-filter:blur(1px)){.b{color:#00f}}",
+    );
+    minify_test(
+      "@supports (-webkit-mask: none) { .a { color: red } } @supports (mask: none) { .b { color: blue } }",
+      "@supports ((-webkit-mask:none)){.a{color:red}}@supports (mask:none){.b{color:#00f}}",
     );
   });
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6451,6 +6451,35 @@ describe("css tests", () => {
     error_test("@media (prefers-color-scheme = dark) { .foo { color: chartreuse }}", "ParserError::InvalidMediaQuery");
   });
 
+  describe("supports", () => {
+    cssTest(
+      `@supports (display: grid) { .a { color: red } }
+@supports (display: grid) { .b { color: blue } }`,
+      indoc`@supports (display: grid) {
+  .a {
+    color: red;
+  }
+
+  .b {
+    color: #00f;
+  }
+}
+`,
+    );
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: grid) { .b { color: blue } }",
+      "@supports (display: grid){.a{color:red}.b{color:#00f}}",
+    );
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: grid) { .b { color: blue } } @supports (display: grid) { .c { color: green } }",
+      "@supports (display: grid){.a{color:red}.b{color:#00f}.c{color:green}}",
+    );
+    minify_test(
+      "@supports (display: grid) { .a { color: red } } @supports (display: flex) { .b { color: blue } }",
+      "@supports (display: grid){.a{color:red}}@supports (display: flex){.b{color:#00f}}",
+    );
+  });
+
   describe("transition", () => {
     minify_test(".foo { transition-duration: 500ms }", ".foo{transition-duration:.5s}");
     minify_test(".foo { transition-duration: .5s }", ".foo{transition-duration:.5s}");

--- a/test/js/bun/css/supports-condition-newline.test.ts
+++ b/test/js/bun/css/supports-condition-newline.test.ts
@@ -11,16 +11,22 @@ const { minifyTest } = cssInternals;
 // tracking instead of panicking.
 
 test("`@supports` condition containing a literal newline prints without panicking", () => {
-  // Unknown variant: a parenthesised condition the parser stores verbatim.
-  const unknown = "@supports (color: lab(0%\n 0 \r\n0)) {.x{color:red}}";
-  const unknownMin = "@supports (color: lab(0%\n 0 \r\n0)){.x{color:red}}";
+  // Declaration variant: a parenthesised `property: value`; the value is a raw input slice.
+  const declaration = "@supports (color: lab(0%\n 0 \r\n0)) {.x{color:red}}";
+  const declarationMin = "@supports (color:lab(0%\n 0 \r\n0)){.x{color:red}}";
+  expect(minifyTest(declaration, "")).toBe(declarationMin);
+  expect(minifyTest(declarationMin, "")).toBe(declarationMin);
+
+  // Unknown variant: parenthesised content that is not a declaration is stored verbatim.
+  const unknown = "@supports (color\n red \r\n0) {.x{color:red}}";
+  const unknownMin = "@supports (color\n red \r\n0){.x{color:red}}";
   expect(minifyTest(unknown, "")).toBe(unknownMin);
   expect(minifyTest(unknownMin, "")).toBe(unknownMin);
 
   // Selector variant: `selector(...)` body is a raw input slice.
   expect(minifyTest("@supports selector(a\n b) {.x{color:red}}", "")).toBe("@supports selector(a\n b){.x{color:red}}");
 
-  // Declaration variant via `@import ... supports(...)`: the value is a raw input slice.
+  // Declaration variant via `@import ... supports(...)`.
   expect(minifyTest("@import url(x.css) supports(color: lab(0%\n 0 0));", "")).toBe(
     '@import "x.css" supports(color:lab(0%\n 0 0));',
   );
@@ -52,7 +58,7 @@ test("fuzzer-minimized input: `@supports` condition with `\\n` and `\\r\\n`", as
 
   expect({ stdout: stdout.trim(), exitCode }).toEqual({
     stdout: JSON.stringify(
-      ".foo{--custom:#b32323!important}@supports (color: lab(0%\n 0 \r\n0)){.foo{--custom:lab(40% 56.6 39)!important}}",
+      ".foo{--custom:#b32323!important}@supports (color:lab(0%\n 0 \r\n0)){.foo{--custom:lab(40% 56.6 39)!important}}",
     ),
     exitCode: 0,
   });


### PR DESCRIPTION
Fixes #24770

### Problem
- Adjacent `@supports` rules with the same condition lose the later rule: `CssRuleList::minify` (src/css/rules/mod.rs, `CssRule::Supports` arm) drops it instead of appending its body to the first rule the way the `@media` arm does, so `bun build` deletes its contents with or without `--minify` (#24770; Tailwind emits this shape nested inside one selector).
- `@supports (display: grid) { ... }` is never minified: `bun build --minify` emits `@supports (display: grid){...}`, while the same condition on `@import url(x.css) supports(display: grid)` comes out as `supports(display:grid)`.
- Cause: `SupportsCondition::parse_in_parens` (src/css/rules/supports.rs, the `OpenParen` arm) only tries to parse the group as a nested condition. `display: grid` is not one, so every `(property: value)` falls through to the verbatim `Unknown` fallback. `SupportsCondition::Declaration` is only produced by the `@import` prelude (src/css/css_parser.rs `parse_declaration` fallback), so the declaration printer and the `or` prefix fold in `SupportsCondition::parse` are unreachable from `@supports`. lightningcss falls back to `parse_declaration` inside the group. The Zig version had the same shape, so this is not a port regression.
- Making that path reachable exposed three bugs in it:
  - `declaration_to_css` never writes the vendor prefix. Reproducible today: `@import url(x.css) supports(-webkit-mask: none)` prints `supports((mask:none))`, a different condition.
  - The prefix fold (unreachable today, since its operands are never declarations) recorded every declaration after the first with its prefix stripped, so `(mask: none) or (-webkit-mask: none)` would fold to `(mask:none)`, and it also folded under `and`, where printing the result as an `or` chain changes the condition. (Upstream lightningcss does both; confirmed against lightningcss 1.30.2.)
  - The fold key and `Declaration::eql` compare custom and unknown properties by tag only (`PropertyId::Custom` is one tag), so `(--a: 1)` and `(--b: 1)` are the same condition. `CssRuleList::minify` (src/css/rules/mod.rs) uses that `eql` on adjacent `@supports` rules, and today it drops the later rule outright (#24770), so with the parse fix alone `@supports (-webkit-backdrop-filter: blur(1px)) {...} @supports (backdrop-filter: blur(1px)) {...}` would have lost its second rule (`backdrop-filter` is not a property bun knows, so both are `Custom`).

### Fix
- `parse_in_parens`: inside a parenthesized group, try `SupportsCondition::parse`, then `parse_declaration`, then keep falling back to `Unknown` as before. Matches lightningcss; content that is neither (`(unknown)`, `(foo bar)`) still round-trips verbatim, and the `@import` path is unchanged because it already did this.
- `declaration_to_css` writes each prefix before the name, the same way `PropertyId::to_css` does, so the printed condition is the one that was parsed. Output format is lightningcss's: `((-webkit-mask:none))`, `((-webkit-mask:none) or (mask:none))`.
- The fold keeps each declaration's own prefix (`add_prefix` with the declaration's prefix, push the condition as written) and only runs under `or`, where `A or A'` for two prefix spellings and the folded declaration's printed `or` chain are the same condition. Under `and` the operands are kept as written. Exact duplicates under `or` still collapse. This diverges from lightningcss only in the two cases where lightningcss changes the condition (prefix dropped, `and` turned into `or`).
- `same_custom_name` is checked by both the fold key and `Declaration::eql`, so two `Custom` ids only compare equal with the same name. (#33684 fixes `PropertyId`'s own `PartialEq` the same way; this PR does not depend on it, since the fold key has to ignore the prefix and cannot use that `PartialEq` anyway.)
- Adjacent `@supports` rules with equal conditions are merged into the first one instead of the later one being dropped (two lines in `CssRuleList::minify`, cherry-picked from #33680 together with its tests; #33680 is closed in favor of this PR). Needed here because conditions now compare by parsed form, so `(display: grid)` followed by `(display:grid)` also counts as equal; with the drop in place this change would have widened #24770. The merge is the same shape as the `@media` arm directly above it (and as upstream): it re-minifies the merged body after each merge, so a long run of same-condition rules in one file has the same cost profile #38531 is fixing for `@media`; once that lands, this arm can use the same deferred flush. The merge only applies within one file (each file's rule list is minified on its own), which the bundler test checks.
- Verified:
  - test/js/bun/css/css.test.ts `supports` block: 37 cases. On the released binary (`USE_SYSTEM_BUN=1`) 34 fail and 3 pass (the three verbatim round-trips that guard the `Unknown` fallback); all 37 pass with this change. Covers the minified output (two cases ported from lightningcss's `test_supports_rule`), `and`/`or`/nested groups, custom and unknown properties, prefixes kept, the fold in both orders and in `@import`, the non-fold cases (different value, `and`, custom names, unknown prefixed names), verbatim fallbacks, the adjacent-rule merge (including spelling variants, a folded condition, `selector()`, and #24770's nested case), and the conditions that must stay separate rules.
  - test/bundler/esbuild/css.test.ts: three `itBundled` cases with exact output (conditions printed from the parsed form in `@supports` and in the wrapper generated for a conditional `@import`, minified and not; same-condition rules merged within a file but not across files). All fail on the released binary.
  - test/js/bun/css/supports-condition-newline.test.ts updated: the `lab()` condition is now a declaration and prints as `(color:lab(...))`; a non-declaration group keeps covering the `Unknown` variant.
  - test/js/bun/css (all files), test/bundler/esbuild/css.test.ts and test/bundler/css pass with the debug build, apart from the css-fuzz / selector-list-error-recovery / nested-vendor-prefix-duplication timeouts that this container's debug build hits on main as well. doesnt_crash.test.ts (bootstrap, pico, uikit, hint round trips) passes.
  - Conditions with a token after a function or block (`(transform: translate(1px) rotate(1deg))`) still fail to parse exactly as they do today; that is `expect_no_error_token`'s early return, fixed separately in #38552, and both paths here go through it. The `@supports  not` double space is #38559.

### Background
- `SupportsCondition` is the parsed `@supports` / `@import ... supports()` condition: `Not`, `And`, `Or`, `Declaration` (a `PropertyId` plus the value as a raw slice of the input), `Selector` (raw slice) and `Unknown` (raw slice of the whole group). Only `Declaration` is printed from parsed data; the raw variants are copied back out, which is why they do not minify.
- `PropertyId` identifies a property; for the 65 prefixable properties it carries a `VendorPrefix` bit set, so one `Declaration` can stand for several prefix spellings and is printed as `((-webkit-x:v) or (x:v))`. Every custom (`--x`) or unknown property is the single `PropertyId::Custom` variant carrying its name, and `PropertyId`'s `PartialEq` / `Hash` currently look at the tag (and prefix) only.
- `parse_nested_block` runs a closure over the contents of the block whose opening token was just consumed and requires it to consume the whole block; `try_parse` rewinds on failure, which is what lets the group be attempted as a condition, then as a declaration, then scanned verbatim.
- `CssRuleList::minify` walks a rule list once, merging each rule into the previously emitted one where possible; the `@media` arm appends the bodies of adjacent same-query rules and re-minifies the merged rule, and the `@supports` arm now does the same.

