### PR TITLE
bundler: bundle HTML entry points for the browser on every entry path of a server build

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2685,6 +2685,26 @@ pub mod bv2_impl {
             Ok(())
         }
 
+        /// The target an entry point with `loader` is bundled for when the build
+        /// asked for `target`.
+        ///
+        /// An HTML entry point's scripts run in the browser, so in a server-side
+        /// build it is bundled for `Target::Browser` regardless of how the entry
+        /// was resolved (resolver, `files:`, or an onResolve plugin). This is the
+        /// same rule `process_resolve_queue` applies to HTML files imported from
+        /// server code. The dev server handles HTML routes itself and is exempt.
+        fn entry_point_target(
+            &mut self,
+            loader: Loader,
+            target: options::Target,
+        ) -> options::Target {
+            if loader == Loader::Html && target.is_server_side() && self.dev_server.is_none() {
+                self.ensure_client_transpiler();
+                return Target::Browser;
+            }
+            target
+        }
+
         pub(crate) fn enqueue_entry_item(
             &mut self,
             resolve: &mut _resolver::Result,
@@ -2700,6 +2720,10 @@ pub mod bv2_impl {
             };
 
             path.assert_file_path_is_absolute();
+            let loader = path
+                .loader(&self.transpiler.options.loaders)
+                .unwrap_or(Loader::File);
+            let target = self.entry_point_target(loader, target);
             // borrowck: get-then-put instead of a single get-or-put.
             if self
                 .path_to_source_index_map(target)
@@ -2710,10 +2734,6 @@ pub mod bv2_impl {
             }
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
-
-            let loader = path
-                .loader(&self.transpiler.options.loaders)
-                .unwrap_or(Loader::File);
 
             // SAFETY: `path_with_pretty_initialized` allocates into `self.graph.heap`, which
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
@@ -3081,21 +3101,8 @@ pub mod bv2_impl {
                     Err(_) => continue,
                 };
 
-                let target = 'brk: {
-                    let main_target = self.transpiler.options.target;
-                    if main_target.is_server_side() {
-                        if let Some(path) = resolved.path_const() {
-                            if let Some(loader) = path.loader(&self.transpiler.options.loaders) {
-                                if loader == Loader::Html {
-                                    self.ensure_client_transpiler();
-                                    break 'brk Target::Browser;
-                                }
-                            }
-                        }
-                    }
-                    break 'brk main_target;
-                };
-                let _ = self.enqueue_entry_item(&mut resolved, true, target)?;
+                let _ =
+                    self.enqueue_entry_item(&mut resolved, true, self.transpiler.options.target)?;
             }
             Ok(())
         }
@@ -4744,6 +4751,14 @@ pub mod bv2_impl {
                         } else {
                             path.namespace = result_ns_static;
                         }
+                        let loader = path
+                            .loader(&this.transpiler.options.loaders)
+                            .unwrap_or(Loader::File);
+                        let target = if resolve.import_record.kind == ImportKind::EntryPointBuild {
+                            this.entry_point_target(loader, resolve.import_record.original_target)
+                        } else {
+                            resolve.import_record.original_target
+                        };
 
                         // SAFETY: `GetOrPutResult` borrows `&mut this` for its whole
                         // lifetime, blocking the `free_list`/`graph` accesses below.
@@ -4752,7 +4767,7 @@ pub mod bv2_impl {
                         // through `value_ptr` (no intervening map mutation).
                         let (value_ptr, found_existing) = {
                             let existing = this
-                                .path_to_source_index_map(resolve.import_record.original_target)
+                                .path_to_source_index_map(target)
                                 .get_or_put(path.text)
                                 .expect("oom");
                             (
@@ -4767,10 +4782,7 @@ pub mod bv2_impl {
                             this.free_list.push(result.namespace);
                             this.free_list.push(result.path);
                             path = this
-                                .path_with_pretty_initialized(
-                                    &path,
-                                    resolve.import_record.original_target,
-                                )
+                                .path_with_pretty_initialized(&path, target)
                                 .expect("oom");
                             // `GetOrPutResult` has no `key_ptr` — `get_or_put` already
                             // duped the key into the map (see PathToSourceIndexMap.rs).
@@ -4782,9 +4794,6 @@ pub mod bv2_impl {
                             unsafe { *value_ptr = source_index.get() };
                             out_source_index = Some(source_index);
                             let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
-                            let loader = path
-                                .loader(&this.transpiler.options.loaders)
-                                .unwrap_or(Loader::File);
 
                             this.graph
                                 .input_files
@@ -4817,16 +4826,12 @@ pub mod bv2_impl {
                                     file: bun_sys::Fd::INVALID,
                                 },
                                 side_effects: bun_ast::SideEffects::HasSideEffects,
-                                jsx: this
-                                    .transpiler_for_target(resolve.import_record.original_target)
-                                    .options
-                                    .jsx
-                                    .clone(),
+                                jsx: this.transpiler_for_target(target).options.jsx.clone(),
                                 source_index: bun_ast::Index::init(source_index.get()),
                                 module_type: options::ModuleType::Unknown,
                                 loader: Some(loader),
                                 tree_shaking: this.linker.options.tree_shaking,
-                                known_target: resolve.import_record.original_target,
+                                known_target: target,
                                 ..Default::default()
                             };
                             // Arena-owned.

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect } from "bun:test";
+import type { BuildOutput } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -1011,4 +1013,89 @@ body {
       expect(htmlContent).toMatch(/href=".*\.webmanifest"/);
     },
   });
+});
+
+// An HTML entry point's scripts run in the browser, so `target: "bun"` / `"node"`
+// builds bundle them for the browser no matter how the entry point was resolved.
+describe.concurrent("html entry point in a server-side build is bundled for the browser", () => {
+  // `pkg` resolves to a different file under the "browser" export condition, which
+  // server targets do not set, so the chunk's contents show which target built it.
+  const fixture = {
+    "page.html": `<!doctype html><html><body><script src="./app.js"></script></body></html>`,
+    "app.js": `import { where } from "pkg"; console.log(where);`,
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      exports: { ".": { browser: "./browser.js", default: "./server.js" } },
+    }),
+    "node_modules/pkg/browser.js": `export const where = "browser build";`,
+    "node_modules/pkg/server.js": `export const where = "server build";`,
+  };
+
+  async function expectBrowserChunk(build: BuildOutput) {
+    expect(build.logs).toBeEmpty();
+    const js = build.outputs.filter(o => o.path.endsWith(".js"));
+    expect(js).toHaveLength(1);
+    expect(build.outputs.filter(o => o.path.endsWith(".html"))).toHaveLength(1);
+    const chunk = await js[0].text();
+    expect(chunk).toContain("browser build");
+    expect(chunk).not.toContain("server build");
+    expect(chunk).not.toContain("// @bun");
+  }
+
+  for (const target of ["bun", "node"] as const) {
+    test(`target ${target}: entry point resolved from disk`, async () => {
+      using dir = tempDir("html-entry-target", fixture);
+      await expectBrowserChunk(await Bun.build({ entrypoints: [`${dir}/page.html`], target }));
+    });
+
+    test(`target ${target}: onResolve plugin matches the entry point and declines it`, async () => {
+      using dir = tempDir("html-entry-target", fixture);
+      await expectBrowserChunk(
+        await Bun.build({
+          entrypoints: [`${dir}/page.html`],
+          target,
+          plugins: [
+            {
+              name: "declines",
+              setup(build) {
+                build.onResolve({ filter: /\.html$/ }, () => undefined);
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    test(`target ${target}: onResolve plugin resolves the entry point to an html file`, async () => {
+      using dir = tempDir("html-entry-target", fixture);
+      await expectBrowserChunk(
+        await Bun.build({
+          entrypoints: ["virtual:page"],
+          target,
+          plugins: [
+            {
+              name: "resolves",
+              setup(build) {
+                build.onResolve({ filter: /^virtual:page$/ }, () => ({ path: `${dir}/page.html` }));
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    test(`target ${target}: entry point comes from the files option`, async () => {
+      using dir = tempDir("html-entry-target", fixture);
+      await expectBrowserChunk(
+        await Bun.build({
+          entrypoints: [`${dir}/mem-page.html`],
+          target,
+          files: {
+            [`${dir}/mem-page.html`]: `<!doctype html><html><body><script src="./mem-app.js"></script></body></html>`,
+            [`${dir}/mem-app.js`]: fixture["app.js"],
+          },
+        }),
+      );
+    });
+  }
 });


### PR DESCRIPTION
### Problem
- `Bun.build({ entrypoints: ["./page.html"], target: "bun" })` bundles the page's scripts for the browser, but the same build with any onResolve plugin whose filter matches the entry (even one that returns `undefined`), with a plugin that returns the path of an `.html` file for an entry, or with the entry supplied through `files:` bundles them as server code: the client chunk starts with `// @bun`, packages resolve through the server conditions instead of `browser`, node builtins are left as bare imports, and so on. Same with `target: "node"` minus the pragma.
- Cause: the HTML -> `Target::Browser` switch lived only in the resolve-from-disk branch of `enqueue_entry_points_normal` (`src/bundler/bundle_v2.rs`). The `files:` branch of the same function, the `EntryPointBuild` fallback in `on_resolve` (plugin declined) and the `EntryPointBuild` success path in `on_resolve` (plugin returned a path) all registered the entry under the server target, so the HTML file and everything it references were parsed with the server transpiler.

### Fix
- `entry_point_target(loader, target)`: an entry point with the `html` loader in a server-side build is bundled for `Target::Browser` (and the client transpiler is created); otherwise the requested target is kept. The dev server is exempt, as before.
- `enqueue_entry_item` applies it, which covers the disk branch (the inline block there is removed), the `files:` branch and the plugin-declined fallback. `on_resolve`'s success path applies it to `EntryPointBuild` records only; plugin-resolved imports keep their importer's target.
- Why this is right: it is the rule the bundler already applies to HTML in a server build when the HTML is imported from server code (`process_resolve_queue`: `loader == Html && target.is_server_side() && dev_server.is_none()` -> browser graph) and to HTML entries resolved from disk. Applying it at the point where an entry point is registered makes the result independent of how the entry was resolved: in the probe below, both plugin variants now emit a chunk byte-identical to the plugin-free build (and to `target: "browser"`), and the `files:` variant differs only in the path comment.
- Registering the entry in the browser graph also fixes the interaction with server code importing the same HTML file: previously a plugin-resolved HTML entry sat in the server graph under its real path, so `import page from "./page.html"` in the server entry linked to the HTML source itself and failed with `No matching export in "page.html" for import "default"` instead of getting the import manifest. Listing the same HTML file twice (once on disk, once through a plugin) now dedupes to one HTML output, as it already did for `target: "browser"`.
- Verified with `test/bundler/bundler_html.test.ts` ("html entry point in a server-side build is bundled for the browser"): for `target: "bun"` and `"node"`, the client chunk of an HTML entry resolved from disk, through a declining onResolve plugin, through an onResolve plugin returning an `.html` path, and through `files:` picks the `browser` export condition and has no `// @bun` pragma. On the release build the six plugin/`files:` cases fail, the two disk cases pass; all pass with this change.
- Also ran `html-import-manifest`, `bundler_files`, `bun-build-api`, `bundler_plugin`, `bundler_html_server`, `standalone` and the bake `dev/html`, `dev/plugins`, `dev/production`, `dev-and-prod` tests against the debug build: no failures related to this change.

### Background
- A server-side (`bun`/`node`) build that contains HTML bundles two module graphs: the server graph, and a browser graph for the HTML and its scripts/styles. Each graph has its own path -> source index map (`path_to_source_index_map(target)`) and its own transpiler; the browser one is created lazily by `ensure_client_transpiler` and must exist before a browser-target parse task is scheduled, because parse workers clone it from `BundleV2::client_transpiler`.
- `ParseTask::known_target` selects which transpiler parses a file; the HTML file's target is inherited by every script and stylesheet it references, so the entry's target decides the target of the whole client chunk. `// @bun` is emitted for chunks whose entry was parsed for the bun target.
- Entry points reach the bundler on three paths: `enqueue_entry_points_normal` (resolver or `files:`), and, when a plugin's onResolve filter matches the entry specifier, `on_resolve` with an `ImportKind::EntryPointBuild` record, which either falls back to the resolver (plugin returned nothing) or registers the path the plugin returned.

<details>
<summary>Probe on bun 1.4.0 (page.html with a script tag for app.js)</summary>

```
baseline:        // app.js\nconsole.log(typeof window, process.platform);\n
plugin-declines: // @bun\n// app.js\nconsole.log(typeof window, process.platform);\n
plugin-returns:  // @bun\n// app.js\nconsole.log(typeof window, process.platform);\n
files:           // @bun\n// /v/app.js\nconsole.log(typeof window, process.platform);\n
```

With a package exporting `{ browser: "./browser.js", default: "./server.js" }`, the plugin and `files:` variants resolve `server.js` under both `target: "bun"` and `target: "node"`; the baseline resolves `browser.js`.

Two neighbouring bugs found while probing are reported separately and are not changed here: a `files:` entry is "ModuleNotFound" when a matching onResolve plugin declines it (the fallback never consults the file map), and a server file importing an `.html` file supplied through `files:` gets no import manifest.
</details>
