### PR TITLE
sourcemap: count an ill-formed UTF-8 lead byte as one byte so the line break after it is not skipped

### DIFF
--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -534,10 +534,8 @@ impl NewBuilder<'_, VLQSourceMap> {
         let mut i: usize = 0;
         let n: usize = slice.len();
         let mut c: i32;
-        // Same decoder as `LineOffsetTable::generate` and `LineColumnOffset::advance`:
-        // a lead byte whose continuation bytes are missing (a Latin-1 byte in a legal
-        // comment) is one U+FFFD, one byte wide, so a line terminator right after it is
-        // still seen below instead of being skipped with the width the lead byte declared.
+        // An ill-formed sequence decodes as one U+FFFD one byte wide, so a line
+        // terminator right after a bad lead byte still reaches the match below.
         let iter = strings::CodepointIterator::init(slice);
         while i < n {
             let mut cursor = strings::Cursor {

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -534,17 +534,19 @@ impl NewBuilder<'_, VLQSourceMap> {
         let mut i: usize = 0;
         let n: usize = slice.len();
         let mut c: i32;
+        // Same decoder as `LineOffsetTable::generate` and `LineColumnOffset::advance`:
+        // a lead byte whose continuation bytes are missing (a Latin-1 byte in a legal
+        // comment) is one U+FFFD, one byte wide, so a line terminator right after it is
+        // still seen below instead of being skipped with the width the lead byte declared.
+        let iter = strings::CodepointIterator::init(slice);
         while i < n {
-            let len = strings::wtf8_byte_sequence_length_with_invalid(slice[i]);
-            let mut cp_bytes = [0u8; 4];
-            let take = (len as usize).min(n - i);
-            cp_bytes[..take].copy_from_slice(&slice[i..i + take]);
-            c = strings::decode_wtf8_rune_t::<i32>(
-                cp_bytes,
-                len,
-                strings::UNICODE_REPLACEMENT as i32,
-            );
-            i += len as usize;
+            let mut cursor = strings::Cursor {
+                i: i as u32,
+                ..Default::default()
+            };
+            let _ = iter.next(&mut cursor);
+            c = cursor.c;
+            i += cursor.width as usize;
 
             match c {
                 14..=127 => {

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -534,8 +534,7 @@ impl NewBuilder<'_, VLQSourceMap> {
         let mut i: usize = 0;
         let n: usize = slice.len();
         let mut c: i32;
-        // An ill-formed sequence decodes as one U+FFFD one byte wide, so a line
-        // terminator right after a bad lead byte still reaches the match below.
+        // An ill-formed sequence is one U+FFFD one byte wide, so a '\n' after it is not skipped.
         let iter = strings::CodepointIterator::init(slice);
         while i < n {
             let mut cursor = strings::Cursor {

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -186,12 +186,8 @@ impl LineOffsetTable {
         // Hoist the base pointer so per-iteration offset math is a single sub + truncate.
         let base = contents.as_ptr() as usize;
 
-        // `CodepointIterator` is also what `LineColumnOffset::advance` and the
-        // generated-side walk in `Chunk.rs` use, so all three agree on what a byte
-        // sequence is: a lead byte whose continuation bytes are missing (Latin-1 text)
-        // is one U+FFFD, one byte wide, and the bytes after it (a line terminator, say)
-        // are looked at on their own rather than skipped as part of the width the lead
-        // byte declared.
+        // Same decoder as the generated-side walk in `Chunk.rs`: an ill-formed sequence
+        // is one U+FFFD one byte wide, so a line terminator right after it is not skipped.
         let iter = strings::CodepointIterator::init(contents);
         let mut remaining = contents;
         while !remaining.is_empty() {

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -186,27 +186,23 @@ impl LineOffsetTable {
         // Hoist the base pointer so per-iteration offset math is a single sub + truncate.
         let base = contents.as_ptr() as usize;
 
+        // `CodepointIterator` is also what `LineColumnOffset::advance` and the
+        // generated-side walk in `Chunk.rs` use, so all three agree on what a byte
+        // sequence is: a lead byte whose continuation bytes are missing (Latin-1 text)
+        // is one U+FFFD, one byte wide, and the bytes after it (a line terminator, say)
+        // are looked at on their own rather than skipped as part of the width the lead
+        // byte declared.
+        let iter = strings::CodepointIterator::init(contents);
         let mut remaining = contents;
         while !remaining.is_empty() {
-            let b0 = remaining[0];
-            let len_ = strings::wtf8_byte_sequence_length_with_invalid(b0);
-            // After the SIMD skip below lands, the loop head
-            // is overwhelmingly an ASCII '\r'/'\n' or a non-ASCII lead byte, so keep the
-            // 1-byte path branch-only and confine the zero+copy pad to the cold
-            // multibyte arm.
-            // `len_` is the lead byte's *declared* width; a source whose final bytes are
-            // a truncated multibyte sequence declares more bytes than remain, so every
-            // slice below (decode, SIMD-skip offset, advance) must use the clamped width.
-            let cp_len = (len_ as usize).min(remaining.len());
-            let c: i32 = if len_ == 1 {
-                b0 as i32
-            } else {
-                let mut cp_bytes = [0u8; 4];
-                cp_bytes[..cp_len].copy_from_slice(&remaining[..cp_len]);
-                strings::decode_wtf8_rune_t::<i32>(cp_bytes, len_, 0)
-            };
-
             let offset = (remaining.as_ptr() as usize - base) as u32;
+            let mut cursor = strings::Cursor {
+                i: offset,
+                ..Default::default()
+            };
+            let _ = iter.next(&mut cursor);
+            let c: i32 = cursor.c;
+            let cp_len = cursor.width as usize;
 
             if column == 0 {
                 line_byte_offset = offset;

--- a/src/sourcemap/LineOffsetTable.rs
+++ b/src/sourcemap/LineOffsetTable.rs
@@ -186,8 +186,7 @@ impl LineOffsetTable {
         // Hoist the base pointer so per-iteration offset math is a single sub + truncate.
         let base = contents.as_ptr() as usize;
 
-        // Same decoder as the generated-side walk in `Chunk.rs`: an ill-formed sequence
-        // is one U+FFFD one byte wide, so a line terminator right after it is not skipped.
+        // Same decoder as `Chunk.rs`: an ill-formed sequence is one U+FFFD one byte wide.
         let iter = strings::CodepointIterator::init(contents);
         let mut remaining = contents;
         while !remaining.is_empty() {

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -513,7 +513,7 @@ describe.concurrent("sourcemap of a source with an ill-formed UTF-8 sequence rig
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
     const outfile = path.join(String(dir), "out", entry);
     const outputLines = readFileSync(outfile, "latin1").split("\n");

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -1,6 +1,7 @@
 import { internalSourceMap } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 
 // --- Reference VLQ codec (mirrors the spec; used as the oracle) ---
@@ -488,6 +489,90 @@ describe.concurrent("sourcemap of a source with a truncated trailing UTF-8 seque
       sources: ["../in.js"],
       mappings: ";AAAA,QAAQ,IAAI,CAAC;",
     });
+  });
+});
+
+// Both sides of a mapping come from walking raw bytes: LineOffsetTable::generate
+// walks the source and the builder in Chunk.rs walks the printed output. A lead
+// byte that is not followed by the continuation bytes it declares (a Latin-1
+// file, a sequence cut short) is one character, one byte wide. Stepping over the
+// declared width instead swallows the line break after it, and every mapping
+// from there on is a line off.
+describe.concurrent("sourcemap of a source with an ill-formed UTF-8 sequence right before a line break", () => {
+  // File contents are given as latin1 text, so "\xe9" is the one byte 0xE9 on
+  // disk; the output is read back the same way. Lines are 0-based like the map's.
+  async function bundle(latin1Files: Record<string, string>, entry: string) {
+    using dir = tempDir(
+      "sourcemap-ill-formed-utf8",
+      Object.fromEntries(Object.entries(latin1Files).map(([name, text]) => [name, Buffer.from(text, "latin1")])),
+    );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--sourcemap=external", "--outdir=out", entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+    const outfile = path.join(String(dir), "out", entry);
+    const outputLines = readFileSync(outfile, "latin1").split("\n");
+    const map = JSON.parse(readFileSync(outfile + ".map", "utf8"));
+    const segs = decodeMappings(map.mappings);
+    // For each statement: the mapping at the start of the output line it was
+    // printed on, i.e. what a stack trace through that line would be remapped to.
+    return (statements: string[]) =>
+      statements.map(statement => {
+        const generatedLine = outputLines.findIndex(line => line.includes(statement));
+        expect(generatedLine).toBeGreaterThanOrEqual(0);
+        const seg = referenceFind(segs, generatedLine, 0);
+        return { statement, mapped: seg && { source: map.sources[seg.srcIdx], line: seg.origLine } };
+      });
+  }
+
+  const illFormed = [
+    ["Latin-1 0xE9, a 3-byte lead with no continuation bytes", "\xe9"],
+    ["0xC3, a 2-byte lead with no continuation byte", "\xc3"],
+    ["0xF0 0x9F 0x92, three bytes of a 4-byte sequence", "\xf0\x9f\x92"],
+  ];
+
+  // Source lines 0-1 are the comment, `first` is on line 2 and `second` on line
+  // 5. The output drops the blank lines between them, so the two walks cannot
+  // each be a line off and still agree with each other by accident.
+  const rest = '\nb */\nconsole.log("first");\n\n\nconsole.log("second");\n';
+  const statements = ['console.log("first")', 'console.log("second")'];
+  const expected = [
+    { statement: 'console.log("first")', mapped: { source: "../in.js", line: 2 } },
+    { statement: 'console.log("second")', mapped: { source: "../in.js", line: 5 } },
+  ];
+
+  // A legal comment is copied into the output, so both walks see the bytes.
+  test.each(illFormed)("in a legal comment: %s", async (_name, bytes) => {
+    const mappingsOf = await bundle({ "in.js": "/*! caf" + bytes + rest }, "in.js");
+    expect(mappingsOf(statements)).toEqual(expected);
+  });
+
+  // A plain comment is dropped from the output, so only the source walk sees them.
+  test.each(illFormed)("in a plain comment: %s", async (_name, bytes) => {
+    const mappingsOf = await bundle({ "in.js": "/* caf" + bytes + rest }, "in.js");
+    expect(mappingsOf(statements)).toEqual(expected);
+  });
+
+  // In a bundle the files' mappings are chained: each file's start where the
+  // line count of the file printed before it left off, so a file that counts
+  // one of its own line breaks short also pulls every file after it up a line.
+  test("in a legal comment of a file printed ahead of the entry point", async () => {
+    const mappingsOf = await bundle(
+      {
+        "in.js": 'import "./dep.js";\nconsole.log("entry");\n',
+        "dep.js": '/*! caf\xe9\nb */\nconsole.log("dep");\n',
+      },
+      "in.js",
+    );
+    expect(mappingsOf(['console.log("dep")', 'console.log("entry")'])).toEqual([
+      { statement: 'console.log("dep")', mapped: { source: "../dep.js", line: 2 } },
+      { statement: 'console.log("entry")', mapped: { source: "../in.js", line: 1 } },
+    ]);
   });
 });
 

--- a/test/js/bun/sourcemap/internal-sourcemap.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap.test.ts
@@ -55,7 +55,7 @@ function extractPositions(stack: string): string[] {
     .filter((s): s is string => s !== null);
 }
 
-async function run(files: Record<string, string>, env: Record<string, string> = {}) {
+async function run(files: Record<string, string | Buffer>, env: Record<string, string> = {}) {
   using dir = tempDir("internal-sourcemap", files);
   await using proc = Bun.spawn({
     cmd: [bunExe(), "index.ts"],
@@ -226,5 +226,50 @@ describe("InternalSourceMap", () => {
       expect(stdout).toMatch(new RegExp(`index\\.ts:${ln}:`));
     }
     expect(exited).toBe(0);
+  });
+
+  // Both line tables behind a remapped frame are built by walking raw bytes: the
+  // source's by LineOffsetTable::generate, the transpiled output's by the builder.
+  // A lead byte without the continuation bytes it declares (the file is Latin-1,
+  // not UTF-8) is one character, one byte wide; stepping over the declared width
+  // instead swallows the line break after it and every frame below comes out a
+  // line early. The fixtures are written to disk as latin1, so "\xe9" is the one
+  // byte 0xE9.
+  describe.concurrent("an ill-formed UTF-8 byte right before a line break", () => {
+    async function framePositions(latin1Source: string) {
+      const { stdout, stderr, exited } = await run({ "index.ts": Buffer.from(latin1Source, "latin1") });
+      expect(stderr).toBe("");
+      expect(exited).toBe(0);
+      return [...stdout.matchAll(/index\.ts:(\d+:\d+)/g)].map(m => m[1]);
+    }
+
+    test("in a comment that is dropped from the output", async () => {
+      // Lines: 1 "/* caf<E9>", 2 "b */", 3 the Error, 4 console.log.
+      const positions = await framePositions(
+        '/* caf\xe9\nb */\nconst err = new Error("x");\nconsole.log(err.stack);\n',
+      );
+      expect(positions).toEqual(["3:17"]);
+    });
+
+    test("in a legal comment that is kept in the output", async () => {
+      // Lines: 1 "/*! caf<E9>", 2 "b */", 3 the Error, 6 console.log. The output
+      // has no blank lines, so the walks over the source and over the output
+      // cannot each be a line off and still produce the right answer together.
+      const positions = await framePositions(
+        '/*! caf\xe9\nb */\nconst err = new Error("x");\n\n\nconsole.log(err.stack);\n',
+      );
+      expect(positions).toEqual(["3:17"]);
+    });
+
+    test("in a template literal, next to a U+FFFD the printer wrote out for another one", async () => {
+      // Line 1 breaks inside the template literal right after the ill-formed
+      // byte. The string on line 3 is printed with a real U+FFFD (three bytes,
+      // one column) ahead of the Error on the same line, which the walk over
+      // the output must not mistake for an ill-formed byte either.
+      const positions = await framePositions(
+        'const s = `caf\xe9\n`;\nconst err = ["caf\xe9", new Error("x")][1];\nconsole.log(err.stack);\n',
+      );
+      expect(positions).toEqual(["3:26"]);
+    });
   });
 });


### PR DESCRIPTION
### Problem

- A byte that looks like the start of a multi-byte UTF-8 sequence but is not followed by continuation bytes (a Latin-1 encoded license header is the usual way to get one) makes the source map line counters skip the bytes after it. When one of those bytes is the line break, every mapping from there to the end of the file is one line off. It shows up in `bun build --sourcemap` output and in the line numbers `bun run` puts in `error.stack`.
- Repro: `printf '/*! caf\xe9\nb */\nconsole.log(1);\nconsole.log(2);\n' > in.js && bun build ./in.js --outdir out --sourcemap=external`. The output has `console.log(1)` on its 4th line, but `mappings` is `;AACA;AAAA,QAAQ,IAAI,CAAC;AACb,...` (5 line groups, the statement in the 3rd), and the original line recorded for it is line 1 instead of line 2. With a well-formed `é` the same file produces `;AAEA;AAAA;AAAA,QAAQ,...` (6 groups, original line 2). At runtime, a file starting with `/* caf\xe9\nb */` reports an error created on line 3 at line 2.
- Cause: both loops advance by the width the lead byte declares (`wtf8_byte_sequence_length_with_invalid`, 3 for `0xE9`) whether or not the decode succeeded. `update_generated_line_and_column_slow` in `src/sourcemap/Chunk.rs` did `i += len` after `decode_wtf8_rune_t` had returned the replacement character, and `LineOffsetTable::generate_in` in `src/sourcemap/LineOffsetTable.rs` did `remaining = &remaining[cp_len..]` the same way, so the `\n` inside the supposed 3-byte sequence never reaches the line terminator arm of either match.
- The bundler chains the per-file map chunks (each file's mappings start where the previous file's line count left off), so a file that counts one of its own line breaks short also pulls every file printed after it up a line.

### Fix

- Both loops decode through `strings::CodepointIterator` instead of their own `wtf8_byte_sequence_length_with_invalid` + `decode_wtf8_rune_t` copies, and advance by the width it reports. An ill-formed sequence comes back as one U+FFFD, one byte wide, so the line break is looked at on its own on the next iteration. Well-formed input decodes exactly as before.
- Why this is the right count: the line break after an ill-formed byte is a line break to everything that reads the file. JSC gets the transpiled code through `String::fromUTF8ReplacingInvalidSequences`, which turns the bad byte into U+FFFD and keeps the `\n`, so the positions it reports are what these tables have to line up with; esbuild, where both loops come from, walks the bytes with Go's range decoding, which also steps one byte past an invalid one. `CodepointIterator` is also what `LineColumnOffset::advance` already uses, and that is the third walk feeding the same line separators (the glue between files in a bundle, and the positions of the placeholder substitutions in `src/bundler/Chunk.rs`), so the three walks now count the same bytes the same way by construction. Open PR #38262 refines `CodepointIterator`'s ill-formed handling to one U+FFFD per maximal subpart; these loops pick that up as is, and since a line break is never part of such a subpart the line count is the same either way.
- The `.min(remaining.len())` clamp from #32774 lives inside the iterator now; the six truncated-tail cases it added still pass.
- Tests, all of which fail on the current build:
  - `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts`: `bun build --sourcemap=external` on Latin-1 files with an ill-formed sequence (a bare `0xE9`, a bare 2-byte lead, three bytes of a 4-byte sequence) right before a line break, once in a legal comment (kept in the output, so both loops see it) and once in a plain comment (dropped, so only the original-side table does), decoding the mappings and checking the line each following statement maps back to. The source has blank lines between the statements that the output does not, so the two off-by-ones cannot cancel out. One more case puts the comment in a dependency and checks the entry point's statement is still placed right.
  - `test/js/bun/sourcemap/internal-sourcemap.test.ts`: the same two comment shapes through `bun run` and `error.stack` (unfixed they report line 2 and line 5 for an error on line 3), plus an ill-formed byte inside a template literal with, on the error's line, a string the printer re-emits with a well-formed U+FFFD, which still has to count as one column (`3:26`; unfixed `2:26`).
- Also ran against the debug build: the rest of `test/js/bun/sourcemap/`, `bundler_comments`, the source map tests in `bundler_edgecase`, the `bun build --compile` source map tests, `test/js/node/module/*sourcemap*`, `test/cli/test/coverage.test.ts`, and `test/bake/dev/{sourcemap,server-sourcemap}.test.ts`.
- #38449 fixes a separate bug (the CRLF peek) in the same generated-side loop; the two changes are on different lines and independent.

### Background

- A source map entry pairs a position in the printed output (generated line and column) with a position in the source file (original line and column). Bun builds the two sides separately. `LineOffsetTable::generate` walks the source file once and records where every line starts, plus a byte-to-UTF-16-column table for lines containing non-ASCII bytes; `add_source_mapping` turns a token's byte offset into an original line and column with it. The builder in `Chunk.rs` is called once per mapped token and walks whatever the printer emitted since the previous call, bumping the generated line at each line terminator. The same builder produces `bun build`'s VLQ maps and the compact maps the runtime uses to rewrite stack traces.
- `wtf8_byte_sequence_length_with_invalid(b)` returns the number of bytes a UTF-8 sequence starting with `b` would have (2 for `0xC0..0xDF`, 3 for `0xE0..0xEF`, 4 for `0xF0..0xF7`), judging by the lead byte alone. `decode_wtf8_rune_t` then checks that the following bytes are continuation bytes and returns a caller-supplied sentinel when they are not. The bug was advancing by the first number after the second call had said the sequence was not there.
- `strings::CodepointIterator` (`src/bun_core/string/immutable.rs`) is the shared way of walking raw bytes as code points: it returns the code point and the number of bytes it took up, reporting an ill-formed sequence as U+FFFD with a width of 1, so a caller never steps over bytes that were not part of a valid sequence.
- Ill-formed bytes get into the printed output through legal comments (`/*! ... */`, copied verbatim, and the only place one can sit right before a line break) and regex literals (which cannot contain a line break); strings and template literals are re-encoded by the printer and other comments are dropped. They get into the source-side table from anywhere in the file.

<details>
<summary>Repro output before and after</summary>

```
$ printf '/*! caf\xe9\nb */\nconsole.log(1);\nconsole.log(2);\n' > in.js
$ bun build ./in.js --outdir out --sourcemap=external
$ cat -A out/in.js
// in.js$
/*! cafM-i$
b */$
console.log(1);$
console.log(2);$

# mappings before: 5 groups, console.log(1) in the 3rd although it is on the 4th line,
# recorded as original line 1 although it is on line 2
;AACA;AAAA,QAAQ,IAAI,CAAC;AACb,QAAQ,IAAI,CAAC;
# mappings after: identical to what the same file with a well-formed é produces
;AAEA;AAAA;AAAA,QAAQ,IAAI,CAAC;AACb,QAAQ,IAAI,CAAC;

# Plain comment (dropped from the output): only the source-side table is affected.
$ printf '/* caf\xe9\nb */\nconst err = new Error("x");\nconsole.log(err.stack.split(String.fromCharCode(10))[1]);\n' > rt.js
$ bun rt.js
    at /tmp/rt.js:2:17     # before (the Error is on line 3)
    at /tmp/rt.js:3:17     # after

# Legal comment (kept in the output): both sides are affected. The blank lines
# keep the two off-by-ones from cancelling out.
$ printf '/*! caf\xe9\nb */\nconst err = new Error("x");\n\n\nconsole.log(err.stack.split(String.fromCharCode(10))[1]);\n' > rt2.js
$ bun rt2.js
    at /tmp/rt2.js:5:17    # before (the Error is on line 3)
    at /tmp/rt2.js:3:17    # after
```

</details>
