### PR TITLE
css: compile the border-inline shorthands the border minifier produces for old targets

### DIFF
--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1028,13 +1028,47 @@ mod border_handler_body {
 
         // State.inlineProp
         // If both values of an inline logical property are equal, then we can just convert them to physical properties.
+        // Evaluates to whether it did.
         macro_rules! inline_prop {
             ($key:ident, $left:ident, $right:ident) => {{
-                if inline_start.$key.is_some()
-                    && css::generic::eql(&inline_start.$key, &inline_end.$key)
-                {
+                let is_eq = inline_start.$key.is_some()
+                    && css::generic::eql(&inline_start.$key, &inline_end.$key);
+                if is_eq {
                     fc_prop!(f, $left, inline_start.$key.take().unwrap());
                     fc_prop!(f, $right, inline_end.$key.take().unwrap());
+                }
+                is_eq
+            }};
+        }
+
+        // A single sub-property differs between the inline sides and the (equal) block sides.
+        // Emits it as a border-inline-* shorthand when the targets support it, or as physical
+        // properties when both inline values are equal. Evaluates to false when the values
+        // differ and must be compiled per side instead.
+        macro_rules! inline_diff {
+            ($key:ident, $shorthand:ident, $left:ident, $right:ident) => {{
+                if f.logical_shorthand_supported {
+                    logical_shorthand!($shorthand, $shorthand, $key, inline_start, inline_end);
+                    true
+                } else {
+                    inline_prop!($key, $left, $right)
+                }
+            }};
+        }
+
+        // Both inline sides are valid and equal: border-inline, or the pair of sides the targets support.
+        macro_rules! equal_inline_sides {
+            () => {{
+                if f.logical_supported {
+                    if f.logical_shorthand_supported {
+                        fc_prop!(f, BorderInline, inline_start.to_border(f.arena));
+                    } else {
+                        fc_prop!(f, BorderInlineStart, inline_start.to_border(f.arena));
+                        fc_prop!(f, BorderInlineEnd, inline_start.to_border(f.arena));
+                    }
+                } else {
+                    fc_prop!(f, BorderLeft, inline_start.to_border(f.arena));
+                    fc_prop!(f, BorderRight, inline_start.to_border(f.arena));
                 }
             }};
         }
@@ -1088,31 +1122,15 @@ mod border_handler_body {
                         }
 
                         if diff == 1 {
-                            if !css::generic::eql(&inline_start.width, &block_start.width) {
-                                fc_prop!(f, BorderInlineWidth, BorderInlineWidth {
-                                    start: inline_start.width.as_ref().unwrap().deep_clone(f.arena),
-                                    end: inline_end.width.as_ref().unwrap().deep_clone(f.arena),
-                                });
-                                handled = true;
+                            handled = if !css::generic::eql(&inline_start.width, &block_start.width) {
+                                inline_diff!(width, BorderInlineWidth, BorderLeftWidth, BorderRightWidth)
                             } else if !css::generic::eql(&inline_start.style, &block_start.style) {
-                                fc_prop!(f, BorderInlineStyle, BorderInlineStyle {
-                                    start: inline_start.style.as_ref().unwrap().deep_clone(f.arena),
-                                    end: inline_end.style.as_ref().unwrap().deep_clone(f.arena),
-                                });
-                                handled = true;
-                            } else if !css::generic::eql(&inline_start.color, &block_start.color) {
-                                fc_prop!(f, BorderInlineColor, BorderInlineColor {
-                                    start: inline_start.color.as_ref().unwrap().deep_clone(f.arena),
-                                    end: inline_end.color.as_ref().unwrap().deep_clone(f.arena),
-                                });
-                                handled = true;
-                            }
-                        } else if diff > 1
-                            && css::generic::eql(&inline_start.width, &inline_end.width)
-                            && css::generic::eql(&inline_start.style, &inline_end.style)
-                            && css::generic::eql(&inline_start.color, &inline_end.color)
-                        {
-                            fc_prop!(f, BorderInline, inline_start.to_border(f.arena));
+                                inline_diff!(style, BorderInlineStyle, BorderLeftStyle, BorderRightStyle)
+                            } else {
+                                inline_diff!(color, BorderInlineColor, BorderLeftColor, BorderRightColor)
+                            };
+                        } else if diff > 1 && left_eq_right {
+                            equal_inline_sides!();
                             handled = true;
                         }
                     }
@@ -1174,17 +1192,7 @@ mod border_handler_body {
             }
 
             if $is_logical && inline_start.eql(inline_end) && inline_start.is_valid() {
-                if f.logical_supported {
-                    if f.logical_shorthand_supported {
-                        fc_prop!(f, BorderInline, inline_start.to_border(f.arena));
-                    } else {
-                        fc_prop!(f, BorderInlineStart, inline_start.to_border(f.arena));
-                        fc_prop!(f, BorderInlineEnd, inline_start.to_border(f.arena));
-                    }
-                } else {
-                    fc_prop!(f, BorderLeft, inline_start.to_border(f.arena));
-                    fc_prop!(f, BorderRight, inline_start.to_border(f.arena));
-                }
+                equal_inline_sides!();
             } else {
                 if $is_logical && !inline_start.is_valid() && !inline_end.is_valid() {
                     if f.logical_shorthand_supported {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -1559,6 +1559,346 @@ describe("css tests", () => {
       },
     );
 
+    // All four logical sides set with equal block sides: the inline sides get minified into
+    // border-inline-width/style/color or border-inline, which have to be compiled away like
+    // any other logical declaration when the targets do not support them.
+    describe("border-inline shorthands for compiled targets", () => {
+      // Safari 8 supports neither logical properties nor their shorthands.
+      describe("safari 8", () => {
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px solid red;
+            border-inline-end: 1px solid red;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-left-width: 1px;
+            border-right-width: 1px;
+          }
+        `,
+          {
+            safari: 8 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 1px solid red;
+            border-block-end: 1px solid red;
+            border-inline-start: 1px dotted red;
+            border-inline-end: 1px dotted red;
+          }
+        `,
+          `
+          .foo {
+            border: 1px solid red;
+            border-left-style: dotted;
+            border-right-style: dotted;
+          }
+        `,
+          {
+            safari: 8 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 1px solid red;
+            border-block-end: 1px solid red;
+            border-inline-start: 1px solid blue;
+            border-inline-end: 1px solid blue;
+          }
+        `,
+          `
+          .foo {
+            border: 1px solid red;
+            border-left-color: #00f;
+            border-right-color: #00f;
+          }
+        `,
+          {
+            safari: 8 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px dotted blue;
+            border-inline-end: 1px dotted blue;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-left: 1px dotted #00f;
+            border-right: 1px dotted #00f;
+          }
+        `,
+          {
+            safari: 8 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px solid red;
+            border-inline-end: 2px solid red;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+          }
+
+          .foo:not(:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+            border-left-width: 1px;
+            border-right-width: 2px;
+          }
+
+          .foo:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+            border-left-width: 1px;
+            border-right-width: 2px;
+          }
+
+          .foo:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+            border-left-width: 2px;
+            border-right-width: 1px;
+          }
+
+          .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+            border-left-width: 2px;
+            border-right-width: 1px;
+          }
+        `,
+          {
+            safari: 8 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 1px solid red;
+            border-block-end: 1px solid red;
+            border-inline-start: 1px solid blue;
+            border-inline-end: 1px solid green;
+          }
+        `,
+          `
+          .foo {
+            border: 1px solid red;
+          }
+
+          .foo:not(:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+            border-left-color: #00f;
+            border-right-color: green;
+          }
+
+          .foo:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
+            border-left-color: #00f;
+            border-right-color: green;
+          }
+
+          .foo:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+            border-left-color: green;
+            border-right-color: #00f;
+          }
+
+          .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+            border-left-color: green;
+            border-right-color: #00f;
+          }
+        `,
+          {
+            safari: 8 << 16,
+          },
+        );
+      });
+
+      // Safari 13 supports the logical longhands but not the border-inline shorthands.
+      describe("safari 13", () => {
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px solid red;
+            border-inline-end: 1px solid red;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-left-width: 1px;
+            border-right-width: 1px;
+          }
+        `,
+          {
+            safari: 13 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px solid red;
+            border-inline-end: 2px solid red;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-inline-start-width: 1px;
+            border-inline-end-width: 2px;
+          }
+        `,
+          {
+            safari: 13 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 1px solid red;
+            border-block-end: 1px solid red;
+            border-inline-start: 1px dotted red;
+            border-inline-end: 1px dashed red;
+          }
+        `,
+          `
+          .foo {
+            border: 1px solid red;
+            border-inline-start-style: dotted;
+            border-inline-end-style: dashed;
+          }
+        `,
+          {
+            safari: 13 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px dotted blue;
+            border-inline-end: 1px dotted blue;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-inline-start: 1px dotted #00f;
+            border-inline-end: 1px dotted #00f;
+          }
+        `,
+          {
+            safari: 13 << 16,
+          },
+        );
+      });
+
+      // Safari 15 supports everything, so the shorthands stay.
+      describe("safari 15", () => {
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px solid red;
+            border-inline-end: 2px solid red;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-inline-width: 1px 2px;
+          }
+        `,
+          {
+            safari: 15 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 1px solid red;
+            border-block-end: 1px solid red;
+            border-inline-start: 1px dotted red;
+            border-inline-end: 1px dotted red;
+          }
+        `,
+          `
+          .foo {
+            border: 1px solid red;
+            border-inline-style: dotted;
+          }
+        `,
+          {
+            safari: 15 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 1px solid red;
+            border-block-end: 1px solid red;
+            border-inline-start: 1px solid blue;
+            border-inline-end: 1px solid green;
+          }
+        `,
+          `
+          .foo {
+            border: 1px solid red;
+            border-inline-color: #00f green;
+          }
+        `,
+          {
+            safari: 15 << 16,
+          },
+        );
+
+        prefix_test(
+          `
+          .foo {
+            border-block-start: 3px solid red;
+            border-block-end: 3px solid red;
+            border-inline-start: 1px dotted blue;
+            border-inline-end: 1px dotted blue;
+          }
+        `,
+          `
+          .foo {
+            border: 3px solid red;
+            border-inline: 1px dotted #00f;
+          }
+        `,
+          {
+            safari: 15 << 16,
+          },
+        );
+      });
+    });
+
     prefix_test(
       `
       .foo {


### PR DESCRIPTION
### Problem

- When a rule sets all four logical border sides and the two block sides are equal, the border minifier folds the inline sides into a `border-inline-*` shorthand. It does that even when the targets do not support logical properties and every other logical border declaration in the sheet is being compiled to physical properties, so the target browsers drop the declaration and the inline sides end up with the block sides' border (released 1.4.0 and main, `targets: { chrome: 60 }`):
  ```
  .a{border-block-start:3px solid red;border-block-end:3px solid red;border-inline-start:1px solid red;border-inline-end:1px solid red}
    -> .a{border:3px solid red;border-inline-width:1px}
  .a{... same block sides ...;border-inline-start:1px solid red;border-inline-end:2px solid red}
    -> .a{border:3px solid red;border-inline-width:1px 2px}
  .a{... same block sides ...;border-inline-start:1px dotted blue;border-inline-end:1px dotted blue}
    -> .a{border:3px solid red;border-inline:1px dotted #00f}
  ```
  Targets that support the longhands but not the shorthands (chrome 69-86, safari 12.1-14.0, firefox 41-65) get the same output.
- Cause: `flush_category!` in `src/css/properties/border.rs`, the `top_eq_bottom` arm (lines 1068-1118 on main). It emits `BorderInlineWidth` / `BorderInlineStyle` / `BorderInlineColor` (one sub-property differs) or `BorderInline` (several differ, inline sides equal) guarded only by `is_logical`. Every other logical shorthand emitted by this macro is guarded by `f.logical_supported` / `f.logical_shorthand_supported`, and `fc_prop!` has no compiling arm for these four properties (it compiles the single-side longhands only), so they are pushed to the output as written.
- Upstream lightningcss 1.30.2 produces the same output for these inputs, so this is inherited rather than a porting error.

### Fix

- The arm now emits through the same target-aware paths the rest of the flush uses for the same values:
  - shorthand supported: unchanged, `border-inline-<sub>: start end` via `logical_shorthand!`, or `border-inline` for whole sides;
  - one sub-property differs and both inline values are equal: the physical pair via `inline_prop!` (`border-left-width: 1px; border-right-width: 1px`), which is direction independent and what the handler already emits for `border-inline-width: 1px` on its own;
  - otherwise the arm reports itself unhandled and the existing `side_diff!` fallback compiles each inline side (logical longhands when the targets have them, `:lang()` ltr/rtl rules otherwise), which is what it already did for unequal whole sides.
- Whole equal sides now go through `equal_inline_sides!`, which is the block that the not-all-sides-set path below already used (`border-inline`, `border-inline-start` + `border-inline-end`, or `border-left` + `border-right` depending on the targets), moved into a macro so both sites share it. That path's output is unchanged.
- Why this is correct: inside this arm both inline sides are known to differ from the block sides (the arms above handle the cases where one of them does not), so when exactly one sub-property differs, it differs on both sides and `side_diff!` emits exactly that sub-property per side; when more than one differs and the sides are equal, every form `equal_inline_sides!` emits carries the whole side. Every declaration the arm now emits is one the handler already emits for the same targets elsewhere, and the `:lang()` rules are only produced when the two inline values actually differ. The physical instantiation of the macro (`is_logical = false`) never enters this code, and `inline_prop!` only gained a boolean result.
- Verified:
  - `test/js/bun/css/css.test.ts`, new `border-inline shorthands for compiled targets` block: safari 8 (nothing logical supported) for each of width / style / color with equal inline values, the whole-side case, and the unequal width and color cases that need `:lang()` rules; safari 13 (longhands only) for the equal width and the unequal width / style cases plus the whole-side case; safari 15 pins the unchanged shorthand output for all four shapes. 10 of the 14 cases fail on the unfixed build, all pass with the fix.
  - `bun bd test test/js/bun/css/css.test.ts`: 1156 pass; `test/bundler/css/` and `test/bundler/esbuild/css.test.ts`: 225 pass.
  - `cargo clippy -p bun_css` and `cargo fmt` are clean.

### Background

- The CSS minifier buffers all border declarations of a block in `BorderHandler` and writes them out in `flush`, as the shortest equivalent set it can find. `flush_category!` is the shared body for the physical sides (`is_logical = false`) and the logical sides (`is_logical = true`); the arm touched here handles "top and bottom equal, left and right differ", emitting `border:` for the block sides and then only the inline differences.
- Logical properties (`border-inline-start`, ...) pick a physical side based on the writing direction. For targets that predate them the handler compiles them away: a value that is the same on both inline sides becomes plain left/right properties, anything else becomes one extra rule per direction, selected with `:lang()` lists (`PropertyHandlerContext::add_logical_rule`). Two compat features drive this: `LogicalBorders` for the single-side longhands and `LogicalBorderShorthand` for the two-sided `border-inline*` / `border-block*` shorthands, exposed to the flush as `logical_supported` and `logical_shorthand_supported`.
- `fc_prop!` is the emission macro: for the single-side logical properties it has arms that compile to the physical property or the direction rules; for everything else it just pushes the declaration. Call sites that want a two-sided shorthand therefore have to check the flags themselves, which is what this arm was missing.

<details>
<summary>Output after the fix for the three inputs above</summary>

```
chrome 60 (nothing logical supported)
  .a { border: 3px solid red; border-left-width: 1px; border-right-width: 1px; }
  .a { border: 3px solid red; }
  .a:not(:-webkit-any(:lang(ae), ...)) { border-left-width: 1px; border-right-width: 2px; }
  .a:not(:is(:lang(ae), ...))          { border-left-width: 1px; border-right-width: 2px; }
  .a:-webkit-any(:lang(ae), ...)       { border-left-width: 2px; border-right-width: 1px; }
  .a:is(:lang(ae), ...)                { border-left-width: 2px; border-right-width: 1px; }
  .a { border: 3px solid red; border-left: 1px dotted #00f; border-right: 1px dotted #00f; }

chrome 80 (longhands supported, shorthands not)
  .a { border: 3px solid red; border-left-width: 1px; border-right-width: 1px; }
  .a { border: 3px solid red; border-inline-start-width: 1px; border-inline-end-width: 2px; }
  .a { border: 3px solid red; border-inline-start: 1px dotted #00f; border-inline-end: 1px dotted #00f; }

chrome 90 (everything supported, unchanged)
  .a { border: 3px solid red; border-inline-width: 1px; }
  .a { border: 3px solid red; border-inline-width: 1px 2px; }
  .a { border: 3px solid red; border-inline: 1px dotted #00f; }
```

Also checked: the `!important` variant, the same sides written as `border-block` + `border-inline`, style attributes (logical properties are never compiled there, output unchanged), and the `left_eq_right` arm next to this one, which does not emit logical shorthands and is unchanged. A `lab()` inline color after `border:` gets no rgb fallback on the new physical path; that matches what the physical handler already does for `border: ...; border-right-color: lab(...)` (the preceding `border:` value is the fallback), so nothing new there.

</details>
