### PR TITLE
Key the runtime transpiler cache on the define table, the module type and --jsx-side-effects

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -954,6 +954,45 @@ pub(crate) fn defines_from_transform_options(
     )?)
 }
 
+/// Hashes the `--define` map and `--drop` list that `defines_from_transform_options`
+/// builds the user part of the `Define` table from. Both lists are sorted so
+/// the order the flags were given in does not matter; every string is
+/// length-prefixed and the define count comes first, so two different inputs
+/// never serialize to the same byte stream.
+fn user_defines_hash(define: Option<&api::StringMap>, drop: &[Box<[u8]>]) -> Option<u64> {
+    let mut defines: Vec<(&[u8], &[u8])> = define
+        .map(|map| {
+            debug_assert_eq!(map.keys.len(), map.values.len());
+            map.keys
+                .iter()
+                .map(|k| &**k)
+                .zip(map.values.iter().map(|v| &**v))
+                .collect()
+        })
+        .unwrap_or_default();
+    if defines.is_empty() && drop.is_empty() {
+        return None;
+    }
+    defines.sort_unstable();
+    let mut drops: Vec<&[u8]> = drop.iter().map(|d| &**d).collect();
+    drops.sort_unstable();
+
+    let mut hasher = bun_wyhash::Wyhash::init(0);
+    hasher.update(&(defines.len() as u64).to_le_bytes());
+    let mut update = |bytes: &[u8]| {
+        hasher.update(&(bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    };
+    for (key, value) in defines {
+        update(key);
+        update(value);
+    }
+    for name in drops {
+        update(name);
+    }
+    Some(hasher.final_())
+}
+
 const DEFAULT_LOADER_EXT_BUN: &[&[u8]] = &[b".node", b".html"];
 const DEFAULT_LOADER_EXT: &[&[u8]] = &[
     b".jsx", b".json", b".js", b".mjs", b".cjs", b".css",
@@ -1169,6 +1208,10 @@ pub struct BundleOptions<'a> {
     pub banner: Cow<'static, [u8]>,
     pub define: Box<defines::Define>,
     pub drop: Box<[Box<[u8]>]>,
+    /// Identifies the user-supplied (`--define` / bunfig `define` / `--drop`)
+    /// part of `define`, for the runtime transpiler cache's features hash.
+    /// Set by `load_defines`; `None` when the user supplied neither.
+    pub user_defines_hash: Option<u64>,
     /// Set of enabled feature flags for dead-code elimination via `import { feature } from "bun:bundle"`.
     /// Initialized once from the CLI --feature flags.
     ///
@@ -1384,6 +1427,7 @@ impl<'a> BundleOptions<'a> {
                 drop_debugger: self.define.drop_debugger,
             }),
             drop: self.drop.clone(),
+            user_defines_hash: self.user_defines_hash,
             bundler_feature_flags: self
                 .bundler_feature_flags
                 .as_deref()
@@ -1590,6 +1634,8 @@ impl<'a> BundleOptions<'a> {
             self.dead_code_elimination && self.minify_syntax,
             arena,
         )?;
+        self.user_defines_hash =
+            user_defines_hash(self.transform_options.define.as_ref(), &self.drop);
         self.defines_loaded = true;
         Ok(())
     }
@@ -1643,6 +1689,7 @@ impl<'a> BundleOptions<'a> {
             transform_options: std::sync::Arc::clone(&transform),
             css_chunking: false,
             drop: transform.drop.clone().into_boxed_slice(),
+            user_defines_hash: None,
             bundler_feature_flags,
 
             jsx: jsx::Pragma::default(),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -826,6 +826,9 @@ pub(crate) mod default_user_defines {
     }
 }
 
+/// Builds the `Define` table. Also returns `BundleOptions::user_defines_hash`
+/// for it, taken from the same resolved `--define` map and `--drop` list the
+/// table is built from.
 pub(crate) fn defines_from_transform_options(
     log: &mut bun_ast::Log,
     // PERF: borrowed, not owned — the caller (`load_defines`) holds
@@ -842,7 +845,7 @@ pub(crate) fn defines_from_transform_options(
     drop: &[&[u8]],
     omit_unused_global_calls: bool,
     bump: &bun_alloc::Arena,
-) -> Result<Box<defines::Define>, crate::Error> {
+) -> Result<(Box<defines::Define>, Option<u64>), crate::Error> {
     let (input_keys, input_values): (&[Box<[u8]>], &[Box<[u8]>]) = match maybe_input_define {
         Some(m) => (&m.keys, &m.values),
         None => (&[], &[]),
@@ -853,6 +856,9 @@ pub(crate) fn defines_from_transform_options(
     for (i, key) in input_keys.iter().enumerate() {
         user_defines.insert(key.as_ref(), input_values[i].clone());
     }
+    // Covers exactly what the user passed; the env-derived defaults added to
+    // the map further down are not part of it.
+    let user_defines_hash = user_defines_hash(&user_defines, drop);
 
     let mut environment_defines = defines::UserDefinesArray::default();
 
@@ -946,35 +952,32 @@ pub(crate) fn defines_from_transform_options(
 
     let drop_debugger = drop.iter().any(|item| *item == b"debugger");
 
-    Ok(defines::Define::init(
+    let define = defines::Define::init(
         Some(resolved_defines),
         Some(environment_defines),
         drop_debugger,
         omit_unused_global_calls,
-    )?)
+    )?;
+    Ok((define, user_defines_hash))
 }
 
-/// Hashes the `--define` map and `--drop` list that `defines_from_transform_options`
-/// builds the user part of the `Define` table from. Both lists are sorted so
-/// the order the flags were given in does not matter; every string is
-/// length-prefixed and the define count comes first, so two different inputs
-/// never serialize to the same byte stream.
-fn user_defines_hash(define: Option<&api::StringMap>, drop: &[Box<[u8]>]) -> Option<u64> {
-    let mut defines: Vec<(&[u8], &[u8])> = define
-        .map(|map| {
-            debug_assert_eq!(map.keys.len(), map.values.len());
-            map.keys
-                .iter()
-                .map(|k| &**k)
-                .zip(map.values.iter().map(|v| &**v))
-                .collect()
-        })
-        .unwrap_or_default();
-    if defines.is_empty() && drop.is_empty() {
+/// `user_defines` is a map, so a key given more than once is already down to
+/// the value that wins; both it and `drop` are sorted here so the order the
+/// flags were given in does not matter either. Every string is length-prefixed
+/// and the define count comes first, so different inputs never serialize to
+/// the same byte stream. `None` when the user gave neither.
+fn user_defines_hash(user_defines: &defines::RawDefines, drop: &[&[u8]]) -> Option<u64> {
+    if user_defines.is_empty() && drop.is_empty() {
         return None;
     }
+    let mut defines: Vec<(&[u8], &[u8])> = user_defines
+        .keys()
+        .iter()
+        .map(|k| &**k)
+        .zip(user_defines.values().iter().map(|v| &**v))
+        .collect();
     defines.sort_unstable();
-    let mut drops: Vec<&[u8]> = drop.iter().map(|d| &**d).collect();
+    let mut drops: Vec<&[u8]> = drop.to_vec();
     drops.sort_unstable();
 
     let mut hasher = bun_wyhash::Wyhash::init(0);
@@ -1619,7 +1622,7 @@ impl<'a> BundleOptions<'a> {
             Some(Cow::Borrowed(b"\"development\"".as_slice()))
         };
         // reshaped for borrowck — node_env computed before passing self.log
-        self.define = defines_from_transform_options(
+        let (define, user_defines_hash) = defines_from_transform_options(
             // No other `&mut Log` is live across this call (see `log_mut`
             // caller contract).
             self.log_mut(),
@@ -1634,8 +1637,8 @@ impl<'a> BundleOptions<'a> {
             self.dead_code_elimination && self.minify_syntax,
             arena,
         )?;
-        self.user_defines_hash =
-            user_defines_hash(self.transform_options.define.as_ref(), &self.drop);
+        self.define = define;
+        self.user_defines_hash = user_defines_hash;
         self.defines_loaded = true;
         Ok(())
     }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -826,7 +826,7 @@ pub(crate) mod default_user_defines {
     }
 }
 
-/// Returns the `Define` table and `BundleOptions::user_defines_hash` for it.
+/// Returns the `Define` table and `BundleOptions::define_hash` for it.
 pub(crate) fn defines_from_transform_options(
     log: &mut bun_ast::Log,
     // PERF: borrowed, not owned — the caller (`load_defines`) holds
@@ -854,8 +854,6 @@ pub(crate) fn defines_from_transform_options(
     for (i, key) in input_keys.iter().enumerate() {
         user_defines.insert(key.as_ref(), input_values[i].clone());
     }
-    // Before the env-derived defaults below join the map.
-    let user_defines_hash = user_defines_hash(&user_defines, drop);
 
     let mut environment_defines = defines::UserDefinesArray::default();
 
@@ -931,6 +929,9 @@ pub(crate) fn defines_from_transform_options(
         }
     }
 
+    // Before `window` (implied by `user_defines`), so the default configuration stays `None`.
+    let define_hash = define_hash(&user_defines, &environment_defines, drop);
+
     if target.is_bun() {
         if !user_defines.contains(b"window") {
             environment_defines.get_or_put_value(
@@ -955,12 +956,18 @@ pub(crate) fn defines_from_transform_options(
         drop_debugger,
         omit_unused_global_calls,
     )?;
-    Ok((define, user_defines_hash))
+    Ok((define, define_hash))
 }
 
-/// Flag order does not matter: both inputs are sorted, and a repeated key was resolved by the map.
-fn user_defines_hash(user_defines: &defines::RawDefines, drop: &[&[u8]]) -> Option<u64> {
-    if user_defines.is_empty() && drop.is_empty() {
+/// Hashes everything the `Define` table is about to be built from, other than the
+/// constant tables. Order does not matter: the maps hold one value per key and
+/// everything is sorted. `None` for the default configuration (all three empty).
+fn define_hash(
+    user_defines: &defines::RawDefines,
+    environment_defines: &defines::UserDefinesArray,
+    drop: &[&[u8]],
+) -> Option<u64> {
+    if user_defines.is_empty() && environment_defines.is_empty() && drop.is_empty() {
         return None;
     }
     let mut defines: Vec<(&[u8], &[u8])> = user_defines
@@ -970,18 +977,34 @@ fn user_defines_hash(user_defines: &defines::RawDefines, drop: &[&[u8]]) -> Opti
         .zip(user_defines.values().iter().map(|v| &**v))
         .collect();
     defines.sort_unstable();
+    let mut env_defines: Vec<(&[u8], &defines::DefineData)> = environment_defines
+        .keys()
+        .iter()
+        .map(|k| &**k)
+        .zip(environment_defines.values().iter())
+        .collect();
+    env_defines.sort_unstable_by_key(|(key, _)| *key);
     let mut drops: Vec<&[u8]> = drop.to_vec();
     drops.sort_unstable();
 
     let mut hasher = bun_wyhash::Wyhash::init(0);
-    hasher.update(&(defines.len() as u64).to_le_bytes());
     let mut update = |bytes: &[u8]| {
         hasher.update(&(bytes.len() as u64).to_le_bytes());
         hasher.update(bytes);
     };
+    update(&(defines.len() as u64).to_le_bytes());
     for (key, value) in defines {
         update(key);
         update(value);
+    }
+    update(&(env_defines.len() as u64).to_le_bytes());
+    for (key, data) in env_defines {
+        update(key);
+        // `copy_env_for_define` stores every value as a string literal.
+        match data.value.e_string() {
+            Some(value) => update(value.slice8()),
+            None => update(b""),
+        }
     }
     for name in drops {
         update(name);
@@ -1204,8 +1227,8 @@ pub struct BundleOptions<'a> {
     pub banner: Cow<'static, [u8]>,
     pub define: Box<defines::Define>,
     pub drop: Box<[Box<[u8]>]>,
-    /// Hash of the `--define` / `--drop` input behind `define`, for the runtime transpiler cache.
-    pub user_defines_hash: Option<u64>,
+    /// Hash of the input `define` was built from (see `define_hash`), for the runtime transpiler cache.
+    pub define_hash: Option<u64>,
     /// Set of enabled feature flags for dead-code elimination via `import { feature } from "bun:bundle"`.
     /// Initialized once from the CLI --feature flags.
     ///
@@ -1421,7 +1444,7 @@ impl<'a> BundleOptions<'a> {
                 drop_debugger: self.define.drop_debugger,
             }),
             drop: self.drop.clone(),
-            user_defines_hash: self.user_defines_hash,
+            define_hash: self.define_hash,
             bundler_feature_flags: self
                 .bundler_feature_flags
                 .as_deref()
@@ -1613,7 +1636,7 @@ impl<'a> BundleOptions<'a> {
             Some(Cow::Borrowed(b"\"development\"".as_slice()))
         };
         // reshaped for borrowck — node_env computed before passing self.log
-        let (define, user_defines_hash) = defines_from_transform_options(
+        let (define, define_hash) = defines_from_transform_options(
             // No other `&mut Log` is live across this call (see `log_mut`
             // caller contract).
             self.log_mut(),
@@ -1629,7 +1652,7 @@ impl<'a> BundleOptions<'a> {
             arena,
         )?;
         self.define = define;
-        self.user_defines_hash = user_defines_hash;
+        self.define_hash = define_hash;
         self.defines_loaded = true;
         Ok(())
     }
@@ -1683,7 +1706,7 @@ impl<'a> BundleOptions<'a> {
             transform_options: std::sync::Arc::clone(&transform),
             css_chunking: false,
             drop: transform.drop.clone().into_boxed_slice(),
-            user_defines_hash: None,
+            define_hash: None,
             bundler_feature_flags,
 
             jsx: jsx::Pragma::default(),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -958,9 +958,7 @@ pub(crate) fn defines_from_transform_options(
     Ok((define, user_defines_hash))
 }
 
-/// Order-independent: `user_defines` is a map (a repeated key is already down to
-/// the value that wins) and both inputs are sorted. Length-prefixed, so distinct
-/// inputs never serialize alike. `None` when the user gave neither.
+/// Flag order does not matter: both inputs are sorted, and a repeated key was resolved by the map.
 fn user_defines_hash(user_defines: &defines::RawDefines, drop: &[&[u8]]) -> Option<u64> {
     if user_defines.is_empty() && drop.is_empty() {
         return None;
@@ -1206,8 +1204,7 @@ pub struct BundleOptions<'a> {
     pub banner: Cow<'static, [u8]>,
     pub define: Box<defines::Define>,
     pub drop: Box<[Box<[u8]>]>,
-    /// Hash of the `--define` / bunfig `define` / `--drop` input behind `define`,
-    /// for the runtime transpiler cache. Set by `load_defines`; `None` if no input.
+    /// Hash of the `--define` / `--drop` input behind `define`, for the runtime transpiler cache.
     pub user_defines_hash: Option<u64>,
     /// Set of enabled feature flags for dead-code elimination via `import { feature } from "bun:bundle"`.
     /// Initialized once from the CLI --feature flags.

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -826,9 +826,7 @@ pub(crate) mod default_user_defines {
     }
 }
 
-/// Builds the `Define` table. Also returns `BundleOptions::user_defines_hash`
-/// for it, taken from the same resolved `--define` map and `--drop` list the
-/// table is built from.
+/// Returns the `Define` table and `BundleOptions::user_defines_hash` for it.
 pub(crate) fn defines_from_transform_options(
     log: &mut bun_ast::Log,
     // PERF: borrowed, not owned — the caller (`load_defines`) holds
@@ -856,8 +854,7 @@ pub(crate) fn defines_from_transform_options(
     for (i, key) in input_keys.iter().enumerate() {
         user_defines.insert(key.as_ref(), input_values[i].clone());
     }
-    // Covers exactly what the user passed; the env-derived defaults added to
-    // the map further down are not part of it.
+    // Before the env-derived defaults below join the map.
     let user_defines_hash = user_defines_hash(&user_defines, drop);
 
     let mut environment_defines = defines::UserDefinesArray::default();
@@ -961,11 +958,9 @@ pub(crate) fn defines_from_transform_options(
     Ok((define, user_defines_hash))
 }
 
-/// `user_defines` is a map, so a key given more than once is already down to
-/// the value that wins; both it and `drop` are sorted here so the order the
-/// flags were given in does not matter either. Every string is length-prefixed
-/// and the define count comes first, so different inputs never serialize to
-/// the same byte stream. `None` when the user gave neither.
+/// Order-independent: `user_defines` is a map (a repeated key is already down to
+/// the value that wins) and both inputs are sorted. Length-prefixed, so distinct
+/// inputs never serialize alike. `None` when the user gave neither.
 fn user_defines_hash(user_defines: &defines::RawDefines, drop: &[&[u8]]) -> Option<u64> {
     if user_defines.is_empty() && drop.is_empty() {
         return None;
@@ -1211,9 +1206,8 @@ pub struct BundleOptions<'a> {
     pub banner: Cow<'static, [u8]>,
     pub define: Box<defines::Define>,
     pub drop: Box<[Box<[u8]>]>,
-    /// Identifies the user-supplied (`--define` / bunfig `define` / `--drop`)
-    /// part of `define`, for the runtime transpiler cache's features hash.
-    /// Set by `load_defines`; `None` when the user supplied neither.
+    /// Hash of the `--define` / bunfig `define` / `--drop` input behind `define`,
+    /// for the runtime transpiler cache. Set by `load_defines`; `None` if no input.
     pub user_defines_hash: Option<u64>,
     /// Set of enabled feature flags for dead-code elimination via `import { feature } from "bun:bundle"`.
     /// Initialized once from the CLI --feature flags.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1622,7 +1622,7 @@ impl<'a> Transpiler<'a> {
                     .bundler_feature_flags
                     .as_deref()
                     .and_then(|s| s.clone().ok().map(Box::new));
-                opts.features.user_defines_hash = self.options.user_defines_hash;
+                opts.features.define_hash = self.options.define_hash;
                 opts.features.repl_mode = self.options.repl_mode;
 
                 // we'll just always enable top-level await

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1622,6 +1622,7 @@ impl<'a> Transpiler<'a> {
                     .bundler_feature_flags
                     .as_deref()
                     .and_then(|s| s.clone().ok().map(Box::new));
+                opts.features.user_defines_hash = self.options.user_defines_hash;
                 opts.features.repl_mode = self.options.repl_mode;
 
                 // we'll just always enable top-level await

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -201,7 +201,7 @@ impl<'a> Options<'a> {
                 runtime_transpiler_cache: None,
                 lower_using: f.lower_using,
                 bundler_feature_flags: None,
-                user_defines_hash: f.user_defines_hash,
+                define_hash: f.define_hash,
                 repl_mode: f.repl_mode,
                 jsx_optimization_inline: f.jsx_optimization_inline,
             },
@@ -250,6 +250,13 @@ impl<'a> Options<'a> {
 
         if !self.use_define_for_class_fields {
             hasher.update(b"udfcf=0");
+        }
+
+        // package.json "type" / .cjs / .mjs: decides `exports_kind` when the syntax does not.
+        match self.module_type {
+            options::ModuleType::Unknown => {}
+            options::ModuleType::Cjs => hasher.update(b"cjs"),
+            options::ModuleType::Esm => hasher.update(b"esm"),
         }
 
         self.features.hash_for_runtime_transpiler(hasher);

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -201,6 +201,7 @@ impl<'a> Options<'a> {
                 runtime_transpiler_cache: None,
                 lower_using: f.lower_using,
                 bundler_feature_flags: None,
+                user_defines_hash: f.user_defines_hash,
                 repl_mode: f.repl_mode,
                 jsx_optimization_inline: f.jsx_optimization_inline,
             },

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -264,6 +264,14 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
+        /// Hash of the user-supplied `--define` map and `--drop` list the
+        /// `Define` table handed to this parse was built from
+        /// (`BundleOptions::user_defines_hash`). Both rewrite the transpiled
+        /// output, so the runtime transpiler cache has to key on them.
+        ///
+        /// `None` ≡ neither was given (contributes nothing to the hash).
+        pub user_defines_hash: Option<u64>,
+
         /// REPL mode: transforms code for interactive evaluation
         /// - Wraps lone object literals `{...}` in parentheses
         /// - Hoists variable declarations for REPL persistence
@@ -311,6 +319,7 @@ pub mod Runtime {
                 runtime_transpiler_cache: None,
                 lower_using: true,
                 bundler_feature_flags: None,
+                user_defines_hash: None,
                 repl_mode: false,
                 jsx_optimization_inline: false,
             }
@@ -397,6 +406,12 @@ pub mod Runtime {
                     hasher.update(flag);
                     hasher.update(b"\x00");
                 }
+            }
+
+            // --define / --drop substitute into the output the same way. As
+            // with --feature, the default (none given) adds nothing.
+            if let Some(user_defines_hash) = self.user_defines_hash {
+                hasher.update(&user_defines_hash.to_le_bytes());
             }
         }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -264,8 +264,8 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
-        /// `BundleOptions::user_defines_hash`; `None` contributes nothing to the hash.
-        pub user_defines_hash: Option<u64>,
+        /// `BundleOptions::define_hash`; `None` contributes nothing to the hash.
+        pub define_hash: Option<u64>,
 
         /// REPL mode: transforms code for interactive evaluation
         /// - Wraps lone object literals `{...}` in parentheses
@@ -314,7 +314,7 @@ pub mod Runtime {
                 runtime_transpiler_cache: None,
                 lower_using: true,
                 bundler_feature_flags: None,
-                user_defines_hash: None,
+                define_hash: None,
                 repl_mode: false,
                 jsx_optimization_inline: false,
             }
@@ -403,9 +403,9 @@ pub mod Runtime {
                 }
             }
 
-            // --define / --drop, likewise adding nothing when not given.
-            if let Some(user_defines_hash) = self.user_defines_hash {
-                hasher.update(&user_defines_hash.to_le_bytes());
+            // The define table, likewise adding nothing in the default configuration.
+            if let Some(define_hash) = self.define_hash {
+                hasher.update(&define_hash.to_le_bytes());
             }
         }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -264,12 +264,8 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
-        /// Hash of the user-supplied `--define` map and `--drop` list the
-        /// `Define` table handed to this parse was built from
-        /// (`BundleOptions::user_defines_hash`). Both rewrite the transpiled
-        /// output, so the runtime transpiler cache has to key on them.
-        ///
-        /// `None` ≡ neither was given (contributes nothing to the hash).
+        /// `BundleOptions::user_defines_hash`: the `--define` / `--drop` input behind
+        /// the `Define` table of this parse. `None` ≡ none (contributes nothing to the hash).
         pub user_defines_hash: Option<u64>,
 
         /// REPL mode: transforms code for interactive evaluation
@@ -408,8 +404,7 @@ pub mod Runtime {
                 }
             }
 
-            // --define / --drop substitute into the output the same way. As
-            // with --feature, the default (none given) adds nothing.
+            // --define / --drop, likewise adding nothing when not given.
             if let Some(user_defines_hash) = self.user_defines_hash {
                 hasher.update(&user_defines_hash.to_le_bytes());
             }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -264,8 +264,7 @@ pub mod Runtime {
         /// in watch/dev-server mode.
         pub bundler_feature_flags: Option<Box<StringSet>>,
 
-        /// `BundleOptions::user_defines_hash`: the `--define` / `--drop` input behind
-        /// the `Define` table of this parse. `None` ≡ none (contributes nothing to the hash).
+        /// `BundleOptions::user_defines_hash`; `None` contributes nothing to the hash.
         pub user_defines_hash: Option<u64>,
 
         /// REPL mode: transforms code for interactive evaluation

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,12 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: `--define` / bunfig `define` / `--drop` participate in the features
+/// hash. Until now only `bun run` turned the cache off for `--define`; every other
+/// path (`bun test`, bunfig, `--drop`) stored output with the substitutions baked
+/// in under the features hash a plain run looks up, so existing entries cannot be
+/// trusted.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,9 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `--define` / bunfig `define` / `--drop` participate in the features
-/// hash. Older entries written by `bun test` or with `--drop` carry those
-/// substitutions under the plain hash.
+/// Version 26: `--define` / bunfig `define` / `--drop` participate in the features hash.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -52,10 +52,8 @@ bun_core::declare_scope!(cache, visible);
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
 /// Version 26: `--define` / bunfig `define` / `--drop` participate in the features
-/// hash. Until now only `bun run` turned the cache off for `--define`; every other
-/// path (`bun test`, bunfig, `--drop`) stored output with the substitutions baked
-/// in under the features hash a plain run looks up, so existing entries cannot be
-/// trusted.
+/// hash. Older entries written by `bun test` or with `--drop` carry those
+/// substitutions under the plain hash.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `--define` / bunfig `define` / `--drop` participate in the features hash.
+/// Version 26: The define table (`--define`, bunfig `define`, `--drop`, inlined env),
+/// the module type (package.json `"type"`, `.cjs`/`.mjs`) and `--jsx-side-effects`
+/// participate in the features hash.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -215,8 +215,13 @@ impl Pragma {
         hasher.update(&self.classic_import_source);
         hasher.update(&self.package_name);
         // `runtime` selects classic vs automatic emission; `development`
-        // selects `jsx` vs `jsxDEV`. Both shape transpiled output.
-        hasher.update(&[self.runtime as u8, self.development as u8]);
+        // selects `jsx` vs `jsxDEV`; `side_effects` keeps unused elements
+        // (`--jsx-side-effects`). All three shape transpiled output.
+        hasher.update(&[
+            self.runtime as u8,
+            self.development as u8,
+            self.side_effects as u8,
+        ]);
     }
 
     pub fn import_source(&self) -> &[u8] {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1578,13 +1578,6 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 };
             }
         }
-
-        if let Some(define) = &opts.define {
-            if !define.keys.is_empty() {
-                bun_jsc::runtime_transpiler_cache::IS_DISABLED
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-        }
     }
 
     if matches!(

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -250,15 +250,16 @@ describe("transpiler cache", () => {
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
 
-  // --define and --drop are substituted into the transpiled output, so an entry
-  // written by one configuration must never be served to another. They are part
-  // of the features hash, like --feature above: a different configuration
-  // replaces the entry (delete + write, net 0 new files), the same one hits it.
-  describe("--define and --drop are part of the cache key", () => {
+  // Everything below changes the transpiled output of the same source bytes, so
+  // an entry written by one configuration must never be served to another. Each
+  // is part of the features hash, like --feature above: a different
+  // configuration replaces the entry (delete + write, net 0 new files), the same
+  // one hits it.
+  describe("the configuration is part of the cache key", () => {
     // Prints what X was defined as, or "nodefine" when it was left alone.
     const defineProbe = { code: 'typeof X === "undefined" ? "nodefine" : X' };
 
-    // Returns the last line a.js printed. (`bun test` reports on stderr, but
+    // Returns the last line the file printed. (`bun test` reports on stderr, but
     // also prints its version banner to stdout ahead of the module's output.)
     function run(args: string[]) {
       const result = Bun.spawnSync({
@@ -374,6 +375,46 @@ describe("transpiler cache", () => {
       expect(newCacheCount()).toBe(0);
 
       expect(run(["a.js"])).toBe("console-kept");
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test('package.json "type" and the .cjs / .mjs extension', () => {
+      // The same bytes under every module type, so all four files share one
+      // entry. The module type decides whether a file without import/export
+      // syntax is wrapped as CommonJS, where `arguments` exists.
+      const source = dummyFile(5 * 1024, "1", { code: "typeof arguments" });
+      mkdirSync(join(temp_dir, "cjs"));
+      mkdirSync(join(temp_dir, "esm"));
+      writeFileSync(join(temp_dir, "cjs", "package.json"), `{ "type": "commonjs" }`);
+      writeFileSync(join(temp_dir, "esm", "package.json"), `{ "type": "module" }`);
+      for (const file of ["cjs/a.js", "esm/a.js", "a.cjs", "a.mjs"]) {
+        writeFileSync(join(temp_dir, file), source);
+      }
+
+      expect(run(["cjs/a.js"])).toBe("object");
+      expect(newCacheCount()).toBe(1);
+      expect(run(["esm/a.js"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["a.cjs"])).toBe("object");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["a.mjs"])).toBe("undefined");
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test("--jsx-side-effects", () => {
+      // With the classic runtime an unused element is a bare call to the
+      // factory, which is dropped as dead code unless --jsx-side-effects says
+      // the call matters. (The flag is read together with the other JSX flags.)
+      const classic = ["--jsx-runtime=classic", "--jsx-factory=h"];
+      const code = `function h() { console.log("h called"); }\n<div />;`;
+      const filler = Buffer.alloc(5 * 1024, "/").toString();
+      writeFileSync(join(temp_dir, "a.jsx"), code + "\n//" + filler);
+
+      expect(run([...classic, "a.jsx"])).toBe("");
+      expect(newCacheCount()).toBe(1);
+      expect(run([...classic, "--jsx-side-effects", "a.jsx"])).toBe("h called");
+      expect(newCacheCount()).toBe(0);
+      expect(run([...classic, "a.jsx"])).toBe("");
       expect(newCacheCount()).toBe(0);
     });
   });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -250,6 +250,122 @@ describe("transpiler cache", () => {
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
 
+  // --define and --drop are substituted into the transpiled output, so an entry
+  // written by one configuration must never be served to another. They are part
+  // of the features hash, like --feature above: a different configuration
+  // replaces the entry (delete + write, net 0 new files), the same one hits it.
+  describe("--define and --drop are part of the cache key", () => {
+    // Prints what X was defined as, or "nodefine" when it was left alone.
+    const defineProbe = { code: 'typeof X === "undefined" ? "nodefine" : X' };
+
+    // Returns the last line a.js printed. (`bun test` reports on stderr, but
+    // also prints its version banner to stdout ahead of the module's output.)
+    function run(args: string[]) {
+      const result = Bun.spawnSync({
+        cmd: [bunExe(), ...args],
+        cwd: temp_dir,
+        env,
+        stdin: "ignore",
+      });
+      const stdout = result.stdout.toString().trim();
+      expect({ stdout, stderr: result.stderr.toString(), exitCode: result.exitCode }).toMatchObject({ exitCode: 0 });
+      return stdout.split("\n").at(-1);
+    }
+
+    // Every configuration of a.js shares one entry (the file name is the hash
+    // of the source), so this is the entry as last written.
+    const cacheEntry = () => readFileSync(join(cache_dir, readdirSync(cache_dir)[0]));
+
+    test("--define", () => {
+      writeFileSync(join(temp_dir, "a.js"), dummyFile(5 * 1024, "1", defineProbe));
+
+      expect(run(["--define", 'X="cli"', "a.js"])).toBe("cli");
+      expect(existsSync(cache_dir)).toBeTrue();
+      expect(newCacheCount()).toBe(1);
+      const withDefine = cacheEntry();
+
+      expect(run(["--define", 'X="cli"', "a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      expect(cacheEntry()).toEqual(withDefine);
+
+      expect(run(["a.js"])).toBe("nodefine");
+      expect(newCacheCount()).toBe(0);
+      expect(cacheEntry()).not.toEqual(withDefine);
+
+      expect(run(["--define", 'X="other"', "a.js"])).toBe("other");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(["--define", 'X="cli"', "a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      expect(cacheEntry()).toEqual(withDefine);
+
+      // The order the defines are given in does not change the key.
+      expect(run(["--define", 'X="cli"', "--define", "Y=1", "a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      const twoDefines = cacheEntry();
+      expect(twoDefines).not.toEqual(withDefine);
+      expect(run(["--define", "Y=1", "--define", 'X="cli"', "a.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      expect(cacheEntry()).toEqual(twoDefines);
+    });
+
+    test("--define passed to bun test", () => {
+      // The test file itself is too small to be cached; the module it imports
+      // is not, and is the same module `bun a.js` loads.
+      writeFileSync(join(temp_dir, "a.js"), dummyFile(5 * 1024, "1", defineProbe));
+      writeFileSync(
+        join(temp_dir, "a.test.js"),
+        `import "./a.js";\nimport { test } from "bun:test";\ntest("x", () => {});\n`,
+      );
+
+      expect(run(["test", "--define", 'X="cli"', "./a.test.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(1);
+
+      expect(run(["test", "./a.test.js"])).toBe("nodefine");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["a.js"])).toBe("nodefine");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(["test", "--define", 'X="cli"', "./a.test.js"])).toBe("cli");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["a.js"])).toBe("nodefine");
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test("define from bunfig.toml", () => {
+      // `bun run <file>` reads bunfig.toml only after the command line has
+      // been parsed; the defines it adds have to be keyed like --define.
+      writeFileSync(join(temp_dir, "a.js"), dummyFile(5 * 1024, "1", defineProbe));
+      writeFileSync(join(temp_dir, "bunfig.toml"), `[define]\nX = '"bunfig"'\n`);
+
+      expect(run(["run", "a.js"])).toBe("bunfig");
+      expect(newCacheCount()).toBe(1);
+      expect(run(["a.js"])).toBe("bunfig");
+      expect(newCacheCount()).toBe(0);
+
+      rmSync(join(temp_dir, "bunfig.toml"));
+      expect(run(["run", "a.js"])).toBe("nodefine");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["a.js"])).toBe("nodefine");
+      expect(newCacheCount()).toBe(0);
+    });
+
+    test("--drop", () => {
+      writeFileSync(join(temp_dir, "a.js"), dummyFile(5 * 1024, "1", "console-kept"));
+
+      expect(run(["a.js"])).toBe("console-kept");
+      expect(newCacheCount()).toBe(1);
+
+      expect(run(["--drop=console", "a.js"])).toBe("");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["--drop=console", "a.js"])).toBe("");
+      expect(newCacheCount()).toBe(0);
+
+      expect(run(["a.js"])).toBe("console-kept");
+      expect(newCacheCount()).toBe(0);
+    });
+  });
+
   // Serving the entry point from the cache must not change how the modules it
   // loads are resolved. Both of these are gated on the `has_loaded` flag, which
   // used to be set only on the path that runs the printer.

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -307,6 +307,18 @@ describe("transpiler cache", () => {
       expect(run(["--define", "Y=1", "--define", 'X="cli"', "a.js"])).toBe("cli");
       expect(newCacheCount()).toBe(0);
       expect(cacheEntry()).toEqual(twoDefines);
+
+      // ...unless the same key is given twice: the last one wins, so these are
+      // two different configurations, and the second is the same one as a
+      // plain X=1.
+      expect(run(["--define", "X=1", "--define", "X=2", "a.js"])).toBe("2");
+      expect(newCacheCount()).toBe(0);
+      expect(run(["--define", "X=2", "--define", "X=1", "a.js"])).toBe("1");
+      expect(newCacheCount()).toBe(0);
+      const lastWins = cacheEntry();
+      expect(run(["--define", "X=1", "a.js"])).toBe("1");
+      expect(newCacheCount()).toBe(0);
+      expect(cacheEntry()).toEqual(lastWins);
     });
 
     test("--define passed to bun test", () => {


### PR DESCRIPTION
### Problem
- `bun test --define X=1 ./a.test.ts` writes runtime transpiler cache entries for the modules the test imports with `X` already replaced by `1`. A later plain `bun test`, or plain `bun a.js` on the same file, reads those entries back and still sees `X === 1`.
- `--drop=console` has the same problem on every command, in both directions: a plain run's entry is served to a `--drop=console` run (the calls are not dropped), and a `--drop=console` run's entry is served to a plain run (the calls stay dropped).
- `bun run a.js` in a project whose bunfig.toml has a `[define]` section writes entries with those defines substituted; running the file after removing the section still sees them.
- Cause: the cache's features hash (`Options::hash_for_runtime_transpiler` in src/js_parser/parse/parse_entry.rs and `Features::hash_for_runtime_transpiler` in src/js_parser/parser.rs) does not cover the define table, although it rewrites the output that gets stored. The only guard was src/runtime/cli/Arguments.rs:1582 storing `runtime_transpiler_cache::IS_DISABLED` when `opts.define` is non-empty, inside `if matches!(cmd, AutoCommand | RunCommand)`. That misses `bun test`, misses `--drop` entirely, and misses bunfig defines for `bun run <file>`, which loads bunfig.toml only later in `RunCommand::boot` (src/runtime/cli/run_command.rs:928).
- Two more inputs that change the output of identical bytes are missing from the same hash, found while reviewing this change: the module type (package.json `"type"`, or the `.cjs` / `.mjs` extension; it picks the module format for files whose syntax does not, parse_entry.rs:1547), so a file first run under `"type": "commonjs"` is still wrapped as CommonJS when the same bytes are later run as `.mjs` or under `"type": "module"`, and vice versa; and `--jsx-side-effects` (with the classic runtime it decides whether an unused element's factory call survives, src/js_parser/visit/visit_expr.rs:482), so a run with the flag is served the output without it. Both verified on the released 1.4.0. The module type one is also what #34721 fixes; that PR is superseded by this one so there is a single cache version bump.
- Reproduces on the released 1.4.0 and on main; only files of at least 4 KiB are cached (`MINIMUM_CACHE_SIZE`).

### Fix
- `defines_from_transform_options` (src/bundler/options.rs) now also returns `define_hash`: a hash of everything it is about to build the `Define` table from, other than the constant tables. That is the resolved define map (`--define` / bunfig `define`, one value per key, plus the `process.env.NODE_ENV` defaults that join it when a boot path runs with env inlining on), the inlined env entries, and the `--drop` list. Maps and lists are sorted and every string is length-prefixed, so flag order does not matter and different inputs cannot serialize to the same bytes. `None` for the default configuration. `load_defines` stores it on `BundleOptions`.
- `Transpiler::parse_maybe_return_file_only_allow_shared_buffer` (src/bundler/transpiler.rs) copies it into `Features` for each parse, and `Features::hash_for_runtime_transpiler` folds it into the features hash, exactly as `--feature` flags are handled. `None` adds nothing.
- `Options::hash_for_runtime_transpiler` adds a `cjs` / `esm` tag for the module type (nothing for the default `Unknown`), and `Pragma::hash_for_runtime_transpiler` (src/options_types/jsx.rs) adds the `side_effects` byte next to `runtime` and `development`.
- The `IS_DISABLED` switch in Arguments.rs is removed: the key now covers what it was guarding against, for every command rather than two of them. `IS_DISABLED` is still set by the debugger paths. As a side effect `bun --define ... file.js` uses the cache now instead of turning it off.
- Cache version 25 -> 26, so entries already written under the old hash are discarded instead of read back.
- Why this is correct: a runtime transpiler's `Define` table is built exactly once, in `load_defines`, and `define_hash` is taken from the very inputs that call feeds into it, so the key and the table cannot disagree, on any command (including `bun test --parallel` workers, which get the same flags from the coordinator) and whatever env behavior a boot path ends up with (a forgotten `LoadAllWithoutInlining`, the bug behind #34210, would now key its entries by the inlined values instead of sharing them). Module type and JSX side effects are plain parser options that the hash functions already cover field by field; these were two missing fields.
- Verified with six new tests in test/cli/run/transpiler-cache.test.ts: `--define` on the run path (flag order, a key given twice), `--define` passed to `bun test`, define from bunfig.toml via `bun run`, `--drop`, package.json `"type"` plus `.cjs` / `.mjs`, and `--jsx-side-effects`. Each fails at the step that is served a stale entry without the src change (release binary and debug build) and passes with it. The rest of that file, test/bundler/bundler_drop.test.ts, test/bundler/cli.test.ts, test/cli/test/isolation.test.ts and the cache regression tests (28159, 30887, 32686) still pass; `cargo clippy` on bun_bundler, bun_js_parser and bun_options_types is clean.
- Not included, noted for follow-ups: a module loaded while a macro is being evaluated is transpiled with `is_macro_runtime` (its own macro calls are left unexpanded) and can be cached as such; and standalone executables built without dotenv autoload run with env behavior `disable`, which makes `defines_from_transform_options` inline `process.env.NODE_ENV` into files loaded from disk. The first is a further missing field; with this change the second is at least keyed correctly.

### Background
- Runtime transpiler cache: when `bun run` / `bun test` load a source file of 4 KiB or more, the transpiled JavaScript is stored in a per-user directory (`.pile` files, src/jsc/RuntimeTranspilerCache.rs) and reused by later processes. The file name is a hash of the source bytes; the entry header carries a "features hash" of the transpiler options that influence the output, assembled by hand in the two `hash_for_runtime_transpiler` functions. On a features hash mismatch the entry is deleted and rewritten, so two configurations of one file alternate between rewriting it rather than sharing it.
- Define table: `--define K=V` (also bunfig `[define]`) makes the parser replace the expression `K` with `V` while transpiling. `--drop=console` goes through the same table (`DefineData::from_input`, src/bundler/defines.rs) and makes matching calls removable. When a transpiler runs with env inlining enabled (bundler mode; at runtime every boot path is supposed to switch it off), `process.env.*` reads are added to the table as well. `defines_from_transform_options` is the one place all of this is turned into the table the parser reads.
- Module type: `ParserOptions.module_type` is derived from the extension or the nearest package.json (src/runtime/jsc_hooks.rs:4518) and decides whether a file without import/export syntax becomes an ES module or gets the CommonJS wrapper, which is why `typeof arguments` differs between the two in the test.

<details>
<summary>Probes against the released binary (1.4.0)</summary>

```console
$ export BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/cache   # every file below is >4 KiB
$ bun test --define X=1 ./probe.test.ts | grep V=      # big.mjs exports v = typeof X === "undefined" ? "nodefine" : X
V=1
$ bun test ./probe.test.ts | grep V=
V=1                      # expected V=nodefine
$ bun run.mjs
V=1                      # expected V=nodefine

$ rm -rf cache/*; bun --drop=console bigdrop.mjs; bun bigdrop.mjs
                         # second run expected: console-kept
$ rm -rf cache/*; bun bigdrop.mjs; bun --drop=console bigdrop.mjs
console-kept
console-kept             # second run expected: nothing

$ printf '[define]\nX = "7"\n' > bunfig.toml; rm -rf cache/*; bun run run.mjs; rm bunfig.toml; bun run run.mjs
V=7
V=7                      # expected V=nodefine

$ rm -rf cache/*; (cd cjs && bun a.js); (cd esm && bun a.js)   # a.js prints typeof arguments; package.json type differs
object
object                   # expected undefined
$ rm -rf cache/*; bun x.mjs; bun x.cjs                          # same bytes
undefined
undefined                # expected object

$ rm -rf cache/*; bun --jsx-runtime=classic --jsx-factory=h a.jsx; bun --jsx-runtime=classic --jsx-factory=h --jsx-side-effects a.jsx
                         # second run expected: h called
```
</details>
